### PR TITLE
fix(workspace): chown bind-mount work_dir to sandbox uid on the host

### DIFF
--- a/crates/temps-agents/src/sandbox/docker.rs
+++ b/crates/temps-agents/src/sandbox/docker.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use super::user::{SANDBOX_CHOWN, SANDBOX_HOME, SANDBOX_USER, SANDBOX_WORK_DIR};
+use super::user::{SANDBOX_CHOWN, SANDBOX_HOME, SANDBOX_UID, SANDBOX_USER, SANDBOX_WORK_DIR};
 use super::{
     ExecStream, OnStreamEventCallback, SandboxCreateConfig, SandboxExecResult, SandboxHandle,
     SandboxProvider,
@@ -182,6 +182,7 @@ RUN cargo build --release --bin temps-git-credential-helper --bin temps-git-cred
     let home = SANDBOX_HOME;
     let chown = SANDBOX_CHOWN;
     let work_dir = SANDBOX_WORK_DIR;
+    let uid = SANDBOX_UID;
 
     format!(
         r#"{pty_agent_stage}FROM {base}
@@ -202,12 +203,12 @@ RUN GLAB_ARCH=$(dpkg --print-architecture) \
     && mv /tmp/bin/glab /usr/local/bin/glab \
     && chmod +x /usr/local/bin/glab \
     && rm -rf /tmp/glab.tar.gz /tmp/bin
-RUN EXISTING_USER=$(getent passwd 1000 | cut -d: -f1) \
+RUN EXISTING_USER=$(getent passwd {uid} | cut -d: -f1) \
     && if [ -n "$EXISTING_USER" ] && [ "$EXISTING_USER" != "{user}" ]; then \
          (userdel -r "$EXISTING_USER" 2>/dev/null || userdel "$EXISTING_USER" 2>/dev/null || true); \
          (groupdel "$EXISTING_USER" 2>/dev/null || true); \
        fi \
-    && useradd -m -s /bin/bash -u 1000 {user} \
+    && useradd -m -s /bin/bash -u {uid} {user} \
     && echo '# temps sandbox: scoped sudo for package install only.' > /etc/sudoers.d/{user} \
     && echo 'Cmnd_Alias TEMPS_PKG = /usr/bin/apt, /usr/bin/apt-get, /usr/bin/dpkg, /usr/bin/pip, /usr/bin/pip3, /usr/local/bin/uv, /usr/bin/npm, /usr/local/bin/bun' >> /etc/sudoers.d/{user} \
     && echo '{user} ALL=(ALL) NOPASSWD: TEMPS_PKG' >> /etc/sudoers.d/{user} \

--- a/crates/temps-agents/src/sandbox/mod.rs
+++ b/crates/temps-agents/src/sandbox/mod.rs
@@ -4,7 +4,10 @@ pub mod local;
 pub mod pty_agent_bundle;
 pub mod user;
 
-pub use user::{SANDBOX_CHOWN, SANDBOX_GROUP, SANDBOX_HOME, SANDBOX_USER, SANDBOX_WORK_DIR};
+pub use user::{
+    SANDBOX_CHOWN, SANDBOX_GID, SANDBOX_GROUP, SANDBOX_HOME, SANDBOX_UID, SANDBOX_USER,
+    SANDBOX_WORK_DIR,
+};
 
 use async_trait::async_trait;
 use std::collections::HashMap;

--- a/crates/temps-agents/src/sandbox/user.rs
+++ b/crates/temps-agents/src/sandbox/user.rs
@@ -18,6 +18,19 @@ pub const SANDBOX_GROUP: &str = "temps";
 /// `chown` argument string — `user:group`.
 pub const SANDBOX_CHOWN: &str = "temps:temps";
 
+/// Numeric uid of [`SANDBOX_USER`] inside the container. Hardcoded to
+/// match the Dockerfile's `useradd -u 1000` directive. Exposed because the
+/// host-side workspace code also chowns the bind-mount source to this uid
+/// before the container starts — host-real-root can do the recursive
+/// chown without DAC_OVERRIDE, whereas in-container "root" runs with
+/// `cap_drop=ALL` plus `cap_add=[CHOWN, FOWNER]` and gets EPERM trying to
+/// traverse a 700 directory it doesn't own.
+pub const SANDBOX_UID: u32 = 1000;
+
+/// Numeric gid of [`SANDBOX_GROUP`] inside the container. Same rationale
+/// as [`SANDBOX_UID`].
+pub const SANDBOX_GID: u32 = 1000;
+
 /// Home directory of [`SANDBOX_USER`].
 pub const SANDBOX_HOME: &str = "/home/temps";
 

--- a/crates/temps-workspace/src/services/message_executor.rs
+++ b/crates/temps-workspace/src/services/message_executor.rs
@@ -5,7 +5,9 @@ use tokio::sync::{Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
 
 use temps_agents::ai_cli::OnEventCallback;
-use temps_agents::sandbox::{SANDBOX_CHOWN, SANDBOX_HOME, SANDBOX_WORK_DIR};
+use temps_agents::sandbox::{
+    SANDBOX_CHOWN, SANDBOX_GID, SANDBOX_HOME, SANDBOX_UID, SANDBOX_WORK_DIR,
+};
 use temps_config::ConfigService;
 use temps_core::{EncryptionService, WorkflowMemoryProvider};
 use temps_deployments::services::deployment_token_service::{
@@ -20,6 +22,81 @@ use crate::services::session_manager::WorkspaceSessionManager;
 use crate::services::workspace_service::{
     SendMessageRequest, UpdateSessionFields, WorkspaceService,
 };
+
+/// Recursively chown a path to the sandbox uid/gid, on the host.
+///
+/// In production, the temps server runs as real root, so the host-side
+/// `git clone` writes files owned by root with mode 700/600 (root's
+/// umask is typically 077 under hardened systemd units). When that
+/// directory is bind-mounted into the sandbox container, the
+/// container's "root" cannot heal it post-start: the container runs
+/// with `cap_drop=ALL` plus `cap_add=[CHOWN, FOWNER]`, which
+/// deliberately omits `CAP_DAC_OVERRIDE` and `CAP_DAC_READ_SEARCH`. So
+/// even with `CAP_CHOWN`, in-container "root" hits EPERM trying to
+/// `opendir(2)` on the 700 work dir before chown ever runs. The fix is
+/// to chown on the host *before* the bind mount sees the wrong uids.
+///
+/// We use blocking `std::os::unix::fs::lchown` (no symlink-follow) inside
+/// `tokio::task::spawn_blocking`. `walkdir` isn't a workspace dep, so we
+/// implement the recursion with a small explicit stack to avoid pulling
+/// in a new crate for ~30 lines of code.
+///
+/// Best-effort: failures are logged but don't fail sandbox creation.
+/// On macOS dev boxes the temps server may not be able to chown to a
+/// uid that doesn't exist on the host (the Linux uid 1000 may not map
+/// to anything meaningful), but the in-container chown post-start (in
+/// `temps-agents`'s `run_root_exec`) still handles the dev case where
+/// the bind-mount source already has world-readable mode bits.
+fn chown_workdir_to_sandbox_user(work_dir: std::path::PathBuf) {
+    use std::os::unix::fs::lchown;
+    let started = std::time::Instant::now();
+    let result = std::panic::catch_unwind(move || -> std::io::Result<usize> {
+        let mut count = 0usize;
+        let mut stack: Vec<std::path::PathBuf> = vec![work_dir.clone()];
+        // Chown the root itself first so we have permission to descend.
+        lchown(&work_dir, Some(SANDBOX_UID), Some(SANDBOX_GID))?;
+        count += 1;
+        while let Some(dir) = stack.pop() {
+            // `read_dir` follows the dir's metadata, but we lchown each
+            // entry directly to avoid following symlinks out of the tree.
+            let entries = match std::fs::read_dir(&dir) {
+                Ok(e) => e,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => return Err(e),
+            };
+            for entry in entries {
+                let entry = entry?;
+                let path = entry.path();
+                let file_type = entry.file_type()?;
+                lchown(&path, Some(SANDBOX_UID), Some(SANDBOX_GID))?;
+                count += 1;
+                if file_type.is_dir() && !file_type.is_symlink() {
+                    stack.push(path);
+                }
+            }
+        }
+        Ok(count)
+    });
+    match result {
+        Ok(Ok(count)) => tracing::debug!(
+            "Chowned {} entries under workspace work_dir to {}:{} in {:?}",
+            count,
+            SANDBOX_UID,
+            SANDBOX_GID,
+            started.elapsed()
+        ),
+        Ok(Err(e)) => tracing::warn!(
+            "Failed to chown workspace work_dir to sandbox uid {}:{}: {} \
+             — sandbox post-start chown will need to heal it",
+            SANDBOX_UID,
+            SANDBOX_GID,
+            e
+        ),
+        Err(_) => tracing::warn!(
+            "chown_workdir_to_sandbox_user panicked — sandbox post-start chown will need to heal it",
+        ),
+    }
+}
 
 /// Executes chat messages within a workspace session.
 ///
@@ -1289,6 +1366,18 @@ impl MessageExecutor {
                 session.id,
                 work_dir.display()
             );
+            // Heal stale root-owned files left behind by older temps
+            // server versions that cloned without chowning. New
+            // workspaces hit the clone branch below; existing ones land
+            // here on session reopen and would otherwise stay broken
+            // until manually chowned.
+            let to_chown = work_dir.clone();
+            tokio::task::spawn_blocking(move || chown_workdir_to_sandbox_user(to_chown))
+                .await
+                .map_err(|e| WorkspaceError::SandboxCreationFailed {
+                    session_id: session.id,
+                    reason: format!("Workspace chown task panicked: {}", e),
+                })?;
         } else if let Some(connection_id) = project.git_provider_connection_id {
             self.git_provider_manager
                 .clone_repository(
@@ -1332,6 +1421,25 @@ impl MessageExecutor {
                     session.id
                 );
             }
+
+            // Chown the work_dir to the sandbox uid. The clone (and any
+            // subsequent branch creation) ran in this temps server
+            // process — root in production, with umask 077 — so the
+            // resulting tree is mode 700/600 owned by root, unreadable
+            // to the in-container sandbox user (uid 1000). The
+            // container's post-start chown can't heal it: sandboxes run
+            // with `cap_drop=ALL` (no `CAP_DAC_OVERRIDE`), so even
+            // in-container "root" cannot traverse a 700 dir it doesn't
+            // own. Chown here on the host where real-root privileges
+            // are available, before the bind mount carries the wrong
+            // uids into the container.
+            let to_chown = work_dir.clone();
+            tokio::task::spawn_blocking(move || chown_workdir_to_sandbox_user(to_chown))
+                .await
+                .map_err(|e| WorkspaceError::SandboxCreationFailed {
+                    session_id: session.id,
+                    reason: format!("Workspace chown task panicked: {}", e),
+                })?;
         } else {
             // No git provider — write a placeholder README so the sandbox
             // has something to mount
@@ -1343,6 +1451,16 @@ impl MessageExecutor {
                 ),
             )
             .await?;
+            // Same host-side chown as the clone branch — the README we
+            // just wrote inherits the temps server's uid (root in prod)
+            // and would otherwise be unwritable from inside the sandbox.
+            let to_chown = work_dir.clone();
+            tokio::task::spawn_blocking(move || chown_workdir_to_sandbox_user(to_chown))
+                .await
+                .map_err(|e| WorkspaceError::SandboxCreationFailed {
+                    session_id: session.id,
+                    reason: format!("Workspace chown task panicked: {}", e),
+                })?;
         }
 
         // Issue a deployment token for this session so the sandbox can


### PR DESCRIPTION
## Summary
Fixes `Permission denied` errors on `git pull`/`git push` inside workspace sandboxes on production hosts where the temps server runs as root with umask 077 (`fatal: cannot open '.git/FETCH_HEAD'` and similar).

## Root cause
The host-side `git clone` runs in the temps server process. In production that's root with umask 077, so the workspace tree is mode 700/600 owned by root. When bind-mounted into the sandbox, the in-container post-start chown cannot heal it: sandboxes run with `cap_drop=ALL` plus `cap_add=[CHOWN, FOWNER]`, deliberately omitting `CAP_DAC_OVERRIDE`/`CAP_DAC_READ_SEARCH`. In-container "root" then hits EPERM at `opendir(2)` on the 700 work_dir before `chown` ever runs.

Verified on prod with `docker exec -u 0 <id> chown -R 1000:1000 /home/temps/workspace` returning ``chown: cannot access '/home/temps/workspace': Permission denied`` while `stat` showed all `.git/` entries owned by `0:0`.

Local dev didn't hit this because temps usually runs as the developer's own uid (or with a permissive umask), producing world-readable directories the in-container chown could traverse.

## Fix
Chown the workspace work_dir to the sandbox uid (`1000:1000`) on the host, where the temps server has real-root privileges and isn't bound by the container's capability set. Runs after the clone, the no-git-provider README write, and on the reuse path so legacy sessions get healed when reopened.

- New `SANDBOX_UID`/`SANDBOX_GID` constants in `temps-agents::sandbox::user` as a single source of truth (Dockerfile generator's previously-hardcoded `1000` now uses them too).
- New `chown_workdir_to_sandbox_user` in `message_executor.rs` using `std::os::unix::fs::lchown` plus an explicit-stack recursive walker. No new dependencies.
- Best-effort: failures are logged but don't fail sandbox creation, since the in-container post-start chown (#83) still handles dev cases where bind-mount sources have world-readable mode bits.

The in-container post-start chown from #83 stays as defense-in-depth — this PR makes it redundant rather than load-bearing on prod.

## Test plan
- [x] `cargo check --lib --workspace` passes
- [x] `cargo test --lib -p temps-agents paths_are_consistent` passes
- [ ] Deploy to prod, create a fresh workspace, verify `.git/` ownership inside the sandbox is `1000:1000` and `git pull` works
- [ ] Reopen a pre-existing broken workspace and verify it gets healed by the reuse-path chown
- [ ] On a macOS dev box, confirm the workspace still works (best-effort chown should warn, not fail)