### PR TITLE
fix(ci): set automatic_deploy=true in E2E project creation

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -241,7 +241,7 @@ jobs:
                 \"preset\": \"$APP_PRESET\",
                 \"git_url\": \"$REPO_URL\",
                 \"is_public_repo\": true,
-                \"automatic_deploy\": false,
+                \"automatic_deploy\": true,
                 \"storage_service_ids\": [],
                 \"performance_metrics_enabled\": false
               }")
@@ -281,10 +281,9 @@ jobs:
             fi
             echo "Environment ID: $ENV_ID"
 
-            # Project creation auto-triggers the initial deployment via queue.
-            # Do NOT call trigger-pipeline here — it would create a second deployment
-            # that cancels the first via cancel_in_flight_deployments, causing a race
-            # where polling sees the cancelled deployment instead of the new one.
+            # Project creation emits a GitPushEvent which is gated by
+            # automatic_deploy. We pass automatic_deploy=true above so the
+            # event creates the initial deployment.
             echo "Waiting for auto-triggered deployment to be created..."
             sleep 5
 


### PR DESCRIPTION
## Summary

E2E tests have been failing on `main` with deployments stuck in `pending` for the full 10-minute timeout × 3 apps. Root cause: the workflow created projects with `automatic_deploy: false`, but project creation auto-deploys via a `GitPushEvent` job that the processor explicitly skips when `automatic_deploy` is disabled (`crates/temps-deployments/src/services/job_processor.rs:651`).

No deployment row was ever created. The polling jq filter `.deployments[0].status // "pending"` fell through to the literal `"pending"` because `.deployments` was empty, masking the real problem (no deployment, not a stuck one).

## Fix

- Set `automatic_deploy: true` in the project-create payload so the auto-emitted `GitPushEvent` actually creates the deployment.
- Update the misleading comment about `trigger-pipeline` (no such HTTP endpoint exists; the auto-trigger goes through the queue regardless).

## Verification

Reproduced locally against `temps serve` on `:8080`:

| automatic_deploy | API result | deployments after 6s |
|---|---|---|
| `false` (broken) | 200 created | `total: 0` (no rows ever created) |
| `true` (fixed)  | 200 created | deployment id 101, transitions through pending → running |

In the broken case the polling loop has nothing to poll — `.deployments[0].status` is `null`, jq returns the `"pending"` fallback, and the script waits the full 10 minutes before failing.

## Test plan

- [ ] E2E Tests workflow passes on this PR
- [ ] Deployments transition out of `pending` within the 10-minute window