### PR TITLE
fix(domains): show renew action for ACME certs with non-standard verification_method

### DIFF
--- a/web/src/pages/DomainDetail.tsx
+++ b/web/src/pages/DomainDetail.tsx
@@ -378,13 +378,11 @@ export function DomainDetail() {
     domain.status === 'pending'
 
 
-  // Renew is only meaningful for ACME flows we can automate.
-  // DNS-01 renewals require the user to re-add TXT records, so we expose
-  // it as "Start renewal" instead of "Renew".
-  const canRenew =
-    canManageCertificates &&
-    (domain.verification_method === 'dns-01' ||
-      domain.verification_method === 'http-01')
+  // Renew is meaningful for any ACME-issued certificate. DNS-01 renewals
+  // require the user to re-add TXT records, so we expose it as "Start renewal"
+  // instead of "Renew". Legacy/unknown values (e.g. "acme") are treated as
+  // auto-renewable since the backend resolves the challenge type.
+  const canRenew = canManageCertificates && !!domain.verification_method
   const renewLabel =
     domain.verification_method === 'dns-01' ? 'Start renewal' : 'Renew certificate'
 


### PR DESCRIPTION
## Summary

The **Renew certificate** action (kebab menu, active-cert card button, and "expiring soon" alert) was hidden on the domain detail page whenever a domain's `verification_method` was anything other than `"http-01"` or `"dns-01"`.

HTTP-01 ACME certificates issued through the provider path persist `verification_method = "acme"` (`crates/temps-domains/src/tls/providers.rs:174`), which then propagates into the `DomainResponse` returned to the frontend. The result: a user sees an `acme` method, a "Certificate expiring soon" alert, but no renew button anywhere on the page.

This widens `canRenew` to any non-empty `verification_method` when the platform can manage certificates. Cloudflare Tunnel mode (`canManageCertificates === false`) still hides the action.

- One-line change in `web/src/pages/DomainDetail.tsx`
- No backend changes required — the existing `POST /domains/{domain}/renew` endpoint already handles all challenge types
- Cloudflare gate preserved

## Test plan

- [ ] Visit a domain detail page with an active ACME cert (`verification_method: "acme"`) — renew button appears in the active-cert card, in the kebab menu, and in the "expiring soon" alert
- [ ] Confirm `dns-01` domains still show "Start renewal" label
- [ ] Confirm `http-01` domains still show "Renew certificate" label
- [ ] Confirm Cloudflare Tunnel mode still hides the renew action