### PR TITLE
fix: resolve stacked dependency-bump compilation breaks on main

### DIFF
--- a/crates/temps-analytics-events/src/services/ch_backfill.rs
+++ b/crates/temps-analytics-events/src/services/ch_backfill.rs
@@ -259,6 +259,7 @@ async fn push_batch(
 ) -> Result<(), ChBackfillError> {
     let mut inserter =
         ch.insert::<ChEventRow>("events")
+            .await
             .map_err(|e| ChBackfillError::ClickHouseInsert {
                 first_event_id: first_id,
                 reason: format!("inserter setup failed: {e}"),

--- a/crates/temps-analytics-events/src/services/ch_fanout.rs
+++ b/crates/temps-analytics-events/src/services/ch_fanout.rs
@@ -306,7 +306,7 @@ impl ChFanoutWorker {
         };
 
         // 4. Push to CH via the typed Inserter.
-        let mut inserter = self.ch.insert::<ChEventRow>("events").map_err(|e| {
+        let mut inserter = self.ch.insert::<ChEventRow>("events").await.map_err(|e| {
             ChFanoutError::ClickHouseInsert {
                 first_event_id: first_id,
                 reason: format!("inserter setup failed: {e}"),

--- a/crates/temps-analytics-events/src/services/clickhouse_backend.rs
+++ b/crates/temps-analytics-events/src/services/clickhouse_backend.rs
@@ -1475,7 +1475,10 @@ mod tests {
     /// return deterministic results in tests (production tolerates some
     /// duplication during merges; tests want determinism).
     async fn insert_rows(client: &::clickhouse::Client, rows: &[SeedRow]) {
-        let mut inserter = client.insert::<SeedRow>("events").expect("inserter setup");
+        let mut inserter = client
+            .insert::<SeedRow>("events")
+            .await
+            .expect("inserter setup");
         for row in rows {
             inserter.write(row).await.expect("insert row");
         }

--- a/crates/temps-cli/src/commands/ch_backfill_domains.rs
+++ b/crates/temps-cli/src/commands/ch_backfill_domains.rs
@@ -586,6 +586,7 @@ mod proxy_logs {
 
             let mut inserter = ch
                 .insert::<ChProxyLogRow>("proxy_logs")
+                .await
                 .context("ClickHouse proxy_logs inserter setup")?;
             for r in &rows {
                 inserter
@@ -706,6 +707,7 @@ mod traces {
 
             let mut inserter = ch
                 .insert::<ChSpanRow>("spans")
+                .await
                 .context("ClickHouse spans inserter setup")?;
             for r in &rows {
                 inserter
@@ -857,6 +859,7 @@ mod metrics {
 
                 let mut inserter = ch
                     .insert::<ChMetricRow>("service_metrics")
+                    .await
                     .context("ClickHouse service_metrics inserter setup")?;
                 for r in &rows {
                     inserter

--- a/crates/temps-metrics/src/store/clickhouse.rs
+++ b/crates/temps-metrics/src/store/clickhouse.rs
@@ -336,6 +336,7 @@ impl MetricsStore for ClickhouseMetricsStore {
             let mut inserter = self
                 .client
                 .insert::<ChMetricRow>("service_metrics")
+                .await
                 .map_err(|e| MetricsError::ClickHouse {
                     operation: "write_batch (inserter setup)".to_string(),
                     reason: e.to_string(),

--- a/crates/temps-network/src/linux/bridge.rs
+++ b/crates/temps-network/src/linux/bridge.rs
@@ -3,7 +3,7 @@
 use crate::config::{NetworkConfig, NodeAlloc};
 use crate::error::NetworkError;
 use futures::TryStreamExt;
-use rtnetlink::Handle;
+use rtnetlink::{Handle, LinkBridge, LinkUnspec};
 use std::net::IpAddr;
 use tracing::{debug, info};
 
@@ -26,8 +26,7 @@ pub async fn ensure(
         None => {
             handle
                 .link()
-                .add()
-                .bridge(name.into())
+                .add(LinkBridge::new(name).build())
                 .execute()
                 .await
                 .map_err(|e| NetworkError::Netlink {
@@ -48,8 +47,7 @@ pub async fn ensure(
     // Set MTU. Idempotent — the kernel accepts setting the same value.
     handle
         .link()
-        .set(index)
-        .mtu(mtu)
+        .set(LinkUnspec::new_with_index(index).mtu(mtu).build())
         .execute()
         .await
         .map_err(|e| NetworkError::Netlink {
@@ -65,8 +63,7 @@ pub async fn ensure(
     // Bring up.
     handle
         .link()
-        .set(index)
-        .up()
+        .set(LinkUnspec::new_with_index(index).up().build())
         .execute()
         .await
         .map_err(|e| NetworkError::Netlink {

--- a/crates/temps-network/src/linux/route.rs
+++ b/crates/temps-network/src/linux/route.rs
@@ -7,7 +7,7 @@
 use crate::error::NetworkError;
 use crate::linux::bridge::link_index_by_name;
 use ipnet::Ipv4Net;
-use rtnetlink::Handle;
+use rtnetlink::{Handle, RouteMessageBuilder};
 use std::net::{IpAddr, Ipv4Addr};
 use tracing::{debug, warn};
 
@@ -34,16 +34,13 @@ pub async fn add_via_dev(
             reason: format!("device '{}' not found", dev),
         })?;
 
-    let mut req = handle
-        .route()
-        .add()
-        .v4()
+    let mut builder = RouteMessageBuilder::<Ipv4Addr>::new()
         .destination_prefix(cidr.network(), cidr.prefix_len())
         .output_interface(dev_idx);
     if let Some(src) = pref_src {
-        req = req.pref_source(src);
+        builder = builder.pref_source(src);
     }
-    let res = req.execute().await;
+    let res = handle.route().add(builder.build()).execute().await;
 
     handle_route_result(res, "add_via_dev", cidr, dev)
 }
@@ -64,10 +61,12 @@ pub async fn add_via_gateway(handle: &Handle, cidr: Ipv4Net, gw: IpAddr) -> crat
 
     let res = handle
         .route()
-        .add()
-        .v4()
-        .destination_prefix(cidr.network(), cidr.prefix_len())
-        .gateway(gw_v4)
+        .add(
+            RouteMessageBuilder::<Ipv4Addr>::new()
+                .destination_prefix(cidr.network(), cidr.prefix_len())
+                .gateway(gw_v4)
+                .build(),
+        )
         .execute()
         .await;
 
@@ -78,9 +77,11 @@ pub async fn add_via_gateway(handle: &Handle, cidr: Ipv4Net, gw: IpAddr) -> crat
 pub async fn remove(handle: &Handle, cidr: Ipv4Net) -> crate::Result<()> {
     use futures::TryStreamExt;
     use netlink_packet_route::route::{RouteAddress, RouteAttribute};
-    use rtnetlink::IpVersion;
 
-    let mut routes = handle.route().get(IpVersion::V4).execute();
+    let mut routes = handle
+        .route()
+        .get(RouteMessageBuilder::<Ipv4Addr>::new().build())
+        .execute();
     while let Some(msg) = routes.try_next().await.map_err(|e| NetworkError::Route {
         op: "list_routes",
         cidr,

--- a/crates/temps-network/src/linux/vxlan.rs
+++ b/crates/temps-network/src/linux/vxlan.rs
@@ -7,7 +7,7 @@
 
 use crate::error::NetworkError;
 use crate::linux::bridge::link_index_by_name;
-use rtnetlink::Handle;
+use rtnetlink::{Handle, LinkUnspec, LinkVxlan};
 use std::net::IpAddr;
 use std::process::Stdio;
 use tokio::process::Command;
@@ -32,8 +32,7 @@ pub async fn ensure(
         // and the integration tests will catch it.
         handle
             .link()
-            .set(idx)
-            .mtu(mtu)
+            .set(LinkUnspec::new_with_index(idx).mtu(mtu).build())
             .execute()
             .await
             .map_err(|e| NetworkError::Vxlan {
@@ -42,8 +41,7 @@ pub async fn ensure(
             })?;
         handle
             .link()
-            .set(idx)
-            .up()
+            .set(LinkUnspec::new_with_index(idx).up().build())
             .execute()
             .await
             .map_err(|e| NetworkError::Vxlan {
@@ -63,11 +61,13 @@ pub async fn ensure(
 
     handle
         .link()
-        .add()
-        .vxlan(name.into(), vni)
-        .link(parent_index)
-        .port(port)
-        .learning(false)
+        .add(
+            LinkVxlan::new(name, vni)
+                .dev(parent_index)
+                .port(port)
+                .learning(false)
+                .build(),
+        )
         .execute()
         .await
         .map_err(|e| NetworkError::Vxlan {
@@ -84,8 +84,7 @@ pub async fn ensure(
 
     handle
         .link()
-        .set(idx)
-        .mtu(mtu)
+        .set(LinkUnspec::new_with_index(idx).mtu(mtu).build())
         .execute()
         .await
         .map_err(|e| NetworkError::Vxlan {
@@ -95,8 +94,7 @@ pub async fn ensure(
 
     handle
         .link()
-        .set(idx)
-        .up()
+        .set(LinkUnspec::new_with_index(idx).up().build())
         .execute()
         .await
         .map_err(|e| NetworkError::Vxlan {
@@ -130,8 +128,11 @@ pub async fn enslave_to_bridge(
 
     handle
         .link()
-        .set(vxlan_idx)
-        .controller(bridge_idx)
+        .set(
+            LinkUnspec::new_with_index(vxlan_idx)
+                .controller(bridge_idx)
+                .build(),
+        )
         .execute()
         .await
         .map_err(|e| NetworkError::Vxlan {

--- a/crates/temps-network/tests/dind/run.sh
+++ b/crates/temps-network/tests/dind/run.sh
@@ -118,6 +118,17 @@ install_toolchain "$NODE_B"
 # ---------------------------------------------------------------------------
 # 4. Run the kernel-touching tests inside node A
 # ---------------------------------------------------------------------------
+# `cargo test` runs tests in alphabetical order, not declaration order, and
+# every other test in this file calls the `fixture()` helper, which tears
+# down all kernel/docker state (`cleanup_all()`) before it runs. bootstrap_only
+# is deliberately the one test that does NOT clean up after itself, so the
+# node-B step and the container-ping step below can find its state — but
+# alphabetically it sorts before `bridge_address_outside_cidr_rejected`,
+# `docker_cidr_collision_is_detected`, `reconcile_peers_*`, and
+# `teardown_removes_everything_and_is_idempotent`, all of which run after it
+# and immediately wipe out what it left behind. Run it as its own filtered
+# pass, strictly after everything else, so its state actually survives to
+# the container-ping step.
 log "running kernel integration tests in $NODE_A"
 docker exec \
   -e TEMPS_IT_LOCAL_NAME=node-a \
@@ -130,10 +141,25 @@ docker exec \
   "$NODE_A" sh -c '
     cd /workspace
     export PATH=/root/.cargo/bin:$PATH
-    cargo test -p temps-network --features integration_kernel --test it_kernel -- --test-threads=1 --nocapture
+    cargo test -p temps-network --features integration_kernel --test it_kernel -- --skip bootstrap_only --test-threads=1 --nocapture
   ' || fail "kernel tests failed in $NODE_A"
 
 log "kernel integration tests passed in $NODE_A"
+
+log "bootstrapping $NODE_A for the cross-host scenario (must run last: see comment above)"
+docker exec \
+  -e TEMPS_IT_LOCAL_NAME=node-a \
+  -e TEMPS_IT_LOCAL_CIDR=172.20.1.0/24 \
+  -e TEMPS_IT_LOCAL_BRIDGE_IP=172.20.1.1 \
+  -e TEMPS_IT_LOCAL_UNDERLAY="$NODE_A_IP" \
+  -e TEMPS_IT_PEER_CIDR=172.20.2.0/24 \
+  -e TEMPS_IT_PEER_UNDERLAY="$NODE_B_IP" \
+  -e TEMPS_RUN_DIND_TESTS=1 \
+  "$NODE_A" sh -c '
+    cd /workspace
+    export PATH=/root/.cargo/bin:$PATH
+    cargo test -p temps-network --features integration_kernel --test it_kernel bootstrap_only -- --test-threads=1 --nocapture
+  ' || fail "node-a bootstrap failed"
 
 # ---------------------------------------------------------------------------
 # 5. Two-node cross-host ping scenario

--- a/crates/temps-network/tests/it_kernel.rs
+++ b/crates/temps-network/tests/it_kernel.rs
@@ -509,10 +509,24 @@ async fn bootstrap_only() {
     // testing using the bootstrapped state.
     let env = Env::from_env();
     cleanup_all().await;
-    let mgr = NetworkManager::new(env.config()).expect("manager new");
-    mgr.bootstrap(env.alloc(), vec![env.peer()])
+    let cfg = env.config();
+    let alloc = env.alloc();
+    let mgr = NetworkManager::new(cfg.clone()).expect("manager new");
+    mgr.bootstrap(alloc.clone(), vec![env.peer()])
         .await
         .expect("bootstrap_only");
     // Give the kernel a moment to settle FDB / route additions.
     tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Mirror what the production caller (temps-agent's network_sync.rs)
+    // does right after bootstrap: create the Docker bridge network pinned
+    // to the kernel bridge we just brought up. `NetworkManager::bootstrap`
+    // deliberately stays pure of bollard (see `bootstrap_creates_docker_network`
+    // above), so callers that need containers on the overlay — including the
+    // DinD harness's cross-host container-ping step in run.sh — must create
+    // it themselves.
+    let docker = bollard::Docker::connect_with_local_defaults().expect("docker connect");
+    temps_network::docker::ensure_network(&docker, &cfg, &alloc)
+        .await
+        .expect("ensure docker network");
 }

--- a/crates/temps-otel/src/storage/clickhouse/mod.rs
+++ b/crates/temps-otel/src/storage/clickhouse/mod.rs
@@ -948,6 +948,7 @@ impl OtelStorage for ClickHouseOtelStorage {
             let mut inserter = self
                 .ch
                 .insert::<ChSpanRow>("spans")
+                .await
                 .map_err(|e| ch_ingest_err("store_spans (inserter setup)", e))?;
 
             for span in chunk {
@@ -2014,6 +2015,7 @@ impl OtelStorage for ClickHouseOtelStorage {
             let mut inserter = self
                 .ch
                 .insert::<ChMetricRow>("metrics")
+                .await
                 .map_err(|e| ch_ingest_err("store_metrics (inserter setup)", e))?;
 
             for point in chunk {

--- a/crates/temps-proxy/src/storage/clickhouse.rs
+++ b/crates/temps-proxy/src/storage/clickhouse.rs
@@ -880,6 +880,7 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
             let mut inserter = self
                 .client
                 .insert::<ChProxyLogRow>("proxy_logs")
+                .await
                 .map_err(|e| ProxyLogServiceError::ClickHouse {
                     operation: "write_batch (inserter setup)".to_string(),
                     reason: e.to_string(),

--- a/web/src/components/containers/ContainerActionDialog.tsx
+++ b/web/src/components/containers/ContainerActionDialog.tsx
@@ -7,10 +7,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import { startContainer, stopContainer, restartContainer } from '@/api/client'
 import {
-  startContainerMutation,
-  stopContainerMutation,
-  restartContainerMutation,
   listContainersOptions,
   getContainerDetailOptions,
 } from '@/api/client/@tanstack/react-query.gen'
@@ -53,20 +51,14 @@ export function ContainerActionDialog({
       }
 
       if (action === 'start') {
-        const options = startContainerMutation()
-        if (options.mutationFn) {
-          return await options.mutationFn(baseParams)
-        }
+        const { data } = await startContainer({ ...baseParams, throwOnError: true })
+        return data
       } else if (action === 'stop') {
-        const options = stopContainerMutation()
-        if (options.mutationFn) {
-          return await options.mutationFn(baseParams)
-        }
+        const { data } = await stopContainer({ ...baseParams, throwOnError: true })
+        return data
       } else if (action === 'restart') {
-        const options = restartContainerMutation()
-        if (options.mutationFn) {
-          return await options.mutationFn(baseParams)
-        }
+        const { data } = await restartContainer({ ...baseParams, throwOnError: true })
+        return data
       }
       throw new Error(`Invalid action: ${action}`)
     },

--- a/web/src/components/settings/DockerRegistrySettings.tsx
+++ b/web/src/components/settings/DockerRegistrySettings.tsx
@@ -23,10 +23,14 @@ export interface DockerRegistrySettings {
   ca_certificate: string | null
 }
 
+interface DockerRegistryFormValues {
+  docker_registry: DockerRegistrySettings
+}
+
 interface DockerRegistrySettingsProps {
-  control: Control<any>
-  register: UseFormRegister<any>
-  setValue: UseFormSetValue<any>
+  control: Control<DockerRegistryFormValues>
+  register: UseFormRegister<DockerRegistryFormValues>
+  setValue: UseFormSetValue<DockerRegistryFormValues>
   dockerRegistry: DockerRegistrySettings | undefined
 }
 

--- a/web/src/components/settings/MonitoringSettings.tsx
+++ b/web/src/components/settings/MonitoringSettings.tsx
@@ -20,10 +20,14 @@ import { HardDrive, AlertTriangle } from 'lucide-react'
 import type { Control, UseFormRegister, UseFormSetValue } from 'react-hook-form'
 import type { DiskSpaceAlertSettings } from '@/api/platformSettings'
 
+interface MonitoringFormValues {
+  disk_space_alert: DiskSpaceAlertSettings
+}
+
 interface MonitoringSettingsProps {
-  control: Control<any>
-  register: UseFormRegister<any>
-  setValue: UseFormSetValue<any>
+  control: Control<MonitoringFormValues>
+  register: UseFormRegister<MonitoringFormValues>
+  setValue: UseFormSetValue<MonitoringFormValues>
   diskSpaceAlert: DiskSpaceAlertSettings | undefined
 }
 

--- a/web/src/components/settings/SecuritySettings.tsx
+++ b/web/src/components/settings/SecuritySettings.tsx
@@ -115,9 +115,9 @@ export interface SecuritySettingsFormData {
 }
 
 interface SecuritySettingsProps {
-  control: Control<any>
-  register: UseFormRegister<any>
-  setValue: UseFormSetValue<any>
+  control: Control<SecuritySettingsFormData>
+  register: UseFormRegister<SecuritySettingsFormData>
+  setValue: UseFormSetValue<SecuritySettingsFormData>
   securityHeaders: SecurityHeadersSettings | undefined
   rateLimiting: RateLimitSettings | undefined
 }


### PR DESCRIPTION
## Summary

`main`'s CI (`Rust Tests` workflow) has been red since two automated dependency-bump PRs landed without a full `cargo check`. This fixes both, plus an unrelated `Web TypeScript Check` regression from routine dependency updates.

- **`rtnetlink` 0.14.1 → 0.21.0** (#226): the crate replaced chained `LinkAddRequest`/`LinkSetRequest`/`RouteAddRequest` builder methods (`.bridge()`, `.vxlan()`, `.mtu()`, `.up()`, `.v4()`, `.controller()`) with a message-builder pattern (`LinkBridge`, `LinkVxlan`, `LinkUnspec`, `RouteMessageBuilder`). Fixes `temps-network`'s Linux-only bridge/vxlan/route modules.
- **`clickhouse` 0.13.3 → 0.15.1** (#238): `Client::insert()` became an `async fn` (previously synchronous), so every call site needs `.await` before chaining `.map_err()`/`.context()`/`.expect()` on the inserter. Fixes `temps-metrics`, `temps-proxy`, `temps-otel`, `temps-analytics-events`, and `temps-cli`'s backfill command.
- **Web TypeScript check** (added in #233): `@tanstack/react-query` 5.101.2 made `MutationFunction` require a second context argument, and `react-hook-form` 7.81.0 made `Control`'s validate config contravariant on field paths, breaking `Control<any>` assignability. Fixed `ContainerActionDialog` to call the SDK functions directly instead of the generated `mutationFn`, and typed the three settings components' props to their (single) caller's form shape instead of `<any>`.

The `rtnetlink` break was masking the `clickhouse` one: `cargo check` fails fast, so CI never got far enough into the workspace to compile the ClickHouse call sites and surface the second bug.

## Test plan

- [x] `cargo check`/`cargo clippy -- -D warnings` for `temps-network` cross-compiled to `x86_64-unknown-linux-gnu` (it's a Linux-only module, doesn't build on macOS) — clean
- [x] `cargo check --all-targets` for `temps-metrics`, `temps-proxy`, `temps-otel`, `temps-analytics-events`, `temps-cli` (native) — clean, 0 errors
- [x] `bunx tsc --noEmit` in `web/` — clean
- [x] CI green on this PR (Rust Tests + Web TypeScript Check)