### PR TITLE
fix(deployer): stop deleting host containers on compose name conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   can get a local build working without trial and error.
 
 ### Fixed
--
+- **Compose deploy container conflict handling**: Removed pre-deploy Docker container deletion based on user-controlled `container_name` values so a Compose name collision fails safely instead of allowing one deployment to stop or remove unrelated host containers.
+
 
 
 ## [0.1.0-beta.39] - 2026-06-25

--- a/crates/temps-deployer/src/compose.rs
+++ b/crates/temps-deployer/src/compose.rs
@@ -127,11 +127,10 @@ impl ComposeExecutor {
             .await?;
         }
 
-        // 3. Remove any containers with hardcoded names that would conflict
-        self.remove_conflicting_containers(&request.compose_content)
-            .await;
-
-        // 4. Run docker compose up (pulls pre-built images, starts built + pulled)
+        // 3. Run docker compose up (pulls pre-built images, starts built + pulled).
+        // If a user-provided `container_name` conflicts with an existing
+        // container, let Compose report the conflict instead of deleting
+        // containers outside this Temps project boundary.
         self.compose_up(
             &effective_dir,
             &project_name,
@@ -439,46 +438,6 @@ impl ComposeExecutor {
 
         info!(project = %project_name, "docker compose build completed");
         Ok(())
-    }
-
-    /// Remove containers that would conflict with compose services.
-    /// This handles the case where a container with a hardcoded `container_name:`
-    /// already exists from a previous deployment (e.g., old stacks system).
-    async fn remove_conflicting_containers(&self, compose_content: &str) {
-        // Parse container_name: values from compose YAML
-        let mut next_is_container_name = false;
-        for line in compose_content.lines() {
-            let trimmed = line.trim();
-            if trimmed.starts_with("container_name:") {
-                let name = trimmed
-                    .trim_start_matches("container_name:")
-                    .trim()
-                    .trim_matches('"')
-                    .trim_matches('\'');
-                if !name.is_empty() {
-                    // Try to stop and remove this container if it exists
-                    debug!(container = %name, "Removing conflicting container");
-                    let _ = self.docker.stop_container(name, None).await;
-                    let _ = self
-                        .docker
-                        .remove_container(
-                            name,
-                            Some(bollard::query_parameters::RemoveContainerOptions {
-                                force: true,
-                                ..Default::default()
-                            }),
-                        )
-                        .await;
-                }
-            }
-            // Handle multi-line container_name (unlikely but safe)
-            if next_is_container_name {
-                next_is_container_name = false;
-            }
-            if trimmed == "container_name:" {
-                next_is_container_name = true;
-            }
-        }
     }
 
     async fn compose_up(


### PR DESCRIPTION
## Summary
The deployer previously scanned user-controlled Compose YAML for `container_name:` lines and unconditionally stopped/removed matching Docker containers, allowing a deploy to delete unrelated host containers.

- Remove the pre-deploy `remove_conflicting_containers` call and its implementation, so untrusted `compose_content` no longer drives destructive host-wide container operations. Docker Compose surfaces genuine name collisions safely on its own.

## CI
CI for these exact commits runs on the source PR: bherila/temps#14

🤖 Generated with [Claude Code](https://claude.com/claude-code)
