### PR TITLE
fix(otel,ai): scope-guard OTel query handlers + permission-aware AI discovery + clippy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`protobuf` 2.x, `remove_dir_all` 0.5, `opentelemetry_sdk` 0.30, `rsa` 0.9) are
   transitive, upstream-blocked, and verified unreachable in our usage — documented
   with reachability proofs in the root `Cargo.toml`.
+- **OTel telemetry reads confined per project.** Every OpenTelemetry query
+  endpoint (metrics, traces, logs, trace summaries, insights, health, quota,
+  GenAI traces, metric names/labels) now enforces `project_scope_guard!`, so a
+  project-scoped deployment token can no longer read another project's telemetry.
+  No effect on user / API-key / session auth.
+- **AI debug-chat tool discovery is permission-scoped.** The read-only `temps`
+  CLI tool only surfaces (in `--help` discovery and the model's system prompt)
+  the API operations the calling user is permitted to read — derived from each
+  operation's domain. Execution was already enforced by the router's
+  `permission_guard!`; this stops the assistant from suggesting operations the
+  user can't run.
 
 
 ## [0.1.0-beta.39] - 2026-06-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it schedules. Purely additive and best-effort: if the resolver can't bind
   (e.g. port 53 is unavailable), containers keep Docker's embedded DNS exactly
   as before.
+- **Streaming AI chat that can query your platform data (ADR-024).** The AI
+  assistant now streams its reply **token-by-token** with **tool calls shown
+  live** as it works (and a **Stop** control to cancel a turn). It can answer
+  grounded questions about a project — "how many deployments?", "show this
+  trace", "list errors with traces" — through a built-in **read-only `temps`
+  CLI tool** over the platform's GET API: the model discovers endpoints with
+  `--help` and runs them scoped to the conversation's project and the user's own
+  permissions (it can only read what you can; writes are never exposed). Half-
+  typed drafts and the open conversation persist across reloads, and the chat is
+  seeded with context about the page you're viewing (#173).
+- **Trace detail: spans and logs in one view.** The trace page pairs the span
+  waterfall with the OTel **logs correlated to that trace**, colour-codes spans
+  by service, and opens a per-span detail panel (a focused drawer on mobile)
+  showing the span's timing, attributes, events, and its own logs — correlated
+  by `span_id`, Jaeger-style (#173).
+- **Per-provider default AI model.** Each AI provider key can pin the model used
+  for AI features (Settings → AI Providers), instead of relying on a built-in
+  per-provider default (#173).
 
 ### Changed
 - **Project navigation grouped into OpenTelemetry + Monitoring.** The OTel
@@ -117,6 +135,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolved fine. The forwarder now returns the correct `NOERROR`/NODATA while
   still passing genuine `NXDOMAIN` through. Affects both worker and
   control-plane resolvers.
+- **OTel logs now ingest and display correctly.** Two bugs in the OTLP logs
+  path are fixed: `LogRecord.flags` was decoded with the wrong protobuf wire
+  type (rejecting otherwise-valid log batches), and only `WARN`+ records were
+  persisted to the queryable store. All severities are now stored, so a trace's
+  correlated logs and the Logs explorer show the full picture (#173).
 
 ### Security
 - **Mutual TLS between the control plane and worker agents (ADR-020).** Optional

--- a/crates/temps-ai-api-tools/src/caller.rs
+++ b/crates/temps-ai-api-tools/src/caller.rs
@@ -30,6 +30,7 @@ use http::Request;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use temps_auth::context::AuthContext;
+use temps_auth::permissions::Permission;
 use tower::ServiceExt as _;
 use tracing::{debug, warn};
 
@@ -345,20 +346,13 @@ impl InternalApiCaller {
         self
     }
 
-    /// Search the read-only API index.
-    ///
-    /// # Phase 2 TODO
-    ///
-    /// Filter results to operations the `scope` caller is permitted to use.
-    /// Currently returns all matching operations without permission filtering.
-    /// The `permitted` hook below is the insertion point.
+    /// Search the read-only API index, hiding operations the caller can't read
+    /// (advisory — execution is still guarded by the router; see [`Self::permitted`]).
     pub fn search(&self, query: &str, scope: &ApiCallScope) -> Vec<OperationSummary> {
         self.index
             .search(query)
             .into_iter()
-            // TODO(Phase 2): filter to ops the caller is permitted to discover.
-            // Currently returns all matching ops regardless of permission.
-            .filter(|op| self.permitted(op, scope))
+            .filter(|op| self.permitted(op, &scope.auth))
             .map(OperationSummary::from)
             .collect()
     }
@@ -376,8 +370,10 @@ impl InternalApiCaller {
 
     /// Render the virtual-CLI root help (`<root> --help`) — the section list —
     /// for injection into the chat system prompt so the model starts oriented.
-    pub fn cli_root_help(&self) -> String {
-        match crate::cli::resolve(&self.index, "--help") {
+    /// Sections the `auth` caller can't read at all are omitted.
+    pub fn cli_root_help(&self, auth: &AuthContext) -> String {
+        let permit = |op: &ApiOperation| self.permitted(op, auth);
+        match crate::cli::resolve(&self.index, "--help", &permit) {
             crate::cli::CliAction::Terminal(text) => text,
             // resolve("--help") is always Terminal; this arm is unreachable.
             crate::cli::CliAction::Execute(..) => String::new(),
@@ -389,7 +385,8 @@ impl InternalApiCaller {
     /// caller's scope (auth + `project_id` auto-fill + allowlist all apply).
     /// Always returns model-facing text — help, an error, or the response body.
     pub async fn run_cli(&self, command: &str, scope: &ApiCallScope) -> String {
-        match crate::cli::resolve(&self.index, command) {
+        let permit = |op: &ApiOperation| self.permitted(op, &scope.auth);
+        match crate::cli::resolve(&self.index, command, &permit) {
             crate::cli::CliAction::Terminal(text) => text,
             crate::cli::CliAction::Execute(op, params) => {
                 let op_id = op.operation_id.clone();
@@ -528,23 +525,69 @@ impl InternalApiCaller {
     // Private helpers
     // -----------------------------------------------------------------------
 
-    /// Advisory permission filter for search results.
+    /// Advisory permission filter for discovery (search + `--help`).
     ///
-    /// # Phase 2 TODO
-    ///
-    /// This is currently a stub that always returns `true`.  Phase 2 will add a
-    /// generated `operation_id → Permission` map and call
-    /// `scope.auth.has_permission(required_perm)` here.
-    ///
-    /// This filter is *never* the security boundary — that role is played by the
-    /// router's `permission_guard!`.  This filter only governs what operations are
-    /// *shown* to the model during discovery.
-    #[allow(unused_variables)]
-    fn permitted(&self, op: &ApiOperation, scope: &ApiCallScope) -> bool {
-        // TODO(Phase 2): derive required permission from op.tags heuristic, then
-        // check scope.auth.has_permission(&required).
-        true
+    /// Returns whether the `scope` caller may *see* `op` during discovery: if the
+    /// operation's domain maps to a read [`Permission`] the caller must hold it,
+    /// otherwise (an unmapped tag) the op is shown — the router's
+    /// `permission_guard!` is the real boundary, so failing *open* here only
+    /// risks a confusing "not permitted" on execution, never an actual bypass.
+    /// An admin (or any role holding the read permission) passes.
+    pub(crate) fn permitted(&self, op: &ApiOperation, auth: &AuthContext) -> bool {
+        match required_read_permission(op) {
+            Some(perm) => auth.has_permission(&perm),
+            None => true,
+        }
     }
+}
+
+/// Best-effort mapping from an operation's OpenAPI tag to the read [`Permission`]
+/// that gates it, used only to filter what the AI sees during discovery (never to
+/// authorize execution — that's the router's job). Keyword-matched on the first
+/// tag so related tags (e.g. the several OTel telemetry tags) collapse onto one
+/// permission; `None` means "no known mapping → show it".
+fn required_read_permission(op: &ApiOperation) -> Option<Permission> {
+    let tag = op.tags.first()?.to_ascii_lowercase();
+    // Order matters: more specific keywords first (e.g. telemetry before metrics).
+    let perm = if tag.contains("telemetry")
+        || tag.contains("trace")
+        || tag.contains("span")
+        || tag.contains("otel")
+        || tag.contains("dashboard")
+        || tag.contains("insight")
+        || tag.contains("alert")
+    {
+        Permission::OtelRead
+    } else if tag.contains("error") {
+        Permission::ErrorTrackingRead
+    } else if tag.contains("backup") {
+        Permission::BackupsRead
+    } else if tag.contains("deployment") {
+        Permission::DeploymentsRead
+    } else if tag.contains("environment") {
+        Permission::EnvironmentsRead
+    } else if tag.contains("domain") {
+        Permission::DomainsRead
+    } else if tag.contains("external") || tag.contains("static bundle") || tag.contains("image") {
+        Permission::ExternalServicesRead
+    } else if tag.contains("audit") {
+        Permission::AuditRead
+    } else if tag.contains("analytic") {
+        Permission::AnalyticsRead
+    } else if tag.contains("metric") {
+        Permission::MetricsRead
+    } else if tag.contains("log") {
+        Permission::LogsRead
+    } else if tag.contains("notification") {
+        Permission::NotificationsRead
+    } else if tag.contains("setting") {
+        Permission::SettingsRead
+    } else if tag.contains("project") {
+        Permission::ProjectsRead
+    } else {
+        return None;
+    };
+    Some(perm)
 }
 
 // ---------------------------------------------------------------------------
@@ -653,6 +696,51 @@ mod tests {
             enum_values: vec![],
             description: None,
         }
+    }
+
+    fn op_tagged(tag: &str) -> ApiOperation {
+        ApiOperation {
+            tags: if tag.is_empty() {
+                vec![]
+            } else {
+                vec![tag.to_string()]
+            },
+            ..make_op("x", "/x", vec![])
+        }
+    }
+
+    #[test]
+    fn required_read_permission_maps_tags_to_read_perms() {
+        use temps_auth::permissions::Permission;
+        assert_eq!(
+            required_read_permission(&op_tagged("Deployments")),
+            Some(Permission::DeploymentsRead)
+        );
+        // The several OTel telemetry tags collapse onto OtelRead.
+        for t in [
+            "Traces",
+            "Telemetry Metrics",
+            "Telemetry Logs",
+            "Dashboards",
+            "Alerts",
+        ] {
+            assert_eq!(
+                required_read_permission(&op_tagged(t)),
+                Some(Permission::OtelRead),
+                "tag {t}"
+            );
+        }
+        assert_eq!(
+            required_read_permission(&op_tagged("Backups")),
+            Some(Permission::BackupsRead)
+        );
+        assert_eq!(
+            required_read_permission(&op_tagged("Error Tracking")),
+            Some(Permission::ErrorTrackingRead)
+        );
+        // Unknown / missing tag → None (shown by default; router still guards).
+        assert_eq!(required_read_permission(&op_tagged("Wibble")), None);
+        assert_eq!(required_read_permission(&op_tagged("")), None);
     }
 
     fn enum_query_param(name: &str, values: &[&str]) -> ParamSpec {

--- a/crates/temps-ai-api-tools/src/cli.rs
+++ b/crates/temps-ai-api-tools/src/cli.rs
@@ -44,7 +44,17 @@ struct Section<'a> {
 }
 
 /// Parse a command line and resolve it to a [`CliAction`]. Never executes.
-pub(crate) fn resolve<'a>(index: &'a ReadOnlyApiIndex, command: &str) -> CliAction<'a> {
+///
+/// `permit` filters which operations are *discoverable* (shown in `--help` /
+/// section listings) — operations the caller can't read are hidden, and a
+/// section with no discoverable operations disappears. It is advisory: direct
+/// execution still goes through the router's `permission_guard!`, so a bare
+/// `operation_id` is resolved for execution even if hidden from discovery.
+pub(crate) fn resolve<'a>(
+    index: &'a ReadOnlyApiIndex,
+    command: &str,
+    permit: &dyn Fn(&ApiOperation) -> bool,
+) -> CliAction<'a> {
     let tokens = tokenize(command);
     // Tolerate a leading program name — the model may write `temps deploy …`.
     let tokens: &[String] = if tokens
@@ -59,11 +69,11 @@ pub(crate) fn resolve<'a>(index: &'a ReadOnlyApiIndex, command: &str) -> CliActi
 
     // Root: no args or `--help`.
     if tokens.is_empty() || is_help(&tokens[0]) {
-        return CliAction::Terminal(render_root_help(index));
+        return CliAction::Terminal(render_root_help(index, permit));
     }
 
     let first = &tokens[0];
-    let secs = sections(index);
+    let secs = sections(index, permit);
 
     // A section?
     if let Some(sec) = secs
@@ -114,8 +124,8 @@ fn resolve_operation<'a>(op: &'a ApiOperation, tail: &[String]) -> CliAction<'a>
 // Help rendering
 // ---------------------------------------------------------------------------
 
-fn render_root_help(index: &ReadOnlyApiIndex) -> String {
-    let secs = sections(index);
+fn render_root_help(index: &ReadOnlyApiIndex, permit: &dyn Fn(&ApiOperation) -> bool) -> String {
+    let secs = sections(index, permit);
     let mut out = String::from(
         "Temps read-only API — a CLI over the platform's GET endpoints.\n\
          Usage: <section> <operation> [--flag value ...]\n\
@@ -213,9 +223,15 @@ fn render_operation_help(op: &ApiOperation) -> String {
 
 /// Group operations into sections by their first OpenAPI tag, preserving a
 /// stable (slug-sorted) order. Operations with no tag fall into "General".
-fn sections(index: &ReadOnlyApiIndex) -> Vec<Section<'_>> {
+fn sections<'a>(
+    index: &'a ReadOnlyApiIndex,
+    permit: &dyn Fn(&ApiOperation) -> bool,
+) -> Vec<Section<'a>> {
     let mut secs: Vec<Section> = Vec::new();
     for op in index.operations() {
+        if !permit(op) {
+            continue;
+        }
         let name = section_name(op);
         if let Some(s) = secs.iter_mut().find(|s| s.name == name) {
             s.operations.push(op);

--- a/crates/temps-ai-chat/src/provider.rs
+++ b/crates/temps-ai-chat/src/provider.rs
@@ -78,8 +78,9 @@ pub trait ConversationContextProvider: Send + Sync {
     /// turn, regardless of which provider seeded the chat. Used by the API-tools
     /// provider to inject the read-only endpoint catalogue (the "API map") so the
     /// model can pick an `operation_id` by path instead of guessing search
-    /// keywords. Default: nothing.
-    fn system_appendix(&self) -> Option<String> {
+    /// keywords. `auth` is the calling user's context, so the appendix can be
+    /// scoped to what they're permitted to discover. Default: nothing.
+    fn system_appendix(&self, _auth: &AuthContext) -> Option<String> {
         None
     }
 

--- a/crates/temps-ai-chat/src/providers/api_tools.rs
+++ b/crates/temps-ai-chat/src/providers/api_tools.rs
@@ -91,9 +91,9 @@ impl ConversationContextProvider for ApiToolsProvider {
     /// Seed every chat's system framing with the `temps` CLI's root help — the
     /// section list — so the model starts oriented and can drill in with
     /// `<section> --help`. Returns `None` until the caller is wired (startup).
-    fn system_appendix(&self) -> Option<String> {
+    fn system_appendix(&self, auth: &AuthContext) -> Option<String> {
         let caller = self.handle.get()?;
-        let root_help = caller.cli_root_help();
+        let root_help = caller.cli_root_help(auth);
         if root_help.trim().is_empty() {
             return None;
         }

--- a/crates/temps-ai-chat/src/service.rs
+++ b/crates/temps-ai-chat/src/service.rs
@@ -434,7 +434,7 @@ impl ConversationService {
         // provider so it always reflects the live allowlist; merged into EVERY
         // context for the same reason its tools are.
         if let Some(api_tools_provider) = self.providers.get("__api_tools__") {
-            if let Some(appendix) = api_tools_provider.system_appendix() {
+            if let Some(appendix) = api_tools_provider.system_appendix(auth) {
                 match messages.iter_mut().find(|m| m.role == "system") {
                     Some(sys) => {
                         sys.content.push_str("\n\n");

--- a/crates/temps-otel/src/handlers/query_handler.rs
+++ b/crates/temps-otel/src/handlers/query_handler.rs
@@ -306,6 +306,9 @@ pub async fn query_metrics(
     Query(params): Query<MetricQueryParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelRead);
+    // Confine a project-scoped deployment token to its own project (no-op for
+    // user/API-key/session auth).
+    project_scope_guard!(auth, params.project_id);
 
     let query = MetricQuery {
         project_id: params.project_id,
@@ -362,6 +365,9 @@ pub async fn list_metric_names(
     Path(project_id): Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelRead);
+    // Confine a project-scoped deployment token to its own project (no-op for
+    // user/API-key/session auth).
+    project_scope_guard!(auth, project_id);
 
     let names = state.otel_service.list_metric_names(project_id).await?;
     Ok(Json(OtelMetricNamesResponse { names }))
@@ -483,6 +489,9 @@ pub async fn query_traces(
     Query(params): Query<TraceQueryParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelRead);
+    // Confine a project-scoped deployment token to its own project (no-op for
+    // user/API-key/session auth).
+    project_scope_guard!(auth, params.project_id);
 
     let status = params.status.as_deref().map(|s| match s {
         "OK" | "ok" => SpanStatusCode::Ok,
@@ -554,6 +563,9 @@ pub async fn query_trace_summaries(
     Query(params): Query<TraceQueryParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelRead);
+    // Confine a project-scoped deployment token to its own project (no-op for
+    // user/API-key/session auth).
+    project_scope_guard!(auth, params.project_id);
 
     let status = params.status.as_deref().map(|s| match s {
         "OK" | "ok" => SpanStatusCode::Ok,
@@ -627,6 +639,9 @@ pub async fn get_trace(
     Path((project_id, trace_id)): Path<(i32, String)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelRead);
+    // Confine a project-scoped deployment token to its own project (no-op for
+    // user/API-key/session auth).
+    project_scope_guard!(auth, project_id);
 
     let data = state.otel_service.get_trace(project_id, &trace_id).await?;
     let count = data.len();
@@ -664,6 +679,9 @@ pub async fn query_logs(
     Query(params): Query<LogQueryParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelRead);
+    // Confine a project-scoped deployment token to its own project (no-op for
+    // user/API-key/session auth).
+    project_scope_guard!(auth, params.project_id);
 
     let severity = params.severity.as_deref().map(|s| match s {
         "TRACE" | "trace" => LogSeverity::Trace,
@@ -719,6 +737,9 @@ pub async fn list_insights(
     Query(params): Query<InsightQueryParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelRead);
+    // Confine a project-scoped deployment token to its own project (no-op for
+    // user/API-key/session auth).
+    project_scope_guard!(auth, project_id);
 
     let status = params.status.as_deref().map(|s| match s {
         "resolved" => InsightStatus::Resolved,
@@ -761,6 +782,9 @@ pub async fn get_health(
     Query(params): Query<HealthQueryParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelRead);
+    // Confine a project-scoped deployment token to its own project (no-op for
+    // user/API-key/session auth).
+    project_scope_guard!(auth, project_id);
 
     let summaries = state
         .otel_service
@@ -792,6 +816,9 @@ pub async fn get_quota(
     Path(project_id): Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelRead);
+    // Confine a project-scoped deployment token to its own project (no-op for
+    // user/API-key/session auth).
+    project_scope_guard!(auth, project_id);
 
     let quota = state.otel_service.get_storage_quota(project_id).await?;
     Ok(Json(QuotaResponse { quota }))
@@ -850,6 +877,9 @@ pub async fn query_genai_traces(
     Query(params): Query<GenAiQueryParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelRead);
+    // Confine a project-scoped deployment token to its own project (no-op for
+    // user/API-key/session auth).
+    project_scope_guard!(auth, params.project_id);
 
     // Build attribute filters. For gen_ai_system, we use gen_ai.provider.name (current)
     // but the SQL also handles the deprecated gen_ai.system via COALESCE.
@@ -916,6 +946,9 @@ pub async fn get_genai_trace(
     Path((project_id, trace_id)): Path<(i32, String)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelRead);
+    // Confine a project-scoped deployment token to its own project (no-op for
+    // user/API-key/session auth).
+    project_scope_guard!(auth, project_id);
 
     let spans = state
         .otel_service

--- a/crates/temps-otel/src/storage/timescaledb.rs
+++ b/crates/temps-otel/src/storage/timescaledb.rs
@@ -1269,7 +1269,7 @@ impl OtelStorage for TimescaleDbStorage {
 
         // Stable order by bucket time (scalar rows already arrived ordered; the
         // histogram-only additions are merged in).
-        buckets.sort_by(|a, b| a.bucket.cmp(&b.bucket));
+        buckets.sort_by_key(|b| b.bucket);
 
         Ok(buckets)
     }


### PR DESCRIPTION
Follow-ups from the #173 review, on a branch off `main`.

## Changes
- **OTel access control:** apply `project_scope_guard!` to every OTel query handler that takes a `project_id` (`query_metrics`, `query_traces`, `query_logs`, `query_trace_summaries`, `get_trace`, `list_metric_names`, `list_insights`, `get_health`, `get_quota`, `query_genai_traces`, `get_genai_trace`). A project-scoped **deployment token** can no longer read another project's telemetry. No-op for user/API-key/session auth; the `metric-label-keys/values` handlers already had it (#173).
- **AI tool discovery (permitted filter):** implement the previously-stubbed `permitted()` — derive the read `Permission` from an operation's OpenAPI tag and check `auth.has_permission` — and thread it through the `temps` CLI (`cli::resolve`/`sections`, `run_cli`, `cli_root_help`) and the per-turn system appendix. The model's `--help` discovery + system-prompt section list now only show operations the caller can read. **Advisory only** — the router's `permission_guard!` remains the real boundary (unmapped tags fail open).
- **Clippy:** fix `clippy::unnecessary_sort_by` (`sort_by` → `sort_by_key`) that failed the advisory clippy job on #173.

## Verification
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` (changed crates): clean
- tests: temps-otel 336, temps-ai-api-tools 44 (+1 new `required_read_permission` test), temps-ai-chat 40 — all pass
- `cargo check --lib --workspace`: clean