### PR TITLE
fix(ci): disable TimescaleDB background workers in integration-tests services container

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -361,28 +361,39 @@ jobs:
             test_args: >-
               --test-threads=1
 
-    services:
-      timescaledb:
-        image: timescale/timescaledb-ha:pg18
-        env:
-          POSTGRES_DB: test_db
-          POSTGRES_USER: test_user
-          POSTGRES_PASSWORD: test_password
-          POSTGRES_HOST_AUTH_METHOD: trust
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U test_user -d test_db"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
       - name: Free up disk space
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
           sudo apt-get autoremove -y && sudo apt-get clean
+
+      # Started as a plain `docker run` step (not a `services:` container)
+      # because GitHub Actions' `services:` block has no way to override a
+      # service image's CMD, and every migration-driven test here creates
+      # its own hypertables/continuous aggregates (with refresh policies)
+      # in a fresh, short-lived schema against this one shared instance.
+      # TimescaleDB's background worker launcher polls for due jobs every
+      # ~60s independent of cargo test's own concurrency, and if its scan
+      # lands while one of those schemas is still alive, it launches a
+      # real background worker that races the test's own foreground
+      # transaction -- the same root cause fixed for TestDatabase's own
+      # containers in #196, just needed here too since this job never
+      # goes through that Rust code path. `max_background_workers=0`
+      # still allows CREATE EXTENSION / create_hypertable /
+      # add_continuous_aggregate_policy to succeed; it only stops the
+      # launcher from ever executing scheduled jobs, which no test here
+      # relies on.
+      - name: Start TimescaleDB (background workers disabled)
+        run: |
+          docker run -d --name timescaledb \
+            -e POSTGRES_DB=test_db \
+            -e POSTGRES_USER=test_user \
+            -e POSTGRES_PASSWORD=test_password \
+            -e POSTGRES_HOST_AUTH_METHOD=trust \
+            -p 5432:5432 \
+            timescale/timescaledb-ha:pg18 \
+            postgres -c timescaledb.max_background_workers=0
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -420,7 +431,14 @@ jobs:
 
       - name: Verify TimescaleDB is ready
         run: |
-          timeout 60 bash -c 'until nc -z localhost 5432; do sleep 1; done'
+          # pg_isready runs inside the container -- GitHub Actions'
+          # `services:` block used to gate the job on this same check via
+          # its `options: --health-cmd`, which we lost by switching to a
+          # plain `docker run` step (needed to pass a custom postgres CMD,
+          # see the step above). A bare `nc -z` here would only prove the
+          # TCP listener is up, not that Postgres has finished its
+          # first-boot initdb+restart cycle.
+          timeout 60 bash -c 'until docker exec timescaledb pg_isready -U test_user -d test_db; do sleep 1; done'
           echo "TimescaleDB is ready"
 
       - name: Run integration tests


### PR DESCRIPTION
## What

Closes the gap in #196: that fix only patched `TestDatabase`'s own
testcontainers-managed containers (used by the `unit-tests` job). The
`integration-tests` job's `docker-providers`/`docker-backups`/
`postgres-upgrades`/`docker-deployments` groups connect instead to a
separate GitHub Actions `services: timescaledb` container via
`TEMPS_TEST_DATABASE_URL` — a completely different code path that #196
never touched, so it stayed fully exposed to the same
background-worker-vs-foreground-transaction race.

## Why

Confirmed this was still live: `main`'s `docker-deployments` run right
after #196 merged logged *dozens* of "deadlock detected" entries (vs. the
1-2 per run seen before #195's serialization), consistent with many
`with_migrations()` calls each registering fresh continuous-aggregate
refresh policies over a now much longer, fully-serialized ~4min run,
giving TimescaleDB's ~60s-interval background launcher many more chances
to fire mid-schema-lifetime.

## Fix

GitHub Actions' `services:` block has no field to override a service
image's CMD, so the only way to pass
`-c timescaledb.max_background_workers=0` is to start the container as a
plain `docker run` step instead. Replaced the `services:` block with an
explicit start step, and upgraded the readiness check from a bare
`nc -z` (which only proves the TCP listener is up) to
`docker exec timescaledb pg_isready` (equivalent to the `--health-cmd`
gating `services:` used to provide automatically).

## Test plan

- [x] Manually started the container with the same `docker run ... postgres -c timescaledb.max_background_workers=0` command used in the workflow; confirmed `SHOW timescaledb.max_background_workers;` returns `0`
- [x] Ran the exact 18-crate `docker-deployments` command (`cargo test --no-fail-fast --jobs 1 -p temps-deployments -p temps-backup ... -- --test-threads=1`) against that container via `TEMPS_TEST_DATABASE_URL` — all 45 test binaries, 0 failures, including `test_rollback_fails_when_image_missing` (one of the tests previously hit by this deadlock class)
- [x] `docker exec timescaledb pg_isready` readiness check validated standalone
- [x] YAML validated with `yaml.safe_load`