### PR TITLE
chore(scripts): add local testcontainer orphan-cleanup script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -69,6 +69,29 @@ Next steps:
 Push now? (y/N)
 ```
 
+## Testcontainer Cleanup
+
+`cleanup-testcontainers.sh` - Removes orphaned `testcontainers`-managed
+Docker containers left over from interrupted `cargo test` runs (the
+companion "Ryuk" reaper testcontainers-rs relies on for guaranteed
+cleanup doesn't reliably register on every machine, notably Docker
+Desktop for Mac). Left running, these accumulate DB connections until
+Postgres hits `max_connections` and refuses new connections entirely.
+
+Scoped to the `org.testcontainers.managed-by=testcontainers` label, so
+it only ever touches test infrastructure, never a real container.
+
+### Usage
+
+```bash
+scripts/cleanup-testcontainers.sh            # remove orphaned testcontainers
+scripts/cleanup-testcontainers.sh --dry-run  # list without removing
+```
+
+Run this whenever `docker ps` looks cluttered with old Postgres/Timescale
+containers after a round of local integration testing, or if Postgres
+itself starts refusing connections.
+
 ## Adding More Scripts
 
 When adding new scripts:

--- a/scripts/cleanup-testcontainers.sh
+++ b/scripts/cleanup-testcontainers.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# cleanup-testcontainers.sh — Remove orphaned `testcontainers`-managed
+# Docker containers left over from interrupted `cargo test` runs.
+#
+# testcontainers-rs (used by TestDatabase and friends, see
+# crates/temps-database/src/test_utils.rs) relies on a companion "Ryuk"
+# reaper container to guarantee container cleanup even when the test
+# process dies ungracefully (crash, SIGKILL, a tool/CI timeout). Ryuk does
+# not reliably register/complete on every machine — notably Docker Desktop
+# for Mac's VM-based networking is a known trouble spot for it — so a
+# killed test run can leave its Postgres/Timescale containers running
+# forever, each holding open DB connections, until something notices
+# Postgres has hit `max_connections` and refuses new connections entirely.
+#
+# CI carries its own safety net for this (a `docker system prune -f` step
+# in .github/workflows/e2e-tests.yml), but `prune` only removes STOPPED
+# containers — it does nothing for orphans that are still running, which
+# is the actual failure mode this script targets. There is no local
+# equivalent of CI's step, so orphans accumulate silently across every
+# local `cargo test` invocation until this script (or a manual `docker rm
+# -f`) is run.
+#
+# Scoped by the `org.testcontainers.managed-by=testcontainers` label that
+# testcontainers-rs stamps on every container it creates, so this only
+# ever touches test infrastructure — never a real dev/demo/deployment
+# container running on the same Docker daemon.
+#
+# Usage:
+#   scripts/cleanup-testcontainers.sh          # remove orphaned testcontainers
+#   scripts/cleanup-testcontainers.sh --dry-run  # list without removing
+
+set -euo pipefail
+
+LABEL="org.testcontainers.managed-by=testcontainers"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker not found — nothing to do." >&2
+  exit 0
+fi
+
+IDS=$(docker ps -aq --filter "label=${LABEL}")
+
+if [ -z "$IDS" ]; then
+  echo "No orphaned testcontainers found."
+  exit 0
+fi
+
+COUNT=$(echo "$IDS" | wc -l | tr -d ' ')
+
+if [ "${1:-}" = "--dry-run" ]; then
+  echo "Would remove ${COUNT} orphaned testcontainers:"
+  docker ps -a --filter "label=${LABEL}" --format "  {{.Names}}\t{{.Image}}\t{{.Status}}"
+  exit 0
+fi
+
+echo "Removing ${COUNT} orphaned testcontainers..."
+# shellcheck disable=SC2086
+docker rm -f $IDS >/dev/null
+echo "Done. Run 'docker ps -a --filter \"label=${LABEL}\"' to verify none remain."


### PR DESCRIPTION
## Summary
Adds `scripts/cleanup-testcontainers.sh`, removing orphaned `testcontainers`-managed Docker containers left over from interrupted `cargo test` runs.

**Why:** testcontainers-rs relies on a companion Ryuk reaper container to guarantee cleanup even when a test process dies ungracefully (crash, `SIGKILL`, a timeout). Ryuk doesn't reliably register/complete on every machine — Docker Desktop for Mac's VM-based networking is a known trouble spot — so a killed test run can leave Postgres/Timescale containers running indefinitely, each holding open DB connections, until Postgres hits `max_connections` and refuses new connections entirely. This happened locally this session: ~147 orphaned containers had fully exhausted the local Postgres connection pool.

CI already has its own safety net (`docker system prune -f` in `.github/workflows/e2e-tests.yml`), but `prune` only removes **stopped** containers — it does nothing for orphans still running, which is the actual failure mode. There was no local equivalent.

Scoped by the `org.testcontainers.managed-by=testcontainers` label testcontainers-rs stamps on everything it creates, so it only ever touches test infrastructure.

## Test plan
- [x] `scripts/cleanup-testcontainers.sh --dry-run` — correctly reports "No orphaned testcontainers found" on a clean machine
- [x] Verified against the actual incident: removed 147 orphaned containers, restored Postgres connectivity, left all other running containers (dev/demo/deployment) untouched