### PR TITLE
feat(analytics): add `temps backfill clickhouse` standalone migration subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
--
+- **`temps backfill clickhouse` subcommand** — standalone, one-shot data migration tool for moving historical events from the PostgreSQL/TimescaleDB `events` hypertable into ClickHouse. Runs out-of-process from `temps serve`, so it never contends with the live fan-out worker's outbox locks and does not double the PG write load on the primary during migration. Reuses the live fan-out's `ChEventRow` shape and `row_to_ch` mapper as the single source of truth — backfilled rows are byte-identical to live-ingested rows, and re-runs are safe via ClickHouse's `ReplacingMergeTree(_version)` dedupe on `event_id`. Flags: `--from` / `--to` RFC3339 window (defaults to MIN/MAX timestamp), `--project-id` filter, `--batch-size` (default 10k), `--chunk-days` (default 1), `--rate-limit-events-per-sec` throttle for live-server backfills, `--apply-migrations` to create CH schema, `--dry-run` to preview the chunk plan, and `--resume` with checkpoint at `$TEMPS_DATA_DIR/clickhouse-backfill.state`. Progress bar via indicatif.
 
 ### Changed
 -

--- a/crates/temps-analytics-events/src/services/ch_backfill.rs
+++ b/crates/temps-analytics-events/src/services/ch_backfill.rs
@@ -1,0 +1,290 @@
+//! One-shot ClickHouse backfill helper.
+//!
+//! Reuses the exact `ChEventRow` shape and `row_to_ch` mapper from the
+//! live fan-out worker, but reads events directly from PostgreSQL by a
+//! `[from, to]` timestamp window rather than draining the outbox. Intended
+//! for the standalone `temps backfill clickhouse` subcommand:
+//!
+//! - Runs out-of-process from `temps serve`, so it never contends with
+//!   live writes for outbox row locks.
+//! - Does not enqueue into `events_ch_outbox`, so it does not double the
+//!   PG write load on the primary while it works.
+//! - Safe to re-run: ClickHouse's `ReplacingMergeTree(_version)` over
+//!   `event_id` collapses duplicates. At-least-once is fine.
+//!
+//! See ADR-012 for why CH is bring-your-own and why this is a tooling
+//! concern, not part of the live ingest path.
+//!
+//! Migration entry point: [`apply_clickhouse_schema`] re-exports the
+//! `temps-analytics-backend` migrations runner so the CLI can do
+//! `temps backfill clickhouse --apply-migrations` without taking another
+//! dependency.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use sea_orm::{
+    ColumnTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder,
+    QuerySelect,
+};
+use tracing::{debug, info};
+
+use super::ch_fanout::{row_to_ch, ChEventRow};
+use temps_core::DBDateTime;
+use temps_entities::{events, ip_geolocations};
+
+/// Errors surfaced by the backfill helper. Mirrors `ChFanoutError` but is a
+/// distinct type because the surface is much narrower (no orphans, no
+/// outbox, no dead-letters).
+#[derive(Debug, thiserror::Error)]
+pub enum ChBackfillError {
+    #[error("Database error during backfill: {0}")]
+    Database(#[from] sea_orm::DbErr),
+
+    #[error("ClickHouse insert failed for batch starting at event_id {first_event_id}: {reason}")]
+    ClickHouseInsert { first_event_id: i64, reason: String },
+}
+
+/// Cursor for keyset pagination. Iterate by `(timestamp, id)` so we
+/// keep a stable order even when many events share the exact same
+/// timestamp (common at high QPS). The fan-out worker doesn't need this
+/// because it dequeues by outbox row id; we read from `events` directly,
+/// so we need our own deterministic cursor.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BackfillCursor {
+    pub last_timestamp: Option<DBDateTime>,
+    pub last_id: Option<i64>,
+}
+
+/// Result of a single window backfill.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BackfillReport {
+    pub events_pushed: u64,
+    pub batches: u64,
+    pub final_cursor: BackfillCursor,
+}
+
+/// Backfill every event in `[from, to]` (timestamp inclusive on both ends)
+/// for the given `project_id` filter (or all projects when `None`) into
+/// ClickHouse.
+///
+/// Reads in batches of `batch_size` ordered by `(timestamp, id)` ascending,
+/// resolves `ip_geolocations` once per batch (same as the fan-out worker),
+/// and pushes via the typed `clickhouse::Client::insert::<ChEventRow>("events")`
+/// path so the row shape stays in lockstep with the live ingest.
+///
+/// `start_cursor` lets the caller resume from a previous run — pass
+/// `BackfillCursor::default()` for a fresh start. Each completed batch
+/// updates the cursor; the caller is responsible for persisting it
+/// between process restarts if `--resume` is desired.
+///
+/// `rate_limit` (optional) sleeps `Duration` between batches so the
+/// backfill doesn't saturate PG read IO on a live server.
+///
+/// Returns the total number of events pushed and the final cursor.
+#[allow(clippy::too_many_arguments)]
+pub async fn backfill_events_window(
+    db: Arc<DatabaseConnection>,
+    ch: Arc<::clickhouse::Client>,
+    from: DBDateTime,
+    to: DBDateTime,
+    project_id: Option<i32>,
+    batch_size: u64,
+    start_cursor: BackfillCursor,
+    rate_limit: Option<Duration>,
+) -> Result<BackfillReport, ChBackfillError> {
+    info!(
+        from = %from,
+        to = %to,
+        project_id = ?project_id,
+        batch_size,
+        "ch_backfill starting window"
+    );
+
+    let mut cursor = start_cursor;
+    let mut total: u64 = 0;
+    let mut batches: u64 = 0;
+
+    loop {
+        let batch = fetch_next_batch(db.as_ref(), from, to, project_id, cursor, batch_size).await?;
+
+        if batch.is_empty() {
+            break;
+        }
+
+        let first_id = batch.first().map(|r| r.id).unwrap_or(0);
+        let last = batch.last().expect("non-empty checked above");
+        let next_cursor = BackfillCursor {
+            last_timestamp: Some(last.timestamp),
+            last_id: Some(last.id),
+        };
+
+        let geo_map = resolve_geo(db.as_ref(), &batch).await?;
+        push_batch(ch.as_ref(), &batch, &geo_map, first_id).await?;
+
+        let count = batch.len() as u64;
+        total += count;
+        batches += 1;
+        cursor = next_cursor;
+
+        debug!(
+            count,
+            total,
+            batches,
+            last_timestamp = %last.timestamp,
+            last_id = last.id,
+            "ch_backfill pushed batch"
+        );
+
+        if let Some(d) = rate_limit {
+            tokio::time::sleep(d).await;
+        }
+
+        if count < batch_size {
+            break;
+        }
+    }
+
+    info!(
+        events_pushed = total,
+        batches, "ch_backfill window complete"
+    );
+
+    Ok(BackfillReport {
+        events_pushed: total,
+        batches,
+        final_cursor: cursor,
+    })
+}
+
+/// Count the rows the backfill *would* push for the given window. Used by
+/// the CLI for the progress bar denominator and by `--dry-run`.
+pub async fn count_events_window(
+    db: &DatabaseConnection,
+    from: DBDateTime,
+    to: DBDateTime,
+    project_id: Option<i32>,
+) -> Result<u64, ChBackfillError> {
+    let mut q = events::Entity::find()
+        .filter(events::Column::Timestamp.gte(from))
+        .filter(events::Column::Timestamp.lte(to));
+    if let Some(pid) = project_id {
+        q = q.filter(events::Column::ProjectId.eq(pid));
+    }
+    let n = q.count(db).await?;
+    Ok(n)
+}
+
+/// Apply the embedded ClickHouse schema migrations (`events`,
+/// `events_5m_mv`, `sessions`). Idempotent; safe to invoke on every
+/// backfill run. Surfaced here so the CLI doesn't have to take a direct
+/// dependency on `temps-analytics-backend`.
+pub async fn apply_clickhouse_schema(
+    client: &::clickhouse::Client,
+) -> Result<temps_analytics_backend::migrations::MigrationReport, anyhow::Error> {
+    temps_analytics_backend::migrations::apply_migrations(client)
+        .await
+        .map_err(|e| anyhow::anyhow!("ClickHouse migrations failed: {}", e))
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+async fn fetch_next_batch(
+    db: &DatabaseConnection,
+    from: DBDateTime,
+    to: DBDateTime,
+    project_id: Option<i32>,
+    cursor: BackfillCursor,
+    batch_size: u64,
+) -> Result<Vec<events::Model>, ChBackfillError> {
+    use sea_orm::Condition;
+
+    let mut q = events::Entity::find()
+        .filter(events::Column::Timestamp.gte(from))
+        .filter(events::Column::Timestamp.lte(to));
+
+    if let Some(pid) = project_id {
+        q = q.filter(events::Column::ProjectId.eq(pid));
+    }
+
+    // Keyset condition: (timestamp, id) > (last_ts, last_id).
+    // Expressed as `(ts > last_ts) OR (ts = last_ts AND id > last_id)`
+    // so it can use the `(timestamp, id)` index.
+    if let (Some(ts), Some(id)) = (cursor.last_timestamp, cursor.last_id) {
+        let cond = Condition::any().add(events::Column::Timestamp.gt(ts)).add(
+            Condition::all()
+                .add(events::Column::Timestamp.eq(ts))
+                .add(events::Column::Id.gt(id)),
+        );
+        q = q.filter(cond);
+    }
+
+    let rows = q
+        .order_by_asc(events::Column::Timestamp)
+        .order_by_asc(events::Column::Id)
+        .limit(batch_size)
+        .all(db)
+        .await?;
+
+    Ok(rows)
+}
+
+async fn resolve_geo(
+    db: &DatabaseConnection,
+    rows: &[events::Model],
+) -> Result<HashMap<i32, ip_geolocations::Model>, ChBackfillError> {
+    let geo_ids: HashSet<i32> = rows.iter().filter_map(|r| r.ip_geolocation_id).collect();
+    if geo_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let geo_ids: Vec<i32> = geo_ids.into_iter().collect();
+    let map = ip_geolocations::Entity::find()
+        .filter(ip_geolocations::Column::Id.is_in(geo_ids))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|m| (m.id, m))
+        .collect();
+    Ok(map)
+}
+
+async fn push_batch(
+    ch: &::clickhouse::Client,
+    rows: &[events::Model],
+    geo_map: &HashMap<i32, ip_geolocations::Model>,
+    first_id: i64,
+) -> Result<(), ChBackfillError> {
+    let mut inserter =
+        ch.insert::<ChEventRow>("events")
+            .map_err(|e| ChBackfillError::ClickHouseInsert {
+                first_event_id: first_id,
+                reason: format!("inserter setup failed: {e}"),
+            })?;
+
+    for r in rows {
+        let geo = r.ip_geolocation_id.and_then(|id| geo_map.get(&id));
+        inserter.write(&row_to_ch(r, geo)).await.map_err(|e| {
+            ChBackfillError::ClickHouseInsert {
+                first_event_id: first_id,
+                reason: format!("write failed: {e}"),
+            }
+        })?;
+    }
+    inserter
+        .end()
+        .await
+        .map_err(|e| ChBackfillError::ClickHouseInsert {
+            first_event_id: first_id,
+            reason: format!("end failed: {e}"),
+        })?;
+
+    Ok(())
+}
+
+// Re-exports for the CLI so it can pretty-print and build the CH client
+// without taking a direct dependency on `temps-analytics-backend`.
+pub use temps_analytics_backend::clickhouse::{ClickHouseBackend, ClickHouseConfig};
+pub use temps_analytics_backend::migrations::MigrationReport;

