### PR TITLE
fix(ci): serialize heavy provider backup tests + dedupe port selection

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -321,13 +321,29 @@ jobs:
           - group: docker-providers
             # temps-providers with Docker tests enabled.
             # NOTE: orchestrator_* tests run in a dedicated `postgres-upgrades`
-            # group below (serial, long timeout, real pg17→pg18 containers).
+            # group, and *_backup_and_restore_to_s3 tests in a dedicated
+            # `docker-backups` group (both serial, long-running, container-heavy).
             # Skip them here so this group stays fast and parallel-safe.
             cargo_args: >-
               test --no-fail-fast --lib
               -p temps-providers --features docker-tests
             test_args: >-
               --skip orchestrator_
+              --skip backup_and_restore_to_s3
+          - group: docker-backups
+            # Heavyweight S3 backup/restore integration tests
+            # (test_{mongodb,postgres,redis,s3}_backup_and_restore_to_s3). Each
+            # spins up a MinIO container plus a service container and streams a
+            # real wal-g/mongodump backup, so running them in parallel saturates
+            # Docker and races for host ports (`port is already allocated`),
+            # causing 300s hangs. --test-threads=1 guarantees serial execution.
+            cargo_args: >-
+              test --no-fail-fast --lib
+              -p temps-providers --features docker-tests
+              backup_and_restore_to_s3
+            test_args: >-
+              --nocapture
+              --test-threads=1
           - group: postgres-upgrades
             # PostgreSQL major-version upgrade orchestrator integration tests.
             # Each test pulls pg17 + pg18 images and runs a real dump/restore,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 ### Fixed
--
+- **`docker-providers` CI no longer hangs/flakes under load.** The heavyweight
+  `test_{mongodb,postgres,redis,s3}_backup_and_restore_to_s3` tests each spin up
+  a MinIO container plus a service container and stream a real wal-g/mongodump
+  backup; running them in parallel saturated Docker and raced for host ports
+  (`Bind for 0.0.0.0:<port> failed: port is already allocated`), causing 300s
+  timeouts (most visibly the MongoDB backup step). They now run in a dedicated
+  serial `docker-backups` CI group (`--test-threads=1`), mirroring the existing
+  `postgres-upgrades` group, and are skipped from the parallel `docker-providers`
+  group.
+- **Host-port selection is less collision-prone.** The per-service
+  `find_available_port` helpers (mongodb/postgres/redis/s3/rustfs and
+  `parameter_strategies`) are consolidated into `externalsvc::port_util`, which
+  advances a process-wide offset so concurrent allocations diverge instead of all
+  landing on the same base port, and exposes a Docker-aware variant that skips
+  ports already published by running containers.
 
 
 ## [0.1.0-beta.38] - 2026-06-23

--- a/crates/temps-providers/src/externalsvc/mod.rs
+++ b/crates/temps-providers/src/externalsvc/mod.rs
@@ -7,6 +7,7 @@ use utoipa::ToSchema;
 pub mod cluster_role;
 pub mod exec_util;
 pub mod mongodb;
+pub mod port_util;
 pub mod postgres;
 pub mod postgres_cluster;
 pub mod postgres_role_reconciler;

--- a/crates/temps-providers/src/externalsvc/mongodb.rs
+++ b/crates/temps-providers/src/externalsvc/mongodb.rs
@@ -11,7 +11,6 @@ use schemars::JsonSchema;
 use sea_orm::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::net::TcpListener;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -225,13 +224,7 @@ pub fn generate_keyfile_content() -> String {
     STANDARD.encode(bytes)
 }
 
