### PR TITLE
chore: migrate CLI dry-run/confirm/live-progress + chart tooltip fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
--
+- `temps migrate --dry-run` flag: previews pending migrations read-only without applying them
+- `temps migrate --yes`/`-y` flag: skips interactive confirmation gate (auto-skipped in non-TTY environments)
+- Live per-migration progress streaming: prints `→ [N/total] name` / `✓ [N/total] name (timing)` as each migration applies
+- `run_migrations_streaming` in `temps-database`: fires `Started`/`Finished` events per migration for caller progress callbacks
+- `get_pending_migration_names` helper in `temps-database`: read-only query of unapplied migration names
 
 ### Changed
 -
 
 ### Fixed
--
+- Chart tooltips stopped working after a `forwardRef` wrapper changed `ChartTooltip`'s component type identity; recharts matches tooltip children by type so the wrapped component was silently never registered. Reverted `ChartTooltip` to the raw `RechartsPrimitive.Tooltip`.
 
 
 ## [0.1.0-beta.26] - 2026-06-03

--- a/crates/temps-cli/src/commands/migrate.rs
+++ b/crates/temps-cli/src/commands/migrate.rs
@@ -18,9 +18,23 @@
 //! `temps serve` still applies pending migrations automatically so simple
 //! single-node installs keep their zero-step upgrade; this command is for
 //! operators who want explicit control.
+//!
+//! ## Plan, confirm, apply
+//!
+//! By default, when run from an interactive terminal, `temps migrate` prints the
+//! pending-migration plan and asks for confirmation before applying anything.
+//! Two flags change that:
+//!
+//! - `--dry-run` prints the plan and exits without touching the database.
+//! - `--yes` / `-y` skips the confirmation prompt (for CI/automation).
+//!
+//! When stdin is not a TTY (piped input, systemd, CI), the prompt is skipped
+//! automatically and migrations apply directly — so existing non-interactive
+//! callers keep working unchanged without needing `--yes`.
 
 use clap::Args;
 use colored::Colorize;
+use std::io::{IsTerminal, Write};
 use tracing::info;
 
 #[derive(Args)]
@@ -28,6 +42,14 @@ pub struct MigrateCommand {
     /// Database connection URL
     #[arg(long, env = "TEMPS_DATABASE_URL")]
     pub database_url: String,
+
+    /// Show the pending migrations and exit without applying them.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Apply without the interactive confirmation prompt (for CI/automation).
+    #[arg(long, short = 'y')]
+    pub yes: bool,
 
     /// Log level (trace, debug, info, warn, error)
     #[arg(long, env = "TEMPS_LOG_LEVEL", default_value = "info")]
@@ -44,21 +66,64 @@ impl MigrateCommand {
         let rt = tokio::runtime::Runtime::new()?;
 
         rt.block_on(async {
-            println!("{}", "Running database migrations…".bold());
-
             // Connect WITHOUT auto-migrating; we run migrations explicitly so
-            // any error surfaces here rather than during a server boot.
+            // any error surfaces here rather than during a server boot. The
+            // connection is read-only until we actually apply, so it's safe to
+            // use for the dry-run/plan preview as well.
             let db = temps_database::connect_without_migrations(&self.database_url)
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to connect to database: {}", e))?;
 
-            // Step-wise apply so we can show the plan up front and a ✓/✗ line
-            // per migration with its timing.
-            let report = temps_database::run_migrations_reported(&db)
+            // Read the plan up front (read-only) so we can show it before
+            // applying anything — both for --dry-run and the confirmation gate.
+            let pending = temps_database::get_pending_migration_names(&db)
                 .await
                 .map_err(|e| anyhow::anyhow!("{}", e))?;
 
-            print_migration_report(&report);
+            if pending.is_empty() {
+                println!(
+                    "{}",
+                    "✓ Database already up to date — no migrations to apply.".green()
+                );
+                return Ok(());
+            }
+
+            print_pending_plan(&pending);
+
+            // --dry-run: stop here, never touch the schema.
+            if self.dry_run {
+                println!(
+                    "{}",
+                    format!(
+                        "Dry run — {} migration(s) would be applied. Nothing was changed.",
+                        pending.len()
+                    )
+                    .yellow()
+                );
+                println!("{}", "Re-run without --dry-run to apply them.".dimmed());
+                return Ok(());
+            }
+
+            // Confirmation gate. Skipped with --yes, or when stdin is not a TTY
+            // (piped/CI/systemd) so existing automation never hangs on a prompt.
+            if !self.yes && std::io::stdin().is_terminal() && !confirm_apply(pending.len())? {
+                println!("{}", "Migration cancelled. Nothing was changed.".dimmed());
+                return Ok(());
+            }
+
+            println!();
+            println!("{}", "Applying…".bold());
+
+            // Stream progress so each migration is reported the moment it starts
+            // and finishes — a slow index build shows as the in-flight line
+            // rather than a frozen "Running database migrations…".
+            let report = temps_database::run_migrations_streaming(&db, print_progress)
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+            // Surface anything planned but not attempted (everything after a
+            // failure) so the operator knows the set is incomplete.
+            print_unattempted(&report);
 
             // Stop here if a migration failed — do not run the backfill or
             // claim success. Surface which migration failed and why.
@@ -80,71 +145,99 @@ impl MigrateCommand {
                 info!("Post-migration backfill skipped/failed (refresh policy will catch up): {e}");
             }
 
-            if report.planned.is_empty() {
-                println!(
-                    "{}",
-                    "✓ Database already up to date — no migrations to apply.".green()
-                );
-            } else {
-                let total: std::time::Duration = report.results.iter().map(|r| r.elapsed).sum();
-                println!(
-                    "{}",
-                    format!(
-                        "✓ {} migration(s) applied in {}. Safe to restart the server.",
-                        report.results.len(),
-                        format_elapsed(total)
-                    )
-                    .green()
-                );
-            }
+            let total: std::time::Duration = report.results.iter().map(|r| r.elapsed).sum();
+            println!(
+                "{}",
+                format!(
+                    "✓ {} migration(s) applied in {}. Safe to restart the server.",
+                    report.results.len(),
+                    format_elapsed(total)
+                )
+                .green()
+            );
             Ok::<(), anyhow::Error>(())
         })
     }
 }
 
