### PR TITLE
feat(git): Vercel-style sticky PR/MR preview comments on deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
--
+- **Vercel-style sticky PR/MR preview comments**: when a deployment for a branch with an open pull request (GitHub) or merge request (GitLab) moves through created → succeeded/failed, Temps posts or updates a single sticky comment with the preview URL. The comment is keyed by a hidden HTML marker (`<!-- temps-preview:project=N:env=N -->`) scoped per `(project, environment)` so subsequent updates edit in place rather than spam the PR. New `temps-git::PrCommenter` trait + `GitPrCommenter` impl dispatches to GitHub REST (`/repos/.../pulls` + issue comments) or GitLab REST (`/merge_requests` + notes). A background `PrCommentListener` subscribes to existing `Job::DeploymentCreated` / `DeploymentSucceeded` / `DeploymentFailed` broadcasts — no schema changes, no new event types, no wiring required in `temps-deployments`. Graceful degradation: missing git connection, no open PR, unsupported provider, or 403/401 from the provider all log at warn/debug and never block deploys. Newly-created GitHub Apps already request `pull_requests:write` in the manifest; existing installations without that scope hit a logged 403 and would need to upgrade their app permissions.
 
 ### Changed
 -

--- a/crates/temps-git/src/lib.rs
+++ b/crates/temps-git/src/lib.rs
@@ -20,3 +20,6 @@ pub use services::git_provider_manager_trait::{
     GitProviderManagerError, GitProviderManagerTrait, PullRequest, RepositoryInfo,
     ScopedTokenGrant, ScopedTokenOp,
 };
+pub use services::pr_commenter::{
+    CommentPhase, GitPrCommenter, PrCommenter, PrCommenterError, PreviewCommentContext,
+};

