### PR TITLE
test(e2e): verify all repo example projects deploy & serve

### DIFF
--- a/apps/temps-e2e/README.md
+++ b/apps/temps-e2e/README.md
@@ -1,0 +1,110 @@
+# @temps-sdk/e2e
+
+End-to-end + load testing CLI for a **live** Temps instance. Drives the real
+control-plane API (via the shared [`@temps-sdk/api`](../../packages/api) client),
+deploys an app, generates traffic, verifies the proxy recorded it, and tears
+everything down.
+
+## Setup
+
+```bash
+cd apps/temps-e2e
+bun install
+```
+
+The tool depends on `@temps-sdk/api` via a local link. If the link isn't set up:
+
+```bash
+cd ../../packages/api && bun install && bun run build && bun link
+cd ../../apps/temps-e2e && bun install
+```
+
+## Auth
+
+Point it at any instance with `--url` / `--api-key`, or the `TEMPS_URL` /
+`TEMPS_API_KEY` env vars (default URL: `http://localhost:8080`).
+
+Mint a key against a **local** instance directly from the server binary:
+
+```bash
+temps api-key \
+  --database-url=postgres://postgres:password@localhost:5432/temps_development \
+  --name=e2e --role=admin --user-email=you@example.com --output-format=json
+```
+
+## Commands
+
+```bash
+# Verify connectivity + auth
+bun run src/index.ts ping
+
+# Generate load against any URL (no Temps deploy required)
+bun run src/index.ts load https://example.com -n 10000 -c 100
+bun run src/index.ts load https://example.com -d 60s -c 200      # by duration
+#   -H "Host: app.localho.st"   to route through a proxy by host header
+
+# Full lifecycle: project -> deploy image -> wait healthy -> load -> verify -> teardown
+bun run src/index.ts scenario --image traefik/whoami:latest -n 2000 -c 50
+bun run src/index.ts scenario --with-db                          # also provision postgres
+bun run src/index.ts scenario --keep                            # leave resources up
+bun run src/index.ts scenario --json                            # machine-readable (CI)
+
+# Build the repo's example projects (Go, Python, Node, …) and run the full
+# deploy/verify lifecycle for EACH — proves every example in examples/ actually
+# deploys to a live Temps and serves real traffic (not just a prebuilt image).
+#
+# Requires Docker + a registry the Temps server can pull from. Start a local one:
+#   docker run -d -p 5111:5000 --name temps-e2e-registry registry:2
+#   export TEMPS_E2E_REGISTRY=localhost:5111
+bun run src/index.ts examples --list                            # show registered examples
+bun run src/index.ts examples                                   # fast subset: go-gin, python-flask, node-nestjs
+bun run src/index.ts examples --only go-gin python-flask        # pick specific ones
+bun run src/index.ts examples --all                             # every example (incl. heavy rust/vite builds)
+bun run src/index.ts examples --registry localhost:5111         # registry (or $TEMPS_E2E_REGISTRY)
+bun run src/index.ts examples --json                            # machine-readable (CI)
+```
+
+### `examples`
+
+Verifies that the source projects under the repo's `examples/` tree actually
+deploy and serve on a live Temps. Each registered example (`src/lib/examples.ts`)
+carries its source path, a minimal generated Dockerfile, its listen port and a
+health path. For every selected example the command:
+
+1. renders the Dockerfile into a scratch build context, `docker build`s it, and
+   **pushes it to `$TEMPS_E2E_REGISTRY`** (Temps deploys by pulling, so the image
+   must live somewhere the server can reach — same path a real user follows),
+2. runs the full `scenario` lifecycle against the pushed image (create project →
+   deploy → wait healthy → **assert the real app responds, not the Temps console
+   fallback** → load → verify proxy logs → teardown),
+3. prints a per-example PASS/FAIL summary and exits non-zero if any fails.
+
+The build context is a scratch copy — the repo's `examples/` tree is never
+mutated. Only HTTP-serving examples are registered; `node/vercel-ai-tracing` is
+excluded (it's a one-shot OTel script needing LLM keys, not a server).
+
+Verified passing (`--all`, 5/5): Go (Gin), Python (Flask), Node (NestJS),
+Vite (React via nginx-unprivileged), Rust (Axum).
+
+### `scenario` steps
+
+1. create a project (`docker_image` source)
+2. *(optional `--with-db`)* provision a Postgres external service
+3. resolve the production environment
+4. deploy a prebuilt public image
+5. wait for the deployment to reach a terminal state
+6. probe HTTP until the app actually serves (routes via the proxy origin with
+   the app's `Host` header — no external DNS/TLS dependency)
+7. warm up, then run the measured load test
+8. verify the proxy-log count for the host is non-zero
+9. tear down the deployment (stops the container + removes the route) and delete
+   the project — even on failure, unless `--keep`
+
+Exits non-zero if any step fails, so it's CI-gateable.
+
+## Notes
+
+- The load engine is pure `fetch`, worker-pooled (exactly `--concurrency`
+  in-flight). Transient connection failures are retried (`--connectRetries`
+  equivalent); real HTTP 4xx/5xx are recorded as-is.
+- Resources are name-prefixed `e2e-<runid>` so leftovers are identifiable.

--- a/apps/temps-e2e/bun.lock
+++ b/apps/temps-e2e/bun.lock
@@ -1,0 +1,135 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@temps-sdk/e2e",
+      "dependencies": {
+        "@hey-api/client-fetch": "^0.13.1",
+        "@temps-sdk/api": "link:@temps-sdk/api",
+        "commander": "^14.0.2",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.6.0",
+      },
+    },
+  },
+  "packages": {
+    "@hey-api/client-fetch": ["@hey-api/client-fetch@0.13.1", "", { "peerDependencies": { "@hey-api/openapi-ts": "< 2" } }, "sha512-29jBRYNdxVGlx5oewFgOrkulZckpIpBIRHth3uHFn1PrL2ucMy52FvWOY3U3dVx2go1Z3kUmMi6lr07iOpUqqA=="],
+
+    "@hey-api/codegen-core": ["@hey-api/codegen-core@0.9.0", "", { "dependencies": { "@hey-api/types": "0.1.4", "ansi-colors": "4.1.3", "c12": "3.3.4", "color-support": "1.1.3" } }, "sha512-OK9/R8WuujwgvnrDIPnEiIf6WnfUOi3GaEr6kIngqoI5FUQwYbeDKHE/frTVUl2A76ZQPCrMknHtPx6Gqtwf8Q=="],
+
+    "@hey-api/json-schema-ref-parser": ["@hey-api/json-schema-ref-parser@1.4.3", "", { "dependencies": { "@jsdevtools/ono": "7.1.3", "@types/json-schema": "7.0.15", "js-yaml": "4.1.1" } }, "sha512-UzGSDzh3QUhrnwl4atnHc2YqDO6KemYVEOwl1Ynowm/tcr0XlpdHOpyWr5UaWIJfiXTXdYRIC9k2Yxm19pcPzQ=="],
+
+    "@hey-api/openapi-ts": ["@hey-api/openapi-ts@0.98.2", "", { "dependencies": { "@hey-api/codegen-core": "0.9.0", "@hey-api/json-schema-ref-parser": "1.4.3", "@hey-api/shared": "0.4.8", "@hey-api/spec-types": "0.2.0", "@hey-api/types": "0.1.4", "@lukeed/ms": "2.0.2", "ansi-colors": "4.1.3", "color-support": "1.1.3", "commander": "15.0.0", "get-tsconfig": "4.14.0" }, "peerDependencies": { "typescript": ">=5.5.3 || >=6.0.0 || 6.0.1-rc" }, "bin": { "openapi-ts": "./bin/run.js" } }, "sha512-2nVJXH8tpFPGTBOhxyjEd1Jw0hsRqJqeTQW3kltAjVdSU4YWxeu97x5sgNOmsbsfeg6Dqz7Wfzs26walBOuswA=="],
+
+    "@hey-api/shared": ["@hey-api/shared@0.4.8", "", { "dependencies": { "@hey-api/codegen-core": "0.9.0", "@hey-api/json-schema-ref-parser": "1.4.3", "@hey-api/spec-types": "0.2.0", "@hey-api/types": "0.1.4", "ansi-colors": "4.1.3", "cross-spawn": "7.0.6", "open": "11.0.0", "semver": "7.8.2" } }, "sha512-29Pg2FB0UW20pplYgcfiQn1hQYpbZ9D2gdDJc7nDK3xh3pvHOTGP0v3R2ueFpFnw9GN1SRhIdhiVuAYWMDimjA=="],
+
+    "@hey-api/spec-types": ["@hey-api/spec-types@0.2.0", "", { "dependencies": { "@hey-api/types": "0.1.4" } }, "sha512-ibQ8Is7evMavzr8GNyJCcTg975d8DpaMUyLmOrQ85UBdy1l6t1KuRAwgChAbesJsIlNV6gjmlXruWyegDX18Fg=="],
+
+    "@hey-api/types": ["@hey-api/types@0.1.4", "", {}, "sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg=="],
+
+    "@jsdevtools/ono": ["@jsdevtools/ono@7.1.3", "", {}, "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="],
+
+    "@lukeed/ms": ["@lukeed/ms@2.0.2", "", {}, "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA=="],
+
+    "@temps-sdk/api": ["@temps-sdk/api@link:@temps-sdk/api", {}],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
+
+    "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
+    "c12": ["c12@3.3.4", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.4", "defu": "^6.1.6", "dotenv": "^17.3.1", "exsolve": "^1.0.8", "giget": "^3.2.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.1.0", "pkg-types": "^2.3.0", "rc9": "^3.0.1" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA=="],
+
+    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "color-support": ["color-support@1.1.3", "", { "bin": { "color-support": "bin.js" } }, "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="],
+
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
+
+    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
+
+    "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
+
+    "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
+
+    "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
+
+    "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
+
+    "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
+
+    "giget": ["giget@3.3.0", "", { "bin": { "giget": "dist/cli.mjs" } }, "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw=="],
+
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
+
+    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
+
+    "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "perfect-debounce": ["perfect-debounce@2.1.0", "", {}, "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="],
+
+    "pkg-types": ["pkg-types@2.3.1", "", { "dependencies": { "confbox": "^0.2.4", "exsolve": "^1.0.8", "pathe": "^2.0.3" } }, "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg=="],
+
+    "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
+
+    "rc9": ["rc9@3.0.1", "", { "dependencies": { "defu": "^6.1.6", "destr": "^2.0.5" } }, "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ=="],
+
+    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
+
+    "semver": ["semver@7.8.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
+
+    "@hey-api/openapi-ts/commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
+  }
+}

