### PR TITLE
test(observability): fix EventFilters compile errors in merge_integration tests

### DIFF
--- a/crates/temps-observability/tests/merge_integration.rs
+++ b/crates/temps-observability/tests/merge_integration.rs
@@ -128,6 +128,7 @@ async fn merge_returns_rows_in_descending_ts_across_kinds() {
             environment_id: None,
             search: None,
             limit: 50,
+            hide_bots: None,
         })
         .await
         .expect("query");
@@ -192,6 +193,7 @@ async fn kinds_filter_excludes_unselected_tables() {
             environment_id: None,
             search: None,
             limit: 50,
+            hide_bots: None,
         })
         .await
         .expect("query errors only");
@@ -239,6 +241,7 @@ async fn time_range_filters_old_rows() {
             environment_id: None,
             search: None,
             limit: 50,
+            hide_bots: None,
         })
         .await
         .expect("query");
@@ -406,6 +409,7 @@ async fn fetch_spans_returns_span_rows_from_otel_table() {
             environment_id: None,
             search: None,
             limit: 50,
+            hide_bots: None,
         })
         .await
         .expect("query spans");
@@ -520,6 +524,7 @@ async fn merge_interleaves_spans_with_other_kinds() {
             environment_id: None,
             search: None,
             limit: 50,
+            hide_bots: None,
         })
         .await
         .expect("merge query");


### PR DESCRIPTION
## Summary

- The recent `hide_bots` filter addition to `EventFilters` (`crates/temps-observability/src/filters.rs`) bumped the struct from 8 to 9 fields, but the 5 struct-literal `EventFilters { ... }` constructors in `crates/temps-observability/tests/merge_integration.rs` were left at 8 fields, producing 5 `E0063: missing field hide_bots` errors under `cargo clippy --all-targets`.
- Set `hide_bots: None` on all 5 sites to preserve the existing test behavior (no bot filtering).
- Caught by running `cargo clippy --workspace --lib --all-targets --no-deps -- -D warnings` against `main`. After the fix: 0 errors, 0 real warnings.

## Test plan

- [ ] `cargo clippy --workspace --lib --all-targets --no-deps -- -D warnings` passes
- [ ] `cargo test --test merge_integration -p temps-observability` compiles (Docker required for the tests themselves to run)