-fn is_port_available(port: u16) -> bool {
-    TcpListener::bind(("0.0.0.0", port)).is_ok()
-}
-
-fn find_available_port(start_port: u16) -> Option<u16> {
-    (start_port..start_port + 100).find(|&port| is_port_available(port))
-}
+use super::port_util::find_available_port;
 
 pub struct MongodbService {
     name: String,

--- a/crates/temps-providers/src/externalsvc/port_util.rs
+++ b/crates/temps-providers/src/externalsvc/port_util.rs
@@ -1,0 +1,124 @@
+//! Shared host-port selection helpers for Docker-backed services.
+//!
+//! Picking a free host port for a container is inherently racy: we can check
+//! that a port is bindable *now*, but Docker only binds it later when the
+//! container starts. Between those two moments a concurrent allocator can grab
+//! the same port, producing `Bind for 0.0.0.0:<port> failed: port is already
+//! allocated`. We saw this in CI when several `temps-providers` Docker tests
+//! created Postgres containers in parallel and all landed on 5433.
+//!
+//! Two mitigations live here:
+//!
+//! 1. [`find_available_port`] advances a process-wide counter on every call so
+//!    that two near-simultaneous allocations start scanning from *different*
+//!    offsets, making them pick different ports even when both observe the
+//!    base port as free.
+//! 2. [`find_available_port_async`] additionally consults Docker's
+//!    currently-published ports, so a leftover/leaked container holding a port
+//!    is skipped even though the OS reports the port as bindable.
+
+use bollard::query_parameters::ListContainersOptions;
+use bollard::Docker;
+use std::collections::HashSet;
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicU16, Ordering};
+
+/// Width of the window scanned starting from a base port.
+const SCAN_WINDOW: u16 = 1000;
+
+/// Advances on every allocation so concurrent callers diverge instead of all
+/// starting from the same base port. Wraps within `SCAN_WINDOW`.
+static NEXT_OFFSET: AtomicU16 = AtomicU16::new(0);
+
+/// Returns `true` if the OS will let us bind the port right now. This does not
+/// reserve the port — see the module docs for why that matters.
+pub fn is_port_available(port: u16) -> bool {
+    TcpListener::bind(("0.0.0.0", port)).is_ok()
+}
+
+/// Find an OS-bindable host port at or after `start_port`.
+///
+/// Each call begins its scan at a different offset (via [`NEXT_OFFSET`]) so two
+/// concurrent allocations are unlikely to return the same port even though both
+/// see `start_port` as free.
+pub fn find_available_port(start_port: u16) -> Option<u16> {
+    let offset = NEXT_OFFSET.fetch_add(1, Ordering::Relaxed) % SCAN_WINDOW;
+    (0..SCAN_WINDOW)
+        .map(|i| start_port.wrapping_add((offset + i) % SCAN_WINDOW))
+        .find(|&port| port >= start_port && is_port_available(port))
+}
+
+/// Check both OS bindability and that no running Docker container has already
+/// published `port`.
+pub async fn is_port_available_async(docker: &Docker, port: u16) -> bool {
+    if !is_port_available(port) {
+        return false;
+    }
+    !docker_published_ports(docker).await.contains(&port)
+}
+
+/// Docker-aware port finder: skips ports already published by any container in
+/// addition to the OS bindability and divergence checks of
+/// [`find_available_port`]. Falls back to the OS-only scan if Docker can't be
+/// queried.
+pub async fn find_available_port_async(docker: &Docker, start_port: u16) -> Option<u16> {
+    let docker_ports = docker_published_ports(docker).await;
+    let offset = NEXT_OFFSET.fetch_add(1, Ordering::Relaxed) % SCAN_WINDOW;
+    (0..SCAN_WINDOW)
+        .map(|i| start_port.wrapping_add((offset + i) % SCAN_WINDOW))
+        .find(|&port| {
+            port >= start_port && !docker_ports.contains(&port) && is_port_available(port)
+        })
+}
+
+/// Collect every host port currently published by a Docker container. Returns
+/// an empty set (treat all ports as free) if Docker can't be listed, so callers
+/// degrade to the OS-only check instead of failing.
+async fn docker_published_ports(docker: &Docker) -> HashSet<u16> {
+    let containers = match docker
+        .list_containers(Some(ListContainersOptions {
+            all: true,
+            ..Default::default()
+        }))
+        .await
+    {
+        Ok(c) => c,
+        Err(_) => return HashSet::new(),
+    };
+
+    let mut ports = HashSet::new();
+    for container in containers {
+        if let Some(port_mappings) = container.ports {
+            for mapping in port_mappings {
+                if let Some(public_port) = mapping.public_port {
+                    ports.insert(public_port);
+                }
+            }
+        }
+    }
+    ports
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_available_port_returns_at_or_after_base() {
+        let port = find_available_port(28000).expect("a port should be free");
+        assert!(port >= 28000, "port {} must be >= base 28000", port);
+        assert!(is_port_available(port), "returned port must be bindable");
+    }
+
+    #[test]
+    fn test_concurrent_allocations_diverge() {
+        // Two back-to-back allocations from the same base should not collide,
+        // because the offset counter advances between them.
+        let a = find_available_port(28100).expect("first port");
+        let b = find_available_port(28100).expect("second port");
+        assert_ne!(
+            a, b,
+            "consecutive allocations must not return the same port"
+        );
+    }
+}

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -7,7 +7,6 @@ use schemars::JsonSchema;
 use sea_orm::{prelude::*, *};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::net::TcpListener;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -228,13 +227,7 @@ fn example_docker_image() -> &'static str {
     "gotempsh/postgres-walg:18-bookworm"
 }
 