--- a/apps/temps-e2e/package.json
+++ b/apps/temps-e2e/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@temps-sdk/e2e",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "End-to-end + load testing CLI for a live Temps instance",
+  "bin": {
+    "temps-e2e": "./src/index.ts"
+  },
+  "scripts": {
+    "e2e": "bun run src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@hey-api/client-fetch": "^0.13.1",
+    "@temps-sdk/api": "link:@temps-sdk/api",
+    "commander": "^14.0.2"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.6.0"
+  }
+}

--- a/apps/temps-e2e/src/commands/examples.ts
+++ b/apps/temps-e2e/src/commands/examples.ts
@@ -1,0 +1,188 @@
+/**
+ * Deploy and verify the repo's source-based example projects against a live
+ * Temps instance. For each selected example this:
+ *   1. renders a minimal Dockerfile into a scratch context and `docker build`s it
+ *   2. runs the standard deploy → load → verify → teardown lifecycle
+ *      (`runScenarioForImage`) against the built image
+ *
+ * This is how we exercise OTHER project types (Go, Python, Node/NestJS, Vite,
+ * Rust, …) end-to-end, not just a single prebuilt hello image.
+ */
+import { resolve, dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { makeClient, resolveConfig } from '../lib/client.ts'
+import { runScenarioForImage, type ScenarioResult } from './scenario.ts'
+import {
+  EXAMPLES,
+  DEFAULT_SUBSET,
+  findExample,
+  buildExampleImage,
+  type ExampleProject,
+} from '../lib/examples.ts'
+
+export interface ExamplesOptions {
+  only?: string[]
+  all?: boolean
+  registry?: string
+  requests?: string
+  concurrency?: string
+  keep?: boolean
+  withDb?: boolean
+  deployTimeout?: string
+  list?: boolean
+  json?: boolean
+  connection: { url?: string; apiKey?: string }
+}
+
+/** Locate the repo's examples/ dir relative to this app (apps/temps-e2e). */
+function examplesRoot(): string {
+  const here = dirname(fileURLToPath(import.meta.url)) // .../apps/temps-e2e/src/commands
+  return resolve(here, '../../../../examples')
+}
+
+function selectExamples(opts: ExamplesOptions): ExampleProject[] {
+  if (opts.only && opts.only.length > 0) {
+    const picked: ExampleProject[] = []
+    for (const key of opts.only) {
+      const ex = findExample(key)
+      if (!ex) {
+        throw new Error(
+          `Unknown example "${key}". Known: ${EXAMPLES.map((e) => e.key).join(', ')}`,
+        )
+      }
+      picked.push(ex)
+    }
+    return picked
+  }
+  if (opts.all) return EXAMPLES
+  return DEFAULT_SUBSET.map((k) => findExample(k)!).filter(Boolean)
+}
+
+export async function examplesCommand(opts: ExamplesOptions): Promise<void> {
+  const json = !!opts.json
+  const log = (msg: string) => {
+    if (!json) process.stderr.write(msg + '\n')
+  }
+
+  if (opts.list) {
+    if (json) {
+      process.stdout.write(
+        JSON.stringify(
+          EXAMPLES.map((e) => ({
+            key: e.key,
+            label: e.label,
+            relDir: e.relDir,
+            port: e.port,
+            weight: e.weight,
+          })),
+          null,
+          2,
+        ) + '\n',
+      )
+    } else {
+      log('Available example projects:')
+      for (const e of EXAMPLES) {
+        const def = DEFAULT_SUBSET.includes(e.key) ? ' (default)' : ''
+        log(`  ${e.key.padEnd(14)} ${e.label.padEnd(28)} [${e.weight}] ${e.relDir}${def}`)
+      }
+    }
+    return
+  }
+
+  const cfg = resolveConfig(opts.connection)
+  const client = makeClient(cfg)
+  const selected = selectExamples(opts)
+  const root = examplesRoot()
+  const scratch = join(process.env.TMPDIR ?? '/tmp', 'temps-e2e-examples')
+  // Temps deploys an image by having the server `docker pull` it, so the built
+  // image must live somewhere the server can pull from. The harness builds each
+  // example and pushes it to a registry, then deploys by that ref — the exact
+  // path a real user follows. A local registry is the simplest fit for local
+  // runs; point at any registry the server can reach for multi-node.
+  const registry = opts.registry ?? process.env.TEMPS_E2E_REGISTRY
+
+  if (!registry) {
+    throw new Error(
+      'A registry is required: Temps deploys images by pulling them, so the built ' +
+        'image must be pushed somewhere the server can pull from. Pass --registry ' +
+        '<host:port> (e.g. localhost:5111) or set TEMPS_E2E_REGISTRY. ' +
+        'Start a local one with: docker run -d -p 5111:5000 --name temps-e2e-registry registry:2',
+    )
+  }
+
+  log(`Temps e2e examples  ->  ${cfg.url}`)
+  log(`Registry: ${registry}`)
+  log(`Examples: ${selected.map((e) => e.key).join(', ')}  (root: ${root})`)
+
+  const results: { example: string; built: boolean; result?: ScenarioResult; error?: string }[] = []
+
+  for (const ex of selected) {
+    log(`\n══════════════════════════════════════════`)
+    log(`▶ EXAMPLE: ${ex.label}  (${ex.key})`)
+    log(`══════════════════════════════════════════`)
+
+    let imageRef: string
+    try {
+      log(`\n▶ build image`)
+      imageRef = await buildExampleImage(ex, {
+        examplesRoot: root,
+        scratchRoot: scratch,
+        registry,
+        onLog: (l) => log(`    ${l}`),
+      })
+      log(`  ✓ built ${imageRef}`)
+    } catch (e) {
+      log(`  ✗ build failed: ${(e as Error).message}`)
+      results.push({ example: ex.key, built: false, error: (e as Error).message })
+      continue
+    }
+
+    const onProgress = json
+      ? undefined
+      : (c: number, t: number | undefined) =>
+          process.stderr.write(`\r    ${c}${t ? `/${t}` : ''} requests   `)
+
+    const result = await runScenarioForImage(
+      client,
+      cfg,
+      {
+        image: imageRef,
+        port: ex.port,
+        healthPath: ex.healthPath,
+        requests: Number(opts.requests ?? '500'),
+        concurrency: Number(opts.concurrency ?? '25'),
+        withDb: opts.withDb,
+        keep: opts.keep,
+        deployTimeoutMs: Number(opts.deployTimeout ?? '300000'),
+        label: ex.key,
+      },
+      log,
+      onProgress,
+    )
+    if (!json) process.stderr.write('\n')
+    results.push({ example: ex.key, built: true, result })
+    log(`\n  ${result.ok ? '✅ ' + ex.key + ' PASSED' : '❌ ' + ex.key + ' FAILED'}`)
+  }
+
+  const passed = results.filter((r) => r.built && r.result?.ok).length
+  const total = results.length
+
+  if (json) {
+    process.stdout.write(
+      JSON.stringify({ url: cfg.url, passed, total, results }, null, 2) + '\n',
+    )
+  } else {
+    log(`\n════════════ SUMMARY ════════════`)
+    for (const r of results) {
+      const status = !r.built
+        ? '❌ build failed'
+        : r.result?.ok
+          ? `✅ pass (${r.result.proxyLogsRecorded} proxy logs)`
+          : '❌ scenario failed'
+      log(`  ${r.example.padEnd(14)} ${status}`)
+    }
+    log(`\n${passed}/${total} examples passed`)
+  }
+
+  if (passed < total) process.exitCode = 1
+}

--- a/apps/temps-e2e/src/commands/load.ts
+++ b/apps/temps-e2e/src/commands/load.ts
@@ -1,0 +1,76 @@
+import { runLoad, formatLoadResult, type LoadResult } from '../lib/load.ts'
+
+export interface LoadCommandOptions {
+  requests?: string
+  concurrency?: string
+  duration?: string
+  method?: string
+  header?: string[]
+  timeout?: string
+  json?: boolean
+}
+
+/** Parse `-H "Key: Value"` repeatable flags into a header record. */
+function parseHeaders(raw: string[] | undefined): Record<string, string> {
+  const headers: Record<string, string> = {}
+  for (const h of raw ?? []) {
+    const idx = h.indexOf(':')
+    if (idx > 0) headers[h.slice(0, idx).trim()] = h.slice(idx + 1).trim()
+  }
+  return headers
+}
+
+/** Parse a duration like "60s", "2m", or a bare number (seconds). */
+function parseDuration(raw: string | undefined): number | undefined {
+  if (!raw) return undefined
+  const m = /^(\d+)(ms|s|m)?$/.exec(raw.trim())
+  if (!m) throw new Error(`Invalid duration: ${raw} (use e.g. 60s, 2m, 500ms)`)
+  const n = Number(m[1])
+  switch (m[2]) {
+    case 'ms':
+      return n
+    case 'm':
+      return n * 60_000
+    default:
+      return n * 1000
+  }
+}
+
+export async function loadCommand(url: string, opts: LoadCommandOptions): Promise<void> {
+  const concurrency = Number(opts.concurrency ?? '50')
+  const durationMs = parseDuration(opts.duration)
+  const requests = durationMs ? undefined : Number(opts.requests ?? '1000')
+  const timeoutMs = opts.timeout ? Number(opts.timeout) : undefined
+
+  if (!opts.json) {
+    const plan = durationMs ? `${durationMs / 1000}s` : `${requests} requests`
+    process.stderr.write(`Load: ${plan} @ concurrency ${concurrency} -> ${url}\n`)
+  }
+
+  const result: LoadResult = await runLoad({
+    url,
+    requests,
+    durationMs,
+    concurrency,
+    method: opts.method,
+    headers: parseHeaders(opts.header),
+    timeoutMs,
+    onProgress: opts.json
+      ? undefined
+      : (completed, total) => {
+          const pct = total ? ` (${Math.round((completed / total) * 100)}%)` : ''
+          process.stderr.write(`\r  ${completed} done${pct}   `)
+        },
+  })
+
+  if (!opts.json) process.stderr.write('\n')
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+  } else {
+    process.stdout.write(formatLoadResult(result) + '\n')
+  }
+
+  // Non-zero exit when any request errored, so CI can gate on it.
+  if (!result.ok) process.exitCode = 1
+}

