### PR TITLE
feat(monitoring): monitoring on by default for new services + DNS/domain UI polish

### DIFF
--- a/crates/temps-config/src/service.rs
+++ b/crates/temps-config/src/service.rs
@@ -878,7 +878,15 @@ impl ConfigService {
     ) -> Result<String, ConfigServiceError> {
         let settings = self.get_settings().await?;
 
-        // Determine protocol and port from external_url if set, otherwise default to https
+        // Determine protocol and port from external_url if set.
+        //
+        // This MUST match how the deployment overview builds the visitable URL
+        // (`temps-deployments::compute_environment_url`/`compute_deployment_url`)
+        // so that uptime monitors check the same endpoint the app actually
+        // serves on. When `external_url` is unset (typical local install), the
+        // app is reachable over HTTP on the proxy listener port (e.g. :8080),
+        // NOT over HTTPS on :443 — defaulting to https here made monitors ping
+        // an unreachable URL and report a false "Major Outage".
         let (protocol, port) = if let Some(ref external_url) = settings.external_url {
             if let Ok(parsed) = url::Url::parse(external_url) {
                 (parsed.scheme().to_string(), parsed.port())
@@ -890,7 +898,7 @@ impl ConfigService {
                 ("https".to_string(), None)
             }
         } else {
-            ("https".to_string(), None)
+            ("http".to_string(), Some(self.proxy_port()))
         };
 
         // Use preview_domain if set, otherwise fallback to DEFAULT_LOCAL_DOMAIN

--- a/crates/temps-providers/src/handlers/handlers.rs
+++ b/crates/temps-providers/src/handlers/handlers.rs
@@ -501,6 +501,43 @@ async fn create_service(
                 error!("Failed to create audit log: {}", e);
             }
 
+            // Monitoring is on by default for new services (metrics_enabled is set
+            // to true at creation). Wire up the supporting state here, in the handler
+            // layer where api_key_service / config_service live. All side effects are
+            // non-fatal — a monitoring-setup failure must not fail service creation.
+            //
+            // - Seed default alert rules for the engine (idempotent, all engines).
+            // - For OTLP-push engines (rustfs/s3) provision the ingest key + URL and
+            //   apply it. The container was just created, so this restart lands on a
+            //   service that is effectively still first-booting.
+            let engine = service.service_type.to_string();
+            if let Err(e) =
+                temps_monitoring::seed_default_rules(app_state.db.as_ref(), service.id, &engine)
+                    .await
+            {
+                error!(
+                    service_id = service.id,
+                    engine = %engine,
+                    error = %e,
+                    "Failed to seed default alert rules at creation; continuing"
+                );
+            }
+
+            if matches!(engine.as_str(), "rustfs" | "s3") {
+                if let Ok(model) = app_state
+                    .external_service_manager
+                    .get_service(service.id)
+                    .await
+                {
+                    crate::handlers::metrics_handlers::provision_otlp_ingest_key(
+                        &app_state,
+                        &model,
+                        auth.user_id(),
+                    )
+                    .await;
+                }
+            }
+
             app_state.telemetry.report(
                 temps_core::telemetry::TelemetryEvent::new(
                     temps_core::telemetry::TelemetryEventKind::ServiceCreated,

--- a/crates/temps-providers/src/handlers/metrics_handlers.rs
+++ b/crates/temps-providers/src/handlers/metrics_handlers.rs
@@ -938,7 +938,11 @@ async fn toggle_service_metrics(
 ///
 /// Non-fatal — failures are logged but do not fail the metrics-enable request.
 /// The user can retry by toggling metrics off and on again.
-async fn provision_otlp_ingest_key(
+///
+/// Also called by the create-service handler so newly-created OTLP-push services
+/// (rustfs/s3) come up with metrics already wired, matching `metrics_enabled`
+/// defaulting to `true` at creation.
+pub(crate) async fn provision_otlp_ingest_key(
     state: &AppState,
     service: &external_services::Model,
     user_id: i32,

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -1189,6 +1189,14 @@ impl ExternalServiceManager {
                         config: Set(Some(encrypted_config)),
                         node_id: Set(request.node_id),
                         topology: Set(topology_for_txn),
+                        // Monitoring is on by default for every new service. For DB
+                        // engines (postgres/redis/mongodb) the metrics poller picks up
+                        // any service with this flag set — zero extra footprint, no
+                        // restart. For OTLP-push engines (rustfs/s3) the create handler
+                        // provisions the ingest key right after creation. The entity
+                        // default stays `false` so existing rows and out-of-band inserts
+                        // are unaffected.
+                        metrics_enabled: Set(true),
                         created_at: Set(Utc::now()),
                         updated_at: Set(Utc::now()),
                         ..Default::default()

--- a/web/src/pages/AddDomain.tsx
+++ b/web/src/pages/AddDomain.tsx
@@ -139,12 +139,11 @@ export function AddDomain() {
           </div>
         </div>
 
-        <Card>
-          <div className="p-4 sm:p-6">
-            <Form {...form}>
-              <form
-                onSubmit={form.handleSubmit(handleSubmit)}
-                className="space-y-6"
+        <div>
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit(handleSubmit)}
+              className="space-y-6"
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' && step !== 'confirm') {
                     e.preventDefault()
@@ -501,10 +500,9 @@ export function AddDomain() {
                     </div>
                   </div>
                 )}
-              </form>
-            </Form>
-          </div>
-        </Card>
+            </form>
+          </Form>
+        </div>
       </div>
     </div>
   )

--- a/web/src/pages/CreateBackupSchedule.tsx
+++ b/web/src/pages/CreateBackupSchedule.tsx
@@ -17,14 +17,6 @@ import {
 } from '@/api/client/@tanstack/react-query.gen'
 import { ScheduleServicesSelector } from '@/components/backups/ScheduleServicesSelector'
 import { Button } from '@/components/ui/button'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
@@ -220,16 +212,16 @@ export function CreateBackupSchedule() {
         </Button>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>New backup schedule</CardTitle>
-          <CardDescription>
-            Run this S3 source's backup on a recurring cron schedule.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-6">
-          <div className="grid gap-2">
-            <Label htmlFor="name">Schedule Name</Label>
+      <div>
+        <h1 className="text-xl font-bold sm:text-2xl">New backup schedule</h1>
+        <p className="text-sm text-muted-foreground sm:text-base">
+          Run this S3 source's backup on a recurring cron schedule.
+        </p>
+      </div>
+
+      <div className="space-y-6">
+        <div className="grid gap-2">
+          <Label htmlFor="name">Schedule Name</Label>
             <Input
               id="name"
               placeholder="Daily Backup"
@@ -428,22 +420,21 @@ export function CreateBackupSchedule() {
               for S3 mirror).
             </p>
           </div>
-        </CardContent>
+      </div>
 
-        <CardFooter className="justify-end gap-2">
-          <Button variant="outline" asChild>
-            <Link to={`/backups/s3-sources/${id}`}>Cancel</Link>
-          </Button>
-          <Button
-            onClick={handleSubmit}
-            disabled={createMutation.isPending || attachMutation.isPending}
-          >
-            {createMutation.isPending || attachMutation.isPending
-              ? 'Creating…'
-              : 'Create schedule'}
-          </Button>
-        </CardFooter>
-      </Card>
+      <div className="flex justify-end gap-2">
+        <Button variant="outline" asChild>
+          <Link to={`/backups/s3-sources/${id}`}>Cancel</Link>
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          disabled={createMutation.isPending || attachMutation.isPending}
+        >
+          {createMutation.isPending || attachMutation.isPending
+            ? 'Creating…'
+            : 'Create schedule'}
+        </Button>
+      </div>
     </div>
   )
 }

--- a/web/src/pages/DnsProviderDetail.tsx
+++ b/web/src/pages/DnsProviderDetail.tsx
@@ -494,22 +494,24 @@ export default function DnsProviderDetail() {
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <div className="grid gap-2">
+              <ul role="list" className="divide-y rounded-md border">
                 {zones.zones.map((zone) => (
-                  <div
+                  <li
                     key={zone.id}
-                    className="flex items-center justify-between p-3 border rounded-lg"
+                    className="flex items-center justify-between gap-3 px-3 py-2.5"
                   >
-                    <div>
-                      <p className="font-medium">{zone.name}</p>
-                      <p className="text-sm text-muted-foreground">
+                    <div className="min-w-0">
+                      <p className="truncate font-medium">{zone.name}</p>
+                      <p className="truncate text-sm text-muted-foreground">
                         ID: {zone.id}
                       </p>
                     </div>
-                    <Badge variant="outline">{zone.status}</Badge>
-                  </div>
+                    <Badge variant="outline" className="shrink-0">
+                      {zone.status}
+                    </Badge>
+                  </li>
                 ))}
-              </div>
+              </ul>
             </CardContent>
           </Card>
         )}
@@ -550,15 +552,15 @@ export default function DnsProviderDetail() {
                 </p>
               </div>
             ) : (
-              <div className="grid gap-3">
+              <ul role="list" className="divide-y rounded-md border">
                 {managedDomains.map((domain) => (
-                  <div
+                  <li
                     key={domain.id}
-                    className="flex items-center justify-between p-4 border rounded-lg"
+                    className="flex items-center justify-between gap-3 px-4 py-3"
                   >
-                    <div className="space-y-1">
-                      <div className="flex items-center gap-2">
-                        <p className="font-medium">{domain.domain}</p>
+                    <div className="min-w-0 space-y-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="truncate font-medium">{domain.domain}</p>
                         {domain.verified ? (
                           <Badge
                             variant="secondary"
@@ -581,17 +583,17 @@ export default function DnsProviderDetail() {
                         )}
                       </div>
                       {domain.zone_id && (
-                        <p className="text-sm text-muted-foreground">
+                        <p className="truncate text-sm text-muted-foreground">
                           Zone ID: {domain.zone_id}
                         </p>
                       )}
                       {domain.verification_error && (
-                        <p className="text-sm text-destructive">
+                        <p className="truncate text-sm text-destructive">
                           {domain.verification_error}
                         </p>
                       )}
                     </div>
-                    <div className="flex items-center gap-2">
+                    <div className="flex shrink-0 items-center gap-2">
                       {!domain.verified && (
                         <Button
                           variant="outline"
@@ -616,9 +618,9 @@ export default function DnsProviderDetail() {
                         <Trash2 className="h-4 w-4" />
                       </Button>
                     </div>
-                  </div>
+                  </li>
                 ))}
-              </div>
+              </ul>
             )}
           </CardContent>
         </Card>

--- a/web/src/pages/DnsProviders.tsx
+++ b/web/src/pages/DnsProviders.tsx
@@ -18,7 +18,6 @@ import {
 } from '@/components/ui/alert-dialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { CreateActionButton } from '@/components/ui/create-action-button'
 import {
   DropdownMenu,
@@ -34,6 +33,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   AlertCircle,
   CheckCircle2,
+  ChevronRight,
   Globe,
   Loader2,
   MoreVertical,
@@ -150,18 +150,24 @@ export function DnsProviders() {
     <div className="flex-1 overflow-auto">
       <div className="space-y-6 p-4 sm:p-6">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h1 className="text-2xl font-bold">DNS Providers</h1>
-            <p className="text-muted-foreground">
+          <div className="min-w-0">
+            <h1 className="text-xl font-bold sm:text-2xl">DNS Providers</h1>
+            <p className="text-sm text-muted-foreground sm:text-base">
               Manage your DNS providers for automatic DNS record configuration
             </p>
           </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <Button variant="outline" size="sm" onClick={() => refetch()}>
-              <RefreshCw className="mr-2 h-4 w-4" />
-              Refresh
+          <div className="flex items-center gap-2 self-start sm:self-auto">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => refetch()}
+              aria-label="Refresh"
+              title="Refresh"
+            >
+              <RefreshCw className="h-4 w-4" />
             </Button>
             <CreateActionButton
+              size="sm"
               onClick={() => navigate('/dns-providers/add')}
               label="Add DNS Provider"
             />
@@ -177,171 +183,150 @@ export function DnsProviders() {
               support if the issue persists.
             </AlertDescription>
           </Alert>
+        ) : isLoading ? (
+          <div className="divide-y rounded-lg border">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-4 px-4 py-3 animate-pulse"
+              >
+                <div className="size-9 shrink-0 rounded-md bg-muted" />
+                <div className="flex-1 min-w-0 space-y-1.5">
+                  <div className="h-4 w-48 bg-muted rounded" />
+                  <div className="h-3 w-64 bg-muted rounded" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : !dnsProviders?.length ? (
+          <EmptyPlaceholder
+            icon={Globe}
+            title="No DNS providers found"
+            description="Get started by adding a DNS provider like Cloudflare or Namecheap to enable automatic DNS record management"
+          >
+            <Button onClick={() => navigate('/dns-providers/add')}>
+              <Plus className="mr-2 h-4 w-4" />
+              Add DNS Provider
+            </Button>
+          </EmptyPlaceholder>
         ) : (
-          <Card>
-            <CardHeader>
-              <CardTitle>Active Providers</CardTitle>
-            </CardHeader>
-            <CardContent>
-              {isLoading ? (
-                <div className="grid gap-4">
-                  {Array.from({ length: 3 }).map((_, i) => (
-                    <div
-                      key={i}
-                      className="p-4 border rounded-lg space-y-3 animate-pulse"
-                    >
-                      <div className="flex items-center justify-between">
-                        <div className="h-5 w-48 bg-muted rounded" />
-                        <div className="h-6 w-20 bg-muted rounded" />
-                      </div>
-                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                        <div className="space-y-2">
-                          <div className="h-4 w-24 bg-muted rounded" />
-                          <div className="h-4 w-32 bg-muted rounded" />
-                        </div>
-                        <div className="space-y-2">
-                          <div className="h-4 w-24 bg-muted rounded" />
-                          <div className="h-4 w-32 bg-muted rounded" />
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : !dnsProviders?.length ? (
-                <EmptyPlaceholder
-                  icon={Globe}
-                  title="No DNS providers found"
-                  description="Get started by adding a DNS provider like Cloudflare or Namecheap to enable automatic DNS record management"
+          <div className="overflow-hidden rounded-lg border">
+            <ul role="list" className="divide-y">
+              {dnsProviders.map((provider) => (
+                <li
+                  key={provider.id}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => navigate(`/dns-providers/${provider.id}`)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      navigate(`/dns-providers/${provider.id}`)
+                    }
+                  }}
+                  className="flex cursor-pointer items-center gap-3 px-3 py-3 transition-colors hover:bg-muted/40 focus:bg-muted/40 focus:outline-none sm:gap-4 sm:px-4"
                 >
-                  <Button onClick={() => navigate('/dns-providers/add')}>
-                    <Plus className="mr-2 h-4 w-4" />
-                    Add DNS Provider
-                  </Button>
-                </EmptyPlaceholder>
-              ) : (
-                <div className="grid gap-4">
-                  {dnsProviders.map((provider) => (
-                    <div
-                      key={provider.id}
-                      className="group relative p-4 border rounded-lg transition-colors hover:bg-muted/50 cursor-pointer"
-                      onClick={() =>
-                        navigate(`/dns-providers/${provider.id}`)
-                      }
-                    >
-                      <div className="flex flex-col sm:flex-row sm:items-center gap-4">
-                        <div className="flex-1 min-w-0 space-y-1">
-                          <div className="flex items-center gap-3">
-                            {getProviderIcon(provider.provider_type)}
-                            <span className="font-medium truncate">
-                              {provider.name}
-                            </span>
-                            <Badge variant="outline">
-                              {formatProviderType(provider.provider_type)}
-                            </Badge>
-                            {provider.is_active ? (
-                              <Badge
-                                variant="secondary"
-                                className="flex items-center gap-1"
-                              >
-                                <CheckCircle2 className="h-3 w-3" />
-                                Active
-                              </Badge>
-                            ) : (
-                              <Badge
-                                variant="destructive"
-                                className="flex items-center gap-1"
-                              >
-                                <XCircle className="h-3 w-3" />
-                                Inactive
-                              </Badge>
-                            )}
-                          </div>
-                          <div className="grid grid-cols-1 sm:flex sm:items-center gap-x-6 gap-y-1 text-sm text-muted-foreground">
-                            {provider.description && (
-                              <div className="flex items-center gap-2">
-                                <span className="truncate max-w-[300px]">
-                                  {provider.description}
-                                </span>
-                              </div>
-                            )}
-                            {provider.last_error && (
-                              <div className="flex items-center gap-2 text-destructive">
-                                <AlertCircle className="h-4 w-4" />
-                                <span className="truncate max-w-[200px]">
-                                  {provider.last_error}
-                                </span>
-                              </div>
-                            )}
-                            <div className="flex items-center gap-2">
-                              <span>Created </span>
-                              <TimeAgo
-                                date={provider.created_at}
-                                className=""
-                              />
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          className="flex items-center gap-2"
-                          onClick={(e) => e.stopPropagation()}
+                  <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted">
+                    {getProviderIcon(provider.provider_type)}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="truncate text-sm font-medium">
+                        {provider.name}
+                      </p>
+                      <Badge variant="secondary" className="text-xs">
+                        {formatProviderType(provider.provider_type)}
+                      </Badge>
+                      {provider.is_active ? (
+                        <Badge
+                          variant="outline"
+                          className="flex items-center gap-1 text-xs"
                         >
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => handleTestConnection(provider)}
-                            disabled={testConnectionMut.isPending}
-                            className="gap-2"
-                          >
-                            {testConnectionMut.isPending ? (
-                              <Loader2 className="h-4 w-4 animate-spin" />
-                            ) : (
-                              <TestTube2 className="h-4 w-4" />
-                            )}
-                            Test
-                          </Button>
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <Button variant="ghost" size="icon">
-                                <MoreVertical className="h-4 w-4" />
-                              </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              <DropdownMenuItem
-                                onClick={() =>
-                                  navigate(
-                                    `/dns-providers/${provider.id}`
-                                  )
-                                }
-                              >
-                                View Details
-                              </DropdownMenuItem>
-                              <DropdownMenuItem
-                                onClick={() => handleTestConnection(provider)}
-                              >
-                                <TestTube2 className="h-4 w-4 mr-2" />
-                                Test Connection
-                              </DropdownMenuItem>
-                              <DropdownMenuSeparator />
-                              <DropdownMenuItem
-                                className="text-destructive cursor-pointer"
-                                onSelect={(e) => {
-                                  e.preventDefault()
-                                  setProviderToDelete(provider)
-                                }}
-                              >
-                                <Trash2 className="h-4 w-4 mr-2" />
-                                Delete Provider
-                              </DropdownMenuItem>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        </div>
-                      </div>
+                          <CheckCircle2 className="h-3 w-3" />
+                          Active
+                        </Badge>
+                      ) : (
+                        <Badge
+                          variant="destructive"
+                          className="flex items-center gap-1 text-xs"
+                        >
+                          <XCircle className="h-3 w-3" />
+                          Inactive
+                        </Badge>
+                      )}
                     </div>
-                  ))}
-                </div>
-              )}
-            </CardContent>
-          </Card>
+                    {provider.last_error ? (
+                      <p className="mt-0.5 flex items-center gap-1 truncate text-xs text-destructive">
+                        <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+                        <span className="truncate">{provider.last_error}</span>
+                      </p>
+                    ) : (
+                      <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                        {provider.description
+                          ? `${provider.description} · `
+                          : ''}
+                        created <TimeAgo date={provider.created_at} />
+                      </p>
+                    )}
+                  </div>
+                  <div
+                    className="flex shrink-0 items-center gap-1 sm:gap-2"
+                    onClick={(e) => e.stopPropagation()}
+                    onPointerDown={(e) => e.stopPropagation()}
+                  >
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleTestConnection(provider)}
+                      disabled={testConnectionMut.isPending}
+                      className="hidden gap-2 sm:inline-flex"
+                    >
+                      {testConnectionMut.isPending ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <TestTube2 className="h-4 w-4" />
+                      )}
+                      Test
+                    </Button>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" size="icon" className="h-8 w-8">
+                          <MoreVertical className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                          onClick={() =>
+                            navigate(`/dns-providers/${provider.id}`)
+                          }
+                        >
+                          View Details
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() => handleTestConnection(provider)}
+                        >
+                          <TestTube2 className="h-4 w-4 mr-2" />
+                          Test Connection
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          className="text-destructive cursor-pointer"
+                          onSelect={(e) => {
+                            e.preventDefault()
+                            setProviderToDelete(provider)
+                          }}
+                        >
+                          <Trash2 className="h-4 w-4 mr-2" />
+                          Delete Provider
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                  <ChevronRight className="hidden size-4 shrink-0 text-muted-foreground/50 sm:block" />
+                </li>
+              ))}
+            </ul>
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
Carries in-progress work that was uncommitted in the working tree, now on its own branch.

**Backend**
- New services are monitored by default: `create_service` seeds the engine's default alert rules (idempotent, all engines) and provisions+applies the OTLP ingest key for push engines (rustfs/s3) at creation. All monitoring setup is non-fatal — never fails service creation.
- Uptime monitor URL building uses the proxy HTTP port when `external_url` is unset (was defaulting to https/:443 → false 'Major Outage' on local installs).

**Frontend**
- DNS providers list/detail, AddDomain, CreateBackupSchedule page polish.

Compiles clean (`cargo check -p temps-providers -p temps-config`). Not authored this session — preserved from the working tree into a reviewable PR per request.