### PR TITLE
fix(ci): serialize docker-deployments integration tests to stop Postgres deadlocks

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -328,9 +328,18 @@ jobs:
               --nocapture
               --test-threads=1
           - group: docker-deployments
-            # Crates that use TestDatabase and/or Docker
+            # Crates that use TestDatabase and/or Docker. Like unit-tests
+            # above, this fans out across many crates in one `cargo test`
+            # invocation against the single shared `services: timescaledb`
+            # container below -- same shape that made cross-binary/cross-test
+            # Postgres deadlocks (40P01) show up in unit-tests, just missing
+            # the same fix here. Reproduced locally: without --test-threads=1,
+            # a plain INSERT in temps-deployments' test setup deadlocked
+            # against a concurrently-running test in the same shared DB within
+            # a couple of runs; with --jobs 1 --test-threads=1 the full
+            # 18-crate suite ran clean.
             cargo_args: >-
-              test --no-fail-fast
+              test --no-fail-fast --jobs 1
               -p temps-deployments
               -p temps-backup
               -p temps-vulnerability-scanner
@@ -349,7 +358,8 @@ jobs:
               -p temps-logs
               -p temps-domains
               -p temps-projects
-            test_args: ""
+            test_args: >-
+              --test-threads=1
 
     services:
       timescaledb:


### PR DESCRIPTION
## What

The `docker-deployments` integration-test matrix group runs 18 crates
(`temps-deployments`, `temps-backup`, `temps-database`, `temps-config`, ...)
against a single shared `services: timescaledb` container, but unlike its
sibling groups it had no `--jobs 1`/`--test-threads=1` serialization.

- `unit-tests` already carries `--jobs 1 -- --test-threads=1` for the exact
  same reason: multiple crates in one `cargo test` invocation racing against
  each other and against themselves.
- `docker-backups` / `postgres-upgrades` already carry `--test-threads=1`.
- `docker-deployments` had `test_args: ""` — no serialization at all.

## Why

PR #189 hit this as `Integration Tests (docker-deployments)` failures:
`test_teardown_deployment_endpoint` and
`test_rollback_fails_when_image_missing` both failed with Postgres error
`40P01` (deadlock detected) while inserting fixture rows during test setup
— unrelated to that PR's actual (auth) changes.

Reproduced locally by pointing `TEMPS_TEST_DATABASE_URL` at a dedicated
TimescaleDB container and running the exact 18-crate command CI uses:

- **Without serialization**: deadlocked on both of two attempts, each time
  a *different* test (`test_start_container_success` locally), always the
  same `40P01` signature — one backend's `AccessExclusiveLock` against
  another's `RowShareLock`. Confirms this is a genuine timing race, not a
  bug in any specific test.
- **With `--jobs 1 -- --test-threads=1`**: the full 18-crate suite ran
  clean (0 failures).

## Fix

Add the same `--jobs 1` (cargo-level) and `--test-threads=1` (libtest-level)
flags already used by `unit-tests`/`docker-backups`/`postgres-upgrades` to
the `docker-deployments` matrix entry. Slower, but eliminates the
cross-test DB contention instead of chasing it test-by-test — the same
trade-off already made for the other groups.

## Test plan

- [x] `cargo test --no-fail-fast --jobs 1 -p temps-deployments -p temps-backup ... -- --test-threads=1` (all 18 crates) passes clean against a dedicated TimescaleDB container
- [x] Reproduced the deadlock twice without the flags before applying the fix
- [x] `.github/workflows/rust-tests.yml` YAML validated with `yaml.safe_load`