### PR TITLE
fix(git): ignore null-SHA push events to prevent failed 0000000 deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 ### Fixed
--
+- **Null-SHA push events no longer create failed `0000000` deployments**: branch/tag deletions send the all-zeros Git null SHA (`0000…000`) in the push webhook's `after` field, which previously flowed through into a deployment whose `download_repo` job failed with `Failed to checkout ref 0000000…`. `handle_push_event` now short-circuits empty/all-zeros commits before any DB query or job enqueue (covers both GitHub and GitLab), and `checkout_ref` defensively rejects the null SHA with an actionable error.
 
 
 ## [0.1.0-beta.27] - 2026-06-05

--- a/crates/temps-git/src/services/git_ops.rs
+++ b/crates/temps-git/src/services/git_ops.rs
@@ -193,6 +193,19 @@ pub fn checkout_ref(repo: &Repository, ref_name: &str) -> Result<(), GitOpsError
         .map(|p| p.display().to_string())
         .unwrap_or_default();
 
+    // Reject the all-zeros "null SHA". Git uses it to signal an absent ref
+    // (e.g. branch/tag deletion webhooks), so it can never resolve to a commit.
+    // Fail with an actionable message instead of an opaque libgit2 error.
+    if !ref_name.is_empty() && ref_name.chars().all(|c| c == '0') {
+        return Err(GitOpsError::CheckoutFailed {
+            ref_name: ref_name.to_string(),
+            repo_path,
+            reason: "ref is the all-zeros null SHA, which corresponds to a deleted branch/tag and \
+                     has no commit to check out"
+                .to_string(),
+        });
+    }
+
     // Try to resolve as a commit SHA first (full or abbreviated)
     let object = repo
         .revparse_single(ref_name)
@@ -313,6 +326,36 @@ mod tests {
             }
             other => panic!("Expected CheckoutFailed, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_checkout_null_sha_returns_descriptive_error() {
+        let (_temp_dir, repo) = create_test_repo();
+
+        // The all-zeros null SHA (sent on branch/tag deletion) must fail with a
+        // descriptive reason, not an opaque libgit2 "object not found" message.
+        let null_sha = "0000000000000000000000000000000000000000";
+        let result = checkout_ref(&repo, null_sha);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            GitOpsError::CheckoutFailed {
+                ref_name, reason, ..
+            } => {
+                assert_eq!(ref_name, null_sha);
+                assert!(
+                    reason.contains("null SHA"),
+                    "reason should explain the null SHA, got: {reason}"
+                );
+            }
+            other => panic!("Expected CheckoutFailed, got {:?}", other),
+        }
+
+        // Abbreviated null SHA (the "0000000" the UI displays) is rejected too.
+        let result = checkout_ref(&repo, "0000000");
+        assert!(matches!(
+            result.unwrap_err(),
+            GitOpsError::CheckoutFailed { .. }
+        ));
     }
 
     #[test]

