### PR TITLE
fix(providers): harden postgres major upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **multi-node:** Real container deploy over mTLS (gated live test)
 - **dev-cluster:** From-scratch multi-node e2e harness (mTLS join + deploy)
 - **providers:** Isolate lifecycle tests' ports and container names ([#171](https://github.com/gotempsh/temps/issues/171))
+- **Postgres lifecycle waits for usable databases**: managed Postgres
+  container startup now waits for real `psql SELECT 1` connectivity, creates
+  the configured database if the cluster is alive but it is absent, and
+  includes container logs on readiness failures. This prevents major-upgrade
+  restores from treating `pg_isready` as sufficient before the target database
+  exists.
+- **Postgres major upgrades require a clean live volume**: the upgrade
+  snapshot and rollback phases now remove the temporary copy sidecar before
+  deleting the old live data volume, fail if Docker still cannot remove that
+  volume, and wait for the final healthy Postgres container before creating
+  the target database, preventing Postgres 18+ containers from reopening stale
+  17-era PGDATA after a supposedly clean handoff.
+
+### Tests
+- **Postgres upgrade Docker tests use real backup FK rows**:
+  `postgres_upgrade` integration fixtures now insert a matching `backups` row
+  for the fake pre-upgrade backup id, keeping the existing rollback/upgrade
+  assertions valid after FK enforcement.
 
 ## [0.1.0-beta.39] - 2026-06-25
 

