### PR TITLE
feat(deployments): view logs of previous deployments + security hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
--
+- **Historical deployment container logs**: runtime container logs used to vanish the moment a deployment was superseded and its containers were torn down — making it impossible to debug "what did the container that ran a few days ago actually print?". Now, just before a previous deployment's containers are stopped and removed (`MarkDeploymentCompleteJob::cancel_previous_deployments`), each container's logs are captured to a plain-text file under the data dir (via `LogService`) and recorded in a new `deployment_container_logs` table. New read endpoints `GET /api/projects/{project_id}/deployments/{deployment_id}/container-logs` (list) and `.../container-logs/{log_id}` (content), and a "Captured container logs" section on the deployment detail page, let you read the logs of a container that no longer exists (e.g. `web-2`). Capture is best-effort and tail-capped at 8 MiB — it never blocks or fails a deployment.
+- **`project_scope_guard!` and `deny_deployment_token!` auth macros** (`temps-auth`) plus `AuthContext::is_scoped_to_project`: the missing tenant-boundary primitive that confines a project-bound deployment token to its own project. `permission_guard!` proves a caller holds a permission; these prove the resource is theirs.
 
 ### Changed
 -
 
 ### Fixed
--
+- **SECURITY (CRITICAL): error-tracking admin API was completely unauthenticated**. Every handler in `temps-error-tracking` (`handler.rs`, `alert_rules_handler.rs`) took only `State`/`Path`/`Query` — no `RequireAuth`, no `permission_guard!`. An unauthenticated attacker could enumerate sequential project ids and read/modify every tenant's error groups, events, stack traces, and raw Sentry payloads (PII). All 14 handlers now require authentication (`ErrorTrackingRead`/`Write`/`Create`), are tenant-scoped, and authorize the path `project_id` against the caller. The DSN-authenticated Sentry ingest path was already correctly self-authenticating and is unchanged.
+- **SECURITY (HIGH): cross-project IDOR via `FullAccess` deployment tokens**. A deployment token is auto-injected into every deployed container, bound to one project, and typically carries `FullAccess` — which satisfies `permission_guard!` for *any* permission. Handlers across `temps-environments`, `temps-providers`, `temps-projects`, and `temps-analytics` trusted a `project_id`/service id from the request without checking it against the token's bound project, letting a compromised app read another tenant's secrets/env-var plaintext, DB connection strings, projects, and visitor PII — and modify/destroy them. All such handlers now call `project_scope_guard!` (or verify `project_services` linkage for shared external services, or deny deployment tokens on fleet-wide/by-id endpoints).
+- **SECURITY (HIGH): SSRF via self-hosted Git provider URL**. `GitProvidersCreate` (granted to ordinary users) synchronously probed `{base_url}/api/v4/user` on create, so a malicious `base_url`/`api_url` (e.g. `http://169.254.169.254`, `http://127.0.0.1`) was a live SSRF oracle into internal infrastructure. URLs are now validated with `temps_core::url_validation::validate_external_url` before use, and the GitHub/GitLab HTTP clients disable redirect following (closing the public-host→metadata 302 bypass).
+- **SECURITY (HIGH): unmasked DB credentials over the external-services API**. `get_service_environment_variables` returned plaintext `POSTGRES_URL`/`POSTGRES_PASSWORD` (`mask_sensitive: false`) to any owner; now only an admin receives unmasked values.
+- **SECURITY (MEDIUM): OTLP ingest logged the full bearer token** at `debug` level, writing live, mostly non-expiring credentials to logs whenever debug logging was enabled. It now logs only the auth scheme and length.
+- **SECURITY (LOW): proxy trusted a client-supplied `X-Forwarded-Proto`**. `is_https_request` now derives the scheme from the actual downstream TLS digest (`is_tls_connection`) instead of the spoofable header, so the `Secure` cookie attribute and the `X-Forwarded-Proto` forwarded upstream can't be influenced by the client.
 
 
 ## [0.1.0-beta.28] - 2026-06-08

--- a/crates/temps-analytics/src/handler.rs
+++ b/crates/temps-analytics/src/handler.rs
@@ -9,8 +9,8 @@ use axum::{
 };
 use serde::Deserialize;
 use std::sync::Arc;
-use temps_auth::permission_guard;
 use temps_auth::RequireAuth;
+use temps_auth::{deny_deployment_token, permission_guard, project_scope_guard};
 use temps_core::error_builder::{bad_request, internal_server_error};
 use temps_core::problemdetails::Problem;
 use temps_core::{not_found, DateTime, UtcDateTime};
