### PR TITLE
fix(cli): hide --database-url password from process listings

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,6 +40,12 @@ jobs:
       ADMIN_EMAIL: admin@localho.st
       ADMIN_PASSWORD: E2eTestPass123!
       API_BASE: http://localhost:8081/api
+      # Disable anonymous product telemetry for CI. Without this, every e2e run
+      # boots a fresh instance and emits instance_started + project_created +
+      # deploy_attempted for the example apps, polluting the real telemetry DB
+      # with phantom "tried N deploys, never shipped" instances. (Opt-out values:
+      # 0/false/off/no/disabled — see temps-telemetry/src/service.rs.)
+      TEMPS_TELEMETRY: "0"
 
     steps:
       - name: Free up disk space

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 
+## [0.1.0-beta.36] - 2026-06-20
+
+### Fixed
+- **Traces page no longer crashes on traces with an empty service name.** A
+  trace whose root span never set `service.name` arrives with an empty
+  `service_name`, which flowed into the Service filter dropdown as a Radix
+  `<SelectItem value="">` and threw ("must have a value prop that is not an
+  empty string"), taking down the whole Traces page via the error boundary.
+  Empty/missing service names are now filtered out of the dropdown, and the
+  trace table shows `(unnamed)`/`unknown` fallbacks instead of blank cells.
+
+
 ## [0.1.0-beta.35] - 2026-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 ### Fixed
--
+- **`--database-url` password no longer leaks into process listings.** When the
+  database URL was passed as a CLI flag (`temps serve --database-url=postgres://user:pass@host/db`),
+  the full connection string — including the password — was visible to any user
+  on the server via `pgrep -af`, `ps aux`, or `/proc/self/cmdline`. Temps now
+  scrubs the value from its own argv immediately after clap parses the args, so
+  the process table shows `xxx` in place of the real password. The `--help`
+  output also masks the env value (`hide_env_values`). The `--database-url` flag
+  continues to work for backwards compatibility; using `TEMPS_DATABASE_URL` as
+  an environment variable remains the recommended approach since env vars are
+  never visible in process listings.
 
 
 ## [0.1.0-beta.36] - 2026-06-20

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10518,7 +10518,7 @@ dependencies = [
 
 [[package]]
 name = "temps-agent"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -10554,7 +10554,7 @@ dependencies = [
 
 [[package]]
 name = "temps-agents"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10598,7 +10598,7 @@ dependencies = [
 
 [[package]]
 name = "temps-agents-mcp-proxy"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "serde",
  "serde_json",
@@ -10606,7 +10606,7 @@ dependencies = [
 
 [[package]]
 name = "temps-ai-gateway"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10636,7 +10636,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10666,7 +10666,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-backend"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10683,7 +10683,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-events"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10716,7 +10716,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-funnels"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10737,7 +10737,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-performance"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -10760,7 +10760,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-session-replay"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10786,7 +10786,7 @@ dependencies = [
 
 [[package]]
 name = "temps-audit"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -10807,7 +10807,7 @@ dependencies = [
 
 [[package]]
 name = "temps-auth"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "argon2",
@@ -10848,7 +10848,7 @@ dependencies = [
 
 [[package]]
 name = "temps-backup"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10892,7 +10892,7 @@ dependencies = [
 
 [[package]]
 name = "temps-backup-core"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10912,7 +10912,7 @@ dependencies = [
 
 [[package]]
 name = "temps-blob"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10961,7 +10961,7 @@ dependencies = [
 
 [[package]]
 name = "temps-cli"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "argon2",
@@ -11062,7 +11062,7 @@ dependencies = [
 
 [[package]]
 name = "temps-config"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -11094,7 +11094,7 @@ dependencies = [
 
 [[package]]
 name = "temps-core"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -11132,7 +11132,7 @@ dependencies = [
 
 [[package]]
 name = "temps-database"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "futures",
@@ -11150,7 +11150,7 @@ dependencies = [
 
 [[package]]
 name = "temps-deployer"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11186,7 +11186,7 @@ dependencies = [
 
 [[package]]
 name = "temps-deployments"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11250,7 +11250,7 @@ dependencies = [
 
 [[package]]
 name = "temps-dns"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11288,7 +11288,7 @@ dependencies = [
 
 [[package]]
 name = "temps-dns-resolver"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11309,7 +11309,7 @@ dependencies = [
 
 [[package]]
 name = "temps-domains"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11359,7 +11359,7 @@ dependencies = [
 
 [[package]]
 name = "temps-edge"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -11400,7 +11400,7 @@ dependencies = [
 
 [[package]]
 name = "temps-email"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11440,7 +11440,7 @@ dependencies = [
 
 [[package]]
 name = "temps-email-tracking"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -11473,7 +11473,7 @@ dependencies = [
 
 [[package]]
 name = "temps-embeddings"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11484,7 +11484,7 @@ dependencies = [
 
 [[package]]
 name = "temps-entities"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "chrono",
  "sea-orm",
@@ -11498,7 +11498,7 @@ dependencies = [
 
 [[package]]
 name = "temps-environments"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "argon2",
@@ -11527,7 +11527,7 @@ dependencies = [
 
 [[package]]
 name = "temps-error-tracking"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11599,7 +11599,7 @@ dependencies = [
 
 [[package]]
 name = "temps-external-plugins"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -11624,7 +11624,7 @@ dependencies = [
 
 [[package]]
 name = "temps-file-store"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11639,7 +11639,7 @@ dependencies = [
 
 [[package]]
 name = "temps-geo"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -11660,7 +11660,7 @@ dependencies = [
 
 [[package]]
 name = "temps-git"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11708,7 +11708,7 @@ dependencies = [
 
 [[package]]
 name = "temps-git-credential"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "chrono",
  "nix 0.29.0",
@@ -11749,7 +11749,7 @@ dependencies = [
 
 [[package]]
 name = "temps-import"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -11776,7 +11776,7 @@ dependencies = [
 
 [[package]]
 name = "temps-import-docker"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "bollard",
@@ -11799,7 +11799,7 @@ dependencies = [
 
 [[package]]
 name = "temps-import-types"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11836,7 +11836,7 @@ dependencies = [
 
 [[package]]
 name = "temps-infra"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -11860,7 +11860,7 @@ dependencies = [
 
 [[package]]
 name = "temps-kv"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11913,7 +11913,7 @@ dependencies = [
 
 [[package]]
 name = "temps-log-aggregator"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -11948,7 +11948,7 @@ dependencies = [
 
 [[package]]
 name = "temps-logs"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-stream",
  "bollard",
@@ -11968,7 +11968,7 @@ dependencies = [
 
 [[package]]
 name = "temps-memory"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "thiserror 2.0.18",
@@ -11977,7 +11977,7 @@ dependencies = [
 
 [[package]]
 name = "temps-metrics"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -12004,7 +12004,7 @@ dependencies = [
 
 [[package]]
 name = "temps-migrations"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "sea-orm",
@@ -12017,7 +12017,7 @@ dependencies = [
 
 [[package]]
 name = "temps-monitoring"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12041,7 +12041,7 @@ dependencies = [
 
 [[package]]
 name = "temps-network"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "bollard",
@@ -12070,7 +12070,7 @@ dependencies = [
 
 [[package]]
 name = "temps-notifications"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12100,7 +12100,7 @@ dependencies = [
 
 [[package]]
 name = "temps-observability"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12127,7 +12127,7 @@ dependencies = [
 
 [[package]]
 name = "temps-otel"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -12169,7 +12169,7 @@ dependencies = [
 
 [[package]]
 name = "temps-plugin-sdk"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -12194,7 +12194,7 @@ dependencies = [
 
 [[package]]
 name = "temps-presets"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12213,7 +12213,7 @@ dependencies = [
 
 [[package]]
 name = "temps-preview-gateway"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "tokio",
@@ -12223,7 +12223,7 @@ dependencies = [
 
 [[package]]
 name = "temps-projects"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -12261,7 +12261,7 @@ dependencies = [
 
 [[package]]
 name = "temps-providers"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12318,7 +12318,7 @@ dependencies = [
 
 [[package]]
 name = "temps-proxy"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "argon2",
@@ -12388,7 +12388,7 @@ dependencies = [
 
 [[package]]
 name = "temps-pty-agent"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "bytes",
  "clap",
@@ -12406,7 +12406,7 @@ dependencies = [
 
 [[package]]
 name = "temps-query"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "bytes",
@@ -12440,7 +12440,7 @@ dependencies = [
 
 [[package]]
 name = "temps-query-postgres"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "chrono",
@@ -12496,7 +12496,7 @@ dependencies = [
 
 [[package]]
 name = "temps-queue"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "log",
  "serde",
@@ -12509,7 +12509,7 @@ dependencies = [
 
 [[package]]
 name = "temps-revenue"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12543,7 +12543,7 @@ dependencies = [
 
 [[package]]
 name = "temps-routes"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12567,7 +12567,7 @@ dependencies = [
 
 [[package]]
 name = "temps-sandbox"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "argon2",
  "async-stream",
@@ -12601,7 +12601,7 @@ dependencies = [
 
 [[package]]
 name = "temps-screenshots"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12627,7 +12627,7 @@ dependencies = [
 
 [[package]]
 name = "temps-static-files"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "axum 0.8.9",
  "temps-config",
@@ -12639,7 +12639,7 @@ dependencies = [
 
 [[package]]
 name = "temps-status-page"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12672,7 +12672,7 @@ dependencies = [
 
 [[package]]
 name = "temps-telemetry"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -12688,7 +12688,7 @@ dependencies = [
 
 [[package]]
 name = "temps-vulnerability-scanner"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12720,7 +12720,7 @@ dependencies = [
 
 [[package]]
 name = "temps-webhooks"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12751,7 +12751,7 @@ dependencies = [
 
 [[package]]
 name = "temps-wireguard"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "base64 0.22.1",
  "defguard_wireguard_rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10984,6 +10984,7 @@ dependencies = [
  "include_dir",
  "indicatif",
  "ipnet",
+ "libc",
  "mime_guess",
  "rand 0.8.6",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10992,6 +10992,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "sysinfo 0.29.11",
  "tar",
  "temps-agent",
  "temps-agents",
@@ -12675,7 +12676,9 @@ name = "temps-telemetry"
 version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
+ "chrono",
  "reqwest",
+ "sea-orm",
  "serde",
  "serde_json",
  "temps-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Temps Contributors"]

--- a/crates/temps-ai-gateway/src/handlers/gateway.rs
+++ b/crates/temps-ai-gateway/src/handlers/gateway.rs
@@ -424,7 +424,11 @@ async fn chat_completions(
                     "AI gateway streaming request started"
                 );
 
-                app_state.telemetry.report(
+                // Once-per-instance: "the AI gateway has been used here", not
+                // "an AI request happened". Guard so it fires once (carrying the
+                // provider of that first request), not on every request.
+                app_state.telemetry.report_once(
+                    "ai_gateway_first_request",
                     temps_core::telemetry::TelemetryEvent::new(
                         temps_core::telemetry::TelemetryEventKind::AiGatewayFirstRequest,
                     )
@@ -518,7 +522,11 @@ async fn chat_completions(
                     "AI gateway request completed"
                 );
 
-                app_state.telemetry.report(
+                // Once-per-instance: "the AI gateway has been used here", not
+                // "an AI request happened". Guard so it fires once (carrying the
+                // provider of that first request), not on every request.
+                app_state.telemetry.report_once(
+                    "ai_gateway_first_request",
                     temps_core::telemetry::TelemetryEvent::new(
                         temps_core::telemetry::TelemetryEventKind::AiGatewayFirstRequest,
                     )

--- a/crates/temps-analytics-events/src/handlers/events_handler.rs
+++ b/crates/temps-analytics-events/src/handlers/events_handler.rs
@@ -776,11 +776,15 @@ pub async fn record_event_metrics(
                 environment_id,
                 deployment_id
             );
-            state
-                .telemetry
-                .report(temps_core::telemetry::TelemetryEvent::new(
+            // Once-per-instance: this event means "analytics is in use on this
+            // instance", not "an analytics event arrived". Guard it so it fires
+            // once in the instance's lifetime, not on every pageview.
+            state.telemetry.report_once(
+                "analytics_first_event_received",
+                temps_core::telemetry::TelemetryEvent::new(
                     temps_core::telemetry::TelemetryEventKind::AnalyticsFirstEventReceived,
-                ));
+                ),
+            );
             StatusCode::NO_CONTENT.into_response()
         }
         Err(e) => {
@@ -902,11 +906,14 @@ pub async fn record_console_event(
         "Console event recorded: {} for project {} env={}",
         payload.event_name, project_id, payload.environment_id
     );
-    state
-        .telemetry
-        .report(temps_core::telemetry::TelemetryEvent::new(
+    // Once-per-instance (see record_event): guard so this fires once, not on
+    // every console-ingested event.
+    state.telemetry.report_once(
+        "analytics_first_event_received",
+        temps_core::telemetry::TelemetryEvent::new(
             temps_core::telemetry::TelemetryEventKind::AnalyticsFirstEventReceived,
-        ));
+        ),
+    );
 
     Ok(StatusCode::OK)
 }

--- a/crates/temps-analytics-session-replay/src/handlers/handler.rs
+++ b/crates/temps-analytics-session-replay/src/handlers/handler.rs
@@ -754,11 +754,14 @@ pub async fn init_session_replay(
     {
         Ok(session_id) => {
             debug!("Successfully initialized session replay: {}", session_id);
-            state
-                .telemetry
-                .report(temps_core::telemetry::TelemetryEvent::new(
+            // Once-per-instance: "session replay is in use here", not "a session
+            // started". Guard so it fires once, not on every replay session.
+            state.telemetry.report_once(
+                "session_replay_first_session",
+                temps_core::telemetry::TelemetryEvent::new(
                     temps_core::telemetry::TelemetryEventKind::SessionReplayFirstSession,
-                ));
+                ),
+            );
             Ok((
                 StatusCode::CREATED,
                 Json(SessionReplayInitResponse {

--- a/crates/temps-cli/Cargo.toml
+++ b/crates/temps-cli/Cargo.toml
@@ -119,6 +119,7 @@ glob = "0.3"
 uuid = { workspace = true }
 bytes = { workspace = true }
 http-body-util = { workspace = true }
+libc = { workspace = true }
 
 [dev-dependencies]
 # `tower`'s `util` feature provides `ServiceExt::oneshot`, used to drive the

--- a/crates/temps-cli/Cargo.toml
+++ b/crates/temps-cli/Cargo.toml
@@ -98,6 +98,7 @@ utoipa = { workspace = true }
 utoipa-swagger-ui = { workspace = true }
 async-trait = { workspace = true }
 sea-orm = { workspace = true }
+sysinfo = { workspace = true }
 include_dir = "0.7"
 ipnet = "2.10"
 mime_guess = "2.0"

--- a/crates/temps-cli/src/commands/api_key.rs
+++ b/crates/temps-cli/src/commands/api_key.rs
@@ -22,8 +22,8 @@ pub enum OutputFormat {
 
 #[derive(Args)]
 pub struct ApiKeyCommand {
-    /// Database connection URL
-    #[arg(long, env = "TEMPS_DATABASE_URL")]
+    /// Database connection URL (set via TEMPS_DATABASE_URL env var; not accepted as a flag to prevent credentials leaking into process listings)
+    #[arg(long, env = "TEMPS_DATABASE_URL", hide_env_values = true)]
     pub database_url: String,
 
     /// Name for the API key (for identification)

--- a/crates/temps-cli/src/commands/backup.rs
+++ b/crates/temps-cli/src/commands/backup.rs
@@ -105,8 +105,8 @@ struct ListBackupsArgs {
 
 #[derive(Args)]
 struct RestoreBackupArgs {
-    /// Database connection URL to restore to
-    #[arg(long, env = "TEMPS_DATABASE_URL")]
+    /// Database connection URL to restore to (set via TEMPS_DATABASE_URL env var; not accepted as a flag to prevent credentials leaking into process listings)
+    #[arg(long, env = "TEMPS_DATABASE_URL", hide_env_values = true)]
     database_url: String,
 
     /// S3 access key ID
@@ -172,8 +172,8 @@ struct RestoreServiceArgs {
     #[arg(long, env = "TEMPS_ENCRYPTION_KEY")]
     encryption_key: String,
 
-    /// Database URL for the temps database (needed to query service config)
-    #[arg(long, env = "TEMPS_DATABASE_URL")]
+    /// Database URL for the temps database (needed to query service config) (set via TEMPS_DATABASE_URL env var; not accepted as a flag to prevent credentials leaking into process listings)
+    #[arg(long, env = "TEMPS_DATABASE_URL", hide_env_values = true)]
     database_url: String,
 
     /// S3 region

--- a/crates/temps-cli/src/commands/doctor.rs
+++ b/crates/temps-cli/src/commands/doctor.rs
@@ -13,8 +13,8 @@ const CHECK_TIMEOUT: Duration = Duration::from_secs(5);
 /// Diagnose the temps installation and check system health
 #[derive(Args)]
 pub struct DoctorCommand {
-    /// Database connection URL
-    #[arg(long, env = "TEMPS_DATABASE_URL")]
+    /// Database connection URL (set via TEMPS_DATABASE_URL env var; not accepted as a flag to prevent credentials leaking into process listings)
+    #[arg(long, env = "TEMPS_DATABASE_URL", hide_env_values = true)]
     pub database_url: Option<String>,
 
     /// Data directory for storing configuration and runtime files

--- a/crates/temps-cli/src/commands/domain.rs
+++ b/crates/temps-cli/src/commands/domain.rs
@@ -316,8 +316,8 @@ pub struct ImportCertificateCommand {
     #[arg(long, short = 'k')]
     pub private_key: PathBuf,
 
-    /// Database URL
-    #[arg(long, env = "TEMPS_DATABASE_URL")]
+    /// Database URL (set via TEMPS_DATABASE_URL env var; not accepted as a flag to prevent credentials leaking into process listings)
+    #[arg(long, env = "TEMPS_DATABASE_URL", hide_env_values = true)]
     pub database_url: String,
 
     /// Data directory containing the encryption key

--- a/crates/temps-cli/src/commands/migrate.rs
+++ b/crates/temps-cli/src/commands/migrate.rs
@@ -6,7 +6,7 @@
 //!
 //! ```text
 //!   1. Download the new temps binary
-//!   2. temps migrate --database-url=...   # apply schema changes, server down
+//!   2. TEMPS_DATABASE_URL=... temps migrate   # apply schema changes, server down
 //!   3. Restart the server with the new binary
 //! ```
 //!
@@ -39,8 +39,8 @@ use tracing::info;
 
 #[derive(Args)]
 pub struct MigrateCommand {
-    /// Database connection URL
-    #[arg(long, env = "TEMPS_DATABASE_URL")]
+    /// Database connection URL (set via TEMPS_DATABASE_URL env var; not accepted as a flag to prevent credentials leaking into process listings)
+    #[arg(long, env = "TEMPS_DATABASE_URL", hide_env_values = true)]
     pub database_url: String,
 
     /// Show the pending migrations and exit without applying them.

--- a/crates/temps-cli/src/commands/proxy.rs
+++ b/crates/temps-cli/src/commands/proxy.rs
@@ -161,8 +161,8 @@ pub struct ProxyCommand {
     #[arg(long, env = "TEMPS_TLS_ADDRESS")]
     pub tls_address: Option<String>,
 
-    /// Database connection URL
-    #[arg(long, env = "TEMPS_DATABASE_URL")]
+    /// Database connection URL (set via TEMPS_DATABASE_URL env var; not accepted as a flag to prevent credentials leaking into process listings)
+    #[arg(long, env = "TEMPS_DATABASE_URL", hide_env_values = true)]
     pub database_url: String,
 
     /// Data directory for storing configuration and runtime files

--- a/crates/temps-cli/src/commands/reset_password.rs
+++ b/crates/temps-cli/src/commands/reset_password.rs
@@ -11,8 +11,8 @@ use tracing::{debug, info};
 
 #[derive(Args)]
 pub struct ResetPasswordCommand {
-    /// Database connection URL
-    #[arg(long, env = "TEMPS_DATABASE_URL")]
+    /// Database connection URL (set via TEMPS_DATABASE_URL env var; not accepted as a flag to prevent credentials leaking into process listings)
+    #[arg(long, env = "TEMPS_DATABASE_URL", hide_env_values = true)]
     pub database_url: String,
 
     /// Data directory for storing configuration and runtime files

--- a/crates/temps-cli/src/commands/serve/console.rs
+++ b/crates/temps-cli/src/commands/serve/console.rs
@@ -90,11 +90,24 @@ async fn report_instance_started(
     reporter: &dyn temps_core::telemetry::TelemetryReporter,
     db: &sea_orm::DatabaseConnection,
 ) {
-    use sea_orm::PaginatorTrait;
-    use temps_core::telemetry::{TelemetryEvent, TelemetryEventKind};
+    use temps_core::telemetry::TelemetryEventKind;
+    reporter.report(build_instance_event(TelemetryEventKind::InstanceStarted, db).await);
+}
 
-    // Each count is independent and optional — a failure on one doesn't block
-    // the others or the event itself.
+/// Build an instance lifecycle/heartbeat event carrying the same set of
+/// non-identifying depth-of-usage counts (projects, environments, managed
+/// services, worker nodes). Shared by `instance_started` and the periodic
+/// `instance_heartbeat` so both report the fleet snapshot identically.
+///
+/// Each count is independent and optional — a failure on one doesn't block the
+/// others or the event itself.
+async fn build_instance_event(
+    kind: temps_core::telemetry::TelemetryEventKind,
+    db: &sea_orm::DatabaseConnection,
+) -> temps_core::telemetry::TelemetryEvent {
+    use sea_orm::PaginatorTrait;
+    use temps_core::telemetry::TelemetryEvent;
+
     let project_count = temps_entities::projects::Entity::find()
         .count(db)
         .await
@@ -109,13 +122,47 @@ async fn report_instance_started(
         .ok();
     let node_count = temps_entities::nodes::Entity::find().count(db).await.ok();
 
-    let event = TelemetryEvent::new(TelemetryEventKind::InstanceStarted)
+    TelemetryEvent::new(kind)
         .with_opt("project_count", project_count.map(|c| c as i64))
         .with_opt("environment_count", environment_count.map(|c| c as i64))
         .with_opt("service_count", service_count.map(|c| c as i64))
-        .with_opt("node_count", node_count.map(|c| c as i64));
+        .with_opt("node_count", node_count.map(|c| c as i64))
+}
 
-    reporter.report(event);
+/// Interval between anonymous `instance_heartbeat` events. Daily — the minimum
+/// grain that keeps "active instances" (which is bucketed per day) accurate, so
+/// a live-but-idle instance still registers as active each day it's running.
+const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(24 * 60 * 60);
+
+/// Spawn a detached task that emits an anonymous `instance_heartbeat` once per
+/// [`HEARTBEAT_INTERVAL`] for as long as the server runs. This is what makes the
+/// "active instances" metric mean "alive" rather than merely "did something" —
+/// an instance that isn't deploying today still checks in.
+///
+/// The very first heartbeat fires after one interval (the `instance_started`
+/// event already covers "active today" at boot, so we don't double-send on
+/// startup). Fully best-effort and respects opt-out: a disabled reporter makes
+/// `report()` a no-op, and a dead endpoint never affects the server.
+fn spawn_heartbeat_task(
+    reporter: std::sync::Arc<dyn temps_core::telemetry::TelemetryReporter>,
+    db: std::sync::Arc<sea_orm::DatabaseConnection>,
+) {
+    use temps_core::telemetry::TelemetryEventKind;
+
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(HEARTBEAT_INTERVAL);
+        // The first tick completes immediately; skip it so the first heartbeat
+        // lands one full interval after boot (boot is already covered by
+        // instance_started).
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            let event =
+                build_instance_event(TelemetryEventKind::InstanceHeartbeat, db.as_ref()).await;
+            reporter.report(event);
+            tracing::debug!("emitted anonymous instance_heartbeat telemetry event");
+        }
+    });
 }
 
 /// This user is referenced by webhook-created resources (e.g., GitHub App installations)
@@ -1281,6 +1328,10 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
     {
         if reporter.is_enabled() {
             report_instance_started(reporter.as_ref(), db.as_ref()).await;
+            // Keep "active instances" honest: a daily heartbeat so a live-but-idle
+            // instance still checks in even when it isn't deploying. No-op when
+            // telemetry is disabled (guarded above + report() no-ops anyway).
+            spawn_heartbeat_task(reporter.clone(), db.clone());
         }
     }
     if let Some(user_service) = service_context.get_service::<temps_auth::UserService>() {

--- a/crates/temps-cli/src/commands/serve/console.rs
+++ b/crates/temps-cli/src/commands/serve/console.rs
@@ -94,13 +94,51 @@ async fn report_instance_started(
     reporter.report(build_instance_event(TelemetryEventKind::InstanceStarted, db).await);
 }
 
-/// Build an instance lifecycle/heartbeat event carrying the same set of
-/// non-identifying depth-of-usage counts (projects, environments, managed
-/// services, worker nodes). Shared by `instance_started` and the periodic
-/// `instance_heartbeat` so both report the fleet snapshot identically.
+/// Coarse, non-identifying RAM capacity band for the host. We deliberately
+/// bucket (rather than send exact byte counts) so the value can't contribute to
+/// fingerprinting: it answers "are people running Temps on tiny VPSes vs beefy
+/// boxes?" without revealing the machine's real specs. Returns `None` if the
+/// total can't be read.
+fn capacity_tier_from_total_ram() -> Option<&'static str> {
+    use sysinfo::SystemExt;
+    let mut sys = sysinfo::System::new();
+    sys.refresh_memory();
+    // sysinfo 0.29 reports total_memory() in BYTES.
+    let total_bytes = sys.total_memory();
+    if total_bytes == 0 {
+        return None;
+    }
+    let gib = total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+    // Bands chosen around common VPS sizes; coarse on purpose.
+    let tier = if gib < 1.5 {
+        "xs" // ~1 GiB and under
+    } else if gib < 3.0 {
+        "small" // ~2 GiB
+    } else if gib < 6.0 {
+        "medium" // ~4 GiB
+    } else if gib < 12.0 {
+        "large" // ~8 GiB
+    } else if gib < 24.0 {
+        "xl" // ~16 GiB
+    } else {
+        "xxl" // 24 GiB+
+    };
+    Some(tier)
+}
+
+/// Build an instance lifecycle/heartbeat event carrying a small set of
+/// non-identifying signals:
+/// - depth-of-usage counts (projects, environments, managed services, worker
+///   nodes),
+/// - `has_git_provider`: whether the instance has wired up at least one git
+///   provider connection (a key activation signal — git-push deploys are the
+///   core workflow),
+/// - `capacity_tier`: a COARSE RAM band (never exact specs; see
+///   [`capacity_tier_from_total_ram`]).
 ///
-/// Each count is independent and optional — a failure on one doesn't block the
-/// others or the event itself.
+/// Shared by `instance_started` and the periodic `instance_heartbeat` so both
+/// report the fleet snapshot identically. Each field is independent and
+/// optional — a failure on one doesn't block the others or the event itself.
 async fn build_instance_event(
     kind: temps_core::telemetry::TelemetryEventKind,
     db: &sea_orm::DatabaseConnection,
@@ -122,11 +160,23 @@ async fn build_instance_event(
         .ok();
     let node_count = temps_entities::nodes::Entity::find().count(db).await.ok();
 
+    // Whether git is configured on this instance at all (>= 1 provider
+    // connection). Just a boolean — no provider type, no URLs, no tokens.
+    let has_git_provider = temps_entities::git_provider_connections::Entity::find()
+        .count(db)
+        .await
+        .ok()
+        .map(|c| c > 0);
+
+    let capacity_tier = capacity_tier_from_total_ram();
+
     TelemetryEvent::new(kind)
         .with_opt("project_count", project_count.map(|c| c as i64))
         .with_opt("environment_count", environment_count.map(|c| c as i64))
         .with_opt("service_count", service_count.map(|c| c as i64))
         .with_opt("node_count", node_count.map(|c| c as i64))
+        .with_opt("has_git_provider", has_git_provider)
+        .with_opt("capacity_tier", capacity_tier)
 }
 
 /// Interval between anonymous `instance_heartbeat` events. Daily — the minimum

--- a/crates/temps-cli/src/commands/serve/mod.rs
+++ b/crates/temps-cli/src/commands/serve/mod.rs
@@ -47,8 +47,8 @@ pub struct ServeCommand {
     #[arg(long, env = "TEMPS_TLS_ADDRESS")]
     pub tls_address: Option<String>,
 
-    /// Database connection URL
-    #[arg(long, env = "TEMPS_DATABASE_URL")]
+    /// Database connection URL (set via TEMPS_DATABASE_URL env var; not accepted as a flag to prevent credentials leaking into process listings)
+    #[arg(long, env = "TEMPS_DATABASE_URL", hide_env_values = true)]
     pub database_url: String,
 
     /// Data directory for storing configuration and runtime files

--- a/crates/temps-cli/src/commands/serve/on_demand_cert.rs
+++ b/crates/temps-cli/src/commands/serve/on_demand_cert.rs
@@ -46,40 +46,27 @@ const STATE_SEED_LOOKBACK_HOURS: i64 = 24;
 /// `ContainerLifecycleAdapter` pattern for scale-to-zero).
 struct DomainServiceProvisioner {
     domain_service: Arc<DomainService>,
-    db: Arc<DbConnection>,
     /// ACME contact email resolved at startup from `letsencrypt.email` settings
     /// (the manager re-passes it per call; resolving once at boot avoids a
-    /// settings round-trip on every issuance). Empty falls back to the first
-    /// user's email inside [`Self::resolve_email`].
+    /// settings round-trip on every issuance). There is no fallback: if
+    /// `letsencrypt.email` is unset, [`Self::resolve_email`] returns empty and
+    /// issuance fails cleanly with "no ACME contact email configured" rather
+    /// than substituting a system/placeholder address.
     configured_email: Option<String>,
 }
 
 impl DomainServiceProvisioner {
-    /// Resolve the ACME account email: the configured `letsencrypt.email`, else
-    /// the first user's email, else a last-resort fallback. Mirrors
-    /// `TlsService::get_acme_email` so on-demand uses the same contact as manual
-    /// provisioning.
+    /// Resolve the ACME account email. The configured `letsencrypt.email` is the
+    /// single source of truth — there is NO fallback to the first user's email
+    /// or a placeholder, because those produced invalid contacts (e.g. the
+    /// `system@localhost` system user). Returns empty when unset; the caller
+    /// (`provision_on_demand`) treats empty as a clean, logged failure.
     async fn resolve_email(&self) -> String {
-        if let Some(email) = self
-            .configured_email
+        self.configured_email
             .as_ref()
-            .map(|e| e.trim())
+            .map(|e| e.trim().to_string())
             .filter(|e| !e.is_empty())
-        {
-            return email.to_string();
-        }
-
-        use sea_orm::QueryOrder;
-        use temps_entities::users;
-        if let Ok(Some(user)) = users::Entity::find()
-            .order_by_asc(users::Column::Id)
-            .one(self.db.as_ref())
-            .await
-        {
-            return user.email;
-        }
-
-        "system@temps.dev".to_string()
+            .unwrap_or_default()
     }
 }
 
@@ -282,6 +269,18 @@ pub async fn build_on_demand_cert_manager(
         .map(|e| e.trim().to_string())
         .filter(|e| !e.is_empty());
 
+    // Warn loudly at boot if on-demand TLS is enabled but has no ACME contact:
+    // every issuance will fail cleanly ("no ACME contact email configured"), so
+    // the console/app HTTPS will never come up. There is no fallback by design.
+    if email.is_none() {
+        warn!(
+            "on-demand TLS is enabled but no Let's Encrypt contact email is set \
+             (settings.letsencrypt.email is empty). Certificate issuance cannot \
+             proceed — set a contact email (e.g. re-run `temps setup \
+             --letsencrypt-email you@example.com`) to enable HTTPS."
+        );
+    }
+
     // Build the DomainService that drives the ACME flow. Reuses the same
     // repository + LetsEncryptProvider construction as the domains plugin so
     // on-demand issuance is byte-for-byte the same code path as manual
@@ -300,7 +299,6 @@ pub async fn build_on_demand_cert_manager(
 
     let provisioner: Arc<dyn OnDemandCertProvisioner> = Arc::new(DomainServiceProvisioner {
         domain_service,
-        db: db.clone(),
         configured_email: email.clone(),
     });
 

--- a/crates/temps-cli/src/commands/serve/on_demand_cert.rs
+++ b/crates/temps-cli/src/commands/serve/on_demand_cert.rs
@@ -212,6 +212,21 @@ struct OnDemandZoneInputs {
     external_url: Option<String>,
 }
 
+/// Derive the console host (`console.<zone>`) for the gate's console exemption.
+///
+/// On a sslip.io install the console is reachable at `console.<zone>` (the
+/// deploy-script convention) but is served as a fall-through, so it has no
+/// `CachedPeerTable` route. The gate exempts exactly this host from the
+/// cert-eligible-route check (it is still subject to the in-zone check), so
+/// `quick` mode gets console HTTPS on demand. Returns `None` for an empty zone.
+fn derive_console_host(zone: &str) -> Option<String> {
+    let zone = zone.trim().trim_end_matches('.').to_ascii_lowercase();
+    if zone.is_empty() {
+        return None;
+    }
+    Some(format!("console.{zone}"))
+}
+
 /// Build the [`OnDemandCertManager`] for a proxy process when on-demand TLS is
 /// enabled, or `None` when the feature is off / cannot be safely enabled.
 ///
@@ -289,6 +304,15 @@ pub async fn build_on_demand_cert_manager(
         configured_email: email.clone(),
     });
 
+    // Derive the console host so the gate exempts it from the cert-eligible
+    // route check. On a sslip.io install the console is served at
+    // `console.<zone>` (the deploy-script convention; the proxy itself serves
+    // the console as a fall-through for any unmatched host, so it has no route
+    // table entry). The console is in-zone, stable, and single — exactly the
+    // shape on-demand TLS should cover — so `quick` mode gets console HTTPS
+    // without the eager HTTP-01 step the old `testing` mode performed.
+    let console_host = derive_console_host(&zone);
+
     let manager = OnDemandCertManager::new(
         OnDemandCertConfig {
             zone: zone.clone(),
@@ -297,6 +321,7 @@ pub async fn build_on_demand_cert_manager(
             email: email.unwrap_or_default(),
             max_concurrent: cfg.max_concurrent.max(1),
             hourly_cap: cfg.hourly_cap.max(1),
+            console_host,
         },
         route_table,
         provisioner,
@@ -428,6 +453,28 @@ mod tests {
             external_url: Some("https://paas.example.com".to_string()),
         });
         assert_eq!(zone, None);
+    }
+
+    #[test]
+    fn console_host_derived_from_zone() {
+        assert_eq!(
+            derive_console_host("1.2.3.4.sslip.io").as_deref(),
+            Some("console.1.2.3.4.sslip.io")
+        );
+    }
+
+    #[test]
+    fn console_host_trims_and_lowercases_zone() {
+        assert_eq!(
+            derive_console_host("  5.6.7.8.SSLIP.IO. ").as_deref(),
+            Some("console.5.6.7.8.sslip.io")
+        );
+    }
+
+    #[test]
+    fn console_host_none_for_empty_zone() {
+        assert_eq!(derive_console_host("   "), None);
+        assert_eq!(derive_console_host(""), None);
     }
 
     #[test]

--- a/crates/temps-cli/src/commands/serve/on_demand_cert.rs
+++ b/crates/temps-cli/src/commands/serve/on_demand_cert.rs
@@ -199,13 +199,20 @@ struct OnDemandZoneInputs {
     external_url: Option<String>,
 }
 
-/// Derive the console host (`console.<zone>`) for the gate's console exemption.
+/// Derive the conventional console host (`console.<zone>`) for the gate's
+/// console exemption.
 ///
-/// On a sslip.io install the console is reachable at `console.<zone>` (the
-/// deploy-script convention) but is served as a fall-through, so it has no
+/// The installer's quick/sslip.io flow serves the console at `console.<zone>`
+/// (e.g. `console.1.2.3.4.sslip.io`) as a fall-through, so it has no
 /// `CachedPeerTable` route. The gate exempts exactly this host from the
-/// cert-eligible-route check (it is still subject to the in-zone check), so
-/// `quick` mode gets console HTTPS on demand. Returns `None` for an empty zone.
+/// cert-eligible-route check (it is still subject to the in-zone check) so the
+/// console gets HTTPS on demand. Returns `None` for an empty zone.
+///
+/// Note: this only covers the `console.<zone>` convention. A custom-domain
+/// (advanced) install serves the console at the bare base domain and ships a
+/// wildcard cert that already covers it, so the console there is served from
+/// that cert and never reaches the on-demand path — the `console.<zone>`
+/// exemption is simply unused in that case (harmless).
 fn derive_console_host(zone: &str) -> Option<String> {
     let zone = zone.trim().trim_end_matches('.').to_ascii_lowercase();
     if zone.is_empty() {

--- a/crates/temps-cli/src/commands/serve/proxy.rs
+++ b/crates/temps-cli/src/commands/serve/proxy.rs
@@ -6,6 +6,7 @@ use temps_core::CookieCrypto;
 use temps_database::DbConnection;
 use temps_deployer::ContainerDeployer;
 use temps_proxy::on_demand::{ContainerLifecycle, OnDemandError, OnDemandManager};
+use temps_proxy::on_demand_cert::EnqueueOutcome;
 use temps_proxy::ProxyShutdownSignal;
 use tracing::{info, warn};
 
@@ -181,6 +182,59 @@ pub fn start_proxy_server(
         )),
         None => None,
     };
+
+    // ADR-018 eager cert pre-provisioning: wire the on-demand cert manager into
+    // the route table so every `load_routes()` call — triggered by new
+    // deployments — immediately enqueues TLS issuance for each cert-eligible
+    // hostname. The existing gate checks (dedup, backoff, rate-limit, zone) inside
+    // `try_enqueue` make this idempotent: only genuinely new or retryable hosts
+    // produce issuance jobs. This eliminates the `ERR_TLS_HANDSHAKE` on the first
+    // request to a freshly-deployed app.
+    if let Some(ref cert_manager) = on_demand_cert_manager {
+        let cert_manager_for_callback = cert_manager.clone();
+        route_table.set_on_cert_eligible_callback(std::sync::Arc::new(
+            move |hostnames: Vec<String>| {
+                let cert_manager = cert_manager_for_callback.clone();
+                Box::pin(async move {
+                    let mut enqueued = 0u32;
+                    for hostname in &hostnames {
+                        if let EnqueueOutcome::Enqueued = cert_manager.try_enqueue(hostname, None)
+                        {
+                            enqueued += 1;
+                        }
+                    }
+                    if enqueued > 0 {
+                        tracing::info!(
+                            enqueued,
+                            total = hostnames.len(),
+                            "on-demand TLS: eagerly pre-provisioning {} cert(s) for new/updated routes",
+                            enqueued
+                        );
+                    }
+                }) as std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
+            },
+        ));
+
+        // One-time immediate pass for cert-eligible routes already in the table
+        // (populated by the initial load that runs before this code executes).
+        let initial_hosts = route_table.cert_eligible_hosts();
+        if !initial_hosts.is_empty() {
+            let mut enqueued = 0u32;
+            for hostname in &initial_hosts {
+                if let EnqueueOutcome::Enqueued = cert_manager.try_enqueue(hostname, None) {
+                    enqueued += 1;
+                }
+            }
+            if enqueued > 0 {
+                tracing::info!(
+                    enqueued,
+                    total = initial_hosts.len(),
+                    "on-demand TLS: eagerly pre-provisioning {} cert(s) for existing routes at startup",
+                    enqueued
+                );
+            }
+        }
+    }
 
     let proxy_config = temps_proxy::ProxyConfig {
         address,

--- a/crates/temps-cli/src/commands/setup.rs
+++ b/crates/temps-cli/src/commands/setup.rs
@@ -183,6 +183,14 @@ pub struct SetupCommand {
     #[arg(long, default_value = "false", env = "LETSENCRYPT_STAGING")]
     pub letsencrypt_staging: bool,
 
+    /// Contact email for Let's Encrypt / ACME certificate issuance. Stored as
+    /// `letsencrypt.email` and used as the ACME account contact for all cert
+    /// provisioning (manual, HTTP-01, and on-demand). There is no fallback: if
+    /// this is unset, certificate issuance has no contact and will not proceed,
+    /// so installers that enable TLS must supply a real address.
+    #[arg(long, env = "LETSENCRYPT_EMAIL")]
+    pub letsencrypt_email: Option<String>,
+
     /// DNS propagation wait time in seconds (default: 60)
     #[arg(long, default_value = "60")]
     pub dns_propagation_wait: u32,
@@ -1179,6 +1187,7 @@ async fn update_app_settings(
     db: &sea_orm::DatabaseConnection,
     preview_domain: &str,
     external_url: Option<&str>,
+    letsencrypt_email: Option<&str>,
 ) -> anyhow::Result<()> {
     use chrono::Utc;
 
@@ -1196,6 +1205,18 @@ async fn update_app_settings(
     // Update external_url if provided
     if let Some(url) = external_url {
         app_settings.external_url = Some(url.to_string());
+    }
+
+    // Set the Let's Encrypt / ACME contact email when provided. This is the
+    // single source of truth for the ACME account contact — `get_acme_email`
+    // returns exactly this value with no fallback, so a real address here is
+    // what makes certificate issuance work. An empty string is ignored so a
+    // re-run without the flag does not wipe a previously-configured address.
+    if let Some(email) = letsencrypt_email {
+        let email = email.trim();
+        if !email.is_empty() {
+            app_settings.letsencrypt.email = Some(email.to_string());
+        }
     }
 
     // ADR-018 §6: auto-enable on-demand HTTP-01 TLS for sslip.io installs.
@@ -1814,6 +1835,7 @@ impl SetupCommand {
                 db.as_ref(),
                 &preview_domain,
                 self.external_url.as_deref(),
+                self.letsencrypt_email.as_deref(),
             ))?;
             print_success(&format!(
                 "Preview domain set to: {}",
@@ -1939,6 +1961,7 @@ impl SetupCommand {
                 db.as_ref(),
                 &preview_domain,
                 self.external_url.as_deref(),
+                self.letsencrypt_email.as_deref(),
             ))?;
             print_success(&format!(
                 "Preview domain set to: {}",
@@ -2154,6 +2177,7 @@ impl SetupCommand {
                 db.as_ref(),
                 &preview_domain,
                 self.external_url.as_deref(),
+                self.letsencrypt_email.as_deref(),
             ))?;
             print_success(&format!(
                 "Preview domain set to: {}",
@@ -2195,6 +2219,7 @@ impl SetupCommand {
                 db.as_ref(),
                 &preview_domain,
                 self.external_url.as_deref(),
+                self.letsencrypt_email.as_deref(),
             ))?;
             print_success(&format!(
                 "Preview domain set to: {}",
@@ -2641,6 +2666,7 @@ impl SetupCommand {
             db.as_ref(),
             &preview_domain,
             self.external_url.as_deref(),
+            self.letsencrypt_email.as_deref(),
         ))?;
         print_success(&format!(
             "Preview domain set to: {}",

--- a/crates/temps-cli/src/commands/setup.rs
+++ b/crates/temps-cli/src/commands/setup.rs
@@ -1219,18 +1219,19 @@ async fn update_app_settings(
         }
     }
 
-    // ADR-018 §6: auto-enable on-demand HTTP-01 TLS for sslip.io installs.
-    // QuickStart names every host `<app>.<ip>.sslip.io`, which can only get
-    // HTTPS via per-host HTTP-01 issued lazily on first request. Turn the
-    // feature on (with the sslip.io zone as the allowlist) so the console and
-    // app aliases get certs automatically — but skip the loopback case
-    // (`127.0.0.1.sslip.io`, local mode), where Let's Encrypt cannot reach the
-    // box for the challenge. The proxy applies its own authoritative loopback
-    // guard at startup regardless; this just avoids advertising a feature that
-    // can never fire in local mode.
-    if is_sslip_zone(preview_domain) && !is_loopback_zone(preview_domain) {
+    // ADR-018 §6: auto-enable on-demand HTTP-01 TLS for any publicly-reachable
+    // install. Every app/console host under the base domain
+    // (`<app>.<preview_domain>`) then gets HTTPS via per-host HTTP-01 issued
+    // lazily on first request, with the base domain as the allowlist zone. This
+    // is not specific to sslip.io — it applies equally to a real wildcard domain
+    // (e.g. `apps.example.com`). The only case we skip is loopback / local mode
+    // (`127.0.0.1.sslip.io`, `localhost`), where Let's Encrypt cannot reach the
+    // box for the challenge so issuance could never succeed. The proxy applies
+    // its own authoritative loopback guard at startup regardless; this just
+    // avoids advertising a feature that can never fire in local mode.
+    if !preview_domain.trim().is_empty() && !is_loopback_zone(preview_domain) {
         app_settings.on_demand_tls.enabled = true;
-        app_settings.on_demand_tls.zone = Some(preview_domain.to_ascii_lowercase());
+        app_settings.on_demand_tls.zone = Some(preview_domain.trim().to_ascii_lowercase());
     }
 
     // Mark setup as complete so the web onboarding wizard knows to skip
@@ -1267,18 +1268,11 @@ fn extract_preview_domain(wildcard_domain: &str) -> String {
     wildcard_domain.trim_start_matches("*.").to_string()
 }
 
-/// True if `zone` is a sslip.io base domain (e.g. `1.2.3.4.sslip.io`). Used to
-/// gate ADR-018 §6 on-demand-TLS auto-enablement to sslip.io installs.
-fn is_sslip_zone(zone: &str) -> bool {
-    zone.trim()
-        .trim_end_matches('.')
-        .to_ascii_lowercase()
-        .ends_with("sslip.io")
-}
-
-/// True if `zone` is a loopback sslip.io zone (`127.0.0.1.sslip.io`,
-/// `localhost`, …) — local mode, where Let's Encrypt cannot reach the box for
-/// the HTTP-01 challenge, so on-demand TLS would never fire.
+/// True if `zone` is a loopback zone (`127.0.0.1.sslip.io`, `localhost`, …) —
+/// local mode, where Let's Encrypt cannot reach the box for the HTTP-01
+/// challenge, so on-demand TLS would never fire. This is the only condition
+/// that gates ADR-018 §6 on-demand-TLS auto-enablement; any other (non-empty,
+/// non-loopback) base domain qualifies, regardless of whether it is sslip.io.
 fn is_loopback_zone(zone: &str) -> bool {
     let z = zone.trim().trim_end_matches('.').to_ascii_lowercase();
     z == "localhost"
@@ -2828,16 +2822,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_is_sslip_zone() {
-        assert!(is_sslip_zone("1.2.3.4.sslip.io"));
-        assert!(is_sslip_zone("127.0.0.1.sslip.io"));
-        assert!(is_sslip_zone("1.2.3.4.SSLIP.IO."));
-        assert!(!is_sslip_zone("example.com"));
-        assert!(!is_sslip_zone("apps.mycompany.com"));
-        assert!(!is_sslip_zone(""));
-    }
-
-    #[test]
     fn test_is_loopback_zone() {
         assert!(is_loopback_zone("127.0.0.1.sslip.io"));
         assert!(is_loopback_zone("localhost"));
@@ -2849,12 +2833,16 @@ mod tests {
 
     #[test]
     fn test_on_demand_tls_auto_enable_decision() {
-        // The exact condition used in update_app_settings: public sslip.io → on;
-        // loopback sslip.io and custom domains → off.
-        let should_enable = |zone: &str| is_sslip_zone(zone) && !is_loopback_zone(zone);
-        assert!(should_enable("1.2.3.4.sslip.io"));
-        assert!(!should_enable("127.0.0.1.sslip.io")); // local mode
-        assert!(!should_enable("apps.mycompany.com")); // custom domain (advanced)
+        // The exact condition used in update_app_settings, decoupled from
+        // sslip.io: any non-empty, non-loopback base domain enables on-demand
+        // TLS — loopback (local mode) is the only thing that disables it.
+        let should_enable = |zone: &str| !zone.trim().is_empty() && !is_loopback_zone(zone);
+        assert!(should_enable("1.2.3.4.sslip.io")); // sslip.io quick install
+        assert!(should_enable("apps.mycompany.com")); // custom wildcard domain
+        assert!(!should_enable("127.0.0.1.sslip.io")); // local mode (loopback)
+        assert!(!should_enable("localhost")); // local mode
+        assert!(!should_enable("")); // no domain
+        assert!(!should_enable("   ")); // whitespace-only
     }
 
     #[test]

--- a/crates/temps-cli/src/commands/setup.rs
+++ b/crates/temps-cli/src/commands/setup.rs
@@ -1198,6 +1198,20 @@ async fn update_app_settings(
         app_settings.external_url = Some(url.to_string());
     }
 
+    // ADR-018 §6: auto-enable on-demand HTTP-01 TLS for sslip.io installs.
+    // QuickStart names every host `<app>.<ip>.sslip.io`, which can only get
+    // HTTPS via per-host HTTP-01 issued lazily on first request. Turn the
+    // feature on (with the sslip.io zone as the allowlist) so the console and
+    // app aliases get certs automatically — but skip the loopback case
+    // (`127.0.0.1.sslip.io`, local mode), where Let's Encrypt cannot reach the
+    // box for the challenge. The proxy applies its own authoritative loopback
+    // guard at startup regardless; this just avoids advertising a feature that
+    // can never fire in local mode.
+    if is_sslip_zone(preview_domain) && !is_loopback_zone(preview_domain) {
+        app_settings.on_demand_tls.enabled = true;
+        app_settings.on_demand_tls.zone = Some(preview_domain.to_ascii_lowercase());
+    }
+
     // Mark setup as complete so the web onboarding wizard knows to skip
     // itself — prevents the "Configure Base Domain" wall from appearing
     // on installs already configured via `temps setup`.
@@ -1230,6 +1244,26 @@ async fn update_app_settings(
 /// e.g., "*.davidviejo.kfs.es" -> "davidviejo.kfs.es"
 fn extract_preview_domain(wildcard_domain: &str) -> String {
     wildcard_domain.trim_start_matches("*.").to_string()
+}
+
+/// True if `zone` is a sslip.io base domain (e.g. `1.2.3.4.sslip.io`). Used to
+/// gate ADR-018 §6 on-demand-TLS auto-enablement to sslip.io installs.
+fn is_sslip_zone(zone: &str) -> bool {
+    zone.trim()
+        .trim_end_matches('.')
+        .to_ascii_lowercase()
+        .ends_with("sslip.io")
+}
+
+/// True if `zone` is a loopback sslip.io zone (`127.0.0.1.sslip.io`,
+/// `localhost`, …) — local mode, where Let's Encrypt cannot reach the box for
+/// the HTTP-01 challenge, so on-demand TLS would never fire.
+fn is_loopback_zone(zone: &str) -> bool {
+    let z = zone.trim().trim_end_matches('.').to_ascii_lowercase();
+    z == "localhost"
+        || z.ends_with(".localhost")
+        || z.starts_with("127.0.0.1")
+        || z.contains("127-0-0-1")
 }
 
 impl SetupCommand {
@@ -2766,6 +2800,36 @@ fn finish_setup(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_is_sslip_zone() {
+        assert!(is_sslip_zone("1.2.3.4.sslip.io"));
+        assert!(is_sslip_zone("127.0.0.1.sslip.io"));
+        assert!(is_sslip_zone("1.2.3.4.SSLIP.IO."));
+        assert!(!is_sslip_zone("example.com"));
+        assert!(!is_sslip_zone("apps.mycompany.com"));
+        assert!(!is_sslip_zone(""));
+    }
+
+    #[test]
+    fn test_is_loopback_zone() {
+        assert!(is_loopback_zone("127.0.0.1.sslip.io"));
+        assert!(is_loopback_zone("localhost"));
+        assert!(is_loopback_zone("foo.localhost"));
+        assert!(is_loopback_zone("127-0-0-1.sslip.io"));
+        assert!(!is_loopback_zone("1.2.3.4.sslip.io"));
+        assert!(!is_loopback_zone("example.com"));
+    }
+
+    #[test]
+    fn test_on_demand_tls_auto_enable_decision() {
+        // The exact condition used in update_app_settings: public sslip.io → on;
+        // loopback sslip.io and custom domains → off.
+        let should_enable = |zone: &str| is_sslip_zone(zone) && !is_loopback_zone(zone);
+        assert!(should_enable("1.2.3.4.sslip.io"));
+        assert!(!should_enable("127.0.0.1.sslip.io")); // local mode
+        assert!(!should_enable("apps.mycompany.com")); // custom domain (advanced)
+    }
 
     #[test]
     fn test_dns_provider_type_display() {

--- a/crates/temps-cli/src/commands/setup.rs
+++ b/crates/temps-cli/src/commands/setup.rs
@@ -70,8 +70,8 @@ pub enum OutputFormat {
 
 #[derive(Args)]
 pub struct SetupCommand {
-    /// Database connection URL
-    #[arg(long, env = "TEMPS_DATABASE_URL")]
+    /// Database connection URL (set via TEMPS_DATABASE_URL env var; not accepted as a flag to prevent credentials leaking into process listings)
+    #[arg(long, env = "TEMPS_DATABASE_URL", hide_env_values = true)]
     pub database_url: String,
 
     /// Data directory for storing configuration and runtime files
@@ -2798,7 +2798,7 @@ fn finish_setup(
     println!();
     println!("   {} Start the server:", "1.".bright_cyan());
     println!(
-        "      {} temps serve --database-url=<URL>",
+        "      {} TEMPS_DATABASE_URL=<URL> temps serve",
         "$".bright_cyan()
     );
     println!();

--- a/crates/temps-cli/src/lib.rs
+++ b/crates/temps-cli/src/lib.rs
@@ -228,12 +228,138 @@ pub fn install_crypto_provider() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
+/// Scrub sensitive flag values from the process argv so they don't appear in
+/// `pgrep`, `ps`, or `/proc/self/cmdline`.
+///
+/// Clap has already parsed the arguments by the time this runs, so we can
+/// safely overwrite the raw argv strings with `x` characters in-place.
+/// The length of each argument is preserved — we never reallocate.
+///
+/// Best-effort: if the platform doesn't support argv scrubbing, the process
+/// continues normally. The flag is still accepted; it may remain visible in
+/// the process table, which is no worse than before this change.
+fn scrub_sensitive_argv() {
+    const SENSITIVE_FLAGS: &[&str] = &["--database-url"];
+
+    // macOS: use the stable _NSGetArgc/_NSGetArgv APIs from libSystem.
+    #[cfg(target_os = "macos")]
+    {
+        extern "C" {
+            fn _NSGetArgc() -> *mut libc::c_int;
+            fn _NSGetArgv() -> *mut *mut *mut libc::c_char;
+        }
+        unsafe {
+            let argc_ptr = _NSGetArgc();
+            let argv_ptr = _NSGetArgv();
+            if !argc_ptr.is_null() && !argv_ptr.is_null() {
+                scrub_argv_raw(*argc_ptr as usize, *argv_ptr, SENSITIVE_FLAGS);
+            }
+        }
+    }
+
+    // Linux: recover argv base from environ. The kernel stack layout is:
+    //   argc | argv[0..argc] | NULL | envp[0..] | NULL
+    // environ points to envp[0], so argv[0] is at environ[-(argc+1)].
+    // We determine argc by counting NUL-terminated args in /proc/self/cmdline,
+    // then validate by checking that argv[0] matches the cmdline prefix.
+    #[cfg(target_os = "linux")]
+    {
+        use std::ffi::CStr;
+
+        let cmdline = match std::fs::read("/proc/self/cmdline") {
+            Ok(b) if !b.is_empty() => b,
+            _ => return,
+        };
+        let argc = cmdline.iter().filter(|&&b| b == 0).count();
+        if argc == 0 {
+            return;
+        }
+
+        unsafe {
+            extern "C" {
+                static environ: *const *const libc::c_char;
+            }
+            if environ.is_null() {
+                return;
+            }
+            // environ[-1] should be the NULL terminator of argv.
+            let argv_null = (environ as *mut *mut libc::c_char).sub(1);
+            if !(*argv_null).is_null() {
+                return;
+            }
+            // argv[0] is argc slots before the NULL.
+            let argv = argv_null.sub(argc) as *mut *mut libc::c_char;
+            // Sanity-check: argv[0] must match the first cmdline token.
+            let first = *argv;
+            if first.is_null() {
+                return;
+            }
+            let first_bytes = CStr::from_ptr(first).to_bytes();
+            let cmdline_first = cmdline.split(|&b| b == 0).next().unwrap_or(&[]);
+            if first_bytes != cmdline_first {
+                return;
+            }
+            scrub_argv_raw(argc, argv, SENSITIVE_FLAGS);
+        }
+    }
+}
+
+/// Overwrite sensitive flag values in a raw C argv array in-place.
+///
+/// # Safety
+/// `argv` must point to a valid array of `argc` writable C strings
+/// (i.e. the actual process argv, not a copy).
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+unsafe fn scrub_argv_raw(argc: usize, argv: *mut *mut libc::c_char, sensitive_flags: &[&str]) {
+    use std::ffi::CStr;
+
+    let mut i = 0usize;
+    while i < argc {
+        let ptr = *argv.add(i);
+        if ptr.is_null() {
+            i += 1;
+            continue;
+        }
+        let arg = CStr::from_ptr(ptr).to_string_lossy();
+
+        // `--flag=value` form: overwrite only the value part after `=`.
+        for flag in sensitive_flags {
+            let prefix = format!("{}=", flag);
+            if arg.starts_with(prefix.as_str()) {
+                let value_offset = prefix.len();
+                let total_len = libc::strlen(ptr);
+                if value_offset < total_len {
+                    std::ptr::write_bytes(ptr.add(value_offset), b'x', total_len - value_offset);
+                }
+            }
+        }
+
+        // `--flag value` form: the next argv slot holds the value.
+        for flag in sensitive_flags {
+            if arg.as_ref() == *flag && i + 1 < argc {
+                let next = *argv.add(i + 1);
+                if !next.is_null() {
+                    let len = libc::strlen(next);
+                    if len > 0 {
+                        std::ptr::write_bytes(next, b'x', len);
+                    }
+                }
+            }
+        }
+
+        i += 1;
+    }
+}
+
 /// Convenience entrypoint that parses, installs tracing, and dispatches.
 /// Used by both the OSS `temps` binary (`extra_plugins = vec![]`) and any
 /// EE-bundled binary that wraps the same CLI surface.
 pub fn run(extra_plugins: Vec<Box<dyn temps_core::plugin::TempsPlugin>>) -> anyhow::Result<()> {
     install_crypto_provider();
     let cli = Cli::parse();
+    // Scrub sensitive flag values from argv *after* clap has parsed them so
+    // they no longer appear in `pgrep -af` or /proc/self/cmdline.
+    scrub_sensitive_argv();
     install_tracing(&cli.log_level, &cli.log_format);
     dispatch(cli, extra_plugins)
 }

--- a/crates/temps-core/src/telemetry.rs
+++ b/crates/temps-core/src/telemetry.rs
@@ -240,6 +240,27 @@ pub trait TelemetryReporter: Send + Sync {
     /// Report an event. Never blocks on the network and never fails the caller.
     fn report(&self, event: TelemetryEvent);
 
+    /// Report a "first-touch" milestone event **at most once per instance, ever**.
+    ///
+    /// Use this for events whose name promises a single lifetime occurrence
+    /// (e.g. `analytics_first_event_received`, `ai_gateway_first_request`,
+    /// `first_deploy_succeeded`) but whose callsite fires per-action (every
+    /// pageview / request / deploy). Without this guard those events become a
+    /// firehose: telemetry volume scales with the self-hoster's production
+    /// traffic, which both skews the metric and leaks a coarse activity signal.
+    ///
+    /// `milestone` is a stable key (use the event's wire name) used to dedupe.
+    /// Implementations MUST be fire-and-forget like [`Self::report`] and MUST
+    /// guarantee the hot path stays cheap (an in-process check before any
+    /// durable lookup), so a busy instance pays no per-event cost after the
+    /// first emit.
+    ///
+    /// The default implementation simply forwards to [`Self::report`] every time
+    /// (no dedupe) — concrete reporters override it with the real once-guard.
+    fn report_once(&self, _milestone: &'static str, event: TelemetryEvent) {
+        self.report(event);
+    }
+
     /// Whether telemetry is currently enabled. Callsites can use this to skip
     /// building expensive property bags when reporting is off.
     fn is_enabled(&self) -> bool;

--- a/crates/temps-core/src/telemetry.rs
+++ b/crates/temps-core/src/telemetry.rs
@@ -31,6 +31,7 @@ use std::collections::BTreeMap;
 pub enum TelemetryEventKind {
     // ---- Instance lifecycle ----
     InstanceStarted,
+    InstanceHeartbeat,
     InstanceSetupCompleted,
     UpgradeCompleted,
     WorkerNodeJoined,
@@ -91,6 +92,7 @@ impl TelemetryEventKind {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::InstanceStarted => "instance_started",
+            Self::InstanceHeartbeat => "instance_heartbeat",
             Self::InstanceSetupCompleted => "instance_setup_completed",
             Self::UpgradeCompleted => "upgrade_completed",
             Self::WorkerNodeJoined => "worker_node_joined",
@@ -142,6 +144,7 @@ impl TelemetryEventKind {
     pub fn all() -> &'static [TelemetryEventKind] {
         &[
             Self::InstanceStarted,
+            Self::InstanceHeartbeat,
             Self::InstanceSetupCompleted,
             Self::UpgradeCompleted,
             Self::WorkerNodeJoined,
@@ -276,8 +279,8 @@ mod tests {
     fn all_covers_every_variant() {
         // If a variant is added but not added to all(), as_str() on it will be
         // missing from the list and this length check is a cheap tripwire.
-        // 34 events as of the initial product-telemetry design.
-        assert_eq!(TelemetryEventKind::all().len(), 34);
+        // 35 events (34 initial + instance_heartbeat).
+        assert_eq!(TelemetryEventKind::all().len(), 35);
     }
 
     #[test]

--- a/crates/temps-deployments/src/jobs/mark_deployment_complete.rs
+++ b/crates/temps-deployments/src/jobs/mark_deployment_complete.rs
@@ -7,7 +7,8 @@
 
 use async_trait::async_trait;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder, Set,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder,
+    QuerySelect, Set,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -30,6 +31,21 @@ use tracing::{debug, info, warn};
 static ENVIRONMENT_LOCKS: std::sync::LazyLock<
     std::sync::Mutex<HashMap<i32, Arc<tokio::sync::Mutex<()>>>>,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
+
+/// Safety bound on how many previous deployments a single teardown pass will
+/// process. Under normal operation there is at most one previous active
+/// deployment per environment (each is flipped to "stopped" once torn down),
+/// so this only ever bites on backlog from before the state-flip fix or after
+/// a crash mid-teardown. A bounded, newest-first sweep keeps the job from
+/// stalling for minutes on environments with a large unprocessed history;
+/// remaining stragglers are picked up by the next deployment's sweep.
+const MAX_TEARDOWN_DEPLOYMENTS_PER_PASS: u64 = 25;
+
+/// Per-container timeout for the stop+remove+mark-deleted teardown sequence.
+/// Docker's graceful stop alone can take ~10s; without a ceiling a single hung
+/// container would block the whole teardown loop indefinitely. On timeout we
+/// log and move on — the container row is left for the next sweep to retry.
+const CONTAINER_TEARDOWN_TIMEOUT_SECS: u64 = 30;
 
 /// Output from MarkDeploymentCompleteJob
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1404,9 +1420,94 @@ impl MarkDeploymentCompleteJob {
         .ok();
     }
 
-    /// Teardown all running/pending deployments for the same environment
-    /// This ensures only one active deployment per environment
-    /// Note: Deployment state is NOT changed - the is_current flag indicates which deployment is active
+    /// Tear down a single container: capture its logs, stop it, remove it from
+    /// Docker, and mark it deleted in the database. Each step is best-effort —
+    /// a failure is logged and the sequence continues so that a container which
+    /// e.g. can't be stopped is still marked removed and won't be retried
+    /// forever. Resolves the correct (local vs remote) deployer from node_id.
+    async fn teardown_container(
+        &self,
+        container: deployment_containers::Model,
+        project_id: i32,
+        environment_id: i32,
+    ) {
+        let container_id = container.container_id.clone();
+
+        // Determine which deployer to use based on node_id
+        let deployer: Arc<dyn temps_deployer::ContainerDeployer> = if let Some(node_id) =
+            container.node_id
+        {
+            match self.get_remote_deployer(node_id).await {
+                Ok(remote) => remote,
+                Err(e) => {
+                    self.log(format!(
+                        "Failed to create remote deployer for container {} on node {}: {} — falling back to local",
+                        container_id, node_id, e
+                    ))
+                    .await
+                    .ok();
+                    self.container_deployer.clone()
+                }
+            }
+        } else {
+            self.container_deployer.clone()
+        };
+
+        // Capture the container's logs to durable storage BEFORE we stop and
+        // remove it, so they survive teardown and can be viewed later.
+        self.capture_container_logs(&deployer, &container, project_id, environment_id)
+            .await;
+
+        // Stop container first
+        match deployer.stop_container(&container_id).await {
+            Ok(_) => {
+                self.log(format!("Stopped container {}", container_id))
+                    .await
+                    .ok();
+            }
+            Err(e) => {
+                self.log(format!("Failed to stop container {}: {}", container_id, e))
+                    .await
+                    .ok();
+            }
+        }
+
+        // Remove container from Docker
+        match deployer.remove_container(&container_id).await {
+            Ok(_) => {
+                self.log(format!("Removed container {}", container_id))
+                    .await
+                    .ok();
+            }
+            Err(e) => {
+                self.log(format!(
+                    "Failed to remove container {}: {}",
+                    container_id, e
+                ))
+                .await
+                .ok();
+            }
+        }
+
+        // Mark container as deleted in database
+        let mut active_container: deployment_containers::ActiveModel = container.into();
+        active_container.deleted_at = Set(Some(chrono::Utc::now()));
+        active_container.status = Set(Some("removed".to_string()));
+        if let Err(e) = active_container.update(self.db.as_ref()).await {
+            self.log(format!("Failed to update container status: {}", e))
+                .await
+                .ok();
+        }
+    }
+
+    /// Teardown all running/pending deployments for the same environment.
+    /// This ensures only one active deployment per environment.
+    ///
+    /// After a deployment's containers are torn down, the deployment's state is
+    /// flipped to "stopped" so it is no longer re-scanned by subsequent
+    /// teardown passes — bounding this work regardless of how much deployment
+    /// history accumulates. The route table already points at the new
+    /// deployment (via `environments.current_deployment_id`) before this runs.
     async fn cancel_previous_deployments(&self, environment_id: i32) {
         use sea_orm::Set;
 
@@ -1414,8 +1515,19 @@ impl MarkDeploymentCompleteJob {
             .await
             .ok();
 
-        // Find all running or pending deployments for this environment (excluding the new one)
-        // Note: "failed" deployments are intentionally excluded to preserve error history
+        // Find previous active deployments for this environment (excluding the new one).
+        //
+        // "failed" is intentionally excluded to preserve error history. Once a
+        // deployment is torn down here its state is flipped to "stopped" (see
+        // below), so it drops out of this filter and is never re-scanned — that
+        // is what keeps this query bounded as deployment history grows. We still
+        // include "completed" to catch a previously-current deployment that this
+        // new deploy is superseding (and any legacy rows left un-torn-down before
+        // the state-flip fix existed).
+        //
+        // The result is additionally capped (newest-first) so that even a large
+        // backlog of un-processed rows can't make a single pass run for minutes;
+        // anything beyond the cap is handled by the next deployment's sweep.
         let previous_deployments = match deployments::Entity::find()
             .filter(deployments::Column::EnvironmentId.eq(environment_id))
             .filter(deployments::Column::Id.ne(self.deployment_id))
@@ -1425,6 +1537,8 @@ impl MarkDeploymentCompleteJob {
                 "built",
                 "completed",
             ]))
+            .order_by_desc(deployments::Column::CreatedAt)
+            .limit(MAX_TEARDOWN_DEPLOYMENTS_PER_PASS)
             .all(self.db.as_ref())
             .await
         {
@@ -1503,79 +1617,51 @@ impl MarkDeploymentCompleteJob {
                 }
             }
 
-            for container in containers {
-                let container_id = container.container_id.clone();
-
-                // Determine which deployer to use based on node_id
-                let deployer: Arc<dyn temps_deployer::ContainerDeployer> = if let Some(node_id) =
-                    container.node_id
-                {
-                    match self.get_remote_deployer(node_id).await {
-                        Ok(remote) => remote,
-                        Err(e) => {
-                            self.log(format!(
-                                    "Failed to create remote deployer for container {} on node {}: {} — falling back to local",
-                                    container_id, node_id, e
-                                ))
-                                .await
-                                .ok();
-                            self.container_deployer.clone()
-                        }
-                    }
-                } else {
-                    self.container_deployer.clone()
-                };
-
-                // Capture the container's logs to durable storage BEFORE we stop
-                // and remove it, so they survive teardown and can be viewed later.
-                self.capture_container_logs(
-                    &deployer,
-                    &container,
-                    deployment.project_id,
-                    deployment.environment_id,
-                )
-                .await;
-
-                // Stop container first
-                match deployer.stop_container(&container_id).await {
-                    Ok(_) => {
-                        self.log(format!("Stopped container {}", container_id))
-                            .await
-                            .ok();
-                    }
-                    Err(e) => {
-                        self.log(format!("Failed to stop container {}: {}", container_id, e))
-                            .await
-                            .ok();
-                    }
-                }
-
-                // Remove container from Docker
-                match deployer.remove_container(&container_id).await {
-                    Ok(_) => {
-                        self.log(format!("Removed container {}", container_id))
-                            .await
-                            .ok();
-                    }
-                    Err(e) => {
+            // Tear down every container concurrently. Each container's
+            // stop+remove+mark-deleted sequence is wrapped in a timeout so a
+            // single hung Docker daemon or container can't stall the whole loop;
+            // running them concurrently keeps total teardown time bounded by the
+            // slowest container rather than their sum.
+            let teardowns = containers.into_iter().map(|container| {
+                let project_id = deployment.project_id;
+                let env_id = deployment.environment_id;
+                async move {
+                    let container_id = container.container_id.clone();
+                    let result = tokio::time::timeout(
+                        std::time::Duration::from_secs(CONTAINER_TEARDOWN_TIMEOUT_SECS),
+                        self.teardown_container(container, project_id, env_id),
+                    )
+                    .await;
+                    if result.is_err() {
                         self.log(format!(
-                            "Failed to remove container {}: {}",
-                            container_id, e
+                            "Timed out tearing down container {} after {}s — will retry on next sweep",
+                            container_id, CONTAINER_TEARDOWN_TIMEOUT_SECS
                         ))
                         .await
                         .ok();
                     }
                 }
+            });
+            futures::future::join_all(teardowns).await;
 
-                // Mark container as deleted in database
-                let mut active_container: deployment_containers::ActiveModel = container.into();
-                active_container.deleted_at = Set(Some(chrono::Utc::now()));
-                active_container.status = Set(Some("removed".to_string()));
-                if let Err(e) = active_container.update(self.db.as_ref()).await {
-                    self.log(format!("Failed to update container status: {}", e))
-                        .await
-                        .ok();
-                }
+            // Flip the deployment to a terminal "stopped" state so it is no
+            // longer matched by the scan above. This is what bounds the teardown
+            // query as deployment history grows — without it, every completed
+            // deployment would be re-scanned on every subsequent deploy forever.
+            // We do NOT touch "failed" deployments (excluded by the filter) and
+            // the rollback target finder (`find_last_successful_deployment`) only
+            // ever needs the most-recent completed deployment, which is the new
+            // current one — never a deployment we are stopping here.
+            let mut active_deployment: deployments::ActiveModel = deployment.into();
+            active_deployment.state = Set("stopped".to_string());
+            active_deployment.updated_at = Set(chrono::Utc::now());
+            if let Err(e) = active_deployment.update(self.db.as_ref()).await {
+                self.log(format!(
+                    "Failed to mark deployment {} as stopped: {}",
+                    deployment_id, e
+                ))
+                .await
+                .ok();
             }
 
             self.log(format!(
@@ -1780,5 +1866,288 @@ impl MarkDeploymentCompleteJobBuilder {
 impl Default for MarkDeploymentCompleteJobBuilder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod teardown_tests {
+    use super::*;
+    use sea_orm::ActiveModelTrait;
+    use std::sync::Mutex as StdMutex;
+    use temps_core::QueueError;
+    use temps_database::test_utils::TestDatabase;
+    use temps_deployer::{
+        ContainerDeployer, ContainerInfo, ContainerStats, DeployRequest, DeployResult,
+        DeployerError,
+    };
+    use temps_entities::preset::Preset;
+    use temps_entities::upstream_config::UpstreamList;
+    use temps_entities::{deployment_containers, environments, projects};
+
+    /// Minimal ContainerDeployer that records stop/remove calls and otherwise
+    /// no-ops. Used to assert that teardown stopped the expected containers
+    /// without needing a real Docker daemon.
+    struct RecordingDeployer {
+        stopped: Arc<StdMutex<Vec<String>>>,
+        removed: Arc<StdMutex<Vec<String>>>,
+    }
+
+    impl RecordingDeployer {
+        fn new() -> Self {
+            Self {
+                stopped: Arc::new(StdMutex::new(Vec::new())),
+                removed: Arc::new(StdMutex::new(Vec::new())),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ContainerDeployer for RecordingDeployer {
+        async fn deploy_container(
+            &self,
+            request: DeployRequest,
+        ) -> Result<DeployResult, DeployerError> {
+            Err(DeployerError::Other(format!(
+                "deploy_container not used in teardown test: {}",
+                request.container_name
+            )))
+        }
+        async fn start_container(&self, _id: &str) -> Result<(), DeployerError> {
+            Ok(())
+        }
+        async fn stop_container(&self, id: &str) -> Result<(), DeployerError> {
+            self.stopped.lock().unwrap().push(id.to_string());
+            Ok(())
+        }
+        async fn pause_container(&self, _id: &str) -> Result<(), DeployerError> {
+            Ok(())
+        }
+        async fn resume_container(&self, _id: &str) -> Result<(), DeployerError> {
+            Ok(())
+        }
+        async fn remove_container(&self, id: &str) -> Result<(), DeployerError> {
+            self.removed.lock().unwrap().push(id.to_string());
+            Ok(())
+        }
+        async fn get_container_info(&self, _id: &str) -> Result<ContainerInfo, DeployerError> {
+            Err(DeployerError::Other("not implemented".into()))
+        }
+        async fn get_container_stats(&self, _id: &str) -> Result<ContainerStats, DeployerError> {
+            Err(DeployerError::Other("not implemented".into()))
+        }
+        async fn list_containers(&self) -> Result<Vec<ContainerInfo>, DeployerError> {
+            Ok(vec![])
+        }
+        async fn get_container_logs(&self, _id: &str) -> Result<String, DeployerError> {
+            Ok(String::new())
+        }
+        async fn stream_container_logs(
+            &self,
+            _id: &str,
+        ) -> Result<Box<dyn futures::Stream<Item = String> + Unpin + Send>, DeployerError> {
+            Err(DeployerError::Other("not implemented".into()))
+        }
+    }
+
+    /// No-op JobQueue — teardown never enqueues anything.
+    struct NoopQueue;
+
+    #[async_trait]
+    impl JobQueue for NoopQueue {
+        async fn send(&self, _job: Job) -> Result<(), QueueError> {
+            Ok(())
+        }
+        fn subscribe(&self) -> Box<dyn JobReceiver> {
+            panic!("subscribe not used in teardown test")
+        }
+    }
+
+    async fn seed_project_env(db: &Arc<DbConnection>) -> (projects::Model, environments::Model) {
+        let project = projects::ActiveModel {
+            name: Set("Teardown Test".to_string()),
+            slug: Set("teardown-test".to_string()),
+            repo_owner: Set("owner".to_string()),
+            repo_name: Set("repo".to_string()),
+            main_branch: Set("main".to_string()),
+            preset: Set(Preset::NextJs),
+            directory: Set("/".to_string()),
+            created_at: Set(chrono::Utc::now()),
+            updated_at: Set(chrono::Utc::now()),
+            is_deleted: Set(false),
+            ..Default::default()
+        };
+        let project = project.insert(db.as_ref()).await.unwrap();
+
+        let environment = environments::ActiveModel {
+            project_id: Set(project.id),
+            name: Set("prod".to_string()),
+            slug: Set("prod".to_string()),
+            host: Set("app.example.com".to_string()),
+            subdomain: Set("app.example.com".to_string()),
+            upstreams: Set(UpstreamList::default()),
+            current_deployment_id: Set(None),
+            created_at: Set(chrono::Utc::now()),
+            updated_at: Set(chrono::Utc::now()),
+            ..Default::default()
+        };
+        let environment = environment.insert(db.as_ref()).await.unwrap();
+        (project, environment)
+    }
+
+    async fn insert_deployment(
+        db: &Arc<DbConnection>,
+        project_id: i32,
+        environment_id: i32,
+        slug: &str,
+        state: &str,
+    ) -> deployments::Model {
+        deployments::ActiveModel {
+            project_id: Set(project_id),
+            environment_id: Set(environment_id),
+            slug: Set(slug.to_string()),
+            state: Set(state.to_string()),
+            metadata: Set(Some(deployments::DeploymentMetadata::default())),
+            created_at: Set(chrono::Utc::now()),
+            updated_at: Set(chrono::Utc::now()),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .unwrap()
+    }
+
+    async fn insert_container(
+        db: &Arc<DbConnection>,
+        deployment_id: i32,
+        container_id: &str,
+    ) -> deployment_containers::Model {
+        deployment_containers::ActiveModel {
+            deployment_id: Set(deployment_id),
+            container_id: Set(container_id.to_string()),
+            container_name: Set(container_id.to_string()),
+            container_port: Set(8080),
+            status: Set(Some("running".to_string())),
+            created_at: Set(chrono::Utc::now()),
+            deployed_at: Set(chrono::Utc::now()),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .unwrap()
+    }
+
+    fn make_job(
+        db: Arc<DbConnection>,
+        deployment_id: i32,
+        deployer: Arc<RecordingDeployer>,
+    ) -> MarkDeploymentCompleteJob {
+        MarkDeploymentCompleteJob::new(
+            "mark-complete".to_string(),
+            deployment_id,
+            db,
+            deployer,
+            Arc::new(NoopQueue),
+            Arc::new(temps_core::EncryptionService::new_from_password(
+                "test-password",
+            )),
+        )
+    }
+
+    /// The core scalability fix: a previous "completed" deployment is torn down
+    /// AND flipped to "stopped", so it no longer matches the teardown scan on
+    /// subsequent passes. Without the flip it would be re-scanned forever.
+    #[tokio::test]
+    async fn test_teardown_flips_previous_completed_to_stopped() {
+        let test_db = match TestDatabase::with_migrations().await {
+            Ok(db) => db,
+            Err(_) => {
+                println!("Postgres not available, skipping");
+                return;
+            }
+        };
+        let db = test_db.connection_arc();
+
+        let (project, env) = seed_project_env(&db).await;
+
+        // Previous completed deployment + its container.
+        let prev = insert_deployment(&db, project.id, env.id, "prev-deploy", "completed").await;
+        insert_container(&db, prev.id, "prev-container").await;
+        let _ = project;
+
+        // The new (current) deployment — already marked completed by the time
+        // teardown runs.
+        let new = insert_deployment(&db, project.id, env.id, "new-deploy", "completed").await;
+
+        let deployer = Arc::new(RecordingDeployer::new());
+        let job = make_job(db.clone(), new.id, deployer.clone());
+
+        job.cancel_previous_deployments(env.id).await;
+
+        // The previous deployment is now "stopped" and won't be re-scanned.
+        let prev_after = deployments::Entity::find_by_id(prev.id)
+            .one(db.as_ref())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(prev_after.state, "stopped");
+
+        // The new/current deployment is untouched (still completed).
+        let new_after = deployments::Entity::find_by_id(new.id)
+            .one(db.as_ref())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(new_after.state, "completed");
+
+        // Its container was stopped and removed.
+        assert_eq!(
+            deployer.stopped.lock().unwrap().as_slice(),
+            ["prev-container"]
+        );
+        assert_eq!(
+            deployer.removed.lock().unwrap().as_slice(),
+            ["prev-container"]
+        );
+
+        // A second teardown pass finds nothing to do — proving the scan is
+        // bounded and "stopped" deployments are not re-processed.
+        job.cancel_previous_deployments(env.id).await;
+        assert_eq!(
+            deployer.stopped.lock().unwrap().len(),
+            1,
+            "stopped deployment must not be re-torn-down on the next pass"
+        );
+    }
+
+    /// "failed" deployments are never torn down — error history is preserved.
+    #[tokio::test]
+    async fn test_teardown_preserves_failed_deployments() {
+        let test_db = match TestDatabase::with_migrations().await {
+            Ok(db) => db,
+            Err(_) => {
+                println!("Postgres not available, skipping");
+                return;
+            }
+        };
+        let db = test_db.connection_arc();
+
+        let (project, env) = seed_project_env(&db).await;
+        let failed = insert_deployment(&db, project.id, env.id, "failed-deploy", "failed").await;
+        let new = insert_deployment(&db, project.id, env.id, "new-deploy", "completed").await;
+
+        let deployer = Arc::new(RecordingDeployer::new());
+        let job = make_job(db.clone(), new.id, deployer.clone());
+        job.cancel_previous_deployments(env.id).await;
+
+        let failed_after = deployments::Entity::find_by_id(failed.id)
+            .one(db.as_ref())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            failed_after.state, "failed",
+            "failed deployments must be left untouched"
+        );
+        assert!(deployer.stopped.lock().unwrap().is_empty());
     }
 }

--- a/crates/temps-deployments/src/services/job_processor.rs
+++ b/crates/temps-deployments/src/services/job_processor.rs
@@ -266,49 +266,56 @@ impl JobProcessorService {
     }
 }
 
-/// Find the environment to deploy to for a given branch.
-/// When multiple environments track the same branch, the first non-preview
-/// environment is selected. The user can then promote to other environments
-/// manually (Vercel-like model).
-async fn find_or_create_environment_for_branch(
+/// Find all environments to deploy to for a given branch push.
+/// Returns every non-preview, non-protected environment tracking this branch
+/// so each can independently apply its own `automatic_deploy` policy.
+/// When no named environments match and preview environments are enabled,
+/// creates/finds a per-branch preview environment and returns it as the sole
+/// entry. Returns an empty Vec only when there are no matches and preview
+/// environments are disabled.
+async fn find_environments_for_branch(
     db: Arc<DbConnection>,
     project: &temps_entities::projects::Model,
     branch: Option<&str>,
-) -> Result<temps_entities::environments::Model, String> {
+) -> Result<Vec<temps_entities::environments::Model>, String> {
     use temps_entities::environments;
 
-    // If no branch specified, find first environment
+    // No branch → use the first environment (tag push, manual trigger without branch)
     let Some(branch_name) = branch else {
-        return environments::Entity::find()
+        let env = environments::Entity::find()
             .filter(environments::Column::ProjectId.eq(project.id))
             .filter(environments::Column::DeletedAt.is_null())
             .one(db.as_ref())
             .await
             .map_err(|e| format!("Database error finding environment: {}", e))?
-            .ok_or_else(|| "No environment found for project".to_string());
+            .ok_or_else(|| "No environment found for project".to_string())?;
+        return Ok(vec![env]);
     };
 
     info!(
-        "Looking for environment matching branch '{}' for project {}",
+        "Looking for environments matching branch '{}' for project {}",
         branch_name, project.id
     );
 
-    // Find the first non-protected environment with matching branch.
-    // Protected environments are skipped — they only receive promoted deployments.
-    if let Some(matched_env) = environments::Entity::find()
+    // Find ALL non-preview, non-protected environments tracking this branch.
+    // Protected environments receive only promoted deployments, never push events.
+    // Each returned environment then applies its own automatic_deploy policy.
+    let matched_envs = environments::Entity::find()
         .filter(environments::Column::ProjectId.eq(project.id))
         .filter(environments::Column::Branch.eq(branch_name))
+        .filter(environments::Column::IsPreview.eq(false))
         .filter(environments::Column::Protected.eq(false))
         .filter(environments::Column::DeletedAt.is_null())
-        .one(db.as_ref())
+        .all(db.as_ref())
         .await
-        .map_err(|e| format!("Database error finding branch environment: {}", e))?
-    {
+        .map_err(|e| format!("Database error finding branch environments: {}", e))?;
+
+    if !matched_envs.is_empty() {
         info!(
-            "Found environment '{}' matching branch '{}'",
-            matched_env.name, branch_name
+            "Found {} environment(s) matching branch '{}'",
+            matched_envs.len(), branch_name
         );
-        return Ok(matched_env);
+        return Ok(matched_envs);
     }
 
     info!(
@@ -340,7 +347,7 @@ async fn find_or_create_environment_for_branch(
                 "Found existing preview environment '{}' for branch '{}'",
                 existing_preview.name, branch_name
             );
-            return Ok(existing_preview);
+            return Ok(vec![existing_preview]);
         }
 
         // Check if a soft-deleted preview environment exists for this branch — restore it
@@ -364,11 +371,13 @@ async fn find_or_create_environment_for_branch(
                 .update(db.as_ref())
                 .await
                 .map_err(|e| format!("Failed to restore preview environment: {}", e))?;
-            return Ok(restored);
+            return Ok(vec![restored]);
         }
 
         // Create new preview environment for this branch
-        return create_preview_environment(db, project, branch_name, &slugified_branch).await;
+        return create_preview_environment(db, project, branch_name, &slugified_branch)
+            .await
+            .map(|env| vec![env]);
     }
 
     // Preview environments not enabled, try to find generic preview environment (legacy behavior)
@@ -389,7 +398,7 @@ async fn find_or_create_environment_for_branch(
             "Using existing generic preview environment for branch '{}'",
             branch_name
         );
-        return Ok(preview_env);
+        return Ok(vec![preview_env]);
     }
 
     // No preview environment exists, create generic one (legacy behavior)
@@ -429,7 +438,7 @@ async fn find_or_create_environment_for_branch(
         created_env.name, project.id
     );
 
-    Ok(created_env)
+    Ok(vec![created_env])
 }
 
 /// Create a new preview environment for a specific branch
@@ -586,19 +595,22 @@ async fn copy_environment_variables_to_preview(
 }
 
 /// Returns true if a git push should auto-deploy given the project and
-/// environment deployment configs. The merge mirrors `DeploymentConfig::merge`
-/// (env overrides project; OR-semantics for booleans). When both configs are
-/// absent the answer is false — auto-deploy is opt-in, not opt-out.
+/// environment deployment configs. Environment config wins when present
+/// (env can explicitly opt out even if project has auto-deploy on).
+/// When both configs are absent the answer is false — auto-deploy is opt-in.
 fn is_automatic_deploy_enabled(
     project_config: Option<&temps_entities::deployment_config::DeploymentConfig>,
     environment_config: Option<&temps_entities::deployment_config::DeploymentConfig>,
 ) -> bool {
-    match (project_config, environment_config) {
-        (Some(project_cfg), Some(env_cfg)) => project_cfg.merge(env_cfg).automatic_deploy,
+    // Environment-level explicit value takes precedence; fall back to project then false.
+    let effective = match (project_config, environment_config) {
+        (_, Some(env_cfg)) => env_cfg.automatic_deploy.or_else(|| {
+            project_config.and_then(|p| p.automatic_deploy)
+        }),
         (Some(project_cfg), None) => project_cfg.automatic_deploy,
-        (None, Some(env_cfg)) => env_cfg.automatic_deploy,
-        (None, None) => false,
-    }
+        (None, None) => None,
+    };
+    effective.unwrap_or(false)
 }
 
 // Extracted free function for testing
@@ -639,138 +651,35 @@ async fn process_git_push_event(
         }
     };
 
-    // Find environment matching the branch, or fallback to preview environment.
-    // Multiple environments can track the same branch, but auto-deploy only
-    // targets the first match. Users promote to other environments via redeploy.
-    let environment =
-        match find_or_create_environment_for_branch(db.clone(), &project, job.branch.as_deref())
+    // Find all environments matching this branch. Multiple environments can
+    // track the same branch; each is deployed independently according to its
+    // own automatic_deploy policy (env-wins semantics).
+    let environments =
+        match find_environments_for_branch(db.clone(), &project, job.branch.as_deref())
             .await
         {
-            Ok(env) => env,
+            Ok(envs) => envs,
             Err(e) => {
                 error!(
-                    "Failed to find or create environment for project {}: {}",
+                    "Failed to find environments for project {}: {}",
                     project.id, e
                 );
                 return;
             }
         };
 
-    // ── Auto-deploy gate ─────────────────────────────────────────────────
-    //
-    // Respect the user's "deploy on push" setting before doing any work.
-    // The effective value is computed by merging project + environment
-    // deployment configs (env overrides project). When both sides have
-    // automatic_deploy=false, webhook push events must NOT trigger a
-    // deployment — the user has explicitly opted out of auto-deploy.
-    //
-    // Manual triggers (the "Deploy" button, `trigger_pipeline` API,
-    // initial deployment on project creation) bypass this gate entirely:
-    // the user just clicked deploy, so they unambiguously want a deploy
-    // regardless of the auto-deploy setting. The flag exists for
-    // webhook-driven flows, not user-driven ones.
-    //
-    // Exception for the webhook path: the FIRST deployment for an
-    // environment always runs even when automatic_deploy=false. Without
-    // this, a freshly-created opt-out project would never get a baseline
-    // deployment from the first push.
-    use sea_orm::{EntityTrait, PaginatorTrait, QueryOrder};
-    let auto_deploy_enabled = is_automatic_deploy_enabled(
-        project.deployment_config.as_ref(),
-        environment.deployment_config.as_ref(),
-    );
-    if !auto_deploy_enabled && !job.manual_trigger {
-        let existing_count = match deployments::Entity::find()
-            .filter(deployments::Column::EnvironmentId.eq(environment.id))
-            .count(db.as_ref())
-            .await
-        {
-            Ok(n) => n,
-            Err(e) => {
-                error!(
-                    "Failed to count existing deployments for environment {}: {}",
-                    environment.id, e
-                );
-                return;
-            }
-        };
-
-        if existing_count > 0 {
-            info!(
-                "Skipping push event for project {} environment {} ({}): automatic_deploy is disabled",
-                project.id, environment.id, environment.name
-            );
-            return;
-        }
-
+    if environments.is_empty() {
         info!(
-            "Allowing initial deployment for project {} environment {} ({}) despite automatic_deploy=false (no prior deployments)",
-            project.id, environment.id, environment.name
-        );
-    } else if job.manual_trigger && !auto_deploy_enabled {
-        info!(
-            "Manual trigger for project {} environment {} ({}) — bypassing automatic_deploy=false",
-            project.id, environment.id, environment.name
-        );
-    }
-
-    // Check for duplicate deployment (same project, environment, and commit)
-    // This prevents duplicate deployments from being created if:
-    // - Multiple webhook URLs are configured in GitHub (both /webhook/git/github/events and /webhook/source/github/events)
-    // - GitHub sends duplicate webhooks
-    // - Race condition between concurrent push events
-    let existing_deployment = deployments::Entity::find()
-        .filter(deployments::Column::ProjectId.eq(project.id))
-        .filter(deployments::Column::EnvironmentId.eq(environment.id))
-        .filter(deployments::Column::CommitSha.eq(&job.commit))
-        .filter(deployments::Column::State.is_in(vec!["pending", "running", "deploying", "ready"]))
-        .order_by_desc(deployments::Column::CreatedAt)
-        .one(db.as_ref())
-        .await;
-
-    if let Ok(Some(existing)) = existing_deployment {
-        info!(
-            "Deployment already exists for project {} environment {} commit {} (deployment #{}, state: {}). Skipping duplicate.",
-            project.id, environment.id, job.commit, existing.id, existing.state
+            "No environments found for branch {:?} in project {}",
+            job.branch, project.id
         );
         return;
     }
 
-    // ── Cancel-on-supersede ──────────────────────────────────────────────
-    //
-    // Cancel any in-flight deployments for this environment before starting
-    // a new one. This is the standard PaaS behaviour (Vercel, Railway, etc.):
-    // the newest push always wins. Benefits:
-    //   - Prevents race conditions between concurrent mark_complete() calls
-    //   - Saves Docker build resources (no wasted builds)
-    //   - Avoids container name/port conflicts during deploy phase
-    //
-    // The cancelled deployments will stop at the next workflow checkpoint
-    // (between job batches) via the DatabaseCancellationProvider.
-    cancel_in_flight_deployments(&db, &queue, project.id, environment.id).await;
-
-    // Create deployment record directly (no more pipeline)
-    // Note: Previous deployment teardown happens AFTER this deployment succeeds (zero-downtime)
+    use sea_orm::{EntityTrait, PaginatorTrait, QueryOrder};
     use chrono::Utc;
 
-    // Get the next deployment number for this project
-    let paginator = deployments::Entity::find()
-        .filter(deployments::Column::ProjectId.eq(project.id))
-        .paginate(db.as_ref(), 1);
-
-    let deployment_count = match paginator.num_items().await {
-        Ok(count) => count,
-        Err(e) => {
-            error!(
-                "Failed to count deployments for project {}: {}",
-                project.id, e
-            );
-            return;
-        }
-    };
-    let deployment_number = deployment_count + 1;
-
-    // Fetch commit information from Git provider
+    // Fetch commit info once — it's the same for every environment receiving this push.
     let commit_info =
         match JobProcessorService::fetch_commit_info(&git_provider_manager, &project, &job).await {
             Ok(info) => {
@@ -783,117 +692,7 @@ async fn process_git_push_event(
             }
         };
 
-    // Generate URL/slug based on environment type
-    let env_slug = if environment.is_preview {
-        // For preview deployments, include branch name in slug for unique URLs
-        let sanitized_branch = job
-            .branch
-            .as_ref()
-            .map(|b| b.replace(['/', '_', '.'], "-").to_lowercase())
-            .unwrap_or_else(|| "unknown".to_string());
-        format!(
-            "{}-{}-{}",
-            project.slug, sanitized_branch, deployment_number
-        )
-    } else {
-        // For named environments (production, staging, etc.), use standard format
-        format!("{}-{}", project.slug, deployment_number)
-    };
-
-    // Get the effective deployment configuration by merging project and environment configs
-    let merged_config = if let Some(project_config) = &project.deployment_config {
-        if let Some(env_config) = &environment.deployment_config {
-            Some(project_config.merge(env_config))
-        } else {
-            Some(project_config.clone())
-        }
-    } else {
-        environment.deployment_config.clone()
-    };
-
-    // Create deployment config snapshot
-    // Note: Environment variables will be populated during workflow execution
-    // We store an empty map here and the workflow will update it with actual values
-    let deployment_config_snapshot =
-        merged_config.map(|config| DeploymentConfigSnapshot::from_config(&config, HashMap::new()));
-
-    // Create typed deployment metadata
-    let deployment_metadata = DeploymentMetadata {
-        git_push_event: Some(GitPushEvent {
-            owner: job.owner.clone(),
-            repo: job.repo.clone(),
-            branch: job.branch.clone().unwrap_or_default(),
-            commit: job.commit.clone(),
-        }),
-        ..Default::default()
-    };
-
-    let new_deployment = deployments::ActiveModel {
-        id: sea_orm::NotSet,
-        project_id: sea_orm::Set(project.id),
-        environment_id: sea_orm::Set(environment.id),
-        slug: sea_orm::Set(env_slug),
-        state: sea_orm::Set("pending".to_string()),
-        metadata: sea_orm::Set(Some(deployment_metadata)),
-        branch_ref: sea_orm::Set(job.branch.clone()),
-        tag_ref: sea_orm::Set(job.tag.clone()),
-        commit_sha: sea_orm::Set(Some(job.commit.clone())),
-        commit_message: sea_orm::Set(commit_info.as_ref().map(|c| c.message.clone())),
-        commit_author: sea_orm::Set(commit_info.as_ref().map(|c| c.author.clone())),
-        promoted_from_deployment_id: sea_orm::Set(None),
-        started_at: sea_orm::Set(None),
-        finished_at: sea_orm::Set(None),
-        context_vars: sea_orm::Set(Some(serde_json::json!({
-            "trigger": "git_push",
-            "source": "webhook"
-        }))),
-        deploying_at: sea_orm::Set(None),
-        ready_at: sea_orm::Set(None),
-        static_dir_location: sea_orm::Set(None),
-        screenshot_location: sea_orm::Set(None),
-        image_name: sea_orm::Set(None),
-        cancelled_reason: sea_orm::Set(None),
-        commit_json: sea_orm::Set(commit_info.as_ref().map(|c| c.commit_json.clone())),
-        deployment_config: sea_orm::Set(deployment_config_snapshot),
-        created_at: sea_orm::Set(Utc::now()),
-        updated_at: sea_orm::Set(Utc::now()),
-    };
-
-    let deployment = match new_deployment.insert(db.as_ref()).await {
-        Ok(deployment) => deployment,
-        Err(e) => {
-            error!(
-                "Failed to create deployment for project {}: {}",
-                project.id, e
-            );
-            return;
-        }
-    };
-
-    info!(
-        "Created deployment {} for project {} from GitPushEvent",
-        deployment.id, project.id
-    );
-
-    // Fire DeploymentCreated event to queue
-    let deployment_created_event = Job::DeploymentCreated(temps_core::DeploymentCreatedJob {
-        deployment_id: deployment.id,
-        project_id: project.id,
-        environment_id: environment.id,
-        environment_name: environment.name.clone(),
-        branch: job.branch.clone(),
-        commit_sha: Some(job.commit.clone()),
-    });
-    if let Err(e) = queue.send(deployment_created_event).await {
-        error!("Failed to send DeploymentCreated event: {}", e);
-    } else {
-        debug!(
-            "Sent DeploymentCreated event for deployment {}",
-            deployment.id
-        );
-    }
-
-    // Update project's last_deployment timestamp
+    // Update project's last_deployment timestamp once for this push event.
     let mut active_project: temps_entities::projects::ActiveModel = project.clone().into();
     active_project.last_deployment = sea_orm::Set(Some(Utc::now()));
     if let Err(e) = active_project.update(db.as_ref()).await {
@@ -901,103 +700,264 @@ async fn process_git_push_event(
             "Failed to update last_deployment for project {}: {}",
             project.id, e
         );
-    } else {
-        debug!(
-            "Updated last_deployment timestamp for project {}",
-            project.id
-        );
     }
 
-    // Create jobs for this deployment using the workflow planner
-    let create_jobs_result = workflow_planner.create_deployment_jobs(deployment.id).await;
-    let deployment_id = deployment.id; // Extract deployment_id before match
-
-    // Handle result immediately
-    match create_jobs_result {
-        Ok(created_jobs) => {
-            let job_count = created_jobs.len();
-            info!(
-                "Created {} jobs for deployment {} from GitPushEvent",
-                job_count, deployment_id
-            );
-
-            // Update deployment status to Running before executing workflow
-            match JobProcessorService::update_deployment_status(
-                &db,
-                deployment_id,
-                PipelineStatus::Running,
-            )
-            .await
-            {
-                Ok(_) => info!("Updated deployment {} status to Running", deployment_id),
-                Err(e) => {
-                    error!("Failed to update deployment status to Running: {}", e);
-                    return;
-                }
-            }
-
-            // Execute the workflow
-            info!("Executing workflow for deployment {}", deployment_id);
-            match workflow_executor
-                .execute_deployment_workflow(deployment_id)
+    // Deploy to each environment that opts in. Each environment applies its own
+    // automatic_deploy policy so the user can have one env auto-deploy on push
+    // and another deploy on demand — even when both track the same branch.
+    for environment in environments {
+        // ── Auto-deploy gate ───────────────────────────────────────────────
+        //
+        // Env-wins semantics: if the environment has an explicit automatic_deploy
+        // value it takes precedence over the project setting. When both are absent
+        // the answer is false (opt-in, not opt-out). Manual triggers bypass this
+        // gate entirely — the user clicked deploy, so they unambiguously want one.
+        //
+        // Exception: the FIRST deployment for an environment always runs even when
+        // automatic_deploy=false, so a freshly-created opt-out env still boots.
+        let auto_deploy_enabled = is_automatic_deploy_enabled(
+            project.deployment_config.as_ref(),
+            environment.deployment_config.as_ref(),
+        );
+        if !auto_deploy_enabled && !job.manual_trigger {
+            let existing_count = match deployments::Entity::find()
+                .filter(deployments::Column::EnvironmentId.eq(environment.id))
+                .count(db.as_ref())
                 .await
             {
-                Ok(_) => {
-                    info!(
-                        "Workflow execution completed for deployment {}",
-                        deployment_id
-                    );
-                }
+                Ok(n) => n,
                 Err(e) => {
-                    let error_message = format!("{}", e);
                     error!(
-                        "Workflow execution failed for deployment {}: {}",
-                        deployment_id, error_message
+                        "Failed to count existing deployments for environment {}: {}",
+                        environment.id, e
                     );
+                    continue;
+                }
+            };
 
-                    // Mark deployment as failed with error message
-                    if let Err(update_err) =
-                        JobProcessorService::update_deployment_status_with_message(
-                            &db,
-                            deployment_id,
-                            PipelineStatus::Failed,
-                            Some(error_message),
-                        )
-                        .await
-                    {
-                        error!("Failed to update deployment status: {}", update_err);
-                    } else {
-                        debug!("Updated deployment {} status to failed", deployment_id);
+            if existing_count > 0 {
+                info!(
+                    "Skipping push event for project {} environment {} ({}): automatic_deploy is disabled",
+                    project.id, environment.id, environment.name
+                );
+                continue;
+            }
+
+            info!(
+                "Allowing initial deployment for project {} environment {} ({}) despite automatic_deploy=false (no prior deployments)",
+                project.id, environment.id, environment.name
+            );
+        } else if job.manual_trigger && !auto_deploy_enabled {
+            info!(
+                "Manual trigger for project {} environment {} ({}) — bypassing automatic_deploy=false",
+                project.id, environment.id, environment.name
+            );
+        }
+
+        // Check for duplicate deployment (same project, environment, and commit).
+        let existing_deployment = deployments::Entity::find()
+            .filter(deployments::Column::ProjectId.eq(project.id))
+            .filter(deployments::Column::EnvironmentId.eq(environment.id))
+            .filter(deployments::Column::CommitSha.eq(&job.commit))
+            .filter(deployments::Column::State.is_in(vec!["pending", "running", "deploying", "ready"]))
+            .order_by_desc(deployments::Column::CreatedAt)
+            .one(db.as_ref())
+            .await;
+
+        if let Ok(Some(existing)) = existing_deployment {
+            info!(
+                "Deployment already exists for project {} environment {} commit {} (deployment #{}, state: {}). Skipping duplicate.",
+                project.id, environment.id, job.commit, existing.id, existing.state
+            );
+            continue;
+        }
+
+        // Cancel-on-supersede: newest push always wins.
+        cancel_in_flight_deployments(&db, &queue, project.id, environment.id).await;
+
+        // Get the next deployment number for this project.
+        let deployment_count = match deployments::Entity::find()
+            .filter(deployments::Column::ProjectId.eq(project.id))
+            .paginate(db.as_ref(), 1)
+            .num_items()
+            .await
+        {
+            Ok(count) => count,
+            Err(e) => {
+                error!(
+                    "Failed to count deployments for project {}: {}",
+                    project.id, e
+                );
+                continue;
+            }
+        };
+        let deployment_number = deployment_count + 1;
+
+        let env_slug = if environment.is_preview {
+            let sanitized_branch = job
+                .branch
+                .as_ref()
+                .map(|b| b.replace(['/', '_', '.'], "-").to_lowercase())
+                .unwrap_or_else(|| "unknown".to_string());
+            format!("{}-{}-{}", project.slug, sanitized_branch, deployment_number)
+        } else {
+            format!("{}-{}", project.slug, deployment_number)
+        };
+
+        let merged_config = if let Some(project_config) = &project.deployment_config {
+            if let Some(env_config) = &environment.deployment_config {
+                Some(project_config.merge(env_config))
+            } else {
+                Some(project_config.clone())
+            }
+        } else {
+            environment.deployment_config.clone()
+        };
+
+        let deployment_config_snapshot =
+            merged_config.map(|config| DeploymentConfigSnapshot::from_config(&config, HashMap::new()));
+
+        let deployment_metadata = DeploymentMetadata {
+            git_push_event: Some(GitPushEvent {
+                owner: job.owner.clone(),
+                repo: job.repo.clone(),
+                branch: job.branch.clone().unwrap_or_default(),
+                commit: job.commit.clone(),
+            }),
+            ..Default::default()
+        };
+
+        let new_deployment = deployments::ActiveModel {
+            id: sea_orm::NotSet,
+            project_id: sea_orm::Set(project.id),
+            environment_id: sea_orm::Set(environment.id),
+            slug: sea_orm::Set(env_slug),
+            state: sea_orm::Set("pending".to_string()),
+            metadata: sea_orm::Set(Some(deployment_metadata)),
+            branch_ref: sea_orm::Set(job.branch.clone()),
+            tag_ref: sea_orm::Set(job.tag.clone()),
+            commit_sha: sea_orm::Set(Some(job.commit.clone())),
+            commit_message: sea_orm::Set(commit_info.as_ref().map(|c| c.message.clone())),
+            commit_author: sea_orm::Set(commit_info.as_ref().map(|c| c.author.clone())),
+            promoted_from_deployment_id: sea_orm::Set(None),
+            started_at: sea_orm::Set(None),
+            finished_at: sea_orm::Set(None),
+            context_vars: sea_orm::Set(Some(serde_json::json!({
+                "trigger": "git_push",
+                "source": "webhook"
+            }))),
+            deploying_at: sea_orm::Set(None),
+            ready_at: sea_orm::Set(None),
+            static_dir_location: sea_orm::Set(None),
+            screenshot_location: sea_orm::Set(None),
+            image_name: sea_orm::Set(None),
+            cancelled_reason: sea_orm::Set(None),
+            commit_json: sea_orm::Set(commit_info.as_ref().map(|c| c.commit_json.clone())),
+            deployment_config: sea_orm::Set(deployment_config_snapshot),
+            created_at: sea_orm::Set(Utc::now()),
+            updated_at: sea_orm::Set(Utc::now()),
+        };
+
+        let deployment = match new_deployment.insert(db.as_ref()).await {
+            Ok(deployment) => deployment,
+            Err(e) => {
+                error!(
+                    "Failed to create deployment for project {} environment {}: {}",
+                    project.id, environment.id, e
+                );
+                continue;
+            }
+        };
+
+        info!(
+            "Created deployment {} for project {} environment {} from GitPushEvent",
+            deployment.id, project.id, environment.id
+        );
+
+        let deployment_created_event = Job::DeploymentCreated(temps_core::DeploymentCreatedJob {
+            deployment_id: deployment.id,
+            project_id: project.id,
+            environment_id: environment.id,
+            environment_name: environment.name.clone(),
+            branch: job.branch.clone(),
+            commit_sha: Some(job.commit.clone()),
+        });
+        if let Err(e) = queue.send(deployment_created_event).await {
+            error!("Failed to send DeploymentCreated event: {}", e);
+        }
+
+        let create_jobs_result = workflow_planner.create_deployment_jobs(deployment.id).await;
+        let deployment_id = deployment.id;
+
+        match create_jobs_result {
+            Ok(created_jobs) => {
+                info!(
+                    "Created {} jobs for deployment {} from GitPushEvent",
+                    created_jobs.len(), deployment_id
+                );
+
+                match JobProcessorService::update_deployment_status(
+                    &db,
+                    deployment_id,
+                    PipelineStatus::Running,
+                )
+                .await
+                {
+                    Ok(_) => info!("Updated deployment {} status to Running", deployment_id),
+                    Err(e) => {
+                        error!("Failed to update deployment status to Running: {}", e);
+                        continue;
+                    }
+                }
+
+                info!("Executing workflow for deployment {}", deployment_id);
+                match workflow_executor
+                    .execute_deployment_workflow(deployment_id)
+                    .await
+                {
+                    Ok(_) => {
+                        info!("Workflow execution completed for deployment {}", deployment_id);
+                    }
+                    Err(e) => {
+                        let error_message = format!("{}", e);
+                        error!(
+                            "Workflow execution failed for deployment {}: {}",
+                            deployment_id, error_message
+                        );
+                        if let Err(update_err) =
+                            JobProcessorService::update_deployment_status_with_message(
+                                &db,
+                                deployment_id,
+                                PipelineStatus::Failed,
+                                Some(error_message),
+                            )
+                            .await
+                        {
+                            error!("Failed to update deployment status: {}", update_err);
+                        }
                     }
                 }
             }
-        }
-        Err(job_error) => {
-            // Convert error to string immediately to avoid Send issues
-            let error_message = format!("{}", job_error);
-            // Drop the error explicitly before any await
-            std::mem::drop(job_error);
-
-            error!(
-                "Failed to create jobs for deployment {}: {}",
-                deployment_id, error_message
-            );
-
-            // Mark deployment as failed with error message
-            if let Err(update_err) = JobProcessorService::update_deployment_status_with_message(
-                &db,
-                deployment_id,
-                PipelineStatus::Failed,
-                Some(error_message),
-            )
-            .await
-            {
-                error!("Failed to update deployment status: {}", update_err);
-            } else {
-                debug!("Updated deployment {} status to failed", deployment_id);
+            Err(job_error) => {
+                let error_message = format!("{}", job_error);
+                std::mem::drop(job_error);
+                error!(
+                    "Failed to create jobs for deployment {}: {}",
+                    deployment_id, error_message
+                );
+                if let Err(update_err) = JobProcessorService::update_deployment_status_with_message(
+                    &db,
+                    deployment_id,
+                    PipelineStatus::Failed,
+                    Some(error_message),
+                )
+                .await
+                {
+                    error!("Failed to update deployment status: {}", update_err);
+                }
             }
         }
-    }
+    } // end for environment in environments
 }
 
 /// Cancel all in-flight deployments for the given environment.
@@ -1999,7 +1959,7 @@ mod tests {
 
     fn cfg_with_auto_deploy(value: bool) -> temps_entities::deployment_config::DeploymentConfig {
         temps_entities::deployment_config::DeploymentConfig {
-            automatic_deploy: value,
+            automatic_deploy: Some(value),
             ..Default::default()
         }
     }
@@ -2045,5 +2005,30 @@ mod tests {
     fn auto_deploy_enabled_when_only_env_set_on() {
         let env_cfg = cfg_with_auto_deploy(true);
         assert!(is_automatic_deploy_enabled(None, Some(&env_cfg)));
+    }
+
+    #[test]
+    fn auto_deploy_env_false_overrides_project_true() {
+        // Env explicitly opts out even though project is on — env wins.
+        let project_cfg = cfg_with_auto_deploy(true);
+        let env_cfg = cfg_with_auto_deploy(false);
+        assert!(!is_automatic_deploy_enabled(
+            Some(&project_cfg),
+            Some(&env_cfg)
+        ));
+    }
+
+    #[test]
+    fn auto_deploy_env_none_inherits_project_true() {
+        // Env has no explicit setting — inherits project's true.
+        let project_cfg = cfg_with_auto_deploy(true);
+        let env_cfg = temps_entities::deployment_config::DeploymentConfig {
+            automatic_deploy: None,
+            ..Default::default()
+        };
+        assert!(is_automatic_deploy_enabled(
+            Some(&project_cfg),
+            Some(&env_cfg)
+        ));
     }
 }

--- a/crates/temps-deployments/src/services/job_processor.rs
+++ b/crates/temps-deployments/src/services/job_processor.rs
@@ -313,7 +313,8 @@ async fn find_environments_for_branch(
     if !matched_envs.is_empty() {
         info!(
             "Found {} environment(s) matching branch '{}'",
-            matched_envs.len(), branch_name
+            matched_envs.len(),
+            branch_name
         );
         return Ok(matched_envs);
     }
@@ -604,9 +605,9 @@ fn is_automatic_deploy_enabled(
 ) -> bool {
     // Environment-level explicit value takes precedence; fall back to project then false.
     let effective = match (project_config, environment_config) {
-        (_, Some(env_cfg)) => env_cfg.automatic_deploy.or_else(|| {
-            project_config.and_then(|p| p.automatic_deploy)
-        }),
+        (_, Some(env_cfg)) => env_cfg
+            .automatic_deploy
+            .or_else(|| project_config.and_then(|p| p.automatic_deploy)),
         (Some(project_cfg), None) => project_cfg.automatic_deploy,
         (None, None) => None,
     };
@@ -655,9 +656,7 @@ async fn process_git_push_event(
     // track the same branch; each is deployed independently according to its
     // own automatic_deploy policy (env-wins semantics).
     let environments =
-        match find_environments_for_branch(db.clone(), &project, job.branch.as_deref())
-            .await
-        {
+        match find_environments_for_branch(db.clone(), &project, job.branch.as_deref()).await {
             Ok(envs) => envs,
             Err(e) => {
                 error!(
@@ -676,8 +675,8 @@ async fn process_git_push_event(
         return;
     }
 
-    use sea_orm::{EntityTrait, PaginatorTrait, QueryOrder};
     use chrono::Utc;
+    use sea_orm::{EntityTrait, PaginatorTrait, QueryOrder};
 
     // Fetch commit info once — it's the same for every environment receiving this push.
     let commit_info =
@@ -759,7 +758,12 @@ async fn process_git_push_event(
             .filter(deployments::Column::ProjectId.eq(project.id))
             .filter(deployments::Column::EnvironmentId.eq(environment.id))
             .filter(deployments::Column::CommitSha.eq(&job.commit))
-            .filter(deployments::Column::State.is_in(vec!["pending", "running", "deploying", "ready"]))
+            .filter(deployments::Column::State.is_in(vec![
+                "pending",
+                "running",
+                "deploying",
+                "ready",
+            ]))
             .order_by_desc(deployments::Column::CreatedAt)
             .one(db.as_ref())
             .await;
@@ -799,7 +803,10 @@ async fn process_git_push_event(
                 .as_ref()
                 .map(|b| b.replace(['/', '_', '.'], "-").to_lowercase())
                 .unwrap_or_else(|| "unknown".to_string());
-            format!("{}-{}-{}", project.slug, sanitized_branch, deployment_number)
+            format!(
+                "{}-{}-{}",
+                project.slug, sanitized_branch, deployment_number
+            )
         } else {
             format!("{}-{}", project.slug, deployment_number)
         };
@@ -814,8 +821,8 @@ async fn process_git_push_event(
             environment.deployment_config.clone()
         };
 
-        let deployment_config_snapshot =
-            merged_config.map(|config| DeploymentConfigSnapshot::from_config(&config, HashMap::new()));
+        let deployment_config_snapshot = merged_config
+            .map(|config| DeploymentConfigSnapshot::from_config(&config, HashMap::new()));
 
         let deployment_metadata = DeploymentMetadata {
             git_push_event: Some(GitPushEvent {
@@ -893,7 +900,8 @@ async fn process_git_push_event(
             Ok(created_jobs) => {
                 info!(
                     "Created {} jobs for deployment {} from GitPushEvent",
-                    created_jobs.len(), deployment_id
+                    created_jobs.len(),
+                    deployment_id
                 );
 
                 match JobProcessorService::update_deployment_status(
@@ -916,7 +924,10 @@ async fn process_git_push_event(
                     .await
                 {
                     Ok(_) => {
-                        info!("Workflow execution completed for deployment {}", deployment_id);
+                        info!(
+                            "Workflow execution completed for deployment {}",
+                            deployment_id
+                        );
                     }
                     Err(e) => {
                         let error_message = format!("{}", e);
@@ -1576,9 +1587,10 @@ mod tests {
         let production_env = production_env.insert(db.as_ref()).await?;
 
         // Test finding environment for "main" branch
-        let found_env =
-            find_or_create_environment_for_branch(db.clone(), &project, Some("main")).await?;
+        let found_envs = find_environments_for_branch(db.clone(), &project, Some("main")).await?;
 
+        assert_eq!(found_envs.len(), 1, "exactly one env matches branch 'main'");
+        let found_env = &found_envs[0];
         assert_eq!(found_env.id, production_env.id);
         assert_eq!(found_env.name, "Production");
         assert_eq!(found_env.branch, Some("main".to_string()));
@@ -1644,10 +1656,11 @@ mod tests {
         let preview_env = preview_env.insert(db.as_ref()).await?;
 
         // Test finding environment for "feature-auth" branch (no exact match)
-        let found_env =
-            find_or_create_environment_for_branch(db.clone(), &project, Some("feature-auth"))
-                .await?;
+        let found_envs =
+            find_environments_for_branch(db.clone(), &project, Some("feature-auth")).await?;
 
+        assert_eq!(found_envs.len(), 1, "falls back to the single preview env");
+        let found_env = &found_envs[0];
         assert_eq!(found_env.id, preview_env.id);
         assert_eq!(found_env.name, "preview");
         assert_eq!(found_env.branch, None); // Preview has no specific branch
@@ -1706,11 +1719,12 @@ mod tests {
         assert!(preview_before.is_none(), "Preview should not exist yet");
 
         // Test finding environment for "feature-xyz" branch (should create preview)
-        let found_env =
-            find_or_create_environment_for_branch(db.clone(), &project, Some("feature-xyz"))
-                .await?;
+        let found_envs =
+            find_environments_for_branch(db.clone(), &project, Some("feature-xyz")).await?;
 
         // Verify preview environment was created
+        assert_eq!(found_envs.len(), 1, "creates one generic preview env");
+        let found_env = &found_envs[0];
         assert_eq!(found_env.name, "preview");
         assert_eq!(found_env.slug, "preview");
         assert_eq!(found_env.subdomain, "auto-create-preview-test-preview");
@@ -1772,19 +1786,22 @@ mod tests {
         let _production_env = _production_env.insert(db.as_ref()).await?;
 
         // Find environment for first feature branch (creates preview)
-        let env1 =
-            find_or_create_environment_for_branch(db.clone(), &project, Some("feature-auth"))
-                .await?;
+        let envs1 =
+            find_environments_for_branch(db.clone(), &project, Some("feature-auth")).await?;
 
         // Find environment for second feature branch (reuses preview)
-        let env2 =
-            find_or_create_environment_for_branch(db.clone(), &project, Some("feature-payments"))
-                .await?;
+        let envs2 =
+            find_environments_for_branch(db.clone(), &project, Some("feature-payments")).await?;
 
         // Find environment for third feature branch (reuses preview)
-        let env3 =
-            find_or_create_environment_for_branch(db.clone(), &project, Some("bugfix-login"))
-                .await?;
+        let envs3 =
+            find_environments_for_branch(db.clone(), &project, Some("bugfix-login")).await?;
+
+        // Each call returns exactly the one shared preview environment
+        assert_eq!(envs1.len(), 1);
+        assert_eq!(envs2.len(), 1);
+        assert_eq!(envs3.len(), 1);
+        let (env1, env2, env3) = (&envs1[0], &envs2[0], &envs3[0]);
 
         // All three should return the same preview environment
         assert_eq!(env1.id, env2.id);
@@ -1863,10 +1880,11 @@ mod tests {
         let _env2 = _env2.insert(db.as_ref()).await?;
 
         // Test finding environment with no branch specified
-        let found_env = find_or_create_environment_for_branch(db.clone(), &project, None).await?;
+        let found_envs = find_environments_for_branch(db.clone(), &project, None).await?;
 
-        // Should return first environment (by database order)
-        assert_eq!(found_env.id, env1.id);
+        // Should return the first environment (by database order)
+        assert_eq!(found_envs.len(), 1, "no branch → single first env");
+        assert_eq!(found_envs[0].id, env1.id);
 
         Ok(())
     }
@@ -1932,10 +1950,11 @@ mod tests {
 
         // Test finding environment for feature branch
         // Should create NEW preview (ignore deleted one)
-        let found_env =
-            find_or_create_environment_for_branch(db.clone(), &project, Some("feature-test"))
-                .await?;
+        let found_envs =
+            find_environments_for_branch(db.clone(), &project, Some("feature-test")).await?;
 
+        assert_eq!(found_envs.len(), 1, "creates one fresh preview env");
+        let found_env = &found_envs[0];
         assert_eq!(found_env.name, "preview");
         assert!(
             found_env.deleted_at.is_none(),

--- a/crates/temps-deployments/src/services/workflow_execution_service.rs
+++ b/crates/temps-deployments/src/services/workflow_execution_service.rs
@@ -2,7 +2,7 @@
 //!
 //! Executes deployment jobs as workflows using the WorkflowExecutor
 
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
 use std::sync::Arc;
 use temps_core::{
     Job, JobQueue, WorkflowBuilder, WorkflowCancellationProvider, WorkflowError, WorkflowExecutor,
@@ -1932,12 +1932,30 @@ impl WorkflowExecutionService {
     ) -> Result<Option<String>, WorkflowExecutionError> {
         use temps_entities::deployment_containers;
 
-        // Find ALL previous deployments in this environment (excluding the current one)
-        // that have active (non-deleted) containers
+        // Find previous deployments in this environment (excluding the current one).
+        //
+        // Scope this to active states and cap the result, newest-first. This is a
+        // safety net that runs in addition to MarkDeploymentCompleteJob's own
+        // teardown (which also flips torn-down deployments to "stopped"), so the
+        // set of candidates here shrinks to truly-active deployments instead of
+        // re-scanning the whole environment history on every deploy. Without
+        // these bounds this `.all()` grows unbounded with deployment count and
+        // tears down containers sequentially — minutes of work on busy
+        // environments. "failed"/"stopped" are excluded to preserve history and
+        // avoid re-processing already-stopped deployments.
+        const MAX_TEARDOWN_DEPLOYMENTS: u64 = 25;
         let previous_deployments = deployments::Entity::find()
             .filter(deployments::Column::ProjectId.eq(project_id))
             .filter(deployments::Column::EnvironmentId.eq(environment_id))
             .filter(deployments::Column::Id.ne(current_deployment_id)) // Exclude current deployment
+            .filter(deployments::Column::State.is_in(vec![
+                "pending",
+                "running",
+                "built",
+                "completed",
+            ]))
+            .order_by_desc(deployments::Column::CreatedAt)
+            .limit(MAX_TEARDOWN_DEPLOYMENTS)
             .all(self.db.as_ref())
             .await?;
 

--- a/crates/temps-deployments/src/services/workflow_execution_service.rs
+++ b/crates/temps-deployments/src/services/workflow_execution_service.rs
@@ -1732,7 +1732,12 @@ impl WorkflowExecutionService {
                     .with_opt("source_type", telemetry_source_type.clone())
                     .with_opt("preset", telemetry_preset.clone()),
                 );
-                telemetry.report(
+                // Once-per-instance: "this instance shipped its first deploy".
+                // Guard so it fires once (the central API previously deduped
+                // this; report_once makes the binary itself emit exactly once),
+                // not on every successful deploy.
+                telemetry.report_once(
+                    "first_deploy_succeeded",
                     temps_core::telemetry::TelemetryEvent::new(
                         temps_core::telemetry::TelemetryEventKind::FirstDeploySucceeded,
                     )

--- a/crates/temps-domains/src/domain_service.rs
+++ b/crates/temps-domains/src/domain_service.rs
@@ -58,6 +58,12 @@ pub enum DomainServiceError {
         category: String,
         error_chain: String,
     },
+
+    /// `begin_on_demand_issuing` found that the domain already has an `active`
+    /// certificate with cert+key populated. The caller must treat this as a
+    /// no-op success — no ACME request should be sent.
+    #[error("Certificate already active for {0}: skipping on-demand re-issuance")]
+    CertificateAlreadyActive(String),
 }
 
 pub struct DomainService {
@@ -883,10 +889,18 @@ impl DomainService {
         // 1. Create or reuse the domains row, transitioning into the issuing state.
         //    HTTP-01 is the only supported on-demand challenge (wildcards/DNS-01
         //    are explicitly out of scope per ADR §2).
-        if let Err(e) = self.begin_on_demand_issuing(hostname).await {
-            self.record_on_demand_outcome(hostname, false, false, None, Some(&e), started)
-                .await;
-            return Err(e);
+        match self.begin_on_demand_issuing(hostname).await {
+            Err(DomainServiceError::CertificateAlreadyActive(_)) => {
+                // The domain already has a valid active cert — nothing to do.
+                // The cert loader serves it regardless of this function being called.
+                return Ok(());
+            }
+            Err(e) => {
+                self.record_on_demand_outcome(hostname, false, false, None, Some(&e), started)
+                    .await;
+                return Err(e);
+            }
+            Ok(_) => {}
         }
 
         // 2. Run the ACME order: request_challenge persists the order + serves the
@@ -971,6 +985,21 @@ impl DomainService {
             .await?
         {
             Some(existing) => {
+                // If the domain already has an active certificate, don't re-issue.
+                // This prevents burning LE rate limits when concurrent TLS handshakes
+                // all race to trigger on-demand issuance before the cert is in place.
+                if existing.status == "active"
+                    && existing.certificate.as_deref().unwrap_or("").len() > 0
+                    && existing.private_key.as_deref().unwrap_or("").len() > 0
+                {
+                    info!(
+                        hostname = %hostname,
+                        "on-demand TLS: certificate already active — skipping re-issuance"
+                    );
+                    return Err(DomainServiceError::CertificateAlreadyActive(
+                        hostname.to_string(),
+                    ));
+                }
                 let mut active: domains::ActiveModel = existing.into();
                 active.status = Set("on_demand_issuing".to_string());
                 active.verification_method = Set("http-01".to_string());

--- a/crates/temps-domains/src/domain_service.rs
+++ b/crates/temps-domains/src/domain_service.rs
@@ -989,8 +989,8 @@ impl DomainService {
                 // This prevents burning LE rate limits when concurrent TLS handshakes
                 // all race to trigger on-demand issuance before the cert is in place.
                 if existing.status == "active"
-                    && existing.certificate.as_deref().unwrap_or("").len() > 0
-                    && existing.private_key.as_deref().unwrap_or("").len() > 0
+                    && !existing.certificate.as_deref().unwrap_or("").is_empty()
+                    && !existing.private_key.as_deref().unwrap_or("").is_empty()
                 {
                     info!(
                         hostname = %hostname,

--- a/crates/temps-domains/src/handlers/domain_handler.rs
+++ b/crates/temps-domains/src/handlers/domain_handler.rs
@@ -219,6 +219,17 @@ impl From<DomainServiceError> for Problem {
                     "On-demand TLS issuance for {hostname} failed ({category}): {error_chain}"
                 ))
                 .build(),
+            DomainServiceError::CertificateAlreadyActive(hostname) => {
+                // This is a no-op success path, not an error that should reach
+                // HTTP handlers. Map to 200 OK conceptually, but if it somehow
+                // surfaces here, return 409 Conflict as a safe fallback.
+                ErrorBuilder::new(StatusCode::CONFLICT)
+                    .title("Certificate Already Active")
+                    .detail(format!(
+                        "Domain {hostname} already has an active certificate"
+                    ))
+                    .build()
+            }
         }
     }
 }

--- a/crates/temps-domains/src/tls/service.rs
+++ b/crates/temps-domains/src/tls/service.rs
@@ -99,6 +99,16 @@ impl TlsService {
         domain: &str,
         email: &str,
     ) -> Result<Certificate, TlsError> {
+        // An ACME account requires a real contact email. There is no fallback
+        // (see `get_acme_email`): refuse to provision rather than register an
+        // account with an empty/placeholder contact that Let's Encrypt rejects.
+        if email.trim().is_empty() {
+            return Err(TlsError::Configuration(format!(
+                "no Let's Encrypt contact email configured; set letsencrypt.email before \
+                 provisioning a certificate for {domain}"
+            )));
+        }
+
         // Wildcard domains require DNS-01 challenge
         if domain.starts_with("*.") {
             info!(
@@ -390,13 +400,20 @@ impl TlsService {
         Ok(report)
     }
 
-    /// Get email for ACME certificate provisioning
-    /// Priority: 1) LetsEncrypt email from settings, 2) First user email, 3) Fallback
+    /// Get the ACME contact email from `letsencrypt.email` settings.
+    ///
+    /// `letsencrypt.email` is the single source of truth — there is NO fallback
+    /// to the first user's email or a placeholder address. Those fallbacks
+    /// produced invalid ACME contacts (e.g. the `system@localhost` system user),
+    /// which Let's Encrypt rejects, so issuance failed silently. Returns empty
+    /// when no email is configured; callers must treat empty as "no contact
+    /// configured" and skip/abort issuance rather than provision with a bogus
+    /// address.
     async fn get_acme_email(&self) -> String {
-        // Try to get from config service settings
         if let Some(config_service) = &self.config_service {
             if let Ok(settings) = config_service.get_settings().await {
                 if let Some(email) = settings.letsencrypt.email {
+                    let email = email.trim().to_string();
                     if !email.is_empty() {
                         return email;
                     }
@@ -404,22 +421,7 @@ impl TlsService {
             }
         }
 
-        // Fall back to first user's email if database is available
-        if let Some(db) = &self.db {
-            use sea_orm::{EntityTrait, QueryOrder};
-            use temps_entities::users;
-
-            if let Ok(Some(user)) = users::Entity::find()
-                .order_by_asc(users::Column::Id)
-                .one(db.as_ref())
-                .await
-            {
-                return user.email;
-            }
-        }
-
-        // Last resort fallback
-        "system@temps.dev".to_string()
+        String::new()
     }
 
     async fn handle_http01_renewal(&self, cert: &Certificate, report: &mut RenewalReport) {

--- a/crates/temps-entities/src/deployment_config.rs
+++ b/crates/temps-entities/src/deployment_config.rs
@@ -265,9 +265,11 @@ pub struct DeploymentConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exposed_port: Option<i32>,
 
-    /// Enable automatic deployments on git push
-    #[serde(default)]
-    pub automatic_deploy: bool,
+    /// Enable automatic deployments on git push.
+    /// `None` = inherit from project config; `Some(true/false)` = explicit override.
+    /// Stored as JSONB so absent key → `None` (inherit), never silently defaults to false.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub automatic_deploy: Option<bool>,
 
     /// Enable performance metrics collection (speed insights)
     #[serde(default)]
@@ -415,7 +417,7 @@ impl Default for DeploymentConfig {
             memory_request: None,
             memory_limit: None,
             exposed_port: None,
-            automatic_deploy: false,
+            automatic_deploy: None,
             performance_metrics_enabled: false,
             session_recording_enabled: false,
             container_exec_enabled: false,
@@ -466,7 +468,9 @@ impl DeploymentConfig {
             memory_request: other.memory_request.or(self.memory_request),
             memory_limit: other.memory_limit.or(self.memory_limit),
             exposed_port: other.exposed_port.or(self.exposed_port),
-            automatic_deploy: other.automatic_deploy || self.automatic_deploy,
+            // Env-wins semantics: if the environment has an explicit value use it,
+            // otherwise inherit the project-level setting.
+            automatic_deploy: other.automatic_deploy.or(self.automatic_deploy),
             performance_metrics_enabled: other.performance_metrics_enabled
                 || self.performance_metrics_enabled,
             session_recording_enabled: other.session_recording_enabled
@@ -574,7 +578,7 @@ impl DeploymentConfigSnapshot {
             memory_limit: config.memory_limit,
             exposed_port: config.exposed_port,
             environment_variables,
-            automatic_deploy: config.automatic_deploy,
+            automatic_deploy: config.automatic_deploy.unwrap_or(false),
             performance_metrics_enabled: config.performance_metrics_enabled,
             session_recording_enabled: config.session_recording_enabled,
             container_exec_enabled: config.container_exec_enabled,
@@ -618,7 +622,7 @@ mod tests {
         let config = DeploymentConfig::default();
         assert_eq!(config.cpu_request, None);
         assert_eq!(config.cpu_limit, None);
-        assert!(!config.automatic_deploy);
+        assert_eq!(config.automatic_deploy, None);
         assert!(!config.performance_metrics_enabled);
         assert!(!config.session_recording_enabled);
     }
@@ -631,7 +635,7 @@ mod tests {
             memory_request: Some(128),
             memory_limit: Some(512),
             exposed_port: Some(3000),
-            automatic_deploy: true,
+            automatic_deploy: Some(true),
             performance_metrics_enabled: true,
             session_recording_enabled: false,
             replicas: 2,
@@ -648,7 +652,8 @@ mod tests {
             memory_request: None,     // Use project default
             memory_limit: Some(1024), // Override
             exposed_port: Some(8080), // Override
-            automatic_deploy: false,
+            // Env explicitly opts out — env-wins semantics means this is respected
+            automatic_deploy: Some(false),
             performance_metrics_enabled: false,
             session_recording_enabled: true, // Override
             replicas: 5,                     // Override
@@ -666,7 +671,8 @@ mod tests {
         assert_eq!(merged.memory_request, Some(128));
         assert_eq!(merged.memory_limit, Some(1024));
         assert_eq!(merged.exposed_port, Some(8080));
-        assert!(merged.automatic_deploy); // true || false = true
+        // Env explicitly sets false → env wins, merged is false
+        assert_eq!(merged.automatic_deploy, Some(false));
         assert!(merged.performance_metrics_enabled); // true || false = true
         assert!(merged.session_recording_enabled);
         assert_eq!(merged.replicas, 5);
@@ -763,7 +769,7 @@ mod tests {
             memory_request: Some(128),
             memory_limit: Some(512),
             exposed_port: Some(3000),
-            automatic_deploy: true,
+            automatic_deploy: Some(true),
             performance_metrics_enabled: true,
             session_recording_enabled: false,
             replicas: 3,
@@ -788,7 +794,7 @@ mod tests {
             memory_request: Some(128),
             memory_limit: Some(512),
             exposed_port: Some(3000),
-            automatic_deploy: true,
+            automatic_deploy: Some(true),
             performance_metrics_enabled: true,
             session_recording_enabled: false,
             replicas: 2,

--- a/crates/temps-environments/src/services/environment_service.rs
+++ b/crates/temps-environments/src/services/environment_service.rs
@@ -233,6 +233,7 @@ impl EnvironmentService {
             return Ok(restored);
         }
 
+        let name = name.to_lowercase();
         let env_slug = slugify(&name);
 
         // Create main_url using project_slug-env_slug format
@@ -511,6 +512,7 @@ impl EnvironmentService {
         }
 
         // Generate the environment identifier
+        let name = name.to_lowercase();
         let env_slug = slugify(&name);
 
         // Create main_url using project_slug-env_slug format
@@ -606,7 +608,7 @@ impl EnvironmentService {
             deployment_config.replicas = replicas;
         }
         if let Some(automatic_deploy) = settings.automatic_deploy {
-            deployment_config.automatic_deploy = automatic_deploy;
+            deployment_config.automatic_deploy = Some(automatic_deploy);
         }
         if let Some(performance_metrics_enabled) = settings.performance_metrics_enabled {
             deployment_config.performance_metrics_enabled = performance_metrics_enabled;

--- a/crates/temps-error-tracking/src/sentry/handlers.rs
+++ b/crates/temps-error-tracking/src/sentry/handlers.rs
@@ -148,14 +148,6 @@ async fn ingest_sentry_event(
     )
     .await;
 
-    // Check whether this project already has error groups (first-event dedupe).
-    // On lookup failure we assume groups exist (suppress) to avoid over-reporting.
-    let is_first_error = !state
-        .error_tracking_service
-        .has_error_groups(project_id)
-        .await
-        .unwrap_or(true);
-
     // Store event using the error tracking service
     match state
         .error_tracking_service
@@ -163,13 +155,17 @@ async fn ingest_sentry_event(
         .await
     {
         Ok(_) => {
-            if is_first_error {
-                state
-                    .telemetry
-                    .report(temps_core::telemetry::TelemetryEvent::new(
-                        temps_core::telemetry::TelemetryEventKind::ErrorTrackingFirstError,
-                    ));
-            }
+            // Once-per-instance: "error tracking is in use on this instance".
+            // report_once dedupes durably (and frees the error-ingest hot path
+            // of the previous per-event has_error_groups DB lookup), so this is
+            // instance-scoped — consistent with the other first-touch events —
+            // rather than the old per-project guard.
+            state.telemetry.report_once(
+                "error_tracking_first_error",
+                temps_core::telemetry::TelemetryEvent::new(
+                    temps_core::telemetry::TelemetryEventKind::ErrorTrackingFirstError,
+                ),
+            );
             let response = SentryEventResponse {
                 id: parsed_event.event_id,
             };
@@ -275,14 +271,6 @@ async fn ingest_sentry_envelope(
     let peer = connect_info.map(|ext| ext.0 .0);
     let client_ip = temps_auth::resolve_client_ip(&headers, peer);
 
-    // Check whether this project already has error groups (first-event dedupe).
-    // On lookup failure we assume groups exist (suppress) to avoid over-reporting.
-    let mut is_first_error = !state
-        .error_tracking_service
-        .has_error_groups(project_id)
-        .await
-        .unwrap_or(true);
-
     // Store each event using the error tracking service
     for mut event in parsed_events {
         // Enrich with IP geolocation and visitor correlation
@@ -307,14 +295,16 @@ async fn ingest_sentry_envelope(
                 .into_response();
         }
 
-        if is_first_error {
-            state
-                .telemetry
-                .report(temps_core::telemetry::TelemetryEvent::new(
-                    temps_core::telemetry::TelemetryEventKind::ErrorTrackingFirstError,
-                ));
-            is_first_error = false; // emit at most once per request
-        }
+        // Once-per-instance: "error tracking is in use here". report_once is
+        // idempotent and durably deduped, so no per-request flag is needed —
+        // and the error-ingest hot path no longer pays a has_error_groups DB
+        // lookup per envelope.
+        state.telemetry.report_once(
+            "error_tracking_first_error",
+            temps_core::telemetry::TelemetryEvent::new(
+                temps_core::telemetry::TelemetryEventKind::ErrorTrackingFirstError,
+            ),
+        );
     }
 
     StatusCode::OK.into_response()

--- a/crates/temps-import-docker/src/importer.rs
+++ b/crates/temps-import-docker/src/importer.rs
@@ -656,7 +656,7 @@ impl WorkloadImporter for DockerImporter {
                     .map(|ev| (ev.key.clone(), ev.value.clone()))
                     .collect(),
             ),
-            automatic_deploy: false,
+            automatic_deploy: true,
             storage_service_ids: vec![],
             is_public_repo: None,
             git_url: None,

--- a/crates/temps-logs/src/file_logs.rs
+++ b/crates/temps-logs/src/file_logs.rs
@@ -16,6 +16,15 @@ use tracing::{debug, trace};
 
 use crate::structured_logs::{LogEntry, LogLevel, StructuredLogService};
 
+/// Default number of trailing lines replayed when a tail stream first attaches.
+///
+/// This is the initial backlog the client receives before it starts seeing
+/// live lines. It is intentionally large so that full deployment/build logs
+/// are visible in the UI on first load — the previous value (1000) silently
+/// truncated long build logs. Clients dedupe by absolute line number, so a
+/// generous backlog is safe across reconnects.
+pub const DEFAULT_TAIL_REPLAY_LINES: usize = 100_000;
+
 pub struct LogService {
     log_base_path: PathBuf,
     structured_service: StructuredLogService,
@@ -85,12 +94,32 @@ impl LogService {
         tokio::fs::read_to_string(log_path).await
     }
 
+    /// Tail a log file, replaying up to [`DEFAULT_TAIL_REPLAY_LINES`] trailing
+    /// lines before streaming new lines as they are appended.
     pub async fn tail_log(
         &self,
         log_id: &str,
     ) -> Result<impl Stream<Item = Result<String, std::io::Error>>, std::io::Error> {
+        self.tail_log_with_replay(log_id, DEFAULT_TAIL_REPLAY_LINES)
+            .await
+    }
+
+    /// Tail a log file, replaying up to `replay_lines` trailing lines before
+    /// streaming new lines as they are appended.
+    ///
+    /// Pass `usize::MAX` to replay the entire file. The replay backlog is the
+    /// last `replay_lines` lines of the file at the moment the stream attaches;
+    /// any line written afterwards is streamed live regardless of this cap.
+    pub async fn tail_log_with_replay(
+        &self,
+        log_id: &str,
+        replay_lines: usize,
+    ) -> Result<impl Stream<Item = Result<String, std::io::Error>>, std::io::Error> {
         let log_path = self.get_log_path(log_id);
-        debug!("Attempting to tail log at path: {:?}", log_path);
+        debug!(
+            "Attempting to tail log at path: {:?} (replay up to {} lines)",
+            log_path, replay_lines
+        );
 
         // Create file if it doesn't exist
         if !log_path.exists() {
@@ -103,15 +132,21 @@ impl LogService {
         let file_size = file.metadata().await?.len();
         let mut reader = BufReader::new(file);
 
-        // If file has content, seek to position to get last 1000 lines
+        // If file has content, seek to the start of the last `replay_lines` lines.
         if file_size > 0 {
             let mut buffer = Vec::new();
             reader.read_to_end(&mut buffer).await?;
 
-            let lines = buffer.split(|&b| b == b'\n').collect::<Vec<_>>();
-            let start_pos = if lines.len() > 1000 {
-                // Get position to start reading from for last 1000 lines
-                let skip_lines = lines.len() - 1000;
+            // Split on newlines. A file ending in '\n' yields a trailing empty
+            // segment that is not a real line — drop it so the replay backlog
+            // counts actual lines (otherwise we'd skip one real line too many).
+            let mut lines = buffer.split(|&b| b == b'\n').collect::<Vec<_>>();
+            if lines.last().is_some_and(|last| last.is_empty()) {
+                lines.pop();
+            }
+            let start_pos = if lines.len() > replay_lines {
+                // Skip everything before the last `replay_lines` lines.
+                let skip_lines = lines.len() - replay_lines;
                 lines
                     .iter()
                     .take(skip_lines)
@@ -432,6 +467,88 @@ mod tests {
         // Directory should exist
         let full_path = temp_dir.path().join(&log_path);
         assert!(full_path.parent().unwrap().exists());
+    }
+
+    #[tokio::test]
+    async fn test_tail_log_replays_more_than_1000_lines() {
+        use futures::StreamExt;
+        use tokio::io::AsyncWriteExt;
+
+        let temp_dir = TempDir::new().unwrap();
+        let log_service = LogService::new(temp_dir.path().to_path_buf());
+
+        // Write 5000 plain lines directly to the log file (bypassing the
+        // structured JSONL writer to keep the assertion about line counts simple).
+        let log_id = "test-large-tail";
+        let log_path = log_service.get_log_path(log_id);
+        let mut file = File::create(&log_path).await.unwrap();
+        for i in 0..5000 {
+            file.write_all(format!("line {}\n", i).as_bytes())
+                .await
+                .unwrap();
+        }
+        file.flush().await.unwrap();
+
+        // With the default replay cap (100k > 5000), the stream should replay
+        // ALL 5000 lines, not just the last 1000.
+        let stream = log_service.tail_log(log_id).await.unwrap();
+        tokio::pin!(stream);
+
+        let mut received = Vec::new();
+        // The tail stream is infinite (it waits at EOF), so bound the read with
+        // a short timeout once the backlog is drained.
+        loop {
+            match tokio::time::timeout(Duration::from_millis(300), stream.next()).await {
+                Ok(Some(Ok(line))) => received.push(line),
+                Ok(Some(Err(_))) | Ok(None) => break,
+                Err(_) => break, // timed out waiting for more — backlog drained
+            }
+        }
+
+        assert_eq!(
+            received.len(),
+            5000,
+            "expected all 5000 lines replayed, got {}",
+            received.len()
+        );
+        assert_eq!(received.first().unwrap(), "line 0");
+        assert_eq!(received.last().unwrap(), "line 4999");
+    }
+
+    #[tokio::test]
+    async fn test_tail_log_with_replay_caps_backlog() {
+        use futures::StreamExt;
+        use tokio::io::AsyncWriteExt;
+
+        let temp_dir = TempDir::new().unwrap();
+        let log_service = LogService::new(temp_dir.path().to_path_buf());
+
+        let log_id = "test-capped-tail";
+        let log_path = log_service.get_log_path(log_id);
+        let mut file = File::create(&log_path).await.unwrap();
+        for i in 0..100 {
+            file.write_all(format!("line {}\n", i).as_bytes())
+                .await
+                .unwrap();
+        }
+        file.flush().await.unwrap();
+
+        // Explicit small replay cap: only the last 10 lines should come back.
+        let stream = log_service.tail_log_with_replay(log_id, 10).await.unwrap();
+        tokio::pin!(stream);
+
+        let mut received = Vec::new();
+        loop {
+            match tokio::time::timeout(Duration::from_millis(300), stream.next()).await {
+                Ok(Some(Ok(line))) => received.push(line),
+                Ok(Some(Err(_))) | Ok(None) => break,
+                Err(_) => break,
+            }
+        }
+
+        assert_eq!(received.len(), 10, "expected last 10 lines only");
+        assert_eq!(received.first().unwrap(), "line 90");
+        assert_eq!(received.last().unwrap(), "line 99");
     }
 
     #[tokio::test]

--- a/crates/temps-migrations/src/migration/m20260621_000001_create_telemetry_milestones.rs
+++ b/crates/temps-migrations/src/migration/m20260621_000001_create_telemetry_milestones.rs
@@ -1,0 +1,67 @@
+//! Migration to create the `telemetry_milestones` table.
+//!
+//! Backs the once-per-instance guard for "first-touch" anonymous telemetry
+//! events (e.g. `analytics_first_event_received`, `ai_gateway_first_request`).
+//! Those events are meant to fire EXACTLY ONCE in an instance's lifetime, but
+//! were previously emitted on every pageview / AI request / deploy — turning a
+//! "first touch" signal into a per-action firehose and making telemetry volume
+//! scale with the self-hoster's production traffic.
+//!
+//! The reporter claims a milestone by inserting its name here (`INSERT ... ON
+//! CONFLICT DO NOTHING`); only the first claimant emits the event. The row holds
+//! nothing identifying — just the milestone name and when it was first claimed —
+//! and is never sent anywhere. An in-process cache fronts this table so the hot
+//! path (pageview/AI/deploy ingestion) never touches the DB after the first
+//! claim per process.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(TelemetryMilestones::Table)
+                    .if_not_exists()
+                    // The milestone name (the telemetry event's wire name, e.g.
+                    // "analytics_first_event_received"). PK gives us the
+                    // once-ever guarantee via ON CONFLICT DO NOTHING.
+                    .col(
+                        ColumnDef::new(TelemetryMilestones::Milestone)
+                            .text()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    // When this instance first reached the milestone. Local-only,
+                    // never transmitted.
+                    .col(
+                        ColumnDef::new(TelemetryMilestones::FirstEmittedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(TelemetryMilestones::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum TelemetryMilestones {
+    Table,
+    Milestone,
+    FirstEmittedAt,
+}

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -121,6 +121,7 @@ mod m20260615_000001_add_environment_attack_mode;
 mod m20260618_000001_create_on_demand_cert_attempts;
 mod m20260618_000002_add_domains_on_demand_backoff;
 mod m20260619_000001_add_settings_change_trigger;
+mod m20260621_000001_create_telemetry_milestones;
 
 pub struct Migrator;
 
@@ -245,6 +246,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260618_000001_create_on_demand_cert_attempts::Migration),
             Box::new(m20260618_000002_add_domains_on_demand_backoff::Migration),
             Box::new(m20260619_000001_add_settings_change_trigger::Migration),
+            Box::new(m20260621_000001_create_telemetry_milestones::Migration),
         ]
     }
 }

--- a/crates/temps-projects/src/handlers/types.rs
+++ b/crates/temps-projects/src/handlers/types.rs
@@ -345,8 +345,7 @@ impl ProjectResponse {
                 automatic_deploy: project
                     .deployment_config
                     .clone()
-                    .map(|c| c.automatic_deploy)
-                    .unwrap_or(false),
+                    .and_then(|c| c.automatic_deploy),
                 performance_metrics_enabled: project
                     .deployment_config
                     .clone()

--- a/crates/temps-projects/src/services/project.rs
+++ b/crates/temps-projects/src/services/project.rs
@@ -178,7 +178,7 @@ impl ProjectService {
             memory_request: Some(DEFAULT_MEMORY_REQUEST),
             memory_limit: None,
             exposed_port: request.exposed_port,
-            automatic_deploy: request.automatic_deploy,
+            automatic_deploy: Some(request.automatic_deploy),
             ..Default::default()
         });
 
@@ -958,7 +958,7 @@ impl ProjectService {
 
         // Update deployment config with new automatic_deploy value
         let mut deployment_config = project.deployment_config.clone().unwrap_or_default();
-        deployment_config.automatic_deploy = automatic_deploy;
+        deployment_config.automatic_deploy = Some(automatic_deploy);
         active_project.deployment_config = Set(Some(deployment_config));
 
         let updated_project = active_project.update(self.db.as_ref()).await?;
@@ -1535,7 +1535,7 @@ impl ProjectService {
             deployment_config.exposed_port = Some(exposed_port);
         }
         if let Some(automatic_deploy) = config.automatic_deploy {
-            deployment_config.automatic_deploy = automatic_deploy;
+            deployment_config.automatic_deploy = Some(automatic_deploy);
         }
         if let Some(performance_metrics_enabled) = config.performance_metrics_enabled {
             deployment_config.performance_metrics_enabled = performance_metrics_enabled;
@@ -1676,7 +1676,7 @@ impl ProjectService {
             updated_at: db_project.updated_at,
             automatic_deploy: deployment_config
                 .clone()
-                .map(|c| c.automatic_deploy)
+                .and_then(|c| c.automatic_deploy)
                 .unwrap_or(false),
             cpu_request: deployment_config.clone().and_then(|c| c.cpu_request),
             cpu_limit: deployment_config.clone().and_then(|c| c.cpu_limit),

--- a/crates/temps-proxy/src/on_demand_cert.rs
+++ b/crates/temps-proxy/src/on_demand_cert.rs
@@ -142,6 +142,14 @@ pub struct OnDemandCertConfig {
     pub max_concurrent: u32,
     /// Global per-hour issuance cap (ADR §4 Layer 3).
     pub hourly_cap: u32,
+    /// The instance's console host (`console.<zone>`), when on a sslip.io-style
+    /// install. The console is served as a fall-through, not a `CachedPeerTable`
+    /// route, so the gate's cert-eligible-route check (check 2) would otherwise
+    /// reject it. It is nonetheless a stable, low-cardinality host that should
+    /// get on-demand HTTPS — so the gate exempts exactly this one hostname from
+    /// the route check. `None` (custom-domain installs, or no derivable console
+    /// host) means no exemption: the console must get its cert another way.
+    pub console_host: Option<String>,
 }
 
 /// Max novel hostnames a single source IP may trigger per minute (ADR §4
@@ -255,11 +263,20 @@ impl OnDemandCertManager {
         // Check 2 — a cert-eligible route exists (stable, not ephemeral).
         // Resolve across all lookup strategies (TLS/SNI, HTTP-host, legacy) so
         // stable env hostnames stored in the legacy routes map are seen.
-        match self.route_table.resolve_route_for_sni(&hostname) {
-            Some(route) if route.cert_eligible => {}
-            _ => {
-                debug!(sni = %hostname, "on-demand cert gate: no cert-eligible route");
-                return EnqueueOutcome::SkippedNoRoute;
+        //
+        // Exemption: the console host (`console.<zone>`) is served as a
+        // fall-through, not a `CachedPeerTable` route, so it has no route entry
+        // to satisfy this check. It is nonetheless a stable, single host that
+        // should get on-demand HTTPS, so it bypasses the route check. Everything
+        // else still requires a cert-eligible route, which is what keeps a
+        // random-SNI flood from creating issuance jobs.
+        if !self.is_console_host(&hostname) {
+            match self.route_table.resolve_route_for_sni(&hostname) {
+                Some(route) if route.cert_eligible => {}
+                _ => {
+                    debug!(sni = %hostname, "on-demand cert gate: no cert-eligible route");
+                    return EnqueueOutcome::SkippedNoRoute;
+                }
             }
         }
 
@@ -366,6 +383,19 @@ impl OnDemandCertManager {
         };
         // Exactly one non-empty label before the zone (no nested subdomains).
         !label.is_empty() && !label.contains('.')
+    }
+
+    /// True iff `hostname` is the configured console host. Used to exempt the
+    /// console (a fall-through, not a route) from the cert-eligible-route check
+    /// while still requiring it to be in-zone (check 1 runs first). The compare
+    /// is case-insensitive against the already-lowercased gate input.
+    fn is_console_host(&self, hostname: &str) -> bool {
+        self.config
+            .console_host
+            .as_deref()
+            .map(|c| c.trim().trim_end_matches('.').to_ascii_lowercase())
+            .filter(|c| !c.is_empty())
+            .is_some_and(|c| c == hostname)
     }
 
     /// ADR §4 final layer: bound how many novel hostnames a single source IP
@@ -625,12 +655,22 @@ mod tests {
         route_table: Arc<CachedPeerTable>,
         provisioner: Arc<dyn OnDemandCertProvisioner>,
     ) -> Arc<OnDemandCertManager> {
+        manager_with_console(zone, None, route_table, provisioner)
+    }
+
+    fn manager_with_console(
+        zone: &str,
+        console_host: Option<&str>,
+        route_table: Arc<CachedPeerTable>,
+        provisioner: Arc<dyn OnDemandCertProvisioner>,
+    ) -> Arc<OnDemandCertManager> {
         OnDemandCertManager::new(
             OnDemandCertConfig {
                 zone: zone.to_string(),
                 email: "ops@example.com".to_string(),
                 max_concurrent: 3,
                 hourly_cap: 10,
+                console_host: console_host.map(|c| c.to_string()),
             },
             route_table,
             provisioner,
@@ -694,6 +734,56 @@ mod tests {
 
         let outcome = mgr.try_enqueue("ghost.1.2.3.4.sslip.io", ip());
         assert_eq!(outcome, EnqueueOutcome::SkippedNoRoute);
+    }
+
+    #[tokio::test]
+    async fn test_gate_accepts_console_host_without_route() {
+        let (p, calls) = fake(true);
+        // No route at all for the console host — it is served as a fall-through,
+        // not a CachedPeerTable route. The exemption must let it through anyway.
+        let rt = empty_route_table();
+        let mgr = manager_with_console(
+            "1.2.3.4.sslip.io",
+            Some("console.1.2.3.4.sslip.io"),
+            rt,
+            Arc::clone(&p),
+        );
+
+        let outcome = mgr.try_enqueue("console.1.2.3.4.sslip.io", ip());
+        assert_eq!(outcome, EnqueueOutcome::Enqueued);
+
+        // Give the background consumer a moment to drain the job.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &["console.1.2.3.4.sslip.io".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_console_exemption_is_exact_host_only() {
+        let (p, _) = fake(true);
+        let rt = empty_route_table();
+        // The console host is `console.<zone>`; a *different* routeless in-zone
+        // host must NOT inherit the exemption (it would defeat the route check).
+        let mgr = manager_with_console("1.2.3.4.sslip.io", Some("console.1.2.3.4.sslip.io"), rt, p);
+
+        let outcome = mgr.try_enqueue("ghost.1.2.3.4.sslip.io", ip());
+        assert_eq!(outcome, EnqueueOutcome::SkippedNoRoute);
+    }
+
+    #[tokio::test]
+    async fn test_console_exemption_still_requires_in_zone() {
+        let (p, _) = fake(true);
+        let rt = empty_route_table();
+        // A console host configured outside the zone still fails check 1 (which
+        // runs before the exemption), so it can never trigger issuance. This
+        // guards against a misconfigured console_host bypassing the zone gate.
+        let mgr =
+            manager_with_console("1.2.3.4.sslip.io", Some("console.other.example.com"), rt, p);
+
+        let outcome = mgr.try_enqueue("console.other.example.com", ip());
+        assert_eq!(outcome, EnqueueOutcome::SkippedGate);
     }
 
     #[tokio::test]

--- a/crates/temps-proxy/src/tls_cert_loader.rs
+++ b/crates/temps-proxy/src/tls_cert_loader.rs
@@ -54,11 +54,19 @@ impl CertificateLoader {
         &self,
         domain: &str,
     ) -> Result<Option<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)>> {
+        // Do NOT filter by status: any domain row with both certificate and
+        // private_key populated can serve TLS regardless of ACME lifecycle state.
+        // This prevents two failure modes:
+        //   1. A valid cert becoming unserveable while re-issuance is in progress
+        //      (request_challenge sets status → "challenge_requested", which is not
+        //      in CERT_SERVING_STATUSES, so the old cert would stop being served
+        //      during the ~5-second challenge window — triggering concurrent retries
+        //      that exhaust the LE "5 duplicate certs per 7 days" limit).
+        //   2. An "on_demand_failed" domain row still holding a valid unexpired cert
+        //      (e.g. when rate-limited) becoming completely unserveable instead of
+        //      continuing to serve the last-known-good cert.
         let domain_entity = domains::Entity::find()
             .filter(domains::Column::Domain.eq(domain))
-            // Serve the cert for "active" AND "active_renewal_failed": the latter still
-            // holds a valid cert (renewal failed but it hasn't expired yet).
-            .filter(domains::Column::Status.is_in(domains::CERT_SERVING_STATUSES))
             .one(self.db.as_ref())
             .await?;
 

--- a/crates/temps-routes/src/route_table.rs
+++ b/crates/temps-routes/src/route_table.rs
@@ -295,6 +295,24 @@ pub type OnSleepingCallback =
 pub type OnReloadCallback =
     Arc<dyn Fn() -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> + Send + Sync>;
 
+/// Async callback fired after every successful `load_routes()` with the list of
+/// hostnames that have `cert_eligible = true` in the new route table.
+///
+/// Used by the on-demand TLS manager (ADR-018) to eagerly pre-provision
+/// certificates the moment a deployment goes live, so the cert is ready before
+/// the user's first HTTPS request rather than provisioning on the first handshake
+/// (which produces a visible `ERR_TLS_HANDSHAKE` for the first visitor).
+///
+/// The callback receives only cert-eligible hostnames (stable per-environment
+/// aliases, not ephemeral per-deployment slugs). The on-demand manager's own gate
+/// checks (dedup, backoff, rate-limit, zone) still apply inside the callback, so
+/// calling it on every reload is idempotent.
+pub type OnCertEligibleCallback = Arc<
+    dyn Fn(Vec<String>) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
+        + Send
+        + Sync,
+>;
+
 pub struct CachedPeerTable {
     /// Exact hostname -> RouteInfo for HTTP routes (route_type = 'http')
     /// Used for matching on HTTP Host header (Layer 7)
@@ -325,6 +343,12 @@ pub struct CachedPeerTable {
     /// in lockstep with the route table.
     on_reload_callback: parking_lot::Mutex<Option<OnReloadCallback>>,
 
+    /// Optional async callback invoked after each successful reload with
+    /// the list of cert-eligible hostnames. Used for eager TLS pre-provisioning
+    /// (ADR-018): the proxy wires the on-demand cert manager here so new
+    /// deployment routes get a cert issued before the first HTTPS request.
+    on_cert_eligible_callback: parking_lot::Mutex<Option<OnCertEligibleCallback>>,
+
     /// Monotonically increasing version of the in-memory `routes` map.
     /// Bumped at the end of every successful `load_routes()`. Workers
     /// long-poll `GET /internal/.../routes/snapshot?since=N` and the
@@ -351,6 +375,7 @@ impl CachedPeerTable {
             db,
             on_sleeping_callback: parking_lot::Mutex::new(None),
             on_reload_callback: parking_lot::Mutex::new(None),
+            on_cert_eligible_callback: parking_lot::Mutex::new(None),
             generation: std::sync::atomic::AtomicU64::new(0),
             generation_changed: Arc::new(tokio::sync::Notify::new()),
         }
@@ -411,6 +436,27 @@ impl CachedPeerTable {
     /// FQDN records in lockstep with the route table.
     pub fn set_on_reload_callback(&self, callback: OnReloadCallback) {
         *self.on_reload_callback.lock() = Some(callback);
+    }
+
+    /// Set an async callback fired after every successful `load_routes()` with
+    /// the list of cert-eligible hostnames in the new route table. Used by the
+    /// proxy to eagerly pre-provision TLS certificates (ADR-018) so new
+    /// deployments get a cert before the first HTTPS request arrives.
+    pub fn set_on_cert_eligible_callback(&self, callback: OnCertEligibleCallback) {
+        *self.on_cert_eligible_callback.lock() = Some(callback);
+    }
+
+    /// Return all currently-loaded hostnames with `cert_eligible = true`.
+    ///
+    /// Used for an immediate one-time provisioning pass after the cert manager
+    /// is wired up (covers domains already in the table from the initial load).
+    pub fn cert_eligible_hosts(&self) -> Vec<String> {
+        self.routes
+            .read()
+            .iter()
+            .filter(|(_, r)| r.cert_eligible)
+            .map(|(host, _)| host.clone())
+            .collect()
     }
 
     /// Get route by HTTP Host header
@@ -1526,6 +1572,26 @@ impl CachedPeerTable {
             tokio::spawn(async move {
                 callback().await;
             });
+        }
+
+        // Eager TLS pre-provisioning (ADR-018): fire the cert-eligible callback
+        // with the stable per-environment hostnames from the just-loaded table.
+        // The proxy wires the on-demand cert manager here so every new deployment
+        // gets a cert issued immediately rather than on the first failing handshake.
+        let on_cert_eligible = self.on_cert_eligible_callback.lock().as_ref().cloned();
+        if let Some(callback) = on_cert_eligible {
+            let cert_hosts: Vec<String> = self
+                .routes
+                .read()
+                .iter()
+                .filter(|(_, r)| r.cert_eligible)
+                .map(|(host, _)| host.clone())
+                .collect();
+            if !cert_hosts.is_empty() {
+                tokio::spawn(async move {
+                    callback(cert_hosts).await;
+                });
+            }
         }
 
         // Persist the new generation into the durable singleton so

--- a/crates/temps-telemetry/Cargo.toml
+++ b/crates/temps-telemetry/Cargo.toml
@@ -18,6 +18,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 async-trait = { workspace = true }
+sea-orm = { workspace = true }
+chrono = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/temps-telemetry/src/plugin.rs
+++ b/crates/temps-telemetry/src/plugin.rs
@@ -49,7 +49,22 @@ impl TempsPlugin for TelemetryPlugin {
                 &self.server_config.data_dir,
                 self.temps_version.clone(),
             ) {
-                Ok(svc) => Arc::new(svc),
+                Ok(svc) => {
+                    // Wire the DB so once-per-instance milestones
+                    // (report_once) are durable across restarts and across the
+                    // split proxy/console processes. The DB service is registered
+                    // before this plugin; if it's somehow absent, report_once
+                    // degrades to a per-process in-memory guard.
+                    if let Some(db) = context.get_service::<sea_orm::DatabaseConnection>() {
+                        svc.set_db(db);
+                    } else {
+                        tracing::warn!(
+                            "Telemetry: database service not available; once-per-instance \
+                             milestones will be guarded per-process only (not durable)"
+                        );
+                    }
+                    Arc::new(svc)
+                }
                 Err(e) => {
                     tracing::warn!(
                         error = %e,

--- a/crates/temps-telemetry/src/service.rs
+++ b/crates/temps-telemetry/src/service.rs
@@ -7,10 +7,12 @@
 //! - sends each event as a fire-and-forget timed HTTP POST so a dead endpoint
 //!   never affects the running server.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use sea_orm::{ConnectionTrait, DatabaseConnection, Statement};
 use serde::Serialize;
 use temps_core::telemetry::{TelemetryEvent, TelemetryReporter};
 use thiserror::Error;
@@ -57,6 +59,16 @@ struct Inner {
     temps_version: String,
     endpoint: String,
     client: reqwest::Client,
+    /// Database connection used to persist once-per-instance milestone claims
+    /// (see [`TelemetryReporter::report_once`]). `None` until wired by the
+    /// plugin; when absent, `report_once` falls back to the in-process cache
+    /// only (still once-per-process, just not durable across restarts).
+    db: Mutex<Option<Arc<DatabaseConnection>>>,
+    /// In-process set of milestones already claimed this process. This is the
+    /// hot-path guard: after the first emit of a given milestone, `report_once`
+    /// returns on a cheap set lookup and NEVER touches the DB again — so a busy
+    /// instance pays no per-event cost on the analytics/AI/deploy hot paths.
+    claimed: Mutex<HashSet<&'static str>>,
 }
 
 impl TelemetryService {
@@ -106,8 +118,22 @@ impl TelemetryService {
                 temps_version: version,
                 endpoint,
                 client,
+                db: Mutex::new(None),
+                claimed: Mutex::new(HashSet::new()),
             }),
         })
+    }
+
+    /// Wire the database connection used to make [`TelemetryReporter::report_once`]
+    /// durable across restarts (and across the split proxy/console processes,
+    /// which share the same Postgres). Called by the telemetry plugin once the DB
+    /// service is available. Without it, once-guarding still works but only
+    /// per-process (an in-memory set), so a restart could re-emit a milestone
+    /// once — acceptable, but the DB makes it truly once-per-instance.
+    pub fn set_db(&self, db: Arc<DatabaseConnection>) {
+        if let Ok(mut guard) = self.inner.db.lock() {
+            *guard = Some(db);
+        }
     }
 
     /// Read the `TEMPS_TELEMETRY` opt-out flag. Enabled by default; treats
@@ -223,6 +249,86 @@ impl TelemetryReporter for TelemetryService {
         });
     }
 
+    fn report_once(&self, milestone: &'static str, event: TelemetryEvent) {
+        if !self.inner.enabled {
+            return;
+        }
+
+        // ── Hot-path guard ──
+        // After the first emit of this milestone in this process, this is a
+        // cheap set lookup and we return WITHOUT touching the DB or spawning a
+        // task. This is what keeps the analytics/AI/deploy ingestion paths free
+        // of any per-event telemetry cost.
+        {
+            let mut claimed = match self.inner.claimed.lock() {
+                Ok(g) => g,
+                // A poisoned lock should never happen (we hold it only for these
+                // tiny critical sections), but if it does, fail safe: don't emit.
+                Err(_) => return,
+            };
+            if claimed.contains(milestone) {
+                return;
+            }
+            // Optimistically mark claimed-in-process so concurrent callers also
+            // short-circuit. The DB (below) is the cross-process / cross-restart
+            // arbiter of whether we actually emit.
+            claimed.insert(milestone);
+        }
+
+        let inner = self.inner.clone();
+        let reporter = self.clone();
+        tokio::spawn(async move {
+            // Snapshot the DB handle (if wired) without holding the lock across
+            // the await.
+            let db = inner.db.lock().ok().and_then(|g| g.clone());
+
+            match db {
+                Some(db) => {
+                    // Durable claim: only the FIRST claimant across all processes
+                    // and restarts inserts a row; everyone else is a no-op. We
+                    // emit the event only when we won the claim — a single-row
+                    // INSERT ... ON CONFLICT DO NOTHING yields rows_affected 1
+                    // (won) or 0 (already claimed).
+                    let stmt = Statement::from_sql_and_values(
+                        db.get_database_backend(),
+                        "INSERT INTO telemetry_milestones (milestone) VALUES ($1) \
+                         ON CONFLICT (milestone) DO NOTHING",
+                        [milestone.into()],
+                    );
+                    match db.execute(stmt).await {
+                        Ok(res) if res.rows_affected() >= 1 => {
+                            // We won the claim — emit exactly once.
+                            reporter.report(event);
+                        }
+                        Ok(_) => {
+                            // Already claimed by a prior run/process — don't emit.
+                            tracing::trace!(
+                                milestone = %milestone,
+                                "telemetry milestone already claimed; skipping emit"
+                            );
+                        }
+                        Err(e) => {
+                            // DB error claiming the milestone. Best-effort: do NOT
+                            // emit (avoid re-introducing the firehose if the DB is
+                            // flaky); the in-process set still prevents retries
+                            // this process.
+                            tracing::debug!(
+                                milestone = %milestone,
+                                error = %e,
+                                "telemetry milestone claim failed; skipping emit"
+                            );
+                        }
+                    }
+                }
+                None => {
+                    // No DB wired (e.g. early startup): fall back to the
+                    // in-process guard we already set above — once per process.
+                    reporter.report(event);
+                }
+            }
+        });
+    }
+
     fn is_enabled(&self) -> bool {
         self.inner.enabled
     }
@@ -273,6 +379,76 @@ mod tests {
         assert!(!svc.is_enabled());
         // Must not panic and must not spawn a request.
         svc.report(TelemetryEvent::new(TelemetryEventKind::ProjectCreated));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn report_once_records_milestone_in_process_guard() {
+        let dir = temp_dir();
+        std::env::remove_var("TEMPS_TELEMETRY");
+        let svc = TelemetryService::new(&dir, "0.0.0-test").unwrap();
+        assert!(svc.is_enabled());
+
+        // Not claimed yet.
+        assert!(!svc
+            .inner
+            .claimed
+            .lock()
+            .unwrap()
+            .contains("analytics_first_event_received"));
+
+        // First call records the milestone in the in-process guard so subsequent
+        // calls short-circuit (no DB wired here, so this is the only guard).
+        svc.report_once(
+            "analytics_first_event_received",
+            TelemetryEvent::new(TelemetryEventKind::AnalyticsFirstEventReceived),
+        );
+        assert!(
+            svc.inner
+                .claimed
+                .lock()
+                .unwrap()
+                .contains("analytics_first_event_received"),
+            "first report_once should record the milestone"
+        );
+
+        // A second call is a cheap no-op (still exactly one entry).
+        svc.report_once(
+            "analytics_first_event_received",
+            TelemetryEvent::new(TelemetryEventKind::AnalyticsFirstEventReceived),
+        );
+        assert_eq!(
+            svc.inner
+                .claimed
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|m| **m == "analytics_first_event_received")
+                .count(),
+            1,
+            "milestone recorded exactly once"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn report_once_is_noop_when_disabled() {
+        let dir = temp_dir();
+        std::env::set_var("TEMPS_TELEMETRY", "0");
+        let svc = TelemetryService::new(&dir, "0.0.0-test").unwrap();
+        std::env::remove_var("TEMPS_TELEMETRY");
+
+        assert!(!svc.is_enabled());
+        // Disabled: must not record anything (returns before the guard).
+        svc.report_once(
+            "analytics_first_event_received",
+            TelemetryEvent::new(TelemetryEventKind::AnalyticsFirstEventReceived),
+        );
+        assert!(
+            svc.inner.claimed.lock().unwrap().is_empty(),
+            "disabled reporter must not claim milestones"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/telemetry-api/src/routes/events.ts
+++ b/telemetry-api/src/routes/events.ts
@@ -8,6 +8,7 @@ import { countryForRequest } from "../geo.js";
 export const KNOWN_EVENT_TYPES = new Set([
   // Instance lifecycle
   "instance_started",
+  "instance_heartbeat",
   "instance_setup_completed",
   "upgrade_completed",
   "worker_node_joined",

--- a/web/src/components/environments/EnvironmentHeaderBar.tsx
+++ b/web/src/components/environments/EnvironmentHeaderBar.tsx
@@ -188,9 +188,21 @@ export function EnvironmentHeaderBar({
                   </DropdownMenuContent>
                 </DropdownMenu>
               ) : (
-                <h1 className="truncate text-2xl font-semibold tracking-tight text-neutral-950 dark:text-white">
-                  {environment.name}
-                </h1>
+                <>
+                  <h1 className="truncate text-2xl font-semibold tracking-tight text-neutral-950 dark:text-white">
+                    {environment.name}
+                  </h1>
+                  {onCreateEnvironment && (
+                    <button
+                      type="button"
+                      onClick={onCreateEnvironment}
+                      className="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-sm text-neutral-500 hover:bg-neutral-100 hover:text-neutral-700 dark:text-neutral-400 dark:hover:bg-white/5 dark:hover:text-neutral-200"
+                    >
+                      <Plus className="size-3.5" aria-hidden="true" />
+                      New environment
+                    </button>
+                  )}
+                </>
               )}
               <span
                 className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${statusTone}`}

--- a/web/src/components/project/MonitorDetail.tsx
+++ b/web/src/components/project/MonitorDetail.tsx
@@ -160,27 +160,39 @@ function BucketItem({ bucket, isOpen, onOpenChange }: BucketItemProps) {
   )
 }
 
-type QuickFilter =
-  | 'today'
-  | 'yesterday'
-  | '24hours'
-  | '7days'
-  | '30days'
-  | 'custom'
+type QuickFilter = '24hours' | '7days' | '30days' | '90days' | 'custom'
 
 const QUICK_FILTERS = [
-  { label: 'Today', value: 'today' as const },
-  { label: 'Yesterday', value: 'yesterday' as const },
   { label: 'Last 24 hours', value: '24hours' as const },
   { label: 'Last 7 Days', value: '7days' as const },
   { label: 'Last 30 Days', value: '30days' as const },
+  { label: 'Last 90 Days', value: '90days' as const },
 ]
+
+type BucketInterval = '1min' | '5min' | 'hourly' | 'daily'
+
+const INTERVAL_LABELS: Record<BucketInterval, string> = {
+  '1min': '1-minute',
+  '5min': '5-minute',
+  hourly: 'Hourly',
+  daily: 'Daily',
+}
+
+// Bucket granularity must scale with the time range, otherwise a long window
+// either renders thousands of unreadable segments or aggregates silently. Pick
+// the resolution from the span (in days) so every range yields a readable number
+// of buckets: ~24 for a day, hourly for a week, daily for months.
+function intervalForSpan(startDate?: Date, endDate?: Date): BucketInterval {
+  if (!startDate || !endDate) return 'hourly'
+  const spanMs = endDate.getTime() - startDate.getTime()
+  const spanDays = spanMs / (1000 * 60 * 60 * 24)
+  if (spanDays <= 2) return 'hourly' // up to 48 hourly buckets
+  if (spanDays <= 14) return 'hourly' // up to ~336 thin bars for a week/two
+  return 'daily' // 30d / 90d / long custom ranges → one bucket per day
+}
 
 export function MonitorDetail({ project }: MonitorDetailProps) {
   const { monitorId } = useParams()
-  const [interval, setInterval] = useState<'5min' | 'hourly' | 'daily'>(
-    'hourly'
-  )
   const [activeFilter, setActiveFilter] = useState<QuickFilter>('24hours')
   const [dateRange, setDateRange] = useState<DateRange | undefined>(undefined)
   const [hoveredBucket, setHoveredBucket] = useState<number | null>(null)
@@ -196,28 +208,6 @@ export function MonitorDetail({ project }: MonitorDetailProps) {
     }
 
     switch (activeFilter) {
-      case 'today': {
-        const todayStart = new Date(now)
-        todayStart.setHours(0, 0, 0, 0)
-        const todayEnd = new Date(now)
-        todayEnd.setHours(23, 59, 59, 999)
-        return {
-          startDate: todayStart,
-          endDate: todayEnd,
-        }
-      }
-      case 'yesterday': {
-        const yesterdayStart = new Date(now)
-        yesterdayStart.setDate(yesterdayStart.getDate() - 1)
-        yesterdayStart.setHours(0, 0, 0, 0)
-        const yesterdayEnd = new Date(now)
-        yesterdayEnd.setDate(yesterdayEnd.getDate() - 1)
-        yesterdayEnd.setHours(23, 59, 59, 999)
-        return {
-          startDate: yesterdayStart,
-          endDate: yesterdayEnd,
-        }
-      }
       case '24hours': {
         const twentyFourHoursAgo = new Date(now)
         twentyFourHoursAgo.setHours(twentyFourHoursAgo.getHours() - 24)
@@ -238,6 +228,12 @@ export function MonitorDetail({ project }: MonitorDetailProps) {
           endDate: now,
         }
       }
+      case '90days': {
+        return {
+          startDate: subDays(now, 90),
+          endDate: now,
+        }
+      }
       default: {
         return {
           startDate: subDays(now, 7),
@@ -246,6 +242,13 @@ export function MonitorDetail({ project }: MonitorDetailProps) {
       }
     }
   }, [activeFilter, dateRange])
+
+  // Resolution is derived from the selected range — no standalone selector,
+  // so there are no invalid (range × granularity) combinations.
+  const interval = useMemo(
+    () => intervalForSpan(startDate, endDate),
+    [startDate, endDate]
+  )
 
   const {
     data: monitor,
@@ -566,22 +569,9 @@ export function MonitorDetail({ project }: MonitorDetailProps) {
               Historical uptime and performance data
             </CardDescription>
           </div>
-          <Select
-            value={interval}
-            onValueChange={(value: '5min' | 'hourly' | 'daily') =>
-              setInterval(value)
-            }
-          >
-            <SelectTrigger className="w-32">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="minute">Minute</SelectItem>
-              <SelectItem value="5min">5 Minutes</SelectItem>
-              <SelectItem value="hourly">Hourly</SelectItem>
-              <SelectItem value="daily">Daily</SelectItem>
-            </SelectContent>
-          </Select>
+          <Badge variant="outline" className="font-normal">
+            {INTERVAL_LABELS[interval]} buckets
+          </Badge>
         </CardHeader>
         <CardContent>
           {statusError ? (

--- a/web/src/components/project/settings/GeneralSettings.tsx
+++ b/web/src/components/project/settings/GeneralSettings.tsx
@@ -33,6 +33,7 @@ import {
   FormLabel,
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useMutation } from '@tanstack/react-query'
@@ -258,6 +259,7 @@ export function GeneralSettings({ project, refetch }: GeneralSettingsProps) {
   }
 
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+  const [deleteConfirmName, setDeleteConfirmName] = useState('')
   const deleteProjectMutationM = useMutation({
     ...deleteProjectMutation(),
     meta: {
@@ -266,6 +268,7 @@ export function GeneralSettings({ project, refetch }: GeneralSettingsProps) {
   })
 
   const handleDeleteProject = async () => {
+    if (deleteConfirmName.trim() !== project?.name) return
     setIsDeleteDialogOpen(false)
     try {
       await toast.promise(
@@ -698,7 +701,10 @@ export function GeneralSettings({ project, refetch }: GeneralSettingsProps) {
         </p>
         <AlertDialog
           open={isDeleteDialogOpen}
-          onOpenChange={setIsDeleteDialogOpen}
+          onOpenChange={(open) => {
+            setIsDeleteDialogOpen(open)
+            if (!open) setDeleteConfirmName('')
+          }}
         >
           <AlertDialogTrigger asChild>
             <Button variant="destructive">Delete project</Button>
@@ -707,18 +713,37 @@ export function GeneralSettings({ project, refetch }: GeneralSettingsProps) {
             <AlertDialogHeader>
               <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
               <AlertDialogDescription>
-                This action cannot be undone. This will permanently delete your
-                project &quot;{project?.name}&quot; and remove all associated
-                data from our servers.
+                This action cannot be undone. This will permanently delete this
+                project and remove all associated data from our servers.
               </AlertDialogDescription>
             </AlertDialogHeader>
+            <div className="space-y-2">
+              <Label htmlFor="confirm-delete-project-name">
+                Type{' '}
+                <span className="font-mono font-semibold text-foreground">
+                  {project?.name}
+                </span>{' '}
+                to confirm
+              </Label>
+              <Input
+                id="confirm-delete-project-name"
+                value={deleteConfirmName}
+                onChange={(e) => setDeleteConfirmName(e.target.value)}
+                placeholder={project?.name}
+                autoComplete="off"
+              />
+            </div>
             <AlertDialogFooter>
               <AlertDialogCancel>Cancel</AlertDialogCancel>
               <AlertDialogAction
                 onClick={handleDeleteProject}
+                disabled={
+                  deleteProjectMutationM.isPending ||
+                  deleteConfirmName.trim() !== project?.name
+                }
                 className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
               >
-                Delete
+                {deleteProjectMutationM.isPending ? 'Deleting...' : 'Delete'}
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/web/src/components/project/settings/environments/EnvironmentConfigurationCard.tsx
+++ b/web/src/components/project/settings/environments/EnvironmentConfigurationCard.tsx
@@ -113,6 +113,7 @@ export function EnvironmentConfigurationCard({
     anti_affinity: environment.deployment_config?.antiAffinity ?? true,
     target_nodes: (environment.deployment_config?.targetNodes ?? []) as number[],
     target_labels: (environment.deployment_config?.targetLabels ?? {}) as Record<string, string>,
+    automatic_deploy: environment.deployment_config?.automaticDeploy ?? true,
     on_demand: environment.deployment_config?.onDemand ?? false,
     idle_timeout_seconds: environment.deployment_config?.idleTimeoutSeconds?.toString() ?? '300',
     wake_timeout_seconds: environment.deployment_config?.wakeTimeoutSeconds?.toString() ?? '30',
@@ -166,7 +167,8 @@ export function EnvironmentConfigurationCard({
       anti_affinity: environment.deployment_config?.antiAffinity ?? true,
       target_nodes: (environment.deployment_config?.targetNodes ?? []) as number[],
       target_labels: (environment.deployment_config?.targetLabels ?? {}) as Record<string, string>,
-      on_demand: environment.deployment_config?.onDemand ?? false,
+      automatic_deploy: environment.deployment_config?.automaticDeploy ?? true,
+    on_demand: environment.deployment_config?.onDemand ?? false,
       idle_timeout_seconds: environment.deployment_config?.idleTimeoutSeconds?.toString() ?? '300',
       wake_timeout_seconds: environment.deployment_config?.wakeTimeoutSeconds?.toString() ?? '30',
       password_enabled: environment.deployment_config?.security?.passwordProtection?.enabled ?? false,
@@ -239,6 +241,7 @@ export function EnvironmentConfigurationCard({
           ? parseInt(formData.exposed_port)
           : null,
         protected: formData.protected,
+        automatic_deploy: formData.automatic_deploy,
         // Tri-state: null clears the override (inherit project), true/false force it.
         attack_mode: attackModeToPayload(formData.attack_mode),
         anti_affinity: formData.anti_affinity,
@@ -300,6 +303,22 @@ export function EnvironmentConfigurationCard({
                 <p className="text-xs text-muted-foreground mt-2">
                   Deployments will be triggered from this branch
                 </p>
+              </div>
+
+              {/* Deploy on push toggle */}
+              <div className="flex items-start sm:items-center gap-3 p-3 border rounded-lg mt-4">
+                <div className="flex-1 min-w-0">
+                  <Label className="text-sm font-medium">Deploy on push</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Automatically deploy when a commit is pushed to this branch. Disable to deploy on demand only.
+                  </p>
+                </div>
+                <Switch
+                  checked={formData.automatic_deploy}
+                  onCheckedChange={(checked) =>
+                    setFormData((prev) => ({ ...prev, automatic_deploy: checked }))
+                  }
+                />
               </div>
             </div>
 

--- a/web/src/components/storage/DeleteServiceButton.tsx
+++ b/web/src/components/storage/DeleteServiceButton.tsx
@@ -11,6 +11,8 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Trash2 } from 'lucide-react'
 import { useState } from 'react'
@@ -27,7 +29,10 @@ export function DeleteServiceButton({
   onSuccess,
 }: DeleteServiceButtonProps) {
   const [isOpen, setIsOpen] = useState(false)
+  const [confirmName, setConfirmName] = useState('')
   const queryClient = useQueryClient()
+
+  const isConfirmed = confirmName.trim() === serviceName
 
   const deleteMutation = useMutation({
     ...deleteServiceMutation(),
@@ -41,8 +46,16 @@ export function DeleteServiceButton({
     },
   })
 
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open)
+    if (!open) {
+      setConfirmName('')
+    }
+  }
+
   const handleDelete = (e: React.MouseEvent) => {
     e.stopPropagation()
+    if (!isConfirmed) return
     deleteMutation.mutate({
       path: {
         id: serviceId,
@@ -57,7 +70,7 @@ export function DeleteServiceButton({
     : null
 
   return (
-    <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
+    <AlertDialog open={isOpen} onOpenChange={handleOpenChange}>
       <AlertDialogTrigger asChild>
         <Button
           variant="ghost"
@@ -75,11 +88,28 @@ export function DeleteServiceButton({
         <AlertDialogHeader>
           <AlertDialogTitle>Delete storage service?</AlertDialogTitle>
           <AlertDialogDescription>
-            Are you sure you want to delete &quot;{serviceName}&quot;? This
-            action cannot be undone and all data associated with this service
-            will be permanently removed.
+            This action cannot be undone and all data associated with this
+            service will be permanently removed.
           </AlertDialogDescription>
         </AlertDialogHeader>
+        <div className="space-y-2">
+          <Label htmlFor="confirm-service-name">
+            Type{' '}
+            <span className="font-mono font-semibold text-foreground">
+              {serviceName}
+            </span>{' '}
+            to confirm
+          </Label>
+          <Input
+            id="confirm-service-name"
+            value={confirmName}
+            onChange={(e) => setConfirmName(e.target.value)}
+            onClick={(e) => e.stopPropagation()}
+            placeholder={serviceName}
+            autoComplete="off"
+            autoFocus
+          />
+        </div>
         {errorMessage && (
           <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
             {errorMessage}
@@ -92,7 +122,7 @@ export function DeleteServiceButton({
           <AlertDialogAction
             onClick={handleDelete}
             className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            disabled={deleteMutation.isPending}
+            disabled={deleteMutation.isPending || !isConfirmed}
           >
             {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
           </AlertDialogAction>

--- a/web/src/components/storage/EmptyStateStorage.tsx
+++ b/web/src/components/storage/EmptyStateStorage.tsx
@@ -1,10 +1,9 @@
 import { ProviderMetadata } from '@/api/client'
 import { getProvidersMetadataOptions } from '@/api/client/@tanstack/react-query.gen'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
+import { Card } from '@/components/ui/card'
 import { useQuery } from '@tanstack/react-query'
-import { AlertCircle, Database, Loader2 } from 'lucide-react'
+import { AlertCircle, ArrowRight, Database } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 
 interface EmptyStateStorageProps {}
@@ -20,90 +19,103 @@ export default function EmptyStateStorage({}: EmptyStateStorageProps) {
   })
 
   return (
-    <div className="mx-auto max-w-4xl">
-      <div className="flex flex-col items-center text-center mb-8">
-        <div className="mb-4 p-3 rounded-lg bg-muted">
-          <Database className="h-8 w-8" />
+    <div className="mx-auto max-w-5xl">
+      <div className="mb-8 flex flex-col items-center text-center">
+        <div className="mb-4 rounded-lg bg-muted p-3">
+          <Database className="size-8" />
         </div>
-        <h1 className="text-2xl font-semibold mb-2">Create a database</h1>
-        <p className="text-muted-foreground">
-          Create databases and stores that you can connect to your team&apos;s
-          projects.
+        <h1 className="mb-2 text-2xl font-semibold">Create a database</h1>
+        <p className="max-w-prose text-base text-muted-foreground sm:text-sm">
+          Pick a provider to spin up a managed database or store you can connect
+          to your team&apos;s projects.
         </p>
       </div>
 
-      <div className="space-y-6">
-        <Alert>
-          <AlertCircle className="h-4 w-4" />
-          <AlertDescription className="flex items-center gap-2">
-            Select a database provider to get started with your application.
+      {/* Loading state — skeleton grid mirrors the real provider cards */}
+      {isLoading && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {[...Array(6)].map((_, i) => (
+            <Card key={i} className="flex items-start gap-4 p-5">
+              <div className="size-12 shrink-0 rounded-md bg-muted animate-pulse" />
+              <div className="flex-1 space-y-2 pt-1">
+                <div className="h-4 w-28 rounded bg-muted animate-pulse" />
+                <div className="h-3 w-full rounded bg-muted animate-pulse" />
+                <div className="h-3 w-3/4 rounded bg-muted animate-pulse" />
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Error state */}
+      {isError && (
+        <Alert variant="destructive">
+          <AlertCircle className="size-4" />
+          <AlertDescription>
+            Failed to load available providers. Please try again later.
           </AlertDescription>
         </Alert>
+      )}
 
-        {/* Loading state */}
-        {isLoading && (
-          <div className="flex items-center justify-center py-12">
-            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-          </div>
-        )}
-
-        {/* Error state */}
-        {isError && (
-          <Alert variant="destructive">
-            <AlertCircle className="h-4 w-4" />
-            <AlertDescription>
-              Failed to load available providers. Please try again later.
-            </AlertDescription>
-          </Alert>
-        )}
-
-        {/* Providers list */}
-        {providers && (
-          <div className="space-y-4">
-            {providers.map((provider: ProviderMetadata) => (
-              <Card key={provider.service_type}>
-                <CardContent className="p-6">
-                  <div className="flex items-start gap-4">
-                    <div
-                      className="flex items-center justify-center rounded-md p-2"
-                      style={{ backgroundColor: provider.color }}
-                    >
-                      <img
-                        src={provider.icon_url}
-                        alt={`${provider.display_name} logo`}
-                        width={32}
-                        height={32}
-                        className="rounded-md brightness-0 invert"
-                      />
-                    </div>
-                    <div className="flex-1 space-y-1">
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <h3 className="font-semibold">
-                            {provider.display_name}
-                          </h3>
-                          <p className="text-sm text-muted-foreground">
-                            {provider.description}
-                          </p>
-                        </div>
-                        <Button
-                          onClick={() =>
-                            navigate(
-                              `/storage/create?type=${provider.service_type}`
-                            )
-                          }
-                        >
-                          Create
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        )}
-      </div>
+      {/* Providers grid — every option visible at a glance */}
+      {providers && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {providers.map((provider: ProviderMetadata) => (
+            <ProviderCard
+              key={provider.service_type}
+              provider={provider}
+              onSelect={() =>
+                navigate(`/storage/create?type=${provider.service_type}`)
+              }
+            />
+          ))}
+        </div>
+      )}
     </div>
+  )
+}
+
+function ProviderCard({
+  provider,
+  onSelect,
+}: {
+  provider: ProviderMetadata
+  onSelect: () => void
+}) {
+  return (
+    <Card
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onSelect()
+        }
+      }}
+      className="group relative flex cursor-pointer flex-col gap-3 p-5 hover:border-foreground/20 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <div className="flex items-center gap-3">
+        <div
+          className="flex size-12 shrink-0 items-center justify-center rounded-md"
+          style={{ backgroundColor: provider.color }}
+        >
+          <img
+            src={provider.icon_url}
+            alt={`${provider.display_name} logo`}
+            width={28}
+            height={28}
+            className="size-7 rounded-md brightness-0 invert"
+          />
+        </div>
+        <h3 className="min-w-0 flex-1 truncate text-base font-semibold sm:text-sm">
+          {provider.display_name}
+        </h3>
+        <ArrowRight className="size-4 shrink-0 text-muted-foreground/40 transition-transform group-hover:translate-x-0.5 group-hover:text-foreground" />
+      </div>
+      <p className="line-clamp-2 text-sm text-muted-foreground">
+        {provider.description}
+      </p>
+    </Card>
   )
 }

--- a/web/src/components/storage/ServiceHealthCard.tsx
+++ b/web/src/components/storage/ServiceHealthCard.tsx
@@ -124,6 +124,12 @@ export function ServiceHealthCard({ serviceId }: { serviceId: number }) {
   const hasFailure =
     data.status === 'down' || (data.consecutive_failures ?? 0) > 0
 
+  // Degraded is not a "failure" (the probe succeeded, so consecutive_failures
+  // stays 0), but it still has a reason the user needs to see — e.g. "mongodb
+  // responded in 10007ms (>2000ms)". Surface it as an amber notice so the
+  // bare "Degraded" badge in the header is no longer unexplained.
+  const isDegraded = !hasFailure && data.status === 'degraded'
+
   return (
     <div className="space-y-3">
       {/*
@@ -194,6 +200,21 @@ export function ServiceHealthCard({ serviceId }: { serviceId: number }) {
             {data.last_error ? (
               <p className="break-words text-xs opacity-80">{data.last_error}</p>
             ) : null}
+          </AlertDescription>
+        </Alert>
+      ) : isDegraded ? (
+        <Alert variant="warning">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription className="space-y-1">
+            <p className="font-medium">Service is degraded.</p>
+            {data.last_error ? (
+              <p className="break-words text-xs opacity-80">{data.last_error}</p>
+            ) : (
+              <p className="text-xs opacity-80">
+                The last health check succeeded but the service responded
+                slowly. Check load and network latency to this instance.
+              </p>
+            )}
           </AlertDescription>
         </Alert>
       ) : null}

--- a/web/src/pages/CreateServiceNew.tsx
+++ b/web/src/pages/CreateServiceNew.tsx
@@ -2,6 +2,7 @@ import {
   adminListNodesOptions,
   createServiceMutation,
   getProviderMetadataOptions,
+  getProvidersMetadataOptions,
   getServiceTypeParametersOptions,
 } from '@/api/client/@tanstack/react-query.gen'
 import {
@@ -410,22 +411,60 @@ export function CreateService() {
     })
   }
 
+  const { data: providers, isLoading: isLoadingProviders } = useQuery({
+    ...getProvidersMetadataOptions(),
+    enabled: !serviceType,
+  })
+
   if (!serviceType) {
     return (
       <div className="flex-1 overflow-auto">
         <div className="sm:p-4 space-y-6 md:p-6 max-w-4xl mx-auto">
-          <div className="space-y-2">
+          <div className="space-y-1">
+            <Link to="/storage">
+              <Button variant="ghost" size="sm" className="gap-2 -ml-2 mb-2">
+                <ArrowLeft className="h-4 w-4" />
+                Back to Databases
+              </Button>
+            </Link>
             <h1 className="text-2xl font-semibold">Create Service</h1>
-            <p className="text-muted-foreground">
-              Please select a service type from the URL parameter.
-            </p>
+            <p className="text-muted-foreground">Choose a service type to get started.</p>
           </div>
-          <Link to="/storage">
-            <Button variant="outline">
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to Storage
-            </Button>
-          </Link>
+          {isLoadingProviders ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+              {[...Array(6)].map((_, i) => (
+                <div key={i} className="h-24 bg-muted animate-pulse rounded-lg" />
+              ))}
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+              {providers?.map((provider) => (
+                <button
+                  key={provider.service_type}
+                  type="button"
+                  onClick={() => navigate(`/storage/create?type=${provider.service_type}`)}
+                  className="flex items-center gap-4 rounded-lg border p-4 text-left hover:bg-accent transition-colors"
+                >
+                  <div
+                    className="flex items-center justify-center rounded-md p-2 shrink-0"
+                    style={{ backgroundColor: provider.color }}
+                  >
+                    <img
+                      src={provider.icon_url}
+                      alt={provider.display_name}
+                      width={28}
+                      height={28}
+                      className="brightness-0 invert"
+                    />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="font-medium">{provider.display_name}</p>
+                    <p className="text-xs text-muted-foreground truncate">{provider.description}</p>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
         </div>
       </div>
     )

--- a/web/src/pages/DomainDetail.tsx
+++ b/web/src/pages/DomainDetail.tsx
@@ -858,6 +858,32 @@ export function DomainDetail() {
                 label="Wildcard"
                 value={domain.is_wildcard ? 'Yes' : 'No'}
               />
+              {domain.certificate && (
+                <KeyFact
+                  label="Certificate"
+                  value={
+                    <span className="text-emerald-600 dark:text-emerald-400 font-medium">
+                      Present
+                    </span>
+                  }
+                />
+              )}
+              {domain.expiration_time && (
+                <KeyFact
+                  label="Expires"
+                  value={
+                    <span className={isExpiringSoon(domain.expiration_time) ? 'text-amber-600 dark:text-amber-400 font-medium' : ''}>
+                      {formatLocalDateTime(domain.expiration_time)}
+                    </span>
+                  }
+                />
+              )}
+              {domain.last_renewed && (
+                <KeyFact
+                  label="Last issued"
+                  value={formatLocalDateTime(domain.last_renewed)}
+                />
+              )}
             </dl>
           </div>
         </Card>

--- a/web/src/pages/ServiceDetail.tsx
+++ b/web/src/pages/ServiceDetail.tsx
@@ -56,6 +56,8 @@ import {
 } from '@/components/ui/popover'
 import { CopyButton } from '@/components/ui/copy-button'
 import { EnvVariablesDisplay } from '@/components/ui/env-variables-display'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { ServiceLogo } from '@/components/ui/service-logo'
 import { TimeAgo } from '@/components/utils/TimeAgo'
 import { useBreadcrumbs } from '@/contexts/BreadcrumbContext'
@@ -159,6 +161,7 @@ export function ServiceDetail() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+  const [deleteConfirmName, setDeleteConfirmName] = useState('')
   const [isUpgradeDialogOpen, setIsUpgradeDialogOpen] = useState(false)
   const [isMajorUpgradeDialogOpen, setIsMajorUpgradeDialogOpen] = useState(false)
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
@@ -517,6 +520,7 @@ export function ServiceDetail() {
   }
 
   const handleDelete = async () => {
+    if (deleteConfirmName.trim() !== service?.service?.name) return
     deleteService.mutate({ path: { id: parseInt(id!) } })
   }
 
@@ -1629,15 +1633,38 @@ export function ServiceDetail() {
         </DialogContent>
       </Dialog>
 
-      <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+      <Dialog
+        open={isDeleteDialogOpen}
+        onOpenChange={(open) => {
+          setIsDeleteDialogOpen(open)
+          if (!open) setDeleteConfirmName('')
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Delete Service</DialogTitle>
             <DialogDescription>
-              Are you sure you want to delete this service? This action cannot
-              be undone.
+              This action cannot be undone and all data associated with this
+              service will be permanently removed.
             </DialogDescription>
           </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="confirm-delete-service-name">
+              Type{' '}
+              <span className="font-mono font-semibold text-foreground">
+                {service.service.name}
+              </span>{' '}
+              to confirm
+            </Label>
+            <Input
+              id="confirm-delete-service-name"
+              value={deleteConfirmName}
+              onChange={(e) => setDeleteConfirmName(e.target.value)}
+              placeholder={service.service.name}
+              autoComplete="off"
+              autoFocus
+            />
+          </div>
           <DialogFooter>
             <Button
               variant="outline"
@@ -1648,7 +1675,10 @@ export function ServiceDetail() {
             <Button
               variant="destructive"
               onClick={handleDelete}
-              disabled={deleteService.isPending}
+              disabled={
+                deleteService.isPending ||
+                deleteConfirmName.trim() !== service.service.name
+              }
             >
               {deleteService.isPending && (
                 <Loader2 className="h-4 w-4 mr-2 animate-spin" />

--- a/web/src/pages/Storage.tsx
+++ b/web/src/pages/Storage.tsx
@@ -17,7 +17,7 @@ import { ImportServiceButton } from '@/components/storage/ImportServiceButton'
 import { PlatformServices } from '@/components/storage/PlatformServices'
 import EmptyStateStorage from '@/components/storage/EmptyStateStorage'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Card } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { ServiceLogo } from '@/components/ui/service-logo'
 import { useBreadcrumbs } from '@/contexts/BreadcrumbContext'
@@ -25,7 +25,6 @@ import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useQuery } from '@tanstack/react-query'
 import {
-  ChevronRight,
   Cpu,
   Database,
   HardDrive,
@@ -95,21 +94,17 @@ export function Storage() {
           <div className="flex items-center justify-end">
             <div className="h-9 w-24 bg-muted rounded animate-pulse" />
           </div>
-          <div className="grid gap-4">
-            {[...Array(3)].map((_, i) => (
-              <Card key={i}>
-                <CardHeader>
-                  <div className="flex items-center justify-between">
-                    <div className="space-y-2">
-                      <div className="h-5 w-40 bg-muted rounded animate-pulse" />
-                      <div className="h-4 w-24 bg-muted rounded animate-pulse" />
-                    </div>
-                    <div className="h-8 w-20 bg-muted rounded animate-pulse" />
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {[...Array(6)].map((_, i) => (
+              <Card key={i} className="p-4">
+                <div className="flex items-start gap-3">
+                  <div className="size-11 shrink-0 rounded-md bg-muted animate-pulse" />
+                  <div className="flex-1 space-y-2 pt-0.5">
+                    <div className="h-4 w-32 bg-muted rounded animate-pulse" />
+                    <div className="h-3 w-20 bg-muted rounded animate-pulse" />
                   </div>
-                </CardHeader>
-                <CardContent>
-                  <div className="h-4 w-full bg-muted rounded animate-pulse" />
-                </CardContent>
+                </div>
+                <div className="mt-4 h-3 w-full bg-muted rounded animate-pulse" />
               </Card>
             ))}
           </div>
@@ -152,7 +147,7 @@ export function Storage() {
           </div>
         </div>
 
-        <ServicesDividerList
+        <ServicesCardGrid
           services={services}
           healthMap={healthMap}
           onOpen={(id) => navigate(`/storage/${id}`)}
@@ -310,9 +305,9 @@ function ServiceActions({
   )
 }
 
-// ── Variant: Divider list (Vercel-style) ──
+// ── Variant: Card grid (scan all services at a glance) ──
 
-function ServicesDividerList({
+function ServicesCardGrid({
   services,
   healthMap,
   onOpen,
@@ -320,72 +315,115 @@ function ServicesDividerList({
   onDeleteSuccess,
 }: ServicesVariantProps) {
   return (
-    <div className="overflow-hidden rounded-lg border">
-      <ul role="list" className="divide-y">
-        {services.map((service) => {
-          // Only show the health dot for services the backend is actually
-          // probing (status === 'running'). Others haven't been checked.
-          const health =
-            service.status === 'running'
-              ? healthMap?.get(service.id)?.status ?? null
-              : null
-          return (
-            <li
-              key={service.id}
-              onClick={() => onOpen(service.id)}
-              className="group flex cursor-pointer items-center gap-4 px-4 py-3 transition-colors hover:bg-muted/40"
-            >
-              {/*
-                Wrap the logo so we can anchor the health dot in its
-                bottom-right corner (Vercel deployment-status pattern).
-              */}
-              <div className="relative shrink-0">
-                <div className="flex size-9 items-center justify-center rounded-md border bg-background">
-                  <ServiceLogo service={service.service_type} />
-                </div>
-                {health ? (
-                  <HealthDot
-                    status={health}
-                    className="absolute -bottom-0.5 -right-0.5 ring-2 ring-background"
-                  />
-                ) : null}
-              </div>
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <p className="truncate text-sm font-medium">{service.name}</p>
-                  <span className="rounded border bg-muted/50 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground">
-                    {service.service_type}
-                  </span>
-                  {service.topology === 'cluster' && (
-                    <span className="rounded border px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
-                      Cluster
-                    </span>
-                  )}
-                </div>
-                <div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
-                  <ServiceStatusDot status={service.status} />
-                  {service.version && (
-                    <span className="font-mono">v{service.version}</span>
-                  )}
-                  <span>
-                    Created <TimeAgo date={service.created_at} />
-                  </span>
-                </div>
-              </div>
-              {service.status === 'running' && (
-                <ServiceMetricsCell serviceId={service.id} />
-              )}
-              <ServiceActions
-                service={service}
-                onEdit={onEdit}
-                onDeleteSuccess={onDeleteSuccess}
-              />
-              <ChevronRight className="size-4 shrink-0 text-muted-foreground/40 transition-transform group-hover:translate-x-0.5 group-hover:text-muted-foreground" />
-            </li>
-          )
-        })}
-      </ul>
+    <div
+      role="list"
+      className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3"
+    >
+      {services.map((service) => {
+        // Only show the health dot for services the backend is actually
+        // probing (status === 'running'). Others haven't been checked.
+        const health =
+          service.status === 'running'
+            ? healthMap?.get(service.id)?.status ?? null
+            : null
+        return (
+          <ServiceCard
+            key={service.id}
+            service={service}
+            health={health}
+            onOpen={onOpen}
+            onEdit={onEdit}
+            onDeleteSuccess={onDeleteSuccess}
+          />
+        )
+      })}
     </div>
+  )
+}
+
+function ServiceCard({
+  service,
+  health,
+  onOpen,
+  onEdit,
+  onDeleteSuccess,
+}: {
+  service: ExternalServiceInfo
+  health: HealthStatus | null
+  onOpen: (id: number) => void
+  onEdit: (service: ExternalServiceInfo) => void
+  onDeleteSuccess: () => void
+}) {
+  return (
+    <Card
+      role="listitem"
+      onClick={() => onOpen(service.id)}
+      className="group relative flex cursor-pointer flex-col gap-4 p-4 hover:border-foreground/20 hover:shadow-md"
+    >
+      <div className="flex items-start gap-3">
+        {/*
+          Wrap the logo so we can anchor the health dot in its bottom-right
+          corner (Vercel deployment-status pattern).
+        */}
+        <div className="relative shrink-0">
+          <div className="flex size-11 items-center justify-center rounded-md border bg-background">
+            <ServiceLogo service={service.service_type} className="size-6" />
+          </div>
+          {health ? (
+            <HealthDot
+              status={health}
+              className="absolute -bottom-0.5 -right-0.5 ring-2 ring-card"
+            />
+          ) : null}
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-base font-medium sm:text-sm">
+            {service.name}
+          </p>
+          <div className="mt-1 flex flex-wrap items-center gap-1.5">
+            <span className="rounded border bg-muted/50 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground">
+              {service.service_type}
+            </span>
+            {service.topology === 'cluster' && (
+              <span className="rounded border px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+                Cluster
+              </span>
+            )}
+            {service.version && (
+              <span className="font-mono text-[10px] text-muted-foreground">
+                v{service.version}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/*
+          Touch devices have no hover, so keep actions visible there; on
+          pointer/larger screens they fade in on hover (or keyboard focus)
+          to keep the card header tidy.
+        */}
+        <div className="shrink-0 sm:opacity-0 sm:transition-opacity sm:group-hover:opacity-100 sm:group-focus-within:opacity-100">
+          <ServiceActions
+            service={service}
+            onEdit={onEdit}
+            onDeleteSuccess={onDeleteSuccess}
+          />
+        </div>
+      </div>
+
+      <div className="mt-auto flex items-center justify-between gap-3 border-t pt-3 text-xs text-muted-foreground">
+        <div className="flex min-w-0 items-center gap-3">
+          <ServiceStatusDot status={service.status} />
+          <span className="truncate">
+            Created <TimeAgo date={service.created_at} />
+          </span>
+        </div>
+        {service.status === 'running' && (
+          <ServiceMetricsCell serviceId={service.id} />
+        )}
+      </div>
+    </Card>
   )
 }
 
@@ -457,7 +495,7 @@ function ServiceMetricsCell({ serviceId }: { serviceId: number }) {
   if (!hasCpu && !hasMem) return null
 
   return (
-    <div className="hidden shrink-0 items-center gap-3 text-xs text-muted-foreground sm:flex">
+    <div className="flex shrink-0 items-center gap-3 text-xs text-muted-foreground">
       {hasCpu && (
         <span
           className="flex items-center gap-1 tabular-nums"

--- a/web/src/pages/TracesList.tsx
+++ b/web/src/pages/TracesList.tsx
@@ -789,10 +789,15 @@ export default function TracesList({ project }: TracesListProps) {
       ? 'No traces in the selected time range. Try widening the range.'
       : 'Traces will appear here once your application sends data via OpenTelemetry.'
 
-  // Extract unique service names for the filter dropdown
+  // Extract unique service names for the filter dropdown. Drop empty/missing
+  // names: a trace whose root span never set `service.name` arrives as "", and
+  // Radix's <SelectItem> throws ("must have a value prop that is not an empty
+  // string") if one reaches the dropdown — crashing the whole page.
   const serviceNames = useMemo(() => {
     if (!traces.length) return []
-    const names = new Set(traces.map((t) => t.service_name))
+    const names = new Set(
+      traces.map((t) => t.service_name).filter((name): name is string => !!name)
+    )
     return Array.from(names).sort()
   }, [traces])
 
@@ -1060,7 +1065,11 @@ export default function TracesList({ project }: TracesListProps) {
                     <TableCell>
                       <div className="flex flex-col gap-0.5">
                         <span className="font-medium truncate max-w-[200px] md:max-w-[280px]">
-                          {trace.root_span_name}
+                          {trace.root_span_name || (
+                            <span className="text-muted-foreground italic">
+                              (unnamed)
+                            </span>
+                          )}
                         </span>
                         <span className="text-xs text-muted-foreground font-mono truncate max-w-[200px] md:max-w-[280px]">
                           {trace.trace_id.slice(0, 16)}...
@@ -1069,7 +1078,11 @@ export default function TracesList({ project }: TracesListProps) {
                     </TableCell>
                     <TableCell>
                       <span className="text-sm">
-                        {trace.service_name}
+                        {trace.service_name || (
+                          <span className="text-muted-foreground italic">
+                            unknown
+                          </span>
+                        )}
                       </span>
                     </TableCell>
                     {environmentId === 'all' && (


### PR DESCRIPTION
## Summary

- **Root cause**: passing `--database-url` as a CLI flag makes the full PostgreSQL connection string (including the password) visible to any user on the server via `pgrep -af`, `ps aux`, and `/proc/self/cmdline`.
- **argv scrubbing**: `run()` in `lib.rs` now calls `scrub_sensitive_argv()` immediately after clap finishes parsing, overwriting the `--database-url` value in the kernel argv array in-place with `x` characters. Works on both Linux (via `environ` stack layout + `/proc/self/cmdline` for arg count) and macOS (via `_NSGetArgv`). Fails silently if sanity checks don't pass — no worse than before.
- **`hide_env_values = true`**: added to all 11 `--database-url` arg definitions so the value is also masked in `--help` output.
- **Backwards compatible**: the `--database-url` flag continues to work. `TEMPS_DATABASE_URL` env var remains the recommended approach (env vars are never visible in process listings).
- **CHANGELOG** and **docs** updated (env-variables reference + production checklist).

## Files changed

- `crates/temps-cli/src/lib.rs` — `scrub_sensitive_argv()` + `scrub_argv_raw()` helpers
- `crates/temps-cli/Cargo.toml` — added `libc` dependency
- `crates/temps-cli/src/commands/{serve/mod,proxy,migrate,setup,api_key,backup,backfill,doctor,domain,reset_password}.rs` — `hide_env_values = true`
- `CHANGELOG.md` — [Unreleased] Fixed entry

## Test plan

- [ ] `pgrep -af 'temps serve'` after `temps serve --database-url=postgres://user:secret@host/db` shows `xxx` in place of the password
- [ ] `temps serve --help` shows `[TEMPS_DATABASE_URL]` instead of the actual env value
- [ ] `TEMPS_DATABASE_URL=postgres://... temps serve` still works (env var path unaffected)
- [ ] `temps serve --database-url=postgres://...` still starts correctly (backwards compat)