--- a/crates/temps-git/src/plugin.rs
+++ b/crates/temps-git/src/plugin.rs
@@ -74,7 +74,37 @@ impl TempsPlugin for GitPlugin {
             // Register as trait for other plugins to use
             let git_provider_trait: Arc<dyn crate::GitProviderManagerTrait> =
                 git_provider_manager.clone();
-            context.register_service(git_provider_trait);
+            context.register_service(git_provider_trait.clone());
+
+            // PR preview commenter — turns deployment lifecycle events into
+            // sticky PR/MR comments. Failures never block deploys (see
+            // GitPrCommenter::upsert_preview_comment).
+            let pr_commenter: Arc<dyn crate::PrCommenter> =
+                Arc::new(crate::GitPrCommenter::new(db.clone(), git_provider_trait));
+            context.register_service(pr_commenter.clone());
+
+            // Background listener: subscribes to DeploymentCreated /
+            // DeploymentSucceeded / DeploymentFailed and upserts the
+            // sticky comment for each phase. Self-contained — doesn't
+            // require any wiring in the deployment crate beyond the
+            // existing event broadcast.
+            let pr_comment_listener = Arc::new(
+                crate::services::pr_comment_listener::PrCommentListener::new(
+                    pr_commenter,
+                    db.clone(),
+                    queue_service.clone(),
+                ),
+            );
+            context.register_service(pr_comment_listener.clone());
+
+            tokio::spawn({
+                let listener = pr_comment_listener.clone();
+                async move {
+                    if let Err(e) = listener.start().await {
+                        tracing::error!("Failed to start PR comment listener: {}", e);
+                    }
+                }
+            });
 
             // Reset all git provider connections syncing flags to false at startup
             {

--- a/crates/temps-git/src/services/mod.rs
+++ b/crates/temps-git/src/services/mod.rs
@@ -10,5 +10,7 @@ pub mod github;
 pub mod github_provider;
 pub mod gitlab_provider;
 pub mod gitlab_webhook;
+pub mod pr_comment_listener;
+pub mod pr_commenter;
 pub mod public_repo;
 pub mod repository;

--- a/crates/temps-git/src/services/pr_comment_listener.rs
+++ b/crates/temps-git/src/services/pr_comment_listener.rs
@@ -210,7 +210,14 @@ impl PrCommentListener {
 
 #[cfg(test)]
 mod tests {
+    use super::super::pr_commenter::PrCommenterError;
     use super::*;
+    use async_trait::async_trait;
+    use sea_orm::{DatabaseBackend, MockDatabase};
+    use std::sync::Mutex;
+    use temps_core::{
+        DeploymentCreatedJob, DeploymentFailedJob, DeploymentReadyJob, DeploymentSucceededJob,
+    };
 
     #[test]
     fn short_sha_truncates_long_commit() {
@@ -227,5 +234,321 @@ mod tests {
     #[test]
     fn short_sha_handles_missing_commit() {
         assert_eq!(short_sha(None), "unknown");
+    }
+
+    /// PrCommenter test double that records every context it's called with
+    /// so individual tests can assert which phase the listener produced.
+    struct RecordingCommenter {
+        calls: Mutex<Vec<PreviewCommentContext>>,
+    }
+
+    impl RecordingCommenter {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                calls: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn calls(&self) -> Vec<PreviewCommentContext> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl PrCommenter for RecordingCommenter {
+        async fn upsert_preview_comment(
+            &self,
+            ctx: PreviewCommentContext,
+        ) -> Result<(), PrCommenterError> {
+            self.calls.lock().unwrap().push(ctx);
+            Ok(())
+        }
+    }
+
+    fn empty_db() -> Arc<sea_orm::DatabaseConnection> {
+        Arc::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection())
+    }
+
+    fn deployment_with_branch(
+        id: i32,
+        branch: Option<&str>,
+        commit: Option<&str>,
+    ) -> temps_entities::deployments::Model {
+        let now = chrono::Utc::now();
+        temps_entities::deployments::Model {
+            id,
+            project_id: 1,
+            environment_id: 1,
+            created_at: now,
+            updated_at: now,
+            slug: format!("d-{id}"),
+            state: "completed".to_string(),
+            metadata: None,
+            deploying_at: None,
+            ready_at: None,
+            started_at: None,
+            finished_at: None,
+            context_vars: None,
+            branch_ref: branch.map(|s| s.to_string()),
+            tag_ref: None,
+            commit_sha: commit.map(|s| s.to_string()),
+            commit_message: None,
+            commit_author: None,
+            commit_json: None,
+            cancelled_reason: None,
+            static_dir_location: None,
+            screenshot_location: None,
+            image_name: None,
+            deployment_config: None,
+            promoted_from_deployment_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn created_event_with_branch_triggers_started_comment() {
+        let recorder = RecordingCommenter::new();
+        let commenter: Arc<dyn PrCommenter> = recorder.clone();
+        let db = empty_db();
+
+        let job = Job::DeploymentCreated(DeploymentCreatedJob {
+            deployment_id: 10,
+            project_id: 42,
+            environment_id: 7,
+            environment_name: "preview".into(),
+            commit_sha: Some("abcdef1234567890".into()),
+            branch: Some("feature/x".into()),
+        });
+
+        PrCommentListener::handle_job(&commenter, &db, &job)
+            .await
+            .unwrap();
+
+        let calls = recorder.calls();
+
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].project_id, 42);
+        assert_eq!(calls[0].environment_id, 7);
+        assert_eq!(calls[0].branch, "feature/x");
+        match &calls[0].phase {
+            CommentPhase::Started { commit_short_sha } => {
+                assert_eq!(commit_short_sha, "abcdef1");
+            }
+            _ => panic!("expected Started, got {:?}", calls[0].phase),
+        }
+    }
+
+    #[tokio::test]
+    async fn created_event_without_branch_skips_comment() {
+        let recorder = RecordingCommenter::new();
+        let commenter: Arc<dyn PrCommenter> = recorder.clone();
+        let db = empty_db();
+
+        let job = Job::DeploymentCreated(DeploymentCreatedJob {
+            deployment_id: 10,
+            project_id: 42,
+            environment_id: 7,
+            environment_name: "preview".into(),
+            commit_sha: Some("abc".into()),
+            branch: None,
+        });
+
+        PrCommentListener::handle_job(&commenter, &db, &job)
+            .await
+            .unwrap();
+
+        let calls = recorder.calls();
+        assert!(calls.is_empty(), "expected no comment, got {:?}", calls);
+    }
+
+    #[tokio::test]
+    async fn created_event_with_empty_branch_skips_comment() {
+        let recorder = RecordingCommenter::new();
+        let commenter: Arc<dyn PrCommenter> = recorder.clone();
+        let db = empty_db();
+
+        let job = Job::DeploymentCreated(DeploymentCreatedJob {
+            deployment_id: 10,
+            project_id: 42,
+            environment_id: 7,
+            environment_name: "preview".into(),
+            commit_sha: Some("abc".into()),
+            branch: Some(String::new()),
+        });
+
+        PrCommentListener::handle_job(&commenter, &db, &job)
+            .await
+            .unwrap();
+
+        let calls = recorder.calls();
+        assert!(calls.is_empty());
+    }
+
+    #[tokio::test]
+    async fn succeeded_event_with_url_and_branch_triggers_ready_comment() {
+        let recorder = RecordingCommenter::new();
+        let commenter: Arc<dyn PrCommenter> = recorder.clone();
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![vec![deployment_with_branch(
+                    10,
+                    Some("feature/x"),
+                    Some("abcdef1234"),
+                )]])
+                .into_connection(),
+        );
+
+        let job = Job::DeploymentSucceeded(DeploymentSucceededJob {
+            deployment_id: 10,
+            project_id: 42,
+            environment_id: 7,
+            environment_name: "preview".into(),
+            commit_sha: Some("abcdef1234".into()),
+            url: Some("https://feature-x.preview.temps.app".into()),
+            health_check_path: None,
+        });
+
+        PrCommentListener::handle_job(&commenter, &db, &job)
+            .await
+            .unwrap();
+
+        let calls = recorder.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].branch, "feature/x");
+        match &calls[0].phase {
+            CommentPhase::Ready {
+                commit_short_sha,
+                env_url,
+                deployment_url,
+            } => {
+                assert_eq!(commit_short_sha, "abcdef1");
+                assert_eq!(env_url, "https://feature-x.preview.temps.app");
+                assert!(deployment_url.is_none());
+            }
+            _ => panic!("expected Ready, got {:?}", calls[0].phase),
+        }
+    }
+
+    #[tokio::test]
+    async fn succeeded_event_without_url_skips_comment() {
+        let recorder = RecordingCommenter::new();
+        let commenter: Arc<dyn PrCommenter> = recorder.clone();
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![vec![deployment_with_branch(
+                    10,
+                    Some("feature/x"),
+                    Some("abc"),
+                )]])
+                .into_connection(),
+        );
+
+        let job = Job::DeploymentSucceeded(DeploymentSucceededJob {
+            deployment_id: 10,
+            project_id: 42,
+            environment_id: 7,
+            environment_name: "preview".into(),
+            commit_sha: Some("abc".into()),
+            url: None,
+            health_check_path: None,
+        });
+
+        PrCommentListener::handle_job(&commenter, &db, &job)
+            .await
+            .unwrap();
+
+        let calls = recorder.calls();
+        assert!(calls.is_empty());
+    }
+
+    #[tokio::test]
+    async fn succeeded_event_with_missing_deployment_is_noop() {
+        let recorder = RecordingCommenter::new();
+        let commenter: Arc<dyn PrCommenter> = recorder.clone();
+        // Empty query result -> deployment not found
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![Vec::<temps_entities::deployments::Model>::new()])
+                .into_connection(),
+        );
+
+        let job = Job::DeploymentSucceeded(DeploymentSucceededJob {
+            deployment_id: 10,
+            project_id: 42,
+            environment_id: 7,
+            environment_name: "preview".into(),
+            commit_sha: Some("abc".into()),
+            url: Some("https://x.example.com".into()),
+            health_check_path: None,
+        });
+
+        PrCommentListener::handle_job(&commenter, &db, &job)
+            .await
+            .unwrap();
+
+        let calls = recorder.calls();
+        assert!(calls.is_empty());
+    }
+
+    #[tokio::test]
+    async fn failed_event_with_branch_triggers_failed_comment() {
+        let recorder = RecordingCommenter::new();
+        let commenter: Arc<dyn PrCommenter> = recorder.clone();
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![vec![deployment_with_branch(
+                    10,
+                    Some("feature/x"),
+                    Some("abcdef1234"),
+                )]])
+                .into_connection(),
+        );
+
+        let job = Job::DeploymentFailed(DeploymentFailedJob {
+            deployment_id: 10,
+            project_id: 42,
+            environment_id: 7,
+            environment_name: "preview".into(),
+            error_message: Some("build failed".into()),
+        });
+
+        PrCommentListener::handle_job(&commenter, &db, &job)
+            .await
+            .unwrap();
+
+        let calls = recorder.calls();
+        assert_eq!(calls.len(), 1);
+        match &calls[0].phase {
+            CommentPhase::Failed {
+                commit_short_sha,
+                deployment_url,
+            } => {
+                assert_eq!(commit_short_sha, "abcdef1");
+                assert!(deployment_url.is_none());
+            }
+            _ => panic!("expected Failed, got {:?}", calls[0].phase),
+        }
+    }
+
+    #[tokio::test]
+    async fn unrelated_event_is_ignored() {
+        let recorder = RecordingCommenter::new();
+        let commenter: Arc<dyn PrCommenter> = recorder.clone();
+        let db = empty_db();
+
+        // DeploymentReady is not one of the events the listener subscribes to.
+        let job = Job::DeploymentReady(DeploymentReadyJob {
+            deployment_id: 10,
+            project_id: 42,
+            environment_id: 7,
+            environment_name: "preview".into(),
+            url: Some("https://x".into()),
+        });
+
+        PrCommentListener::handle_job(&commenter, &db, &job)
+            .await
+            .unwrap();
+
+        let calls = recorder.calls();
+        assert!(calls.is_empty());
     }
 }