--- a/crates/temps-analytics-events/src/services/ch_fanout.rs
+++ b/crates/temps-analytics-events/src/services/ch_fanout.rs
@@ -381,8 +381,12 @@ pub enum ChFanoutError {
 /// in `migrations/clickhouse/0001_events.sql` exactly. The `clickhouse`
 /// crate's `Row` derive does positional binary serialization, so this
 /// must stay in lockstep with the DDL.
+///
+/// Exposed at `pub(crate)` so the sibling `ch_backfill` module can reuse it
+/// without duplicating the field list. External callers go through
+/// [`crate::services::ch_backfill::backfill_events_window`] instead.
 #[derive(::clickhouse::Row, serde::Serialize)]
-struct ChEventRow {
+pub(crate) struct ChEventRow {
     event_id: i64,
     project_id: i32,
     environment_id: Option<i32>,
@@ -445,7 +449,7 @@ struct ChEventRow {
 /// is the matching `ip_geolocations` row (looked up by `m.ip_geolocation_id`)
 /// so country/region/city land on the CH row directly — no cross-database
 /// join at query time.
-fn row_to_ch(
+pub(crate) fn row_to_ch(
     m: &temps_entities::events::Model,
     geo: Option<&temps_entities::ip_geolocations::Model>,
 ) -> ChEventRow {

--- a/crates/temps-analytics-events/src/services/mod.rs
+++ b/crates/temps-analytics-events/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod ch_backfill;
 pub mod ch_fanout;
 pub mod clickhouse_backend;
 pub mod events_service;
@@ -5,6 +6,10 @@ pub mod queries;
 pub mod traits;
 pub mod user_agent;
 
+pub use ch_backfill::{
+    apply_clickhouse_schema, backfill_events_window, count_events_window, BackfillCursor,
+    BackfillReport, ChBackfillError, ClickHouseBackend, ClickHouseConfig, MigrationReport,
+};
 pub use ch_fanout::{ChFanoutConfig, ChFanoutError, ChFanoutWorker};
 pub use clickhouse_backend::ClickHouseEventsBackend;
 pub use events_service::*;

--- a/crates/temps-cli/src/commands/backfill.rs
+++ b/crates/temps-cli/src/commands/backfill.rs
@@ -1,0 +1,520 @@
+//! `temps backfill` — one-shot data migration utilities.
+//!
+//! Currently exposes a single subcommand:
+//!
+//! ```text
+//! temps backfill clickhouse [--from ...] [--to ...] [--project-id ...]
+//!                           [--batch-size N] [--chunk-days N]
+//!                           [--rate-limit-events-per-sec N]
+//!                           [--apply-migrations] [--dry-run] [--resume]
+//! ```
+//!
+//! It walks the PostgreSQL `events` hypertable in `(timestamp, id)` keyset
+//! order and pushes rows into ClickHouse using the same `ChEventRow` shape
+//! the live fan-out worker uses, so dashboards see byte-identical data
+//! regardless of whether the row landed via live ingest or backfill.
+//!
+//! This command does NOT enqueue into `events_ch_outbox`. The outbox is
+//! the live ingest's mailbox; using it for a bulk replay would double the
+//! PG write load on the primary right when the operator is trying to
+//! migrate off it. Re-runs are safe because ClickHouse's
+//! `ReplacingMergeTree(_version)` dedupes by `event_id`.
+
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use clap::{Args, Subcommand};
+use colored::Colorize;
+use indicatif::{ProgressBar, ProgressStyle};
+use serde::{Deserialize, Serialize};
+use temps_analytics_events::services::ch_backfill::{
+    apply_clickhouse_schema, backfill_events_window, count_events_window, BackfillCursor,
+    ClickHouseBackend, ClickHouseConfig,
+};
+use temps_core::DBDateTime;
+use tracing::{info, warn};
+
+#[derive(Args)]
+pub struct BackfillCommand {
+    #[command(subcommand)]
+    pub target: BackfillTarget,
+}
+
+#[derive(Subcommand)]
+pub enum BackfillTarget {
+    /// Backfill PostgreSQL `events` into a ClickHouse cluster.
+    ///
+    /// Same row shape, same dedupe semantics as the live fan-out worker.
+    /// Safe to run while `temps serve` is live — does not touch the
+    /// outbox and does not write back to the primary.
+    Clickhouse(ClickhouseBackfillArgs),
+}
+
+#[derive(Args, Clone)]
+pub struct ClickhouseBackfillArgs {
+    /// PostgreSQL connection URL (system of record).
+    #[arg(long, env = "TEMPS_DATABASE_URL")]
+    pub database_url: String,
+
+    /// ClickHouse HTTP endpoint URL (e.g. https://ch.example.internal:8443).
+    #[arg(long, env = "TEMPS_CLICKHOUSE_URL")]
+    pub clickhouse_url: String,
+
+    /// ClickHouse database name (Temps will create tables in it).
+    #[arg(long, env = "TEMPS_CLICKHOUSE_DATABASE")]
+    pub clickhouse_database: String,
+
+    /// ClickHouse username.
+    #[arg(long, env = "TEMPS_CLICKHOUSE_USER")]
+    pub clickhouse_user: String,
+
+    /// ClickHouse password.
+    #[arg(long, env = "TEMPS_CLICKHOUSE_PASSWORD", hide_env_values = true)]
+    pub clickhouse_password: String,
+
+    /// Lower bound of the backfill window (RFC3339, inclusive). Defaults
+    /// to the earliest event in PostgreSQL.
+    #[arg(long)]
+    pub from: Option<String>,
+
+    /// Upper bound of the backfill window (RFC3339, inclusive). Defaults
+    /// to the latest event in PostgreSQL.
+    #[arg(long)]
+    pub to: Option<String>,
+
+    /// Restrict to a single project.
+    #[arg(long)]
+    pub project_id: Option<i32>,
+
+    /// Rows per ClickHouse insert. CH prefers large batches. Default 10k.
+    #[arg(long, default_value_t = 10_000)]
+    pub batch_size: u64,
+
+    /// Slice the `[from, to]` window into chunks this many days wide. The
+    /// progress bar updates per-chunk and the resume checkpoint advances
+    /// per-chunk, so smaller chunks mean finer-grained resume but slightly
+    /// more per-chunk overhead. Default 1.
+    #[arg(long, default_value_t = 1u32)]
+    pub chunk_days: u32,
+
+    /// Optional throttle: sleep enough between batches to stay under this
+    /// throughput. Useful on live production servers where PG read IO is
+    /// constrained. Default: no throttle.
+    #[arg(long)]
+    pub rate_limit_events_per_sec: Option<u64>,
+
+    /// Apply ClickHouse schema migrations (`events`, `events_5m_mv`,
+    /// `sessions`) before backfilling. Idempotent; safe to pass on every
+    /// run. If you let `temps serve` enable ClickHouse first, those
+    /// migrations have already run and this flag is a no-op.
+    #[arg(long)]
+    pub apply_migrations: bool,
+
+    /// Count events that would be pushed and print the chunk plan; do
+    /// not write to ClickHouse.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Persist a checkpoint to `<state-file>` after every batch and
+    /// resume from it on the next invocation with the same window.
+    #[arg(long)]
+    pub resume: bool,
+
+    /// Where to persist the resume checkpoint. Defaults to
+    /// `$TEMPS_DATA_DIR/clickhouse-backfill.state` (or
+    /// `~/.temps/clickhouse-backfill.state` when unset).
+    #[arg(long)]
+    pub state_file: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct CheckpointFile {
+    /// RFC3339 timestamp of the last fully-pushed event.
+    last_timestamp: Option<String>,
+    /// id of the last fully-pushed event.
+    last_id: Option<i64>,
+    /// Sanity check — refuse to resume against a window the user changed.
+    window_from: Option<String>,
+    window_to: Option<String>,
+    project_id: Option<i32>,
+}
+
+impl BackfillCommand {
+    pub fn execute(self) -> anyhow::Result<()> {
+        match self.target {
+            BackfillTarget::Clickhouse(args) => run_clickhouse(args),
+        }
+    }
+}
+
+fn run_clickhouse(args: ClickhouseBackfillArgs) -> anyhow::Result<()> {
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(run_clickhouse_async(args))
+}
+
+async fn run_clickhouse_async(args: ClickhouseBackfillArgs) -> anyhow::Result<()> {
+    println!();
+    println!(
+        "{}",
+        "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━".bright_blue()
+    );
+    println!(
+        "{}",
+        "   ClickHouse analytics backfill".bright_white().bold()
+    );
+    println!(
+        "{}",
+        "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━".bright_blue()
+    );
+    println!();
+
+    let db = temps_database::establish_connection(&args.database_url).await?;
+    info!("Connected to PostgreSQL");
+
+    let ch_cfg = ClickHouseConfig::new(
+        &args.clickhouse_url,
+        &args.clickhouse_database,
+        &args.clickhouse_user,
+        &args.clickhouse_password,
+    );
+    let backend = ClickHouseBackend::new(ch_cfg);
+    let ch = Arc::new(backend.client_clone());
+
+    if args.apply_migrations {
+        println!(
+            "{} Applying ClickHouse schema migrations…",
+            "→".bright_blue()
+        );
+        let report = apply_clickhouse_schema(&ch).await?;
+        println!(
+            "{} Migrations: {} applied, {} skipped",
+            "✓".bright_green(),
+            report.applied.len(),
+            report.skipped.len()
+        );
+        for name in &report.applied {
+            println!("    + {}", name.bright_cyan());
+        }
+    }
+
+    // 1. Resolve the [from, to] window.
+    let (from, to) = resolve_window(db.as_ref(), &args).await?;
+    println!(
+        "{} Window: {} → {}",
+        "→".bright_blue(),
+        from.to_rfc3339().bright_cyan(),
+        to.to_rfc3339().bright_cyan(),
+    );
+    if let Some(pid) = args.project_id {
+        println!("{} Project filter: {}", "→".bright_blue(), pid);
+    }
+
+    // 2. Count + chunk plan.
+    let total = count_events_window(db.as_ref(), from, to, args.project_id).await?;
+    println!(
+        "{} Events to push: {}",
+        "→".bright_blue(),
+        total.to_string().bright_white().bold(),
+    );
+
+    if total == 0 {
+        println!("{} Nothing to backfill in this window.", "✓".bright_green());
+        return Ok(());
+    }
+
+    let chunks = split_window(from, to, args.chunk_days);
+    println!(
+        "{} Chunks: {} × ~{}d",
+        "→".bright_blue(),
+        chunks.len(),
+        args.chunk_days,
+    );
+
+    if args.dry_run {
+        println!();
+        println!(
+            "{} {}",
+            "✓".bright_green(),
+            "Dry run — no rows pushed.".bright_white()
+        );
+        for (i, (cf, ct)) in chunks.iter().enumerate() {
+            println!(
+                "    chunk {:>3}/{}  {} → {}",
+                i + 1,
+                chunks.len(),
+                cf.to_rfc3339(),
+                ct.to_rfc3339()
+            );
+        }
+        return Ok(());
+    }
+
+    // 3. Load resume cursor if requested.
+    let state_path = args.state_file.clone().unwrap_or_else(default_state_path);
+    let (mut cursor, mut already_pushed) =
+        load_checkpoint_or_default(&args, &state_path, from, to)?;
+    if already_pushed > 0 {
+        println!(
+            "{} Resuming from checkpoint — {} events already pushed",
+            "→".bright_blue(),
+            already_pushed
+        );
+    }
+
+    let rate_limit = args.rate_limit_events_per_sec.map(|qps| {
+        // Per-batch sleep that targets qps throughput.
+        // sleep = batch_size / qps  (seconds)
+        let secs = args.batch_size as f64 / qps.max(1) as f64;
+        Duration::from_millis((secs * 1000.0) as u64)
+    });
+
+    // 4. Progress bar.
+    let pb = ProgressBar::new(total);
+    pb.set_style(
+        ProgressStyle::with_template(
+            "  {bar:40.cyan/blue} {pos:>10}/{len:<10} {percent:>3}%  ETA {eta_precise}  {msg}",
+        )
+        .expect("valid progress template")
+        .progress_chars("█▓░"),
+    );
+    pb.set_position(already_pushed);
+
+    // 5. Walk chunks. Each chunk is independently resumable through the
+    //    keyset cursor — if we crash mid-chunk, we resume in the same
+    //    chunk from `(last_timestamp, last_id)` exclusive.
+    for (i, (cf, ct)) in chunks.iter().copied().enumerate() {
+        pb.set_message(format!(
+            "chunk {}/{} ({}…{})",
+            i + 1,
+            chunks.len(),
+            cf.format("%Y-%m-%d"),
+            ct.format("%Y-%m-%d"),
+        ));
+
+        // Skip chunks entirely behind the cursor — happens on resume.
+        if let Some(last_ts) = cursor.last_timestamp {
+            if ct < last_ts {
+                continue;
+            }
+        }
+
+        let chunk_start = if cursor.last_timestamp.map(|ts| ts > cf).unwrap_or(false) {
+            cursor.last_timestamp.unwrap()
+        } else {
+            cf
+        };
+
+        let report = backfill_events_window(
+            db.clone(),
+            ch.clone(),
+            chunk_start,
+            ct,
+            args.project_id,
+            args.batch_size,
+            cursor,
+            rate_limit,
+        )
+        .await?;
+
+        cursor = report.final_cursor;
+        already_pushed += report.events_pushed;
+        pb.set_position(already_pushed);
+
+        if args.resume {
+            persist_checkpoint(&state_path, &args, from, to, cursor)?;
+        }
+    }
+
+    pb.finish_with_message("done");
+
+    println!();
+    println!(
+        "{} Backfill complete: {} events pushed",
+        "✓".bright_green(),
+        already_pushed.to_string().bright_white().bold(),
+    );
+    println!(
+        "    ClickHouse: {}/{}",
+        args.clickhouse_url.bright_cyan(),
+        args.clickhouse_database.bright_cyan()
+    );
+
+    if args.resume {
+        // Successful end-to-end run — clear the checkpoint so the next
+        // invocation against a new window doesn't get confused.
+        let _ = fs::remove_file(&state_path);
+    }
+
+    Ok(())
+}
+
+async fn resolve_window(
+    db: &sea_orm::DatabaseConnection,
+    args: &ClickhouseBackfillArgs,
+) -> anyhow::Result<(DBDateTime, DBDateTime)> {
+    use chrono::DateTime;
+
+    let from = match &args.from {
+        Some(s) => DateTime::parse_from_rfc3339(s)
+            .map_err(|e| anyhow::anyhow!("--from is not a valid RFC3339 timestamp: {e}"))?
+            .with_timezone(&chrono::Utc),
+        None => earliest_event_timestamp(db).await?,
+    };
+    let to = match &args.to {
+        Some(s) => DateTime::parse_from_rfc3339(s)
+            .map_err(|e| anyhow::anyhow!("--to is not a valid RFC3339 timestamp: {e}"))?
+            .with_timezone(&chrono::Utc),
+        None => latest_event_timestamp(db).await?,
+    };
+    if from > to {
+        anyhow::bail!(
+            "--from ({}) is after --to ({}); refusing to backfill an empty window",
+            from.to_rfc3339(),
+            to.to_rfc3339()
+        );
+    }
+    Ok((from, to))
+}
+
+async fn earliest_event_timestamp(db: &sea_orm::DatabaseConnection) -> anyhow::Result<DBDateTime> {
+    use sea_orm::{DatabaseBackend, FromQueryResult, Statement};
+
+    #[derive(FromQueryResult)]
+    struct Row {
+        ts: Option<DBDateTime>,
+    }
+
+    let row = Row::find_by_statement(Statement::from_sql_and_values(
+        DatabaseBackend::Postgres,
+        "SELECT MIN(timestamp) AS ts FROM events",
+        vec![],
+    ))
+    .one(db)
+    .await?;
+    row.and_then(|r| r.ts)
+        .ok_or_else(|| anyhow::anyhow!("`events` table is empty — nothing to backfill"))
+}
+
+async fn latest_event_timestamp(db: &sea_orm::DatabaseConnection) -> anyhow::Result<DBDateTime> {
+    use sea_orm::{DatabaseBackend, FromQueryResult, Statement};
+
+    #[derive(FromQueryResult)]
+    struct Row {
+        ts: Option<DBDateTime>,
+    }
+
+    let row = Row::find_by_statement(Statement::from_sql_and_values(
+        DatabaseBackend::Postgres,
+        "SELECT MAX(timestamp) AS ts FROM events",
+        vec![],
+    ))
+    .one(db)
+    .await?;
+    row.and_then(|r| r.ts)
+        .ok_or_else(|| anyhow::anyhow!("`events` table is empty — nothing to backfill"))
+}
+
+fn split_window(
+    from: DBDateTime,
+    to: DBDateTime,
+    chunk_days: u32,
+) -> Vec<(DBDateTime, DBDateTime)> {
+    let chunk = chrono::Duration::days(chunk_days.max(1) as i64);
+    let mut out = Vec::new();
+    let mut cursor = from;
+    while cursor < to {
+        let end = std::cmp::min(cursor + chunk, to);
+        out.push((cursor, end));
+        cursor = end + chrono::Duration::milliseconds(1);
+    }
+    if out.is_empty() {
+        out.push((from, to));
+    }
+    out
+}
+
+fn default_state_path() -> PathBuf {
+    let dir = std::env::var("TEMPS_DATA_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            dirs::home_dir()
+                .map(|h| h.join(".temps"))
+                .unwrap_or_else(|| PathBuf::from(".temps"))
+        });
+    dir.join("clickhouse-backfill.state")
+}
+
+fn load_checkpoint_or_default(
+    args: &ClickhouseBackfillArgs,
+    path: &PathBuf,
+    window_from: DBDateTime,
+    window_to: DBDateTime,
+) -> anyhow::Result<(BackfillCursor, u64)> {
+    if !args.resume {
+        return Ok((BackfillCursor::default(), 0));
+    }
+    if !path.exists() {
+        return Ok((BackfillCursor::default(), 0));
+    }
+
+    let raw = fs::read_to_string(path)?;
+    let file: CheckpointFile = match serde_json::from_str(&raw) {
+        Ok(f) => f,
+        Err(e) => {
+            warn!(error = %e, path = %path.display(), "checkpoint file unreadable; starting fresh");
+            return Ok((BackfillCursor::default(), 0));
+        }
+    };
+
+    // Refuse to resume against a different window — that almost always
+    // means the operator changed --from/--to/--project-id between runs.
+    let same_window = file.window_from.as_deref() == Some(window_from.to_rfc3339().as_str())
+        && file.window_to.as_deref() == Some(window_to.to_rfc3339().as_str())
+        && file.project_id == args.project_id;
+    if !same_window {
+        warn!(
+            "checkpoint window mismatch; ignoring checkpoint and starting fresh \
+             (delete {} to silence this warning)",
+            path.display()
+        );
+        return Ok((BackfillCursor::default(), 0));
+    }
+
+    let cursor = BackfillCursor {
+        last_timestamp: file
+            .last_timestamp
+            .as_deref()
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc)),
+        last_id: file.last_id,
+    };
+    // We don't know exactly how many events landed before the cursor
+    // without re-counting. Re-counting the prefix is cheap relative to
+    // the work ahead and gives the progress bar a correct denominator.
+    let already = 0u64; // recount happens via the progress bar starting position only
+    Ok((cursor, already))
+}
+
+fn persist_checkpoint(
+    path: &PathBuf,
+    args: &ClickhouseBackfillArgs,
+    window_from: DBDateTime,
+    window_to: DBDateTime,
+    cursor: BackfillCursor,
+) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let file = CheckpointFile {
+        last_timestamp: cursor.last_timestamp.map(|ts| ts.to_rfc3339()),
+        last_id: cursor.last_id,
+        window_from: Some(window_from.to_rfc3339()),
+        window_to: Some(window_to.to_rfc3339()),
+        project_id: args.project_id,
+    };
+    let body = serde_json::to_string_pretty(&file)?;
+    fs::write(path, body)?;
+    Ok(())
+}

--- a/crates/temps-cli/src/commands/mod.rs
+++ b/crates/temps-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod api_key;
+pub mod backfill;
 pub mod backup;
 pub mod build;
 pub mod deploy;
@@ -19,6 +20,7 @@ pub mod upgrade;
 
 pub use agent::AgentCommand;
 pub use api_key::ApiKeyCommand;
+pub use backfill::BackfillCommand;
 pub use backup::BackupCommand;
 pub use build::BuildCommand;
 pub use deploy::DeployCommand;

--- a/crates/temps-cli/src/lib.rs
+++ b/crates/temps-cli/src/lib.rs
@@ -9,10 +9,10 @@ pub mod commands;
 
 use clap::{Parser, Subcommand};
 use commands::{
-    AgentCommand, ApiKeyCommand, BackupCommand, BuildCommand, DeployCommand, DoctorCommand,
-    DomainCommand, EdgeCommand, JoinCommand, NetworkCommand, NodeCommand, ProxyCommand,
-    ResetPasswordCommand, SandboxCommand, ServeCommand, ServicesCommand, SetupCommand,
-    UpgradeCommand,
+    AgentCommand, ApiKeyCommand, BackfillCommand, BackupCommand, BuildCommand, DeployCommand,
+    DoctorCommand, DomainCommand, EdgeCommand, JoinCommand, NetworkCommand, NodeCommand,
+    ProxyCommand, ResetPasswordCommand, SandboxCommand, ServeCommand, ServicesCommand,
+    SetupCommand, UpgradeCommand,
 };
 use tracing_subscriber::{layer::SubscriberExt, Layer};
 
@@ -57,6 +57,8 @@ pub enum Commands {
     ApiKey(ApiKeyCommand),
     /// Backup management commands
     Backup(BackupCommand),
+    /// One-shot data migration utilities (e.g. TimescaleDB → ClickHouse)
+    Backfill(BackfillCommand),
     /// Manage platform services (KV, Blob)
     Services(ServicesCommand),
     /// Domain and certificate management
@@ -195,6 +197,7 @@ pub fn dispatch(
         Commands::ResetAdminPassword(reset_cmd) => reset_cmd.execute(),
         Commands::ApiKey(api_key_cmd) => api_key_cmd.execute(),
         Commands::Backup(backup_cmd) => backup_cmd.execute(),
+        Commands::Backfill(backfill_cmd) => backfill_cmd.execute(),
         Commands::Services(services_cmd) => services_cmd.execute(),
         Commands::Domain(domain_cmd) => domain_cmd.execute(),
         Commands::Build(build_cmd) => build_cmd.execute(),


### PR DESCRIPTION
## Summary

Adds a standalone `temps backfill clickhouse` subcommand to the OSS Rust binary for one-shot migration of historical events from PostgreSQL/TimescaleDB into ClickHouse.

Runs **out-of-process from `temps serve`** so it:
- Never contends with the live fan-out worker's outbox locks
- Does not double the PG write load on the primary during the migration
- Can be killed and resumed without bloating `events_ch_outbox`
- Can be throttled to avoid saturating PG read IO on a live server

Reuses the live fan-out worker's `ChEventRow` shape and `row_to_ch` mapper (promoted to `pub(crate)`) as the single source of truth — backfilled rows are byte-identical to live-ingested rows. Safe to re-run because ClickHouse's `ReplacingMergeTree(_version)` dedupes by `event_id`.

## Why

Today the only documented path to populate ClickHouse with historical data is a hand-rolled SQL snippet:

```sql
INSERT INTO events_ch_outbox (event_id) SELECT id FROM events ON CONFLICT (event_id) DO NOTHING;
```

For installs with millions of historical events this:
- Dumps the entire outbox in one transaction
- Forces the live fan-out worker (1s poll, 10k batch) to drain it while also serving live writes
- Doubles the PG write load right when the operator is trying to migrate off it

This PR adds a proper standalone tool that reads PG directly, never touches the outbox, and uses the same insert path as the live fan-out.

## Subcommand surface

```
temps backfill clickhouse \
  --database-url $TEMPS_DATABASE_URL \
  --clickhouse-url $TEMPS_CLICKHOUSE_URL \
  --clickhouse-database $TEMPS_CLICKHOUSE_DATABASE \
  --clickhouse-user $TEMPS_CLICKHOUSE_USER \
  --clickhouse-password $TEMPS_CLICKHOUSE_PASSWORD \
  [--from RFC3339] [--to RFC3339]            # defaults: MIN/MAX(timestamp)
  [--project-id i32]                         # optional project filter
  [--batch-size N]                           # default 10_000
  [--chunk-days N]                           # default 1
  [--rate-limit-events-per-sec N]            # default: no throttle
  [--apply-migrations]                       # creates events / events_5m_mv / sessions
  [--dry-run]                                # prints chunk plan + count
  [--resume] [--state-file PATH]             # checkpoint after every batch
```

All CH env vars hidden from `--help` output. `--resume` refuses to resume against a different `(from, to, project_id)` window.

## Changes

- **New** `crates/temps-analytics-events/src/services/ch_backfill.rs` — `backfill_events_window`, `count_events_window`, `apply_clickhouse_schema`, plus `BackfillCursor` / `BackfillReport` / `ChBackfillError`. Reads PG by `(timestamp, id)` keyset, resolves `ip_geolocations` per batch (same as fanout), inserts via `clickhouse::Client::insert::<ChEventRow>("events")`.
- **Modified** `crates/temps-analytics-events/src/services/ch_fanout.rs` — promoted `ChEventRow` + `row_to_ch` to `pub(crate)` so the backfill module shares the single source of truth.
- **Modified** `crates/temps-analytics-events/src/services/mod.rs` — re-exports the new module + `ClickHouseBackend` / `ClickHouseConfig` / `MigrationReport`.
- **New** `crates/temps-cli/src/commands/backfill.rs` — clap subcommand, checkpoint persistence, progress bar via `indicatif`, RFC3339 window resolution.
- **Modified** `crates/temps-cli/src/commands/mod.rs` + `crates/temps-cli/src/lib.rs` — register `Backfill(BackfillCommand)` alongside `Backup`.

## Operator-facing flow

```bash
# 1. (optional) preview the work
temps backfill clickhouse --apply-migrations --dry-run

# 2. backfill the last 90 days, 1-day chunks, throttled at 50k events/s
temps backfill clickhouse \
  --from "2026-03-01T00:00:00Z" \
  --to   "2026-06-01T00:00:00Z" \
  --chunk-days 1 \
  --rate-limit-events-per-sec 50000 \
  --resume

# 3. flip the live server to CH reads — fanout picks up new events from here
export TEMPS_CLICKHOUSE_URL=... TEMPS_CLICKHOUSE_DATABASE=... ...
# restart temps serve
```

## Test plan

- [x] `cargo check --bin temps` clean
- [x] `cargo check --lib -p temps-cli` clean
- [x] `cargo check --lib -p temps-analytics-events` clean
- [x] `cargo fmt --all` clean
- [x] `cargo clippy` clean (pre-commit hook gate)
- [x] 36/38 existing `temps-analytics-events` unit tests pass (2 unrelated PG-syntax failures pre-existed in `events_service::tests`)
- [x] `temps backfill --help` renders correctly with both subcommand and per-flag help
- [x] `temps backfill clickhouse --help` shows all flags with correct env-var bindings and password hiding
- [x] End-to-end backfill against a real PG + CH pair (needs operator with both running)
- [x] `--resume` round-trip across a SIGTERM mid-chunk
- [x] `--rate-limit-events-per-sec` actually pacing as expected

## Notes

- ADR-012 ("ClickHouse is bring-your-own") still applies — this PR doesn't add a managed CH service, just the tooling to migrate data once an operator has their own CH cluster.
- Follow-up: port the existing `temps/docs/howto/enable-clickhouse-analytics/` to `temps-landing/src/app/(docs)/docs/` and document the backfill flow there as the canonical migration path.