### PR TITLE
docs: add local build prerequisites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 ### Changed
--
+- **Documentation: local build prerequisites.** The installation guide and
+  `CONTRIBUTING.md` now document the system prerequisites required to build
+  Temps from source locally (toolchain and dependencies), so new contributors
+  can get a local build working without trial and error.
 
 ### Fixed
 -

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,27 +18,46 @@ Thank you for your interest in contributing to Temps. Whether you are reporting 
 - **PostgreSQL** with TimescaleDB extension
 - **Bun** (for frontend development)
 - **Node.js** 18+
+- **C/C++ build toolchain**, **CMake**, and **pkg-config** -- required by native Rust dependencies
+- **OpenSSL development headers** -- required by Pingora/OpenSSL and Git dependencies
 - **protobuf compiler** (`protoc`) -- required by the `temps-otel` crate to compile OpenTelemetry `.proto` files
+- **rustfmt** -- required by generated-code build scripts
 - **wasm-pack** -- required to build the `temps-captcha-wasm` crate
+- **wasm32-unknown-unknown Rust target** -- required by the `temps-captcha-wasm` crate
 
-#### Installing protoc
+#### Amazon Linux 2023 build prerequisites
 
 ```bash
-# macOS
-brew install protobuf
+sudo dnf groupinstall -y "Development Tools"
+sudo dnf install -y \
+  rust cargo rustfmt rust-std-static-wasm32-unknown-unknown \
+  cmake pkgconf-pkg-config openssl-devel protobuf-compiler \
+  perl-FindBin perl-IPC-Cmd perl-File-Compare perl-File-Copy perl-Time-Piece
 
-# Debian/Ubuntu
-sudo apt-get install -y protobuf-compiler
-
-# Fedora
-sudo dnf install -y protobuf-compiler
-
-# Or download from https://github.com/protocolbuffers/protobuf/releases
+cargo install wasm-pack
 ```
 
-#### Installing wasm-pack
+If `cargo install` places `wasm-pack` in `~/.cargo/bin`, make sure that directory is on your `PATH`.
+
+#### Debian/Ubuntu build prerequisites
 
 ```bash
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential cmake pkg-config libssl-dev protobuf-compiler
+
+rustup component add rustfmt
+rustup target add wasm32-unknown-unknown
+cargo install wasm-pack
+```
+
+#### macOS build prerequisites
+
+```bash
+brew install cmake openssl pkg-config protobuf
+
+rustup component add rustfmt
+rustup target add wasm32-unknown-unknown
 cargo install wasm-pack
 ```
 

--- a/docs/installation/page.mdx
+++ b/docs/installation/page.mdx
@@ -191,6 +191,20 @@ temps --version
 
 ### Build from Source
 
+Install the local build prerequisites before compiling from source. The release build compiles native Rust dependencies, OpenTelemetry protobufs, and the web UI bundle.
+
+```bash {{ title: 'Amazon Linux 2023 prerequisites' }}
+sudo dnf groupinstall -y "Development Tools"
+sudo dnf install -y \
+  rust cargo rustfmt rust-std-static-wasm32-unknown-unknown \
+  cmake pkgconf-pkg-config openssl-devel protobuf-compiler \
+  perl-FindBin perl-IPC-Cmd perl-File-Compare perl-File-Copy perl-Time-Piece
+
+cargo install wasm-pack
+```
+
+For Debian/Ubuntu, macOS, and contributor setup details, see [CONTRIBUTING.md](https://github.com/gotempsh/temps/blob/main/CONTRIBUTING.md#prerequisites).
+
 ```bash
 # Clone the repository
 git clone https://github.com/gotempsh/temps.git


### PR DESCRIPTION
## Summary
- expand contributor prerequisites for native Rust, OpenSSL, protobuf, rustfmt, wasm, and wasm-pack tooling
- add validated Amazon Linux 2023 prerequisite commands
- add a source-build prerequisite note to the installation docs
- add a `## [Unreleased]` CHANGELOG.md entry under **Changed** describing the new local-build-prerequisites documentation (satisfies the "Check Changelog Updated" CI gate)

## Test Plan
- Docs-only change (`CONTRIBUTING.md`, `docs/installation/page.mdx`, `CHANGELOG.md`); no Rust code touched, so no local cargo build required.
- Rebased onto latest `upstream/main` (clean, no conflicts).
- `git diff --check` clean (no whitespace errors).
- CI: **Check Changelog Updated** passes, **Formatting** passes; remaining Rust jobs (Cargo Check / Clippy / Build Test Binaries / E2E) expected green for a docs-only change.
- Latest CI run: https://github.com/gotempsh/temps/actions/runs/28249986158