--- a/crates/temps-providers/src/externalsvc/exec_util.rs
+++ b/crates/temps-providers/src/externalsvc/exec_util.rs
@@ -257,7 +257,7 @@ mod tests {
     /// is the exact trigger — and the shape every backup's
     /// `pg_dumpall … > file` uses, which is how the hang shipped.
     #[cfg(feature = "docker-tests")]
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn run_exec_returns_for_a_command_with_no_stdout() {
         use bollard::models::ContainerCreateBody;
         use bollard::query_parameters::{
@@ -311,11 +311,19 @@ mod tests {
 
         // Exits 0 and writes only to files -> the exec's stdout/stderr are
         // empty, so the output stream EOFs immediately.
-        let outcome = tokio::time::timeout(
-            Duration::from_secs(60),
+        //
+        // Run `run_exec` on a SEPARATE task (multi_thread runtime) and time out
+        // the JoinHandle. A regression re-introduces a synchronous busy loop
+        // that never yields `Pending`, so a `timeout` wrapping the future
+        // directly could never fire — but as a spawned task the spin occupies
+        // one worker while the timeout fires on another, so the test FAILS
+        // instead of hanging CI.
+        let docker_task = docker.clone();
+        let name_task = name.clone();
+        let handle = tokio::spawn(async move {
             run_exec(
-                &docker,
-                &name,
+                &docker_task,
+                &name_task,
                 vec![
                     "sh".to_string(),
                     "-c".to_string(),
@@ -323,9 +331,10 @@ mod tests {
                 ],
                 None,
                 Duration::from_secs(30),
-            ),
-        )
-        .await;
+            )
+            .await
+        });
+        let outcome = tokio::time::timeout(Duration::from_secs(60), handle).await;
 
         let _ = docker
             .remove_container(
@@ -337,10 +346,11 @@ mod tests {
             )
             .await;
 
-        let result = outcome.expect(
+        let joined = outcome.expect(
             "run_exec must return for a no-stdout command instead of spinning \
              forever (regression: biased-select busy loop on a drained stream)",
         );
+        let result = joined.expect("run_exec task panicked");
         let exec = result.expect("run_exec should succeed");
         assert_eq!(exec.exit_code, 0, "expected exit 0, got {}", exec.exit_code);
     }

--- a/crates/temps-providers/src/externalsvc/exec_util.rs
+++ b/crates/temps-providers/src/externalsvc/exec_util.rs
@@ -102,7 +102,15 @@ pub async fn run_exec(
             tokio::select! {
                 biased;
 
-                chunk = output.next() => {
+                // `if !output_done` is load-bearing: once the stream hits
+                // EOF, `output.next()` returns `Ready(None)` immediately on
+                // every poll. Without this guard, the `biased` select would
+                // always take this branch and starve the `inspect_exec`
+                // branch below — spinning at 100% CPU and never detecting that
+                // the exec finished (the exact hang that wedged pre-upgrade
+                // backups until the 6h timeout). Disabling the branch once
+                // drained lets the poll branch observe `running == false`.
+                chunk = output.next(), if !output_done => {
                     match chunk {
                         Some(Ok(msg)) => {
                             captured.push_str(&msg.to_string());
@@ -238,5 +246,102 @@ mod tests {
         let result = tail(&big, 100);
         assert!(result.contains("earlier bytes elided"));
         assert!(result.ends_with(&"x".repeat(100)));
+    }
+
+    /// Regression guard for the `biased`-select busy loop. Once the exec's
+    /// output stream hits EOF, `output.next()` returns `Ready(None)` on every
+    /// poll; without the `if !output_done` guard the biased select always
+    /// takes that branch and starves the `inspect_exec` branch — spinning at
+    /// 100% CPU forever, never returning and never even hitting `run_exec`'s
+    /// own timeout. A command that writes only to a file (empty exec stdout)
+    /// is the exact trigger — and the shape every backup's
+    /// `pg_dumpall … > file` uses, which is how the hang shipped.
+    #[cfg(feature = "docker-tests")]
+    #[tokio::test]
+    async fn run_exec_returns_for_a_command_with_no_stdout() {
+        use bollard::models::ContainerCreateBody;
+        use bollard::query_parameters::{
+            CreateContainerOptionsBuilder, CreateImageOptions, RemoveContainerOptions,
+            StartContainerOptions,
+        };
+        use futures::TryStreamExt;
+
+        let docker = match Docker::connect_with_local_defaults() {
+            Ok(d) => d,
+            Err(e) => {
+                println!("Docker unavailable, skipping: {e}");
+                return;
+            }
+        };
+        if docker.ping().await.is_err() {
+            println!("Docker daemon not responding, skipping");
+            return;
+        }
+
+        let _ = docker
+            .create_image(
+                Some(CreateImageOptions {
+                    from_image: Some("busybox".to_string()),
+                    tag: Some("latest".to_string()),
+                    ..Default::default()
+                }),
+                None,
+                None,
+            )
+            .try_collect::<Vec<_>>()
+            .await;
+
+        let name = format!("temps_run_exec_nostdout_{}", rand::random::<u32>());
+        docker
+            .create_container(
+                Some(CreateContainerOptionsBuilder::new().name(&name).build()),
+                ContainerCreateBody {
+                    image: Some("busybox:latest".to_string()),
+                    entrypoint: Some(vec!["sleep".to_string()]),
+                    cmd: Some(vec!["120".to_string()]),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("create sidecar");
+        docker
+            .start_container(&name, None::<StartContainerOptions>)
+            .await
+            .expect("start sidecar");
+
+        // Exits 0 and writes only to files -> the exec's stdout/stderr are
+        // empty, so the output stream EOFs immediately.
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(60),
+            run_exec(
+                &docker,
+                &name,
+                vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "echo hi > /tmp/out 2>/tmp/err".to_string(),
+                ],
+                None,
+                Duration::from_secs(30),
+            ),
+        )
+        .await;
+
+        let _ = docker
+            .remove_container(
+                &name,
+                Some(RemoveContainerOptions {
+                    force: true,
+                    ..Default::default()
+                }),
+            )
+            .await;
+
+        let result = outcome.expect(
+            "run_exec must return for a no-stdout command instead of spinning \
+             forever (regression: biased-select busy loop on a drained stream)",
+        );
+        let exec = result.expect("run_exec should succeed");
+        assert_eq!(exec.exit_code, 0, "expected exit 0, got {}", exec.exit_code);
     }
 }

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -4924,6 +4924,31 @@ mod tests {
     // ── Database Name SQL Injection Prevention Tests ─────────────────
 
     #[test]
+    fn postgres_upgrade_rejected_roundtrips_through_anyhow() {
+        // `ExternalServiceManager::upgrade_service` downcasts the anyhow error
+        // back to this typed variant to map it to HTTP 400. Guard that the type
+        // stays downcastable (a 'static std::error::Error) through the
+        // `?`/`.into()` path — if it stopped being downcastable the response
+        // would silently degrade to 500.
+        let mv: anyhow::Error =
+            PostgresUpgradeRejected::MajorVersionChange { from: 17, to: 18 }.into();
+        assert!(matches!(
+            mv.downcast_ref::<PostgresUpgradeRejected>(),
+            Some(PostgresUpgradeRejected::MajorVersionChange { from: 17, to: 18 })
+        ));
+        assert!(mv
+            .to_string()
+            .contains("Cannot change PostgreSQL major version"));
+
+        let dg: anyhow::Error = PostgresUpgradeRejected::Downgrade { from: 18, to: 17 }.into();
+        assert!(matches!(
+            dg.downcast_ref::<PostgresUpgradeRejected>(),
+            Some(PostgresUpgradeRejected::Downgrade { .. })
+        ));
+        assert!(dg.to_string().contains("Cannot downgrade PostgreSQL"));
+    }
+
+    #[test]
     fn test_validate_pg_username_accepts_realistic_names() {
         assert!(validate_pg_username("postgres").is_ok());
         assert!(validate_pg_username("appuser").is_ok());

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -32,15 +32,44 @@ use super::{
 
 /// POSIX-safe shell escaping: wraps value in single quotes, escaping any
 /// embedded single quotes. Safe for use in `sh -c` command strings.
-fn shell_escape(s: &str) -> String {
+///
+/// Shared across the Postgres provider files (`postgres_upgrade`,
+/// `postgres_lifecycle`) instead of each keeping its own copy -- the drift
+/// between duplicated copies of this exact kind of string-builder is what
+/// caused the healthcheck bug this crate's `postgres_healthcheck_cmd` fixes.
+pub(crate) fn shell_escape(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Rejections from same-version-only [`PostgresService::upgrade`]. The
+/// `ExternalService::upgrade` trait method returns `anyhow::Result<()>`
+/// across every provider, so this can't be a variant of a typed
+/// `Result<(), E>` without changing that trait's signature everywhere.
+/// Instead it's wrapped into the `anyhow::Error` via `?`/`.into()` so
+/// callers can `downcast_ref::<PostgresUpgradeRejected>()` for an exact,
+/// wording-independent match instead of matching on `e.to_string()`.
+#[derive(Debug, thiserror::Error)]
+pub enum PostgresUpgradeRejected {
+    #[error("Cannot downgrade PostgreSQL (from {from} to {to})")]
+    Downgrade { from: u32, to: u32 },
+
+    #[error(
+        "Cannot change PostgreSQL major version via this endpoint (from {from} to {to}). \
+         Use the major-version upgrade API (POST /external-services/{{id}}/upgrades) instead, \
+         which performs a real pg_dumpall/restore with a retained rollback volume and a \
+         mandatory pre-upgrade backup."
+    )]
+    MajorVersionChange { from: u32, to: u32 },
 }
 
 /// Builds the `pg_isready` healthcheck command pinned to the configured
 /// username/database. Without `-d`, `pg_isready` (via libpq) defaults the
 /// target database to the username, so any service where `database !=
 /// username` would log a FATAL on every healthcheck tick.
-fn postgres_healthcheck_cmd(username: &str, database: &str) -> String {
+///
+/// Shared with `postgres_lifecycle` so both container-creation sites build
+/// the exact same healthcheck command.
+pub(crate) fn postgres_healthcheck_cmd(username: &str, database: &str) -> String {
     format!(
         "pg_isready -U {} -d {}",
         shell_escape(username),
@@ -3088,11 +3117,11 @@ impl ExternalService for PostgresService {
         );
 
         if old_version > new_version {
-            return Err(anyhow::anyhow!(
-                "Cannot downgrade PostgreSQL (from {} to {})",
-                old_version,
-                new_version
-            ));
+            return Err(PostgresUpgradeRejected::Downgrade {
+                from: old_version,
+                to: new_version,
+            }
+            .into());
         }
 
         // Major version upgrades (e.g. 17 -> 18) are handled exclusively by
@@ -3110,14 +3139,11 @@ impl ExternalService for PostgresService {
         // nothing has been touched yet (no stop, no volume changes), so this
         // is a safe no-op rejection, not a partial failure.
         if old_version != new_version {
-            return Err(anyhow::anyhow!(
-                "Cannot change PostgreSQL major version via this endpoint (from {} to {}). \
-                 Use the major-version upgrade API (POST /external-services/{{id}}/upgrades) \
-                 instead, which performs a real pg_dumpall/restore with a retained rollback \
-                 volume and a mandatory pre-upgrade backup.",
-                old_version,
-                new_version
-            ));
+            return Err(PostgresUpgradeRejected::MajorVersionChange {
+                from: old_version,
+                to: new_version,
+            }
+            .into());
         }
 
         // Verify the new image can be pulled BEFORE stopping the old container

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -36,6 +36,18 @@ fn shell_escape(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
+/// Builds the `pg_isready` healthcheck command pinned to the configured
+/// username/database. Without `-d`, `pg_isready` (via libpq) defaults the
+/// target database to the username, so any service where `database !=
+/// username` would log a FATAL on every healthcheck tick.
+fn postgres_healthcheck_cmd(username: &str, database: &str) -> String {
+    format!(
+        "pg_isready -U {} -d {}",
+        shell_escape(username),
+        shell_escape(database)
+    )
+}
+
 /// Input configuration for creating a PostgreSQL service
 /// This is what users provide when creating the service
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -460,11 +472,7 @@ impl PostgresService {
                     // server did respond), so this was invisible in the UI,
                     // just a permanent log-spam leak. Use the real
                     // configured username/database instead.
-                    format!(
-                        "pg_isready -U {} -d {}",
-                        shell_escape(&config.username),
-                        shell_escape(&config.database)
-                    ),
+                    postgres_healthcheck_cmd(&config.username, &config.database),
                 ]),
                 interval: Some(1000000000), // 1 second
                 timeout: Some(3000000000),  // 3 seconds
@@ -3816,6 +3824,18 @@ mod tests {
     use super::*;
 
     use crate::externalsvc::DEPLOYMENT_MODE_MUTEX as ENV_MUTEX;
+
+    #[test]
+    fn healthcheck_cmd_pins_database_when_it_differs_from_username() {
+        let cmd = postgres_healthcheck_cmd("appuser", "appdb");
+        assert_eq!(cmd, "pg_isready -U 'appuser' -d 'appdb'");
+    }
+
+    #[test]
+    fn healthcheck_cmd_escapes_single_quotes_in_username_and_database() {
+        let cmd = postgres_healthcheck_cmd("a'user", "a'db");
+        assert_eq!(cmd, "pg_isready -U 'a'\\''user' -d 'a'\\''db'");
+    }
 
     #[test]
     fn test_postgres_input_config_default_values() {

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -449,7 +449,22 @@ impl PostgresService {
             healthcheck: Some(bollard::models::HealthConfig {
                 test: Some(vec![
                     "CMD-SHELL".to_string(),
-                    "pg_isready -U postgres".to_string(),
+                    // Without -d, pg_isready (via libpq) defaults the target
+                    // database to the username being checked. The hardcoded
+                    // "postgres" here was wrong for any service with a
+                    // non-default username/database (e.g. username="appuser",
+                    // database="appdb") — the postmaster would receive a
+                    // connection attempt for a role/database that doesn't
+                    // exist, logging a FATAL every interval (1s) forever.
+                    // pg_isready still reports healthy either way (the
+                    // server did respond), so this was invisible in the UI,
+                    // just a permanent log-spam leak. Use the real
+                    // configured username/database instead.
+                    format!(
+                        "pg_isready -U {} -d {}",
+                        shell_escape(&config.username),
+                        shell_escape(&config.database)
+                    ),
                 ]),
                 interval: Some(1000000000), // 1 second
                 timeout: Some(3000000000),  // 3 seconds

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -77,6 +77,34 @@ pub(crate) fn postgres_healthcheck_cmd(username: &str, database: &str) -> String
     )
 }
 
+/// Validate a PostgreSQL role/username before it is interpolated into a
+/// shell command or SQL. Allows only `[A-Za-z0-9_]` (the realistic role-name
+/// charset), non-empty, and at most 63 bytes.
+///
+/// Defense-in-depth: the upgrade orchestrator already `shell_escape`s the
+/// username at every interpolation site, but rejecting shell/SQL
+/// metacharacters (quotes, `$`, `;`, spaces, backticks, …) up front means a
+/// crafted username can never reach a `sh -c` string or a `sed` program in
+/// the first place. Mirrors [`PostgresService::validate_database_name`], but
+/// permits uppercase since role names are commonly mixed-case.
+pub(crate) fn validate_pg_username(name: &str) -> std::result::Result<(), String> {
+    if name.is_empty() {
+        return Err("PostgreSQL username cannot be empty".to_string());
+    }
+    if name.len() > 63 {
+        return Err(format!(
+            "PostgreSQL username '{name}' exceeds the 63 character limit"
+        ));
+    }
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return Err(format!(
+            "PostgreSQL username '{name}' contains invalid characters; only \
+             ASCII letters, digits, and underscores are allowed"
+        ));
+    }
+    Ok(())
+}
+
 /// Input configuration for creating a PostgreSQL service
 /// This is what users provide when creating the service
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -4894,6 +4922,32 @@ mod tests {
     }
 
     // ── Database Name SQL Injection Prevention Tests ─────────────────
+
+    #[test]
+    fn test_validate_pg_username_accepts_realistic_names() {
+        assert!(validate_pg_username("postgres").is_ok());
+        assert!(validate_pg_username("appuser").is_ok());
+        assert!(validate_pg_username("My_User123").is_ok());
+        assert!(validate_pg_username("_svc").is_ok());
+        assert!(validate_pg_username(&"a".repeat(63)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_pg_username_rejects_shell_and_sed_injection() {
+        // Empty / too long.
+        assert!(validate_pg_username("").is_err());
+        assert!(validate_pg_username(&"a".repeat(64)).is_err());
+        // The exact break-out vector for the phase_restore sed filter: a
+        // single quote closes the sed program's quoting.
+        assert!(validate_pg_username("admin'").is_err());
+        assert!(validate_pg_username("a'$(id)#").is_err());
+        // Other shell/SQL metacharacters.
+        assert!(validate_pg_username("u;drop").is_err());
+        assert!(validate_pg_username("a b").is_err());
+        assert!(validate_pg_username("a`b`").is_err());
+        assert!(validate_pg_username("a$b").is_err());
+        assert!(validate_pg_username("a-b").is_err());
+    }
 
     #[test]
     fn test_validate_database_name_valid_names() {

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -1267,293 +1267,6 @@ impl PostgresService {
         Ok(format!("/var/lib/postgresql/{}/docker", version))
     }
 
-    /// Run pg_upgrade to migrate data from old version to new version
-    /// Uses pg_dump/pg_restore for cross-architecture compatibility
-    async fn run_pg_upgrade(
-        &self,
-        _old_config: &PostgresConfig,
-        new_config: &PostgresConfig,
-        old_version: u32,
-        new_version: u32,
-    ) -> Result<()> {
-        info!(
-            "Running PostgreSQL upgrade from version {} to {} using pg_dump/pg_restore",
-            old_version, new_version
-        );
-
-        let container_name = self.get_container_name();
-        let volume_name = format!("{}_data", container_name);
-        let backup_volume = format!("{}_backup_{}", container_name, old_version);
-
-        // STEP 1: Create a backup of the original volume before attempting upgrade
-        info!("Creating backup of original data volume for recovery");
-
-        // Pull busybox image for backup and copy operations
-        info!("Pulling busybox image for backup operations");
-        self.docker
-            .create_image(
-                Some(bollard::query_parameters::CreateImageOptions {
-                    from_image: Some("busybox".to_string()),
-                    tag: Some("latest".to_string()),
-                    ..Default::default()
-                }),
-                None,
-                None,
-            )
-            .try_collect::<Vec<_>>()
-            .await
-            .context("Failed to pull busybox image")?;
-
-        self.docker
-            .create_volume(bollard::models::VolumeCreateRequest {
-                name: Some(backup_volume.clone()),
-                ..Default::default()
-            })
-            .await
-            .context("Failed to create backup volume")?;
-
-        // Copy original data to backup
-        let backup_container_name = format!("{}_backup_copy", container_name);
-        let backup_config = bollard::models::ContainerCreateBody {
-            image: Some("busybox:latest".to_string()),
-            entrypoint: Some(vec![
-                "sh".to_string(),
-                "-c".to_string(),
-                "cp -r /src/* /dest/ && sync".to_string(),
-            ]),
-            host_config: Some(bollard::models::HostConfig {
-                mounts: Some(vec![
-                    bollard::models::Mount {
-                        target: Some("/src".to_string()),
-                        source: Some(volume_name.clone()),
-                        typ: Some(bollard::models::MountTypeEnum::VOLUME),
-                        ..Default::default()
-                    },
-                    bollard::models::Mount {
-                        target: Some("/dest".to_string()),
-                        source: Some(backup_volume.clone()),
-                        typ: Some(bollard::models::MountTypeEnum::VOLUME),
-                        ..Default::default()
-                    },
-                ]),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-
-        let backup_container = self
-            .docker
-            .create_container(
-                Some(
-                    bollard::query_parameters::CreateContainerOptionsBuilder::new()
-                        .name(&backup_container_name)
-                        .build(),
-                ),
-                backup_config,
-            )
-            .await
-            .context("Failed to create backup container")?;
-
-        self.docker
-            .start_container(
-                &backup_container.id,
-                None::<bollard::query_parameters::StartContainerOptions>,
-            )
-            .await
-            .context("Failed to start backup container")?;
-
-        // Wait for backup to complete
-        let backup_result = self
-            .docker
-            .wait_container(
-                &backup_container.id,
-                None::<bollard::query_parameters::WaitContainerOptions>,
-            )
-            .try_collect::<Vec<_>>()
-            .await;
-
-        // Clean up backup container
-        let _ = self
-            .docker
-            .remove_container(
-                &backup_container_name,
-                Some(bollard::query_parameters::RemoveContainerOptions {
-                    force: true,
-                    ..Default::default()
-                }),
-            )
-            .await;
-
-        backup_result.context("Backup process failed")?;
-        info!("Backup completed: {}", backup_volume);
-
-        // STEP 2: Create volume for upgraded data
-        let newdata_volume = format!("{}_newdata", container_name);
-        self.docker
-            .create_volume(bollard::models::VolumeCreateRequest {
-                name: Some(newdata_volume.clone()),
-                ..Default::default()
-            })
-            .await
-            .context("Failed to create newdata volume")?;
-
-        // STEP 3: Clean up volumes and remove old container
-        info!("Removing old PostgreSQL {} container", old_version);
-        let _ = self
-            .docker
-            .stop_container(&container_name, None::<StopContainerOptions>)
-            .await;
-
-        let remove_result = self
-            .docker
-            .remove_container(
-                &container_name,
-                Some(bollard::query_parameters::RemoveContainerOptions {
-                    force: true,
-                    ..Default::default()
-                }),
-            )
-            .await;
-
-        if let Err(e) = remove_result {
-            let error_msg = e.to_string();
-            if !error_msg.contains("No such container") {
-                info!("Note: Failed to remove old container: {}", error_msg);
-            }
-        }
-
-        // Wait a moment for the container to be fully removed
-        sleep(Duration::from_millis(500)).await;
-
-        // Remove the old data volume - we'll create a fresh one with v17
-        info!("Removing old data volume for upgrade");
-        let _ = self
-            .docker
-            .remove_volume(
-                &volume_name,
-                None::<bollard::query_parameters::RemoveVolumeOptions>,
-            )
-            .await;
-
-        sleep(Duration::from_millis(500)).await;
-
-        // Pull the new PostgreSQL image
-        info!("Pulling postgres:{}-alpine", new_version);
-        self.docker
-            .create_image(
-                Some(bollard::query_parameters::CreateImageOptions {
-                    from_image: Some("postgres".to_string()),
-                    tag: Some(format!("{}-alpine", new_version)),
-                    ..Default::default()
-                }),
-                None,
-                None,
-            )
-            .try_collect::<Vec<_>>()
-            .await?;
-
-        // STEP 4: Create fresh v17 container - the actual upgrade happens
-        // The PostgreSQL server will automatically migrate data when it starts
-        // if the data format is compatible or will initialize fresh otherwise
-        info!(
-            "Creating new PostgreSQL {} container with fresh volume",
-            new_version
-        );
-
-        // Now create the final v17 container with the upgraded data
-        info!("Creating final PostgreSQL {} container", new_version);
-        let new_docker_image = format!("postgres:{}-alpine", new_version);
-        let pgdata_path = Self::get_pgdata_path(&new_docker_image)
-            .map_err(|e| anyhow::anyhow!("Failed to determine PGDATA path: {}", e))?;
-
-        let final_container_config = bollard::models::ContainerCreateBody {
-            image: Some(new_docker_image),
-            env: Some(vec![
-                "POSTGRES_HOST_AUTH_METHOD=md5".to_string(),
-                format!("POSTGRES_USER=postgres"),
-                format!("POSTGRES_PASSWORD={}", new_config.password),
-                format!("PGDATA={}", pgdata_path),
-            ]),
-            cmd: Some(vec![
-                "postgres".to_string(),
-                "-c".to_string(),
-                format!("max_connections={}", new_config.max_connections),
-            ]),
-            host_config: Some(bollard::models::HostConfig {
-                mounts: Some(vec![bollard::models::Mount {
-                    // Always mount at /var/lib/postgresql - PGDATA env var controls subdirectory
-                    target: Some("/var/lib/postgresql".to_string()),
-                    source: Some(volume_name.clone()),
-                    typ: Some(bollard::models::MountTypeEnum::VOLUME),
-                    read_only: Some(false),
-                    ..Default::default()
-                }]),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-
-        let final_container = self
-            .docker
-            .create_container(
-                Some(
-                    bollard::query_parameters::CreateContainerOptionsBuilder::new()
-                        .name(&container_name) // Use original service name
-                        .build(),
-                ),
-                final_container_config,
-            )
-            .await
-            .map_err(|e| {
-                anyhow::anyhow!(format!(
-                    "Failed to create final postgres:{} container: {}",
-                    new_version, e
-                ))
-            })?;
-
-        self.docker
-            .start_container(
-                &final_container.id,
-                None::<bollard::query_parameters::StartContainerOptions>,
-            )
-            .await
-            .map_err(|e| {
-                anyhow::anyhow!(format!(
-                    "Failed to start final postgres:{} container: {}",
-                    new_version, e
-                ))
-            })?;
-
-        // Wait for final container to be ready
-        info!(
-            "Waiting for PostgreSQL {} container to be ready...",
-            new_version
-        );
-        sleep(Duration::from_secs(3)).await;
-
-        // Keep the upgraded v17 container running - it replaces the old v16 container
-        info!(
-            "PostgreSQL {} container is now running and ready to use",
-            new_version
-        );
-
-        // Clean up temporary volumes
-        let _ = self
-            .docker
-            .remove_volume(
-                &newdata_volume,
-                None::<bollard::query_parameters::RemoveVolumeOptions>,
-            )
-            .await;
-
-        info!(
-            "Upgrade complete. PostgreSQL has been upgraded from v{} to v{}",
-            old_version, new_version
-        );
-
-        Ok(())
-    }
-
     async fn restore_backup_file(
         &self,
         docker: &Docker,
@@ -3382,6 +3095,31 @@ impl ExternalService for PostgresService {
             ));
         }
 
+        // Major version upgrades (e.g. 17 -> 18) are handled exclusively by
+        // the dedicated PostgresUpgradeOrchestrator via
+        // `POST /external-services/{id}/upgrades` (plural). That path does a
+        // real pg_dumpall/restore with a retained rollback volume and a
+        // mandatory pre-upgrade S3 backup. This same-version-only `upgrade()`
+        // used to also handle major-version bumps itself (`run_pg_upgrade`),
+        // but that implementation never actually migrated data — it deleted
+        // the live volume, kept an unused raw-file copy in a `_backup_N`
+        // volume, and booted a brand-new empty cluster hardcoded to
+        // `postgres:{version}-alpine` with `POSTGRES_USER=postgres`,
+        // silently discarding the real configured username/database/data
+        // while reporting success. Refuse here instead of repeating that;
+        // nothing has been touched yet (no stop, no volume changes), so this
+        // is a safe no-op rejection, not a partial failure.
+        if old_version != new_version {
+            return Err(anyhow::anyhow!(
+                "Cannot change PostgreSQL major version via this endpoint (from {} to {}). \
+                 Use the major-version upgrade API (POST /external-services/{{id}}/upgrades) \
+                 instead, which performs a real pg_dumpall/restore with a retained rollback \
+                 volume and a mandatory pre-upgrade backup.",
+                old_version,
+                new_version
+            ));
+        }
+
         // Verify the new image can be pulled BEFORE stopping the old container
         info!(
             "Verifying new Docker image is available: {}",
@@ -3391,40 +3129,27 @@ impl ExternalService for PostgresService {
             .await?;
         info!("New Docker image verified and is available");
 
-        if old_version == new_version {
-            // Same major version — image swap only (e.g., postgres:18 -> gotempsh/postgres-walg:18).
-            // No pg_upgrade needed. Just recreate the container with the new image;
-            // data is preserved on the Docker volume.
-            if old_pg_config.docker_image == new_pg_config.docker_image {
-                return Err(anyhow::anyhow!(
-                    "New image is identical to current image ({})",
-                    old_pg_config.docker_image
-                ));
-            }
-            info!(
-                "Same PostgreSQL major version ({}), swapping image without pg_upgrade",
-                old_version
-            );
-            self.stop().await?;
-            let limits = self.resource_limits.read().await.clone();
-            // Preserve archiving state across the image swap by reading
-            // `walg.env` from the existing volume — same rule as `start()`.
-            let enable_archiving = self.compute_desired_enable_archiving().await;
-            self.create_container(&self.docker, &new_pg_config, &limits, enable_archiving)
-                .await?;
-            info!("PostgreSQL image swap completed successfully");
-        } else {
-            // Major version upgrade — requires pg_upgrade
-            info!("Major version upgrade, running pg_upgrade");
-            self.stop().await?;
-            self.run_pg_upgrade(&old_pg_config, &new_pg_config, old_version, new_version)
-                .await?;
-            let limits = self.resource_limits.read().await.clone();
-            let enable_archiving = self.compute_desired_enable_archiving().await;
-            self.create_container(&self.docker, &new_pg_config, &limits, enable_archiving)
-                .await?;
-            info!("PostgreSQL major version upgrade completed successfully");
+        // Same major version — image swap only (e.g., postgres:18 -> gotempsh/postgres-walg:18).
+        // No pg_upgrade needed. Just recreate the container with the new image;
+        // data is preserved on the Docker volume.
+        if old_pg_config.docker_image == new_pg_config.docker_image {
+            return Err(anyhow::anyhow!(
+                "New image is identical to current image ({})",
+                old_pg_config.docker_image
+            ));
         }
+        info!(
+            "Same PostgreSQL major version ({}), swapping image without pg_upgrade",
+            old_version
+        );
+        self.stop().await?;
+        let limits = self.resource_limits.read().await.clone();
+        // Preserve archiving state across the image swap by reading
+        // `walg.env` from the existing volume — same rule as `start()`.
+        let enable_archiving = self.compute_desired_enable_archiving().await;
+        self.create_container(&self.docker, &new_pg_config, &limits, enable_archiving)
+            .await?;
+        info!("PostgreSQL image swap completed successfully");
 
         Ok(())
     }
@@ -4271,10 +3996,22 @@ mod tests {
 
     #[cfg(feature = "docker-tests")]
     #[tokio::test]
-    async fn test_postgres_v17_to_v18_actual_upgrade() {
-        // This test creates a real PostgreSQL 17 container, upgrades it to v18,
-        // and verifies the upgrade by checking the version via SQL
-        // Note: Requires Docker to be running
+    async fn test_postgres_v17_to_v18_upgrade_rejected_and_data_survives() {
+        // `ExternalService::upgrade()` used to attempt major-version bumps
+        // itself via a broken `run_pg_upgrade` that deleted the live volume
+        // and booted a brand-new empty cluster hardcoded to
+        // `postgres:{version}-alpine` / `POSTGRES_USER=postgres` — silently
+        // discarding the real data while reporting success. The old version
+        // of this test only asserted `SELECT version()` on the post-upgrade
+        // container, which is exactly why that data loss went unnoticed: it
+        // never checked that pre-upgrade data was still there.
+        //
+        // `upgrade()` now refuses any major-version change outright and
+        // points callers at the dedicated orchestrator
+        // (`POST /external-services/{id}/upgrades`, `postgres_upgrade.rs`).
+        // This test asserts that refusal, and — the part the original test
+        // was missing — that the v17 container and its data are completely
+        // untouched afterward.
 
         let docker = match Docker::connect_with_defaults() {
             Ok(d) => Arc::new(d),
@@ -4309,7 +4046,9 @@ mod tests {
             parameters: v17_params,
         };
 
-        // Create v18 service configuration
+        // Create v18 service configuration (used only as the `upgrade()`
+        // target — the call is expected to be rejected before touching
+        // anything).
         let v18_params = serde_json::json!({
             "host": "localhost",
             "port": port.to_string(),
@@ -4360,7 +4099,8 @@ mod tests {
             }
         }
 
-        // Connect and verify v17 version
+        // Connect, verify v17 version, and seed a marker row we can check
+        // for survival after the rejected upgrade attempt.
         let connection_string = format!(
             "postgresql://postgres:{}@127.0.0.1:{}/postgres",
             urlencoding::encode(password),
@@ -4418,48 +4158,44 @@ mod tests {
             version_v17.0
         );
 
-        // Close connection pool before upgrade
+        sqlx::query("CREATE TABLE upgrade_survives_marker (id int PRIMARY KEY, note text)")
+            .execute(&db_pool)
+            .await
+            .expect("failed to create marker table");
+        sqlx::query("INSERT INTO upgrade_survives_marker (id, note) VALUES (1, 'pre-upgrade')")
+            .execute(&db_pool)
+            .await
+            .expect("failed to insert marker row");
+
         db_pool.close().await;
 
-        // Perform the upgrade
-        match v17_service
+        // Attempt the major-version upgrade via `upgrade()` — must be
+        // rejected, not attempted.
+        let upgrade_result = v17_service
             .upgrade(v17_config.clone(), v18_config.clone())
-            .await
-        {
+            .await;
+
+        let err = match upgrade_result {
             Ok(_) => {
-                println!("pg_upgrade completed successfully");
-            }
-            Err(e) => {
-                // Cleanup before panicking
                 let _ = v17_service.remove().await;
-                panic!("Failed to upgrade PostgreSQL from v17 to v18: {}", e);
+                panic!(
+                    "upgrade() must reject a major-version change (17 -> 18) instead of \
+                     attempting it directly; use the dedicated orchestrator instead"
+                );
             }
-        }
+            Err(e) => e,
+        };
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains("Cannot change PostgreSQL major version"),
+            "expected rejection to name the major-version-change restriction, got: {}",
+            err_msg
+        );
 
-        // Give the upgraded container time to start and initialize
-        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
-
-        // Create v18 service to check health
-        let v18_service = PostgresService::new(service_name.clone(), docker.clone());
-
-        // Wait for v18 PostgreSQL to be healthy
-        retries = 0;
-        loop {
-            match v18_service.health_check().await {
-                Ok(healthy) if healthy => break,
-                _ if retries < 60 => {
-                    retries += 1;
-                    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-                }
-                _ => {
-                    println!("PostgreSQL 18 failed to start after 60 retries (30 seconds)");
-                    let _ = v18_service.remove().await;
-                    return;
-                }
-            }
-        }
-
-        // Connect and verify v18 version with retries
+        // Nothing should have been touched: same container, same image,
+        // same data. Re-verify against the ORIGINAL v17 service handle —
+        // if `upgrade()` had stopped/replaced the container despite
+        // rejecting, this reconnect would fail or return a different image.
         let mut db_pool = None;
         for attempt in 0..10 {
             match sqlx::postgres::PgPoolOptions::new()
@@ -4472,53 +4208,44 @@ mod tests {
                     break;
                 }
                 Err(e) if attempt < 9 => {
-                    println!(
-                        "V18 connection attempt {} failed: {}. Retrying...",
-                        attempt + 1,
-                        e
-                    );
                     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+                    let _ = e;
                 }
                 Err(e) => {
-                    println!(
-                        "Failed to connect to v18 PostgreSQL after 10 attempts: {}. Skipping test",
+                    let _ = v17_service.remove().await;
+                    panic!(
+                        "container should still be reachable on v17 after a rejected upgrade, \
+                         but reconnect failed: {}",
                         e
                     );
-                    let _ = v18_service.remove().await;
-                    return;
                 }
             }
         }
-
         let db_pool = db_pool.unwrap();
 
-        let version_v18: (String,) =
-            match sqlx::query_as("SELECT version()").fetch_one(&db_pool).await {
-                Ok(v) => v,
-                Err(e) => {
-                    println!("Failed to query version from v18: {}. Skipping test", e);
-                    db_pool.close().await;
-                    let _ = v18_service.remove().await;
-                    return;
-                }
-            };
-
-        println!("PostgreSQL 18 version: {}", version_v18.0);
+        let version_after: (String,) = sqlx::query_as("SELECT version()")
+            .fetch_one(&db_pool)
+            .await
+            .expect("version query should still work against the untouched v17 container");
         assert!(
-            version_v18.0.contains("18"),
-            "Version should contain '18', got: {}",
-            version_v18.0
+            version_after.0.contains("17"),
+            "container must still be on v17 after a rejected upgrade, got: {}",
+            version_after.0
         );
 
-        // Verify upgrade was successful
-        println!("PostgreSQL upgrade test passed!");
-        println!("  Before: {}", version_v17.0);
-        println!("  After:  {}", version_v18.0);
+        let marker: (i32, String) =
+            sqlx::query_as("SELECT id, note FROM upgrade_survives_marker WHERE id = 1")
+                .fetch_one(&db_pool)
+                .await
+                .expect("marker row must survive a rejected upgrade attempt");
+        assert_eq!(marker.1, "pre-upgrade");
+
+        println!("Major-version upgrade correctly rejected; v17 data intact.");
 
         // Cleanup
         db_pool.close().await;
-        let _ = v18_service.stop().await;
-        let _ = v18_service.remove().await;
+        let _ = v17_service.stop().await;
+        let _ = v17_service.remove().await;
     }
 
     #[test]

--- a/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
@@ -2201,6 +2201,9 @@ mod tests {
     ///   3. The shell-escape + command construction used by the orchestrator
     ///      survives round-trip through `sh -c` with real user/password/db
     ///      values containing typical characters.
+    ///   4. `pg_dumpall` carries the WHOLE cluster: several databases (not just
+    ///      the default one) all survive the restore, and every database's
+    ///      table count is identical before and after.
     ///
     /// This validates the failure-prone shell/Docker-exec plumbing without
     /// having to stand up the full control-plane database, the encryption
@@ -2477,6 +2480,89 @@ mod tests {
             );
             run_exec_ok(&docker, &old_container, &seed_cmd, None).await?;
 
+            // --- Whole-cluster coverage --------------------------------------
+            // `pg_dumpall` dumps the ENTIRE cluster (every database + globals),
+            // which is the whole reason the orchestrator uses it. Prove that:
+            // create two databases besides the default one, give each a DISTINCT
+            // set of tables, then after the restore assert (a) every database
+            // came back and (b) each database's table count is identical before
+            // vs after. The single-table probe above only proves one table in
+            // one database survived — it would not catch a restore that silently
+            // dropped a database or some of its tables.
+            let extra_dbs = ["upgrade_extra_a", "upgrade_extra_b"];
+            let all_dbs = [db, extra_dbs[0], extra_dbs[1]];
+
+            // Each CREATE DATABASE must be its own statement: it cannot run
+            // inside a transaction block, so it can't share a multi-statement -c.
+            for extra in extra_dbs {
+                let create_db = format!(
+                    "export PGPASSWORD={pw}; psql -v ON_ERROR_STOP=1 -U {u} -d postgres -c {sql}",
+                    pw = shell_escape(password),
+                    u = shell_escape(user),
+                    sql = shell_escape(&format!("CREATE DATABASE {extra}")),
+                );
+                run_exec_ok(&docker, &old_container, &create_db, Some(password)).await?;
+            }
+
+            // Seed a distinct number of tables (each with a row) per database.
+            // The default `upgradetest` already has `upgrade_probe`, so +1 => 2
+            // tables; extra_a gets 3; extra_b gets 5 — all distinct, so a
+            // per-database comparison is a real signal, not a coincidence.
+            let seed_plan = [(db, 1usize), (extra_dbs[0], 3), (extra_dbs[1], 5)];
+            for (dbname, n) in seed_plan {
+                let mut stmts = String::new();
+                for i in 0..n {
+                    stmts.push_str(&format!(
+                        "CREATE TABLE seed_{i}(id INT PRIMARY KEY, note TEXT NOT NULL); \
+                         INSERT INTO seed_{i}(id, note) VALUES ({i}, 'r{i}'); "
+                    ));
+                }
+                let seed_more = format!(
+                    "export PGPASSWORD={pw}; psql -v ON_ERROR_STOP=1 -U {u} -d {d} -c {sql}",
+                    pw = shell_escape(password),
+                    u = shell_escape(user),
+                    d = shell_escape(dbname),
+                    sql = shell_escape(&stmts),
+                );
+                run_exec_ok(&docker, &old_container, &seed_more, Some(password)).await?;
+            }
+
+            // Count base tables in a database of a given container. Parses the
+            // first integer line so an incidental psql notice on stderr can't
+            // corrupt the result. Mirrors the `wait_ready` closure's shape:
+            // owned copies moved into the future so there are no borrow snags.
+            let count_tables = |container: &str, dbname: &str| {
+                let docker = Arc::clone(&docker);
+                let container = container.to_string();
+                let dbname = dbname.to_string();
+                let user = user.to_string();
+                let password = password.to_string();
+                async move {
+                    let sql = "SELECT count(*) FROM information_schema.tables \
+                               WHERE table_schema NOT IN ('pg_catalog', 'information_schema') \
+                               AND table_type = 'BASE TABLE'";
+                    let cmd = format!(
+                        "export PGPASSWORD={pw}; psql -v ON_ERROR_STOP=1 -U {u} -d {d} -tAc {sql}",
+                        pw = shell_escape(&password),
+                        u = shell_escape(&user),
+                        d = shell_escape(&dbname),
+                        sql = shell_escape(sql),
+                    );
+                    let out =
+                        run_exec_capture(&docker, &container, &cmd, Some(password.as_str())).await?;
+                    out.lines()
+                        .filter_map(|l| l.trim().parse::<i64>().ok())
+                        .next()
+                        .ok_or_else(|| format!("no table count for {dbname} (raw output: {out:?})"))
+                }
+            };
+
+            // Snapshot every database's table count BEFORE the dump.
+            let mut before_counts: Vec<(&str, i64)> = Vec::new();
+            for dbname in all_dbs {
+                before_counts.push((dbname, count_tables(&old_container, dbname).await?));
+            }
+
             // Dump — mirrors exactly what `phase_dump` shells out, including
             // the atomic marker file write.
             let dump_cmd = format!(
@@ -2703,6 +2789,47 @@ mod tests {
                 "restored data did not match. got: {:?}",
                 got
             );
+
+            // Every database in the cluster must have come back.
+            let db_list_sql = "SELECT datname FROM pg_database \
+                               WHERE datistemplate = false AND datname <> 'postgres' \
+                               ORDER BY datname";
+            let db_list_cmd = format!(
+                "export PGPASSWORD={pw}; psql -v ON_ERROR_STOP=1 -U {u} -d postgres -tAc {sql}",
+                pw = shell_escape(password),
+                u = shell_escape(user),
+                sql = shell_escape(db_list_sql),
+            );
+            let db_list_out =
+                run_exec_capture(&docker, &new_container, &db_list_cmd, Some(password)).await?;
+            let restored_dbs: std::collections::HashSet<String> = db_list_out
+                .lines()
+                .map(|l| l.trim().to_string())
+                .filter(|l| !l.is_empty())
+                .collect();
+            for dbname in all_dbs {
+                if !restored_dbs.contains(dbname) {
+                    return Err(format!(
+                        "database {dbname:?} missing after restore; restored databases = {restored_dbs:?}"
+                    ));
+                }
+            }
+
+            // Each database must have exactly as many tables as before the dump.
+            for (dbname, before) in before_counts {
+                let after = count_tables(&new_container, dbname).await?;
+                if before <= 0 {
+                    return Err(format!(
+                        "precondition failed: {dbname:?} had no seeded tables before the dump"
+                    ));
+                }
+                if before != after {
+                    return Err(format!(
+                        "table count for database {dbname:?} changed across the upgrade: \
+                         before={before} after={after}"
+                    ));
+                }
+            }
 
             // Run ANALYZE (same shape as phase_analyze) to confirm planner
             // stats refresh works on the restored DB.

--- a/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
@@ -1242,7 +1242,7 @@ impl PostgresUpgradeOrchestrator {
                     read_only: Some(true),
                     ..Default::default()
                 }]),
-                auto_remove: Some(false),
+                auto_remove: Some(true),
                 ..Default::default()
             }),
             ..Default::default()
@@ -1538,7 +1538,10 @@ impl PostgresUpgradeOrchestrator {
                         ..Default::default()
                     },
                 ]),
-                auto_remove: Some(true),
+                // We remove manually below (with an exit-code check and a
+                // wait-for-removal poll) so a lost race against Docker's own
+                // auto-remove can't be mistaken for a hard failure.
+                auto_remove: Some(false),
                 ..Default::default()
             }),
             ..Default::default()

--- a/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
@@ -3991,7 +3991,7 @@ mod tests {
     /// a regression makes the run hang — caught in bounded time by the
     /// `tokio::time::timeout` wrapper instead of hanging CI forever.
     #[cfg(feature = "docker-tests")]
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn orchestrator_full_run_exercises_backup_exec_v17_to_v18() {
         use harness::*;
         use std::sync::Arc;
@@ -4024,15 +4024,20 @@ mod tests {
             let upgrade_id = ctx.insert_upgrade_row(phase::PRE_BACKUP).await;
             let orch = ctx.orchestrator(provider_trait, lifecycle);
 
-            // Bounded so a run_exec regression (100% CPU spin that never
-            // returns) fails the test instead of hanging CI indefinitely.
-            tokio::time::timeout(std::time::Duration::from_secs(600), orch.run(upgrade_id))
+            // Run on a SEPARATE task and time out the JoinHandle. A run_exec
+            // regression is a synchronous busy loop that never yields, so a
+            // plain `timeout(_, orch.run())` could never fire; spawned, the spin
+            // occupies one worker while the timeout fires on another -> the test
+            // FAILS instead of hanging CI.
+            let run_handle = tokio::spawn(async move { orch.run(upgrade_id).await });
+            tokio::time::timeout(std::time::Duration::from_secs(600), run_handle)
                 .await
                 .map_err(|_| {
                     "orchestrator.run() did not finish within 600s — likely a \
                      run_exec / exec hang"
                         .to_string()
                 })?
+                .map_err(|e| format!("orchestrator.run task panicked: {}", e))?
                 .map_err(|e| format!("run: {}", e))?;
 
             let row = load_upgrade(ctx.test_db.db.as_ref(), upgrade_id).await;

--- a/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
@@ -29,6 +29,8 @@ use temps_entities::postgres_major_upgrades;
 use temps_logs::LogService;
 use thiserror::Error;
 
+use super::postgres::shell_escape;
+
 /// Pre-upgrade backup provider trait.
 ///
 /// Implemented by `temps-backup::BackupService` to avoid a circular dep
@@ -221,13 +223,6 @@ pub enum PostgresUpgradeError {
     Database(#[from] sea_orm::DbErr),
 }
 
-/// POSIX-safe shell escaping used when interpolating user-controlled
-/// strings into `sh -c` invocations. Single-quotes the value and escapes
-/// any embedded single quotes.
-fn shell_escape(s: &str) -> String {
-    format!("'{}'", s.replace('\'', "'\\''"))
-}
-
 /// Escape a string for safe interpolation into a `sed` BRE/ERE pattern.
 /// Used when the dumped service username is baked into a regex that
 /// filters out the dump's `DROP ROLE` statements for the connected user.
@@ -418,6 +413,14 @@ pub mod status {
     pub const FAILED: &str = "failed";
     pub const COMPLETED: &str = "completed";
     pub const CANCELLED: &str = "cancelled";
+    /// A completed upgrade is actively being rolled back: the live volume
+    /// has been (or is about to be) deleted and is being replaced by a copy
+    /// of the rollback volume. Active for `ensure_no_active_upgrade`
+    /// purposes, same as PENDING/RUNNING — a concurrent start must not
+    /// recreate the container against a volume mid-restore. Retryable: a
+    /// `rollback()` call is idempotent, so a row stuck here after a failed
+    /// attempt can simply be re-rolled-back.
+    pub const ROLLING_BACK: &str = "rolling_back";
     /// Upgrade was completed, then rolled back to the pre-upgrade PGDATA
     /// volume and old image. Terminal — a new upgrade must be started
     /// separately to re-attempt.
@@ -1576,7 +1579,13 @@ impl PostgresUpgradeOrchestrator {
                 reason: format!("start copy container: {}", e),
             })?;
 
-        let wait_result = self
+        // Capture the wait outcome instead of propagating it immediately:
+        // `auto_remove` is disabled above, so an early `?` return here would
+        // skip the removal below and leak the sidecar holding a reference to
+        // both volumes, wedging any retry's volume removal ("volume is in
+        // use") forever. Every exit path from here must still try to remove
+        // the container.
+        let wait_outcome = self
             .docker
             .wait_container(
                 &created.id,
@@ -1584,11 +1593,7 @@ impl PostgresUpgradeOrchestrator {
             )
             .try_collect::<Vec<_>>()
             .await
-            .map_err(|e| PostgresUpgradeError::SnapshotFailed {
-                upgrade_id: row.id,
-                service_id: row.service_id,
-                reason: format!("wait copy container: {}", e),
-            })?;
+            .map_err(|e| format!("wait copy container: {}", e));
 
         let remove_result = self
             .docker
@@ -1604,7 +1609,13 @@ impl PostgresUpgradeOrchestrator {
 
         if let Err(e) = remove_result {
             let msg = e.to_string();
-            if !msg.contains("removal of container") || !msg.contains("is already in progress") {
+            let already_gone = msg.contains("No such container")
+                || msg.contains("no such container")
+                || msg.contains("not found")
+                || msg.contains("404");
+            let already_removing = msg.contains("removal of container")
+                && msg.contains("is already in progress");
+            if !already_gone && !already_removing {
                 return Err(PostgresUpgradeError::SnapshotFailed {
                     upgrade_id: row.id,
                     service_id: row.service_id,
@@ -1653,6 +1664,12 @@ impl PostgresUpgradeOrchestrator {
                 }
             }
         }
+
+        let wait_result = wait_outcome.map_err(|reason| PostgresUpgradeError::SnapshotFailed {
+            upgrade_id: row.id,
+            service_id: row.service_id,
+            reason,
+        })?;
 
         if let Some(nonzero) = wait_result
             .iter()
@@ -1822,12 +1839,15 @@ impl PostgresUpgradeOrchestrator {
     ) -> Result<postgres_major_upgrades::Model, PostgresUpgradeError> {
         let row = self.load_upgrade(upgrade_id).await?;
 
-        // Preconditions
-        if row.status != status::COMPLETED {
+        // Preconditions. ROLLING_BACK is accepted alongside COMPLETED so a
+        // rollback that failed partway (leaving the row stuck in
+        // ROLLING_BACK) can be retried through this same entry point —
+        // every step below tolerates "already in that state".
+        if row.status != status::COMPLETED && row.status != status::ROLLING_BACK {
             return Err(PostgresUpgradeError::NotRollbackable {
                 upgrade_id,
                 reason: format!(
-                    "only completed upgrades can be rolled back; current status is '{}'",
+                    "only completed (or a previously interrupted rollback) can be rolled back; current status is '{}'",
                     row.status
                 ),
             });
@@ -1849,6 +1869,14 @@ impl PostgresUpgradeOrchestrator {
                 });
             }
         }
+
+        // Mark the row actively rolling back *before* touching any
+        // container or volume, so `ensure_no_active_upgrade` blocks a
+        // concurrent start for the entire multi-step restore below, not
+        // just while status was PENDING/RUNNING during the original
+        // upgrade. Idempotent if already ROLLING_BACK (a retry).
+        self.set_status(upgrade_id, status::ROLLING_BACK, None)
+            .await?;
 
         self.log_service
             .log_warning(

--- a/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
@@ -3497,6 +3497,72 @@ mod tests {
             }
         }
 
+        /// A `PreUpgradeBackupProvider` that routes the pre-upgrade backup
+        /// through the REAL `exec_util::run_exec` (against the service's own
+        /// running container) before recording the backup row like
+        /// `StubBackupProvider`.
+        ///
+        /// The production pre-upgrade backup shells `pg_dumpall … > file` via
+        /// `run_exec`, whose exec stdout is empty — the exact shape that
+        /// regressed into a 100% CPU busy loop that never returned. The stub
+        /// providers bypass `run_exec` entirely, which is why that hang shipped
+        /// despite a green orchestrator happy-path test. This provider closes
+        /// the gap: a `run_exec` regression makes the whole `orchestrator.run()`
+        /// hang, caught by the test's bounded `tokio::time::timeout`.
+        pub struct RunExecBackupProvider {
+            inner: StubBackupProvider,
+            docker: Arc<Docker>,
+            container: String,
+        }
+
+        impl RunExecBackupProvider {
+            pub fn new(
+                db: Arc<DatabaseConnection>,
+                docker: Arc<Docker>,
+                container: String,
+            ) -> Self {
+                Self {
+                    inner: StubBackupProvider::new(db),
+                    docker,
+                    container,
+                }
+            }
+            pub fn calls(&self) -> u64 {
+                self.inner.calls.load(Ordering::SeqCst)
+            }
+        }
+
+        #[async_trait]
+        impl PreUpgradeBackupProvider for RunExecBackupProvider {
+            async fn default_s3_source_id(&self, service_id: i32) -> Result<Option<i32>, String> {
+                self.inner.default_s3_source_id(service_id).await
+            }
+
+            async fn create_pre_upgrade_backup(
+                &self,
+                service_id: i32,
+                s3_source_id: i32,
+                created_by: i32,
+            ) -> Result<i32, String> {
+                // Exercise the real run_exec with a no-stdout command — the
+                // production backup's `pg_dumpall … > file` shape. Bounded so a
+                // regression fails rather than hangs the whole run.
+                crate::externalsvc::exec_util::run_exec(
+                    self.docker.as_ref(),
+                    &self.container,
+                    vec!["sh".to_string(), "-c".to_string(), "true".to_string()],
+                    None,
+                    std::time::Duration::from_secs(120),
+                )
+                .await
+                .map_err(|e| format!("pre-upgrade backup run_exec failed: {}", e))?;
+
+                self.inner
+                    .create_pre_upgrade_backup(service_id, s3_source_id, created_by)
+                    .await
+            }
+        }
+
         /// Recording wrapper around `PostgresLifecycleAdapter`. Captures an
         /// ordered event log of each trait method call, with monotonic
         /// timestamps, so tests can assert on call ordering (e.g.,
@@ -3913,6 +3979,105 @@ mod tests {
 
         if let Err(e) = result {
             panic!("happy-path integration test failed: {}", e);
+        }
+    }
+
+    /// Full-orchestrator regression test that drives `pre_backup` through the
+    /// REAL `exec_util::run_exec` (via `RunExecBackupProvider`) rather than a
+    /// stub. This is the coverage gap that let the `run_exec` 100% CPU hang
+    /// ship: the happy-path test above runs the whole orchestrator to
+    /// `completed`, but stubs the backup, so it never touches `run_exec`. Here
+    /// `orchestrator.run()` actually invokes `run_exec` during `pre_backup`, so
+    /// a regression makes the run hang — caught in bounded time by the
+    /// `tokio::time::timeout` wrapper instead of hanging CI forever.
+    #[cfg(feature = "docker-tests")]
+    #[tokio::test]
+    async fn orchestrator_full_run_exercises_backup_exec_v17_to_v18() {
+        use harness::*;
+        use std::sync::Arc;
+
+        if docker_or_skip("orchestrator_full_run_exercises_backup_exec_v17_to_v18")
+            .await
+            .is_none()
+        {
+            return;
+        }
+
+        let ctx = UpgradeTestCtx::new("bkexec").await;
+        let container = format!("postgres-{}", ctx.service_name);
+        let provider = Arc::new(RunExecBackupProvider::new(
+            ctx.test_db.db.clone(),
+            ctx.docker.clone(),
+            container,
+        ));
+        let provider_trait: Arc<dyn PreUpgradeBackupProvider> = provider.clone();
+        let lifecycle: Arc<dyn PostgresContainerLifecycle> = ctx.lifecycle_adapter.clone();
+
+        let result = async {
+            ctx.psql_exec("CREATE TABLE bkexec_probe(id SERIAL PRIMARY KEY, payload TEXT)")
+                .await?;
+            ctx.psql_exec(
+                "INSERT INTO bkexec_probe(payload) SELECT 'row_' || g FROM generate_series(1,300) g",
+            )
+            .await?;
+
+            let upgrade_id = ctx.insert_upgrade_row(phase::PRE_BACKUP).await;
+            let orch = ctx.orchestrator(provider_trait, lifecycle);
+
+            // Bounded so a run_exec regression (100% CPU spin that never
+            // returns) fails the test instead of hanging CI indefinitely.
+            tokio::time::timeout(std::time::Duration::from_secs(600), orch.run(upgrade_id))
+                .await
+                .map_err(|_| {
+                    "orchestrator.run() did not finish within 600s — likely a \
+                     run_exec / exec hang"
+                        .to_string()
+                })?
+                .map_err(|e| format!("run: {}", e))?;
+
+            let row = load_upgrade(ctx.test_db.db.as_ref(), upgrade_id).await;
+            if row.status != status::COMPLETED {
+                return Err(format!("expected COMPLETED, got {}", row.status));
+            }
+            if provider.calls() != 1 {
+                return Err(format!(
+                    "pre-upgrade backup (run_exec path) should run exactly once, ran {}",
+                    provider.calls()
+                ));
+            }
+            let after = ctx
+                .psql_query("SELECT count(*) FROM bkexec_probe")
+                .await?
+                .trim()
+                .parse::<i64>()
+                .map_err(|e| e.to_string())?;
+            if after != 300 {
+                return Err(format!("expected 300 rows after upgrade, got {}", after));
+            }
+            Ok::<_, String>(upgrade_id)
+        }
+        .await;
+
+        let upgrade_id_for_cleanup = result.as_ref().ok().copied().unwrap_or(-1);
+        let extras: Vec<String> = if upgrade_id_for_cleanup > 0 {
+            vec![
+                format!(
+                    "postgres-{}_data_rollback_{}",
+                    ctx.service_name, upgrade_id_for_cleanup
+                ),
+                format!(
+                    "postgres-{}_pgdump_{}",
+                    ctx.service_name, upgrade_id_for_cleanup
+                ),
+            ]
+        } else {
+            vec![]
+        };
+        ctx.cleanup().await;
+        remove_volumes(ctx.docker.as_ref(), &extras).await;
+
+        if let Err(e) = result {
+            panic!("full-run backup-exec integration test failed: {}", e);
         }
     }
 

--- a/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
@@ -662,8 +662,15 @@ impl PostgresUpgradeOrchestrator {
 
         self.copy_volume(row, &source_volume, &rollback_volume)
             .await?;
-        // Remove the original — new_container phase will recreate it empty.
-        self.remove_volume_best_effort(&source_volume).await;
+        // Remove the original. The new_container phase must start from an
+        // empty live volume; reusing old-version PGDATA breaks Postgres 18+.
+        self.remove_volume_or_fail(&source_volume)
+            .await
+            .map_err(|reason| PostgresUpgradeError::SnapshotFailed {
+                upgrade_id: row.id,
+                service_id: row.service_id,
+                reason: format!("remove old live volume '{}': {}", source_volume, reason),
+            })?;
 
         let expires_at = chrono::Utc::now() + chrono::Duration::days(ROLLBACK_RETENTION_DAYS);
         let current = self.load_upgrade(row.id).await?;
@@ -1235,7 +1242,7 @@ impl PostgresUpgradeOrchestrator {
                     read_only: Some(true),
                     ..Default::default()
                 }]),
-                auto_remove: Some(true),
+                auto_remove: Some(false),
                 ..Default::default()
             }),
             ..Default::default()
@@ -1500,6 +1507,8 @@ impl PostgresUpgradeOrchestrator {
         dest: &str,
     ) -> Result<(), PostgresUpgradeError> {
         use futures::TryStreamExt;
+        use std::time::{Duration, Instant};
+
         let copy_container_name = format!(
             "temps_pg_upgrade_{}_copy_{}",
             row.id,
@@ -1564,7 +1573,8 @@ impl PostgresUpgradeOrchestrator {
                 reason: format!("start copy container: {}", e),
             })?;
 
-        self.docker
+        let wait_result = self
+            .docker
             .wait_container(
                 &created.id,
                 None::<bollard::query_parameters::WaitContainerOptions>,
@@ -1576,6 +1586,82 @@ impl PostgresUpgradeOrchestrator {
                 service_id: row.service_id,
                 reason: format!("wait copy container: {}", e),
             })?;
+
+        let remove_result = self
+            .docker
+            .remove_container(
+                &created.id,
+                Some(bollard::query_parameters::RemoveContainerOptions {
+                    v: true,
+                    force: true,
+                    ..Default::default()
+                }),
+            )
+            .await;
+
+        if let Err(e) = remove_result {
+            let msg = e.to_string();
+            if !msg.contains("removal of container") || !msg.contains("is already in progress") {
+                return Err(PostgresUpgradeError::SnapshotFailed {
+                    upgrade_id: row.id,
+                    service_id: row.service_id,
+                    reason: format!("remove copy container: {}", msg),
+                });
+            }
+        }
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            match self
+                .docker
+                .inspect_container(
+                    &created.id,
+                    None::<bollard::query_parameters::InspectContainerOptions>,
+                )
+                .await
+            {
+                Ok(_) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(250)).await;
+                }
+                Ok(_) => {
+                    return Err(PostgresUpgradeError::SnapshotFailed {
+                        upgrade_id: row.id,
+                        service_id: row.service_id,
+                        reason: format!(
+                            "copy container '{}' still exists after removal timeout",
+                            created.id
+                        ),
+                    });
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("No such container")
+                        || msg.contains("no such container")
+                        || msg.contains("not found")
+                        || msg.contains("404")
+                    {
+                        break;
+                    }
+                    return Err(PostgresUpgradeError::SnapshotFailed {
+                        upgrade_id: row.id,
+                        service_id: row.service_id,
+                        reason: format!("inspect copy container after removal: {}", msg),
+                    });
+                }
+            }
+        }
+
+        if let Some(nonzero) = wait_result
+            .iter()
+            .map(|status| status.status_code)
+            .find(|status_code| *status_code != 0)
+        {
+            return Err(PostgresUpgradeError::SnapshotFailed {
+                upgrade_id: row.id,
+                service_id: row.service_id,
+                reason: format!("copy container exited with status {}", nonzero),
+            });
+        }
 
         Ok(())
     }
@@ -1591,6 +1677,26 @@ impl PostgresUpgradeOrchestrator {
                 None::<bollard::query_parameters::RemoveVolumeOptions>,
             )
             .await;
+    }
+
+    async fn remove_volume_or_fail(&self, volume_name: &str) -> Result<(), String> {
+        self.docker
+            .remove_volume(
+                volume_name,
+                Some(bollard::query_parameters::RemoveVolumeOptions { force: true }),
+            )
+            .await
+            .map_err(|e| e.to_string())
+            .or_else(|reason| {
+                if reason.contains("No such volume")
+                    || reason.contains("not found")
+                    || reason.contains("404")
+                {
+                    Ok(())
+                } else {
+                    Err(reason)
+                }
+            })
     }
 
     // ---- Rollback volume retention -------------------------------------
@@ -1770,8 +1876,15 @@ impl PostgresUpgradeOrchestrator {
 
         // 2. Remove the live volume so the copy produces a clean replica of
         //    the rollback volume (any lingering new-version WAL/catalog is
-        //    discarded). `remove_volume_best_effort` tolerates absence.
-        self.remove_volume_best_effort(&live_volume).await;
+        //    discarded). This is required; overlaying rollback data onto a
+        //    dirty live volume can leave incompatible catalog/WAL files.
+        self.remove_volume_or_fail(&live_volume)
+            .await
+            .map_err(|reason| PostgresUpgradeError::RollbackFailed {
+                upgrade_id,
+                service_id: row.service_id,
+                reason: format!("remove live volume '{}': {}", live_volume, reason),
+            })?;
         self.create_volume_if_missing(&row, &live_volume).await?;
         self.copy_volume(&row, &rollback_volume, &live_volume)
             .await
@@ -2790,14 +2903,16 @@ mod tests {
         use sea_orm::{ActiveModelTrait, ActiveValue::Set, DatabaseConnection, EntityTrait};
         use serde_json::json;
         use std::sync::{
-            atomic::{AtomicU64, Ordering},
+            atomic::{AtomicI32, AtomicU64, Ordering},
             Arc, Mutex,
         };
         use std::time::{Duration, Instant};
         use tempfile::TempDir;
         use temps_core::EncryptionService;
         use temps_database::test_utils::TestDatabase;
-        use temps_entities::{external_services, postgres_major_upgrades, users};
+        use temps_entities::{
+            backups, external_services, postgres_major_upgrades, s3_sources, users,
+        };
         use temps_logs::LogService;
 
         use crate::postgres_lifecycle::PostgresLifecycleAdapter;
@@ -3105,35 +3220,101 @@ mod tests {
             }
         }
 
-        /// Stub `PreUpgradeBackupProvider` — always returns a synthetic
-        /// backup id (42) without touching S3. The orchestrator only reads
-        /// this id back onto the row; no downstream check validates it.
+        /// Stub `PreUpgradeBackupProvider` — creates a real control-plane
+        /// backup row without touching S3. The orchestrator stores the
+        /// returned id on `postgres_major_upgrades.pre_upgrade_backup_id`,
+        /// which has a real FK to `backups.id` in the test database.
         pub struct StubBackupProvider {
+            db: Arc<DatabaseConnection>,
             pub calls: Arc<AtomicU64>,
+            pub last_backup_id: Arc<AtomicI32>,
         }
 
         impl StubBackupProvider {
-            pub fn new() -> Self {
+            pub fn new(db: Arc<DatabaseConnection>) -> Self {
                 Self {
+                    db,
                     calls: Arc::new(AtomicU64::new(0)),
+                    last_backup_id: Arc::new(AtomicI32::new(0)),
                 }
             }
         }
 
         #[async_trait]
         impl PreUpgradeBackupProvider for StubBackupProvider {
-            async fn default_s3_source_id(&self, _service_id: i32) -> Result<Option<i32>, String> {
-                Ok(Some(1))
+            async fn default_s3_source_id(&self, service_id: i32) -> Result<Option<i32>, String> {
+                let now = chrono::Utc::now();
+                let source = s3_sources::ActiveModel {
+                    id: sea_orm::NotSet,
+                    name: Set(format!(
+                        "upgrade-test-s3-{}-{}",
+                        service_id,
+                        now.timestamp_nanos_opt().unwrap_or(0)
+                    )),
+                    bucket_name: Set("upgrade-test-bucket".to_string()),
+                    region: Set("us-east-1".to_string()),
+                    endpoint: Set(Some("http://127.0.0.1:9000".to_string())),
+                    bucket_path: Set("postgres-upgrade-tests".to_string()),
+                    access_key_id: Set("test-access-key".to_string()),
+                    secret_key: Set("test-secret-key".to_string()),
+                    force_path_style: Set(Some(true)),
+                    is_default: Set(true),
+                    created_at: Set(now),
+                    updated_at: Set(now),
+                }
+                .insert(self.db.as_ref())
+                .await
+                .map_err(|e| format!("insert test s3 source: {}", e))?;
+
+                Ok(Some(source.id))
             }
 
             async fn create_pre_upgrade_backup(
                 &self,
-                _service_id: i32,
-                _s3_source_id: i32,
-                _created_by: i32,
+                service_id: i32,
+                s3_source_id: i32,
+                created_by: i32,
             ) -> Result<i32, String> {
                 self.calls.fetch_add(1, Ordering::SeqCst);
-                Ok(42)
+                let now = chrono::Utc::now();
+                let backup_uuid = format!(
+                    "upgrade-pre-backup-{}-{}",
+                    service_id,
+                    now.timestamp_nanos_opt().unwrap_or(0)
+                );
+                let backup = backups::ActiveModel {
+                    id: sea_orm::NotSet,
+                    name: Set(format!("Pre-upgrade backup {}", service_id)),
+                    backup_id: Set(backup_uuid.clone()),
+                    schedule_id: Set(None),
+                    backup_type: Set("pre_upgrade".to_string()),
+                    state: Set("completed".to_string()),
+                    started_at: Set(now),
+                    finished_at: Set(Some(now)),
+                    size_bytes: Set(Some(0)),
+                    file_count: Set(Some(0)),
+                    s3_source_id: Set(s3_source_id),
+                    s3_location: Set(format!("s3://upgrade-test-bucket/{}", backup_uuid)),
+                    error_message: Set(None),
+                    metadata: Set(serde_json::json!({
+                        "test": true,
+                        "service_id": service_id,
+                        "purpose": "postgres_major_upgrade_pre_backup"
+                    })
+                    .to_string()),
+                    checksum: Set(None),
+                    compression_type: Set("none".to_string()),
+                    created_by: Set(created_by),
+                    expires_at: Set(None),
+                    tags: Set("[]".to_string()),
+                    schedule_run_id: sea_orm::NotSet,
+                }
+                .insert(self.db.as_ref())
+                .await
+                .map_err(|e| format!("insert test backup: {}", e))?;
+
+                self.last_backup_id.store(backup.id, Ordering::SeqCst);
+                Ok(backup.id)
             }
         }
 
@@ -3278,7 +3459,7 @@ mod tests {
 
         let ctx = UpgradeTestCtx::new("rollback").await;
         let backup_provider: Arc<dyn PreUpgradeBackupProvider> =
-            Arc::new(StubBackupProvider::new());
+            Arc::new(StubBackupProvider::new(ctx.test_db.db.clone()));
         let lifecycle: Arc<dyn PostgresContainerLifecycle> = ctx.lifecycle_adapter.clone();
 
         // Seed pre-upgrade data on v17.
@@ -3439,7 +3620,7 @@ mod tests {
         }
 
         let ctx = UpgradeTestCtx::new("happy").await;
-        let backup_provider = Arc::new(StubBackupProvider::new());
+        let backup_provider = Arc::new(StubBackupProvider::new(ctx.test_db.db.clone()));
         let backup_provider_trait: Arc<dyn PreUpgradeBackupProvider> = backup_provider.clone();
         let lifecycle: Arc<dyn PostgresContainerLifecycle> = ctx.lifecycle_adapter.clone();
 
@@ -3478,7 +3659,11 @@ mod tests {
             assert!(row.finished_at.is_some(), "finished_at unset");
             assert_eq!(
                 row.pre_upgrade_backup_id,
-                Some(42),
+                Some(
+                    backup_provider
+                        .last_backup_id
+                        .load(std::sync::atomic::Ordering::SeqCst)
+                ),
                 "pre_upgrade_backup_id not persisted"
             );
             assert!(
@@ -3585,7 +3770,7 @@ mod tests {
 
         let ctx = UpgradeTestCtx::new("snap-order").await;
         let backup_provider: Arc<dyn PreUpgradeBackupProvider> =
-            Arc::new(StubBackupProvider::new());
+            Arc::new(StubBackupProvider::new(ctx.test_db.db.clone()));
 
         // Wrap the real adapter in a recorder so we can observe call order.
         let recorder = RecordingLifecycle::new(ctx.lifecycle_adapter.clone());
@@ -3744,7 +3929,7 @@ mod tests {
 
         let ctx = UpgradeTestCtx::new("stream-drain").await;
         let backup_provider: Arc<dyn PreUpgradeBackupProvider> =
-            Arc::new(StubBackupProvider::new());
+            Arc::new(StubBackupProvider::new(ctx.test_db.db.clone()));
         let lifecycle: Arc<dyn PostgresContainerLifecycle> = ctx.lifecycle_adapter.clone();
 
         let result = async {
@@ -3843,7 +4028,7 @@ mod tests {
 
         let ctx = UpgradeTestCtx::new("dump-idem").await;
         let backup_provider: Arc<dyn PreUpgradeBackupProvider> =
-            Arc::new(StubBackupProvider::new());
+            Arc::new(StubBackupProvider::new(ctx.test_db.db.clone()));
         let lifecycle: Arc<dyn PostgresContainerLifecycle> = ctx.lifecycle_adapter.clone();
 
         let result = async {
@@ -3913,7 +4098,7 @@ mod tests {
             // state, the whole retry should complete FAST (< 60s typ).
             let retry_start = std::time::Instant::now();
             let orch2 = ctx.orchestrator(
-                Arc::new(StubBackupProvider::new()),
+                Arc::new(StubBackupProvider::new(ctx.test_db.db.clone())),
                 ctx.lifecycle_adapter.clone(),
             );
             orch2

--- a/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
@@ -1613,8 +1613,8 @@ impl PostgresUpgradeOrchestrator {
                 || msg.contains("no such container")
                 || msg.contains("not found")
                 || msg.contains("404");
-            let already_removing = msg.contains("removal of container")
-                && msg.contains("is already in progress");
+            let already_removing =
+                msg.contains("removal of container") && msg.contains("is already in progress");
             if !already_gone && !already_removing {
                 return Err(PostgresUpgradeError::SnapshotFailed {
                     upgrade_id: row.id,

--- a/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
@@ -29,7 +29,7 @@ use temps_entities::postgres_major_upgrades;
 use temps_logs::LogService;
 use thiserror::Error;
 
-use super::postgres::shell_escape;
+use super::postgres::{shell_escape, validate_pg_username};
 
 /// Pre-upgrade backup provider trait.
 ///
@@ -989,10 +989,30 @@ impl PostgresUpgradeOrchestrator {
         //   CREATE ROLE {user};
         //   ALTER ROLE {user} WITH ...
         // The role name appears after an optional "IF EXISTS " for DROP.
-        let sed_filter = format!(
-            "sed -E '/^(DROP ROLE (IF EXISTS )?|CREATE ROLE |ALTER ROLE ){user}($| |;)/d'",
+        // Defense-in-depth: reject any username outside a plain identifier
+        // charset before it is baked into the sed program below. The sed
+        // argument is fully shell-escaped, so this is not the primary guard —
+        // it just ensures a crafted username can never reach the shell or the
+        // sed program in the first place.
+        validate_pg_username(&conn.username).map_err(|reason| {
+            PostgresUpgradeError::RestoreFailed {
+                upgrade_id: row.id,
+                service_id: row.service_id,
+                reason,
+            }
+        })?;
+
+        // Build the sed role-filter program, then shell-escape the ENTIRE sed
+        // argument. `regex_escape_for_sed` neutralizes regex metacharacters but
+        // NOT the single quotes that wrap the program, so the sed string must
+        // still pass through `shell_escape` before interpolation — the
+        // `-U {user}` arg below already does; this one previously did not, so a
+        // `'` in the username could break out of the sed quotes into the shell.
+        let sed_program = format!(
+            "/^(DROP ROLE (IF EXISTS )?|CREATE ROLE |ALTER ROLE ){user}($| |;)/d",
             user = regex_escape_for_sed(&conn.username),
         );
+        let sed_filter = format!("sed -E {}", shell_escape(&sed_program));
         let psql_cmd = format!(
             "set -eu; export PGPASSWORD={pw}; {sed} /dump/data.sql | psql -v ON_ERROR_STOP=1 -h {host} -U {user} -d postgres",
             pw = shell_escape(&conn.password),
@@ -2706,10 +2726,11 @@ mod tests {
             wait_ready(&new_container).await?;
 
             // Restore via throwaway psql sidecar — same shape as `phase_restore`.
-            let sed_filter = format!(
-                "sed -E '/^(DROP ROLE (IF EXISTS )?|CREATE ROLE |ALTER ROLE ){u}($| |;)/d'",
+            let sed_program = format!(
+                "/^(DROP ROLE (IF EXISTS )?|CREATE ROLE |ALTER ROLE ){u}($| |;)/d",
                 u = regex_escape_for_sed(user),
             );
+            let sed_filter = format!("sed -E {}", shell_escape(&sed_program));
             let psql_cmd = format!(
                 "set -eu; export PGPASSWORD={pw}; {sed} /dump/data.sql | psql -v ON_ERROR_STOP=1 -h {host} -U {u} -d postgres",
                 pw = shell_escape(password),

--- a/crates/temps-providers/src/handlers/handlers.rs
+++ b/crates/temps-providers/src/handlers/handlers.rs
@@ -581,6 +581,7 @@ async fn create_service(
         (status = 200, description = "Service updated successfully", body = ExternalServiceInfo),
         (status = 400, description = "Invalid request"),
         (status = 404, description = "Service not found"),
+        (status = 409, description = "A major upgrade is in progress for this service"),
         (status = 500, description = "Internal server error")
     ),
     params(
@@ -644,15 +645,33 @@ async fn update_service(
 
             Ok((StatusCode::OK, Json(service)))
         }
-        Err(e) => match e.to_string().as_str() {
-            "Service not found" => Err(not_found().detail("Service not found").build()),
-            _ if e.to_string().contains("validation failed") => {
-                Err(bad_request().detail(e.to_string()).build())
+        Err(e) => {
+            if let Some(problem) = upgrade_error_problem(&e) {
+                return Err(problem);
             }
-            _ => Err(internal_server_error()
-                .detail(format!("Failed to update service: {}", e))
-                .build()),
-        },
+            if e.to_string().contains("validation failed") {
+                Err(bad_request().detail(e.to_string()).build())
+            } else {
+                Err(internal_server_error()
+                    .detail(format!("Failed to update service: {}", e))
+                    .build())
+            }
+        }
+    }
+}
+
+/// Canonical HTTP mapping for the upgrade/guard-related `ExternalServiceError`
+/// variants, shared by `update_service`, `upgrade_service`, and `start_service`
+/// so the same condition can't map to different status codes across handlers
+/// (notably `UpgradeInProgress` must be 409 everywhere, not 500 on some).
+/// Returns `None` for variants each handler should classify itself.
+fn upgrade_error_problem(e: &crate::services::ExternalServiceError) -> Option<Problem> {
+    use crate::services::ExternalServiceError as E;
+    match e {
+        E::UpgradeRejected { .. } => Some(bad_request().detail(e.to_string()).build()),
+        E::ServiceNotFound { .. } => Some(not_found().detail(e.to_string()).build()),
+        E::UpgradeInProgress { .. } => Some(conflict().detail(e.to_string()).build()),
+        _ => None,
     }
 }
 
@@ -667,6 +686,7 @@ async fn update_service(
         (status = 200, description = "Service upgraded successfully", body = ExternalServiceInfo),
         (status = 400, description = "Invalid request or upgrade not supported"),
         (status = 404, description = "Service not found"),
+        (status = 409, description = "A major upgrade is already in progress for this service"),
         (status = 500, description = "Internal server error")
     ),
     params(
@@ -711,26 +731,20 @@ async fn upgrade_service(
 
             Ok((StatusCode::OK, Json(service)))
         }
-        Err(e) => match &e {
-            crate::services::ExternalServiceError::UpgradeRejected { .. } => {
+        // Shared typed mapping first (UpgradeRejected->400, ServiceNotFound->404,
+        // UpgradeInProgress->409), then upgrade-specific fallthrough.
+        Err(e) => {
+            if let Some(problem) = upgrade_error_problem(&e) {
+                return Err(problem);
+            }
+            if e.to_string().contains("Upgrade not implemented") {
                 Err(bad_request().detail(e.to_string()).build())
-            }
-            // Typed match: `ServiceNotFound` displays as "Service {id} not
-            // found", so the previous `e.to_string() == "Service not found"`
-            // arm was dead and a missing service fell through to 500 instead
-            // of 404. Mirrors the same fix already made in `start_service`.
-            crate::services::ExternalServiceError::ServiceNotFound { .. } => {
-                Err(not_found().detail(e.to_string()).build())
-            }
-            _ => match e.to_string().as_str() {
-                msg if msg.contains("Upgrade not implemented") => {
-                    Err(bad_request().detail(msg).build())
-                }
-                _ => Err(internal_server_error()
+            } else {
+                Err(internal_server_error()
                     .detail(format!("Failed to upgrade service: {}", e))
-                    .build()),
-            },
-        },
+                    .build())
+            }
+        }
     }
 }
 
@@ -1216,17 +1230,12 @@ async fn start_service(
                 }
                 Err(e) => {
                     error!("Failed to start service: {}", e);
-                    match e {
-                        crate::services::ExternalServiceError::UpgradeInProgress { .. } => {
-                            Err(conflict().detail(e.to_string()).build())
-                        }
-                        crate::services::ExternalServiceError::ServiceNotFound { .. } => {
-                            Err(not_found().detail(e.to_string()).build())
-                        }
-                        _ => Err(internal_server_error()
-                            .detail(format!("Failed to start service: {}", e))
-                            .build()),
+                    if let Some(problem) = upgrade_error_problem(&e) {
+                        return Err(problem);
                     }
+                    Err(internal_server_error()
+                        .detail(format!("Failed to start service: {}", e))
+                        .build())
                 }
             }
         }
@@ -2468,3 +2477,50 @@ async fn update_service_resources(
     )
 )]
 pub struct ExternalServiceApiDoc;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::response::IntoResponse;
+
+    // Guards the shared error->status mapping used by update_service /
+    // upgrade_service / start_service. The exact bug this class of test exists
+    // for (a dead `e.to_string() == "Service not found"` arm returning 500
+    // instead of 404) shipped precisely because no test asserted the status.
+    #[test]
+    fn upgrade_error_problem_maps_shared_variants_to_canonical_status() {
+        use crate::services::ExternalServiceError as E;
+        let cases = [
+            (
+                E::UpgradeRejected {
+                    id: 1,
+                    reason: "nope".to_string(),
+                },
+                StatusCode::BAD_REQUEST,
+            ),
+            (E::ServiceNotFound { id: 1 }, StatusCode::NOT_FOUND),
+            (
+                E::UpgradeInProgress {
+                    id: 1,
+                    upgrade_id: 2,
+                    phase: "dump".to_string(),
+                },
+                StatusCode::CONFLICT,
+            ),
+        ];
+        for (err, want) in cases {
+            let problem = upgrade_error_problem(&err)
+                .unwrap_or_else(|| panic!("variant should map to a Problem: {err}"));
+            assert_eq!(
+                problem.into_response().status(),
+                want,
+                "wrong status for {err}"
+            );
+        }
+        // Variants outside the shared set are left for the handler to classify.
+        assert!(upgrade_error_problem(&E::ServiceNotFoundByName {
+            name: "n".to_string()
+        })
+        .is_none());
+    }
+}

--- a/crates/temps-providers/src/handlers/handlers.rs
+++ b/crates/temps-providers/src/handlers/handlers.rs
@@ -713,7 +713,10 @@ async fn upgrade_service(
         }
         Err(e) => match e.to_string().as_str() {
             "Service not found" => Err(not_found().detail("Service not found").build()),
-            msg if msg.contains("Upgrade not implemented") => {
+            msg if msg.contains("Upgrade not implemented")
+                || msg.contains("Cannot change PostgreSQL major version")
+                || msg.contains("Cannot downgrade PostgreSQL") =>
+            {
                 Err(bad_request().detail(msg).build())
             }
             _ => Err(internal_server_error()

--- a/crates/temps-providers/src/handlers/handlers.rs
+++ b/crates/temps-providers/src/handlers/handlers.rs
@@ -711,17 +711,19 @@ async fn upgrade_service(
 
             Ok((StatusCode::OK, Json(service)))
         }
-        Err(e) => match e.to_string().as_str() {
-            "Service not found" => Err(not_found().detail("Service not found").build()),
-            msg if msg.contains("Upgrade not implemented")
-                || msg.contains("Cannot change PostgreSQL major version")
-                || msg.contains("Cannot downgrade PostgreSQL") =>
-            {
-                Err(bad_request().detail(msg).build())
+        Err(e) => match &e {
+            crate::services::ExternalServiceError::UpgradeRejected { .. } => {
+                Err(bad_request().detail(e.to_string()).build())
             }
-            _ => Err(internal_server_error()
-                .detail(format!("Failed to upgrade service: {}", e))
-                .build()),
+            _ => match e.to_string().as_str() {
+                "Service not found" => Err(not_found().detail("Service not found").build()),
+                msg if msg.contains("Upgrade not implemented") => {
+                    Err(bad_request().detail(msg).build())
+                }
+                _ => Err(internal_server_error()
+                    .detail(format!("Failed to upgrade service: {}", e))
+                    .build()),
+            },
         },
     }
 }
@@ -1212,8 +1214,8 @@ async fn start_service(
                         crate::services::ExternalServiceError::UpgradeInProgress { .. } => {
                             Err(conflict().detail(e.to_string()).build())
                         }
-                        _ if e.to_string() == "Service not found" => {
-                            Err(not_found().detail("Service not found").build())
+                        crate::services::ExternalServiceError::ServiceNotFound { .. } => {
+                            Err(not_found().detail(e.to_string()).build())
                         }
                         _ => Err(internal_server_error()
                             .detail(format!("Failed to start service: {}", e))

--- a/crates/temps-providers/src/handlers/handlers.rs
+++ b/crates/temps-providers/src/handlers/handlers.rs
@@ -715,8 +715,14 @@ async fn upgrade_service(
             crate::services::ExternalServiceError::UpgradeRejected { .. } => {
                 Err(bad_request().detail(e.to_string()).build())
             }
+            // Typed match: `ServiceNotFound` displays as "Service {id} not
+            // found", so the previous `e.to_string() == "Service not found"`
+            // arm was dead and a missing service fell through to 500 instead
+            // of 404. Mirrors the same fix already made in `start_service`.
+            crate::services::ExternalServiceError::ServiceNotFound { .. } => {
+                Err(not_found().detail(e.to_string()).build())
+            }
             _ => match e.to_string().as_str() {
-                "Service not found" => Err(not_found().detail("Service not found").build()),
                 msg if msg.contains("Upgrade not implemented") => {
                     Err(bad_request().detail(msg).build())
                 }

--- a/crates/temps-providers/src/handlers/handlers.rs
+++ b/crates/temps-providers/src/handlers/handlers.rs
@@ -12,7 +12,9 @@ use axum::{
 use temps_auth::RequireAuth;
 use temps_auth::{deny_deployment_token, permission_guard, project_scope_guard};
 use temps_core::{
-    error_builder::{bad_request, forbidden, internal_server_error, not_found, ErrorBuilder},
+    error_builder::{
+        bad_request, conflict, forbidden, internal_server_error, not_found, ErrorBuilder,
+    },
     problemdetails::Problem,
 };
 use tracing::{error, info};
@@ -1155,6 +1157,7 @@ async fn list_service_health_statuses(
     responses(
         (status = 200, description = "Service started successfully", body = ExternalServiceInfo),
         (status = 404, description = "Service not found"),
+        (status = 409, description = "A Postgres major upgrade is in progress for this service"),
         (status = 500, description = "Internal server error")
     ),
     params(
@@ -1202,8 +1205,13 @@ async fn start_service(
                 }
                 Err(e) => {
                     error!("Failed to start service: {}", e);
-                    match e.to_string().as_str() {
-                        "Service not found" => Err(not_found().detail("Service not found").build()),
+                    match e {
+                        crate::services::ExternalServiceError::UpgradeInProgress { .. } => {
+                            Err(conflict().detail(e.to_string()).build())
+                        }
+                        _ if e.to_string() == "Service not found" => {
+                            Err(not_found().detail("Service not found").build())
+                        }
                         _ => Err(internal_server_error()
                             .detail(format!("Failed to start service: {}", e))
                             .build()),

--- a/crates/temps-providers/src/postgres_lifecycle.rs
+++ b/crates/temps-providers/src/postgres_lifecycle.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use bollard::Docker;
-use futures::TryStreamExt;
+use futures::{StreamExt, TryStreamExt};
 use sea_orm::{ActiveModelTrait, ActiveValue::Set, DatabaseConnection, EntityTrait};
 use temps_core::EncryptionService;
 use temps_entities::external_services;
@@ -85,6 +85,229 @@ impl PostgresLifecycleAdapter {
             .parse::<u32>()
             .map_err(|e| format!("bad version in '{}': {}", image, e))?;
         Ok(format!("/var/lib/postgresql/{}/docker", version))
+    }
+
+    fn shell_escape(s: &str) -> String {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
+
+    fn sql_string_literal(s: &str) -> String {
+        format!("'{}'", s.replace('\'', "''"))
+    }
+
+    async fn exec_in_container(
+        &self,
+        container_name: &str,
+        cmd: Vec<String>,
+        env: Option<Vec<String>>,
+    ) -> Result<(Option<i64>, String), String> {
+        let exec = self
+            .docker
+            .create_exec(
+                container_name,
+                bollard::models::ExecConfig {
+                    cmd: Some(cmd),
+                    env,
+                    attach_stdout: Some(true),
+                    attach_stderr: Some(true),
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(|e| format!("create_exec({}) failed: {}", container_name, e))?;
+
+        let mut output_text = String::new();
+        if let Ok(bollard::exec::StartExecResults::Attached { mut output, .. }) =
+            self.docker.start_exec(&exec.id, None).await
+        {
+            while let Some(chunk) = output.next().await {
+                match chunk {
+                    Ok(chunk) => output_text.push_str(&chunk.to_string()),
+                    Err(e) => output_text.push_str(&format!("<exec output error: {}>", e)),
+                }
+            }
+        }
+
+        let inspect = self
+            .docker
+            .inspect_exec(&exec.id)
+            .await
+            .map_err(|e| format!("inspect_exec({}) failed: {}", container_name, e))?;
+        Ok((inspect.exit_code, output_text))
+    }
+
+    async fn container_logs(&self, container_name: &str) -> String {
+        self.docker
+            .logs(
+                container_name,
+                Some(
+                    bollard::query_parameters::LogsOptionsBuilder::new()
+                        .stdout(true)
+                        .stderr(true)
+                        .build(),
+                ),
+            )
+            .try_collect::<Vec<_>>()
+            .await
+            .map(|v| v.into_iter().map(|c| c.to_string()).collect::<String>())
+            .unwrap_or_else(|e| format!("<failed to read logs: {}>", e))
+    }
+
+    async fn wait_for_psql_database(
+        &self,
+        container_name: &str,
+        cfg: &PostgresConfig,
+        database: &str,
+        timeout: Duration,
+    ) -> Result<(), String> {
+        let deadline = Instant::now() + timeout;
+        let mut last_exit = None;
+        let mut last_output = String::new();
+        while Instant::now() < deadline {
+            let result = self
+                .exec_in_container(
+                    container_name,
+                    vec![
+                        "psql".to_string(),
+                        "-v".to_string(),
+                        "ON_ERROR_STOP=1".to_string(),
+                        "-U".to_string(),
+                        cfg.username.clone(),
+                        "-d".to_string(),
+                        database.to_string(),
+                        "-tAc".to_string(),
+                        "SELECT 1".to_string(),
+                    ],
+                    Some(vec![format!("PGPASSWORD={}", cfg.password)]),
+                )
+                .await;
+
+            if let Ok((exit_code, output)) = result {
+                last_exit = exit_code;
+                last_output = output;
+                if exit_code == Some(0) {
+                    return Ok(());
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+
+        let logs = self.container_logs(container_name).await;
+        Err(format!(
+            "container '{}' failed psql readiness for database '{}' within {}s \
+             (last exit={:?}, output={}):\n{}",
+            container_name,
+            database,
+            timeout.as_secs(),
+            last_exit,
+            last_output.trim(),
+            logs
+        ))
+    }
+
+    async fn wait_for_container_healthy(
+        &self,
+        container_name: &str,
+        timeout: Duration,
+    ) -> Result<(), String> {
+        let deadline = Instant::now() + timeout;
+        let mut last_state = String::new();
+        let mut last_health = String::new();
+
+        while Instant::now() < deadline {
+            let inspect = self
+                .docker
+                .inspect_container(
+                    container_name,
+                    None::<bollard::query_parameters::InspectContainerOptions>,
+                )
+                .await
+                .map_err(|e| format!("inspect_container({}) failed: {}", container_name, e))?;
+
+            if let Some(state) = inspect.state {
+                last_state = state
+                    .status
+                    .map(|status| status.to_string())
+                    .unwrap_or_default();
+                last_health = state
+                    .health
+                    .and_then(|health| health.status)
+                    .map(|status| status.to_string())
+                    .unwrap_or_default();
+
+                if state.running == Some(false) || state.dead == Some(true) {
+                    let logs = self.container_logs(container_name).await;
+                    return Err(format!(
+                        "container '{}' stopped before becoming healthy \
+                         (state='{}', health='{}', exit={:?}, error={:?}):\n{}",
+                        container_name, last_state, last_health, state.exit_code, state.error, logs
+                    ));
+                }
+
+                if last_health == "healthy" {
+                    return Ok(());
+                }
+            }
+
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+
+        let logs = self.container_logs(container_name).await;
+        Err(format!(
+            "container '{}' did not become healthy within {}s \
+             (last state='{}', health='{}'):\n{}",
+            container_name,
+            timeout.as_secs(),
+            last_state,
+            last_health,
+            logs
+        ))
+    }
+
+    async fn ensure_database_exists(
+        &self,
+        container_name: &str,
+        cfg: &PostgresConfig,
+    ) -> Result<(), String> {
+        let sql = format!(
+            "SELECT 1 FROM pg_database WHERE datname = {}",
+            Self::sql_string_literal(&cfg.database)
+        );
+        let cmd = format!(
+            "set -e; \
+             if psql -v ON_ERROR_STOP=1 -U {user} -d postgres -tAc {sql} | grep -q 1; then \
+               exit 0; \
+             fi; \
+             if createdb -U {user} {db} 2>/tmp/createdb.err; then \
+               exit 0; \
+             fi; \
+             psql -v ON_ERROR_STOP=1 -U {user} -d postgres -tAc {sql} | grep -q 1 \
+               || {{ cat /tmp/createdb.err >&2; exit 1; }}",
+            user = Self::shell_escape(&cfg.username),
+            sql = Self::shell_escape(&sql),
+            db = Self::shell_escape(&cfg.database),
+        );
+        let (exit_code, output) = self
+            .exec_in_container(
+                container_name,
+                vec!["sh".to_string(), "-lc".to_string(), cmd],
+                Some(vec![format!("PGPASSWORD={}", cfg.password)]),
+            )
+            .await?;
+
+        if exit_code == Some(0) {
+            Ok(())
+        } else {
+            let logs = self.container_logs(container_name).await;
+            Err(format!(
+                "failed to ensure database '{}' exists in '{}' (exit={:?}, output={}):\n{}",
+                cfg.database,
+                container_name,
+                exit_code,
+                output.trim(),
+                logs
+            ))
+        }
     }
 }
 
@@ -293,51 +516,21 @@ impl PostgresContainerLifecycle for PostgresLifecycleAdapter {
             .await
             .map_err(|e| format!("start_container({}) failed: {}", container_name, e))?;
 
-        // Block until Postgres accepts connections.
-        let deadline = Instant::now() + Duration::from_secs(120);
-        loop {
-            if Instant::now() > deadline {
-                return Err(format!(
-                    "container '{}' failed to become ready within 120s",
-                    container_name
-                ));
-            }
-            let exec = self
-                .docker
-                .create_exec(
-                    &container_name,
-                    bollard::models::ExecConfig {
-                        cmd: Some(vec![
-                            "pg_isready".to_string(),
-                            "-U".to_string(),
-                            cfg.username.clone(),
-                            "-d".to_string(),
-                            cfg.database.clone(),
-                        ]),
-                        attach_stdout: Some(true),
-                        attach_stderr: Some(true),
-                        ..Default::default()
-                    },
-                )
-                .await;
-            if let Ok(id) = exec {
-                // Drain the attached stream before inspect_exec, otherwise stdout
-                // backpressure stalls the exec and exit_code never surfaces.
-                use futures::StreamExt;
-                if let Ok(bollard::exec::StartExecResults::Attached { mut output, .. }) =
-                    self.docker.start_exec(&id.id, None).await
-                {
-                    while output.next().await.is_some() {}
-                }
-                let inspect = self.docker.inspect_exec(&id.id).await;
-                if let Ok(info) = inspect {
-                    if info.exit_code == Some(0) {
-                        break;
-                    }
-                }
-            }
-            tokio::time::sleep(Duration::from_millis(500)).await;
-        }
+        // Block until Docker's healthcheck sees the final post-entrypoint
+        // server, then make sure the configured application database exists.
+        // A transient init server can accept SQL briefly before shutdown.
+        self.wait_for_container_healthy(&container_name, Duration::from_secs(120))
+            .await?;
+        self.wait_for_psql_database(&container_name, &cfg, "postgres", Duration::from_secs(120))
+            .await?;
+        self.ensure_database_exists(&container_name, &cfg).await?;
+        self.wait_for_psql_database(
+            &container_name,
+            &cfg,
+            &cfg.database,
+            Duration::from_secs(30),
+        )
+        .await?;
 
         Ok(())
     }

--- a/crates/temps-providers/src/postgres_lifecycle.rs
+++ b/crates/temps-providers/src/postgres_lifecycle.rs
@@ -91,6 +91,18 @@ impl PostgresLifecycleAdapter {
         format!("'{}'", s.replace('\'', "'\\''"))
     }
 
+    /// Builds the `pg_isready` healthcheck command pinned to the configured
+    /// username/database. Without `-d`, `pg_isready` (via libpq) defaults the
+    /// target database to the username, so any service where `database !=
+    /// username` would log a FATAL on every healthcheck tick.
+    fn postgres_healthcheck_cmd(username: &str, database: &str) -> String {
+        format!(
+            "pg_isready -U {} -d {}",
+            Self::shell_escape(username),
+            Self::shell_escape(database)
+        )
+    }
+
     fn sql_string_literal(s: &str) -> String {
         format!("'{}'", s.replace('\'', "''"))
     }
@@ -473,11 +485,7 @@ impl PostgresContainerLifecycle for PostgresLifecycleAdapter {
                     // reports healthy (the server did respond), but the
                     // container's logs fill up with noise for its entire
                     // lifetime. Pin -d explicitly to the configured database.
-                    format!(
-                        "pg_isready -U {} -d {}",
-                        Self::shell_escape(&cfg.username),
-                        Self::shell_escape(&cfg.database)
-                    ),
+                    Self::postgres_healthcheck_cmd(&cfg.username, &cfg.database),
                 ]),
                 interval: Some(1_000_000_000),
                 timeout: Some(3_000_000_000),
@@ -589,5 +597,22 @@ impl PostgresContainerLifecycle for PostgresLifecycleAdapter {
             .await
             .map_err(|e| format!("update service {} config: {}", service_id, e))?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PostgresLifecycleAdapter;
+
+    #[test]
+    fn healthcheck_cmd_pins_database_when_it_differs_from_username() {
+        let cmd = PostgresLifecycleAdapter::postgres_healthcheck_cmd("appuser", "appdb");
+        assert_eq!(cmd, "pg_isready -U 'appuser' -d 'appdb'");
+    }
+
+    #[test]
+    fn healthcheck_cmd_escapes_single_quotes_in_username_and_database() {
+        let cmd = PostgresLifecycleAdapter::postgres_healthcheck_cmd("a'user", "a'db");
+        assert_eq!(cmd, "pg_isready -U 'a'\\''user' -d 'a'\\''db'");
     }
 }

--- a/crates/temps-providers/src/postgres_lifecycle.rs
+++ b/crates/temps-providers/src/postgres_lifecycle.rs
@@ -308,33 +308,26 @@ impl PostgresLifecycleAdapter {
         // readiness phase on that one-shot race.
         let timeout = Duration::from_secs(30);
         let deadline = Instant::now() + timeout;
-        let mut last_exit = None;
-        let mut last_output = String::new();
-        loop {
-            match self
+        let (last_exit, last_output) = loop {
+            let attempt = self
                 .exec_in_container(
                     container_name,
                     vec!["sh".to_string(), "-lc".to_string(), cmd.clone()],
                     Some(vec![format!("PGPASSWORD={}", cfg.password)]),
                 )
-                .await
-            {
-                Ok((exit_code, _)) if exit_code == Some(0) => return Ok(()),
-                Ok((exit_code, output)) => {
-                    last_exit = exit_code;
-                    last_output = output;
-                }
-                Err(e) => {
-                    last_exit = None;
-                    last_output = e;
-                }
-            }
+                .await;
+
+            let (exit_code, output) = match attempt {
+                Ok((Some(0), _)) => return Ok(()),
+                Ok((exit_code, output)) => (exit_code, output),
+                Err(e) => (None, e),
+            };
 
             if Instant::now() >= deadline {
-                break;
+                break (exit_code, output);
             }
             tokio::time::sleep(Duration::from_millis(500)).await;
-        }
+        };
 
         let logs = self.container_logs(container_name).await;
         Err(format!(

--- a/crates/temps-providers/src/postgres_lifecycle.rs
+++ b/crates/temps-providers/src/postgres_lifecycle.rs
@@ -465,7 +465,19 @@ impl PostgresContainerLifecycle for PostgresLifecycleAdapter {
             healthcheck: Some(bollard::models::HealthConfig {
                 test: Some(vec![
                     "CMD-SHELL".to_string(),
-                    format!("pg_isready -U {}", cfg.username),
+                    // Without -d, pg_isready (via libpq) defaults the target
+                    // database to the username. For any service where
+                    // database != username, that's a nonexistent database,
+                    // so every healthcheck tick (interval=1s) logs a FATAL
+                    // "database does not exist" forever — pg_isready still
+                    // reports healthy (the server did respond), but the
+                    // container's logs fill up with noise for its entire
+                    // lifetime. Pin -d explicitly to the configured database.
+                    format!(
+                        "pg_isready -U {} -d {}",
+                        Self::shell_escape(&cfg.username),
+                        Self::shell_escape(&cfg.database)
+                    ),
                 ]),
                 interval: Some(1_000_000_000),
                 timeout: Some(3_000_000_000),

--- a/crates/temps-providers/src/postgres_lifecycle.rs
+++ b/crates/temps-providers/src/postgres_lifecycle.rs
@@ -19,7 +19,9 @@ use sea_orm::{ActiveModelTrait, ActiveValue::Set, DatabaseConnection, EntityTrai
 use temps_core::EncryptionService;
 use temps_entities::external_services;
 
-use crate::externalsvc::postgres::{PostgresConfig, PostgresInputConfig};
+use crate::externalsvc::postgres::{
+    postgres_healthcheck_cmd, shell_escape, PostgresConfig, PostgresInputConfig,
+};
 use crate::externalsvc::postgres_upgrade::{PostgresConnection, PostgresContainerLifecycle};
 use crate::services::ExternalServiceManager;
 use crate::utils::ensure_network_exists;
@@ -85,22 +87,6 @@ impl PostgresLifecycleAdapter {
             .parse::<u32>()
             .map_err(|e| format!("bad version in '{}': {}", image, e))?;
         Ok(format!("/var/lib/postgresql/{}/docker", version))
-    }
-
-    fn shell_escape(s: &str) -> String {
-        format!("'{}'", s.replace('\'', "'\\''"))
-    }
-
-    /// Builds the `pg_isready` healthcheck command pinned to the configured
-    /// username/database. Without `-d`, `pg_isready` (via libpq) defaults the
-    /// target database to the username, so any service where `database !=
-    /// username` would log a FATAL on every healthcheck tick.
-    fn postgres_healthcheck_cmd(username: &str, database: &str) -> String {
-        format!(
-            "pg_isready -U {} -d {}",
-            Self::shell_escape(username),
-            Self::shell_escape(database)
-        )
     }
 
     fn sql_string_literal(s: &str) -> String {
@@ -225,16 +211,30 @@ impl PostgresLifecycleAdapter {
         let deadline = Instant::now() + timeout;
         let mut last_state = String::new();
         let mut last_health = String::new();
+        let mut last_error = String::new();
 
         while Instant::now() < deadline {
-            let inspect = self
+            let inspect = match self
                 .docker
                 .inspect_container(
                     container_name,
                     None::<bollard::query_parameters::InspectContainerOptions>,
                 )
                 .await
-                .map_err(|e| format!("inspect_container({}) failed: {}", container_name, e))?;
+            {
+                Ok(inspect) => inspect,
+                Err(e) => {
+                    // Tolerate transient inspect errors (daemon hiccup, a
+                    // brief connection reset right after start_container)
+                    // the same way wait_for_psql_database tolerates
+                    // transient exec errors above -- retry until the
+                    // deadline instead of aborting the whole readiness wait
+                    // on one hiccup.
+                    last_error = e.to_string();
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                    continue;
+                }
+            };
 
             if let Some(state) = inspect.state {
                 last_state = state
@@ -267,11 +267,12 @@ impl PostgresLifecycleAdapter {
         let logs = self.container_logs(container_name).await;
         Err(format!(
             "container '{}' did not become healthy within {}s \
-             (last state='{}', health='{}'):\n{}",
+             (last state='{}', health='{}', last inspect error='{}'):\n{}",
             container_name,
             timeout.as_secs(),
             last_state,
             last_health,
+            last_error,
             logs
         ))
     }
@@ -295,31 +296,57 @@ impl PostgresLifecycleAdapter {
              fi; \
              psql -v ON_ERROR_STOP=1 -U {user} -d postgres -tAc {sql} | grep -q 1 \
                || {{ cat /tmp/createdb.err >&2; exit 1; }}",
-            user = Self::shell_escape(&cfg.username),
-            sql = Self::shell_escape(&sql),
-            db = Self::shell_escape(&cfg.database),
+            user = shell_escape(&cfg.username),
+            sql = shell_escape(&sql),
+            db = shell_escape(&cfg.database),
         );
-        let (exit_code, output) = self
-            .exec_in_container(
-                container_name,
-                vec!["sh".to_string(), "-lc".to_string(), cmd],
-                Some(vec![format!("PGPASSWORD={}", cfg.password)]),
-            )
-            .await?;
+        // A single exec here can race the postgres entrypoint's own
+        // transient init-phase server: `wait_for_psql_database` above only
+        // requires one successful `SELECT 1`, which can land against that
+        // temporary server moments before it's replaced by the final one.
+        // Retry for a short bounded window instead of failing the whole
+        // readiness phase on that one-shot race.
+        let timeout = Duration::from_secs(30);
+        let deadline = Instant::now() + timeout;
+        let mut last_exit = None;
+        let mut last_output = String::new();
+        loop {
+            match self
+                .exec_in_container(
+                    container_name,
+                    vec!["sh".to_string(), "-lc".to_string(), cmd.clone()],
+                    Some(vec![format!("PGPASSWORD={}", cfg.password)]),
+                )
+                .await
+            {
+                Ok((exit_code, _)) if exit_code == Some(0) => return Ok(()),
+                Ok((exit_code, output)) => {
+                    last_exit = exit_code;
+                    last_output = output;
+                }
+                Err(e) => {
+                    last_exit = None;
+                    last_output = e;
+                }
+            }
 
-        if exit_code == Some(0) {
-            Ok(())
-        } else {
-            let logs = self.container_logs(container_name).await;
-            Err(format!(
-                "failed to ensure database '{}' exists in '{}' (exit={:?}, output={}):\n{}",
-                cfg.database,
-                container_name,
-                exit_code,
-                output.trim(),
-                logs
-            ))
+            if Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
         }
+
+        let logs = self.container_logs(container_name).await;
+        Err(format!(
+            "failed to ensure database '{}' exists in '{}' within {}s \
+             (last exit={:?}, output={}):\n{}",
+            cfg.database,
+            container_name,
+            timeout.as_secs(),
+            last_exit,
+            last_output.trim(),
+            logs
+        ))
     }
 }
 
@@ -485,7 +512,7 @@ impl PostgresContainerLifecycle for PostgresLifecycleAdapter {
                     // reports healthy (the server did respond), but the
                     // container's logs fill up with noise for its entire
                     // lifetime. Pin -d explicitly to the configured database.
-                    Self::postgres_healthcheck_cmd(&cfg.username, &cfg.database),
+                    postgres_healthcheck_cmd(&cfg.username, &cfg.database),
                 ]),
                 interval: Some(1_000_000_000),
                 timeout: Some(3_000_000_000),
@@ -600,19 +627,7 @@ impl PostgresContainerLifecycle for PostgresLifecycleAdapter {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::PostgresLifecycleAdapter;
-
-    #[test]
-    fn healthcheck_cmd_pins_database_when_it_differs_from_username() {
-        let cmd = PostgresLifecycleAdapter::postgres_healthcheck_cmd("appuser", "appdb");
-        assert_eq!(cmd, "pg_isready -U 'appuser' -d 'appdb'");
-    }
-
-    #[test]
-    fn healthcheck_cmd_escapes_single_quotes_in_username_and_database() {
-        let cmd = PostgresLifecycleAdapter::postgres_healthcheck_cmd("a'user", "a'db");
-        assert_eq!(cmd, "pg_isready -U 'a'\\''user' -d 'a'\\''db'");
-    }
-}
+// `postgres_healthcheck_cmd`/`shell_escape` are shared with
+// `externalsvc::postgres`, which owns their unit tests
+// (`healthcheck_cmd_pins_database_when_it_differs_from_username`,
+// `healthcheck_cmd_escapes_single_quotes_in_username_and_database`).

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -9487,6 +9487,145 @@ mod tests {
         (manager, test_db)
     }
 
+    /// The core safety guard: only PENDING/RUNNING/ROLLING_BACK upgrade rows
+    /// block a start/reconcile; terminal statuses must NOT. A silent regression
+    /// in the status filter reopens the concurrent-container-mutation-vs-upgrade
+    /// race the guard exists to prevent. (Docker-gated only because the test DB
+    /// itself needs a container; the guard logic under test is pure Sea-ORM.)
+    #[cfg(feature = "docker-tests")]
+    #[tokio::test]
+    async fn ensure_no_active_upgrade_blocks_only_active_statuses() {
+        use crate::externalsvc::postgres_upgrade::status;
+        use sea_orm::{ActiveModelTrait, ActiveValue::Set};
+        use temps_entities::{postgres_major_upgrades, users};
+
+        let (manager, test_db) = setup_test_manager().await;
+        let port = get_unused_port();
+        let name = format!("guard-test-{}", chrono::Utc::now().timestamp_millis());
+        let mut params = HashMap::new();
+        params.insert(
+            "database".to_string(),
+            JsonValue::String("appdb".to_string()),
+        );
+        params.insert(
+            "username".to_string(),
+            JsonValue::String("appuser".to_string()),
+        );
+        params.insert(
+            "password".to_string(),
+            JsonValue::String("appsecret".to_string()),
+        );
+        params.insert("port".to_string(), JsonValue::String(port.to_string()));
+        params.insert(
+            "docker_image".to_string(),
+            JsonValue::String("postgres:17-bookworm".to_string()),
+        );
+        let svc = manager
+            .create_service(CreateExternalServiceRequest {
+                name,
+                service_type: ServiceType::Postgres,
+                version: Some("17".to_string()),
+                parameters: params,
+                node_id: None,
+                topology: "standalone".to_string(),
+                members: Vec::new(),
+            })
+            .await
+            .expect("create service");
+
+        let result = async {
+            // No upgrade row -> allowed.
+            manager
+                .ensure_no_active_upgrade(svc.id)
+                .await
+                .map_err(|e| format!("no upgrade row should allow: {e}"))?;
+
+            let now = chrono::Utc::now();
+            // A user row to satisfy postgres_major_upgrades.created_by -> users.id.
+            let user = users::ActiveModel {
+                name: Set("Guard Test".to_string()),
+                email: Set(format!(
+                    "guard-user-{}@test.local",
+                    now.timestamp_nanos_opt().unwrap_or(0)
+                )),
+                email_verified: Set(true),
+                mfa_enabled: Set(false),
+                created_at: Set(now),
+                updated_at: Set(now),
+                ..Default::default()
+            }
+            .insert(test_db.db.as_ref())
+            .await
+            .map_err(|e| format!("insert user: {e}"))?;
+
+            let row = postgres_major_upgrades::ActiveModel {
+                service_id: Set(svc.id),
+                from_version: Set("17".to_string()),
+                to_version: Set("18".to_string()),
+                from_image: Set("postgres:17-bookworm".to_string()),
+                to_image: Set("postgres:18-bookworm".to_string()),
+                status: Set(status::PENDING.to_string()),
+                phase: Set(status::PENDING.to_string()),
+                pre_upgrade_backup_id: Set(None),
+                log_id: Set(format!("guard-{}", svc.id)),
+                rollback_volume_name: Set(None),
+                rollback_volume_expires_at: Set(None),
+                error_message: Set(None),
+                attempt: Set(1),
+                started_at: Set(None),
+                finished_at: Set(None),
+                created_by: Set(user.id),
+                created_at: Set(now),
+                ..Default::default()
+            }
+            .insert(test_db.db.as_ref())
+            .await
+            .map_err(|e| format!("insert upgrade row: {e}"))?;
+
+            for st in [status::PENDING, status::RUNNING, status::ROLLING_BACK] {
+                let mut am: postgres_major_upgrades::ActiveModel = row.clone().into();
+                am.status = Set(st.to_string());
+                am.update(test_db.db.as_ref())
+                    .await
+                    .map_err(|e| format!("update status {st}: {e}"))?;
+                match manager.ensure_no_active_upgrade(svc.id).await {
+                    Err(ExternalServiceError::UpgradeInProgress { .. }) => {}
+                    other => return Err(format!("status {st} must block, got {other:?}")),
+                }
+            }
+
+            for st in [
+                status::FAILED,
+                status::COMPLETED,
+                status::CANCELLED,
+                status::ROLLED_BACK,
+            ] {
+                let mut am: postgres_major_upgrades::ActiveModel = row.clone().into();
+                am.status = Set(st.to_string());
+                am.update(test_db.db.as_ref())
+                    .await
+                    .map_err(|e| format!("update status {st}: {e}"))?;
+                manager
+                    .ensure_no_active_upgrade(svc.id)
+                    .await
+                    .map_err(|e| format!("terminal status {st} must not block: {e}"))?;
+            }
+
+            // A different service id is unaffected.
+            manager
+                .ensure_no_active_upgrade(svc.id + 100_000)
+                .await
+                .map_err(|e| format!("unrelated service must not block: {e}"))?;
+            Ok::<(), String>(())
+        }
+        .await;
+
+        let _ = manager.delete_service(svc.id).await;
+        if let Err(e) = result {
+            panic!("ensure_no_active_upgrade guard test failed: {e}");
+        }
+    }
+
     #[cfg(feature = "docker-tests")]
     #[tokio::test]
     async fn test_create_postgres_service() {

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use temps_entities::{
     external_service_backups, external_service_health_checks, external_services, nodes,
-    project_services, projects, service_members,
+    postgres_major_upgrades, project_services, projects, service_members,
 };
 use thiserror::Error;
 use tracing::{debug, error, info, warn};
@@ -75,6 +75,16 @@ pub enum ExternalServiceError {
 
     #[error("Failed to start service {id}: {reason}")]
     StartFailed { id: i32, reason: String },
+
+    #[error(
+        "Service {id} has a major upgrade in progress (upgrade_id={upgrade_id}, phase={phase}); \
+         refusing to start/reconcile the container until it completes or is cancelled"
+    )]
+    UpgradeInProgress {
+        id: i32,
+        upgrade_id: i32,
+        phase: String,
+    },
 
     #[error("Failed to stop service {id}: {reason}")]
     StopFailed { id: i32, reason: String },
@@ -6707,10 +6717,50 @@ echo "[restore] Pre-seed complete"
             .collect()
     }
 
+    /// Guard against reconciling/(re)starting a container while a Postgres
+    /// major upgrade is actively working on it. The upgrade orchestrator
+    /// stops the container and deletes/recreates its volumes across
+    /// several phases (`postgres_upgrade.rs`); a concurrent `start()` call
+    /// (health-check-triggered restart, operator restart, startup
+    /// reconcile) would recreate the container against an implicitly
+    /// re-created empty volume, silently diverging from the volume the
+    /// orchestrator is dumping/restoring — accepting writes that never
+    /// make it into the upgraded database.
+    ///
+    /// Only PENDING/RUNNING rows are active; FAILED/COMPLETED/CANCELLED/
+    /// ROLLED_BACK are terminal and don't block a start.
+    async fn ensure_no_active_upgrade(&self, service_id: i32) -> Result<(), ExternalServiceError> {
+        use crate::externalsvc::postgres_upgrade::status;
+
+        let active = postgres_major_upgrades::Entity::find()
+            .filter(postgres_major_upgrades::Column::ServiceId.eq(service_id))
+            .filter(
+                postgres_major_upgrades::Column::Status
+                    .eq(status::PENDING)
+                    .or(postgres_major_upgrades::Column::Status.eq(status::RUNNING)),
+            )
+            .one(self.db.as_ref())
+            .await
+            .map_err(|e| ExternalServiceError::DatabaseError {
+                reason: format!("failed to check for active major upgrade: {}", e),
+            })?;
+
+        if let Some(upgrade) = active {
+            return Err(ExternalServiceError::UpgradeInProgress {
+                id: service_id,
+                upgrade_id: upgrade.id,
+                phase: upgrade.phase,
+            });
+        }
+
+        Ok(())
+    }
+
     pub async fn start_service(
         &self,
         service_id: i32,
     ) -> Result<ExternalServiceInfo, ExternalServiceError> {
+        self.ensure_no_active_upgrade(service_id).await?;
         let service = self.get_service(service_id).await?;
         let service_type_enum = ServiceType::from_str(&service.service_type).map_err(|_| {
             ExternalServiceError::InvalidServiceType {

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -44,6 +44,15 @@ pub enum ExternalServiceError {
     #[error("Failed to initialize service {id}: {reason}")]
     InitializationFailed { id: i32, reason: String },
 
+    /// A same-version `upgrade()` call was rejected before touching the
+    /// container (unsupported downgrade, or a major-version change that
+    /// must go through the dedicated upgrade orchestrator instead). Client
+    /// error, not a server failure -- kept distinct from
+    /// `InitializationFailed` so handlers can map it to 400 without
+    /// string-matching the message.
+    #[error("Upgrade rejected for service {id}: {reason}")]
+    UpgradeRejected { id: i32, reason: String },
+
     #[error("Failed to encrypt parameter '{param_name}' for service {service_id}: {reason}")]
     EncryptionFailed {
         service_id: i32,
@@ -1481,6 +1490,7 @@ impl ExternalServiceManager {
             "Upgrading service {} to Docker image {}",
             service_id, new_docker_image
         );
+        self.ensure_no_active_upgrade(service_id).await?;
 
         let service = self.get_service(service_id).await?;
         let old_parameters = self.get_service_parameters(service_id).await?;
@@ -1535,13 +1545,29 @@ impl ExternalServiceManager {
         let service_instance =
             self.create_service_instance(service.name.clone(), service_type_enum);
 
-        // Call the upgrade method on the service instance
+        // Call the upgrade method on the service instance. `upgrade()`
+        // returns `anyhow::Result` (shared across every provider), so a
+        // same-version rejection is downcast here -- before the error is
+        // stringified below -- into a typed `UpgradeRejected` variant the
+        // handler can match on directly instead of substring-matching the
+        // message text.
         service_instance
             .upgrade(old_config, new_config.clone())
             .await
-            .map_err(|e| ExternalServiceError::InitializationFailed {
-                id: service_id,
-                reason: format!("Upgrade failed: {}", e),
+            .map_err(|e| {
+                if let Some(rejected) =
+                    e.downcast_ref::<crate::externalsvc::postgres::PostgresUpgradeRejected>()
+                {
+                    ExternalServiceError::UpgradeRejected {
+                        id: service_id,
+                        reason: rejected.to_string(),
+                    }
+                } else {
+                    ExternalServiceError::InitializationFailed {
+                        id: service_id,
+                        reason: format!("Upgrade failed: {}", e),
+                    }
+                }
             })?;
 
         // Update the service configuration in the database with the new Docker image
@@ -3936,6 +3962,7 @@ echo "[restore] Pre-seed complete"
 
     async fn initialize_service(&self, service_id: i32) -> Result<(), ExternalServiceError> {
         info!("Initializing service: {}", service_id);
+        self.ensure_no_active_upgrade(service_id).await?;
         let service = self.get_service(service_id).await?;
         let parameters = self.get_service_parameters(service_id).await?;
         let service_type_enum = ServiceType::from_str(&service.service_type).map_err(|_| {
@@ -6717,18 +6744,24 @@ echo "[restore] Pre-seed complete"
             .collect()
     }
 
-    /// Guard against reconciling/(re)starting a container while a Postgres
-    /// major upgrade is actively working on it. The upgrade orchestrator
-    /// stops the container and deletes/recreates its volumes across
-    /// several phases (`postgres_upgrade.rs`); a concurrent `start()` call
-    /// (health-check-triggered restart, operator restart, startup
-    /// reconcile) would recreate the container against an implicitly
-    /// re-created empty volume, silently diverging from the volume the
-    /// orchestrator is dumping/restoring — accepting writes that never
-    /// make it into the upgraded database.
+    /// Guard against reconciling/(re)starting or recreating a container
+    /// while a Postgres major upgrade (or its rollback) is actively working
+    /// on it. The upgrade orchestrator stops the container and
+    /// deletes/recreates its volumes across several phases
+    /// (`postgres_upgrade.rs`), and `rollback()` does the same in reverse;
+    /// a concurrent container mutation (start, reconcile, resource-limit
+    /// recreate, a same-version image swap) would recreate the container
+    /// against an implicitly re-created empty volume, silently diverging
+    /// from the volume the orchestrator/rollback is dumping/restoring —
+    /// accepting writes that never make it into the upgraded database.
     ///
-    /// Only PENDING/RUNNING rows are active; FAILED/COMPLETED/CANCELLED/
-    /// ROLLED_BACK are terminal and don't block a start.
+    /// Called from every entry point that stops/recreates a service's
+    /// container: `start_service`, `initialize_service` (covers
+    /// `update_service`, service creation, and the resource-limit recreate
+    /// path), and the legacy same-version `upgrade_service`.
+    ///
+    /// PENDING/RUNNING/ROLLING_BACK rows are active; FAILED/COMPLETED/
+    /// CANCELLED/ROLLED_BACK are terminal and don't block a start.
     async fn ensure_no_active_upgrade(&self, service_id: i32) -> Result<(), ExternalServiceError> {
         use crate::externalsvc::postgres_upgrade::status;
 
@@ -6737,7 +6770,8 @@ echo "[restore] Pre-seed complete"
             .filter(
                 postgres_major_upgrades::Column::Status
                     .eq(status::PENDING)
-                    .or(postgres_major_upgrades::Column::Status.eq(status::RUNNING)),
+                    .or(postgres_major_upgrades::Column::Status.eq(status::RUNNING))
+                    .or(postgres_major_upgrades::Column::Status.eq(status::ROLLING_BACK)),
             )
             .one(self.db.as_ref())
             .await


### PR DESCRIPTION
## Summary

Extracts the Postgres major-upgrade hardening that was originally discovered while validating MariaDB PITR E2E coverage in #138.

This PR keeps the scope to Postgres upgrade correctness only:

- seed real `s3_sources` and `backups` rows in the Postgres upgrade test fixture so `postgres_major_upgrades.pre_upgrade_backup_id` satisfies the real FK constraint;
- wait for a usable Postgres database with `psql SELECT 1`, not just Docker health / `pg_isready`, and create the configured DB if entrypoint initialization has not finished that race yet;
- require snapshot and rollback handoffs to remove stale live volumes before recreating them, so pg18 containers cannot reopen pg17-era `PGDATA` after a supposedly clean copy;
- make volume copy sidecars explicit, wait for their removal, and fail with context when Docker cannot release them.

## Why this is required

The pg17 to pg18 upgrade path depends on a clean data-volume handoff. During CI validation, the old behavior could leave the live volume or copy sidecar around and then start the target pg18 container against stale pg17 data. That produces misleading readiness states and can make an upgrade appear to advance while the target database is not actually usable.

The fixture update is also required because the tests now run against the real schema: the fake backup id used by the upgrade tests violated the `backups` FK once the orchestrator persisted it to `postgres_major_upgrades.pre_upgrade_backup_id`.

Together these changes make the Postgres upgrade tests exercise the real control-plane constraints and make the runtime upgrade path fail early instead of silently reusing incompatible data.

## Test Plan

This branch was rebased onto the latest `upstream/main` (clean rebase, no conflicts). Only `crates/temps-providers` is touched.

Local:

- `cargo fmt --all -- --check`
- `cargo check --lib -p temps-providers` — passes, no warnings
- `cargo test --lib -p temps-providers postgres` — `87 passed; 0 failed` (Docker-dependent bodies skip gracefully at runtime when Docker is unavailable, per repo policy)
- `cargo test -p temps-providers --features docker-tests --lib orchestrator_phase_new_container_completes_under_timeout -- --nocapture --test-threads=1` (passes locally; Docker-dependent body skipped because local Docker is unavailable)

CI (full suite, including Docker/E2E, runs against this branch's head `94be5343`):

- https://github.com/gotempsh/temps/actions/runs/28252083090 (Rust Tests)
