### PR TITLE
fix(ci): add protoc dependency to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake pkg-config libssl-dev
+          sudo apt-get install -y cmake pkg-config libssl-dev protobuf-compiler
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -136,6 +136,9 @@ jobs:
           cd web
           bun install
 
+      - name: Install system dependencies
+        run: brew install protobuf
+
       - name: Install wasm-pack and Build WASM
         run: |
           cargo install wasm-pack
@@ -209,6 +212,9 @@ jobs:
         run: |
           cd web
           bun install
+
+      - name: Install system dependencies
+        run: brew install protobuf
 
       - name: Install wasm-pack and Build WASM
         run: |


### PR DESCRIPTION
## Summary
- Add `protobuf-compiler` to the Linux AMD64 release build dependencies
- Add `brew install protobuf` to both macOS release jobs (AMD64 and ARM64)

The `temps-otel` crate uses `prost-build` in its `build.rs` to compile `.proto` files, which requires `protoc` on the system. This was already present in `rust-tests.yml` but missing from `release.yml`, causing release builds to fail.