### PR TITLE
fix(deployments): add pre-flight image existence check before rollback

### DIFF
--- a/crates/temps-deployer/src/docker.rs
+++ b/crates/temps-deployer/src/docker.rs
@@ -1193,6 +1193,19 @@ impl ContainerDeployer for DockerRuntime {
 
         Ok(Box::new(Box::pin(logs_stream)))
     }
+
+    async fn image_exists(&self, image_name: &str) -> Result<bool, DeployerError> {
+        match self.docker.inspect_image(image_name).await {
+            Ok(_) => Ok(true),
+            Err(bollard::errors::Error::DockerResponseServerError {
+                status_code: 404, ..
+            }) => Ok(false),
+            Err(e) => Err(DeployerError::Other(format!(
+                "Failed to check image '{}': {}",
+                image_name, e
+            ))),
+        }
+    }
 }
 
 #[async_trait]

--- a/crates/temps-deployer/src/lib.rs
+++ b/crates/temps-deployer/src/lib.rs
@@ -468,6 +468,13 @@ pub trait ContainerDeployer: Send + Sync {
         &self,
         container_id: &str,
     ) -> Result<Box<dyn futures::Stream<Item = String> + Unpin + Send>, DeployerError>;
+
+    /// Check if a Docker image exists locally.
+    /// Returns Ok(true) if the image exists, Ok(false) if it does not.
+    /// Default implementation returns true (assumes image exists) for backward compatibility.
+    async fn image_exists(&self, _image_name: &str) -> Result<bool, DeployerError> {
+        Ok(true)
+    }
 }
 
 /// Combined trait for both building and deploying

--- a/crates/temps-deployments/src/services/services.rs
+++ b/crates/temps-deployments/src/services/services.rs
@@ -659,6 +659,32 @@ impl DeploymentService {
                 environment_id, deployment_id
             );
         } else {
+            // Pre-flight check: verify the Docker image still exists locally before
+            // attempting rollback. Without this check, rollback would fail mid-way
+            // (during container creation) after potentially disrupting the current deployment.
+            match self.deployer.image_exists(&image_name).await {
+                Ok(true) => {
+                    info!(
+                        "Rollback: Image '{}' exists locally, proceeding",
+                        image_name
+                    );
+                }
+                Ok(false) => {
+                    return Err(DeploymentError::Other(format!(
+                        "Cannot rollback: Docker image '{}' no longer exists locally. \
+                         The image may have been removed by Docker pruning. \
+                         Consider redeploying from source instead.",
+                        image_name
+                    )));
+                }
+                Err(e) => {
+                    return Err(DeploymentError::Other(format!(
+                        "Cannot rollback: failed to verify Docker image '{}' exists: {}",
+                        image_name, e
+                    )));
+                }
+            }
+
             // Rollback workflow for non-static presets:
             // 1. Deploy the image using DeployImageJob (will deploy/redeploy containers as needed)
             // 2. Mark deployment as complete using MarkDeploymentCompleteJob (will stop previous deployments)
@@ -2081,6 +2107,7 @@ mod tests {
             async fn list_containers(&self) -> Result<Vec<temps_deployer::ContainerInfo>, temps_deployer::DeployerError>;
             async fn get_container_logs(&self, container_id: &str) -> Result<String, temps_deployer::DeployerError>;
             async fn stream_container_logs(&self, container_id: &str) -> Result<Box<dyn futures::Stream<Item = String> + Unpin + Send>, temps_deployer::DeployerError>;
+            async fn image_exists(&self, image_name: &str) -> Result<bool, temps_deployer::DeployerError>;
         }
     }
     fn create_test_external_service_manager(
@@ -2310,6 +2337,7 @@ mod tests {
             let stream = stream::empty();
             Ok(Box::new(stream))
         });
+        deployer.expect_image_exists().returning(|_| Ok(true));
         let deployer: Arc<dyn temps_deployer::ContainerDeployer> = Arc::new(deployer);
 
         // For tests, we'll create a service that directly accepts the trait
@@ -2490,6 +2518,98 @@ mod tests {
                 assert!(msg.contains("deployed"));
             }
             e => panic!("Expected InvalidDeploymentState error, got: {:?}", e),
