### PR TITLE
Add required extra Docker network attachments

### DIFF
--- a/crates/temps-config/src/service.rs
+++ b/crates/temps-config/src/service.rs
@@ -72,6 +72,12 @@ pub struct ServerConfig {
     pub clickhouse_database: Option<String>,
     pub clickhouse_user: Option<String>,
     pub clickhouse_password: Option<String>,
+
+    // Required Docker networks that every deployed app container should join
+    // before start, in addition to Temps' primary app network. This is useful
+    // for self-hosted installs where apps depend on services exposed by a
+    // sibling Docker Compose network.
+    pub docker_extra_networks: Vec<String>,
 }
 
 impl ServerConfig {
@@ -171,6 +177,8 @@ impl ServerConfig {
             clickhouse_password: std::env::var("TEMPS_CLICKHOUSE_PASSWORD")
                 .ok()
                 .filter(|s| !s.is_empty()),
+
+            docker_extra_networks: parse_csv_env("TEMPS_DOCKER_EXTRA_NETWORKS"),
         })
     }
 
@@ -247,6 +255,20 @@ impl ServerConfig {
     pub fn get_postgres_max_lifetime_secs(&self) -> u64 {
         self.postgres_max_lifetime_secs.unwrap_or(1800)
     }
+}
+
+fn parse_csv_env(key: &str) -> Vec<String> {
+    std::env::var(key)
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToString::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 // Default domain for local development (resolves to 127.0.0.1)

--- a/crates/temps-deployer/README.md
+++ b/crates/temps-deployer/README.md
@@ -117,12 +117,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             env.insert("PORT".to_string(), "3000".to_string());
             env
         },
+        secrets: HashMap::new(),
         port_mappings: vec![PortMapping {
             host_port: 8080,
             container_port: 3000,
             protocol: Protocol::Tcp,
         }],
         network_name: Some("my-network".to_string()),
+        extra_networks: vec![],
         resource_limits: ResourceLimits {
             cpu_limit: Some(2.0),
             memory_limit_mb: Some(512),
@@ -130,6 +132,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
         restart_policy: RestartPolicy::Always,
         log_path: PathBuf::from("./deploy.log"),
+        command: None,
+        log_config: None,
+        labels: HashMap::new(),
     };
 
     let result = runtime.deploy_container(deploy_request).await?;

--- a/crates/temps-deployer/src/docker.rs
+++ b/crates/temps-deployer/src/docker.rs
@@ -14,7 +14,7 @@ use bollard::{
     Docker,
 };
 use futures::{Stream, StreamExt, TryStreamExt};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
@@ -35,6 +35,11 @@ pub struct DockerRuntime {
     /// that's the legitimate "overlay not yet bootstrapped on this node"
     /// state, not an error. Set via [`Self::with_overlay_network`].
     overlay_network: Option<String>,
+    /// Operator-level dependency networks that every app container must join
+    /// before start. Unlike the optional overlay network, these are required:
+    /// missing or failing attachments fail the deploy because the app is
+    /// expected to depend on DNS/services from these networks.
+    extra_networks: Vec<String>,
     /// Static resolvers to write into each new container's
     /// `/etc/resolv.conf`. Use [`Self::with_dns_servers`] for tests or
     /// fixed-IP setups; in the live agent we use
@@ -87,6 +92,22 @@ fn signal_name_from_exit_code(code: i64) -> Option<&'static str> {
         15 => Some("SIGTERM"),
         _ => None,
     }
+}
+
+fn normalize_extra_networks(
+    networks: Vec<String>,
+    primary_network: &str,
+    overlay_network: Option<&str>,
+) -> Vec<String> {
+    let mut seen = HashSet::new();
+    networks
+        .into_iter()
+        .map(|network| network.trim().to_string())
+        .filter(|network| !network.is_empty())
+        .filter(|network| network != primary_network)
+        .filter(|network| Some(network.as_str()) != overlay_network)
+        .filter(|network| seen.insert(network.clone()))
+        .collect()
 }
 
 /// Build a short human-readable explanation of why a container is in its
