### PR TITLE
feat(notifications): add Cloudflare Email Sending provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
--
+- **Cloudflare Email Sending notification provider.** A new notification
+  provider delivers alert emails through Cloudflare's transactional Email
+  Sending API instead of a self-managed SMTP relay. Operators configure only an
+  account id, an API token with the Email Sending permission, the verified
+  sender (from name/address), and the recipients — the subject and HTML/text
+  bodies are derived from each notification (HTML reuses the shared notification
+  email template). Adds dedicated `POST`/`PUT /notification-providers/cloudflare`
+  endpoints plus a "Cloudflare Email" option in the notification provider UI
+  (#160).
 
 ### Changed
 -

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12098,6 +12098,7 @@ dependencies = [
  "tracing",
  "utoipa",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/temps-notifications/Cargo.toml
+++ b/crates/temps-notifications/Cargo.toml
@@ -34,3 +34,4 @@ thiserror = { workspace = true }
 tokio-test = "0.4"
 testcontainers = { workspace = true }
 tower = { version = "0.4", features = ["util"] }
+wiremock = "0.6"

--- a/crates/temps-notifications/src/handlers.rs
+++ b/crates/temps-notifications/src/handlers.rs
@@ -115,9 +115,11 @@ fn make_audit_context(auth: &temps_auth::AuthContext, metadata: &RequestMetadata
         create_slack_provider,
         create_notification_email_provider,
         create_webhook_provider,
+        create_cloudflare_provider,
         update_slack_provider,
         update_email_provider,
         update_webhook_provider,
+        update_cloudflare_provider,
         get_preferences,
         update_preferences,
         delete_preferences,
@@ -136,9 +138,12 @@ fn make_audit_context(auth: &temps_auth::AuthContext, metadata: &RequestMetadata
             CreateSlackProviderRequest,
             CreateNotificationEmailProviderRequest,
             CreateWebhookProviderRequest,
+            CloudflareConfig,
+            CreateCloudflareProviderRequest,
             UpdateSlackProviderRequest,
             UpdateNotificationEmailProviderRequest,
             UpdateWebhookProviderRequest,
+            UpdateCloudflareProviderRequest,
             NotificationPreferencesResponse,
             UpdatePreferencesRequest,
             TriggerDigestResponse,
@@ -291,6 +296,44 @@ pub struct CreateWebhookProviderRequest {
 pub struct UpdateWebhookProviderRequest {
     pub name: Option<String>,
     pub config: WebhookConfig,
+    pub enabled: Option<bool>,
+}
+
+/// Configuration for a Cloudflare Email Sending notification provider.
+///
+/// Notifications are delivered through Cloudflare's transactional Email Sending
+/// API. Only the account, token, sender and recipients are configured here —
+/// subject and body are derived from each notification.
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct CloudflareConfig {
+    /// Cloudflare account id that owns the Email Sending configuration.
+    #[schema(example = "023e105f4ecef8ad9ca31a8372d0c353")]
+    pub account_id: String,
+    /// Cloudflare API token with the Email Sending permission. Stored encrypted
+    /// and masked in responses.
+    pub api_token: String,
+    /// Verified sender address (must belong to a domain enabled for Cloudflare
+    /// Email Sending).
+    #[schema(example = "welcome@infracf.example.com")]
+    pub from_address: String,
+    /// Optional human-friendly sender name shown in the recipient's inbox.
+    #[serde(default)]
+    pub from_name: Option<String>,
+    /// Recipients that should receive the notification.
+    pub to_addresses: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct CreateCloudflareProviderRequest {
+    pub name: String,
+    pub config: CloudflareConfig,
+    pub enabled: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct UpdateCloudflareProviderRequest {
+    pub name: Option<String>,
+    pub config: CloudflareConfig,
     pub enabled: Option<bool>,
 }
 
@@ -1207,6 +1250,164 @@ async fn update_webhook_provider(
     }
 }
 
+/// Create a new Cloudflare Email Sending notification provider
+#[utoipa::path(
+    post,
+    path = "/notification-providers/cloudflare",
+    request_body = CreateCloudflareProviderRequest,
+    responses(
+        (status = 201, description = "Successfully created Cloudflare provider", body = NotificationProviderResponse),
+        (status = 400, description = "Invalid request"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "Notification Providers",
+    security(
+        ("bearer_auth" = [])
+    )
+)]
+async fn create_cloudflare_provider(
+    State(app_state): State<Arc<NotificationState>>,
+    RequireAuth(auth): RequireAuth,
+    Extension(metadata): Extension<RequestMetadata>,
+    Json(request): Json<CreateCloudflareProviderRequest>,
+) -> Result<impl IntoResponse, Problem> {
+    permission_guard!(auth, NotificationProvidersCreate);
+    info!("Creating Cloudflare notification provider {}", request.name);
+    let config = serde_json::to_value(request.config).unwrap_or_default();
+    match app_state
+        .notification_service
+        .add_provider(request.name, "cloudflare".to_string(), config)
+        .await
+    {
+        Ok(provider) => {
+            let audit = NotificationProviderAudit {
+                context: make_audit_context(&auth, &metadata),
+                provider_id: provider.id,
+                provider_type: "cloudflare".to_string(),
+                action: "NOTIFICATION_PROVIDER_CREATED".to_string(),
+            };
+            if let Err(e) = app_state.audit_service.create_audit_log(&audit).await {
+                error!("Failed to create audit log: {}", e);
+            }
+
+            let config = app_state
+                .notification_service
+                .decrypt_provider_config(&provider.config)
+                .map_err(|e| {
+                    error!("Failed to decrypt provider config: {}", e);
+                    ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
+                        .title("Failed to decrypt provider configuration")
+                        .detail(format!("Error: {}", e))
+                        .build()
+                })?;
+            let response = NotificationProviderResponse {
+                id: provider.id,
+                name: provider.name,
+                provider_type: provider.provider_type,
+                config,
+                enabled: provider.enabled,
+                created_at: provider.created_at.timestamp_millis(),
+                updated_at: provider.updated_at.timestamp_millis(),
+            };
+            Ok((StatusCode::CREATED, Json(response)))
+        }
+        Err(e) => {
+            error!("Failed to create Cloudflare notification provider: {}", e);
+            Err(ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
+                .title("Failed to create Cloudflare notification provider")
+                .detail(format!("Error: {}", e))
+                .build())
+        }
+    }
+}
+
+/// Update a Cloudflare Email Sending notification provider
+#[utoipa::path(
+    put,
+    path = "/notification-providers/cloudflare/{id}",
+    request_body = UpdateCloudflareProviderRequest,
+    responses(
+        (status = 200, description = "Successfully updated Cloudflare provider", body = NotificationProviderResponse),
+        (status = 404, description = "Provider not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    params(
+        ("id" = i32, Path, description = "Provider ID")
+    ),
+    tag = "Notification Providers",
+    security(
+        ("bearer_auth" = [])
+    )
+)]
+async fn update_cloudflare_provider(
+    State(app_state): State<Arc<NotificationState>>,
+    Path(id): Path<i32>,
+    RequireAuth(auth): RequireAuth,
+    Extension(metadata): Extension<RequestMetadata>,
+    Json(request): Json<UpdateCloudflareProviderRequest>,
+) -> Result<impl IntoResponse, Problem> {
+    permission_guard!(auth, NotificationProvidersWrite);
+    info!("Updating Cloudflare notification provider {}", id);
+    let config = serde_json::to_value(request.config).unwrap_or_default();
+    let update_request = UpdateProviderRequest {
+        name: request.name,
+        config: Some(config),
+        enabled: request.enabled,
+    };
+    match app_state
+        .notification_service
+        .update_provider(id, update_request.into())
+        .await
+    {
+        Ok(Some(provider)) => {
+            let audit = NotificationProviderAudit {
+                context: make_audit_context(&auth, &metadata),
+                provider_id: provider.id,
+                provider_type: "cloudflare".to_string(),
+                action: "NOTIFICATION_PROVIDER_UPDATED".to_string(),
+            };
+            if let Err(e) = app_state.audit_service.create_audit_log(&audit).await {
+                error!("Failed to create audit log: {}", e);
+            }
+
+            let config = app_state
+                .notification_service
+                .decrypt_provider_config(&provider.config)
+                .map_err(|e| {
+                    error!("Failed to decrypt provider config: {}", e);
+                    ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
+                        .title("Failed to decrypt provider configuration")
+                        .detail(format!("Error: {}", e))
+                        .build()
+                })?;
+            let response = NotificationProviderResponse {
+                id: provider.id,
+                name: provider.name,
+                provider_type: provider.provider_type,
+                config,
+                enabled: provider.enabled,
+                created_at: provider.created_at.timestamp_millis(),
+                updated_at: provider.updated_at.timestamp_millis(),
+            };
+            Ok((StatusCode::OK, Json(response)))
+        }
+        Ok(None) => Err(ErrorBuilder::new(StatusCode::NOT_FOUND)
+            .title("Provider not found")
+            .detail("The requested Cloudflare notification provider does not exist")
+            .build()),
+        Err(e) => {
+            error!(
+                "Failed to update Cloudflare notification provider {}: {}",
+                id, e
+            );
+            Err(ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
+                .title("Failed to update Cloudflare notification provider")
+                .detail(format!("Error: {}", e))
+                .build())
+        }
+    }
+}
+
 // Notification Preferences Types and Handlers
 
 #[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
@@ -1548,6 +1749,10 @@ pub fn configure_routes() -> Router<Arc<NotificationState>> {
             post(create_webhook_provider),
         )
         .route(
+            "/notification-providers/cloudflare",
+            post(create_cloudflare_provider),
+        )
+        .route(
             "/notification-providers/{id}",
             get(get_notification_provider),
         )
@@ -1566,6 +1771,10 @@ pub fn configure_routes() -> Router<Arc<NotificationState>> {
         .route(
             "/notification-providers/webhook/{id}",
             put(update_webhook_provider),
+        )
+        .route(
+            "/notification-providers/cloudflare/{id}",
+            put(update_cloudflare_provider),
         )
         .route(
             "/notification-providers/{id}",

--- a/crates/temps-notifications/src/handlers.rs
+++ b/crates/temps-notifications/src/handlers.rs
@@ -309,8 +309,9 @@ pub struct CloudflareConfig {
     /// Cloudflare account id that owns the Email Sending configuration.
     #[schema(example = "023e105f4ecef8ad9ca31a8372d0c353")]
     pub account_id: String,
-    /// Cloudflare API token with the Email Sending permission. Stored encrypted
-    /// and masked in responses.
+    /// Cloudflare API token with the Email Sending permission. Encrypted at
+    /// rest; like the other notification providers, it is returned decrypted to
+    /// authorized callers so the edit form can prefill (not masked).
     pub api_token: String,
     /// Verified sender address (must belong to a domain enabled for Cloudflare
     /// Email Sending).

--- a/crates/temps-notifications/src/services.rs
+++ b/crates/temps-notifications/src/services.rs
@@ -141,6 +141,11 @@ pub struct CloudflareProvider {
     pub from_name: Option<String>,
     /// Recipients that should receive the notification.
     pub to_addresses: Vec<String>,
+    /// Override for the Cloudflare API base URL. Never serialized into stored
+    /// config — it exists only so integration tests can point the provider at a
+    /// local mock server. Production always uses [`Self::API_BASE`].
+    #[serde(skip)]
+    pub api_base: Option<String>,
 }
 
 impl CloudflareProvider {
@@ -148,10 +153,15 @@ impl CloudflareProvider {
     /// build the same URL.
     const API_BASE: &'static str = "https://api.cloudflare.com/client/v4";
 
+    /// Effective API base — the test override if set, otherwise the real one.
+    fn api_base(&self) -> &str {
+        self.api_base.as_deref().unwrap_or(Self::API_BASE)
+    }
+
     fn send_endpoint(&self) -> String {
         format!(
             "{}/accounts/{}/email/sending/send",
-            Self::API_BASE,
+            self.api_base(),
             self.account_id
         )
     }
@@ -311,7 +321,7 @@ impl NotificationProvider for CloudflareProvider {
 
         let url = format!(
             "{}/accounts/{}/email/sending/addresses",
-            Self::API_BASE,
+            self.api_base(),
             self.account_id
         );
 
@@ -2175,6 +2185,7 @@ mod tests {
             from_address: "welcome@infracf.example.com".to_string(),
             from_name: Some("Temps".to_string()),
             to_addresses: to.into_iter().map(String::from).collect(),
+            api_base: None,
         }
     }
 
@@ -2243,10 +2254,118 @@ mod tests {
     fn test_cloudflare_config_serialization_roundtrip() {
         let provider = cloudflare_provider(vec!["a@example.com", "b@example.com"]);
         let json = serde_json::to_string(&provider).unwrap();
+        // The api_base test override must never leak into stored config.
+        assert!(!json.contains("api_base"));
         let parsed: CloudflareProvider = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.account_id, "acct123");
         assert_eq!(parsed.to_addresses.len(), 2);
         assert_eq!(parsed.from_name.as_deref(), Some("Temps"));
+        assert_eq!(parsed.api_base, None);
+    }
+
+    // ---- Integration tests against a local mock HTTP server (wiremock) ----
+    // These exercise the real `send` / `health_check` HTTP paths: request
+    // method, path, bearer auth, JSON payload shape and response handling.
+
+    #[tokio::test]
+    async fn test_cloudflare_send_posts_to_each_recipient_with_auth_and_payload() {
+        use wiremock::matchers::{body_partial_json, header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/accounts/acct123/email/sending/send"))
+            .and(header("authorization", "Bearer cf-token"))
+            .and(body_partial_json(serde_json::json!({
+                "from": "Temps <welcome@infracf.example.com>",
+                "subject": "Deploy failed",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+            })))
+            .expect(2) // one POST per recipient
+            .mount(&server)
+            .await;
+
+        let mut provider = cloudflare_provider(vec!["a@example.com", "b@example.com"]);
+        provider.api_base = Some(server.uri());
+
+        let notification = Notification::new("Deploy failed", "The build crashed");
+        let result = provider.send(&notification).await;
+
+        assert!(result.is_ok(), "send should succeed: {:?}", result.err());
+        // `expect(2)` is verified on drop of the server.
+    }
+
+    #[tokio::test]
+    async fn test_cloudflare_send_errors_when_all_recipients_fail() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/accounts/acct123/email/sending/send"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "success": false,
+                "errors": [{ "message": "Authentication error" }],
+            })))
+            .mount(&server)
+            .await;
+
+        let mut provider = cloudflare_provider(vec!["a@example.com"]);
+        provider.api_base = Some(server.uri());
+
+        let notification = Notification::new("Alert", "Something broke");
+        let err = provider.send(&notification).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("403") && msg.contains("a@example.com"),
+            "error should carry status and recipient: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cloudflare_health_check_true_on_success() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/accounts/acct123/email/sending/addresses"))
+            .and(header("authorization", "Bearer cf-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "result": [],
+            })))
+            .mount(&server)
+            .await;
+
+        let mut provider = cloudflare_provider(vec!["a@example.com"]);
+        provider.api_base = Some(server.uri());
+
+        assert!(provider.health_check().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_cloudflare_health_check_false_on_bad_credentials() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/accounts/acct123/email/sending/addresses"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+
+        let mut provider = cloudflare_provider(vec!["a@example.com"]);
+        provider.api_base = Some(server.uri());
+
+        assert!(!provider.health_check().await.unwrap());
     }
 
     #[test]

--- a/crates/temps-notifications/src/services.rs
+++ b/crates/temps-notifications/src/services.rs
@@ -119,6 +119,212 @@ pub struct WebhookProvider {
     pub timeout_secs: u64,
 }
 
+/// Cloudflare Email Sending provider.
+///
+/// Delivers notification emails through Cloudflare's transactional Email
+/// Sending API (`POST /accounts/{account_id}/email/sending/send`) instead of a
+/// self-managed SMTP relay. The operator only needs to configure their
+/// Cloudflare account id, an API token with the *Email Sending* permission, the
+/// verified sender, and the list of recipients — everything else (HTML/text
+/// rendering, subject) is derived from the notification itself.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloudflareProvider {
+    /// Cloudflare account id that owns the Email Sending configuration.
+    pub account_id: String,
+    /// Cloudflare API token with the Email Sending permission. Stored encrypted.
+    pub api_token: String,
+    /// Verified sender address (must belong to a domain configured for
+    /// Cloudflare Email Sending, e.g. `welcome@infracf.example.com`).
+    pub from_address: String,
+    /// Optional human-friendly sender name shown in the recipient's inbox.
+    #[serde(default)]
+    pub from_name: Option<String>,
+    /// Recipients that should receive the notification.
+    pub to_addresses: Vec<String>,
+}
+
+impl CloudflareProvider {
+    /// Cloudflare API base. Kept as an associated const so tests and call sites
+    /// build the same URL.
+    const API_BASE: &'static str = "https://api.cloudflare.com/client/v4";
+
+    fn send_endpoint(&self) -> String {
+        format!(
+            "{}/accounts/{}/email/sending/send",
+            Self::API_BASE,
+            self.account_id
+        )
+    }
+
+    /// Build the `from` field. Cloudflare accepts a bare address or an RFC 5322
+    /// `Name <address>` form — mirror what an inbox would display.
+    fn sender_field(&self) -> String {
+        match &self.from_name {
+            Some(name) if !name.trim().is_empty() => format!("{} <{}>", name, self.from_address),
+            _ => self.from_address.clone(),
+        }
+    }
+
+    /// Plain-text fallback body. Cloudflare requires a `text` part alongside the
+    /// HTML one, so derive a readable version from the notification.
+    fn render_text_body(notification: &Notification) -> String {
+        let mut body = format!("{}\n\n{}", notification.title, notification.message);
+        if !notification.metadata.is_empty() {
+            body.push_str("\n\n---\n");
+            for (key, value) in &notification.metadata {
+                body.push_str(&format!("{}: {}\n", key, value));
+            }
+        }
+        body
+    }
+
+    /// POST a single rendered email to Cloudflare. Returns an error carrying the
+    /// status and response body so failures are diagnosable from the logs.
+    async fn post_email(
+        &self,
+        client: &reqwest::Client,
+        to: &str,
+        subject: &str,
+        html: &str,
+        text: &str,
+    ) -> Result<()> {
+        let payload = serde_json::json!({
+            "to": to,
+            "from": self.sender_field(),
+            "subject": subject,
+            "html": html,
+            "text": text,
+        });
+
+        let response = client
+            .post(self.send_endpoint())
+            .bearer_auth(&self.api_token)
+            .header("Content-Type", "application/json")
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Cloudflare email send to {} failed (request error): {}",
+                    to,
+                    e
+                )
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(anyhow::anyhow!(
+                "Cloudflare email send to {} failed with status {}: {}",
+                to,
+                status,
+                body
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl NotificationProvider for CloudflareProvider {
+    async fn initialize(&mut self, _db: Arc<DatabaseConnection>) -> Result<()> {
+        if self.account_id.trim().is_empty() {
+            return Err(anyhow::anyhow!("Cloudflare account_id cannot be empty"));
+        }
+        if self.api_token.trim().is_empty() {
+            return Err(anyhow::anyhow!("Cloudflare api_token cannot be empty"));
+        }
+        if self.from_address.trim().is_empty() {
+            return Err(anyhow::anyhow!("Cloudflare from_address cannot be empty"));
+        }
+        if self.to_addresses.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Cloudflare provider requires at least one recipient in to_addresses"
+            ));
+        }
+        Ok(())
+    }
+
+    async fn send(&self, notification: &Notification) -> Result<()> {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()?;
+
+        let priority_prefix = match notification.priority {
+            NotificationPriority::Low => "[LOW] ",
+            NotificationPriority::Normal => "",
+            NotificationPriority::High => "[HIGH] ",
+            NotificationPriority::Critical => "[CRITICAL] ",
+        };
+        let subject = format!("{}{}", priority_prefix, notification.title);
+
+        // Reuse the shared notification email template unless the message is
+        // already a full HTML document (matching EmailProvider's behaviour).
+        let trimmed = notification.message.trim_start();
+        let is_full_document = trimmed.starts_with("<!DOCTYPE")
+            || trimmed.starts_with("<!doctype")
+            || trimmed.starts_with("<html")
+            || trimmed.starts_with("<HTML");
+        let html = if is_full_document {
+            notification.message.clone()
+        } else {
+            EmailProvider::render_notification_email(notification)
+        };
+        let text = Self::render_text_body(notification);
+
+        // De-duplicate recipients while preserving determinism.
+        let mut recipients = self.to_addresses.clone();
+        recipients.sort();
+        recipients.dedup();
+
+        let mut last_err: Option<anyhow::Error> = None;
+        let mut delivered = false;
+        for addr in &recipients {
+            match self.post_email(&client, addr, &subject, &html, &text).await {
+                Ok(()) => delivered = true,
+                Err(e) => {
+                    error!("Failed to send Cloudflare email to {}: {}", addr, e);
+                    last_err = Some(e);
+                }
+            }
+        }
+
+        // Surface a failure only if every recipient failed — partial delivery
+        // still counts as a successful notification, consistent with SMTP.
+        if !delivered {
+            return Err(last_err.unwrap_or_else(|| {
+                anyhow::anyhow!("Cloudflare provider had no recipients to deliver to")
+            }));
+        }
+
+        Ok(())
+    }
+
+    async fn health_check(&self) -> Result<bool> {
+        // Verify the token/account by listing the account's Email Sending
+        // domains. This is a cheap, side-effect-free GET that fails fast on bad
+        // credentials without sending a real email.
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(15))
+            .build()?;
+
+        let url = format!(
+            "{}/accounts/{}/email/sending/addresses",
+            Self::API_BASE,
+            self.account_id
+        );
+
+        match client.get(url).bearer_auth(&self.api_token).send().await {
+            Ok(response) => Ok(response.status().is_success()),
+            Err(e) => {
+                error!("Cloudflare provider health check failed: {}", e);
+                Ok(false)
+            }
+        }
+    }
+}
+
 #[async_trait]
 pub trait NotificationProvider: Send + Sync {
     async fn initialize(&mut self, db: Arc<DatabaseConnection>) -> Result<()>;
@@ -1195,6 +1401,11 @@ impl NotificationService {
                 config.initialize(self.db.clone()).await?;
                 Box::new(config)
             }
+            "cloudflare" => {
+                let mut config: CloudflareProvider = serde_json::from_str(&decrypted_config)?;
+                config.initialize(self.db.clone()).await?;
+                Box::new(config)
+            }
             _ => return Err(anyhow::anyhow!("Unsupported provider type")),
         };
         Ok(provider)
@@ -1955,6 +2166,87 @@ mod tests {
             let upper = method.to_uppercase();
             assert!(!["POST", "PUT", "PATCH"].contains(&upper.as_str()));
         }
+    }
+
+    fn cloudflare_provider(to: Vec<&str>) -> CloudflareProvider {
+        CloudflareProvider {
+            account_id: "acct123".to_string(),
+            api_token: "cf-token".to_string(),
+            from_address: "welcome@infracf.example.com".to_string(),
+            from_name: Some("Temps".to_string()),
+            to_addresses: to.into_iter().map(String::from).collect(),
+        }
+    }
+
+    #[test]
+    fn test_cloudflare_send_endpoint() {
+        let provider = cloudflare_provider(vec!["a@example.com"]);
+        assert_eq!(
+            provider.send_endpoint(),
+            "https://api.cloudflare.com/client/v4/accounts/acct123/email/sending/send"
+        );
+    }
+
+    #[test]
+    fn test_cloudflare_from_field() {
+        let with_name = cloudflare_provider(vec!["a@example.com"]);
+        assert_eq!(
+            with_name.sender_field(),
+            "Temps <welcome@infracf.example.com>"
+        );
+
+        let mut without_name = cloudflare_provider(vec!["a@example.com"]);
+        without_name.from_name = None;
+        assert_eq!(without_name.sender_field(), "welcome@infracf.example.com");
+
+        // Whitespace-only name is treated as absent.
+        let mut blank_name = cloudflare_provider(vec!["a@example.com"]);
+        blank_name.from_name = Some("   ".to_string());
+        assert_eq!(blank_name.sender_field(), "welcome@infracf.example.com");
+    }
+
+    #[test]
+    fn test_cloudflare_text_body_includes_metadata() {
+        let notification = Notification::new("Deploy failed", "The build crashed")
+            .with_metadata("project", "temps")
+            .with_metadata("environment", "production");
+        let text = CloudflareProvider::render_text_body(&notification);
+        assert!(text.starts_with("Deploy failed\n\nThe build crashed"));
+        assert!(text.contains("project: temps"));
+        assert!(text.contains("environment: production"));
+    }
+
+    #[tokio::test]
+    async fn test_cloudflare_initialize_validates_required_fields() {
+        let db = Arc::new(MockDatabase::new(sea_orm::DatabaseBackend::Postgres).into_connection());
+
+        let mut ok = cloudflare_provider(vec!["a@example.com"]);
+        assert!(ok.initialize(db.clone()).await.is_ok());
+
+        let mut no_account = cloudflare_provider(vec!["a@example.com"]);
+        no_account.account_id = String::new();
+        assert!(no_account.initialize(db.clone()).await.is_err());
+
+        let mut no_token = cloudflare_provider(vec!["a@example.com"]);
+        no_token.api_token = String::new();
+        assert!(no_token.initialize(db.clone()).await.is_err());
+
+        let mut no_from = cloudflare_provider(vec!["a@example.com"]);
+        no_from.from_address = String::new();
+        assert!(no_from.initialize(db.clone()).await.is_err());
+
+        let mut no_recipients = cloudflare_provider(vec![]);
+        assert!(no_recipients.initialize(db).await.is_err());
+    }
+
+    #[test]
+    fn test_cloudflare_config_serialization_roundtrip() {
+        let provider = cloudflare_provider(vec!["a@example.com", "b@example.com"]);
+        let json = serde_json::to_string(&provider).unwrap();
+        let parsed: CloudflareProvider = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.account_id, "acct123");
+        assert_eq!(parsed.to_addresses.len(), 2);
+        assert_eq!(parsed.from_name.as_deref(), Some("Temps"));
     }
 
     #[test]