--- a/apps/temps-e2e/src/commands/scenario.ts
+++ b/apps/temps-e2e/src/commands/scenario.ts
@@ -1,0 +1,296 @@
+/**
+ * Full end-to-end lifecycle against a live Temps instance:
+ *   1. create a project
+ *   2. (optional) provision a postgres service
+ *   3. deploy a prebuilt image (public, or a locally-built example image)
+ *   4. poll until the deployment is healthy
+ *   5. resolve the public URL and smoke-check it
+ *   6. fire N requests at it (load)
+ *   7. verify the proxy recorded the traffic
+ *   8. tear everything down (unless --keep)
+ *
+ * Every created resource is deleted in a finally block so a failed run still
+ * leaves the instance clean.
+ *
+ * The per-image lifecycle is exposed as `runScenarioForImage` so other commands
+ * (e.g. `examples`, which builds a source example into a local image first) can
+ * reuse the exact same deploy → load → verify → teardown path.
+ */
+import { makeClient, resolveConfig, type TempsClientConfig } from '../lib/client.ts'
+import type { Client } from '@temps-sdk/api/client'
+import {
+  createE2eProject,
+  getProductionEnvironment,
+  deployImage,
+  waitForDeployment,
+  waitForHttpReady,
+  resolveLoadTarget,
+  createE2eService,
+  countProxyLogs,
+  getDeployStatus,
+  assertNotConsoleFallback,
+  teardown,
+  makeRunId,
+} from '../lib/flows.ts'
+import { runLoad, formatLoadResult, type LoadResult } from '../lib/load.ts'
+
+export interface ScenarioOptions {
+  image: string
+  port?: string
+  requests?: string
+  concurrency?: string
+  withDb?: boolean
+  keep?: boolean
+  deployTimeout?: string
+  json?: boolean
+  connection: { url?: string; apiKey?: string }
+}
+
+export interface StepLog {
+  step: string
+  ok: boolean
+  detail?: string
+  ms?: number
+}
+
+export interface ScenarioResult {
+  runId: string
+  ok: boolean
+  url: string
+  appUrl: string
+  steps: StepLog[]
+  load?: LoadResult
+  proxyLogsRecorded: number
+}
+
+/** Spec for one deploy → load → verify → teardown run against a single image. */
+export interface ScenarioSpec {
+  /** Image ref to deploy (public or locally-built). */
+  image: string
+  /** Container port the image listens on. */
+  port: number
+  /** Number of load requests after the app is healthy. */
+  requests: number
+  /** Load concurrency. */
+  concurrency: number
+  /** HTTP path used for the readiness probe (defaults to "/"). */
+  healthPath?: string
+  withDb?: boolean
+  keep?: boolean
+  deployTimeoutMs?: number
+  /** Label prefix for the run id / project name. */
+  label?: string
+}
+
+/**
+ * Run the deploy → load → verify → teardown lifecycle for one image and return a
+ * structured result. `log` is called with human progress lines (silenced in JSON
+ * mode by the caller). Never throws for an expected failure — the failure is
+ * recorded in `steps` and reflected in `ok`; it only throws if teardown itself
+ * cannot run.
+ */
+export async function runScenarioForImage(
+  client: Client,
+  cfg: TempsClientConfig,
+  spec: ScenarioSpec,
+  log: (msg: string) => void,
+  onProgress?: (completed: number, total: number | undefined) => void,
+): Promise<ScenarioResult> {
+  const runId = makeRunId(Date.now())
+  const steps: StepLog[] = []
+  const projectIds: number[] = []
+  const serviceIds: number[] = []
+  const deployments: { projectId: number; deploymentId: number }[] = []
+
+  const step = async <T>(name: string, fn: () => Promise<T>): Promise<T> => {
+    const t0 = performance.now()
+    log(`\n▶ ${name}`)
+    try {
+      const r = await fn()
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: true, ms })
+      log(`  ✓ ${name} (${(ms / 1000).toFixed(1)}s)`)
+      return r
+    } catch (e) {
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: false, detail: (e as Error).message, ms })
+      log(`  ✗ ${name}: ${(e as Error).message}`)
+      throw e
+    }
+  }
+
+  let loadResult: LoadResult | undefined
+  let recorded = 0
+  let appUrl = ''
+
+  try {
+    const project = await step('create project', () =>
+      createE2eProject(client, { name: `${runId}-app`, exposedPort: spec.port }),
+    )
+    projectIds.push(project.id)
+    log(`  project #${project.id} (${project.slug})`)
+
+    if (spec.withDb) {
+      const svc = await step('provision postgres', () =>
+        createE2eService(client, { name: `${runId}-db`, serviceType: 'postgres' }),
+      )
+      serviceIds.push(svc.id)
+      log(`  service #${svc.id} (${svc.name})`)
+    }
+
+    const env = await step('resolve production environment', () =>
+      getProductionEnvironment(client, project.id),
+    )
+    appUrl = env.mainUrl
+    log(`  env #${env.id} (${env.name})  url=${appUrl}`)
+
+    const deploymentId = await step('deploy image', () =>
+      deployImage(client, { projectId: project.id, environmentId: env.id, imageRef: spec.image }),
+    )
+    deployments.push({ projectId: project.id, deploymentId })
+    log(`  deployment #${deploymentId}  image=${spec.image}`)
+
+    await step('wait for deployment', () =>
+      waitForDeployment(client, {
+        projectId: project.id,
+        deploymentId,
+        timeoutMs: spec.deployTimeoutMs ?? 300_000,
+        onPoll: (s) => log(`    ...${s.state}`),
+      }),
+    )
+
+    // A deployment can transiently report `running` and then flip to `failed`
+    // (e.g. the image pull 404s after the route is provisioned). Re-read the
+    // state and refuse to proceed on a failed deploy — otherwise the proxy's
+    // catch-all console fallback answers 200 and the run looks healthy when the
+    // app never started.
+    await step('confirm deployment did not fail', async () => {
+      const s = await getDeployStatus(client, project.id, deploymentId)
+      if (!s.ok) {
+        throw new Error(
+          `deployment ${deploymentId} is in state "${s.state}" — the app did not start`,
+        )
+      }
+    })
+
+    // Resolve a target the load generator can actually reach: hit the proxy
+    // origin (the instance URL) with the app's Host header. main_url is often
+    // https on :443 and not directly dialable.
+    if (!appUrl) throw new Error('deployment produced no public URL to hit')
+    const target = resolveLoadTarget(cfg.url, appUrl)
+    const healthUrl = target.url.replace(/\/$/, '') + (spec.healthPath ?? '/')
+    log(`  load target ${target.url}  (Host: ${target.host})`)
+
+    // The deployment status flipping to a terminal state doesn't guarantee the
+    // container is already serving — probe HTTP (on the health path) until it
+    // answers.
+    await step('wait for HTTP ready', () =>
+      waitForHttpReady({
+        url: healthUrl,
+        headers: target.headers,
+        timeoutMs: 120_000,
+        onPoll: (status) => log(`    ...HTTP ${status || 'unreachable'}`),
+      }),
+    )
+
+    // CRITICAL: a 200 alone is not proof the app is serving — the Temps proxy
+    // answers unknown/failed hosts with the console SPA (HTTP 200, HTML). Assert
+    // the response is NOT that fallback so a broken deploy can never pass.
+    await step('assert app is serving (not console fallback)', () =>
+      assertNotConsoleFallback({ url: healthUrl, headers: target.headers }),
+    )
+
+    // Warm the container/connection pool at low concurrency so cold-start blips
+    // don't pollute the measured run. Results are discarded.
+    await step('warmup', () =>
+      runLoad({ url: target.url, headers: target.headers, requests: 20, concurrency: 4, timeoutMs: 15_000 }),
+    )
+
+    loadResult = await step('load test', () =>
+      runLoad({
+        url: target.url,
+        headers: target.headers,
+        requests: spec.requests,
+        concurrency: spec.concurrency,
+        timeoutMs: 10_000,
+        onProgress,
+      }),
+    )
+    if (loadResult) log(formatLoadResult(loadResult))
+    if (loadResult && !loadResult.ok) {
+      throw new Error(
+        `load test had ${loadResult.errors} errored requests (status codes: ${JSON.stringify(loadResult.statusCodes)})`,
+      )
+    }
+
+    // Verify traffic landed. Proxy-log ingest is async and batched, so allow a
+    // generous grace window (up to ~30s) before declaring the host unseen.
+    await step('verify proxy logs', async () => {
+      for (let i = 0; i < 20; i++) {
+        recorded = await countProxyLogs(client, { host: target.logHost })
+        if (recorded > 0) break
+        await new Promise((r) => setTimeout(r, 1500))
+      }
+      if (recorded === 0) {
+        throw new Error(`no proxy-log entries recorded for host ${target.logHost}`)
+      }
+      log(`  proxy recorded ${recorded} request(s) for ${target.logHost}`)
+    })
+  } catch {
+    // Failure already recorded in `steps`; fall through to teardown.
+  } finally {
+    if (spec.keep) {
+      log(`\n(kept resources: projects=${projectIds.join(',')} services=${serviceIds.join(',')})`)
+    } else {
+      const td = await teardown(client, { deployments, projectIds, serviceIds })
+      log(
+        `\n▶ teardown: tore down ${td.teardownDeployments} deployment(s), ` +
+          `deleted ${td.deletedProjects} project(s), ${td.deletedServices} service(s)` +
+          (td.errors.length ? ` (${td.errors.length} errors)` : ''),
+      )
+      for (const e of td.errors) log(`    ! ${e}`)
+    }
+  }
+
+  const ok = steps.every((s) => s.ok)
+  return { runId, ok, url: cfg.url, appUrl, steps, load: loadResult, proxyLogsRecorded: recorded }
+}
+
+export async function scenarioCommand(opts: ScenarioOptions): Promise<void> {
+  const cfg = resolveConfig(opts.connection)
+  const client = makeClient(cfg)
+  const json = !!opts.json
+  const log = (msg: string) => {
+    if (!json) process.stderr.write(msg + '\n')
+  }
+  const onProgress = json
+    ? undefined
+    : (c: number, t: number | undefined) =>
+        process.stderr.write(`\r    ${c}${t ? `/${t}` : ''} requests   `)
+
+  if (!json) log(`Temps e2e scenario  ->  ${cfg.url}`)
+
+  const result = await runScenarioForImage(
+    client,
+    cfg,
+    {
+      image: opts.image,
+      port: Number(opts.port ?? '80'),
+      requests: Number(opts.requests ?? '2000'),
+      concurrency: Number(opts.concurrency ?? '50'),
+      withDb: opts.withDb,
+      keep: opts.keep,
+      deployTimeoutMs: Number(opts.deployTimeout ?? '300000'),
+    },
+    log,
+    onProgress,
+  )
+  if (!json) process.stderr.write('\n')
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+  } else {
+    log(`\n${result.ok ? '✅ scenario PASSED' : '❌ scenario FAILED'}`)
+  }
+  if (!result.ok) process.exitCode = 1
+}

