### PR TITLE
fix(temps-cli): per-instance default project, static deploy in `up`, and full build logs

### DIFF
--- a/apps/temps-cli/package.json
+++ b/apps/temps-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temps-sdk/cli",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "CLI for Temps deployment platform",
   "type": "module",
   "bin": {

--- a/apps/temps-cli/package.json
+++ b/apps/temps-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temps-sdk/cli",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "CLI for Temps deployment platform",
   "type": "module",
   "bin": {

--- a/apps/temps-cli/src/commands/configure.ts
+++ b/apps/temps-cli/src/commands/configure.ts
@@ -1,5 +1,7 @@
 import type { Command } from 'commander'
 import { config, credentials, type TempsConfig } from '../config/store.js'
+import { setDefaultProject } from '../config/resolve-project.js'
+import { getActiveDefaultProjectSync } from '../config/contexts.js'
 import { promptUrl, promptSelect, promptConfirm, promptPassword } from '../ui/prompts.js'
 import { success, info, colors, newline, header, keyValue, icons, box } from '../ui/output.js'
 import { shouldBeInteractive } from '../utils/tty.js'
@@ -253,11 +255,18 @@ function getConfigValue(key: string): void {
     process.exit(1)
   }
 
+  // defaultProject is scoped per context — read the active context's value,
+  // falling back to the legacy global key for older configs.
+  if (key === 'defaultProject') {
+    console.log(getActiveDefaultProjectSync() ?? config.get('defaultProject') ?? '')
+    return
+  }
+
   const value = config.get(key as keyof TempsConfig)
   console.log(value ?? '')
 }
 
-function setConfigValue(key: string, value: string): void {
+async function setConfigValue(key: string, value: string): Promise<void> {
   const validKeys: (keyof TempsConfig)[] = [
     'apiUrl',
     'defaultProject',
@@ -270,6 +279,14 @@ function setConfigValue(key: string, value: string): void {
     console.error(colors.error(`Unknown configuration key: ${key}`))
     console.error(colors.muted(`Valid keys: ${validKeys.join(', ')}`))
     process.exit(1)
+  }
+
+  // defaultProject is scoped per context — write it to the active context
+  // (falls back to the legacy global key when no context is active).
+  if (key === 'defaultProject') {
+    await setDefaultProject(value)
+    success(`Set ${key} = ${value}`)
+    return
   }
 
   // Type conversion

--- a/apps/temps-cli/src/commands/deploy/deploy-local-image.ts
+++ b/apps/temps-cli/src/commands/deploy/deploy-local-image.ts
@@ -10,6 +10,7 @@ import {
   succeedSpinner,
   failSpinner,
   updateSpinner,
+  isQuietMode,
 } from '../../ui/spinner.js'
 import {
   success,
@@ -235,7 +236,15 @@ export async function deployLocalImage(options: DeployLocalImageOptions): Promis
     )
     newline()
 
-    startSpinner('Building Docker image...')
+    // Stream the full Docker build log instead of collapsing it into a single
+    // spinner line. A spinner can't coexist with multi-line streamed output —
+    // it would fight the build lines for the cursor — so we stop it and print
+    // each line dimmed, like subordinate log output. Quiet mode stays silent.
+    const quiet = isQuietMode()
+    if (!quiet) {
+      info('Building Docker image...')
+      newline()
+    }
 
     try {
       await dockerBuild({
@@ -244,16 +253,18 @@ export async function deployLocalImage(options: DeployLocalImageOptions): Promis
         tag: imageName,
         buildArgs: allBuildArgs,
         onOutput: (line) => {
-          const trimmed = line.trim()
-          if (trimmed) {
-            updateSpinner(`Building: ${trimmed.substring(0, 60)}${trimmed.length > 60 ? '...' : ''}`)
+          const trimmed = line.trimEnd()
+          if (trimmed && !quiet) {
+            console.log(colors.dim(`  ${trimmed}`))
           }
         },
       })
-      succeedSpinner(`Image built: ${imageName}`)
+      if (!quiet) newline()
+      success(`Image built: ${imageName}`)
       didBuild = true
     } catch (err) {
-      failSpinner('Docker build failed')
+      if (!quiet) newline()
+      warning('Docker build failed')
       if (err instanceof Error) {
         warning(err.message)
       }
@@ -459,6 +470,11 @@ async function dockerBuild(options: DockerBuildOptions): Promise<void> {
   return new Promise((resolve, reject) => {
     const args = [
       'build',
+      // Force the plain, line-oriented BuildKit renderer. The default `auto`
+      // renderer collapses into a single rewriting line when stdout isn't a
+      // TTY (which it isn't — we pipe it), so the per-step build log is lost.
+      // `plain` emits every step/line, which we stream through to the user.
+      '--progress=plain',
       '-f', options.dockerfile,
       '-t', options.tag,
     ]
@@ -471,6 +487,10 @@ async function dockerBuild(options: DockerBuildOptions): Promise<void> {
 
     const docker = spawn('docker', args, {
       stdio: ['ignore', 'pipe', 'pipe'],
+      // BuildKit's plain renderer keys off whether *its* stdout is a TTY;
+      // setting this env makes it deterministic regardless of how docker is
+      // invoked, and keeps colour codes out of the piped stream.
+      env: { ...process.env, BUILDKIT_PROGRESS: 'plain' },
     })
 
     let stderr = ''

--- a/apps/temps-cli/src/commands/projects/create.ts
+++ b/apps/temps-cli/src/commands/projects/create.ts
@@ -1,4 +1,5 @@
-import { requireAuth, config } from '../../config/store.js'
+import { requireAuth } from '../../config/store.js'
+import { setDefaultProject } from '../../config/resolve-project.js'
 import {
   promptText,
   promptConfirm,
@@ -284,7 +285,7 @@ export async function create(options: CreateOptions): Promise<void> {
 
     // Ask if user wants to set as default (auto-set with --yes)
     if (skipPrompts) {
-      config.set('defaultProject', project.slug)
+      await setDefaultProject(project.slug)
       success(`Default project set to "${project.slug}"`)
     } else {
       const setDefault = await promptConfirm({
@@ -293,7 +294,7 @@ export async function create(options: CreateOptions): Promise<void> {
       })
 
       if (setDefault) {
-        config.set('defaultProject', project.slug)
+        await setDefaultProject(project.slug)
         success(`Default project set to "${project.slug}"`)
       }
     }
@@ -430,7 +431,7 @@ async function createManualProject(
 
     // Ask if user wants to set as default (auto-set with --yes)
     if (skipPrompts) {
-      config.set('defaultProject', project.slug)
+      await setDefaultProject(project.slug)
       success(`Default project set to "${project.slug}"`)
     } else {
       const setDefault = await promptConfirm({
@@ -439,7 +440,7 @@ async function createManualProject(
       })
 
       if (setDefault) {
-        config.set('defaultProject', project.slug)
+        await setDefaultProject(project.slug)
         success(`Default project set to "${project.slug}"`)
       }
     }

--- a/apps/temps-cli/src/commands/projects/delete.ts
+++ b/apps/temps-cli/src/commands/projects/delete.ts
@@ -1,5 +1,6 @@
 import { requireAuth, config } from '../../config/store.js'
-import { requireProjectSlug } from '../../config/resolve-project.js'
+import { requireProjectSlug, setDefaultProject } from '../../config/resolve-project.js'
+import { getActiveDefaultProjectSync } from '../../config/contexts.js'
 import { promptConfirm } from '../../ui/prompts.js'
 import { withSpinner } from '../../ui/spinner.js'
 import { success, warning, newline, colors, info } from '../../ui/output.js'
@@ -65,7 +66,12 @@ export async function remove(options: DeleteOptions): Promise<void> {
 
   success(`Project "${projectIdOrName}" deleted`)
 
-  // Clear default if this was the default project
+  // Clear the default if this was it — check both the active context's
+  // default (the per-server location new writes go to) and the legacy
+  // global key (for configs written before defaults were scoped).
+  if (getActiveDefaultProjectSync() === projectIdOrName) {
+    await setDefaultProject(undefined)
+  }
   if (config.get('defaultProject') === projectIdOrName) {
     config.set('defaultProject', undefined)
   }

--- a/apps/temps-cli/src/commands/up/index.ts
+++ b/apps/temps-cli/src/commands/up/index.ts
@@ -25,6 +25,8 @@ interface UpOptions {
   name?: string
   preset?: string
   manual?: boolean
+  static?: boolean
+  staticDir?: string
   noServices?: boolean
   wait?: boolean
   yes?: boolean
@@ -44,6 +46,8 @@ async function up(projectArg: string | undefined, options: UpOptions): Promise<v
       preset: options.preset,
       branch: options.branch,
       manual: options.manual,
+      static: options.static,
+      staticDir: options.staticDir,
       noServices: options.noServices,
       yes: options.yes,
     })
@@ -78,13 +82,39 @@ async function up(projectArg: string | undefined, options: UpOptions): Promise<v
     })
 
     if (error || !data) {
-      const rawApiUrl = config.get('apiUrl')
-      const baseUrl = client.getConfig().baseUrl ?? rawApiUrl
-      failSpinner(`Project "${resolved.slug}" not found`)
-      info(`API: ${colors.muted(`${baseUrl}/projects/by-slug/${resolved.slug}`)}`)
-      if (error) {
-        info(`Error: ${getErrorMessage(error)}`)
+      // The project didn't resolve to a real project on this server. When the
+      // slug came from an explicit --project flag, that's a genuine error —
+      // the user named something that doesn't exist. But when it came from a
+      // saved default (context-default / global-config / local-config), it's
+      // almost always a stale default left over from another instance, so
+      // fall through to the setup wizard and offer to create one instead of
+      // dead-ending on a 404.
+      if (resolved.source === 'flag') {
+        const rawApiUrl = config.get('apiUrl')
+        const baseUrl = client.getConfig().baseUrl ?? rawApiUrl
+        failSpinner(`Project "${resolved.slug}" not found`)
+        info(`API: ${colors.muted(`${baseUrl}/projects/by-slug/${resolved.slug}`)}`)
+        if (error) {
+          info(`Error: ${getErrorMessage(error)}`)
+        }
+        return
       }
+
+      failSpinner(`No project "${resolved.slug}" on this server (from ${resolved.source})`)
+      info('Setting up a new project instead...')
+      newline()
+
+      const result = await runSetupWizard({
+        name: options.name,
+        preset: options.preset,
+        branch: options.branch,
+        manual: options.manual,
+        noServices: options.noServices,
+        yes: options.yes,
+      })
+
+      // Wizard (when not cancelled) already triggered the deploy and saved config.
+      void result
       return
     }
 
@@ -325,6 +355,8 @@ export function registerUpCommand(program: Command): void {
     .option('-n, --name <name>', 'Project name (for new projects)')
     .option('--preset <preset>', 'Framework preset slug (skip auto-detection)')
     .option('--manual', 'Use manual deployment mode (no git)')
+    .option('--static', 'Deploy a pre-built static folder (no Docker, no git)')
+    .option('--static-dir <dir>', 'Folder to upload for static deploys (auto-detected by default)')
     .option('--no-services', 'Skip external service setup')
     .option('--no-wait', 'Do not wait for deployment to complete')
     .option('-y, --yes', 'Skip confirmation prompts')

--- a/apps/temps-cli/src/commands/up/setup-wizard.ts
+++ b/apps/temps-cli/src/commands/up/setup-wizard.ts
@@ -8,6 +8,7 @@ import {
   detectGitRemote,
   detectGitBranch,
   detectServiceHints,
+  detectStaticDir,
   suggestProjectName,
   refinePythonPreset,
   isGitRepo,
@@ -29,8 +30,8 @@ import {
 } from '../../lib/service-setup.js'
 import { writeProjectConfig } from '../../config/project-config.js'
 import { promptText, promptSelect, promptConfirm } from '../../ui/prompts.js'
-import { withSpinner, startSpinner, succeedSpinner, failSpinner } from '../../ui/spinner.js'
-import { success, error, info, warning, newline, icons, colors, header, keyValue, box } from '../../ui/output.js'
+import { withSpinner } from '../../ui/spinner.js'
+import { success, info, warning, newline, icons, colors, header, keyValue, box } from '../../ui/output.js'
 import {
   createProject,
   triggerProjectPipeline,
@@ -38,10 +39,11 @@ import {
   generatePresetDockerfile,
   listPresets,
 } from '../../api/sdk.gen.js'
-import type { ConnectionResponse, RepositoryResponse } from '../../api/types.gen.js'
+import type { RepositoryResponse } from '../../api/types.gen.js'
 import { config } from '../../config/store.js'
 import { watchDeployment } from '../../lib/deployment-watcher.jsx'
 import { deployLocalImage } from '../deploy/deploy-local-image.js'
+import { deployStatic } from '../deploy/deploy-static.js'
 import { existsSync, writeFileSync, mkdirSync } from 'node:fs'
 import { resolve, join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -51,6 +53,10 @@ interface SetupWizardOptions {
   preset?: string
   branch?: string
   manual?: boolean
+  /** Deploy as a pre-built static bundle (source_type: static_files). */
+  static?: boolean
+  /** Directory to upload as the static bundle (defaults to auto-detected). */
+  staticDir?: string
   noServices?: boolean
   yes?: boolean
 }
@@ -130,7 +136,8 @@ export async function runSetupWizard(options: SetupWizardOptions): Promise<Setup
       }))
 
   // ─── Step 3: Deployment Method ───────────────────────────────────────────
-  let isGitBased = !options.manual
+  let isGitBased = !options.manual && !options.static
+  let isStatic = !!options.static
   let connectionId: number | null = null
   let repository: RepositoryResponse | null = null
   let branch = gitBranch
@@ -140,7 +147,15 @@ export async function runSetupWizard(options: SetupWizardOptions): Promise<Setup
   let presetSlug = detectedPreset?.slug ?? 'dockerfile'
   let directory = './'
 
-  if (options.manual) {
+  // Auto-detect a built static-output directory (dist/build/out/…) up front so
+  // we can surface it in the deploy-method choice and pre-fill the prompt.
+  const detectedStaticDir = options.staticDir ?? detectStaticDir() ?? undefined
+
+  if (options.static) {
+    isStatic = true
+    isGitBased = false
+    info('Static deployment mode selected')
+  } else if (options.manual) {
     isGitBased = false
     info('Manual deployment mode selected')
   } else if (options.yes && gitRemote) {
@@ -157,6 +172,13 @@ export async function runSetupWizard(options: SetupWizardOptions): Promise<Setup
           description: gitRemote ? `Using ${gitRemote.owner}/${gitRemote.repo}` : 'Requires a git connection',
         },
         {
+          name: 'Static (upload a pre-built folder)',
+          value: 'static',
+          description: detectedStaticDir
+            ? `Detected ./${detectedStaticDir}`
+            : 'Upload HTML/CSS/JS — no Docker, no git',
+        },
+        {
           name: 'Manual (upload Docker images from CLI)',
           value: 'manual',
           description: 'Build locally, deploy with temps deploy:local-image',
@@ -166,6 +188,36 @@ export async function runSetupWizard(options: SetupWizardOptions): Promise<Setup
     })
 
     isGitBased = deployMethod === 'git'
+    isStatic = deployMethod === 'static'
+  }
+
+  // ─── Step 3-static: Pick the folder to upload ────────────────────────────
+  // Auto-detect, but always let the user override with a custom folder.
+  let staticDir = detectedStaticDir ?? './'
+  if (isStatic) {
+    // Static bundles aren't built, so there's no real framework preset. The
+    // API marks them via `project_type: 'static'`; `preset` must still be a
+    // valid slug, so use the safe `dockerfile` default (mirrors `projects
+    // create`). "static" is only a local detection label, not an API preset.
+    presetSlug = 'dockerfile'
+    if (options.staticDir) {
+      staticDir = options.staticDir
+    } else if (!options.yes) {
+      staticDir = await promptText({
+        message: 'Folder to upload (built static output)',
+        default: detectedStaticDir ?? 'dist',
+        required: true,
+      })
+    } else {
+      // Non-interactive: use the detection, falling back to a sensible default.
+      staticDir = detectedStaticDir ?? 'dist'
+    }
+
+    if (!existsSync(resolve(staticDir))) {
+      warning(`Folder not found: ${colors.bold(staticDir)}`)
+      info('Build your project first, then re-run, or pass --static-dir <path>.')
+      return null
+    }
   }
 
   // ─── Step 3a: Git Connection Setup ───────────────────────────────────────
@@ -213,8 +265,9 @@ export async function runSetupWizard(options: SetupWizardOptions): Promise<Setup
     }
   }
 
-  // If manual mode and no API preset detection happened, use local detection or prompt
-  if (!isGitBased && !options.preset) {
+  // If manual mode and no API preset detection happened, use local detection or prompt.
+  // Static deploys don't build an image, so they don't need a Dockerfile preset.
+  if (!isGitBased && !isStatic && !options.preset) {
     if (detectedPreset) {
       // Confirm the detected preset
       if (!options.yes) {
@@ -253,17 +306,27 @@ export async function runSetupWizard(options: SetupWizardOptions): Promise<Setup
 
   const serviceNames = serviceIds.length > 0 ? `${serviceIds.length} service(s) linked` : 'None'
 
+  const deployLabel = isGitBased
+    ? 'Automatic (on push)'
+    : isStatic
+      ? 'Static (folder upload)'
+      : 'Manual (CLI upload)'
+
   box(
     [
       `Project:    ${colors.bold(projectName)}`,
-      `Preset:     ${colors.bold(presetSlug)}`,
-      `Directory:  ${colors.bold(directory)}`,
+      // Static bundles have no real framework preset — don't show the
+      // internal `dockerfile` placeholder, it just confuses.
+      isStatic ? null : `Preset:     ${colors.bold(presetSlug)}`,
+      isStatic
+        ? `Folder:     ${colors.bold(staticDir)}`
+        : `Directory:  ${colors.bold(directory)}`,
       isGitBased && repoOwner && repoName
         ? `Repository: ${colors.bold(`${repoOwner}/${repoName}`)}`
         : null,
-      `Branch:     ${colors.bold(branch)}`,
+      isStatic ? null : `Branch:     ${colors.bold(branch)}`,
       `Services:   ${colors.bold(serviceNames)}`,
-      `Deploy:     ${colors.bold(isGitBased ? 'Automatic (on push)' : 'Manual (CLI upload)')}`,
+      `Deploy:     ${colors.bold(deployLabel)}`,
     ]
       .filter(Boolean)
       .join('\n'),
@@ -298,7 +361,10 @@ export async function runSetupWizard(options: SetupWizardOptions): Promise<Setup
         git_url: gitUrl,
         git_provider_connection_id: connectionId,
         automatic_deploy: isGitBased,
-        source_type: isGitBased ? 'git' : 'manual',
+        source_type: isGitBased ? 'git' : isStatic ? 'static_files' : 'manual',
+        // project_type mirrors the web configurator: 'static' for static_files,
+        // 'docker' otherwise. This is what actually marks the project static.
+        project_type: isStatic ? 'static' : 'docker',
         storage_service_ids: serviceIds,
       },
     })
@@ -329,7 +395,24 @@ export async function runSetupWizard(options: SetupWizardOptions): Promise<Setup
   newline()
 
   // ─── Step 8: First Deployment ────────────────────────────────────────────
-  if (isGitBased) {
+  if (isStatic) {
+    // Upload the built folder as a static bundle and deploy it. deployStatic
+    // archives the directory, uploads it, triggers the deploy, and watches it.
+    info(`Uploading ${colors.bold(staticDir)} and deploying...`)
+    newline()
+
+    try {
+      await deployStatic({
+        path: staticDir,
+        project: project.slug,
+        yes: true,
+      })
+    } catch {
+      newline()
+      warning('Static deploy failed. You can retry with:')
+      info(`  ${colors.muted(`temps deploy:static -p ${project.slug} --path ${staticDir}`)}`)
+    }
+  } else if (isGitBased) {
     info('Triggering first deployment...')
     newline()
 

--- a/apps/temps-cli/src/config/contexts.ts
+++ b/apps/temps-cli/src/config/contexts.ts
@@ -21,6 +21,11 @@
  *                    the key in the web UI without revealing the secret
  *   - expiresAt      ISO 8601 timestamp when the API key expires
  *   - isActive       only one context is the active one at a time
+ *   - defaultProject slug of the project commands target when none is given
+ *                    on the CLI / in .temps/config.json. Scoped per context
+ *                    because a project only exists on the server it was
+ *                    created against — a global default would leak across
+ *                    instances and 404.
  */
 
 import { readFile, writeFile, mkdir, unlink } from 'node:fs/promises'
@@ -35,6 +40,7 @@ export interface CliContext {
   keyPrefix?: string
   expiresAt?: string
   isActive?: boolean
+  defaultProject?: string
 }
 
 function getContextsPath(): string {
@@ -70,6 +76,7 @@ async function saveContexts(contexts: CliContext[]): Promise<void> {
     if (c.keyPrefix !== undefined) out.keyPrefix = c.keyPrefix
     if (c.expiresAt !== undefined) out.expiresAt = c.expiresAt
     if (c.isActive !== undefined) out.isActive = c.isActive
+    if (c.defaultProject !== undefined) out.defaultProject = c.defaultProject
     return out
   })
   await writeFile(path, JSON.stringify(normalized, null, 2) + '\n', { mode: 0o600 })
@@ -243,6 +250,35 @@ export function defaultContextName(url: string): string {
 /** Path to the contexts file (for display in UI / errors). */
 export function contextsPath(): string {
   return getContextsPath()
+}
+
+/**
+ * Read the active context's default project slug, honoring `TEMPS_CONTEXT`.
+ * Returns undefined when there's no active context or it has no default —
+ * callers then fall back to the legacy global key in `config/store.ts`.
+ */
+export function getActiveDefaultProjectSync(): string | undefined {
+  return getActiveContextSync()?.defaultProject
+}
+
+/**
+ * Set (or clear, with `undefined`) the default project on the active context.
+ * No-op returning false when there's no active context to attach it to.
+ * Does not change which context is active.
+ */
+export async function setActiveDefaultProject(slug: string | undefined): Promise<boolean> {
+  const contexts = await loadContexts()
+  const active = pickActiveContext(contexts)
+  if (!active) return false
+  const target = contexts.find((c) => c.name === active.name)
+  if (!target) return false
+  if (slug) {
+    target.defaultProject = slug
+  } else {
+    delete target.defaultProject
+  }
+  await saveContexts(contexts)
+  return true
 }
 
 /**

--- a/apps/temps-cli/src/config/resolve-project.ts
+++ b/apps/temps-cli/src/config/resolve-project.ts
@@ -1,7 +1,8 @@
 import { config } from './store.js'
 import { readProjectConfig } from './project-config.js'
+import { getActiveDefaultProjectSync, setActiveDefaultProject } from './contexts.js'
 
-export type ProjectSource = 'flag' | 'local-config' | 'env-var' | 'global-config'
+export type ProjectSource = 'flag' | 'local-config' | 'env-var' | 'context-default' | 'global-config'
 
 export interface ResolvedProject {
   slug: string
@@ -10,7 +11,8 @@ export interface ResolvedProject {
 
 /**
  * Resolve the project slug using priority chain:
- * CLI flag > .temps/config.json > TEMPS_PROJECT env var > global defaultProject
+ * CLI flag > .temps/config.json > TEMPS_PROJECT env var
+ *   > active context's defaultProject > legacy global defaultProject
  */
 export async function resolveProjectSlug(flagValue?: string): Promise<ResolvedProject | null> {
   // 1. CLI flag takes highest priority
@@ -30,13 +32,34 @@ export async function resolveProjectSlug(flagValue?: string): Promise<ResolvedPr
     return { slug: envProject, source: 'env-var' }
   }
 
-  // 4. Global default project
+  // 4. Active context's default project (scoped per Temps server).
+  const contextDefault = getActiveDefaultProjectSync()
+  if (contextDefault) {
+    return { slug: contextDefault, source: 'context-default' }
+  }
+
+  // 5. Legacy global default project. Kept for back-compat with configs
+  //    written before defaults were scoped per context. New writes go to the
+  //    active context, so this drains over time.
   const defaultProject = config.get('defaultProject')
   if (defaultProject) {
     return { slug: defaultProject, source: 'global-config' }
   }
 
   return null
+}
+
+/**
+ * Persist the default project slug. Writes to the active context so the
+ * default is scoped to the Temps server it belongs to. When there's no
+ * active context (e.g. env-var-only auth), falls back to the legacy global
+ * key so the behaviour still works. Pass `undefined` to clear it.
+ */
+export async function setDefaultProject(slug: string | undefined): Promise<void> {
+  const wroteToContext = await setActiveDefaultProject(slug)
+  if (!wroteToContext) {
+    config.set('defaultProject', slug)
+  }
 }
 
 /**

--- a/apps/temps-cli/src/lib/detect-project.test.ts
+++ b/apps/temps-cli/src/lib/detect-project.test.ts
@@ -1,0 +1,53 @@
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { detectStaticDir } from './detect-project.js'
+
+describe('detectStaticDir', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'temps-static-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  test('returns null when no candidate folder or root index.html exists', () => {
+    expect(detectStaticDir(dir)).toBeNull()
+  })
+
+  test('detects a build-output folder that contains index.html', () => {
+    mkdirSync(join(dir, 'dist'))
+    writeFileSync(join(dir, 'dist', 'index.html'), '<html></html>')
+    expect(detectStaticDir(dir)).toBe('dist')
+  })
+
+  test('prefers an index.html-bearing candidate over a bare one', () => {
+    // `dist` exists but is empty; `build` has the real entrypoint.
+    mkdirSync(join(dir, 'dist'))
+    mkdirSync(join(dir, 'build'))
+    writeFileSync(join(dir, 'build', 'index.html'), '<html></html>')
+    expect(detectStaticDir(dir)).toBe('build')
+  })
+
+  test('falls back to a bare candidate folder when none has index.html', () => {
+    mkdirSync(join(dir, 'out'))
+    writeFileSync(join(dir, 'out', 'app.js'), 'console.log(1)')
+    expect(detectStaticDir(dir)).toBe('out')
+  })
+
+  test('respects candidate ordering (dist before build)', () => {
+    mkdirSync(join(dir, 'build'))
+    mkdirSync(join(dir, 'dist'))
+    // Neither has index.html → first candidate in the ordered list wins.
+    expect(detectStaticDir(dir)).toBe('dist')
+  })
+
+  test('treats a root index.html (no build step) as the current directory', () => {
+    writeFileSync(join(dir, 'index.html'), '<html></html>')
+    expect(detectStaticDir(dir)).toBe('.')
+  })
+})

--- a/apps/temps-cli/src/lib/detect-project.ts
+++ b/apps/temps-cli/src/lib/detect-project.ts
@@ -180,6 +180,41 @@ export async function refinePythonPreset(dir?: string): Promise<DetectedPreset> 
   return { slug: 'python', label: 'Python', confidence: 'low' }
 }
 
+// ─── Static Output Detection ─────────────────────────────────────────────────
+
+/**
+ * Common build-output directory names, ordered by how strongly they imply a
+ * ready-to-serve static bundle. The first one that exists wins.
+ */
+const STATIC_DIR_CANDIDATES = ['dist', 'build', 'out', 'public', '_site', 'output'] as const
+
+/**
+ * Detect a likely static-output directory to deploy (e.g. `dist`, `build`,
+ * `out`). Returns the directory name (relative to `dir`) or null when none of
+ * the well-known candidates exist. The caller can fall back to prompting.
+ *
+ * A bare `index.html` in the project root counts too — that's a static site
+ * with no build step, deployable as `./`.
+ */
+export function detectStaticDir(dir?: string): string | null {
+  const projectDir = dir ?? process.cwd()
+  for (const candidate of STATIC_DIR_CANDIDATES) {
+    if (existsSync(join(projectDir, candidate, 'index.html'))) {
+      return candidate
+    }
+  }
+  // A built bundle directory without an index.html is still plausible output.
+  for (const candidate of STATIC_DIR_CANDIDATES) {
+    if (existsSync(join(projectDir, candidate))) {
+      return candidate
+    }
+  }
+  if (existsSync(join(projectDir, 'index.html'))) {
+    return '.'
+  }
+  return null
+}
+
 // ─── Git Remote Detection ────────────────────────────────────────────────────
 
 export interface DetectedGitRemote {


### PR DESCRIPTION
## Summary

A batch of `@temps-sdk/cli` fixes and improvements, all scoped to `apps/temps-cli/`. Bumps the CLI to **0.1.28**.

### 1. Default project is now scoped per instance
Previously `defaultProject` lived in a single global config key with no instance association, while `apiUrl` was already context-aware. So a project created on one Temps server leaked as the default on another and 404'd:
```
ℹ Using project telemetry-dashboard (from global-config)
✖ Project "telemetry-dashboard" not found
```
- `defaultProject` now lives on the **active CLI context** (`~/.temps/.contexts.json`). A new instance starts with no default.
- Resolution reads the active context's default (`context-default`) before the legacy global key (kept for back-compat, drains over time).
- `create` / `delete` / `configure get|set defaultProject` all write through the new `setDefaultProject` helper.

### 2. `temps up` falls back to the create wizard on a stale default
When a resolved-but-stale slug 404s, `up` now runs the setup wizard (offers to create) instead of dead-ending on a 404 — unless the slug came from an explicit `--project` flag.

### 3. Static deploy support in the `up` wizard
Static sites were being routed through the Docker-image **manual** path (Dockerfile generation), which made no sense for a pre-built folder.
- New **"Static (upload a pre-built folder)"** option → `source_type: static_files`, `project_type: static` (preset stays the valid `dockerfile` placeholder; `static` is only a local detection label, not an API preset — this was the `Invalid preset: static` error).
- `detectStaticDir()` auto-detects the build-output folder (`dist`/`build`/`out`/`public`/`_site`/`output`, or a root `index.html`), and the wizard **always lets you pick a custom folder**.
- New `--static` / `--static-dir` flags. Uploads via `deployStatic`.

### 4. Full Docker build logs instead of one spinner line
The local-image build funneled every output line into a single rewriting spinner, so the per-step BuildKit log was lost — you'd only see e.g. `#25 exporting layers`.
- Force `--progress=plain` (+ `BUILDKIT_PROGRESS=plain`) and stream each build line to the terminal (dimmed/indented). Quiet/`--json` mode stays silent.
- Affects both `deploy:local-image` and the `up` manual path.

## Testing
- `bun run typecheck`: zero errors in touched files (14 pre-existing errors remain in untouched `env-sync`/`environments`/`providers`/`notifications`).
- New `detect-project.test.ts` (6 tests for `detectStaticDir`) + existing `contexts.test.ts` → 15 pass, 0 fail.
- Static path verified end-to-end against a local server: project created, bundle uploaded, deployment completed, live URL served the content.
- `--progress=plain` verified to stream the full step log on a real `docker build`.

## Note
This is the `@temps-sdk/cli` npm package — changes take effect for `bunx @temps-sdk/cli` only after publishing 0.1.28 to npm.