### PR TITLE
fix(deps): bump mongodb to 3.7.0 (drops vulnerable hickory 0.25)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3349,18 +3349,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "enumset"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4235,36 +4223,11 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "idna",
  "ipnet",
  "jni",
  "rand 0.10.1",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna",
- "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -4295,27 +4258,6 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto 0.25.2",
- "ipconfig",
- "moka",
- "once_cell",
- "parking_lot",
- "rand 0.9.4",
- "resolv-conf",
- "smallvec",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hickory-resolver"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
@@ -4323,7 +4265,7 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-net",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "ipconfig",
  "ipnet",
  "jni",
@@ -4352,7 +4294,7 @@ dependencies = [
  "data-encoding",
  "futures-util",
  "hickory-net",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "ipnet",
  "prefix-trie",
  "serde",
@@ -6035,9 +5977,9 @@ checksum = "224484c5d09285a7b8cb0a0c117e847ebd14cb6e4470ecf68cdb89c503b0edb9"
 
 [[package]]
 name = "mongodb"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ef2c933617431ad0246fb5b43c425ebdae18c7f7259c87de0726d93b0e7e91b"
+checksum = "276ba0cd571553d1f6936c6f180964776ece6ab7507dc8765f8a9c9c49d8cd00"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.11.1",
@@ -6048,8 +5990,9 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hex",
- "hickory-proto 0.25.2",
- "hickory-resolver 0.25.2",
+ "hickory-net",
+ "hickory-proto",
+ "hickory-resolver",
  "hmac 0.12.1",
  "macro_magic",
  "md-5 0.10.6",
@@ -6060,7 +6003,6 @@ dependencies = [
  "rand 0.9.4",
  "rustc_version_runtime",
  "rustls",
- "rustversion",
  "serde",
  "serde_bytes",
  "serde_with 3.20.0",
@@ -6081,9 +6023,9 @@ dependencies = [
 
 [[package]]
 name = "mongodb-internal-macros"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5758dc828eb2d02ec30563cba365609d56ddd833190b192beaee2b475a7bb3"
+checksum = "99ceb1a9a1018e470077ec94cf3a8c2d0e6da542b2c05ea95a59a0a627147375"
 dependencies = [
  "macro_magic",
  "proc-macro2",
@@ -11196,8 +11138,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "hickory-proto 0.26.1",
- "hickory-resolver 0.26.1",
+ "hickory-proto",
+ "hickory-resolver",
  "hickory-server",
  "reqwest",
  "serde",
@@ -11221,7 +11163,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "cloudflare 0.14.1",
- "hickory-resolver 0.26.1",
+ "hickory-resolver",
  "instant-acme",
  "log",
  "rcgen",
@@ -11304,7 +11246,7 @@ dependencies = [
  "axum-macros",
  "chrono",
  "futures",
- "hickory-resolver 0.26.1",
+ "hickory-resolver",
  "http 1.4.0",
  "http-body-util",
  "md5",
@@ -11736,7 +11678,7 @@ dependencies = [
  "bollard",
  "env_logger 0.11.10",
  "get_if_addrs",
- "hickory-resolver 0.26.1",
+ "hickory-resolver",
  "log",
  "parking_lot",
  "reqwest",
@@ -13077,6 +13019,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/crates/temps-providers/Cargo.toml
+++ b/crates/temps-providers/Cargo.toml
@@ -30,7 +30,7 @@ tracing = { workspace = true }
 reqwest = { workspace = true }
 sea-orm = { workspace = true }
 redis = { version = "0.28.2", features = ["tokio-comp", "connection-manager"] }
-mongodb = "3.3.0"
+mongodb = "3.7.0"
 aws-sdk-s3 = { workspace = true }
 aws-smithy-runtime = "1.9"
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "http2", "tokio"] }

--- a/crates/temps-query-mongodb/Cargo.toml
+++ b/crates/temps-query-mongodb/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 temps-query = { path = "../temps-query" }
 
 # MongoDB driver
-mongodb = "3.1"
+mongodb = "3.7.0"
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
## Summary

- mongodb 3.6.0 pinned hickory-resolver / hickory-proto 0.25 for its `mongodb+srv` SRV stub resolver, leaving one vulnerable hickory-proto 0.25.2 copy in the tree even after the rest of the workspace moved to hickory 0.26.1.
- mongodb 3.7.0 updates its hickory dep to 0.26.
- After this bump, `cargo tree` resolves a single hickory-proto / hickory-resolver 0.26.1 across the whole workspace.

## Why

Clears the residual DNS CVEs (NSEC3 unbounded loop, O(n²) name compression) reported by `cargo audit` against hickory-proto 0.25.

## Test plan

- [x] `cargo check --bin temps` compiles clean
- [ ] `cargo audit` shows hickory-proto 0.25.x no longer present in tree
- [ ] CI green