### PR TITLE
fix(presets): fix incorrect corepack command for pnpm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deleted legacy `web/src/pages/CreateService.tsx` and `CreateServiceRefactored.tsx` (superseded by current service creation flow)
 
 ### Fixed
+- Fix incorrect `corepack` command used for pnpm in the Next.js preset
 - BuildKit build log output now emits vertex names (build step descriptions) in addition to command output, making cached layers visible in deployment logs
 - Install script command in documentation now uses `bash` instead of `sh`, fixing failures on Ubuntu 24 where `/bin/sh` is `dash` (#15)
 - Build failures when web UI is skipped in debug mode

--- a/crates/temps-presets/src/nextjs.rs
+++ b/crates/temps-presets/src/nextjs.rs
@@ -108,7 +108,7 @@ RUN corepack enable
         } else if matches!(package_manager, PackageManager::Pnpm) {
             r#"# Enable corepack for pnpm
 RUN corepack enable
-RUN corepack prepare pnpxm@latest --activate
+RUN corepack prepare pnpm@latest --activate
 
 "#
         } else {


### PR DESCRIPTION
## Description
Deploying a next js app with pnpm currently fails with the following error:
```
Usage Error: Unsupported package manager specification (pnpxm@latest)
```

I believe this line is wrong:
https://github.com/gotempsh/temps/blob/921ab979735eaa7fe11d44ec61243f7829c98c60/crates/temps-presets/src/nextjs.rs#L111

and should instead be 
```
RUN corepack prepare pnpm@latest --activate
```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I have written tests that cover the changes
- [ ] All new and existing tests pass (`cargo test --lib`)
- [ ] `cargo check --lib` passes with no warnings
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated documentation where necessary

## Related issues

<!-- Link related issues below. Use "Closes #123" to auto-close an issue when this PR is merged. -->
