### PR TITLE
ci: add dependency and container scanning for Temps' own supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+version: 2
+
+updates:
+  # Rust workspace (51 crates under a single Cargo.lock at the repo root).
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "rust"
+    groups:
+      # Patch/minor bumps are low-risk and numerous across 51 crates; batching
+      # them into one PR keeps the review queue sane. Majors are left
+      # ungrouped so each gets its own PR and full CI signal, since majors
+      # are the ones most likely to need an actual code change.
+      cargo-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Web frontend (web/). Package manager is bun (web/bun.lock present, no
+  # package-lock.json/yarn.lock/pnpm-lock.yaml) per CLAUDE.md, which is why
+  # this uses the "bun" ecosystem (GA since Feb 2025) rather than "npm".
+  - package-ecosystem: "bun"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "web"
+    groups:
+      web-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used across .github/workflows/*.yml (including this PR's
+  # new dependency-scan.yml).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "ci"
+    groups:
+      github-actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -67,12 +67,31 @@ jobs:
       #   separately, not a drop-in version bump.
       # - RUSTSEC-2018-0017 (tempdir): transitive via nixpacks, no newer
       #   nixpacks release drops it yet.
+      #
+      # The three below are real vulnerabilities (not just "unmaintained"
+      # notices), blocked on upstream fixes with no non-forking workaround.
+      # Full reachability analysis for each lives in the root Cargo.toml
+      # under "Dependency Overrides - Security Fixes" -- re-verify that
+      # analysis before removing/renewing these on advisory-db updates:
+      # - RUSTSEC-2024-0437 (protobuf 2.28.0 via prometheus 0.13 <- pingora
+      #   0.8.x): recursion-crash-on-parse; pingora only ever *emits*
+      #   metrics via TextEncoder, never parses protobuf-encoded input, so
+      #   the vulnerable parse path is compiled in but unreachable.
+      # - RUSTSEC-2023-0018 (remove_dir_all 0.5.3 via tempdir <- nixpacks
+      #   1.41.0, crates.io latest): TOCTOU race lives in a nixpacks code
+      #   path (implicit output dir) that temps-presets never takes (it
+      #   always passes an explicit out_dir).
+      # - RUSTSEC-2023-0071 (rsa 0.9.10 via jsonwebtoken <- octocrab /
+      #   openidconnect): Marvin Attack targets private-key ops; our usage
+      #   is RS256 JWT sign/verify with no remote timing oracle exposed to
+      #   the signing key, and OIDC token verification is public-key only.
+      #   No fixed `rsa` release exists upstream yet.
       # Remove an entry once its upstream is fixed/replaced.
       - name: Run cargo-audit
         uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: RUSTSEC-2024-0370,RUSTSEC-2025-0134,RUSTSEC-2018-0017
+          ignore: RUSTSEC-2024-0370,RUSTSEC-2025-0134,RUSTSEC-2018-0017,RUSTSEC-2024-0437,RUSTSEC-2023-0018,RUSTSEC-2023-0071
 
   web-audit:
     name: Web Dependency Audit (bun audit)

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -57,10 +57,22 @@ jobs:
       # just a severity subset -- cargo-audit's advisory-db entries don't
       # uniformly carry CVSS severity, so "any match" is the safer default
       # for a supply-chain gate). See PR body for rationale on fail-vs-warn.
+      #
+      # Ignored below are "unmaintained crate" notices (not exploitable
+      # CVEs) for deps we don't control directly:
+      # - RUSTSEC-2024-0370 (proc-macro-error2): transitive via pingora's
+      #   tracing stack (cf-rustracing-jaeger -> neli -> local-ip-address).
+      # - RUSTSEC-2025-0134 (rustls-pemfile): used directly across several
+      #   crates; migrating to rustls-pki-types' PemObject API is tracked
+      #   separately, not a drop-in version bump.
+      # - RUSTSEC-2018-0017 (tempdir): transitive via nixpacks, no newer
+      #   nixpacks release drops it yet.
+      # Remove an entry once its upstream is fixed/replaced.
       - name: Run cargo-audit
         uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ignore: RUSTSEC-2024-0370,RUSTSEC-2025-0134,RUSTSEC-2018-0017
 
   web-audit:
     name: Web Dependency Audit (bun audit)
@@ -93,6 +105,11 @@ jobs:
       # web/'s dependency tree. `bun audit` exits non-zero when findings meet
       # or exceed --audit-level. Lower severities (low/moderate) are still
       # printed by the command's own output but do not fail the build.
+      #
+      # Note: `bun audit --ignore` is silently non-functional in bun 1.3.14
+      # (confirmed against both GHSA slugs and bun's own internal advisory
+      # ids -- neither suppresses the finding). Transitive advisories here
+      # are fixed via package.json `overrides` instead of ignored.
       - name: Run bun audit
         run: |
           cd web

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -1,0 +1,140 @@
+name: Dependency & Container Scan
+
+# Supply-chain scanning for Temps' own code (tracked as bherila/temps#23).
+# This is distinct from crates/temps-vulnerability-scanner, which only scans
+# *deployed customer application images* -- nothing here previously checked
+# Temps' own crates, its own web dependencies, or its own build images.
+#
+# - `cargo-audit` scans the Rust workspace's Cargo.lock against the RustSec
+#   Advisory Database.
+# - `web-audit` scans web/ (bun) dependencies against the same class of
+#   advisory data via `bun audit`.
+# - `container-scan` (best-effort, schedule/dispatch only) scans the latest
+#   published release image with Trivy. It intentionally does not run on
+#   pull_request: a PR has no fresh image to scan (release.yml only builds
+#   images for pushed `v*.*.*` tags), so scanning the last published
+#   `:latest` tag weekly is the meaningful signal here.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "web/package.json"
+      - "web/bun.lock"
+      - ".github/workflows/dependency-scan.yml"
+  schedule:
+    # Every Monday at 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  cargo-audit:
+    name: Rust Dependency Audit (cargo-audit)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # rustsec/audit-check publishes results as a GitHub check run.
+      checks: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: dependency-scan-cargo-audit
+
+      # Runs `cargo audit` against Cargo.lock and fails the job if any
+      # RUSTSEC advisory matches a resolved dependency (all advisories, not
+      # just a severity subset -- cargo-audit's advisory-db entries don't
+      # uniformly carry CVSS severity, so "any match" is the safer default
+      # for a supply-chain gate). See PR body for rationale on fail-vs-warn.
+      - name: Run cargo-audit
+        uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  web-audit:
+    name: Web Dependency Audit (bun audit)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: web/node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('web/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install web dependencies
+        run: |
+          cd web
+          bun install
+
+      # Fails the job if any high or critical severity advisory is found in
+      # web/'s dependency tree. `bun audit` exits non-zero when findings meet
+      # or exceed --audit-level. Lower severities (low/moderate) are still
+      # printed by the command's own output but do not fail the build.
+      - name: Run bun audit
+        run: |
+          cd web
+          bun audit --audit-level=high
+
+  container-scan:
+    name: Container Image Scan (Trivy, best-effort)
+    # Only meaningful on a schedule/manual run: PRs don't produce a fresh
+    # published image to scan (release.yml only builds+pushes on `v*.*.*`
+    # tags). This job scans whatever is currently published as `:latest`.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Trivy vulnerability scanner on published image
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          # Matches the tag naming release.yml publishes for stable releases
+          # (ghcr.io/${{ github.repository_owner }}/temps:<channel_tag>) --
+          # dynamic owner so this also resolves correctly if run from a fork
+          # that publishes its own images under the same convention.
+          image-ref: ghcr.io/${{ github.repository_owner }}/temps:latest
+          format: sarif
+          output: trivy-results.sarif
+          severity: "CRITICAL,HIGH"
+          # Report all findings in the SARIF/table output, but only fail the
+          # job (exit-code 1) on CRITICAL/HIGH -- matches the fail threshold
+          # used for cargo-audit/bun audit above.
+          exit-code: "1"
+          ignore-unfixed: true
+
+      # Best-effort: only succeeds if the repo has GitHub code scanning
+      # (Advanced Security / public repo) enabled. Non-fatal if not, so it
+      # never masks or replaces the pass/fail signal from the step above.
+      - name: Upload Trivy results to GitHub code scanning
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -81,11 +81,15 @@ jobs:
       #   1.41.0, crates.io latest): TOCTOU race lives in a nixpacks code
       #   path (implicit output dir) that temps-presets never takes (it
       #   always passes an explicit out_dir).
-      # - RUSTSEC-2023-0071 (rsa 0.9.10 via jsonwebtoken <- octocrab /
-      #   openidconnect): Marvin Attack targets private-key ops; our usage
-      #   is RS256 JWT sign/verify with no remote timing oracle exposed to
-      #   the signing key, and OIDC token verification is public-key only.
-      #   No fixed `rsa` release exists upstream yet.
+      # - RUSTSEC-2023-0071 (rsa 0.9.10 via jsonwebtoken <- octocrab, and
+      #   direct in temps-dns/gcp.rs): Marvin Attack is a chosen-ciphertext
+      #   *decryption* oracle attack; temps has zero RSA decryption, only
+      #   RSA signing (GitHub App JWTs, GCP DNS service-account JWTs). The
+      #   signing timing side-channel isn't remotely exploitable here
+      #   (signing latency is buried in 100-500ms of network I/O, and the
+      #   signed payload isn't attacker-controlled). Keys are per-customer,
+      #   not a shared temps secret. No fixed `rsa` release exists upstream
+      #   yet -- tracked for a ring/aws-lc-rs-backed signing migration.
       # Remove an entry once its upstream is fixed/replaced.
       - name: Run cargo-audit
         uses: rustsec/audit-check@v2.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -369,7 +369,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2233,7 +2233,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3182,7 +3182,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3470,7 +3470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4018,9 +4018,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
@@ -4604,7 +4604,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -4640,7 +4640,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5040,7 +5040,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5758,9 +5758,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -6481,7 +6481,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6613,7 +6613,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.0",
@@ -7383,7 +7383,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sfv",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "strum",
  "strum_macros",
  "tokio",
@@ -7465,7 +7465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91bb5030596a3d442c0866ac68afe29c14ba558e77c726dcdf7016b0dbb359d9"
 dependencies = [
  "arrayvec",
- "hashbrown 0.12.3",
+ "hashbrown 0.17.1",
  "parking_lot",
  "rand 0.8.6",
 ]
@@ -7897,7 +7897,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -8053,7 +8053,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8090,7 +8090,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -9029,7 +9029,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9097,7 +9097,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10012,7 +10012,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10035,7 +10035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10572,7 +10572,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14701,7 +14701,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -8032,9 +8032,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -429,14 +429,28 @@ debug = false
 #
 # 5. RUSTSEC-2023-0071: rsa 0.9.10 (MEDIUM severity)
 #    - Title: Marvin Attack: potential key recovery through timing sidechannels
-#    - Path: jsonwebtoken 10.4.0 → { octocrab (GitHub App JWT signing),
-#      openidconnect (OIDC id_token verification) }
+#    - Dependency paths:
+#        jsonwebtoken 10.4.0 <- octocrab      (GitHub App JWT signing;
+#          crates/temps-git/src/services/github.rs,
+#          crates/temps-git/src/services/git_provider_manager.rs)
+#        jsonwebtoken 10.4.0 <- openidconnect (OIDC id_token verification)
+#        rsa direct usage in crates/temps-dns/src/providers/gcp.rs
+#          (GCP Cloud DNS service-account JWT signing, sign_rs256())
 #    - Status: no fixed version exists upstream (the rsa crate has no constant-time
 #      release yet). Tracked.
-#    - Mitigation: used for RS256 JWT sign/verify, NOT for RSA decryption of
-#      attacker-supplied ciphertext. The Marvin side-channel targets PKCS#1v1.5
-#      private-key ops; our JWT signing key is not exposed to a remote timing
-#      oracle, and OIDC token verification is a public-key op (unaffected).
+#    - Assessment: the Marvin Attack is an adaptive chosen-ciphertext attack against
+#      RSA-PKCS#1v1.5 *decryption*. Temps has zero RSA decryption usage -- all three
+#      paths above are RSA *signing* only (OIDC verification is a separate,
+#      unaffected public-key op). Signing uses a non-constant-time modexp, which is
+#      a real but much narrower timing side-channel than Marvin's decryption
+#      oracle: exploiting it needs millions of samples at nanosecond precision, the
+#      signing op itself (~10-50us) is buried inside git/DNS operations dominated
+#      by 100-500ms of network I/O, and the signed payload (app_id/iat/exp or
+#      service-account claims) isn't attacker-controlled. Blast radius if ever
+#      exploited is per-customer only: each org supplies its own GitHub App or GCP
+#      service-account private key, not a shared temps platform secret.
+#    - Follow-up: monitor upstream `rsa` for a constant-time release; evaluate
+#      ring/aws-lc-rs-backed signing as a replacement for both paths.
 #
 # All remaining items are transitive dependencies from third-party crates that we
 # cannot directly patch without forking. Monitoring upstream for updates.

--- a/crates/temps-auth/src/handlers.rs
+++ b/crates/temps-auth/src/handlers.rs
@@ -1,8 +1,8 @@
 use super::AuthState;
 use crate::audit::{
-    EmailVerifiedAudit, LoginAudit, LogoutAudit, MfaDisabledAudit, MfaEnabledAudit,
-    MfaVerifiedAudit, PasswordResetAudit, RoleAssignedAudit, RoleRemovedAudit, UpdatedFields,
-    UserCreatedAudit, UserDeletedAudit, UserRestoredAudit, UserUpdatedAudit,
+    ConcurrentSessionDetectedAudit, EmailVerifiedAudit, LoginAudit, LogoutAudit, MfaDisabledAudit,
+    MfaEnabledAudit, MfaVerifiedAudit, PasswordResetAudit, RoleAssignedAudit, RoleRemovedAudit,
+    UpdatedFields, UserCreatedAudit, UserDeletedAudit, UserRestoredAudit, UserUpdatedAudit,
 };
 use crate::avatar::generate_avatar_data_url;
 use crate::user_service::UserServiceError;
@@ -199,13 +199,30 @@ pub async fn verify_mfa_challenge(
             };
 
             let audit = MfaVerifiedAudit {
-                context: audit_context,
+                context: audit_context.clone(),
                 username: user.email.clone(),
             };
 
             if let Err(e) = auth_state.audit_service.create_audit_log(&audit).await {
                 error!("Failed to create audit log: {}", e);
             }
+
+            // Count this user's already-active sessions *before* creating a
+            // new one (the temporary MFA-challenge session was already
+            // deleted by `verify_mfa_challenge` above, so this only reflects
+            // pre-existing real sessions). Purely observational -- see
+            // bherila/temps#24; a lookup failure must never block the login.
+            let existing_active_sessions =
+                match auth_state.auth_service.count_active_sessions(user.id).await {
+                    Ok(count) => count,
+                    Err(e) => {
+                        error!(
+                            "Failed to count active sessions for user {} after MFA verification: {}",
+                            user.id, e
+                        );
+                        0
+                    }
+                };
 
             let session_token = auth_state
                 .auth_service
@@ -217,6 +234,23 @@ pub async fn verify_mfa_challenge(
                         .with_title("Session Creation Failed")
                         .with_detail("Could not create session. Please try logging in again.")
                 })?;
+
+            if existing_active_sessions > 0 {
+                if let Err(e) = auth_state
+                    .audit_service
+                    .create_audit_log(&ConcurrentSessionDetectedAudit {
+                        context: audit_context,
+                        login_method: "password-mfa".to_string(),
+                        existing_active_session_count: existing_active_sessions,
+                    })
+                    .await
+                {
+                    error!(
+                        "Failed to create concurrent-session audit log for user {}: {}",
+                        user.id, e
+                    );
+                }
+            }
 
             let session_token_encrypted = match auth_state.cookie_crypto.encrypt(&session_token) {
                 Ok(enc) => enc,
@@ -570,6 +604,7 @@ pub async fn register(
     responses(
         (status = 200, description = "Login successful, session cookie set", body = AuthResponse),
         (status = 401, description = "Invalid credentials"),
+        (status = 403, description = "MFA enrollment required for this account's role"),
         (status = 500, description = "Internal server error")
     ),
     tag = "Authentication"
@@ -629,6 +664,22 @@ pub async fn login(
                     }
                 }
             } else {
+                // Count this user's already-active sessions *before* creating
+                // a new one, so we can flag concurrent logins in the audit
+                // trail (bherila/temps#24). A lookup failure here must not
+                // block the login -- graceful degradation per CLAUDE.md.
+                let existing_active_sessions =
+                    match state.auth_service.count_active_sessions(user.id).await {
+                        Ok(count) => count,
+                        Err(e) => {
+                            error!(
+                                "Failed to count active sessions for user {} before login: {}",
+                                user.id, e
+                            );
+                            0
+                        }
+                    };
+
                 // Create regular session
                 match state.auth_service.create_session(user.id).await {
                     Ok(session_token) => {
@@ -647,20 +698,37 @@ pub async fn login(
                         let headers = state
                             .auth_service
                             .create_session_cookie(&encrypted_token, metadata.is_secure);
+                        let audit_context = AuditContext {
+                            user_id: user.id,
+                            ip_address: Some(metadata.ip_address.to_string()),
+                            user_agent: metadata.user_agent.as_str().to_string(),
+                        };
                         if let Err(e) = state
                             .audit_service
                             .create_audit_log(&LoginAudit {
-                                context: AuditContext {
-                                    user_id: user.id,
-                                    ip_address: Some(metadata.ip_address.to_string()),
-                                    user_agent: metadata.user_agent.as_str().to_string(),
-                                },
+                                context: audit_context.clone(),
                                 success: true,
                                 login_method: "password".to_string(),
                             })
                             .await
                         {
                             error!("Failed to create audit log: {}", e);
+                        }
+                        if existing_active_sessions > 0 {
+                            if let Err(e) = state
+                                .audit_service
+                                .create_audit_log(&ConcurrentSessionDetectedAudit {
+                                    context: audit_context,
+                                    login_method: "password".to_string(),
+                                    existing_active_session_count: existing_active_sessions,
+                                })
+                                .await
+                            {
+                                error!(
+                                    "Failed to create concurrent-session audit log for user {}: {}",
+                                    user.id, e
+                                );
+                            }
                         }
                         Ok((
                             headers,
@@ -702,6 +770,19 @@ pub async fn login(
                 Err(problem_new(StatusCode::UNAUTHORIZED)
                     .with_title("Invalid Credentials")
                     .with_detail("Invalid email or password."))
+            }
+            crate::auth_service::UserAuthError::MfaRequiredForRole { user_id, role } => {
+                warn!(
+                    user_id,
+                    role = %role,
+                    email = %login_email,
+                    "Login blocked: MFA is required for this role but is not enrolled"
+                );
+                Err(problem_new(StatusCode::FORBIDDEN)
+                    .with_title("MFA Required")
+                    .with_detail(format!(
+                        "Your account's '{role}' role requires multi-factor authentication. Please contact an administrator or enroll MFA before logging in."
+                    )))
             }
             _ => {
                 // Log the real error server-side (email is PII but legitimate

--- a/crates/temps-auth/src/handlers.rs
+++ b/crates/temps-auth/src/handlers.rs
@@ -1,8 +1,8 @@
 use super::AuthState;
 use crate::audit::{
-    ConcurrentSessionDetectedAudit, EmailVerifiedAudit, LoginAudit, LogoutAudit, MfaDisabledAudit,
-    MfaEnabledAudit, MfaVerifiedAudit, PasswordResetAudit, RoleAssignedAudit, RoleRemovedAudit,
-    UpdatedFields, UserCreatedAudit, UserDeletedAudit, UserRestoredAudit, UserUpdatedAudit,
+    EmailVerifiedAudit, LoginAudit, LogoutAudit, MfaDisabledAudit, MfaEnabledAudit,
+    MfaVerifiedAudit, PasswordResetAudit, RoleAssignedAudit, RoleRemovedAudit, UpdatedFields,
+    UserCreatedAudit, UserDeletedAudit, UserRestoredAudit, UserUpdatedAudit,
 };
 use crate::avatar::generate_avatar_data_url;
 use crate::user_service::UserServiceError;
@@ -199,30 +199,13 @@ pub async fn verify_mfa_challenge(
             };
 
             let audit = MfaVerifiedAudit {
-                context: audit_context.clone(),
+                context: audit_context,
                 username: user.email.clone(),
             };
 
             if let Err(e) = auth_state.audit_service.create_audit_log(&audit).await {
                 error!("Failed to create audit log: {}", e);
             }
-
-            // Count this user's already-active sessions *before* creating a
-            // new one (the temporary MFA-challenge session was already
-            // deleted by `verify_mfa_challenge` above, so this only reflects
-            // pre-existing real sessions). Purely observational -- see
-            // bherila/temps#24; a lookup failure must never block the login.
-            let existing_active_sessions =
-                match auth_state.auth_service.count_active_sessions(user.id).await {
-                    Ok(count) => count,
-                    Err(e) => {
-                        error!(
-                            "Failed to count active sessions for user {} after MFA verification: {}",
-                            user.id, e
-                        );
-                        0
-                    }
-                };
 
             let session_token = auth_state
                 .auth_service
@@ -234,23 +217,6 @@ pub async fn verify_mfa_challenge(
                         .with_title("Session Creation Failed")
                         .with_detail("Could not create session. Please try logging in again.")
                 })?;
-
-            if existing_active_sessions > 0 {
-                if let Err(e) = auth_state
-                    .audit_service
-                    .create_audit_log(&ConcurrentSessionDetectedAudit {
-                        context: audit_context,
-                        login_method: "password-mfa".to_string(),
-                        existing_active_session_count: existing_active_sessions,
-                    })
-                    .await
-                {
-                    error!(
-                        "Failed to create concurrent-session audit log for user {}: {}",
-                        user.id, e
-                    );
-                }
-            }
 
             let session_token_encrypted = match auth_state.cookie_crypto.encrypt(&session_token) {
                 Ok(enc) => enc,
@@ -604,7 +570,6 @@ pub async fn register(
     responses(
         (status = 200, description = "Login successful, session cookie set", body = AuthResponse),
         (status = 401, description = "Invalid credentials"),
-        (status = 403, description = "MFA enrollment required for this account's role"),
         (status = 500, description = "Internal server error")
     ),
     tag = "Authentication"
@@ -664,22 +629,6 @@ pub async fn login(
                     }
                 }
             } else {
-                // Count this user's already-active sessions *before* creating
-                // a new one, so we can flag concurrent logins in the audit
-                // trail (bherila/temps#24). A lookup failure here must not
-                // block the login -- graceful degradation per CLAUDE.md.
-                let existing_active_sessions =
-                    match state.auth_service.count_active_sessions(user.id).await {
-                        Ok(count) => count,
-                        Err(e) => {
-                            error!(
-                                "Failed to count active sessions for user {} before login: {}",
-                                user.id, e
-                            );
-                            0
-                        }
-                    };
-
                 // Create regular session
                 match state.auth_service.create_session(user.id).await {
                     Ok(session_token) => {
@@ -698,37 +647,20 @@ pub async fn login(
                         let headers = state
                             .auth_service
                             .create_session_cookie(&encrypted_token, metadata.is_secure);
-                        let audit_context = AuditContext {
-                            user_id: user.id,
-                            ip_address: Some(metadata.ip_address.to_string()),
-                            user_agent: metadata.user_agent.as_str().to_string(),
-                        };
                         if let Err(e) = state
                             .audit_service
                             .create_audit_log(&LoginAudit {
-                                context: audit_context.clone(),
+                                context: AuditContext {
+                                    user_id: user.id,
+                                    ip_address: Some(metadata.ip_address.to_string()),
+                                    user_agent: metadata.user_agent.as_str().to_string(),
+                                },
                                 success: true,
                                 login_method: "password".to_string(),
                             })
                             .await
                         {
                             error!("Failed to create audit log: {}", e);
-                        }
-                        if existing_active_sessions > 0 {
-                            if let Err(e) = state
-                                .audit_service
-                                .create_audit_log(&ConcurrentSessionDetectedAudit {
-                                    context: audit_context,
-                                    login_method: "password".to_string(),
-                                    existing_active_session_count: existing_active_sessions,
-                                })
-                                .await
-                            {
-                                error!(
-                                    "Failed to create concurrent-session audit log for user {}: {}",
-                                    user.id, e
-                                );
-                            }
                         }
                         Ok((
                             headers,
@@ -770,19 +702,6 @@ pub async fn login(
                 Err(problem_new(StatusCode::UNAUTHORIZED)
                     .with_title("Invalid Credentials")
                     .with_detail("Invalid email or password."))
-            }
-            crate::auth_service::UserAuthError::MfaRequiredForRole { user_id, role } => {
-                warn!(
-                    user_id,
-                    role = %role,
-                    email = %login_email,
-                    "Login blocked: MFA is required for this role but is not enrolled"
-                );
-                Err(problem_new(StatusCode::FORBIDDEN)
-                    .with_title("MFA Required")
-                    .with_detail(format!(
-                        "Your account's '{role}' role requires multi-factor authentication. Please contact an administrator or enroll MFA before logging in."
-                    )))
             }
             _ => {
                 // Log the real error server-side (email is PII but legitimate

--- a/crates/temps-dns/Cargo.toml
+++ b/crates/temps-dns/Cargo.toml
@@ -44,7 +44,7 @@ rsa = "0.9"
 base64 = "0.22"
 
 # XML parsing for Route53
-quick-xml = { version = "0.37", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 
 # URL encoding
 urlencoding = "2.1"

--- a/crates/temps-git/Cargo.toml
+++ b/crates/temps-git/Cargo.toml
@@ -51,7 +51,7 @@ serde_derive = { workspace = true }
 jsonwebtoken = "10.3.0"
 uuid = { workspace = true }
 http-body-util = { workspace = true }
-git2 = "0.20.4"
+git2 = { version = "0.21.0", features = ["https", "ssh"] }
 anyhow = { workspace = true }
 bytes = { workspace = true }
 tracing = { workspace = true }

--- a/crates/temps-git/src/services/git_service.rs
+++ b/crates/temps-git/src/services/git_service.rs
@@ -518,7 +518,7 @@ impl GitService {
             let branch_ref = branch
                 .get()
                 .name()
-                .ok_or_else(|| anyhow!("Invalid branch reference"))?;
+                .map_err(|e| anyhow!("Invalid branch reference: {}", e))?;
             repo.set_head(branch_ref)?;
             repo.checkout_head(None)?;
 

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -57,7 +57,7 @@
         "react-icons": "^5.5.0",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^3.0.6",
-        "react-router-dom": "^7.9.1",
+        "react-router-dom": "^7.18.1",
         "react-simple-maps": "^3.0.0",
         "recharts": "2.15.4",
         "rehype-highlight": "^7.0.2",
@@ -96,6 +96,12 @@
         "typescript-eslint": "^8.46.0",
       },
     },
+  },
+  "overrides": {
+    "d3-color": "^3.1.0",
+    "flatted": "^3.4.2",
+    "handlebars": "^4.7.9",
+    "picomatch": "^2.3.2",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -860,7 +866,7 @@
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
-    "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
@@ -906,7 +912,7 @@
 
     "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
 
-    "handlebars": ["handlebars@4.7.8", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": "bin/handlebars" }, "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ=="],
+    "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -1278,7 +1284,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
@@ -1330,9 +1336,9 @@
 
     "react-resizable-panels": ["react-resizable-panels@3.0.6", "", { "peerDependencies": { "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew=="],
 
-    "react-router": ["react-router@7.9.4", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-SD3G8HKviFHg9xj7dNODUKDFgpG4xqD5nhyd0mYoB5iISepuZAvzSr8ywxgxKJ52yRzf/HWtVHc9AWwoTbljvA=="],
+    "react-router": ["react-router@7.18.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg=="],
 
-    "react-router-dom": ["react-router-dom@7.9.4", "", { "dependencies": { "react-router": "7.9.4" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-f30P6bIkmYvnHHa5Gcu65deIXoA2+r3Eb6PJIAddvsT9aGlchMatJ51GgpU470aSqRRbFX22T70yQNUGuW3DfA=="],
+    "react-router-dom": ["react-router-dom@7.18.1", "", { "dependencies": { "react-router": "7.18.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg=="],
 
     "react-simple-maps": ["react-simple-maps@3.0.0", "", { "dependencies": { "d3-geo": "^2.0.2", "d3-selection": "^2.0.0", "d3-zoom": "^2.0.0", "topojson-client": "^3.1.0" }, "peerDependencies": { "prop-types": "^15.7.2", "react": "^16.8.0 || 17.x || 18.x", "react-dom": "^16.8.0 || 17.x || 18.x" } }, "sha512-vKNFrvpPG8Vyfdjnz5Ne1N56rZlDfHXv5THNXOVZMqbX1rWZA48zQuYT03mx6PAKanqarJu/PDLgshIZAfHHqw=="],
 
@@ -1614,8 +1620,6 @@
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
-    "d3-interpolate/d3-color": ["d3-color@2.0.0", "", {}, "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="],
-
     "d3-scale/d3-format": ["d3-format@3.1.0", "", {}, "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="],
 
     "d3-scale/d3-interpolate": ["d3-interpolate@2.0.1", "", { "dependencies": { "d3-color": "1 - 2" } }, "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ=="],
@@ -1623,8 +1627,6 @@
     "d3-scale/d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
 
     "d3-scale/d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
-
-    "d3-transition/d3-color": ["d3-color@2.0.0", "", {}, "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="],
 
     "d3-transition/d3-ease": ["d3-ease@2.0.0", "", {}, "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ=="],
 
@@ -1685,10 +1687,6 @@
     "@nivo/scales/@types/d3-interpolate/@types/d3-color": ["@types/d3-color@2.0.6", "", {}, "sha512-tbaFGDmJWHqnenvk3QGSvD3RVwr631BjKRD7Sc7VLRgrdX5mk5hTyoeBL6rXZaeoXzmZwIl1D2HPogEdt1rHBg=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
-    "d3-scale/d3-interpolate/d3-color": ["d3-color@2.0.0", "", {}, "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="],
-
-    "d3-zoom/d3-interpolate/d3-color": ["d3-color@2.0.0", "", {}, "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="],
 
     "fs-minipass/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -99,9 +99,13 @@
   },
   "overrides": {
     "d3-color": "^3.1.0",
+    "defu": "^6.1.5",
     "flatted": "^3.4.2",
     "handlebars": "^4.7.9",
+    "lodash": "^4.17.24",
+    "minimatch": "^9.0.7",
     "picomatch": "^2.3.2",
+    "tar": "^7.5.7",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -608,7 +612,7 @@
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
-    "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+    "brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -667,8 +671,6 @@
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "commander": ["commander@13.0.0", "", {}, "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ=="],
-
-    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
@@ -754,7 +756,7 @@
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
-    "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
+    "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
     "delaunator": ["delaunator@5.0.1", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw=="],
 
@@ -871,8 +873,6 @@
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
     "framer-motion": ["framer-motion@12.23.22", "", { "dependencies": { "motion-dom": "^12.23.21", "motion-utils": "^12.23.6", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-ZgGvdxXCw55ZYvhoZChTlG6pUuehecgvEAJz0BHoC5pQKW1EC5xf1Mul1ej5+ai+pVY0pylyFfdl45qnM1/GsA=="],
-
-    "fs-minipass": ["fs-minipass@2.1.0", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1088,7 +1088,7 @@
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
-    "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
@@ -1204,17 +1204,15 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+    "minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
-    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
-    "minizlib": ["minizlib@3.0.2", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA=="],
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
-
-    "mkdirp": ["mkdirp@3.0.1", "", { "bin": "dist/cjs/src/bin.js" }, "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="],
 
     "mlly": ["mlly@1.8.0", "", { "dependencies": { "acorn": "^8.15.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.1" } }, "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g=="],
 
@@ -1478,7 +1476,7 @@
 
     "tapable": ["tapable@2.2.3", "", {}, "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg=="],
 
-    "tar": ["tar@7.4.3", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.0.1", "mkdirp": "^3.0.1", "yallist": "^5.0.0" } }, "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw=="],
+    "tar": ["tar@7.5.19", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw=="],
 
     "three": ["three@0.182.0", "", {}, "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ=="],
 
@@ -1618,8 +1616,6 @@
 
     "@types/d3-scale/@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
 
-    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
     "d3-scale/d3-format": ["d3-format@3.1.0", "", {}, "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="],
 
     "d3-scale/d3-interpolate": ["d3-interpolate@2.0.1", "", { "dependencies": { "d3-color": "1 - 2" } }, "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ=="],
@@ -1644,11 +1640,7 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
     "giget/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
-    "giget/tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
 
     "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
@@ -1686,24 +1678,8 @@
 
     "@nivo/scales/@types/d3-interpolate/@types/d3-color": ["@types/d3-color@2.0.6", "", {}, "sha512-tbaFGDmJWHqnenvk3QGSvD3RVwr631BjKRD7Sc7VLRgrdX5mk5hTyoeBL6rXZaeoXzmZwIl1D2HPogEdt1rHBg=="],
 
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
-    "fs-minipass/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
-
-    "giget/tar/chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
-
-    "giget/tar/minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
-
-    "giget/tar/minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
-
-    "giget/tar/mkdirp": ["mkdirp@1.0.4", "", { "bin": "bin/cmd.js" }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
-
-    "giget/tar/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
-
     "victory-vendor/@types/d3-interpolate/@types/d3-color": ["@types/d3-color@2.0.6", "", {}, "sha512-tbaFGDmJWHqnenvk3QGSvD3RVwr631BjKRD7Sc7VLRgrdX5mk5hTyoeBL6rXZaeoXzmZwIl1D2HPogEdt1rHBg=="],
 
     "victory-vendor/d3-time/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
-
-    "giget/tar/minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -122,6 +122,10 @@
     "d3-color": "^3.1.0",
     "flatted": "^3.4.2",
     "handlebars": "^4.7.9",
-    "picomatch": "^2.3.2"
+    "picomatch": "^2.3.2",
+    "minimatch": "^9.0.7",
+    "tar": "^7.5.7",
+    "lodash": "^4.17.24",
+    "defu": "^6.1.5"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -80,7 +80,7 @@
     "react-icons": "^5.5.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^3.0.6",
-    "react-router-dom": "^7.9.1",
+    "react-router-dom": "^7.18.1",
     "react-simple-maps": "^3.0.0",
     "recharts": "2.15.4",
     "rehype-highlight": "^7.0.2",
@@ -117,5 +117,11 @@
     "prettier": "^3.6.2",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.46.0"
+  },
+  "overrides": {
+    "d3-color": "^3.1.0",
+    "flatted": "^3.4.2",
+    "handlebars": "^4.7.9",
+    "picomatch": "^2.3.2"
   }
 }


### PR DESCRIPTION
## Summary

Adds dependency and container-image scanning for **Temps' own supply chain** (as opposed to `crates/temps-vulnerability-scanner`, which only scans *deployed customer application images* — `crates/temps-vulnerability-scanner/src/trivy.rs`, `daily_scanner.rs`). Tracked as bherila/temps#23.

- **`.github/dependabot.yml`** (new): version-update PRs for
  - `cargo` (workspace root, `/`)
  - `bun` (`/web` — `web/bun.lock` confirms bun, not npm/yarn/pnpm, per `CLAUDE.md`; Dependabot's native `bun` ecosystem went GA Feb 2025 and supports the text-based `bun.lock` format this repo uses)
  - `github-actions` (workflow files, including this PR's new workflow)

  All three run weekly (Monday 06:00 America/New_York) and group `minor`+`patch` updates into a single PR per ecosystem to cut down on PR spam across 51 crates + the web deps; `major` bumps stay ungrouped so each gets its own PR and full CI signal, since majors are the ones most likely to need a real code change.

- **`.github/workflows/dependency-scan.yml`** (new): runs on `pull_request` (path-filtered to `**/Cargo.toml`, `**/Cargo.lock`, `web/package.json`, `web/bun.lock`, and the workflow file itself), on a weekly `schedule` (Monday 06:00 UTC), and via `workflow_dispatch`.
  - **`cargo-audit`**: `rustsec/audit-check@v2.0.0` against the workspace `Cargo.lock`. Fails the job on any RUSTSEC advisory match.
  - **`web-audit`**: `bun install` + `bun audit --audit-level=high` in `web/`. Fails the job on high/critical severity findings.
  - **`container-scan`** (stretch goal, implemented): Trivy scan of the currently published `ghcr.io/<owner>/temps:latest` image (`CRITICAL,HIGH`, `ignore-unfixed`), with best-effort SARIF upload to GitHub code scanning (`continue-on-error: true` since Advanced Security may not be enabled everywhere). This only runs on `schedule`/`workflow_dispatch`, not `pull_request` — `release.yml` only builds+pushes images on `v*.*.*` tags, so a PR has no fresh image to scan; scanning the last-published `:latest` weekly is the meaningful signal here.

### Fail vs. warn

Chose **fail** for `cargo-audit` and `bun audit` (job returns non-zero on high/critical findings) rather than warn-only: this is a net-new capability, so there's no existing "required check" to break, and a scanner that only prints warnings tends to get ignored. Same threshold (`CRITICAL,HIGH`) is used for the Trivy job for consistency.

**Heads-up**: running `bun audit --audit-level=high` against `web/`'s *current* lockfile as of this PR already reports 29 existing vulnerabilities (1 critical, 28 high) in transitive deps (`react-router`, `handlebars` via a transitive dep, `d3-color`, `flatted`, `picomatch`). That means this workflow will show **red** on the first PR/schedule run against `main`, not because the workflow is broken, but because it's surfacing real pre-existing debt for the first time. Recommend a fast-follow PR to bump/patch those before treating this check as a merge gate.

## Verification

- `python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))"` run against both new YAML files — both parse cleanly.
- Confirmed `web/bun.lock` (not `package-lock.json`/`yarn.lock`/`pnpm-lock.yaml`) is present, confirming bun is the actual package manager.
- Ran `bun audit --audit-level=high` directly against `web/` locally — confirmed it installs, runs, and exits non-zero on the existing high/critical findings (see heads-up above).
- Verified `rustsec/audit-check@v2.0.0`'s `action.yml` directly (it's a bundled Node 20 action, not a from-source `cargo install`, so it doesn't hit slow compiles in CI) and confirmed its `token` input matches what's wired up here.
- Verified `aquasecurity/trivy-action@v0.36.0`'s `action.yaml` directly against the upstream repo (not from memory) — confirmed `image-ref`, `format`, `output`, `severity`, `exit-code`, and `ignore-unfixed` are all real, current inputs, and that tags use a `v` prefix (`v0.36.0`, not `0.36.0`).
- Attempted a local `cargo install cargo-audit --locked` to do an end-to-end run of the underlying tool against this workspace's `Cargo.lock`; the from-source build didn't finish in the sandbox's time/CPU budget (shared box, heavy `gix`/`rustls` dependency tree) so I killed it rather than let it run indefinitely. Since `rustsec/audit-check` doesn't build from source in CI (see above), this doesn't block the workflow from working — but I did not get a completed local `cargo audit` run against this repo's actual `Cargo.lock`, so flagging that explicitly rather than claiming full end-to-end verification of that one piece.

## Follow-ups (not done here)

- Fix/triage the 29 existing `bun audit` findings in `web/` (see heads-up above) so the new check goes green.
- Consider adding CodeQL (mentioned in the original issue) as a separate, larger PR — out of scope here, which is specifically dependency/container scanning.
