### PR TITLE
feat(deployments): rebuild from source on rollback for git projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 ### Changed
-- **Rollback rebuilds from source for git projects instead of reusing the
-  stored image.** Reusing the target deployment's Docker image failed once the
-  nightly cleanup pruned it (`image no longer exists locally` for anything older
-  than ~7 days), skipped readiness checks (`health_check_path` was `None`), and
-  couldn't reconstruct static deployments. Git-sourced rollbacks now re-run the
-  full build pipeline at the target deployment's commit — always available, with
-  the same build + health-check pipeline as a normal deploy. Non-git projects
-  (docker_image / static_files / manual without a git ref) keep the image-reuse
-  path unchanged (#155).
+- **Rollback falls back to rebuilding from source for git projects when the
+  stored image is gone.** Rollback reuses the target deployment's Docker image
+  when it's still in the local cache (the common case — rolling back a recent
+  deploy), which is near-instant and byte-identical to what you're rolling back
+  to. Previously that was the *only* path, so it failed once the nightly cleanup
+  pruned the image (`image no longer exists locally` for anything older than
+  ~7 days) and couldn't reconstruct static deployments. Now, for git-sourced
+  projects, rollback rebuilds from source at the target deployment's commit
+  whenever the image is unavailable (pruned, or a static preset with no runnable
+  image) — going through the same build + health-check pipeline as a normal
+  deploy. Non-git projects (docker_image / static_files / manual without a git
+  ref) keep the image-reuse path unchanged (#155).
 
 ### Fixed
 - **`docker-providers` CI no longer hangs/flakes under load.** The heavyweight

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 ### Changed
--
+- **Rollback rebuilds from source for git projects instead of reusing the
+  stored image.** Reusing the target deployment's Docker image failed once the
+  nightly cleanup pruned it (`image no longer exists locally` for anything older
+  than ~7 days), skipped readiness checks (`health_check_path` was `None`), and
+  couldn't reconstruct static deployments. Git-sourced rollbacks now re-run the
+  full build pipeline at the target deployment's commit — always available, with
+  the same build + health-check pipeline as a normal deploy. Non-git projects
+  (docker_image / static_files / manual without a git ref) keep the image-reuse
+  path unchanged (#155).
 
 ### Fixed
 - **`docker-providers` CI no longer hangs/flakes under load.** The heavyweight

--- a/crates/temps-agents/src/services/executor.rs
+++ b/crates/temps-agents/src/services/executor.rs
@@ -2855,6 +2855,7 @@ impl AgentExecutor {
             // rules apply. The first-deploy exception covers a freshly
             // created preview env.
             manual_trigger: false,
+            rollback_from_deployment_id: None,
         });
 
         if let Err(e) = self.queue.send(push_job).await {

--- a/crates/temps-core/src/jobs.rs
+++ b/crates/temps-core/src/jobs.rs
@@ -20,6 +20,15 @@ pub struct GitPushEventJob {
     /// pre-existing gate behaviour for them.
     #[serde(default)]
     pub manual_trigger: bool,
+    /// Set to the source deployment's id when this push is a rollback that
+    /// rebuilds from source (git projects). The deployment record created by
+    /// the pipeline is then marked `is_rollback` / `rolled_back_from_id` so the
+    /// UI and history show it as a rollback rather than a normal deploy.
+    ///
+    /// `None` for ordinary pushes. `#[serde(default)]` keeps older queued jobs
+    /// (no field) deserializing as non-rollback.
+    #[serde(default)]
+    pub rollback_from_deployment_id: Option<i32>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/crates/temps-deployments/src/services/job_processor.rs
+++ b/crates/temps-deployments/src/services/job_processor.rs
@@ -824,6 +824,9 @@ async fn process_git_push_event(
         let deployment_config_snapshot = merged_config
             .map(|config| DeploymentConfigSnapshot::from_config(&config, HashMap::new()));
 
+        // A rebuild-from-source rollback rides the same git-push pipeline but
+        // must be recorded as a rollback so the UI/history reflect it.
+        let is_rollback = job.rollback_from_deployment_id.is_some();
         let deployment_metadata = DeploymentMetadata {
             git_push_event: Some(GitPushEvent {
                 owner: job.owner.clone(),
@@ -831,7 +834,21 @@ async fn process_git_push_event(
                 branch: job.branch.clone().unwrap_or_default(),
                 commit: job.commit.clone(),
             }),
+            is_rollback,
+            rolled_back_from_id: job.rollback_from_deployment_id,
             ..Default::default()
+        };
+        let trigger_context = if is_rollback {
+            serde_json::json!({
+                "trigger": "rollback",
+                "source": "rebuild_from_source",
+                "source_deployment_id": job.rollback_from_deployment_id,
+            })
+        } else {
+            serde_json::json!({
+                "trigger": "git_push",
+                "source": "webhook"
+            })
         };
 
         let new_deployment = deployments::ActiveModel {
@@ -849,10 +866,7 @@ async fn process_git_push_event(
             promoted_from_deployment_id: sea_orm::Set(None),
             started_at: sea_orm::Set(None),
             finished_at: sea_orm::Set(None),
-            context_vars: sea_orm::Set(Some(serde_json::json!({
-                "trigger": "git_push",
-                "source": "webhook"
-            }))),
+            context_vars: sea_orm::Set(Some(trigger_context)),
             deploying_at: sea_orm::Set(None),
             ready_at: sea_orm::Set(None),
             static_dir_location: sea_orm::Set(None),
@@ -1220,6 +1234,7 @@ mod tests {
             commit: "abc123".to_string(),
             project_id: 0,
             manual_trigger: false,
+            rollback_from_deployment_id: None,
         };
 
         // Try to find the project (should return None)

--- a/crates/temps-deployments/src/services/services.rs
+++ b/crates/temps-deployments/src/services/services.rs
@@ -1002,6 +1002,22 @@ impl DeploymentService {
         tag: Option<String>,
         commit: Option<String>,
     ) -> Result<(), DeploymentError> {
+        self.trigger_pipeline_inner(project_id, environment_id, branch, tag, commit, None)
+            .await
+    }
+
+    /// Internal pipeline trigger that also carries an optional rollback marker.
+    /// `rollback_from_deployment_id` is `Some(id)` only for rebuild-from-source
+    /// rollbacks, which tags the resulting deployment as a rollback of `id`.
+    async fn trigger_pipeline_inner(
+        &self,
+        project_id: i32,
+        environment_id: i32,
+        branch: Option<String>,
+        tag: Option<String>,
+        commit: Option<String>,
+        rollback_from_deployment_id: Option<i32>,
+    ) -> Result<(), DeploymentError> {
         info!("Triggering pipeline for project_id: {}", project_id);
         let project = projects::Entity::find_by_id(project_id)
             .one(self.db.as_ref())
@@ -1041,6 +1057,7 @@ impl DeploymentService {
             project_id,
             // User-initiated trigger — bypasses environments.automatic_deploy.
             manual_trigger: true,
+            rollback_from_deployment_id,
         };
 
         tracing::debug!(
@@ -1125,19 +1142,98 @@ impl DeploymentService {
             )));
         }
 
-        // Ensure target deployment has an image to roll back to
-        let image_name = target_deployment.image_name.clone().ok_or_else(|| {
-            DeploymentError::Other(
-                "Target deployment has no image_name - cannot rollback".to_string(),
-            )
-        })?;
-
         let environment_id = target_deployment.environment_id;
 
         let project = projects::Entity::find_by_id(project_id)
             .one(self.db.as_ref())
             .await?
             .ok_or_else(|| DeploymentError::NotFound("Project not found".to_string()))?;
+
+        // --- Git projects: rebuild from source instead of reusing the image ---
+        //
+        // The image-reuse path below is fast but fragile: it redeploys the
+        // target deployment's stored Docker image, which the nightly cleanup
+        // prunes after ~7 days — so rolling back to anything older fails with
+        // "image no longer exists locally". It also skips the build + health
+        // pipeline and can't reconstruct static deployments.
+        //
+        // For git-sourced projects we instead re-run the full build pipeline at
+        // the target deployment's commit. This always works (no dependency on a
+        // surviving image), goes through the same health checks as a normal
+        // deploy, and rebuilds static bundles correctly. Non-git projects
+        // (docker_image / static_files / manual without a git ref) have no
+        // source to rebuild, so they fall through to image reuse.
+        let has_git_ref = target_deployment
+            .commit_sha
+            .as_ref()
+            .is_some_and(|c| !c.is_empty())
+            || target_deployment
+                .branch_ref
+                .as_ref()
+                .is_some_and(|b| !b.is_empty());
+
+        if project.source_type == temps_entities::source_type::SourceType::Git && has_git_ref {
+            info!(
+                "Rollback: project {} is git-sourced — rebuilding from source at commit {:?} (rolling back to #{})",
+                project_id, target_deployment.commit_sha, deployment_id
+            );
+
+            // Snapshot the latest deployment id BEFORE triggering, so we can
+            // identify the one the pipeline creates and return it.
+            let prev_max_id = deployments::Entity::find()
+                .filter(deployments::Column::ProjectId.eq(project_id))
+                .filter(deployments::Column::EnvironmentId.eq(environment_id))
+                .order_by_desc(deployments::Column::Id)
+                .one(self.db.as_ref())
+                .await?
+                .map(|d| d.id)
+                .unwrap_or(0);
+
+            self.trigger_pipeline_inner(
+                project_id,
+                environment_id,
+                target_deployment.branch_ref.clone(),
+                target_deployment.tag_ref.clone(),
+                target_deployment.commit_sha.clone(),
+                Some(deployment_id),
+            )
+            .await?;
+
+            // Anonymous telemetry: a rollback was initiated. No identifying props.
+            self.telemetry()
+                .report(temps_core::telemetry::TelemetryEvent::new(
+                    temps_core::telemetry::TelemetryEventKind::RollbackTriggered,
+                ));
+
+            // The pipeline created a new deployment row; return it so the API
+            // response carries the rollback deployment's id/status. It's the
+            // newest row for this environment above the prior max.
+            let created = deployments::Entity::find()
+                .filter(deployments::Column::ProjectId.eq(project_id))
+                .filter(deployments::Column::EnvironmentId.eq(environment_id))
+                .filter(deployments::Column::Id.gt(prev_max_id))
+                .order_by_desc(deployments::Column::Id)
+                .one(self.db.as_ref())
+                .await?;
+
+            let model = match created {
+                Some(dep) => dep,
+                // The job is queued; the row may not be visible yet. Surface the
+                // target as a stand-in rather than failing — the rollback is
+                // already in flight.
+                None => target_deployment,
+            };
+            return Ok(self
+                .map_db_deployment_to_deployment(model, false, None)
+                .await);
+        }
+
+        // Ensure target deployment has an image to roll back to
+        let image_name = target_deployment.image_name.clone().ok_or_else(|| {
+            DeploymentError::Other(
+                "Target deployment has no image_name - cannot rollback".to_string(),
+            )
+        })?;
 
         let environment = environments::Entity::find_by_id(environment_id)
             .one(self.db.as_ref())
@@ -3963,6 +4059,59 @@ mod tests {
             .await?
             .unwrap();
         assert_eq!(updated_environment.current_deployment_id, Some(result.id));
+
+        Ok(())
+    }
+
+    /// When the target deployment carries a git commit on a git-sourced
+    /// project, rollback should rebuild from source (enqueue a GitPushEvent)
+    /// rather than reuse the stored image. We assert it does NOT take the
+    /// image-reuse path: that path synchronously inserts a brand-new
+    /// deployment row (different id) and flips the environment pointer. The
+    /// rebuild path enqueues an async job, so within the test the only
+    /// deployments present are the originals — no extra image-reuse row.
+    #[tokio::test]
+    async fn test_rollback_rebuilds_from_source_for_git_projects(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+
+        // setup_test_data creates a Git-source project (SourceType default).
+        let (_project, _environment, target_deployment) = setup_test_data(&db).await?;
+
+        // Give the target a real git commit so it's rebuildable from source.
+        let mut active: deployments::ActiveModel = target_deployment.clone().into();
+        active.commit_sha = Set(Some("abc1234deadbeef".to_string()));
+        active.branch_ref = Set(Some("main".to_string()));
+        let target_deployment = active.update(db.as_ref()).await?;
+
+        let count_before = deployments::Entity::find()
+            .filter(deployments::Column::ProjectId.eq(target_deployment.project_id))
+            .count(db.as_ref())
+            .await?;
+
+        let deployment_service = create_deployment_service_for_test(db.clone());
+
+        let result = deployment_service
+            .rollback_to_deployment(target_deployment.project_id, target_deployment.id)
+            .await?;
+
+        // The image-reuse path would have inserted a new deployment row and
+        // returned its (different) id. The rebuild path enqueues a job instead,
+        // so no synchronous row is added and we get the target back as a
+        // stand-in (the queued pipeline row isn't visible in-test).
+        let count_after = deployments::Entity::find()
+            .filter(deployments::Column::ProjectId.eq(target_deployment.project_id))
+            .count(db.as_ref())
+            .await?;
+        assert_eq!(
+            count_before, count_after,
+            "rebuild-from-source must not synchronously create an image-reuse deployment"
+        );
+        assert_eq!(
+            result.id, target_deployment.id,
+            "rebuild path returns the target as a stand-in while the job is queued"
+        );
 
         Ok(())
     }

--- a/crates/temps-deployments/src/services/services.rs
+++ b/crates/temps-deployments/src/services/services.rs
@@ -1149,20 +1149,30 @@ impl DeploymentService {
             .await?
             .ok_or_else(|| DeploymentError::NotFound("Project not found".to_string()))?;
 
-        // --- Git projects: rebuild from source instead of reusing the image ---
+        let preset = temps_presets::get_preset_by_slug(project.preset.as_str())
+            .ok_or_else(|| DeploymentError::NotFound("Preset not found".to_string()))?;
+
+        // --- Git projects: rebuild from source when the image isn't reusable ---
         //
-        // The image-reuse path below is fast but fragile: it redeploys the
-        // target deployment's stored Docker image, which the nightly cleanup
-        // prunes after ~7 days — so rolling back to anything older fails with
-        // "image no longer exists locally". It also skips the build + health
-        // pipeline and can't reconstruct static deployments.
+        // The image-reuse path below is fast — it redeploys the target
+        // deployment's stored Docker image as-is — but it only works when that
+        // image is still present locally. The nightly cleanup prunes images
+        // after ~7 days, so reusing an older one fails with "image no longer
+        // exists locally", and static deployments have no runnable server image
+        // to reuse at all.
         //
-        // For git-sourced projects we instead re-run the full build pipeline at
-        // the target deployment's commit. This always works (no dependency on a
-        // surviving image), goes through the same health checks as a normal
-        // deploy, and rebuilds static bundles correctly. Non-git projects
-        // (docker_image / static_files / manual without a git ref) have no
-        // source to rebuild, so they fall through to image reuse.
+        // So for git-sourced projects we PREFER image reuse when the image is
+        // still in the local Docker cache (the common case — rolling back a
+        // recent deploy): it's near-instant and byte-identical to what we're
+        // rolling back to, with no dependency on the git remote or registry.
+        // We only fall back to a full rebuild-from-source at the target
+        // deployment's commit when the image is gone (pruned) or the preset is
+        // static (no reusable server image). The rebuild path always works (no
+        // dependency on a surviving image), goes through the same health checks
+        // as a normal deploy, and reconstructs static bundles correctly.
+        //
+        // Non-git projects (docker_image / static_files / manual without a git
+        // ref) have no source to rebuild, so they always use image reuse.
         let has_git_ref = target_deployment
             .commit_sha
             .as_ref()
@@ -1172,10 +1182,32 @@ impl DeploymentService {
                 .as_ref()
                 .is_some_and(|b| !b.is_empty());
 
-        if project.source_type == temps_entities::source_type::SourceType::Git && has_git_ref {
+        // Is the target's image still in the local cache? A static preset has no
+        // reusable server image, so treat it as "not present" to force a rebuild.
+        // Any error probing Docker is treated as "not present" — rebuilding from
+        // source is always safe, whereas trusting a possibly-stale image is not.
+        let is_static = preset.project_type() == temps_presets::ProjectType::Static;
+        let image_present = if is_static {
+            false
+        } else {
+            match target_deployment.image_name.as_deref() {
+                Some(img) if !img.is_empty() => {
+                    self.deployer.image_exists(img).await.unwrap_or(false)
+                }
+                _ => false,
+            }
+        };
+
+        if project.source_type == temps_entities::source_type::SourceType::Git
+            && has_git_ref
+            && !image_present
+        {
             info!(
-                "Rollback: project {} is git-sourced — rebuilding from source at commit {:?} (rolling back to #{})",
-                project_id, target_deployment.commit_sha, deployment_id
+                "Rollback: project {} is git-sourced and the target image is unavailable ({}) — rebuilding from source at commit {:?} (rolling back to #{})",
+                project_id,
+                if is_static { "static preset" } else { "image not in local cache" },
+                target_deployment.commit_sha,
+                deployment_id
             );
 
             // Snapshot the latest deployment id BEFORE triggering, so we can
@@ -1244,9 +1276,6 @@ impl DeploymentService {
             "Initiating rollback for project_id: {}, to deployment_id: {}, image: {}, environment_id: {}",
             project_id, deployment_id, image_name, environment_id
         );
-
-        let preset = temps_presets::get_preset_by_slug(project.preset.as_str())
-            .ok_or_else(|| DeploymentError::NotFound("Preset not found".to_string()))?;
 
         // --- Create a NEW deployment record for the rollback ---
         // This gives us fresh timestamps, a unique slug, and proper tracking.
@@ -4064,14 +4093,14 @@ mod tests {
     }
 
     /// When the target deployment carries a git commit on a git-sourced
-    /// project, rollback should rebuild from source (enqueue a GitPushEvent)
-    /// rather than reuse the stored image. We assert it does NOT take the
-    /// image-reuse path: that path synchronously inserts a brand-new
-    /// deployment row (different id) and flips the environment pointer. The
-    /// rebuild path enqueues an async job, so within the test the only
-    /// deployments present are the originals — no extra image-reuse row.
+    /// project AND the stored image is gone (pruned), rollback should rebuild
+    /// from source (enqueue a GitPushEvent) rather than fail. We assert it does
+    /// NOT take the image-reuse path: that path synchronously inserts a
+    /// brand-new deployment row (different id) and flips the environment
+    /// pointer. The rebuild path enqueues an async job, so within the test the
+    /// only deployments present are the originals — no extra image-reuse row.
     #[tokio::test]
-    async fn test_rollback_rebuilds_from_source_for_git_projects(
+    async fn test_rollback_rebuilds_from_source_when_image_missing(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let test_db = TestDatabase::with_migrations().await?;
         let db = test_db.connection_arc();
@@ -4090,7 +4119,9 @@ mod tests {
             .count(db.as_ref())
             .await?;
 
-        let deployment_service = create_deployment_service_for_test(db.clone());
+        // image_exists -> false simulates the nightly prune having removed the
+        // target's image, so rollback must rebuild from source.
+        let deployment_service = create_deployment_service_with_missing_image(db.clone());
 
         let result = deployment_service
             .rollback_to_deployment(target_deployment.project_id, target_deployment.id)
@@ -4111,6 +4142,63 @@ mod tests {
         assert_eq!(
             result.id, target_deployment.id,
             "rebuild path returns the target as a stand-in while the job is queued"
+        );
+
+        Ok(())
+    }
+
+    /// When the target deployment carries a git commit on a git-sourced project
+    /// AND the stored image is still in the local Docker cache (the common case
+    /// — rolling back a recent deploy), rollback should REUSE that image rather
+    /// than pay for a full rebuild from source. Reuse is near-instant and
+    /// byte-identical to the deployment we're rolling back to. We assert it
+    /// takes the image-reuse path: that path synchronously inserts a brand-new
+    /// rollback deployment row (a different id from the target) and returns it.
+    #[tokio::test]
+    async fn test_rollback_reuses_local_image_for_git_projects(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+
+        // setup_test_data creates a Git-source project (SourceType default)
+        // with a non-static preset (NextJs) and image_name "nginx:latest".
+        let (_project, _environment, target_deployment) = setup_test_data(&db).await?;
+
+        // Give the target a real git commit — without the fix this alone would
+        // force a rebuild even though the image is sitting right here.
+        let mut active: deployments::ActiveModel = target_deployment.clone().into();
+        active.commit_sha = Set(Some("abc1234deadbeef".to_string()));
+        active.branch_ref = Set(Some("main".to_string()));
+        let target_deployment = active.update(db.as_ref()).await?;
+
+        let count_before = deployments::Entity::find()
+            .filter(deployments::Column::ProjectId.eq(target_deployment.project_id))
+            .count(db.as_ref())
+            .await?;
+
+        // Default test service: image_exists -> true (image present locally).
+        let deployment_service = create_deployment_service_for_test(db.clone());
+
+        let result = deployment_service
+            .rollback_to_deployment(target_deployment.project_id, target_deployment.id)
+            .await?;
+
+        // The image-reuse path synchronously inserts a fresh rollback row, so
+        // the count grows and the returned id differs from the target's. (The
+        // rebuild path would have left the count unchanged and returned the
+        // target as a stand-in.)
+        let count_after = deployments::Entity::find()
+            .filter(deployments::Column::ProjectId.eq(target_deployment.project_id))
+            .count(db.as_ref())
+            .await?;
+        assert_eq!(
+            count_before + 1,
+            count_after,
+            "image reuse must synchronously create a new rollback deployment"
+        );
+        assert_ne!(
+            result.id, target_deployment.id,
+            "image reuse returns the freshly-created rollback deployment, not the target"
         );
 
         Ok(())

--- a/crates/temps-git/src/services/git_provider_manager.rs
+++ b/crates/temps-git/src/services/git_provider_manager.rs
@@ -4069,6 +4069,7 @@ impl GitProviderManager {
                 project_id: project.id,
                 // Real git provider webhook — honour automatic_deploy.
                 manual_trigger: false,
+                rollback_from_deployment_id: None,
             };
 
             if let Err(e) = self

--- a/crates/temps-projects/src/services/project.rs
+++ b/crates/temps-projects/src/services/project.rs
@@ -1822,6 +1822,7 @@ impl ProjectService {
             // Initial deployment is a user-initiated event (project creation),
             // not a git webhook — bypass automatic_deploy.
             manual_trigger: true,
+            rollback_from_deployment_id: None,
         };
 
         self.queue_service
@@ -1993,6 +1994,7 @@ impl ProjectService {
             // `trigger_pipeline` on the projects service is hit by the
             // "Deploy" button and the CLI — both are user-initiated.
             manual_trigger: true,
+            rollback_from_deployment_id: None,
         };
 
         // Send the job to the queue

--- a/crates/temps-queue/src/queue.rs
+++ b/crates/temps-queue/src/queue.rs
@@ -585,6 +585,7 @@ mod tests {
             commit: "abc123def456".to_string(),
             project_id: 123,
             manual_trigger: false,
+            rollback_from_deployment_id: None,
         };
 
         // Publish job
@@ -740,6 +741,7 @@ mod tests {
             commit: "abc123".to_string(),
             project_id: 123,
             manual_trigger: false,
+            rollback_from_deployment_id: None,
         });
 
         let cert_job = Job::ProvisionCertificate(ProvisionCertificateJob {

--- a/crates/temps-queue/src/subscriber.rs
+++ b/crates/temps-queue/src/subscriber.rs
@@ -25,6 +25,7 @@ mod tests {
             commit: "abc123".to_string(),
             project_id: 123,
             manual_trigger: false,
+            rollback_from_deployment_id: None,
         };
         queue.send(Job::GitPushEvent(git_push_job)).await.unwrap();
 
@@ -79,6 +80,7 @@ mod tests {
             commit: "def456".to_string(),
             project_id: 999,
             manual_trigger: false,
+            rollback_from_deployment_id: None,
         };
         queue.send(Job::GitPushEvent(git_push_job)).await.unwrap();
 
@@ -119,6 +121,7 @@ mod tests {
             commit: "xyz789".to_string(),
             project_id: 42,
             manual_trigger: false,
+            rollback_from_deployment_id: None,
         };
         queue.send(Job::GitPushEvent(git_push_job)).await.unwrap();
 


### PR DESCRIPTION
## Summary

Rollback previously **reused the target deployment's stored Docker image** unconditionally. That approach is fragile, with three documented failure modes:

1. **Pruned images break rollback.** The nightly cleanup prunes dangling images after ~7 days, so rolling back to anything older failed with `Docker image '...' no longer exists locally`.
2. **No readiness check** on the old image-reuse promotion path.
3. **Static deployments can't roll back** via image reuse — the prior image lacks a server runtime.

This PR makes rollback **prefer image reuse when the image is still local, and fall back to rebuild-from-source only when it isn't**:

- **Image present in the local Docker cache** (the common case — rolling back a recent deploy) → **reuse it**. Near-instant and byte-identical to the deployment you're rolling back to, with no dependency on the git remote or registry.
- **Image pruned, or a static preset** (no runnable server image) → **rebuild from source** at the target deployment's commit, going through the same build + health-check pipeline as a normal deploy.

**Non-git projects** (`docker_image` / `static_files` / `manual` without a git ref) have no source to rebuild, so they **keep the existing image-reuse path unchanged**.

## Mechanism
- `GitPushEventJob` gains an optional `rollback_from_deployment_id` (`#[serde(default)]` for back-compat with in-flight queued jobs).
- `rollback_to_deployment` probes `deployer.image_exists(...)` (static presets count as "not present"); a git project rebuilds from source only when `source_type == Git && has_git_ref && !image_present`. Otherwise it falls through to the unchanged image-reuse path.
- When rebuilding, `process_git_push_event` marks the created deployment `is_rollback` / `rolled_back_from_id` and tags `context_vars` with `trigger=rollback` / `source=rebuild_from_source`, so the UI/history show it as a rollback.
- `trigger_pipeline`'s public signature is unchanged — it delegates to a private `trigger_pipeline_inner` that carries the marker. All other `GitPushEventJob` construction sites pass `None`.

## Testing

**Unit (real Postgres):**
- `test_rollback_reuses_local_image_for_git_projects` — git project + image present → image-reuse (synchronous new row, different id).
- `test_rollback_rebuilds_from_source_when_image_missing` — git project + pruned image → rebuild (GitPushEvent enqueued, no synchronous row).
- `test_rollback_fails_when_image_missing` (non-git) and `test_rollback_to_deployment` (non-git happy path) — unchanged behavior, still pass.
- Full `temps-deployments` suite: **388 passed**, `cargo check` + `clippy` + `fmt` clean.

**End-to-end (live server, real GitHub repo + Docker images), project `sandbox-test-nextjs`:**
- **Reuse** — rollback to a deployment whose image was in the cache: `Rollback: Image '...' exists locally, proceeding`; new deployment `completed` in **911 ms**, image reused, no clone/build/GitPushEvent.
- **Rebuild** — after `docker rmi` of the target's image: `... target image is unavailable (image not in local cache) — rebuilding from source at commit ...`; a GitPushEvent was enqueued, a new deployment (`isRollback:true`, `source=rebuild_from_source`) downloaded the source archive and built a fresh image via BuildKit.

## Notes
- **Server-side** (Rust). The CLI `temps rollback` needs no change — it calls the same endpoint.
