### PR TITLE
fix(serve): remove duplicate backup scheduler + feat(console-kit): headerActions extension slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
--
+- **`headerActions` console extension slot**: `ConsoleExtensions` now accepts a `headerActions?: ConsoleHeaderAction[]` array rendered top-right in the dashboard `Header` (via `@temps-sdk/console-kit`). Additive and backward-compatible — consoles that register no header actions are unchanged. This is the OSS-side hook the EE AI SRE Copilot header button plugs into.
 
 ### Changed
 -
 
 ### Fixed
+- **Duplicate backup runs eliminated**: `start_console_api` spawned its own backup scheduler loop in addition to the one `BackupPlugin` already starts during plugin initialization. With both loops running, each independently found every due `backup_schedules` row and enqueued a `Job::BackupRequested`, producing two completed backup runs per service at the same timestamp. The console-side scheduler is removed; the plugin is now the single owner.
 - **Null-SHA push events no longer create failed `0000000` deployments**: branch/tag deletions send the all-zeros Git null SHA (`0000…000`) in the push webhook's `after` field, which previously flowed through into a deployment whose `download_repo` job failed with `Failed to checkout ref 0000000…`. `handle_push_event` now short-circuits empty/all-zeros commits before any DB query or job enqueue (covers both GitHub and GitLab), and `checkout_ref` defensively rejects the null SHA with an actionable error.
 
 

--- a/crates/temps-cli/src/commands/serve/console.rs
+++ b/crates/temps-cli/src/commands/serve/console.rs
@@ -1203,27 +1203,11 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
         debug!("UserService not available, skipping user initialization");
     }
 
-    // Start backup scheduler if BackupService is available.
-    // The scheduler enqueues due jobs; the in-process BackupExecutor (registered
-    // by BackupPlugin) picks them up and runs them.
-    if let Some(backup_service) = service_context.get_service::<temps_backup::BackupService>() {
-        let cancellation_token = tokio_util::sync::CancellationToken::new();
-        let scheduler_token = cancellation_token.clone();
-        let scheduler_service = backup_service.clone();
-
-        tokio::spawn(async move {
-            debug!("Starting backup scheduler");
-            if let Err(e) = scheduler_service
-                .start_backup_scheduler(scheduler_token)
-                .await
-            {
-                tracing::error!("Backup scheduler error: {}", e);
-            }
-        });
-        debug!("Backup scheduler started in background");
-        // Note: Currently no graceful shutdown mechanism for cancellation_token
-        // In the future, this could be wired to a shutdown signal handler
-    }
+    // NOTE: The backup scheduler is started by `BackupPlugin` during plugin
+    // initialization (see `temps-backup/src/plugin.rs`). Do NOT start it here as
+    // well -- spawning a second scheduler loop makes both loops independently
+    // find each due `backup_schedules` row and enqueue a `Job::BackupRequested`,
+    // producing two completed backup runs per service at the same timestamp.
 
     // Start certificate renewal scheduler (optional - fails gracefully if TlsService unavailable)
     if let Some(tls_service) = service_context.get_service::<temps_domains::TlsService>() {

--- a/web/packages/console-kit/src/extensions.tsx
+++ b/web/packages/console-kit/src/extensions.tsx
@@ -13,9 +13,25 @@ export interface ConsoleRoute {
   element: ReactElement
 }
 
+/**
+ * An action rendered in the top-right of the console header, left of the
+ * built-in Create / alerts / theme controls. Intended for compact icon
+ * buttons that navigate to or open an extension surface (e.g. EE's SRE
+ * Copilot). Order follows array order.
+ */
+export interface ConsoleHeaderAction {
+  /** Stable id (React key + test hook). */
+  id: string
+  /** The rendered control — typically an icon `Button`. The extension owns
+   *  its own onClick/navigation; the console shell only places it. */
+  element: ReactNode
+}
+
 export interface ConsoleExtensions {
   routes?: ConsoleRoute[]
   navItems?: ConsoleNavItem[]
+  /** Compact actions placed top-right in the header (see [`ConsoleHeaderAction`]). */
+  headerActions?: ConsoleHeaderAction[]
   logoBadge?: ReactNode
   /**
    * Replace the OSS unauthenticated login screen with an extension-provided

--- a/web/packages/console-kit/src/index.ts
+++ b/web/packages/console-kit/src/index.ts
@@ -2,6 +2,7 @@ export {
   type ConsoleExtensions,
   type ConsoleNavItem,
   type ConsoleRoute,
+  type ConsoleHeaderAction,
   emptyConsoleExtensions,
 } from './extensions'
 export {

--- a/web/src/components/dashboard/Header.tsx
+++ b/web/src/components/dashboard/Header.tsx
@@ -5,6 +5,7 @@ import {
 import { BackupAlertsButton } from '@/components/dashboard/BackupAlertsButton'
 import { ThemeToggle } from '@/components/theme/ThemeToggle'
 import { useBreadcrumbs } from '@/contexts/BreadcrumbContext'
+import { useConsoleExtensions } from '@temps-sdk/console-kit'
 import { useQuery } from '@tanstack/react-query'
 import {
   Check,
@@ -175,6 +176,9 @@ export function Header() {
   const { breadcrumbs } = useBreadcrumbs()
   const navigate = useNavigate()
   const location = useLocation()
+  // Extension-provided header actions (e.g. EE's SRE Copilot), rendered
+  // leftmost in the top-right control cluster.
+  const { headerActions } = useConsoleExtensions()
 
   const projectSlugMatch = location.pathname.match(/^\/projects\/([^/]+)/)
   const projectSlug =
@@ -237,6 +241,9 @@ export function Header() {
           </Breadcrumb>
         </div>
         <div className="ml-auto flex items-center space-x-2">
+          {headerActions?.map((action) => (
+            <React.Fragment key={action.id}>{action.element}</React.Fragment>
+          ))}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="outline" size="icon">


### PR DESCRIPTION
Two independent, ready-to-land fixes (both compile clean; backup fix verified against the plugin).

## 1. `feat(console-kit): headerActions extension slot`
Adds a `headerActions?: ConsoleHeaderAction[]` slot to `ConsoleExtensions`, rendered top-right in the dashboard `Header`. This is the OSS-side hook the **EE AI SRE Copilot** header button plugs into (the EE feature already landed on `temps-ee` main and depends on this slot existing in OSS).

- `web/packages/console-kit/src/extensions.tsx` + `index.ts` — new `ConsoleHeaderAction` type + slot, exported.
- `web/src/components/dashboard/Header.tsx` — renders `headerActions` leftmost in the top-right control cluster via `useConsoleExtensions()`.

Additive and backward-compatible — no behavior change for consoles that don't register header actions.

## 2. `fix(serve): remove duplicate backup scheduler in console startup`
`start_console_api` spawned a backup scheduler loop, but `BackupPlugin` already starts one during plugin init (`temps-backup/src/plugin.rs:337`). With both loops running, each independently found every due `backup_schedules` row and enqueued a `Job::BackupRequested` — producing **two completed backup runs per service at the same timestamp**.

Fix: remove the console-side scheduler; the plugin is the single owner.

## Verification
- `cargo check -p temps-cli` passes; pre-commit hooks (fmt, clippy, conventional-commit) passed.
- Confirmed `BackupPlugin` is the surviving scheduler owner.