### PR TITLE
fix(auth): preserve session cookie when clearing mfa_session after verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Stale skill content tests**: updated to match current `temps-cli/SKILL.md` headings so the suite stops failing on docs drift
+- **MFA verification left users stranded on the login page**: `verify_mfa_challenge` built a `HeaderMap` containing the new `session=…` cookie via `create_session_cookie`, then called `response_headers.insert(SET_COOKIE, mfa_clear_cookie)` to expire the temporary `mfa_session` cookie. `HeaderMap::insert` replaces all values for the key, so the response went out with only `mfa_session=; Max-Age=0` and no real session — the immediate `/user/me` refetch returned 401, and `ProtectedLayout` bounced the user back to `<Login />` even though the toast had already announced "MFA verified successfully". Fixed by switching to `append`, plus a regression test that mirrors the handler's exact header merge and asserts both `Set-Cookie` entries survive
 
 ### Security
 - **Shell-escape user-controllable `--model` flag**: AI CLI invocations now escape the model name before passing it to the shell, preventing argument injection via crafted model strings

--- a/crates/temps-auth/src/auth_service.rs
+++ b/crates/temps-auth/src/auth_service.rs
@@ -971,6 +971,48 @@ mod tests {
         assert!(session_cookie.contains("Secure"));
     }
 
+    // Regression: verify_mfa_challenge handler must `append` (not `insert`) the
+    // mfa_session clear cookie onto the headers returned by `create_session_cookie`.
+    // Using `insert` overwrites all existing Set-Cookie headers, dropping the new
+    // session cookie and leaving the user stuck on the login page after MFA.
+    #[tokio::test]
+    async fn test_verify_mfa_handler_cookie_merge_preserves_session_cookie() {
+        let (_db, auth_service, _) = setup_test_env().await;
+
+        let mut response_headers = auth_service.create_session_cookie("session_tok", true);
+        let pre_count = response_headers.get_all(SET_COOKIE).iter().count();
+        assert_eq!(pre_count, 2, "session_cookie + mfa_session clear");
+
+        // Simulate the exact merge done in verify_mfa_challenge handler:
+        // append a fresh mfa_session=; Max-Age=0 cookie.
+        let clear_mfa_cookie = Cookie::build(("mfa_session", ""))
+            .http_only(true)
+            .path("/")
+            .max_age(cookie::time::Duration::seconds(0))
+            .same_site(cookie::SameSite::Strict)
+            .secure(true)
+            .build();
+        response_headers.append(SET_COOKIE, clear_mfa_cookie.to_string().parse().unwrap());
+
+        let cookies: Vec<String> = response_headers
+            .get_all(SET_COOKIE)
+            .iter()
+            .map(|v| v.to_str().unwrap().to_string())
+            .collect();
+
+        // The session cookie MUST still be present alongside the mfa_session clear.
+        assert!(
+            cookies.iter().any(|c| c.contains("session=session_tok")),
+            "session cookie was clobbered: {:?}",
+            cookies,
+        );
+        assert!(
+            cookies.iter().any(|c| c.contains("mfa_session=")),
+            "mfa_session clear cookie missing: {:?}",
+            cookies,
+        );
+    }
+
     #[tokio::test]
     async fn test_create_session_cookie_does_not_panic() {
         // Verify that cookie creation never panics, even with unusual tokens.

--- a/crates/temps-auth/src/handlers.rs
+++ b/crates/temps-auth/src/handlers.rs
@@ -242,7 +242,7 @@ pub async fn verify_mfa_challenge(
                 .same_site(cookie::SameSite::Strict)
                 .secure(metadata.is_secure)
                 .build();
-            response_headers.insert(SET_COOKIE, clear_mfa_cookie.to_string().parse().unwrap());
+            response_headers.append(SET_COOKIE, clear_mfa_cookie.to_string().parse().unwrap());
 
             Ok((StatusCode::NO_CONTENT, response_headers))
         }


### PR DESCRIPTION
## Summary
- After successful MFA verification, users were stuck on the login page despite the "MFA verified successfully" toast firing.
- Root cause: `verify_mfa_challenge` in `crates/temps-auth/src/handlers.rs:245` called `response_headers.insert(SET_COOKIE, mfa_clear_cookie…)` on a `HeaderMap` that already contained the freshly-created session cookie. `HeaderMap::insert` replaces all values for the key, so the response went out with only `mfa_session=; Max-Age=0` — no real session — and the next `/user/me` returned 401, bouncing the user back to `<Login />` via `ProtectedLayout`.
- Fix: switch `insert` → `append` so both `Set-Cookie` headers (the new `session=…` and the `mfa_session=;` clear) ride out together.
- Adds a regression test in `auth_service.rs` that mirrors the handler's exact `HeaderMap` merge and asserts both cookies survive.

## Test plan
- [x] `cargo check --lib -p temps-auth` — clean
- [x] `cargo test --lib -p temps-auth test_verify_mfa_handler_cookie_merge_preserves_session_cookie` — passes
- [x] `cargo test --lib -p temps-auth mfa` — all 4 MFA tests pass
- [ ] Manual: log in to a prod-like deploy with an MFA-enabled user, complete the TOTP challenge, confirm the dashboard loads (no Login bounce).

## Notes
- Security-sensitive (auth path). Per CLAUDE.md, `security-auditor` should sign off before merge.