### PR TITLE
fix(deployments): deploy environments uncapped by default, limits opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 ### Fixed
--
+- **Deployed environments are no longer silently CPU/memory-capped when no limit is configured** (`temps-deployments`): `ResourceUsage::default()` seeded `1000000u` (1 core) / `512Mi`, so any deploy path that built a job without calling `.resources(...)` — notably `rollback_to_deployment` and `promote_deployment` — applied a phantom Docker `nano_cpus`/`memory` cap even though neither the project nor the environment `deployment_config` set one. (This became live in v0.1.0-beta when the microcore parser started honoring the suffix the default emits.) The default is now all-`None` (uncapped unless opted in), and rollback/promote resolve CPU/memory limits + requests env→project the same way the normal deploy path does — so a configured limit is preserved across rollback/promote, and an unconfigured environment runs with no Docker limit. Verified end-to-end: a `None`-limit deploy produces `HostConfig.NanoCpus=0`/`Memory=0`, while an explicit limit still reaches the container.
 
 
 ## [0.1.0-beta.31] - 2026-06-11

--- a/crates/temps-deployer/src/docker.rs
+++ b/crates/temps-deployer/src/docker.rs
@@ -2867,6 +2867,118 @@ CMD ["cat", "/hello.txt"]
         }
     }
 