+        }
+
+        Ok(())
+    }
+
+    /// Creates a DeploymentService where image_exists returns false,
+    /// simulating a pruned/missing Docker image.
+    fn create_deployment_service_with_missing_image(
+        db: Arc<temps_database::DbConnection>,
+    ) -> DeploymentService {
+        let log_service = Arc::new(temps_logs::LogService::new(std::env::temp_dir()));
+        let test_db_url = "postgresql://test_user:test_password@localhost:5432/test_db";
+        let server_config = Arc::new(
+            temps_config::ServerConfig::new(
+                "127.0.0.1:8080".to_string(),
+                test_db_url.to_string(),
+                None,
+                None,
+            )
+            .expect("Failed to create test server config"),
+        );
+        let config_service = Arc::new(temps_config::ConfigService::new(server_config, db.clone()));
+
+        let mut queue_service = MockQueueService::new();
+        queue_service.expect_send().returning(|_| Ok(()));
+        queue_service
+            .expect_subscribe()
+            .returning(|| Box::new(MockJobReceiver::new()));
+        let queue_service: Arc<dyn temps_core::JobQueue> = Arc::new(queue_service);
+
+        let docker = Arc::new(bollard::Docker::connect_with_local_defaults().unwrap());
+        let docker_log_service = Arc::new(temps_logs::DockerLogService::new(docker));
+
+        let mut deployer = MockContainerDeployer::new();
+        deployer.expect_deploy_container().returning(|_| {
+            Ok(temps_deployer::DeployResult {
+                container_id: "test-container".to_string(),
+                container_name: "test-container".to_string(),
+                container_port: 3000,
+                host_port: 3000,
+                status: temps_deployer::ContainerStatus::Running,
+            })
+        });
+        deployer.expect_stop_container().returning(|_| Ok(()));
+        deployer.expect_remove_container().returning(|_| Ok(()));
+        deployer.expect_image_exists().returning(|_| Ok(false));
+        let deployer: Arc<dyn temps_deployer::ContainerDeployer> = Arc::new(deployer);
+
+        DeploymentService {
+            db,
+            log_service,
+            config_service,
+            queue_service,
+            docker_log_service,
+            deployer,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rollback_fails_when_image_missing() -> Result<(), Box<dyn std::error::Error>> {
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+
+        // Setup test data (creates a non-static project with a deployed deployment)
+        let (_project, _environment, target_deployment) = setup_test_data(&db).await?;
+
+        // Use a service where image_exists returns false
+        let deployment_service = create_deployment_service_with_missing_image(db.clone());
+
+        // Attempt rollback — should fail with a clear error before any containers are touched
+        let result = deployment_service
+            .rollback_to_deployment(target_deployment.project_id, target_deployment.id)
+            .await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            DeploymentError::Other(msg) => {
+                assert!(
+                    msg.contains("no longer exists locally"),
+                    "Expected 'no longer exists locally' in error message, got: {}",
+                    msg
+                );
+                assert!(
+                    msg.contains("Docker image"),
+                    "Expected 'Docker image' in error message, got: {}",
+                    msg
+                );
+            }
+            e => panic!(
+                "Expected DeploymentError::Other with image-not-found message, got: {:?}",
+                e
+            ),
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

- Adds a pre-flight Docker image existence check in `rollback_to_deployment` before any container operations begin, preventing mid-rollback failures that could disrupt the currently running deployment
- Introduces `ContainerDeployer::image_exists()` trait method with a default `Ok(true)` fallback for backward compatibility; `DockerRuntime` overrides it using Docker's inspect API (returns `false` on 404)
- Returns a clear, actionable error message when the target image has been pruned/removed, suggesting the user redeploy from source instead

## Problem

When rolling back to a previous deployment whose Docker image had been pruned or removed, the rollback would fail mid-way during `docker.create_container()` with a confusing nested error. By that point, the current deployment's containers may have already been disrupted, leaving the environment in a broken state.

## Solution

The image existence check runs **before** any deployment work begins (before `DeployImageJob` execution). If the image is missing, rollback is aborted cleanly with no side effects.

## Changes

| File | Change |
|---|---|
| `crates/temps-deployer/src/lib.rs` | Added `image_exists()` to `ContainerDeployer` trait with default impl |
| `crates/temps-deployer/src/docker.rs` | `DockerRuntime` override using `inspect_image` API, 404 → `false` |
| `crates/temps-deployments/src/services/services.rs` | Pre-flight check in `rollback_to_deployment`, mock updates, new test |

## Testing

- `test_rollback_fails_when_image_missing` — verifies rollback returns clear error when image doesn't exist
- All 4 rollback tests pass, all 165 deployment tests pass, all 39 deployer tests pass