### PR TITLE
feat(deployments): add generic DeploymentGate extension point

### DIFF
--- a/crates/temps-core/src/deployment.rs
+++ b/crates/temps-core/src/deployment.rs
@@ -16,3 +16,46 @@ pub trait DeploymentCanceller: Send + Sync {
         environment_id: i32,
     ) -> Result<u64, Box<dyn std::error::Error + Send + Sync>>;
 }
+
+/// The result of a [`DeploymentGate`] check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GateDecision {
+    /// The deployment may proceed.
+    Allow,
+    /// The deployment must not proceed yet. `reason` is an opaque,
+    /// human-readable string supplied by whatever implemented the gate —
+    /// OSS displays it as-is without needing to understand its meaning.
+    Block { reason: String },
+}
+
+/// Generic, gate-agnostic extension point for pausing a deployment before it
+/// transitions to `PipelineStatus::Running`.
+///
+/// OSS itself never implements this trait and has no concept of what a gate
+/// represents — it just asks "is this deployment allowed to proceed?" and, if
+/// not, leaves the deployment in its current (pre-`Running`) status until a
+/// [`crate::DeploymentGateRecheckJob`] arrives asking it to check again.
+///
+/// A plugin (e.g. one implementing manual deployment approvals) registers
+/// an implementation via the service registry — `context.register_service(gate)`
+/// — only when appropriate (e.g. gated by its own licensing/config check).
+/// Core looks it up with an OPTIONAL `get_service::<dyn DeploymentGate>()`
+/// (never `require_service`), so a plugin-free binary deploys
+/// unconditionally when no gate is registered. This is the ONE extension
+/// point for this whole class of feature — a future gate concept (budget
+/// limits, security-scan results, etc.) reuses this same trait rather than
+/// requiring a new core status or migration; if it needs to combine
+/// multiple independent conditions, the plugin's implementation composes
+/// them internally before answering.
+#[async_trait]
+pub trait DeploymentGate: Send + Sync {
+    /// Returns [`GateDecision::Allow`] if the deployment may proceed.
+    /// Errors are treated as [`GateDecision::Block`] by the caller
+    /// (fail-closed) — a broken gate must never fail open.
+    async fn check(
+        &self,
+        project_id: i32,
+        environment_name: &str,
+        deployment_id: &str,
+    ) -> Result<GateDecision, Box<dyn std::error::Error + Send + Sync>>;
+}

--- a/crates/temps-core/src/jobs.rs
+++ b/crates/temps-core/src/jobs.rs
@@ -358,6 +358,22 @@ pub struct BackupFailedJob {
     pub error_message: String,
 }
 
+/// Ask the deployment job processor to re-run its [`DeploymentGate`] check for
+/// a deployment that a previous check left sitting in `Pending`.
+///
+/// Generic, gate-agnostic: this job type carries no knowledge of *why* the
+/// deployment was blocked (a manual approval workflow, or any future gate)
+/// — it just says "conditions may have changed, please re-evaluate."
+/// Whatever registered a [`DeploymentGate`] implementation is responsible
+/// for enqueuing this once its own state changes (e.g. an approval request
+/// reaching its required approval count).
+///
+/// [`DeploymentGate`]: crate::DeploymentGate
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeploymentGateRecheckJob {
+    pub deployment_id: i32,
+}
+
 /// Cancel request from the HTTP cancel handler. The processor looks the
 /// `backup_id` up in its in-memory cancel-token map and fires the token,
 /// which signals the in-flight container to stop.
@@ -424,6 +440,10 @@ pub enum Job {
     /// (hourly/daily rollups) have their own TimescaleDB retention policies
     /// and do not need to be pruned here.
     PruneMetrics,
+    /// Re-evaluate the [`DeploymentGate`](crate::DeploymentGate) for a
+    /// deployment that a previous check left sitting pre-`Running`. See
+    /// [`DeploymentGateRecheckJob`].
+    DeploymentGateRecheck(DeploymentGateRecheckJob),
 }
 
 impl fmt::Display for Job {
@@ -474,6 +494,9 @@ impl fmt::Display for Job {
             Job::BackupFailed(job) => write!(f, "BackupFailed(backup: {}, engine: {})", job.backup_id, job.engine),
             Job::BackupCancelRequested(job) => write!(f, "BackupCancelRequested(backup: {})", job.backup_id),
             Job::PruneMetrics => write!(f, "PruneMetrics"),
+            Job::DeploymentGateRecheck(job) => {
+                write!(f, "DeploymentGateRecheck(deployment: {})", job.deployment_id)
+            }
         }
     }
 }

