### PR TITLE
fix(test-utils): disable TimescaleDB background workers to stop recurring test deadlocks

### DIFF
--- a/crates/temps-database/src/test_utils.rs
+++ b/crates/temps-database/src/test_utils.rs
@@ -125,6 +125,7 @@ impl SharedContainer {
             .with_env_var("POSTGRES_USER", username)
             .with_env_var("POSTGRES_PASSWORD", password)
             .with_env_var("POSTGRES_HOST_AUTH_METHOD", "trust")
+            .with_cmd(TIMESCALEDB_NO_BACKGROUND_WORKERS_CMD)
             .start()
             .await?;
 
@@ -145,6 +146,25 @@ impl SharedContainer {
         })
     }
 }
+
+/// Every migration-driven test creates its own hypertables/continuous
+/// aggregates (with refresh policies) in a fresh, short-lived schema.
+/// TimescaleDB's background worker launcher polls for due jobs every
+/// ~60s (`timescaledb.bgw_launcher_poll_time`) and, if its scan happens to
+/// land while one of those schemas is still alive, launches a real
+/// background worker to refresh it -- a second Postgres backend racing the
+/// test's own foreground transaction. That's a plausible root cause of the
+/// Postgres deadlocks (40P01) observed even under full test serialization
+/// (confirmed: a background job did execute mid-test-run against a fresh
+/// container). Tests never rely on a background refresh actually firing
+/// (job timing isn't something a test could deterministically wait on
+/// anyway), so disabling the launcher entirely removes the race with no
+/// loss of coverage. This only affects test containers, not migrations
+/// themselves -- `max_background_workers=0` still allows `CREATE
+/// EXTENSION`/`create_hypertable`/`add_continuous_aggregate_policy` to
+/// succeed, it just means no worker ever executes the scheduled jobs.
+const TIMESCALEDB_NO_BACKGROUND_WORKERS_CMD: [&str; 3] =
+    ["postgres", "-c", "timescaledb.max_background_workers=0"];
 
 /// Test database setup with TimescaleDB container
 pub struct TestDatabase {
@@ -496,6 +516,7 @@ impl TestDatabase {
             .with_env_var("POSTGRES_USER", username)
             .with_env_var("POSTGRES_PASSWORD", password)
             .with_env_var("POSTGRES_HOST_AUTH_METHOD", "trust")
+            .with_cmd(TIMESCALEDB_NO_BACKGROUND_WORKERS_CMD)
             .start()
             .await?;
 


### PR DESCRIPTION
## What

Root-causes the Postgres deadlocks (`40P01`) that keep surfacing across
unrelated crates/tests **even under full test serialization**
(`--jobs 1 --test-threads=1`):

- `temps-routes::test_route_table_loads_environment_domains` (previously)
- `temps-error-tracking::test_get_error_group_by_id` and
  `temps-proxy::test_project_context_creation` (main, post-#189/#195)

This is a *different* class of deadlock than the one fixed in #195
(cross-binary/cross-test contention against a shared external DB). This
one recurs even when Rust-level test execution is fully serialized to one
test at a time in one process, which means the second lock-holder can't
be another test thread/process at all.

## Why

Every test using `TestDatabase::with_migrations()` runs the full migration
set, which creates hypertables/continuous aggregates with refresh policies
(`add_continuous_aggregate_policy`) in a fresh, short-lived per-test
schema. TimescaleDB's background worker launcher polls for due jobs every
~60s (`timescaledb.bgw_launcher_poll_time`) — a separate Postgres backend
process, entirely outside cargo test's thread/process model. If the
launcher's scan happens to land while one of these short-lived schemas is
still alive, it launches a real background worker to refresh it, racing
the test's own foreground transaction on shared TimescaleDB catalog
structures.

Confirmed empirically: pointed a test run at a dedicated container and
found in `timescaledb_information.job_stats` that a background job (the
built-in Telemetry Reporter) had actually executed mid-run — proving the
launcher fires real workers during a test process's lifetime, independent
of any Rust-level serialization.

## Fix

Start `TestDatabase`'s container with `-c
timescaledb.max_background_workers=0`. Confirmed via manual container
inspection that this still allows `CREATE EXTENSION` /
`create_hypertable` / `add_continuous_aggregate_policy` to succeed during
migrations — it only stops the launcher from ever executing scheduled
jobs, which no test relies on (job timing isn't something a test could
deterministically wait on anyway).

## Test plan

- [x] `cargo test --lib -p temps-database -p temps-error-tracking -p temps-proxy -p temps-routes -- --test-threads=1` — 519 tests, 0 failures (the crates previously hit by this deadlock class)
- [x] Manually verified `CREATE EXTENSION timescaledb`/`max_background_workers=0` together against a scratch container
- [x] `cargo fmt --check` / `cargo clippy --lib --tests -- -D warnings` clean on `temps-database`