### PR TITLE
fix(proxy): remove internal ID headers from proxy responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ curl -fsSL https://temps.sh/deploy.sh | sh
 
 ![Temps Dashboard](assets/screenshots/dashboard.png)
 
-Stop paying for 5 different SaaS tools. Temps replaces your deployment platform, analytics, error tracking, session replay, and uptime monitoring -- all self-hosted, all in one binary.
+Stop paying for 6 different SaaS tools. Temps replaces your deployment platform, analytics, error tracking, session replay, uptime monitoring, and transactional email -- all self-hosted, all in one binary.
 
 ---
 
@@ -93,6 +93,20 @@ Monitors for deploy failures, runtime crashes, certificate expiry, and backup he
 
 </td>
 </tr>
+<tr>
+<td width="50%">
+
+**Transactional Email**
+Add sender domains with DKIM records through the UI. Send transactional emails via `@temps-sdk/node-sdk`. No external email service needed.
+
+</td>
+<td width="50%">
+
+**AI-Ready (MCP Server)**
+Ship with a Model Context Protocol server (`@temps-sdk/mcp`) so AI agents can deploy, monitor, and manage your infrastructure through natural language.
+
+</td>
+</tr>
 </table>
 
 ### Works with your stack
@@ -119,6 +133,8 @@ Monitors for deploy failures, runtime crashes, certificate expiry, and backup he
 curl -fsSL https://temps.sh/deploy.sh | sh
 ```
 
+**Tested on:** Ubuntu 24.04 / 22.04 &nbsp;|&nbsp; Also works on macOS
+
 ---
 
 ## What Temps replaces
@@ -131,6 +147,7 @@ curl -fsSL https://temps.sh/deploy.sh | sh
 | Error tracking | Sentry ($26+/mo) |
 | Uptime monitoring | Better Uptime / Pingdom ($20+/mo) |
 | Managed Postgres/Redis/S3 | AWS RDS / ElastiCache ($50+/mo) |
+| Transactional email + DKIM | Resend / SendGrid ($20-100/mo) |
 | Request logs + proxy | Cloudflare ($0-200/mo) |
 | **Total with Temps** | **$0 (self-hosted)** |
 
@@ -147,6 +164,7 @@ curl -fsSL https://temps.sh/deploy.sh | sh
 | Session replay | Yes | No | No | No | No | No |
 | Error tracking (Sentry-compatible) | Yes | No | No | No | No | No |
 | Uptime monitoring | Yes | No | No | No | No | No |
+| Transactional email + DKIM | Yes | No | No | No | No | No |
 | Managed Postgres/Redis/S3 | Yes | Yes | Partial | Plugin | Yes | Add-on |
 | Pingora proxy (Cloudflare-grade) | Yes | No | No | No | No | No |
 | Auto TLS (HTTP-01 + DNS-01) | Yes | Yes | Yes | Plugin | Yes | Yes |

--- a/crates/temps-proxy/src/proxy.rs
+++ b/crates/temps-proxy/src/proxy.rs
@@ -421,16 +421,6 @@ impl LoadBalancer {
     ) -> Result<()> {
         upstream_response.insert_header("X-Request-ID", &ctx.request_id)?;
 
-        if let Some(project) = &ctx.project {
-            upstream_response.insert_header("X-Project-ID", project.id.to_string())?;
-        }
-        if let Some(environment) = &ctx.environment {
-            upstream_response.insert_header("X-Environment-ID", environment.id.to_string())?;
-        }
-        if let Some(deployment) = &ctx.deployment {
-            upstream_response.insert_header("X-Deployment-ID", deployment.id.to_string())?;
-        }
-
         // Apply security headers from project settings or global config
         self.apply_security_headers(upstream_response, ctx.project.as_deref())
             .await?;


### PR DESCRIPTION
## Summary

- **Remove `X-Project-ID`, `X-Environment-ID`, and `X-Deployment-ID`** headers from proxy responses — these leaked sequential internal integer IDs to end users, enabling enumeration and exposing potential IDOR attack surface
- **Preserve `X-Request-ID`** for request tracing — operators can correlate with server-side logs for full routing context
- **Update README** to add transactional email + DKIM and MCP server features to the feature matrix

## Security

The removed headers exposed internal database IDs (sequential integers) on every proxied response. This allowed external observers to:
- Enumerate how many projects/environments/deployments exist
- Track growth rate over time
- Potentially use IDs for IDOR attacks against any endpoint that accepts these IDs