### PR TITLE
fix(cli): move logs under deployments subcommand and fix log rendering

### DIFF
--- a/apps/temps-cli/src/commands/deploy/index.ts
+++ b/apps/temps-cli/src/commands/deploy/index.ts
@@ -143,10 +143,9 @@ export function registerDeployCommands(program: Command): void {
     .option('-f, --force', 'Skip confirmation')
     .action(teardownDeploymentAction)
 
-  // Logs command at root level
-  program
+  deployments
     .command('logs')
-    .description('Stream deployment logs')
+    .description('Show deployment build logs')
     .option('-p, --project <project>', 'Project slug or ID')
     .option('-e, --environment <env>', 'Environment', 'production')
     .option('-f, --follow', 'Follow log output')

--- a/apps/temps-cli/src/commands/deploy/logs.ts
+++ b/apps/temps-cli/src/commands/deploy/logs.ts
@@ -1,5 +1,6 @@
-import { requireAuth, config } from '../../config/store.js'
+import { requireAuth } from '../../config/store.js'
 import { setupClient, client } from '../../lib/api-client.js'
+import { resolveProjectSlug } from '../../config/resolve-project.js'
 import {
   getProjectBySlug,
   getProjectDeployments,
@@ -25,16 +26,51 @@ interface LogEntry {
   line?: number
 }
 
+/**
+ * Parse JSONL log content (string) into LogEntry[].
+ * The API returns raw file content where each line is a JSON object.
+ * Falls back to treating each line as a plain-text message if parsing fails.
+ */
+function parseLogEntries(data: unknown): LogEntry[] {
+  if (Array.isArray(data)) {
+    return data as LogEntry[]
+  }
+
+  if (typeof data !== 'string') {
+    return []
+  }
+
+  const lines = data.split('\n').filter(line => line.trim() !== '')
+  return lines.map((line, index) => {
+    try {
+      const parsed = JSON.parse(line)
+      return {
+        timestamp: parsed.timestamp,
+        level: parsed.level,
+        message: parsed.message ?? line,
+        line: parsed.line ?? (index + 1),
+      } as LogEntry
+    } catch {
+      // Plain text line — treat as info-level message
+      return { message: line, line: index + 1 } as LogEntry
+    }
+  })
+}
+
 export async function logs(options: LogsOptions): Promise<void> {
   await requireAuth()
   await setupClient()
 
-  const projectName = options.project ?? config.get('defaultProject')
+  const resolved = await resolveProjectSlug(options.project)
 
-  if (!projectName) {
-    warning('No project specified. Use: temps logs --project <project>')
+  if (!resolved) {
+    warning('No project specified')
+    info('Use: bunx @temps-sdk/cli deployments logs --project <slug>')
+    info('Or link this directory: bunx @temps-sdk/cli link <slug>')
     return
   }
+
+  const projectName = resolved.slug
 
   // Get project ID
   const { data: projectData, error: projectError } = await getProjectBySlug({
@@ -133,7 +169,7 @@ async function fetchLogs(
       continue
     }
 
-    const logs = (Array.isArray(data) ? data : [data]) as LogEntry[]
+    const logs = parseLogEntries(data)
     const limitedLogs = logs.slice(-limit)
 
     for (const log of limitedLogs) {
@@ -167,7 +203,7 @@ async function streamLogs(
         })
 
         if (data) {
-          const logs = (Array.isArray(data) ? data : [data]) as LogEntry[]
+          const logs = parseLogEntries(data)
           const lastLine = lastLines[job.id] || 0
 
           for (const log of logs) {
@@ -175,15 +211,6 @@ async function streamLogs(
               console.log(colors.muted(`[${job.name}]`), formatLogMessage(log))
               lastLines[job.id] = log.line
             }
-          }
-
-          // If no line numbers, just print new logs based on count
-          if (logs.length > 0 && logs[0]?.line) {
-            const newLogs = logs.slice(lastLine)
-            for (const log of newLogs) {
-              console.log(colors.muted(`[${job.name}]`), formatLogMessage(log))
-            }
-            lastLines[job.id] = logs.length
           }
         }
       } catch {

--- a/apps/temps-cli/src/commands/runtime-logs.ts
+++ b/apps/temps-cli/src/commands/runtime-logs.ts
@@ -1,6 +1,7 @@
 import type { Command } from 'commander'
 import { requireAuth, config, credentials } from '../config/store.js'
-import { setupClient, client } from '../lib/api-client.js'
+import { setupClient, client, normalizeApiUrl } from '../lib/api-client.js'
+import { resolveProjectSlug } from '../config/resolve-project.js'
 import { getProjectBySlug, listContainers, getEnvironments } from '../api/sdk.gen.js'
 import { colors, info, warning, newline } from '../ui/output.js'
 import { startSpinner, succeedSpinner, failSpinner } from '../ui/spinner.js'
@@ -30,11 +31,19 @@ async function runtimeLogs(options: RuntimeLogsOptions): Promise<void> {
   const apiKey = await requireAuth()
   await setupClient()
 
-  const projectName = options.project ?? config.get('defaultProject')
+  const resolved = await resolveProjectSlug(options.project)
 
-  if (!projectName) {
+  if (!resolved) {
     warning('No project specified')
+    info('Use: bunx @temps-sdk/cli runtime-logs --project <slug>')
+    info('Or link this directory: bunx @temps-sdk/cli link <slug>')
     return
+  }
+
+  const projectName = resolved.slug
+
+  if (resolved.source !== 'flag') {
+    info(`Using project ${colors.bold(projectName)} (from ${resolved.source})`)
   }
 
   // Get project by slug
@@ -117,7 +126,7 @@ async function runtimeLogs(options: RuntimeLogsOptions): Promise<void> {
   newline()
 
   // Build WebSocket URL
-  const apiUrl = config.get('apiUrl')
+  const apiUrl = normalizeApiUrl(config.get('apiUrl'))
   const wsProtocol = apiUrl.startsWith('https') ? 'wss' : 'ws'
   // Remove protocol and any trailing slash, keep the path (e.g., /api)
   const urlWithoutProtocol = apiUrl.replace(/^https?:\/\//, '').replace(/\/$/, '')
@@ -153,7 +162,11 @@ async function connectWebSocket(url: string, apiKey: string): Promise<void> {
     }
 
     ws.onmessage = (event) => {
-      const data = event.data.toString()
+      const raw = event.data.toString()
+
+      // Docker log lines include trailing newlines; strip them so
+      // console.log doesn't produce double-spaced output.
+      const data = raw.replace(/\r?\n$/, '')
 
       // Try to parse as JSON for structured logs
       try {
@@ -164,7 +177,7 @@ async function connectWebSocket(url: string, apiKey: string): Promise<void> {
             console.log(colors.muted(`  ${parsed.detail}`))
           }
         } else if (parsed.message) {
-          console.log(parsed.message)
+          console.log(parsed.message.replace(/\r?\n$/, ''))
         } else {
           console.log(data)
         }


### PR DESCRIPTION
## Summary

- Moves `temps logs` to `temps deployments logs` — deployment build logs belong under the deployments command group, not as a generic root command
- Fixes build log rendering showing `undefined` for every job — the API returns JSONL as a raw string, but the CLI was treating it as a JSON array
- Fixes runtime-logs double-spacing — Docker log lines include trailing `\n` that `console.log` doubles up

## Before

```
$ temps logs
=== Verify Local Image ===
undefined
=== Deploy Container ===
undefined
```

```
$ temps runtime-logs
 ✓ Starting...

   ▲ Next.js 15.2.8

   - Local:        http://localhost:3000
```
(double-spaced output)

## After

```
$ temps deployments logs
=== Verify Local Image ===
10:15:47 ✅ Image nginx:latest verified
=== Deploy Container ===
10:15:48 Starting container deployment...
```

```
$ temps runtime-logs
 ✓ Starting...
   ▲ Next.js 15.2.8
   - Local:        http://localhost:3000
```
(single-spaced output)

## Changes

| File | Change |
|---|---|
| `apps/temps-cli/src/commands/deploy/index.ts` | Move `logs` from `program` (root) to `deployments` subcommand group |
| `apps/temps-cli/src/commands/deploy/logs.ts` | Add `parseLogEntries()` to properly parse JSONL string responses into `LogEntry[]`; fix streaming dedup logic |
| `apps/temps-cli/src/commands/runtime-logs.ts` | Strip trailing `\r?\n` from WebSocket messages before `console.log` |