-fn is_port_available(port: u16) -> bool {
-    TcpListener::bind(("0.0.0.0", port)).is_ok()
-}
-
-fn find_available_port(start_port: u16) -> Option<u16> {
-    (start_port..start_port + 100).find(|&port| is_port_available(port))
-}
+use super::port_util::find_available_port;
 
 pub struct PostgresService {
     name: String,

--- a/crates/temps-providers/src/externalsvc/redis.rs
+++ b/crates/temps-providers/src/externalsvc/redis.rs
@@ -13,7 +13,6 @@ use schemars::JsonSchema;
 use sea_orm::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::net::TcpListener;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -149,13 +148,7 @@ fn example_docker_image() -> &'static str {
     "gotempsh/redis-walg:8-bookworm"
 }
 
-fn is_port_available(port: u16) -> bool {
-    TcpListener::bind(("0.0.0.0", port)).is_ok()
-}
-
-fn find_available_port(start_port: u16) -> Option<u16> {
-    (start_port..start_port + 100).find(|&port| is_port_available(port))
-}
+use super::port_util::find_available_port;
 
 pub struct RedisService {
     name: String,

--- a/crates/temps-providers/src/externalsvc/rustfs.rs
+++ b/crates/temps-providers/src/externalsvc/rustfs.rs
@@ -18,7 +18,6 @@ use sea_orm::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::{self};
 use std::collections::HashMap;
-use std::net::TcpListener;
 use std::sync::Arc;
 use std::time::Duration;
 use temps_core::EncryptionService;
@@ -292,80 +291,7 @@ fn example_image() -> &'static str {
     "rustfs/rustfs:latest"
 }
 
-fn is_port_available(port: u16) -> bool {
-    TcpListener::bind(("0.0.0.0", port)).is_ok()
-}
-
-fn find_available_port(start_port: u16) -> Option<u16> {
-    (start_port..start_port + 1000).find(|&port| is_port_available(port))
-}
-
-/// Check if a specific port is available (both OS and Docker)
-async fn is_port_available_async(docker: &Docker, port: u16) -> bool {
-    // Check OS-level availability first
-    if !is_port_available(port) {
-        return false;
-    }
-
-    // Check Docker containers
-    let containers = match docker
-        .list_containers(Some(bollard::query_parameters::ListContainersOptions {
-            all: true,
-            ..Default::default()
-        }))
-        .await
-    {
-        Ok(c) => c,
-        Err(_) => return true, // If we can't check Docker, assume available
-    };
-
-    for container in containers {
-        if let Some(port_mappings) = container.ports {
-            for port_mapping in port_mappings {
-                if let Some(public_port) = port_mapping.public_port {
-                    if public_port == port {
-                        return false;
-                    }
-                }
-            }
-        }
-    }
-
-    true
-}
-
-/// Async version that checks both OS and Docker port availability
-async fn find_available_port_async(docker: &Docker, start_port: u16) -> Option<u16> {
-    // Get all ports currently used by Docker containers
-    let docker_ports: std::collections::HashSet<u16> = {
-        let containers = match docker
-            .list_containers(Some(bollard::query_parameters::ListContainersOptions {
-                all: true,
-                ..Default::default()
-            }))
-            .await
-        {
-            Ok(c) => c,
-            Err(_) => return find_available_port(start_port), // Fallback to OS-only check
-        };
-
-        let mut ports = std::collections::HashSet::new();
-        for container in containers {
-            if let Some(port_mappings) = container.ports {
-                for port_mapping in port_mappings {
-                    if let Some(public_port) = port_mapping.public_port {
-                        ports.insert(public_port);
-                    }
-                }
-            }
-        }
-        ports
-    };
-
-    // Find a port that's available both at OS level and not used by Docker
-    (start_port..start_port + 1000)
-        .find(|&port| !docker_ports.contains(&port) && is_port_available(port))
-}
+use super::port_util::{find_available_port, find_available_port_async, is_port_available_async};
 
 pub struct RustfsService {
     name: String,

--- a/crates/temps-providers/src/externalsvc/s3.rs
+++ b/crates/temps-providers/src/externalsvc/s3.rs
@@ -11,7 +11,6 @@ use sea_orm::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::{self};
 use std::collections::HashMap;
-use std::net::TcpListener;
 use std::sync::Arc;
 use std::time::Duration;
 use temps_core::EncryptionService;
@@ -161,13 +160,7 @@ fn example_image() -> &'static str {
     "minio/minio:RELEASE.2025-09-07T16-13-09Z"
 }
 
