### PR TITLE
fix(analytics): stop fabricating +/-100% dashboard trend when there's no baseline

### DIFF
--- a/crates/temps-analytics-events/Cargo.toml
+++ b/crates/temps-analytics-events/Cargo.toml
@@ -55,7 +55,7 @@ woothee = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
-testcontainers = { workspace = true }
+testcontainers = { workspace = true, features = ["http_wait_plain"] }
 temps-migrations = { path = "../temps-migrations" }
 tower = { version = "0.5", features = ["util"] }
 uuid = { version = "1", features = ["v4"] }

--- a/crates/temps-analytics-events/src/services/clickhouse_backend.rs
+++ b/crates/temps-analytics-events/src/services/clickhouse_backend.rs
@@ -1290,143 +1290,159 @@ mod tests {
         Some((backend, client, Box::new(container)))
     }
 
+    // Local row type: matches the production DDL field-for-field. We duplicate it
+    // here rather than taking a dep on the fan-out module, because the fan-out
+    // type is `#[cfg(feature = "clickhouse")]`-gated within ch_fanout but the test
+    // module here is already feature-gated, so we could in principle use it. The
+    // duplication is intentional: if the test row diverges from the production
+    // row, the test fails loudly. Shared by every seeding helper below so we
+    // don't duplicate the 50-field struct a third time per test.
+    #[derive(::clickhouse::Row, serde::Serialize)]
+    struct SeedRow {
+        event_id: i64,
+        project_id: i32,
+        environment_id: Option<i32>,
+        deployment_id: Option<i32>,
+        session_id: String,
+        visitor_id: Option<i32>,
+        timestamp: i64,
+        hostname: String,
+        pathname: String,
+        page_path: String,
+        href: String,
+        querystring: String,
+        page_title: String,
+        referrer: String,
+        referrer_hostname: String,
+        event_type: String,
+        event_name: String,
+        props: String,
+        user_agent: String,
+        browser: String,
+        browser_version: String,
+        operating_system: String,
+        operating_system_version: String,
+        device_type: String,
+        screen_width: Option<i16>,
+        screen_height: Option<i16>,
+        viewport_width: Option<i16>,
+        viewport_height: Option<i16>,
+        ip_geolocation_id: Option<i32>,
+        country: String,
+        region: String,
+        city: String,
+        channel: String,
+        utm_source: String,
+        utm_medium: String,
+        utm_campaign: String,
+        utm_term: String,
+        utm_content: String,
+        ttfb: Option<f32>,
+        lcp: Option<f32>,
+        fid: Option<f32>,
+        fcp: Option<f32>,
+        cls: Option<f32>,
+        inp: Option<f32>,
+        is_entry: u8,
+        is_exit: u8,
+        is_bounce: u8,
+        is_crawler: u8,
+        time_on_page: Option<i32>,
+        session_page_number: Option<i32>,
+        scroll_depth: Option<i32>,
+        clicks: Option<i32>,
+        language: String,
+        crawler_name: String,
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn make_row(
+        event_id: i64,
+        project_id: i32,
+        session_id: &str,
+        visitor_id: Option<i32>,
+        event_type: &str,
+        event_name: &str,
+        ts_ms: i64,
+    ) -> SeedRow {
+        SeedRow {
+            event_id,
+            project_id,
+            environment_id: Some(1),
+            deployment_id: None,
+            session_id: session_id.to_string(),
+            visitor_id,
+            timestamp: ts_ms,
+            hostname: "example.com".into(),
+            pathname: "/".into(),
+            page_path: "/".into(),
+            href: "https://example.com/".into(),
+            querystring: String::new(),
+            page_title: "Home".into(),
+            referrer: String::new(),
+            referrer_hostname: String::new(),
+            event_type: event_type.into(),
+            event_name: event_name.into(),
+            props: "{}".into(),
+            user_agent: "test-agent".into(),
+            browser: "Firefox".into(),
+            browser_version: "120".into(),
+            operating_system: "Linux".into(),
+            operating_system_version: "6".into(),
+            device_type: "desktop".into(),
+            screen_width: Some(1920),
+            screen_height: Some(1080),
+            viewport_width: Some(1920),
+            viewport_height: Some(1080),
+            ip_geolocation_id: None,
+            country: "US".into(),
+            region: "CA".into(),
+            city: "San Francisco".into(),
+            channel: "direct".into(),
+            utm_source: String::new(),
+            utm_medium: String::new(),
+            utm_campaign: String::new(),
+            utm_term: String::new(),
+            utm_content: String::new(),
+            ttfb: None,
+            lcp: None,
+            fid: None,
+            fcp: None,
+            cls: None,
+            inp: None,
+            is_entry: 0,
+            is_exit: 0,
+            is_bounce: 0,
+            is_crawler: 0,
+            time_on_page: None,
+            session_page_number: None,
+            scroll_depth: None,
+            clicks: None,
+            language: "en".into(),
+            crawler_name: String::new(),
+        }
+    }
+
+    /// Writes rows via the inserter, then forces the background
+    /// ReplacingMergeTree merge with `OPTIMIZE TABLE ... FINAL` so `FINAL` reads
+    /// return deterministic results in tests (production tolerates some
+    /// duplication during merges; tests want determinism).
+    async fn insert_rows(client: &::clickhouse::Client, rows: &[SeedRow]) {
+        let mut inserter = client.insert::<SeedRow>("events").expect("inserter setup");
+        for row in rows {
+            inserter.write(row).await.expect("insert row");
+        }
+        inserter.end().await.expect("inserter end");
+
+        client
+            .query("OPTIMIZE TABLE events FINAL")
+            .execute()
+            .await
+            .expect("optimize");
+    }
+
     /// Insert a few hand-crafted rows so we have something to query.
-    /// Mirrors the field order of the `ChEventRow` shape in
-    /// `ch_fanout::ChEventRow`. Uses the public clickhouse client API so
-    /// any drift between this and the worker would also fail compilation.
     async fn seed_rows(client: &::clickhouse::Client) {
-        // Local row type: matches the production DDL field-for-field. We
-        // duplicate it here rather than taking a dep on the fan-out
-        // module, because the fan-out type is `#[cfg(feature =
-        // "clickhouse")]`-gated within ch_fanout but the test module here
-        // is already feature-gated, so we could in principle use it. The
-        // duplication is intentional: if the test row diverges from the
-        // production row, the test fails loudly.
-        #[derive(::clickhouse::Row, serde::Serialize)]
-        struct SeedRow {
-            event_id: i64,
-            project_id: i32,
-            environment_id: Option<i32>,
-            deployment_id: Option<i32>,
-            session_id: String,
-            visitor_id: Option<i32>,
-            timestamp: i64,
-            hostname: String,
-            pathname: String,
-            page_path: String,
-            href: String,
-            querystring: String,
-            page_title: String,
-            referrer: String,
-            referrer_hostname: String,
-            event_type: String,
-            event_name: String,
-            props: String,
-            user_agent: String,
-            browser: String,
-            browser_version: String,
-            operating_system: String,
-            operating_system_version: String,
-            device_type: String,
-            screen_width: Option<i16>,
-            screen_height: Option<i16>,
-            viewport_width: Option<i16>,
-            viewport_height: Option<i16>,
-            ip_geolocation_id: Option<i32>,
-            country: String,
-            region: String,
-            city: String,
-            channel: String,
-            utm_source: String,
-            utm_medium: String,
-            utm_campaign: String,
-            utm_term: String,
-            utm_content: String,
-            ttfb: Option<f32>,
-            lcp: Option<f32>,
-            fid: Option<f32>,
-            fcp: Option<f32>,
-            cls: Option<f32>,
-            inp: Option<f32>,
-            is_entry: u8,
-            is_exit: u8,
-            is_bounce: u8,
-            is_crawler: u8,
-            time_on_page: Option<i32>,
-            session_page_number: Option<i32>,
-            scroll_depth: Option<i32>,
-            clicks: Option<i32>,
-            language: String,
-            crawler_name: String,
-        }
-
-        fn make(
-            event_id: i64,
-            project_id: i32,
-            session_id: &str,
-            visitor_id: Option<i32>,
-            event_type: &str,
-            event_name: &str,
-            ts_ms: i64,
-        ) -> SeedRow {
-            SeedRow {
-                event_id,
-                project_id,
-                environment_id: Some(1),
-                deployment_id: None,
-                session_id: session_id.to_string(),
-                visitor_id,
-                timestamp: ts_ms,
-                hostname: "example.com".into(),
-                pathname: "/".into(),
-                page_path: "/".into(),
-                href: "https://example.com/".into(),
-                querystring: String::new(),
-                page_title: "Home".into(),
-                referrer: String::new(),
-                referrer_hostname: String::new(),
-                event_type: event_type.into(),
-                event_name: event_name.into(),
-                props: "{}".into(),
-                user_agent: "test-agent".into(),
-                browser: "Firefox".into(),
-                browser_version: "120".into(),
-                operating_system: "Linux".into(),
-                operating_system_version: "6".into(),
-                device_type: "desktop".into(),
-                screen_width: Some(1920),
-                screen_height: Some(1080),
-                viewport_width: Some(1920),
-                viewport_height: Some(1080),
-                ip_geolocation_id: None,
-                country: "US".into(),
-                region: "CA".into(),
-                city: "San Francisco".into(),
-                channel: "direct".into(),
-                utm_source: String::new(),
-                utm_medium: String::new(),
-                utm_campaign: String::new(),
-                utm_term: String::new(),
-                utm_content: String::new(),
-                ttfb: None,
-                lcp: None,
-                fid: None,
-                fcp: None,
-                cls: None,
-                inp: None,
-                is_entry: 0,
-                is_exit: 0,
-                is_bounce: 0,
-                is_crawler: 0,
-                time_on_page: None,
-                session_page_number: None,
-                scroll_depth: None,
-                clicks: None,
-                language: "en".into(),
-                crawler_name: String::new(),
-            }
-        }
-
         let now = Utc::now();
         let t = |mins_ago: i64| (now - Duration::minutes(mins_ago)).timestamp_millis();
 
@@ -1435,29 +1451,15 @@ mod tests {
         // Project 8, session C, visitor 102: 1 page_view (different project — must
         // not leak into project 7 queries).
         let rows = [
-            make(1, 7, "sess-a", Some(100), "page_view", "page_view", t(60)),
-            make(2, 7, "sess-a", Some(100), "page_view", "page_view", t(50)),
-            make(3, 7, "sess-a", Some(100), "signup", "signup", t(45)),
-            make(4, 7, "sess-b", Some(101), "page_view", "page_view", t(30)),
-            make(5, 7, "sess-b", Some(101), "click", "click", t(25)),
-            make(6, 8, "sess-c", Some(102), "page_view", "page_view", t(20)),
+            make_row(1, 7, "sess-a", Some(100), "page_view", "page_view", t(60)),
+            make_row(2, 7, "sess-a", Some(100), "page_view", "page_view", t(50)),
+            make_row(3, 7, "sess-a", Some(100), "signup", "signup", t(45)),
+            make_row(4, 7, "sess-b", Some(101), "page_view", "page_view", t(30)),
+            make_row(5, 7, "sess-b", Some(101), "click", "click", t(25)),
+            make_row(6, 8, "sess-c", Some(102), "page_view", "page_view", t(20)),
         ];
 
-        let mut inserter = client.insert::<SeedRow>("events").expect("inserter setup");
-        for row in &rows {
-            inserter.write(row).await.expect("insert row");
-        }
-        inserter.end().await.expect("inserter end");
-
-        // ReplacingMergeTree merges happen in the background; OPTIMIZE FINAL
-        // forces them so FINAL reads return deterministic results in this
-        // test. Production queries use FINAL on the read side and tolerate
-        // some duplication during merges, but tests want determinism.
-        client
-            .query("OPTIMIZE TABLE events FINAL")
-            .execute()
-            .await
-            .expect("optimize");
+        insert_rows(client, &rows).await;
     }
 
     fn project_scope(project_id: i32) -> AnalyticsScope {
@@ -1773,6 +1775,189 @@ mod tests {
             report.applied
         );
         assert_eq!(report.skipped.len(), 3, "all three migrations skipped");
+    }
+
+    /// Regression test: `query_dashboard_projects` used to hardcode the trend to a
+    /// flat `+100.0` whenever a project's previous-period count was 0 — whether
+    /// that was a genuinely brand-new project or (on the Timescale backend) an
+    /// artifact of a not-yet-warmed continuous aggregate. The ClickHouse backend
+    /// never had the aggregate-staleness problem (it always read raw `events` for
+    /// both periods), but it carried the identical fabricated-percentage bug,
+    /// explicitly written to "mirror the Timescale impl". This locks in the fix:
+    /// no previous-period baseline must omit the trend, and a real previous count
+    /// must produce the real ratio, not a hardcoded value.
+    #[tokio::test]
+    async fn ch_dashboard_trend_omits_fabricated_percentage() {
+        let Some((backend, client, _container)) = setup_clickhouse().await else {
+            return; // Docker not available, skip.
+        };
+
+        let now = Utc::now();
+        let t = |mins_ago: i64| (now - Duration::minutes(mins_ago)).timestamp_millis();
+
+        // Project 20: brand new -- only current-period traffic (3 visitors),
+        // nothing in the previous period at all.
+        let rows_new_project = [
+            make_row(
+                101,
+                20,
+                "sess-new-a",
+                Some(200),
+                "page_view",
+                "page_view",
+                t(30),
+            ),
+            make_row(
+                102,
+                20,
+                "sess-new-b",
+                Some(201),
+                "page_view",
+                "page_view",
+                t(20),
+            ),
+            make_row(
+                103,
+                20,
+                "sess-new-c",
+                Some(202),
+                "page_view",
+                "page_view",
+                t(10),
+            ),
+        ];
+
+        // Project 21: real traffic in both periods -- previous=4, current=6,
+        // a genuine +50% trend, to prove real ratios still compute correctly.
+        let range = full_range();
+        let duration = range.end - range.start;
+        // Anchor "recent" (current period) and "older" (previous period) relative
+        // to the query range rather than `now`, so this doesn't depend on how
+        // `full_range()`'s slack is defined.
+        let prev_ms = (range.start - duration + chrono::Duration::minutes(10)).timestamp_millis();
+        let curr_ms = (range.start + chrono::Duration::minutes(10)).timestamp_millis();
+        let rows_baseline_project = [
+            make_row(
+                104,
+                21,
+                "sess-prev-a",
+                Some(210),
+                "page_view",
+                "page_view",
+                prev_ms,
+            ),
+            make_row(
+                105,
+                21,
+                "sess-prev-b",
+                Some(211),
+                "page_view",
+                "page_view",
+                prev_ms,
+            ),
+            make_row(
+                106,
+                21,
+                "sess-prev-c",
+                Some(212),
+                "page_view",
+                "page_view",
+                prev_ms,
+            ),
+            make_row(
+                107,
+                21,
+                "sess-prev-d",
+                Some(213),
+                "page_view",
+                "page_view",
+                prev_ms,
+            ),
+            make_row(
+                108,
+                21,
+                "sess-curr-a",
+                Some(220),
+                "page_view",
+                "page_view",
+                curr_ms,
+            ),
+            make_row(
+                109,
+                21,
+                "sess-curr-b",
+                Some(221),
+                "page_view",
+                "page_view",
+                curr_ms,
+            ),
+            make_row(
+                110,
+                21,
+                "sess-curr-c",
+                Some(222),
+                "page_view",
+                "page_view",
+                curr_ms,
+            ),
+            make_row(
+                111,
+                21,
+                "sess-curr-d",
+                Some(223),
+                "page_view",
+                "page_view",
+                curr_ms,
+            ),
+            make_row(
+                112,
+                21,
+                "sess-curr-e",
+                Some(224),
+                "page_view",
+                "page_view",
+                curr_ms,
+            ),
+            make_row(
+                113,
+                21,
+                "sess-curr-f",
+                Some(225),
+                "page_view",
+                "page_view",
+                curr_ms,
+            ),
+        ];
+
+        insert_rows(&client, &rows_new_project).await;
+        insert_rows(&client, &rows_baseline_project).await;
+
+        let dash = backend
+            .query_dashboard_projects(crate::services::queries::DashboardProjectsSpec {
+                project_ids: vec![20, 21],
+                range,
+            })
+            .await
+            .expect("query_dashboard_projects");
+
+        let new_project = dash.projects.get("20").expect("project 20 in response");
+        assert_eq!(new_project.unique_visitors, 3);
+        assert_eq!(new_project.previous_unique_visitors, 0);
+        assert_eq!(
+            new_project.trend_percentage, None,
+            "a brand-new project with no previous-period baseline must not show a fabricated +100%"
+        );
+
+        let baseline_project = dash.projects.get("21").expect("project 21 in response");
+        assert_eq!(baseline_project.unique_visitors, 6);
+        assert_eq!(baseline_project.previous_unique_visitors, 4);
+        assert_eq!(
+            baseline_project.trend_percentage,
+            Some(50.0),
+            "trend must be the real (6-4)/4*100 ratio, not a hardcoded fallback"
+        );
+
+        println!("✅ ClickHouse dashboard trend regression test passed!");
     }
 
     // ── SQL-shape guards (no Docker required) ──────────────────────────────

--- a/crates/temps-analytics-events/src/services/clickhouse_backend.rs
+++ b/crates/temps-analytics-events/src/services/clickhouse_backend.rs
@@ -92,6 +92,27 @@ fn ch_interval(bucket: Option<&str>) -> &'static str {
     }
 }
 