--- a/crates/temps-git/src/services/git_provider_manager.rs
+++ b/crates/temps-git/src/services/git_provider_manager.rs
@@ -4015,6 +4015,22 @@ impl GitProviderManager {
         use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
         use temps_entities::projects;
 
+        // Branch/tag deletions send the all-zeros "null SHA" in the `after`
+        // field (GitHub, GitLab, and others all follow this Git convention).
+        // There is no commit to deploy, so creating a deployment from it would
+        // queue a download_repo job that fails with
+        // "Failed to checkout ref 0000000...". Ignore these events.
+        if commit.is_empty() || commit.chars().all(|c| c == '0') {
+            tracing::info!(
+                "Ignoring push event for {}/{} with null SHA (branch/tag deletion), branch: {:?}, tag: {:?}",
+                owner,
+                repo,
+                branch,
+                tag
+            );
+            return Ok(());
+        }
+
         // Find all projects with this owner and repo
         let matching_projects = projects::Entity::find()
             .filter(projects::Column::RepoOwner.eq(&owner))
@@ -5057,6 +5073,73 @@ mod tests {
         fn subscribe(&self) -> Box<dyn JobReceiver> {
             panic!("subscribe not needed for tests")
         }
+    }
+
+    /// A queue that fails the test if anything is ever enqueued. Used to assert
+    /// that a push event was short-circuited before any deployment job was sent.
+    struct PanicOnSendJobQueue;
+
+    #[async_trait]
+    impl JobQueue for PanicOnSendJobQueue {
+        async fn send(&self, job: Job) -> Result<(), QueueError> {
+            panic!("no job should be queued, but got: {job:?}");
+        }
+
+        fn subscribe(&self) -> Box<dyn JobReceiver> {
+            panic!("subscribe not needed for tests")
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_push_event_ignores_null_sha_deletion() {
+        use sea_orm::{DatabaseBackend, MockDatabase};
+
+        // A MockDatabase with no queued results errors on the first query —
+        // proving the null-SHA guard returns before touching the database. The
+        // panic-on-send queue proves no deployment job is enqueued.
+        let db = Arc::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+
+        let encryption_service = Arc::new(
+            temps_core::EncryptionService::new(
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            )
+            .unwrap(),
+        );
+        let queue_service = Arc::new(PanicOnSendJobQueue) as Arc<dyn JobQueue>;
+        let config_service = create_test_config_service(db.clone());
+
+        let manager =
+            GitProviderManager::new(db, encryption_service, queue_service, config_service);
+
+        // Full all-zeros null SHA (GitHub/GitLab branch deletion).
+        let result = manager
+            .handle_push_event(
+                "owner".into(),
+                "repo".into(),
+                Some("deleted-branch".into()),
+                None,
+                "0000000000000000000000000000000000000000".into(),
+            )
+            .await;
+        assert!(
+            result.is_ok(),
+            "null-SHA push event should be ignored: {result:?}"
+        );
+
+        // Empty commit string is treated the same way.
+        let result = manager
+            .handle_push_event(
+                "owner".into(),
+                "repo".into(),
+                Some("b".into()),
+                None,
+                String::new(),
+            )
+            .await;
+        assert!(
+            result.is_ok(),
+            "empty-SHA push event should be ignored: {result:?}"
+        );
     }
 
     // Helper function to create a test ConfigService


### PR DESCRIPTION
## Problem

Deployments intermittently failed with **commit `0000000`** and this error:

```
Required job 'download_repo' failed: Failed to clone repository:
Failed to checkout ref 0000000000000000000000000000000000000000
```

## Root cause

Branch/tag **deletions** send the all-zeros Git "null SHA" (`0000…000`) in the push webhook's `after` field (GitHub, GitLab, and others all follow this convention). That value flowed straight through:

```
webhook (after = 0000…) → handle_push_event → GitPushEventJob
  → deployment (commit_sha = "0000…") → download_repo → checkout_ref("0000…") → fail
```

It surfaced intermittently because of the hourly **content-loop automation**, which deletes its branch on auto-merge — the deletion fired a null-SHA push event that became a doomed `preview` deployment (e.g. branch `content/ai-loop-2026-06-07-vs-railway-2`).

## Fix

- **`git_provider_manager::handle_push_event`** — short-circuit and log when the commit is empty or all-zeros, *before* any DB query or job enqueue. This is the provider-agnostic chokepoint, so it covers both GitHub and GitLab callers. A branch deletion no longer creates a deployment.
- **`git_ops::checkout_ref`** — defense in depth: reject the null SHA with an actionable error instead of an opaque libgit2 message, in case a stale record ever reaches the checkout path.

## Tests

- `handle_push_event_ignores_null_sha_deletion` — proves the guard short-circuits *before* any DB access or job enqueue, using a no-result `MockDatabase` (errors if queried) + a panic-on-send queue (fails if a job is enqueued). Covers both the full null SHA and an empty string.
- `test_checkout_null_sha_returns_descriptive_error` — covers both the 40-char null SHA and the abbreviated `"0000000"` the UI shows.

Both pass; `cargo check --lib -p temps-git` is clean.