### PR TITLE
ci(changelog): skip preview comment on fork PRs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -74,7 +74,13 @@ jobs:
         env:
           OUTPUT: CHANGELOG_PREVIEW.md
 
+      # Posting a PR comment needs a write-scoped GITHUB_TOKEN. On pull_request
+      # runs from a fork, GitHub forces the token to read-only regardless of the
+      # `permissions:` block above, so this step 403s ("Resource not accessible
+      # by integration"). Skip it for fork PRs — the Conventional Commits lint
+      # above still runs and gates every PR; only the preview comment is skipped.
       - name: Post preview comment
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Problem
The `Changelog` workflow's **Post preview comment** step (`actions/github-script`) needs a write-scoped `GITHUB_TOKEN`. On `pull_request` runs from a **fork**, GitHub forces the token to read-only regardless of the workflow's `permissions:` block, so the step fails with:

```
403 Resource not accessible by integration
POST /repos/gotempsh/temps/issues/{n}/comments
```

This happens on **every cross-repo PR** (e.g. #170 from `bherila/temps`) and is unrelated to the PR's code or commits.

## Fix
Guard only the comment step with `head.repo.full_name == github.repository` so it runs for same-repo PRs and is **skipped** on forks (where it can't post anyway).

The **Lint Conventional Commits** step still runs for forks, so the commit-message gate is unchanged — only the non-essential preview comment is skipped.

## Not changed
- The Node 20 deprecation notice on `actions/github-script@v7` is separate/informational and left as-is.