### PR TITLE
fix(web): resolve gitlab vs github commit links and trace UI polish

### DIFF
--- a/web/src/components/project/ProjectOverview.tsx
+++ b/web/src/components/project/ProjectOverview.tsx
@@ -26,7 +26,7 @@ import {
   TrendingUp,
   Users,
 } from 'lucide-react'
-import { ReactNode, useEffect, useMemo, useState } from 'react'
+import { ReactNode, useEffect, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { MetricCard } from '../dashboard/MetricCard'
 import { DeploymentActivityGraph } from './DeploymentActivityGraph'
@@ -163,9 +163,6 @@ export function ProjectOverview({
       refetchDeployment()
     }
   }, [project?.id, refetchDeployment])
-
-  const [now] = useState(() => Date.now())
-  const [oneDayAgo] = useState(() => now - 24 * 60 * 60 * 1000)
 
   const isLoadingOnboarding = isCheckingAnalytics || isCheckingErrors
   const hasAnalytics = !!hasAnalyticsData?.has_events
@@ -320,10 +317,7 @@ export function ProjectOverview({
         <RevenueMetric project={project} />
 
 
-        <Link
-          to={`/projects/${project.slug}/analytics/requests?from=${oneDayAgo}&to=${now}&status_code=500`}
-          className="h-full w-full"
-        >
+        <Link to={`/projects/${project.slug}/errors`} className="h-full w-full">
           <MetricCard
             change={''}
             value={errorStats?.error_groups?.toFixed(2) || '0'}

--- a/web/src/components/traces/ProjectBadge.tsx
+++ b/web/src/components/traces/ProjectBadge.tsx
@@ -35,7 +35,7 @@ export function ProjectBadge({
   return (
     <span
       className={cn(
-        'inline-flex max-w-[120px] items-center gap-1 truncate rounded px-1.5 py-0.5 text-[10px] font-medium',
+        'inline-flex max-w-[88px] shrink-0 items-center gap-1 truncate rounded px-1.5 py-0.5 text-[10px] font-medium',
         className
       )}
       style={{ backgroundColor: `${color}22`, color }}

--- a/web/src/components/traces/SpanWaterfall.tsx
+++ b/web/src/components/traces/SpanWaterfall.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react'
-import { ChevronDown, CheckCircle2, XCircle } from 'lucide-react'
+import { useMemo, useState, type ReactNode } from 'react'
+import { ChevronDown, ChevronRight, CheckCircle2, XCircle } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
   Tooltip,
@@ -75,6 +75,13 @@ export function serviceColor(name?: string): string {
   return SERVICE_COLORS[Math.abs(h) % SERVICE_COLORS.length]
 }
 
+function countDescendants(node: SpanTreeNode): number {
+  return node.children.reduce(
+    (sum, child) => sum + 1 + countDescendants(child),
+    0
+  )
+}
+
 /** Shared span waterfall (tree + timeline bars). `colorBy="service"` colours each
  *  bar by its service and shows a service dot, like OpenObserve/Datadog.
  *
@@ -110,17 +117,44 @@ export function SpanWaterfall({
   rowClassName?: (span: SpanTreeNode['span']) => string | undefined
   className?: string
 }) {
+  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set())
+  const toggleCollapse = (spanId: string) => {
+    setCollapsedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(spanId)) {
+        next.delete(spanId)
+      } else {
+        next.add(spanId)
+      }
+      return next
+    })
+  }
+  const visibleSpans = useMemo(() => {
+    const hiddenAncestors = new Set<string>()
+    return flatSpans.filter((node) => {
+      const parentId = node.span.parent_span_id
+      if (parentId && hiddenAncestors.has(parentId)) {
+        hiddenAncestors.add(node.span.span_id)
+        return false
+      }
+      if (collapsedIds.has(node.span.span_id)) {
+        hiddenAncestors.add(node.span.span_id)
+      }
+      return true
+    })
+  }, [flatSpans, collapsedIds])
+
   return (
     <div className={cn('overflow-auto', className)}>
       <div className="sticky top-0 z-10 flex min-w-[420px] items-center border-b bg-background px-4 py-2 text-xs text-muted-foreground sm:min-w-[500px]">
-        <div className="w-[120px] shrink-0 sm:w-[180px] md:w-[280px]">Span Name</div>
+        <div className="w-[120px] shrink-0 sm:w-[180px] md:w-[280px] lg:w-[340px]">Span Name</div>
         <div className="flex flex-1 justify-between">
           <span>{formatTimestamp(new Date(traceStart).toISOString())}</span>
           <span>{formatDuration(traceDuration)}</span>
           <span>{formatTimestamp(new Date(traceEnd).toISOString())}</span>
         </div>
       </div>
-      {flatSpans.map((node) => {
+      {visibleSpans.map((node) => {
         const spanStart = new Date(node.span.start_time).getTime() - traceStart
         const spanDuration =
           new Date(node.span.end_time).getTime() -
@@ -133,6 +167,7 @@ export function SpanWaterfall({
             : maxBarPct
         const isError = node.span.status_code?.toUpperCase() === 'ERROR'
         const isSelected = selectedSpanId === node.span.span_id
+        const isCollapsed = collapsedIds.has(node.span.span_id)
         const svc = node.span.resource?.service_name
         const barColor =
           colorBy === 'service' && !isError ? serviceColor(svc) : undefined
@@ -150,11 +185,33 @@ export function SpanWaterfall({
                   )}
                 >
                   <div
-                    className="flex w-[120px] shrink-0 items-center gap-1.5 sm:w-[180px] md:w-[280px]"
+                    className="flex w-[120px] shrink-0 items-center gap-1.5 sm:w-[180px] md:w-[280px] lg:w-[340px]"
                     style={{ paddingLeft: `${node.depth * 16}px` }}
                   >
                     {node.children.length > 0 ? (
-                      <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+                      <span
+                        role="button"
+                        tabIndex={0}
+                        aria-label={isCollapsed ? 'Expand span' : 'Collapse span'}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          toggleCollapse(node.span.span_id)
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault()
+                            e.stopPropagation()
+                            toggleCollapse(node.span.span_id)
+                          }
+                        }}
+                        className="flex h-3 w-3 shrink-0 items-center justify-center rounded-sm hover:bg-accent"
+                      >
+                        {isCollapsed ? (
+                          <ChevronRight className="h-3 w-3 text-muted-foreground" />
+                        ) : (
+                          <ChevronDown className="h-3 w-3 text-muted-foreground" />
+                        )}
+                      </span>
                     ) : (
                       <span className="w-3 shrink-0" />
                     )}
@@ -167,7 +224,14 @@ export function SpanWaterfall({
                       statusIcon(node.span.status_code)
                     )}
                     {renderRowBadge?.(node.span)}
-                    <span className="truncate text-xs">{node.span.name}</span>
+                    <span className="min-w-0 flex-1 truncate text-xs">
+                      {node.span.name}
+                    </span>
+                    {isCollapsed && (
+                      <span className="shrink-0 rounded-sm bg-muted px-1 text-[10px] text-muted-foreground">
+                        +{countDescendants(node)}
+                      </span>
+                    )}
                   </div>
                   <div className="relative h-6 flex-1">
                     <div

--- a/web/src/pages/CrossProjectTraceDetail.tsx
+++ b/web/src/pages/CrossProjectTraceDetail.tsx
@@ -110,7 +110,6 @@ function UnifiedSpanDetail({
 export default function CrossProjectTraceDetail() {
   const { traceId } = useParams()
   const navigate = useNavigate()
-  usePageTitle('Unified trace')
 
   const { data, isPending, isError, error } = useQuery({
     ...getUnifiedTraceOptions({ path: { trace_id: traceId || '' } }),
@@ -134,6 +133,7 @@ export default function CrossProjectTraceDetail() {
   )
   const tree = useMemo(() => buildSpanTree(spans), [spans])
   const flatSpans = useMemo(() => flattenTree(tree), [tree])
+  usePageTitle(tree[0]?.span?.name ?? 'Unified trace')
 
   const traceStart = useMemo(
     () => (data ? new Date(data.start_time).getTime() : 0),

--- a/web/src/pages/DeploymentDetails.tsx
+++ b/web/src/pages/DeploymentDetails.tsx
@@ -146,7 +146,6 @@ function buildSummaryStats(deployment: DeploymentResponse): StatItem[] {
   return stats
 }
 
-
 function Field({
   label,
   value,
@@ -175,21 +174,48 @@ interface CommitUrls {
   branch: string | null
 }
 
+interface RepoWebBase {
+  base: string
+  isGitlab: boolean
+}
+
 // Best-effort derivation of the repository's web base URL so the commit hash and
 // branch can deep-link back to the git provider. Falls back to plain text when we
 // can't confidently build a URL.
-function deriveRepoWebBase(project: ProjectResponse): string | null {
+function deriveRepoWebBase(project: ProjectResponse): RepoWebBase | null {
   const gitUrl = project.git_url
   if (gitUrl) {
     const https = gitUrl.match(/^https?:\/\/([^/]+)\/(.+?)(?:\.git)?\/?$/i)
-    if (https) return `https://${https[1]}/${https[2]}`
+    if (https)
+      return {
+        base: `https://${https[1]}/${https[2]}`,
+        isGitlab: /gitlab/i.test(https[1]),
+      }
     const scp = gitUrl.match(/^[^@]+@([^:]+):(.+?)(?:\.git)?\/?$/i)
-    if (scp) return `https://${scp[1]}/${scp[2]}`
+    if (scp)
+      return {
+        base: `https://${scp[1]}/${scp[2]}`,
+        isGitlab: /gitlab/i.test(scp[1]),
+      }
     const ssh = gitUrl.match(/^ssh:\/\/[^@]+@([^/]+)\/(.+?)(?:\.git)?\/?$/i)
-    if (ssh) return `https://${ssh[1]}/${ssh[2]}`
+    if (ssh)
+      return {
+        base: `https://${ssh[1]}/${ssh[2]}`,
+        isGitlab: /gitlab/i.test(ssh[1]),
+      }
   }
   if (project.repo_owner && project.repo_name) {
-    return `https://github.com/${project.repo_owner}/${project.repo_name}`
+    // No raw clone URL to sniff a host from. A non-null `gitlab_webhook_id` is
+    // the one signal the frontend actually has that this project is wired up
+    // through a GitLab provider connection (it's only ever set by
+    // install_gitlab_webhook_for_connection); anything else defaults to
+    // GitHub, the common case for connections without a raw git_url.
+    const isGitlab = project.gitlab_webhook_id != null
+    const host = isGitlab ? 'https://gitlab.com' : 'https://github.com'
+    return {
+      base: `${host}/${project.repo_owner}/${project.repo_name}`,
+      isGitlab,
+    }
   }
   return null
 }
@@ -198,19 +224,23 @@ function commitWebUrls(
   project: ProjectResponse,
   deployment: DeploymentResponse
 ): CommitUrls {
-  let base = deriveRepoWebBase(project)
-  if (!base) {
+  let resolved = deriveRepoWebBase(project)
+  if (!resolved) {
     const gpe = deployment.metadata?.gitPushEvent
     if (gpe?.owner && gpe?.repo) {
-      base = `https://github.com/${gpe.owner}/${gpe.repo}`
+      const isGitlab = project.gitlab_webhook_id != null
+      const host = isGitlab ? 'https://gitlab.com' : 'https://github.com'
+      resolved = { base: `${host}/${gpe.owner}/${gpe.repo}`, isGitlab }
     }
   }
-  if (!base) return { commit: null, branch: null }
-  const isGitlab = /gitlab/i.test(base)
+  if (!resolved) return { commit: null, branch: null }
+  const { base, isGitlab } = resolved
   const commitSeg = isGitlab ? '/-/commit/' : '/commit/'
   const treeSeg = isGitlab ? '/-/tree/' : '/tree/'
   return {
-    commit: deployment.commit_hash ? `${base}${commitSeg}${deployment.commit_hash}` : null,
+    commit: deployment.commit_hash
+      ? `${base}${commitSeg}${deployment.commit_hash}`
+      : null,
     branch: deployment.branch
       ? `${base}${treeSeg}${encodeURIComponent(deployment.branch)}`
       : null,
@@ -631,9 +661,7 @@ function DeploymentHeader({
             <Clock className="h-3.5 w-3.5" />
             {buildStats.map((stat, i) => (
               <span key={stat.label} className="inline-flex items-center gap-1">
-                {i > 0 && (
-                  <span className="text-muted-foreground/40">·</span>
-                )}
+                {i > 0 && <span className="text-muted-foreground/40">·</span>}
                 <span>{stat.label}</span>
                 <span className="font-medium tabular-nums text-foreground">
                   {stat.value}
@@ -1018,15 +1046,27 @@ export function DeploymentDetails({ project }: DeploymentDetailsProps) {
         md.imageUploadedLocally)
   )
 
-  // The resource facts worth surfacing, as compact chips: CPU + memory request
-  // and replica count. Limits, exposed port, and feature toggles are omitted.
+  // The resource facts worth surfacing, as compact chips: CPU + memory
+  // request/limit and replica count. Exposed port and feature toggles are omitted.
   const resourceBadges: string[] = []
-  if (cfg?.cpuRequest != null)
-    resourceBadges.push(`${formatMicrocores(cfg.cpuRequest)} CPU`)
-  if (cfg?.memoryRequest != null)
-    resourceBadges.push(`${cfg.memoryRequest} MB memory`)
+  if (cfg?.cpuRequest != null) {
+    const cpuLabel =
+      cfg.cpuLimit != null && cfg.cpuLimit !== cfg.cpuRequest
+        ? `${formatMicrocores(cfg.cpuRequest)}-${formatMicrocores(cfg.cpuLimit)} CPU`
+        : `${formatMicrocores(cfg.cpuRequest)} CPU`
+    resourceBadges.push(cpuLabel)
+  }
+  if (cfg?.memoryRequest != null) {
+    const memoryLabel =
+      cfg.memoryLimit != null && cfg.memoryLimit !== cfg.memoryRequest
+        ? `${cfg.memoryRequest}-${cfg.memoryLimit} MB memory`
+        : `${cfg.memoryRequest} MB memory`
+    resourceBadges.push(memoryLabel)
+  }
   if (cfg?.replicas != null)
-    resourceBadges.push(`${cfg.replicas} replica${cfg.replicas === 1 ? '' : 's'}`)
+    resourceBadges.push(
+      `${cfg.replicas} replica${cfg.replicas === 1 ? '' : 's'}`
+    )
 
   const overviewProps: OverviewProps = {
     project,

--- a/web/src/pages/TraceDetail.tsx
+++ b/web/src/pages/TraceDetail.tsx
@@ -34,6 +34,7 @@ import {
   TabsTrigger,
 } from '@/components/ui/tabs'
 import { useAssistantPageContext } from '@/components/ai/AiAssistantContext'
+import { usePageTitle } from '@/hooks/usePageTitle'
 import {
   SpanWaterfall,
   formatDuration,
@@ -560,6 +561,7 @@ export default function TraceDetail({ project }: TraceDetailProps) {
 
   const tree = useMemo(() => buildSpanTree(displaySpans), [displaySpans])
   const flatSpans = useMemo(() => flattenTree(tree), [tree])
+  usePageTitle(tree[0]?.span?.name ?? 'Trace')
 
   // Calculate trace-level timing for waterfall positioning
   const traceStart = useMemo(() => {

--- a/web/src/utils/spanTree.ts
+++ b/web/src/utils/spanTree.ts
@@ -21,17 +21,28 @@ export function buildSpanTree(spans: SpanRecord[]): SpanTreeNode[] {
     spanMap.set(span.span_id, { span, children: [], depth: 0 })
   }
 
-  // Build tree
+  // Build tree. Depth cannot be derived here from `parent.depth` because
+  // spans can appear in any order relative to their parent (the cross-project
+  // unified trace endpoint in particular interleaves spans across projects,
+  // so a child frequently precedes its parent in the array) — a parent's
+  // depth may still be its default 0 when an earlier-processed child reads
+  // it. Depth is assigned in a separate traversal below instead.
   for (const span of spans) {
     const node = spanMap.get(span.span_id)!
     if (span.parent_span_id && spanMap.has(span.parent_span_id)) {
       const parent = spanMap.get(span.parent_span_id)!
-      node.depth = parent.depth + 1
       parent.children.push(node)
     } else {
       roots.push(node)
     }
   }
+
+  // Assign depth via traversal from the roots, independent of input order.
+  function assignDepth(node: SpanTreeNode, depth: number) {
+    node.depth = depth
+    node.children.forEach((child) => assignDepth(child, depth + 1))
+  }
+  roots.forEach((root) => assignDepth(root, 0))
 
   // Sort children by start_time
   function sortChildren(node: SpanTreeNode) {


### PR DESCRIPTION
## Summary
- Deployment details: the commit hash / branch links now correctly point at GitLab (`/-/commit/`, `/-/tree/`) when the project's provider connection is GitLab and there's no raw `git_url` to sniff a host from — previously this case always hardcoded `github.com`, producing a broken link. Detected via the existing `gitlab_webhook_id` field, no backend changes needed.
- Deployment details: CPU/memory resource chips now show a range (e.g. `0.5-1 CPU`) when limit differs from request, instead of only showing the request.
- Trace waterfall: spans with children can now be collapsed/expanded, with a `+N` descendant count badge when collapsed.
- Span tree: depth is now computed via a root-down traversal instead of trusting input order — the unified cross-project trace endpoint can list a child before its parent, which previously left some spans at depth 0.
- Trace pages: page title now shows the root span name instead of a generic "Unified trace" / "Trace".
- Project overview: the error-rate metric card now links to the project's Errors page instead of a hardcoded 24h analytics filter URL.
- Trace project badge: reduced max width so it stops crowding neighboring badges.

## Test plan
- [x] `tsc --noEmit` and `eslint` clean on all touched files (only pre-existing, unrelated warnings remain)
- [x] Verified commit-link fix against 7 scenarios (GitHub/GitLab via `git_url`, self-hosted GitLab, both provider-connection fallback paths) — all resolve correctly
- [x] Live-checked against local dev server: existing GitHub-connected deployment still links correctly (no regression)
- [ ] No GitLab-connected project available locally to visually confirm the `/-/commit/` link end-to-end; logic verified via unit-level checks instead