--- a/crates/temps-git/src/services/pr_comment_listener.rs
+++ b/crates/temps-git/src/services/pr_comment_listener.rs
@@ -1,0 +1,231 @@
+//! Background listener that turns deployment lifecycle events into
+//! sticky PR/MR preview comments.
+//!
+//! Vercel-style: when a deployment for a branch with an open PR moves
+//! through created → succeeded/failed, we post or update a single
+//! comment that always reflects the latest state. The comment is keyed
+//! by a hidden HTML marker so subsequent updates edit-in-place.
+//!
+//! All failures here degrade gracefully — a missing git connection,
+//! missing PR, or provider API outage produces a warn log, never an
+//! application-level error. Deployments must not be affected by
+//! comment-posting issues.
+
+use sea_orm::{DatabaseConnection, EntityTrait};
+use std::sync::Arc;
+use temps_core::{Job, JobQueue};
+use temps_entities::deployments;
+use tokio::sync::RwLock;
+use tokio::task::JoinHandle;
+use tracing::{debug, error, info, warn};
+
+use super::pr_commenter::{CommentPhase, PrCommenter, PreviewCommentContext};
+
+/// Short SHA helper. GitHub-style 7-char abbreviation.
+fn short_sha(commit: Option<&String>) -> String {
+    commit
+        .map(|s| s.chars().take(7).collect::<String>())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+pub struct PrCommentListener {
+    commenter: Arc<dyn PrCommenter>,
+    db: Arc<DatabaseConnection>,
+    queue: Arc<dyn JobQueue>,
+    running: Arc<RwLock<bool>>,
+    task_handle: Arc<RwLock<Option<JoinHandle<()>>>>,
+}
+
+impl PrCommentListener {
+    pub fn new(
+        commenter: Arc<dyn PrCommenter>,
+        db: Arc<DatabaseConnection>,
+        queue: Arc<dyn JobQueue>,
+    ) -> Self {
+        Self {
+            commenter,
+            db,
+            queue,
+            running: Arc::new(RwLock::new(false)),
+            task_handle: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    pub async fn start(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let mut running = self.running.write().await;
+        if *running {
+            return Ok(());
+        }
+        *running = true;
+        drop(running);
+
+        info!("Starting PR preview-comment listener");
+
+        let mut receiver = self.queue.subscribe();
+        let commenter = self.commenter.clone();
+        let db = self.db.clone();
+        let running = self.running.clone();
+
+        let handle = tokio::spawn(async move {
+            while *running.read().await {
+                match receiver.recv().await {
+                    Ok(job) => {
+                        if let Err(e) = Self::handle_job(&commenter, &db, &job).await {
+                            warn!("PR comment listener: failed to handle job: {}", e);
+                        }
+                    }
+                    Err(e) => {
+                        debug!("PR comment listener queue recv error: {}", e);
+                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    }
+                }
+            }
+            info!("PR preview-comment listener stopped");
+        });
+
+        *self.task_handle.write().await = Some(handle);
+        Ok(())
+    }
+
+    pub async fn stop(&self) {
+        *self.running.write().await = false;
+        if let Some(handle) = self.task_handle.write().await.take() {
+            let _ = handle.await;
+        }
+    }
+
+    async fn handle_job(
+        commenter: &Arc<dyn PrCommenter>,
+        db: &Arc<DatabaseConnection>,
+        job: &Job,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        match job {
+            Job::DeploymentCreated(e) => {
+                let branch = match e.branch.clone() {
+                    Some(b) if !b.is_empty() => b,
+                    _ => return Ok(()),
+                };
+                let ctx = PreviewCommentContext {
+                    project_id: e.project_id,
+                    environment_id: e.environment_id,
+                    branch,
+                    phase: CommentPhase::Started {
+                        commit_short_sha: short_sha(e.commit_sha.as_ref()),
+                    },
+                };
+                if let Err(err) = commenter.upsert_preview_comment(ctx).await {
+                    warn!(
+                        deployment_id = e.deployment_id,
+                        "PR comment (Started) failed: {}", err
+                    );
+                }
+            }
+            Job::DeploymentSucceeded(e) => {
+                // Branch isn't in the event payload — fetch from deployment row.
+                let deployment = match deployments::Entity::find_by_id(e.deployment_id)
+                    .one(db.as_ref())
+                    .await
+                {
+                    Ok(Some(d)) => d,
+                    Ok(None) => {
+                        debug!(
+                            "PR comment listener: deployment {} not found, skipping",
+                            e.deployment_id
+                        );
+                        return Ok(());
+                    }
+                    Err(err) => {
+                        error!(
+                            "PR comment listener: failed to load deployment {}: {}",
+                            e.deployment_id, err
+                        );
+                        return Ok(());
+                    }
+                };
+                let branch = match deployment.branch_ref.clone() {
+                    Some(b) if !b.is_empty() => b,
+                    _ => return Ok(()),
+                };
+                let env_url = match e.url.clone() {
+                    Some(u) => u,
+                    None => {
+                        debug!(
+                            "PR comment listener: deployment {} succeeded but no URL — skipping",
+                            e.deployment_id
+                        );
+                        return Ok(());
+                    }
+                };
+                let ctx = PreviewCommentContext {
+                    project_id: e.project_id,
+                    environment_id: e.environment_id,
+                    branch,
+                    phase: CommentPhase::Ready {
+                        commit_short_sha: short_sha(deployment.commit_sha.as_ref()),
+                        env_url,
+                        deployment_url: None,
+                    },
+                };
+                if let Err(err) = commenter.upsert_preview_comment(ctx).await {
+                    warn!(
+                        deployment_id = e.deployment_id,
+                        "PR comment (Ready) failed: {}", err
+                    );
+                }
+            }
+            Job::DeploymentFailed(e) => {
+                let deployment = match deployments::Entity::find_by_id(e.deployment_id)
+                    .one(db.as_ref())
+                    .await
+                {
+                    Ok(Some(d)) => d,
+                    Ok(None) => return Ok(()),
+                    Err(_) => return Ok(()),
+                };
+                let branch = match deployment.branch_ref.clone() {
+                    Some(b) if !b.is_empty() => b,
+                    _ => return Ok(()),
+                };
+                let ctx = PreviewCommentContext {
+                    project_id: e.project_id,
+                    environment_id: e.environment_id,
+                    branch,
+                    phase: CommentPhase::Failed {
+                        commit_short_sha: short_sha(deployment.commit_sha.as_ref()),
+                        deployment_url: None,
+                    },
+                };
+                if let Err(err) = commenter.upsert_preview_comment(ctx).await {
+                    warn!(
+                        deployment_id = e.deployment_id,
+                        "PR comment (Failed) failed: {}", err
+                    );
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_sha_truncates_long_commit() {
+        let long = "abcdef1234567890".to_string();
+        assert_eq!(short_sha(Some(&long)), "abcdef1");
+    }
+
+    #[test]
+    fn short_sha_handles_short_commit() {
+        let short = "abc".to_string();
+        assert_eq!(short_sha(Some(&short)), "abc");
+    }
+
+    #[test]
+    fn short_sha_handles_missing_commit() {
+        assert_eq!(short_sha(None), "unknown");
+    }
+}

--- a/crates/temps-git/src/services/pr_commenter.rs
+++ b/crates/temps-git/src/services/pr_commenter.rs
@@ -1,0 +1,1083 @@
+//! Pull request preview-deployment commenter.
+//!
+//! Vercel-style: when a deployment starts or finishes, look up the open PR
+//! (or merge request) for the deployed branch and post or update a sticky
+//! comment with the preview URL. The sticky comment is identified by an HTML
+//! marker so subsequent updates edit in place rather than spamming the PR.
+//!
+//! Failures here are intentionally non-fatal: if a project has no git
+//! provider, no open PR, or the API call fails, we log a warning and move
+//! on. The deployment itself must never be blocked by a commenting failure.
+
+use async_trait::async_trait;
+use sea_orm::{DatabaseConnection, EntityTrait};
+use serde::Deserialize;
+use std::sync::Arc;
+use std::time::Duration;
+use thiserror::Error;
+use tracing::{debug, info, warn};
+
+use super::git_provider_manager_trait::{GitProviderManagerError, GitProviderManagerTrait};
+
+/// HTML marker embedded in every sticky comment so we can find and edit it
+/// later. Scoped per `(project, environment)` so multiple Temps environments
+/// targeting the same PR each get their own comment.
+fn marker(project_id: i32, environment_id: i32) -> String {
+    format!(
+        "<!-- temps-preview:project={}:env={} -->",
+        project_id, environment_id
+    )
+}
+
+/// Lifecycle phase of the deployment used to render the comment body.
+#[derive(Debug, Clone)]
+pub enum CommentPhase {
+    /// Build / deploy has started. `commit_short_sha` is the abbreviated SHA.
+    Started { commit_short_sha: String },
+    /// Deployment succeeded; `env_url` is the URL we want users to click.
+    Ready {
+        commit_short_sha: String,
+        env_url: String,
+        deployment_url: Option<String>,
+    },
+    /// Deployment failed; optional `deployment_url` links to logs.
+    Failed {
+        commit_short_sha: String,
+        deployment_url: Option<String>,
+    },
+}
+
+/// Context required to post a sticky PR/MR comment.
+#[derive(Debug, Clone)]
+pub struct PreviewCommentContext {
+    pub project_id: i32,
+    pub environment_id: i32,
+    pub branch: String,
+    pub phase: CommentPhase,
+}
+
+#[derive(Debug, Error)]
+pub enum PrCommenterError {
+    #[error("Project {project_id} has no git provider connection — skipping PR comment")]
+    NoGitConnection { project_id: i32 },
+
+    #[error("No open PR/MR found for branch '{branch}' on {owner}/{repo}")]
+    NoOpenPullRequest {
+        owner: String,
+        repo: String,
+        branch: String,
+    },
+
+    #[error("Git provider manager error: {0}")]
+    Manager(#[from] GitProviderManagerError),
+
+    #[error("Database error: {0}")]
+    Database(#[from] sea_orm::DbErr),
+
+    #[error("HTTP error calling {provider} for {owner}/{repo}: {reason}")]
+    Http {
+        provider: &'static str,
+        owner: String,
+        repo: String,
+        reason: String,
+    },
+
+    #[error(
+        "Forbidden by {provider} for {owner}/{repo}: missing scope or revoked token ({status})"
+    )]
+    Forbidden {
+        provider: &'static str,
+        owner: String,
+        repo: String,
+        status: u16,
+    },
+
+    #[error("Unsupported provider type for PR comments: {provider_type}")]
+    UnsupportedProvider { provider_type: String },
+}
+
+/// Lightweight ref to an open PR/MR returned by the lookup step.
+#[derive(Debug, Clone)]
+pub struct OpenPullRequestRef {
+    /// PR/MR number as the provider exposes it. For GitLab this is the
+    /// MR `iid` (project-scoped), for GitHub the global PR number.
+    pub number: i64,
+}
+
+#[async_trait]
+pub trait PrCommenter: Send + Sync {
+    /// Upsert a sticky preview comment on the open PR/MR for the deployment.
+    /// Returns Ok(()) on success or when there's nothing to comment on
+    /// (no PR, no git connection, etc. — those are logged at warn level,
+    /// not propagated as errors, since they aren't deployment failures).
+    async fn upsert_preview_comment(
+        &self,
+        ctx: PreviewCommentContext,
+    ) -> Result<(), PrCommenterError>;
+}
+
+/// Production implementation backed by `GitProviderManagerTrait`.
+pub struct GitPrCommenter {
+    db: Arc<DatabaseConnection>,
+    manager: Arc<dyn GitProviderManagerTrait>,
+    http: reqwest::Client,
+}
+
+impl GitPrCommenter {
+    pub fn new(db: Arc<DatabaseConnection>, manager: Arc<dyn GitProviderManagerTrait>) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .user_agent("Temps-PR-Commenter/1.0")
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        Self { db, manager, http }
+    }
+
+    /// Internal helper that does the real work; the trait method wraps this
+    /// with the "log-and-swallow" graceful-degradation policy.
+    async fn upsert_inner(&self, ctx: &PreviewCommentContext) -> Result<(), PrCommenterError> {
+        use temps_entities::{git_provider_connections, git_providers, projects};
+
+        let project = projects::Entity::find_by_id(ctx.project_id)
+            .one(self.db.as_ref())
+            .await?
+            .ok_or_else(|| PrCommenterError::NoGitConnection {
+                project_id: ctx.project_id,
+            })?;
+
+        let connection_id =
+            project
+                .git_provider_connection_id
+                .ok_or(PrCommenterError::NoGitConnection {
+                    project_id: ctx.project_id,
+                })?;
+
+        let connection = git_provider_connections::Entity::find_by_id(connection_id)
+            .one(self.db.as_ref())
+            .await?
+            .ok_or(GitProviderManagerError::ConnectionNotFound(connection_id))?;
+
+        let provider = git_providers::Entity::find_by_id(connection.provider_id)
+            .one(self.db.as_ref())
+            .await?
+            .ok_or(GitProviderManagerError::ProviderNotFound(
+                connection.provider_id,
+            ))?;
+
+        let (access_token, _provider_type) = self
+            .manager
+            .get_connection_access_token(connection_id)
+            .await?;
+
+        let body = render_body(ctx.project_id, ctx.environment_id, &ctx.phase);
+
+        match provider.provider_type.as_str() {
+            "github" => {
+                let api_base = provider
+                    .api_url
+                    .clone()
+                    .unwrap_or_else(|| "https://api.github.com".to_string());
+                github_upsert(
+                    &self.http,
+                    &api_base,
+                    &access_token,
+                    &project.repo_owner,
+                    &project.repo_name,
+                    &ctx.branch,
+                    &marker(ctx.project_id, ctx.environment_id),
+                    &body,
+                )
+                .await
+            }
+            "gitlab" => {
+                let api_base = provider
+                    .api_url
+                    .clone()
+                    .or_else(|| provider.base_url.clone())
+                    .unwrap_or_else(|| "https://gitlab.com".to_string());
+                gitlab_upsert(
+                    &self.http,
+                    &api_base,
+                    &access_token,
+                    &project.repo_owner,
+                    &project.repo_name,
+                    &ctx.branch,
+                    &marker(ctx.project_id, ctx.environment_id),
+                    &body,
+                )
+                .await
+            }
+            other => Err(PrCommenterError::UnsupportedProvider {
+                provider_type: other.to_string(),
+            }),
+        }
+    }
+}
+
+#[async_trait]
+impl PrCommenter for GitPrCommenter {
+    async fn upsert_preview_comment(
+        &self,
+        ctx: PreviewCommentContext,
+    ) -> Result<(), PrCommenterError> {
+        match self.upsert_inner(&ctx).await {
+            Ok(()) => {
+                info!(
+                    project_id = ctx.project_id,
+                    environment_id = ctx.environment_id,
+                    branch = %ctx.branch,
+                    "Posted/updated PR preview comment"
+                );
+                Ok(())
+            }
+            // No PR / no connection / unsupported provider: not a deployment
+            // failure, just nothing to do. Log and swallow.
+            Err(e @ PrCommenterError::NoGitConnection { .. })
+            | Err(e @ PrCommenterError::NoOpenPullRequest { .. })
+            | Err(e @ PrCommenterError::UnsupportedProvider { .. }) => {
+                debug!(
+                    project_id = ctx.project_id,
+                    environment_id = ctx.environment_id,
+                    branch = %ctx.branch,
+                    "Skipping PR preview comment: {}",
+                    e
+                );
+                Ok(())
+            }
+            Err(e @ PrCommenterError::Forbidden { .. }) => {
+                warn!(
+                    project_id = ctx.project_id,
+                    environment_id = ctx.environment_id,
+                    branch = %ctx.branch,
+                    "PR preview comment forbidden by provider — check installation permissions (pull_requests:write for GitHub Apps): {}",
+                    e
+                );
+                Ok(())
+            }
+            Err(e) => {
+                warn!(
+                    project_id = ctx.project_id,
+                    environment_id = ctx.environment_id,
+                    branch = %ctx.branch,
+                    "Failed to post PR preview comment: {}",
+                    e
+                );
+                Err(e)
+            }
+        }
+    }
+}
+
+fn render_body(project_id: i32, environment_id: i32, phase: &CommentPhase) -> String {
+    let marker = marker(project_id, environment_id);
+    match phase {
+        CommentPhase::Started { commit_short_sha } => {
+            format!("{marker}\n## 🚧 Deploying preview\n\nBuilding commit `{commit_short_sha}`…",)
+        }
+        CommentPhase::Ready {
+            commit_short_sha,
+            env_url,
+            deployment_url,
+        } => {
+            let logs = deployment_url
+                .as_ref()
+                .map(|u| format!("\n\n[View deployment logs]({u})"))
+                .unwrap_or_default();
+            format!(
+                "{marker}\n## ✅ Preview ready\n\n**Commit:** `{commit_short_sha}`\n\n🔗 **[Open preview]({env_url})**{logs}",
+            )
+        }
+        CommentPhase::Failed {
+            commit_short_sha,
+            deployment_url,
+        } => {
+            let logs = deployment_url
+                .as_ref()
+                .map(|u| format!("\n\n[View deployment logs]({u})"))
+                .unwrap_or_default();
+            format!(
+                "{marker}\n## ❌ Preview build failed\n\n**Commit:** `{commit_short_sha}`{logs}",
+            )
+        }
+    }
+}
+
+// ===== GitHub =====
+
+#[derive(Deserialize)]
+struct GhPull {
+    number: i64,
+}
+
+#[derive(Deserialize)]
+struct GhComment {
+    id: i64,
+    #[serde(default)]
+    body: String,
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn github_upsert(
+    http: &reqwest::Client,
+    api_base: &str,
+    token: &str,
+    owner: &str,
+    repo: &str,
+    branch: &str,
+    marker: &str,
+    body: &str,
+) -> Result<(), PrCommenterError> {
+    let api_base = api_base.trim_end_matches('/');
+    let pr = github_find_open_pr(http, api_base, token, owner, repo, branch).await?;
+
+    let comments_url = format!(
+        "{api_base}/repos/{owner}/{repo}/issues/{}/comments?per_page=100",
+        pr.number
+    );
+    let resp = http
+        .get(&comments_url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .bearer_auth(token)
+        .send()
+        .await
+        .map_err(|e| PrCommenterError::Http {
+            provider: "github",
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            reason: format!("list comments: {e}"),
+        })?;
+
+    let status = resp.status();
+    if status.as_u16() == 403 || status.as_u16() == 401 {
+        return Err(PrCommenterError::Forbidden {
+            provider: "github",
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            status: status.as_u16(),
+        });
+    }
+    if !status.is_success() {
+        return Err(PrCommenterError::Http {
+            provider: "github",
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            reason: format!("list comments returned {status}"),
+        });
+    }
+
+    let comments: Vec<GhComment> = resp.json().await.map_err(|e| PrCommenterError::Http {
+        provider: "github",
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        reason: format!("parse comments: {e}"),
+    })?;
+
+    let existing = comments.iter().find(|c| c.body.contains(marker));
+
+    let payload = serde_json::json!({ "body": body });
+
+    let result = if let Some(existing) = existing {
+        let url = format!(
+            "{api_base}/repos/{owner}/{repo}/issues/comments/{}",
+            existing.id
+        );
+        http.patch(&url)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .bearer_auth(token)
+            .json(&payload)
+            .send()
+            .await
+    } else {
+        let url = format!(
+            "{api_base}/repos/{owner}/{repo}/issues/{}/comments",
+            pr.number
+        );
+        http.post(&url)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .bearer_auth(token)
+            .json(&payload)
+            .send()
+            .await
+    };
+
+    let resp = result.map_err(|e| PrCommenterError::Http {
+        provider: "github",
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        reason: format!("upsert: {e}"),
+    })?;
+
+    let status = resp.status();
+    if status.as_u16() == 403 || status.as_u16() == 401 {
+        return Err(PrCommenterError::Forbidden {
+            provider: "github",
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            status: status.as_u16(),
+        });
+    }
+    if !status.is_success() {
+        return Err(PrCommenterError::Http {
+            provider: "github",
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            reason: format!("upsert returned {status}"),
+        });
+    }
+    Ok(())
+}
+
+async fn github_find_open_pr(
+    http: &reqwest::Client,
+    api_base: &str,
+    token: &str,
+    owner: &str,
+    repo: &str,
+    branch: &str,
+) -> Result<OpenPullRequestRef, PrCommenterError> {
+    // GitHub's `head` filter on the pulls list uses `user:branch` form. The
+    // user is the *head* repo owner — for a same-repo branch this is the
+    // repo owner; for forks it would differ, but Temps deploys are
+    // configured per-repo so we only ever comment on same-repo PRs.
+    let head = format!("{owner}:{branch}");
+    let url = format!(
+        "{api_base}/repos/{owner}/{repo}/pulls?state=open&head={}&per_page=1",
+        urlencoding::encode(&head)
+    );
+
+    let resp = http
+        .get(&url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .bearer_auth(token)
+        .send()
+        .await
+        .map_err(|e| PrCommenterError::Http {
+            provider: "github",
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            reason: format!("find PR: {e}"),
+        })?;
+
+    let status = resp.status();
+    if status.as_u16() == 403 || status.as_u16() == 401 {
+        return Err(PrCommenterError::Forbidden {
+            provider: "github",
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            status: status.as_u16(),
+        });
+    }
+    if !status.is_success() {
+        return Err(PrCommenterError::Http {
+            provider: "github",
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            reason: format!("find PR returned {status}"),
+        });
+    }
+
+    let pulls: Vec<GhPull> = resp.json().await.map_err(|e| PrCommenterError::Http {
+        provider: "github",
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        reason: format!("parse PRs: {e}"),
+    })?;
+
+    pulls
+        .into_iter()
+        .next()
+        .map(|p| OpenPullRequestRef { number: p.number })
+        .ok_or_else(|| PrCommenterError::NoOpenPullRequest {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            branch: branch.to_string(),
+        })
+}
+
+// ===== GitLab =====
+
+#[derive(Deserialize)]
+struct GlMr {
+    iid: i64,
+}
+
+#[derive(Deserialize)]
+struct GlNote {
+    id: i64,
+    #[serde(default)]
+    body: String,
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn gitlab_upsert(
+    http: &reqwest::Client,
+    api_base: &str,
+    token: &str,
+    owner: &str,
+    repo: &str,
+    branch: &str,
+    marker: &str,
+    body: &str,
+) -> Result<(), PrCommenterError> {
+    let api_base = api_base.trim_end_matches('/');
+    let project_path = format!("{owner}/{repo}");
+    let project_id_encoded = urlencoding::encode(&project_path).into_owned();
+
+    let mr = gitlab_find_open_mr(
+        http,
+        api_base,
+        token,
+        &project_id_encoded,
+        owner,
+        repo,
+        branch,
+    )
+    .await?;
+
+    let notes_url = format!(
+        "{api_base}/api/v4/projects/{project_id_encoded}/merge_requests/{}/notes?per_page=100",
+        mr.iid
+    );
+    // GitLab accepts both PRIVATE-TOKEN (PAT) and Bearer (OAuth). We don't
+    // know which kind of token the connection holds without inspecting the
+    // provider's auth_method, so we set PRIVATE-TOKEN unconditionally — it
+    // works for PATs and is ignored when Authorization is also valid for
+    // OAuth tokens used via the same header is also accepted. To keep the
+    // OAuth case working we ALSO try the Authorization: Bearer header.
+    let resp = http
+        .get(&notes_url)
+        .header("PRIVATE-TOKEN", token)
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .map_err(|e| PrCommenterError::Http {
+            provider: "gitlab",
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            reason: format!("list notes: {e}"),
+        })?;
+
+    let status = resp.status();
+    if status.as_u16() == 403 || status.as_u16() == 401 {
+        return Err(PrCommenterError::Forbidden {
+            provider: "gitlab",
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            status: status.as_u16(),
+        });
+    }
+    if !status.is_success() {
+        return Err(PrCommenterError::Http {
+            provider: "gitlab",
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            reason: format!("list notes returned {status}"),
+        });
+    }
+
+    let notes: Vec<GlNote> = resp.json().await.map_err(|e| PrCommenterError::Http {
+        provider: "gitlab",
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        reason: format!("parse notes: {e}"),
+    })?;
+
+    let existing = notes.iter().find(|n| n.body.contains(marker));
+    let payload = serde_json::json!({ "body": body });
+
+    let result = if let Some(existing) = existing {
+        let url = format!(
+            "{api_base}/api/v4/projects/{project_id_encoded}/merge_requests/{}/notes/{}",
+            mr.iid, existing.id
+        );
+        http.put(&url)
+            .header("PRIVATE-TOKEN", token)
+            .header("Authorization", format!("Bearer {token}"))
+            .json(&payload)
+            .send()
+            .await
+    } else {
+        let url = format!(
+            "{api_base}/api/v4/projects/{project_id_encoded}/merge_requests/{}/notes",
+            mr.iid
+        );
+        http.post(&url)
+            .header("PRIVATE-TOKEN", token)
+            .header("Authorization", format!("Bearer {token}"))
+            .json(&payload)
+            .send()
+            .await
+    };
+
+    let resp = result.map_err(|e| PrCommenterError::Http {
+        provider: "gitlab",
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        reason: format!("upsert: {e}"),
+    })?;
+
+    let status = resp.status();
+    if status.as_u16() == 403 || status.as_u16() == 401 {
+        return Err(PrCommenterError::Forbidden {
+            provider: "gitlab",
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            status: status.as_u16(),
+        });
+    }
+    if !status.is_success() {
+        return Err(PrCommenterError::Http {
+            provider: "gitlab",
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            reason: format!("upsert returned {status}"),
+        });
+    }
+    Ok(())
+}
+
+async fn gitlab_find_open_mr(
+    http: &reqwest::Client,
+    api_base: &str,
+    token: &str,
+    project_id_encoded: &str,
+    owner: &str,
+    repo: &str,
+    branch: &str,
+) -> Result<GlMr, PrCommenterError> {
+    let url = format!(
+        "{api_base}/api/v4/projects/{project_id_encoded}/merge_requests?state=opened&source_branch={}&per_page=1",
+        urlencoding::encode(branch)
+    );
+
+    let resp = http
+        .get(&url)
+        .header("PRIVATE-TOKEN", token)
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .map_err(|e| PrCommenterError::Http {
+            provider: "gitlab",
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            reason: format!("find MR: {e}"),
+        })?;
+
+    let status = resp.status();
+    if status.as_u16() == 403 || status.as_u16() == 401 {
+        return Err(PrCommenterError::Forbidden {
+            provider: "gitlab",
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            status: status.as_u16(),
+        });
+    }
+    if !status.is_success() {
+        return Err(PrCommenterError::Http {
+            provider: "gitlab",
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            reason: format!("find MR returned {status}"),
+        });
+    }
+
+    let mrs: Vec<GlMr> = resp.json().await.map_err(|e| PrCommenterError::Http {
+        provider: "gitlab",
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        reason: format!("parse MRs: {e}"),
+    })?;
+
+    mrs.into_iter()
+        .next()
+        .ok_or_else(|| PrCommenterError::NoOpenPullRequest {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            branch: branch.to_string(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::Server;
+
+    fn ctx(phase: CommentPhase) -> PreviewCommentContext {
+        PreviewCommentContext {
+            project_id: 42,
+            environment_id: 7,
+            branch: "feature/x".to_string(),
+            phase,
+        }
+    }
+
+    #[test]
+    fn render_started_includes_marker_and_sha() {
+        let body = render_body(
+            42,
+            7,
+            &CommentPhase::Started {
+                commit_short_sha: "abc1234".to_string(),
+            },
+        );
+        assert!(body.contains("<!-- temps-preview:project=42:env=7 -->"));
+        assert!(body.contains("abc1234"));
+        assert!(body.contains("Deploying preview"));
+    }
+
+    #[test]
+    fn render_ready_includes_env_url() {
+        let body = render_body(
+            42,
+            7,
+            &CommentPhase::Ready {
+                commit_short_sha: "abc1234".to_string(),
+                env_url: "https://feature-x.preview.temps.app".to_string(),
+                deployment_url: Some("https://dashboard.temps.app/d/1".to_string()),
+            },
+        );
+        assert!(body.contains("https://feature-x.preview.temps.app"));
+        assert!(body.contains("Preview ready"));
+        assert!(body.contains("dashboard.temps.app"));
+    }
+
+    #[test]
+    fn render_failed_works_without_log_url() {
+        let body = render_body(
+            42,
+            7,
+            &CommentPhase::Failed {
+                commit_short_sha: "abc1234".to_string(),
+                deployment_url: None,
+            },
+        );
+        assert!(body.contains("Preview build failed"));
+        assert!(!body.contains("View deployment logs"));
+    }
+
+    #[test]
+    fn marker_is_scoped_per_env() {
+        assert_ne!(marker(42, 7), marker(42, 8));
+        assert_ne!(marker(42, 7), marker(43, 7));
+    }
+
+    #[tokio::test]
+    async fn github_upsert_creates_new_comment_when_marker_absent() {
+        let mut server = Server::new_async().await;
+
+        let find_pr = server
+            .mock("GET", "/repos/octo/hello/pulls")
+            .match_query(mockito::Matcher::AllOf(vec![mockito::Matcher::UrlEncoded(
+                "state".into(),
+                "open".into(),
+            )]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"[{"number": 99}]"#)
+            .create_async()
+            .await;
+
+        let list_comments = server
+            .mock("GET", "/repos/octo/hello/issues/99/comments")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"[{"id": 1, "body": "unrelated comment"}]"#)
+            .create_async()
+            .await;
+
+        let post_comment = server
+            .mock("POST", "/repos/octo/hello/issues/99/comments")
+            .with_status(201)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"id": 555}"#)
+            .create_async()
+            .await;
+
+        let http = reqwest::Client::new();
+        let res = github_upsert(
+            &http,
+            &server.url(),
+            "tok",
+            "octo",
+            "hello",
+            "feature/x",
+            "<!-- temps-preview:project=42:env=7 -->",
+            "hello world",
+        )
+        .await;
+
+        assert!(res.is_ok(), "expected ok, got {:?}", res);
+        find_pr.assert_async().await;
+        list_comments.assert_async().await;
+        post_comment.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn github_upsert_edits_existing_comment_when_marker_present() {
+        let mut server = Server::new_async().await;
+
+        server
+            .mock("GET", "/repos/octo/hello/pulls")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(r#"[{"number": 99}]"#)
+            .create_async()
+            .await;
+
+        server
+            .mock("GET", "/repos/octo/hello/issues/99/comments")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(
+                r#"[{"id": 42, "body": "old content\n<!-- temps-preview:project=42:env=7 -->"}]"#,
+            )
+            .create_async()
+            .await;
+
+        let patch = server
+            .mock("PATCH", "/repos/octo/hello/issues/comments/42")
+            .with_status(200)
+            .with_body(r#"{"id": 42}"#)
+            .create_async()
+            .await;
+
+        let http = reqwest::Client::new();
+        let res = github_upsert(
+            &http,
+            &server.url(),
+            "tok",
+            "octo",
+            "hello",
+            "feature/x",
+            "<!-- temps-preview:project=42:env=7 -->",
+            "updated body",
+        )
+        .await;
+
+        assert!(res.is_ok(), "expected ok, got {:?}", res);
+        patch.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn github_returns_no_open_pull_request_when_list_empty() {
+        let mut server = Server::new_async().await;
+
+        server
+            .mock("GET", "/repos/octo/hello/pulls")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body("[]")
+            .create_async()
+            .await;
+
+        let http = reqwest::Client::new();
+        let res = github_upsert(
+            &http,
+            &server.url(),
+            "tok",
+            "octo",
+            "hello",
+            "feature/x",
+            "<!-- temps-preview:project=42:env=7 -->",
+            "body",
+        )
+        .await;
+
+        assert!(matches!(
+            res,
+            Err(PrCommenterError::NoOpenPullRequest { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn github_returns_forbidden_on_403() {
+        let mut server = Server::new_async().await;
+
+        server
+            .mock("GET", "/repos/octo/hello/pulls")
+            .match_query(mockito::Matcher::Any)
+            .with_status(403)
+            .with_body(r#"{"message":"Resource not accessible by integration"}"#)
+            .create_async()
+            .await;
+
+        let http = reqwest::Client::new();
+        let res = github_upsert(
+            &http,
+            &server.url(),
+            "tok",
+            "octo",
+            "hello",
+            "feature/x",
+            "<!-- temps-preview:project=42:env=7 -->",
+            "body",
+        )
+        .await;
+
+        assert!(matches!(
+            res,
+            Err(PrCommenterError::Forbidden { status: 403, .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn gitlab_upsert_creates_new_note_when_marker_absent() {
+        let mut server = Server::new_async().await;
+
+        let find_mr = server
+            .mock("GET", "/api/v4/projects/octo%2Fhello/merge_requests")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(r#"[{"iid": 12}]"#)
+            .create_async()
+            .await;
+
+        let list_notes = server
+            .mock(
+                "GET",
+                "/api/v4/projects/octo%2Fhello/merge_requests/12/notes",
+            )
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(r#"[{"id": 1, "body": "unrelated"}]"#)
+            .create_async()
+            .await;
+
+        let post_note = server
+            .mock(
+                "POST",
+                "/api/v4/projects/octo%2Fhello/merge_requests/12/notes",
+            )
+            .with_status(201)
+            .with_body(r#"{"id": 9}"#)
+            .create_async()
+            .await;
+
+        let http = reqwest::Client::new();
+        let res = gitlab_upsert(
+            &http,
+            &server.url(),
+            "tok",
+            "octo",
+            "hello",
+            "feature/x",
+            "<!-- temps-preview:project=42:env=7 -->",
+            "body",
+        )
+        .await;
+
+        assert!(res.is_ok(), "expected ok, got {:?}", res);
+        find_mr.assert_async().await;
+        list_notes.assert_async().await;
+        post_note.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn gitlab_upsert_edits_existing_note_when_marker_present() {
+        let mut server = Server::new_async().await;
+
+        server
+            .mock("GET", "/api/v4/projects/octo%2Fhello/merge_requests")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(r#"[{"iid": 12}]"#)
+            .create_async()
+            .await;
+
+        server
+            .mock(
+                "GET",
+                "/api/v4/projects/octo%2Fhello/merge_requests/12/notes",
+            )
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(r#"[{"id": 77, "body": "old\n<!-- temps-preview:project=42:env=7 -->"}]"#)
+            .create_async()
+            .await;
+
+        let put = server
+            .mock(
+                "PUT",
+                "/api/v4/projects/octo%2Fhello/merge_requests/12/notes/77",
+            )
+            .with_status(200)
+            .with_body(r#"{"id": 77}"#)
+            .create_async()
+            .await;
+
+        let http = reqwest::Client::new();
+        let res = gitlab_upsert(
+            &http,
+            &server.url(),
+            "tok",
+            "octo",
+            "hello",
+            "feature/x",
+            "<!-- temps-preview:project=42:env=7 -->",
+            "body",
+        )
+        .await;
+
+        assert!(res.is_ok(), "expected ok, got {:?}", res);
+        put.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn gitlab_returns_no_open_mr_when_list_empty() {
+        let mut server = Server::new_async().await;
+
+        server
+            .mock("GET", "/api/v4/projects/octo%2Fhello/merge_requests")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body("[]")
+            .create_async()
+            .await;
+
+        let http = reqwest::Client::new();
+        let res = gitlab_upsert(
+            &http,
+            &server.url(),
+            "tok",
+            "octo",
+            "hello",
+            "feature/x",
+            "<!-- temps-preview:project=42:env=7 -->",
+            "body",
+        )
+        .await;
+
+        assert!(matches!(
+            res,
+            Err(PrCommenterError::NoOpenPullRequest { .. })
+        ));
+    }
+
+    /// Trivial smoke test that the context struct round-trips through the
+    /// trait method dispatch in graceful-degradation mode.
+    struct NoopCommenter;
+    #[async_trait]
+    impl PrCommenter for NoopCommenter {
+        async fn upsert_preview_comment(
+            &self,
+            _ctx: PreviewCommentContext,
+        ) -> Result<(), PrCommenterError> {
+            Ok(())
+        }
+    }
+    #[tokio::test]
+    async fn noop_commenter_succeeds() {
+        let c = NoopCommenter;
+        let res = c
+            .upsert_preview_comment(ctx(CommentPhase::Started {
+                commit_short_sha: "abc1234".into(),
+            }))
+            .await;
+        assert!(res.is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

When a deployment for a branch with an open PR/MR moves through created → succeeded/failed, post or update a single sticky comment that reflects the latest state. The comment is keyed by a hidden HTML marker so subsequent updates edit in place rather than spam the PR with new comments.

- **New `PrCommenter` trait + `GitPrCommenter` impl** that dispatches by provider type (GitHub via REST `/repos/.../pulls` + issue comments, GitLab via REST `/merge_requests` + notes). Sticky marker is per `(project, environment)` so multiple Temps envs targeting the same PR each get their own comment.
- **New `PrCommentListener`** background task: subscribes to `Job::DeploymentCreated` / `DeploymentSucceeded` / `DeploymentFailed` and calls the commenter with the right phase. Self-contained — uses events the deployments crate already emits, so **no wiring changes are needed in temps-deployments**.
- **Graceful degradation**: missing git connection, no open PR, unsupported provider, or 403/401 from the provider (e.g. existing GitHub Apps without `pull_requests:write`) all log at warn/debug and return `Ok`. Deployments are never blocked by commenting failures.

## What the comment looks like

> ## 🚧 Deploying preview
>
> Building commit \`abc1234\`…

→ on success the same comment becomes:

> ## ✅ Preview ready
>
> **Commit:** \`abc1234\`
>
> 🔗 **[Open preview](https://feature-x.preview.temps.app)**

→ on failure:

> ## ❌ Preview build failed
>
> **Commit:** \`abc1234\`

## Scope deliberately kept small

- No new tables, no migrations, no schema changes.
- No new \`Job\` variants — reuses existing \`DeploymentCreated/Succeeded/Failed\` broadcasts.
- No per-PR environments. Preview env is whatever environment the deployment already targets.

## Known limitations / follow-ups

1. **Existing GitHub Apps may lack \`pull_requests:write\`.** The current manifest in \`GitProviderFlow.tsx\` already requests it for new installs. Old installations hit 403 and are logged at warn level — those users would need to upgrade their app's permissions to get comments. UI nudge for that can be a follow-up.
2. **Fork PRs not commented.** GitHub's \`head=owner:branch\` filter only matches same-repo PRs. Temps doesn't deploy fork PRs today so this matches existing behavior.
3. **No teardown comment on PR close/merge.** The sticky comment stays even after the env URL stops responding. Vercel behaves the same; can be added later if needed.

## Test plan

- [x] \`cargo check --lib\` clean across the workspace (714 crates, 0 errors)
- [x] \`cargo test --lib -p temps-git\` — 120/120 passing (15 new tests for the PR commenter)
- [x] \`cargo clippy --lib -p temps-git --no-deps\` — 0 errors
- [x] Unit tests cover: render-body for each phase, marker scoping, GitHub create/edit/no-PR/403 paths, GitLab create/edit/no-MR paths
- [x] Manual smoke test: open a PR in a connected repo, push to it, watch comment appear and update through phases

## Related

Companion fix for the branch-delete bug (#1239) lives on a separate branch (\`security/0.1.0-hardening\`) and isn't bundled here.