### PR TITLE
fix(providers): bind provisioned service ports to 127.0.0.1 instead of 0.0.0.0

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,7 @@ When deploying Temps, please ensure:
 
 1. **Use HTTPS** — Always configure TLS certificates for your deployment.
 2. **Strong passwords** — Use strong passwords for admin accounts and database connections.
-3. **Firewall rules** — Restrict access to management ports (see `docs/server-firewall-setup.md`).
+3. **Firewall rules** — Restrict access to management ports at the network/OS level, and use the [Admin Listener](https://temps.sh/docs/admin-listener) to bind the admin/dashboard surface to a private interface with CIDR + Host allowlists.
 4. **Keep updated** — Run `temps upgrade` regularly to get the latest security patches.
 5. **Database security** — Use strong PostgreSQL credentials and restrict network access.
 6. **API keys** — Rotate API keys periodically and use the minimum required permissions.

--- a/crates/temps-providers/src/externalsvc/mongodb.rs
+++ b/crates/temps-providers/src/externalsvc/mongodb.rs
@@ -375,13 +375,7 @@ impl MongodbService {
         }
 
         let mut host_config = bollard::models::HostConfig {
-            port_bindings: Some(HashMap::from([(
-                "27017/tcp".to_string(),
-                Some(vec![bollard::models::PortBinding {
-                    host_ip: Some("0.0.0.0".to_string()),
-                    host_port: Some(config.port.clone()),
-                }]),
-            )])),
+            port_bindings: Some(crate::utils::local_port_binding("27017/tcp", &config.port)),
             mounts: Some(vec![bollard::models::Mount {
                 target: Some("/data/db".to_string()),
                 source: Some(volume_name),

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -448,13 +448,7 @@ impl PostgresService {
         ];
 
         let mut host_config = bollard::models::HostConfig {
-            port_bindings: Some(HashMap::from([(
-                "5432/tcp".to_string(),
-                Some(vec![bollard::models::PortBinding {
-                    host_ip: Some("0.0.0.0".to_string()),
-                    host_port: Some(config.port.clone()),
-                }]),
-            )])),
+            port_bindings: Some(crate::utils::local_port_binding("5432/tcp", &config.port)),
             mounts: Some(vec![bollard::models::Mount {
                 // Always mount at /var/lib/postgresql - PGDATA env var controls subdirectory
                 target: Some("/var/lib/postgresql".to_string()),

--- a/crates/temps-providers/src/externalsvc/redis.rs
+++ b/crates/temps-providers/src/externalsvc/redis.rs
@@ -341,13 +341,7 @@ impl RedisService {
 
         let volume_name = format!("redis_data_{}", self.name);
         let mut host_config = bollard::models::HostConfig {
-            port_bindings: Some(HashMap::from([(
-                "6379/tcp".to_string(),
-                Some(vec![bollard::models::PortBinding {
-                    host_ip: Some("0.0.0.0".to_string()),
-                    host_port: Some(config.port.to_string()),
-                }]),
-            )])),
+            port_bindings: Some(crate::utils::local_port_binding("6379/tcp", &config.port)),
             mounts: Some(vec![bollard::models::Mount {
                 target: Some("/data".to_string()),
                 source: Some(volume_name.clone()),

--- a/crates/temps-providers/src/externalsvc/rustfs.rs
+++ b/crates/temps-providers/src/externalsvc/rustfs.rs
@@ -566,23 +566,14 @@ impl RustfsService {
             )])),
         });
 
+        let mut port_bindings = crate::utils::local_port_binding("9000/tcp", &config.port);
+        port_bindings.extend(crate::utils::local_port_binding(
+            "9001/tcp",
+            &config.console_port,
+        ));
+
         let mut host_config = bollard::models::HostConfig {
-            port_bindings: Some(HashMap::from([
-                (
-                    "9000/tcp".to_string(),
-                    Some(vec![bollard::models::PortBinding {
-                        host_ip: Some("0.0.0.0".to_string()),
-                        host_port: Some(config.port.to_string()),
-                    }]),
-                ),
-                (
-                    "9001/tcp".to_string(),
-                    Some(vec![bollard::models::PortBinding {
-                        host_ip: Some("0.0.0.0".to_string()),
-                        host_port: Some(config.console_port.to_string()),
-                    }]),
-                ),
-            ])),
+            port_bindings: Some(port_bindings),
             // Add volume mounts for data and logs
             mounts: Some(vec![
                 bollard::models::Mount {

--- a/crates/temps-providers/src/externalsvc/s3.rs
+++ b/crates/temps-providers/src/externalsvc/s3.rs
@@ -314,13 +314,7 @@ impl S3Service {
             )])),
         });
         let mut host_config = bollard::models::HostConfig {
-            port_bindings: Some(HashMap::from([(
-                "9000/tcp".to_string(),
-                Some(vec![bollard::models::PortBinding {
-                    host_ip: Some("0.0.0.0".to_string()),
-                    host_port: Some(config.port.to_string()),
-                }]),
-            )])),
+            port_bindings: Some(crate::utils::local_port_binding("9000/tcp", &config.port)),
             // Add volume mount
             mounts: Some(vec![bollard::models::Mount {
                 target: Some("/data".to_string()),

--- a/crates/temps-providers/src/postgres_lifecycle.rs
+++ b/crates/temps-providers/src/postgres_lifecycle.rs
@@ -452,13 +452,7 @@ impl PostgresContainerLifecycle for PostgresLifecycleAdapter {
         ];
 
         let host_config = bollard::models::HostConfig {
-            port_bindings: Some(HashMap::from([(
-                "5432/tcp".to_string(),
-                Some(vec![bollard::models::PortBinding {
-                    host_ip: Some("0.0.0.0".to_string()),
-                    host_port: Some(cfg.port.clone()),
-                }]),
-            )])),
+            port_bindings: Some(crate::utils::local_port_binding("5432/tcp", &cfg.port)),
             mounts: Some(vec![bollard::models::Mount {
                 target: Some("/var/lib/postgresql".to_string()),
                 source: Some(volume_name.clone()),

--- a/crates/temps-providers/src/utils.rs
+++ b/crates/temps-providers/src/utils.rs
@@ -106,9 +106,11 @@ mod tests {
 
     #[test]
     fn test_local_port_binding_never_binds_to_all_interfaces() {
-        for (container_port, host_port) in
-            [("5432/tcp", "5432"), ("6379/tcp", "6379"), ("9000/tcp", "9000")]
-        {
+        for (container_port, host_port) in [
+            ("5432/tcp", "5432"),
+            ("6379/tcp", "6379"),
+            ("9000/tcp", "9000"),
+        ] {
             let bindings = local_port_binding(container_port, host_port);
             let host_ip = bindings
                 .get(container_port)

--- a/crates/temps-providers/src/utils.rs
+++ b/crates/temps-providers/src/utils.rs
@@ -56,3 +56,70 @@ pub(crate) fn service_log_config(
 pub(crate) fn default_service_log_config() -> bollard::models::HostConfigLogConfig {
     service_log_config("20m", 3)
 }
+
+/// Build a Docker port-binding map that maps `container_port_key`
+/// (e.g. `"5432/tcp"`) to `host_port` on the loopback interface only.
+///
+/// This is the single source of truth for how managed-service containers
+/// (Postgres, Redis, MongoDB, S3/RustFS) publish their ports to the host.
+/// It must always bind to `127.0.0.1` — never `0.0.0.0` — so services are
+/// reachable from the host and from other containers on the Docker network,
+/// but never from outside the server without an explicit reverse proxy or
+/// port-forward. This matches the documented behavior in
+/// `docs/howto/set-up-managed-services`. See bherila/temps#29.
+pub(crate) fn local_port_binding(
+    container_port_key: &str,
+    host_port: &str,
+) -> HashMap<String, Option<Vec<bollard::models::PortBinding>>> {
+    HashMap::from([(
+        container_port_key.to_string(),
+        Some(vec![bollard::models::PortBinding {
+            host_ip: Some("127.0.0.1".to_string()),
+            host_port: Some(host_port.to_string()),
+        }]),
+    )])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_local_port_binding_binds_to_loopback_only() {
+        let bindings = local_port_binding("5432/tcp", "15432");
+
+        let port_binding = bindings
+            .get("5432/tcp")
+            .expect("port bindings should contain the requested container port key")
+            .as_ref()
+            .expect("port binding list should be present")
+            .first()
+            .expect("port binding list should have one entry");
+
+        assert_eq!(
+            port_binding.host_ip.as_deref(),
+            Some("127.0.0.1"),
+            "managed service ports must bind to loopback only, never 0.0.0.0"
+        );
+        assert_eq!(port_binding.host_port.as_deref(), Some("15432"));
+    }
+
+    #[test]
+    fn test_local_port_binding_never_binds_to_all_interfaces() {
+        for (container_port, host_port) in
+            [("5432/tcp", "5432"), ("6379/tcp", "6379"), ("9000/tcp", "9000")]
+        {
+            let bindings = local_port_binding(container_port, host_port);
+            let host_ip = bindings
+                .get(container_port)
+                .and_then(|b| b.as_ref())
+                .and_then(|v| v.first())
+                .and_then(|pb| pb.host_ip.as_deref());
+            assert_ne!(
+                host_ip,
+                Some("0.0.0.0"),
+                "port {container_port} must never bind to 0.0.0.0"
+            );
+        }
+    }
+}

--- a/docs/advanced/security/page.mdx
+++ b/docs/advanced/security/page.mdx
@@ -99,102 +99,22 @@ const response = await fetch('/api/users/assign-role', {
 
 ## Firewall Configuration {{ anchor: true, id: 'firewall' }}
 
-Temps includes built-in firewall features to control access and prevent abuse through IP filtering and rate limiting.
+<Note>
+  **Planned, not yet implemented.** Temps does not currently ship a
+  general-purpose, platform-wide IP allow/block-list firewall — there is no
+  `temps firewall` CLI and no `config/settings.yml` file. A dedicated CLI and
+  a persisted, per-record IP allow/block list (configurable via the
+  API/dashboard) are on the roadmap.
+</Note>
 
-### IP Address Management
+For IP-based access control today, use the [Admin Listener](/docs/admin-listener),
+which restricts the admin/dashboard surface to specific CIDR ranges and `Host`
+headers via `TEMPS_ADMIN_ALLOWED_IPS` / `TEMPS_ADMIN_ALLOWED_HOSTS`. For
+broader protection, layer your own network-level firewall (iptables, cloud
+security groups) in front of the server.
 
-Control access to your Temps instance and deployments using IP allowlists and blocklists.
-
-#### Blocked IP Addresses
-
-Block specific IP addresses or CIDR ranges from accessing your platform:
-
-<CodeGroup title="Configure Blocked IPs">
-```yaml {{ title: 'Config File' }}
-# config/settings.yml
-security:
-  firewall:
-    enabled: true
-    blocked_ips:
-      - "192.168.1.100"
-      - "10.0.0.0/8"
-      - "172.16.0.0/12"
-      - "203.0.113.0/24"
-```
-
-```bash {{ title: 'CLI' }}
-# Block a single IP address
-temps firewall block --ip 192.168.1.100
-
-# Block a CIDR range
-temps firewall block --ip 10.0.0.0/8
-
-# List all blocked IPs
-temps firewall list-blocked
-
-# Unblock an IP
-temps firewall unblock --ip 192.168.1.100
-```
-
-```typescript {{ title: 'API' }}
-// Block an IP address via API
-await fetch('/api/firewall/blocked-ips', {
-  method: 'POST',
-  headers: {
-    'Authorization': `Bearer ${API_KEY}`,
-    'Content-Type': 'application/json'
-  },
-  body: JSON.stringify({
-    ip: '192.168.1.100',
-    reason: 'Suspicious activity detected'
-  })
-});
-```
-</CodeGroup>
-
-#### Allowed IP Addresses
-
-Restrict access to specific IP addresses (whitelist mode):
-
-<CodeGroup title="Configure Allowed IPs">
-```yaml {{ title: 'Config File' }}
-# config/settings.yml
-security:
-  firewall:
-    enabled: true
-    whitelist_mode: true
-    allowed_ips:
-      - "203.0.113.0/24"  # Office network
-      - "198.51.100.10"    # VPN gateway
-      - "192.0.2.50"       # Admin workstation
-```
-
-```bash {{ title: 'CLI' }}
-# Add IP to allowlist
-temps firewall allow --ip 203.0.113.0/24
-
-# Enable whitelist mode (blocks all IPs not on allowlist)
-temps firewall whitelist-mode --enable
-
-# List allowed IPs
-temps firewall list-allowed
-```
-
-```typescript {{ title: 'API' }}
-// Add IP to allowlist
-await fetch('/api/firewall/allowed-ips', {
-  method: 'POST',
-  headers: {
-    'Authorization': `Bearer ${API_KEY}`,
-    'Content-Type': 'application/json'
-  },
-  body: JSON.stringify({
-    ip: '203.0.113.0/24',
-    description: 'Office network'
-  })
-});
-```
-</CodeGroup>
+Temps does include configurable rate limiting per project and path to protect
+against abuse — see below.
 
 ### Rate Limiting
 
@@ -555,7 +475,7 @@ Temps maintains comprehensive audit logs of all security-relevant events for com
     Project/deployment/domain create/update/delete operations
   </Property>
   <Property name="Security Events">
-    API key creation/rotation/revocation, secret access, firewall rule changes
+    API key creation/rotation/revocation, secret access
   </Property>
   <Property name="Settings Changes">
     Configuration updates, security policy changes
@@ -790,7 +710,7 @@ Follow these security best practices for production deployments:
   **Production Deployment Checklist:**
 
   - [ ] Enable MFA for all admin accounts
-  - [ ] Configure firewall rules (IP allowlist/blocklist)
+  - [ ] Configure network-level firewall rules and/or the Admin Listener IP allowlist
   - [ ] Enable rate limiting
   - [ ] Apply strict security headers preset
   - [ ] Enable automatic TLS with HSTS


### PR DESCRIPTION
## What

Managed services provisioned by Temps (Postgres, Redis, MongoDB, S3/RustFS) were binding their Docker-published ports to `0.0.0.0` — publicly reachable on any host without an external firewall in front of it — while `docs/howto/set-up-managed-services` already claims "All ports are bound to `127.0.0.1` only." This closes that gap so the code actually matches the documented behavior.

Factored the binding logic into a single `crate::utils::local_port_binding` helper (with tests asserting it never returns `0.0.0.0`), used consistently by `postgres.rs`, `redis.rs`, `s3.rs`, `rustfs.rs` (both its data and console ports), and `postgres_lifecycle.rs` — a fifth call site the original audit had missed.

Also cleans up `docs/advanced/security` to remove references to a `temps firewall` CLI command and a `config/settings.yml` file, neither of which exists in this codebase (tracked as part of bherila/temps#37).

## Why

Self-hosting hardening pass (applies to anyone running Temps for a production workload, not specific to any one deployment) — tracked in bherila/temps#29 and part of bherila/temps#37.

## Testing

- `cargo check --lib -p temps-providers`: clean, zero warnings.
- `cargo test --lib -p temps-providers`: 238 passed, 0 failed (includes 2 new tests for the port-binding helper).