### PR TITLE
fix(web): wrap long values in trace span detail panel

### DIFF
--- a/web/src/pages/TraceDetail.tsx
+++ b/web/src/pages/TraceDetail.tsx
@@ -496,7 +496,7 @@ export default function TraceDetail({ project }: TraceDetailProps) {
                       </Badge>
                     </div>
                     {selectedSpan.status_message && (
-                      <p className="text-xs text-destructive bg-destructive/10 rounded p-2">
+                      <p className="text-xs text-destructive bg-destructive/10 rounded p-2 break-words">
                         {selectedSpan.status_message}
                       </p>
                     )}
@@ -539,20 +539,20 @@ export default function TraceDetail({ project }: TraceDetailProps) {
                         <span className="text-muted-foreground shrink-0">
                           span:
                         </span>
-                        <span className="truncate">{selectedSpan.span_id}</span>
+                        <span className="break-all">{selectedSpan.span_id}</span>
                       </div>
                       <div className="flex gap-2">
                         <span className="text-muted-foreground shrink-0">
                           trace:
                         </span>
-                        <span className="truncate">{selectedSpan.trace_id}</span>
+                        <span className="break-all">{selectedSpan.trace_id}</span>
                       </div>
                       {selectedSpan.parent_span_id && (
                         <div className="flex gap-2">
                           <span className="text-muted-foreground shrink-0">
                             parent:
                           </span>
-                          <span className="truncate">
+                          <span className="break-all">
                             {selectedSpan.parent_span_id}
                           </span>
                         </div>
@@ -569,18 +569,22 @@ export default function TraceDetail({ project }: TraceDetailProps) {
                       <div className="space-y-1 text-xs">
                         {selectedSpan.resource.service_name && (
                           <div className="flex gap-2">
-                            <span className="text-muted-foreground">
+                            <span className="text-muted-foreground shrink-0">
                               service.name:
                             </span>
-                            <span>{selectedSpan.resource.service_name}</span>
+                            <span className="break-all">
+                              {selectedSpan.resource.service_name}
+                            </span>
                           </div>
                         )}
                         {selectedSpan.resource.service_version && (
                           <div className="flex gap-2">
-                            <span className="text-muted-foreground">
+                            <span className="text-muted-foreground shrink-0">
                               service.version:
                             </span>
-                            <span>{selectedSpan.resource.service_version}</span>
+                            <span className="break-all">
+                              {selectedSpan.resource.service_version}
+                            </span>
                           </div>
                         )}
                       </div>
@@ -606,7 +610,7 @@ export default function TraceDetail({ project }: TraceDetailProps) {
                                   <span className="text-muted-foreground shrink-0">
                                     {key}:
                                   </span>
-                                  <span className="truncate">
+                                  <span className="break-all">
                                     {typeof value === 'object'
                                       ? JSON.stringify(value)
                                       : String(value)}
@@ -651,10 +655,10 @@ export default function TraceDetail({ project }: TraceDetailProps) {
                                           key={k}
                                           className="flex gap-2 font-mono"
                                         >
-                                          <span className="text-muted-foreground">
+                                          <span className="text-muted-foreground shrink-0">
                                             {k}:
                                           </span>
-                                          <span className="truncate">
+                                          <span className="break-all">
                                             {typeof v === 'object'
                                               ? JSON.stringify(v)
                                               : String(v)}


### PR DESCRIPTION
## What
The trace **span detail panel** (`web/src/pages/TraceDetail.tsx`) truncated its value cells with `truncate`, so long span/trace/parent IDs, resource fields, attribute values, and the error message were clipped at the panel's right edge with no way to read them.

## Change
- Value cells (IDs, resource, span attributes, event attributes) → `break-all` so they wrap and are fully visible.
- Error/status message → `break-words`.
- Label cells get `shrink-0` so the key stays intact and the value wraps.
- Span-name **headers** (page header + panel title) intentionally keep `truncate`.

## Verification
Tested in-browser against a real trace (via agent-browser): the IDs and attribute values now render `break-all` with `overflow: false` (wrap, no clipping).

`skip-changelog`: UI-only CSS tweak, no user-facing behavior/API change.