### PR TITLE
fix(cli): simplify closure to function reference in domain list

### DIFF
--- a/crates/temps-cli/src/commands/domain.rs
+++ b/crates/temps-cli/src/commands/domain.rs
@@ -813,7 +813,7 @@ async fn execute_list_api(cmd: ListDomainsApiCommand) -> anyhow::Result<()> {
 
         let expiration = domain
             .expiration_time
-            .map(|t| format_millis_date(t))
+            .map(format_millis_date)
             .unwrap_or_else(|| "N/A".to_string());
 
         println!(


### PR DESCRIPTION
## Summary
- Simplify `.map(|t| format_millis_date(t))` to `.map(format_millis_date)` in the domain list command, addressing a Clippy lint (`redundant_closure`)