### PR TITLE
ci: auto-merge dependabot patch/minor PRs once CI passes

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Dependabot auto-merge
+
+# Automatically merges Dependabot PRs once required CI checks pass, but only
+# for patch/minor bumps. Major version bumps are left for manual review since
+# they're the ones most likely to need an actual code change.
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch/minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a `dependabot-auto-merge.yml` workflow that enables GitHub's native auto-merge on Dependabot PRs, but only for patch/minor semver bumps (major bumps are left for manual review since they're the ones most likely to need a real code change).
- Uses the `dependabot/fetch-metadata` action to read the update type, then `gh pr merge --auto --squash` to flip on auto-merge — the PR still won't actually merge until required status checks pass.

## Why patch/minor only
Patch/minor bumps follow semver's "no breaking changes" contract and are already batched into low-risk grouped PRs in `dependabot.yml`. Majors are excluded because they explicitly signal a breaking change and deserve a human look.

## Note
This workflow only takes effect once branch protection on `main` has required status checks configured — otherwise GitHub's auto-merge has nothing to wait for. I'm applying that separately via the repo settings API in the same change window (Cargo Check, Formatting, Unit Tests, Integration Tests), since branch protection is a repo setting, not something that can be shipped inside a PR diff.

## Test plan
- [ ] Confirm a future Dependabot patch/minor PR gets auto-merge enabled by this workflow
- [ ] Confirm a Dependabot major-version PR does NOT get auto-merge enabled