-fn is_port_available(port: u16) -> bool {
-    TcpListener::bind(("0.0.0.0", port)).is_ok()
-}
-
-fn find_available_port(start_port: u16) -> Option<u16> {
-    (start_port..start_port + 100).find(|&port| is_port_available(port))
-}
+use super::port_util::find_available_port;
 
 pub struct S3Service {
     name: String,

--- a/crates/temps-providers/src/parameter_strategies.rs
+++ b/crates/temps-providers/src/parameter_strategies.rs
@@ -966,12 +966,7 @@ fn is_empty_value(value: Option<&JsonValue>) -> bool {
     }
 }
 
-fn find_available_port(start_port: u16) -> Option<u16> {
-    use std::net::TcpListener;
-    // Simple OS-level port check - Docker port conflicts will be handled at container creation time
-    // with proper error handling and retry logic
-    (start_port..start_port + 1000).find(|&port| TcpListener::bind(("0.0.0.0", port)).is_ok())
-}
+use crate::externalsvc::port_util::find_available_port;
 
 fn generate_secure_password() -> String {
     use rand::Rng;


### PR DESCRIPTION
## Problem

The `docker-providers` integration job runs every
`test_{mongodb,postgres,redis,s3}_backup_and_restore_to_s3` test in **parallel**.
Each spins up a MinIO container plus a service container and streams a real
wal-g/mongodump backup. Under load (e.g. when an in-flight PR adds more docker
tests) they saturate Docker and race for host ports
(`Bind for 0.0.0.0:<port> failed: port is already allocated`), blowing the 300s
per-test budget — most visibly the MongoDB backup step hanging at "Step 5:
Backing up to S3".

This is environmental (parallel container/port contention), **not** a bug in any
provider's backup path — the same tests pass when the job is under less load.

## Fix

1. **Serialize the heavy backup tests.** New dedicated `docker-backups` matrix
   group runs `*_backup_and_restore_to_s3` with `--test-threads=1`, mirroring the
   existing `postgres-upgrades` group; they're `--skip`ped in the parallel
   `docker-providers` group.
2. **Dedupe + harden port selection.** The duplicated per-service
   `find_available_port` helpers (mongodb/postgres/redis/s3/rustfs and
   `parameter_strategies`) are consolidated into `externalsvc::port_util`. The
   shared sync finder advances a process-wide offset so concurrent allocations
   diverge instead of all landing on the same base port; a Docker-aware async
   variant (lifted from rustfs) also skips ports already published by running
   containers.

## Verification

- `cargo fmt -p temps-providers -- --check`, `cargo check --lib -p temps-providers`
  (default + `--features docker-tests`) clean.
- New `port_util` unit tests pass.
- CI: confirm `Integration Tests (docker-backups)` (serial) and
  `Integration Tests (docker-providers)` (parallel, no port-allocation errors /
  300s hangs) are both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)