### PR TITLE
docs(agents): document changelog CI gate and skip-changelog label

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,22 @@ If you're touching code without writing a CHANGELOG entry, you're
 either doing the wrong thing or you forgot. Stop and add the entry
 before staging the commit.
 
+**This is CI-enforced on every PR to `main`.** The `changelog-check`
+workflow fails the PR unless the diff touches `CHANGELOG.md` (with a
+valid `## [Unreleased]` category) **or** the PR carries the
+`skip-changelog` label. So for every PR you open, do one of:
+
+- **Add a `CHANGELOG.md` entry** (the default — see above). This is
+  also required for changes to the `@temps-sdk/cli` npm package, even
+  though it versions separately; tag those bullets with `(\`@temps-sdk/cli\`, #PR)`.
+- **Apply the `skip-changelog` label** (`gh pr edit <n> --add-label
+  skip-changelog`) only when the change is genuinely changelog-exempt:
+  docs/typos, CI/build config, dependency bumps with no operator
+  impact, pure refactors, or test-only changes.
+
+Don't open a PR and leave the changelog check red — resolve it the
+same way you'd resolve a failing test.
+
 ## Use the generated OpenAPI SDK in `web/`
 
 The frontend has a generated TypeScript SDK at `web/src/api/client/`


### PR DESCRIPTION
## Summary

`AGENTS.md` already had an "Always update `CHANGELOG.md`" section, but it didn't mention the **CI enforcement** or the **`skip-changelog` escape hatch**. This adds both so the rule is actionable when opening a PR:

- The `changelog-check` workflow **fails any PR to `main`** unless `CHANGELOG.md` is touched (with a valid `## [Unreleased]` category) **or** the PR carries the `skip-changelog` label.
- For every PR, do one of: add a changelog entry (default), or apply `skip-changelog` (`gh pr edit <n> --add-label skip-changelog`) when genuinely exempt (docs/CI/deps/refactor/test-only).
- Notes that `@temps-sdk/cli` changes still need an entry despite versioning separately, tagged `(\`@temps-sdk/cli\`, #PR)`.

Docs-only — carries the `skip-changelog` label itself (and serves as a worked example of it).