--- a/crates/temps-deployments/src/handlers/deployments.rs
+++ b/crates/temps-deployments/src/handlers/deployments.rs
@@ -3285,6 +3285,7 @@ mod tests {
                 bollard::Docker::connect_with_local_defaults()
                     .unwrap_or_else(|_| bollard::Docker::connect_with_defaults().unwrap()),
             ),
+            deployment_gate: None,
         })
     }
 

--- a/crates/temps-deployments/src/handlers/remote_deployments.rs
+++ b/crates/temps-deployments/src/handlers/remote_deployments.rs
@@ -500,47 +500,26 @@ pub async fn deploy_from_image(
                 deployment.id
             );
 
-            // Update deployment status to Running
-            if let Err(e) =
-                crate::services::job_processor::JobProcessorService::update_deployment_status(
-                    &state.db,
-                    deployment.id,
-                    PipelineStatus::Running,
-                )
-                .await
-            {
-                error!("Failed to update deployment status: {}", e);
-            }
-
-            // Execute the workflow in background
+            // Gate check (if a plugin registered one), then transition to
+            // Running and execute the workflow. Delegates to the same
+            // helper the job-queue dispatch loop uses so this manual-deploy
+            // path can't bypass a gate that the git-push / deploy-image job
+            // paths honor.
             let workflow_executor = state.workflow_executor.clone();
+            let deployment_gate = state.deployment_gate.clone();
             let deployment_id = deployment.id;
             let db = state.db.clone();