--- a/apps/temps-e2e/src/index.ts
+++ b/apps/temps-e2e/src/index.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env bun
+import { Command } from 'commander'
+import { getProjects } from '@temps-sdk/api'
+import { makeClient, resolveConfig, unwrap } from './lib/client.ts'
+import { loadCommand } from './commands/load.ts'
+import { scenarioCommand } from './commands/scenario.ts'
+import { examplesCommand } from './commands/examples.ts'
+
+const program = new Command()
+
+program
+  .name('temps-e2e')
+  .description('End-to-end + load testing CLI for a live Temps instance')
+  .version('0.1.0')
+
+// Global connection options (also read from TEMPS_URL / TEMPS_API_KEY).
+program
+  .option('--url <url>', 'Temps instance base URL (default: $TEMPS_URL or http://localhost:8080)')
+  .option('--api-key <key>', 'API key (default: $TEMPS_API_KEY)')
+
+function connection(): { url?: string; apiKey?: string } {
+  const o = program.opts<{ url?: string; apiKey?: string }>()
+  return { url: o.url, apiKey: o.apiKey }
+}
+
+program
+  .command('ping')
+  .description('Verify connectivity + auth against the instance')
+  .option('--json', 'machine-readable output')
+  .action(async (opts: { json?: boolean }) => {
+    const client = makeClient(resolveConfig(connection()))
+    const data = unwrap(
+      await getProjects({ client, query: { page: 1, per_page: 1 } }),
+      'getProjects',
+    ) as { total?: number }
+    if (opts.json) {
+      process.stdout.write(JSON.stringify({ ok: true, projects: data.total ?? 0 }) + '\n')
+    } else {
+      process.stdout.write(`OK — connected. ${data.total ?? 0} project(s) visible.\n`)
+    }
+  })
+
+program
+  .command('load')
+  .description('Generate HTTP load against a URL (no Temps deploy required)')
+  .argument('<url>', 'target URL to hammer')
+  .option('-n, --requests <n>', 'total requests to send', '1000')
+  .option('-c, --concurrency <n>', 'max in-flight requests', '50')
+  .option('-d, --duration <dur>', 'run for a duration instead of a fixed count (e.g. 60s, 2m)')
+  .option('-m, --method <method>', 'HTTP method', 'GET')
+  .option('-H, --header <header...>', 'request header "Key: Value" (repeatable)')
+  .option('--timeout <ms>', 'per-request timeout in ms')
+  .option('--json', 'machine-readable output')
+  .action(loadCommand)
+
+program
+  .command('scenario')
+  .description('Full lifecycle: project -> deploy image -> wait healthy -> load -> verify -> teardown')
+  .option('--image <ref>', 'public Docker image to deploy', 'ghcr.io/temps-sh/e2e-hello:latest')
+  .option('--port <port>', 'container port the image listens on', '80')
+  .option('-n, --requests <n>', 'load requests after deploy', '2000')
+  .option('-c, --concurrency <n>', 'load concurrency', '50')
+  .option('--with-db', 'also provision a postgres service')
+  .option('--keep', 'do not tear down created resources')
+  .option('--deploy-timeout <ms>', 'max wait for deploy to go healthy', '300000')
+  .option('--json', 'machine-readable output')
+  .action(async (opts) => {
+    await scenarioCommand({ ...opts, connection: connection() })
+  })
+
+program
+  .command('examples')
+  .description('Build the repo example projects (Go, Python, Node, …) and run the full deploy/verify lifecycle for each')
+  .option('--only <key...>', 'run only these example keys (repeatable); default = fast subset')
+  .option('--all', 'run every registered example (includes heavy Rust/Vite builds)')
+  .option('--registry <host>', 'registry to push built images to so Temps can pull them (e.g. localhost:5111); or $TEMPS_E2E_REGISTRY')
+  .option('--list', 'list available examples and exit')
+  .option('-n, --requests <n>', 'load requests per example', '500')
+  .option('-c, --concurrency <n>', 'load concurrency', '25')
+  .option('--with-db', 'also provision a postgres service per example')
+  .option('--keep', 'do not tear down created resources')
+  .option('--deploy-timeout <ms>', 'max wait for each deploy to go healthy', '300000')
+  .option('--json', 'machine-readable output')
+  .action(async (opts) => {
+    await examplesCommand({ ...opts, connection: connection() })
+  })
+
+program.parseAsync().catch((err: unknown) => {
+  process.stderr.write(`\nerror: ${(err as Error).message}\n`)
+  process.exit(1)
+})

