### PR TITLE
fix(ci): wait for deployment 'completed' state before verifying app

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -288,6 +288,10 @@ jobs:
             sleep 5
 
             # --- Poll deployment status ---
+            # PipelineStatus enum: pending | running | built | completed | failed | cancelled
+            # 'running' means the workflow is executing (build, deploy_container, etc).
+            # 'completed' is the only terminal-success state — the route table is updated
+            # and the container is serving traffic only after this.
             echo "Polling deployment status (timeout: 10 minutes)..."
             DEPLOY_STATE="pending"
             DEPLOY_ID=""
@@ -301,8 +305,8 @@ jobs:
               DEPLOY_STATE=$(echo "$DEPLOY_LIST" | jq -r '.deployments[0].status // "pending"' 2>/dev/null || echo "pending")
               DEPLOY_ID=$(echo "$DEPLOY_LIST" | jq -r '.deployments[0].id // empty' 2>/dev/null || true)
 
-              if [ "$DEPLOY_STATE" = "running" ] || [ "$DEPLOY_STATE" = "deployed" ] || [ "$DEPLOY_STATE" = "completed" ]; then
-                echo "Deployment $DEPLOY_ID reached state: $DEPLOY_STATE"
+              if [ "$DEPLOY_STATE" = "completed" ]; then
+                echo "Deployment $DEPLOY_ID reached terminal state: $DEPLOY_STATE"
                 break
               fi
 
@@ -316,39 +320,41 @@ jobs:
                 break
               fi
 
-              echo "  State: $DEPLOY_STATE (waiting...)"
+              echo "  State: $DEPLOY_STATE (waiting for completed...)"
               sleep 15
             done
 
-            if [ "$DEPLOY_STATE" != "running" ] && [ "$DEPLOY_STATE" != "deployed" ] && [ "$DEPLOY_STATE" != "completed" ]; then
-              echo "FAIL: Deployment did not reach running state (last state: $DEPLOY_STATE)"
+            if [ "$DEPLOY_STATE" != "completed" ]; then
+              echo "FAIL: Deployment did not reach completed state (last state: $DEPLOY_STATE)"
               RESULTS+=("$APP_NAME: FAIL (state: $DEPLOY_STATE)")
               FAILED=$((FAILED + 1))
               continue
             fi
 
             # --- Verify app is reachable ---
+            # Even after deployment.status=completed the route table propagation and
+            # container HTTP readiness can lag a few seconds; retry up to ~60s.
             APP_URL="https://$APP_NAME.localho.st:3443/"
             echo "Verifying app at $APP_URL ..."
-            sleep 5
 
-            VERIFY_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "$APP_URL" || echo "000")
+            VERIFY_DEADLINE=$((SECONDS + 60))
+            VERIFY_CODE="000"
+            while [ $SECONDS -lt $VERIFY_DEADLINE ]; do
+              VERIFY_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$APP_URL" || echo "000")
+              if [ "$VERIFY_CODE" = "200" ] || [ "$VERIFY_CODE" = "304" ]; then
+                break
+              fi
+              echo "  HTTP $VERIFY_CODE — waiting for app to be reachable..."
+              sleep 5
+            done
 
             if [ "$VERIFY_CODE" = "200" ] || [ "$VERIFY_CODE" = "304" ]; then
               echo "PASS: $APP_NAME is reachable (HTTP $VERIFY_CODE)"
               RESULTS+=("$APP_NAME: PASS (HTTP $VERIFY_CODE)")
             else
-              echo "WARN: $APP_NAME returned HTTP $VERIFY_CODE — retrying..."
-              sleep 10
-              VERIFY_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "$APP_URL" || echo "000")
-              if [ "$VERIFY_CODE" = "200" ] || [ "$VERIFY_CODE" = "304" ]; then
-                echo "PASS: $APP_NAME is reachable on retry (HTTP $VERIFY_CODE)"
-                RESULTS+=("$APP_NAME: PASS (HTTP $VERIFY_CODE, retry)")
-              else
-                echo "FAIL: $APP_NAME not reachable (HTTP $VERIFY_CODE)"
-                RESULTS+=("$APP_NAME: FAIL (HTTP $VERIFY_CODE)")
-                FAILED=$((FAILED + 1))
-              fi
+              echo "FAIL: $APP_NAME not reachable (HTTP $VERIFY_CODE)"
+              RESULTS+=("$APP_NAME: FAIL (HTTP $VERIFY_CODE)")
+              FAILED=$((FAILED + 1))
             fi
           done
 