+            let environment_name = environment.name.clone();
             tokio::spawn(async move {
-                match workflow_executor
-                    .execute_deployment_workflow(deployment_id)
-                    .await
-                {
-                    Ok(_) => {
-                        info!(
-                            "Workflow execution completed for deployment {}",
-                            deployment_id
-                        );
-                    }
-                    Err(e) => {
-                        error!(
-                            "Workflow execution failed for deployment {}: {}",
-                            deployment_id, e
-                        );
-                        let _ = crate::services::job_processor::JobProcessorService::update_deployment_status_with_message(
-                            &db,
-                            deployment_id,
-                            PipelineStatus::Failed,
-                            Some(e.to_string()),
-                        )
-                        .await;
-                    }
-                }
+                crate::services::job_processor::JobProcessorService::gate_check_then_run(
+                    &db,
+                    &workflow_executor,
+                    &deployment_gate,
+                    project_id,
+                    &environment_name,
+                    deployment_id,
+                )
+                .await;
             });
         }
         Err(e) => {
@@ -785,47 +764,26 @@ pub async fn deploy_from_static(
                 deployment.id
             );
 
-            // Update deployment status to Running
-            if let Err(e) =
-                crate::services::job_processor::JobProcessorService::update_deployment_status(
-                    &state.db,
-                    deployment.id,
-                    PipelineStatus::Running,
-                )
-                .await
-            {
-                error!("Failed to update deployment status: {}", e);
-            }
-
-            // Execute the workflow in background
+            // Gate check (if a plugin registered one), then transition to
+            // Running and execute the workflow. Delegates to the same
+            // helper the job-queue dispatch loop uses so this manual-deploy
+            // path can't bypass a gate that the git-push / deploy-image job
+            // paths honor.
             let workflow_executor = state.workflow_executor.clone();
+            let deployment_gate = state.deployment_gate.clone();
             let deployment_id = deployment.id;
             let db = state.db.clone();
+            let environment_name = environment.name.clone();
             tokio::spawn(async move {
-                match workflow_executor
-                    .execute_deployment_workflow(deployment_id)
-                    .await
-                {
-                    Ok(_) => {
-                        info!(
-                            "Workflow execution completed for deployment {}",
-                            deployment_id
-                        );
-                    }
-                    Err(e) => {
-                        error!(
-                            "Workflow execution failed for deployment {}: {}",
-                            deployment_id, e
-                        );
-                        let _ = crate::services::job_processor::JobProcessorService::update_deployment_status_with_message(
-                            &db,
-                            deployment_id,
-                            PipelineStatus::Failed,
-                            Some(e.to_string()),
-                        )
-                        .await;
-                    }
-                }
+                crate::services::job_processor::JobProcessorService::gate_check_then_run(
+                    &db,
+                    &workflow_executor,
+                    &deployment_gate,
+                    project_id,
+                    &environment_name,
+                    deployment_id,
+                )
+                .await;
             });
         }
         Err(e) => {
@@ -1201,51 +1159,26 @@ pub async fn deploy_from_image_upload(
                 deployment.id
             );
 
-            // Update deployment status to Running
-            if let Err(e) =
-                crate::services::job_processor::JobProcessorService::update_deployment_status(
-                    &state.db,
-                    deployment.id,
-                    PipelineStatus::Running,
-                )
-                .await
-            {
-                error!("Failed to update deployment status: {}", e);
-            }
-
-            // Execute the workflow in background
+            // Gate check (if a plugin registered one), then transition to
+            // Running and execute the workflow. Delegates to the same
+            // helper the job-queue dispatch loop uses so this manual-deploy
+            // path can't bypass a gate that the git-push / deploy-image job
+            // paths honor.
             let workflow_executor = state.workflow_executor.clone();
+            let deployment_gate = state.deployment_gate.clone();
             let deployment_id = deployment.id;
             let db = state.db.clone();
+            let environment_name = environment.name.clone();
             tokio::spawn(async move {
-                match workflow_executor
-                    .execute_deployment_workflow(deployment_id)
-                    .await
-                {
-                    Ok(_) => {
-                        info!(
-                            "Workflow execution completed for deployment {}",
-                            deployment_id
-                        );
-                    }
-                    Err(e) => {
-                        error!(
-                            "Workflow execution failed for deployment {}: {}",
-                            deployment_id, e
-                        );
-                        // Update deployment status to Failed
-                        if let Err(e) =
-                            crate::services::job_processor::JobProcessorService::update_deployment_status(
-                                &db,
-                                deployment_id,
-                                PipelineStatus::Failed,
-                            )
-                            .await
-                        {
-                            error!("Failed to update deployment status: {}", e);
-                        }
-                    }
-                }
+                crate::services::job_processor::JobProcessorService::gate_check_then_run(
+                    &db,
+                    &workflow_executor,
+                    &deployment_gate,
+                    project_id,
+                    &environment_name,
+                    deployment_id,
+                )
+                .await;
             });
         }
         Err(e) => {

--- a/crates/temps-deployments/src/handlers/types.rs
+++ b/crates/temps-deployments/src/handlers/types.rs
@@ -38,6 +38,16 @@ pub struct AppState {
     pub config_service: Arc<temps_config::ConfigService>,
     /// Docker client for container exec/terminal
     pub docker: Arc<bollard::Docker>,
+    /// Optional gate checked before manual-deploy handlers transition a
+    /// deployment to `Running` (e.g. a plugin implementing manual
+    /// approvals). `None` when no such plugin is registered — deploys
+    /// proceed unconditionally, matching today's behaviour. Safe to
+    /// resolve once here (unlike the job processor's `DeploymentGateSlot`):
+    /// `configure_routes` runs only after every plugin's
+    /// `initialize_plugin_services` has completed, so a registered gate is
+    /// guaranteed to already be present by this point. See
+    /// [`temps_core::DeploymentGate`].
+    pub deployment_gate: Option<Arc<dyn temps_core::DeploymentGate>>,
 }
 
 use crate::services::types::Deployment;

--- a/crates/temps-deployments/src/plugin.rs
+++ b/crates/temps-deployments/src/plugin.rs
@@ -9,16 +9,30 @@ use utoipa::{openapi::OpenApi, OpenApi as UtoimaOpenApi};
 
 use crate::{
     handlers,
-    services::{DeploymentService, JobProcessorService, WorkflowExecutionService},
+    services::{
+        DeploymentGateSlot, DeploymentService, JobProcessorService, WorkflowExecutionService,
+    },
     WorkflowPlanner,
 };
 
 /// Deployments Plugin for managing deployment operations
-pub struct DeploymentsPlugin;
+pub struct DeploymentsPlugin {
+    /// Handle to the job processor's `deployment_gate` slot, captured in
+    /// `register_services` (before the processor is moved into its spawned
+    /// task) and written into from `initialize_plugin_services`, which runs
+    /// only after every plugin has registered its services. See
+    /// `JobProcessorService::deployment_gate` for why this two-phase
+    /// handoff is needed: `register_services` runs in plugin-registration
+    /// order, and this plugin registers (and starts its processor) before
+    /// any later-registered plugin gets a chance to provide a gate.
+    deployment_gate_slot: tokio::sync::OnceCell<DeploymentGateSlot>,
+}
 
 impl DeploymentsPlugin {
     pub fn new() -> Self {
-        Self
+        Self {
+            deployment_gate_slot: tokio::sync::OnceCell::new(),
+        }
     }
 }
 
@@ -260,6 +274,20 @@ impl TempsPlugin for DeploymentsPlugin {
                 git_provider_manager,
             );
 
+            // Capture a handle to the job processor's gate slot before it's
+            // moved into the spawned task below. Any plugin that registers
+            // after this one would still be unregistered at this point, so
+            // looking the gate up here with get_service would always find
+            // nothing — initialize_plugin_services (below) does the actual
+            // lookup once every plugin has registered.
+            if self
+                .deployment_gate_slot
+                .set(job_processor.deployment_gate_handle())
+                .is_err()
+            {
+                unreachable!("register_services runs exactly once per plugin instance");
+            }
+
             // Start the job processor in a background task
             tokio::spawn(async move {
                 tracing::debug!("Starting deployment job processor");
@@ -286,10 +314,35 @@ impl TempsPlugin for DeploymentsPlugin {
         })
     }
 
+    fn initialize_plugin_services<'a>(
+        &'a self,
+        context: &'a PluginContext,
+    ) -> Pin<Box<dyn Future<Output = Result<(), PluginError>> + Send + 'a>> {
+        Box::pin(async move {
+            // Runs after every plugin has registered its services, so this
+            // is the first point at which an optional DeploymentGate (e.g.
+            // from a plugin implementing manual approvals) can actually be
+            // found.
+            if let Some(slot) = self.deployment_gate_slot.get() {
+                if let Some(gate) = context.get_service::<dyn temps_core::DeploymentGate>() {
+                    *slot.write().await = Some(gate);
+                    tracing::debug!("Deployment gate wired into job processor");
+                }
+            }
+            Ok(())
+        })
+    }
+
     fn configure_routes(&self, context: &PluginContext) -> Option<PluginRoutes> {
         let deployment_service = context.require_service::<DeploymentService>();
         let log_service = context.require_service::<temps_logs::LogService>();
         let cron_service = context.require_service::<crate::services::DatabaseCronConfigService>();
+
+        // Optional. configure_routes runs only after every plugin's
+        // initialize_plugin_services has completed (see PluginManager::initialize_plugins),
+        // so unlike register_services this get_service call reliably finds
+        // a gate registered by any plugin.
+        let deployment_gate = context.get_service::<dyn temps_core::DeploymentGate>();
 
         // Create external deployment manager for handling external images and operations
         let external_deployment_manager =
@@ -363,6 +416,7 @@ impl TempsPlugin for DeploymentsPlugin {
             encryption_service,
             config_service: config_service.clone(),
             docker: docker_for_exec,
+            deployment_gate,
         });
 
         let deployments_routes = handlers::deployments::configure_routes();