--- a/apps/temps-e2e/src/lib/client.ts
+++ b/apps/temps-e2e/src/lib/client.ts
@@ -1,0 +1,76 @@
+/**
+ * Builds a standalone @hey-api client pointed at a live Temps instance and wires
+ * the bearer-token auth header. Mirrors apps/temps-cli/src/lib/api-client.ts but
+ * is fully self-contained (no CLI config/context machinery) so the e2e tool can
+ * target any instance from flags/env.
+ *
+ * The generated SDK comes from the shared, publishable @temps-sdk/api package —
+ * the single source of truth, consumed here exactly as an external consumer
+ * would after `npm install @temps-sdk/api`.
+ */
+import { createClient, type Client } from '@temps-sdk/api/client'
+
+export interface TempsClientConfig {
+  /** Base URL of the instance, e.g. http://localhost:8080 (with or without /api). */
+  url: string
+  /** Bearer API key (tk_...). */
+  apiKey: string
+}
+
+/** Normalize a base URL to always end in exactly one `/api`. */
+export function normalizeApiUrl(url: string): string {
+  let normalized = url.replace(/\/+$/, '')
+  if (!normalized.endsWith('/api')) {
+    normalized += '/api'
+  }
+  return normalized
+}
+
+/**
+ * Create an isolated client instance. Every generated SDK function accepts
+ * `{ client }` so this can be passed per-call without touching global state.
+ */
+export function makeClient(cfg: TempsClientConfig): Client {
+  const baseUrl = normalizeApiUrl(cfg.url)
+  const client = createClient({ baseUrl })
+  client.interceptors.request.use((request: Request) => {
+    request.headers.set('Authorization', `Bearer ${cfg.apiKey}`)
+    return request
+  })
+  return client
+}
+
+/**
+ * Resolve instance url + key from explicit args, falling back to env.
+ * TEMPS_URL / TEMPS_API_KEY are the canonical env vars (match the CLI).
+ */
+export function resolveConfig(opts: { url?: string; apiKey?: string }): TempsClientConfig {
+  const env = (globalThis as { process?: { env: Record<string, string | undefined> } })
+    .process?.env ?? {}
+  const url = opts.url || env.TEMPS_URL || 'http://localhost:8080'
+  const apiKey = opts.apiKey || env.TEMPS_API_KEY || ''
+  if (!apiKey) {
+    throw new Error(
+      'No API key. Pass --api-key or set TEMPS_API_KEY (mint one with: temps api-key --database-url=... --name=e2e --user-email=... --output-format=json)',
+    )
+  }
+  return { url, apiKey }
+}
+
+/** Unwrap a hey-api `{ data, error, response }` result, throwing a useful error. */
+export function unwrap<T>(
+  result: { data?: T; error?: unknown; response?: Response },
+  context: string,
+): T {
+  if (result.error !== undefined && result.error !== null) {
+    const status = result.response?.status
+    const detail =
+      typeof result.error === 'object' ? JSON.stringify(result.error) : String(result.error)
+    throw new Error(`${context} failed${status ? ` (HTTP ${status})` : ''}: ${detail}`)
+  }
+  if (result.data === undefined) {
+    const status = result.response?.status
+    throw new Error(`${context}: empty response${status ? ` (HTTP ${status})` : ''}`)
+  }
+  return result.data
+}