--- a/crates/temps-notifications/src/services.rs
+++ b/crates/temps-notifications/src/services.rs
@@ -166,12 +166,19 @@ impl CloudflareProvider {
         )
     }
 
-    /// Build the `from` field. Cloudflare accepts a bare address or an RFC 5322
-    /// `Name <address>` form — mirror what an inbox would display.
-    fn sender_field(&self) -> String {
+    /// Build the `from` field for the Cloudflare payload.
+    ///
+    /// Cloudflare Email Sending accepts either a bare address string or a
+    /// structured `{ "email", "name" }` object for a display name (the RFC 5322
+    /// `Name <address>` *string* form is NOT parsed — it would be treated as a
+    /// literal address). We emit the object form only when a name is set.
+    fn sender_value(&self) -> serde_json::Value {
         match &self.from_name {
-            Some(name) if !name.trim().is_empty() => format!("{} <{}>", name, self.from_address),
-            _ => self.from_address.clone(),
+            Some(name) if !name.trim().is_empty() => serde_json::json!({
+                "email": self.from_address,
+                "name": name,
+            }),
+            _ => serde_json::json!(self.from_address),
         }
     }
 
@@ -200,7 +207,7 @@ impl CloudflareProvider {
     ) -> Result<()> {
         let payload = serde_json::json!({
             "to": to,
-            "from": self.sender_field(),
+            "from": self.sender_value(),
             "subject": subject,
             "html": html,
             "text": text,
@@ -312,18 +319,15 @@ impl NotificationProvider for CloudflareProvider {
     }
 
     async fn health_check(&self) -> Result<bool> {
-        // Verify the token/account by listing the account's Email Sending
-        // domains. This is a cheap, side-effect-free GET that fails fast on bad
-        // credentials without sending a real email.
+        // Validate the API token via Cloudflare's documented token-verify
+        // endpoint (`GET /user/tokens/verify`). This is a cheap, side-effect-free
+        // check that fails fast on bad/expired credentials without sending a real
+        // email. It is account-independent by design.
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(15))
             .build()?;
 
-        let url = format!(
-            "{}/accounts/{}/email/sending/addresses",
-            self.api_base(),
-            self.account_id
-        );
+        let url = format!("{}/user/tokens/verify", self.api_base());
 
         match client.get(url).bearer_auth(&self.api_token).send().await {
             Ok(response) => Ok(response.status().is_success()),
@@ -2199,21 +2203,33 @@ mod tests {
     }
 
     #[test]
-    fn test_cloudflare_from_field() {
+    fn test_cloudflare_sender_value() {
+        // With a display name → structured { email, name } object (Cloudflare's
+        // documented format; the RFC `Name <addr>` string is NOT used).
         let with_name = cloudflare_provider(vec!["a@example.com"]);
         assert_eq!(
-            with_name.sender_field(),
-            "Temps <welcome@infracf.example.com>"
+            with_name.sender_value(),
+            serde_json::json!({
+                "email": "welcome@infracf.example.com",
+                "name": "Temps",
+            })
         );
 
+        // Without a name → bare address string.
         let mut without_name = cloudflare_provider(vec!["a@example.com"]);
         without_name.from_name = None;
-        assert_eq!(without_name.sender_field(), "welcome@infracf.example.com");
+        assert_eq!(
+            without_name.sender_value(),
+            serde_json::json!("welcome@infracf.example.com")
+        );
 
         // Whitespace-only name is treated as absent.
         let mut blank_name = cloudflare_provider(vec!["a@example.com"]);
         blank_name.from_name = Some("   ".to_string());
-        assert_eq!(blank_name.sender_field(), "welcome@infracf.example.com");
+        assert_eq!(
+            blank_name.sender_value(),
+            serde_json::json!("welcome@infracf.example.com")
+        );
     }
 
     #[test]
@@ -2278,7 +2294,7 @@ mod tests {
             .and(path("/accounts/acct123/email/sending/send"))
             .and(header("authorization", "Bearer cf-token"))
             .and(body_partial_json(serde_json::json!({
-                "from": "Temps <welcome@infracf.example.com>",
+                "from": { "email": "welcome@infracf.example.com", "name": "Temps" },
                 "subject": "Deploy failed",
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
@@ -2334,11 +2350,11 @@ mod tests {
         let server = MockServer::start().await;
 
         Mock::given(method("GET"))
-            .and(path("/accounts/acct123/email/sending/addresses"))
+            .and(path("/user/tokens/verify"))
             .and(header("authorization", "Bearer cf-token"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "success": true,
-                "result": [],
+                "result": { "id": "tok123", "status": "active" },
             })))
             .mount(&server)
             .await;
@@ -2357,7 +2373,7 @@ mod tests {
         let server = MockServer::start().await;
 
         Mock::given(method("GET"))
-            .and(path("/accounts/acct123/email/sending/addresses"))
+            .and(path("/user/tokens/verify"))
             .respond_with(ResponseTemplate::new(401))
             .mount(&server)
             .await;

--- a/web/src/components/monitoring/ProviderForm.tsx
+++ b/web/src/components/monitoring/ProviderForm.tsx
@@ -101,6 +101,9 @@ export function ProviderForm({
                       <SelectItem value="email">Email</SelectItem>
                       <SelectItem value="slack">Slack</SelectItem>
                       <SelectItem value="webhook">Webhook</SelectItem>
+                      <SelectItem value="cloudflare">
+                        Cloudflare Email
+                      </SelectItem>
                     </SelectContent>
                   </Select>
                   <FormMessage />
@@ -590,6 +593,127 @@ export function ProviderForm({
 }`}
               </pre>
             </div>
+          </div>
+        )}
+
+        {providerType === 'cloudflare' && (
+          <div className="space-y-6">
+            <div className="space-y-4">
+              <h3 className="text-sm font-medium leading-none">
+                Cloudflare Email Sending
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                Sends notification emails through Cloudflare&apos;s
+                transactional Email Sending API. The sender domain must be
+                configured for Email Sending in your Cloudflare account.
+              </p>
+            </div>
+
+            <FormField
+              control={form.control}
+              name="config.account_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Account ID</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="023e105f4ecef8ad9ca31a8372d0c353"
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Your Cloudflare account identifier
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="config.api_token"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>API Token</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      type="password"
+                      placeholder="••••••••"
+                      autoComplete="off"
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    A Cloudflare API token with the Email Sending permission
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="config.from_name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>From Name</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder="Notification System" />
+                  </FormControl>
+                  <FormDescription>
+                    The name that will appear in the email sender field
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="config.from_address"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>From Address</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      type="email"
+                      placeholder="welcome@infracf.example.com"
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Must belong to a domain enabled for Cloudflare Email Sending
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="config.to_addresses"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>To Addresses</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="recipient1@example.com, recipient2@example.com"
+                      onChange={(e) =>
+                        field.onChange(
+                          e.target.value.split(',').map((email) => email.trim())
+                        )
+                      }
+                      value={field.value?.join(', ') || ''}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Separate multiple email addresses with commas
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
           </div>
         )}
 

--- a/web/src/components/monitoring/ProvidersManagement.tsx
+++ b/web/src/components/monitoring/ProvidersManagement.tsx
@@ -39,7 +39,7 @@ import { ProviderForm } from './ProviderForm'
 import { ProviderFormData, providerSchema } from './schemas'
 
 interface ExtendedNotificationProvider extends NotificationProviderResponse {
-  provider_type: 'email' | 'slack' | 'webhook'
+  provider_type: 'email' | 'slack' | 'webhook' | 'cloudflare'
   config: {
     // Slack config
     webhook_url?: string
@@ -60,6 +60,10 @@ interface ExtendedNotificationProvider extends NotificationProviderResponse {
     method?: 'POST' | 'PUT' | 'PATCH'
     headers?: Record<string, string>
     timeout_secs?: number
+
+    // Cloudflare config
+    account_id?: string
+    api_token?: string
   }
 }
 
@@ -110,6 +114,21 @@ export function ProvidersManagement() {
     },
     onSuccess: () => {
       toast.success('Webhook provider updated successfully')
+      setIsEditDialogOpen(false)
+      setEditingProvider(null)
+      refetch()
+    },
+  })
+
+  // Cloudflare uses the generic notification-provider endpoint (provider_type
+  // + opaque config) rather than a dedicated typed mutation.
+  const updateCloudflareMutation = useMutation({
+    ...updateNotificationProviderMutation(),
+    meta: {
+      errorTitle: 'Failed to update Cloudflare provider',
+    },
+    onSuccess: () => {
+      toast.success('Cloudflare provider updated successfully')
       setIsEditDialogOpen(false)
       setEditingProvider(null)
       refetch()
@@ -180,6 +199,21 @@ export function ProvidersManagement() {
             method: data.config.method || 'POST',
             headers: (data.config.headers || {}) as Record<string, string>,
             timeout_secs: data.config.timeout_secs || 30,
+          },
+        },
+      })
+    } else if (data.provider_type === 'cloudflare') {
+      await updateCloudflareMutation.mutateAsync({
+        path: { id: editingProvider.id },
+        body: {
+          name: data.name,
+          enabled: editingProvider.enabled,
+          config: {
+            account_id: data.config.account_id!,
+            api_token: data.config.api_token!,
+            from_address: data.config.from_address!,
+            from_name: data.config.from_name || undefined,
+            to_addresses: data.config.to_addresses!,
           },
         },
       })
@@ -266,11 +300,14 @@ export function ProvidersManagement() {
         ? updateEmailMutation.isPending
         : watchedProviderType === 'slack'
           ? updateSlackMutation.isPending
-          : updateWebhookMutation.isPending,
+          : watchedProviderType === 'cloudflare'
+            ? updateCloudflareMutation.isPending
+            : updateWebhookMutation.isPending,
     [
       watchedProviderType,
       updateEmailMutation.isPending,
       updateSlackMutation.isPending,
+      updateCloudflareMutation.isPending,
       updateWebhookMutation.isPending,
     ]
   )
@@ -358,7 +395,8 @@ export function ProvidersManagement() {
                 </CardHeader>
                 <CardContent>
                   <p className="text-sm text-muted-foreground truncate">
-                    {provider.provider_type === 'email'
+                    {provider.provider_type === 'email' ||
+                    provider.provider_type === 'cloudflare'
                       ? typedProvider.config?.from_address ||
                         'No address configured'
                       : provider.provider_type === 'slack'

--- a/web/src/components/monitoring/schemas.ts
+++ b/web/src/components/monitoring/schemas.ts
@@ -66,12 +66,16 @@ export const weeklyDigestSchema = z.object({
 export const providerSchema = z
   .object({
     name: z.string().min(1, 'Name is required'),
-    provider_type: z.enum(['email', 'slack', 'webhook']),
+    provider_type: z.enum(['email', 'slack', 'webhook', 'cloudflare']),
     config: z.object({
       // Slack config
       webhook_url: z.string().optional(),
       channel: z.string().optional(),
       slack_username: z.string().optional(),
+
+      // Cloudflare config
+      account_id: z.string().optional(),
+      api_token: z.string().optional(),
 
       // Email config
       smtp_host: z.string().optional(),
@@ -151,6 +155,32 @@ export const providerSchema = z
         } catch {
           return false
         }
+      }
+      // Cloudflare provider validation
+      if (data.provider_type === 'cloudflare') {
+        const { account_id, api_token, from_address, to_addresses } =
+          data.config
+
+        if (
+          !account_id ||
+          !api_token ||
+          !from_address ||
+          !to_addresses ||
+          to_addresses.length === 0
+        ) {
+          return false
+        }
+
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+        if (!emailRegex.test(from_address)) {
+          return false
+        }
+        for (const email of to_addresses) {
+          if (!emailRegex.test(email)) {
+            return false
+          }
+        }
+        return true
       }
       return false
     },

--- a/web/src/pages/AddNotificationProvider.tsx
+++ b/web/src/pages/AddNotificationProvider.tsx
@@ -1,5 +1,6 @@
 import {
   createNotificationEmailProviderMutation,
+  createNotificationProviderMutation,
   createSlackProviderMutation,
   createWebhookProviderMutation,
 } from '@/api/client/@tanstack/react-query.gen'
@@ -20,6 +21,7 @@ import {
   ArrowRight,
   Bell,
   Check,
+  Cloud,
   Mail,
   MoreHorizontal,
   Slack,
@@ -37,7 +39,12 @@ import {
 import { cn } from '@/lib/utils'
 
 type Step = 'provider-type' | 'configuration' | 'complete'
-type ProviderType = 'email' | 'slack' | 'webhook' | 'coming-soon'
+type ProviderType =
+  | 'email'
+  | 'slack'
+  | 'webhook'
+  | 'cloudflare'
+  | 'coming-soon'
 
 interface ProviderOption {
   id: ProviderType
@@ -45,6 +52,13 @@ interface ProviderOption {
   description: string
   icon: React.ReactNode
   available: boolean
+}
+
+const providerLabels: Partial<Record<ProviderType, string>> = {
+  email: 'Email',
+  slack: 'Slack',
+  webhook: 'Webhook',
+  cloudflare: 'Cloudflare Email',
 }
 
 const providerOptions: ProviderOption[] = [
@@ -67,6 +81,14 @@ const providerOptions: ProviderOption[] = [
     name: 'Webhook',
     description: 'Send JSON payloads to any HTTP endpoint for custom integrations',
     icon: <Webhook className="h-6 w-6" />,
+    available: true,
+  },
+  {
+    id: 'cloudflare',
+    name: 'Cloudflare Email',
+    description:
+      'Send notification emails through Cloudflare Email Sending (no SMTP required)',
+    icon: <Cloud className="h-6 w-6" />,
     available: true,
   },
   {
@@ -168,10 +190,29 @@ export function AddNotificationProvider() {
     },
   })
 
+  // Cloudflare uses the generic notification-provider endpoint (provider_type
+  // + opaque config) rather than a dedicated typed mutation.
+  const createCloudflareMutation = useMutation({
+    ...createNotificationProviderMutation(),
+    meta: {
+      errorTitle: 'Failed to add Cloudflare provider',
+    },
+    onSuccess: () => {
+      setCurrentStep('complete')
+      toast.success('Cloudflare provider added successfully')
+      setTimeout(() => {
+        navigate('/settings/notifications')
+      }, 2000)
+    },
+  })
+
   const handleProviderSelect = (provider: ProviderType) => {
     if (provider === 'coming-soon') return
     setSelectedProvider(provider)
-    form.setValue('provider_type', provider as 'email' | 'slack' | 'webhook')
+    form.setValue(
+      'provider_type',
+      provider as 'email' | 'slack' | 'webhook' | 'cloudflare'
+    )
     setCurrentStep('configuration')
   }
 
@@ -206,6 +247,21 @@ export function AddNotificationProvider() {
           },
         },
       })
+    } else if (data.provider_type === 'cloudflare') {
+      await createCloudflareMutation.mutateAsync({
+        body: {
+          name: data.name,
+          provider_type: 'cloudflare',
+          enabled: true,
+          config: {
+            account_id: data.config.account_id!,
+            api_token: data.config.api_token!,
+            from_address: data.config.from_address!,
+            from_name: data.config.from_name || undefined,
+            to_addresses: data.config.to_addresses!,
+          },
+        },
+      })
     } else {
       await createEmailMutation.mutateAsync({
         body: {
@@ -232,7 +288,10 @@ export function AddNotificationProvider() {
   }
 
   const isLoading =
-    createEmailMutation.isPending || createSlackMutation.isPending || createWebhookMutation.isPending
+    createEmailMutation.isPending ||
+    createSlackMutation.isPending ||
+    createWebhookMutation.isPending ||
+    createCloudflareMutation.isPending
 
   const renderStepIndicator = () => {
     const steps = [
@@ -340,12 +399,12 @@ export function AddNotificationProvider() {
           <Card>
             <CardHeader>
               <CardTitle>
-                Configure {selectedProvider === 'email' ? 'Email' : selectedProvider === 'slack' ? 'Slack' : 'Webhook'}{' '}
+                Configure {providerLabels[selectedProvider] ?? 'Notification'}{' '}
                 Provider
               </CardTitle>
               <CardDescription>
                 Enter the configuration details for your{' '}
-                {selectedProvider === 'email' ? 'email' : selectedProvider === 'slack' ? 'Slack' : 'webhook'} notification
+                {providerLabels[selectedProvider] ?? 'notification'} notification
                 provider
               </CardDescription>
             </CardHeader>

--- a/web/src/pages/EditNotificationProvider.tsx
+++ b/web/src/pages/EditNotificationProvider.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner'
 import {
   getNotificationProviderOptions,
   updateEmailProviderMutation,
+  updateNotificationProviderMutation,
   updateSlackProviderMutation,
   updateWebhookProviderMutation,
   testNotificationProviderMutation as testProvider2Mutation,
@@ -105,11 +106,19 @@ export function EditNotificationProvider() {
       const config = provider.config as Record<string, unknown>
       form.reset({
         name: provider.name,
-        provider_type: provider.provider_type as 'email' | 'slack' | 'webhook',
+        provider_type: provider.provider_type as
+          | 'email'
+          | 'slack'
+          | 'webhook'
+          | 'cloudflare',
         config: {
           // Slack config
           webhook_url: config.webhook_url as string,
           channel: config.channel as string,
+
+          // Cloudflare config
+          account_id: config.account_id as string,
+          api_token: config.api_token as string,
 
           // Email config
           smtp_host: config.smtp_host as string,
@@ -173,6 +182,20 @@ export function EditNotificationProvider() {
     },
   })
 
+  // Cloudflare uses the generic notification-provider endpoint (provider_type
+  // + opaque config) rather than a dedicated typed mutation.
+  const updateCloudflareMutation = useMutation({
+    ...updateNotificationProviderMutation(),
+    meta: {
+      errorTitle: 'Failed to update Cloudflare provider',
+    },
+    onSuccess: () => {
+      toast.success('Cloudflare provider updated successfully')
+      queryClient.invalidateQueries({ queryKey: ['getNotificationProviders'] })
+      navigate('/settings/notifications')
+    },
+  })
+
   // Test mutation with toast.promise
   const testMutation = useMutation({
     ...testProvider2Mutation(),
@@ -222,6 +245,21 @@ export function EditNotificationProvider() {
             method: data.config.method || 'POST',
             headers: (data.config.headers as Record<string, string>) || {},
             timeout_secs: data.config.timeout_secs || 30,
+          },
+        },
+      })
+    } else if (data.provider_type === 'cloudflare') {
+      await updateCloudflareMutation.mutateAsync({
+        path: { id: provider.id },
+        body: {
+          name: data.name,
+          enabled: provider.enabled,
+          config: {
+            account_id: data.config.account_id!,
+            api_token: data.config.api_token!,
+            from_address: data.config.from_address!,
+            from_name: data.config.from_name || undefined,
+            to_addresses: data.config.to_addresses!,
           },
         },
       })
@@ -302,7 +340,10 @@ export function EditNotificationProvider() {
   }
 
   const isSubmitting =
-    updateEmailMutation.isPending || updateSlackMutation.isPending || updateWebhookMutation.isPending
+    updateEmailMutation.isPending ||
+    updateSlackMutation.isPending ||
+    updateWebhookMutation.isPending ||
+    updateCloudflareMutation.isPending
 
   return (
     <div className="max-w-4xl mx-auto space-y-6">


### PR DESCRIPTION
## What

Adds a new notification provider that delivers emails through **Cloudflare's transactional Email Sending API** (`POST /accounts/{account_id}/email/sending/send`) instead of a self-managed SMTP relay.

Operators configure only:
- **Account ID** + **API token** (Email Sending permission)
- **From address** (+ optional From name)
- **To addresses**

Subject and HTML/text bodies are derived from each notification — the HTML reuses the existing shared notification email template (`EmailProvider::render_notification_email`), with a plain-text fallback built from title/message/metadata.

## Backend (`crates/temps-notifications/`)
- `CloudflareProvider` struct + `NotificationProvider` impl:
  - `initialize` validates required fields
  - `send` posts per-recipient with partial-delivery tolerance (matches SMTP behaviour); `from` uses Cloudflare's `{ email, name }` object form when a display name is set, bare string otherwise
  - `health_check` validates the token via Cloudflare's documented `GET /user/tokens/verify` (side-effect-free, sends no mail)
- Wired `"cloudflare"` into `load_provider` dispatch
- Dedicated `POST`/`PUT /notification-providers/cloudflare` handlers with permission guards, audit logging, and OpenAPI registration (`CloudflareConfig`, `Create/UpdateCloudflareProviderRequest`)
- 9 tests — 5 unit + **4 wiremock integration tests** exercising the real HTTP paths (per-recipient POST with bearer auth + payload shape, all-fail → error, health-check 200→true / 401→false). Crate tests pass, clippy + fmt clean.

### API contract verified against Cloudflare's docs
The `send` endpoint/payload come from the public docs; verifying against them also corrected two early mistakes (caught after the first cut): the `from` display-name format (object, not RFC string) and the `health_check` endpoint (`/user/tokens/verify`, not an invented addresses endpoint).

## Frontend (`web/`)
- `cloudflare` provider type + config fields + validation in `schemas.ts`
- "Cloudflare Email" option and config section in `ProviderForm.tsx`
- Create / edit / display wiring in `AddNotificationProvider`, `EditNotificationProvider`, `ProvidersManagement`

The UI talks to the **generic** `notification-providers` create/update endpoints (which accept any `provider_type` + opaque config), so it works against the committed SDK with **no codegen round-trip**. The dedicated typed `/cloudflare` REST endpoints are also available for API consumers and will get generated SDK bindings on the next `openapi-ts` run.

## Notes
- Consistent with the existing email/slack/webhook providers, the API returns the decrypted config so the edit form can prefill (the token is not masked — same as the existing SMTP password behaviour).