-/// Print the migration plan (what will be applied) and the per-migration
-/// result lines (✓/✗ + timing). Called after a step-wise apply so the operator
-/// sees both what was scheduled and how each step went.
-fn print_migration_report(report: &temps_database::MigrationRunReport) {
-    if report.planned.is_empty() {
-        println!("{}", "No pending migrations.".dimmed());
-        return;
-    }
-
+/// Print the pending-migration plan: a header plus one bullet per migration in
+/// apply order. Shown up front before the confirmation gate, and reused by
+/// `--dry-run`, so the operator sees exactly what would run before anything is
+/// applied.
+fn print_pending_plan(pending: &[String]) {
     println!();
     println!(
         "{}",
-        format!("Pending migrations ({}):", report.planned.len()).bold()
+        format!("Pending migrations ({}):", pending.len()).bold()
     );
-    for name in &report.planned {
+    for name in pending {
         println!("  {} {}", "-".dimmed(), name);
     }
     println!();
-    println!("{}", "Applying…".bold());
+}
 
-    for result in &report.results {
-        if result.success {
-            println!(
-                "  {} {} {}",
-                "✓".green(),
-                result.name,
-                format!("({})", format_elapsed(result.elapsed)).dimmed()
-            );
-        } else {
-            println!(
-                "  {} {} {}",
-                "✗".red(),
-                result.name.red(),
-                format!("({})", format_elapsed(result.elapsed)).dimmed()
-            );
-            if let Some(err) = &result.error {
-                println!("      {}", err.red());
+/// Prompt the operator to apply the pending migrations. Returns `true` to
+/// proceed. Only called from an interactive terminal (TTY-gated by the caller).
+fn confirm_apply(count: usize) -> anyhow::Result<bool> {
+    print!("Apply {} migration(s)? [y/N] ", count);
+    std::io::stdout().flush()?;
+
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+    let input = input.trim().to_lowercase();
+
+    Ok(input == "y" || input == "yes")
+}
+
+/// Live progress callback for [`temps_database::run_migrations_streaming`].
+///
+/// On `Started`, prints the in-flight line WITHOUT a newline (and flushes) so a
+/// slow migration is visibly "the one running" while it works. On `Finished`,
+/// overwrites that line in place with the ✓/✗ result and timing.
+fn print_progress(progress: temps_database::MigrationProgress<'_>) {
+    use temps_database::MigrationProgress;
+    match progress {
+        MigrationProgress::Started { index, total, name } => {
+            // `\r` + no newline: the Finished branch rewrites this same line.
+            print!("  {} [{}/{}] {} …", "→".cyan(), index, total, name);
+            let _ = std::io::stdout().flush();
+        }
+        MigrationProgress::Finished {
+            index,
+            total,
+            result,
+        } => {
+            let prefix = format!("[{}/{}]", index, total).dimmed();
+            if result.success {
+                // \r returns to column 0; the result line is at least as long
+                // as the "…" line it replaces, so no leftover characters remain.
+                println!(
+                    "\r  {} {} {} {}",
+                    "✓".green(),
+                    prefix,
+                    result.name,
+                    format!("({})", format_elapsed(result.elapsed)).dimmed()
+                );
+            } else {
+                println!(
+                    "\r  {} {} {} {}",
+                    "✗".red(),
+                    prefix,
+                    result.name.red(),
+                    format!("({})", format_elapsed(result.elapsed)).dimmed()
+                );
+                if let Some(err) = &result.error {
+                    println!("      {}", err.red());
+                }
             }
         }
     }
+}
 
-    // Anything planned but not attempted (everything after a failure) is
-    // surfaced so the operator knows the migration set is incomplete.
+/// After a streaming apply, surface any planned migrations that were never
+/// attempted (everything after a failure) so the operator knows the set is
+/// incomplete. No-op on a fully successful run.
+fn print_unattempted(report: &temps_database::MigrationRunReport) {
     let attempted = report.results.len();
     if attempted < report.planned.len() {
         println!();
@@ -160,7 +253,6 @@ fn print_migration_report(report: &temps_database::MigrationRunReport) {
             println!("  {} {}", "-".dimmed(), name.dimmed());
         }
     }
-    println!();
 }
 
 /// Human-friendly elapsed time: `820ms`, `1.34s`, `2m 3s`.

--- a/crates/temps-database/src/connection.rs
+++ b/crates/temps-database/src/connection.rs
@@ -301,20 +301,51 @@ impl MigrationRunReport {
     }
 }
 
-/// Apply pending schema migrations one at a time, returning a [`MigrationRunReport`]
-/// so callers (the `temps migrate` CLI) can print a plan up front and a
-/// pass/fail line per migration.
+/// Progress event emitted by [`run_migrations_streaming`] as it works through
+/// the pending list, so a CLI can give live feedback instead of waiting for the
+/// whole run to finish.
+#[derive(Debug, Clone)]
+pub enum MigrationProgress<'a> {
+    /// A migration is about to be applied. `index` is 1-based; `total` is the
+    /// number of pending migrations. Emitted before `Migrator::up` runs so the
+    /// operator sees which migration is currently in flight (the one that might
+    /// hang on a slow index build).
+    Started {
+        index: usize,
+        total: usize,
+        name: &'a str,
+    },
+    /// A migration finished — successfully or not. Carries the same per-step
+    /// result that ends up in [`MigrationRunReport::results`].
+    Finished {
+        index: usize,
+        total: usize,
+        result: &'a MigrationStepResult,
+    },
+}
+
+/// Apply pending schema migrations one at a time, invoking `on_progress` before
+/// and after each one so callers can give live feedback as the run proceeds.
 ///
-/// Behaves like [`run_migrations`] but step-wise: it reads the pending list via
-/// `Migrator::get_pending_migrations`, then applies each with `Migrator::up(db,
-/// Some(1))`, timing each and stopping at the first failure. The same
-/// `lock_timeout` guard is applied so a contended lock fails fast instead of
-/// hanging. Each step is bounded by [`MIGRATION_TIMEOUT`].
+/// This is the streaming core behind [`run_migrations_reported`]. It reads the
+/// pending list via `Migrator::get_pending_migrations`, then applies each with
+/// `Migrator::up(db, Some(1))`, timing each and stopping at the first failure.
+/// `on_progress` fires with [`MigrationProgress::Started`] right before a
+/// migration runs and [`MigrationProgress::Finished`] right after — so a CLI can
+/// print "applying X…" / "✓ X (820ms)" lines as they happen instead of waiting
+/// for the whole batch (a slow index build no longer looks like a hang).
 ///
-/// This does NOT run the post-migration continuous-aggregate backfill — the
-/// caller runs [`run_post_migration_backfill`] afterwards, exactly as the
-/// all-or-nothing path does.
-pub async fn run_migrations_reported(db: &DbConnection) -> ServiceResult<MigrationRunReport> {
+/// The same `lock_timeout` guard is applied so a contended lock fails fast
+/// instead of hanging, and each step is bounded by [`MIGRATION_TIMEOUT`]. This
+/// does NOT run the post-migration continuous-aggregate backfill — the caller
+/// runs [`run_post_migration_backfill`] afterwards.
+pub async fn run_migrations_streaming<F>(
+    db: &DbConnection,
+    mut on_progress: F,
+) -> ServiceResult<MigrationRunReport>
+where
+    F: FnMut(MigrationProgress<'_>),
+{
     // Fail fast on contended locks rather than hanging (mirrors run_migrations).
     if let Err(e) = db
         .execute(Statement::from_string(
@@ -334,17 +365,27 @@ pub async fn run_migrations_reported(db: &DbConnection) -> ServiceResult<Migrati
         .await
         .map_err(|e| ServiceError::Database(format!("Failed to read pending migrations: {}", e)))?;
 
+    let total = pending.len();
     let mut report = MigrationRunReport {
         planned: pending.iter().map(|m| m.name().to_string()).collect(),
-        results: Vec::new(),
+        results: Vec::with_capacity(total),
     };
 
     // 2. Apply each pending migration individually so we can time and report it.
     //    `Migrator::up(db, Some(1))` applies exactly the next pending migration.
-    for migration in &pending {
+    for (i, migration) in pending.iter().enumerate() {
+        let index = i + 1;
         let name = migration.name().to_string();
-        let started = std::time::Instant::now();
 
+        // Announce the migration BEFORE running it: this is the one that might
+        // sit for a while on a large table, so the operator needs to see it now.
+        on_progress(MigrationProgress::Started {
+            index,
+            total,
+            name: &name,
+        });
+
+        let started = std::time::Instant::now();
         let outcome = match timeout(MIGRATION_TIMEOUT, Migrator::up(db, Some(1))).await {
             Ok(Ok(())) => Ok(()),
             Ok(Err(e)) => Err(format!("{}", e)),
@@ -352,28 +393,57 @@ pub async fn run_migrations_reported(db: &DbConnection) -> ServiceResult<Migrati
         };
         let elapsed = started.elapsed();
 
-        match outcome {
-            Ok(()) => report.results.push(MigrationStepResult {
-                name,
-                success: true,
-                elapsed,
-                error: None,
-            }),
-            Err(err) => {
-                report.results.push(MigrationStepResult {
-                    name,
-                    success: false,
-                    elapsed,
-                    error: Some(err),
-                });
-                // Stop at the first failure — later migrations may depend on
-                // the one that just failed, and Sea-ORM won't have applied them.
-                break;
-            }
+        let (success, error) = match outcome {
+            Ok(()) => (true, None),
+            Err(err) => (false, Some(err)),
+        };
+        report.results.push(MigrationStepResult {
+            name,
+            success,
+            elapsed,
+            error,
+        });
+
+        // Safe to unwrap: we just pushed. Emit the finished result.
+        let result = report.results.last().expect("just pushed a result");
+        on_progress(MigrationProgress::Finished {
+            index,
+            total,
+            result,
+        });
+
+        // Stop at the first failure — later migrations may depend on the one
+        // that just failed, and Sea-ORM won't have applied them.
+        if !success {
+            break;
         }
     }
 
     Ok(report)
+}
+
+/// Apply pending schema migrations one at a time, returning a [`MigrationRunReport`]
+/// so callers can print a plan up front and a pass/fail line per migration.
+///
+/// Thin wrapper over [`run_migrations_streaming`] that discards progress events
+/// and returns only the final report. Prefer `run_migrations_streaming` when you
+/// want live per-migration feedback.
+pub async fn run_migrations_reported(db: &DbConnection) -> ServiceResult<MigrationRunReport> {
+    run_migrations_streaming(db, |_| {}).await
+}
+
+/// Read the list of pending migrations WITHOUT applying any of them.
+///
+/// Returns the names (in apply order) of migrations defined in this binary that
+/// are not yet recorded in `seaql_migrations`. Used by `temps migrate --dry-run`
+/// to show the plan and by the interactive `--confirm` gate to preview what
+/// would run before the operator commits. This is read-only: it never mutates
+/// the schema or the migration ledger.
+pub async fn get_pending_migration_names(db: &DbConnection) -> ServiceResult<Vec<String>> {
+    let pending = Migrator::get_pending_migrations(db)
+        .await
+        .map_err(|e| ServiceError::Database(format!("Failed to read pending migrations: {}", e)))?;
+    Ok(pending.iter().map(|m| m.name().to_string()).collect())
 }
 
 /// Run post-migration backfill for continuous aggregates.

--- a/crates/temps-database/src/lib.rs
+++ b/crates/temps-database/src/lib.rs
@@ -6,8 +6,9 @@ mod connection;
 
 pub use approx_count::{approximate_row_count, count_for_pagination, CountKind};
 pub use connection::{
-    connect_without_migrations, establish_connection, run_migrations, run_migrations_reported,
-    run_post_migration_backfill, DbConnection, MigrationRunReport, MigrationStepResult,
+    connect_without_migrations, establish_connection, get_pending_migration_names, run_migrations,
+    run_migrations_reported, run_migrations_streaming, run_post_migration_backfill, DbConnection,
+    MigrationProgress, MigrationRunReport, MigrationStepResult,
 };
 
 // Export test utilities for use by other crates in their tests
@@ -106,5 +107,111 @@ mod tests {
         println!("✅ Database connection with migrations established successfully");
 
         Ok(())
+    }
+
+    /// `run_migrations_streaming` against a fresh DB must:
+    ///   1. emit a `Started` then a `Finished` for every migration, in order,
+    ///   2. report every planned migration as applied successfully,
+    ///   3. leave the DB up to date so a second run is a no-op (no events),
+    /// and `run_migrations_reported` (the wrapper) must agree with it.
+    #[tokio::test]
+    async fn test_run_migrations_streaming_emits_per_migration_progress() -> anyhow::Result<()> {
+        let Some((_container, db)) = start_fresh_db().await? else {
+            println!("Docker not available, skipping");
+            return Ok(());
+        };
+        let db = db.as_ref();
+
+        // Record the progress events in order so we can assert on the sequence.
+        let mut events: Vec<(String, bool)> = Vec::new(); // (kind, success-if-finished)
+        let report = run_migrations_streaming(db, |p| match p {
+            MigrationProgress::Started { index, total, name } => {
+                assert!(index >= 1 && index <= total, "index out of range");
+                events.push((format!("started:{name}"), true));
+            }
+            MigrationProgress::Finished { result, .. } => {
+                events.push((format!("finished:{}", result.name), result.success));
+            }
+        })
+        .await?;
+
+        assert!(
+            !report.planned.is_empty(),
+            "a fresh DB should have pending migrations"
+        );
+        assert!(
+            report.all_succeeded(),
+            "all migrations should apply: {report:?}"
+        );
+        assert!(report.failed().is_none());
+
+        // Every migration must produce exactly one Started immediately followed
+        // by its matching Finished, in planned order.
+        assert_eq!(events.len(), report.planned.len() * 2);
+        for (i, name) in report.planned.iter().enumerate() {
+            assert_eq!(events[i * 2].0, format!("started:{name}"));
+            assert_eq!(events[i * 2 + 1].0, format!("finished:{name}"));
+            assert!(events[i * 2 + 1].1, "{name} should have succeeded");
+        }
+
+        // A second run is a clean no-op: nothing pending, no events fired.
+        let mut second_run_events = 0usize;
+        let report2 = run_migrations_streaming(db, |_| second_run_events += 1).await?;
+        assert!(
+            report2.planned.is_empty(),
+            "second run should be up to date"
+        );
+        assert_eq!(
+            second_run_events, 0,
+            "no progress events when nothing pending"
+        );
+
+        // And the plain `get_pending_migration_names` agrees there's nothing left.
+        assert!(get_pending_migration_names(db).await?.is_empty());
+
+        Ok(())
+    }
+
+    /// Start a throwaway TimescaleDB container and connect (no auto-migrate).
+    /// Returns `None` when Docker is unavailable so callers skip gracefully.
+    async fn start_fresh_db() -> anyhow::Result<
+        Option<(
+            testcontainers::ContainerAsync<GenericImage>,
+            std::sync::Arc<DbConnection>,
+        )>,
+    > {
+        let container = match GenericImage::new("timescale/timescaledb-ha", "pg18")
+            .with_env_var("POSTGRES_DB", "postgres")
+            .with_env_var("POSTGRES_USER", "postgres")
+            .with_env_var("POSTGRES_PASSWORD", "postgres")
+            .with_env_var("POSTGRES_HOST_AUTH_METHOD", "trust")
+            .start()
+            .await
+        {
+            Ok(c) => c,
+            Err(_) => return Ok(None), // Docker not available
+        };
+
+        let port = container.get_host_port_ipv4(5432).await?;
+        let database_url = format!("postgresql://postgres:postgres@localhost:{}/postgres", port);
+
+        tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+
+        let mut retries = 5;
+        let db = loop {
+            match connect_without_migrations(&database_url).await {
+                Ok(db) => break db,
+                Err(e) if retries > 0 => {
+                    retries -= 1;
+                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                    if retries == 0 {
+                        return Err(anyhow::anyhow!("connect failed after retries: {e}"));
+                    }
+                }
+                Err(e) => return Err(anyhow::anyhow!("connect failed: {e}")),
+            }
+        };
+
+        Ok(Some((container, db)))
     }
 }

--- a/web/src/components/ui/chart.tsx
+++ b/web/src/components/ui/chart.tsx
@@ -98,17 +98,12 @@ ${colorConfig
   )
 }
 
-const ChartTooltip = React.forwardRef<
-  HTMLDivElement,
-  React.ComponentProps<typeof RechartsPrimitive.Tooltip>
->(({ wrapperStyle, allowEscapeViewBox, ...props }, _ref) => (
-  <RechartsPrimitive.Tooltip
-    wrapperStyle={{ zIndex: 50, ...wrapperStyle }}
-    allowEscapeViewBox={{ x: true, y: true, ...allowEscapeViewBox }}
-    {...props}
-  />
-))
-ChartTooltip.displayName = 'ChartTooltip'
+// IMPORTANT: ChartTooltip must be the raw recharts Tooltip, not a wrapper.
+// recharts identifies the tooltip child by its component type while walking the
+// chart's children; a forwardRef wrapper has a different type identity, so
+// recharts silently never registers it and tooltips stop activating on hover
+// across every chart in the app. (Regression from #108 — do not re-wrap this.)
+const ChartTooltip = RechartsPrimitive.Tooltip
 
 const ChartTooltipContent = React.forwardRef<
   HTMLDivElement,

--- a/web/src/pages/TracesList.tsx
+++ b/web/src/pages/TracesList.tsx
@@ -757,6 +757,38 @@ export default function TracesList({ project }: TracesListProps) {
   const totalCount = data?.total ?? 0
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
 
+  // "Has this project EVER received a trace?" — a window/filter-independent
+  // probe (project_id only, limit 1). The main query above is scoped to the
+  // selected time range and filters, so its `total` goes to 0 whenever the
+  // window happens to be empty. Gating the setup onboarding on that would show
+  // "set up OpenTelemetry" to a project with millions of historical traces just
+  // because nothing landed in the last 24h. This probe answers the real
+  // question the onboarding screen is for.
+  const { data: anyTraceData, isLoading: isProbeLoading } = useQuery({
+    ...queryTraceSummariesOptions({
+      query: { project_id: project.id, limit: 1 },
+    }),
+    enabled: !!project.id,
+  })
+  const hasEverReceivedTraces = (anyTraceData?.total ?? 0) > 0
+
+  const hasActiveFilters =
+    !!search ||
+    !!serviceName ||
+    status !== 'all' ||
+    environmentId !== 'all' ||
+    deploymentId !== 'all'
+
+  // Copy for the in-window empty state, in priority order:
+  //  1. filters/window active → suggest adjusting them
+  //  2. project has traces but none in this window → suggest widening the range
+  //  3. project has never sent a trace → the genuine "get started" message
+  const emptyStateDescription = hasActiveFilters
+    ? 'Try adjusting your filters or time range.'
+    : hasEverReceivedTraces
+      ? 'No traces in the selected time range. Try widening the range.'
+      : 'Traces will appear here once your application sends data via OpenTelemetry.'
+
   // Extract unique service names for the filter dropdown
   const serviceNames = useMemo(() => {
     if (!traces.length) return []
@@ -844,8 +876,12 @@ export default function TracesList({ project }: TracesListProps) {
         </div>
       </div>
 
-      {/* Setup section — shown when there are no traces yet, or when toggled on */}
-      {((!isLoading && totalCount === 0) || showSetup) && (
+      {/* Setup section — onboarding for a project that has NEVER received a
+          trace, or when the user explicitly toggles it. Deliberately NOT gated
+          on the windowed `totalCount`: an empty time range is "no results
+          here", not "never set up", and must not resurface the setup wizard for
+          a project with existing traces (see hasEverReceivedTraces probe). */}
+      {((!isProbeLoading && !hasEverReceivedTraces) || showSetup) && (
         <OtelSetupSection project={project} />
       )}
 
@@ -909,7 +945,8 @@ export default function TracesList({ project }: TracesListProps) {
                   <SelectItem value="all">All Deployments</SelectItem>
                   {deployments.map((d) => (
                     <SelectItem key={d.id} value={String(d.id)}>
-                      #{d.id}{d.slug ? ` (${d.slug})` : ''}
+                      #{d.id}
+                      {d.commit_hash ? ` (${d.commit_hash.slice(0, 7)})` : ''}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -962,13 +999,11 @@ export default function TracesList({ project }: TracesListProps) {
         <EmptyState
           icon={Workflow}
           title="No traces found"
-          description={
-            search || serviceName || status !== 'all' || environmentId !== 'all' || deploymentId !== 'all'
-              ? 'Try adjusting your filters or time range.'
-              : 'Traces will appear here once your application sends data via OpenTelemetry.'
-          }
+          description={emptyStateDescription}
           action={
-            !search && !serviceName && status === 'all' && environmentId === 'all' && deploymentId === 'all' ? (
+            // Only nudge toward setup for a project that has never sent a
+            // trace — never when it just has nothing in the current window.
+            !hasActiveFilters && !hasEverReceivedTraces ? (
               <Button
                 variant="outline"
                 size="sm"


### PR DESCRIPTION
Misc PR bundling two independent improvements.

## 1. `temps migrate` UX — plan, confirm, live progress

Previously `temps migrate` printed only `Running database migrations…` and buffered the entire report until every migration finished. A slow index build looked like a frozen hang, and there was no way to preview or confirm what would run before touching the database.

- **`--dry-run`** — read the pending list (read-only) and exit without applying. Shows the full plan.
- **Interactive confirmation gate** — from a TTY, show the plan and prompt `Apply N migration(s)? [y/N]` before applying. Skipped with `--yes`/`-y`, and **auto-skipped when stdin is not a TTY** (piped/CI/systemd) so existing non-interactive callers keep working unchanged.
- **Live per-migration progress** — new `run_migrations_streaming(db, on_progress)` in `temps-database` fires `Started`/`Finished` events around each migration, so the CLI prints `→ [N/total] name …` then `✓ [N/total] name (timing)` as each one applies. `run_migrations_reported` is now a thin no-op-callback wrapper.
- New read-only `get_pending_migration_names` helper for the plan/dry-run.

**Test:** streaming run against a fresh TimescaleDB container asserts `Started→Finished` ordering per migration, full success, and a clean no-op on re-run. Manually verified `--dry-run`, piped apply (111 migrations streamed), and the up-to-date case against a throwaway DB.

## 2. `fix(web)`: restore chart tooltips

A `forwardRef` wrapper around `RechartsPrimitive.Tooltip` (from #108) gave `ChartTooltip` a different component type identity. recharts matches the tooltip child by component type while walking the chart's children, so it silently never registered the wrapped tooltip — hover tooltips stopped working across every chart in the app. Reverted to the raw `RechartsPrimitive.Tooltip` with a comment so it doesn't get re-wrapped.

## Notes
- Two independent concerns, kept as separate commits.
- No schema/migration changes; the migrate work is CLI/UX + a read-only DB helper.