--- a/apps/temps-e2e/src/lib/examples.ts
+++ b/apps/temps-e2e/src/lib/examples.ts
@@ -1,0 +1,251 @@
+/**
+ * Registry of source-based example projects (from the repo's `examples/` tree)
+ * and a helper to build each into a local Docker image the e2e scenario can
+ * deploy.
+ *
+ * The examples ship as source only (no Dockerfile), so each entry carries a
+ * minimal Dockerfile rendered into a scratch build context — the repo tree is
+ * never mutated. The built image is tagged `temps-e2e-example/<key>:latest` and
+ * deployed through the same image path the `scenario` command already uses, so
+ * "test other project types" is just "build the example, then run the normal
+ * deploy → load → verify → teardown lifecycle".
+ *
+ * Only HTTP-serving examples are listed: an example must expose an HTTP port and
+ * (ideally) a health route so the deploy can be verified end-to-end. The
+ * `node/vercel-ai-tracing` example is intentionally absent — it is a one-shot
+ * OTel tracing script, not a server, and needs external LLM API keys.
+ */
+import { mkdir, rm, cp, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export interface ExampleProject {
+  /** Stable key used on the CLI (`--only`) and in the image tag. */
+  key: string
+  /** Human label for output. */
+  label: string
+  /** Path of the example relative to the repo's `examples/` dir. */
+  relDir: string
+  /** Container port the app listens on (also passed to the app as $PORT). */
+  port: number
+  /** HTTP path that should return 2xx once the app is up. */
+  healthPath: string
+  /** Minimal Dockerfile rendered into the scratch build context. */
+  dockerfile: string
+  /** Rough build-cost hint so callers can pick a fast subset. */
+  weight: 'light' | 'medium' | 'heavy'
+}
+
+/**
+ * The example registry. Dockerfiles are deliberately minimal and self-contained
+ * (no reliance on a lockfile-specific toolchain) so they build from a clean
+ * checkout. PORT is injected as an env var because every example reads it.
+ */
+export const EXAMPLES: ExampleProject[] = [
+  {
+    key: 'go-gin',
+    label: 'Go (Gin)',
+    relDir: 'go/gin-basic',
+    port: 3000,
+    healthPath: '/health',
+    weight: 'light',
+    dockerfile: `FROM golang:1.24-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /server main.go
+
+FROM gcr.io/distroless/static-debian12
+COPY --from=build /server /server
+ENV PORT=3000
+EXPOSE 3000
+ENTRYPOINT ["/server"]
+`,
+  },
+  {
+    key: 'python-flask',
+    label: 'Python (Flask + gunicorn)',
+    relDir: 'python/flask-basic',
+    port: 3000,
+    healthPath: '/health',
+    weight: 'light',
+    dockerfile: `FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENV PORT=3000
+EXPOSE 3000
+# main.py exposes a Flask app named "app"; serve it with gunicorn.
+CMD ["sh", "-c", "gunicorn -w 2 -b 0.0.0.0:\${PORT} main:app"]
+`,
+  },
+  {
+    key: 'node-nestjs',
+    label: 'Node (NestJS)',
+    relDir: 'nestjs/basic',
+    port: 3000,
+    healthPath: '/',
+    weight: 'medium',
+    dockerfile: `FROM node:22-slim AS build
+WORKDIR /app
+COPY package.json ./
+# No lockfile coupling: install then build the Nest dist.
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:22-slim
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package.json ./
+RUN npm install --omit=dev
+COPY --from=build /app/dist ./dist
+ENV PORT=3000
+EXPOSE 3000
+CMD ["node", "dist/main"]
+`,
+  },
+  {
+    key: 'vite-react',
+    label: 'Vite (React, static via nginx)',
+    relDir: 'vite/react-basic',
+    // nginx-unprivileged listens on 8080 and runs rootless — required because
+    // Temps runs containers as a non-root user, which makes the stock nginx
+    // image crash-loop ("chown(/var/cache/nginx/...) Operation not permitted").
+    port: 8080,
+    healthPath: '/',
+    weight: 'medium',
+    dockerfile: `FROM node:22-slim AS build
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginxinc/nginx-unprivileged:1.27-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 8080
+`,
+  },
+  {
+    key: 'rust-axum',
+    label: 'Rust (Axum)',
+    relDir: 'rust/axum-basic',
+    port: 3000,
+    healthPath: '/health',
+    weight: 'heavy',
+    dockerfile: `FROM rust:1-slim AS build
+WORKDIR /src
+COPY . .
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+# Cargo.toml package name is "axum-basic" -> binary target/release/axum-basic.
+COPY --from=build /src/target/release/axum-basic /usr/local/bin/server
+ENV PORT=3000
+EXPOSE 3000
+CMD ["/usr/local/bin/server"]
+`,
+  },
+]
+
+export function findExample(key: string): ExampleProject | undefined {
+  return EXAMPLES.find((e) => e.key === key)
+}
+
+/** The fast, reliable default subset (light + medium, skips heavy builds). */
+export const DEFAULT_SUBSET = ['go-gin', 'python-flask', 'node-nestjs']
+
+/**
+ * Render the example into a scratch build context (copying its source and the
+ * generated Dockerfile) and `docker build` it. Returns the image ref to deploy.
+ * Never mutates the repo source tree.
+ *
+ * IMPORTANT: Temps deploys an image by having the server `docker pull` it, so a
+ * bare local tag (`temps-e2e-example/<key>`) is NOT deployable — the pull 404s
+ * and the deploy fails (the proxy then serves the console fallback, masking the
+ * failure). Pass `registry` (e.g. `localhost:5111`) to tag + push the image so
+ * the server can actually pull it; the returned ref is the pushed registry ref.
+ */
+export async function buildExampleImage(
+  ex: ExampleProject,
+  opts: {
+    examplesRoot: string
+    scratchRoot: string
+    /** Registry host[:port] to tag + push to (e.g. "localhost:5111"). */
+    registry?: string
+    tag?: string
+    onLog?: (line: string) => void
+  },
+): Promise<string> {
+  const srcDir = join(opts.examplesRoot, ex.relDir)
+  const ctxDir = join(opts.scratchRoot, ex.key)
+  const imageRef = opts.tag
+    ? opts.tag
+    : opts.registry
+      ? `${opts.registry}/e2e-${ex.key}:latest`
+      : `temps-e2e-example/${ex.key}:latest`
+
+  await rm(ctxDir, { recursive: true, force: true })
+  await mkdir(ctxDir, { recursive: true })
+  // Copy the example source, skipping heavy/regenerable dirs so the build
+  // context stays small and reproducible.
+  await cp(srcDir, ctxDir, {
+    recursive: true,
+    filter: (s) =>
+      !/(^|\/)(node_modules|target|dist|\.next|\.git)(\/|$)/.test(s),
+  })
+  await writeFile(join(ctxDir, 'Dockerfile'), ex.dockerfile, 'utf8')
+
+  opts.onLog?.(`docker build -t ${imageRef} ${ctxDir}`)
+  await dockerBuild(ctxDir, imageRef, opts.onLog)
+
+  if (opts.registry) {
+    opts.onLog?.(`docker push ${imageRef}`)
+    await dockerPush(imageRef, opts.onLog)
+  }
+  return imageRef
+}
+
+/** Run `docker build`, streaming output through onLog; throws on non-zero exit. */
+async function dockerBuild(
+  contextDir: string,
+  tag: string,
+  onLog?: (line: string) => void,
+): Promise<void> {
+  await runDocker(['build', '--load', '-t', tag, contextDir], onLog, `docker build ${tag}`)
+}
+
+/** Run `docker push`, streaming output through onLog; throws on non-zero exit. */
+async function dockerPush(tag: string, onLog?: (line: string) => void): Promise<void> {
+  await runDocker(['push', tag], onLog, `docker push ${tag}`)
+}
+
+/** Spawn a docker subcommand, stream its output through onLog, throw on failure. */
+async function runDocker(
+  args: string[],
+  onLog: ((line: string) => void) | undefined,
+  what: string,
+): Promise<void> {
+  const proc = Bun.spawn(['docker', ...args], { stdout: 'pipe', stderr: 'pipe' })
+  const pump = async (stream: ReadableStream<Uint8Array>) => {
+    const reader = stream.getReader()
+    const decoder = new TextDecoder()
+    let buf = ''
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buf += decoder.decode(value, { stream: true })
+      const lines = buf.split('\n')
+      buf = lines.pop() ?? ''
+      for (const l of lines) if (l.trim()) onLog?.(l)
+    }
+    if (buf.trim()) onLog?.(buf)
+  }
+  await Promise.all([pump(proc.stdout), pump(proc.stderr)])
+  const code = await proc.exited
+  if (code !== 0) {
+    throw new Error(`${what} failed (exit ${code})`)
+  }
+}

