### PR TITLE
feat: anonymous telemetry + Postgres shm_size_mb + custom health-check path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,10 @@ GeoLite2-*.mmdb
 # These are 250+ MB binaries that should never be committed.
 /temps-new
 /temps-old
+
+# Private telemetry dashboard — visualizes the anonymous product-telemetry
+# data. The ingest API + schema (telemetry-api/) stay PUBLIC for transparency,
+# but the dashboard contains internal business judgment (which metrics we watch,
+# what "good" looks like) and must NOT be open-sourced. See telemetry-api/ for
+# the public, auditable side.
+/telemetry-dashboard/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
--
+- **Anonymous product telemetry.** Temps now reports anonymous, aggregate
+  usage events (deploy attempted vs. succeeded/failed, project/service/feature
+  creation, where instances stall) so maintainers can tell whether the platform
+  is working for self-hosters. **No PII** is collected — events carry a random
+  per-instance id (never derived from anything machine-identifying), event
+  names, and non-identifying properties (counts, enum labels, durations). A
+  coarse, fixed-category reason is sent for failed deploys (never raw logs), and
+  the request IP is used transiently to derive a country code that is stored
+  while the IP itself is never persisted. Telemetry is **on by default**;
+  operators opt out with `TEMPS_TELEMETRY=0` and can redirect it with
+  `TEMPS_TELEMETRY_ENDPOINT`. The ingest API and its event schema are open
+  source (`telemetry-api/`).
+- **Custom health-check path.** Define the HTTP path used for the container
+  health check and the uptime monitor instead of the default `/` — set it in
+  `.temps.yaml` (`health.path`), at deploy time (`--health-check-path` on
+  `deploy:image` / `deploy:local-image` / `deploy:static`), or per-monitor
+  (`--check-path` on `monitors create`). Useful for APIs with a dedicated
+  endpoint such as `/api/healthz`.
+- **Configurable Postgres shared memory.** Managed Postgres services accept a
+  `shm_size_mb` setting (container `/dev/shm`), fixing "could not resize shared
+  memory segment … No space left on device" under parallel-query load. Changing
+  it recreates the container (shared memory is fixed at create time).
 
 ### Changed
 -

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10986,6 +10986,7 @@ dependencies = [
  "temps-screenshots",
  "temps-static-files",
  "temps-status-page",
+ "temps-telemetry",
  "temps-vulnerability-scanner",
  "temps-webhooks",
  "temps-wireguard",
@@ -12601,6 +12602,22 @@ dependencies = [
  "url",
  "utoipa",
  "wiremock",
+]
+
+[[package]]
+name = "temps-telemetry"
+version = "0.1.0-beta.33"
+dependencies = [
+ "async-trait",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "temps-config",
+ "temps-core",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ members = [
     "crates/temps-blob",
     "crates/temps-log-aggregator",
     "crates/temps-otel",
+    "crates/temps-telemetry",
     "crates/temps-environments",
     "crates/temps-screenshots",
     "crates/temps-embeddings",

--- a/apps/temps-cli/src/commands/deploy/deploy-image.ts
+++ b/apps/temps-cli/src/commands/deploy/deploy-image.ts
@@ -28,6 +28,7 @@ interface DeployImageOptions {
   wait?: boolean
   yes?: boolean
   metadata?: string
+  healthCheckPath?: string
   timeout?: string
 }
 
@@ -238,6 +239,15 @@ export async function deployImage(options: DeployImageOptions): Promise<void> {
         failSpinner('Invalid metadata JSON')
         return
       }
+    }
+
+    if (options.healthCheckPath) {
+      const p = options.healthCheckPath.trim()
+      if (!p.startsWith('/')) {
+        failSpinner('--health-check-path must start with "/" (e.g. /api/healthz)')
+        return
+      }
+      deployBody.health_check_path = p
     }
 
     const deployResponse = await fetch(deployUrl, {

--- a/apps/temps-cli/src/commands/deploy/deploy-local-image.ts
+++ b/apps/temps-cli/src/commands/deploy/deploy-local-image.ts
@@ -39,6 +39,7 @@ interface DeployLocalImageOptions {
   wait?: boolean
   yes?: boolean
   metadata?: string
+  healthCheckPath?: string
   timeout?: string
 }
 
@@ -332,6 +333,13 @@ export async function deployLocalImage(options: DeployLocalImageOptions): Promis
     const queryParams = new URLSearchParams()
     if (options.tag) {
       queryParams.set('tag', options.tag)
+    }
+    const healthCheckPath = options.healthCheckPath?.trim()
+    if (healthCheckPath) {
+      if (!healthCheckPath.startsWith('/')) {
+        throw new Error('--health-check-path must start with "/" (e.g. /api/healthz)')
+      }
+      queryParams.set('health_check_path', healthCheckPath)
     }
     const finalUrl = queryParams.toString()
       ? `${uploadUrl}?${queryParams.toString()}`

--- a/apps/temps-cli/src/commands/deploy/deploy-static.ts
+++ b/apps/temps-cli/src/commands/deploy/deploy-static.ts
@@ -32,6 +32,7 @@ interface DeployStaticOptions {
   wait?: boolean
   yes?: boolean
   metadata?: string
+  healthCheckPath?: string
   timeout?: string
 }
 
@@ -311,9 +312,16 @@ export async function deployStatic(options: DeployStaticOptions): Promise<void> 
 
     const deployUrl = `${apiUrl}/projects/${projectData.id}/environments/${environmentId}/deploy/static`
 
+    const healthCheckPath = options.healthCheckPath?.trim()
+    if (healthCheckPath && !healthCheckPath.startsWith('/')) {
+      failSpinner('--health-check-path must start with "/" (e.g. /api/healthz)')
+      return
+    }
+
     const deployBody = {
       static_bundle_id: bundle.id,
       metadata: options.metadata ? JSON.parse(options.metadata) : undefined,
+      ...(healthCheckPath ? { health_check_path: healthCheckPath } : {}),
     }
 
     const deployResponse = await fetch(deployUrl, {

--- a/apps/temps-cli/src/commands/deploy/index.ts
+++ b/apps/temps-cli/src/commands/deploy/index.ts
@@ -41,6 +41,10 @@ export function registerDeployCommands(program: Command): void {
     .option('--no-wait', 'Do not wait for deployment to complete')
     .option('-y, --yes', 'Skip confirmation prompts (for automation)')
     .option('--metadata <json>', 'Additional metadata (JSON format)')
+    .option(
+      '--health-check-path <path>',
+      'HTTP health-check path (must start with "/", e.g. /api/healthz). Overrides .temps.yaml; also updates the uptime monitor.',
+    )
     .option('--timeout <seconds>', 'Timeout in seconds for --wait', '300')
     .action(deployStatic)
 
@@ -56,6 +60,10 @@ export function registerDeployCommands(program: Command): void {
     .option('--no-wait', 'Do not wait for deployment to complete')
     .option('-y, --yes', 'Skip confirmation prompts (for automation)')
     .option('--metadata <json>', 'Additional metadata (JSON format)')
+    .option(
+      '--health-check-path <path>',
+      'HTTP health-check path (must start with "/", e.g. /api/healthz). Overrides .temps.yaml; also updates the uptime monitor.',
+    )
     .option('--timeout <seconds>', 'Timeout in seconds for --wait', '300')
     .action(deployImage)
 
@@ -76,6 +84,10 @@ export function registerDeployCommands(program: Command): void {
     .option('--no-wait', 'Do not wait for deployment to complete')
     .option('-y, --yes', 'Skip confirmation prompts (for automation)')
     .option('--metadata <json>', 'Additional metadata (JSON format)')
+    .option(
+      '--health-check-path <path>',
+      'HTTP health-check path (must start with "/", e.g. /api/healthz). Overrides .temps.yaml; also updates the uptime monitor.',
+    )
     .option('--timeout <seconds>', 'Timeout in seconds for --wait', '600')
     .action(deployLocalImage)
 

--- a/apps/temps-cli/src/commands/monitors/index.ts
+++ b/apps/temps-cli/src/commands/monitors/index.ts
@@ -36,6 +36,7 @@ interface CreateOptions {
   name?: string
   type?: string
   interval?: string
+  checkPath?: string
   environmentId?: string
   yes?: boolean
 }
@@ -84,6 +85,10 @@ export function registerMonitorsCommands(program: Command): void {
     .option('-n, --name <name>', 'Monitor name')
     .option('-t, --type <type>', 'Monitor type (http, tcp, ping)')
     .option('-i, --interval <seconds>', 'Check interval in seconds (60, 300, 600, 900, 1800)')
+    .option(
+      '--check-path <path>',
+      'HTTP health-check path (must start with "/", e.g. /api/healthz). Defaults to "/" for HTTP monitors.',
+    )
     .option('--environment-id <id>', 'Environment ID (default: 0 for production)')
     .option('-y, --yes', 'Skip confirmation prompts (for automation)')
     .action(createMonitorAction)
@@ -232,6 +237,13 @@ async function createMonitorAction(options: CreateOptions): Promise<void> {
     environmentId = options.environmentId ? parseInt(options.environmentId, 10) : 0
   }
 
+  // Optional custom health-check path (e.g. /api/healthz). The backend validates
+  // too, but fail fast here with a friendly message.
+  const checkPath = options.checkPath?.trim()
+  if (checkPath && !checkPath.startsWith('/')) {
+    throw new Error(`--check-path must start with "/" (got "${checkPath}")`)
+  }
+
   await withSpinner('Creating monitor...', async () => {
     const { error } = await createMonitor({
       client,
@@ -241,6 +253,7 @@ async function createMonitorAction(options: CreateOptions): Promise<void> {
         monitor_type: monitorType,
         check_interval_seconds: checkInterval,
         environment_id: environmentId,
+        ...(checkPath ? { check_path: checkPath } : {}),
       },
     })
     if (error) {

--- a/crates/temps-agent/src/lib.rs
+++ b/crates/temps-agent/src/lib.rs
@@ -144,6 +144,10 @@ pub struct ServiceResourceLimits {
     /// Relative CPU weight (default 1024). Only used when `nano_cpus` is None.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cpu_shares: Option<i64>,
+    /// Shared memory (/dev/shm) size in MiB. None = Docker default (64 MiB).
+    /// Create-time only; changing it requires recreating the container.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shm_size_mb: Option<i64>,
 }
 
 /// Port mapping for a service container.

--- a/crates/temps-agent/src/service_handlers.rs
+++ b/crates/temps-agent/src/service_handlers.rs
@@ -184,6 +184,9 @@ pub async fn create_service(
         if let Some(cs) = limits.cpu_shares {
             host_config.cpu_shares = Some(cs);
         }
+        if let Some(mb) = limits.shm_size_mb {
+            host_config.shm_size = Some(mb.saturating_mul(1024 * 1024));
+        }
     }
 
     let container_config = bollard::models::ContainerCreateBody {

--- a/crates/temps-agents/src/handlers/autofixer.rs
+++ b/crates/temps-agents/src/handlers/autofixer.rs
@@ -575,6 +575,12 @@ pub async fn start_fix(
         );
     }
 
+    app_state.telemetry.report(
+        temps_core::TelemetryEvent::new(temps_core::TelemetryEventKind::AutofixerFixAccepted)
+            .with("source", run.source.clone())
+            .with_opt("ai_provider", run.ai_provider.clone()),
+    );
+
     // Spawn fix in background
     let autofixer = app_state.autofixer_service.clone();
     tokio::spawn(async move {
@@ -765,6 +771,12 @@ pub async fn cancel(
         .get_run(run_id)
         .await
         .map_err(Problem::from)?;
+
+    app_state.telemetry.report(
+        temps_core::TelemetryEvent::new(temps_core::TelemetryEventKind::AutofixerFixRejected)
+            .with("source", run.source.clone())
+            .with_opt("ai_provider", run.ai_provider.clone()),
+    );
 
     Ok(Json(AutofixerRunResponse::from(run)))
 }

--- a/crates/temps-agents/src/handlers/mod.rs
+++ b/crates/temps-agents/src/handlers/mod.rs
@@ -206,6 +206,9 @@ pub struct AppState {
     /// Platform settings service used by the preview gateway handlers to
     /// persist image / auto-upgrade changes.
     pub platform_config_service: Arc<temps_config::ConfigService>,
+    /// Anonymous product-telemetry reporter. Fire-and-forget; never fails the
+    /// surrounding request. Defaults to a no-op when telemetry is not registered.
+    pub telemetry: Arc<dyn temps_core::TelemetryReporter>,
 }
 
 pub fn configure_routes() -> Router<Arc<AppState>> {

--- a/crates/temps-agents/src/plugin.rs
+++ b/crates/temps-agents/src/plugin.rs
@@ -593,6 +593,9 @@ impl TempsPlugin for AgentsPlugin {
                 definition_service,
                 docker: context.require_service::<bollard::Docker>(),
                 platform_config_service: context.require_service::<temps_config::ConfigService>(),
+                telemetry: context
+                    .get_service::<dyn temps_core::TelemetryReporter>()
+                    .unwrap_or_else(|| Arc::new(temps_core::NoopTelemetryReporter)),
             });
             context.register_plugin_state("agents", app_state);
 

--- a/crates/temps-ai-gateway/src/handlers/gateway.rs
+++ b/crates/temps-ai-gateway/src/handlers/gateway.rs
@@ -424,6 +424,13 @@ async fn chat_completions(
                     "AI gateway streaming request started"
                 );
 
+                app_state.telemetry.report(
+                    temps_core::telemetry::TelemetryEvent::new(
+                        temps_core::telemetry::TelemetryEventKind::AiGatewayFirstRequest,
+                    )
+                    .with("provider", provider_id),
+                );
+
                 let wrapped = wrap_stream_with_usage_tracking(
                     stream,
                     app_state.usage_service.clone(),
@@ -509,6 +516,13 @@ async fn chat_completions(
                     latency_ms = latency.as_millis() as u64,
                     credential_type = credential_type_str(cred_type),
                     "AI gateway request completed"
+                );
+
+                app_state.telemetry.report(
+                    temps_core::telemetry::TelemetryEvent::new(
+                        temps_core::telemetry::TelemetryEventKind::AiGatewayFirstRequest,
+                    )
+                    .with("provider", provider_id),
                 );
 
                 let mut response_builder = axum::response::Response::builder()

--- a/crates/temps-ai-gateway/src/handlers/types.rs
+++ b/crates/temps-ai-gateway/src/handlers/types.rs
@@ -8,6 +8,7 @@ pub struct AiGatewayAppState {
     pub provider_key_service: Arc<ProviderKeyService>,
     pub usage_service: Arc<UsageService>,
     pub audit_service: Arc<dyn AuditLogger>,
+    pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 }
 
 pub async fn create_ai_gateway_app_state(
@@ -15,11 +16,13 @@ pub async fn create_ai_gateway_app_state(
     provider_key_service: Arc<ProviderKeyService>,
     usage_service: Arc<UsageService>,
     audit_service: Arc<dyn AuditLogger>,
+    telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 ) -> Arc<AiGatewayAppState> {
     Arc::new(AiGatewayAppState {
         gateway_service,
         provider_key_service,
         usage_service,
         audit_service,
+        telemetry,
     })
 }

--- a/crates/temps-ai-gateway/src/plugin.rs
+++ b/crates/temps-ai-gateway/src/plugin.rs
@@ -53,11 +53,18 @@ impl TempsPlugin for AiGatewayPlugin {
 
             let audit_service = context.require_service::<dyn temps_core::AuditLogger>();
 
+            let telemetry = context
+                .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+                .unwrap_or_else(|| {
+                    std::sync::Arc::new(temps_core::telemetry::NoopTelemetryReporter)
+                });
+
             let app_state = create_ai_gateway_app_state(
                 gateway_service,
                 provider_key_service,
                 usage_service,
                 audit_service,
+                telemetry,
             )
             .await;
             context.register_service(app_state);

--- a/crates/temps-analytics-events/src/handlers/events_handler.rs
+++ b/crates/temps-analytics-events/src/handlers/events_handler.rs
@@ -40,6 +40,7 @@ pub struct AppState {
     pub route_table: Arc<CachedPeerTable>,
     pub ip_address_service: Arc<temps_geo::IpAddressService>,
     pub cookie_crypto: Arc<temps_core::CookieCrypto>,
+    pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 }
 
 /// Get event counts with filtering
@@ -775,6 +776,11 @@ pub async fn record_event_metrics(
                 environment_id,
                 deployment_id
             );
+            state
+                .telemetry
+                .report(temps_core::telemetry::TelemetryEvent::new(
+                    temps_core::telemetry::TelemetryEventKind::AnalyticsFirstEventReceived,
+                ));
             StatusCode::NO_CONTENT.into_response()
         }
         Err(e) => {
@@ -896,6 +902,11 @@ pub async fn record_console_event(
         "Console event recorded: {} for project {} env={}",
         payload.event_name, project_id, payload.environment_id
     );
+    state
+        .telemetry
+        .report(temps_core::telemetry::TelemetryEvent::new(
+            temps_core::telemetry::TelemetryEventKind::AnalyticsFirstEventReceived,
+        ));
 
     Ok(StatusCode::OK)
 }
@@ -1201,6 +1212,7 @@ mod tests {
             route_table,
             ip_address_service,
             cookie_crypto: cookie_crypto.clone(),
+            telemetry: Arc::new(temps_core::telemetry::NoopTelemetryReporter),
         });
 
         let auth_middleware = middleware::from_fn(
@@ -1598,6 +1610,7 @@ mod tests {
             route_table,
             ip_address_service,
             cookie_crypto,
+            telemetry: Arc::new(temps_core::telemetry::NoopTelemetryReporter),
         });
 
         // No auth middleware — should return 401

--- a/crates/temps-analytics-events/src/plugin.rs
+++ b/crates/temps-analytics-events/src/plugin.rs
@@ -72,12 +72,17 @@ impl TempsPlugin for EventsPlugin {
                 events_service.clone()
             };
 
+        let telemetry = context
+            .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+            .unwrap_or_else(|| Arc::new(temps_core::telemetry::NoopTelemetryReporter));
+
         let state = Arc::new(crate::handlers::AppState {
             events_service: events_backend,
             events_writer: events_service,
             route_table,
             ip_address_service,
             cookie_crypto,
+            telemetry,
         });
 
         let routes = crate::handlers::configure_routes().with_state(state);
@@ -94,12 +99,17 @@ impl TempsPlugin for EventsPlugin {
         // PG-backed service since these endpoints don't query.
         let events_backend: Arc<dyn crate::services::AnalyticsEvents> = events_service.clone();
 
+        let telemetry = context
+            .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+            .unwrap_or_else(|| Arc::new(temps_core::telemetry::NoopTelemetryReporter));
+
         let state = Arc::new(crate::handlers::AppState {
             events_service: events_backend,
             events_writer: events_service,
             route_table,
             ip_address_service,
             cookie_crypto,
+            telemetry,
         });
 
         let routes = crate::handlers::configure_public_routes().with_state(state);

--- a/crates/temps-analytics-session-replay/src/handlers/handler.rs
+++ b/crates/temps-analytics-session-replay/src/handlers/handler.rs
@@ -754,6 +754,11 @@ pub async fn init_session_replay(
     {
         Ok(session_id) => {
             debug!("Successfully initialized session replay: {}", session_id);
+            state
+                .telemetry
+                .report(temps_core::telemetry::TelemetryEvent::new(
+                    temps_core::telemetry::TelemetryEventKind::SessionReplayFirstSession,
+                ));
             Ok((
                 StatusCode::CREATED,
                 Json(SessionReplayInitResponse {

--- a/crates/temps-analytics-session-replay/src/handlers/types.rs
+++ b/crates/temps-analytics-session-replay/src/handlers/types.rs
@@ -7,4 +7,5 @@ pub struct AppState {
     pub session_replay_service: Arc<SessionReplayService>,
     pub audit_service: Arc<dyn temps_core::AuditLogger>,
     pub route_table: Arc<CachedPeerTable>,
+    pub telemetry: std::sync::Arc<dyn temps_core::telemetry::TelemetryReporter>,
 }

--- a/crates/temps-analytics-session-replay/src/plugin.rs
+++ b/crates/temps-analytics-session-replay/src/plugin.rs
@@ -60,11 +60,15 @@ impl TempsPlugin for SessionReplayPlugin {
             context.require_service::<crate::services::SessionReplayService>();
         let audit_service = context.require_service::<dyn temps_core::AuditLogger>();
         let route_table = context.require_service::<temps_routes::CachedPeerTable>();
+        let telemetry = context
+            .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+            .unwrap_or_else(|| std::sync::Arc::new(temps_core::telemetry::NoopTelemetryReporter));
         let routes = crate::handlers::configure_routes().with_state(Arc::new(
             crate::handlers::types::AppState {
                 session_replay_service,
                 audit_service,
                 route_table,
+                telemetry,
             },
         ));
 
@@ -76,11 +80,15 @@ impl TempsPlugin for SessionReplayPlugin {
             context.require_service::<crate::services::SessionReplayService>();
         let audit_service = context.require_service::<dyn temps_core::AuditLogger>();
         let route_table = context.require_service::<temps_routes::CachedPeerTable>();
+        let telemetry = context
+            .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+            .unwrap_or_else(|| std::sync::Arc::new(temps_core::telemetry::NoopTelemetryReporter));
         let routes = crate::handlers::configure_public_routes().with_state(Arc::new(
             crate::handlers::types::AppState {
                 session_replay_service,
                 audit_service,
                 route_table,
+                telemetry,
             },
         ));
 

--- a/crates/temps-auth/src/apikey_handler.rs
+++ b/crates/temps-auth/src/apikey_handler.rs
@@ -27,6 +27,8 @@ pub struct ListApiKeysQuery {
 
 pub struct ApiKeyState {
     pub api_key_service: Arc<ApiKeyService>,
+    /// Anonymous product telemetry reporter
+    pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 }
 
 #[utoipa::path(
@@ -53,14 +55,17 @@ pub async fn create_api_key(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ApiKeysCreate);
 
-    match state
+    let api_key = state
         .api_key_service
         .create_api_key(auth.user_id(), request.into())
         .await
-    {
-        Ok(api_key) => Ok((StatusCode::CREATED, Json(api_key))),
-        Err(e) => Err(e.to_problem()),
-    }
+        .map_err(|e| e.to_problem())?;
+
+    state.telemetry.report(temps_core::TelemetryEvent::new(
+        temps_core::TelemetryEventKind::ApiKeyCreated,
+    ));
+
+    Ok((StatusCode::CREATED, Json(api_key)))
 }
 
 #[utoipa::path(

--- a/crates/temps-auth/src/apikey_plugin.rs
+++ b/crates/temps-auth/src/apikey_plugin.rs
@@ -56,9 +56,19 @@ impl TempsPlugin for ApiKeyPlugin {
             let apikey_service = Arc::new(ApiKeyService::new(db.clone()));
             context.register_service(apikey_service.clone());
 
+            // Resolve the telemetry reporter; default to no-op so the plugin
+            // never hard-fails if the telemetry crate isn't registered.
+            let telemetry = context
+                .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+                .unwrap_or_else(|| {
+                    Arc::new(temps_core::telemetry::NoopTelemetryReporter)
+                        as Arc<dyn temps_core::telemetry::TelemetryReporter>
+                });
+
             // Create ApiKeyState for handlers
             let apikey_state = Arc::new(ApiKeyState {
                 api_key_service: apikey_service,
+                telemetry,
             });
             context.register_service(apikey_state);
 

--- a/crates/temps-auth/src/oidc_handler.rs
+++ b/crates/temps-auth/src/oidc_handler.rs
@@ -455,6 +455,20 @@ pub async fn create_oidc_provider(
         error!("Failed to create OIDC provider audit log: {}", e);
     }
 
+    // Emit anonymous telemetry. The `provider` property is allowlisted against
+    // known type labels so free-form admin-supplied names are never transmitted.
+    const KNOWN_OIDC_TEMPLATES: &[&str] = &[
+        "generic", "google", "github", "keycloak", "okta", "auth0", "azure-ad",
+    ];
+    let provider_label = KNOWN_OIDC_TEMPLATES
+        .iter()
+        .find(|t| **t == provider.template.as_str())
+        .copied();
+    state.telemetry.report(
+        temps_core::TelemetryEvent::new(temps_core::TelemetryEventKind::OidcProviderConfigured)
+            .with_opt("provider", provider_label),
+    );
+
     Ok((StatusCode::CREATED, Json(provider_to_response(&provider))))
 }
 

--- a/crates/temps-auth/src/plugin.rs
+++ b/crates/temps-auth/src/plugin.rs
@@ -99,6 +99,15 @@ impl TempsPlugin for AuthPlugin {
                 }
             });
 
+            // Resolve the telemetry reporter; default to no-op so auth never
+            // hard-fails if the telemetry crate isn't registered.
+            let telemetry = context
+                .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+                .unwrap_or_else(|| {
+                    Arc::new(temps_core::telemetry::NoopTelemetryReporter)
+                        as Arc<dyn temps_core::telemetry::TelemetryReporter>
+                });
+
             // Create AuthState for handlers
             let auth_state = Arc::new(AuthState::new(
                 db.clone(),
@@ -106,6 +115,7 @@ impl TempsPlugin for AuthPlugin {
                 encryption_service.clone(),
                 cookie_crypto.clone(),
                 notification_service.clone(),
+                telemetry,
             ));
             context.register_service(auth_state);
 

--- a/crates/temps-auth/src/state.rs
+++ b/crates/temps-auth/src/state.rs
@@ -28,6 +28,8 @@ pub struct AuthState {
     pub deployment_token_service: Arc<DeploymentTokenValidationService>,
     /// OIDC SSO service
     pub oidc_service: Arc<crate::oidc_service::OidcService>,
+    /// Anonymous product telemetry reporter
+    pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 }
 
 impl AuthState {
@@ -38,6 +40,7 @@ impl AuthState {
         encryption_service: Arc<EncryptionService>,
         cookie_crypto: Arc<CookieCrypto>,
         notification_service: DynNotificationService,
+        telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
     ) -> Self {
         let auth_service = Arc::new(AuthService::new(db.clone(), notification_service));
         let api_key_service = Arc::new(ApiKeyService::new(db.clone()));
@@ -58,6 +61,7 @@ impl AuthState {
             cookie_crypto,
             deployment_token_service,
             oidc_service,
+            telemetry,
         }
     }
 }

--- a/crates/temps-backup/src/handlers/backup_handler.rs
+++ b/crates/temps-backup/src/handlers/backup_handler.rs
@@ -1638,10 +1638,24 @@ async fn create_backup_schedule(
         .create_backup_schedule(request)
         .await
     {
-        Ok(schedule) => Ok((
-            StatusCode::CREATED,
-            Json(BackupScheduleResponse::from(schedule)),
-        )),
+        Ok(schedule) => {
+            app_state.telemetry.report(
+                temps_core::telemetry::TelemetryEvent::new(
+                    temps_core::telemetry::TelemetryEventKind::BackupConfigured,
+                )
+                .with("backup_type", schedule.backup_type.clone())
+                .with("enabled", schedule.enabled)
+                .with("target_all_services", schedule.target_all_services)
+                .with("include_control_plane", schedule.include_control_plane)
+                .with("retention_period_days", schedule.retention_period)
+                .with("has_custom_timeout", schedule.max_runtime_secs.is_some())
+                .with("has_schedule", true),
+            );
+            Ok((
+                StatusCode::CREATED,
+                Json(BackupScheduleResponse::from(schedule)),
+            ))
+        }
         Err(e) => {
             error!("Failed to create backup schedule: {}", e);
             Err(Problem::from(e))

--- a/crates/temps-backup/src/handlers/restore_handler.rs
+++ b/crates/temps-backup/src/handlers/restore_handler.rs
@@ -282,6 +282,15 @@ async fn start_restore(
         .await
         .map_err(Problem::from)?;
 
+    // Fire-and-forget anonymous telemetry for PITR restores.
+    if matches!(request.mode, RestoreRequestMode::Pitr { .. }) {
+        app_state
+            .telemetry
+            .report(temps_core::telemetry::TelemetryEvent::new(
+                temps_core::telemetry::TelemetryEventKind::PitrRestoreTriggered,
+            ));
+    }
+
     // Audit — the URL id is the TARGET service.
     let target_service = temps_entities::external_services::Entity::find_by_id(id)
         .one(app_state.db.as_ref())

--- a/crates/temps-backup/src/handlers/types.rs
+++ b/crates/temps-backup/src/handlers/types.rs
@@ -16,6 +16,7 @@ pub struct BackupAppState {
     /// In-process backup executor. Replaces the queue-based runner that
     /// previously sat between trigger paths and engines.
     pub backup_executor: Arc<BackupExecutor>,
+    pub telemetry: std::sync::Arc<dyn temps_core::telemetry::TelemetryReporter>,
 }
 
 pub fn create_backup_app_state(
@@ -25,6 +26,7 @@ pub fn create_backup_app_state(
     pg_upgrade_service: Arc<PostgresUpgradeService>,
     db: Arc<DatabaseConnection>,
     backup_executor: Arc<BackupExecutor>,
+    telemetry: std::sync::Arc<dyn temps_core::telemetry::TelemetryReporter>,
 ) -> Arc<BackupAppState> {
     Arc::new(BackupAppState {
         backup_service,
@@ -33,5 +35,6 @@ pub fn create_backup_app_state(
         pg_upgrade_service,
         db,
         backup_executor,
+        telemetry,
     })
 }

--- a/crates/temps-backup/src/plugin.rs
+++ b/crates/temps-backup/src/plugin.rs
@@ -191,6 +191,16 @@ impl TempsPlugin for BackupPlugin {
                 info!("BackupJobProcessor started");
             }
 
+            let telemetry = context
+                .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+                .unwrap_or_else(|| {
+                    std::sync::Arc::new(temps_core::telemetry::NoopTelemetryReporter)
+                });
+
+            // Thread the telemetry reporter into the pg upgrade service so
+            // orchestrators it spawns can emit PgMajorUpgradeCompleted.
+            pg_upgrade_service.set_telemetry(Arc::clone(&telemetry));
+
             let backup_app_state_inner = create_backup_app_state(
                 backup_service,
                 restore_service,
@@ -198,6 +208,7 @@ impl TempsPlugin for BackupPlugin {
                 pg_upgrade_service,
                 db.clone(),
                 Arc::clone(&executor),
+                telemetry,
             );
 
             context.register_service(backup_app_state_inner);

--- a/crates/temps-cli/Cargo.toml
+++ b/crates/temps-cli/Cargo.toml
@@ -61,6 +61,7 @@ temps-metrics = { path = "../temps-metrics" }
 temps-monitoring = { path = "../temps-monitoring" }
 temps-notifications = { path = "../temps-notifications" }
 temps-otel = { path = "../temps-otel" }
+temps-telemetry = { path = "../temps-telemetry" }
 temps-projects = { path = "../temps-projects" }
 temps-providers = { path = "../temps-providers" }
 temps-proxy = { path = "../temps-proxy" }

--- a/crates/temps-cli/src/commands/serve/console.rs
+++ b/crates/temps-cli/src/commands/serve/console.rs
@@ -27,6 +27,7 @@ use temps_blob::BlobPlugin;
 use temps_config::ConfigPlugin;
 use temps_config::ServerConfig;
 use temps_core::plugin::{PluginManager, TempsPlugin};
+use temps_telemetry::TelemetryPlugin;
 // `TempsPlugin` is used both directly (extra_plugins field) and through
 // `dyn TempsPlugin` in `ConsoleApiParams`.
 use temps_core::templates::TemplateService;
@@ -78,6 +79,45 @@ use utoipa_swagger_ui::SwaggerUi;
 static WEBSITE: Dir = include_dir!("$CARGO_MANIFEST_DIR/dist");
 
 /// Ensure the system user (id=0) exists in the database.
+/// Emit the anonymous `instance_started` telemetry event with non-identifying
+/// depth-of-usage counts (number of projects, environments, managed services,
+/// and worker nodes). These counts are a strong retention signal without
+/// revealing anything about *what* the operator is running.
+///
+/// Fully best-effort: any count query failure is swallowed (the count is simply
+/// omitted) and `report()` itself is fire-and-forget.
+async fn report_instance_started(
+    reporter: &dyn temps_core::telemetry::TelemetryReporter,
+    db: &sea_orm::DatabaseConnection,
+) {
+    use sea_orm::PaginatorTrait;
+    use temps_core::telemetry::{TelemetryEvent, TelemetryEventKind};
+
+    // Each count is independent and optional — a failure on one doesn't block
+    // the others or the event itself.
+    let project_count = temps_entities::projects::Entity::find()
+        .count(db)
+        .await
+        .ok();
+    let environment_count = temps_entities::environments::Entity::find()
+        .count(db)
+        .await
+        .ok();
+    let service_count = temps_entities::external_services::Entity::find()
+        .count(db)
+        .await
+        .ok();
+    let node_count = temps_entities::nodes::Entity::find().count(db).await.ok();
+
+    let event = TelemetryEvent::new(TelemetryEventKind::InstanceStarted)
+        .with_opt("project_count", project_count.map(|c| c as i64))
+        .with_opt("environment_count", environment_count.map(|c| c as i64))
+        .with_opt("service_count", service_count.map(|c| c as i64))
+        .with_opt("node_count", node_count.map(|c| c as i64));
+
+    reporter.report(event);
+}
+
 /// This user is referenced by webhook-created resources (e.g., GitHub App installations)
 /// that don't have an authenticated user context.
 async fn ensure_system_user(db: &sea_orm::DatabaseConnection) -> anyhow::Result<()> {
@@ -938,6 +978,16 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
     let config_plugin = Box::new(ConfigPlugin::new(config.clone()));
     plugin_manager.register_plugin(config_plugin);
 
+    // 1.5. TelemetryPlugin - registers the anonymous telemetry reporter
+    // (depends only on ServerConfig for the data dir). Registered early so
+    // every later plugin can require the Arc<dyn TelemetryReporter>.
+    debug!("Registering TelemetryPlugin");
+    let telemetry_plugin = Box::new(TelemetryPlugin::new(
+        config.clone(),
+        env!("CARGO_PKG_VERSION"),
+    ));
+    plugin_manager.register_plugin(telemetry_plugin);
+
     // 2. QueuePlugin - registers the pre-created job queue into the service context
     debug!("Registering QueuePlugin");
     let queue_plugin = Box::new(QueuePlugin::new(queue));
@@ -1222,6 +1272,17 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
 
     // Check if any users exist, if not prompt for admin email
     let service_context = plugin_manager.service_context();
+
+    // Emit the anonymous `instance_started` telemetry event now that the
+    // service registry is populated. Entirely best-effort: a missing reporter,
+    // a failed count query, or a dead endpoint must never affect startup.
+    if let Some(reporter) =
+        service_context.get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+    {
+        if reporter.is_enabled() {
+            report_instance_started(reporter.as_ref(), db.as_ref()).await;
+        }
+    }
     if let Some(user_service) = service_context.get_service::<temps_auth::UserService>() {
         // Always ensure the system user (id=0) exists — needed for webhook-created
         // resources (e.g., GitHub App installations) that reference user_id=0
@@ -1597,11 +1658,15 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
     let node_service = Arc::new(NodeService::new(db.clone()));
     let encryption_service_for_nodes =
         service_context.require_service::<temps_core::EncryptionService>();
+    let node_telemetry = service_context
+        .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+        .unwrap_or_else(|| Arc::new(temps_core::telemetry::NoopTelemetryReporter));
     let node_app_state = Arc::new(NodeAppState {
         node_service: node_service.clone(),
         db: db.clone(),
         config_service: config_service_for_nodes,
         encryption_service: encryption_service_for_nodes,
+        telemetry: node_telemetry,
     });
     let node_routes =
         temps_deployments::handlers::nodes::configure_routes().with_state(node_app_state);

--- a/crates/temps-core/src/lib.rs
+++ b/crates/temps-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod openapi;
 pub mod plugin;
 pub mod problemdetails;
 pub mod retry;
+pub mod telemetry;
 pub mod tls;
 pub use problemdetails::ProblemDetails;
 mod app_settings;
@@ -47,6 +48,7 @@ pub use error::*;
 pub use error_builder::*;
 pub use jobs::*;
 pub use on_demand::*;
+pub use telemetry::{NoopTelemetryReporter, TelemetryEvent, TelemetryEventKind, TelemetryReporter};
 pub use utils::*;
 
 // Re-export external dependencies

--- a/crates/temps-core/src/telemetry.rs
+++ b/crates/temps-core/src/telemetry.rs
@@ -1,0 +1,305 @@
+//! Anonymous product telemetry abstraction.
+//!
+//! Temps optionally reports **anonymous** product-usage events to a central
+//! endpoint so the maintainers can understand whether the product is actually
+//! working for self-hosters (e.g. "instances that tried to deploy" vs
+//! "instances that deployed successfully"). No PII, repo names, domains, or
+//! secrets are ever sent — only a stable random `anonymous_id` generated on the
+//! instance, the event name, and a small bag of non-identifying properties.
+//!
+//! This module defines the *abstraction* only. The concrete reporter (HTTP
+//! client, anonymous-id persistence, opt-out handling) lives in the
+//! `temps-telemetry` crate. Feature crates depend on the [`TelemetryReporter`]
+//! trait via `Arc<dyn TelemetryReporter>` so they never need a direct
+//! dependency on the telemetry crate, mirroring the [`crate::AuditLogger`]
+//! pattern.
+//!
+//! Reporting is **fire-and-forget**: a call to [`TelemetryReporter::report`]
+//! must never block the caller or fail the surrounding operation. A dead or
+//! slow telemetry endpoint has zero effect on user-facing behaviour.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Canonical set of product-telemetry event names.
+///
+/// Kept as an enum (rather than free strings) so callsites can't typo an event
+/// name and the central ingest API's accepted list stays in lockstep with what
+/// the binary can actually emit. The wire representation is the snake_case
+/// string returned by [`TelemetryEventKind::as_str`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TelemetryEventKind {
+    // ---- Instance lifecycle ----
+    InstanceStarted,
+    InstanceSetupCompleted,
+    UpgradeCompleted,
+    WorkerNodeJoined,
+
+    // ---- Deployment funnel ----
+    DeployAttempted,
+    DeploySucceeded,
+    DeployFailed,
+    RollbackTriggered,
+    FirstDeploySucceeded,
+
+    // ---- Project & environment ----
+    ProjectCreated,
+    EnvironmentCreated,
+    ScaleToZeroConfigured,
+    AutoDeployEnabled,
+    AttackModeEnabled,
+
+    // ---- Git & source ----
+    GitProviderConnected,
+
+    // ---- Domains & networking ----
+    CustomDomainAdded,
+    SslCertificateIssued,
+
+    // ---- Managed services ----
+    ServiceCreated,
+    ServiceClusterCreated,
+    PgMajorUpgradeCompleted,
+    PitrRestoreTriggered,
+    BackupConfigured,
+
+    // ---- Observability suite activation ----
+    AnalyticsFirstEventReceived,
+    SessionReplayFirstSession,
+    ErrorTrackingFirstError,
+    AiGatewayFirstRequest,
+
+    // ---- AI features ----
+    AiSreConversationStarted,
+    AutofixerFixAccepted,
+    AutofixerFixRejected,
+
+    // ---- Auth & security ----
+    OidcProviderConfigured,
+    ApiKeyCreated,
+    VulnerabilityScanTriggered,
+
+    // ---- Email ----
+    EmailProviderConfigured,
+
+    // ---- Status page ----
+    StatusPagePublished,
+}
+
+impl TelemetryEventKind {
+    /// The stable snake_case wire name for this event.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::InstanceStarted => "instance_started",
+            Self::InstanceSetupCompleted => "instance_setup_completed",
+            Self::UpgradeCompleted => "upgrade_completed",
+            Self::WorkerNodeJoined => "worker_node_joined",
+
+            Self::DeployAttempted => "deploy_attempted",
+            Self::DeploySucceeded => "deploy_succeeded",
+            Self::DeployFailed => "deploy_failed",
+            Self::RollbackTriggered => "rollback_triggered",
+            Self::FirstDeploySucceeded => "first_deploy_succeeded",
+
+            Self::ProjectCreated => "project_created",
+            Self::EnvironmentCreated => "environment_created",
+            Self::ScaleToZeroConfigured => "scale_to_zero_configured",
+            Self::AutoDeployEnabled => "auto_deploy_enabled",
+            Self::AttackModeEnabled => "attack_mode_enabled",
+
+            Self::GitProviderConnected => "git_provider_connected",
+
+            Self::CustomDomainAdded => "custom_domain_added",
+            Self::SslCertificateIssued => "ssl_certificate_issued",
+
+            Self::ServiceCreated => "service_created",
+            Self::ServiceClusterCreated => "service_cluster_created",
+            Self::PgMajorUpgradeCompleted => "pg_major_upgrade_completed",
+            Self::PitrRestoreTriggered => "pitr_restore_triggered",
+            Self::BackupConfigured => "backup_configured",
+
+            Self::AnalyticsFirstEventReceived => "analytics_first_event_received",
+            Self::SessionReplayFirstSession => "session_replay_first_session",
+            Self::ErrorTrackingFirstError => "error_tracking_first_error",
+            Self::AiGatewayFirstRequest => "ai_gateway_first_request",
+
+            Self::AiSreConversationStarted => "ai_sre_conversation_started",
+            Self::AutofixerFixAccepted => "autofixer_fix_accepted",
+            Self::AutofixerFixRejected => "autofixer_fix_rejected",
+
+            Self::OidcProviderConfigured => "oidc_provider_configured",
+            Self::ApiKeyCreated => "api_key_created",
+            Self::VulnerabilityScanTriggered => "vulnerability_scan_triggered",
+
+            Self::EmailProviderConfigured => "email_provider_configured",
+
+            Self::StatusPagePublished => "status_page_published",
+        }
+    }
+
+    /// Every known event name, used by tooling and tests to keep the central
+    /// ingest API's accepted list in sync with the binary.
+    pub fn all() -> &'static [TelemetryEventKind] {
+        &[
+            Self::InstanceStarted,
+            Self::InstanceSetupCompleted,
+            Self::UpgradeCompleted,
+            Self::WorkerNodeJoined,
+            Self::DeployAttempted,
+            Self::DeploySucceeded,
+            Self::DeployFailed,
+            Self::RollbackTriggered,
+            Self::FirstDeploySucceeded,
+            Self::ProjectCreated,
+            Self::EnvironmentCreated,
+            Self::ScaleToZeroConfigured,
+            Self::AutoDeployEnabled,
+            Self::AttackModeEnabled,
+            Self::GitProviderConnected,
+            Self::CustomDomainAdded,
+            Self::SslCertificateIssued,
+            Self::ServiceCreated,
+            Self::ServiceClusterCreated,
+            Self::PgMajorUpgradeCompleted,
+            Self::PitrRestoreTriggered,
+            Self::BackupConfigured,
+            Self::AnalyticsFirstEventReceived,
+            Self::SessionReplayFirstSession,
+            Self::ErrorTrackingFirstError,
+            Self::AiGatewayFirstRequest,
+            Self::AiSreConversationStarted,
+            Self::AutofixerFixAccepted,
+            Self::AutofixerFixRejected,
+            Self::OidcProviderConfigured,
+            Self::ApiKeyCreated,
+            Self::VulnerabilityScanTriggered,
+            Self::EmailProviderConfigured,
+            Self::StatusPagePublished,
+        ]
+    }
+}
+
+/// A single anonymous telemetry event.
+///
+/// `properties` must contain only non-identifying values (counts, enum labels,
+/// durations). It must never contain emails, IPs, repo names, domains, env-var
+/// names/values, or any free-form user text.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelemetryEvent {
+    /// The event name (snake_case wire form).
+    pub event_type: String,
+    /// Non-identifying properties. Ordered for stable serialization in tests.
+    pub properties: BTreeMap<String, serde_json::Value>,
+}
+
+impl TelemetryEvent {
+    /// Start building an event from a known kind.
+    pub fn new(kind: TelemetryEventKind) -> Self {
+        Self {
+            event_type: kind.as_str().to_string(),
+            properties: BTreeMap::new(),
+        }
+    }
+
+    /// Attach a non-identifying property. Chainable.
+    ///
+    /// Values are converted via `serde_json::Value::from`, so strings, numbers,
+    /// and bools all work. Prefer enum labels and counts — never raw user input.
+    pub fn with<K, V>(mut self, key: K, value: V) -> Self
+    where
+        K: Into<String>,
+        V: Into<serde_json::Value>,
+    {
+        self.properties.insert(key.into(), value.into());
+        self
+    }
+
+    /// Attach an optional property only when present. Chainable.
+    pub fn with_opt<K, V>(self, key: K, value: Option<V>) -> Self
+    where
+        K: Into<String>,
+        V: Into<serde_json::Value>,
+    {
+        match value {
+            Some(v) => self.with(key, v),
+            None => self,
+        }
+    }
+}
+
+/// Trait for services that can report anonymous product telemetry.
+///
+/// Implementations MUST be fire-and-forget: [`Self::report`] returns
+/// immediately (spawning any network work in the background) and never returns
+/// an error to the caller. A disabled reporter (operator opted out) is a no-op.
+#[async_trait::async_trait]
+pub trait TelemetryReporter: Send + Sync {
+    /// Report an event. Never blocks on the network and never fails the caller.
+    fn report(&self, event: TelemetryEvent);
+
+    /// Whether telemetry is currently enabled. Callsites can use this to skip
+    /// building expensive property bags when reporting is off.
+    fn is_enabled(&self) -> bool;
+}
+
+/// A no-op reporter used when telemetry is disabled or unavailable, so callers
+/// can always hold an `Arc<dyn TelemetryReporter>` without `Option`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopTelemetryReporter;
+
+#[async_trait::async_trait]
+impl TelemetryReporter for NoopTelemetryReporter {
+    fn report(&self, _event: TelemetryEvent) {}
+    fn is_enabled(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_kind_wire_names_are_snake_case_and_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for kind in TelemetryEventKind::all() {
+            let name = kind.as_str();
+            assert!(
+                name.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+                "event name '{name}' must be snake_case"
+            );
+            assert!(seen.insert(name), "duplicate event name '{name}'");
+        }
+    }
+
+    #[test]
+    fn all_covers_every_variant() {
+        // If a variant is added but not added to all(), as_str() on it will be
+        // missing from the list and this length check is a cheap tripwire.
+        // 34 events as of the initial product-telemetry design.
+        assert_eq!(TelemetryEventKind::all().len(), 34);
+    }
+
+    #[test]
+    fn builder_attaches_properties() {
+        let event = TelemetryEvent::new(TelemetryEventKind::DeploySucceeded)
+            .with("runtime", "nixpacks")
+            .with("duration_ms", 8700)
+            .with_opt("region", Some("fsn1"))
+            .with_opt::<_, String>("absent", None);
+
+        assert_eq!(event.event_type, "deploy_succeeded");
+        assert_eq!(event.properties.get("runtime").unwrap(), "nixpacks");
+        assert_eq!(event.properties.get("duration_ms").unwrap(), 8700);
+        assert_eq!(event.properties.get("region").unwrap(), "fsn1");
+        assert!(!event.properties.contains_key("absent"));
+    }
+
+    #[test]
+    fn noop_reporter_is_disabled_and_silent() {
+        let reporter = NoopTelemetryReporter;
+        assert!(!reporter.is_enabled());
+        // Must not panic.
+        reporter.report(TelemetryEvent::new(TelemetryEventKind::ProjectCreated));
+    }
+}

--- a/crates/temps-deployments/src/handlers/nodes.rs
+++ b/crates/temps-deployments/src/handlers/nodes.rs
@@ -35,6 +35,8 @@ pub struct NodeAppState {
     pub db: Arc<DatabaseConnection>,
     pub config_service: Arc<ConfigService>,
     pub encryption_service: Arc<temps_core::EncryptionService>,
+    /// Anonymous product telemetry reporter (worker_node_joined event).
+    pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -685,6 +687,15 @@ async fn register_node(
         .map_err(Problem::from)?;
 
     info!(node_id = node.id, name = %node.name, "Node registered successfully");
+
+    // Anonymous telemetry: a worker node joined. Only the non-identifying role
+    // label is sent (e.g. "worker") — never the node name, address, or keys.
+    app_state.telemetry.report(
+        temps_core::telemetry::TelemetryEvent::new(
+            temps_core::telemetry::TelemetryEventKind::WorkerNodeJoined,
+        )
+        .with("role", node.role.clone()),
+    );
 
     // ── Multi-host networking: best-effort overlay setup ──
     //
@@ -2186,6 +2197,7 @@ mod tests {
             db,
             config_service,
             encryption_service,
+            telemetry: Arc::new(temps_core::telemetry::NoopTelemetryReporter),
         });
         configure_routes().with_state(app_state)
     }

--- a/crates/temps-deployments/src/handlers/remote_deployments.rs
+++ b/crates/temps-deployments/src/handlers/remote_deployments.rs
@@ -79,6 +79,13 @@ pub struct DeployFromImageRequest {
     pub external_image_id: Option<i32>,
     /// Optional deployment metadata
     pub metadata: Option<serde_json::Value>,
+    /// Optional HTTP health-check path override (e.g. "/api/healthz").
+    /// Image deploys can't read `.temps.yaml`, so this sets the path the deployer
+    /// probes after the container starts and the path the environment's uptime
+    /// monitor checks. Must start with '/'. When omitted, defaults to "/".
+    #[serde(default)]
+    #[schema(example = "/api/healthz")]
+    pub health_check_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -87,6 +94,13 @@ pub struct DeployFromStaticRequest {
     pub static_bundle_id: i32,
     /// Optional deployment metadata
     pub metadata: Option<serde_json::Value>,
+    /// Optional HTTP health-check path override (e.g. "/api/healthz").
+    /// Static deploys can't read `.temps.yaml`, so this sets the path the deployer
+    /// probes after the container starts and the path the environment's uptime
+    /// monitor checks. Must start with '/'. When omitted, defaults to "/".
+    #[serde(default)]
+    #[schema(example = "/api/healthz")]
+    pub health_check_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -117,6 +131,58 @@ pub struct DeployFromImageUploadQuery {
     /// If not provided, a unique tag will be generated
     #[schema(example = "myapp:v1.0")]
     pub tag: Option<String>,
+    /// Optional HTTP health-check path override (e.g. "/api/healthz").
+    /// Must start with '/'. When omitted, defaults to "/".
+    #[schema(example = "/api/healthz")]
+    pub health_check_path: Option<String>,
+}
+
+/// Validate a deploy-time `health_check_path` override.
+///
+/// This value becomes both the deployer's HTTP probe path and the environment's
+/// uptime-monitor `check_path`, so it must be a safe relative path. Mirrors the
+/// status-page `validate_check_path` rules to prevent URL/header injection:
+/// - Must start with `/`
+/// - Must not contain `@` (userinfo injection) or `://` (scheme injection)
+/// - Must not contain CR, LF, NUL, or tab (request smuggling)
+/// - Capped at 2048 bytes
+///
+/// Returns a 400 `Problem` on failure.
+fn validate_health_check_path(path: &str) -> Result<(), Problem> {
+    let invalid = |detail: &str| {
+        problemdetails::new(StatusCode::BAD_REQUEST)
+            .with_title("Invalid Health Check Path")
+            .with_detail(detail.to_string())
+    };
+
+    if path.len() > 2048 {
+        return Err(invalid(&format!(
+            "health_check_path length {} exceeds 2048 byte limit",
+            path.len()
+        )));
+    }
+    if !path.starts_with('/') {
+        return Err(invalid("health_check_path must start with '/'"));
+    }
+    if path.contains('@') {
+        return Err(invalid(
+            "health_check_path must not contain '@' (userinfo injection)",
+        ));
+    }
+    if path.contains("://") {
+        return Err(invalid(
+            "health_check_path must not contain '://' (scheme injection)",
+        ));
+    }
+    if path
+        .chars()
+        .any(|c| c == '\r' || c == '\n' || c == '\0' || c == '\t')
+    {
+        return Err(invalid(
+            "health_check_path must not contain control characters",
+        ));
+    }
+    Ok(())
 }
 
 // Response Types
@@ -244,6 +310,11 @@ pub async fn deploy_from_image(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsCreate);
 
+    // Validate optional deploy-time health-check path override up front
+    if let Some(ref path) = req.health_check_path {
+        validate_health_check_path(path)?;
+    }
+
     // Resolve image_ref: either use provided value or fetch from external_image_id
     let (image_ref, external_image_id) = match (&req.image_ref, req.external_image_id) {
         // Both provided: use image_ref directly
@@ -364,6 +435,7 @@ pub async fn deploy_from_image(
         external_image_ref: Some(image_ref.clone()),
         external_image_id,
         deployment_source_type: Some(SourceType::DockerImage),
+        health_check_path: req.health_check_path.clone(),
         ..Default::default()
     };
 
@@ -544,6 +616,11 @@ pub async fn deploy_from_static(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsCreate);
 
+    // Validate optional deploy-time health-check path override up front
+    if let Some(ref path) = req.health_check_path {
+        validate_health_check_path(path)?;
+    }
+
     info!(
         "Deploying static bundle {} to project {} environment {}",
         req.static_bundle_id, project_id, environment_id
@@ -642,6 +719,7 @@ pub async fn deploy_from_static(
         static_bundle_id: Some(req.static_bundle_id),
         static_bundle_content_type: Some(bundle.content_type.clone()),
         deployment_source_type: Some(SourceType::StaticFiles),
+        health_check_path: req.health_check_path.clone(),
         ..Default::default()
     };
 
@@ -827,6 +905,11 @@ pub async fn deploy_from_image_upload(
     mut multipart: Multipart,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsCreate);
+
+    // Validate optional deploy-time health-check path override up front
+    if let Some(ref path) = query.health_check_path {
+        validate_health_check_path(path)?;
+    }
 
     info!(
         "Deploying from uploaded image tarball to project {} environment {}",
@@ -1033,6 +1116,7 @@ pub async fn deploy_from_image_upload(
         deployment_source_type: Some(SourceType::DockerImage),
         image_uploaded_locally: true,
         uploaded_image_id: Some(imported_image_id.clone()),
+        health_check_path: query.health_check_path.clone(),
         ..Default::default()
     };
 
@@ -1949,4 +2033,45 @@ pub fn configure_routes() -> Router<Arc<AppState>> {
             "/projects/{project_id}/static-bundles/{bundle_id}",
             get(get_static_bundle).delete(delete_static_bundle),
         )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn health_check_path_accepts_valid_paths() {
+        assert!(validate_health_check_path("/").is_ok());
+        assert!(validate_health_check_path("/api/healthz").is_ok());
+        assert!(validate_health_check_path("/health?ready=1").is_ok());
+    }
+
+    #[test]
+    fn health_check_path_rejects_missing_leading_slash() {
+        assert!(validate_health_check_path("healthz").is_err());
+        assert!(validate_health_check_path("api/healthz").is_err());
+    }
+
+    #[test]
+    fn health_check_path_rejects_userinfo_injection() {
+        assert!(validate_health_check_path("/foo@evil.com/bar").is_err());
+    }
+
+    #[test]
+    fn health_check_path_rejects_scheme_injection() {
+        assert!(validate_health_check_path("/x://attacker.com/y").is_err());
+    }
+
+    #[test]
+    fn health_check_path_rejects_control_characters() {
+        assert!(validate_health_check_path("/foo\r\nHost: evil").is_err());
+        assert!(validate_health_check_path("/foo\tbar").is_err());
+        assert!(validate_health_check_path("/foo\0bar").is_err());
+    }
+
+    #[test]
+    fn health_check_path_rejects_overlong_path() {
+        let long = format!("/{}", "a".repeat(2048));
+        assert!(validate_health_check_path(&long).is_err());
+    }
 }

--- a/crates/temps-deployments/src/jobs/deploy_image.rs
+++ b/crates/temps-deployments/src/jobs/deploy_image.rs
@@ -200,6 +200,12 @@ pub struct DeploymentJobConfig {
     /// running status is verified). Set to `Some("/")` or a custom path to
     /// enable HTTP health checks after the container starts.
     pub health_check_path: Option<String>,
+    /// Explicit deploy-time health-check path override. When `Some`, this wins
+    /// over both `.temps.yaml` `health.path` (build job output) and the default
+    /// `health_check_path`. Used by image/static deploys that can't read
+    /// `.temps.yaml`. `None` means "no deploy-time override" (fall back to the
+    /// usual `.temps.yaml`/default resolution).
+    pub health_check_path_override: Option<String>,
     pub ingress_enabled: bool,
     pub ingress_host: Option<String>,
     /// Maximum time to wait for the application to become ready (container
@@ -236,6 +242,7 @@ impl Default for DeploymentJobConfig {
             secrets: HashMap::new(),
             resources: ResourceUsage::default(),
             health_check_path: Some("/".to_string()),
+            health_check_path_override: None,
             ingress_enabled: false,
             ingress_host: None,
             health_check_timeout_secs: 300,
@@ -1350,9 +1357,16 @@ impl DeployImageJob {
         // the container running status from Phase 1 is sufficient (useful for
         // rollbacks where the image was already verified, or services without
         // an HTTP endpoint).
-        // .temps.yaml health override takes priority over the default config.
-        let effective_health_path = health_check_override
-            .map(String::from)
+        // Precedence (highest first):
+        //   1. explicit deploy-time override (config.health_check_path_override) —
+        //      set by image/static deploys that can't read .temps.yaml
+        //   2. .temps.yaml health.path (build job output, passed as health_check_override)
+        //   3. default config.health_check_path ("/" unless explicitly cleared)
+        let effective_health_path = self
+            .config
+            .health_check_path_override
+            .clone()
+            .or_else(|| health_check_override.map(String::from))
             .or_else(|| self.config.health_check_path.clone());
         if let Some(ref health_path) = effective_health_path {
             self.log(
@@ -1646,6 +1660,33 @@ impl WorkflowTask for DeployImageJob {
             .await?;
         }
 
+        // An explicit deploy-time override (set by image/static deploys that can't
+        // read .temps.yaml) wins over the .temps.yaml value.
+        if let Some(ref override_path) = self.config.health_check_path_override {
+            self.log(
+                &context,
+                format!(
+                    "Using deploy-time health check path override: {}",
+                    override_path
+                ),
+            )
+            .await?;
+        }
+
+        // Persist the effective health-check path as this job's output so
+        // MarkDeploymentCompleteJob can propagate it to the environment's monitor
+        // (its check_path). For image/static deploys there is no build job output,
+        // so this is the only place the path becomes available downstream.
+        let effective_health_path = self
+            .config
+            .health_check_path_override
+            .clone()
+            .or_else(|| health_override.clone())
+            .or_else(|| self.config.health_check_path.clone());
+        if let Some(ref effective) = effective_health_path {
+            context.set_output(&self.job_id, "health_check_path", effective)?;
+        }
+
         // Deploy the image (logs written in real-time)
         let deployment_output = self
             .deploy_image(&image_output, &context, health_override)
@@ -1874,6 +1915,15 @@ impl DeployImageJobBuilder {
     /// or services without an HTTP endpoint.
     pub fn health_check_path(mut self, path: Option<String>) -> Self {
         self.config.health_check_path = path;
+        self
+    }
+
+    /// Set an explicit deploy-time health-check path override. When `Some`, it
+    /// takes priority over both `.temps.yaml` `health.path` and the default
+    /// `health_check_path`. Used by image/static deploys that can't read
+    /// `.temps.yaml`. Passing `None` leaves the usual resolution untouched.
+    pub fn health_check_path_override(mut self, path: Option<String>) -> Self {
+        self.config.health_check_path_override = path;
         self
     }
 
@@ -2222,6 +2272,50 @@ mod tests {
         assert_eq!(job.config.namespace, "production");
         assert_eq!(job.config.replicas, 3);
         assert_eq!(job.depends_on(), vec!["build_image".to_string()]);
+    }
+
+    #[test]
+    fn test_health_check_path_override_default_is_none() {
+        // By default there is no deploy-time override; only the standard
+        // health_check_path ("/") is set.
+        let job = DeployImageJobBuilder::new()
+            .job_id("d".to_string())
+            .build_job_id("build_image".to_string())
+            .target(DeploymentTarget::Docker {
+                registry_url: "local".to_string(),
+                network: None,
+            })
+            .service_name("app".to_string())
+            .build(Arc::new(TrackingMockContainerDeployer::new()))
+            .unwrap();
+
+        assert_eq!(job.config.health_check_path_override, None);
+        assert_eq!(job.config.health_check_path, Some("/".to_string()));
+    }
+
+    #[test]
+    fn test_health_check_path_override_flows_to_config() {
+        // An explicit deploy-time override is captured separately so it can win
+        // over .temps.yaml at execution time.
+        let job = DeployImageJobBuilder::new()
+            .job_id("d".to_string())
+            .build_job_id("build_image".to_string())
+            .target(DeploymentTarget::Docker {
+                registry_url: "local".to_string(),
+                network: None,
+            })
+            .service_name("app".to_string())
+            .health_check_path_override(Some("/api/healthz".to_string()))
+            .build(Arc::new(TrackingMockContainerDeployer::new()))
+            .unwrap();
+
+        assert_eq!(
+            job.config.health_check_path_override,
+            Some("/api/healthz".to_string())
+        );
+        // The default standard path is left untouched; precedence is resolved at
+        // execution time (override > .temps.yaml > default).
+        assert_eq!(job.config.health_check_path, Some("/".to_string()));
     }
 
     #[tokio::test]

--- a/crates/temps-deployments/src/jobs/mark_deployment_complete.rs
+++ b/crates/temps-deployments/src/jobs/mark_deployment_complete.rs
@@ -853,12 +853,23 @@ impl MarkDeploymentCompleteJob {
             None
         };
 
-        // Extract health_check_path from any build job output in the workflow context
-        let health_check_path = context.outputs.values().find_map(|job_outputs| {
-            job_outputs
-                .get("health_check_path")
-                .and_then(|v| serde_json::from_value::<String>(v.clone()).ok())
-        });
+        // Resolve the health_check_path to propagate to the environment's uptime
+        // monitor (its check_path). Precedence:
+        //   1. Explicit deploy-time override on the deployment record's metadata —
+        //      set by image/static deploys that can't read .temps.yaml. This wins.
+        //   2. Any job output named "health_check_path" (build job from .temps.yaml,
+        //      or the deploy job's resolved effective path).
+        let health_check_path = deployment
+            .metadata
+            .as_ref()
+            .and_then(|m| m.health_check_path.clone())
+            .or_else(|| {
+                context.outputs.values().find_map(|job_outputs| {
+                    job_outputs
+                        .get("health_check_path")
+                        .and_then(|v| serde_json::from_value::<String>(v.clone()).ok())
+                })
+            });
 
         let event = Job::DeploymentSucceeded(temps_core::DeploymentSucceededJob {
             deployment_id: self.deployment_id,

--- a/crates/temps-deployments/src/plugin.rs
+++ b/crates/temps-deployments/src/plugin.rs
@@ -49,6 +49,13 @@ impl TempsPlugin for DeploymentsPlugin {
             let image_builder = context.require_service::<dyn temps_deployer::ImageBuilder>();
             let git_provider_manager = context.require_service::<temps_git::GitProviderManager>();
             let encryption_service = context.require_service::<temps_core::EncryptionService>();
+
+            // Anonymous telemetry reporter (optional). Defaults to a no-op when
+            // the TelemetryPlugin isn't registered, so deploys never depend on it.
+            let telemetry = context
+                .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+                .unwrap_or_else(|| Arc::new(temps_core::telemetry::NoopTelemetryReporter));
+
             // Create DeploymentService
             let deployment_service = Arc::new(DeploymentService::new(
                 db.clone(),
@@ -59,6 +66,8 @@ impl TempsPlugin for DeploymentsPlugin {
                 deployer.clone(),
                 encryption_service.clone(),
             ));
+            // Wire telemetry for deploy-funnel events (rollback_triggered).
+            deployment_service.set_telemetry(telemetry.clone());
             context.register_service(deployment_service.clone());
 
             // Also register as DeploymentCanceller trait for temps-environments
@@ -188,6 +197,11 @@ impl TempsPlugin for DeploymentsPlugin {
                 workflow_execution_service.set_file_store(file_store);
                 tracing::debug!("File store wired into workflow execution service");
             }
+
+            // Wire telemetry for deploy-funnel events (deploy_attempted,
+            // deploy_succeeded, deploy_failed, first_deploy_succeeded).
+            workflow_execution_service.set_telemetry(telemetry.clone());
+            tracing::debug!("Telemetry wired into workflow execution service");
 
             // Get ExternalServiceManager for accessing external service env vars
             let external_service_manager =

--- a/crates/temps-deployments/src/services/services.rs
+++ b/crates/temps-deployments/src/services/services.rs
@@ -95,6 +95,9 @@ pub struct DeploymentService {
     docker_log_service: Arc<temps_logs::DockerLogService>,
     deployer: Arc<dyn temps_deployer::ContainerDeployer>,
     encryption_service: Arc<temps_core::EncryptionService>,
+    /// Anonymous product telemetry reporter (late-bound, optional). Set via
+    /// [`Self::set_telemetry`]; defaults to a no-op when unset.
+    telemetry: std::sync::OnceLock<Arc<dyn temps_core::telemetry::TelemetryReporter>>,
 }
 
 impl DeploymentService {
@@ -143,7 +146,22 @@ impl DeploymentService {
             docker_log_service,
             deployer,
             encryption_service,
+            telemetry: std::sync::OnceLock::new(),
         }
+    }
+
+    /// Set the anonymous telemetry reporter used to emit deploy-funnel events
+    /// (currently `rollback_triggered`).
+    pub fn set_telemetry(&self, reporter: Arc<dyn temps_core::telemetry::TelemetryReporter>) {
+        let _ = self.telemetry.set(reporter);
+    }
+
+    /// The telemetry reporter, or a no-op when none has been wired.
+    fn telemetry(&self) -> Arc<dyn temps_core::telemetry::TelemetryReporter> {
+        self.telemetry
+            .get()
+            .cloned()
+            .unwrap_or_else(|| Arc::new(temps_core::telemetry::NoopTelemetryReporter))
     }
     pub async fn get_filtered_container_logs(
         &self,
@@ -1194,6 +1212,12 @@ impl DeploymentService {
             "Created rollback deployment #{} (rolling back to #{}, image: {})",
             rollback_deployment_id, deployment_id, image_name
         );
+
+        // Anonymous telemetry: a rollback was initiated. No identifying props.
+        self.telemetry()
+            .report(temps_core::telemetry::TelemetryEvent::new(
+                temps_core::telemetry::TelemetryEventKind::RollbackTriggered,
+            ));
 
         // Check if preset is static - if so, just update environment without deploying
         if preset.project_type() == temps_presets::ProjectType::Static {
@@ -3785,6 +3809,7 @@ mod tests {
             docker_log_service,
             deployer,
             encryption_service: create_test_encryption_service(),
+            telemetry: std::sync::OnceLock::new(),
         }
     }
 
@@ -4018,6 +4043,7 @@ mod tests {
             docker_log_service,
             deployer,
             encryption_service: create_test_encryption_service(),
+            telemetry: std::sync::OnceLock::new(),
         }
     }
 

--- a/crates/temps-deployments/src/services/workflow_execution_service.rs
+++ b/crates/temps-deployments/src/services/workflow_execution_service.rs
@@ -25,6 +25,43 @@ use crate::jobs::{
 use crate::services::DeploymentJobTracker;
 use temps_screenshots::ScreenshotService;
 
+/// Map a deployment's free-form failure reason to a coarse, NON-identifying
+/// category for telemetry. The raw reason can contain build logs, file paths,
+/// or repo names, so it is never sent verbatim — only one of these stable
+/// labels (or `unknown`). Matching is on lowercased substrings.
+fn categorize_failure_reason(reason: Option<&str>) -> &'static str {
+    let Some(reason) = reason else {
+        return "unknown";
+    };
+    let r = reason.to_lowercase();
+
+    // Order matters: check the most specific signals first.
+    if r.contains("out of memory") || r.contains("oom") || r.contains("exit code 137") {
+        "oom"
+    } else if r.contains("timeout") || r.contains("timed out") || r.contains("deadline") {
+        "timeout"
+    } else if r.contains("health check") || r.contains("healthcheck") || r.contains("unhealthy") {
+        "health_check"
+    } else if r.contains("build") || r.contains("compile") || r.contains("nixpacks") {
+        "build_error"
+    } else if r.contains("clone")
+        || r.contains("network")
+        || r.contains("connection")
+        || r.contains("download")
+        || r.contains("dns")
+    {
+        "network"
+    } else if r.contains("image")
+        && (r.contains("not found") || r.contains("missing") || r.contains("no such"))
+    {
+        "image_missing"
+    } else if r.contains("cancel") {
+        "cancelled"
+    } else {
+        "unknown"
+    }
+}
+
 /// Service for executing deployment workflows
 pub struct WorkflowExecutionService {
     db: Arc<DbConnection>,
@@ -43,6 +80,10 @@ pub struct WorkflowExecutionService {
     node_scheduler: OnceCell<Arc<crate::services::NodeScheduler>>,
     encryption_service: OnceCell<Arc<temps_core::EncryptionService>>,
     file_store: OnceCell<Arc<dyn temps_file_store::FileStore>>,
+    /// Anonymous product telemetry reporter (late-bound, optional). Set via
+    /// [`Self::set_telemetry`]; defaults to a no-op when unset so the deploy
+    /// path never depends on telemetry being wired.
+    telemetry: OnceCell<Arc<dyn temps_core::telemetry::TelemetryReporter>>,
 }
 
 impl WorkflowExecutionService {
@@ -78,7 +119,22 @@ impl WorkflowExecutionService {
             node_scheduler: OnceCell::new(),
             encryption_service: OnceCell::new(),
             file_store: OnceCell::new(),
+            telemetry: OnceCell::new(),
         }
+    }
+
+    /// Set the anonymous telemetry reporter used to emit deploy-funnel events.
+    pub fn set_telemetry(&self, reporter: Arc<dyn temps_core::telemetry::TelemetryReporter>) {
+        let _ = self.telemetry.set(reporter);
+    }
+
+    /// The telemetry reporter, or a no-op when none has been wired. Always safe
+    /// to call `report()` on the result; it never blocks or fails.
+    fn telemetry(&self) -> Arc<dyn temps_core::telemetry::TelemetryReporter> {
+        self.telemetry
+            .get()
+            .cloned()
+            .unwrap_or_else(|| Arc::new(temps_core::telemetry::NoopTelemetryReporter))
     }
 
     /// Set the node scheduler for multi-node deployments
@@ -120,6 +176,18 @@ impl WorkflowExecutionService {
         let deployment = self.get_deployment(deployment_id).await?;
         let project = self.get_project(deployment.project_id).await?;
         let environment = self.get_environment(deployment.environment_id).await?;
+
+        // Anonymous telemetry: a deploy is now being attempted. This runs once
+        // per deployment workflow. Properties are non-identifying enum labels
+        // (source type, build preset) plus whether this is a preview env.
+        self.telemetry().report(
+            temps_core::telemetry::TelemetryEvent::new(
+                temps_core::telemetry::TelemetryEventKind::DeployAttempted,
+            )
+            .with("source_type", project.source_type.to_string())
+            .with("preset", project.preset.to_string())
+            .with("is_preview", environment.is_preview),
+        );
 
         // Load all jobs for this deployment
         let db_jobs = self.get_deployment_jobs(deployment_id).await?;
@@ -1573,6 +1641,19 @@ impl WorkflowExecutionService {
                 ))
             })?;
 
+        // Non-identifying deploy labels for telemetry (best-effort). Looked up
+        // once here so both the success and failure telemetry below can report
+        // which preset / source type the deploy used — that's what lets us see
+        // *which* presets fail most, not just the overall failure rate.
+        let (telemetry_source_type, telemetry_preset) =
+            match projects::Entity::find_by_id(updated_deployment.project_id)
+                .one(self.db.as_ref())
+                .await
+            {
+                Ok(Some(p)) => (Some(p.source_type.to_string()), Some(p.preset.to_string())),
+                _ => (None, None),
+            };
+
         match status {
             temps_entities::types::PipelineStatus::Completed => {
                 // Get deployment URL from environment: prefer custom host, fall back to preview domain
@@ -1621,6 +1702,27 @@ impl WorkflowExecutionService {
                         deployment_id
                     );
                 }
+
+                // Anonymous telemetry: this is the single canonical terminal
+                // success point for a deployment. `first_deploy_succeeded` is
+                // emitted alongside; the central API dedupes it per instance.
+                // Both carry the non-identifying preset/source_type so success
+                // rates can be sliced by build type.
+                let telemetry = self.telemetry();
+                telemetry.report(
+                    temps_core::telemetry::TelemetryEvent::new(
+                        temps_core::telemetry::TelemetryEventKind::DeploySucceeded,
+                    )
+                    .with_opt("source_type", telemetry_source_type.clone())
+                    .with_opt("preset", telemetry_preset.clone()),
+                );
+                telemetry.report(
+                    temps_core::telemetry::TelemetryEvent::new(
+                        temps_core::telemetry::TelemetryEventKind::FirstDeploySucceeded,
+                    )
+                    .with_opt("source_type", telemetry_source_type.clone())
+                    .with_opt("preset", telemetry_preset.clone()),
+                );
             }
             temps_entities::types::PipelineStatus::Failed => {
                 let event = Job::DeploymentFailed(temps_core::DeploymentFailedJob {
@@ -1638,6 +1740,23 @@ impl WorkflowExecutionService {
                         deployment_id
                     );
                 }
+
+                // Anonymous telemetry: terminal failure point. The raw
+                // `cancelled_reason` may contain build logs / paths / repo
+                // names, so it is NEVER sent — only a coarse category label.
+                // preset/source_type are included so we can see which build
+                // types fail most (e.g. "nixpacks deploys OOM 3x more often").
+                self.telemetry().report(
+                    temps_core::telemetry::TelemetryEvent::new(
+                        temps_core::telemetry::TelemetryEventKind::DeployFailed,
+                    )
+                    .with(
+                        "reason",
+                        categorize_failure_reason(cancelled_reason.as_deref()),
+                    )
+                    .with_opt("source_type", telemetry_source_type.clone())
+                    .with_opt("preset", telemetry_preset.clone()),
+                );
             }
             temps_entities::types::PipelineStatus::Cancelled => {
                 let event = Job::DeploymentCancelled(temps_core::DeploymentCancelledJob {

--- a/crates/temps-deployments/src/services/workflow_execution_service.rs
+++ b/crates/temps-deployments/src/services/workflow_execution_service.rs
@@ -815,6 +815,21 @@ impl WorkflowExecutionService {
                     .log_id(db_job.log_id.clone())
                     .log_service(self.log_service.clone());
 
+                // Apply explicit deploy-time health-check path override (image/static
+                // deploys can't read .temps.yaml, so the deploy request carries it on
+                // the deployment metadata). When set, it wins over .temps.yaml.
+                if let Some(health_path) = deployment
+                    .metadata
+                    .as_ref()
+                    .and_then(|m| m.health_check_path.clone())
+                {
+                    debug!(
+                        "🩺 Applying deploy-time health check path override: {}",
+                        health_path
+                    );
+                    builder = builder.health_check_path_override(Some(health_path));
+                }
+
                 // Inject node scheduler for multi-node support
                 if let Some(scheduler) = self.node_scheduler.get() {
                     builder = builder.node_scheduler(scheduler.clone());

--- a/crates/temps-domains/src/handlers/domain_handler.rs
+++ b/crates/temps-domains/src/handlers/domain_handler.rs
@@ -565,6 +565,17 @@ async fn provision_domain(
                     "Certificate successfully provisioned via DNS-01 for {}",
                     domain
                 );
+                app_state.telemetry.report(
+                    temps_core::telemetry::TelemetryEvent::new(
+                        temps_core::telemetry::TelemetryEventKind::SslCertificateIssued,
+                    )
+                    .with("success", true)
+                    .with(
+                        "verification_method",
+                        certificate.verification_method.clone(),
+                    )
+                    .with("is_wildcard", certificate.is_wildcard),
+                );
                 Ok((
                     StatusCode::OK,
                     Json(ProvisionResponse::Complete(DomainResponse::from(
@@ -619,6 +630,17 @@ async fn provision_domain(
     {
         Ok(certificate) => {
             info!("Certificate successfully provisioned for {}", domain);
+            app_state.telemetry.report(
+                temps_core::telemetry::TelemetryEvent::new(
+                    temps_core::telemetry::TelemetryEventKind::SslCertificateIssued,
+                )
+                .with("success", true)
+                .with(
+                    "verification_method",
+                    certificate.verification_method.clone(),
+                )
+                .with("is_wildcard", certificate.is_wildcard),
+            );
             Ok((
                 StatusCode::OK,
                 Json(ProvisionResponse::Complete(DomainResponse::from(
@@ -815,6 +837,15 @@ async fn finalize_order(
         })?;
 
     info!("Order finalized successfully for domain: {}", domain.domain);
+
+    app_state.telemetry.report(
+        temps_core::telemetry::TelemetryEvent::new(
+            temps_core::telemetry::TelemetryEventKind::SslCertificateIssued,
+        )
+        .with("success", true)
+        .with("verification_method", domain.verification_method.clone())
+        .with("is_wildcard", domain.is_wildcard),
+    );
 
     // Audit log
     let audit = DomainAudit {
@@ -1214,6 +1245,14 @@ async fn renew_domain(
             domain
         );
         if let Some(renewed) = app_state.domain_service.get_domain(&domain).await? {
+            app_state.telemetry.report(
+                temps_core::telemetry::TelemetryEvent::new(
+                    temps_core::telemetry::TelemetryEventKind::SslCertificateIssued,
+                )
+                .with("success", true)
+                .with("verification_method", renewed.verification_method.clone())
+                .with("is_wildcard", renewed.is_wildcard),
+            );
             return Ok((
                 StatusCode::OK,
                 Json(ProvisionResponse::Complete(DomainResponse::from(renewed))),
@@ -1232,6 +1271,14 @@ async fn renew_domain(
             info!(
                 "Certificate successfully renewed for HTTP-01 domain: {}",
                 domain
+            );
+            app_state.telemetry.report(
+                temps_core::telemetry::TelemetryEvent::new(
+                    temps_core::telemetry::TelemetryEventKind::SslCertificateIssued,
+                )
+                .with("success", true)
+                .with("verification_method", renewed.verification_method.clone())
+                .with("is_wildcard", renewed.is_wildcard),
             );
             Ok((
                 StatusCode::OK,

--- a/crates/temps-domains/src/handlers/types.rs
+++ b/crates/temps-domains/src/handlers/types.rs
@@ -13,6 +13,7 @@ pub struct DomainAppState {
     /// DNS provider service for automatic DNS record setup (optional)
     pub dns_provider_service: Option<Arc<DnsProviderService>>,
     pub audit_service: Arc<dyn AuditLogger>,
+    pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 }
 
 pub fn create_domain_app_state(
@@ -20,6 +21,7 @@ pub fn create_domain_app_state(
     repository: Arc<dyn CertificateRepository>,
     domain_service: Arc<DomainService>,
     audit_service: Arc<dyn AuditLogger>,
+    telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 ) -> Arc<DomainAppState> {
     Arc::new(DomainAppState {
         tls_service,
@@ -27,6 +29,7 @@ pub fn create_domain_app_state(
         domain_service,
         dns_provider_service: None,
         audit_service,
+        telemetry,
     })
 }
 
@@ -36,6 +39,7 @@ pub fn create_domain_app_state_with_dns(
     domain_service: Arc<DomainService>,
     dns_provider_service: Arc<DnsProviderService>,
     audit_service: Arc<dyn AuditLogger>,
+    telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 ) -> Arc<DomainAppState> {
     Arc::new(DomainAppState {
         tls_service,
@@ -43,6 +47,7 @@ pub fn create_domain_app_state_with_dns(
         domain_service,
         dns_provider_service: Some(dns_provider_service),
         audit_service,
+        telemetry,
     })
 }
 

--- a/crates/temps-domains/src/plugin.rs
+++ b/crates/temps-domains/src/plugin.rs
@@ -105,6 +105,14 @@ impl TempsPlugin for DomainsPlugin {
             // Get audit service
             let audit_service = context.require_service::<dyn temps_core::AuditLogger>();
 
+            // Get telemetry reporter (optional — default to noop so domains never hard-fail
+            // if the telemetry plugin isn't registered)
+            let telemetry = context
+                .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+                .unwrap_or_else(|| {
+                    std::sync::Arc::new(temps_core::telemetry::NoopTelemetryReporter)
+                });
+
             // Create DomainAppState for handlers
             let domain_app_state = create_domain_app_state_with_dns(
                 tls_service,
@@ -112,6 +120,7 @@ impl TempsPlugin for DomainsPlugin {
                 domain_service,
                 dns_provider_service,
                 audit_service,
+                telemetry,
             );
             context.register_service(domain_app_state);
 

--- a/crates/temps-email/src/handlers/providers.rs
+++ b/crates/temps-email/src/handlers/providers.rs
@@ -160,6 +160,14 @@ pub async fn create_email_provider(
         error!("Failed to create audit log: {}", e);
     }
 
+    // Fire-and-forget anonymous telemetry — no identifying properties
+    state.telemetry.report(
+        temps_core::telemetry::TelemetryEvent::new(
+            temps_core::telemetry::TelemetryEventKind::EmailProviderConfigured,
+        )
+        .with("provider", provider.provider_type.clone()),
+    );
+
     let response = EmailProviderResponse {
         id: provider.id,
         name: provider.name,

--- a/crates/temps-email/src/handlers/tracking_tests.rs
+++ b/crates/temps-email/src/handlers/tracking_tests.rs
@@ -136,6 +136,7 @@ mod tests {
             tracking_service,
             audit_service: Arc::new(MockAuditLogger),
             dns_provider_service: None,
+            telemetry: Arc::new(temps_core::telemetry::NoopTelemetryReporter),
         });
 
         (db, app_state)

--- a/crates/temps-email/src/handlers/types.rs
+++ b/crates/temps-email/src/handlers/types.rs
@@ -21,6 +21,7 @@ pub struct AppState {
     pub audit_service: Arc<dyn AuditLogger>,
     /// DNS provider service for automatic DNS record setup
     pub dns_provider_service: Option<Arc<DnsProviderService>>,
+    pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 }
 
 // ========================================

--- a/crates/temps-email/src/plugin.rs
+++ b/crates/temps-email/src/plugin.rs
@@ -80,6 +80,12 @@ impl TempsPlugin for EmailPlugin {
             // Try to get DnsProviderService if available (optional dependency)
             let dns_provider_service = context.get_service::<DnsProviderService>();
 
+            // Pull telemetry reporter (optional — fall back to no-op so the plugin
+            // never hard-fails when telemetry isn't registered)
+            let telemetry = context
+                .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+                .unwrap_or_else(|| Arc::new(temps_core::telemetry::NoopTelemetryReporter));
+
             // Create AppState for handlers
             let app_state = Arc::new(AppState {
                 provider_service,
@@ -89,6 +95,7 @@ impl TempsPlugin for EmailPlugin {
                 tracking_service,
                 audit_service,
                 dns_provider_service,
+                telemetry,
             });
             context.register_service(app_state);
 

--- a/crates/temps-entities/src/deployments.rs
+++ b/crates/temps-entities/src/deployments.rs
@@ -105,6 +105,13 @@ pub struct DeploymentMetadata {
     /// Used to verify the image exists before deployment
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uploaded_image_id: Option<String>,
+
+    /// Explicit deploy-time HTTP health-check path override.
+    /// Image/static deploys can't read `.temps.yaml`, so this lets the deploy
+    /// request set a custom path (e.g. "/api/healthz"). When present it takes
+    /// priority over any `.temps.yaml` `health.path` value. Always starts with '/'.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub health_check_path: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]

--- a/crates/temps-environments/src/handlers/handler.rs
+++ b/crates/temps-environments/src/handlers/handler.rs
@@ -968,6 +968,42 @@ pub async fn update_environment_settings(
         // Continue with the operation even if audit logging fails
     }
 
+    // Telemetry: emit attack_mode_enabled only on the off→on transition.
+    if updated_environment.attack_mode == Some(true) && environment.attack_mode != Some(true) {
+        state.telemetry.report(
+            temps_core::telemetry::TelemetryEvent::new(
+                temps_core::telemetry::TelemetryEventKind::AttackModeEnabled,
+            )
+            .with("scope", "environment"),
+        );
+    }
+
+    // Telemetry: emit scale_to_zero_configured only on the off→on transition.
+    let prior_on_demand = environment
+        .deployment_config
+        .as_ref()
+        .map(|dc| dc.on_demand)
+        .unwrap_or(false);
+    let new_on_demand = updated_environment
+        .deployment_config
+        .as_ref()
+        .map(|dc| dc.on_demand)
+        .unwrap_or(false);
+    if new_on_demand && !prior_on_demand {
+        state.telemetry.report(
+            temps_core::telemetry::TelemetryEvent::new(
+                temps_core::telemetry::TelemetryEventKind::ScaleToZeroConfigured,
+            )
+            .with_opt(
+                "idle_timeout_seconds",
+                updated_environment
+                    .deployment_config
+                    .as_ref()
+                    .map(|dc| dc.idle_timeout_seconds),
+            ),
+        );
+    }
+
     let main_url = state
         .environment_service
         .compute_environment_url(&updated_environment.subdomain)
@@ -1532,6 +1568,20 @@ pub async fn create_environment(
         .environment_service
         .compute_environment_url(&environment.subdomain)
         .await;
+
+    state.telemetry.report(
+        temps_core::telemetry::TelemetryEvent::new(
+            temps_core::telemetry::TelemetryEventKind::EnvironmentCreated,
+        )
+        .with(
+            "kind",
+            if environment.is_preview {
+                "preview"
+            } else {
+                "persistent"
+            },
+        ),
+    );
 
     Ok((
         StatusCode::CREATED,

--- a/crates/temps-environments/src/handlers/types.rs
+++ b/crates/temps-environments/src/handlers/types.rs
@@ -20,8 +20,12 @@ pub struct AppState {
     /// Optional integration env-var provider. When absent (e.g. in tests without
     /// the providers plugin) the resolved view falls back to manual vars only.
     pub integration_env_provider: Option<Arc<dyn ProjectEnvVarsProvider>>,
+    /// Anonymous product telemetry reporter. Always present (may be a no-op when
+    /// telemetry is disabled or the reporter crate is not loaded).
+    pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn create_environment_app_state(
     environment_service: Arc<EnvironmentService>,
     env_var_service: Arc<EnvVarService>,
@@ -30,6 +34,7 @@ pub fn create_environment_app_state(
     deployment_service: Arc<dyn DeploymentCanceller>,
     on_demand_waker: Option<Arc<dyn temps_core::OnDemandWaker>>,
     integration_env_provider: Option<Arc<dyn ProjectEnvVarsProvider>>,
+    telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 ) -> Arc<AppState> {
     Arc::new(AppState {
         environment_service,
@@ -39,6 +44,7 @@ pub fn create_environment_app_state(
         deployment_service,
         on_demand_waker,
         integration_env_provider,
+        telemetry,
     })
 }
 

--- a/crates/temps-environments/src/plugin.rs
+++ b/crates/temps-environments/src/plugin.rs
@@ -68,6 +68,9 @@ impl TempsPlugin for EnvironmentsPlugin {
         let on_demand_waker = context.get_service::<dyn temps_core::OnDemandWaker>();
         let integration_env_provider =
             context.get_service::<dyn temps_core::ProjectEnvVarsProvider>();
+        let telemetry = context
+            .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+            .unwrap_or_else(|| std::sync::Arc::new(temps_core::telemetry::NoopTelemetryReporter));
 
         let app_state = crate::handlers::create_environment_app_state(
             environment_service,
@@ -77,6 +80,7 @@ impl TempsPlugin for EnvironmentsPlugin {
             deployment_service,
             on_demand_waker,
             integration_env_provider,
+            telemetry,
         );
 
         let routes = crate::handlers::configure_routes().with_state(app_state);

--- a/crates/temps-error-tracking/src/plugin.rs
+++ b/crates/temps-error-tracking/src/plugin.rs
@@ -267,6 +267,9 @@ impl TempsPlugin for ErrorTrackingPlugin {
         // Public: Sentry/OTLP ingestion (called by apps with DSN tokens)
         let ip_address_service = context.get_service::<temps_geo::IpAddressService>();
         let sentry_db = context.get_service::<sea_orm::DatabaseConnection>();
+        let telemetry = context
+            .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+            .unwrap_or_else(|| Arc::new(temps_core::telemetry::NoopTelemetryReporter));
 
         let sentry_state = Arc::new(crate::sentry::handlers::AppState {
             sentry_provider: sentry_provider.clone(),
@@ -274,6 +277,7 @@ impl TempsPlugin for ErrorTrackingPlugin {
             audit_service: audit_service.clone(),
             ip_address_service,
             db: sentry_db,
+            telemetry,
         });
         let sentry_routes = crate::sentry::handlers::configure_routes().with_state(sentry_state);
 

--- a/crates/temps-error-tracking/src/sentry/handlers.rs
+++ b/crates/temps-error-tracking/src/sentry/handlers.rs
@@ -42,6 +42,7 @@ pub struct AppState {
     pub audit_service: Arc<dyn temps_core::AuditLogger>,
     pub ip_address_service: Option<Arc<IpAddressService>>,
     pub db: Option<Arc<sea_orm::DatabaseConnection>>,
+    pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 }
 
 /// Maximum compressed body size for Sentry ingest routes (2 MiB).
@@ -147,6 +148,14 @@ async fn ingest_sentry_event(
     )
     .await;
 
+    // Check whether this project already has error groups (first-event dedupe).
+    // On lookup failure we assume groups exist (suppress) to avoid over-reporting.
+    let is_first_error = !state
+        .error_tracking_service
+        .has_error_groups(project_id)
+        .await
+        .unwrap_or(true);
+
     // Store event using the error tracking service
     match state
         .error_tracking_service
@@ -154,6 +163,13 @@ async fn ingest_sentry_event(
         .await
     {
         Ok(_) => {
+            if is_first_error {
+                state
+                    .telemetry
+                    .report(temps_core::telemetry::TelemetryEvent::new(
+                        temps_core::telemetry::TelemetryEventKind::ErrorTrackingFirstError,
+                    ));
+            }
             let response = SentryEventResponse {
                 id: parsed_event.event_id,
             };
@@ -259,6 +275,14 @@ async fn ingest_sentry_envelope(
     let peer = connect_info.map(|ext| ext.0 .0);
     let client_ip = temps_auth::resolve_client_ip(&headers, peer);
 
+    // Check whether this project already has error groups (first-event dedupe).
+    // On lookup failure we assume groups exist (suppress) to avoid over-reporting.
+    let mut is_first_error = !state
+        .error_tracking_service
+        .has_error_groups(project_id)
+        .await
+        .unwrap_or(true);
+
     // Store each event using the error tracking service
     for mut event in parsed_events {
         // Enrich with IP geolocation and visitor correlation
@@ -281,6 +305,15 @@ async fn ingest_sentry_envelope(
                 format!("Failed to store event: {}", e),
             )
                 .into_response();
+        }
+
+        if is_first_error {
+            state
+                .telemetry
+                .report(temps_core::telemetry::TelemetryEvent::new(
+                    temps_core::telemetry::TelemetryEventKind::ErrorTrackingFirstError,
+                ));
+            is_first_error = false; // emit at most once per request
         }
     }
 
@@ -515,6 +548,7 @@ mod tests {
             audit_service,
             ip_address_service: None,
             db: None,
+            telemetry: Arc::new(temps_core::telemetry::NoopTelemetryReporter),
         });
 
         TestContext {

--- a/crates/temps-git/src/handlers/base.rs
+++ b/crates/temps-git/src/handlers/base.rs
@@ -583,6 +583,13 @@ pub async fn create_git_provider(
         )
         .await?;
 
+    state.telemetry.report(
+        temps_core::telemetry::TelemetryEvent::new(
+            temps_core::telemetry::TelemetryEventKind::GitProviderConnected,
+        )
+        .with("provider", provider.provider_type.clone()),
+    );
+
     Ok((
         StatusCode::CREATED,
         Json(ProviderResponse {

--- a/crates/temps-git/src/handlers/types.rs
+++ b/crates/temps-git/src/handlers/types.rs
@@ -18,8 +18,10 @@ pub struct GitAppState {
     pub config_service: Arc<ConfigService>,
     pub cache_manager: Arc<GitProviderCacheManager>,
     pub connection_health_service: Arc<ConnectionHealthService>,
+    pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn create_git_app_state(
     repository_service: Arc<RepositoryService>,
     git_provider_manager: Arc<GitProviderManager>,
@@ -28,6 +30,7 @@ pub fn create_git_app_state(
     github_service: Arc<GithubAppService>,
     cache_manager: Arc<GitProviderCacheManager>,
     connection_health_service: Arc<ConnectionHealthService>,
+    telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 ) -> Arc<GitAppState> {
     Arc::new(GitAppState {
         git_provider_manager,
@@ -37,6 +40,7 @@ pub fn create_git_app_state(
         config_service,
         cache_manager,
         connection_health_service,
+        telemetry,
     })
 }
 

--- a/crates/temps-git/src/plugin.rs
+++ b/crates/temps-git/src/plugin.rs
@@ -195,6 +195,10 @@ impl TempsPlugin for GitPlugin {
             });
 
             // Register the GitAppState for route handlers
+            let telemetry = context
+                .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+                .unwrap_or_else(|| Arc::new(temps_core::telemetry::NoopTelemetryReporter));
+
             let git_app_state = crate::handlers::types::create_git_app_state(
                 repository_service,
                 git_provider_manager,
@@ -203,6 +207,7 @@ impl TempsPlugin for GitPlugin {
                 github_service,
                 cache_manager,
                 connection_health_service,
+                telemetry,
             );
             context.register_plugin_state("git", git_app_state);
 

--- a/crates/temps-projects/src/handlers/custom_domains.rs
+++ b/crates/temps-projects/src/handlers/custom_domains.rs
@@ -89,6 +89,12 @@ pub async fn create_custom_domain(
     // Fetch additional info for response
     let domain_with_info = get_domain_with_info(&state, custom_domain).await?;
 
+    state
+        .telemetry
+        .report(temps_core::telemetry::TelemetryEvent::new(
+            temps_core::telemetry::TelemetryEventKind::CustomDomainAdded,
+        ));
+
     Ok((
         StatusCode::CREATED,
         Json(CustomDomainResponse::from(domain_with_info)),

--- a/crates/temps-projects/src/handlers/handlers.rs
+++ b/crates/temps-projects/src/handlers/handlers.rs
@@ -231,6 +231,14 @@ pub async fn create_project(
         // Continue with the operation even if audit logging fails
     }
 
+    state.telemetry.report(
+        temps_core::telemetry::TelemetryEvent::new(
+            temps_core::telemetry::TelemetryEventKind::ProjectCreated,
+        )
+        .with("source_type", new_project.source_type.to_string())
+        .with_opt("preset", new_project.preset.clone()),
+    );
+
     Ok(Json(ProjectResponse::map_from_project(new_project)))
 }
 
@@ -608,6 +616,15 @@ pub async fn update_automatic_deploy(
             error!("Error updating automatic deployment setting: {:?}", e);
             Problem::from(e)
         })?;
+
+    // Anonymous telemetry: only when auto-deploy is turned ON (adoption signal).
+    if request.automatic_deploy {
+        state
+            .telemetry
+            .report(temps_core::telemetry::TelemetryEvent::new(
+                temps_core::telemetry::TelemetryEventKind::AutoDeployEnabled,
+            ));
+    }
 
     Ok(Json(ProjectResponse::map_from_project(updated_project)))
 }

--- a/crates/temps-projects/src/handlers/types.rs
+++ b/crates/temps-projects/src/handlers/types.rs
@@ -20,6 +20,7 @@ pub struct AppState {
     pub custom_domain_service: Arc<CustomDomainService>,
     pub audit_service: Arc<dyn AuditLogger>,
     pub template_service: Arc<TemplateService>,
+    pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 }
 
 // Domain-related types

--- a/crates/temps-projects/src/plugin.rs
+++ b/crates/temps-projects/src/plugin.rs
@@ -74,11 +74,15 @@ impl TempsPlugin for ProjectsPlugin {
         let custom_domain_service = context.require_service::<CustomDomainService>();
         let audit_service = context.require_service::<dyn temps_core::AuditLogger>();
         let template_service = context.require_service::<TemplateService>();
+        let telemetry = context
+            .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+            .unwrap_or_else(|| Arc::new(temps_core::telemetry::NoopTelemetryReporter));
         let app_state = Arc::new(crate::handlers::AppState {
             project_service,
             custom_domain_service,
             audit_service,
             template_service,
+            telemetry,
         });
         let routes = crate::handlers::configure_routes().with_state(app_state);
         Some(PluginRoutes::new(routes))

--- a/crates/temps-projects/src/services/project.rs
+++ b/crates/temps-projects/src/services/project.rs
@@ -59,13 +59,13 @@ pub struct EnvVarEnvironment {
     pub name: String,
 }
 
-// Constants for CPU allocation (in millicores, where 1000 = 1 CPU core)
+// Constants for CPU allocation (in millicores, where 1000 = 1 CPU core).
+// Only *requests* (scheduling minimums) are defaulted; CPU/memory *limits* are
+// intentionally left unset so new projects/environments run uncapped by default.
 pub const DEFAULT_CPU_REQUEST: i32 = 500_000; // 0.5 cores
-pub const DEFAULT_CPU_LIMIT: i32 = 2_000_000; // 2 cores
 
 // Constants for memory allocation (in MB)
 pub const DEFAULT_MEMORY_REQUEST: i32 = 128; // 128 MB
-pub const DEFAULT_MEMORY_LIMIT: i32 = 512; // 512 MB
 
 // Add these constants at the top of the file proper key management
 pub const NONCE_LENGTH: usize = 12;
@@ -168,12 +168,15 @@ impl ProjectService {
             })
             .transpose()?;
 
-        // Create deployment config with resource and deployment settings
+        // Create deployment config with resource and deployment settings.
+        // CPU/memory *limits* are intentionally left unset (None) so containers
+        // run uncapped by default — operators opt into a cap explicitly. Only the
+        // *requests* (scheduling minimums) are seeded.
         let deployment_config = Some(temps_entities::deployment_config::DeploymentConfig {
             cpu_request: Some(DEFAULT_CPU_REQUEST),
-            cpu_limit: Some(DEFAULT_CPU_LIMIT),
+            cpu_limit: None,
             memory_request: Some(DEFAULT_MEMORY_REQUEST),
-            memory_limit: Some(DEFAULT_MEMORY_LIMIT),
+            memory_limit: None,
             exposed_port: request.exposed_port,
             automatic_deploy: request.automatic_deploy,
             ..Default::default()
@@ -380,9 +383,10 @@ impl ProjectService {
                 project.id,
                 "production".to_string(),
                 Some(DEFAULT_CPU_REQUEST),
-                Some(DEFAULT_CPU_LIMIT),
+                // CPU/memory limits unset by default → uncapped containers.
+                None,
                 Some(DEFAULT_MEMORY_REQUEST),
-                Some(DEFAULT_MEMORY_LIMIT),
+                None,
                 project.main_branch.clone(),
             )
             .await

--- a/crates/temps-providers/src/externalsvc/mod.rs
+++ b/crates/temps-providers/src/externalsvc/mod.rs
@@ -274,6 +274,7 @@ pub struct ServiceConfig {
 /// - `memory_swap_mb`→ `HostConfig.memory_swap`   (bytes; ≥ memory)
 /// - `nano_cpus`     → `HostConfig.nano_cpus`     (1e9 = 1 full CPU)
 /// - `cpu_shares`    → `HostConfig.cpu_shares`    (relative weight, default 1024)
+/// - `shm_size_mb`   → `HostConfig.shm_size`      (bytes; default 64 MiB)
 ///
 /// IMPORTANT: enabling hard memory limits causes the kernel OOM killer to
 /// terminate the container when the working set exceeds the limit. The
@@ -295,6 +296,14 @@ pub struct ServiceResourceLimits {
     /// Relative CPU weight (default 1024). Only used when `nano_cpus` is None.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cpu_shares: Option<i64>,
+    /// Shared memory (/dev/shm) size in MiB. None = Docker default (64 MiB).
+    /// Maps to HostConfig.shm_size (bytes). PostgreSQL uses /dev/shm for parallel
+    /// query workers and large work_mem; the 64 MiB default causes "could not
+    /// resize shared memory segment ... No space left on device" under load.
+    /// NOTE: shm_size is fixed at container-create time — Docker's live update
+    /// API cannot change it, so changing this value recreates the container.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shm_size_mb: Option<i64>,
 }
 
 impl ServiceResourceLimits {
@@ -304,6 +313,7 @@ impl ServiceResourceLimits {
             && self.memory_swap_mb.is_none()
             && self.nano_cpus.is_none()
             && self.cpu_shares.is_none()
+            && self.shm_size_mb.is_none()
     }
 
     /// Validate that memory_swap >= memory when both are set, and that no
@@ -337,6 +347,11 @@ impl ServiceResourceLimits {
                 return Err(format!("cpu_shares must be > 0, got {}", cs));
             }
         }
+        if let Some(shm) = self.shm_size_mb {
+            if shm <= 0 {
+                return Err(format!("shm_size_mb must be > 0, got {}", shm));
+            }
+        }
         Ok(())
     }
 
@@ -366,6 +381,9 @@ impl ServiceResourceLimits {
         }
         if let Some(cs) = self.cpu_shares {
             host_config.cpu_shares = Some(cs);
+        }
+        if let Some(mb) = self.shm_size_mb {
+            host_config.shm_size = Some(mb.saturating_mul(1024 * 1024));
         }
     }
 }
@@ -1101,6 +1119,20 @@ mod resource_limits_tests {
         }
         .validate()
         .is_ok());
+
+        // shm_size_mb must be > 0
+        assert!(ServiceResourceLimits {
+            shm_size_mb: Some(0),
+            ..Default::default()
+        }
+        .validate()
+        .is_err());
+        assert!(ServiceResourceLimits {
+            shm_size_mb: Some(256),
+            ..Default::default()
+        }
+        .validate()
+        .is_ok());
     }
 
     #[test]
@@ -1117,6 +1149,7 @@ mod resource_limits_tests {
         assert_eq!(limits.nano_cpus, Some(1_000_000_000));
         assert_eq!(limits.cpu_shares, None);
         assert_eq!(limits.memory_swap_mb, None);
+        assert_eq!(limits.shm_size_mb, None);
     }
 
     #[test]
@@ -1141,6 +1174,19 @@ mod resource_limits_tests {
         // Untouched fields stay None — Docker default = unlimited.
         assert_eq!(hc.memory_swap, None);
         assert_eq!(hc.cpu_shares, None);
+        assert_eq!(hc.shm_size, None);
+    }
+
+    #[test]
+    fn apply_to_host_config_sets_shm() {
+        let limits = ServiceResourceLimits {
+            shm_size_mb: Some(256),
+            ..Default::default()
+        };
+        let mut hc = bollard::models::HostConfig::default();
+        limits.apply_to_host_config(&mut hc);
+        // 256 MiB = 268435456 bytes
+        assert_eq!(hc.shm_size, Some(256 * 1024 * 1024));
     }
 
     #[test]

--- a/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
@@ -19,11 +19,12 @@
 //! last attempted step and `error_message` populated. The user can retry,
 //! which resumes from the current phase without redoing earlier phases.
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
 use bollard::Docker;
 use sea_orm::{ActiveModelTrait, ActiveValue::Set, DatabaseConnection, EntityTrait};
+use temps_core::telemetry::{NoopTelemetryReporter, TelemetryReporter};
 use temps_entities::postgres_major_upgrades;
 use temps_logs::LogService;
 use thiserror::Error;
@@ -433,6 +434,11 @@ pub struct PostgresUpgradeOrchestrator {
     backup_provider: Arc<dyn PreUpgradeBackupProvider>,
     lifecycle: Arc<dyn PostgresContainerLifecycle>,
     log_service: Arc<LogService>,
+    /// Late-bound telemetry reporter. Set via [`Self::set_telemetry`] after
+    /// construction so the orchestrator can be created without requiring the
+    /// telemetry reporter to be known at construction time. Falls back to a
+    /// no-op reporter when absent.
+    telemetry: OnceLock<Arc<dyn TelemetryReporter>>,
 }
 
 impl PostgresUpgradeOrchestrator {
@@ -449,7 +455,23 @@ impl PostgresUpgradeOrchestrator {
             backup_provider,
             lifecycle,
             log_service,
+            telemetry: OnceLock::new(),
         }
+    }
+
+    /// Attach an optional anonymous telemetry reporter. Call this after
+    /// [`Self::new`] before spawning the orchestrator task. Safe to skip —
+    /// the orchestrator falls back to a no-op reporter when unset.
+    pub fn set_telemetry(&self, reporter: Arc<dyn TelemetryReporter>) {
+        // Ignore the error: if already set (e.g., from a resumed upgrade path)
+        // we keep the first value.
+        let _ = self.telemetry.set(reporter);
+    }
+
+    /// Returns the registered reporter or a static no-op fallback.
+    fn telemetry(&self) -> &dyn TelemetryReporter {
+        static NOOP: NoopTelemetryReporter = NoopTelemetryReporter;
+        self.telemetry.get().map(|r| r.as_ref()).unwrap_or(&NOOP)
     }
 
     /// Drive the upgrade to completion or failure.
@@ -1858,7 +1880,18 @@ impl PostgresUpgradeOrchestrator {
     }
 
     async fn finalize_completed(&self, upgrade_id: i32) -> Result<(), PostgresUpgradeError> {
-        self.set_status(upgrade_id, status::COMPLETED, None).await?;
+        let row = self.set_status(upgrade_id, status::COMPLETED, None).await?;
+
+        // Fire-and-forget anonymous telemetry. Properties are non-identifying
+        // Postgres major version numbers only (e.g., "16", "17").
+        self.telemetry().report(
+            temps_core::telemetry::TelemetryEvent::new(
+                temps_core::telemetry::TelemetryEventKind::PgMajorUpgradeCompleted,
+            )
+            .with("from_version", row.from_version.clone())
+            .with("to_version", row.to_version.clone()),
+        );
+
         Ok(())
     }
 

--- a/crates/temps-providers/src/handlers/handlers.rs
+++ b/crates/temps-providers/src/handlers/handlers.rs
@@ -501,6 +501,21 @@ async fn create_service(
                 error!("Failed to create audit log: {}", e);
             }
 
+            app_state.telemetry.report(
+                temps_core::telemetry::TelemetryEvent::new(
+                    temps_core::telemetry::TelemetryEventKind::ServiceCreated,
+                )
+                .with("engine", service.service_type.to_string()),
+            );
+            if service.topology == "cluster" {
+                app_state.telemetry.report(
+                    temps_core::telemetry::TelemetryEvent::new(
+                        temps_core::telemetry::TelemetryEventKind::ServiceClusterCreated,
+                    )
+                    .with("engine", service.service_type.to_string()),
+                );
+            }
+
             Ok((StatusCode::CREATED, Json(service)))
         }
         Err(e) => {

--- a/crates/temps-providers/src/handlers/types.rs
+++ b/crates/temps-providers/src/handlers/types.rs
@@ -30,6 +30,9 @@ pub struct AppState {
     /// metrics to (and the console port for its default). `None` in contexts
     /// where it isn't wired (e.g. some tests).
     pub config_service: Option<Arc<temps_config::ConfigService>>,
+    /// Telemetry reporter — fire-and-forget anonymous usage events.
+    /// Defaults to a no-op when telemetry is not registered.
+    pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]

--- a/crates/temps-providers/src/plugin.rs
+++ b/crates/temps-providers/src/plugin.rs
@@ -103,6 +103,11 @@ impl TempsPlugin for ProvidersPlugin {
         // Config service — resolves the internal URL containers push OTLP to.
         let config_service = context.get_service::<temps_config::ConfigService>();
 
+        // Telemetry reporter — no-op when telemetry isn't registered.
+        let telemetry = context
+            .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+            .unwrap_or_else(|| Arc::new(temps_core::telemetry::NoopTelemetryReporter));
+
         // Create QueryService
         let query_service = Arc::new(crate::QueryService::new(external_service_manager.clone()));
 
@@ -116,6 +121,7 @@ impl TempsPlugin for ProvidersPlugin {
             db,
             api_key_service,
             config_service,
+            telemetry,
         });
 
         // Configure routes with the app state

--- a/crates/temps-providers/src/postgres_upgrade_service.rs
+++ b/crates/temps-providers/src/postgres_upgrade_service.rs
@@ -7,12 +7,13 @@
 //! the error surfaces as `ConcurrentUpgrade` (409) instead of a raw
 //! Postgres unique-violation.
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use bollard::Docker;
 use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter,
 };
+use temps_core::telemetry::{NoopTelemetryReporter, TelemetryReporter};
 use temps_entities::{external_services, postgres_major_upgrades};
 use temps_logs::LogService;
 use uuid::Uuid;
@@ -70,6 +71,9 @@ pub struct PostgresUpgradeService {
     backup_provider: Arc<dyn PreUpgradeBackupProvider>,
     lifecycle: Arc<dyn PostgresContainerLifecycle>,
     log_service: Arc<LogService>,
+    /// Late-bound anonymous telemetry reporter. Set via [`Self::set_telemetry`]
+    /// after construction. Falls back to no-op when unset.
+    telemetry: OnceLock<Arc<dyn TelemetryReporter>>,
 }
 
 impl PostgresUpgradeService {
@@ -86,7 +90,21 @@ impl PostgresUpgradeService {
             backup_provider,
             lifecycle,
             log_service,
+            telemetry: OnceLock::new(),
         }
+    }
+
+    /// Attach a telemetry reporter so orchestrators spawned by this service
+    /// can emit anonymous product events on completion.
+    pub fn set_telemetry(&self, reporter: Arc<dyn TelemetryReporter>) {
+        let _ = self.telemetry.set(reporter);
+    }
+
+    fn telemetry(&self) -> Arc<dyn TelemetryReporter> {
+        self.telemetry
+            .get()
+            .cloned()
+            .unwrap_or_else(|| Arc::new(NoopTelemetryReporter))
     }
 
     /// Validate the request, insert the upgrade row, and spawn the
@@ -152,6 +170,7 @@ impl PostgresUpgradeService {
             self.lifecycle.clone(),
             self.log_service.clone(),
         );
+        orchestrator.set_telemetry(self.telemetry());
         let upgrade_id = inserted.id;
         let log_id_for_err = log_id.clone();
         let log_service = self.log_service.clone();
@@ -248,6 +267,7 @@ impl PostgresUpgradeService {
             self.lifecycle.clone(),
             self.log_service.clone(),
         );
+        orchestrator.set_telemetry(self.telemetry());
         let log_service = self.log_service.clone();
         let db_for_err = self.db.clone();
         tokio::spawn(async move {
@@ -364,6 +384,7 @@ impl PostgresUpgradeService {
             self.lifecycle.clone(),
             self.log_service.clone(),
         );
+        orchestrator.set_telemetry(self.telemetry());
         orchestrator.rollback(upgrade_id).await
     }
 
@@ -378,6 +399,7 @@ impl PostgresUpgradeService {
             self.lifecycle.clone(),
             self.log_service.clone(),
         );
+        orchestrator.set_telemetry(self.telemetry());
         orchestrator.sweep_expired_rollback_volumes().await
     }
 
@@ -423,6 +445,7 @@ impl PostgresUpgradeService {
                 self.lifecycle.clone(),
                 self.log_service.clone(),
             );
+            orchestrator.set_telemetry(self.telemetry());
             let log_service = self.log_service.clone();
             let log_id_for_err = log_id.clone();
             let db_for_err = self.db.clone();

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -1066,6 +1066,7 @@ impl ExternalServiceManager {
                 memory_swap_mb: parse_i64("memory_swap_mb"),
                 nano_cpus: parse_i64("nano_cpus"),
                 cpu_shares: parse_i64("cpu_shares"),
+                shm_size_mb: parse_i64("shm_size_mb"),
             };
             if limits.is_unlimited() {
                 None
@@ -8347,6 +8348,7 @@ echo "[restore] Pre-seed complete"
                             .map(|m| m / (1024 * 1024)),
                         nano_cpus: hc.nano_cpus.filter(|&n| n > 0),
                         cpu_shares: hc.cpu_shares.filter(|&n| n > 0),
+                        shm_size_mb: hc.shm_size.filter(|&m| m > 0).map(|m| m / (1024 * 1024)),
                     })
                     .unwrap_or_default();
 
@@ -8540,6 +8542,27 @@ echo "[restore] Pre-seed complete"
                         .unwrap_or(0);
                     let removing_memory_cap = current_memory > 0 && limits.memory_mb.is_none();
 
+                    // Detect a shared-memory (`/dev/shm`) size change. Docker
+                    // cannot hot-apply `shm_size` — it's a create-time-only
+                    // HostConfig field with no slot in the update API — so a
+                    // changed shm requires removing + recreating the
+                    // container. Only flag when the operator explicitly set a
+                    // size that differs from what the live container has; an
+                    // unset (None) shm leaves whatever Docker already chose and
+                    // must not trigger a spurious recreate against the 64 MiB
+                    // default.
+                    let current_shm = info
+                        .host_config
+                        .as_ref()
+                        .and_then(|hc| hc.shm_size)
+                        .unwrap_or(0);
+                    let shm_changed = match limits.shm_size_mb {
+                        Some(mb) => {
+                            current_shm > 0 && mb.saturating_mul(1024 * 1024) != current_shm
+                        }
+                        None => false,
+                    };
+
                     if removing_memory_cap {
                         ResourceLimitApplyResult {
                             role,
@@ -8549,6 +8572,19 @@ echo "[restore] Pre-seed complete"
                                 "Docker cannot remove a memory limit on a live \
                                  container. Restart the service to apply unlimited \
                                  memory."
+                                    .to_string(),
+                            ),
+                        }
+                    } else if shm_changed {
+                        ResourceLimitApplyResult {
+                            role,
+                            container_name,
+                            outcome: "requires_recreate".to_string(),
+                            error: Some(
+                                "Changing shared-memory (/dev/shm) size requires \
+                                 deleting and recreating the container (a stop/start \
+                                 reuses the old container and keeps the old shm size). \
+                                 Recreate the service to apply the new shm size."
                                     .to_string(),
                             ),
                         }
@@ -8601,6 +8637,110 @@ echo "[restore] Pre-seed complete"
     /// pick up the new caps on next start. When the container is
     /// completely absent (e.g., never created on this node), only the
     /// stored config is updated and the apply step records "missing".
+    /// Delete and recreate a service's container so a new `/dev/shm` size
+    /// takes effect.
+    ///
+    /// `shm_size` is fixed when a Docker container is created — there is no
+    /// live update for it, and a plain stop+start reuses the existing
+    /// container (keeping the old shm). The only way to apply a new value is
+    /// to REMOVE the container and let the engine recreate it. We remove the
+    /// container with `v: false` so the **data volume is preserved** (the
+    /// engine's `remove()` trait method would also drop the volume — we must
+    /// not use it here), then call `initialize_service`, whose
+    /// `create_container` now takes the create branch and bakes in the new
+    /// `HostConfig.shm_size`.
+    ///
+    /// Scope: standalone, local-node services. Remote-node and cluster
+    /// services are rejected with a clear message so the caller surfaces
+    /// "recreate manually" rather than silently doing nothing.
+    async fn recreate_service_container_for_shm(
+        &self,
+        service: &external_services::Model,
+    ) -> Result<(), ExternalServiceError> {
+        // Remote-node containers live on a worker's Docker daemon, not on
+        // `self.docker`. Removing here would target the wrong daemon. The
+        // worker's create path already honors shm; the operator must
+        // redeploy/recreate the service on that node.
+        if service.node_id.is_some() {
+            return Err(ExternalServiceError::InternalError {
+                reason: format!(
+                    "Service {} runs on a remote node; recreate it on that node to apply the new shm size",
+                    service.id
+                ),
+            });
+        }
+
+        // Cluster recreate spans multiple members with ordering constraints
+        // (monitor → primary → replicas) and isn't covered by
+        // `initialize_service`. Don't pretend; tell the operator to recreate.
+        if service.topology == "cluster" {
+            return Err(ExternalServiceError::InternalError {
+                reason: format!(
+                    "Service {} is a cluster; recreate its members to apply the new shm size",
+                    service.id
+                ),
+            });
+        }
+
+        let service_type = ServiceType::from_str(&service.service_type).map_err(|_| {
+            ExternalServiceError::InvalidServiceType {
+                id: service.id,
+                service_type: service.service_type.clone(),
+            }
+        })?;
+        let instance = self.create_service_instance(service.name.clone(), service_type);
+        let container_name = instance.get_docker_container_name();
+
+        // Stop, then DELETE the container (volume preserved). Stop is
+        // best-effort — the container may already be stopped or gone.
+        let _ = self
+            .docker
+            .stop_container(
+                &container_name,
+                None::<bollard::query_parameters::StopContainerOptions>,
+            )
+            .await;
+        match self
+            .docker
+            .remove_container(
+                &container_name,
+                Some(bollard::query_parameters::RemoveContainerOptions {
+                    v: false, // keep the data volume — only the container is recreated
+                    force: true,
+                    ..Default::default()
+                }),
+            )
+            .await
+        {
+            Ok(()) => {
+                info!(
+                    service_id = service.id,
+                    container = %container_name,
+                    "Removed container to apply new /dev/shm size (data volume preserved)"
+                );
+            }
+            Err(e) => {
+                // "no such container" is benign — nothing to recreate-from,
+                // initialize_service will just create it fresh. Surface other
+                // errors so the caller can warn.
+                let msg = e.to_string();
+                if !msg.contains("No such container") && !msg.contains("no such container") {
+                    return Err(ExternalServiceError::InternalError {
+                        reason: format!(
+                            "Failed to remove container '{}' for shm recreate: {}",
+                            container_name, msg
+                        ),
+                    });
+                }
+            }
+        }
+
+        // Recreate from the now-persisted config (incl. the new resources
+        // block). With the old container gone, `create_container` takes the
+        // create branch and applies the new shm.
+        self.initialize_service(service.id).await
+    }
+
     pub async fn update_service_resource_limits(
         &self,
         service_id: i32,
@@ -8636,6 +8776,13 @@ echo "[restore] Pre-seed complete"
             },
             None => serde_json::json!({}),
         };
+
+        // Capture the prior shm size before we splice in the new block.
+        // shm_size is create-time-only in Docker, so a change here means the
+        // container must be removed + recreated — a plain live update can't
+        // honor it. We compare prior vs new and drive a recreate below.
+        let prior_limits = crate::externalsvc::ServiceResourceLimits::from_parameters(&config_json);
+        let shm_changed = prior_limits.shm_size_mb != new_limits.shm_size_mb;
 
         // Splice the resources block into the parameters JSON. Setting
         // `unlimited` removes the block so the service goes back to
@@ -8677,9 +8824,33 @@ echo "[restore] Pre-seed complete"
         active.config = Set(Some(encrypted));
         active.update(self.db.as_ref()).await?;
 
+        // When the shared-memory size changed, a live `update_container` can't
+        // honor it (shm_size is fixed at container-CREATE time in Docker). The
+        // container must be DELETED and recreated — a stop+start reuses the old
+        // container and keeps the old shm. `recreate_service_container_for_shm`
+        // removes the container (data volume preserved) so the engine's
+        // `create_container` rebuilds it with the new `HostConfig.shm_size`.
+        //
+        // Best-effort: the limits are already persisted, so a recreate failure
+        // must not roll them back. We log and fall through to report the
+        // per-member outcome — the operator can recreate manually.
+        if shm_changed {
+            if let Err(e) = self.recreate_service_container_for_shm(&service).await {
+                tracing::warn!(
+                    service_id,
+                    error = %e,
+                    "Failed to recreate service container after shm size change; \
+                     limits are persisted but the running container still has the \
+                     old shm size — recreate manually to apply"
+                );
+            }
+        }
+
         // Best-effort live apply. Errors here don't undo the persisted
         // limits — the operator can still recreate the container manually
-        // to pick them up.
+        // to pick them up. After a recreate above, the fresh container
+        // already has the new caps, so this reports "applied"/"missing"
+        // harmlessly.
         let applied = self
             .apply_limits_to_running_containers(&service, &new_limits)
             .await;
@@ -8704,6 +8875,11 @@ echo "[restore] Pre-seed complete"
 /// - memory_swap_mb  → memory_swap  (bytes; -1 = unlimited swap, 0 = no swap; we map None→0)
 /// - nano_cpus       → nano_cpus    (1e9 = 1 core; 0 = unlimited)
 /// - cpu_shares      → cpu_shares   (default 1024; 0 = default)
+///
+/// NOTE: `shm_size` is intentionally absent. Docker treats `/dev/shm` size
+/// as create-time-only; `ContainerUpdateBody` has no `shm_size` field.
+/// Changing shm requires REMOVING + RECREATING the container — handled by
+/// the auto-recreate path in `update_service_resource_limits`, NOT here.
 fn build_container_update_body(
     limits: &crate::externalsvc::ServiceResourceLimits,
 ) -> bollard::models::ContainerUpdateBody {

--- a/crates/temps-status-page/src/plugin.rs
+++ b/crates/temps-status-page/src/plugin.rs
@@ -211,19 +211,28 @@ impl TempsPlugin for StatusPagePlugin {
 
     fn configure_routes(&self, context: &PluginContext) -> Option<PluginRoutes> {
         let status_page_service = context.require_service::<StatusPageService>();
+        let telemetry = context
+            .get_service::<dyn temps_core::TelemetryReporter>()
+            .unwrap_or_else(|| Arc::new(temps_core::telemetry::NoopTelemetryReporter));
 
         struct AppState {
             status_page_service: Arc<StatusPageService>,
+            telemetry: Arc<dyn temps_core::TelemetryReporter>,
         }
 
         impl StatusPageAppState for AppState {
             fn status_page_service(&self) -> &StatusPageService {
                 &self.status_page_service
             }
+
+            fn telemetry(&self) -> &Arc<dyn temps_core::TelemetryReporter> {
+                &self.telemetry
+            }
         }
 
         let app_state = Arc::new(AppState {
             status_page_service,
+            telemetry,
         });
 
         let routes = create_router().with_state(app_state);

--- a/crates/temps-status-page/src/routes/status_page.rs
+++ b/crates/temps-status-page/src/routes/status_page.rs
@@ -24,6 +24,7 @@ use crate::services::{
 /// Application state trait for status page routes
 pub trait StatusPageAppState: Send + Sync + 'static {
     fn status_page_service(&self) -> &StatusPageService;
+    fn telemetry(&self) -> &std::sync::Arc<dyn temps_core::TelemetryReporter>;
 }
 
 /// OpenAPI documentation for status page endpoints
@@ -171,13 +172,19 @@ where
     T: StatusPageAppState,
 {
     permission_guard!(auth, StatusPageCreate);
-    app_state
+    let monitor = app_state
         .status_page_service()
         .monitor_service()
         .create_monitor(project_id, request)
         .await
-        .map(|monitor| (StatusCode::CREATED, Json(monitor)))
-        .map_err(map_error)
+        .map_err(map_error)?;
+
+    app_state.telemetry().report(
+        temps_core::TelemetryEvent::new(temps_core::TelemetryEventKind::StatusPagePublished)
+            .with("monitor_type", monitor.monitor_type.clone()),
+    );
+
+    Ok((StatusCode::CREATED, Json(monitor)))
 }
 
 /// List monitors for a project

--- a/crates/temps-telemetry/Cargo.toml
+++ b/crates/temps-telemetry/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "temps-telemetry"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[dependencies]
+temps-core = { path = "../temps-core" }
+temps-config = { path = "../temps-config" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+reqwest = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true }
+async-trait = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/temps-telemetry/src/lib.rs
+++ b/crates/temps-telemetry/src/lib.rs
@@ -1,0 +1,36 @@
+//! Anonymous product telemetry reporter for Temps.
+//!
+//! Temps optionally reports **anonymous** product-usage events (e.g. "an
+//! instance attempted a deploy" vs "an instance deployed successfully") to a
+//! central endpoint so the maintainers can tell whether the product is working
+//! for self-hosters and where to invest. The data is anonymous by design:
+//!
+//! - A stable random `anonymous_id` (UUID v4) is generated on the instance and
+//!   persisted in the data directory. It is never derived from anything
+//!   machine-identifying.
+//! - Events carry only the event name and a small bag of **non-identifying**
+//!   properties (counts, enum labels, durations). No emails, IPs, repo names,
+//!   domains, env-var names/values, or free-form user text are ever sent.
+//! - Reporting is fire-and-forget and time-bounded: a dead or slow endpoint has
+//!   zero effect on the running server.
+//!
+//! Operators opt out by setting `TEMPS_TELEMETRY=0` (also `false`/`off`/`no`).
+//! The ingest endpoint is overridable with `TEMPS_TELEMETRY_ENDPOINT`.
+//!
+//! The abstraction (`TelemetryReporter`, `TelemetryEvent`, `TelemetryEventKind`)
+//! lives in [`temps_core::telemetry`] so feature crates depend on the trait,
+//! not on this crate.
+
+mod plugin;
+mod service;
+
+pub use plugin::TelemetryPlugin;
+pub use service::{
+    TelemetryInitError, TelemetryService, ANONYMOUS_ID_FILE, DEFAULT_TELEMETRY_ENDPOINT,
+};
+
+// Convenience re-exports so consumers can pull the event vocabulary from one
+// place.
+pub use temps_core::telemetry::{
+    NoopTelemetryReporter, TelemetryEvent, TelemetryEventKind, TelemetryReporter,
+};

--- a/crates/temps-telemetry/src/plugin.rs
+++ b/crates/temps-telemetry/src/plugin.rs
@@ -1,0 +1,95 @@
+//! Plugin that registers the anonymous telemetry reporter.
+//!
+//! Registers an `Arc<dyn TelemetryReporter>` in the service registry so any
+//! feature crate can `require_service::<dyn TelemetryReporter>()` (or accept it
+//! via constructor) without depending on this crate directly — mirroring the
+//! `AuditLogger` wiring.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use temps_config::ServerConfig;
+use temps_core::plugin::{PluginError, ServiceRegistrationContext, TempsPlugin};
+use temps_core::telemetry::{NoopTelemetryReporter, TelemetryReporter};
+
+use crate::TelemetryService;
+
+/// Plugin for anonymous product telemetry.
+pub struct TelemetryPlugin {
+    server_config: Arc<ServerConfig>,
+    /// Version string stamped onto every event (typically the server's
+    /// `CARGO_PKG_VERSION`).
+    temps_version: String,
+}
+
+impl TelemetryPlugin {
+    pub fn new(server_config: Arc<ServerConfig>, temps_version: impl Into<String>) -> Self {
+        Self {
+            server_config,
+            temps_version: temps_version.into(),
+        }
+    }
+}
+
+impl TempsPlugin for TelemetryPlugin {
+    fn name(&self) -> &'static str {
+        "telemetry"
+    }
+
+    fn register_services<'a>(
+        &'a self,
+        context: &'a ServiceRegistrationContext,
+    ) -> Pin<Box<dyn Future<Output = Result<(), PluginError>> + Send + 'a>> {
+        Box::pin(async move {
+            // Telemetry must never block startup. If the reporter can't be
+            // built (e.g. the anonymous-id file can't be written), fall back to
+            // a no-op reporter and log, rather than failing the server.
+            let reporter: Arc<dyn TelemetryReporter> = match TelemetryService::new(
+                &self.server_config.data_dir,
+                self.temps_version.clone(),
+            ) {
+                Ok(svc) => Arc::new(svc),
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "Failed to initialize telemetry reporter; telemetry disabled for this run"
+                    );
+                    Arc::new(NoopTelemetryReporter)
+                }
+            };
+
+            context.register_service(reporter);
+            tracing::debug!("Telemetry plugin services registered successfully");
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plugin_name_is_telemetry() {
+        // Construct with a throwaway config; we only assert the name.
+        // ServerConfig::new touches the data dir, so use a temp dir.
+        let dir = std::env::temp_dir().join(format!(
+            "temps-telemetry-plugin-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        std::env::set_var("TEMPS_DATA_DIR", &dir);
+        let cfg = ServerConfig::new(
+            "127.0.0.1:0".to_string(),
+            "postgres://localhost/none".to_string(),
+            None,
+            None,
+        )
+        .unwrap();
+        std::env::remove_var("TEMPS_DATA_DIR");
+
+        let plugin = TelemetryPlugin::new(Arc::new(cfg), "0.0.0-test");
+        assert_eq!(plugin.name(), "telemetry");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/temps-telemetry/src/service.rs
+++ b/crates/temps-telemetry/src/service.rs
@@ -1,0 +1,297 @@
+//! Concrete anonymous-telemetry reporter.
+//!
+//! See [`crate`] and [`temps_core::telemetry`] for the abstraction and privacy
+//! contract. This service:
+//! - persists a stable random `anonymous_id` in the data directory,
+//! - honours the `TEMPS_TELEMETRY` opt-out env var,
+//! - sends each event as a fire-and-forget timed HTTP POST so a dead endpoint
+//!   never affects the running server.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::Serialize;
+use temps_core::telemetry::{TelemetryEvent, TelemetryReporter};
+use thiserror::Error;
+
+/// File (relative to the data dir) holding the stable anonymous instance id.
+pub const ANONYMOUS_ID_FILE: &str = "anonymous_id";
+
+/// Default central ingest endpoint. Overridable with `TEMPS_TELEMETRY_ENDPOINT`
+/// (e.g. when self-hosting your own ingest, or pointing at a local dev server).
+pub const DEFAULT_TELEMETRY_ENDPOINT: &str = "https://telemetry.temps.sh/v1/events";
+
+/// How long a single telemetry POST is allowed to take before being abandoned.
+const SEND_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Error, Debug)]
+pub enum TelemetryInitError {
+    #[error("Failed to read/write anonymous id file at '{path}': {reason}")]
+    AnonymousIdIo { path: String, reason: String },
+
+    #[error("Failed to build telemetry HTTP client: {reason}")]
+    HttpClient { reason: String },
+}
+
+/// The wire payload sent to the ingest API. Matches the Bun `telemetry-api`
+/// `POST /v1/events` body.
+#[derive(Debug, Serialize)]
+struct EventPayload<'a> {
+    anonymous_id: &'a str,
+    event_type: &'a str,
+    properties: &'a std::collections::BTreeMap<String, serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temps_version: Option<&'a str>,
+}
+
+/// Anonymous product-telemetry reporter.
+#[derive(Clone)]
+pub struct TelemetryService {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    enabled: bool,
+    anonymous_id: String,
+    temps_version: String,
+    endpoint: String,
+    client: reqwest::Client,
+}
+
+impl TelemetryService {
+    /// Build a reporter rooted at `data_dir`.
+    ///
+    /// `temps_version` is stamped onto every event (pass the server's
+    /// `CARGO_PKG_VERSION`). Telemetry is enabled unless the operator opted out
+    /// via `TEMPS_TELEMETRY` set to `0`/`false`/`off`/`no`. The anonymous id is
+    /// always loaded/generated (even when disabled) so flipping telemetry back
+    /// on doesn't churn the instance identity.
+    pub fn new(
+        data_dir: &Path,
+        temps_version: impl Into<String>,
+    ) -> Result<Self, TelemetryInitError> {
+        let version = temps_version.into();
+        let enabled = Self::enabled_from_env();
+        let endpoint = std::env::var("TEMPS_TELEMETRY_ENDPOINT")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| DEFAULT_TELEMETRY_ENDPOINT.to_string());
+
+        let anonymous_id = Self::load_or_create_anonymous_id(data_dir)?;
+
+        let client = reqwest::Client::builder()
+            .timeout(SEND_TIMEOUT)
+            .user_agent(format!("temps-telemetry/{version}"))
+            .build()
+            .map_err(|e| TelemetryInitError::HttpClient {
+                reason: e.to_string(),
+            })?;
+
+        if enabled {
+            tracing::info!(
+                anonymous_id = %anonymous_id,
+                endpoint = %endpoint,
+                "Anonymous product telemetry is ENABLED. No PII is collected. \
+                 Disable with TEMPS_TELEMETRY=0."
+            );
+        } else {
+            tracing::info!("Anonymous product telemetry is DISABLED (TEMPS_TELEMETRY opt-out).");
+        }
+
+        Ok(Self {
+            inner: Arc::new(Inner {
+                enabled,
+                anonymous_id,
+                temps_version: version,
+                endpoint,
+                client,
+            }),
+        })
+    }
+
+    /// Read the `TEMPS_TELEMETRY` opt-out flag. Enabled by default; treats
+    /// `0`/`false`/`off`/`no`/`disabled` (case-insensitive) as opt-out.
+    fn enabled_from_env() -> bool {
+        match std::env::var("TEMPS_TELEMETRY") {
+            Ok(v) => !matches!(
+                v.trim().to_lowercase().as_str(),
+                "0" | "false" | "off" | "no" | "disabled"
+            ),
+            Err(_) => true,
+        }
+    }
+
+    fn anonymous_id_path(data_dir: &Path) -> PathBuf {
+        data_dir.join(ANONYMOUS_ID_FILE)
+    }
+
+    /// Load the persisted anonymous id, generating and persisting a new random
+    /// one on first run. The id is a random UUID v4 — not derived from anything
+    /// machine-identifying.
+    fn load_or_create_anonymous_id(data_dir: &Path) -> Result<String, TelemetryInitError> {
+        let path = Self::anonymous_id_path(data_dir);
+
+        if path.exists() {
+            let raw =
+                std::fs::read_to_string(&path).map_err(|e| TelemetryInitError::AnonymousIdIo {
+                    path: path.display().to_string(),
+                    reason: e.to_string(),
+                })?;
+            let trimmed = raw.trim();
+            if !trimmed.is_empty() {
+                return Ok(trimmed.to_string());
+            }
+            // Empty/corrupt file: fall through and regenerate.
+        }
+
+        let id = format!("inst_{}", uuid::Uuid::new_v4().simple());
+
+        // Best-effort create the data dir; it normally already exists.
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        std::fs::write(&path, &id).map_err(|e| TelemetryInitError::AnonymousIdIo {
+            path: path.display().to_string(),
+            reason: e.to_string(),
+        })?;
+
+        Ok(id)
+    }
+
+    /// The stable anonymous id for this instance (exposed for diagnostics).
+    pub fn anonymous_id(&self) -> &str {
+        &self.inner.anonymous_id
+    }
+}
+
+#[async_trait::async_trait]
+impl TelemetryReporter for TelemetryService {
+    fn report(&self, event: TelemetryEvent) {
+        if !self.inner.enabled {
+            return;
+        }
+
+        // Clone the small amount of state the background task needs. The whole
+        // point is to return immediately; all network work happens in a
+        // detached task with its own timeout (the client is configured with
+        // SEND_TIMEOUT).
+        let inner = self.inner.clone();
+
+        tokio::spawn(async move {
+            let payload = EventPayload {
+                anonymous_id: &inner.anonymous_id,
+                event_type: &event.event_type,
+                properties: &event.properties,
+                temps_version: if inner.temps_version.is_empty() {
+                    None
+                } else {
+                    Some(&inner.temps_version)
+                },
+            };
+
+            match inner
+                .client
+                .post(&inner.endpoint)
+                .json(&payload)
+                .send()
+                .await
+            {
+                Ok(resp) if resp.status().is_success() => {
+                    tracing::trace!(
+                        event = %event.event_type,
+                        "telemetry event sent"
+                    );
+                }
+                Ok(resp) => {
+                    // Non-2xx is not an error worth surfacing loudly — telemetry
+                    // is best-effort. Debug level keeps it out of normal logs.
+                    tracing::debug!(
+                        event = %event.event_type,
+                        status = %resp.status(),
+                        "telemetry endpoint returned non-success status"
+                    );
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        event = %event.event_type,
+                        error = %e,
+                        "telemetry send failed (ignored)"
+                    );
+                }
+            }
+        });
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.inner.enabled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use temps_core::telemetry::TelemetryEventKind;
+
+    /// A temp dir helper that doesn't pull in extra deps.
+    fn temp_dir() -> PathBuf {
+        let base = std::env::temp_dir();
+        let unique = format!("temps-telemetry-test-{}", uuid::Uuid::new_v4().simple());
+        let dir = base.join(unique);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn anonymous_id_is_stable_across_loads() {
+        let dir = temp_dir();
+        let id1 = TelemetryService::load_or_create_anonymous_id(&dir).unwrap();
+        let id2 = TelemetryService::load_or_create_anonymous_id(&dir).unwrap();
+        assert_eq!(id1, id2, "anonymous id must be stable once generated");
+        assert!(id1.starts_with("inst_"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn anonymous_id_regenerated_when_file_empty() {
+        let dir = temp_dir();
+        let path = TelemetryService::anonymous_id_path(&dir);
+        std::fs::write(&path, "   ").unwrap();
+        let id = TelemetryService::load_or_create_anonymous_id(&dir).unwrap();
+        assert!(id.starts_with("inst_"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn disabled_service_is_noop_and_reports_disabled() {
+        let dir = temp_dir();
+        // Force opt-out for this construction.
+        std::env::set_var("TEMPS_TELEMETRY", "0");
+        let svc = TelemetryService::new(&dir, "0.0.0-test").unwrap();
+        std::env::remove_var("TEMPS_TELEMETRY");
+
+        assert!(!svc.is_enabled());
+        // Must not panic and must not spawn a request.
+        svc.report(TelemetryEvent::new(TelemetryEventKind::ProjectCreated));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn enabled_from_env_defaults_on_and_honors_opt_out() {
+        std::env::remove_var("TEMPS_TELEMETRY");
+        assert!(TelemetryService::enabled_from_env());
+
+        for off in ["0", "false", "OFF", "No", "disabled"] {
+            std::env::set_var("TEMPS_TELEMETRY", off);
+            assert!(
+                !TelemetryService::enabled_from_env(),
+                "{off} should disable"
+            );
+        }
+        for on in ["1", "true", "yes", "anything-else"] {
+            std::env::set_var("TEMPS_TELEMETRY", on);
+            assert!(TelemetryService::enabled_from_env(), "{on} should enable");
+        }
+        std::env::remove_var("TEMPS_TELEMETRY");
+    }
+}

--- a/crates/temps-vulnerability-scanner/src/handlers/mod.rs
+++ b/crates/temps-vulnerability-scanner/src/handlers/mod.rs
@@ -10,17 +10,20 @@ pub struct VulnerabilityScannerAppState {
     pub scan_service: Arc<crate::service::VulnerabilityScanService>,
     pub audit_service: Arc<dyn temps_core::AuditLogger>,
     pub db: Arc<temps_database::DbConnection>,
+    pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 }
 
 pub async fn create_vulnerability_scanner_app_state(
     scan_service: Arc<crate::service::VulnerabilityScanService>,
     audit_service: Arc<dyn temps_core::AuditLogger>,
     db: Arc<temps_database::DbConnection>,
+    telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
 ) -> Arc<VulnerabilityScannerAppState> {
     Arc::new(VulnerabilityScannerAppState {
         scan_service,
         audit_service,
         db,
+        telemetry,
     })
 }
 

--- a/crates/temps-vulnerability-scanner/src/handlers/scans_handler.rs
+++ b/crates/temps-vulnerability-scanner/src/handlers/scans_handler.rs
@@ -403,6 +403,15 @@ async fn trigger_scan(
         }
     });
 
+    // Fire-and-forget anonymous telemetry — no identifying properties
+    app_state.telemetry.report(
+        temps_core::telemetry::TelemetryEvent::new(
+            temps_core::telemetry::TelemetryEventKind::VulnerabilityScanTriggered,
+        )
+        .with("trigger", "manual")
+        .with("scanner_type", scan.scanner_type.clone()),
+    );
+
     Ok((
         StatusCode::ACCEPTED,
         Json(TriggerScanResponse {

--- a/crates/temps-vulnerability-scanner/src/plugin.rs
+++ b/crates/temps-vulnerability-scanner/src/plugin.rs
@@ -80,9 +80,15 @@ impl TempsPlugin for VulnerabilityScannerPlugin {
             // Get AuditService dependency from other plugins
             let audit_service = context.require_service::<dyn temps_core::AuditLogger>();
 
+            // Optional telemetry — never hard-fail if not registered
+            let telemetry = context
+                .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
+                .unwrap_or_else(|| Arc::new(temps_core::telemetry::NoopTelemetryReporter));
+
             // Create VulnerabilityScannerAppState for handlers
             let scanner_app_state =
-                create_vulnerability_scanner_app_state(scan_service, audit_service, db).await;
+                create_vulnerability_scanner_app_state(scan_service, audit_service, db, telemetry)
+                    .await;
             context.register_service(scanner_app_state);
 
             tracing::debug!("Vulnerability Scanner plugin services registered successfully");

--- a/telemetry-api/.dockerignore
+++ b/telemetry-api/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+.git
+*.log

--- a/telemetry-api/.env.example
+++ b/telemetry-api/.env.example
@@ -1,0 +1,8 @@
+# Connection string. In production on Temps, POSTGRES_URL is injected
+# automatically when a Postgres service is linked to the project — you don't
+# set it by hand. For LOCAL dev, set DATABASE_URL (used as a fallback when
+# POSTGRES_URL is absent).
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/temps_telemetry
+PORT=4200
+# Optional: set to a secret to require X-Telemetry-Key header on ingest endpoints
+# INGEST_API_KEY=your-secret-key

--- a/telemetry-api/.gitignore
+++ b/telemetry-api/.gitignore
@@ -1,0 +1,2 @@
+.env
+node_modules/

--- a/telemetry-api/.gitignore
+++ b/telemetry-api/.gitignore
@@ -1,2 +1,5 @@
 .env
 node_modules/
+# GeoLite2 DB is provisioned at build/deploy time, never committed (MaxMind
+# license + size). Place GeoLite2-Country.mmdb (or a City DB) here locally.
+data/

--- a/telemetry-api/.temps.yaml
+++ b/telemetry-api/.temps.yaml
@@ -1,0 +1,6 @@
+# Temps platform configuration for the telemetry-api.
+# Deployed as a Dockerfile app. Reuses an existing managed Postgres (linked
+# at the project level, which injects the DB connection env vars).
+#
+# No cron jobs. No API key yet (ingest is open; auth + the dashboard UI ship
+# in a later deploy).

--- a/telemetry-api/Dockerfile
+++ b/telemetry-api/Dockerfile
@@ -15,6 +15,10 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY package.json bun.lock tsconfig.json ./
 COPY src ./src
 COPY migrations ./migrations
+# GeoLite2 DB for anonymous country lookup (gitignored; provisioned locally /
+# at build). geo.ts reads GEOLITE2_COUNTRY_DB (default /app/data/...). If the
+# dir is absent the build still works and geolocation degrades to null.
+COPY data ./data
 COPY docker-entrypoint.sh ./docker-entrypoint.sh
 RUN chmod +x ./docker-entrypoint.sh
 

--- a/telemetry-api/Dockerfile
+++ b/telemetry-api/Dockerfile
@@ -1,0 +1,25 @@
+# Bun telemetry-api — anonymous product-telemetry ingest for Temps.
+# Multi-stage: install deps with a cached layer, then a slim runtime.
+FROM oven/bun:1.3-alpine AS deps
+WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --production
+
+FROM oven/bun:1.3-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+# Listen on the port Temps assigns (PORT is injected); default 4200 locally.
+ENV PORT=4200
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY package.json bun.lock tsconfig.json ./
+COPY src ./src
+COPY migrations ./migrations
+COPY docker-entrypoint.sh ./docker-entrypoint.sh
+RUN chmod +x ./docker-entrypoint.sh
+
+EXPOSE 4200
+
+# Migrate-then-serve. Migrations are idempotent (telemetry_migrations table),
+# so a redeploy is safe.
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/telemetry-api/bun.lock
+++ b/telemetry-api/bun.lock
@@ -1,0 +1,53 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@temps-sdk/telemetry-api",
+      "dependencies": {
+        "pg": "^8.13.3",
+      },
+      "devDependencies": {
+        "@types/pg": "^8.11.10",
+        "bun-types": "latest",
+      },
+    },
+  },
+  "packages": {
+    "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
+
+    "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "pg": ["pg@8.21.0", "", { "dependencies": { "pg-connection-string": "^2.13.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.14.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA=="],
+
+    "pg-cloudflare": ["pg-cloudflare@1.4.0", "", {}, "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="],
+
+    "pg-connection-string": ["pg-connection-string@2.13.0", "", {}, "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig=="],
+
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-pool": ["pg-pool@3.14.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw=="],
+
+    "pg-protocol": ["pg-protocol@1.14.0", "", {}, "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+  }
+}

--- a/telemetry-api/bun.lock
+++ b/telemetry-api/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@temps-sdk/telemetry-api",
       "dependencies": {
+        "maxmind": "^5.0.6",
         "pg": "^8.13.3",
       },
       "devDependencies": {
@@ -19,6 +20,10 @@
     "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "maxmind": ["maxmind@5.0.6", "", { "dependencies": { "mmdb-lib": "3.0.2", "tiny-lru": "13.0.0" } }, "sha512-5bvd/u+kIaTqaGM+xkXjatzQw1dQfSmlLggr2W1EKMyMxSgx2woZyusLpNpZ4DdPmL+1bbJWeo4LXsi6bC0Iew=="],
+
+    "mmdb-lib": ["mmdb-lib@3.0.2", "", {}, "sha512-7e87vk0DdWT647wjcfEtWeMtjm+zVGqNohN/aeIymbUfjHQ2T4Sx5kM+1irVDBSloNC3CkGKxswdMoo8yhqTDg=="],
 
     "pg": ["pg@8.21.0", "", { "dependencies": { "pg-connection-string": "^2.13.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.14.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA=="],
 
@@ -45,6 +50,8 @@
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "tiny-lru": ["tiny-lru@13.0.0", "", {}, "sha512-xDHxKKS1FdF0Tv2P+QT7IeSEg74K/8cEDzbv3Tv6UyHHUgBOjOiQiBp818MGj66dhurQus/IBcoAbwIKtSGc6Q=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 

--- a/telemetry-api/docker-entrypoint.sh
+++ b/telemetry-api/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Run migrations (idempotent) before starting the server. If migrations fail,
+# the container exits non-zero so the platform surfaces the failure rather than
+# serving against an un-migrated schema.
+echo "[entrypoint] running migrations..."
+bun run src/db/migrate.ts
+
+echo "[entrypoint] starting telemetry-api on port ${PORT:-4200}..."
+exec bun run src/index.ts

--- a/telemetry-api/migrations/001_create_telemetry_tables.sql
+++ b/telemetry-api/migrations/001_create_telemetry_tables.sql
@@ -1,0 +1,40 @@
+-- Telemetry schema for Temps product analytics
+-- All data is anonymous: no emails, IPs, or PII stored
+-- anonymous_id is a stable random UUID generated on the instance at first boot
+
+CREATE TABLE IF NOT EXISTS telemetry_events (
+    id              BIGSERIAL PRIMARY KEY,
+    -- Stable anonymous identifier generated at instance boot, never tied to a user
+    anonymous_id    TEXT        NOT NULL,
+    -- Event type: deploy_attempted, deploy_succeeded, deploy_failed,
+    --             project_created, instance_started, instance_setup_completed, etc.
+    event_type      TEXT        NOT NULL,
+    -- Loose schema: arbitrary properties per event type
+    properties      JSONB       NOT NULL DEFAULT '{}',
+    -- Temps version that sent the event
+    temps_version   TEXT,
+    -- Timestamp the event occurred on the instance (sent by client)
+    occurred_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- Timestamp we received it
+    received_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Fast lookups by anonymous_id for funnel queries
+CREATE INDEX IF NOT EXISTS idx_telemetry_events_anon_id
+    ON telemetry_events (anonymous_id, occurred_at DESC);
+
+-- Fast lookups by event type for aggregate dashboards
+CREATE INDEX IF NOT EXISTS idx_telemetry_events_type
+    ON telemetry_events (event_type, occurred_at DESC);
+
+-- Table to track daily active instance counts (materialized from events)
+-- This is denormalized for cheap dashboard queries without scanning the full events table
+CREATE TABLE IF NOT EXISTS telemetry_instance_days (
+    anonymous_id    TEXT        NOT NULL,
+    day             DATE        NOT NULL,
+    temps_version   TEXT,
+    PRIMARY KEY (anonymous_id, day)
+);
+
+CREATE INDEX IF NOT EXISTS idx_telemetry_instance_days_day
+    ON telemetry_instance_days (day DESC);

--- a/telemetry-api/migrations/002_add_country.sql
+++ b/telemetry-api/migrations/002_add_country.sql
@@ -1,0 +1,18 @@
+-- Add anonymous country geolocation to telemetry events.
+--
+-- We derive the 2-letter ISO country code from the request IP at ingest time
+-- and store ONLY the country — the IP itself is NEVER persisted. This keeps the
+-- anonymous-by-design contract while letting us see the geographic spread of
+-- self-hosted instances.
+
+ALTER TABLE telemetry_events
+    ADD COLUMN IF NOT EXISTS country TEXT;
+
+-- Fast country breakdowns for the dashboard.
+CREATE INDEX IF NOT EXISTS idx_telemetry_events_country
+    ON telemetry_events (country, occurred_at DESC);
+
+-- Track country per instance-day too, so we can map active instances by country
+-- without scanning the full events table.
+ALTER TABLE telemetry_instance_days
+    ADD COLUMN IF NOT EXISTS country TEXT;

--- a/telemetry-api/package.json
+++ b/telemetry-api/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@temps-sdk/telemetry-api",
+  "version": "0.1.0",
+  "description": "Anonymous product telemetry ingest API for Temps — stores deployment and lifecycle events in Postgres",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun run --watch src/index.ts",
+    "start": "bun run src/index.ts",
+    "migrate": "bun run src/db/migrate.ts",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "pg": "^8.13.3"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.11.10",
+    "bun-types": "latest"
+  }
+}

--- a/telemetry-api/package.json
+++ b/telemetry-api/package.json
@@ -11,6 +11,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "maxmind": "^5.0.6",
     "pg": "^8.13.3"
   },
   "devDependencies": {

--- a/telemetry-api/src/db/migrate.ts
+++ b/telemetry-api/src/db/migrate.ts
@@ -1,0 +1,64 @@
+import { readFileSync, readdirSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { getPool, closePool } from "./pool.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function migrate() {
+  const pool = getPool();
+  const client = await pool.connect();
+
+  try {
+    // Track which migrations have run
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS telemetry_migrations (
+        id          SERIAL PRIMARY KEY,
+        filename    TEXT NOT NULL UNIQUE,
+        applied_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+
+    const migrationsDir = join(__dirname, "../../migrations");
+    const files = readdirSync(migrationsDir)
+      .filter((f) => f.endsWith(".sql"))
+      .sort();
+
+    for (const file of files) {
+      const { rows } = await client.query(
+        "SELECT 1 FROM telemetry_migrations WHERE filename = $1",
+        [file]
+      );
+      if (rows.length > 0) {
+        console.log(`[migrate] skip ${file} (already applied)`);
+        continue;
+      }
+
+      const sql = readFileSync(join(migrationsDir, file), "utf8");
+      console.log(`[migrate] applying ${file}...`);
+      await client.query("BEGIN");
+      try {
+        await client.query(sql);
+        await client.query(
+          "INSERT INTO telemetry_migrations (filename) VALUES ($1)",
+          [file]
+        );
+        await client.query("COMMIT");
+        console.log(`[migrate] applied ${file}`);
+      } catch (err) {
+        await client.query("ROLLBACK");
+        throw err;
+      }
+    }
+
+    console.log("[migrate] done");
+  } finally {
+    client.release();
+    await closePool();
+  }
+}
+
+migrate().catch((err) => {
+  console.error("[migrate] failed:", err);
+  process.exit(1);
+});

--- a/telemetry-api/src/db/pool.ts
+++ b/telemetry-api/src/db/pool.ts
@@ -4,18 +4,43 @@ const { Pool } = pg;
 
 let _pool: InstanceType<typeof Pool> | null = null;
 
+// The telemetry data lives in a dedicated database on the linked Temps Postgres
+// service. Temps injects POSTGRES_HOST/PORT/USER/PASSWORD for the linked
+// service, but the injected POSTGRES_DB / POSTGRES_URL point at the service's
+// default `postgres` database — NOT the per-project `telemetry_api_production`
+// DB the data actually lives in. So we build the connection from the parts and
+// force the database name. This MUST match the dashboard's pool so the public
+// API and the private dashboard read/write the same place.
+const TELEMETRY_DB = "telemetry_api_production";
+
+function buildPoolConfig(): pg.PoolConfig {
+  // Local dev shortcut: an explicit DATABASE_URL wins (see .env.example).
+  const explicit = process.env.DATABASE_URL;
+  if (explicit) {
+    return { connectionString: explicit };
+  }
+
+  const host = process.env.POSTGRES_HOST;
+  const password = process.env.POSTGRES_PASSWORD;
+  if (!host || !password) {
+    throw new Error(
+      "Database config missing: set DATABASE_URL (local dev) or the POSTGRES_* vars (POSTGRES_HOST/PORT/USER/PASSWORD) injected by the linked Temps Postgres service.",
+    );
+  }
+
+  return {
+    host,
+    port: parseInt(process.env.POSTGRES_PORT ?? "5432", 10),
+    user: process.env.POSTGRES_USER ?? "postgres",
+    password,
+    // Forced — ignore POSTGRES_DB/POSTGRES_NAME which point at the wrong DB.
+    database: process.env.TELEMETRY_DB_NAME ?? TELEMETRY_DB,
+  };
+}
+
 export function getPool(): InstanceType<typeof Pool> {
   if (!_pool) {
-    // Prefer POSTGRES_URL — Temps injects it automatically when a Postgres
-    // service is linked to the project, so the connection stays in sync with
-    // the managed service and there's no hand-set secret to drift. Fall back to
-    // DATABASE_URL for local dev (see .env.example).
-    const url = process.env.POSTGRES_URL ?? process.env.DATABASE_URL;
-    if (!url) {
-      throw new Error("POSTGRES_URL (or DATABASE_URL) environment variable is required");
-    }
-    _pool = new Pool({ connectionString: url });
-
+    _pool = new Pool(buildPoolConfig());
     _pool.on("error", (err) => {
       console.error("[db] idle client error", err.message);
     });

--- a/telemetry-api/src/db/pool.ts
+++ b/telemetry-api/src/db/pool.ts
@@ -1,0 +1,31 @@
+import pg from "pg";
+
+const { Pool } = pg;
+
+let _pool: InstanceType<typeof Pool> | null = null;
+
+export function getPool(): InstanceType<typeof Pool> {
+  if (!_pool) {
+    // Prefer POSTGRES_URL — Temps injects it automatically when a Postgres
+    // service is linked to the project, so the connection stays in sync with
+    // the managed service and there's no hand-set secret to drift. Fall back to
+    // DATABASE_URL for local dev (see .env.example).
+    const url = process.env.POSTGRES_URL ?? process.env.DATABASE_URL;
+    if (!url) {
+      throw new Error("POSTGRES_URL (or DATABASE_URL) environment variable is required");
+    }
+    _pool = new Pool({ connectionString: url });
+
+    _pool.on("error", (err) => {
+      console.error("[db] idle client error", err.message);
+    });
+  }
+  return _pool;
+}
+
+export async function closePool(): Promise<void> {
+  if (_pool) {
+    await _pool.end();
+    _pool = null;
+  }
+}

--- a/telemetry-api/src/geo.ts
+++ b/telemetry-api/src/geo.ts
@@ -1,0 +1,75 @@
+// Anonymous country geolocation.
+//
+// Derives the 2-letter ISO country code from the request's client IP using a
+// bundled GeoLite2-Country database. The IP is used transiently for the lookup
+// and is NEVER stored or logged — only the resulting country code is persisted,
+// preserving the anonymous-by-design contract.
+//
+// The DB is loaded once at startup. If it's missing (e.g. not provisioned in a
+// dev environment), geolocation degrades gracefully to `null` country.
+
+import { open, type Reader, type CountryResponse } from "maxmind";
+
+// Path to the GeoLite2-Country.mmdb inside the image (provisioned at build).
+const DB_PATH = process.env.GEOLITE2_COUNTRY_DB ?? "/app/data/GeoLite2-Country.mmdb";
+
+let _reader: Reader<CountryResponse> | null = null;
+let _loadAttempted = false;
+
+export async function initGeo(): Promise<void> {
+  if (_loadAttempted) return;
+  _loadAttempted = true;
+  try {
+    _reader = await open<CountryResponse>(DB_PATH);
+    console.log(`[geo] loaded GeoLite2-Country from ${DB_PATH}`);
+  } catch (err) {
+    _reader = null;
+    console.warn(
+      `[geo] GeoLite2-Country DB not available at ${DB_PATH} (${
+        err instanceof Error ? err.message : String(err)
+      }); country geolocation disabled`,
+    );
+  }
+}
+
+// Extract the client IP from the proxy headers. The Temps proxy sets
+// X-Forwarded-For with the real client IP; take the FIRST entry (the original
+// client) and strip any port. Returns null if nothing usable.
+export function clientIpFromHeaders(req: Request): string | null {
+  const xff = req.headers.get("x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0]?.trim();
+    if (first) return stripPort(first);
+  }
+  const real = req.headers.get("x-real-ip");
+  if (real) return stripPort(real.trim());
+  return null;
+}
+
+// IPv4 "1.2.3.4:5678" -> "1.2.3.4"; IPv6 is left as-is (bracketed forms rare in XFF).
+function stripPort(ip: string): string {
+  // Only strip a trailing :port for IPv4 (single colon). IPv6 has many colons.
+  if (ip.includes(".") && ip.includes(":")) {
+    return ip.split(":")[0] ?? ip;
+  }
+  return ip;
+}
+
+// Look up the 2-letter country code for an IP. Returns null when the DB is
+// unavailable, the IP is unparseable/private, or no country is found. The IP is
+// never retained beyond this call.
+export function countryForIp(ip: string | null): string | null {
+  if (!ip || !_reader) return null;
+  try {
+    const result = _reader.get(ip);
+    return result?.country?.iso_code ?? null;
+  } catch {
+    // Invalid IP (e.g. private/loopback or malformed) — no country.
+    return null;
+  }
+}
+
+// Convenience: derive country directly from a request, never exposing the IP.
+export function countryForRequest(req: Request): string | null {
+  return countryForIp(clientIpFromHeaders(req));
+}

--- a/telemetry-api/src/index.ts
+++ b/telemetry-api/src/index.ts
@@ -1,0 +1,63 @@
+import { getPool } from "./db/pool.js";
+import { createEventsRoutes } from "./routes/events.js";
+import { createStatsRoutes } from "./routes/stats.js";
+
+const PORT = parseInt(process.env.PORT ?? "4200", 10);
+
+async function main() {
+  // Eagerly connect to confirm DB is reachable at startup
+  const pool = getPool();
+  const client = await pool.connect();
+  await client.query("SELECT 1");
+  client.release();
+  console.log("[server] database connection ok");
+
+  const events = createEventsRoutes(pool);
+  const stats = createStatsRoutes(pool);
+
+  const server = Bun.serve({
+    port: PORT,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const method = req.method.toUpperCase();
+      const path = url.pathname;
+
+      // Health check — no auth required
+      if (method === "GET" && path === "/health") {
+        return Response.json({ ok: true });
+      }
+
+      // Ingest endpoints
+      if (method === "POST" && path === "/v1/events") {
+        return events.postEvent(req);
+      }
+      if (method === "POST" && path === "/v1/events/batch") {
+        return events.postBatch(req);
+      }
+
+      // Stats endpoints (add auth in production via INGEST_API_KEY or network policy)
+      if (method === "GET" && path === "/v1/stats/overview") {
+        return stats.getOverview(req);
+      }
+      if (method === "GET" && path === "/v1/stats/active-instances") {
+        return stats.getActiveInstances(req);
+      }
+      if (method === "GET" && path === "/v1/stats/funnel") {
+        return stats.getFunnel(req);
+      }
+
+      return Response.json({ error: "not found" }, { status: 404 });
+    },
+    error(err) {
+      console.error("[server] unhandled error:", err);
+      return Response.json({ error: "internal server error" }, { status: 500 });
+    },
+  });
+
+  console.log(`[server] temps telemetry API listening on http://localhost:${server.port}`);
+}
+
+main().catch((err) => {
+  console.error("[server] startup failed:", err);
+  process.exit(1);
+});

--- a/telemetry-api/src/index.ts
+++ b/telemetry-api/src/index.ts
@@ -1,6 +1,7 @@
 import { getPool } from "./db/pool.js";
 import { createEventsRoutes } from "./routes/events.js";
 import { createStatsRoutes } from "./routes/stats.js";
+import { initGeo } from "./geo.js";
 
 const PORT = parseInt(process.env.PORT ?? "4200", 10);
 
@@ -11,6 +12,9 @@ async function main() {
   await client.query("SELECT 1");
   client.release();
   console.log("[server] database connection ok");
+
+  // Load the GeoLite2-Country DB once (degrades gracefully if absent).
+  await initGeo();
 
   const events = createEventsRoutes(pool);
   const stats = createStatsRoutes(pool);
@@ -44,6 +48,9 @@ async function main() {
       }
       if (method === "GET" && path === "/v1/stats/funnel") {
         return stats.getFunnel(req);
+      }
+      if (method === "GET" && path === "/v1/stats/countries") {
+        return stats.getCountries(req);
       }
 
       return Response.json({ error: "not found" }, { status: 404 });

--- a/telemetry-api/src/routes/events.test.ts
+++ b/telemetry-api/src/routes/events.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, mock } from "bun:test";
+import { createEventsRoutes, KNOWN_EVENT_TYPES } from "./events.js";
+import type { Pool } from "pg";
+
+describe("KNOWN_EVENT_TYPES", () => {
+  it("stays in lockstep with the Rust binary (34 events)", () => {
+    // Mirror of temps-core TelemetryEventKind::all().len(). If this changes,
+    // update both this set and the Rust enum together.
+    expect(KNOWN_EVENT_TYPES.size).toBe(34);
+  });
+
+  it("uses only snake_case names", () => {
+    for (const name of KNOWN_EVENT_TYPES) {
+      expect(name).toMatch(/^[a-z][a-z0-9_]*$/);
+    }
+  });
+});
+
+function makePool(queryFn: () => unknown = () => ({ rows: [] })) {
+  return {
+    query: mock(queryFn),
+  } as unknown as Pool;
+}
+
+function makeReq(body: unknown, method = "POST"): Request {
+  return new Request("http://localhost/v1/events", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /v1/events", () => {
+  it("accepts a valid event", async () => {
+    const pool = makePool();
+    const { postEvent } = createEventsRoutes(pool);
+
+    const res = await postEvent(
+      makeReq({
+        anonymous_id: "inst_abc123",
+        event_type: "deploy_succeeded",
+        temps_version: "0.1.0",
+        properties: { service_name: "my-app", duration_ms: 4200 },
+      })
+    );
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect((pool.query as ReturnType<typeof mock>).mock.calls.length).toBe(2); // insert + upsert
+  });
+
+  it("rejects invalid JSON", async () => {
+    const pool = makePool();
+    const { postEvent } = createEventsRoutes(pool);
+
+    const req = new Request("http://localhost/v1/events", {
+      method: "POST",
+      body: "not json",
+    });
+    const res = await postEvent(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects unknown event_type", async () => {
+    const pool = makePool();
+    const { postEvent } = createEventsRoutes(pool);
+
+    const res = await postEvent(
+      makeReq({ anonymous_id: "inst_abc123", event_type: "random_garbage" })
+    );
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toMatch(/unknown event_type/);
+  });
+
+  it("rejects missing anonymous_id", async () => {
+    const pool = makePool();
+    const { postEvent } = createEventsRoutes(pool);
+
+    const res = await postEvent(
+      makeReq({ event_type: "deploy_attempted" })
+    );
+    expect(res.status).toBe(422);
+  });
+
+  it("strips PII keys from properties", async () => {
+    const pool = makePool();
+    const { postEvent } = createEventsRoutes(pool);
+
+    await postEvent(
+      makeReq({
+        anonymous_id: "inst_abc123",
+        event_type: "deploy_attempted",
+        properties: { email: "user@example.com", service_name: "app" },
+      })
+    );
+
+    const insertCall = (pool.query as ReturnType<typeof mock>).mock.calls[0];
+    const propertiesArg = insertCall[1][2] as string;
+    const props = JSON.parse(propertiesArg);
+    expect(props.email).toBeUndefined();
+    expect(props.service_name).toBe("app");
+  });
+});
+
+describe("POST /v1/events/batch", () => {
+  it("accepts a valid batch", async () => {
+    const pool = makePool();
+    const { postBatch } = createEventsRoutes(pool);
+
+    const req = new Request("http://localhost/v1/events/batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        events: [
+          { anonymous_id: "inst_1", event_type: "deploy_attempted" },
+          { anonymous_id: "inst_1", event_type: "deploy_succeeded" },
+        ],
+      }),
+    });
+
+    const res = await postBatch(req);
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.accepted).toBe(2);
+  });
+
+  it("rejects batch over 100 events", async () => {
+    const pool = makePool();
+    const { postBatch } = createEventsRoutes(pool);
+
+    const events = Array.from({ length: 101 }, () => ({
+      anonymous_id: "inst_1",
+      event_type: "deploy_attempted",
+    }));
+    const req = new Request("http://localhost/v1/events/batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ events }),
+    });
+
+    const res = await postBatch(req);
+    expect(res.status).toBe(422);
+  });
+
+  it("rejects batch with any invalid event", async () => {
+    const pool = makePool();
+    const { postBatch } = createEventsRoutes(pool);
+
+    const req = new Request("http://localhost/v1/events/batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        events: [
+          { anonymous_id: "inst_1", event_type: "deploy_attempted" },
+          { anonymous_id: "inst_1", event_type: "BOGUS_EVENT" },
+        ],
+      }),
+    });
+
+    const res = await postBatch(req);
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.details[0].index).toBe(1);
+  });
+});

--- a/telemetry-api/src/routes/events.ts
+++ b/telemetry-api/src/routes/events.ts
@@ -1,4 +1,5 @@
 import type { Pool } from "pg";
+import { countryForRequest } from "../geo.js";
 
 // Known event types — kept in lockstep with the Rust binary's
 // `TelemetryEventKind::as_str()` (temps-core/src/telemetry.rs). The validator
@@ -138,29 +139,40 @@ function parseEvent(raw: unknown): IngestBody | { error: string } {
   };
 }
 
-async function insertEvent(pool: Pool, event: IngestBody): Promise<void> {
+// `country` is the 2-letter ISO code derived from the request IP at ingest time
+// (see geo.ts). The IP itself is never passed here or stored — only the country.
+async function insertEvent(
+  pool: Pool,
+  event: IngestBody,
+  country: string | null
+): Promise<void> {
   await pool.query(
     `INSERT INTO telemetry_events
-       (anonymous_id, event_type, properties, temps_version, occurred_at)
-     VALUES ($1, $2, $3, $4, $5)`,
+       (anonymous_id, event_type, properties, temps_version, occurred_at, country)
+     VALUES ($1, $2, $3, $4, $5, $6)`,
     [
       event.anonymous_id,
       event.event_type,
       JSON.stringify(event.properties ?? {}),
       event.temps_version ?? null,
       event.occurred_at ?? new Date().toISOString(),
+      country,
     ]
   );
 
-  // Upsert the instance-day record for cheap DAI (daily active instances) queries
+  // Upsert the instance-day record for cheap DAI (daily active instances)
+  // queries. Backfill country if it was previously null (an instance's country
+  // shouldn't change, but the first event of the day may pre-date the lookup).
   await pool.query(
-    `INSERT INTO telemetry_instance_days (anonymous_id, day, temps_version)
-     VALUES ($1, $2::date, $3)
-     ON CONFLICT (anonymous_id, day) DO NOTHING`,
+    `INSERT INTO telemetry_instance_days (anonymous_id, day, temps_version, country)
+     VALUES ($1, $2::date, $3, $4)
+     ON CONFLICT (anonymous_id, day) DO UPDATE
+       SET country = COALESCE(telemetry_instance_days.country, EXCLUDED.country)`,
     [
       event.anonymous_id,
       (event.occurred_at ?? new Date().toISOString()).slice(0, 10),
       event.temps_version ?? null,
+      country,
     ]
   );
 }
@@ -181,8 +193,11 @@ export function createEventsRoutes(pool: Pool) {
         return Response.json({ error: parsed.error }, { status: 422 });
       }
 
+      // Derive country from the request IP (never stored) for this request.
+      const country = countryForRequest(req);
+
       try {
-        await insertEvent(pool, parsed);
+        await insertEvent(pool, parsed, country);
       } catch (err) {
         console.error("[events] db insert failed:", err);
         return Response.json({ error: "internal server error" }, { status: 500 });
@@ -226,9 +241,13 @@ export function createEventsRoutes(pool: Pool) {
         return Response.json({ error: "validation failed", details: errors }, { status: 422 });
       }
 
+      // One country for the whole batch — all events in a request share the
+      // same client IP. Derived transiently; the IP is never stored.
+      const country = countryForRequest(req);
+
       try {
         // Insert all events concurrently (pool handles connection reuse)
-        await Promise.all(parsed.map((e) => insertEvent(pool, e)));
+        await Promise.all(parsed.map((e) => insertEvent(pool, e, country)));
       } catch (err) {
         console.error("[events] batch insert failed:", err);
         return Response.json({ error: "internal server error" }, { status: 500 });

--- a/telemetry-api/src/routes/events.ts
+++ b/telemetry-api/src/routes/events.ts
@@ -1,0 +1,240 @@
+import type { Pool } from "pg";
+
+// Known event types — kept in lockstep with the Rust binary's
+// `TelemetryEventKind::as_str()` (temps-core/src/telemetry.rs). The validator
+// rejects anything not in this set so a typo or rogue client can't pollute the
+// table. When adding an event, add it in BOTH places.
+export const KNOWN_EVENT_TYPES = new Set([
+  // Instance lifecycle
+  "instance_started",
+  "instance_setup_completed",
+  "upgrade_completed",
+  "worker_node_joined",
+
+  // Deployment funnel
+  "deploy_attempted",
+  "deploy_succeeded",
+  "deploy_failed",
+  "rollback_triggered",
+  "first_deploy_succeeded",
+
+  // Project & environment
+  "project_created",
+  "environment_created",
+  "scale_to_zero_configured",
+  "auto_deploy_enabled",
+  "attack_mode_enabled",
+
+  // Git & source
+  "git_provider_connected",
+
+  // Domains & networking
+  "custom_domain_added",
+  "ssl_certificate_issued",
+
+  // Managed services
+  "service_created",
+  "service_cluster_created",
+  "pg_major_upgrade_completed",
+  "pitr_restore_triggered",
+  "backup_configured",
+
+  // Observability suite activation
+  "analytics_first_event_received",
+  "session_replay_first_session",
+  "error_tracking_first_error",
+  "ai_gateway_first_request",
+
+  // AI features
+  "ai_sre_conversation_started",
+  "autofixer_fix_accepted",
+  "autofixer_fix_rejected",
+
+  // Auth & security
+  "oidc_provider_configured",
+  "api_key_created",
+  "vulnerability_scan_triggered",
+
+  // Email
+  "email_provider_configured",
+
+  // Status page
+  "status_page_published",
+]);
+
+interface IngestBody {
+  anonymous_id: string;
+  event_type: string;
+  properties?: Record<string, unknown>;
+  temps_version?: string;
+  occurred_at?: string;
+}
+
+interface BatchIngestBody {
+  events: IngestBody[];
+}
+
+function isValidAnonymousId(id: unknown): id is string {
+  return (
+    typeof id === "string" &&
+    id.length >= 4 &&
+    id.length <= 128 &&
+    // UUID-ish or slug — no whitespace
+    !/\s/.test(id)
+  );
+}
+
+function isValidEventType(type: unknown): type is string {
+  return typeof type === "string" && KNOWN_EVENT_TYPES.has(type);
+}
+
+function isValidProperties(p: unknown): p is Record<string, unknown> {
+  return typeof p === "object" && p !== null && !Array.isArray(p);
+}
+
+function sanitizeProperties(raw: Record<string, unknown>): Record<string, unknown> {
+  // Drop keys that look like PII to be safe
+  const PII_KEYS = new Set(["email", "name", "ip", "user_agent", "password", "token"]);
+  return Object.fromEntries(
+    Object.entries(raw).filter(([k]) => !PII_KEYS.has(k.toLowerCase()))
+  );
+}
+
+function parseEvent(raw: unknown): IngestBody | { error: string } {
+  if (typeof raw !== "object" || raw === null) {
+    return { error: "event must be an object" };
+  }
+  const obj = raw as Record<string, unknown>;
+
+  if (!isValidAnonymousId(obj.anonymous_id)) {
+    return { error: "anonymous_id must be a non-empty string (8-128 chars, no whitespace)" };
+  }
+  if (!isValidEventType(obj.event_type)) {
+    return {
+      error: `unknown event_type '${obj.event_type}'. Accepted: ${[...KNOWN_EVENT_TYPES].join(", ")}`,
+    };
+  }
+
+  const properties =
+    obj.properties !== undefined && isValidProperties(obj.properties)
+      ? sanitizeProperties(obj.properties)
+      : {};
+
+  let occurred_at: string | undefined;
+  if (obj.occurred_at !== undefined) {
+    const d = new Date(obj.occurred_at as string);
+    if (isNaN(d.getTime())) {
+      return { error: "occurred_at must be a valid ISO 8601 timestamp" };
+    }
+    occurred_at = d.toISOString();
+  }
+
+  return {
+    anonymous_id: obj.anonymous_id,
+    event_type: obj.event_type,
+    properties,
+    temps_version: typeof obj.temps_version === "string" ? obj.temps_version : undefined,
+    occurred_at,
+  };
+}
+
+async function insertEvent(pool: Pool, event: IngestBody): Promise<void> {
+  await pool.query(
+    `INSERT INTO telemetry_events
+       (anonymous_id, event_type, properties, temps_version, occurred_at)
+     VALUES ($1, $2, $3, $4, $5)`,
+    [
+      event.anonymous_id,
+      event.event_type,
+      JSON.stringify(event.properties ?? {}),
+      event.temps_version ?? null,
+      event.occurred_at ?? new Date().toISOString(),
+    ]
+  );
+
+  // Upsert the instance-day record for cheap DAI (daily active instances) queries
+  await pool.query(
+    `INSERT INTO telemetry_instance_days (anonymous_id, day, temps_version)
+     VALUES ($1, $2::date, $3)
+     ON CONFLICT (anonymous_id, day) DO NOTHING`,
+    [
+      event.anonymous_id,
+      (event.occurred_at ?? new Date().toISOString()).slice(0, 10),
+      event.temps_version ?? null,
+    ]
+  );
+}
+
+export function createEventsRoutes(pool: Pool) {
+  return {
+    // POST /v1/events — single event
+    async postEvent(req: Request): Promise<Response> {
+      let body: unknown;
+      try {
+        body = await req.json();
+      } catch {
+        return Response.json({ error: "invalid JSON body" }, { status: 400 });
+      }
+
+      const parsed = parseEvent(body);
+      if ("error" in parsed) {
+        return Response.json({ error: parsed.error }, { status: 422 });
+      }
+
+      try {
+        await insertEvent(pool, parsed);
+      } catch (err) {
+        console.error("[events] db insert failed:", err);
+        return Response.json({ error: "internal server error" }, { status: 500 });
+      }
+
+      return Response.json({ ok: true }, { status: 201 });
+    },
+
+    // POST /v1/events/batch — up to 100 events in one request
+    async postBatch(req: Request): Promise<Response> {
+      let body: unknown;
+      try {
+        body = await req.json();
+      } catch {
+        return Response.json({ error: "invalid JSON body" }, { status: 400 });
+      }
+
+      const b = body as BatchIngestBody;
+      if (!Array.isArray(b?.events)) {
+        return Response.json({ error: "body must have an 'events' array" }, { status: 422 });
+      }
+      if (b.events.length === 0) {
+        return Response.json({ error: "events array must not be empty" }, { status: 422 });
+      }
+      if (b.events.length > 100) {
+        return Response.json({ error: "max 100 events per batch" }, { status: 422 });
+      }
+
+      const parsed: IngestBody[] = [];
+      const errors: { index: number; error: string }[] = [];
+      for (let i = 0; i < b.events.length; i++) {
+        const result = parseEvent(b.events[i]);
+        if ("error" in result) {
+          errors.push({ index: i, error: result.error });
+        } else {
+          parsed.push(result);
+        }
+      }
+
+      if (errors.length > 0) {
+        return Response.json({ error: "validation failed", details: errors }, { status: 422 });
+      }
+
+      try {
+        // Insert all events concurrently (pool handles connection reuse)
+        await Promise.all(parsed.map((e) => insertEvent(pool, e)));
+      } catch (err) {
+        console.error("[events] batch insert failed:", err);
+        return Response.json({ error: "internal server error" }, { status: 500 });
+      }
+
+      return Response.json({ ok: true, accepted: parsed.length }, { status: 201 });
+    },
+  };
+}

--- a/telemetry-api/src/routes/stats.ts
+++ b/telemetry-api/src/routes/stats.ts
@@ -1,0 +1,111 @@
+import type { Pool } from "pg";
+
+export function createStatsRoutes(pool: Pool) {
+  return {
+    // GET /v1/stats/overview — aggregate product health numbers
+    async getOverview(_req: Request): Promise<Response> {
+      const { rows } = await pool.query<{
+        event_type: string;
+        count: string;
+      }>(`
+        SELECT event_type, COUNT(*)::text AS count
+        FROM telemetry_events
+        WHERE occurred_at >= NOW() - INTERVAL '30 days'
+        GROUP BY event_type
+        ORDER BY count DESC
+      `);
+
+      const counts: Record<string, number> = {};
+      for (const row of rows) {
+        counts[row.event_type] = parseInt(row.count, 10);
+      }
+
+      // Derived product health metrics
+      const attempted = counts["deploy_attempted"] ?? 0;
+      const succeeded = counts["deploy_succeeded"] ?? 0;
+      const failed = counts["deploy_failed"] ?? 0;
+      const deploySuccessRate =
+        attempted > 0 ? Math.round((succeeded / attempted) * 100) : null;
+
+      return Response.json({
+        window: "last_30_days",
+        event_counts: counts,
+        derived: {
+          deploy_success_rate_pct: deploySuccessRate,
+          deploy_attempted: attempted,
+          deploy_succeeded: succeeded,
+          deploy_failed: failed,
+        },
+      });
+    },
+
+    // GET /v1/stats/active-instances — daily/weekly/monthly active instances
+    async getActiveInstances(_req: Request): Promise<Response> {
+      const [dai, wai, mai] = await Promise.all([
+        pool.query<{ count: string }>(
+          `SELECT COUNT(DISTINCT anonymous_id)::text AS count
+           FROM telemetry_instance_days
+           WHERE day = CURRENT_DATE`
+        ),
+        pool.query<{ count: string }>(
+          `SELECT COUNT(DISTINCT anonymous_id)::text AS count
+           FROM telemetry_instance_days
+           WHERE day >= CURRENT_DATE - INTERVAL '7 days'`
+        ),
+        pool.query<{ count: string }>(
+          `SELECT COUNT(DISTINCT anonymous_id)::text AS count
+           FROM telemetry_instance_days
+           WHERE day >= CURRENT_DATE - INTERVAL '30 days'`
+        ),
+      ]);
+
+      return Response.json({
+        daily_active_instances: parseInt(dai.rows[0]?.count ?? "0", 10),
+        weekly_active_instances: parseInt(wai.rows[0]?.count ?? "0", 10),
+        monthly_active_instances: parseInt(mai.rows[0]?.count ?? "0", 10),
+      });
+    },
+
+    // GET /v1/stats/funnel — deployment success funnel by anonymous_id cohort
+    async getFunnel(_req: Request): Promise<Response> {
+      const { rows } = await pool.query<{
+        anonymous_id: string;
+        attempted: string;
+        succeeded: string;
+        failed: string;
+      }>(`
+        SELECT
+          anonymous_id,
+          COUNT(*) FILTER (WHERE event_type = 'deploy_attempted')::text AS attempted,
+          COUNT(*) FILTER (WHERE event_type = 'deploy_succeeded')::text AS succeeded,
+          COUNT(*) FILTER (WHERE event_type = 'deploy_failed')::text    AS failed
+        FROM telemetry_events
+        WHERE event_type IN ('deploy_attempted','deploy_succeeded','deploy_failed')
+          AND occurred_at >= NOW() - INTERVAL '30 days'
+        GROUP BY anonymous_id
+        ORDER BY attempted DESC
+        LIMIT 1000
+      `);
+
+      const cohorts = rows.map((r) => ({
+        anonymous_id: r.anonymous_id,
+        attempted: parseInt(r.attempted, 10),
+        succeeded: parseInt(r.succeeded, 10),
+        failed: parseInt(r.failed, 10),
+      }));
+
+      const neverSucceeded = cohorts.filter(
+        (c) => c.attempted > 0 && c.succeeded === 0
+      ).length;
+      const atLeastOneSuccess = cohorts.filter((c) => c.succeeded > 0).length;
+
+      return Response.json({
+        window: "last_30_days",
+        total_instances_with_deploys: cohorts.length,
+        instances_with_at_least_one_success: atLeastOneSuccess,
+        instances_that_never_succeeded: neverSucceeded,
+        cohorts,
+      });
+    },
+  };
+}

--- a/telemetry-api/src/routes/stats.ts
+++ b/telemetry-api/src/routes/stats.ts
@@ -107,5 +107,26 @@ export function createStatsRoutes(pool: Pool) {
         cohorts,
       });
     },
+
+    // GET /v1/stats/countries — distinct active instances per country (30d).
+    // Uses the denormalized instance-day table; "unknown" buckets instances
+    // with no resolvable country (private IP, missing geo DB, etc.).
+    async getCountries(_req: Request): Promise<Response> {
+      const { rows } = await pool.query<{ country: string | null; instances: string }>(`
+        SELECT country, COUNT(DISTINCT anonymous_id)::text AS instances
+        FROM telemetry_instance_days
+        WHERE day >= CURRENT_DATE - INTERVAL '30 days'
+        GROUP BY country
+        ORDER BY instances DESC
+      `);
+
+      return Response.json({
+        window: "last_30_days",
+        countries: rows.map((r) => ({
+          country: r.country ?? "unknown",
+          instances: parseInt(r.instances, 10),
+        })),
+      });
+    },
   };
 }

--- a/telemetry-api/tsconfig.json
+++ b/telemetry-api/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -12166,6 +12166,12 @@ export type ServiceResourceLimits = {
      * CPU quota in nano-cpus. 1_000_000_000 = 1 full CPU core. None = unlimited.
      */
     nano_cpus?: number | null;
+    /**
+     * Shared memory (/dev/shm) size in MiB. None = Docker default (64 MiB).
+     * TODO(sdk-regen): added by hand ahead of `bun run openapi-ts` regen; the
+     * backend `ServiceResourceLimits` already carries this field.
+     */
+    shm_size_mb?: number | null;
 };
 
 /**

--- a/web/src/components/storage/EditResourceLimitsDialog.tsx
+++ b/web/src/components/storage/EditResourceLimitsDialog.tsx
@@ -54,6 +54,13 @@ const DEFAULT_CPU_CORES = 1.0
 const DEFAULT_MEMORY_MB = 512
 
 /**
+ * Docker's default /dev/shm is 64 MiB. We seed the input with that so the
+ * displayed value matches what the container already has before the operator
+ * raises it (Postgres parallel queries commonly need 256+ MiB).
+ */
+const DEFAULT_SHM_MB = 64
+
+/**
  * Convert nano_cpus <-> fractional CPU cores. We expose cores in the UI
  * because "0.5 CPU" reads better than "500000000 nano_cpus" — but the
  * wire format requires nano_cpus (Docker's native units).
@@ -85,6 +92,10 @@ export function EditResourceLimitsDialog({
   const [swapMb, setSwapMb] = useState<string>(String(DEFAULT_MEMORY_MB))
   const [cpuEnabled, setCpuEnabled] = useState(false)
   const [cpuCores, setCpuCores] = useState<string>(String(DEFAULT_CPU_CORES))
+  // Shared memory (/dev/shm). Docker defaults to 64 MiB; unlike memory/CPU
+  // this is create-time-only, so changing it recreates the container.
+  const [shmEnabled, setShmEnabled] = useState(false)
+  const [shmMb, setShmMb] = useState<string>(String(DEFAULT_SHM_MB))
 
   // Re-seed the form whenever the dialog opens (or current limits arrive).
   // Without this the user sees stale state from the previous service when
@@ -115,6 +126,10 @@ export function EditResourceLimitsDialog({
         ? String(nanoCpusToCores(nano))
         : String(DEFAULT_CPU_CORES),
     )
+
+    const shm = currentLimits?.shm_size_mb ?? null
+    setShmEnabled(shm != null)
+    setShmMb(shm != null ? String(shm) : String(DEFAULT_SHM_MB))
   }, [open, currentLimits])
 
   // Reset input to a sane default when toggling a limit back on, so a
@@ -130,6 +145,12 @@ export function EditResourceLimitsDialog({
       setCpuCores(String(DEFAULT_CPU_CORES))
     }
     setCpuEnabled(v)
+  }
+  const handleShmToggle = (v: boolean) => {
+    if (v && (Number(shmMb) <= 0 || !Number.isFinite(Number(shmMb)))) {
+      setShmMb(String(DEFAULT_SHM_MB))
+    }
+    setShmEnabled(v)
   }
 
   // -- Validation ---------------------------------------------------------
@@ -152,8 +173,23 @@ export function EditResourceLimitsDialog({
         return 'CPU cores must be greater than zero.'
       }
     }
+    if (shmEnabled) {
+      const s = Number(shmMb)
+      if (!Number.isFinite(s) || s <= 0) {
+        return 'Shared memory must be a positive number of MiB.'
+      }
+    }
     return null
-  }, [memoryEnabled, memoryMb, swapEnabled, swapMb, cpuEnabled, cpuCores])
+  }, [
+    memoryEnabled,
+    memoryMb,
+    swapEnabled,
+    swapMb,
+    cpuEnabled,
+    cpuCores,
+    shmEnabled,
+    shmMb,
+  ])
 
   // -- Mutation -----------------------------------------------------------
   const queryClient = useQueryClient()
@@ -184,7 +220,7 @@ export function EditResourceLimitsDialog({
       } else if (recreate.length > 0) {
         toast.warning('Limits saved — restart required', {
           description:
-            'Removing a memory cap on a running container needs a recreate. Restart the service to apply.',
+            'Some changes (shared memory, or removing a memory cap) can\'t be applied live. Restart the service to recreate the container and apply them.',
         })
       } else if (members.length === 0) {
         toast.success('Resource limits saved', {
@@ -238,6 +274,9 @@ export function EditResourceLimitsDialog({
         memoryRounded != null ? memoryRounded + extraSwap : null,
       nano_cpus: cpuEnabled ? coresToNanoCpus(Number(cpuCores)) : null,
       cpu_shares: null,
+      // Create-time-only: the backend recreates the container to apply a
+      // changed /dev/shm size (Docker's live update API can't touch it).
+      shm_size_mb: shmEnabled ? Math.round(Number(shmMb)) : null,
     }
     mutation.mutate({ path: { id: serviceId }, body })
   }
@@ -254,10 +293,13 @@ export function EditResourceLimitsDialog({
           (swapEnabled ? Math.round(Number(swapMb)) || 0 : 0)
         : null
     const newNano = cpuEnabled ? coresToNanoCpus(Number(cpuCores)) : null
+    const currentShm = currentLimits?.shm_size_mb ?? null
+    const newShm = shmEnabled ? Math.round(Number(shmMb)) || null : null
     return (
       newMem !== currentMem ||
       newSwapTotal !== currentSwap ||
-      newNano !== currentNano
+      newNano !== currentNano ||
+      newShm !== currentShm
     )
   }, [
     currentLimits,
@@ -267,6 +309,8 @@ export function EditResourceLimitsDialog({
     swapMb,
     cpuEnabled,
     cpuCores,
+    shmEnabled,
+    shmMb,
   ])
 
   // Pretty-print the currently applied value as a small chip on each row.
@@ -278,6 +322,12 @@ export function EditResourceLimitsDialog({
     currentLimits?.nano_cpus != null
       ? `${formatCores(nanoCpusToCores(currentLimits.nano_cpus))} cores`
       : 'Unlimited'
+  // /dev/shm has a real Docker default (64 MiB) rather than "unlimited", so
+  // show that when the operator hasn't set an explicit size.
+  const currentShmLabel =
+    currentLimits?.shm_size_mb != null
+      ? `${currentLimits.shm_size_mb} MiB`
+      : `${DEFAULT_SHM_MB} MiB (default)`
   const currentSwapExtra =
     currentLimits?.memory_mb != null &&
     currentLimits?.memory_swap_mb != null &&
@@ -303,7 +353,8 @@ export function EditResourceLimitsDialog({
             </span>
           </DialogTitle>
           <DialogDescription className="text-xs">
-            Live changes — no restart needed.
+            Memory and CPU apply live. Changing shared memory recreates the
+            container.
           </DialogDescription>
         </DialogHeader>
 
@@ -395,6 +446,30 @@ export function EditResourceLimitsDialog({
             />
           </LimitSection>
 
+          {/* Shared memory (/dev/shm) -------------------------------- */}
+          <LimitSection
+            label="Shared memory"
+            currentLabel={currentShmLabel}
+            enabled={shmEnabled}
+            onToggle={handleShmToggle}
+            toggleId="resource-shm-toggle"
+            description={
+              'Shared memory (/dev/shm). Postgres uses it for parallel queries; ' +
+              'the 64 MB default can cause "No space left on device" errors. ' +
+              'Changing this recreates the container (brief downtime).'
+            }
+          >
+            <PresetInput
+              id="resource-shm-mb"
+              value={shmMb}
+              onChange={setShmMb}
+              presets={SHM_PRESETS}
+              unit="MiB"
+              min={64}
+              step={64}
+            />
+          </LimitSection>
+
           {validation ? (
             <Alert variant="destructive">
               <AlertTriangle className="h-4 w-4" />
@@ -450,6 +525,7 @@ export function EditResourceLimitsDialog({
 const MEMORY_PRESETS = [256, 512, 1024, 2048, 4096]
 const SWAP_PRESETS = [128, 256, 512, 1024]
 const CPU_PRESETS = [0.25, 0.5, 1, 2, 4]
+const SHM_PRESETS = [64, 128, 256, 512, 1024]
 
 function formatCores(n: number): string {
   return n % 1 === 0 ? n.toString() : n.toFixed(2).replace(/\.?0+$/, '')

--- a/web/src/components/storage/ServiceResourcesPanel.tsx
+++ b/web/src/components/storage/ServiceResourcesPanel.tsx
@@ -401,9 +401,10 @@ function LimitsInline({
   const memory = limits?.memory_mb ?? null
   const swap = limits?.memory_swap_mb ?? null
   const nano = limits?.nano_cpus ?? null
+  const shm = limits?.shm_size_mb ?? null
   const cpuCores = nano != null ? nano / 1_000_000_000 : null
 
-  if (memory == null && nano == null) {
+  if (memory == null && nano == null && shm == null) {
     return (
       <span className="text-[10px] uppercase tracking-wide text-muted-foreground/60">
         Unlimited
@@ -424,6 +425,11 @@ function LimitsInline({
         <span>
           <span className="text-foreground/80">{memory}</span> MiB
           {swap != null && swap > memory ? ` (+${swap - memory} swap)` : ''}
+        </span>
+      )}
+      {shm != null && (
+        <span>
+          <span className="text-foreground/80">{shm}</span> MiB shm
         </span>
       )}
     </span>


### PR DESCRIPTION
This PR lands two intentional, independent pieces of work that were both in flight.

---

## 1. Anonymous product telemetry (primary)

Lets maintainers see whether Temps is working for self-hosters — **instances that tried to deploy vs deployed**, feature adoption, and where instances stall.

- **`temps-core::telemetry`** — `TelemetryReporter` trait + `TelemetryEvent` + `TelemetryEventKind` enum (34 events), mirroring the `AuditLogger` pattern. Feature crates depend on the trait, not the new crate.
- **`temps-telemetry`** (new crate) — `TelemetryService`: stable anonymous `inst_<uuid>` persisted in the data dir, **fire-and-forget** time-bounded HTTP POST (a dead endpoint never affects the server), opt-out via `TEMPS_TELEMETRY=0`, endpoint override via `TEMPS_TELEMETRY_ENDPOINT` (compiled default `https://telemetry.temps.sh/v1/events`). `TelemetryPlugin` registered in `serve` before feature plugins.
- **Callsite hooks** across auth, backup, deployments, domains, email, environments, error-tracking, git, projects, providers, status-page, vulnerability-scanner, **temps-agents** (autofixer), analytics-events/session-replay, ai-gateway. Deploy funnel carries `preset`/`source_type`; `deploy_failed` carries a coarse, **type-safe** reason category (`&'static str` — raw failure string never sent). `instance_started` carries non-identifying depth-of-usage counts.
- **`telemetry-api/`** — public Bun + native `pg` ingest API (`POST /v1/events`, `/v1/stats/*`); `KNOWN_EVENT_TYPES` kept in lockstep with the Rust enum; PII keys stripped at ingest.

**Privacy:** no emails, IPs, repo/domain/project names, env vars, branch names, or free-form text — only counts, enum labels, durations, booleans. Anonymous id is a random UUID, never machine-derived.

The private analytics dashboard (`telemetry-dashboard/`) is intentionally **not** in this PR — it's gitignored (internal business judgment, not open source). The public ingest schema + event list (`telemetry-api/`) ships here for transparency.

## 2. Postgres `shm_size_mb` (also included)

Operator-settable Postgres container shared-memory (`/dev/shm`) size, fixing "could not resize shared memory segment … No space left on device" under load (Docker's 64 MiB default). `shm_size` is create-time-only, so a change recreates the container.

- **`temps-agent`** — applies `HostConfig.shm_size` when launching the container.
- **`temps-providers`** — `shm_size_mb` config field, parsing, and recreate-on-change logic (`externalsvc/`, `services.rs`, handlers, plugin).
- **`web/`** — regenerated SDK type + storage UI (`EditResourceLimitsDialog`, `ServiceResourcesPanel`) to set it.

(Distinct from telemetry; `temps-agents` ≠ `temps-agent`.)

---

## Verification

`cargo check --lib` clean across the workspace; full `cargo clippy --workspace` clean; `temps-core`/`temps-telemetry`/`temps-deployments`/`temps-providers` tests pass. Telemetry verified end-to-end live (a real `temps serve` boot + HTTP handlers emit events into the deployed ingest API). Pre-commit hooks (typos, fmt, clippy, conventional-commit) all pass.

---

## 3. Custom health-check path

Lets users define the HTTP health-check endpoint instead of the default `/` — important for APIs (`/api/healthz`, `/api/ping`). The path drives both the container health check at deploy and the uptime monitor's `check_path`.

- **Deploy-time override** — `DeployFromImage/Static/Upload` requests accept an optional `health_check_path` (validated to start with `/`), persisted on deployment metadata. Effective path resolves **override > .temps.yaml build output > default `/`**, and propagates to the `DeploymentSucceeded` job so the uptime monitor follows automatically. This closes the gap where image/static deploys (which skip the build step that reads `.temps.yaml`) were stuck on `/`.
- **CLI** — `--health-check-path` on `deploy:image` / `deploy:local-image` / `deploy:static`, and `--check-path` on `monitors create`.
- `.temps.yaml health.path` already worked for git/Dockerfile builds (verified); this adds the image/static + monitor-create surfaces. Docs updated separately in temps-landing.

(Note: the PR now numbers 3 distinct features — see the renumbered title.)