+    /// Empirical proof of the "no limit unless opted in" contract: a deploy
+    /// with `cpu_limit: None` / `memory_limit_mb: None` must produce a Docker
+    /// container whose `HostConfig.NanoCpus` and `Memory` are 0 (unset =
+    /// uncapped), and an explicit limit must actually reach Docker. Inspects
+    /// the live container via bollard rather than trusting the request struct.
+    #[tokio::test]
+    #[serial]
+    async fn test_resource_limits_none_means_uncapped() {
+        let runtime = match create_test_docker_runtime().await {
+            Ok(r) => r,
+            Err(e) => {
+                println!("🔧 Docker not available, skipping: {}", e);
+                return;
+            }
+        };
+        let docker = match Docker::connect_with_local_defaults() {
+            Ok(d) => d,
+            Err(e) => {
+                println!("🔧 Docker not available, skipping: {}", e);
+                return;
+            }
+        };
+        if docker.ping().await.is_err() {
+            println!("🔧 Docker ping failed, skipping");
+            return;
+        }
+
+        let base = |name: &str, limits: ResourceLimits| DeployRequest {
+            image_name: "alpine:latest".to_string(),
+            container_name: name.to_string(),
+            environment_vars: HashMap::new(),
+            secrets: HashMap::new(),
+            port_mappings: vec![],
+            network_name: None,
+            resource_limits: limits,
+            restart_policy: RestartPolicy::Never,
+            log_path: PathBuf::from(format!("/tmp/{}.log", name)),
+            command: Some(vec!["sleep".to_string(), "30".to_string()]),
+            log_config: Some(ContainerLogConfig::app_default()),
+            labels: HashMap::new(),
+        };
+
+        let inspect_caps = |id: String| {
+            let docker = docker.clone();
+            async move {
+                let i = docker
+                    .inspect_container(
+                        &id,
+                        None::<bollard::query_parameters::InspectContainerOptions>,
+                    )
+                    .await
+                    .expect("inspect");
+                let hc = i.host_config.expect("host_config");
+                (hc.nano_cpus.unwrap_or(0), hc.memory.unwrap_or(0))
+            }
+        };
+
+        // --- Case 1: no limits configured -> container must be UNCAPPED ---
+        let uncapped_name = "temps-rl-uncapped-test";
+        let _ = runtime.remove_container(uncapped_name).await;
+        let info = runtime
+            .deploy_container(base(
+                uncapped_name,
+                ResourceLimits {
+                    cpu_limit: None,
+                    memory_limit_mb: None,
+                    disk_limit_mb: None,
+                },
+            ))
+            .await
+            .expect("deploy uncapped");
+        let (nano_cpus, memory) = inspect_caps(info.container_id.clone()).await;
+        let _ = runtime.remove_container(&info.container_id).await;
+        println!(
+            "UNCAPPED deploy -> NanoCpus={} Memory={} (both must be 0)",
+            nano_cpus, memory
+        );
+        assert_eq!(
+            nano_cpus, 0,
+            "None cpu_limit leaked a CPU cap into the container ({})",
+            nano_cpus
+        );
+        assert_eq!(
+            memory, 0,
+            "None memory_limit_mb leaked a memory cap into the container ({})",
+            memory
+        );
+
+        // --- Case 2 (control): explicit limits MUST reach Docker ---
+        let capped_name = "temps-rl-capped-test";
+        let _ = runtime.remove_container(capped_name).await;
+        let info = runtime
+            .deploy_container(base(
+                capped_name,
+                ResourceLimits {
+                    cpu_limit: Some(0.5),
+                    memory_limit_mb: Some(64),
+                    disk_limit_mb: None,
+                },
+            ))
+            .await
+            .expect("deploy capped");
+        let (nano_cpus, memory) = inspect_caps(info.container_id.clone()).await;
+        let _ = runtime.remove_container(&info.container_id).await;
+        println!(
+            "CAPPED deploy -> NanoCpus={} Memory={} (expect 500000000 / 67108864)",
+            nano_cpus, memory
+        );
+        assert_eq!(nano_cpus, 500_000_000, "explicit 0.5 CPU not applied");
+        assert_eq!(memory, 64 * 1024 * 1024, "explicit 64MB not applied");
+    }
+
     #[tokio::test]
     async fn test_image_operations() {
         match create_test_docker_runtime().await {

--- a/crates/temps-deployments/src/jobs/deploy_image.rs
+++ b/crates/temps-deployments/src/jobs/deploy_image.rs
@@ -107,13 +107,21 @@ pub struct ResourceUsage {
 }
 
 impl Default for ResourceUsage {
+    /// No limits by default — an environment is uncapped unless the operator
+    /// opts in by configuring `cpu_limit`/`memory_limit` on the project or
+    /// environment `deployment_config`. A `None` here flows through
+    /// `parse_cpu_cores`/`parse_memory_mb` (→ `None`) to the Docker
+    /// `HostConfig`, where `nano_cpus`/`memory` are left unset (= uncapped).
+    ///
+    /// Historically this seeded `1000000u`/`512Mi`, which silently capped any
+    /// deploy path that built a job without calling `.resources(...)` (e.g.
+    /// rollback/promote) even when no limit was configured.
     fn default() -> Self {
-        // Microcore convention: 1_000_000u = 1 core, 100_000u = 0.1 core.
         Self {
-            cpu_limit: Some("1000000u".to_string()),
-            memory_limit: Some("512Mi".to_string()),
-            cpu_request: Some("100000u".to_string()),
-            memory_request: Some("128Mi".to_string()),
+            cpu_limit: None,
+            memory_limit: None,
+            cpu_request: None,
+            memory_request: None,
         }
     }
 }
@@ -2001,6 +2009,29 @@ impl Default for DeployImageJobBuilder {
 mod tests {
     use super::*;
     use async_trait::async_trait;
+
+    #[test]
+    fn resource_usage_default_is_uncapped() {
+        // Regression guard: the default MUST be all-None so any deploy path that
+        // builds a job without calling `.resources(...)` (rollback/promote)
+        // leaves the container uncapped rather than silently applying a phantom
+        // CPU/memory limit. `None` here → `parse_cpu_cores`/`parse_memory_mb`
+        // return None → Docker `HostConfig` nano_cpus/memory stay unset.
+        let d = ResourceUsage::default();
+        assert_eq!(
+            d.cpu_limit, None,
+            "default cpu_limit must be None (uncapped)"
+        );
+        assert_eq!(
+            d.memory_limit, None,
+            "default memory_limit must be None (uncapped)"
+        );
+        assert_eq!(d.cpu_request, None);
+        assert_eq!(d.memory_request, None);
+        // And it must parse to no limit at the deployer boundary.
+        assert_eq!(d.cpu_limit.as_deref().and_then(parse_cpu_cores), None);
+        assert_eq!(d.memory_limit.as_deref().and_then(parse_memory_mb), None);
+    }
 
     #[test]
     fn parse_cpu_cores_handles_millicores_and_whole_cores() {

--- a/crates/temps-deployments/src/services/services.rs
+++ b/crates/temps-deployments/src/services/services.rs
@@ -98,6 +98,34 @@ pub struct DeploymentService {
 }
 
 impl DeploymentService {
+    /// Resolve CPU/memory limits + requests for a deploy from the environment
+    /// config first, then the project config, leaving each field unset when
+    /// neither configures it (→ no Docker limit = uncapped). Mirrors the
+    /// resolution in `WorkflowExecutionService` so every deploy path (initial,
+    /// rollback, promote) treats resource limits as opt-in identically.
+    ///
+    /// CPU is stored as microcores in the DB (1_000_000 = 1 core), memory as MB;
+    /// emitted with the `u`/`Mi` suffixes the deployer's parsers understand.
+    fn resolve_resource_usage(
+        env_cfg: Option<&temps_entities::deployment_config::DeploymentConfig>,
+        proj_cfg: Option<&temps_entities::deployment_config::DeploymentConfig>,
+    ) -> crate::jobs::ResourceUsage {
+        let resolve = |getter: fn(
+            &temps_entities::deployment_config::DeploymentConfig,
+        ) -> Option<i32>|
+         -> Option<i32> {
+            env_cfg
+                .and_then(getter)
+                .or_else(|| proj_cfg.and_then(getter))
+        };
+        crate::jobs::ResourceUsage {
+            cpu_limit: resolve(|c| c.cpu_limit).map(|u| format!("{}u", u)),
+            memory_limit: resolve(|c| c.memory_limit).map(|mb| format!("{}Mi", mb)),
+            cpu_request: resolve(|c| c.cpu_request).map(|u| format!("{}u", u)),
+            memory_request: resolve(|c| c.memory_request).map(|mb| format!("{}Mi", mb)),
+        }
+    }
+
     pub fn new(
         db: Arc<temps_database::DbConnection>,
         log_service: Arc<temps_logs::LogService>,
@@ -1369,6 +1397,18 @@ impl DeploymentService {
                     ));
             }
 
+            // Resolve CPU/memory limits + requests (env → project), matching the
+            // normal deploy path (WorkflowExecutionService). Each field resolves
+            // independently; when neither side configures a value it stays unset
+            // so the deployer applies no Docker limit. Without this, a rollback
+            // would inherit `ResourceUsage::default()` (now all-None) and silently
+            // drop a configured limit — or, before the default was fixed, cap an
+            // unconfigured environment.
+            deploy_builder = deploy_builder.resources(Self::resolve_resource_usage(
+                environment.deployment_config.as_ref(),
+                project.deployment_config.as_ref(),
+            ));
+
             let deploy_job = deploy_builder
                 .build(self.deployer.clone())
                 .map_err(|e| DeploymentError::Other(format!("Failed to create deploy job: {}", e)))?
@@ -1906,6 +1946,14 @@ impl DeploymentService {
                         settings.container_logs.max_file,
                     ));
             }
+
+            // Resolve CPU/memory limits + requests (target env → project),
+            // matching the normal deploy path so a promotion preserves a
+            // configured limit and leaves an unconfigured environment uncapped.
+            deploy_builder = deploy_builder.resources(Self::resolve_resource_usage(
+                target_env.deployment_config.as_ref(),
+                project.deployment_config.as_ref(),
+            ));
 
             let deploy_job = deploy_builder
                 .build(self.deployer.clone())
@@ -5258,5 +5306,39 @@ mod tests {
 
         assert!(matches!(result, Err(DeploymentError::NotFound(_))));
         Ok(())
+    }
+
+    #[test]
+    fn resolve_resource_usage_is_opt_in_with_env_over_project() {
+        let cfg = |cpu: Option<i32>, mem: Option<i32>| DeploymentConfig {
+            cpu_limit: cpu,
+            memory_limit: mem,
+            ..Default::default()
+        };
+
+        // 1. Nothing configured anywhere -> fully uncapped (the default).
+        let none = DeploymentService::resolve_resource_usage(None, None);
+        assert_eq!(none.cpu_limit, None);
+        assert_eq!(none.memory_limit, None);
+
+        // 2. Project sets a limit, env doesn't -> inherit project (microcores → `u`, MB → `Mi`).
+        let proj = cfg(Some(2_000_000), Some(512));
+        let inherited = DeploymentService::resolve_resource_usage(None, Some(&proj));
+        assert_eq!(inherited.cpu_limit.as_deref(), Some("2000000u"));
+        assert_eq!(inherited.memory_limit.as_deref(), Some("512Mi"));
+
+        // 3. Env overrides project per-field (env cpu wins, project memory inherited).
+        let env = cfg(Some(500_000), None);
+        let overridden = DeploymentService::resolve_resource_usage(Some(&env), Some(&proj));
+        assert_eq!(overridden.cpu_limit.as_deref(), Some("500000u"));
+        assert_eq!(overridden.memory_limit.as_deref(), Some("512Mi"));
+
+        // 4. Env config present but with all-None limits -> still uncapped
+        //    (an environment existing must NOT imply a limit).
+        let empty_env = cfg(None, None);
+        let still_none =
+            DeploymentService::resolve_resource_usage(Some(&empty_env), Some(&cfg(None, None)));
+        assert_eq!(still_none.cpu_limit, None);
+        assert_eq!(still_none.memory_limit, None);
     }
 }


### PR DESCRIPTION
## Problem

Deployed app containers were silently CPU/memory-capped **even when no limit was configured**. `docker inspect` on running containers showed `HostConfig.NanoCpus`/`Memory` set despite the project *and* environment `deployment_config` having `NULL` `cpu_limit`/`memory_limit` (verified by SQL: zero rows had any limit set).

### Root cause

`ResourceUsage::default()` (`crates/temps-deployments/src/jobs/deploy_image.rs`) seeded `cpu_limit: Some("1000000u")` (1 core) / `memory_limit: Some("512Mi")`. Any deploy path that builds a `DeployImageJob[Builder]` **without calling `.resources(...)`** inherits that default and applies it as a real Docker `nano_cpus`/`memory` cap. The normal git-push path (`WorkflowExecutionService`) resolves limits field-by-field and correctly passes `None`, but **`rollback_to_deployment` and `promote_deployment` never call `.resources(...)`** — so they leaked the default.

This became *live* in a v0.1.0-beta commit that fixed the microcore parser (`parse_cpu_cores`): previously the suffixed default silently parsed to `None` and evaporated; once the parser honored the `u`/`Mi` suffix, the long-dormant default started reaching Docker.

## Fix

1. **`ResourceUsage::default()` → all-`None`** — uncapped unless the operator opts in by configuring `cpu_limit`/`memory_limit` on the project or environment. `None` flows through `parse_cpu_cores`/`parse_memory_mb` (→ `None`) to the Docker `HostConfig`, leaving `nano_cpus`/`memory` unset.
2. **`DeploymentService::resolve_resource_usage(env_cfg, proj_cfg)`** — shared helper resolving each limit/request field env→project (per-field `.or_else()`), mirroring `WorkflowExecutionService`. Wired into `rollback_to_deployment` and `promote_deployment` so a *configured* limit is preserved across those paths and an *unconfigured* environment stays uncapped.

Net behavior:
- Fresh deploy, blank limits → **uncapped**.
- Rollback / promote, blank limits → **uncapped** (was the bug).
- Any limit configured on env or project → **applied**, env overrides project, across all deploy paths.

## Verification

Empirical (real `DockerRuntime::deploy_container` + `docker inspect`), not just code-reading:

| Test | Result |
|---|---|
| `test_resource_limits_none_means_uncapped` (Docker integration) | `None` → `NanoCpus=0, Memory=0`; explicit `0.5 CPU / 64MB` → `NanoCpus=500000000, Memory=67108864` |
| `resource_usage_default_is_uncapped` (unit) | default is all-`None`, parses to no limit |
| `resolve_resource_usage_is_opt_in_with_env_over_project` (unit) | none→uncapped, project-inherit, env-override, empty-env→uncapped |
| `temps-deployer` full suite | 86 passed, 0 failed |
| `temps-deployments` full suite | 373 passed (1 pre-existing unrelated failure: a cron `TestDatabase` migration error `column "service_id" does not exist`, untouched by this PR) |

## Scope

Only the resource-limit code + tests. No migrations, no API surface change. Backward-compatible: existing environments with an explicit limit keep it; only the *unconfigured* default changes from "1 core / 512MB" to "uncapped".