@@ -415,7 +469,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_deployments_plugin_default() {
-        let deployments_plugin = DeploymentsPlugin;
+        let deployments_plugin = DeploymentsPlugin::default();
         assert_eq!(deployments_plugin.name(), "deployments");
     }
 

--- a/crates/temps-deployments/src/services/job_processor.rs
+++ b/crates/temps-deployments/src/services/job_processor.rs
@@ -42,6 +42,11 @@ struct CommitInfo {
     commit_json: serde_json::Value,
 }
 
+/// Shared slot for the optional [`temps_core::DeploymentGate`] — see the
+/// `deployment_gate` field doc on [`JobProcessorService`] for why this is
+/// a lock instead of a plain `Option`.
+pub type DeploymentGateSlot = Arc<tokio::sync::RwLock<Option<Arc<dyn temps_core::DeploymentGate>>>>;
+
 pub struct JobProcessorService {
     db: Arc<DbConnection>,
     job_receiver: Box<dyn JobReceiver>,
@@ -49,6 +54,21 @@ pub struct JobProcessorService {
     workflow_planner: Arc<WorkflowPlanner>,
     workflow_executor: Arc<WorkflowExecutionService>,
     git_provider_manager: Arc<temps_git::GitProviderManager>,
+    /// Optional gate checked before a deployment transitions to `Running`
+    /// (e.g. a plugin implementing manual approvals). Defaults to
+    /// `None` — a no-op — so deploys never depend on it. See
+    /// [`temps_core::DeploymentGate`].
+    ///
+    /// Held behind a shared lock rather than a plain `Option` because it
+    /// must be settable *after* this service is constructed (and even
+    /// after `run()` has been spawned): `DeploymentsPlugin::register_services`
+    /// runs, and starts this processor, before later-registered plugins get
+    /// a chance to register a gate. `DeploymentsPlugin::initialize_plugin_services`
+    /// — which runs only after every plugin has registered — writes into
+    /// the same slot via a clone taken before `run()` was spawned. `run()`'s
+    /// dispatch loop re-reads it per job, so a gate registered after
+    /// startup still protects every job dispatched from that point on.
+    deployment_gate: DeploymentGateSlot,
 }
 
 impl JobProcessorService {
@@ -67,6 +87,7 @@ impl JobProcessorService {
             workflow_planner,
             workflow_executor,
             git_provider_manager,
+            deployment_gate: Arc::new(tokio::sync::RwLock::new(None)),
         }
     }
 
@@ -85,7 +106,18 @@ impl JobProcessorService {
             workflow_planner,
             workflow_executor,
             git_provider_manager,
+            deployment_gate: Arc::new(tokio::sync::RwLock::new(None)),
         }
+    }
+
+    /// Returns a clone of the shared gate slot. Call this *before* moving
+    /// `self` into the spawned `run()` task, so the caller retains a handle
+    /// it can write into later (from `DeploymentsPlugin::initialize_plugin_services`,
+    /// which runs after every plugin has registered its services). See the
+    /// field doc on `deployment_gate` for why a direct
+    /// `set_deployment_gate(&mut self, ...)` setter doesn't work here.
+    pub fn deployment_gate_handle(&self) -> DeploymentGateSlot {
+        self.deployment_gate.clone()
     }
 
     pub async fn run(&mut self) -> Result<(), JobProcessorError> {
@@ -111,6 +143,7 @@ impl JobProcessorService {
                             let db = Arc::clone(&self.db);
                             let git_provider_manager = Arc::clone(&self.git_provider_manager);
                             let queue = Arc::clone(&self.queue);
+                            let deployment_gate = self.deployment_gate.read().await.clone();
 
                             // Spawn a task to handle the job asynchronously
                             tokio::spawn(async move {
@@ -121,6 +154,7 @@ impl JobProcessorService {
                                     db,
                                     git_provider_manager,
                                     queue,
+                                    deployment_gate,
                                     git_push_job,
                                 )
                                 .await;
@@ -136,6 +170,7 @@ impl JobProcessorService {
                             let workflow_executor = Arc::clone(&self.workflow_executor);
                             let db = Arc::clone(&self.db);
                             let queue = Arc::clone(&self.queue);
+                            let deployment_gate = self.deployment_gate.read().await.clone();
 
                             tokio::spawn(async move {
                                 Self::process_deploy_image_requested_job(
@@ -143,7 +178,27 @@ impl JobProcessorService {
                                     workflow_executor,
                                     db,
                                     queue,
+                                    deployment_gate,
                                     image_job,
+                                )
+                                .await;
+                            });
+                        }
+                        Job::DeploymentGateRecheck(recheck_job) => {
+                            debug!(
+                                "🔥 Handling DeploymentGateRecheck job - deployment: {}",
+                                recheck_job.deployment_id
+                            );
+                            let workflow_executor = Arc::clone(&self.workflow_executor);
+                            let db = Arc::clone(&self.db);
+                            let deployment_gate = self.deployment_gate.read().await.clone();
+
+                            tokio::spawn(async move {
+                                Self::process_deployment_gate_recheck_job(
+                                    db,
+                                    workflow_executor,
+                                    deployment_gate,
+                                    recheck_job,
                                 )
                                 .await;
                             });
@@ -180,6 +235,7 @@ impl JobProcessorService {
         workflow_executor: Arc<WorkflowExecutionService>,
         db: Arc<DbConnection>,
         queue: Arc<dyn JobQueue>,
+        deployment_gate: Option<Arc<dyn temps_core::DeploymentGate>>,
         job: temps_core::DeployImageRequestedJob,
     ) {
         use chrono::Utc;
@@ -314,52 +370,18 @@ impl JobProcessorService {
                         created_jobs.len(),
                         deployment.id
                     );
-                    if let Err(e) = JobProcessorService::update_deployment_status(
-                        &db,
-                        deployment.id,
-                        PipelineStatus::Running,
-                    )
-                    .await
-                    {
-                        error!(
-                            "Failed to update deployment {} status to Running: {}",
-                            deployment.id, e
-                        );
-                        continue;
-                    }
 
-                    // Kick off the workflow (pull image → deploy container). Jobs
-                    // sit pending until the executor runs them, same as the
-                    // git-push path.
-                    info!("Executing workflow for image deployment {}", deployment.id);
-                    if let Err(e) = workflow_executor
-                        .execute_deployment_workflow(deployment.id)
-                        .await
-                    {
-                        let msg = format!("{}", e);
-                        error!(
-                            "Workflow execution failed for image deployment {}: {}",
-                            deployment.id, msg
-                        );
-                        if let Err(e2) = JobProcessorService::update_deployment_status_with_message(
-                            &db,
-                            deployment.id,
-                            PipelineStatus::Failed,
-                            Some(msg),
-                        )
-                        .await
-                        {
-                            error!(
-                                "Failed to mark image deployment {} failed: {}",
-                                deployment.id, e2
-                            );
-                        }
-                    } else {
-                        info!(
-                            "Workflow execution completed for image deployment {}",
-                            deployment.id
-                        );
-                    }
+                    // Gate check (optional — no-op when no gate is registered),
+                    // then transition to Running and execute the workflow.
+                    Self::gate_check_then_run(
+                        &db,
+                        &workflow_executor,
+                        &deployment_gate,
+                        project.id,
+                        &environment.name,
+                        deployment.id,
+                    )
+                    .await;
                 }
                 Err(e) => {
                     error!(
@@ -483,12 +505,179 @@ impl JobProcessorService {
         Ok(())
     }
 
+    /// Check the optional [`temps_core::DeploymentGate`] and, if allowed,
+    /// transition the deployment to `Running` and execute its workflow.
+    ///
+    /// If a gate blocks the deployment (or errors — fail-closed), this
+    /// leaves the deployment in whatever status it already had. The jobs
+    /// `create_deployment_jobs` already created are untouched, so a later
+    /// [`temps_core::DeploymentGateRecheckJob`] can call this same helper
+    /// again once conditions change, without recreating anything.
+    ///
+    /// `pub(crate)` — also called directly by the manual-deploy HTTP
+    /// handlers (`handlers::remote_deployments::{deploy_from_image,
+    /// deploy_from_image_upload, deploy_from_static}`), which run outside
+    /// the job-queue dispatch loop and would otherwise skip the gate
+    /// entirely.
+    pub(crate) async fn gate_check_then_run(
+        db: &Arc<DbConnection>,
+        workflow_executor: &Arc<WorkflowExecutionService>,
+        deployment_gate: &Option<Arc<dyn temps_core::DeploymentGate>>,
+        project_id: i32,
+        environment_name: &str,
+        deployment_id: i32,
+    ) {
+        if let Some(gate) = deployment_gate {
+            match gate
+                .check(project_id, environment_name, &deployment_id.to_string())
+                .await
+            {
+                Ok(temps_core::GateDecision::Allow) => {}
+                Ok(temps_core::GateDecision::Block { reason }) => {
+                    info!(
+                        "Deployment {} blocked pending an external gate: {}",
+                        deployment_id, reason
+                    );
+                    return;
+                }
+                Err(e) => {
+                    // Fail-closed: a broken gate must never fail open.
+                    error!(
+                        "Deployment gate check errored for deployment {} — blocking (fail-closed): {}",
+                        deployment_id, e
+                    );
+                    return;
+                }
+            }
+        }
+
+        if let Err(e) = JobProcessorService::update_deployment_status(
+            db,
+            deployment_id,
+            PipelineStatus::Running,
+        )
+        .await
+        {
+            error!(
+                "Failed to update deployment {} status to Running: {}",
+                deployment_id, e
+            );
+            return;
+        }
+        info!("Updated deployment {} status to Running", deployment_id);
+
+        info!("Executing workflow for deployment {}", deployment_id);
+        if let Err(e) = workflow_executor
+            .execute_deployment_workflow(deployment_id)
+            .await
+        {
+            let error_message = format!("{}", e);
+            error!(
+                "Workflow execution failed for deployment {}: {}",
+                deployment_id, error_message
+            );
+            if let Err(update_err) = JobProcessorService::update_deployment_status_with_message(
+                db,
+                deployment_id,
+                PipelineStatus::Failed,
+                Some(error_message),
+            )
+            .await
+            {
+                error!("Failed to update deployment status: {}", update_err);
+            }
+        } else {
+            info!(
+                "Workflow execution completed for deployment {}",
+                deployment_id
+            );
+        }
+    }
+
+    /// Handle a [`temps_core::DeploymentGateRecheckJob`] — re-evaluate the
+    /// gate for a deployment that a previous check blocked. Looks the
+    /// deployment up to recover its project id and environment name (the
+    /// recheck job carries only the deployment id, deliberately —
+    /// gate-agnostic, no plugin-specific fields).
+    ///
+    /// No-ops (with a log line) if the deployment is no longer `Pending`
+    /// (e.g. it was cancelled while waiting, or a race already processed
+    /// it) — recheck jobs must never resurrect a deployment that moved on.
+    async fn process_deployment_gate_recheck_job(
+        db: Arc<DbConnection>,
+        workflow_executor: Arc<WorkflowExecutionService>,
+        deployment_gate: Option<Arc<dyn temps_core::DeploymentGate>>,
+        job: temps_core::DeploymentGateRecheckJob,
+    ) {
+        let deployment = match deployments::Entity::find_by_id(job.deployment_id)
+            .one(db.as_ref())
+            .await
+        {
+            Ok(Some(d)) => d,
+            Ok(None) => {
+                error!(
+                    "DeploymentGateRecheck: deployment {} not found",
+                    job.deployment_id
+                );
+                return;
+            }
+            Err(e) => {
+                error!(
+                    "DeploymentGateRecheck: db error loading deployment {}: {}",
+                    job.deployment_id, e
+                );
+                return;
+            }
+        };
+
+        if deployment.state != "pending" {
+            info!(
+                "DeploymentGateRecheck: deployment {} is no longer pending (state={}), ignoring",
+                deployment.id, deployment.state
+            );
+            return;
+        }
+
+        let environment =
+            match temps_entities::environments::Entity::find_by_id(deployment.environment_id)
+                .one(db.as_ref())
+                .await
+            {
+                Ok(Some(e)) => e,
+                Ok(None) => {
+                    error!(
+                        "DeploymentGateRecheck: environment {} for deployment {} not found",
+                        deployment.environment_id, deployment.id
+                    );
+                    return;
+                }
+                Err(e) => {
+                    error!(
+                    "DeploymentGateRecheck: db error loading environment {} for deployment {}: {}",
+                    deployment.environment_id, deployment.id, e
+                );
+                    return;
+                }
+            };
+
+        Self::gate_check_then_run(
+            &db,
+            &workflow_executor,
+            &deployment_gate,
+            deployment.project_id,
+            &environment.name,
+            deployment.id,
+        )
+        .await;
+    }
+
     async fn process_git_push_event_job(
         workflow_planner: Arc<WorkflowPlanner>,
         workflow_executor: Arc<WorkflowExecutionService>,
         db: Arc<DbConnection>,
         git_provider_manager: Arc<temps_git::GitProviderManager>,
         queue: Arc<dyn JobQueue>,
+        deployment_gate: Option<Arc<dyn temps_core::DeploymentGate>>,
         job: temps_core::GitPushEventJob,
     ) {
         process_git_push_event(
@@ -497,6 +686,7 @@ impl JobProcessorService {
             db,
             git_provider_manager,
             queue,
+            deployment_gate,
             job,
         )
         .await;
@@ -899,6 +1089,7 @@ async fn process_git_push_event(
     db: Arc<DbConnection>,
     git_provider_manager: Arc<temps_git::GitProviderManager>,
     queue: Arc<dyn JobQueue>,
+    deployment_gate: Option<Arc<dyn temps_core::DeploymentGate>>,
     job: temps_core::GitPushEventJob,
 ) {
     info!(
@@ -1198,50 +1389,17 @@ async fn process_git_push_event(
                     deployment_id
                 );
 
-                match JobProcessorService::update_deployment_status(
+                // Gate check (optional — no-op when no gate is registered),
+                // then transition to Running and execute the workflow.
+                JobProcessorService::gate_check_then_run(
                     &db,
+                    &workflow_executor,
+                    &deployment_gate,
+                    project.id,
+                    &environment.name,
                     deployment_id,
-                    PipelineStatus::Running,
                 )
-                .await
-                {
-                    Ok(_) => info!("Updated deployment {} status to Running", deployment_id),
-                    Err(e) => {
-                        error!("Failed to update deployment status to Running: {}", e);
-                        continue;
-                    }
-                }
-
-                info!("Executing workflow for deployment {}", deployment_id);
-                match workflow_executor
-                    .execute_deployment_workflow(deployment_id)
-                    .await
-                {
-                    Ok(_) => {
-                        info!(
-                            "Workflow execution completed for deployment {}",
-                            deployment_id
-                        );
-                    }
-                    Err(e) => {
-                        let error_message = format!("{}", e);
-                        error!(
-                            "Workflow execution failed for deployment {}: {}",
-                            deployment_id, error_message
-                        );
-                        if let Err(update_err) =
-                            JobProcessorService::update_deployment_status_with_message(
-                                &db,
-                                deployment_id,
-                                PipelineStatus::Failed,
-                                Some(error_message),
-                            )
-                            .await
-                        {
-                            error!("Failed to update deployment status: {}", update_err);
-                        }
-                    }
-                }
+                .await;
             }
             Err(job_error) => {
                 let error_message = format!("{}", job_error);


### PR DESCRIPTION
## Summary
- Adds `temps_core::DeploymentGate` — a generic, gate-agnostic trait for pausing a deployment before it transitions to `Running`. Core never implements it; it's an optional service (`get_service`, never `require_service`), so a plugin-free binary deploys unconditionally.
- Adds `temps_core::Job::DeploymentGateRecheck` — asks the job processor to re-evaluate the gate for a deployment left in a pre-`Running` state.
- Adds `JobProcessorService::gate_check_then_run` (shared by every deployment-trigger path — git-push, the template one-click `DeployImageRequested` job, AND the three manual-deploy HTTP handlers: `deploy_from_image`, `deploy_from_image_upload`, `deploy_from_static`) and `process_deployment_gate_recheck_job`.
- **Zero migrations, zero new `PipelineStatus` variants.** A blocked deployment simply stays in whatever status it already had (`Pending`) — no schema change, no core enum change.

## Design rationale
Kubernetes Conditions / GitHub Checks precedent: keep the core status enum fixed, add ONE generic extensible side-channel instead of a new enum variant per feature. Any future plugin that needs to pause a deployment (a manual sign-off step, a budget cap, a security-scan result, etc.) implements this one trait rather than requiring another core migration.

## Bugs found and fixed while testing end-to-end against a sample gate implementation
1. **Plugin-registration-order race**: `DeploymentsPlugin::register_services` runs (and starts the job processor) before later-registered plugins get a chance to register a gate, so the original `get_service` lookup inside `register_services` always found nothing. Fixed with a two-phase handoff: the job processor's gate is now a shared `Arc<RwLock<Option<...>>>` slot (`DeploymentGateSlot`), and the actual lookup + write-in happens in the new `DeploymentsPlugin::initialize_plugin_services`, which the plugin framework only calls after every plugin has finished `register_services`.
2. **Coverage gap in manual-deploy handlers**: the three manual HTTP deploy handlers in `handlers/remote_deployments.rs` had their own inline "set Running + spawn workflow" logic instead of going through the job-queue dispatch loop, so only git-push and the one-click template job were ever actually gated. Fixed by resolving the gate once in `configure_routes` (safe there — it runs after every plugin's `initialize_plugin_services` has completed) and routing all three handlers through the same `gate_check_then_run` helper.

## Test plan
- [x] `cargo check --workspace --lib` passes (0 errors)
- [x] `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` pass
- [x] `cargo test -p temps-deployments --lib` — 400 passed
- [x] End-to-end verified live with a sample gate plugin: registered a gate that blocks a specific environment, triggered a deploy via the console UI, confirmed it stayed `pending`, approved it out-of-band, confirmed the `DeploymentGateRecheck` job fired and the deployment proceeded to `Running` → `completed`.