--- a/scripts/test-e2e-polling-locally.sh
+++ b/scripts/test-e2e-polling-locally.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Local validator for the e2e-tests.yml polling+verify logic.
+#
+# Purpose: prove the patched polling logic terminates on the right state
+# ('completed') and verifies an app over HTTPS, before pushing to CI again.
+#
+# Usage:
+#   ./scripts/test-e2e-polling-locally.sh \
+#     --api-base http://localhost:8080/api \
+#     --api-key  $TEMPS_API_KEY \
+#     --project  42 \
+#     --app-url  https://my-app.localho.st:3443/
+#
+# The script does NOT create projects or trigger deployments — point it at a
+# project that already has a deployment in flight (or just-finished). Mirrors
+# .github/workflows/e2e-tests.yml lines 290-360.
+
+set -euo pipefail
+
+API_BASE=""
+API_KEY=""
+PROJECT_ID=""
+APP_URL=""
+TIMEOUT=600
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --api-base) API_BASE="$2"; shift 2 ;;
+    --api-key)  API_KEY="$2";  shift 2 ;;
+    --project)  PROJECT_ID="$2"; shift 2 ;;
+    --app-url)  APP_URL="$2"; shift 2 ;;
+    --timeout)  TIMEOUT="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,18p' "$0"; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+for var in API_BASE API_KEY PROJECT_ID APP_URL; do
+  if [ -z "${!var}" ]; then
+    echo "Missing required arg: --${var,,}" >&2
+    exit 2
+  fi
+done
+
+echo "============================================"
+echo "Polling project $PROJECT_ID at $API_BASE"
+echo "Verify URL: $APP_URL"
+echo "Timeout: ${TIMEOUT}s"
+echo "============================================"
+
+# --- Poll deployment status ---
+DEPLOY_STATE="pending"
+DEPLOY_ID=""
+DEADLINE=$((SECONDS + TIMEOUT))
+
+while [ $SECONDS -lt $DEADLINE ]; do
+  DEPLOY_LIST=$(curl -s \
+    -H "Authorization: Bearer $API_KEY" \
+    "$API_BASE/projects/$PROJECT_ID/deployments?per_page=1")
+
+  DEPLOY_STATE=$(echo "$DEPLOY_LIST" | jq -r '.deployments[0].status // "pending"' 2>/dev/null || echo "pending")
+  DEPLOY_ID=$(echo "$DEPLOY_LIST" | jq -r '.deployments[0].id // empty' 2>/dev/null || true)
+
+  if [ "$DEPLOY_STATE" = "completed" ]; then
+    echo "Deployment $DEPLOY_ID reached terminal state: $DEPLOY_STATE"
+    break
+  fi
+
+  if [ "$DEPLOY_STATE" = "failed" ] || [ "$DEPLOY_STATE" = "cancelled" ]; then
+    echo "Deployment $DEPLOY_ID failed with state: $DEPLOY_STATE"
+    if [ -n "$DEPLOY_ID" ]; then
+      echo "--- Deployment jobs ---"
+      curl -s -H "Authorization: Bearer $API_KEY" \
+        "$API_BASE/projects/$PROJECT_ID/deployments/$DEPLOY_ID/jobs" | jq '.[] | {name: .name, status: .status}' 2>/dev/null || true
+    fi
+    break
+  fi
+
+  echo "  State: $DEPLOY_STATE (waiting for completed...)"
+  sleep 5
+done
+
+if [ "$DEPLOY_STATE" != "completed" ]; then
+  echo "FAIL: Deployment did not reach completed state (last: $DEPLOY_STATE)"
+  exit 1
+fi
+
+# --- Verify app is reachable (60s budget after completion) ---
+echo ""
+echo "Verifying $APP_URL ..."
+VERIFY_DEADLINE=$((SECONDS + 60))
+VERIFY_CODE="000"
+while [ $SECONDS -lt $VERIFY_DEADLINE ]; do
+  VERIFY_CODE=$(curl -sk -o /dev/null -w "%{http_code}" --max-time 10 "$APP_URL" || echo "000")
+  if [ "$VERIFY_CODE" = "200" ] || [ "$VERIFY_CODE" = "304" ]; then
+    break
+  fi
+  echo "  HTTP $VERIFY_CODE — waiting for app to be reachable..."
+  sleep 5
+done
+
+if [ "$VERIFY_CODE" = "200" ] || [ "$VERIFY_CODE" = "304" ]; then
+  echo "PASS: $APP_URL is reachable (HTTP $VERIFY_CODE)"
+  exit 0
+fi
+
+echo "FAIL: $APP_URL not reachable (HTTP $VERIFY_CODE)"
+exit 1


### PR DESCRIPTION
## Summary
- e2e-tests.yml was treating deployment `state == "running"` as terminal success, racing the build and curling the app before its container existed (HTTP 000).
- Poll for `state == "completed"` only — the single terminal-success variant in `temps-entities::PipelineStatus`. Drop `deployed`, which isn't in the enum.
- After completion, retry HTTPS verify up to 60s to absorb route-table propagation.

## Why this surfaced now
PRs #80 and #81 just unblocked initial deployment creation. Before those, CI failed earlier with "no deployment created", masking this latent polling bug.

## Test plan
- [x] Validated locally with `scripts/test-e2e-polling-locally.sh` against `localhost:8080` — deploy 104 (Go example) sat in `running` for ~45s, polling correctly waited for `completed`, then HTTP 200 on first verify attempt.
- [ ] CI green on this PR