@@ -261,6 +261,7 @@ pub async fn get_analytics_events_count(
     Query(query): Query<EventsCountQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
     let project_id = query.project_id;
 
     match app_state
@@ -319,6 +320,7 @@ pub async fn get_visitors(
     Query(query): Query<VisitorsListQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
     let project_id = query.project_id;
 
     match app_state
@@ -377,6 +379,7 @@ pub async fn get_visitor_facets(
     Query(query): Query<VisitorFacetsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
     let project_id = query.project_id;
 
     match app_state
@@ -424,6 +427,7 @@ pub async fn get_visitor_details(
     axum::extract::Path(visitor_id): axum::extract::Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    deny_deployment_token!(auth);
 
     match app_state
         .analytics_service
@@ -461,6 +465,7 @@ pub async fn get_visitor_info(
     axum::extract::Path(visitor_id): axum::extract::Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    deny_deployment_token!(auth);
 
     match app_state
         .analytics_service
@@ -498,6 +503,7 @@ pub async fn get_visitor_stats(
     axum::extract::Path(visitor_id): axum::extract::Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    deny_deployment_token!(auth);
 
     match app_state
         .analytics_service
@@ -538,6 +544,7 @@ pub async fn get_analytics_visitor_sessions(
     Query(query): Query<VisitorSessionsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    deny_deployment_token!(auth);
 
     match app_state
         .analytics_service
@@ -577,6 +584,7 @@ pub async fn get_visitor_journey(
     Query(query): Query<VisitorJourneyQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
 
     match app_state
         .analytics_service
@@ -616,6 +624,7 @@ pub async fn get_session_details(
     Query(query): Query<SessionDetailsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
 
     let project_id = query.project_id;
     match app_state
@@ -659,6 +668,7 @@ pub async fn get_analytics_session_events(
     Query(query): Query<SessionEventsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
 
     let project_id = query.project_id;
 
@@ -714,6 +724,7 @@ pub async fn get_session_logs(
     Query(query): Query<SessionLogsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
 
     let project_id = query.project_id;
 
@@ -766,6 +777,7 @@ pub async fn enrich_visitor(
     Json(request): Json<EnrichVisitorRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsWrite);
+    deny_deployment_token!(auth);
 
     // Check if visitor_id is a numeric ID or a GUID/encrypted GUID
     if let Ok(numeric_id) = visitor_id.parse::<i32>() {
@@ -815,6 +827,7 @@ pub async fn check_analytics_has_events(
     Query(query): Query<ProjectQuery>,
 ) -> Result<Json<HasAnalyticsEventsResponse>, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
 
     let project_id = query.project_id;
     match app_state
@@ -883,6 +896,7 @@ pub async fn get_page_paths(
     Query(query): Query<PagePathsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
 
     match app_state
         .analytics_service
@@ -935,6 +949,7 @@ pub async fn get_page_path_visitors(
     Query(query): Query<requests::PagePathVisitorsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
 
     let start_date: UtcDateTime = query.start_date.into();
     let end_date: UtcDateTime = query.end_date.into();
@@ -988,6 +1003,7 @@ pub async fn get_page_path_detail(
     Query(query): Query<requests::PagePathDetailQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
 
     let start_date: UtcDateTime = query.start_date.into();
     let end_date: UtcDateTime = query.end_date.into();
@@ -1043,6 +1059,7 @@ pub async fn get_active_visitors_count(
     Query(query): Query<ActiveVisitorsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
 
     let project_id = query.project_id;
     match app_state
@@ -1081,6 +1098,7 @@ pub async fn get_analytics_active_visitors(
     Query(query): Query<ActiveVisitorsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
 
     let project_id = query.project_id;
     let window = query.window_minutes.unwrap_or(5);
@@ -1131,6 +1149,7 @@ pub async fn get_live_visitors_list(
     Query(query): Query<ActiveVisitorsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
 
     let project_id = query.project_id;
     let window = query.window_minutes.unwrap_or(5);
@@ -1191,6 +1210,7 @@ pub async fn get_page_paths_sparklines(
     Query(query): Query<PagePathsSparklineQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
 
     let start_time: UtcDateTime = query.start_time.into();
     let end_time: UtcDateTime = query.end_time.into();
@@ -1266,6 +1286,7 @@ pub async fn get_page_hourly_sessions(
     Query(query): Query<PageHourlySessionsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
 
     let project_id = query.project_id;
     let start_time: UtcDateTime = query.start_time.into();
@@ -1322,6 +1343,7 @@ pub async fn get_visitor_by_id(
     axum::extract::Path(id): axum::extract::Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    deny_deployment_token!(auth);
 
     match app_state
         .analytics_service
@@ -1360,6 +1382,7 @@ pub async fn get_visitor_by_guid(
     axum::extract::Path(visitor_id): axum::extract::Path<String>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    deny_deployment_token!(auth);
 
     match app_state
         .analytics_service
@@ -1399,6 +1422,7 @@ pub async fn get_general_stats(
     Query(query): Query<GeneralStatsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    deny_deployment_token!(auth);
 
     match app_state
         .analytics_service
@@ -1439,6 +1463,7 @@ pub async fn get_page_flow(
     Query(query): Query<requests::PageFlowQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
 
     let start_date: UtcDateTime = query.start_date.into();
     let end_date: UtcDateTime = query.end_date.into();
@@ -1500,6 +1525,7 @@ pub async fn get_recent_activity(
     Query(query): Query<RecentActivityQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
 
     match app_state
         .analytics_service
@@ -1547,6 +1573,7 @@ pub async fn get_event_detail(
     Query(query): Query<requests::EventDetailQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
 
     let start_date: UtcDateTime = query.start_date.into();
     let end_date: UtcDateTime = query.end_date.into();
@@ -1600,6 +1627,7 @@ pub async fn get_event_visitors(
     Query(query): Query<requests::EventVisitorsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
 
     let start_date: UtcDateTime = query.start_date.into();
     let end_date: UtcDateTime = query.end_date.into();

--- a/crates/temps-auth/src/context.rs
+++ b/crates/temps-auth/src/context.rs
@@ -298,4 +298,75 @@ impl AuthContext {
             .as_ref()
             .ok_or("This endpoint requires user authentication. Deployment tokens are not allowed.")
     }
+
+    /// Whether this auth context is permitted to act on `project_id`.
+    ///
+    /// A deployment token is bound to exactly one project at issuance. It must
+    /// only ever touch that project — even when it carries `FullAccess` (which
+    /// makes `has_permission` return `true` for everything). This is the tenant
+    /// boundary that `permission_guard!` alone does NOT enforce: the guard
+    /// proves the caller holds a permission, not that the resource is theirs.
+    ///
+    /// For user/API-key/CLI auth this returns `true` (project-level ACLs for
+    /// human principals are an Enterprise/RBAC concern handled elsewhere); the
+    /// check exists specifically to stop a project-scoped machine credential
+    /// from reaching another tenant's resources (cross-project IDOR).
+    ///
+    /// Handlers should prefer the [`project_scope_guard!`] macro, which turns a
+    /// failure into an RFC 7807 403 response.
+    pub fn is_scoped_to_project(&self, project_id: i32) -> bool {
+        match self.project_id() {
+            // Deployment token: must match its bound project exactly.
+            Some(token_project_id) => token_project_id == project_id,
+            // Not a deployment token (user/API key/CLI/session): no per-project
+            // confinement at this layer.
+            None => true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn deployment_token_ctx(
+        project_id: i32,
+        permissions: Vec<DeploymentTokenPermission>,
+    ) -> AuthContext {
+        AuthContext::new_deployment_token(
+            project_id,
+            None,
+            None,
+            1,
+            "test-token".to_string(),
+            permissions,
+        )
+    }
+
+    #[test]
+    fn deployment_token_is_scoped_to_its_own_project() {
+        let ctx = deployment_token_ctx(7, vec![DeploymentTokenPermission::FullAccess]);
+        assert!(ctx.is_scoped_to_project(7));
+    }
+
+    #[test]
+    fn deployment_token_rejected_for_other_project_even_with_full_access() {
+        // FullAccess makes has_permission() return true for everything, so the
+        // ONLY thing stopping cross-tenant access is this scope check.
+        let ctx = deployment_token_ctx(7, vec![DeploymentTokenPermission::FullAccess]);
+        assert!(
+            !ctx.is_scoped_to_project(8),
+            "a project-7 token must not be scoped to project 8"
+        );
+        // Sanity: FullAccess really does grant the permission, proving the
+        // scope check is the load-bearing boundary.
+        assert!(ctx.has_permission(&Permission::EnvironmentsRead));
+    }
+
+    #[test]
+    fn deployment_token_rejected_for_other_project_with_narrow_permission() {
+        let ctx = deployment_token_ctx(7, vec![DeploymentTokenPermission::AnalyticsRead]);
+        assert!(ctx.is_scoped_to_project(7));
+        assert!(!ctx.is_scoped_to_project(8));
+    }
 }

--- a/crates/temps-auth/src/permission_guard.rs
+++ b/crates/temps-auth/src/permission_guard.rs
@@ -35,6 +35,89 @@ macro_rules! permission_guard {
     };
 }
 
+/// Guard that confines a deployment token to its bound project.
+///
+/// `permission_guard!` proves the caller holds a permission; it does NOT prove
+/// the resource they're touching is theirs. A deployment token carrying
+/// `FullAccess` satisfies every `permission_guard!`, so without this check it
+/// can read/modify another tenant's project by passing a different `project_id`
+/// in the path (cross-project IDOR). Call this immediately after the relevant
+/// `permission_guard!` in every handler that takes a `project_id` and may be
+/// reached by a deployment token.
+///
+/// For user/API-key/session/CLI auth this is a no-op (returns Ok), matching the
+/// semantics of [`AuthContext::is_scoped_to_project`].
+///
+/// Usage in handler:
+/// ```ignore
+/// pub async fn get_environment_variables(
+///     RequireAuth(auth): RequireAuth,
+///     State(state): State<Arc<AppState>>,
+///     Path(project_id): Path<i32>,
+/// ) -> Result<impl IntoResponse, Problem> {
+///     permission_guard!(auth, EnvironmentsRead);
+///     project_scope_guard!(auth, project_id);
+///
+///     // Your handler logic here
+/// }
+/// ```
+#[macro_export]
+macro_rules! project_scope_guard {
+    ($auth:expr, $project_id:expr) => {
+        if !$auth.is_scoped_to_project($project_id) {
+            return Err(temps_core::error_builder::ErrorBuilder::new(
+                ::axum::http::StatusCode::FORBIDDEN,
+            )
+            .type_("https://temps.sh/probs/cross-project-access-denied")
+            .title("Cross-Project Access Denied")
+            .detail(
+                "This deployment token is scoped to a different project and \
+                 cannot access this resource",
+            )
+            .build());
+        }
+    };
+}
+
+/// Guard that rejects deployment-token auth entirely (403).
+///
+/// Use on endpoints that take a resource id with no `project_id` in scope to
+/// confine it to the caller's project — e.g. analytics "by visitor/session id"
+/// reads. A deployment token is a project-scoped machine credential; without a
+/// `project_id` to compare against, the safe default is to require a real user
+/// or API-key session for these by-id reads (which the console already uses).
+/// No-op for user/API-key/session/CLI auth.
+///
+/// Usage in handler:
+/// ```ignore
+/// pub async fn get_visitor_by_id(
+///     RequireAuth(auth): RequireAuth,
+///     State(state): State<Arc<AppState>>,
+///     Path(id): Path<i32>,
+/// ) -> Result<impl IntoResponse, Problem> {
+///     permission_guard!(auth, AnalyticsRead);
+///     deny_deployment_token!(auth);
+///     // ...
+/// }
+/// ```
+#[macro_export]
+macro_rules! deny_deployment_token {
+    ($auth:expr) => {
+        if $auth.is_deployment_token() {
+            return Err(temps_core::error_builder::ErrorBuilder::new(
+                ::axum::http::StatusCode::FORBIDDEN,
+            )
+            .type_("https://temps.sh/probs/deployment-token-not-allowed")
+            .title("Deployment Token Not Allowed")
+            .detail(
+                "This endpoint requires user or API-key authentication; \
+                 deployment tokens are not permitted",
+            )
+            .build());
+        }
+    };
+}
+
 /// Alias for permission_guard! macro for backwards compatibility
 ///
 /// Usage in handler:

--- a/crates/temps-deployments/src/handlers/deployments.rs
+++ b/crates/temps-deployments/src/handlers/deployments.rs
@@ -29,9 +29,10 @@ use utoipa::OpenApi;
 use crate::handlers::types::{
     ActivityDay, ActivityGraphQuery, ActivityGraphResponse, ContainerActionResponse,
     ContainerDetailResponse, ContainerInfoResponse, ContainerListResponse, ContainerLogsQuery,
-    ContainerMetricsResponse, DeploymentJobResponse, DeploymentJobsResponse,
-    DeploymentListResponse, DeploymentResponse, DeploymentStateResponse, EnvVarResponse,
-    PromoteDeploymentRequest, ResourceLimitsResponse,
+    ContainerMetricsResponse, DeploymentContainerLogContentResponse,
+    DeploymentContainerLogResponse, DeploymentContainerLogsListResponse, DeploymentJobResponse,
+    DeploymentJobsResponse, DeploymentListResponse, DeploymentResponse, DeploymentStateResponse,
+    EnvVarResponse, PromoteDeploymentRequest, ResourceLimitsResponse,
 };
 use temps_core::problemdetails;
 use temps_core::problemdetails::Problem;
@@ -45,6 +46,8 @@ use temps_core::problemdetails::Problem;
         get_deployment_jobs,
         get_deployment_job_logs,
         tail_deployment_job_logs,
+        list_deployment_container_logs,
+        get_deployment_container_log_content,
         rollback_to_deployment,
         promote_deployment,
         pause_deployment,
@@ -81,7 +84,10 @@ use temps_core::problemdetails::Problem;
         ActivityGraphQuery,
         ActivityGraphResponse,
         ActivityDay,
-        PromoteDeploymentRequest
+        PromoteDeploymentRequest,
+        DeploymentContainerLogResponse,
+        DeploymentContainerLogsListResponse,
+        DeploymentContainerLogContentResponse
     )),
     info(
         title = "Deployments API",
@@ -113,6 +119,17 @@ pub fn configure_routes() -> Router<Arc<super::types::AppState>> {
         .route(
             "/projects/{project_id}/deployments/{deployment_id}/jobs/{job_id}/logs",
             get(get_deployment_job_logs),
+        )
+        // Historical (captured) container logs for previous deployments. These
+        // survive teardown so users can read the logs of a container that no
+        // longer exists (e.g. "web-2" from a few days ago).
+        .route(
+            "/projects/{project_id}/deployments/{deployment_id}/container-logs",
+            get(list_deployment_container_logs),
+        )
+        .route(
+            "/projects/{project_id}/deployments/{deployment_id}/container-logs/{log_id}",
+            get(get_deployment_container_log_content),
         )
         // Deployment operations
         .route(
@@ -1275,6 +1292,93 @@ pub async fn get_deployment_job_logs(
         })?;
 
     Ok((StatusCode::OK, log_content))
+}
+
+/// List the captured (historical) container-log dumps for a deployment.
+///
+/// Container runtime logs are normally only available live from the running
+/// container. When a deployment is superseded its containers are torn down and
+/// those logs would be lost — so just before teardown we capture each
+/// container's logs to durable storage. This endpoint lists what was captured
+/// for a given (often older) deployment, so a user can read the logs of a
+/// container that no longer exists.
+#[utoipa::path(
+    tag = "Deployments",
+    get,
+    params(
+        ("project_id" = i32, Path, description = "Project ID"),
+        ("deployment_id" = i32, Path, description = "Deployment ID")
+    ),
+    responses(
+        (status = 200, description = "Captured container logs for the deployment", body = DeploymentContainerLogsListResponse),
+        (status = 404, description = "Deployment not found in this project"),
+        (status = 500, description = "Internal server error")
+    ),
+    path = "/projects/{project_id}/deployments/{deployment_id}/container-logs",
+    security(("bearer_token" = []))
+)]
+pub async fn list_deployment_container_logs(
+    RequireAuth(auth): RequireAuth,
+    State(state): State<Arc<AppState>>,
+    Path((project_id, deployment_id)): Path<(i32, i32)>,
+) -> Result<impl IntoResponse, Problem> {
+    permission_guard!(auth, DeploymentsRead);
+
+    let logs = state
+        .deployment_service
+        .list_deployment_container_logs(project_id, deployment_id)
+        .await?;
+
+    let response = DeploymentContainerLogsListResponse {
+        logs: logs
+            .into_iter()
+            .map(DeploymentContainerLogResponse::from)
+            .collect(),
+    };
+
+    Ok((StatusCode::OK, Json(response)).into_response())
+}
+
+/// Get the captured text content of a single historical container-log dump.
+#[utoipa::path(
+    tag = "Deployments",
+    get,
+    params(
+        ("project_id" = i32, Path, description = "Project ID"),
+        ("deployment_id" = i32, Path, description = "Deployment ID"),
+        ("log_id" = i32, Path, description = "Captured log ID")
+    ),
+    responses(
+        (status = 200, description = "Captured container log content", body = DeploymentContainerLogContentResponse),
+        (status = 404, description = "Captured log not found in this project"),
+        (status = 500, description = "Internal server error")
+    ),
+    path = "/projects/{project_id}/deployments/{deployment_id}/container-logs/{log_id}",
+    security(("bearer_token" = []))
+)]
+pub async fn get_deployment_container_log_content(
+    RequireAuth(auth): RequireAuth,
+    State(state): State<Arc<AppState>>,
+    Path((project_id, deployment_id, log_id)): Path<(i32, i32, i32)>,
+) -> Result<impl IntoResponse, Problem> {
+    permission_guard!(auth, DeploymentsRead);
+
+    let (row, content) = state
+        .deployment_service
+        .get_deployment_container_log_content(project_id, deployment_id, log_id)
+        .await?;
+
+    let response = DeploymentContainerLogContentResponse {
+        id: row.id,
+        container_name: row.container_name,
+        service_name: row.service_name,
+        size_bytes: row.size_bytes,
+        truncated: row.truncated,
+        captured_at: row.captured_at.timestamp_millis(),
+        content,
+    };
+
+    Ok((StatusCode::OK, Json(response)).into_response())
 }
 
 /// Tail logs for a specific deployment job in real-time via WebSocket

--- a/crates/temps-deployments/src/handlers/types.rs
+++ b/crates/temps-deployments/src/handlers/types.rs
@@ -54,6 +54,58 @@ pub struct DeploymentDomainResponse {
     pub domain: String,
 }
 
+/// Metadata for one captured (historical) container-log dump. Listed on the
+/// deployment detail page so a user can pick which past container's logs to read.
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct DeploymentContainerLogResponse {
+    pub id: i32,
+    pub deployment_id: i32,
+    pub container_id: String,
+    pub container_name: String,
+    pub service_name: Option<String>,
+    pub node_id: Option<i32>,
+    pub size_bytes: i64,
+    pub truncated: bool,
+    /// Unix epoch milliseconds of when the logs were captured (just before
+    /// teardown). Matches the timestamp convention used by `DeploymentResponse`.
+    pub captured_at: i64,
+}
+
+impl From<temps_entities::deployment_container_logs::Model> for DeploymentContainerLogResponse {
+    fn from(m: temps_entities::deployment_container_logs::Model) -> Self {
+        Self {
+            id: m.id,
+            deployment_id: m.deployment_id,
+            container_id: m.container_id,
+            container_name: m.container_name,
+            service_name: m.service_name,
+            node_id: m.node_id,
+            size_bytes: m.size_bytes,
+            truncated: m.truncated,
+            captured_at: m.captured_at.timestamp_millis(),
+        }
+    }
+}
+
+/// The list of captured container-log dumps for a deployment.
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct DeploymentContainerLogsListResponse {
+    pub logs: Vec<DeploymentContainerLogResponse>,
+}
+
+/// A single captured container-log dump, including its full text content.
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct DeploymentContainerLogContentResponse {
+    pub id: i32,
+    pub container_name: String,
+    pub service_name: Option<String>,
+    pub size_bytes: i64,
+    pub truncated: bool,
+    pub captured_at: i64,
+    /// The captured plain-text log content.
+    pub content: String,
+}
+
 #[derive(Serialize, Deserialize, ToSchema)]
 pub struct CreateProjectRequest {
     pub name: String,

--- a/crates/temps-deployments/src/jobs/mark_deployment_complete.rs
+++ b/crates/temps-deployments/src/jobs/mark_deployment_complete.rs
@@ -17,7 +17,9 @@ use temps_core::{
     WorkflowTask,
 };
 use temps_database::DbConnection;
-use temps_entities::{deployment_containers, deployments, environments, nodes, projects};
+use temps_entities::{
+    deployment_container_logs, deployment_containers, deployments, environments, nodes, projects,
+};
 use temps_logs::{LogLevel, LogService};
 use tracing::{debug, info, warn};
 
@@ -1267,6 +1269,130 @@ impl MarkDeploymentCompleteJob {
         Ok(Arc::new(remote))
     }
 
+    /// Capture a container's logs to durable storage before it is torn down.
+    ///
+    /// Runtime logs are otherwise only available live from Docker; once the
+    /// container is removed they are gone. We dump them to a plain-text file
+    /// under the data dir (via `LogService`) and record a
+    /// `deployment_container_logs` row so users can read the logs of a
+    /// superseded container (e.g. "web-2") days later.
+    ///
+    /// Best-effort: any failure is logged and swallowed — capturing logs must
+    /// never block or fail a deployment teardown.
+    async fn capture_container_logs(
+        &self,
+        deployer: &Arc<dyn temps_deployer::ContainerDeployer>,
+        container: &deployment_containers::Model,
+        project_id: i32,
+        environment_id: i32,
+    ) {
+        // Tail cap: a single dump is bounded so a runaway log can't fill the
+        // disk. We keep the last MAX_BYTES and flag the row as truncated.
+        const MAX_BYTES: usize = 8 * 1024 * 1024; // 8 MiB
+
+        let Some(log_service) = self.log_service.as_ref() else {
+            debug!(
+                "No log service configured; skipping log capture for container {}",
+                container.container_id
+            );
+            return;
+        };
+
+        // Pull the full logs from the (still-running) container.
+        let mut logs = match deployer.get_container_logs(&container.container_id).await {
+            Ok(logs) => logs,
+            Err(e) => {
+                // Not fatal — the container may have already exited/been pruned.
+                self.log(format!(
+                    "Could not capture logs for container {} before teardown: {}",
+                    container.container_name, e
+                ))
+                .await
+                .ok();
+                return;
+            }
+        };
+
+        // Truncate to the tail if oversized, on a char boundary to keep valid UTF-8.
+        let truncated = logs.len() > MAX_BYTES;
+        if truncated {
+            let mut start = logs.len() - MAX_BYTES;
+            while start < logs.len() && !logs.is_char_boundary(start) {
+                start += 1;
+            }
+            let tail = logs.split_off(start);
+            logs = format!(
+                "[… earlier output truncated; showing last {} bytes …]\n{}",
+                MAX_BYTES, tail
+            );
+        }
+
+        // Server-generated relative path. Contains only the deployment id (i32),
+        // the container's i32 row id, and a static suffix — no user-controlled
+        // input — so it cannot be used for path traversal.
+        let log_path = format!(
+            "deployment-container-logs/{}/{}.log",
+            container.deployment_id, container.id
+        );
+        let full_path = log_service.base_path().join(&log_path);
+
+        if let Some(parent) = full_path.parent() {
+            if let Err(e) = tokio::fs::create_dir_all(parent).await {
+                self.log(format!(
+                    "Failed to create log capture directory for container {}: {}",
+                    container.container_name, e
+                ))
+                .await
+                .ok();
+                return;
+            }
+        }
+
+        let size_bytes = logs.len() as i64;
+        if let Err(e) = tokio::fs::write(&full_path, logs.as_bytes()).await {
+            self.log(format!(
+                "Failed to write captured logs for container {}: {}",
+                container.container_name, e
+            ))
+            .await
+            .ok();
+            return;
+        }
+
+        // Record the metadata row. If the row write fails the file is orphaned
+        // (harmless — it's just disk), so we still don't fail teardown.
+        let row = deployment_container_logs::ActiveModel {
+            deployment_id: Set(container.deployment_id),
+            project_id: Set(project_id),
+            environment_id: Set(environment_id),
+            container_id: Set(container.container_id.clone()),
+            container_name: Set(container.container_name.clone()),
+            service_name: Set(container.service_name.clone()),
+            node_id: Set(container.node_id),
+            log_path: Set(log_path),
+            size_bytes: Set(size_bytes),
+            truncated: Set(truncated),
+            ..Default::default()
+        };
+
+        if let Err(e) = row.insert(self.db.as_ref()).await {
+            self.log(format!(
+                "Failed to record captured logs for container {}: {}",
+                container.container_name, e
+            ))
+            .await
+            .ok();
+            return;
+        }
+
+        self.log(format!(
+            "Captured {} bytes of logs for container {} before teardown",
+            size_bytes, container.container_name
+        ))
+        .await
+        .ok();
+    }
+
     /// Teardown all running/pending deployments for the same environment
     /// This ensures only one active deployment per environment
     /// Note: Deployment state is NOT changed - the is_current flag indicates which deployment is active
@@ -1388,6 +1514,16 @@ impl MarkDeploymentCompleteJob {
                 } else {
                     self.container_deployer.clone()
                 };
+
+                // Capture the container's logs to durable storage BEFORE we stop
+                // and remove it, so they survive teardown and can be viewed later.
+                self.capture_container_logs(
+                    &deployer,
+                    &container,
+                    deployment.project_id,
+                    deployment.environment_id,
+                )
+                .await;
 
                 // Stop container first
                 match deployer.stop_container(&container_id).await {

--- a/crates/temps-deployments/src/services/services.rs
+++ b/crates/temps-deployments/src/services/services.rs
@@ -6,7 +6,8 @@ use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 use temps_entities::{
-    deployment_containers, deployment_domains, deployments, environments, projects,
+    deployment_container_logs, deployment_containers, deployment_domains, deployments,
+    environments, projects,
 };
 use thiserror::Error;
 use tracing::{debug, error, info, warn};
@@ -832,6 +833,84 @@ impl DeploymentService {
         Ok(self
             .map_db_deployment_to_deployment(deployment, is_current, environment)
             .await)
+    }
+
+    /// List the captured (historical) container-log dumps for a deployment.
+    ///
+    /// These are written just before a superseded deployment's containers are
+    /// torn down (see `MarkDeploymentCompleteJob::capture_container_logs`), so
+    /// they let a user read the logs of a container that no longer exists
+    /// (e.g. "web-2" from a few days ago).
+    ///
+    /// Scoped to `project_id`: the deployment must belong to the caller's
+    /// project or this returns `NotFound`, preventing cross-tenant access.
+    pub async fn list_deployment_container_logs(
+        &self,
+        project_id: i32,
+        deployment_id: i32,
+    ) -> Result<Vec<deployment_container_logs::Model>, DeploymentError> {
+        // Authorize: confirm the deployment is in this project before exposing
+        // anything tied to it.
+        deployments::Entity::find()
+            .filter(deployments::Column::ProjectId.eq(project_id))
+            .filter(deployments::Column::Id.eq(deployment_id))
+            .one(self.db.as_ref())
+            .await?
+            .ok_or_else(|| {
+                DeploymentError::NotFound(format!(
+                    "deployment {} for project {} not found",
+                    deployment_id, project_id
+                ))
+            })?;
+
+        let logs = deployment_container_logs::Entity::find()
+            .filter(deployment_container_logs::Column::DeploymentId.eq(deployment_id))
+            .filter(deployment_container_logs::Column::ProjectId.eq(project_id))
+            .order_by_desc(deployment_container_logs::Column::CapturedAt)
+            .all(self.db.as_ref())
+            .await?;
+
+        Ok(logs)
+    }
+
+    /// Read the captured text content for a single historical container-log
+    /// dump, returning the metadata row alongside the log body.
+    ///
+    /// Scoped to `project_id` via the `log_id` row's own `project_id` column —
+    /// a caller can only read dumps that belong to their project.
+    pub async fn get_deployment_container_log_content(
+        &self,
+        project_id: i32,
+        deployment_id: i32,
+        log_id: i32,
+    ) -> Result<(deployment_container_logs::Model, String), DeploymentError> {
+        let row = deployment_container_logs::Entity::find()
+            .filter(deployment_container_logs::Column::Id.eq(log_id))
+            .filter(deployment_container_logs::Column::DeploymentId.eq(deployment_id))
+            .filter(deployment_container_logs::Column::ProjectId.eq(project_id))
+            .one(self.db.as_ref())
+            .await?
+            .ok_or_else(|| {
+                DeploymentError::NotFound(format!(
+                    "captured log {} for deployment {} in project {} not found",
+                    log_id, deployment_id, project_id
+                ))
+            })?;
+
+        // `log_path` is a server-generated relative path (never user input), so
+        // `get_log_content` resolves it safely under the data dir.
+        let content = self
+            .log_service
+            .get_log_content(&row.log_path)
+            .await
+            .map_err(|e| {
+                DeploymentError::Other(format!(
+                    "Failed to read captured log file for log {} (deployment {}): {}",
+                    log_id, deployment_id, e
+                ))
+            })?;
+
+        Ok((row, content))
     }
 
     pub async fn get_deployment_domains(
@@ -5057,5 +5136,127 @@ mod tests {
         let container = container.insert(db.as_ref()).await?;
 
         Ok((project, environment, deployment, container))
+    }
+
+    /// Insert a captured-log metadata row and write its backing file under the
+    /// service's log base path so the service can read it back. Returns the row.
+    async fn seed_captured_log(
+        db: &Arc<temps_database::DbConnection>,
+        log_base: &std::path::Path,
+        deployment: &deployments::Model,
+        container_name: &str,
+        content: &str,
+    ) -> Result<deployment_container_logs::Model, Box<dyn std::error::Error>> {
+        let row = deployment_container_logs::ActiveModel {
+            deployment_id: Set(deployment.id),
+            project_id: Set(deployment.project_id),
+            environment_id: Set(deployment.environment_id),
+            container_id: Set(format!("cid-{}", container_name)),
+            container_name: Set(container_name.to_string()),
+            service_name: Set(None),
+            node_id: Set(None),
+            log_path: Set(String::new()), // filled in after we know the row id
+            size_bytes: Set(content.len() as i64),
+            truncated: Set(false),
+            ..Default::default()
+        };
+        let row = row.insert(db.as_ref()).await?;
+
+        // Mirror the path scheme used by capture_container_logs.
+        let log_path = format!("deployment-container-logs/{}/{}.log", deployment.id, row.id);
+        let full_path = log_base.join(&log_path);
+        if let Some(parent) = full_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        tokio::fs::write(&full_path, content.as_bytes()).await?;
+
+        let mut active: deployment_container_logs::ActiveModel = row.into();
+        active.log_path = Set(log_path);
+        let row = active.update(db.as_ref()).await?;
+        Ok(row)
+    }
+
+    #[tokio::test]
+    async fn test_list_deployment_container_logs_returns_captured_rows(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+        let (_project, _environment, deployment) = setup_test_data(&db).await?;
+
+        let log_base = std::env::temp_dir();
+        seed_captured_log(&db, &log_base, &deployment, "web-1", "old logs").await?;
+        seed_captured_log(&db, &log_base, &deployment, "web-2", "newer logs").await?;
+
+        let service = create_deployment_service_for_test(db.clone());
+        let logs = service
+            .list_deployment_container_logs(deployment.project_id, deployment.id)
+            .await?;
+
+        assert_eq!(logs.len(), 2);
+        // All captured logs belong to the requested deployment.
+        assert!(logs.iter().all(|l| l.deployment_id == deployment.id));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_list_deployment_container_logs_wrong_project_not_found(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+        let (_project, _environment, deployment) = setup_test_data(&db).await?;
+
+        let service = create_deployment_service_for_test(db.clone());
+        // A different project id must not see this deployment's logs — IDOR guard.
+        let result = service
+            .list_deployment_container_logs(deployment.project_id + 999, deployment.id)
+            .await;
+
+        assert!(matches!(result, Err(DeploymentError::NotFound(_))));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_deployment_container_log_content_reads_file(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+        let (_project, _environment, deployment) = setup_test_data(&db).await?;
+
+        let log_base = std::env::temp_dir();
+        let row =
+            seed_captured_log(&db, &log_base, &deployment, "web-2", "hello from web-2").await?;
+
+        let service = create_deployment_service_for_test(db.clone());
+        let (got_row, content) = service
+            .get_deployment_container_log_content(deployment.project_id, deployment.id, row.id)
+            .await?;
+
+        assert_eq!(got_row.id, row.id);
+        assert_eq!(content, "hello from web-2");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_deployment_container_log_content_wrong_project_not_found(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+        let (_project, _environment, deployment) = setup_test_data(&db).await?;
+
+        let log_base = std::env::temp_dir();
+        let row = seed_captured_log(&db, &log_base, &deployment, "web-2", "secret").await?;
+
+        let service = create_deployment_service_for_test(db.clone());
+        // Reading with a foreign project id must be denied even with the right log id.
+        let result = service
+            .get_deployment_container_log_content(
+                deployment.project_id + 999,
+                deployment.id,
+                row.id,
+            )
+            .await;
+
+        assert!(matches!(result, Err(DeploymentError::NotFound(_))));
+        Ok(())
     }
 }

--- a/crates/temps-entities/src/deployment_container_logs.rs
+++ b/crates/temps-entities/src/deployment_container_logs.rs
@@ -1,0 +1,81 @@
+use async_trait::async_trait;
+use sea_orm::entity::prelude::*;
+use sea_orm::{ActiveValue::Set, ConnectionTrait, DbErr};
+use serde::{Deserialize, Serialize};
+use temps_core::DBDateTime;
+
+/// A captured, persisted log dump for a deployment container that has since been
+/// torn down. Written just before a superseded deployment's containers are
+/// stopped and removed, so the logs of "the container that ran a few days ago"
+/// survive and can be viewed later.
+///
+/// The dump itself is a plain-text file on disk under the data dir (managed by
+/// `temps_logs::LogService`); this row carries only the metadata and the
+/// server-generated relative `log_path` to it.
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "deployment_container_logs")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub deployment_id: i32,
+    /// Denormalised for fast project-scoped authorization on read.
+    pub project_id: i32,
+    pub environment_id: i32,
+    /// Docker container id at capture time (the container no longer exists).
+    pub container_id: String,
+    /// Human-visible container name, e.g. "web-2".
+    pub container_name: String,
+    /// Compose service name (e.g. "web"). NULL for single-container deployments.
+    #[sea_orm(column_type = "String(StringLen::N(255))", nullable)]
+    pub service_name: Option<String>,
+    /// Node this container ran on. NULL = local node (single-node mode).
+    pub node_id: Option<i32>,
+    /// Server-generated relative path of the captured log file under the data
+    /// dir. Never user-supplied — safe from path traversal.
+    pub log_path: String,
+    /// Size of the captured dump in bytes.
+    pub size_bytes: i64,
+    /// True when the dump was truncated to the tail because the live log
+    /// exceeded the capture cap.
+    pub truncated: bool,
+    /// When the logs were captured (just before teardown).
+    pub captured_at: DBDateTime,
+    pub created_at: DBDateTime,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::deployments::Entity",
+        from = "Column::DeploymentId",
+        to = "super::deployments::Column::Id"
+    )]
+    Deployment,
+}
+
+impl Related<super::deployments::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Deployment.def()
+    }
+}
+
+#[async_trait]
+impl ActiveModelBehavior for ActiveModel {
+    async fn before_save<C>(mut self, _db: &C, insert: bool) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        let now = chrono::Utc::now();
+
+        if insert {
+            if self.created_at.is_not_set() {
+                self.created_at = Set(now);
+            }
+            if self.captured_at.is_not_set() {
+                self.captured_at = Set(now);
+            }
+        }
+
+        Ok(self)
+    }
+}

--- a/crates/temps-entities/src/lib.rs
+++ b/crates/temps-entities/src/lib.rs
@@ -28,6 +28,7 @@ pub mod cron_executions;
 pub mod crons;
 pub mod custom_routes;
 pub mod deployment_config;
+pub mod deployment_container_logs;
 pub mod deployment_containers;
 pub mod deployment_domains;
 pub mod deployment_jobs;

--- a/crates/temps-environments/src/handlers/handler.rs
+++ b/crates/temps-environments/src/handlers/handler.rs
@@ -12,7 +12,7 @@ use axum::{
     Json,
 };
 use std::sync::Arc;
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_scope_guard, RequireAuth};
 use temps_core::AuditContext;
 use temps_core::RequestMetadata;
 use tracing::{error, info};
@@ -121,6 +121,7 @@ pub async fn get_environments(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsRead);
+    project_scope_guard!(auth, project_id);
 
     let environments = state
         .environment_service
@@ -189,6 +190,7 @@ pub async fn get_environment(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsRead);
+    project_scope_guard!(auth, project_id);
 
     let env = state
         .environment_service
@@ -253,6 +255,7 @@ pub async fn get_environment_domains(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsRead);
+    project_scope_guard!(auth, project_id);
 
     let domains = state
         .environment_service
@@ -303,6 +306,7 @@ pub async fn add_environment_domain(
     Json(request): Json<AddEnvironmentDomainRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsWrite);
+    project_scope_guard!(auth, project_id);
 
     let domain = state
         .environment_service
@@ -348,6 +352,7 @@ pub async fn delete_environment_domain(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsDelete);
+    project_scope_guard!(auth, project_id);
 
     state
         .environment_service
@@ -383,6 +388,7 @@ pub async fn get_environment_variables(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsRead);
+    project_scope_guard!(auth, project_id);
 
     let vars = state
         .env_var_service
@@ -463,6 +469,7 @@ pub async fn get_resolved_environment_variables(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsRead);
+    project_scope_guard!(auth, project_id);
 
     // Manual vars (already includes environment memberships).
     let manual = state
@@ -616,6 +623,7 @@ pub async fn get_resolved_environment_variable_value(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsRead);
+    project_scope_guard!(auth, project_id);
 
     info!(
         user_id = auth.user_id(),
@@ -706,6 +714,7 @@ pub async fn create_environment_variable(
     Json(request): Json<CreateEnvironmentVariableRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsCreate);
+    project_scope_guard!(auth, project_id);
 
     let var = state
         .env_var_service
@@ -764,6 +773,7 @@ pub async fn delete_environment_variable(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsDelete);
+    project_scope_guard!(auth, project_id);
 
     state
         .env_var_service
@@ -797,6 +807,7 @@ pub async fn update_environment_variable(
     Json(request): Json<UpdateEnvironmentVariableRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsWrite);
+    project_scope_guard!(auth, project_id);
 
     let var = state
         .env_var_service
@@ -857,6 +868,7 @@ pub async fn get_environment_variable_value(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsRead);
+    project_scope_guard!(auth, project_id);
 
     // Reveal of a single decrypted secret. Logged at info so any
     // bulk-reveal pattern (one of the obvious post-compromise behaviors)
@@ -902,6 +914,7 @@ pub async fn update_environment_settings(
     Json(settings): Json<UpdateEnvironmentSettingsRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsWrite);
+    project_scope_guard!(auth, project_id);
 
     // Get project details for audit log
     let project = state.environment_service.get_project(project_id).await?;
@@ -1019,6 +1032,7 @@ pub async fn update_environment_subdomain(
     Json(request): Json<UpdateEnvironmentSubdomainRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsWrite);
+    project_scope_guard!(auth, project_id);
 
     let project = state.environment_service.get_project(project_id).await?;
     let environment = state
@@ -1119,6 +1133,7 @@ pub async fn wake_environment(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsWrite);
+    project_scope_guard!(auth, project_id);
 
     // Cooldown: reject if last state change was less than 30 seconds ago
     let environment = state
@@ -1270,6 +1285,7 @@ pub async fn sleep_environment(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsWrite);
+    project_scope_guard!(auth, project_id);
 
     // Cooldown: reject if last state change was less than 30 seconds ago
     let environment = state
@@ -1410,6 +1426,7 @@ pub async fn delete_environment(
     Extension(metadata): Extension<temps_core::RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsDelete);
+    project_scope_guard!(auth, project_id);
 
     // Get environment details before deletion for audit log
     let environment = state
@@ -1495,6 +1512,7 @@ pub async fn create_environment(
     Json(request): Json<CreateEnvironmentRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsCreate);
+    project_scope_guard!(auth, project_id);
 
     let environment = state
         .environment_service
@@ -1575,6 +1593,7 @@ pub async fn list_project_secrets(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsRead);
+    project_scope_guard!(auth, project_id);
 
     let secrets = state
         .secret_service
@@ -1631,6 +1650,7 @@ pub async fn create_project_secret(
     Json(request): Json<CreateProjectSecretRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsCreate);
+    project_scope_guard!(auth, project_id);
 
     let secret = state
         .secret_service
@@ -1691,6 +1711,7 @@ pub async fn update_project_secret(
     Json(request): Json<UpdateProjectSecretRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsWrite);
+    project_scope_guard!(auth, project_id);
 
     let secret = state
         .secret_service
@@ -1747,6 +1768,7 @@ pub async fn delete_project_secret(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsDelete);
+    project_scope_guard!(auth, project_id);
 
     state.secret_service.delete(project_id, secret_id).await?;
     Ok(StatusCode::NO_CONTENT.into_response())

--- a/crates/temps-error-tracking/src/handlers/alert_rules_handler.rs
+++ b/crates/temps-error-tracking/src/handlers/alert_rules_handler.rs
@@ -1,5 +1,4 @@
 use super::types::AppState;
-use crate::services::ErrorTrackingError;
 use axum::{
     extract::{Path, State},
     http::StatusCode,
@@ -9,6 +8,8 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use temps_auth::{permission_guard, project_scope_guard, RequireAuth};
+use temps_core::problemdetails::Problem;
 use temps_entities::error_alert_rules;
 use utoipa::{OpenApi, ToSchema};
 
@@ -150,8 +151,11 @@ impl From<error_alert_rules::Model> for AlertRuleResponse {
 )]
 pub async fn list_alert_rules(
     State(state): State<Arc<AppState>>,
+    RequireAuth(auth): RequireAuth,
     Path(project_id): Path<i32>,
-) -> Result<Json<Vec<AlertRuleResponse>>, ErrorTrackingError> {
+) -> Result<Json<Vec<AlertRuleResponse>>, Problem> {
+    permission_guard!(auth, ErrorTrackingRead);
+    project_scope_guard!(auth, project_id);
     let rules = state.alert_service.list_rules(project_id).await?;
     Ok(Json(
         rules.into_iter().map(AlertRuleResponse::from).collect(),
@@ -175,8 +179,11 @@ pub async fn list_alert_rules(
 )]
 pub async fn get_alert_rule(
     State(state): State<Arc<AppState>>,
+    RequireAuth(auth): RequireAuth,
     Path((project_id, rule_id)): Path<(i32, i32)>,
-) -> Result<Json<AlertRuleResponse>, ErrorTrackingError> {
+) -> Result<Json<AlertRuleResponse>, Problem> {
+    permission_guard!(auth, ErrorTrackingRead);
+    project_scope_guard!(auth, project_id);
     let rule = state.alert_service.get_rule(rule_id, project_id).await?;
     Ok(Json(AlertRuleResponse::from(rule)))
 }
@@ -198,9 +205,12 @@ pub async fn get_alert_rule(
 )]
 pub async fn create_alert_rule(
     State(state): State<Arc<AppState>>,
+    RequireAuth(auth): RequireAuth,
     Path(project_id): Path<i32>,
     Json(request): Json<CreateAlertRuleRequest>,
-) -> Result<(StatusCode, Json<AlertRuleResponse>), ErrorTrackingError> {
+) -> Result<(StatusCode, Json<AlertRuleResponse>), Problem> {
+    permission_guard!(auth, ErrorTrackingCreate);
+    project_scope_guard!(auth, project_id);
     let rule = state
         .alert_service
         .create_rule(
@@ -238,9 +248,12 @@ pub async fn create_alert_rule(
 )]
 pub async fn update_alert_rule(
     State(state): State<Arc<AppState>>,
+    RequireAuth(auth): RequireAuth,
     Path((project_id, rule_id)): Path<(i32, i32)>,
     Json(request): Json<UpdateAlertRuleRequest>,
-) -> Result<Json<AlertRuleResponse>, ErrorTrackingError> {
+) -> Result<Json<AlertRuleResponse>, Problem> {
+    permission_guard!(auth, ErrorTrackingWrite);
+    project_scope_guard!(auth, project_id);
     let rule = state
         .alert_service
         .update_rule(
@@ -277,8 +290,11 @@ pub async fn update_alert_rule(
 )]
 pub async fn delete_alert_rule(
     State(state): State<Arc<AppState>>,
+    RequireAuth(auth): RequireAuth,
     Path((project_id, rule_id)): Path<(i32, i32)>,
-) -> Result<StatusCode, ErrorTrackingError> {
+) -> Result<StatusCode, Problem> {
+    permission_guard!(auth, ErrorTrackingWrite);
+    project_scope_guard!(auth, project_id);
     state.alert_service.delete_rule(rule_id, project_id).await?;
 
     Ok(StatusCode::NO_CONTENT)

--- a/crates/temps-error-tracking/src/handlers/handler.rs
+++ b/crates/temps-error-tracking/src/handlers/handler.rs
@@ -9,6 +9,8 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use temps_auth::{permission_guard, project_scope_guard, RequireAuth};
+use temps_core::problemdetails::Problem;
 use temps_core::DateTime;
 use utoipa::{IntoParams, OpenApi, ToSchema};
 
@@ -270,6 +272,34 @@ pub struct ErrorResponse {
     pub details: Option<String>,
 }
 
+impl From<ErrorTrackingError> for temps_core::problemdetails::Problem {
+    fn from(err: ErrorTrackingError) -> Self {
+        use temps_core::problemdetails;
+        match err {
+            ErrorTrackingError::GroupNotFound
+            | ErrorTrackingError::EventNotFound
+            | ErrorTrackingError::ProjectNotFound => problemdetails::new(StatusCode::NOT_FOUND)
+                .with_title("Not Found")
+                .with_detail(err.to_string()),
+            ErrorTrackingError::InvalidFingerprint | ErrorTrackingError::Validation(_) => {
+                problemdetails::new(StatusCode::BAD_REQUEST)
+                    .with_title("Validation Error")
+                    .with_detail(err.to_string())
+            }
+            ErrorTrackingError::PayloadTooLarge { .. } => {
+                problemdetails::new(StatusCode::PAYLOAD_TOO_LARGE)
+                    .with_title("Payload Too Large")
+                    .with_detail(err.to_string())
+            }
+            ErrorTrackingError::Database(_) | ErrorTrackingError::EmbeddingService(_) => {
+                problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
+                    .with_title("Internal Server Error")
+                    .with_detail(err.to_string())
+            }
+        }
+    }
+}
+
 impl axum::response::IntoResponse for ErrorTrackingError {
     fn into_response(self) -> axum::response::Response {
         let (status, message) = match self {
@@ -339,9 +369,12 @@ impl axum::response::IntoResponse for ErrorTrackingError {
 )]
 pub async fn list_error_groups(
     State(state): State<Arc<AppState>>,
+    RequireAuth(auth): RequireAuth,
     Path(project_id): Path<i32>,
     Query(query): Query<ListErrorGroupsQuery>,
-) -> Result<Json<PaginatedErrorGroupsResponse>, ErrorTrackingError> {
+) -> Result<Json<PaginatedErrorGroupsResponse>, Problem> {
+    permission_guard!(auth, ErrorTrackingRead);
+    project_scope_guard!(auth, project_id);
     let page = query.page;
     let page_size = std::cmp::min(query.page_size, 100);
 
@@ -392,8 +425,11 @@ pub async fn list_error_groups(
 )]
 pub async fn get_error_group(
     State(state): State<Arc<AppState>>,
+    RequireAuth(auth): RequireAuth,
     Path((project_id, group_id)): Path<(i32, i32)>,
-) -> Result<Json<ErrorGroupResponse>, ErrorTrackingError> {
+) -> Result<Json<ErrorGroupResponse>, Problem> {
+    permission_guard!(auth, ErrorTrackingRead);
+    project_scope_guard!(auth, project_id);
     let group = state
         .error_tracking_service
         .get_error_group(group_id, project_id)
@@ -420,13 +456,27 @@ pub async fn get_error_group(
 )]
 pub async fn update_error_group(
     State(state): State<Arc<AppState>>,
+    RequireAuth(auth): RequireAuth,
     Path((project_id, group_id)): Path<(i32, i32)>,
     Json(request): Json<UpdateErrorGroupRequest>,
-) -> Result<StatusCode, ErrorTrackingError> {
+) -> Result<StatusCode, Problem> {
+    permission_guard!(auth, ErrorTrackingWrite);
+    project_scope_guard!(auth, project_id);
     state
         .error_tracking_service
         .update_error_group_status(group_id, project_id, request.status, request.assigned_to)
         .await?;
+
+    // TODO(security): emit a structured audit event for this mutation once the
+    // crate is wired to the audit service (it currently has no AuditLogger in
+    // AppState). For now the write is at least authenticated, authorized, and
+    // tenant-scoped.
+    tracing::info!(
+        user_id = auth.user_id(),
+        project_id,
+        group_id,
+        "error group updated"
+    );
 
     Ok(StatusCode::OK)
 }
@@ -449,9 +499,12 @@ pub async fn update_error_group(
 )]
 pub async fn list_error_events(
     State(state): State<Arc<AppState>>,
+    RequireAuth(auth): RequireAuth,
     Path((project_id, group_id)): Path<(i32, i32)>,
     Query(query): Query<ListErrorEventsQuery>,
-) -> Result<Json<PaginatedErrorEventsResponse>, ErrorTrackingError> {
+) -> Result<Json<PaginatedErrorEventsResponse>, Problem> {
+    permission_guard!(auth, ErrorTrackingRead);
+    project_scope_guard!(auth, project_id);
     let page = query.page;
     let page_size = std::cmp::min(query.page_size, 100);
 
@@ -495,8 +548,11 @@ pub async fn list_error_events(
 )]
 pub async fn get_error_event(
     State(state): State<Arc<AppState>>,
+    RequireAuth(auth): RequireAuth,
     Path((project_id, group_id, event_id)): Path<(i32, i32, i64)>,
-) -> Result<Json<ErrorEventResponse>, ErrorTrackingError> {
+) -> Result<Json<ErrorEventResponse>, Problem> {
+    permission_guard!(auth, ErrorTrackingRead);
+    project_scope_guard!(auth, project_id);
     let event = state
         .error_tracking_service
         .get_error_event(event_id, group_id, project_id)
@@ -520,8 +576,11 @@ pub async fn get_error_event(
 )]
 pub async fn get_error_stats(
     State(state): State<Arc<AppState>>,
+    RequireAuth(auth): RequireAuth,
     Path(project_id): Path<i32>,
-) -> Result<Json<ErrorGroupStatsResponse>, ErrorTrackingError> {
+) -> Result<Json<ErrorGroupStatsResponse>, Problem> {
+    permission_guard!(auth, ErrorTrackingRead);
+    project_scope_guard!(auth, project_id);
     let stats = state
         .error_tracking_service
         .get_error_stats(project_id, None)
@@ -551,9 +610,12 @@ pub async fn get_error_stats(
 )]
 pub async fn get_error_dashboard_stats(
     State(state): State<Arc<AppState>>,
+    RequireAuth(auth): RequireAuth,
     Path(project_id): Path<i32>,
     Query(query): Query<ErrorDashboardStatsQuery>,
-) -> Result<Json<ErrorDashboardStatsResponse>, ErrorTrackingError> {
+) -> Result<Json<ErrorDashboardStatsResponse>, Problem> {
+    permission_guard!(auth, ErrorTrackingRead);
+    project_scope_guard!(auth, project_id);
     let stats = state
         .error_tracking_service
         .get_dashboard_stats(
@@ -594,9 +656,12 @@ pub async fn get_error_dashboard_stats(
 )]
 pub async fn get_error_time_series(
     State(state): State<Arc<AppState>>,
+    RequireAuth(auth): RequireAuth,
     Path(project_id): Path<i32>,
     Query(query): Query<ErrorTimeSeriesQuery>,
-) -> Result<Json<Vec<ErrorTimeSeriesDataResponse>>, ErrorTrackingError> {
+) -> Result<Json<Vec<ErrorTimeSeriesDataResponse>>, Problem> {
+    permission_guard!(auth, ErrorTrackingRead);
+    project_scope_guard!(auth, project_id);
     let data = state
         .error_tracking_service
         .get_error_time_series(
@@ -633,8 +698,11 @@ pub async fn get_error_time_series(
 )]
 pub async fn has_error_groups(
     State(state): State<Arc<AppState>>,
+    RequireAuth(auth): RequireAuth,
     Path(project_id): Path<i32>,
-) -> Result<Json<HasErrorGroupsResponse>, ErrorTrackingError> {
+) -> Result<Json<HasErrorGroupsResponse>, Problem> {
+    permission_guard!(auth, ErrorTrackingRead);
+    project_scope_guard!(auth, project_id);
     let has_error_groups = state
         .error_tracking_service
         .has_error_groups(project_id)

--- a/crates/temps-git/src/handlers/base.rs
+++ b/crates/temps-git/src/handlers/base.rs
@@ -27,6 +27,32 @@ use temps_core::UtcDateTime;
 use temps_entities::git_provider_connections;
 use utoipa::ToSchema;
 
+/// Reject self-hosted Git provider URLs that point at internal infrastructure
+/// (loopback, RFC1918 private ranges, link-local, cloud metadata 169.254.169.254).
+///
+/// `GitProvidersCreate` is granted to ordinary users, and the create handlers
+/// synchronously probe `{base_url}/api/v4/user` (GitLab) with the supplied
+/// token. Without this check a user could point `base_url`/`api_url` at an
+/// internal service and use the create call as an SSRF oracle (SEC-07). The
+/// validation is synchronous (it blocks literal private/loopback/link-local/
+/// metadata IPs and `localhost`); the provider HTTP clients additionally
+/// disable redirect following so a public host can't 302 to an internal one.
+///
+/// Residual gap: this synchronous validator does NOT resolve domains, so a
+/// public hostname that resolves to a private IP (DNS rebinding) is not caught
+/// here. Closing that needs a connect-time blocklisting DNS resolver on the
+/// provider clients (tracked separately).
+fn reject_ssrf_url(label: &str, url: Option<&String>) -> Result<(), Problem> {
+    if let Some(url) = url {
+        if let Err(e) = temps_core::url_validation::validate_external_url(url) {
+            return Err(problem_new(StatusCode::BAD_REQUEST)
+                .with_title("Invalid Provider URL")
+                .with_detail(format!("{} '{}' is not allowed: {}", label, url, e)));
+        }
+    }
+    Ok(())
+}
+
 // Convert RepositoryServiceError to Problem Details
 impl From<RepositoryServiceError> for Problem {
     fn from(error: RepositoryServiceError) -> Self {
@@ -524,6 +550,10 @@ pub async fn create_git_provider(
     Json(request): Json<CreateProviderRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_check!(auth, Permission::GitProvidersCreate);
+
+    // SSRF guard: a self-hosted base_url/api_url must not point at internal infra.
+    reject_ssrf_url("base_url", request.base_url.as_ref())?;
+    reject_ssrf_url("api_url", request.api_url.as_ref())?;
 
     // Parse provider type
     let provider_type = GitProviderType::try_from(request.provider_type.as_str()).map_err(|e| {
@@ -1815,6 +1845,10 @@ pub async fn create_gitlab_pat_provider(
     Json(request): Json<CreateGitLabPATRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_check!(auth, Permission::GitProvidersCreate);
+
+    // SSRF guard: this handler synchronously probes {base_url}/api/v4/user with
+    // the supplied token, so a malicious base_url is a live SSRF vector.
+    reject_ssrf_url("base_url", request.base_url.as_ref())?;
 
     let user_id = auth.user_id();
 

--- a/crates/temps-git/src/services/github_provider.rs
+++ b/crates/temps-git/src/services/github_provider.rs
@@ -176,6 +176,8 @@ impl GitHubProvider {
         reqwest::Client::builder()
             .user_agent("Temps-Engine/1.0")
             .timeout(std::time::Duration::from_secs(30))
+            // SSRF defense-in-depth: never follow redirects (see gitlab_provider).
+            .redirect(reqwest::redirect::Policy::none())
             .build()
             .expect("Failed to build reqwest client with static config")
     }

--- a/crates/temps-git/src/services/gitlab_provider.rs
+++ b/crates/temps-git/src/services/gitlab_provider.rs
@@ -61,6 +61,10 @@ impl GitLabProvider {
         reqwest::Client::builder()
             .user_agent("Temps-Engine/1.0")
             .timeout(std::time::Duration::from_secs(30))
+            // SSRF defense-in-depth: never follow redirects — a public host
+            // could otherwise 302 to an internal address (e.g. cloud metadata)
+            // after URL validation has already passed at create time.
+            .redirect(reqwest::redirect::Policy::none())
             .build()
             .expect("Failed to build reqwest client with static config")
     }

--- a/crates/temps-migrations/src/migration/m20260609_000001_create_deployment_container_logs.rs
+++ b/crates/temps-migrations/src/migration/m20260609_000001_create_deployment_container_logs.rs
@@ -1,0 +1,194 @@
+//! Migration to create the `deployment_container_logs` table.
+//!
+//! Runtime container logs are normally only available live, streamed straight
+//! from Docker. The moment a deployment is superseded its old containers are
+//! stopped and removed (see `mark_deployment_complete::cancel_previous_deployments`),
+//! and their logs vanish with them. That makes post-mortem debugging of "what
+//! did the container that ran a few days ago actually print?" impossible.
+//!
+//! This table records, for each previous container we tear down, a pointer to a
+//! captured plain-text log dump. The dump itself lives on disk under the data
+//! dir (via `temps_logs::LogService`) — this row stores only the metadata and
+//! the server-generated relative path to it, never user-controlled file paths.
+//! Logs of replaced containers therefore survive teardown and can be viewed
+//! later from the deployment detail page.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(DeploymentContainerLogs::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(DeploymentContainerLogs::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    // The deployment whose container this log belongs to. The row
+                    // outlives the container (which is removed from Docker), so we
+                    // key on the durable deployment id rather than the container id.
+                    .col(
+                        ColumnDef::new(DeploymentContainerLogs::DeploymentId)
+                            .integer()
+                            .not_null(),
+                    )
+                    // Denormalised for fast project-scoped authorization on read
+                    // without a join back through deployments → environments.
+                    .col(
+                        ColumnDef::new(DeploymentContainerLogs::ProjectId)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(DeploymentContainerLogs::EnvironmentId)
+                            .integer()
+                            .not_null(),
+                    )
+                    // Docker container id at capture time. Kept for reference/debugging;
+                    // the container itself no longer exists once this row is written.
+                    .col(
+                        ColumnDef::new(DeploymentContainerLogs::ContainerId)
+                            .string()
+                            .not_null(),
+                    )
+                    // Human-visible container name (e.g. "web-2"). This is
+                    // what a user recognises when picking which past container's logs to read.
+                    .col(
+                        ColumnDef::new(DeploymentContainerLogs::ContainerName)
+                            .string()
+                            .not_null(),
+                    )
+                    // Compose service name (e.g. "web", "redis"). NULL for single-container
+                    // deployments, mirroring `deployment_containers.service_name`.
+                    .col(
+                        ColumnDef::new(DeploymentContainerLogs::ServiceName)
+                            .string_len(255)
+                            .null(),
+                    )
+                    // Node the container ran on. NULL = local node (single-node mode),
+                    // mirroring `deployment_containers.node_id`.
+                    .col(
+                        ColumnDef::new(DeploymentContainerLogs::NodeId)
+                            .integer()
+                            .null(),
+                    )
+                    // Server-generated relative path of the captured log file under the
+                    // data dir (resolved by `LogService`). Never user-supplied, so it
+                    // cannot be used for path traversal.
+                    .col(
+                        ColumnDef::new(DeploymentContainerLogs::LogPath)
+                            .string()
+                            .not_null(),
+                    )
+                    // Size of the captured dump in bytes. i64 to stay safe for large
+                    // (multi-GB) log dumps, matching the backups size column convention.
+                    .col(
+                        ColumnDef::new(DeploymentContainerLogs::SizeBytes)
+                            .big_integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    // True when the dump was truncated to the tail because the live log
+                    // exceeded the capture cap. Surfaced in the UI so users know there's more.
+                    .col(
+                        ColumnDef::new(DeploymentContainerLogs::Truncated)
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    // When the logs were captured (i.e. just before teardown).
+                    .col(
+                        ColumnDef::new(DeploymentContainerLogs::CapturedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        ColumnDef::new(DeploymentContainerLogs::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_deployment_container_logs_deployment_id")
+                            .from(
+                                DeploymentContainerLogs::Table,
+                                DeploymentContainerLogs::DeploymentId,
+                            )
+                            .to(Deployments::Table, Deployments::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Hot read path: list all captured logs for one deployment, newest first.
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_deployment_container_logs_deployment_id")
+                    .table(DeploymentContainerLogs::Table)
+                    .col(DeploymentContainerLogs::DeploymentId)
+                    .to_owned(),
+            )
+            .await?;
+
+        // Project-scoped authorization checks on read.
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_deployment_container_logs_project_id")
+                    .table(DeploymentContainerLogs::Table)
+                    .col(DeploymentContainerLogs::ProjectId)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(DeploymentContainerLogs::Table)
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum DeploymentContainerLogs {
+    Table,
+    Id,
+    DeploymentId,
+    ProjectId,
+    EnvironmentId,
+    ContainerId,
+    ContainerName,
+    ServiceName,
+    NodeId,
+    LogPath,
+    SizeBytes,
+    Truncated,
+    CapturedAt,
+    CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum Deployments {
+    Table,
+    Id,
+}

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -115,6 +115,7 @@ mod m20260601_000008_alarms_nullable_env_deployment;
 mod m20260601_000009_metrics_caggs_keep_labels;
 mod m20260601_000010_add_service_id_to_alarms;
 mod m20260603_000001_create_otel_trace_summaries;
+mod m20260609_000001_create_deployment_container_logs;
 
 pub struct Migrator;
 
@@ -233,6 +234,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260601_000009_metrics_caggs_keep_labels::Migration),
             Box::new(m20260601_000010_add_service_id_to_alarms::Migration),
             Box::new(m20260603_000001_create_otel_trace_summaries::Migration),
+            Box::new(m20260609_000001_create_deployment_container_logs::Migration),
         ]
     }
 }

--- a/crates/temps-otel/src/handlers/ingest_handler.rs
+++ b/crates/temps-otel/src/handlers/ingest_handler.rs
@@ -87,7 +87,13 @@ impl From<OtelError> for Problem {
 fn extract_token(headers: &HeaderMap) -> Option<String> {
     if let Some(auth) = headers.get("authorization") {
         if let Ok(value) = auth.to_str() {
-            tracing::debug!(authorization = %value, "OTLP extract_token");
+            // SECURITY: never log the raw header — it carries a live, mostly
+            // non-expiring credential (Bearer dt_/tk_/si_). Log only its shape.
+            tracing::debug!(
+                scheme = value.split_whitespace().next().unwrap_or(""),
+                len = value.len(),
+                "OTLP extract_token"
+            );
             if let Some(key) = value.strip_prefix("Bearer ") {
                 return Some(key.trim().to_string());
             }

--- a/crates/temps-projects/src/handlers/handlers.rs
+++ b/crates/temps-projects/src/handlers/handlers.rs
@@ -14,8 +14,8 @@ use axum::{
     Json,
 };
 use std::sync::Arc;
-use temps_auth::permission_guard;
 use temps_auth::RequireAuth;
+use temps_auth::{permission_guard, project_scope_guard};
 use temps_core::RequestMetadata;
 use tracing::{debug, error, info};
 
@@ -303,6 +303,7 @@ pub async fn get_project(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_scope_guard!(auth, id);
 
     info!("get project called with id: {}", id);
     let project = state
@@ -369,6 +370,7 @@ pub async fn update_project(
     Json(project): Json<CreateProjectRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, id);
 
     let project_req = crate::services::types::CreateProjectRequest {
         name: project.name.clone(),
@@ -449,6 +451,7 @@ pub async fn delete_project(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsDelete);
+    project_scope_guard!(auth, id);
 
     // Get project details before deletion
     let project = state.project_service.get_project(id).await?;
@@ -508,6 +511,7 @@ pub async fn update_project_settings(
     Json(settings): Json<UpdateProjectSettingsRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
 
     let updated_project = state
         .project_service
@@ -589,6 +593,7 @@ pub async fn update_automatic_deploy(
     Json(request): Json<UpdateAutomaticDeployRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
 
     info!(
         "Updating automatic deployment setting for project: {}",
@@ -636,6 +641,7 @@ pub async fn update_git_settings(
     Json(settings): Json<UpdateGitSettingsRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
 
     info!(
         "Updating git settings for project: {} (branch: {}, repo: {}/{})",
@@ -726,6 +732,7 @@ pub async fn reinstall_gitlab_webhook(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
 
     info!("Reinstalling GitLab webhook for project: {}", project_id);
 
@@ -800,6 +807,7 @@ pub async fn update_project_deployment_config(
     Json(config): Json<UpdateDeploymentConfigRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
 
     info!("Updating deployment config for project: {}", project_id);
 
@@ -897,6 +905,7 @@ pub async fn trigger_project_pipeline(
     Json(payload): Json<super::types::TriggerPipelinePayload>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, id);
 
     info!("Triggering pipeline for project with id: {}", id);
 

--- a/crates/temps-providers/src/handlers/handlers.rs
+++ b/crates/temps-providers/src/handlers/handlers.rs
@@ -9,8 +9,8 @@ use axum::{
     routing::{delete, get, patch, post, put},
     Json, Router,
 };
-use temps_auth::permission_guard;
 use temps_auth::RequireAuth;
+use temps_auth::{deny_deployment_token, permission_guard, project_scope_guard};
 use temps_core::{
     error_builder::{bad_request, forbidden, internal_server_error, not_found, ErrorBuilder},
     problemdetails::Problem,
@@ -382,6 +382,10 @@ async fn list_services(
     Query(pagination): Query<temps_core::PaginationParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
+    // This returns every service in the fleet (unscoped). A project-bound
+    // deployment token must not enumerate other tenants' services — it can use
+    // GET /external-services/projects/{its_own_project_id} instead.
+    deny_deployment_token!(auth);
 
     let (page, page_size) = pagination.normalize();
 
@@ -420,6 +424,7 @@ async fn get_service(
     Path(id): Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     match app_state
         .external_service_manager
@@ -536,6 +541,7 @@ async fn update_service(
     Json(request): Json<UpdateExternalServiceRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesWrite);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     let service_config = crate::services::UpdateExternalServiceRequest {
         parameters: request.parameters.clone(),
@@ -621,6 +627,7 @@ async fn upgrade_service(
     Json(request): Json<UpgradeExternalServiceRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesWrite);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     match app_state
         .external_service_manager
@@ -684,6 +691,7 @@ async fn delete_service(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesDelete);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
     match app_state
         .external_service_manager
         .get_service_details(id)
@@ -752,6 +760,7 @@ async fn check_health(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     match app_state
         .external_service_manager
@@ -800,6 +809,7 @@ async fn get_cluster_health(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     // Fetch the underlying row to (a) confirm existence, (b) check topology.
     let service = match app_state.external_service_manager.get_service(id).await {
@@ -862,6 +872,7 @@ async fn get_service_health_status(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     let limit = params
         .get("limit")
@@ -910,6 +921,7 @@ async fn trigger_service_health_check(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesWrite);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     let Some(monitor) = app_state.health_monitor.as_ref() else {
         return Err(ErrorBuilder::new(StatusCode::SERVICE_UNAVAILABLE)
@@ -991,6 +1003,7 @@ async fn get_postgres_wal_health(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     match app_state
         .external_service_manager
@@ -1035,6 +1048,9 @@ async fn list_service_health_statuses(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
+    // When `ids` is omitted this reports health for the whole fleet. A
+    // project-bound deployment token must not enumerate foreign services.
+    deny_deployment_token!(auth);
 
     let ids: Vec<i32> = params
         .get("ids")
@@ -1100,6 +1116,7 @@ async fn start_service(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesWrite);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
     match app_state
         .external_service_manager
         .get_service_details(id)
@@ -1173,6 +1190,7 @@ async fn retry_cluster(
     Json(request): Json<RetryClusterRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesWrite);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     let members: Vec<crate::services::ClusterMemberRequest> = request
         .members
@@ -1255,6 +1273,7 @@ async fn add_cluster_member(
     Json(request): Json<AddClusterMemberRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesWrite);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     match app_state
         .external_service_manager
@@ -1341,6 +1360,7 @@ async fn get_cluster_member(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     match app_state
         .external_service_manager
@@ -1393,6 +1413,7 @@ async fn remove_cluster_member(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesWrite);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     match app_state
         .external_service_manager
@@ -1471,6 +1492,7 @@ async fn promote_cluster_member(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesWrite);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     match app_state
         .external_service_manager
@@ -1555,6 +1577,7 @@ async fn stop_service(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesWrite);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
     match app_state
         .external_service_manager
         .get_service_details(id)
@@ -1742,6 +1765,7 @@ async fn list_project_services(
     Query(pagination): Query<temps_core::PaginationParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
+    project_scope_guard!(auth, project_id);
 
     let (page, page_size) = pagination.normalize();
 
@@ -1783,6 +1807,8 @@ async fn get_service_environment_variable(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
+    project_scope_guard!(auth, project_id);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     match app_state
         .external_service_manager
@@ -1825,11 +1851,15 @@ async fn get_service_environment_variables(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
+    project_scope_guard!(auth, project_id);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     let options = EnvironmentVariableOptions {
         include_docker: false,
         include_runtime: false,
-        mask_sensitive: false,
+        // Only an admin may read plaintext connection strings / passwords.
+        // Non-admin owners get masked values to prevent credential exfiltration.
+        mask_sensitive: !auth.is_admin(),
         names_only: false,
     };
 
@@ -1870,6 +1900,7 @@ async fn get_project_service_environment_variables(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
+    project_scope_guard!(auth, project_id);
 
     match app_state
         .external_service_manager
@@ -1906,6 +1937,9 @@ async fn get_service_by_slug(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
+    // No project_id/service-id to scope against here; a deployment token has no
+    // business resolving services by global slug. Require user/API-key auth.
+    deny_deployment_token!(auth);
     let service = match app_state
         .external_service_manager
         .get_service_by_slug(&slug)
@@ -1954,11 +1988,13 @@ async fn get_service_preview_environment_variable_names(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     let options = EnvironmentVariableOptions {
         include_docker: false,
         include_runtime: false,
-        mask_sensitive: false,
+        // names_only, so values aren't returned regardless.
+        mask_sensitive: true,
         names_only: true,
     };
 
@@ -2061,6 +2097,7 @@ async fn get_service_runtime(
     Path(id): Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     match app_state
         .external_service_manager
@@ -2099,6 +2136,7 @@ async fn get_service_stats(
     Path(id): Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     match app_state
         .external_service_manager
@@ -2152,6 +2190,7 @@ async fn update_service_resources(
     Json(request): Json<crate::externalsvc::ServiceResourceLimits>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesWrite);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     match app_state
         .external_service_manager

--- a/crates/temps-providers/src/handlers/metrics_handlers.rs
+++ b/crates/temps-providers/src/handlers/metrics_handlers.rs
@@ -1279,7 +1279,7 @@ fn validate_severity(sev: &str) -> Result<(), Problem> {
 /// Returns `Ok(())` if the caller may access the service, or `Err(Problem)`
 /// with a 404 response (does not distinguish "not found" from "forbidden"
 /// to avoid leaking the existence of services in other projects).
-async fn assert_service_owned_by_caller(
+pub(crate) async fn assert_service_owned_by_caller(
     service_id: i32,
     auth: &temps_auth::AuthContext,
     state: &AppState,

--- a/crates/temps-proxy/src/proxy.rs
+++ b/crates/temps-proxy/src/proxy.rs
@@ -1059,13 +1059,13 @@ impl LoadBalancer {
     }
 
     fn is_https_request(&self, session: &PingoraSession) -> bool {
-        session
-            .req_header()
-            .headers
-            .get("x-forwarded-proto")
-            .and_then(|v| v.to_str().ok())
-            .map(|proto| proto == "https")
-            .unwrap_or_else(|| session.req_header().uri.scheme_str() == Some("https"))
+        // SECURITY (SEC-12): do NOT trust a client-supplied `X-Forwarded-Proto`.
+        // Pingora is the edge TLS terminator, so the only authoritative signal
+        // is whether this downstream connection actually has a TLS digest.
+        // Trusting the header let a client on the plain-HTTP listener spoof
+        // `https`, influencing Secure-cookie attributes and the proto we forward
+        // upstream.
+        self.is_tls_connection(session)
     }
 
     /// Check if the connection is a TLS connection by checking for SSL digest

--- a/web/src/components/deployments/DeploymentContainerLogs.tsx
+++ b/web/src/components/deployments/DeploymentContainerLogs.tsx
@@ -1,0 +1,222 @@
+import { client } from '@/api/client/client.gen'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { TimeAgo } from '@/components/utils/TimeAgo'
+import { useQuery } from '@tanstack/react-query'
+import { Download, FileText, ScrollText } from 'lucide-react'
+import { useState } from 'react'
+
+// These types mirror the backend DeploymentContainerLog* response DTOs. Once
+// the OpenAPI SDK is regenerated (bun run openapi-ts) the generated
+// types/wrappers can replace these and the raw `client.get` calls below.
+interface DeploymentContainerLog {
+  id: number
+  deployment_id: number
+  container_id: string
+  container_name: string
+  service_name: string | null
+  node_id: number | null
+  size_bytes: number
+  truncated: boolean
+  captured_at: number
+}
+
+interface DeploymentContainerLogsListResponse {
+  logs: DeploymentContainerLog[]
+}
+
+interface DeploymentContainerLogContentResponse {
+  id: number
+  container_name: string
+  service_name: string | null
+  size_bytes: number
+  truncated: boolean
+  captured_at: number
+  content: string
+}
+
+const bearer = [{ scheme: 'bearer' as const, type: 'http' as const }]
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+async function fetchCapturedLogs(
+  projectId: number,
+  deploymentId: number
+): Promise<DeploymentContainerLogsListResponse> {
+  const response = await client.get({
+    url: `/projects/${projectId}/deployments/${deploymentId}/container-logs`,
+    security: bearer,
+  })
+  return response.data as DeploymentContainerLogsListResponse
+}
+
+async function fetchCapturedLogContent(
+  projectId: number,
+  deploymentId: number,
+  logId: number
+): Promise<DeploymentContainerLogContentResponse> {
+  const response = await client.get({
+    url: `/projects/${projectId}/deployments/${deploymentId}/container-logs/${logId}`,
+    security: bearer,
+  })
+  return response.data as DeploymentContainerLogContentResponse
+}
+
+interface DeploymentContainerLogsProps {
+  projectId: number
+  deploymentId: number
+}
+
+/**
+ * Shows the logs that were captured for this deployment's containers just
+ * before they were torn down. Lets users read the output of a container that
+ * no longer exists (e.g. "web-2" from a previous deployment).
+ */
+export function DeploymentContainerLogs({
+  projectId,
+  deploymentId,
+}: DeploymentContainerLogsProps) {
+  const [selectedLogId, setSelectedLogId] = useState<number | null>(null)
+
+  const {
+    data: list,
+    isPending,
+    isError,
+  } = useQuery({
+    queryKey: ['deployment-container-logs', projectId, deploymentId],
+    queryFn: () => fetchCapturedLogs(projectId, deploymentId),
+    enabled: projectId > 0 && deploymentId > 0,
+  })
+
+  const { data: content, isPending: isContentPending } = useQuery({
+    queryKey: [
+      'deployment-container-log-content',
+      projectId,
+      deploymentId,
+      selectedLogId,
+    ],
+    queryFn: () =>
+      fetchCapturedLogContent(projectId, deploymentId, selectedLogId as number),
+    enabled: selectedLogId != null,
+  })
+
+  // The capture feature is best-effort and only runs on teardown, so most
+  // deployments legitimately have nothing captured. Render nothing rather than
+  // an empty card to avoid clutter on the deployment detail page.
+  if (isError) return null
+  if (isPending) {
+    return (
+      <Card>
+        <CardContent className="p-6 space-y-3">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-10 w-full" />
+        </CardContent>
+      </Card>
+    )
+  }
+  if (!list || list.logs.length === 0) return null
+
+  return (
+    <Card>
+      <CardContent className="p-6">
+        <div className="flex items-center gap-2 mb-4">
+          <ScrollText className="h-4 w-4 text-muted-foreground" />
+          <h3 className="text-sm font-semibold">Captured container logs</h3>
+          <Badge variant="secondary" className="ml-1">
+            {list.logs.length}
+          </Badge>
+        </div>
+        <p className="text-xs text-muted-foreground mb-4">
+          Logs captured from this deployment&apos;s containers before they were
+          torn down. Available even after the containers no longer exist.
+        </p>
+
+        <div className="flex flex-col gap-2">
+          {list.logs.map((log) => {
+            const isSelected = log.id === selectedLogId
+            return (
+              <div
+                key={log.id}
+                className="rounded-md border border-border/60 overflow-hidden"
+              >
+                <button
+                  type="button"
+                  onClick={() =>
+                    setSelectedLogId(isSelected ? null : log.id)
+                  }
+                  className="w-full flex items-center gap-3 px-3 py-2 text-left hover:bg-muted/50 transition-colors"
+                >
+                  <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <span className="text-sm font-mono truncate">
+                    {log.container_name}
+                  </span>
+                  {log.service_name && (
+                    <Badge variant="outline" className="shrink-0">
+                      {log.service_name}
+                    </Badge>
+                  )}
+                  {log.truncated && (
+                    <Badge variant="outline" className="shrink-0">
+                      truncated
+                    </Badge>
+                  )}
+                  <span className="ml-auto text-xs text-muted-foreground shrink-0">
+                    {formatBytes(log.size_bytes)}
+                  </span>
+                  <span className="text-xs text-muted-foreground shrink-0 hidden sm:inline">
+                    <TimeAgo date={new Date(log.captured_at)} />
+                  </span>
+                </button>
+
+                {isSelected && (
+                  <div className="border-t border-border/60 bg-muted/30">
+                    {isContentPending ? (
+                      <div className="p-3 space-y-2">
+                        <Skeleton className="h-3 w-full" />
+                        <Skeleton className="h-3 w-5/6" />
+                        <Skeleton className="h-3 w-4/6" />
+                      </div>
+                    ) : (
+                      <div>
+                        <div className="flex items-center justify-end px-3 py-2 border-b border-border/40">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => {
+                              if (!content) return
+                              const blob = new Blob([content.content], {
+                                type: 'text/plain',
+                              })
+                              const url = URL.createObjectURL(blob)
+                              const a = document.createElement('a')
+                              a.href = url
+                              a.download = `${log.container_name}.log`
+                              a.click()
+                              URL.revokeObjectURL(url)
+                            }}
+                          >
+                            <Download className="h-3.5 w-3.5 mr-1.5" />
+                            Download
+                          </Button>
+                        </div>
+                        <pre className="max-h-96 overflow-auto p-3 text-xs font-mono whitespace-pre-wrap break-all">
+                          {content?.content || '(empty)'}
+                        </pre>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/src/pages/DeploymentDetails.tsx
+++ b/web/src/pages/DeploymentDetails.tsx
@@ -8,6 +8,7 @@ import {
   rollbackToDeploymentMutation,
   triggerProjectPipelineMutation,
 } from '@/api/client/@tanstack/react-query.gen'
+import { DeploymentContainerLogs } from '@/components/deployments/DeploymentContainerLogs'
 import { DeploymentStages } from '@/components/deployments/DeploymentStages'
 import { RedeploymentModal } from '@/components/deployments/RedeploymentModal'
 import { Badge } from '@/components/ui/badge'
@@ -655,6 +656,14 @@ export function DeploymentDetails({ project }: DeploymentDetailsProps) {
         {/* Deployment Pipeline */}
         {deployment && (
           <DeploymentStages project={project} deployment={deployment} />
+        )}
+
+        {/* Captured logs from previous containers (survive teardown) */}
+        {deployment && (
+          <DeploymentContainerLogs
+            projectId={deployment.project_id}
+            deploymentId={deployment.id}
+          />
         )}
 
         <RedeploymentModal


### PR DESCRIPTION
# feat(deployments): view logs of previous deployments + security hardening

Branch: `feat/deployment-logs-history` → `main` · commit `528b1629`

Two things in one branch, as requested: the **"view logs of previous deployments"** feature, and **fixes for the vulnerabilities** found by a multi-agent adversarial security audit run over the backend.

---

## 1. Feature — view logs of previous deployments

**Problem.** Runtime container logs were only available live from Docker. The moment a deployment was superseded (e.g. `web-2` replacing `web-1`), the old containers were stopped and removed and their logs were gone — so you couldn't debug "what did the container that ran a few days ago actually print?".

**Solution** (the "dump to a txt file + simple storage" approach):
- Just before a superseded deployment's containers are torn down (`MarkDeploymentCompleteJob::cancel_previous_deployments`), each container's logs are pulled via the existing `ContainerDeployer::get_container_logs`, written to a plain-text file under the data dir (via `LogService`), and recorded in a new `deployment_container_logs` table.
- **Capture is best-effort** — any failure is logged and swallowed; it never blocks or fails a deployment. Logs are **tail-capped at 8 MiB** (truncation flagged in the UI).
- Log file paths are **server-generated** (`deployment-container-logs/{deployment_id}/{row_id}.log`) — no user input, no path traversal.

**API** (both tenant-scoped to the caller's project):
- `GET /api/projects/{project_id}/deployments/{deployment_id}/container-logs` — list captured logs
- `GET /api/projects/{project_id}/deployments/{deployment_id}/container-logs/{log_id}` — log content

**UI.** A "Captured container logs" section on the deployment detail page lists each past container, expands to show its captured output, and offers download.

**New files:** migration `m20260609_000001_create_deployment_container_logs`, entity `deployment_container_logs.rs`, web component `DeploymentContainerLogs.tsx`.

---

## 2. Security audit + fixes

A workflow fanned out finders across 6 threat categories, then **adversarially verified every finding** (a skeptic tried to refute each). 14 of 18 findings survived. CRITICAL + HIGH are fixed on this branch; the fixes were then independently correctness-reviewed (which caught 6 additional missed handlers, now also fixed).

**Root cause (most HIGH findings):** a deployment token is auto-injected into every deployed container, bound to one project, and typically carries `FullAccess` — which makes `permission_guard!` pass for *every* permission. Many handlers trusted a `project_id`/service id from the request without checking it against the token's bound project → cross-project IDOR. The fix is a new shared primitive in `temps-auth`:
- `AuthContext::is_scoped_to_project(project_id)` + `project_scope_guard!(auth, project_id)` — confines a deployment token to its bound project (403 otherwise; no-op for user/API-key/session).
- `deny_deployment_token!(auth)` — for by-id / fleet-wide endpoints that have no project_id to scope against.

| ID | Sev | Fix |
|----|-----|-----|
| SEC-01 | **CRITICAL** | error-tracking admin API had **no auth at all** — added `RequireAuth` + `ErrorTracking*` permission + project scope to all 14 handlers (`handler.rs`, `alert_rules_handler.rs`). DSN-ingest path was already self-authenticating and is unchanged. |
| SEC-02 | HIGH | `temps-environments`: deployment token could read any project's env-var **plaintext** / CRUD secrets — `project_scope_guard!` on all 23 project-scoped handlers. |
| SEC-03 | HIGH | `temps-providers`: deployment token could read/modify/destroy any project's external services — `assert_service_owned_by_caller` (project_services linkage) on all 21 service-id handlers; deny on fleet-list endpoints. |
| SEC-04 | HIGH | `temps-projects`: deployment token could read/update/delete any project + trigger pipelines — `project_scope_guard!` on all 9 handlers. |
| SEC-05 | HIGH | `temps-analytics`: deployment token could read any project's analytics + visitor PII — `project_scope_guard!` on 20 query handlers, `deny_deployment_token!` on 8 by-id handlers. |
| SEC-06 | HIGH | external-services env-var endpoint returned **unmasked** `POSTGRES_URL`/`POSTGRES_PASSWORD` to any owner — now plaintext is admin-only (`mask_sensitive: !auth.is_admin()`). |
| SEC-07 | HIGH | SSRF via self-hosted Git provider `base_url`/`api_url` (probed on create) — validated with `url_validation::validate_external_url`; provider HTTP clients now disable redirect following. |
| SEC-09 | MED | OTLP ingest logged the full bearer token at `debug` — now logs scheme + length only. |
| SEC-12 | LOW | proxy `is_https_request` trusted client `X-Forwarded-Proto` — now derived from the downstream TLS digest. |

---

## Testing
- `cargo check --bin temps` — **0 errors** across all 51 crates.
- `temps-auth` scope-guard unit tests pass (prove `FullAccess` does NOT bypass the scope check).
- `temps-deployments` captured-log service tests added (list / content / cross-tenant-denied). These use `TestDatabase` + the deployment-service test harness, which requires **Docker + Postgres** — they fail to *initialize* locally without Docker (same as every pre-existing test in that module, e.g. `test_deployment_not_found`), not due to the new code. They run in CI / with Docker available.

## Follow-ups (need a running server / not blocking)
- **Regenerate the web SDK** (`bun run openapi-ts`, needs a running server + admin key). The two new endpoints are registered in the OpenAPI doc; until regen, the UI calls them via the generated `client` (same pattern as `useDashboardHealth.ts`), not a hand-rolled fetch. Regen also fixes a pre-existing stale-SDK TS error (`DeploymentEnvironmentResponse.main_url`) already present on `main`.
- **SEC-08 (MED, webhook DNS-rebinding)**, **SEC-10/SEC-11 (LOW)** and the Git-provider DNS-rebinding residual are documented in the audit report but not fixed here — lower severity, fast-follow.
- The full audit report (with exploit detail) is intentionally **not** committed.

> Security-sensitive — please review the auth-scoping changes closely before merge.
