### PR TITLE
feat(analytics-sdk): exclude sensitive paths from session replay by default

### DIFF
--- a/sdks/node/packages/analytics-core/package.json
+++ b/sdks/node/packages/analytics-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temps-sdk/analytics-core",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"description": "Framework-agnostic core for Temps analytics, engagement, Web Vitals, and session replay.",
 	"private": false,
 	"type": "module",

--- a/sdks/node/packages/analytics-core/src/SessionRecorder.test.ts
+++ b/sdks/node/packages/analytics-core/src/SessionRecorder.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { SessionRecorder, type SessionRecorderOptions } from "./SessionRecorder";
+import { DEFAULT_EXCLUDED_PATHS } from "./constants";
+
+/**
+ * `shouldRecord()` is private, but it is the single source of truth for
+ * whether a given pathname is recorded. We flip `enabled` on directly
+ * (bypassing `start()`, which would spin up rrweb/network calls) so these
+ * tests exercise the real exclusion logic without needing to mock rrweb or
+ * fetch.
+ */
+function shouldRecordAt(path: string, options: SessionRecorderOptions = {}): boolean {
+  const recorder = new SessionRecorder({ ...options, enabled: false });
+  const internal = recorder as unknown as { enabled: boolean; shouldRecord(): boolean };
+  internal.enabled = true;
+  window.history.pushState({}, "", path);
+  return internal.shouldRecord();
+}
+
+describe("SessionRecorder excludedPaths defaults", () => {
+  afterEach(() => {
+    window.history.pushState({}, "", "/");
+  });
+
+  it("ships the documented list of default excluded paths", () => {
+    expect(DEFAULT_EXCLUDED_PATHS).toEqual([
+      "/login",
+      "/log-in",
+      "/signin",
+      "/sign-in",
+      "/logout",
+      "/log-out",
+      "/signup",
+      "/sign-up",
+      "/register",
+      "/checkout*",
+      "/payment*",
+      "/billing*",
+      "/reset-password*",
+      "/forgot-password*",
+      "/mfa*",
+      "/2fa*",
+      "/verify*",
+    ]);
+  });
+
+  it("excludes sensitive routes out of the box with zero configuration", () => {
+    const sensitivePaths = [
+      "/login",
+      "/log-in",
+      "/signin",
+      "/sign-in",
+      "/logout",
+      "/signup",
+      "/sign-up",
+      "/register",
+      "/checkout",
+      "/checkout/step-2",
+      "/payment/confirm",
+      "/billing",
+      "/billing/invoices",
+      "/reset-password",
+      "/forgot-password",
+      "/mfa/verify",
+      "/2fa",
+      "/verify-email",
+    ];
+
+    for (const path of sensitivePaths) {
+      expect(shouldRecordAt(path)).toBe(false);
+    }
+  });
+
+  it("records a non-sensitive path normally by default", () => {
+    expect(shouldRecordAt("/dashboard")).toBe(true);
+    expect(shouldRecordAt("/")).toBe(true);
+    expect(shouldRecordAt("/blog/hello-world")).toBe(true);
+  });
+
+  it("merges user-supplied excludedPaths additively instead of replacing the defaults", () => {
+    const options: SessionRecorderOptions = { excludedPaths: ["/internal-tool"] };
+
+    // The user-supplied path is now excluded too...
+    expect(shouldRecordAt("/internal-tool", options)).toBe(false);
+    // ...but the built-in defaults are still active alongside it.
+    expect(shouldRecordAt("/login", options)).toBe(false);
+    expect(shouldRecordAt("/checkout/step-1", options)).toBe(false);
+    // Unrelated paths are still recorded.
+    expect(shouldRecordAt("/dashboard", options)).toBe(true);
+  });
+
+  it("supports opting out of the built-in defaults entirely via useDefaultExcludedPaths: false", () => {
+    const options: SessionRecorderOptions = {
+      excludedPaths: ["/internal-tool"],
+      useDefaultExcludedPaths: false,
+    };
+
+    // Only the user-supplied path is excluded now.
+    expect(shouldRecordAt("/internal-tool", options)).toBe(false);
+    // The default sensitive paths are no longer excluded.
+    expect(shouldRecordAt("/login", options)).toBe(true);
+    expect(shouldRecordAt("/checkout", options)).toBe(true);
+  });
+
+  it("records everything when useDefaultExcludedPaths is false and no excludedPaths are given", () => {
+    const options: SessionRecorderOptions = { useDefaultExcludedPaths: false };
+
+    expect(shouldRecordAt("/login", options)).toBe(true);
+    expect(shouldRecordAt("/checkout", options)).toBe(true);
+    expect(shouldRecordAt("/dashboard", options)).toBe(true);
+  });
+});