@@ -212,6 +233,7 @@ impl DockerRuntime {
             network_name,
             host_bind_address: "127.0.0.1".to_string(),
             overlay_network: None,
+            extra_networks: Vec::new(),
             dns_servers: Vec::new(),
             overlay_dns_slot: None,
             overlay_peers: None,
@@ -285,6 +307,18 @@ impl DockerRuntime {
         self
     }
 
+    /// Configure required dependency networks for all containers created by
+    /// this runtime. Blank entries, duplicates, the primary network, and the
+    /// optional overlay network are ignored.
+    pub fn with_extra_networks(mut self, networks: Vec<String>) -> Self {
+        self.extra_networks = normalize_extra_networks(
+            networks,
+            &self.network_name,
+            self.overlay_network.as_deref(),
+        );
+        self
+    }
+
     /// Best-effort additional attachment to the overlay network. Logs and
     /// returns `Ok(())` when the overlay isn't configured or doesn't
     /// exist; only true bollard errors propagate.
@@ -336,6 +370,70 @@ impl DockerRuntime {
                 overlay, e
             ))),
         }
+    }
+
+    /// Attach required dependency networks before container start so Docker's
+    /// embedded DNS can resolve service names during app boot.
+    async fn attach_required_networks(
+        &self,
+        container_id: &str,
+        request_networks: &[String],
+    ) -> Result<(), DeployerError> {
+        let mut requested = self.extra_networks.clone();
+        requested.extend(request_networks.iter().cloned());
+        let networks = normalize_extra_networks(
+            requested,
+            &self.network_name,
+            self.overlay_network.as_deref(),
+        );
+        if networks.is_empty() {
+            return Ok(());
+        }
+
+        let existing_networks = self
+            .docker
+            .list_networks(None::<bollard::query_parameters::ListNetworksOptions>)
+            .await
+            .map_err(|e| DeployerError::NetworkError(format!("list_networks: {}", e)))?;
+
+        for network in networks {
+            let exists = existing_networks
+                .iter()
+                .any(|candidate| candidate.name.as_deref() == Some(network.as_str()));
+            if !exists {
+                return Err(DeployerError::NetworkError(format!(
+                    "required network '{}' does not exist",
+                    network
+                )));
+            }
+
+            let req = bollard::models::NetworkConnectRequest {
+                container: container_id.to_string(),
+                ..Default::default()
+            };
+            match self.docker.connect_network(&network, req).await {
+                Ok(()) => {
+                    tracing::info!(container = %container_id, network, "attached to required network");
+                }
+                Err(bollard::errors::Error::DockerResponseServerError {
+                    status_code: 403, ..
+                }) => {
+                    tracing::debug!(
+                        container = %container_id,
+                        network,
+                        "container already connected to required network (403)"
+                    );
+                }
+                Err(e) => {
+                    return Err(DeployerError::NetworkError(format!(
+                        "connect_network({}): {}",
+                        network, e
+                    )));
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Install per-peer routes inside the container's netns. Must be
@@ -1442,6 +1540,9 @@ impl ContainerDeployer for DockerRuntime {
         // network isn't present yet on this node.
         self.maybe_attach_overlay(&container.id).await?;
 
+        self.attach_required_networks(&container.id, &request.extra_networks)
+            .await?;
+
         // Start container
         self.docker
             .start_container(&container.id, None::<StartContainerOptions>)
@@ -2430,6 +2531,10 @@ mod docker_tests {
                     runtime.overlay_network.is_none(),
                     "overlay_network must default to None for backwards compatibility"
                 );
+                assert!(
+                    runtime.extra_networks.is_empty(),
+                    "extra_networks must default to empty for backwards compatibility"
+                );
             }
             Err(e) => {
                 println!("🔧 Docker not available: {}", e);
@@ -2446,6 +2551,50 @@ mod docker_tests {
             }
             Err(e) => {
                 println!("🔧 Docker not available: {}", e);
+            }
+        }
+    }
+
+    #[test]
+    fn test_normalize_extra_networks_drops_empty_duplicates_primary_and_overlay() {
+        let normalized = normalize_extra_networks(
+            vec![
+                " ".to_string(),
+                "temps-app-network".to_string(),
+                "supabase_default".to_string(),
+                "supabase_default".to_string(),
+                "temps-overlay".to_string(),
+                "analytics_default".to_string(),
+            ],
+            "temps-app-network",
+            Some("temps-overlay"),
+        );
+
+        assert_eq!(
+            normalized,
+            vec![
+                "supabase_default".to_string(),
+                "analytics_default".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_with_extra_networks_sets_normalized_field() {
+        match create_test_docker_runtime().await {
+            Ok(runtime) => {
+                let runtime = runtime
+                    .with_overlay_network("temps-overlay")
+                    .with_extra_networks(vec![
+                        "test-network".to_string(),
+                        "supabase_default".to_string(),
+                        "supabase_default".to_string(),
+                        "temps-overlay".to_string(),
+                    ]);
+                assert_eq!(runtime.extra_networks, vec!["supabase_default"]);
+            }
+            Err(e) => {
+                println!("Docker not available: {}", e);
             }
         }
     }
@@ -2609,6 +2758,7 @@ CMD ["cat", "/hello.txt"]
                     secrets: HashMap::new(),
                     port_mappings: vec![],
                     network_name: None,
+                    extra_networks: Vec::new(),
                     resource_limits: ResourceLimits {
                         cpu_limit: Some(0.5),
                         memory_limit_mb: Some(64),

--- a/crates/temps-deployer/src/docker.rs
+++ b/crates/temps-deployer/src/docker.rs
@@ -110,6 +110,14 @@ fn normalize_extra_networks(
         .collect()
 }
 
+fn network_matches_identifier(
+    candidate_name: Option<&str>,
+    candidate_id: Option<&str>,
+    identifier: &str,
+) -> bool {
+    candidate_name == Some(identifier) || candidate_id == Some(identifier)
+}
+
 /// Build a short human-readable explanation of why a container is in its
 /// current state. Returns None for containers that are still running, have
 /// never been started, or exited cleanly with status 0 and no Docker error.
@@ -397,9 +405,13 @@ impl DockerRuntime {
             .map_err(|e| DeployerError::NetworkError(format!("list_networks: {}", e)))?;
 
         for network in networks {
-            let exists = existing_networks
-                .iter()
-                .any(|candidate| candidate.name.as_deref() == Some(network.as_str()));
+            let exists = existing_networks.iter().any(|candidate| {
+                network_matches_identifier(
+                    candidate.name.as_deref(),
+                    candidate.id.as_deref(),
+                    &network,
+                )
+            });
             if !exists {
                 return Err(DeployerError::NetworkError(format!(
                     "required network '{}' does not exist",
@@ -434,6 +446,21 @@ impl DockerRuntime {
         }
 
         Ok(())
+    }
+
+    async fn cleanup_created_container_after_error(
+        &self,
+        container_id: &str,
+        error: DeployerError,
+    ) -> DeployerError {
+        if let Err(cleanup_error) = self.remove_container(container_id).await {
+            tracing::warn!(
+                container = %container_id,
+                error = %cleanup_error,
+                "failed to remove container after deploy error"
+            );
+        }
+        error
     }
 
     /// Install per-peer routes inside the container's netns. Must be
@@ -1538,18 +1565,34 @@ impl ContainerDeployer for DockerRuntime {
         // their primary network interface (`temps-app-network`); the overlay
         // attachment is purely additive and silently no-ops when the overlay
         // network isn't present yet on this node.
-        self.maybe_attach_overlay(&container.id).await?;
+        if let Err(e) = self.maybe_attach_overlay(&container.id).await {
+            return Err(self
+                .cleanup_created_container_after_error(&container.id, e)
+                .await);
+        }
 
-        self.attach_required_networks(&container.id, &request.extra_networks)
-            .await?;
+        if let Err(e) = self
+            .attach_required_networks(&container.id, &request.extra_networks)
+            .await
+        {
+            return Err(self
+                .cleanup_created_container_after_error(&container.id, e)
+                .await);
+        }
 
         // Start container
-        self.docker
+        if let Err(e) = self
+            .docker
             .start_container(&container.id, None::<StartContainerOptions>)
             .await
             .map_err(|e| {
                 DeployerError::DeploymentFailed(format!("Failed to start container: {}", e))
-            })?;
+            })
+        {
+            return Err(self
+                .cleanup_created_container_after_error(&container.id, e)
+                .await);
+        }
 
         // Install overlay peer routes inside the container's netns.
         // Must run *after* start_container — `docker inspect` only
@@ -1566,7 +1609,7 @@ impl ContainerDeployer for DockerRuntime {
 
         // When host_port was 0 (Docker picks), inspect the container to get the actual port
         let host_port = if requested_host_port == 0 && container_port > 0 {
-            let inspect = self
+            let inspect = match self
                 .docker
                 .inspect_container(&container.id, None::<InspectContainerOptions>)
                 .await
@@ -1575,10 +1618,17 @@ impl ContainerDeployer for DockerRuntime {
                         "Failed to inspect container {} for port mapping: {}",
                         container.id, e
                     ))
-                })?;
+                }) {
+                Ok(inspect) => inspect,
+                Err(e) => {
+                    return Err(self
+                        .cleanup_created_container_after_error(&container.id, e)
+                        .await);
+                }
+            };
 
             let port_key = format!("{}/tcp", container_port);
-            inspect
+            match inspect
                 .network_settings
                 .and_then(|ns| ns.ports)
                 .and_then(|ports| ports.get(&port_key).cloned())
@@ -1591,7 +1641,14 @@ impl ContainerDeployer for DockerRuntime {
                         "Container {} has no host port binding for {}",
                         container.id, port_key
                     ))
-                })?
+                }) {
+                Ok(host_port) => host_port,
+                Err(e) => {
+                    return Err(self
+                        .cleanup_created_container_after_error(&container.id, e)
+                        .await);
+                }
+            }
         } else {
             requested_host_port
         };
@@ -2071,7 +2128,7 @@ fn default_secrets_root() -> PathBuf {
 fn write_secrets_to_host_dir(
     dir: &Path,
     secrets: &HashMap<String, String>,
-    owner: Option<(u32, u32)>,
+    _owner: Option<(u32, u32)>,
 ) -> std::io::Result<()> {
     use std::fs;
     use std::io::Write;
@@ -2191,7 +2248,7 @@ fn write_secrets_to_host_dir(
     // `no-new-privileges`, and the bind mount is read-only — the trust
     // boundary is still the container itself.
     #[cfg(unix)]
-    if let Some((uid, gid)) = owner {
+    if let Some((uid, gid)) = _owner {
         use std::os::unix::fs::{chown, PermissionsExt};
 
         let chown_result: std::io::Result<()> = (|| {
@@ -2285,6 +2342,36 @@ mod docker_tests {
             false,
             "test-network".to_string(),
         ))
+    }
+
+    fn unique_test_name(prefix: &str) -> String {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis();
+        format!("{}-{}", prefix, now)
+    }
+
+    fn alpine_deploy_request(container_name: String, extra_networks: Vec<String>) -> DeployRequest {
+        DeployRequest {
+            image_name: "alpine:latest".to_string(),
+            container_name,
+            environment_vars: HashMap::new(),
+            secrets: HashMap::new(),
+            port_mappings: vec![],
+            network_name: None,
+            extra_networks,
+            resource_limits: ResourceLimits {
+                cpu_limit: Some(0.5),
+                memory_limit_mb: Some(64),
+                disk_limit_mb: Some(256),
+            },
+            restart_policy: RestartPolicy::Never,
+            log_path: PathBuf::from("/tmp/temps-extra-network-test.log"),
+            command: Some(vec!["sleep".to_string(), "30".to_string()]),
+            log_config: Some(ContainerLogConfig::app_default()),
+            labels: HashMap::new(),
+        }
     }
 
     #[test]
@@ -2579,6 +2666,25 @@ mod docker_tests {
         );
     }
 
+    #[test]
+    fn test_required_network_identifier_matches_name_or_id() {
+        assert!(network_matches_identifier(
+            Some("supabase_default"),
+            Some("abc123"),
+            "supabase_default"
+        ));
+        assert!(network_matches_identifier(
+            Some("supabase_default"),
+            Some("abc123"),
+            "abc123"
+        ));
+        assert!(!network_matches_identifier(
+            Some("supabase_default"),
+            Some("abc123"),
+            "missing"
+        ));
+    }
+
     #[tokio::test]
     async fn test_with_extra_networks_sets_normalized_field() {
         match create_test_docker_runtime().await {
@@ -2592,6 +2698,134 @@ mod docker_tests {
                         "temps-overlay".to_string(),
                     ]);
                 assert_eq!(runtime.extra_networks, vec!["supabase_default"]);
+            }
+            Err(e) => {
+                println!("Docker not available: {}", e);
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_deploy_attaches_required_network_by_id() {
+        match create_test_docker_runtime().await {
+            Ok(runtime) => {
+                let extra_network_name = unique_test_name("temps-extra-network");
+                let container_name = unique_test_name("temps-extra-network-container");
+
+                let create_options = bollard::models::NetworkCreateRequest {
+                    name: extra_network_name.clone(),
+                    driver: Some("bridge".to_string()),
+                    ..Default::default()
+                };
+
+                if let Err(e) = runtime.docker.create_network(create_options).await {
+                    println!("Docker network create failed (may be expected): {}", e);
+                    return;
+                }
+
+                let network_id = match runtime
+                    .docker
+                    .list_networks(None::<bollard::query_parameters::ListNetworksOptions>)
+                    .await
+                    .ok()
+                    .and_then(|networks| {
+                        networks
+                            .into_iter()
+                            .find(|network| network.name.as_deref() == Some(&extra_network_name))
+                            .and_then(|network| network.id)
+                    }) {
+                    Some(id) => id,
+                    None => {
+                        let _ = runtime.docker.remove_network(&extra_network_name).await;
+                        panic!("created network {} was not listed", extra_network_name);
+                    }
+                };
+
+                let deploy_result = runtime
+                    .deploy_container(alpine_deploy_request(
+                        container_name.clone(),
+                        vec![network_id.clone()],
+                    ))
+                    .await;
+
+                match deploy_result {
+                    Ok(deploy_info) => {
+                        let inspect = runtime
+                            .docker
+                            .inspect_container(
+                                &deploy_info.container_id,
+                                None::<InspectContainerOptions>,
+                            )
+                            .await
+                            .expect("inspect deployed container");
+
+                        let attached = inspect
+                            .network_settings
+                            .and_then(|settings| settings.networks)
+                            .map(|networks| networks.contains_key(&extra_network_name))
+                            .unwrap_or(false);
+                        assert!(attached, "container should be attached to required network");
+
+                        let _ = runtime.remove_container(&deploy_info.container_id).await;
+                    }
+                    Err(e) => {
+                        println!(
+                            "Docker deploy failed before required-network assertion (may be expected): {}",
+                            e
+                        );
+                    }
+                }
+
+                let _ = runtime.docker.remove_network(&extra_network_name).await;
+            }
+            Err(e) => {
+                println!("Docker not available: {}", e);
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_deploy_missing_required_network_removes_created_container() {
+        match create_test_docker_runtime().await {
+            Ok(runtime) => {
+                let container_name = unique_test_name("temps-missing-network-container");
+                let missing_network = unique_test_name("temps-missing-network");
+                let deploy_result = runtime
+                    .deploy_container(alpine_deploy_request(
+                        container_name.clone(),
+                        vec![missing_network.clone()],
+                    ))
+                    .await;
+
+                match deploy_result {
+                    Ok(deploy_info) => {
+                        let _ = runtime.remove_container(&deploy_info.container_id).await;
+                        panic!("deploy should fail when required network is missing");
+                    }
+                    Err(DeployerError::NetworkError(message))
+                        if message.contains(&format!(
+                            "required network '{}' does not exist",
+                            missing_network
+                        )) =>
+                    {
+                        let leftover = runtime
+                            .find_container_by_name(&container_name)
+                            .await
+                            .expect("container lookup after failed deploy");
+                        assert!(
+                            leftover.is_none(),
+                            "failed required-network deploy should remove the created container"
+                        );
+                    }
+                    Err(e) => {
+                        println!(
+                            "Docker deploy failed before required-network assertion (may be expected): {}",
+                            e
+                        );
+                    }
+                }
             }
             Err(e) => {
                 println!("Docker not available: {}", e);

--- a/crates/temps-deployer/src/lib.rs
+++ b/crates/temps-deployer/src/lib.rs
@@ -145,6 +145,12 @@ pub struct DeployRequest {
     pub secrets: HashMap<String, String>,
     pub port_mappings: Vec<PortMapping>,
     pub network_name: Option<String>,
+    /// Additional Docker networks that this container must join before it
+    /// starts. Use this for host-local dependency networks, such as a
+    /// self-hosted database Compose network, where a successful deploy is not
+    /// useful unless service DNS is available at application boot.
+    #[serde(default)]
+    pub extra_networks: Vec<String>,
     pub resource_limits: ResourceLimits,
     pub restart_policy: RestartPolicy,
     #[schema(value_type = String)]
@@ -703,6 +709,7 @@ mod tests {
             secrets: HashMap::new(),
             port_mappings,
             network_name: Some("test-network".to_string()),
+            extra_networks: vec!["dependency-network".to_string()],
             resource_limits: ResourceLimits::default(),
             restart_policy: RestartPolicy::Always,
             log_path,
@@ -719,6 +726,7 @@ mod tests {
         assert_eq!(request.port_mappings[0].container_port, 3000);
         assert!(matches!(request.port_mappings[0].protocol, Protocol::Tcp));
         assert_eq!(request.network_name.as_ref().unwrap(), "test-network");
+        assert_eq!(request.extra_networks, vec!["dependency-network"]);
         assert_eq!(request.command.as_ref().unwrap().len(), 2);
         assert_eq!(request.command.as_ref().unwrap()[0], "node");
         assert_eq!(request.command.as_ref().unwrap()[1], "server.js");
@@ -1010,6 +1018,7 @@ CMD ["echo", "Hello from container"]
             secrets: HashMap::new(),
             port_mappings: vec![],
             network_name: None,
+            extra_networks: Vec::new(),
             resource_limits: ResourceLimits::default(),
             restart_policy: RestartPolicy::Always,
             log_path: temp_dir.path().join("deploy.log"),

--- a/crates/temps-deployer/src/plugin.rs
+++ b/crates/temps-deployer/src/plugin.rs
@@ -119,11 +119,17 @@ impl TempsPlugin for DeployerPlugin {
             tracing::debug!("Using buildkit: {}", use_buildkit);
 
             // Create DockerRuntime service
-            let docker_runtime = Arc::new(DockerRuntime::new(
-                docker.clone(),
-                use_buildkit,
-                temps_core::NETWORK_NAME.to_string(),
-            ));
+            let config_service = context.require_service::<temps_config::ConfigService>();
+            let server_config = config_service.get_server_config();
+
+            let docker_runtime = Arc::new(
+                DockerRuntime::new(
+                    docker.clone(),
+                    use_buildkit,
+                    temps_core::NETWORK_NAME.to_string(),
+                )
+                .with_extra_networks(server_config.docker_extra_networks.clone()),
+            );
 
             // Register the concrete service
             context.register_service(docker_runtime.clone());
@@ -137,7 +143,6 @@ impl TempsPlugin for DeployerPlugin {
             context.register_service(image_builder);
 
             // Create and register StaticDeployer
-            let config_service = context.require_service::<temps_config::ConfigService>();
             let static_files_dir = config_service.get_server_config().data_dir.join("static");
             let filesystem_static_deployer =
                 Arc::new(FilesystemStaticDeployer::new(static_files_dir));

--- a/crates/temps-deployer/src/remote.rs
+++ b/crates/temps-deployer/src/remote.rs
@@ -601,6 +601,7 @@ mod tests {
             secrets: std::collections::HashMap::new(),
             port_mappings: vec![],
             network_name: None,
+            extra_networks: Vec::new(),
             resource_limits: crate::ResourceLimits::default(),
             restart_policy: crate::RestartPolicy::default(),
             log_path: PathBuf::from("/tmp/deploy.log"),

--- a/crates/temps-deployments/src/handlers/nodes.rs
+++ b/crates/temps-deployments/src/handlers/nodes.rs
@@ -1987,6 +1987,7 @@ mod tests {
             clickhouse_database: None,
             clickhouse_user: None,
             clickhouse_password: None,
+            docker_extra_networks: Vec::new(),
         });
         let config_service = Arc::new(temps_config::ConfigService::new(
             server_config,

--- a/crates/temps-deployments/src/jobs/deploy_image.rs
+++ b/crates/temps-deployments/src/jobs/deploy_image.rs
@@ -1126,6 +1126,7 @@ impl DeployImageJob {
             secrets: self.config.secrets.clone(),
             port_mappings,
             network_name: None,
+            extra_networks: Vec::new(),
             resource_limits,
             restart_policy: RestartPolicy::Always,
             log_path,

--- a/crates/temps-email/src/handlers/tracking_tests.rs
+++ b/crates/temps-email/src/handlers/tracking_tests.rs
@@ -104,6 +104,7 @@ mod tests {
             clickhouse_database: None,
             clickhouse_user: None,
             clickhouse_password: None,
+            docker_extra_networks: Vec::new(),
         });
         let config_service = Arc::new(temps_config::ConfigService::new(
             server_config,

--- a/crates/temps-email/src/services/email_service.rs
+++ b/crates/temps-email/src/services/email_service.rs
@@ -487,6 +487,7 @@ mod tests {
             clickhouse_database: None,
             clickhouse_user: None,
             clickhouse_password: None,
+            docker_extra_networks: Vec::new(),
         });
         let config_service = Arc::new(temps_config::ConfigService::new(
             server_config,

--- a/crates/temps-email/src/services/tracking_service_integration_tests.rs
+++ b/crates/temps-email/src/services/tracking_service_integration_tests.rs
@@ -35,6 +35,7 @@ mod tests {
             clickhouse_database: None,
             clickhouse_user: None,
             clickhouse_password: None,
+            docker_extra_networks: Vec::new(),
         });
         Arc::new(temps_config::ConfigService::new(server_config, db))
     }

--- a/crates/temps-status-page/src/tests.rs
+++ b/crates/temps-status-page/src/tests.rs
@@ -1089,6 +1089,7 @@ mod integration_tests {
             clickhouse_database: None,
             clickhouse_user: None,
             clickhouse_password: None,
+            docker_extra_networks: Vec::new(),
         });
         let config_service = Arc::new(temps_config::ConfigService::new(server_config, db.clone()));
 

--- a/docs/reference/environment-variables/page.mdx
+++ b/docs/reference/environment-variables/page.mdx
@@ -26,13 +26,14 @@ Complete reference for all environment variables used in Temps. {{ className: 'l
 
 These environment variables configure the Temps server itself:
 
-| Variable                | CLI Flag            | Default          | Description                                          |
-| ----------------------- | ------------------- | ---------------- | ---------------------------------------------------- |
-| `TEMPS_ADDRESS`         | `--address`         | `127.0.0.1:3000` | HTTP server address and port                         |
-| `TEMPS_TLS_ADDRESS`     | `--tls-address`     | (optional)       | HTTPS server address and port                        |
-| `TEMPS_DATA_DIR`        | `--data-dir`        | `~/.temps`       | Data directory for keys and configuration            |
-| `TEMPS_LOG_LEVEL`       | `--log-level`       | `info`           | Log level: `trace`, `debug`, `info`, `warn`, `error` |
-| `TEMPS_CONSOLE_ADDRESS` | `--console-address` | (optional)       | Admin console address and port                       |
+| Variable                       | CLI Flag            | Default          | Description                                                                  |
+| ------------------------------ | ------------------- | ---------------- | ---------------------------------------------------------------------------- |
+| `TEMPS_ADDRESS`                | `--address`         | `127.0.0.1:3000` | HTTP server address and port                                                 |
+| `TEMPS_TLS_ADDRESS`            | `--tls-address`     | (optional)       | HTTPS server address and port                                                |
+| `TEMPS_DATA_DIR`               | `--data-dir`        | `~/.temps`       | Data directory for keys and configuration                                    |
+| `TEMPS_LOG_LEVEL`              | `--log-level`       | `info`           | Log level: `trace`, `debug`, `info`, `warn`, `error`                         |
+| `TEMPS_CONSOLE_ADDRESS`        | `--console-address` | (optional)       | Admin console address and port                                               |
+| `TEMPS_DOCKER_EXTRA_NETWORKS`  | (none)              | (empty)          | Comma-separated Docker networks that app containers must join before startup |
 
 ### Example
 
@@ -42,6 +43,20 @@ export TEMPS_TLS_ADDRESS=0.0.0.0:8443
 export TEMPS_LOG_LEVEL=debug
 export TEMPS_DATA_DIR=/var/lib/temps
 ```
+
+### External Docker Dependency Networks
+
+Self-hosted installations sometimes run shared dependencies, such as a
+database or cache, on a sibling Docker Compose network outside Temps' primary
+app network. Set `TEMPS_DOCKER_EXTRA_NETWORKS` to attach every deployed app
+container to those required networks before the container starts:
+
+```bash
+export TEMPS_DOCKER_EXTRA_NETWORKS=supabase_default,redis_default
+```
+
+If any configured network is missing or cannot be attached, the deploy fails
+instead of starting an app that cannot resolve its dependency hostnames.
 
 ---
 


### PR DESCRIPTION
## Summary
- add TEMPS_DOCKER_EXTRA_NETWORKS for self-hosted installs that need app containers attached to external Docker dependency networks before startup
- add DeployRequest.extra_networks for future per-request attachments while keeping default behavior empty/backwards compatible
- fail deployment when a configured required network is missing or cannot be attached, avoiding green deploys with dependency DNS failures
- document the operator env var and update deployer sample struct construction

## Verification
- cargo fmt
- cargo check -p temps-config -p temps-deployer
- cargo test -p temps-deployer test_normalize_extra_networks_drops_empty_duplicates_primary_and_overlay -- --nocapture
- cargo test -p temps-deployer test_deploy_request_creation -- --nocapture

Note: cargo check -p temps-config -p temps-deployer -p temps-deployments still fails on Windows in existing docker_cleanup_service code using Docker::connect_with_unix_defaults and inferred cleanup result types; this patch did not touch that path.