### PR TITLE
fix(deployments): always trigger initial deployment for new environments

### DIFF
--- a/crates/temps-deployments/src/services/job_processor.rs
+++ b/crates/temps-deployments/src/services/job_processor.rs
@@ -645,15 +645,44 @@ async fn process_git_push_event(
     // deployment configs (env overrides project). When both sides have
     // automatic_deploy=false, push events must NOT trigger a deployment —
     // the user has explicitly opted out.
-    if !is_automatic_deploy_enabled(
+    //
+    // Exception: the FIRST deployment for an environment always runs even
+    // when automatic_deploy=false. Without this, an opted-out project would
+    // never get a baseline deployment, and project creation would silently
+    // produce zero deployments.
+    use sea_orm::{EntityTrait, PaginatorTrait, QueryOrder};
+    let auto_deploy_enabled = is_automatic_deploy_enabled(
         project.deployment_config.as_ref(),
         environment.deployment_config.as_ref(),
-    ) {
+    );
+    if !auto_deploy_enabled {
+        let existing_count = match deployments::Entity::find()
+            .filter(deployments::Column::EnvironmentId.eq(environment.id))
+            .count(db.as_ref())
+            .await
+        {
+            Ok(n) => n,
+            Err(e) => {
+                error!(
+                    "Failed to count existing deployments for environment {}: {}",
+                    environment.id, e
+                );
+                return;
+            }
+        };
+
+        if existing_count > 0 {
+            info!(
+                "Skipping push event for project {} environment {} ({}): automatic_deploy is disabled",
+                project.id, environment.id, environment.name
+            );
+            return;
+        }
+
         info!(
-            "Skipping push event for project {} environment {} ({}): automatic_deploy is disabled",
+            "Allowing initial deployment for project {} environment {} ({}) despite automatic_deploy=false (no prior deployments)",
             project.id, environment.id, environment.name
         );
-        return;
     }
 
     // Check for duplicate deployment (same project, environment, and commit)
@@ -661,7 +690,6 @@ async fn process_git_push_event(
     // - Multiple webhook URLs are configured in GitHub (both /webhook/git/github/events and /webhook/source/github/events)
     // - GitHub sends duplicate webhooks
     // - Race condition between concurrent push events
-    use sea_orm::{EntityTrait, PaginatorTrait, QueryOrder};
     let existing_deployment = deployments::Entity::find()
         .filter(deployments::Column::ProjectId.eq(project.id))
         .filter(deployments::Column::EnvironmentId.eq(environment.id))


### PR DESCRIPTION
## Summary

Project creation queues a `GitPushEvent` to fire the initial deployment, but the auto-deploy gate in `process_git_push_event` was rejecting it whenever `automatic_deploy=false`. The result: opting out of auto-deploy on push also opted you out of ever getting a baseline deployment, leaving the environment with zero deployment rows and nothing to roll back to or promote from.

This caused the silent E2E failure fixed in #80 and is a UX trap for any user who creates a project with auto-deploy disabled — they get zero deploys with no clear error.

## Fix

In `crates/temps-deployments/src/services/job_processor.rs`, when the gate would otherwise reject the event, check whether the target environment has any existing deployments. If it has zero, allow the deployment through and log:

```
Allowing initial deployment for project N environment M (production) despite automatic_deploy=false (no prior deployments)
```

Subsequent push events still respect `automatic_deploy` exactly as before.

## Verification

Local against `temps serve` on `:8080`, with the live admin API:

| Scenario | Before | After |
|---|---|---|
| Create project, `automatic_deploy: false` | `total: 0` deployments, no log line | deployment id 102 created, "Allowing initial deployment" logged |
| Create project, `automatic_deploy: true`  | deployment created (existing path) | unchanged |
| Subsequent push, `automatic_deploy: false`, env has prior deploy | "Skipping push event" | "Skipping push event" (gate still works) |

All 332 `temps-deployments` tests pass.

## Test plan

- [ ] CI passes
- [ ] E2E run on this PR still works (now via two independent paths: workflow sets `automatic_deploy=true`, AND the bypass would catch it anyway)