--- a/sdks/node/packages/analytics-core/src/SessionRecorder.ts
+++ b/sdks/node/packages/analytics-core/src/SessionRecorder.ts
@@ -1,6 +1,6 @@
 import { record, type eventWithTime } from "rrweb";
 import { pack } from "@rrweb/packer";
-import { SESSION_RECORDER_ENDPOINT, DEFAULT_BASE_PATH } from "./constants";
+import { SESSION_RECORDER_ENDPOINT, DEFAULT_BASE_PATH, DEFAULT_EXCLUDED_PATHS } from "./constants";
 import type { SessionRecordingConfig } from "./types";
 
 export interface SessionRecorderOptions extends SessionRecordingConfig {
@@ -31,6 +31,13 @@ function generateVisitorId(): string {
     return visitorId;
   }
   return `visitor_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
+}
+
+function matchesAnyPath(currentPath: string, paths: string[]): boolean {
+  return paths.some((path) => {
+    const regex = new RegExp(`^${path.replace(/\*/g, ".*")}$`);
+    return regex.test(currentPath);
+  });
 }
 
 function getSessionMetadata(): Record<string, unknown> {
@@ -96,7 +103,10 @@ export class SessionRecorder {
 
   constructor(options: SessionRecorderOptions = {}) {
     this.basePath = options.basePath || DEFAULT_BASE_PATH;
-    this.excludedPaths = options.excludedPaths || [];
+    this.excludedPaths =
+      options.useDefaultExcludedPaths === false
+        ? options.excludedPaths || []
+        : [...DEFAULT_EXCLUDED_PATHS, ...(options.excludedPaths || [])];
     this.sessionSampleRate = options.sessionSampleRate ?? 1.0;
     this.maskAllInputs = options.maskAllInputs ?? true;
     this.maskTextSelector = options.maskTextSelector || "[data-mask]";
@@ -150,10 +160,7 @@ export class SessionRecorder {
   private shouldRecord(): boolean {
     if (!this.enabled || typeof window === "undefined") return false;
     const currentPath = window.location.pathname;
-    const isExcluded = this.excludedPaths.some((path) => {
-      const regex = new RegExp(`^${path.replace(/\*/g, ".*")}$`);
-      return regex.test(currentPath);
-    });
+    const isExcluded = matchesAnyPath(currentPath, this.excludedPaths);
     if (isExcluded) return false;
     if (this.sessionSampleRate < 1.0 && Math.random() > this.sessionSampleRate) return false;
     return true;
@@ -395,10 +402,7 @@ export class SessionRecorder {
       return;
     }
     const currentPath = window.location.pathname;
-    const isExcluded = this.excludedPaths.some((path) => {
-      const regex = new RegExp(`^${path.replace(/\*/g, ".*")}$`);
-      return regex.test(currentPath);
-    });
+    const isExcluded = matchesAnyPath(currentPath, this.excludedPaths);
     const isRecording = this.stopFn !== null;
     if (isExcluded && isRecording) {
       this.stopRecording();

--- a/sdks/node/packages/analytics-core/src/constants.ts
+++ b/sdks/node/packages/analytics-core/src/constants.ts
@@ -1,2 +1,31 @@
 export const DEFAULT_BASE_PATH = "/api/_temps";
 export const SESSION_RECORDER_ENDPOINT = "session-replay";
+
+/**
+ * Built-in paths excluded from session replay by default, covering common
+ * authentication and payment flows so integrators don't accidentally record
+ * sensitive pages. Supports `*` wildcards, matched against
+ * `window.location.pathname` only (case-sensitive, anchored at both ends).
+ *
+ * Merged with any user-supplied `excludedPaths` unless
+ * `useDefaultExcludedPaths: false` is passed to `SessionRecorder`.
+ */
+export const DEFAULT_EXCLUDED_PATHS: string[] = [
+  "/login",
+  "/log-in",
+  "/signin",
+  "/sign-in",
+  "/logout",
+  "/log-out",
+  "/signup",
+  "/sign-up",
+  "/register",
+  "/checkout*",
+  "/payment*",
+  "/billing*",
+  "/reset-password*",
+  "/forgot-password*",
+  "/mfa*",
+  "/2fa*",
+  "/verify*",
+];

--- a/sdks/node/packages/analytics-core/src/types.ts
+++ b/sdks/node/packages/analytics-core/src/types.ts
@@ -9,8 +9,19 @@ export interface AnalyticsEventBase {
 }
 
 export interface SessionRecordingConfig {
-  /** Paths to exclude from recording. Supports `*` wildcards. */
+  /**
+   * Paths to exclude from recording. Supports `*` wildcards. Merged with the
+   * built-in `DEFAULT_EXCLUDED_PATHS` (login, checkout, payment, etc.) unless
+   * `useDefaultExcludedPaths` is set to `false`.
+   */
   excludedPaths?: string[];
+  /**
+   * Whether to merge the built-in default excluded paths (see
+   * `DEFAULT_EXCLUDED_PATHS`) with `excludedPaths`. Defaults to `true`. Set to
+   * `false` to record every path except the ones you explicitly list in
+   * `excludedPaths`.
+   */
+  useDefaultExcludedPaths?: boolean;
   /** Sample rate for recording sessions (0.0 to 1.0). Defaults to 1.0. */
   sessionSampleRate?: number;
   /** Mask all inputs. Defaults to true. */

--- a/sdks/node/packages/analytics-core/vitest.config.ts
+++ b/sdks/node/packages/analytics-core/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "jsdom",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      exclude: ["node_modules", "dist", "*.config.ts", "src/index.ts", "**/*.test.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Session replay (`@temps-sdk/analytics-core`'s `SessionRecorder`) is opt-in and already masks password/email inputs by default, but page-level exclusion (`excludedPaths`) defaulted to an empty array. An integrator who enabled replay would record every page — including login, checkout, and payment flows — unless they remembered to configure exclusions manually.

This PR ships a safer default: a built-in list of sensitive routes is now excluded out of the box.

Refs bherila/temps#28 (cross-repo reference, informational only).

## What changed

- Added `DEFAULT_EXCLUDED_PATHS` (exported from `constants.ts`):
  ```
  /login, /log-in, /signin, /sign-in, /logout, /log-out, /signup, /sign-up,
  /register, /checkout*, /payment*, /billing*, /reset-password*,
  /forgot-password*, /mfa*, /2fa*, /verify*
  ```
  Matching is against `window.location.pathname` only (case-sensitive, `*` → `.*`, anchored at both ends) — the same hand-rolled matcher `SessionRecorder` already used, unchanged.
- **Merge behavior**: user-supplied `excludedPaths` are merged additively with `DEFAULT_EXCLUDED_PATHS` (defaults + user paths), not replaced. This follows the same "merge defaults with user overrides" convention already used in this file for `samplingConfig` (spread defaults, then apply user values), rather than the full-replace (`||`) convention used for scalar options like `maskInputOptions`/`slimDOMOptions` — since dropping a security default silently on override felt like the wrong choice here.
- **Opt-out**: added `useDefaultExcludedPaths?: boolean` (default `true`) to `SessionRecordingConfig`. Setting it to `false` disables the built-in defaults entirely, so only the paths explicitly passed in `excludedPaths` are excluded (or none, if `excludedPaths` is also omitted).
- Deduplicated the two copies of the path-matching regex logic (`shouldRecord()` and `checkPath()`) into a single `matchesAnyPath()` helper.
- Bumped `@temps-sdk/analytics-core` from `0.0.1` → `0.0.2` (patch bump — no CHANGELOG convention exists anywhere in `sdks/node`, and other packages in this workspace bump patch versions for both features and fixes at this pre-1.0 stage).

## Behavior change note for existing integrators

If you already use `SessionRecorder`/`useSessionRecording` with your own `excludedPaths`, more paths will now be excluded than before (the defaults are added on top of your list). If you need the old exact behavior (only your explicit paths excluded), pass `useDefaultExcludedPaths: false`.

## Test plan

- [x] Added `src/SessionRecorder.test.ts` covering:
  - Default sensitive paths are excluded with zero configuration
  - A non-sensitive path is still recorded normally
  - User-supplied `excludedPaths` are additive (defaults still apply)
  - `useDefaultExcludedPaths: false` disables the built-in defaults (only user paths excluded)
  - `useDefaultExcludedPaths: false` with no `excludedPaths` records everything (full opt-out works)
- [x] `bun run test:run` in `sdks/node/packages/analytics-core` — 6/6 passed
- [x] `tsc --noEmit` — zero type errors
- [x] `bun run build` — builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmJbBkcFSnk9ER6WA66gF2