--- a/apps/temps-e2e/src/lib/flows.ts
+++ b/apps/temps-e2e/src/lib/flows.ts
@@ -1,0 +1,369 @@
+/**
+ * High-level Temps control-plane flows used by the e2e commands: create a
+ * project, provision a database service, deploy a prebuilt image, poll for
+ * health, resolve the public URL, and verify traffic via proxy logs.
+ *
+ * Each helper takes the per-call `client` so a run is fully isolated.
+ */
+import {
+  createProject,
+  deleteProject,
+  getEnvironments,
+  deployFromImage,
+  getDeployment,
+  createService,
+  deleteService,
+  getProxyLogs,
+  teardownDeployment,
+} from '@temps-sdk/api'
+import type { Client } from '@temps-sdk/api/client'
+import { unwrap } from './client.ts'
+
+/** Terminal-success deployment states (see ADR / generated DeploymentResponse.state). */
+const DEPLOY_SUCCESS = new Set(['completed', 'succeeded', 'running', 'active'])
+const DEPLOY_FAILED = new Set(['failed', 'cancelled', 'errored', 'error'])
+
+export interface CreatedProject {
+  id: number
+  name: string
+  slug: string
+}
+
+/** Create a Dockerfile/image-based project tagged with the run id. */
+export async function createE2eProject(
+  client: Client,
+  opts: { name: string; exposedPort?: number },
+): Promise<CreatedProject> {
+  const res = await createProject({
+    client,
+    body: {
+      name: opts.name,
+      directory: '.',
+      main_branch: 'main',
+      // 'dockerfile' preset is the generic container path; image deploys don't
+      // need a git repo or build command.
+      preset: 'dockerfile',
+      storage_service_ids: [],
+      source_type: 'docker_image',
+      exposed_port: opts.exposedPort ?? 80,
+      is_web_app: true,
+    },
+  })
+  const p = unwrap(res, 'createProject')
+  return { id: p.id, name: p.name, slug: p.slug }
+}
+
+/** Pick the production (non-preview) environment for a project. */
+export async function getProductionEnvironment(
+  client: Client,
+  projectId: number,
+): Promise<{ id: number; mainUrl: string; name: string }> {
+  const res = await getEnvironments({ client, path: { project_id: projectId } })
+  const envs = unwrap(res, 'getEnvironments')
+  const prod = envs.find((e) => e.is_preview === false) ?? envs[0]
+  if (!prod) throw new Error(`No environment found for project ${projectId}`)
+  return { id: prod.id, mainUrl: prod.main_url, name: prod.name }
+}
+
+/** Trigger a deploy from a prebuilt public image; returns the deployment id. */
+export async function deployImage(
+  client: Client,
+  opts: { projectId: number; environmentId: number; imageRef: string },
+): Promise<number> {
+  const res = await deployFromImage({
+    client,
+    path: { project_id: opts.projectId, environment_id: opts.environmentId },
+    body: { image_ref: opts.imageRef },
+  })
+  const d = unwrap(res, 'deployFromImage')
+  return d.id
+}
+
+export interface DeployStatus {
+  state: string
+  url?: string | null
+  terminal: boolean
+  ok: boolean
+}
+
+/** Read a deployment's current state. */
+export async function getDeployStatus(
+  client: Client,
+  projectId: number,
+  deploymentId: number,
+): Promise<DeployStatus> {
+  const res = await getDeployment({
+    client,
+    path: { project_id: projectId, deployment_id: deploymentId },
+  })
+  const d = unwrap(res, 'getDeployment') as { state?: string; status?: string; url?: string | null }
+  const state = (d.state ?? d.status ?? 'unknown').toLowerCase()
+  const ok = DEPLOY_SUCCESS.has(state)
+  const failed = DEPLOY_FAILED.has(state)
+  return { state, url: d.url, terminal: ok || failed, ok }
+}
+
+/** Poll a deployment until it reaches a terminal state or times out. */
+export async function waitForDeployment(
+  client: Client,
+  opts: {
+    projectId: number
+    deploymentId: number
+    timeoutMs?: number
+    intervalMs?: number
+    onPoll?: (s: DeployStatus, elapsedMs: number) => void
+  },
+): Promise<DeployStatus> {
+  const timeoutMs = opts.timeoutMs ?? 5 * 60_000
+  const intervalMs = opts.intervalMs ?? 3000
+  const start = performance.now()
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const s = await getDeployStatus(client, opts.projectId, opts.deploymentId)
+    const elapsed = performance.now() - start
+    opts.onPoll?.(s, elapsed)
+    if (s.terminal) return s
+    if (elapsed > timeoutMs) {
+      throw new Error(
+        `Deployment ${opts.deploymentId} did not reach a terminal state within ${Math.round(timeoutMs / 1000)}s (last state: ${s.state})`,
+      )
+    }
+    await sleep(intervalMs)
+  }
+}
+
+export interface CreatedService {
+  id: number
+  name: string
+}
+
+/** Provision an external service (postgres/redis/etc.) tagged with the run id. */
+export async function createE2eService(
+  client: Client,
+  opts: {
+    name: string
+    serviceType: 'postgres' | 'redis' | 'mongodb' | 's3' | 'kv' | 'blob' | 'rustfs' | 'minio'
+    version?: string
+    parameters?: Record<string, unknown>
+  },
+): Promise<CreatedService> {
+  const res = await createService({
+    client,
+    body: {
+      name: opts.name,
+      service_type: opts.serviceType,
+      parameters: opts.parameters ?? {},
+      ...(opts.version ? { version: opts.version } : {}),
+    },
+  })
+  const s = unwrap(res, 'createService') as { id: number; name: string }
+  return { id: s.id, name: s.name }
+}
+
+/**
+ * Count proxy-log entries recorded for a host since a given time. Used to verify
+ * that generated traffic actually landed on the proxy/ingest pipeline.
+ */
+export async function countProxyLogs(
+  client: Client,
+  opts: { host?: string; sinceMs?: number },
+): Promise<number> {
+  const query: Record<string, unknown> = { page: 1, page_size: 1 }
+  if (opts.host) query.host = opts.host
+  if (opts.sinceMs) query.start_date = new Date(opts.sinceMs).toISOString()
+  const res = await getProxyLogs({ client, query })
+  const data = unwrap(res, 'getProxyLogs') as { total?: number; logs?: unknown[] }
+  return data.total ?? data.logs?.length ?? 0
+}
+
+/**
+ * Best-effort teardown of resources created by a run. Never throws.
+ * Order matters: tear down running deployments (stops the container + removes
+ * the proxy route) BEFORE deleting the project row, otherwise the container can
+ * linger serving traffic after the project is gone.
+ */
+export async function teardown(
+  client: Client,
+  resources: {
+    deployments?: { projectId: number; deploymentId: number }[]
+    projectIds?: number[]
+    serviceIds?: number[]
+  },
+): Promise<{
+  teardownDeployments: number
+  deletedProjects: number
+  deletedServices: number
+  errors: string[]
+}> {
+  const errors: string[] = []
+  let teardownDeployments = 0
+  let deletedProjects = 0
+  let deletedServices = 0
+
+  for (const d of resources.deployments ?? []) {
+    try {
+      await teardownDeployment({
+        client,
+        path: { project_id: d.projectId, deployment_id: d.deploymentId },
+      })
+      teardownDeployments++
+    } catch (e) {
+      errors.push(`teardownDeployment(${d.deploymentId}): ${(e as Error).message}`)
+    }
+  }
+  // teardownDeployment returns before the container is fully removed (the stop
+  // is async server-side). Give it a short grace so deleting the project below
+  // doesn't orphan a still-stopping container.
+  if ((resources.deployments ?? []).length > 0) {
+    await sleep(3000)
+  }
+  for (const id of resources.projectIds ?? []) {
+    try {
+      await deleteProject({ client, path: { id } })
+      deletedProjects++
+    } catch (e) {
+      errors.push(`deleteProject(${id}): ${(e as Error).message}`)
+    }
+  }
+  for (const id of resources.serviceIds ?? []) {
+    try {
+      await deleteService({ client, path: { id } })
+      deletedServices++
+    } catch (e) {
+      errors.push(`deleteService(${id}): ${(e as Error).message}`)
+    }
+  }
+  return { teardownDeployments, deletedProjects, deletedServices, errors }
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+/**
+ * Turn a deployment's public `main_url` into a target the load generator can
+ * actually reach. The proxy routes by Host header, so we send requests to the
+ * INSTANCE's address (e.g. http://localhost:8080) while passing the app's
+ * hostname as the Host header. This avoids depending on the app's scheme/port
+ * (the main_url is often https on :443) and on external DNS — it always lands on
+ * the same proxy that serves real traffic.
+ */
+export function resolveLoadTarget(
+  instanceUrl: string,
+  appMainUrl: string,
+): { url: string; host: string; logHost: string; headers: Record<string, string> } {
+  const parsed = new URL(appMainUrl)
+  // `host` includes the port (e.g. `app.sslip.io:8080`) — this is what the proxy
+  // routes on, so it's the Host header we send.
+  const appHost = parsed.host
+  // The proxy records the bare HOSTNAME (no port) in `proxy_logs.host`, so the
+  // verification query must match on hostname-only — otherwise a host carrying a
+  // non-standard port (the common local case) never matches and traffic looks
+  // "unrecorded" even though it landed.
+  const logHost = parsed.hostname
+  // Strip any /api suffix the instance URL might carry; the proxy data plane is
+  // the bare origin.
+  const base = instanceUrl.replace(/\/+$/, '').replace(/\/api$/, '')
+  const baseUrl = new URL(base)
+  // Hit the proxy origin with the app's host header.
+  const url = `${baseUrl.protocol}//${baseUrl.host}/`
+  return { url, host: appHost, logHost, headers: { Host: appHost } }
+}
+
+/**
+ * Poll an HTTP target until it returns a non-5xx/non-0 response or times out.
+ * Confirms the deployed app is actually serving before we load-test it (the
+ * deployment status string alone is not a reliability signal).
+ */
+export async function waitForHttpReady(opts: {
+  url: string
+  headers?: Record<string, string>
+  timeoutMs?: number
+  intervalMs?: number
+  onPoll?: (status: number, elapsedMs: number) => void
+}): Promise<number> {
+  const timeoutMs = opts.timeoutMs ?? 120_000
+  const intervalMs = opts.intervalMs ?? 2000
+  const start = performance.now()
+  let last = 0
+  while (performance.now() - start < timeoutMs) {
+    try {
+      const ctrl = new AbortController()
+      const t = setTimeout(() => ctrl.abort(), 10_000)
+      const res = await fetch(opts.url, { headers: opts.headers, signal: ctrl.signal })
+      clearTimeout(t)
+      await res.arrayBuffer().catch(() => undefined)
+      last = res.status
+      opts.onPoll?.(res.status, performance.now() - start)
+      if (res.status > 0 && res.status < 500) return res.status
+    } catch {
+      opts.onPoll?.(0, performance.now() - start)
+    }
+    await sleep(intervalMs)
+  }
+  throw new Error(
+    `App did not become HTTP-ready within ${Math.round(timeoutMs / 1000)}s (last status: ${last})`,
+  )
+}
+
+/**
+ * True when a response body is the Temps console SPA shell, not an app.
+ *
+ * Must match ONLY the console — a deployed React/Vite app is also an HTML
+ * document with a `<div id="root">`, so matching on that generic marker gives
+ * false positives. Key on the console's own page <title> (and its favicon path),
+ * which a deployed example never sets.
+ */
+function looksLikeConsoleFallback(body: string): boolean {
+  if (!/<!doctype html>/i.test(body)) return false
+  // The Temps console index.html sets `<title>Temps</title>`. A static SPA
+  // example sets its own title (e.g. "react-basic"), so this stays specific.
+  return /<title>\s*Temps\s*<\/title>/i.test(body)
+}
+
+/**
+ * Poll the target until it serves the deployed app rather than the Temps console
+ * SPA fallback, then return. The proxy serves the console shell (HTTP 200,
+ * `<title>Temps</title>`) for unknown/failed hosts AND for the brief window
+ * before a freshly-started container's route propagates — so a bare status check
+ * cannot distinguish "app is serving" from "deploy failed / not routed yet".
+ * This is the guard that makes a broken deploy actually fail (after giving the
+ * route a fair chance to propagate).
+ */
+export async function assertNotConsoleFallback(opts: {
+  url: string
+  headers?: Record<string, string>
+  timeoutMs?: number
+  intervalMs?: number
+}): Promise<void> {
+  const timeoutMs = opts.timeoutMs ?? 30_000
+  const intervalMs = opts.intervalMs ?? 1500
+  const start = performance.now()
+  let body = ''
+  let status = 0
+  while (performance.now() - start < timeoutMs) {
+    const ctrl = new AbortController()
+    const t = setTimeout(() => ctrl.abort(), 10_000)
+    try {
+      const res = await fetch(opts.url, { headers: opts.headers, signal: ctrl.signal })
+      status = res.status
+      body = await res.text()
+      if (!looksLikeConsoleFallback(body)) return // real app response
+    } catch {
+      // transient — retry
+    } finally {
+      clearTimeout(t)
+    }
+    await sleep(intervalMs)
+  }
+  throw new Error(
+    `served the Temps console fallback (HTTP ${status}) instead of the app after ` +
+      `${Math.round(timeoutMs / 1000)}s — the deployment is not actually serving ` +
+      `(body starts: ${JSON.stringify(body.slice(0, 80))})`,
+  )
+}
+
+/** A stable, unique-ish run id derived from a timestamp passed in by the caller. */
+export function makeRunId(nowMs: number): string {
+  return `e2e-${nowMs.toString(36)}`
+}

--- a/apps/temps-e2e/src/lib/load.ts
+++ b/apps/temps-e2e/src/lib/load.ts
@@ -1,0 +1,184 @@
+/**
+ * Worker-pooled HTTP load generator. Fires a fixed number of requests (or runs
+ * for a fixed duration) at a target URL with bounded concurrency, then reports
+ * throughput, latency percentiles, status-code histogram and error rate.
+ *
+ * Pure fetch-based — no external load-test dependency. Designed to push tens of
+ * thousands of requests from a single process by keeping `concurrency` in-flight
+ * promises rather than spawning one promise per request up front.
+ */
+
+export interface LoadOptions {
+  url: string
+  /** Total requests to send. Ignored if `durationMs` is set. */
+  requests?: number
+  /** Run for this many ms instead of a fixed request count. */
+  durationMs?: number
+  /** Max in-flight requests. */
+  concurrency: number
+  method?: string
+  headers?: Record<string, string>
+  body?: string
+  /** Per-request timeout in ms. */
+  timeoutMs?: number
+  /**
+   * Retries for transient connection-level failures (socket reset/timeout with
+   * no HTTP response). HTTP error statuses (4xx/5xx) are NOT retried — they are
+   * real responses. Defaults to 2.
+   */
+  connectRetries?: number
+  /** Called periodically with progress (completed count). */
+  onProgress?: (completed: number, total: number | undefined) => void
+}
+
+export interface LoadResult {
+  url: string
+  sent: number
+  completed: number
+  errors: number
+  /** requests/second over the wall-clock run. */
+  rps: number
+  durationMs: number
+  latency: {
+    minMs: number
+    p50Ms: number
+    p95Ms: number
+    p99Ms: number
+    maxMs: number
+    meanMs: number
+  }
+  /** statusCode -> count. Network errors are bucketed under 0. */
+  statusCodes: Record<number, number>
+  /** True when every completed request returned a 2xx/3xx. */
+  ok: boolean
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))
+  return sorted[idx] ?? 0
+}
+
+export async function runLoad(opts: LoadOptions): Promise<LoadResult> {
+  const {
+    url,
+    concurrency,
+    method = 'GET',
+    headers,
+    body,
+    timeoutMs = 10_000,
+    connectRetries = 2,
+    durationMs,
+  } = opts
+  const totalRequests = durationMs ? undefined : (opts.requests ?? 1000)
+
+  const latencies: number[] = []
+  const statusCodes: Record<number, number> = {}
+  let sent = 0
+  let completed = 0
+  let errors = 0
+
+  const startWall = performance.now()
+  const deadline = durationMs ? startWall + durationMs : undefined
+
+  function shouldContinue(): boolean {
+    if (deadline !== undefined) return performance.now() < deadline
+    return sent < (totalRequests as number)
+  }
+
+  let lastProgressAt = 0
+  function reportProgress() {
+    if (!opts.onProgress) return
+    const now = performance.now()
+    if (now - lastProgressAt > 250) {
+      lastProgressAt = now
+      opts.onProgress(completed, totalRequests)
+    }
+  }
+
+  async function attempt(): Promise<{ status: number; ms: number }> {
+    const t0 = performance.now()
+    const ctrl = new AbortController()
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs)
+    try {
+      const res = await fetch(url, { method, headers, body, signal: ctrl.signal })
+      // Drain the body so the connection can be reused and timing is realistic.
+      await res.arrayBuffer().catch(() => undefined)
+      return { status: res.status, ms: performance.now() - t0 }
+    } catch {
+      // Connection-level failure (reset/abort/timeout) — no HTTP response.
+      return { status: 0, ms: performance.now() - t0 }
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  async function oneRequest(): Promise<void> {
+    let result = await attempt()
+    let totalMs = result.ms
+    // Retry only transient connection failures (status 0). A real 4xx/5xx is a
+    // genuine response and is recorded as-is.
+    let retries = connectRetries
+    while (result.status === 0 && retries > 0) {
+      retries--
+      result = await attempt()
+      totalMs += result.ms
+    }
+    latencies.push(totalMs)
+    statusCodes[result.status] = (statusCodes[result.status] ?? 0) + 1
+    if (result.status === 0 || result.status >= 400) errors++
+    completed++
+    reportProgress()
+  }
+
+  // A worker pulls work until the stop condition is met. We run `concurrency`
+  // workers; each keeps exactly one request in flight at a time, so total
+  // in-flight === concurrency.
+  async function worker(): Promise<void> {
+    while (shouldContinue()) {
+      sent++
+      await oneRequest()
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, () => worker()))
+
+  const wallMs = performance.now() - startWall
+  latencies.sort((a, b) => a - b)
+  const sum = latencies.reduce((acc, v) => acc + v, 0)
+
+  return {
+    url,
+    sent,
+    completed,
+    errors,
+    rps: completed / (wallMs / 1000),
+    durationMs: wallMs,
+    latency: {
+      minMs: latencies[0] ?? 0,
+      p50Ms: percentile(latencies, 50),
+      p95Ms: percentile(latencies, 95),
+      p99Ms: percentile(latencies, 99),
+      maxMs: latencies[latencies.length - 1] ?? 0,
+      meanMs: latencies.length ? sum / latencies.length : 0,
+    },
+    statusCodes,
+    ok: errors === 0,
+  }
+}
+
+/** Pretty one-block summary for human output. */
+export function formatLoadResult(r: LoadResult): string {
+  const codes = Object.entries(r.statusCodes)
+    .sort(([a], [b]) => Number(a) - Number(b))
+    .map(([code, n]) => `${code === '0' ? 'ERR' : code}:${n}`)
+    .join('  ')
+  const ms = (n: number) => `${n.toFixed(1)}ms`
+  return [
+    `  target      ${r.url}`,
+    `  requests    ${r.completed} completed / ${r.sent} sent  (${r.errors} errors)`,
+    `  throughput  ${r.rps.toFixed(0)} req/s  over ${(r.durationMs / 1000).toFixed(1)}s`,
+    `  latency     p50 ${ms(r.latency.p50Ms)}  p95 ${ms(r.latency.p95Ms)}  p99 ${ms(r.latency.p99Ms)}  max ${ms(r.latency.maxMs)}`,
+    `  status      ${codes}`,
+  ].join('\n')
+}

--- a/apps/temps-e2e/tsconfig.json
+++ b/apps/temps-e2e/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["bun"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Adds an `examples` command to `apps/temps-e2e` that proves every source project under `examples/` actually deploys to a live Temps and serves real traffic.

For each example it renders a minimal Dockerfile into a scratch context (repo tree untouched), builds + pushes to a registry the server can pull from, then runs the full lifecycle: create project → deploy → wait healthy → **assert the real app responds (not the Temps console fallback)** → load → verify proxy logs → teardown.

**Verified `--all` 5/5:** Go (Gin), Python (Flask), Node (NestJS), Vite (React via nginx-unprivileged), Rust (Axum).

Also hardens the shared scenario lifecycle:
- `assertNotConsoleFallback`: a 200 alone isn't proof — the proxy serves the console SPA for unknown/failed hosts, so assert the body is the app
- `confirm deployment did not fail`: reject a deploy that flipped to failed
- `resolveLoadTarget`: query proxy_logs by bare hostname (proxy stores host without port), fixing false 'no logs recorded' failures

Scope: 12 files, +1815, all under `apps/temps-e2e/` (TypeScript). No Rust/migrations/web. Reviewed via /review-pr (APPROVE) + security-auditor (APPROVE, nits only).