+/// Millisecond width matching each [`ch_interval`] bucket size, for use as the
+/// numeric STEP in a `WITH FILL` clause over a Unix-milliseconds column.
+/// Interval values aren't castable via `toInt64(...)` in CH 24.8 ("Illegal
+/// type IntervalHour of argument of function toInt64"), so STEP must be a
+/// plain number matching the bucket width instead. Month has no fixed
+/// length; 30 days is an approximation, consistent with this file's existing
+/// "approximate is fine" tolerance for CH-backed analytics (see module docs).
+fn ch_interval_step_ms(bucket: Option<&str>) -> i64 {
+    const MINUTE: i64 = 60_000;
+    const HOUR: i64 = 3_600_000;
+    const DAY: i64 = 86_400_000;
+    match bucket {
+        Some("hour") | Some("1 hour") | Some("1h") => HOUR,
+        Some("day") | Some("1 day") | Some("1d") => DAY,
+        Some("week") | Some("1 week") | Some("1w") => 7 * DAY,
+        Some("month") | Some("1 month") | Some("1mo") => 30 * DAY,
+        Some("5 minutes") | Some("5m") => 5 * MINUTE,
+        _ => HOUR,
+    }
+}
+
 /// Convert a `chrono::DateTime<Utc>` to seconds since the Unix epoch — the
 /// shape ClickHouse's `DateTime64(3)` parses cleanly via `fromUnixTimestamp64Milli`.
 fn to_unix_milli(t: UtcDateTime) -> i64 {
@@ -508,19 +529,30 @@ impl AnalyticsEvents for ClickHouseEventsBackend {
         // Auto-detect bucket size if not provided. Same heuristic as the
         // Timescale impl so dashboards pick the same granularity.
         let duration = q.range.end - q.range.start;
-        let interval = match q.bucket_size.as_deref() {
-            Some("hour") => "INTERVAL 1 HOUR",
-            Some("day") => "INTERVAL 1 DAY",
-            Some("week") => "INTERVAL 1 WEEK",
-            _ => {
-                if duration.num_days() <= 1 {
-                    "INTERVAL 1 HOUR"
-                } else if duration.num_days() <= 30 {
-                    "INTERVAL 1 DAY"
-                } else {
-                    "INTERVAL 1 WEEK"
-                }
-            }
+        let bucket_size = q
+            .bucket_size
+            .as_deref()
+            .unwrap_or(if duration.num_days() <= 1 {
+                "hour"
+            } else if duration.num_days() <= 30 {
+                "day"
+            } else {
+                "week"
+            });
+        let interval = match bucket_size {
+            "hour" => "INTERVAL 1 HOUR",
+            "day" => "INTERVAL 1 DAY",
+            _ => "INTERVAL 1 WEEK",
+        };
+        // `bucket_ms` is a numeric (Unix-milliseconds) column, so WITH FILL's STEP
+        // must be a plain number, not an Interval value -- `toInt64(INTERVAL 1
+        // HOUR)` fails in CH 24.8 with "Illegal type IntervalHour of argument of
+        // function toInt64". Interval types aren't castable that way; step by the
+        // equivalent millisecond count instead.
+        let step_ms: i64 = match bucket_size {
+            "hour" => 3_600_000,
+            "day" => 86_400_000,
+            _ => 604_800_000,
         };
 
         let env_filter_flag: i32 = q.scope.environment_id.map(|_| 1).unwrap_or(0);
@@ -548,7 +580,7 @@ impl AnalyticsEvents for ClickHouseEventsBackend {
             WITH FILL
                 FROM toUnixTimestamp64Milli(toDateTime64(toStartOfInterval(fromUnixTimestamp64Milli(?), {interval}), 3, 'UTC'))
                 TO toUnixTimestamp64Milli(toDateTime64(toStartOfInterval(fromUnixTimestamp64Milli(?), {interval}), 3, 'UTC')) + 1
-                STEP toInt64({interval})
+                STEP {step_ms}
             "#
         );
 
@@ -1075,6 +1107,7 @@ impl AnalyticsEvents for ClickHouseEventsBackend {
     ) -> Result<AggregatedBucketsResponse, EventsError> {
         let level_expr = count_expr(q.aggregation_level);
         let interval = ch_interval(Some(q.bucket_size.as_str()));
+        let step_ms = ch_interval_step_ms(Some(q.bucket_size.as_str()));
         let env_filter_flag: i32 = q.scope.environment_id.map(|_| 1).unwrap_or(0);
         let env_filter_value: i32 = q.scope.environment_id.unwrap_or(0);
         let dep_filter_flag: i32 = q.scope.deployment_id.map(|_| 1).unwrap_or(0);
@@ -1098,7 +1131,7 @@ impl AnalyticsEvents for ClickHouseEventsBackend {
             WITH FILL
                 FROM toUnixTimestamp64Milli(toDateTime64(toStartOfInterval(fromUnixTimestamp64Milli(?), {interval}), 3, 'UTC'))
                 TO toUnixTimestamp64Milli(toDateTime64(toStartOfInterval(fromUnixTimestamp64Milli(?), {interval}), 3, 'UTC')) + 1
-                STEP toInt64({interval})
+                STEP {step_ms}
             "#
         );
 
@@ -1223,18 +1256,31 @@ mod tests {
         Box<dyn std::any::Any + Send>,
     )> {
         use testcontainers::{
-            core::{ContainerPort, WaitFor},
+            core::{wait::HttpWaitStrategy, ContainerPort, WaitFor},
             runners::AsyncRunner,
             GenericImage, ImageExt,
         };
 
         // Probe Docker. If not reachable, skip.
+        //
+        // The clickhouse-server image writes "Ready for connections" only to its
+        // in-container log file — never to stdout/stderr — so a log-message wait
+        // always times out and the test silently skips. Wait on the HTTP /ping
+        // endpoint (returns 200 "Ok." once the server accepts queries) instead,
+        // per the same fix already applied in temps-otel's clickhouse tests.
         let image = GenericImage::new("clickhouse/clickhouse-server", "24.8")
             .with_exposed_port(ContainerPort::Tcp(8123))
-            .with_wait_for(WaitFor::message_on_stdout("Ready for connections"))
+            .with_wait_for(WaitFor::http(
+                HttpWaitStrategy::new("/ping")
+                    .with_port(ContainerPort::Tcp(8123))
+                    .with_expected_status_code(200u16),
+            ))
             .with_env_var("CLICKHOUSE_DB", "temps_test")
-            .with_env_var("CLICKHOUSE_USER", "default")
-            .with_env_var("CLICKHOUSE_PASSWORD", "");
+            // Do NOT set CLICKHOUSE_USER=default (the image's user-init then
+            // rejects the pre-existing default user) and do NOT use an empty
+            // password (an empty CLICKHOUSE_PASSWORD leaves `default`
+            // unauthenticatable in 24.8).
+            .with_env_var("CLICKHOUSE_PASSWORD", "test");
 
         let container = match image.start().await {
             Ok(c) => c,
@@ -1257,7 +1303,7 @@ mod tests {
             .with_url(&url)
             .with_database("temps_test")
             .with_user("default")
-            .with_password("");
+            .with_password("test");
 
         // Wait briefly for CH to fully accept HTTP queries (the readiness
         // message is on stdout but the HTTP listener can lag a moment).
@@ -1774,7 +1820,12 @@ mod tests {
             "second migration run must apply nothing, got {:?}",
             report.applied
         );
-        assert_eq!(report.skipped.len(), 3, "all three migrations skipped");
+        // Keep in sync with `MIGRATIONS` in temps-analytics-backend/src/migrations.rs.
+        // This assertion was stale (hardcoded at 3 from when the list had only 3
+        // entries) and went unnoticed because this test always silently skipped
+        // before the ClickHouse container wait-condition fix above -- it never
+        // actually ran against a live container to catch the drift.
+        assert_eq!(report.skipped.len(), 6, "all six migrations skipped");
     }
 
     /// Regression test: `query_dashboard_projects` used to hardcode the trend to a

--- a/crates/temps-analytics-events/src/services/clickhouse_backend.rs
+++ b/crates/temps-analytics-events/src/services/clickhouse_backend.rs
@@ -36,7 +36,7 @@ use clickhouse::Row;
 use serde::Deserialize;
 use temps_core::UtcDateTime;
 
-use crate::services::events_service::EventsError;
+use crate::services::events_service::{calculate_trend_percentage, EventsError};
 use crate::services::queries::{
     ActiveVisitorsSpec, AggregatedBucketsSpec, DashboardProjectsSpec, EventTypeBreakdownSpec,
     EventsCountSpec, EventsTimelineSpec, HasEventsSpec, HourlyVisitsSpec, PropertyBreakdownSpec,
@@ -1052,16 +1052,7 @@ impl AnalyticsEvents for ClickHouseEventsBackend {
 
             let current = current_map.get(&pid).copied().unwrap_or(0);
             let previous = previous_map.get(&pid).copied().unwrap_or(0);
-            // Identical trend semantics to the Timescale impl: None when
-            // both periods are zero, 100% when previous is zero but
-            // current is positive.
-            let trend_percentage = if previous > 0 {
-                Some(((current - previous) as f64 / previous as f64) * 100.0)
-            } else if current > 0 {
-                Some(100.0)
-            } else {
-                None
-            };
+            let trend_percentage = calculate_trend_percentage(current, previous);
 
             projects.insert(
                 pid.to_string(),

--- a/crates/temps-analytics-events/src/services/events_service.rs
+++ b/crates/temps-analytics-events/src/services/events_service.rs
@@ -2763,6 +2763,261 @@ mod tests {
         println!("✅ record_event crawler-flag persistence test passed!");
     }
 
+    /// Regression test for the dashboard "visitors in last 24h" trend badge showing
+    /// a fabricated +100%/-100% right after a restart. The `events_hourly`
+    /// continuous aggregate is created `WITH NO DATA` by migrations and is only
+    /// backfilled by a best-effort async job at server startup
+    /// (`run_post_migration_backfill`), which this test deliberately never calls —
+    /// leaving the aggregate empty, exactly like a freshly restarted server.
+    /// `get_dashboard_projects_analytics` must still report accurate
+    /// previous-period counts (read from raw `events`, not the empty aggregate) and
+    /// must not fabricate a trend percentage when a project has no baseline.
+    #[tokio::test]
+    async fn test_dashboard_projects_analytics_survives_empty_continuous_aggregate() {
+        use chrono::Duration;
+        use sea_orm::{ActiveModelTrait, ActiveValue::Set};
+        use temps_database::test_utils::TestDatabase;
+        use temps_entities::{deployments, environments, events, projects, visitor};
+
+        let test_db: TestDatabase = match TestDatabase::with_migrations().await {
+            Ok(db) => db,
+            Err(e) => {
+                println!("Database not available, skipping test: {}", e);
+                return;
+            }
+        };
+        let db = test_db.connection_arc();
+
+        async fn make_project(db: &DatabaseConnection, slug: &str) -> projects::Model {
+            projects::ActiveModel {
+                name: Set(slug.to_string()),
+                repo_name: Set(slug.to_string()),
+                repo_owner: Set("test-owner".to_string()),
+                directory: Set("/".to_string()),
+                main_branch: Set("main".to_string()),
+                preset: Set(temps_entities::preset::Preset::NextJs),
+                slug: Set(slug.to_string()),
+                is_deleted: Set(false),
+                is_public_repo: Set(false),
+                deleted_at: Set(None),
+                last_deployment: Set(None),
+                created_at: Set(Utc::now()),
+                updated_at: Set(Utc::now()),
+                ..Default::default()
+            }
+            .insert(db)
+            .await
+            .expect("insert project")
+        }
+
+        async fn make_environment(
+            db: &DatabaseConnection,
+            project_id: i32,
+            slug: &str,
+        ) -> environments::Model {
+            environments::ActiveModel {
+                project_id: Set(project_id),
+                name: Set(slug.to_string()),
+                slug: Set(slug.to_string()),
+                subdomain: Set(slug.to_string()),
+                host: Set(String::new()),
+                upstreams: Set(UpstreamList::new()),
+                current_deployment_id: Set(None),
+                last_deployment: Set(None),
+                created_at: Set(Utc::now()),
+                updated_at: Set(Utc::now()),
+                ..Default::default()
+            }
+            .insert(db)
+            .await
+            .expect("insert environment")
+        }
+
+        async fn make_deployment(
+            db: &DatabaseConnection,
+            project_id: i32,
+            environment_id: i32,
+            slug: &str,
+        ) -> deployments::Model {
+            deployments::ActiveModel {
+                project_id: Set(project_id),
+                environment_id: Set(environment_id),
+                slug: Set(slug.to_string()),
+                state: Set("ready".to_string()),
+                metadata: Set(Some(deployments::DeploymentMetadata::default())),
+                created_at: Set(Utc::now()),
+                updated_at: Set(Utc::now()),
+                ..Default::default()
+            }
+            .insert(db)
+            .await
+            .expect("insert deployment")
+        }
+
+        async fn make_visitor(
+            db: &DatabaseConnection,
+            project_id: i32,
+            environment_id: i32,
+            visitor_id: &str,
+            seen_at: UtcDateTime,
+        ) -> visitor::Model {
+            visitor::ActiveModel {
+                visitor_id: Set(visitor_id.to_string()),
+                project_id: Set(project_id),
+                environment_id: Set(environment_id),
+                first_seen: Set(seen_at),
+                last_seen: Set(seen_at),
+                ..Default::default()
+            }
+            .insert(db)
+            .await
+            .expect("insert visitor")
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        async fn make_page_view(
+            db: &DatabaseConnection,
+            project_id: i32,
+            environment_id: i32,
+            deployment_id: i32,
+            visitor_row_id: i32,
+            session_id: &str,
+            at: UtcDateTime,
+        ) {
+            events::ActiveModel {
+                project_id: Set(project_id),
+                environment_id: Set(Some(environment_id)),
+                deployment_id: Set(Some(deployment_id)),
+                visitor_id: Set(Some(visitor_row_id)),
+                session_id: Set(Some(session_id.to_string())),
+                event_type: Set("page_view".to_string()),
+                hostname: Set("example.com".to_string()),
+                pathname: Set("/".to_string()),
+                page_path: Set("/".to_string()),
+                href: Set("https://example.com/".to_string()),
+                timestamp: Set(at),
+                ..Default::default()
+            }
+            .insert(db)
+            .await
+            .expect("insert event");
+        }
+
+        let now = Utc::now();
+        let start = now - Duration::hours(24);
+        let end = now;
+        // get_dashboard_projects_analytics's previous window is [start - (end-start), start).
+        let prev_ts = start - Duration::hours(6);
+        let curr_ts = now - Duration::hours(2);
+
+        // Project A: real traffic in both windows -- a genuine +50% trend (6 vs 4).
+        let project_a = make_project(&db, "trend-baseline").await;
+        let env_a = make_environment(&db, project_a.id, "trend-baseline-env").await;
+        let dep_a = make_deployment(&db, project_a.id, env_a.id, "trend-baseline-dep").await;
+        for i in 0..4 {
+            let v =
+                make_visitor(&db, project_a.id, env_a.id, &format!("a-prev-{i}"), prev_ts).await;
+            make_page_view(
+                &db,
+                project_a.id,
+                env_a.id,
+                dep_a.id,
+                v.id,
+                &format!("a-prev-sess-{i}"),
+                prev_ts,
+            )
+            .await;
+        }
+        for i in 0..6 {
+            let v =
+                make_visitor(&db, project_a.id, env_a.id, &format!("a-curr-{i}"), curr_ts).await;
+            make_page_view(
+                &db,
+                project_a.id,
+                env_a.id,
+                dep_a.id,
+                v.id,
+                &format!("a-curr-sess-{i}"),
+                curr_ts,
+            )
+            .await;
+        }
+
+        // Project B: brand new -- only current-period traffic, nothing previously.
+        let project_b = make_project(&db, "trend-new-project").await;
+        let env_b = make_environment(&db, project_b.id, "trend-new-project-env").await;
+        let dep_b = make_deployment(&db, project_b.id, env_b.id, "trend-new-project-dep").await;
+        for i in 0..3 {
+            let v =
+                make_visitor(&db, project_b.id, env_b.id, &format!("b-curr-{i}"), curr_ts).await;
+            make_page_view(
+                &db,
+                project_b.id,
+                env_b.id,
+                dep_b.id,
+                v.id,
+                &format!("b-curr-sess-{i}"),
+                curr_ts,
+            )
+            .await;
+        }
+
+        // Sanity-check the regression scenario itself: `events_hourly` must still be
+        // empty here, since only `run_post_migration_backfill` (never called in this
+        // test) populates it. This is what a freshly restarted server looks like.
+        #[derive(FromQueryResult)]
+        struct Count {
+            count: i64,
+        }
+        let agg_row_count = Count::find_by_statement(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "SELECT COUNT(*)::bigint as count FROM events_hourly",
+        ))
+        .one(db.as_ref())
+        .await
+        .expect("count events_hourly")
+        .map(|c| c.count)
+        .unwrap_or(0);
+        assert_eq!(
+            agg_row_count, 0,
+            "events_hourly must be empty to exercise the restart-staleness scenario"
+        );
+
+        let service = AnalyticsEventsService::new(db.clone());
+        let response = service
+            .get_dashboard_projects_analytics(&[project_a.id, project_b.id], start, end)
+            .await
+            .expect("get_dashboard_projects_analytics");
+
+        let a = response
+            .projects
+            .get(&project_a.id.to_string())
+            .expect("project A in response");
+        assert_eq!(a.unique_visitors, 6);
+        assert_eq!(
+            a.previous_unique_visitors, 4,
+            "previous-period count must come from raw events, not the empty continuous aggregate"
+        );
+        assert_eq!(
+            a.trend_percentage,
+            Some(50.0),
+            "trend must be the real (6-4)/4*100 ratio, not derived from a stale/empty aggregate"
+        );
+
+        let b = response
+            .projects
+            .get(&project_b.id.to_string())
+            .expect("project B in response");
+        assert_eq!(b.unique_visitors, 3);
+        assert_eq!(b.previous_unique_visitors, 0);
+        assert_eq!(
+            b.trend_percentage, None,
+            "a brand-new project with no previous-period baseline must not show a fabricated +100%"
+        );
+
+        println!("✅ dashboard trend regression test passed (TimescaleDB)!");
+    }
+
     #[test]
     fn test_calculate_trend_percentage_no_previous_baseline_omits_trend() {
         // Previously this returned a hardcoded Some(100.0), which showed a misleading

--- a/crates/temps-analytics-events/src/services/events_service.rs
+++ b/crates/temps-analytics-events/src/services/events_service.rs
@@ -1030,12 +1030,16 @@ WHERE project_id = $1
     /// Get dashboard analytics for multiple projects in a single batch.
     /// Returns unique visitor counts, previous-period comparison, and hourly sparkline.
     ///
-    /// Uses a hybrid approach:
-    /// - **Current period**: queries raw `events` table for exact accuracy (the continuous
-    ///   aggregate has a 1-hour end_offset gap, so recent data would be missing).
-    ///   For a 24h window this is fast with the `idx_events_project_timestamp` index.
-    /// - **Previous period**: queries `events_hourly` continuous aggregate for speed
-    ///   (older data is fully materialized, approximate is fine for trend comparison).
+    /// Both periods query the raw `events` table directly with the same
+    /// `idx_events_project_timestamp` index. The previous period used to read from the
+    /// `events_hourly` continuous aggregate for speed, but that aggregate's older buckets
+    /// are only backfilled by a best-effort async job on startup
+    /// (`run_post_migration_backfill`) and its recurring policy only refreshes the last
+    /// 3 hours — so right after a restart (or if that job is still catching up), the
+    /// aggregate could return no row for a project's previous-period window. That missing
+    /// row was indistinguishable from "genuinely zero visitors" and fed straight into the
+    /// trend fallback below, producing a misleading +/-100% instead of the real change.
+    /// Reading raw events for both periods removes that dependency entirely.
     pub async fn get_dashboard_projects_analytics(
         &self,
         project_ids: &[i32],
@@ -1108,16 +1112,15 @@ WHERE project_id = $1
             .map(|r| (r.project_id, r.count))
             .collect();
 
-        // Query 2: Unique visitor counts per project (previous period — continuous aggregate)
-        // Previous period is older data, fully covered by the aggregate. Approximate is fine
-        // for trend comparison (SUM of hourly distincts may slightly overcount).
+        // Query 2: Unique visitor counts per project (previous period — raw events, same
+        // source and index as the current period, so it's never stale after a restart).
         let prev_counts_sql = format!(
             r#"
             SELECT
                 project_id,
-                COALESCE(SUM(unique_visitors), 0)::bigint as count
-            FROM events_hourly
-            WHERE bucket >= $1 AND bucket <= $2
+                COUNT(DISTINCT visitor_id) FILTER (WHERE visitor_id IS NOT NULL)::bigint as count
+            FROM events
+            WHERE timestamp >= $1 AND timestamp <= $2
               AND project_id IN ({in_clause})
             GROUP BY project_id
             "#,
@@ -1210,16 +1213,7 @@ WHERE project_id = $1
             let current = counts_map.get(&pid).copied().unwrap_or(0);
             let previous = prev_counts_map.get(&pid).copied().unwrap_or(0);
 
-            // Calculate trend percentage: None if previous was 0 (no baseline)
-            let trend_percentage = if previous > 0 {
-                Some(((current - previous) as f64 / previous as f64) * 100.0)
-            } else if current > 0 {
-                // Had zero visitors before, now has some — show as 100% growth
-                Some(100.0)
-            } else {
-                // Both zero — no trend to show
-                None
-            };
+            let trend_percentage = calculate_trend_percentage(current, previous);
 
             projects.insert(
                 pid.to_string(),
@@ -1558,6 +1552,18 @@ WHERE project_id = $1
         }
 
         Ok(result)
+    }
+}
+
+/// Computes the percentage change between two visitor counts for the dashboard
+/// trend badge. Returns `None` when there's no previous-period baseline to compare
+/// against — a `previous` of 0 can't be turned into a real ratio, so we omit the
+/// trend entirely rather than fabricate a flat +/-100%.
+fn calculate_trend_percentage(current: i64, previous: i64) -> Option<f64> {
+    if previous > 0 {
+        Some(((current - previous) as f64 / previous as f64) * 100.0)
+    } else {
+        None
     }
 }
 
@@ -2751,5 +2757,34 @@ mod tests {
         );
 
         println!("✅ record_event crawler-flag persistence test passed!");
+    }
+
+    #[test]
+    fn test_calculate_trend_percentage_no_previous_baseline_omits_trend() {
+        // Previously this returned a hardcoded Some(100.0), which showed a misleading
+        // flat "+100%" badge any time the previous-period count was missing or zero —
+        // notably right after a restart, before the previous-period query had accurate
+        // data. There's no real baseline to compute a ratio against, so this must be None.
+        assert_eq!(calculate_trend_percentage(1, 0), None);
+        assert_eq!(calculate_trend_percentage(50, 0), None);
+    }
+
+    #[test]
+    fn test_calculate_trend_percentage_both_zero_omits_trend() {
+        assert_eq!(calculate_trend_percentage(0, 0), None);
+    }
+
+    #[test]
+    fn test_calculate_trend_percentage_computes_real_ratio() {
+        assert_eq!(calculate_trend_percentage(150, 100), Some(50.0));
+        assert_eq!(calculate_trend_percentage(50, 100), Some(-50.0));
+        assert_eq!(calculate_trend_percentage(100, 100), Some(0.0));
+    }
+
+    #[test]
+    fn test_calculate_trend_percentage_drop_to_zero_is_negative_hundred() {
+        // A real drop to zero visitors is a genuine -100%, unlike the fabricated case
+        // above where there was never a previous baseline to measure against.
+        assert_eq!(calculate_trend_percentage(0, 100), Some(-100.0));
     }
 }

--- a/crates/temps-analytics-events/src/services/events_service.rs
+++ b/crates/temps-analytics-events/src/services/events_service.rs
@@ -1559,7 +1559,11 @@ WHERE project_id = $1
 /// trend badge. Returns `None` when there's no previous-period baseline to compare
 /// against — a `previous` of 0 can't be turned into a real ratio, so we omit the
 /// trend entirely rather than fabricate a flat +/-100%.
-fn calculate_trend_percentage(current: i64, previous: i64) -> Option<f64> {
+///
+/// Shared by both the Timescale (`events_service`) and ClickHouse
+/// (`clickhouse_backend`) `AnalyticsEvents` implementations so the two backends
+/// can't drift back into inconsistent trend semantics.
+pub(crate) fn calculate_trend_percentage(current: i64, previous: i64) -> Option<f64> {
     if previous > 0 {
         Some(((current - previous) as f64 / previous as f64) * 100.0)
     } else {


### PR DESCRIPTION
## Summary
- The "visitors in last 24h" trend badge on the Projects dashboard was showing misleading flat +100%/-100% swings, especially noticeable right after a server restart.
- This affected **both analytics backends** (Temps supports either TimescaleDB or ClickHouse as the events store, selected via `AnalyticsEvents` trait impl):
  - **TimescaleDB** (`events_service.rs`): the previous-period visitor count was read from the `events_hourly` continuous aggregate for speed. That aggregate's older buckets are only backfilled by a best-effort async job on startup, and its recurring policy only refreshes the last 3 hours — so right after a restart it can return no row for a project's previous-period window. A missing row was indistinguishable from "genuinely zero visitors."
  - **ClickHouse** (`clickhouse_backend.rs`): no staleness issue (it already queries raw `events FINAL` for both periods), but it had the *identical* hardcoded fallback, explicitly written to mirror the Timescale implementation.
  - Both paths fed a missing/zero previous count into a fallback that hardcoded the trend to a flat `+100.0` (or `-100.0`), instead of a real percentage or "no data yet."
- Fix:
  - TimescaleDB: query the previous period from the raw `events` table (same source/index as the current period), eliminating the staleness window entirely.
  - Both backends: stop fabricating `+/-100%` when there's no real previous-period baseline — omit the trend instead (consistent with the existing both-zero case).
  - Extracted the trend math into a single shared `calculate_trend_percentage()` (`pub(crate)` in `events_service`, reused by `clickhouse_backend`) so the two backends can't drift into inconsistent semantics again.

## Regression tests (testcontainers, real DB/CH — verified live, not just compiled)
- **TimescaleDB** — `test_dashboard_projects_analytics_survives_empty_continuous_aggregate`: runs full migrations against a real `timescale/timescaledb-ha` container but deliberately never calls `run_post_migration_backfill`, leaving `events_hourly` completely empty — exactly what a freshly restarted server looks like. Asserts the previous-period count and trend still come out correct (read from raw `events`), and that a brand-new project with no baseline gets `None` instead of a fabricated `+100%`. **Passes end-to-end** against a live container.
- **ClickHouse** — `ch_dashboard_trend_omits_fabricated_percentage`: exercises the same two scenarios against a real `clickhouse/clickhouse-server` container. **Passes end-to-end** against a live container.

### Bonus: fixed the ClickHouse test harness itself, which uncovered two real pre-existing bugs
Actually running the ClickHouse tests (rather than trusting a compile-only pass) surfaced that `setup_clickhouse()`'s wait condition was broken and had been silently skipping *every* ClickHouse test in this file, including the pre-existing `ch_backend_full_query_surface` — it never once ran against a live container:
- `WaitFor::message_on_stdout("Ready for connections")` never matches, because clickhouse-server 24.8 writes that message only to its in-container log file, never stdout/stderr. Switched to `WaitFor::http("/ping")` + a non-empty `CLICKHOUSE_PASSWORD`, the same fix already applied in `temps-otel`'s ClickHouse tests (added `http_wait_plain` to this crate's `testcontainers` dev-dependency to match).

With the harness actually running, two previously-undetected live bugs surfaced and are fixed here too:
- `query_events_timeline` and `query_aggregated_buckets` both built `WITH FILL ... STEP toInt64(INTERVAL 1 HOUR)`, which CH 24.8 rejects ("Illegal type IntervalHour of argument of function toInt64") — Interval values aren't `toInt64`-castable. `bucket_ms` is a numeric (Unix-ms) column, so `STEP` needs a plain number; added `ch_interval_step_ms()` alongside the existing `ch_interval()` and step by the equivalent millisecond width.
- `ch_backend_full_query_surface` asserted the migration runner skips exactly 3 migrations on a second run; the list has grown to 6 (0004-0006 added later) and nobody caught the drift since the assertion was never reached.

## Test plan
- [x] `cargo check --lib --tests -p temps-analytics-events`
- [x] `cargo clippy -p temps-analytics-events --all-targets` — clean
- [x] `cargo fmt -p temps-analytics-events -- --check` — clean
- [x] `cargo test --lib -p temps-analytics-events` — **50/50 passed, live**, including both new regression tests and the now-repaired pre-existing ClickHouse test, all run against real TimescaleDB/ClickHouse testcontainers (not skipped)