### PR TITLE
security: gate unauthenticated admin endpoints + expand AI chat allowlist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2561,9 +2561,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5040,7 +5040,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "rcgen",
+ "rcgen 0.14.8",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -6686,7 +6686,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.2",
@@ -8417,6 +8417,20 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser 0.16.0",
+ "yasna 0.5.2",
+]
+
+[[package]]
+name = "rcgen"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
@@ -8427,7 +8441,7 @@ dependencies = [
  "rustls-pki-types",
  "time",
  "x509-parser 0.18.1",
- "yasna",
+ "yasna 0.6.0",
 ]
 
 [[package]]
@@ -10910,6 +10924,7 @@ dependencies = [
  "sea-orm",
  "serde",
  "serde_json",
+ "temps-auth",
  "temps-core",
  "temps-entities",
  "temps-geo",
@@ -11283,7 +11298,7 @@ dependencies = [
  "log",
  "once_cell",
  "rand 0.8.6",
- "rcgen",
+ "rcgen 0.13.2",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -11508,7 +11523,7 @@ dependencies = [
  "hyper-util",
  "instant-acme",
  "log",
- "rcgen",
+ "rcgen 0.14.8",
  "reqwest 0.12.28",
  "rustls",
  "rustls-native-certs",
@@ -11832,6 +11847,7 @@ dependencies = [
  "rand 0.8.6",
  "sea-orm",
  "serde",
+ "temps-auth",
  "temps-core",
  "temps-database",
  "temps-entities",
@@ -12548,7 +12564,7 @@ dependencies = [
  "pingora-openssl",
  "pingora-proxy",
  "rand 0.8.6",
- "rcgen",
+ "rcgen 0.13.2",
  "regex",
  "rustls",
  "rustls-pemfile",
@@ -12829,6 +12845,7 @@ name = "temps-static-files"
 version = "0.1.0-beta.42"
 dependencies = [
  "axum 0.8.9",
+ "temps-auth",
  "temps-config",
  "temps-core",
  "tokio",
@@ -15418,6 +15435,7 @@ dependencies = [
  "lazy_static",
  "nom 7.1.3",
  "oid-registry 0.7.1",
+ "ring",
  "rusticata-macros",
  "thiserror 1.0.69",
  "time",
@@ -15499,6 +15517,15 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yasna"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5040,7 +5040,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "rcgen 0.14.8",
+ "rcgen",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -8417,20 +8417,6 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
-dependencies = [
- "pem",
- "ring",
- "rustls-pki-types",
- "time",
- "x509-parser 0.16.0",
- "yasna 0.5.2",
-]
-
-[[package]]
-name = "rcgen"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
@@ -8441,7 +8427,7 @@ dependencies = [
  "rustls-pki-types",
  "time",
  "x509-parser 0.18.1",
- "yasna 0.6.0",
+ "yasna",
 ]
 
 [[package]]
@@ -11298,7 +11284,7 @@ dependencies = [
  "log",
  "once_cell",
  "rand 0.8.6",
- "rcgen 0.13.2",
+ "rcgen",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -11523,7 +11509,7 @@ dependencies = [
  "hyper-util",
  "instant-acme",
  "log",
- "rcgen 0.14.8",
+ "rcgen",
  "reqwest 0.12.28",
  "rustls",
  "rustls-native-certs",
@@ -12564,7 +12550,7 @@ dependencies = [
  "pingora-openssl",
  "pingora-proxy",
  "rand 0.8.6",
- "rcgen 0.13.2",
+ "rcgen",
  "regex",
  "rustls",
  "rustls-pemfile",
@@ -15435,7 +15421,6 @@ dependencies = [
  "lazy_static",
  "nom 7.1.3",
  "oid-registry 0.7.1",
- "ring",
  "rusticata-macros",
  "thiserror 1.0.69",
  "time",
@@ -15517,15 +15502,6 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "yasna"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
-dependencies = [
- "time",
-]
 
 [[package]]
 name = "yasna"

--- a/crates/temps-analytics-performance/Cargo.toml
+++ b/crates/temps-analytics-performance/Cargo.toml
@@ -12,6 +12,7 @@ temps-core = { path = "../temps-core" }
 temps-entities = { path = "../temps-entities" }
 temps-routes = { path = "../temps-routes" }
 temps-geo = { path = "../temps-geo" }
+temps-auth = { path = "../temps-auth" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/temps-analytics-performance/src/handlers/handler.rs
+++ b/crates/temps-analytics-performance/src/handlers/handler.rs
@@ -14,9 +14,44 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use temps_auth::{AuthContext, Permission, RequireAuth};
 use temps_core::DateTime;
 use tracing::{error, info};
 use utoipa::{OpenApi, ToSchema};
+
+/// Manual auth check for this crate's dashboard-query handlers.
+///
+/// These handlers predate the `Result<impl IntoResponse, Problem>` convention
+/// used elsewhere and return `(StatusCode, Json<ErrorResponse>)` instead, so
+/// they can't use the `permission_guard!`/`project_scope_guard!` macros
+/// directly (those return `Problem`). This mirrors the same two checks.
+fn require_analytics_read(
+    auth: &AuthContext,
+    project_id: i32,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    if !auth.has_permission(&Permission::AnalyticsRead) {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse {
+                error: "Insufficient permissions".to_string(),
+                details: Some("This operation requires the AnalyticsRead permission".to_string()),
+            }),
+        ));
+    }
+    if !auth.is_scoped_to_project(project_id) {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse {
+                error: "Cross-project access denied".to_string(),
+                details: Some(
+                    "This deployment token is scoped to a different project and cannot access this resource"
+                        .to_string(),
+                ),
+            }),
+        ));
+    }
+    Ok(())
+}
 
 #[derive(Deserialize, Clone, ToSchema)]
 pub struct PerformanceMetricsQuery {
@@ -160,13 +195,19 @@ pub fn configure_public_routes() -> Router<Arc<AppState>> {
     responses(
         (status = 200, description = "Successfully retrieved performance metrics", body = PerformanceMetricsResponse),
         (status = 400, description = "Invalid date format or missing parameters", body = ErrorResponse),
+        (status = 401, description = "Authentication required", body = ErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
-    )
+    ),
+    security(("bearer_auth" = []))
 )]
 async fn get_performance_metrics(
+    RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
     Query(query): Query<PerformanceMetricsQuery>,
 ) -> Result<Json<PerformanceMetricsResponse>, (StatusCode, Json<ErrorResponse>)> {
+    require_analytics_read(&auth, query.project_id)?;
+
     match state
         .performance_service
         .get_metrics(
@@ -209,13 +250,19 @@ async fn get_performance_metrics(
     responses(
         (status = 200, description = "Successfully retrieved metrics over time", body = MetricsOverTimeResponse),
         (status = 400, description = "Invalid date format or missing parameters", body = ErrorResponse),
+        (status = 401, description = "Authentication required", body = ErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
-    )
+    ),
+    security(("bearer_auth" = []))
 )]
 async fn get_metrics_over_time(
+    RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
     Query(query): Query<PerformanceMetricsQuery>,
 ) -> Result<Json<MetricsOverTimeResponse>, (StatusCode, Json<ErrorResponse>)> {
+    require_analytics_read(&auth, query.project_id)?;
+
     match state
         .performance_service
         .get_metrics_over_time(
@@ -258,13 +305,19 @@ async fn get_metrics_over_time(
     responses(
         (status = 200, description = "Successfully retrieved grouped page metrics", body = GroupedPageMetricsResponse),
         (status = 400, description = "Invalid date format, missing parameters, or invalid group_by value", body = ErrorResponse),
+        (status = 401, description = "Authentication required", body = ErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
-    )
+    ),
+    security(("bearer_auth" = []))
 )]
 async fn get_grouped_page_metrics(
+    RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
     Query(query): Query<GroupedPageMetricsQuery>,
 ) -> Result<Json<GroupedPageMetricsResponse>, (StatusCode, Json<ErrorResponse>)> {
+    require_analytics_read(&auth, query.project_id)?;
+
     let group_by = match query.group_by.as_str() {
         "path" => GroupBy::Path,
         "country" => GroupBy::Country,
@@ -321,13 +374,19 @@ async fn get_grouped_page_metrics(
     ),
     responses(
         (status = 200, description = "Successfully checked performance metrics availability", body = HasMetricsResponse),
+        (status = 401, description = "Authentication required", body = ErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
-    )
+    ),
+    security(("bearer_auth" = []))
 )]
 async fn has_performance_metrics(
+    RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
     Query(query): Query<HasMetricsQuery>,
 ) -> Result<Json<HasMetricsResponse>, (StatusCode, Json<ErrorResponse>)> {
+    require_analytics_read(&auth, query.project_id)?;
+
     match state
         .performance_service
         .has_metrics(query.project_id)

--- a/crates/temps-analytics-session-replay/src/handlers/handler.rs
+++ b/crates/temps-analytics-session-replay/src/handlers/handler.rs
@@ -12,6 +12,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use temps_auth::{deny_deployment_token, permission_guard, project_scope_guard, RequireAuth};
 use temps_core::error_builder::ErrorBuilder;
 use temps_core::problemdetails::Problem;
 use temps_core::RequestMetadata;
@@ -391,14 +392,21 @@ impl From<SessionReplayError> for Problem {
     responses(
         (status = 200, description = "Session replays retrieved successfully", body = GetProjectSessionReplaysResponse),
         (status = 400, description = "Bad request", body = ErrorResponse),
+        (status = 401, description = "Authentication required", body = ErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
-    tag = "Analytics"
+    tag = "Analytics",
+    security(("bearer_auth" = []))
 )]
 pub async fn get_project_session_replays(
+    RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
     Query(query): Query<GetProjectSessionReplaysQuery>,
 ) -> Result<Json<GetProjectSessionReplaysResponse>, Problem> {
+    permission_guard!(auth, AnalyticsRead);
+    project_scope_guard!(auth, query.project_id);
+
     debug!("Getting session replays for project: {}", query.project_id);
 
     let page = query.page.unwrap_or(1);
@@ -435,15 +443,24 @@ pub async fn get_project_session_replays(
     ),
     responses(
         (status = 200, description = "Session replays retrieved successfully", body = GetVisitorSessionsResponse),
+        (status = 401, description = "Authentication required", body = ErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
-    tag = "Analytics"
+    tag = "Analytics",
+    security(("bearer_auth" = []))
 )]
 pub async fn get_visitor_sessions(
+    RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
     Path(visitor_id): Path<i32>,
     Query(query): Query<GetVisitorSessionsQuery>,
 ) -> Result<Json<GetVisitorSessionsResponse>, Problem> {
+    permission_guard!(auth, AnalyticsRead);
+    // No project_id is available on this route (only visitor_id) — deny
+    // project-scoped deployment tokens outright rather than skip scoping.
+    deny_deployment_token!(auth);
+
     debug!("Getting session replays for visitor: {}", visitor_id);
 
     let page = query.page.unwrap_or(1);
@@ -480,15 +497,22 @@ pub async fn get_visitor_sessions(
     ),
     responses(
         (status = 200, description = "Session replay retrieved successfully", body = GetSessionReplayResponse),
+        (status = 401, description = "Authentication required", body = ErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ErrorResponse),
         (status = 404, description = "Session not found", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
-    tag = "Analytics"
+    tag = "Analytics",
+    security(("bearer_auth" = []))
 )]
 pub async fn get_session_replay(
+    RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
     Path((visitor_id, session_id)): Path<(i32, i32)>,
 ) -> Result<Json<GetSessionReplayResponse>, Problem> {
+    permission_guard!(auth, AnalyticsRead);
+    deny_deployment_token!(auth);
+
     debug!(
         "Getting session replay: {} for visitor: {}",
         session_id, visitor_id
@@ -516,15 +540,22 @@ pub async fn get_session_replay(
     ),
     responses(
         (status = 200, description = "Session replay with events retrieved successfully", body = SessionReplayWithEventsDto),
+        (status = 401, description = "Authentication required", body = ErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ErrorResponse),
         (status = 404, description = "Session not found", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
-    tag = "Analytics"
+    tag = "Analytics",
+    security(("bearer_auth" = []))
 )]
 pub async fn get_session_replay_events(
+    RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
     Path((visitor_id, session_id)): Path<(i32, i32)>,
 ) -> Result<Json<SessionReplayWithEventsDto>, Problem> {
+    permission_guard!(auth, AnalyticsRead);
+    deny_deployment_token!(auth);
+
     debug!(
         "Getting session replay events: {} for visitor: {}",
         session_id, visitor_id
@@ -551,16 +582,23 @@ pub async fn get_session_replay_events(
     request_body = UpdateSessionDurationRequest,
     responses(
         (status = 200, description = "Session duration updated successfully", body = UpdateSessionDurationResponse),
+        (status = 401, description = "Authentication required", body = ErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ErrorResponse),
         (status = 404, description = "Session not found", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
-    tag = "Analytics"
+    tag = "Analytics",
+    security(("bearer_auth" = []))
 )]
 pub async fn update_session_duration(
+    RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
     Path((visitor_id, session_id)): Path<(i32, String)>,
     Json(request): Json<UpdateSessionDurationRequest>,
 ) -> Result<Json<UpdateSessionDurationResponse>, Problem> {
+    permission_guard!(auth, AnalyticsWrite);
+    deny_deployment_token!(auth);
+
     debug!(
         "Updating duration for session: {} for visitor: {}",
         session_id, visitor_id
@@ -588,15 +626,22 @@ pub async fn update_session_duration(
     ),
     responses(
         (status = 200, description = "Session replay deleted successfully"),
+        (status = 401, description = "Authentication required", body = ErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ErrorResponse),
         (status = 404, description = "Session not found", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
-    tag = "Analytics"
+    tag = "Analytics",
+    security(("bearer_auth" = []))
 )]
 pub async fn delete_session_replay(
+    RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
     Path((visitor_id, session_id)): Path<(i32, String)>,
 ) -> Result<StatusCode, Problem> {
+    permission_guard!(auth, AnalyticsWrite);
+    deny_deployment_token!(auth);
+
     debug!(
         "Deleting session replay: {} for visitor: {}",
         session_id, visitor_id
@@ -624,16 +669,23 @@ pub async fn delete_session_replay(
     responses(
         (status = 200, description = "Events added successfully", body = AddEventsResponse),
         (status = 400, description = "Bad request", body = ErrorResponse),
+        (status = 401, description = "Authentication required", body = ErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ErrorResponse),
         (status = 404, description = "Session not found", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
-    tag = "Analytics"
+    tag = "Analytics",
+    security(("bearer_auth" = []))
 )]
 pub async fn add_events(
+    RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
     Path((visitor_id, session_id)): Path<(i32, String)>,
     Json(request): Json<AddEventsRequest>,
 ) -> Result<Json<AddEventsResponse>, Problem> {
+    permission_guard!(auth, AnalyticsWrite);
+    deny_deployment_token!(auth);
+
     debug!(
         "Adding events to session: {} for visitor: {}",
         session_id, visitor_id

--- a/crates/temps-backup/src/engines/dispatch.rs
+++ b/crates/temps-backup/src/engines/dispatch.rs
@@ -243,6 +243,7 @@ mod tests {
             health_metadata: None,
             metrics_enabled: false,
             default_backup_provisioned: false,
+            container_name: None,
         }
     }
 

--- a/crates/temps-backup/src/services/backup.rs
+++ b/crates/temps-backup/src/services/backup.rs
@@ -9346,6 +9346,7 @@ mod tests {
             health_metadata: Set(None),
             metrics_enabled: Set(false),
             default_backup_provisioned: Set(false),
+            container_name: Set(None),
             created_at: Set(chrono::Utc::now()),
             updated_at: Set(chrono::Utc::now()),
         };
@@ -9522,6 +9523,7 @@ mod tests {
             health_metadata: Set(None),
             metrics_enabled: Set(false),
             default_backup_provisioned: Set(false),
+            container_name: Set(None),
             created_at: Set(chrono::Utc::now()),
             updated_at: Set(chrono::Utc::now()),
         }
@@ -9955,6 +9957,7 @@ mod tests {
             health_metadata: Set(None),
             metrics_enabled: Set(false),
             default_backup_provisioned: Set(false),
+            container_name: Set(None),
             created_at: Set(chrono::Utc::now()),
             updated_at: Set(chrono::Utc::now()),
         }

--- a/crates/temps-cli/src/commands/serve/console.rs
+++ b/crates/temps-cli/src/commands/serve/console.rs
@@ -1917,6 +1917,16 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
                     // observability, runtime/deploy status, errors, and MASKED
                     // metadata. Adding an entry is a security decision — verify the
                     // operation's response contains NO decrypted secret/token/key.
+                    //
+                    // Analytics `custom_data`/`event_data` (freeform JSON on
+                    // visitors/events) is an ACCEPTED risk, not an oversight: it's
+                    // developer-controlled data the project operator already sends
+                    // themselves, gated by the same AnalyticsRead + project scope
+                    // as every other analytics tool below — not a platform secret.
+                    // Raw HTTP request/response headers (session logs) and
+                    // session-replay DOM/keystroke capture are excluded on purpose;
+                    // those can carry Authorization/Cookie values or typed
+                    // passwords and are a different risk class entirely.
                     let allowlist: Vec<String> = [
                         // ── OpenTelemetry: metrics / traces / logs / health ──
                         "query_metrics",
@@ -2028,12 +2038,141 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
                         // ── Analytics (the user's own traffic data) ──
                         "get_general_stats",
                         "get_visitor_stats",
+                        "get_visitors",
                         "get_today_stats",
                         "get_recent_activity",
                         "get_events_timeline",
                         "get_events_count",
                         "get_page_paths",
                         "get_performance_metrics",
+                        // Aggregates / counts / booleans — no PII, no secrets
+                        "get_analytics_events_count",
+                        "get_event_detail",
+                        "get_visitor_facets",
+                        "check_analytics_has_events",
+                        "get_page_path_detail",
+                        "get_page_hourly_sessions",
+                        "get_page_paths_sparklines",
+                        "get_page_flow",
+                        "has_analytics_events",
+                        "get_event_type_breakdown",
+                        "get_active_visitors",
+                        "get_hourly_visits",
+                        "get_unique_counts",
+                        "get_aggregated_buckets",
+                        "get_dashboard_projects_analytics",
+                        "get_metrics_over_time",
+                        "get_grouped_page_metrics",
+                        "has_performance_metrics",
+                        "get_funnel_metrics",
+                        "list_funnels",
+                        "get_unique_events",
+                        // Per-visitor/session metadata — same risk class as
+                        // get_visitors/get_visitor_stats above (IP, geolocation,
+                        // user_agent, is_crawler, custom_data/event_data)
+                        "get_event_visitors",
+                        "get_visitor_details",
+                        "get_visitor_info",
+                        "get_analytics_visitor_sessions",
+                        "get_visitor_journey",
+                        "get_session_details",
+                        "get_session_events",
+                        "get_page_path_visitors",
+                        "get_analytics_active_visitors",
+                        "get_live_visitors_list",
+                        "get_visitor_by_id",
+                        "get_visitor_by_guid",
+                        // Excluded on purpose: get_property_breakdown /
+                        // get_property_timeline (developer custom-property VALUES
+                        // by name — held pending explicit review), get_session_logs
+                        // (raw request/response headers), and all
+                        // temps-analytics-session-replay reads (raw DOM/keystroke
+                        // capture) — see allowlist comment above.
+                        //
+                        // ── Auth / API keys / OIDC (masked keys/secrets only) ──
+                        "list_api_keys",
+                        "get_api_key",
+                        "list_public_providers",
+                        "list_oidc_providers",
+                        "list_oidc_provider_users",
+                        "list_oidc_role_mappings",
+                        "get_current_user",
+                        // ── Webhooks (no signing secrets — those are excluded) ──
+                        "list_webhooks",
+                        "get_webhook",
+                        "list_deliveries",
+                        "get_delivery",
+                        "list_event_types",
+                        // ── KV / Blob: status only, no connection strings ──
+                        "kv_status",
+                        "blob_status",
+                        "blob_list",
+                        // ── Email: stats/tracking/DNS, no provider credentials ──
+                        "list_emails",
+                        "get_email",
+                        "get_email_stats",
+                        "list_email_domains",
+                        "get_global_event_stats",
+                        "get_global_events",
+                        "get_email_tracking",
+                        "get_email_events",
+                        "get_email_links",
+                        // ── Git: provider/connection/repo metadata, no OAuth tokens ──
+                        "list_git_providers",
+                        "get_git_provider",
+                        "list_connections",
+                        "list_repositories_by_connection",
+                        "list_repositories_by_provider",
+                        "list_synced_repositories",
+                        "get_repository_preset_by_name",
+                        "get_repository_by_name",
+                        "get_public_branches",
+                        "get_public_repository",
+                        // ── Agents / skills / MCP / sandbox — config + run status ──
+                        "list_agents",
+                        "get_agent",
+                        "list_skills",
+                        "get_skill",
+                        "list_mcps",
+                        "get_mcp",
+                        "list_global_skills",
+                        "get_global_skill",
+                        "list_global_mcps",
+                        "get_global_mcp",
+                        "get_run",
+                        "get_cli_status",
+                        "get_sandbox_status",
+                        "get_global_sandbox_status",
+                        // ── AI Gateway: masked keys, usage/cost stats, conversations ──
+                        "list_models",
+                        "get_usage_summary",
+                        "get_usage_by_provider",
+                        "get_usage_timeseries",
+                        "get_usage_top_models",
+                        "get_usage_recent",
+                        "get_conversations",
+                        "get_conversation_detail",
+                        "get_pricing",
+                        "list_provider_keys",
+                        // ── Status page: monitors/incidents/uptime ──
+                        "list_monitors",
+                        "get_monitor",
+                        "get_uptime_history",
+                        "get_bucketed_status",
+                        "list_incidents",
+                        "get_incident",
+                        "get_incident_updates",
+                        "get_bucketed_incidents",
+                        // ── Vulnerability scanning: results, no credentials ──
+                        "list_project_scans",
+                        "get_scan",
+                        "get_scan_vulnerabilities",
+                        "get_latest_scan",
+                        "get_latest_scans_per_environment",
+                        "get_scan_by_deployment",
+                        // ── Import ──
+                        "list_sources",
+                        "get_import_status",
                     ]
                     .iter()
                     .map(|s| s.to_string())

--- a/crates/temps-cli/src/commands/serve/console.rs
+++ b/crates/temps-cli/src/commands/serve/console.rs
@@ -81,6 +81,22 @@ use utoipa_swagger_ui::SwaggerUi;
 // Embed the dist directory at compile time
 static WEBSITE: Dir = include_dir!("$CARGO_MANIFEST_DIR/dist");
 
+/// Optional replacement UI bundle supplied by an embedding binary (EE,
+/// VibeTemps, ...) via [`crate::set_embedded_ui`] before `dispatch`. When
+/// set, the SPA fallback serves this bundle at the document root instead of
+/// the OSS console. The OSS console's API surface is unaffected.
+static WEBSITE_OVERRIDE: std::sync::OnceLock<&'static Dir<'static>> = std::sync::OnceLock::new();
+
+pub(crate) fn set_embedded_ui(dir: &'static Dir<'static>) -> Result<(), &'static str> {
+    WEBSITE_OVERRIDE
+        .set(dir)
+        .map_err(|_| "embedded UI override already set")
+}
+
+fn website() -> &'static Dir<'static> {
+    WEBSITE_OVERRIDE.get().copied().unwrap_or(&WEBSITE)
+}
+
 /// Ensure the system user (id=0) exists in the database.
 /// Emit the anonymous `instance_started` telemetry event with non-identifying
 /// depth-of-usage counts (number of projects, environments, managed services,
@@ -612,7 +628,7 @@ async fn serve_static_file(req: Request) -> Response {
 
     debug!("Attempting to serve static file: {}", path);
 
-    match WEBSITE.get_file(path) {
+    match website().get_file(path) {
         Some(file) => {
             let mime_type = mime_guess::from_path(path)
                 .first_or_octet_stream()
@@ -638,7 +654,7 @@ async fn serve_static_file(req: Request) -> Response {
         }
         None => {
             // If file not found, try serving index.html (for SPA routing)
-            if let Some(index) = WEBSITE.get_file("index.html") {
+            if let Some(index) = website().get_file("index.html") {
                 debug!("File not found, serving index.html for SPA routing");
                 Response::builder()
                     .status(StatusCode::OK)

--- a/crates/temps-cli/src/commands/serve/console.rs
+++ b/crates/temps-cli/src/commands/serve/console.rs
@@ -93,6 +93,19 @@ pub(crate) fn set_embedded_ui(dir: &'static Dir<'static>) -> Result<(), &'static
         .map_err(|_| "embedded UI override already set")
 }
 
+/// Optional extra listener that serves the ORIGINAL temps console (admin API
+/// + original SPA bundle) when the document root has been overridden by an
+/// embedding binary. A separate listener — not a path prefix — because the
+/// console SPA assumes it owns its origin (absolute asset paths, client-side
+/// routing). Bind to loopback unless you mean to expose it.
+static PLATFORM_CONSOLE_ADDR: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+pub(crate) fn set_platform_console_addr(addr: String) -> Result<(), &'static str> {
+    PLATFORM_CONSOLE_ADDR
+        .set(addr)
+        .map_err(|_| "platform console address already set")
+}
+
 fn website() -> &'static Dir<'static> {
     WEBSITE_OVERRIDE.get().copied().unwrap_or(&WEBSITE)
 }
@@ -602,6 +615,16 @@ fn create_swagger_router(plugin_manager: &PluginManager) -> anyhow::Result<Route
 
 /// Static file handler for embedded website
 async fn serve_static_file(req: Request) -> Response {
+    serve_static_from(website(), req)
+}
+
+/// Same, but always the ORIGINAL console bundle (for the platform-console
+/// listener when the root bundle has been overridden by an embedding binary).
+async fn serve_original_console(req: Request) -> Response {
+    serve_static_from(&WEBSITE, req)
+}
+
+fn serve_static_from(site: &'static Dir<'static>, req: Request) -> Response {
     let raw_path = req.uri().path();
 
     // Never serve the SPA for /api/ paths — those should 404 if unmatched
@@ -628,7 +651,7 @@ async fn serve_static_file(req: Request) -> Response {
 
     debug!("Attempting to serve static file: {}", path);
 
-    match website().get_file(path) {
+    match site.get_file(path) {
         Some(file) => {
             let mime_type = mime_guess::from_path(path)
                 .first_or_octet_stream()
@@ -654,7 +677,7 @@ async fn serve_static_file(req: Request) -> Response {
         }
         None => {
             // If file not found, try serving index.html (for SPA routing)
-            if let Some(index) = website().get_file("index.html") {
+            if let Some(index) = site.get_file("index.html") {
                 debug!("File not found, serving index.html for SPA routing");
                 Response::builder()
                     .status(StatusCode::OK)
@@ -2359,6 +2382,17 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
     let public_app = Router::new()
         .merge(health_router(ready_flag.clone()))
         .nest("/api", public_router);
+
+    // Platform-console listener: when an embedding binary overrode the root
+    // bundle AND configured an address, serve the ORIGINAL console (same
+    // admin API + admin gate) on its own listener/origin.
+    let platform_router = if WEBSITE_OVERRIDE.get().is_some() && PLATFORM_CONSOLE_ADDR.get().is_some()
+    {
+        Some(admin_router.clone())
+    } else {
+        None
+    };
+
     let admin_app = Router::new()
         .nest("/api", admin_router)
         .fallback(serve_static_file);
@@ -2374,6 +2408,28 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
         admin_gate_handle.clone(),
         super::admin_gate::admin_gate,
     ));
+
+    if let (Some(router), Some(addr)) = (platform_router, PLATFORM_CONSOLE_ADDR.get()) {
+        let platform_app = Router::new()
+            .nest("/api", router)
+            .fallback(serve_original_console)
+            .layer(axum::middleware::from_fn_with_state(
+                admin_gate_handle.clone(),
+                super::admin_gate::admin_gate,
+            ));
+        let listener = TcpListener::bind(addr).await?;
+        info!("Platform console (original temps UI) listening on {addr}");
+        tokio::spawn(async move {
+            if let Err(e) = axum::serve(
+                listener,
+                platform_app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .await
+            {
+                tracing::error!("Platform console listener failed: {e}");
+            }
+        });
+    }
 
     info!("Plugin system initialized successfully with static file serving");
 

--- a/crates/temps-cli/src/commands/serve/console.rs
+++ b/crates/temps-cli/src/commands/serve/console.rs
@@ -94,7 +94,7 @@ pub(crate) fn set_embedded_ui(dir: &'static Dir<'static>) -> Result<(), &'static
 }
 
 /// Optional extra listener that serves the ORIGINAL temps console (admin API
-/// + original SPA bundle) when the document root has been overridden by an
+/// and original SPA bundle) when the document root has been overridden by an
 /// embedding binary. A separate listener — not a path prefix — because the
 /// console SPA assumes it owns its origin (absolute asset paths, client-side
 /// routing). Bind to loopback unless you mean to expose it.
@@ -2386,12 +2386,12 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
     // Platform-console listener: when an embedding binary overrode the root
     // bundle AND configured an address, serve the ORIGINAL console (same
     // admin API + admin gate) on its own listener/origin.
-    let platform_router = if WEBSITE_OVERRIDE.get().is_some() && PLATFORM_CONSOLE_ADDR.get().is_some()
-    {
-        Some(admin_router.clone())
-    } else {
-        None
-    };
+    let platform_router =
+        if WEBSITE_OVERRIDE.get().is_some() && PLATFORM_CONSOLE_ADDR.get().is_some() {
+            Some(admin_router.clone())
+        } else {
+            None
+        };
 
     let admin_app = Router::new()
         .nest("/api", admin_router)

--- a/crates/temps-cli/src/lib.rs
+++ b/crates/temps-cli/src/lib.rs
@@ -90,12 +90,26 @@ pub enum Commands {
 
 /// Install the global tracing subscriber. Safe to call once per process.
 pub fn install_tracing(log_level: &str, log_format: &str) {
+    install_tracing_extra(log_level, log_format, "");
+}
+
+/// Like [`install_tracing`], with extra filter directives appended — for
+/// embedding binaries whose own crate targets aren't in the default list
+/// (e.g. `vibetemps_api={level}`). `extra` is comma-separated directives,
+/// empty for none.
+pub fn install_tracing_extra(log_level: &str, log_format: &str, extra: &str) {
     let filter = if std::env::var("RUST_LOG").is_ok() {
         tracing_subscriber::EnvFilter::try_from_default_env()
             .expect("Invalid RUST_LOG environment variable")
     } else {
+        let extra = if extra.is_empty() {
+            String::new()
+        } else {
+            format!("{extra},")
+        };
         tracing_subscriber::EnvFilter::new(format!(
-            "temps_cli={level},\
+            "{extra}\
+             temps_cli={level},\
              temps_deployments={level},\
              temps_deployer={level},\
              temps_core={level},\

--- a/crates/temps-cli/src/lib.rs
+++ b/crates/temps-cli/src/lib.rs
@@ -191,6 +191,18 @@ pub fn install_tracing(log_level: &str, log_format: &str) {
         .expect("Failed to set global default subscriber");
 }
 
+// Re-exported so embedding binaries build their UI bundle with the exact
+// `include_dir` version this crate compares `Dir` types against.
+pub use include_dir;
+
+/// Replace the embedded console SPA with the embedding binary's own UI
+/// bundle. Call once, before [`dispatch`]. The bundle is served at the
+/// document root with the same SPA-fallback semantics as the OSS console;
+/// the `/api` surface is unaffected. Returns `Err` if already set.
+pub fn set_embedded_ui(dir: &'static include_dir::Dir<'static>) -> Result<(), &'static str> {
+    commands::serve::console::set_embedded_ui(dir)
+}
+
 /// Dispatch the parsed CLI. `extra_plugins` is forwarded to `temps serve`
 /// only; every other subcommand ignores it (they have no plugin lifecycle).
 pub fn dispatch(

--- a/crates/temps-cli/src/lib.rs
+++ b/crates/temps-cli/src/lib.rs
@@ -203,6 +203,16 @@ pub fn set_embedded_ui(dir: &'static include_dir::Dir<'static>) -> Result<(), &'
     commands::serve::console::set_embedded_ui(dir)
 }
 
+/// Serve the ORIGINAL temps console on its own dedicated listener (extra
+/// port) when the root bundle has been replaced via [`set_embedded_ui`].
+/// The console SPA assumes it owns its origin, so a path prefix cannot work;
+/// a separate listener gives it a clean origin. Same `/api`, same auth and
+/// admin gate. Bind to loopback (e.g. `127.0.0.1:8082`) unless you
+/// deliberately want it exposed. Call once, before [`dispatch`].
+pub fn set_platform_console_addr(addr: impl Into<String>) -> Result<(), &'static str> {
+    commands::serve::console::set_platform_console_addr(addr.into())
+}
+
 /// Dispatch the parsed CLI. `extra_plugins` is forwarded to `temps serve`
 /// only; every other subcommand ignores it (they have no plugin lifecycle).
 pub fn dispatch(

--- a/crates/temps-core/Cargo.toml
+++ b/crates/temps-core/Cargo.toml
@@ -45,7 +45,12 @@ arc-swap = "1.7"
 # Per-cluster CA + per-node certificate issuance for multi-node mTLS (ADR-020 WS-2.1).
 # Pinned to match temps-domains; x509-parser feature enables loading an existing CA
 # and parsing CSRs.
-rcgen = { version = "0.14.8", features = ["x509-parser"] }
+# NOTE: pinned below 0.14 -- the 0.14.8 bump (dependabot PR #222) breaks
+# node_pki.rs: `CertificateParams::from_ca_cert_pem` was removed (0.14 moved
+# CA-signing to the new `Issuer` API) and `Ia5String` is no longer re-exported.
+# Same failure class as the sha2 0.11 bump reverted in #247. Revert until
+# node_pki is migrated to the 0.14 Issuer API in a dedicated PR.
+rcgen = { version = "0.13.2", features = ["x509-parser"] }
 
 # Internal dependencies - only core dependencies to avoid cycles
 temps-memory = { path = "../temps-memory" }

--- a/crates/temps-core/Cargo.toml
+++ b/crates/temps-core/Cargo.toml
@@ -43,14 +43,10 @@ cookie = { workspace = true }
 ipnet = "2.10"
 arc-swap = "1.7"
 # Per-cluster CA + per-node certificate issuance for multi-node mTLS (ADR-020 WS-2.1).
-# Pinned to match temps-domains; x509-parser feature enables loading an existing CA
-# and parsing CSRs.
-# NOTE: pinned below 0.14 -- the 0.14.8 bump (dependabot PR #222) breaks
-# node_pki.rs: `CertificateParams::from_ca_cert_pem` was removed (0.14 moved
-# CA-signing to the new `Issuer` API) and `Ia5String` is no longer re-exported.
-# Same failure class as the sha2 0.11 bump reverted in #247. Revert until
-# node_pki is migrated to the 0.14 Issuer API in a dedicated PR.
-rcgen = { version = "0.13.2", features = ["x509-parser"] }
+# x509-parser feature enables loading an existing CA and parsing CSRs. Uses the
+# workspace 0.14.8; node_pki.rs was migrated to the 0.14 `Issuer` API in #250
+# (merged from main), so the earlier 0.13.2 pin is no longer needed.
+rcgen = { workspace = true }
 
 # Internal dependencies - only core dependencies to avoid cycles
 temps-memory = { path = "../temps-memory" }

--- a/crates/temps-deployer/src/node_metrics.rs
+++ b/crates/temps-deployer/src/node_metrics.rs
@@ -1,0 +1,86 @@
+//! Node resource-metric collection.
+//!
+//! Single source of truth for the `nodes.capacity` JSON shape, shared by:
+//! - the worker agent's heartbeat loop (`temps-agent`), which reports a worker's
+//!   resources to the control plane, and
+//! - the control plane's own self-reporting loop (`temps serve`), which reports
+//!   the control-plane node's resources in-process.
+//!
+//! Keeping a single collector guarantees both rows carry an identical shape so
+//! the nodes UI renders control-plane and worker resources the same way.
+
+/// Recommended minimum delay between the two CPU samples. CPU usage is a delta
+/// between successive refreshes, so a single refresh always reads ~0%; sysinfo
+/// recommends ~200ms between samples for an accurate reading.
+const CPU_SAMPLE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(200);
+
+/// Collect this host's CPU/memory/disk usage as the `capacity` JSON stored on a
+/// node's heartbeat.
+///
+/// Fields:
+/// - `cpu_percent`: global CPU utilisation (0–100, summed across cores / core count)
+/// - `memory_used_bytes` / `memory_total_bytes`
+/// - `disk_used_bytes` / `disk_total_bytes` for the root (`/`) mount
+///
+/// Async because it samples the CPU twice with a short delay in between — a
+/// single sample would always report 0% on the first refresh.
+pub async fn collect_capacity_metrics() -> serde_json::Value {
+    use sysinfo::{CpuExt, DiskExt, SystemExt};
+
+    let mut sys = sysinfo::System::new();
+    // Two CPU samples a short interval apart so cpu_percent reflects real load
+    // instead of a cold 0 on the first refresh.
+    sys.refresh_cpu();
+    tokio::time::sleep(CPU_SAMPLE_INTERVAL).await;
+    sys.refresh_cpu();
+    sys.refresh_memory();
+    sys.refresh_disks_list();
+    sys.refresh_disks();
+
+    // Use only the root mount point to avoid double-counting overlapping mounts.
+    let (disk_used, disk_total) = sys
+        .disks()
+        .iter()
+        .find(|d| d.mount_point() == std::path::Path::new("/"))
+        .map(|d| (d.total_space() - d.available_space(), d.total_space()))
+        .unwrap_or((0, 0));
+
+    serde_json::json!({
+        "cpu_percent": sys.global_cpu_info().cpu_usage(),
+        "memory_used_bytes": sys.used_memory(),
+        "memory_total_bytes": sys.total_memory(),
+        "disk_used_bytes": disk_used,
+        "disk_total_bytes": disk_total,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn collect_capacity_metrics_has_expected_shape() {
+        let capacity = collect_capacity_metrics().await;
+        let obj = capacity
+            .as_object()
+            .expect("capacity metrics should be a JSON object");
+
+        // The nodes UI keys off exactly these fields; all must be present and
+        // numeric so the control-plane and worker rows render identically.
+        for key in [
+            "cpu_percent",
+            "memory_used_bytes",
+            "memory_total_bytes",
+            "disk_used_bytes",
+            "disk_total_bytes",
+        ] {
+            let value = obj
+                .get(key)
+                .unwrap_or_else(|| panic!("capacity metrics missing key '{key}'"));
+            assert!(
+                value.is_number(),
+                "capacity metric '{key}' should be numeric, got {value}"
+            );
+        }
+    }
+}

--- a/crates/temps-deployments/src/services/job_processor.rs
+++ b/crates/temps-deployments/src/services/job_processor.rs
@@ -514,12 +514,13 @@ impl JobProcessorService {
     /// [`temps_core::DeploymentGateRecheckJob`] can call this same helper
     /// again once conditions change, without recreating anything.
     ///
-    /// `pub(crate)` — also called directly by the manual-deploy HTTP
-    /// handlers (`handlers::remote_deployments::{deploy_from_image,
-    /// deploy_from_image_upload, deploy_from_static}`), which run outside
-    /// the job-queue dispatch loop and would otherwise skip the gate
-    /// entirely.
-    pub(crate) async fn gate_check_then_run(
+    /// `pub` — also called directly by the manual-deploy HTTP handlers
+    /// (`handlers::remote_deployments::{deploy_from_image,
+    /// deploy_from_image_upload, deploy_from_static}`) and by embedding
+    /// binaries that create deployments in-process (e.g. vibetemps' Ship
+    /// It), all of which run outside the job-queue dispatch loop and would
+    /// otherwise skip the gate entirely.
+    pub async fn gate_check_then_run(
         db: &Arc<DbConnection>,
         workflow_executor: &Arc<WorkflowExecutionService>,
         deployment_gate: &Option<Arc<dyn temps_core::DeploymentGate>>,

--- a/crates/temps-deployments/src/services/remote_log_source.rs
+++ b/crates/temps-deployments/src/services/remote_log_source.rs
@@ -48,9 +48,9 @@ impl RemoteContainerLogSource for RemoteLogSourceImpl {
     async fn list_remote_containers(
         &self,
     ) -> Result<Vec<RemoteContainerInfo>, RemoteLogSourceError> {
-        use temps_entities::{deployment_containers, deployments, nodes};
+        use temps_entities::{deployment_containers, deployments, nodes, service_members};
 
-        // Currently-tracked containers that run on a remote worker node.
+        // Currently-tracked deployment containers that run on a remote worker node.
         let containers = deployment_containers::Entity::find()
             .filter(deployment_containers::Column::NodeId.is_not_null())
             .filter(deployment_containers::Column::DeletedAt.is_null())
@@ -58,12 +58,24 @@ impl RemoteContainerLogSource for RemoteLogSourceImpl {
             .await
             .map_err(|e| RemoteLogSourceError::Database(e.to_string()))?;
 
-        if containers.is_empty() {
+        // Cluster members (Postgres HA monitor/primary/replica, etc.) placed on
+        // a remote node. Their logs are invisible to the local collector too,
+        // so we pull them the same way — but they key on the owning external
+        // service rather than a project, so a remote replica's output surfaces
+        // under `/storage/{id}/logs` alongside control-plane-local members.
+        let members = service_members::Entity::find()
+            .filter(service_members::Column::NodeId.is_not_null())
+            .filter(service_members::Column::ContainerId.is_not_null())
+            .all(self.db.as_ref())
+            .await
+            .map_err(|e| RemoteLogSourceError::Database(e.to_string()))?;
+
+        if containers.is_empty() && members.is_empty() {
             return Ok(Vec::new());
         }
 
-        // Batch-resolve deployment → (project_id, environment_id) and
-        // node_id → node_name, avoiding per-container N+1 queries.
+        // Batch-resolve deployment → (project_id, environment_id), avoiding
+        // per-container N+1 queries.
         let deploy_ids: Vec<i32> = containers
             .iter()
             .map(|c| c.deployment_id)
@@ -79,9 +91,11 @@ impl RemoteContainerLogSource for RemoteLogSourceImpl {
             .map(|d| (d.id, (d.project_id, d.environment_id)))
             .collect();
 
+        // node_id → node_name for both deployment containers and cluster members.
         let node_ids: Vec<i32> = containers
             .iter()
             .filter_map(|c| c.node_id)
+            .chain(members.iter().filter_map(|m| m.node_id))
             .collect::<HashSet<_>>()
             .into_iter()
             .collect();
@@ -94,7 +108,14 @@ impl RemoteContainerLogSource for RemoteLogSourceImpl {
             .map(|n| (n.id, n.name))
             .collect();
 
-        let mut out = Vec::with_capacity(containers.len());
+        let node_name_for = |node_id: i32| {
+            node_map
+                .get(&node_id)
+                .cloned()
+                .unwrap_or_else(|| format!("node-{node_id}"))
+        };
+
+        let mut out = Vec::with_capacity(containers.len() + members.len());
         for c in containers {
             let Some(node_id) = c.node_id else {
                 continue;
@@ -104,10 +125,6 @@ impl RemoteContainerLogSource for RemoteLogSourceImpl {
             let Some(&(project_id, environment_id)) = dep_map.get(&c.deployment_id) else {
                 continue;
             };
-            let node_name = node_map
-                .get(&node_id)
-                .cloned()
-                .unwrap_or_else(|| format!("node-{node_id}"));
             // `service` mirrors the local collector's `sh.temps.service` label
             // semantics: compose service name when present, else the container
             // name. Container-level filtering (by container_id) is the precise
@@ -119,12 +136,33 @@ impl RemoteContainerLogSource for RemoteLogSourceImpl {
 
             out.push(RemoteContainerInfo {
                 node_id,
-                node_name,
+                node_name: node_name_for(node_id),
                 container_id: c.container_id,
                 project_id,
                 env: environment_id.to_string(),
                 service,
                 deploy_id: Some(c.deployment_id),
+                external_service_id: None,
+            });
+        }
+
+        for m in members {
+            let (Some(node_id), Some(container_id)) = (m.node_id, m.container_id) else {
+                continue;
+            };
+            out.push(RemoteContainerInfo {
+                node_id,
+                node_name: node_name_for(node_id),
+                container_id,
+                // Sentinel: external-service chunks key on external_service_id,
+                // not project_id (see the local collector's resolution).
+                project_id: 0,
+                env: "default".to_string(),
+                // Per-member container name so members stay distinguishable
+                // within the service's log scope.
+                service: m.container_name,
+                deploy_id: None,
+                external_service_id: Some(m.service_id),
             });
         }
 

--- a/crates/temps-entities/src/external_services.rs
+++ b/crates/temps-entities/src/external_services.rs
@@ -53,6 +53,14 @@ pub struct Model {
     /// `m20260623_000001_add_external_services_default_backup_provisioned`.
     #[sea_orm(default_value = false)]
     pub default_backup_provisioned: bool,
+    /// Real Docker container name this service's logs are collected under.
+    /// Plaintext (unlike the encrypted `config`) so the log collector can map
+    /// a running container back to its service without decryption. Set for
+    /// IMPORTED services to the pre-existing container's actual name (which
+    /// carries no `temps.*` labels); NULL for Temps-created services, which
+    /// the collector already resolves via the `temps.service_name` Docker
+    /// label. Added by `m20260707_000002_add_external_services_container_name`.
+    pub container_name: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/temps-entities/src/log_chunks.rs
+++ b/crates/temps-entities/src/log_chunks.rs
@@ -8,6 +8,11 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: Uuid,
     pub project_id: i32,
+    /// Set when this chunk belongs to an imported/managed external service
+    /// (Postgres, MariaDB, Redis, MongoDB, MinIO, …) rather than a deployment.
+    /// External-service chunks store `project_id = 0` (sentinel) and key on
+    /// this instead — a service isn't owned by a single project.
+    pub external_service_id: Option<i32>,
     pub env: String,
     pub service: String,
     pub container_id: String,

--- a/crates/temps-entities/src/log_events.rs
+++ b/crates/temps-entities/src/log_events.rs
@@ -13,6 +13,9 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub time: DBDateTime,
     pub project_id: i32,
+    /// Set for imported/managed external-service logs — see
+    /// `log_chunks::Model::external_service_id`.
+    pub external_service_id: Option<i32>,
     pub service: String,
     pub env: String,
     /// Normalized level: ERROR or WARN

--- a/crates/temps-geo/Cargo.toml
+++ b/crates/temps-geo/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = { workspace = true }
 temps-core = { path = "../temps-core" }
 temps-database = { path = "../temps-database" }
 temps-entities = { path = "../temps-entities" }
+temps-auth = { path = "../temps-auth" }
 utoipa = "5.1"
 tracing = { workspace = true }
 

--- a/crates/temps-geo/src/handlers.rs
+++ b/crates/temps-geo/src/handlers.rs
@@ -8,6 +8,7 @@ use axum::{
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
+use temps_auth::{permission_guard, RequireAuth};
 use temps_core::{
     problemdetails::{self, Problem},
     ProblemDetails,
@@ -98,14 +99,20 @@ impl From<(String, GeoLocation)> for GeoLocationResponse {
     responses(
         (status = 200, description = "Geolocation information retrieved", body = GeoLocationResponse),
         (status = 400, description = "Invalid IP address", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 403, description = "Insufficient permissions", body = ProblemDetails),
         (status = 404, description = "IP address not found in database", body = ProblemDetails),
         (status = 500, description = "Internal server error", body = ProblemDetails)
-    )
+    ),
+    security(("bearer_auth" = []))
 )]
 pub async fn get_ip_geolocation(
+    RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
     Path(ip_str): Path<String>,
 ) -> Result<impl IntoResponse, Problem> {
+    permission_guard!(auth, AnalyticsRead);
+
     // Parse IP address
     let ip = ip_str.parse().map_err(|_| {
         problemdetails::new(StatusCode::BAD_REQUEST)
@@ -136,6 +143,29 @@ mod tests {
     use super::*;
     use crate::MockGeoIpService;
 
+    fn test_auth_context() -> temps_auth::AuthContext {
+        let user = temps_entities::users::Model {
+            id: 1,
+            name: "Test User".to_string(),
+            email: "test@example.com".to_string(),
+            password_hash: Some("hashed".to_string()),
+            email_verified: true,
+            email_verification_token: None,
+            email_verification_expires: None,
+            password_reset_token: None,
+            password_reset_expires: None,
+            deleted_at: None,
+            mfa_secret: None,
+            mfa_enabled: false,
+            mfa_recovery_codes: None,
+            oidc_subject: None,
+            oidc_provider_id: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        temps_auth::AuthContext::new_session(user, temps_auth::Role::Admin)
+    }
+
     #[tokio::test]
     async fn test_get_ip_geolocation_success() {
         let geo_service = Arc::new(GeoIpService::Mock(MockGeoIpService::new()));
@@ -143,7 +173,12 @@ mod tests {
             geo_ip_service: geo_service,
         });
 
-        let result = get_ip_geolocation(State(state), Path("127.0.0.1".to_string())).await;
+        let result = get_ip_geolocation(
+            RequireAuth(test_auth_context()),
+            State(state),
+            Path("127.0.0.1".to_string()),
+        )
+        .await;
         assert!(result.is_ok(), "Should successfully geolocate localhost");
     }
 
@@ -154,7 +189,12 @@ mod tests {
             geo_ip_service: geo_service,
         });
 
-        let result = get_ip_geolocation(State(state), Path("not-an-ip".to_string())).await;
+        let result = get_ip_geolocation(
+            RequireAuth(test_auth_context()),
+            State(state),
+            Path("not-an-ip".to_string()),
+        )
+        .await;
         assert!(result.is_err(), "Should fail with invalid IP");
     }
 

--- a/crates/temps-git/src/handlers/public.rs
+++ b/crates/temps-git/src/handlers/public.rs
@@ -15,10 +15,11 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
     response::Json,
-    Router,
+    Extension, Router,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use temps_auth::AuthContext;
 use temps_core::problemdetails::{new as problem_new, Problem};
 use utoipa::{IntoParams, OpenApi, ToSchema};
 
@@ -140,6 +141,7 @@ fn map_error(err: PublicRepoError, owner: &str, repo: &str) -> Problem {
     tag = "Public Repositories"
 )]
 pub async fn get_public_branches(
+    auth: Option<Extension<AuthContext>>,
     State(state): State<Arc<AppState>>,
     Path((provider, owner, repo)): Path<(String, String, String)>,
     Query(params): Query<PublicRepoQueryParams>,
@@ -165,8 +167,9 @@ pub async fn get_public_branches(
     }
 
     // Try to get a token from any existing GitHub connection for higher rate limits
+    // (authenticated callers only — see get_github_token_from_connections)
     let token = if provider == "github" {
-        get_github_token_from_connections(&state).await
+        get_github_token_from_connections(&state, auth.is_some()).await
     } else {
         None
     };
@@ -232,13 +235,15 @@ pub async fn get_public_branches(
     tag = "Public Repositories"
 )]
 pub async fn detect_public_presets(
+    auth: Option<Extension<AuthContext>>,
     State(state): State<Arc<AppState>>,
     Path((provider, owner, repo)): Path<(String, String, String)>,
     Query(params): Query<PresetQueryParams>,
 ) -> Result<Json<PublicPresetResponse>, Problem> {
     // Try to get a token from any existing GitHub connection for higher rate limits
+    // (authenticated callers only — see get_github_token_from_connections)
     let token = if provider == "github" {
-        get_github_token_from_connections(&state).await
+        get_github_token_from_connections(&state, auth.is_some()).await
     } else {
         None
     };
@@ -360,12 +365,14 @@ pub async fn detect_public_presets(
     tag = "Public Repositories"
 )]
 pub async fn get_public_repository(
+    auth: Option<Extension<AuthContext>>,
     State(state): State<Arc<AppState>>,
     Path((provider, owner, repo)): Path<(String, String, String)>,
 ) -> Result<Json<PublicRepositoryInfo>, Problem> {
     // Try to get a token from any existing GitHub connection for higher rate limits
+    // (authenticated callers only — see get_github_token_from_connections)
     let token = if provider == "github" {
-        get_github_token_from_connections(&state).await
+        get_github_token_from_connections(&state, auth.is_some()).await
     } else {
         None
     };
@@ -435,7 +442,19 @@ pub struct PublicRepositoriesApiDoc;
 
 /// Try to get a GitHub access token from any configured GitHub connection.
 /// This avoids the 60 req/hr unauthenticated rate limit by using an existing token (5000 req/hr).
-async fn get_github_token_from_connections(state: &AppState) -> Option<String> {
+///
+/// Only ever returns a token for authenticated callers. These routes are
+/// intentionally public (no `RequireAuth` — see module docs), but that means
+/// an anonymous internet caller must not be able to silently spend the
+/// server's own GitHub OAuth quota; unauthenticated requests fall back to
+/// GitHub's unauthenticated rate limit instead.
+async fn get_github_token_from_connections(
+    state: &AppState,
+    is_authenticated: bool,
+) -> Option<String> {
+    if !is_authenticated {
+        return None;
+    }
     state.git_provider_manager.get_any_github_token().await
 }
 

--- a/crates/temps-log-aggregator/src/handlers/log_handler.rs
+++ b/crates/temps-log-aggregator/src/handlers/log_handler.rs
@@ -155,6 +155,10 @@ impl temps_core::AuditOperation for LogsPurgedAudit {
 pub struct SearchLogsRequest {
     /// Project ID (integer, as used by the rest of the platform)
     pub project_id: i32,
+    /// When set, search an imported/managed external service's logs instead
+    /// of a project's. `project_id` is ignored in this mode.
+    #[serde(default)]
+    pub external_service_id: Option<i32>,
     /// Start of time range (ISO 8601). Defaults to 1 hour ago.
     pub start_time: Option<String>,
     /// End of time range (ISO 8601). Defaults to now.
@@ -223,6 +227,10 @@ pub struct ContextLogsResponse {
 pub struct TailLogsRequest {
     /// Project ID (integer, as used by the rest of the platform)
     pub project_id: i32,
+    /// When set, tail an imported/managed external service's logs instead of
+    /// a project's (`project_id` is ignored in this mode).
+    #[serde(default)]
+    pub external_service_id: Option<i32>,
     pub service: String,
     pub env: String,
     #[serde(default)]
@@ -324,6 +332,7 @@ async fn search_logs(
 
     let filter = LogSearchFilter {
         project_id: request.project_id,
+        external_service_id: request.external_service_id,
         start_time,
         end_time,
         levels,
@@ -422,6 +431,7 @@ async fn tail_logs(
 
     let filter = TailFilter {
         project_id: request.project_id,
+        external_service_id: request.external_service_id,
         service: request.service,
         env: request.env,
         levels,
@@ -707,6 +717,7 @@ mod tests {
             service: service.to_string(),
             env: env.to_string(),
             project_id,
+            external_service_id: None,
             deploy_id: None,
             node_id: None,
             node_name: None,

--- a/crates/temps-log-aggregator/src/parser.rs
+++ b/crates/temps-log-aggregator/src/parser.rs
@@ -86,6 +86,7 @@ pub fn parse_log_line(
             service: ctx.service.clone(),
             env: ctx.env.clone(),
             project_id: ctx.project_id,
+            external_service_id: ctx.external_service_id,
             deploy_id: ctx.deploy_id,
             // node fields are stamped by the collector after parsing — the
             // parser only knows Docker-label-derived context, not platform
@@ -108,6 +109,7 @@ pub fn parse_log_line(
         service: ctx.service.clone(),
         env: ctx.env.clone(),
         project_id: ctx.project_id,
+        external_service_id: ctx.external_service_id,
         deploy_id: ctx.deploy_id,
         node_id: None,
         node_name: None,
@@ -306,6 +308,7 @@ mod tests {
     fn test_ctx() -> ContainerContext {
         ContainerContext {
             project_id: 1,
+            external_service_id: None,
             env: "1".to_string(),
             service: "web".to_string(),
             container_id: "abc123".to_string(),
@@ -475,6 +478,7 @@ mod tests {
     fn test_context_fields_applied() {
         let ctx = ContainerContext {
             project_id: 7,
+            external_service_id: None,
             env: "2".to_string(),
             service: "api".to_string(),
             container_id: "container-abc".to_string(),

--- a/crates/temps-log-aggregator/src/plugin.rs
+++ b/crates/temps-log-aggregator/src/plugin.rs
@@ -175,6 +175,7 @@ impl TempsPlugin for LogAggregatorPlugin {
             let metadata_service = context.require_service::<LogMetadataService>();
             let collector = context.require_service::<CollectorService>();
             let docker = context.require_service::<bollard::Docker>();
+            let db = context.require_service::<sea_orm::DatabaseConnection>();
             let retention_service = context.require_service::<RetentionService>();
             let retention_metadata = context.require_service::<LogMetadataService>();
 
@@ -265,6 +266,7 @@ impl TempsPlugin for LogAggregatorPlugin {
             // temporarily unavailable.
             let startup_collector = collector.clone();
             let startup_docker = docker.clone();
+            let startup_db = db.clone();
             tokio::spawn(async move {
                 use bollard::query_parameters::ListContainersOptions;
                 use std::collections::{HashMap, HashSet};
@@ -293,6 +295,44 @@ impl TempsPlugin for LogAggregatorPlugin {
                             Err(e) => {
                                 scan_result = Err(e);
                                 break;
+                            }
+                        }
+                    }
+
+                    // Imported external-service containers carry NO temps.*
+                    // labels, so the label scans above miss them. Discover them
+                    // by the plaintext container names recorded at import time
+                    // and add any that are running by name filter.
+                    if let Ok(ids) = scan_result.as_mut() {
+                        use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QuerySelect};
+                        let imported_names: Vec<String> =
+                            temps_entities::external_services::Entity::find()
+                                .filter(
+                                    temps_entities::external_services::Column::ContainerName
+                                        .is_not_null(),
+                                )
+                                .select_only()
+                                .column(temps_entities::external_services::Column::ContainerName)
+                                .into_tuple::<Option<String>>()
+                                .all(startup_db.as_ref())
+                                .await
+                                .unwrap_or_default()
+                                .into_iter()
+                                .flatten()
+                                .collect();
+                        for name in imported_names {
+                            let mut filters = HashMap::new();
+                            filters.insert("status".to_string(), vec!["running".to_string()]);
+                            filters.insert("name".to_string(), vec![name.clone()]);
+                            let options = ListContainersOptions {
+                                all: false,
+                                filters: Some(filters),
+                                ..Default::default()
+                            };
+                            if let Ok(containers) =
+                                startup_docker.list_containers(Some(options)).await
+                            {
+                                ids.extend(containers.into_iter().filter_map(|c| c.id));
                             }
                         }
                     }

--- a/crates/temps-log-aggregator/src/plugin.rs
+++ b/crates/temps-log-aggregator/src/plugin.rs
@@ -337,6 +337,42 @@ impl TempsPlugin for LogAggregatorPlugin {
                         }
                     }
 
+                    // Local cluster members (monitor/primary/replica) carry
+                    // deployment-style `sh.temps.service.*` labels the scans
+                    // above don't target, and their names live in
+                    // `service_members`, not on the service row. Discover the
+                    // control-plane-local ones (node_id IS NULL) by name — the
+                    // collector resolves each to its owning service via
+                    // `service_members.container_name`. Remote members are
+                    // handled separately by the remote collector.
+                    if let Ok(ids) = scan_result.as_mut() {
+                        use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QuerySelect};
+                        let member_names: Vec<String> =
+                            temps_entities::service_members::Entity::find()
+                                .filter(temps_entities::service_members::Column::NodeId.is_null())
+                                .select_only()
+                                .column(temps_entities::service_members::Column::ContainerName)
+                                .into_tuple::<String>()
+                                .all(startup_db.as_ref())
+                                .await
+                                .unwrap_or_default();
+                        for name in member_names {
+                            let mut filters = HashMap::new();
+                            filters.insert("status".to_string(), vec!["running".to_string()]);
+                            filters.insert("name".to_string(), vec![name.clone()]);
+                            let options = ListContainersOptions {
+                                all: false,
+                                filters: Some(filters),
+                                ..Default::default()
+                            };
+                            if let Ok(containers) =
+                                startup_docker.list_containers(Some(options)).await
+                            {
+                                ids.extend(containers.into_iter().filter_map(|c| c.id));
+                            }
+                        }
+                    }
+
                     match scan_result {
                         Ok(ids) => {
                             let count = ids.len();

--- a/crates/temps-log-aggregator/src/plugin.rs
+++ b/crates/temps-log-aggregator/src/plugin.rs
@@ -256,38 +256,57 @@ impl TempsPlugin for LogAggregatorPlugin {
             }
 
             // ── Container discovery: startup scan ───────────────────────
-            // Find already-running containers with sh.temps.* labels and start streaming.
-            // Retries with exponential backoff if Docker is temporarily unavailable.
+            // Find already-running containers and start streaming. Two label
+            // families are collected: deployment/application containers
+            // (`sh.temps.project_id`) and imported/managed external-service
+            // containers (`temps.service_type`). Docker's `label` filter ANDs
+            // multiple values, so each family needs its own list call; the IDs
+            // are unioned. Retries with exponential backoff if Docker is
+            // temporarily unavailable.
             let startup_collector = collector.clone();
             let startup_docker = docker.clone();
             tokio::spawn(async move {
                 use bollard::query_parameters::ListContainersOptions;
-                use std::collections::HashMap;
+                use std::collections::{HashMap, HashSet};
+
+                let scan_labels = ["sh.temps.project_id", "temps.service_type"];
 
                 let mut delay = STARTUP_SCAN_BASE_DELAY;
                 for attempt in 0..=STARTUP_SCAN_MAX_RETRIES {
-                    let mut filters = HashMap::new();
-                    filters.insert("status".to_string(), vec!["running".to_string()]);
-                    filters.insert("label".to_string(), vec!["sh.temps.project_id".to_string()]);
+                    let mut scan_result: Result<HashSet<String>, bollard::errors::Error> =
+                        Ok(HashSet::new());
+                    for label in scan_labels {
+                        let mut filters = HashMap::new();
+                        filters.insert("status".to_string(), vec!["running".to_string()]);
+                        filters.insert("label".to_string(), vec![label.to_string()]);
+                        let options = ListContainersOptions {
+                            all: false,
+                            filters: Some(filters),
+                            ..Default::default()
+                        };
+                        match startup_docker.list_containers(Some(options)).await {
+                            Ok(containers) => {
+                                if let Ok(ids) = scan_result.as_mut() {
+                                    ids.extend(containers.into_iter().filter_map(|c| c.id));
+                                }
+                            }
+                            Err(e) => {
+                                scan_result = Err(e);
+                                break;
+                            }
+                        }
+                    }
 
-                    let options = ListContainersOptions {
-                        all: false,
-                        filters: Some(filters),
-                        ..Default::default()
-                    };
-
-                    match startup_docker.list_containers(Some(options)).await {
-                        Ok(containers) => {
-                            let count = containers.len();
-                            for container in containers {
-                                if let Some(id) = container.id {
-                                    if let Err(e) = startup_collector.start_streaming(&id).await {
-                                        tracing::warn!(
-                                            container_id = %id,
-                                            error = %e,
-                                            "Failed to start streaming for existing container"
-                                        );
-                                    }
+                    match scan_result {
+                        Ok(ids) => {
+                            let count = ids.len();
+                            for id in ids {
+                                if let Err(e) = startup_collector.start_streaming(&id).await {
+                                    tracing::warn!(
+                                        container_id = %id,
+                                        error = %e,
+                                        "Failed to start streaming for existing container"
+                                    );
                                 }
                             }
                             tracing::info!(

--- a/crates/temps-log-aggregator/src/plugin.rs
+++ b/crates/temps-log-aggregator/src/plugin.rs
@@ -101,7 +101,8 @@ impl TempsPlugin for LogAggregatorPlugin {
                 chunk_writer.clone(),
                 collector_metadata.clone(),
                 10_000,
-            );
+            )
+            .with_db(db.clone());
 
             // Wire callback: when a chunk is flushed during streaming, insert chunk metadata into DB.
             // This callback runs in the collector's streaming task, so it must be Send + Sync.

--- a/crates/temps-log-aggregator/src/services/chunk_writer.rs
+++ b/crates/temps-log-aggregator/src/services/chunk_writer.rs
@@ -269,6 +269,7 @@ impl ChunkWriterService {
         let chunk_id = Uuid::new_v4();
         let first_line = &data.lines[0];
         let project_id = first_line.project_id;
+        let external_service_id = first_line.external_service_id;
         let service = first_line.service.clone();
         let env = first_line.env.clone();
         let deploy_id = first_line.deploy_id;
@@ -312,6 +313,7 @@ impl ChunkWriterService {
             .unwrap_or(0);
         let storage_key = build_storage_key(
             project_id,
+            external_service_id,
             &env,
             &service,
             &date,
@@ -344,6 +346,7 @@ impl ChunkWriterService {
             meta: ChunkMeta {
                 id: chunk_id,
                 project_id,
+                external_service_id,
                 env,
                 service,
                 container_id: container_id.to_string(),
@@ -388,6 +391,7 @@ mod tests {
             service: "web".to_string(),
             env: "1".to_string(),
             project_id: 1,
+            external_service_id: None,
             deploy_id: None,
             node_id: None,
             node_name: None,

--- a/crates/temps-log-aggregator/src/services/collector.rs
+++ b/crates/temps-log-aggregator/src/services/collector.rs
@@ -56,6 +56,10 @@ pub struct CollectorService {
     docker: Arc<Docker>,
     chunk_writer: Arc<ChunkWriterService>,
     metadata_service: Arc<LogMetadataService>,
+    /// DB handle used to resolve an imported external service's
+    /// `temps.service_name` label to its `external_services.id`. `None` in
+    /// tests that don't exercise external-service log collection.
+    db: Option<Arc<sea_orm::DatabaseConnection>>,
     /// Broadcast channel for live tail subscribers
     tail_tx: broadcast::Sender<LogLine>,
     /// Active streaming tasks per container_id
@@ -76,10 +80,19 @@ impl CollectorService {
             docker,
             chunk_writer,
             metadata_service,
+            db: None,
             tail_tx,
             active_streams: Mutex::new(HashMap::new()),
             on_chunk_flushed: None,
         }
+    }
+
+    /// Attach a DB handle so external-service containers (labelled
+    /// `temps.service_type`/`temps.service_name`) resolve to their
+    /// `external_services.id` and get first-class log history.
+    pub fn with_db(mut self, db: Arc<sea_orm::DatabaseConnection>) -> Self {
+        self.db = Some(db);
+        self
     }
 
     /// Set a callback that is invoked whenever a chunk is flushed.
@@ -264,6 +277,17 @@ impl CollectorService {
             None => return Ok(None),
         };
 
+        // Deployment/application containers carry `sh.temps.project_id`.
+        // Imported/managed external-service containers (Postgres, Redis, …)
+        // carry `temps.service_type` + `temps.service_name` instead (set by
+        // the providers) and have no project — collect their logs under the
+        // external-service dimension so they get the same history/search.
+        if !labels.contains_key(LABEL_PROJECT_ID) {
+            return self
+                .extract_external_service_context(container_id, labels)
+                .await;
+        }
+
         let project_id = match labels.get(LABEL_PROJECT_ID) {
             Some(id) => match id.parse::<i32>() {
                 Ok(pid) => pid,
@@ -286,10 +310,56 @@ impl CollectorService {
 
         Ok(Some(ContainerContext {
             project_id,
+            external_service_id: None,
             env,
             service,
             container_id: container_id.to_string(),
             deploy_id,
+        }))
+    }
+
+    /// Build context for an imported/managed external-service container from
+    /// its `temps.service_type`/`temps.service_name` labels. Resolves the
+    /// service name to `external_services.id` via the DB; skips (returns None)
+    /// if the labels are absent, no DB handle is attached, or no matching row
+    /// exists.
+    async fn extract_external_service_context(
+        &self,
+        container_id: &str,
+        labels: &std::collections::HashMap<String, String>,
+    ) -> Result<Option<ContainerContext>, LogAggregatorError> {
+        let prefix = temps_core::DOCKER_LABEL_PREFIX; // "temps."
+        let service_name = match labels.get(&format!("{prefix}service_name")) {
+            Some(name) => name.clone(),
+            None => return Ok(None),
+        };
+        let Some(db) = self.db.as_ref() else {
+            return Ok(None);
+        };
+
+        use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+        let svc = temps_entities::external_services::Entity::find()
+            .filter(temps_entities::external_services::Column::Name.eq(service_name.clone()))
+            .one(db.as_ref())
+            .await
+            .map_err(|e| LogAggregatorError::DockerStreamFailed {
+                container_id: container_id.to_string(),
+                reason: format!("Failed to resolve external service '{service_name}': {e}"),
+            })?;
+        let svc = match svc {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+
+        Ok(Some(ContainerContext {
+            // Sentinel: external-service chunks key on external_service_id, not
+            // project_id (a service isn't owned by a single project).
+            project_id: 0,
+            external_service_id: Some(svc.id),
+            env: "default".to_string(),
+            service: service_name,
+            container_id: container_id.to_string(),
+            deploy_id: None,
         }))
     }
 

--- a/crates/temps-log-aggregator/src/services/collector.rs
+++ b/crates/temps-log-aggregator/src/services/collector.rs
@@ -270,21 +270,31 @@ impl CollectorService {
                 }
             })?;
 
-        let labels = inspect.config.as_ref().and_then(|c| c.labels.as_ref());
+        // Real Docker container name (e.g. "legacy-postgres"), used to resolve
+        // imported external-service containers that carry no temps.* labels.
+        let container_name = inspect
+            .name
+            .as_deref()
+            .map(|n| n.trim_start_matches('/').to_string());
 
-        let labels = match labels {
-            Some(l) => l,
-            None => return Ok(None),
-        };
+        // Empty map when the container has no labels at all (e.g. an imported
+        // pre-existing container) — still fall through to the external-service
+        // resolution below rather than bailing out.
+        let empty_labels = std::collections::HashMap::new();
+        let labels = inspect
+            .config
+            .as_ref()
+            .and_then(|c| c.labels.as_ref())
+            .unwrap_or(&empty_labels);
 
         // Deployment/application containers carry `sh.temps.project_id`.
-        // Imported/managed external-service containers (Postgres, Redis, …)
-        // carry `temps.service_type` + `temps.service_name` instead (set by
-        // the providers) and have no project — collect their logs under the
-        // external-service dimension so they get the same history/search.
+        // Everything else is a candidate external-service container: either
+        // Temps-created (carries `temps.service_type`/`temps.service_name`
+        // labels) or IMPORTED (no temps.* labels — resolved by matching the
+        // real container name against `external_services.container_name`).
         if !labels.contains_key(LABEL_PROJECT_ID) {
             return self
-                .extract_external_service_context(container_id, labels)
+                .extract_external_service_context(container_id, container_name.as_deref(), labels)
                 .await;
         }
 
@@ -318,38 +328,68 @@ impl CollectorService {
         }))
     }
 
-    /// Build context for an imported/managed external-service container from
-    /// its `temps.service_type`/`temps.service_name` labels. Resolves the
-    /// service name to `external_services.id` via the DB; skips (returns None)
-    /// if the labels are absent, no DB handle is attached, or no matching row
-    /// exists.
+    /// Resolve an external-service container to its `external_services` row.
+    ///
+    /// Two resolution paths, in order:
+    ///  1. **Created** services carry a `temps.service_name` label → look the
+    ///     service up by name.
+    ///  2. **Imported** services' pre-existing containers have no temps.*
+    ///     labels (Docker labels are immutable) → match the real container
+    ///     name against the plaintext `external_services.container_name`
+    ///     column stamped at import time.
+    ///
+    /// Returns `None` (container skipped) when neither resolves, no DB handle
+    /// is attached, or the container has no name.
     async fn extract_external_service_context(
         &self,
         container_id: &str,
+        container_name: Option<&str>,
         labels: &std::collections::HashMap<String, String>,
     ) -> Result<Option<ContainerContext>, LogAggregatorError> {
-        let prefix = temps_core::DOCKER_LABEL_PREFIX; // "temps."
-        let service_name = match labels.get(&format!("{prefix}service_name")) {
-            Some(name) => name.clone(),
-            None => return Ok(None),
-        };
+        use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
         let Some(db) = self.db.as_ref() else {
             return Ok(None);
         };
+        let prefix = temps_core::DOCKER_LABEL_PREFIX; // "temps."
 
-        use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
-        let svc = temps_entities::external_services::Entity::find()
-            .filter(temps_entities::external_services::Column::Name.eq(service_name.clone()))
-            .one(db.as_ref())
-            .await
-            .map_err(|e| LogAggregatorError::DockerStreamFailed {
-                container_id: container_id.to_string(),
-                reason: format!("Failed to resolve external service '{service_name}': {e}"),
-            })?;
+        // Path 1: created service — resolve by the temps.service_name label.
+        // Path 2: imported service — resolve by the real container name.
+        let (svc, service_label) = if let Some(name) = labels.get(&format!("{prefix}service_name"))
+        {
+            let svc = temps_entities::external_services::Entity::find()
+                .filter(temps_entities::external_services::Column::Name.eq(name.clone()))
+                .one(db.as_ref())
+                .await
+                .map_err(|e| LogAggregatorError::DockerStreamFailed {
+                    container_id: container_id.to_string(),
+                    reason: format!("Failed to resolve external service '{name}': {e}"),
+                })?;
+            (svc, Some(name.clone()))
+        } else if let Some(cname) = container_name {
+            let svc = temps_entities::external_services::Entity::find()
+                .filter(temps_entities::external_services::Column::ContainerName.eq(cname))
+                .one(db.as_ref())
+                .await
+                .map_err(|e| LogAggregatorError::DockerStreamFailed {
+                    container_id: container_id.to_string(),
+                    reason: format!(
+                        "Failed to resolve imported service for container '{cname}': {e}"
+                    ),
+                })?;
+            (svc, None)
+        } else {
+            return Ok(None);
+        };
+
         let svc = match svc {
             Some(s) => s,
             None => return Ok(None),
         };
+
+        // Service name for display/grouping: the label if present, else the
+        // service's own name from the DB row.
+        let service = service_label.unwrap_or_else(|| svc.name.clone());
 
         Ok(Some(ContainerContext {
             // Sentinel: external-service chunks key on external_service_id, not
@@ -357,7 +397,7 @@ impl CollectorService {
             project_id: 0,
             external_service_id: Some(svc.id),
             env: "default".to_string(),
-            service: service_name,
+            service,
             container_id: container_id.to_string(),
             deploy_id: None,
         }))

--- a/crates/temps-log-aggregator/src/services/collector.rs
+++ b/crates/temps-log-aggregator/src/services/collector.rs
@@ -328,18 +328,28 @@ impl CollectorService {
         }))
     }
 
-    /// Resolve an external-service container to its `external_services` row.
+    /// Resolve an external-service container to its owning `external_services`
+    /// row, returning a context keyed on `external_service_id` (with the
+    /// `project_id = 0` sentinel, since a service isn't owned by one project).
     ///
-    /// Two resolution paths, in order:
-    ///  1. **Created** services carry a `temps.service_name` label → look the
-    ///     service up by name.
-    ///  2. **Imported** services' pre-existing containers have no temps.*
-    ///     labels (Docker labels are immutable) → match the real container
-    ///     name against the plaintext `external_services.container_name`
+    /// Three resolution paths, in order:
+    ///  1. **Created standalone** services carry a `temps.service_name` label
+    ///     → look the service up by name.
+    ///  2. **Imported standalone** services' pre-existing containers have no
+    ///     temps.* labels (Docker labels are immutable) → match the real
+    ///     container name against the plaintext `external_services.container_name`
     ///     column stamped at import time.
+    ///  3. **Cluster members** (monitor/primary/replica) carry deployment-style
+    ///     `sh.temps.service.*` labels the standalone paths don't recognise, and
+    ///     their per-member names live in `service_members`, not on the service
+    ///     row. Match the real container name against `service_members.container_name`
+    ///     → its `service_id` ties every member to the one external service, so
+    ///     the whole cluster's logs aggregate under one `/storage/{id}/logs`.
+    ///     The member container name becomes `service` so members stay
+    ///     distinguishable within that scope.
     ///
-    /// Returns `None` (container skipped) when neither resolves, no DB handle
-    /// is attached, or the container has no name.
+    /// Returns `None` (container skipped) when none resolve, no DB handle is
+    /// attached, or the container has no name.
     async fn extract_external_service_context(
         &self,
         container_id: &str,
@@ -353,10 +363,8 @@ impl CollectorService {
         };
         let prefix = temps_core::DOCKER_LABEL_PREFIX; // "temps."
 
-        // Path 1: created service — resolve by the temps.service_name label.
-        // Path 2: imported service — resolve by the real container name.
-        let (svc, service_label) = if let Some(name) = labels.get(&format!("{prefix}service_name"))
-        {
+        // Path 1: created standalone service — resolve by the temps.service_name label.
+        if let Some(name) = labels.get(&format!("{prefix}service_name")) {
             let svc = temps_entities::external_services::Entity::find()
                 .filter(temps_entities::external_services::Column::Name.eq(name.clone()))
                 .one(db.as_ref())
@@ -365,42 +373,64 @@ impl CollectorService {
                     container_id: container_id.to_string(),
                     reason: format!("Failed to resolve external service '{name}': {e}"),
                 })?;
-            (svc, Some(name.clone()))
-        } else if let Some(cname) = container_name {
-            let svc = temps_entities::external_services::Entity::find()
-                .filter(temps_entities::external_services::Column::ContainerName.eq(cname))
-                .one(db.as_ref())
-                .await
-                .map_err(|e| LogAggregatorError::DockerStreamFailed {
-                    container_id: container_id.to_string(),
-                    reason: format!(
-                        "Failed to resolve imported service for container '{cname}': {e}"
-                    ),
-                })?;
-            (svc, None)
-        } else {
+            return Ok(svc.map(|svc| ContainerContext {
+                project_id: 0,
+                external_service_id: Some(svc.id),
+                env: "default".to_string(),
+                service: name.clone(),
+                container_id: container_id.to_string(),
+                deploy_id: None,
+            }));
+        }
+
+        // Paths 2 & 3 both key off the real container name.
+        let Some(cname) = container_name else {
             return Ok(None);
         };
 
-        let svc = match svc {
-            Some(s) => s,
-            None => return Ok(None),
-        };
+        // Path 2: imported standalone service — real container name matches the
+        // plaintext external_services.container_name stamped at import.
+        if let Some(svc) = temps_entities::external_services::Entity::find()
+            .filter(temps_entities::external_services::Column::ContainerName.eq(cname))
+            .one(db.as_ref())
+            .await
+            .map_err(|e| LogAggregatorError::DockerStreamFailed {
+                container_id: container_id.to_string(),
+                reason: format!("Failed to resolve imported service for container '{cname}': {e}"),
+            })?
+        {
+            return Ok(Some(ContainerContext {
+                project_id: 0,
+                external_service_id: Some(svc.id),
+                env: "default".to_string(),
+                service: svc.name,
+                container_id: container_id.to_string(),
+                deploy_id: None,
+            }));
+        }
 
-        // Service name for display/grouping: the label if present, else the
-        // service's own name from the DB row.
-        let service = service_label.unwrap_or_else(|| svc.name.clone());
+        // Path 3: cluster member — real container name matches a
+        // service_members row; its service_id is the owning external service.
+        if let Some(member) = temps_entities::service_members::Entity::find()
+            .filter(temps_entities::service_members::Column::ContainerName.eq(cname))
+            .one(db.as_ref())
+            .await
+            .map_err(|e| LogAggregatorError::DockerStreamFailed {
+                container_id: container_id.to_string(),
+                reason: format!("Failed to resolve cluster member for container '{cname}': {e}"),
+            })?
+        {
+            return Ok(Some(ContainerContext {
+                project_id: 0,
+                external_service_id: Some(member.service_id),
+                env: "default".to_string(),
+                service: cname.to_string(),
+                container_id: container_id.to_string(),
+                deploy_id: None,
+            }));
+        }
 
-        Ok(Some(ContainerContext {
-            // Sentinel: external-service chunks key on external_service_id, not
-            // project_id (a service isn't owned by a single project).
-            project_id: 0,
-            external_service_id: Some(svc.id),
-            env: "default".to_string(),
-            service,
-            container_id: container_id.to_string(),
-            deploy_id: None,
-        }))
+        Ok(None)
     }
 
     /// Returns true if the error string indicates the container no longer exists.
@@ -552,5 +582,102 @@ impl CollectorService {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{FilesystemStorage, LogStorage};
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    /// Build a CollectorService backed by a MockDatabase. `extract_external_service_context`
+    /// only touches `self.db`, so the Docker handle is never dialed — but `new`
+    /// requires one, so we lazily construct a client (no daemon connection).
+    fn collector_with_db(db: Arc<sea_orm::DatabaseConnection>) -> Option<CollectorService> {
+        let docker = Docker::connect_with_local_defaults().ok()?;
+        let tmp = tempfile::tempdir().unwrap();
+        let storage: Arc<dyn LogStorage> =
+            Arc::new(FilesystemStorage::new(tmp.path().to_path_buf()).unwrap());
+        let chunk_writer = Arc::new(ChunkWriterService::new(storage));
+        let metadata = Arc::new(LogMetadataService::new(db.clone()));
+        Some(CollectorService::new(Arc::new(docker), chunk_writer, metadata, 16).with_db(db))
+    }
+
+    fn member(service_id: i32, container_name: &str) -> temps_entities::service_members::Model {
+        temps_entities::service_members::Model {
+            id: 1,
+            service_id,
+            node_id: None,
+            role: "primary".into(),
+            container_id: Some("abc123".into()),
+            container_name: container_name.into(),
+            hostname: None,
+            port: Some(5432),
+            compute_ip: None,
+            status: "running".into(),
+            ordinal: 1,
+            config: None,
+            provisioning_step: None,
+            provisioning_error: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    // A cluster member carries neither the standalone `temps.service_name` label
+    // (Path 1) nor an `external_services.container_name` match (Path 2); it must
+    // resolve via `service_members.container_name` → its owning service (Path 3),
+    // so every member's logs aggregate under the one external service.
+    #[tokio::test]
+    async fn test_cluster_member_resolves_via_service_members() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // Path 2: external_services by container_name → miss.
+            .append_query_results(vec![Vec::<temps_entities::external_services::Model>::new()])
+            // Path 3: service_members by container_name → the member.
+            .append_query_results(vec![vec![member(7, "postgres-mydb-1")]])
+            .into_connection();
+        let Some(collector) = collector_with_db(Arc::new(db)) else {
+            println!("Docker client unavailable, skipping");
+            return;
+        };
+
+        let labels = HashMap::new(); // no temps.service_name label
+        let ctx = collector
+            .extract_external_service_context("cid", Some("postgres-mydb-1"), &labels)
+            .await
+            .expect("resolution must not error")
+            .expect("cluster member should resolve to its owning external service");
+
+        assert_eq!(ctx.external_service_id, Some(7));
+        assert_eq!(
+            ctx.project_id, 0,
+            "external-service chunks use the 0 sentinel"
+        );
+        assert_eq!(
+            ctx.service, "postgres-mydb-1",
+            "member container name is kept as `service` for per-member distinction"
+        );
+    }
+
+    // A container that matches no standalone service and no cluster member is
+    // skipped (None), not misattributed.
+    #[tokio::test]
+    async fn test_unknown_container_resolves_to_none() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![Vec::<temps_entities::external_services::Model>::new()])
+            .append_query_results(vec![Vec::<temps_entities::service_members::Model>::new()])
+            .into_connection();
+        let Some(collector) = collector_with_db(Arc::new(db)) else {
+            println!("Docker client unavailable, skipping");
+            return;
+        };
+
+        let labels = HashMap::new();
+        let ctx = collector
+            .extract_external_service_context("cid", Some("some-random-container"), &labels)
+            .await
+            .expect("resolution must not error");
+        assert!(ctx.is_none(), "unresolved container must be skipped");
     }
 }

--- a/crates/temps-log-aggregator/src/services/metadata.rs
+++ b/crates/temps-log-aggregator/src/services/metadata.rs
@@ -46,6 +46,7 @@ impl LogMetadataService {
         let model = temps_entities::log_chunks::ActiveModel {
             id: Set(meta.id),
             project_id: Set(meta.project_id),
+            external_service_id: Set(meta.external_service_id),
             env: Set(meta.env.clone()),
             service: Set(meta.service.clone()),
             container_id: Set(meta.container_id.clone()),
@@ -96,6 +97,7 @@ impl LogMetadataService {
             let model = temps_entities::log_events::ActiveModel {
                 time: Set(line.ts),
                 project_id: Set(line.project_id),
+                external_service_id: Set(line.external_service_id),
                 service: Set(line.service.clone()),
                 env: Set(line.env.clone()),
                 level: Set(line.level.to_string()),
@@ -152,6 +154,7 @@ impl LogMetadataService {
     pub async fn find_chunks(
         &self,
         project_id: i32,
+        external_service_id: Option<i32>,
         service: Option<&str>,
         start_time: DateTime<Utc>,
         end_time: DateTime<Utc>,
@@ -159,8 +162,14 @@ impl LogMetadataService {
         container_ids: &[String],
         node_ids: &[i32],
     ) -> Result<Vec<ChunkMeta>, LogAggregatorError> {
+        // Scope by external service when set (its chunks carry project_id = 0),
+        // otherwise by project — see `LogSearchFilter::external_service_id`.
+        let scope = match external_service_id {
+            Some(id) => temps_entities::log_chunks::Column::ExternalServiceId.eq(id),
+            None => temps_entities::log_chunks::Column::ProjectId.eq(project_id),
+        };
         let mut condition = Condition::all()
-            .add(temps_entities::log_chunks::Column::ProjectId.eq(project_id))
+            .add(scope)
             .add(temps_entities::log_chunks::Column::StartedAt.lte(end_time))
             .add(temps_entities::log_chunks::Column::EndedAt.gte(start_time));
 
@@ -197,6 +206,7 @@ impl LogMetadataService {
             .map(|m| ChunkMeta {
                 id: m.id,
                 project_id: m.project_id,
+                external_service_id: m.external_service_id,
                 env: m.env,
                 service: m.service,
                 container_id: m.container_id,
@@ -222,6 +232,7 @@ impl LogMetadataService {
     pub async fn list_sources(
         &self,
         project_id: i32,
+        external_service_id: Option<i32>,
         env: Option<&str>,
         deploy_id: Option<i32>,
         start_time: DateTime<Utc>,
@@ -237,8 +248,12 @@ impl LogMetadataService {
             node_name: Option<String>,
         }
 
+        let scope = match external_service_id {
+            Some(id) => temps_entities::log_chunks::Column::ExternalServiceId.eq(id),
+            None => temps_entities::log_chunks::Column::ProjectId.eq(project_id),
+        };
         let mut condition = Condition::all()
-            .add(temps_entities::log_chunks::Column::ProjectId.eq(project_id))
+            .add(scope)
             .add(temps_entities::log_chunks::Column::StartedAt.lte(end_time))
             .add(temps_entities::log_chunks::Column::EndedAt.gte(start_time));
 
@@ -327,6 +342,7 @@ impl LogMetadataService {
             .map(|m| ChunkMeta {
                 id: m.id,
                 project_id: m.project_id,
+                external_service_id: m.external_service_id,
                 env: m.env,
                 service: m.service,
                 container_id: m.container_id,
@@ -403,6 +419,7 @@ impl LogMetadataService {
         Ok(chunk.map(|m| ChunkMeta {
             id: m.id,
             project_id: m.project_id,
+            external_service_id: m.external_service_id,
             env: m.env,
             service: m.service,
             container_id: m.container_id,
@@ -436,6 +453,7 @@ mod tests {
         let chunk = ChunkMeta {
             id: Uuid::new_v4(),
             project_id,
+            external_service_id: None,
             env: env.to_string(),
             service: svc.to_string(),
             container_id: "test-container".to_string(),
@@ -525,6 +543,7 @@ mod tests {
         let mk = |cid: &str, node: Option<i32>, nname: Option<&str>| ChunkMeta {
             id: Uuid::new_v4(),
             project_id: project,
+            external_service_id: None,
             env: "1".to_string(),
             service: "web".to_string(),
             container_id: cid.to_string(),
@@ -561,6 +580,7 @@ mod tests {
         let sources = service
             .list_sources(
                 project,
+                None,
                 Some("1"),
                 None,
                 now - Duration::hours(1),

--- a/crates/temps-log-aggregator/src/services/remote_collector.rs
+++ b/crates/temps-log-aggregator/src/services/remote_collector.rs
@@ -64,6 +64,13 @@ pub struct RemoteContainerInfo {
     pub service: String,
     /// Active deployment ID (`deployments.id`), if known.
     pub deploy_id: Option<i32>,
+    /// Owning managed external service (`external_services.id`) when this
+    /// container is a **cluster member** running on a worker node, rather than
+    /// an ordinary deployment container. `None` for deployments. When set, the
+    /// collected chunks key on the external service (with the `project_id = 0`
+    /// sentinel) so a remote replica's logs surface under the service's history
+    /// identically to a control-plane-local member.
+    pub external_service_id: Option<i32>,
 }
 
 /// A stream of raw, timestamp-prefixed log lines from a remote container — one
@@ -245,9 +252,10 @@ impl RemoteLogCollectorService {
     ) {
         let ctx = ContainerContext {
             project_id: info.project_id,
-            // Remote workers only run deployment containers; managed external
-            // services are control-plane-local.
-            external_service_id: None,
+            // Set for cluster members on worker nodes; None for deployments.
+            // When set, chunks key on the external service (project_id is the
+            // 0 sentinel) so remote members join the service's log history.
+            external_service_id: info.external_service_id,
             env: info.env.clone(),
             service: info.service.clone(),
             container_id: info.container_id.clone(),
@@ -399,6 +407,7 @@ mod tests {
             env: "1".into(),
             service: "web".into(),
             deploy_id: Some(7),
+            external_service_id: None,
         }
     }
 

--- a/crates/temps-log-aggregator/src/services/remote_collector.rs
+++ b/crates/temps-log-aggregator/src/services/remote_collector.rs
@@ -245,6 +245,9 @@ impl RemoteLogCollectorService {
     ) {
         let ctx = ContainerContext {
             project_id: info.project_id,
+            // Remote workers only run deployment containers; managed external
+            // services are control-plane-local.
+            external_service_id: None,
             env: info.env.clone(),
             service: info.service.clone(),
             container_id: info.container_id.clone(),

--- a/crates/temps-log-aggregator/src/services/search.rs
+++ b/crates/temps-log-aggregator/src/services/search.rs
@@ -89,6 +89,7 @@ impl LogSearchService {
                 .metadata_service
                 .list_sources(
                     filter.project_id,
+                    filter.external_service_id,
                     filter.envs.first().map(|s| s.as_str()),
                     filter.deploy_id,
                     filter.start_time,
@@ -212,6 +213,7 @@ impl LogSearchService {
             .metadata_service
             .find_chunks(
                 filter.project_id,
+                filter.external_service_id,
                 service_filter,
                 filter.start_time,
                 effective_end,
@@ -655,6 +657,7 @@ mod tests {
     fn make_filter() -> LogSearchFilter {
         LogSearchFilter {
             project_id: 1,
+            external_service_id: None,
             start_time: Utc::now() - Duration::hours(1),
             end_time: Utc::now() + Duration::hours(1),
             levels: vec![],
@@ -682,6 +685,7 @@ mod tests {
             service: "web".to_string(),
             env: "1".to_string(),
             project_id: 1,
+            external_service_id: None,
             deploy_id: None,
             node_id: None,
             node_name: None,
@@ -984,6 +988,7 @@ mod tests {
             let project_id = test_project_id();
             let web_ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "web".into(),
                 container_id: "cnt-web".into(),
@@ -991,6 +996,7 @@ mod tests {
             };
             let worker_ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "worker".into(),
                 container_id: "cnt-worker".into(),
@@ -1004,6 +1010,7 @@ mod tests {
 
             let mut filter = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1041,6 +1048,7 @@ mod tests {
                 .map(|svc| {
                     let ctx = ContainerContext {
                         project_id,
+                        external_service_id: None,
                         env: "production".into(),
                         service: svc.to_string(),
                         container_id: format!("cnt-{}", svc),
@@ -1055,6 +1063,7 @@ mod tests {
 
             let filter = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1084,6 +1093,7 @@ mod tests {
             let project_id = test_project_id();
             let prod_ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "web".into(),
                 container_id: "cnt-prod".into(),
@@ -1091,6 +1101,7 @@ mod tests {
             };
             let staging_ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "staging".into(),
                 service: "web".into(),
                 container_id: "cnt-staging".into(),
@@ -1103,6 +1114,7 @@ mod tests {
 
             let filter = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1132,6 +1144,7 @@ mod tests {
             let deploy = test_deploy_id();
             let ctx_with_deploy = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "web".into(),
                 container_id: "cnt-1".into(),
@@ -1139,6 +1152,7 @@ mod tests {
             };
             let ctx_other_deploy = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "web".into(),
                 container_id: "cnt-2".into(),
@@ -1156,6 +1170,7 @@ mod tests {
 
             let filter = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1184,6 +1199,7 @@ mod tests {
             let project_id = test_project_id();
             let ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "api".into(),
                 container_id: "cnt-api".into(),
@@ -1196,6 +1212,7 @@ mod tests {
             // Filter: production + api + error only
             let filter = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![LogLevel::Error],
@@ -1226,6 +1243,7 @@ mod tests {
 
             let ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "web".into(),
                 container_id: "cnt-1".into(),
@@ -1239,6 +1257,7 @@ mod tests {
 
             let filter = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1266,6 +1285,7 @@ mod tests {
 
             let ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "web".into(),
                 container_id: "cnt-1".into(),
@@ -1280,6 +1300,7 @@ mod tests {
             // Partial URL match
             let mut filter = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1314,6 +1335,7 @@ mod tests {
 
             let ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "web".into(),
                 container_id: "cnt-1".into(),
@@ -1332,6 +1354,7 @@ mod tests {
             // Text "timeout" + level ERROR
             let filter = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![LogLevel::Error],
@@ -1362,6 +1385,7 @@ mod tests {
 
             let ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "api".into(),
                 container_id: "cnt-1".into(),
@@ -1383,6 +1407,7 @@ mod tests {
             // Filter by status=500
             let filter = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1406,6 +1431,7 @@ mod tests {
             // Filter by request_id
             let filter_req = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1436,6 +1462,7 @@ mod tests {
 
             let ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "api".into(),
                 container_id: "cnt-1".into(),
@@ -1456,6 +1483,7 @@ mod tests {
             // Gt: duration_ms > 30 → true
             let filter_gt = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1479,6 +1507,7 @@ mod tests {
             // Gt: duration_ms > 100 → false
             let filter_gt_high = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1502,6 +1531,7 @@ mod tests {
             // Lt: duration_ms < 100 → true
             let filter_lt = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1525,6 +1555,7 @@ mod tests {
             // Gte: duration_ms >= 45 → true
             let filter_gte = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1548,6 +1579,7 @@ mod tests {
             // Lte: duration_ms <= 44 → false
             let filter_lte = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1578,6 +1610,7 @@ mod tests {
 
             let ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "web".into(),
                 container_id: "cnt-1".into(),
@@ -1589,6 +1622,7 @@ mod tests {
 
             let filter = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1620,6 +1654,7 @@ mod tests {
 
             let ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "api".into(),
                 container_id: "cnt-1".into(),
@@ -1634,6 +1669,7 @@ mod tests {
             // Both status=500 AND duration_ms > 1000 → should match
             let filter_both = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1664,6 +1700,7 @@ mod tests {
             // status=500 AND duration_ms > 5000 → second fails
             let filter_partial = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1704,6 +1741,7 @@ mod tests {
             let project_id = test_project_id();
             let ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "payments".into(),
                 container_id: "cnt-pay".into(),
@@ -1725,6 +1763,7 @@ mod tests {
             // Filter: service=payments → all match
             let filter = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1749,6 +1788,7 @@ mod tests {
             // Filter: service=billing → none match
             let filter_none = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1783,6 +1823,7 @@ mod tests {
             let project_id = test_project_id();
             let ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "web".into(),
                 container_id: "cnt-remote".into(),
@@ -1811,6 +1852,7 @@ mod tests {
             let project_id = test_project_id();
             let ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "web".into(),
                 container_id: "cnt-web".into(),
@@ -1840,6 +1882,7 @@ mod tests {
             // Search for "users"
             let filter_users = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1864,6 +1907,7 @@ mod tests {
             // Search for "500" (appears in orders error)
             let filter_500 = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1889,6 +1933,7 @@ mod tests {
             // Search for "connection refused" — case insensitive
             let filter_conn = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1922,6 +1967,7 @@ mod tests {
             let project_id = test_project_id();
             let ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "api".into(),
                 container_id: "cnt-api".into(),
@@ -1957,6 +2003,7 @@ mod tests {
             // Filter: status=500 → 1 match
             let filter_500 = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -1986,6 +2033,7 @@ mod tests {
             // Filter: duration_ms > 1000 → 1 match (the 3500ms one)
             let filter_slow = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -2018,6 +2066,7 @@ mod tests {
             // Filter: user_id=u-1 → 2 matches
             let filter_user = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -2054,6 +2103,7 @@ mod tests {
             let project_id = test_project_id();
             let ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "api".into(),
                 container_id: "cnt-api2".into(),
@@ -2081,6 +2131,7 @@ mod tests {
             // Text "timeout" + status=503 + duration_ms > 6000 → only postgres
             let filter = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![LogLevel::Error],
@@ -2127,6 +2178,7 @@ mod tests {
             let project_id = test_project_id();
             let ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "legacy".into(),
                 container_id: "cnt-legacy".into(),
@@ -2146,6 +2198,7 @@ mod tests {
             // Filter ERROR only
             let filter_error = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![LogLevel::Error],
@@ -2171,6 +2224,7 @@ mod tests {
             // Fulltext "disk" across all levels
             let filter_disk = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -2205,6 +2259,7 @@ mod tests {
 
             let ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "web".into(),
                 container_id: "cnt-1".into(),
@@ -2221,6 +2276,7 @@ mod tests {
             // Filter last hour
             let filter = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: now - Duration::hours(1),
                 end_time: now + Duration::hours(1),
                 levels: vec![],
@@ -2250,6 +2306,7 @@ mod tests {
 
             let filter = LogSearchFilter {
                 project_id: test_project_id(),
+                external_service_id: None,
                 start_time: Utc::now() + Duration::hours(1),
                 end_time: Utc::now(),
                 levels: vec![],
@@ -2283,6 +2340,7 @@ mod tests {
 
             let filter = LogSearchFilter {
                 project_id: test_project_id(),
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(48),
                 end_time: Utc::now(),
                 levels: vec![],
@@ -2322,6 +2380,7 @@ mod tests {
             let project_id = test_project_id();
             let ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "api".into(),
                 container_id: "cnt-large".into(),
@@ -2370,6 +2429,7 @@ mod tests {
             // Filter: ERROR level + "timeout" text + status=503
             let filter = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![LogLevel::Error],
@@ -2424,6 +2484,7 @@ mod tests {
 
             let ctx = ContainerContext {
                 project_id,
+                external_service_id: None,
                 env: "production".into(),
                 service: "web".into(),
                 container_id: "cnt-1".into(),
@@ -2440,6 +2501,7 @@ mod tests {
             // No level, service, env, text, or field filters
             let filter = LogSearchFilter {
                 project_id,
+                external_service_id: None,
                 start_time: Utc::now() - Duration::hours(1),
                 end_time: Utc::now() + Duration::hours(1),
                 levels: vec![],
@@ -2481,6 +2543,7 @@ mod tests {
                     service: "web".to_string(),
                     env: "1".to_string(),
                     project_id: 1,
+                    external_service_id: None,
                     deploy_id: None,
                     node_id: None,
                     node_name: None,

--- a/crates/temps-log-aggregator/src/services/tail.rs
+++ b/crates/temps-log-aggregator/src/services/tail.rs
@@ -58,9 +58,17 @@ impl TailService {
 
 /// Check if a log line matches the tail filter.
 fn matches_tail_filter(line: &LogLine, filter: &TailFilter) -> bool {
-    // Project ID must match
-    if line.project_id != filter.project_id {
-        return false;
+    // External-service tail: match on the service dimension, not project_id
+    // (external-service lines carry the sentinel project_id = 0).
+    if let Some(svc_id) = filter.external_service_id {
+        if line.external_service_id != Some(svc_id) {
+            return false;
+        }
+    } else {
+        // Deployment/application tail: project ID must match.
+        if line.project_id != filter.project_id {
+            return false;
+        }
     }
 
     // Service must match
@@ -104,6 +112,7 @@ mod tests {
             service: service.to_string(),
             env: "1".to_string(),
             project_id: 42,
+            external_service_id: None,
             deploy_id: None,
             node_id: None,
             node_name: None,
@@ -113,6 +122,7 @@ mod tests {
     fn make_filter(service: &str) -> TailFilter {
         TailFilter {
             project_id: 42,
+            external_service_id: None,
             service: service.to_string(),
             env: "1".to_string(),
             levels: vec![],

--- a/crates/temps-log-aggregator/src/storage/traits.rs
+++ b/crates/temps-log-aggregator/src/storage/traits.rs
@@ -48,9 +48,14 @@ pub trait LogStorage: Send + Sync + 'static {
 
 /// Build the storage key for a log chunk.
 ///
-/// Layout: `logs/{project_id}/{env}/{service}/{YYYY-MM-DD}/{HH}/{container_id}-{sequence}.ndjson.zst`
+/// Deployment/application layout:
+///   `logs/{project_id}/{env}/{service}/{YYYY-MM-DD}/{HH}/{container_id}-{sequence}.ndjson.zst`
+/// Imported/managed external-service layout (when `external_service_id` is set):
+///   `logs/external-services/{service_id}/{env}/{service}/{YYYY-MM-DD}/{HH}/{container_id}-{sequence}.ndjson.zst`
+#[allow(clippy::too_many_arguments)]
 pub fn build_storage_key(
     project_id: i32,
+    external_service_id: Option<i32>,
     env: &str,
     service: &str,
     date: &chrono::NaiveDate,
@@ -58,9 +63,13 @@ pub fn build_storage_key(
     container_id: &str,
     sequence: u64,
 ) -> String {
+    let scope = match external_service_id {
+        Some(id) => format!("external-services/{id}"),
+        None => project_id.to_string(),
+    };
     format!(
-        "logs/{project_id}/{env}/{service}/{date}/{hour:02}/{container_id}-{sequence:06}.ndjson.zst",
-        project_id = project_id,
+        "logs/{scope}/{env}/{service}/{date}/{hour:02}/{container_id}-{sequence:06}.ndjson.zst",
+        scope = scope,
         env = env,
         service = service,
         date = date.format("%Y-%m-%d"),
@@ -78,7 +87,7 @@ mod tests {
     #[test]
     fn test_build_storage_key() {
         let date = NaiveDate::from_ymd_opt(2026, 2, 25).unwrap();
-        let key = build_storage_key(2, "3", "web", &date, 14, "abc123def456", 1);
+        let key = build_storage_key(2, None, "3", "web", &date, 14, "abc123def456", 1);
         assert_eq!(
             key,
             "logs/2/3/web/2026-02-25/14/abc123def456-000001.ndjson.zst"
@@ -88,7 +97,28 @@ mod tests {
     #[test]
     fn test_build_storage_key_truncates_long_container_id() {
         let date = NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
-        let key = build_storage_key(5, "1", "api", &date, 0, "abcdef123456789extra", 42);
+        let key = build_storage_key(5, None, "1", "api", &date, 0, "abcdef123456789extra", 42);
         assert!(key.contains("abcdef123456-000042.ndjson.zst"));
+    }
+
+    #[test]
+    fn test_build_storage_key_external_service() {
+        let date = NaiveDate::from_ymd_opt(2026, 2, 25).unwrap();
+        // External-service chunks (project_id sentinel = 0) key under
+        // logs/external-services/{id}/… instead of logs/{project_id}/….
+        let key = build_storage_key(
+            0,
+            Some(7),
+            "default",
+            "postgres",
+            &date,
+            14,
+            "abc123def456",
+            1,
+        );
+        assert_eq!(
+            key,
+            "logs/external-services/7/default/postgres/2026-02-25/14/abc123def456-000001.ndjson.zst"
+        );
     }
 }

--- a/crates/temps-log-aggregator/src/types.rs
+++ b/crates/temps-log-aggregator/src/types.rs
@@ -25,8 +25,13 @@ pub struct LogLine {
     pub service: String,
     /// Environment (ID as string) from Docker label
     pub env: String,
-    /// Platform integer project ID from Docker label
+    /// Platform integer project ID from Docker label. `0` (sentinel) for
+    /// external-service logs, which key on `external_service_id` instead.
     pub project_id: i32,
+    /// Set for imported/managed external-service containers (Postgres, Redis,
+    /// …). `None` for deployment/application containers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_service_id: Option<i32>,
     /// Active deployment ID (deployments.id) at time of log
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deploy_id: Option<i32>,
@@ -107,6 +112,9 @@ impl std::fmt::Display for LogLevel {
 pub struct ChunkMeta {
     pub id: Uuid,
     pub project_id: i32,
+    /// Set for external-service chunks — see [`LogLine::external_service_id`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_service_id: Option<i32>,
     pub env: String,
     pub service: String,
     pub container_id: String,
@@ -129,6 +137,9 @@ pub struct ChunkMeta {
 #[derive(Debug, Clone)]
 pub struct ContainerContext {
     pub project_id: i32,
+    /// Set for imported/managed external-service containers — see
+    /// [`LogLine::external_service_id`].
+    pub external_service_id: Option<i32>,
     pub env: String,
     pub service: String,
     pub container_id: String,
@@ -139,6 +150,11 @@ pub struct ContainerContext {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogSearchFilter {
     pub project_id: i32,
+    /// When set, scope the search to an imported/managed external service
+    /// instead of a project. `project_id` is ignored in this mode (external
+    /// -service chunks carry the sentinel `project_id = 0`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_service_id: Option<i32>,
     pub start_time: DateTime<Utc>,
     pub end_time: DateTime<Utc>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -328,6 +344,10 @@ pub struct ContextLine {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TailFilter {
     pub project_id: i32,
+    /// When set, tail an imported/managed external service instead of a
+    /// project (external-service lines carry `project_id = 0`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_service_id: Option<i32>,
     pub service: String,
     pub env: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -441,6 +461,7 @@ mod tests {
             service: "web".to_string(),
             env: "2".to_string(),
             project_id: 42,
+            external_service_id: None,
             deploy_id: None,
             node_id: None,
             node_name: None,

--- a/crates/temps-migrations/src/migration/m20260707_000001_add_external_service_to_logs.rs
+++ b/crates/temps-migrations/src/migration/m20260707_000001_add_external_service_to_logs.rs
@@ -1,0 +1,97 @@
+//! Add an `external_service_id` dimension to the log-aggregator tables so that
+//! logs from **imported/managed external-service containers** (Postgres,
+//! MariaDB, Redis, MongoDB, MinIO, …) can be persisted, retained, and searched
+//! exactly like deployment/application logs.
+//!
+//! # Why a new dimension instead of reusing `project_id`
+//!
+//! The whole log pipeline is keyed on a mandatory `project_id: i32`
+//! (`log_chunks.project_id NOT NULL`, storage keys, search filters, indexes).
+//! An external service is **not** owned by a single project — it can be linked
+//! to zero or many. So there is no honest `project_id` to file its logs under.
+//!
+//! This migration keeps `project_id` as-is (external-service chunks store the
+//! sentinel `0`) and adds a nullable `external_service_id`:
+//!   * deployment/application chunks: `external_service_id IS NULL`, keyed by
+//!     `project_id` (unchanged behaviour).
+//!   * external-service chunks: `external_service_id = <external_services.id>`,
+//!     `project_id = 0`, keyed by service.
+//!
+//! `log_events` is an optional/legacy table (see
+//! `m20260611_000001_change_log_deploy_id_to_integer`), so its ALTER is guarded
+//! by `to_regclass`.
+
+use sea_orm_migration::prelude::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20260707_000001_add_external_service_to_logs"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // log_chunks always exists.
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE log_chunks
+                    ADD COLUMN IF NOT EXISTS external_service_id integer;
+
+                -- Service-scoped lookup: mirrors the (project_id, service,
+                -- started_at) primary index but leads with external_service_id
+                -- so the external-service logs view is an index range scan.
+                CREATE INDEX IF NOT EXISTS idx_log_chunks_extsvc_time
+                    ON log_chunks (external_service_id, started_at)
+                    WHERE external_service_id IS NOT NULL;
+                "#,
+            )
+            .await?;
+
+        // log_events is optional — only touch it if it exists.
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                DO $$
+                BEGIN
+                    IF to_regclass('public.log_events') IS NOT NULL THEN
+                        ALTER TABLE log_events
+                            ADD COLUMN IF NOT EXISTS external_service_id integer;
+                        CREATE INDEX IF NOT EXISTS idx_log_events_extsvc_time
+                            ON log_events (external_service_id, time)
+                            WHERE external_service_id IS NOT NULL;
+                    END IF;
+                END $$;
+                "#,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                DROP INDEX IF EXISTS idx_log_chunks_extsvc_time;
+                ALTER TABLE log_chunks DROP COLUMN IF EXISTS external_service_id;
+
+                DO $$
+                BEGIN
+                    IF to_regclass('public.log_events') IS NOT NULL THEN
+                        DROP INDEX IF EXISTS idx_log_events_extsvc_time;
+                        ALTER TABLE log_events DROP COLUMN IF EXISTS external_service_id;
+                    END IF;
+                END $$;
+                "#,
+            )
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/temps-migrations/src/migration/m20260707_000002_add_external_services_container_name.rs
+++ b/crates/temps-migrations/src/migration/m20260707_000002_add_external_services_container_name.rs
@@ -1,0 +1,54 @@
+//! Add a plaintext `container_name` column to `external_services` so the log
+//! collector can map a running container back to its service.
+//!
+//! Imported external-service containers pre-date Temps: they carry no
+//! `temps.*` Docker labels (labels are immutable, and import only attaches the
+//! container to the Temps network — it can't relabel), and their real
+//! container name lives inside the ENCRYPTED `config` blob, which the
+//! log-aggregator can't decrypt. This plaintext column lets the collector
+//! resolve `inspected container name -> external_services.id` for imported
+//! services. Created services still resolve via the `temps.service_name`
+//! Docker label, so this stays NULL for them.
+
+use sea_orm_migration::prelude::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20260707_000002_add_external_services_container_name"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE external_services
+                    ADD COLUMN IF NOT EXISTS container_name text;
+                -- Collector resolves imported containers by exact name match.
+                CREATE INDEX IF NOT EXISTS idx_external_services_container_name
+                    ON external_services (container_name)
+                    WHERE container_name IS NOT NULL;
+                "#,
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                DROP INDEX IF EXISTS idx_external_services_container_name;
+                ALTER TABLE external_services DROP COLUMN IF EXISTS container_name;
+                "#,
+            )
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -141,6 +141,7 @@ mod m20260702_000002_add_dynamic_alerting_to_metric_alert_rules;
 mod m20260702_000003_add_grouped_threshold_and_series_state_to_metric_alert_rules;
 mod m20260703_000001_cross_project_trace_refs;
 mod m20260705_000001_add_visitor_unique_index;
+mod m20260707_000001_add_external_service_to_logs;
 
 pub struct Migrator;
 
@@ -287,6 +288,7 @@ impl MigratorTrait for Migrator {
             ),
             Box::new(m20260703_000001_cross_project_trace_refs::Migration),
             Box::new(m20260705_000001_add_visitor_unique_index::Migration),
+            Box::new(m20260707_000001_add_external_service_to_logs::Migration),
         ]
     }
 }

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -142,6 +142,7 @@ mod m20260702_000003_add_grouped_threshold_and_series_state_to_metric_alert_rule
 mod m20260703_000001_cross_project_trace_refs;
 mod m20260705_000001_add_visitor_unique_index;
 mod m20260707_000001_add_external_service_to_logs;
+mod m20260707_000002_add_external_services_container_name;
 
 pub struct Migrator;
 
@@ -289,6 +290,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260703_000001_cross_project_trace_refs::Migration),
             Box::new(m20260705_000001_add_visitor_unique_index::Migration),
             Box::new(m20260707_000001_add_external_service_to_logs::Migration),
+            Box::new(m20260707_000002_add_external_services_container_name::Migration),
         ]
     }
 }

--- a/crates/temps-monitoring/src/alarm_service.rs
+++ b/crates/temps-monitoring/src/alarm_service.rs
@@ -1266,6 +1266,7 @@ mod tests {
             health_metadata: None,
             metrics_enabled: true,
             default_backup_provisioned: false,
+            container_name: None,
         }
     }
 

--- a/crates/temps-providers/src/externalsvc/mariadb.rs
+++ b/crates/temps-providers/src/externalsvc/mariadb.rs
@@ -282,6 +282,23 @@ pub struct MariaDbInputConfig {
     /// to S3. Smaller = less data lost on restore, more frequent uploads.
     #[serde(default)]
     pub binlog_archive_interval: BinlogArchiveInterval,
+
+    /// Real Docker container name when this service was imported from an
+    /// existing MariaDB-compatible container (set by `import_from_container`,
+    /// never user-editable — omitted from the create form). Overrides the
+    /// derived `mariadb-{name}` container name so internal addressing
+    /// targets the actual pre-existing container instead of a synthesized
+    /// name that doesn't exist.
+    ///
+    /// Deserialized through `deserialize_optional_non_empty` as a second,
+    /// independent guard alongside `#[schemars(skip)]`: an empty string here
+    /// previously made `init` treat the service as imported (skipping
+    /// container creation) and fail with a Docker 301 on
+    /// `POST /containers//start` — normalize blank to `None` regardless of
+    /// how the value reaches this struct.
+    #[serde(default, deserialize_with = "deserialize_optional_non_empty")]
+    #[schemars(skip)]
+    pub container_name: Option<String>,
 }
 
 /// Internal runtime configuration for MariaDB service.
@@ -294,6 +311,10 @@ pub struct MariaDbConfig {
     pub password: String,
     pub root_password: String,
     pub docker_image: String,
+    /// Real container name for imported services — see
+    /// `MariaDbInputConfig::container_name`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_name: Option<String>,
     #[serde(default)]
     pub size_profile: MariaDbSizeProfile,
     #[serde(default)]
@@ -314,6 +335,7 @@ impl From<MariaDbInputConfig> for MariaDbConfig {
             password: input.password.unwrap_or_else(generate_password),
             root_password: input.root_password.unwrap_or_else(generate_password),
             docker_image: input.docker_image,
+            container_name: input.container_name,
             size_profile: input.size_profile,
             binlog_archive_interval: input.binlog_archive_interval,
         }
@@ -329,6 +351,18 @@ where
         Some(s) if !s.is_empty() && s.len() >= MIN_PASSWORD_LENGTH => Some(s),
         _ => None,
     })
+}
+
+/// Treats a blank string the same as an absent value. Used for
+/// `container_name` so a stray `""` (e.g. from a generic parameters-edit
+/// path that isn't schema-driven) can never be mistaken for "this service is
+/// imported from an existing container" — see `MariaDbInputConfig::container_name`.
+fn deserialize_optional_non_empty<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let opt: Option<String> = Option::deserialize(deserializer)?;
+    Ok(opt.filter(|s| !s.is_empty()))
 }
 
 fn default_host() -> String {
@@ -411,6 +445,19 @@ impl MariaDbService {
 
     fn get_container_name(&self) -> String {
         format!("mariadb-{}", self.name)
+    }
+
+    /// The container this service actually runs in: the imported container's
+    /// real name when `config.container_name` is set, otherwise the derived
+    /// `mariadb-{name}`. Every operation that talks to the live container
+    /// (admin SQL, backup, restore, binlog shipping, start/stop) must resolve
+    /// through this, not `get_container_name()` directly, or it targets a
+    /// synthesized name that doesn't exist for imported services.
+    fn get_live_container_name(&self, config: &MariaDbConfig) -> String {
+        config
+            .container_name
+            .clone()
+            .unwrap_or_else(|| self.get_container_name())
     }
 
     fn get_mariadb_config(&self, service_config: ServiceConfig) -> Result<MariaDbConfig> {
@@ -548,13 +595,7 @@ impl MariaDbService {
             .map_err(|e| anyhow::anyhow!("Failed to create MariaDB volume: {}", e))?;
 
         let mut host_config = bollard::models::HostConfig {
-            port_bindings: Some(HashMap::from([(
-                "3306/tcp".to_string(),
-                Some(vec![bollard::models::PortBinding {
-                    host_ip: Some("0.0.0.0".to_string()),
-                    host_port: Some(config.port.clone()),
-                }]),
-            )])),
+            port_bindings: Some(crate::utils::local_port_binding("3306/tcp", &config.port)),
             mounts: Some(vec![bollard::models::Mount {
                 target: Some("/var/lib/mysql".to_string()),
                 source: Some(volume_name),
@@ -838,7 +879,7 @@ impl MariaDbService {
     }
 
     async fn run_admin_sql(&self, config: &MariaDbConfig, sql: &str) -> Result<()> {
-        let container_name = self.get_container_name();
+        let container_name = self.get_live_container_name(config);
         self.run_container_command(
             &container_name,
             vec![
@@ -863,7 +904,7 @@ impl MariaDbService {
     }
 
     async fn ping(&self, config: &MariaDbConfig) -> Result<()> {
-        let container_name = self.get_container_name();
+        let container_name = self.get_live_container_name(config);
         self.run_container_command(
             &container_name,
             vec![
@@ -920,7 +961,7 @@ impl MariaDbService {
     ) -> Result<HashMap<String, String>> {
         let config = self.get_mariadb_config(service_config)?;
         Self::build_env_vars(
-            &self.get_container_name(),
+            &self.get_live_container_name(&config),
             MARIADB_INTERNAL_PORT,
             resource_name,
             &config.username,
@@ -1173,7 +1214,7 @@ impl MariaDbService {
         s3_source: &temps_entities::s3_sources::Model,
         config: &MariaDbConfig,
     ) -> Result<usize> {
-        let container_name = self.get_container_name();
+        let container_name = self.get_live_container_name(config);
         let bucket = &s3_source.bucket_name;
         let prefix = s3_source.bucket_path.trim_matches('/');
 
@@ -1277,7 +1318,7 @@ impl MariaDbService {
 
     /// Raw `SHOW BINARY LOGS` output (tab-separated rows: filename, size, ...).
     async fn show_binary_logs(&self, config: &MariaDbConfig) -> Result<String> {
-        let container_name = self.get_container_name();
+        let container_name = self.get_live_container_name(config);
         self.run_container_command(
             &container_name,
             vec![
@@ -1520,7 +1561,7 @@ impl MariaDbService {
     ) -> Result<()> {
         use std::io::Write;
 
-        let container_name = self.get_container_name();
+        let container_name = self.get_live_container_name(config);
         let env = [
             format!("MYSQL_PWD={}", config.root_password),
             format!("MARIADB_PWD={}", config.root_password),
@@ -1630,7 +1671,7 @@ impl MariaDbService {
         config: &MariaDbConfig,
         sql_path: &std::path::Path,
     ) -> Result<()> {
-        let container_name = self.get_container_name();
+        let container_name = self.get_live_container_name(config);
         let restore_filename = "temps_mariadb_restore.sql";
 
         let tar_data = {
@@ -1815,7 +1856,7 @@ impl MariaDbService {
         config: &MariaDbConfig,
         mbstream_host_path: &std::path::Path,
     ) -> Result<()> {
-        let container_name = self.get_container_name();
+        let container_name = self.get_live_container_name(config);
 
         // 1. Disable restart policy FIRST so Docker doesn't bounce the
         //    container back up while the helper holds the volume.
@@ -2308,7 +2349,7 @@ impl MariaDbService {
             return Ok(());
         }
 
-        let container_name = self.get_container_name();
+        let container_name = self.get_live_container_name(config);
         let container_dir = "/var/tmp/temps-binlogs";
 
         // Upload every segment into the container, preserving filenames.
@@ -2474,7 +2515,9 @@ impl MariaDbService {
     ) -> Result<(MariaDbService, MariaDbConfig)> {
         let mut config = self.get_mariadb_config(source_config.clone())?;
 
-        // Fresh port (the source's is taken).
+        // Fresh port (the source's is taken). A restored new service is its own
+        // container, not an imported one.
+        config.container_name = None;
         let new_port = find_available_port(3306)
             .ok_or_else(|| anyhow::anyhow!("No available ports for new MariaDB service"))?
             .to_string();
@@ -2606,8 +2649,16 @@ impl ExternalService for MariaDbService {
         *self.config.write().await = Some(mariadb_config.clone());
         *self.resource_limits.write().await = resource_limits.clone();
 
-        self.create_container(&self.docker, &mariadb_config, &resource_limits)
-            .await?;
+        if mariadb_config.container_name.is_none() {
+            self.create_container(&self.docker, &mariadb_config, &resource_limits)
+                .await?;
+        } else {
+            info!(
+                "MariaDB service '{}' is imported from container '{}'; skipping container creation",
+                self.name,
+                self.get_live_container_name(&mariadb_config)
+            );
+        }
 
         let runtime_config_json = serde_json::to_value(&mariadb_config)
             .map_err(|e| anyhow::anyhow!("Failed to serialize MariaDB runtime config: {}", e))?;
@@ -2753,7 +2804,10 @@ impl ExternalService for MariaDbService {
 
     async fn start(&self) -> Result<()> {
         let existing_config = self.config.read().await.as_ref().cloned();
-        let container_name = self.get_container_name();
+        let container_name = existing_config
+            .as_ref()
+            .map(|config| self.get_live_container_name(config))
+            .unwrap_or_else(|| self.get_container_name());
         info!("Starting MariaDB container {}", container_name);
 
         let containers = self
@@ -2771,6 +2825,12 @@ impl ExternalService for MariaDbService {
         if containers.is_empty() {
             let config = existing_config
                 .ok_or_else(|| anyhow::anyhow!("MariaDB configuration not found"))?;
+            if config.container_name.is_some() {
+                return Err(anyhow::anyhow!(
+                    "Imported MariaDB container '{}' not found",
+                    container_name
+                ));
+            }
             let limits = self.resource_limits.read().await.clone();
             self.create_container(&self.docker, &config, &limits)
                 .await?;
@@ -2798,7 +2858,13 @@ impl ExternalService for MariaDbService {
     }
 
     async fn stop(&self) -> Result<()> {
-        let container_name = self.get_container_name();
+        let container_name = self
+            .config
+            .read()
+            .await
+            .as_ref()
+            .map(|config| self.get_live_container_name(config))
+            .unwrap_or_else(|| self.get_container_name());
         let containers = self
             .docker
             .list_containers(Some(bollard::query_parameters::ListContainersOptions {
@@ -2997,7 +3063,10 @@ impl ExternalService for MariaDbService {
         let config = self.get_mariadb_config(service_config)?;
 
         if temps_core::DeploymentMode::is_docker() {
-            Ok((self.get_container_name(), MARIADB_INTERNAL_PORT.to_string()))
+            Ok((
+                self.get_live_container_name(&config),
+                MARIADB_INTERNAL_PORT.to_string(),
+            ))
         } else {
             Ok(("localhost".to_string(), config.port))
         }
@@ -3603,6 +3672,7 @@ mod tests {
             password: Some("secretpass".to_string()),
             root_password: Some("rootpass1".to_string()),
             docker_image: DEFAULT_MARIADB_IMAGE.to_string(),
+            container_name: None,
             size_profile: MariaDbSizeProfile::Standard,
             binlog_archive_interval: BinlogArchiveInterval::Min15,
         });
@@ -4140,6 +4210,7 @@ mod tests {
             password: None,
             root_password: None,
             docker_image: default_docker_image(),
+            container_name: None,
             size_profile: MariaDbSizeProfile::default(),
             binlog_archive_interval: BinlogArchiveInterval::default(),
         };
@@ -4179,6 +4250,7 @@ mod tests {
             password: Some("mypassword".to_string()),
             root_password: Some("myrootpassword".to_string()),
             docker_image: "mariadb:11.4".to_string(),
+            container_name: None,
             size_profile: MariaDbSizeProfile::default(),
             binlog_archive_interval: BinlogArchiveInterval::default(),
         };

--- a/crates/temps-providers/src/externalsvc/mariadb.rs
+++ b/crates/temps-providers/src/externalsvc/mariadb.rs
@@ -282,10 +282,6 @@ pub struct MariaDbInputConfig {
     /// to S3. Smaller = less data lost on restore, more frequent uploads.
     #[serde(default)]
     pub binlog_archive_interval: BinlogArchiveInterval,
-
-    /// Existing Docker container name for imported services.
-    #[serde(default)]
-    pub container_name: Option<String>,
 }
 
 /// Internal runtime configuration for MariaDB service.
@@ -302,8 +298,6 @@ pub struct MariaDbConfig {
     pub size_profile: MariaDbSizeProfile,
     #[serde(default)]
     pub binlog_archive_interval: BinlogArchiveInterval,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub container_name: Option<String>,
 }
 
 impl From<MariaDbInputConfig> for MariaDbConfig {
@@ -322,7 +316,6 @@ impl From<MariaDbInputConfig> for MariaDbConfig {
             docker_image: input.docker_image,
             size_profile: input.size_profile,
             binlog_archive_interval: input.binlog_archive_interval,
-            container_name: input.container_name,
         }
     }
 }
@@ -418,13 +411,6 @@ impl MariaDbService {
 
     fn get_container_name(&self) -> String {
         format!("mariadb-{}", self.name)
-    }
-
-    fn get_live_container_name(&self, config: &MariaDbConfig) -> String {
-        config
-            .container_name
-            .clone()
-            .unwrap_or_else(|| self.get_container_name())
     }
 
     fn get_mariadb_config(&self, service_config: ServiceConfig) -> Result<MariaDbConfig> {
@@ -852,7 +838,7 @@ impl MariaDbService {
     }
 
     async fn run_admin_sql(&self, config: &MariaDbConfig, sql: &str) -> Result<()> {
-        let container_name = self.get_live_container_name(config);
+        let container_name = self.get_container_name();
         self.run_container_command(
             &container_name,
             vec![
@@ -877,7 +863,7 @@ impl MariaDbService {
     }
 
     async fn ping(&self, config: &MariaDbConfig) -> Result<()> {
-        let container_name = self.get_live_container_name(config);
+        let container_name = self.get_container_name();
         self.run_container_command(
             &container_name,
             vec![
@@ -934,7 +920,7 @@ impl MariaDbService {
     ) -> Result<HashMap<String, String>> {
         let config = self.get_mariadb_config(service_config)?;
         Self::build_env_vars(
-            &self.get_live_container_name(&config),
+            &self.get_container_name(),
             MARIADB_INTERNAL_PORT,
             resource_name,
             &config.username,
@@ -1187,7 +1173,7 @@ impl MariaDbService {
         s3_source: &temps_entities::s3_sources::Model,
         config: &MariaDbConfig,
     ) -> Result<usize> {
-        let container_name = self.get_live_container_name(config);
+        let container_name = self.get_container_name();
         let bucket = &s3_source.bucket_name;
         let prefix = s3_source.bucket_path.trim_matches('/');
 
@@ -1291,7 +1277,7 @@ impl MariaDbService {
 
     /// Raw `SHOW BINARY LOGS` output (tab-separated rows: filename, size, ...).
     async fn show_binary_logs(&self, config: &MariaDbConfig) -> Result<String> {
-        let container_name = self.get_live_container_name(config);
+        let container_name = self.get_container_name();
         self.run_container_command(
             &container_name,
             vec![
@@ -1534,7 +1520,7 @@ impl MariaDbService {
     ) -> Result<()> {
         use std::io::Write;
 
-        let container_name = self.get_live_container_name(config);
+        let container_name = self.get_container_name();
         let env = [
             format!("MYSQL_PWD={}", config.root_password),
             format!("MARIADB_PWD={}", config.root_password),
@@ -1644,7 +1630,7 @@ impl MariaDbService {
         config: &MariaDbConfig,
         sql_path: &std::path::Path,
     ) -> Result<()> {
-        let container_name = self.get_live_container_name(config);
+        let container_name = self.get_container_name();
         let restore_filename = "temps_mariadb_restore.sql";
 
         let tar_data = {
@@ -1829,7 +1815,7 @@ impl MariaDbService {
         config: &MariaDbConfig,
         mbstream_host_path: &std::path::Path,
     ) -> Result<()> {
-        let container_name = self.get_live_container_name(config);
+        let container_name = self.get_container_name();
 
         // 1. Disable restart policy FIRST so Docker doesn't bounce the
         //    container back up while the helper holds the volume.
@@ -2170,7 +2156,8 @@ impl MariaDbService {
     ///   only meaningful when that file is the final segment replayed. A bare
     ///   position (no `file:`) is rejected as ambiguous across segments.
     /// - `Xid`   → GTID stop is not yet expressible via a single mysqlbinlog
-    ///   invocation here; rejected rather than silently mis-recovering.
+    ///   invocation here; rejected rather than silently recovering to the
+    ///   wrong point.
     /// - `Name`  → no MariaDB equivalent; rejected.
     pub(crate) fn recovery_target_to_stop_flag(
         target: &RecoveryTarget,
@@ -2321,7 +2308,7 @@ impl MariaDbService {
             return Ok(());
         }
 
-        let container_name = self.get_live_container_name(config);
+        let container_name = self.get_container_name();
         let container_dir = "/var/tmp/temps-binlogs";
 
         // Upload every segment into the container, preserving filenames.
@@ -2487,9 +2474,7 @@ impl MariaDbService {
     ) -> Result<(MariaDbService, MariaDbConfig)> {
         let mut config = self.get_mariadb_config(source_config.clone())?;
 
-        // Fresh port (the source's is taken). A restored new service is its own
-        // container, not an imported one.
-        config.container_name = None;
+        // Fresh port (the source's is taken).
         let new_port = find_available_port(3306)
             .ok_or_else(|| anyhow::anyhow!("No available ports for new MariaDB service"))?
             .to_string();
@@ -2621,16 +2606,8 @@ impl ExternalService for MariaDbService {
         *self.config.write().await = Some(mariadb_config.clone());
         *self.resource_limits.write().await = resource_limits.clone();
 
-        if mariadb_config.container_name.is_none() {
-            self.create_container(&self.docker, &mariadb_config, &resource_limits)
-                .await?;
-        } else {
-            info!(
-                "MariaDB service '{}' is imported from container '{}'; skipping container creation",
-                self.name,
-                self.get_live_container_name(&mariadb_config)
-            );
-        }
+        self.create_container(&self.docker, &mariadb_config, &resource_limits)
+            .await?;
 
         let runtime_config_json = serde_json::to_value(&mariadb_config)
             .map_err(|e| anyhow::anyhow!("Failed to serialize MariaDB runtime config: {}", e))?;
@@ -2776,10 +2753,7 @@ impl ExternalService for MariaDbService {
 
     async fn start(&self) -> Result<()> {
         let existing_config = self.config.read().await.as_ref().cloned();
-        let container_name = existing_config
-            .as_ref()
-            .map(|config| self.get_live_container_name(config))
-            .unwrap_or_else(|| self.get_container_name());
+        let container_name = self.get_container_name();
         info!("Starting MariaDB container {}", container_name);
 
         let containers = self
@@ -2797,12 +2771,6 @@ impl ExternalService for MariaDbService {
         if containers.is_empty() {
             let config = existing_config
                 .ok_or_else(|| anyhow::anyhow!("MariaDB configuration not found"))?;
-            if config.container_name.is_some() {
-                return Err(anyhow::anyhow!(
-                    "Imported MariaDB container '{}' not found",
-                    container_name
-                ));
-            }
             let limits = self.resource_limits.read().await.clone();
             self.create_container(&self.docker, &config, &limits)
                 .await?;
@@ -2830,13 +2798,7 @@ impl ExternalService for MariaDbService {
     }
 
     async fn stop(&self) -> Result<()> {
-        let container_name = self
-            .config
-            .read()
-            .await
-            .as_ref()
-            .map(|config| self.get_live_container_name(config))
-            .unwrap_or_else(|| self.get_container_name());
+        let container_name = self.get_container_name();
         let containers = self
             .docker
             .list_containers(Some(bollard::query_parameters::ListContainersOptions {
@@ -3035,10 +2997,7 @@ impl ExternalService for MariaDbService {
         let config = self.get_mariadb_config(service_config)?;
 
         if temps_core::DeploymentMode::is_docker() {
-            Ok((
-                self.get_live_container_name(&config),
-                MARIADB_INTERNAL_PORT.to_string(),
-            ))
+            Ok((self.get_container_name(), MARIADB_INTERNAL_PORT.to_string()))
         } else {
             Ok(("localhost".to_string(), config.port))
         }
@@ -3646,7 +3605,6 @@ mod tests {
             docker_image: DEFAULT_MARIADB_IMAGE.to_string(),
             size_profile: MariaDbSizeProfile::Standard,
             binlog_archive_interval: BinlogArchiveInterval::Min15,
-            container_name: None,
         });
 
         assert_eq!(config.size_profile, MariaDbSizeProfile::Standard);
@@ -4184,7 +4142,6 @@ mod tests {
             docker_image: default_docker_image(),
             size_profile: MariaDbSizeProfile::default(),
             binlog_archive_interval: BinlogArchiveInterval::default(),
-            container_name: None,
         };
 
         let config: MariaDbConfig = input.into();
@@ -4224,7 +4181,6 @@ mod tests {
             docker_image: "mariadb:11.4".to_string(),
             size_profile: MariaDbSizeProfile::default(),
             binlog_archive_interval: BinlogArchiveInterval::default(),
-            container_name: None,
         };
 
         let config: MariaDbConfig = input.into();
@@ -4667,5 +4623,19 @@ mod tests {
         // which version upgrades actually happen.
         let env_vars = ["MARIADB_AUTO_UPGRADE=1".to_string()];
         assert!(env_vars.contains(&"MARIADB_AUTO_UPGRADE=1".to_string()));
+    }
+
+    #[test]
+    fn test_container_name_is_not_a_user_input() {
+        // container_name is derived from the service name at creation time
+        // (`mariadb-{name}`), never supplied by the client — same as Postgres.
+        // The create form is generated from this schema, so the field must not
+        // appear in it (previously a stray "" made init skip container creation
+        // and start POST /containers//start, which Docker answers with a 301).
+        let schema = serde_json::to_value(schemars::schema_for!(MariaDbInputConfig)).unwrap();
+        assert!(
+            !schema.to_string().contains("container_name"),
+            "container_name leaked into the MariaDB create schema"
+        );
     }
 }

--- a/crates/temps-providers/src/externalsvc/mongodb.rs
+++ b/crates/temps-providers/src/externalsvc/mongodb.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 use tokio::time::sleep;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Bound for a single MongoDB backup `docker exec`. Mongo dumps can be
 /// large; 4 hours is a reasonable middle ground.
@@ -74,6 +74,17 @@ pub struct MongodbInputConfig {
     #[serde(default, deserialize_with = "deserialize_optional_replica_set")]
     #[schemars(with = "Option<String>", example = "example_replica_set")]
     pub replica_set: Option<String>,
+
+    /// Real Docker container name when this service was imported from an
+    /// existing MongoDB-compatible container (set by `import_from_container`,
+    /// never user-editable — omitted from the create form). Overrides the
+    /// derived `temps-mongodb-{name}` container name so internal addressing
+    /// targets the actual pre-existing container instead of a synthesized
+    /// name that doesn't exist. Mirrors the MariaDB/Postgres/Redis fix for
+    /// the same class of bug.
+    #[serde(default, deserialize_with = "deserialize_optional_non_empty")]
+    #[schemars(skip)]
+    pub container_name: Option<String>,
 }
 
 // Example functions for schemars
@@ -129,6 +140,10 @@ pub struct MongodbRuntimeConfig {
     /// here so the same keyfile is written into the container on every restart.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub keyfile_content: Option<String>,
+    /// Real container name for imported services — see
+    /// `MongodbInputConfig::container_name`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_name: Option<String>,
 }
 
 impl From<MongodbInputConfig> for MongodbRuntimeConfig {
@@ -152,6 +167,7 @@ impl From<MongodbInputConfig> for MongodbRuntimeConfig {
             docker_image: input.docker_image,
             replica_set,
             keyfile_content,
+            container_name: input.container_name,
         }
     }
 }
@@ -168,6 +184,16 @@ where
         Some(s) if !s.is_empty() => Some(s),
         _ => None,
     })
+}
+
+/// Treats a blank string the same as an absent value — see
+/// `MongodbInputConfig::container_name`.
+fn deserialize_optional_non_empty<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let opt: Option<String> = Option::deserialize(deserializer)?;
+    Ok(opt.filter(|s| !s.is_empty()))
 }
 
 /// Treat empty string as `None` so the UI can submit a blank field without
@@ -313,6 +339,19 @@ impl MongodbService {
 
     fn get_container_name(&self) -> String {
         format!("temps-mongodb-{}", self.name)
+    }
+
+    /// The container this service actually runs in: the imported container's
+    /// real name when `config.container_name` is set, otherwise the derived
+    /// `temps-mongodb-{name}`. Every operation that talks to the live
+    /// container must resolve through this, not `get_container_name()`
+    /// directly, or it targets a synthesized name that doesn't exist for
+    /// imported services.
+    fn get_live_container_name(&self, config: &MongodbRuntimeConfig) -> String {
+        config
+            .container_name
+            .clone()
+            .unwrap_or_else(|| self.get_container_name())
     }
 
     /// Creates and starts the MongoDB container, retrying with a fresh host
@@ -717,9 +756,18 @@ impl MongodbService {
                 .inspect_container(container_id, None::<InspectContainerOptions>)
                 .await?;
             if let Some(state) = info.state {
-                if state.status == Some(bollard::models::ContainerStateStatusEnum::RUNNING)
-                    && state.health.as_ref().and_then(|h| h.status.as_ref())
-                        == Some(&bollard::models::HealthStatusEnum::HEALTHY)
+                // Considered ready if it's running and either has a HEALTHY
+                // Docker healthcheck status or no healthcheck is defined at
+                // all (e.g. an imported container from a vanilla image with
+                // no HEALTHCHECK directive — requiring an explicit HEALTHY
+                // here would spin until `max_wait` every time).
+                let is_running =
+                    state.status == Some(bollard::models::ContainerStateStatusEnum::RUNNING);
+                let health_status = state.health.as_ref().and_then(|h| h.status.as_ref());
+
+                if is_running
+                    && (health_status.is_none()
+                        || health_status == Some(&bollard::models::HealthStatusEnum::HEALTHY))
                 {
                     return Ok(());
                 }
@@ -925,7 +973,7 @@ impl MongodbService {
             .map(String::from);
 
         let config = self.get_mongodb_config(service_config)?;
-        let container_name = self.get_container_name();
+        let container_name = self.get_live_container_name(&config);
 
         info!(
             "Restoring MongoDB from WAL-G backup (prefix: {}) in container '{}'",
@@ -1150,7 +1198,7 @@ impl MongodbService {
         service_config: ServiceConfig,
     ) -> Result<()> {
         let config = self.get_mongodb_config(service_config)?;
-        let container_name = self.get_container_name();
+        let container_name = self.get_live_container_name(&config);
 
         info!(
             "Restoring MongoDB from legacy backup format: {}",
@@ -1414,7 +1462,7 @@ impl MongodbService {
         use bollard::exec::CreateExecOptions;
 
         let config = self.get_mongodb_config(service_config)?;
-        let container_name = self.get_container_name();
+        let container_name = self.get_live_container_name(&config);
         let timestamp = chrono::Utc::now().format("%Y%m%d_%H%M%S");
         let backup_file = format!("mongodb_backup_{}.gz", timestamp);
         let backup_path = format!("{}/{}", subpath, backup_file);
@@ -1551,7 +1599,7 @@ impl MongodbService {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("MongoDB not configured"))?;
 
-        let effective_host = self.get_container_name();
+        let effective_host = self.get_live_container_name(config);
         let effective_port = MONGODB_INTERNAL_PORT.to_string();
 
         let mut env_vars = HashMap::new();
@@ -1583,7 +1631,10 @@ impl ExternalService for MongodbService {
 
         if temps_core::DeploymentMode::is_docker() {
             // Docker mode: use container name and internal port
-            Ok((self.get_container_name(), MONGODB_INTERNAL_PORT.to_string()))
+            Ok((
+                self.get_live_container_name(&config),
+                MONGODB_INTERNAL_PORT.to_string(),
+            ))
         } else {
             // Baremetal mode: use localhost and exposed port
             Ok(("localhost".to_string(), config.port))
@@ -1810,7 +1861,11 @@ impl ExternalService for MongodbService {
 
     async fn start(&self) -> Result<()> {
         let docker = &self.docker;
-        let container_name = self.get_container_name();
+        let existing_config = self.config.read().await.as_ref().cloned();
+        let container_name = existing_config
+            .as_ref()
+            .map(|config| self.get_live_container_name(config))
+            .unwrap_or_else(|| self.get_container_name());
         info!("Starting MongoDB container {}", container_name);
 
         let containers = docker
@@ -1824,13 +1879,38 @@ impl ExternalService for MongodbService {
             }))
             .await?;
 
-        let config = self
-            .config
-            .read()
-            .await
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("MongoDB configuration not found"))?
-            .clone();
+        let config =
+            existing_config.ok_or_else(|| anyhow::anyhow!("MongoDB configuration not found"))?;
+
+        // Imported services skip the replica-set drift-reconciliation path
+        // entirely: the stop+remove+recreate below assumes Temps owns the
+        // container's lifecycle and volume naming. Running that against a
+        // pre-existing container the operator brought in would delete their
+        // real database to "fix" a mismatch that was never Temps' to manage.
+        if config.container_name.is_some() {
+            if containers.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "Imported MongoDB container '{}' not found",
+                    container_name
+                ));
+            }
+            let is_running = matches!(
+                containers[0].state,
+                Some(bollard::models::ContainerSummaryStateEnum::RUNNING)
+            );
+            if !is_running {
+                docker
+                    .start_container(
+                        &container_name,
+                        None::<bollard::query_parameters::StartContainerOptions>,
+                    )
+                    .await
+                    .map_err(|e| {
+                        anyhow::anyhow!("Failed to start imported MongoDB container: {}", e)
+                    })?;
+            }
+            return Ok(());
+        }
 
         let limits = self.resource_limits.read().await.clone();
         if containers.is_empty() {
@@ -1895,7 +1975,13 @@ impl ExternalService for MongodbService {
     }
 
     async fn stop(&self) -> Result<()> {
-        let container_name = self.get_container_name();
+        let container_name = self
+            .config
+            .read()
+            .await
+            .as_ref()
+            .map(|config| self.get_live_container_name(config))
+            .unwrap_or_else(|| self.get_container_name());
         info!("Stopping MongoDB container {}", container_name);
 
         self.docker
@@ -1960,8 +2046,13 @@ impl ExternalService for MongodbService {
             .get("password")
             .ok_or_else(|| anyhow::anyhow!("Missing password parameter"))?;
 
-        // Always use container name and internal port for container-to-container communication
-        let effective_host = self.get_container_name();
+        // An imported service's real container name (stored raw in
+        // parameters, since the typed config isn't available here) wins
+        // over the derived one.
+        let effective_host = parameters
+            .get("container_name")
+            .cloned()
+            .unwrap_or_else(|| self.get_container_name());
         let effective_port = MONGODB_INTERNAL_PORT.to_string();
         let replica_set = parameters.get("replica_set").map(String::as_str);
 
@@ -2000,8 +2091,13 @@ impl ExternalService for MongodbService {
             .get("password")
             .ok_or_else(|| anyhow::anyhow!("Missing password parameter"))?;
 
-        // Always use container name and internal port for container-to-container communication
-        let effective_host = self.get_container_name();
+        // An imported service's real container name (stored raw in
+        // parameters, since the typed config isn't available here) wins
+        // over the derived one.
+        let effective_host = parameters
+            .get("container_name")
+            .cloned()
+            .unwrap_or_else(|| self.get_container_name());
         let effective_port = MONGODB_INTERNAL_PORT.to_string();
         let replica_set = parameters.get("replica_set").map(String::as_str);
 
@@ -2161,7 +2257,8 @@ impl ExternalService for MongodbService {
         use chrono::Utc;
         use sea_orm::*;
 
-        let container_name = self.get_container_name();
+        let mongodb_config = self.get_mongodb_config(service_config.clone())?;
+        let container_name = self.get_live_container_name(&mongodb_config);
 
         if !self.container_has_walg(&container_name).await {
             info!(
@@ -2309,7 +2406,13 @@ impl ExternalService for MongodbService {
     }
 
     async fn get_current_docker_image(&self) -> Result<(String, String)> {
-        let container_name = self.get_container_name();
+        let container_name = self
+            .config
+            .read()
+            .await
+            .as_ref()
+            .map(|config| self.get_live_container_name(config))
+            .unwrap_or_else(|| self.get_container_name());
         let container = self
             .docker
             .inspect_container(
@@ -2390,6 +2493,15 @@ impl ExternalService for MongodbService {
                 anyhow::anyhow!("Failed to inspect container '{}': {}", container_id, e)
             })?;
 
+        // The real Docker container name — every operation on an imported
+        // service must target this, not the derived `temps-mongodb-{name}`.
+        let imported_container_name = container
+            .name
+            .as_deref()
+            .unwrap_or(&container_id)
+            .trim_start_matches('/')
+            .to_string();
+
         // Extract image name and version
         let image = container.config.and_then(|c| c.image).ok_or_else(|| {
             anyhow::anyhow!("Could not determine image for container '{}'", container_id)
@@ -2430,23 +2542,61 @@ impl ExternalService for MongodbService {
             format!("mongodb://localhost:{}", port)
         };
 
-        // Verify connection to the imported service
-        match tokio::runtime::Runtime::new().ok().and_then(|rt| {
-            rt.block_on(async {
-                match mongodb::Client::with_uri_str(&connection_url).await {
-                    Ok(client) => client.list_databases().await.ok(),
-                    Err(_) => None,
-                }
-            })
-        }) {
-            Some(_) => {
-                info!("Successfully verified MongoDB connection for import");
+        // Verify connection to the imported service. Connects directly with
+        // `.await` on the current runtime — spinning up a nested
+        // `tokio::runtime::Runtime` and calling `block_on` here panics with
+        // "Cannot start a runtime from within a runtime", since this
+        // `async fn` is already driven by one.
+        use std::future::IntoFuture;
+        let client = mongodb::Client::with_uri_str(&connection_url)
+            .await
+            .map_err(|e| anyhow::anyhow!("Invalid MongoDB connection URL: {}", e))?;
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            client.list_databases().into_future(),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("MongoDB connection timed out after 5 seconds"))?
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to connect to MongoDB at localhost:{} with provided credentials: {}",
+                port,
+                e
+            )
+        })?;
+        info!("Successfully verified MongoDB connection for import");
+
+        let network_ready = match ensure_network_exists(&self.docker).await {
+            Ok(()) => true,
+            Err(e) => {
+                warn!(
+                    "Failed to ensure Temps Docker network before MongoDB import attach: {:?}",
+                    e
+                );
+                false
             }
-            None => {
-                return Err(anyhow::anyhow!(
-                    "Failed to connect to MongoDB at localhost:{} with provided credentials. Verify port, username, and password.",
-                    port
-                ));
+        };
+        if network_ready {
+            let network_name = temps_core::NETWORK_NAME.as_str();
+            let request = bollard::models::NetworkConnectRequest {
+                container: container_id.clone(),
+                ..Default::default()
+            };
+            match self.docker.connect_network(network_name, request).await {
+                Ok(()) => info!(
+                    "Attached imported MongoDB container '{}' to {}",
+                    imported_container_name, network_name
+                ),
+                Err(bollard::errors::Error::DockerResponseServerError {
+                    status_code: 403, ..
+                }) => debug!(
+                    "Imported MongoDB container '{}' is already attached to {}",
+                    imported_container_name, network_name
+                ),
+                Err(e) => warn!(
+                    "Failed to attach imported MongoDB container '{}' to {}: {}",
+                    imported_container_name, network_name, e
+                ),
             }
         }
 
@@ -2462,7 +2612,7 @@ impl ExternalService for MongodbService {
                 "password": password.unwrap_or_default(),
                 "database": database,
                 "docker_image": image,
-                "container_id": container_id,
+                "container_name": imported_container_name,
             }),
         };
 
@@ -2535,6 +2685,52 @@ mod tests {
         let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
         let service = MongodbService::new("test-service".to_string(), docker);
         assert_eq!(service.get_container_name(), "temps-mongodb-test-service");
+    }
+
+    #[test]
+    fn test_get_effective_address_docker_mode_uses_imported_container_name() {
+        let _lock = crate::externalsvc::DEPLOYMENT_MODE_MUTEX
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        unsafe { std::env::set_var("DEPLOYMENT_MODE", "docker") };
+
+        let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
+        let service = MongodbService::new("imported-svc".to_string(), docker);
+
+        let config = ServiceConfig {
+            name: "imported-svc".to_string(),
+            service_type: ServiceType::Mongodb,
+            version: None,
+            parameters: serde_json::json!({
+                "host": "localhost",
+                "port": "27018",
+                "database": "admin",
+                "username": "root",
+                "password": "testpass",
+                "container_name": "legacy-mongo",
+            }),
+        };
+
+        let (host, port) = service.get_effective_address(config).unwrap();
+        // The imported container name wins over the derived
+        // `temps-mongodb-{name}`.
+        assert_eq!(host, "legacy-mongo");
+        assert_eq!(port, "27017");
+
+        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
+    }
+
+    #[test]
+    fn test_container_name_is_not_a_user_input() {
+        // container_name is derived from the service name at creation time
+        // (`temps-mongodb-{name}`), never supplied by the client — same as
+        // MariaDB (see mariadb.rs's identical test). The create form is
+        // generated from this schema, so the field must not appear in it.
+        let schema = serde_json::to_value(schemars::schema_for!(MongodbInputConfig)).unwrap();
+        assert!(
+            !schema.to_string().contains("container_name"),
+            "container_name leaked into the MongoDB create schema"
+        );
     }
 
     #[test]
@@ -3058,6 +3254,7 @@ mod tests {
             docker_image: "gotempsh/mongodb-walg:8.0".to_string(),
             replica_set: None,
             keyfile_content: None,
+            container_name: None,
         };
 
         *service.config.write().await = Some(mongodb_config.clone());

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -5100,6 +5100,50 @@ mod tests {
     }
 
     #[test]
+    fn test_get_effective_address_docker_mode_uses_imported_container_name() {
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe { std::env::set_var("DEPLOYMENT_MODE", "docker") };
+
+        let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
+        let service = PostgresService::new("imported-svc".to_string(), docker);
+
+        let config = ServiceConfig {
+            name: "imported-svc".to_string(),
+            service_type: super::ServiceType::Postgres,
+            version: None,
+            parameters: serde_json::json!({
+                "host": "localhost",
+                "port": "5432",
+                "database": "testdb",
+                "username": "postgres",
+                "password": "testpass",
+                "max_connections": 100,
+                "container_name": "legacy-postgres",
+            }),
+        };
+
+        let (host, port) = service.get_effective_address(config).unwrap();
+        // The imported container name wins over the derived `postgres-{name}`.
+        assert_eq!(host, "legacy-postgres");
+        assert_eq!(port, "5432");
+
+        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
+    }
+
+    #[test]
+    fn test_container_name_is_not_a_user_input() {
+        // container_name is derived from the service name at creation time
+        // (`postgres-{name}`), never supplied by the client — same as
+        // MariaDB (see mariadb.rs's identical test). The create form is
+        // generated from this schema, so the field must not appear in it.
+        let schema = serde_json::to_value(schemars::schema_for!(PostgresInputConfig)).unwrap();
+        assert!(
+            !schema.to_string().contains("container_name"),
+            "container_name leaked into the PostgreSQL create schema"
+        );
+    }
+
+    #[test]
     fn test_get_environment_variables_always_uses_container_name() {
         // get_environment_variables always uses container name and internal port
         // for container-to-container communication, regardless of deployment mode

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -7,7 +7,6 @@ use schemars::JsonSchema;
 use sea_orm::{prelude::*, *};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use temps_entities::external_service_backups;
@@ -157,6 +156,19 @@ pub struct PostgresInputConfig {
     #[serde(default = "default_docker_image")]
     #[schemars(example = "example_docker_image", default = "default_docker_image")]
     pub docker_image: Option<String>,
+
+    /// Real Docker container name when this service was imported from an
+    /// existing PostgreSQL-compatible container (set by
+    /// `import_from_container`, never user-editable — omitted from the
+    /// create form). Overrides the derived `postgres-{name}` container name
+    /// so internal addressing targets the actual pre-existing container
+    /// instead of a synthesized name that doesn't exist. Deserialized
+    /// through `deserialize_optional_non_empty` as a second guard alongside
+    /// `#[schemars(skip)]`, mirroring the MariaDB fix for the same class of
+    /// bug (see `crates/temps-providers/src/externalsvc/mariadb.rs`).
+    #[serde(default, deserialize_with = "deserialize_optional_non_empty")]
+    #[schemars(skip)]
+    pub container_name: Option<String>,
 }
 
 /// Internal runtime configuration for PostgreSQL service
@@ -172,6 +184,10 @@ pub struct PostgresConfig {
     pub max_connections: u32,
     pub ssl_mode: Option<String>,
     pub docker_image: String,
+    /// Real container name for imported services — see
+    /// `PostgresInputConfig::container_name`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_name: Option<String>,
 }
 
 impl From<PostgresInputConfig> for PostgresConfig {
@@ -191,8 +207,19 @@ impl From<PostgresInputConfig> for PostgresConfig {
             docker_image: input
                 .docker_image
                 .unwrap_or_else(|| "gotempsh/postgres-walg:18-bookworm".to_string()),
+            container_name: input.container_name,
         }
     }
+}
+
+/// Treats a blank string the same as an absent value — see
+/// `PostgresInputConfig::container_name`.
+fn deserialize_optional_non_empty<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let opt: Option<String> = Option::deserialize(deserializer)?;
+    Ok(opt.filter(|s| !s.is_empty()))
 }
 
 fn deserialize_optional_password<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
@@ -330,6 +357,19 @@ impl PostgresService {
     }
     fn get_container_name(&self) -> String {
         format!("postgres-{}", self.name)
+    }
+
+    /// The container this service actually runs in: the imported container's
+    /// real name when `config.container_name` is set, otherwise the derived
+    /// `postgres-{name}`. Every operation that talks to the live container
+    /// (admin SQL, backup, restore, start/stop) must resolve through this,
+    /// not `get_container_name()` directly, or it targets a synthesized name
+    /// that doesn't exist for imported services.
+    fn get_live_container_name(&self, config: &PostgresConfig) -> String {
+        config
+            .container_name
+            .clone()
+            .unwrap_or_else(|| self.get_container_name())
     }
 
     /// Creates and starts the PostgreSQL container, retrying with a fresh host
@@ -1283,7 +1323,7 @@ impl PostgresService {
         let config: PostgresConfig = self.get_postgres_config(service_config)?;
         let mut env_vars = HashMap::new();
 
-        let effective_host = self.get_container_name();
+        let effective_host = self.get_live_container_name(&config);
         let effective_port = POSTGRES_INTERNAL_PORT.to_string();
 
         env_vars.insert("POSTGRES_DATABASE".to_string(), resource_name.to_string());
@@ -1565,7 +1605,7 @@ impl PostgresService {
         use bollard::exec::CreateExecOptions;
 
         let postgres_config = self.get_postgres_config(service_config)?;
-        let container_name = self.get_container_name();
+        let container_name = self.get_live_container_name(&postgres_config);
 
         info!(
             "Restoring PostgreSQL from WAL-G backup (prefix: {}) in container '{}'",
@@ -1969,7 +2009,7 @@ impl PostgresService {
         let mut decompressed_data = Vec::new();
         std::io::Read::read_to_end(&mut decoder, &mut decompressed_data)?;
 
-        let container_name = self.get_container_name();
+        let container_name = self.get_live_container_name(&postgres_config);
 
         // Detect backup format from the S3 location
         let is_plain_format = backup_location.ends_with(".sql.gz");
@@ -2023,7 +2063,7 @@ impl PostgresService {
         use sea_orm::*;
 
         let postgres_config = self.get_postgres_config(service_config)?;
-        let container_name = self.get_container_name();
+        let container_name = self.get_live_container_name(&postgres_config);
 
         let metadata = serde_json::json!({
             "service_type": "postgres",
@@ -2281,7 +2321,7 @@ impl PostgresService {
         use bollard::query_parameters::RemoveContainerOptions;
         use chrono::Utc;
 
-        let db_container_name = self.get_container_name();
+        let db_container_name = self.get_live_container_name(postgres_config);
         let sidecar_image = postgres_config.docker_image.clone();
 
         info!("Pulling sidecar image {} for pg_dump", sidecar_image);
@@ -2538,7 +2578,7 @@ impl ExternalService for PostgresService {
         if temps_core::DeploymentMode::is_docker() {
             // Docker mode: use container name and internal port
             Ok((
-                self.get_container_name(),
+                self.get_live_container_name(&config),
                 POSTGRES_INTERNAL_PORT.to_string(),
             ))
         } else {
@@ -2574,7 +2614,8 @@ impl ExternalService for PostgresService {
         external_service: &temps_entities::external_services::Model,
         service_config: ServiceConfig,
     ) -> anyhow::Result<super::BackupOutcome> {
-        let container_name = self.get_container_name();
+        let postgres_config = self.get_postgres_config(service_config.clone())?;
+        let container_name = self.get_live_container_name(&postgres_config);
 
         if self.container_has_walg(&container_name).await {
             info!(
@@ -2632,11 +2673,19 @@ impl ExternalService for PostgresService {
         *self.config.write().await = Some(postgres_config.clone());
         *self.resource_limits.write().await = resource_limits.clone();
 
-        // Create Docker container. New services always start with archiving
-        // off — `enable_wal_archiving()` recreates with archiving on when
-        // WAL-G is later configured.
-        self.create_container(&self.docker, &postgres_config, &resource_limits, false)
-            .await?;
+        if postgres_config.container_name.is_none() {
+            // Create Docker container. New services always start with archiving
+            // off — `enable_wal_archiving()` recreates with archiving on when
+            // WAL-G is later configured.
+            self.create_container(&self.docker, &postgres_config, &resource_limits, false)
+                .await?;
+        } else {
+            info!(
+                "PostgreSQL service '{}' is imported from container '{}'; skipping container creation",
+                self.name,
+                self.get_live_container_name(&postgres_config)
+            );
+        }
 
         // Serialize the full runtime config to save to database
         // This ensures auto-generated values (password, port) are persisted
@@ -2829,8 +2878,14 @@ impl ExternalService for PostgresService {
             .get("database")
             .context("Missing database parameter")?;
 
-        // Always use container name and internal port for container-to-container communication
-        let effective_host = self.get_container_name();
+        // Always use container name and internal port for container-to-container
+        // communication. An imported service's real container name (stored raw
+        // in parameters, since the typed config isn't available here) wins over
+        // the derived one.
+        let effective_host = parameters
+            .get("container_name")
+            .cloned()
+            .unwrap_or_else(|| self.get_container_name());
         let effective_port = POSTGRES_INTERNAL_PORT.to_string();
 
         let url = format!(
@@ -2894,8 +2949,58 @@ impl ExternalService for PostgresService {
     }
 
     async fn start(&self) -> Result<()> {
-        let container_name = self.get_container_name();
+        let existing_config = self.config.read().await.as_ref().cloned();
+        let container_name = existing_config
+            .as_ref()
+            .map(|config| self.get_live_container_name(config))
+            .unwrap_or_else(|| self.get_container_name());
         info!("Starting PostgreSQL container {}", container_name);
+
+        // Imported services skip the drift-reconciliation path entirely: the
+        // archive_mode CMD check and its stop+remove+recreate response below
+        // assume Temps owns the container's lifecycle and volume naming.
+        // Running that against a pre-existing container the operator brought
+        // in would delete their real database to "fix" a CMD mismatch that
+        // was never Temps' to manage.
+        if let Some(config) = existing_config
+            .as_ref()
+            .filter(|c| c.container_name.is_some())
+        {
+            let containers = self
+                .docker
+                .list_containers(Some(bollard::query_parameters::ListContainersOptions {
+                    all: true,
+                    filters: Some(HashMap::from([(
+                        "name".to_string(),
+                        vec![container_name.clone()],
+                    )])),
+                    ..Default::default()
+                }))
+                .await?;
+            if containers.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "Imported PostgreSQL container '{}' not found",
+                    container_name
+                ));
+            }
+            let is_running = matches!(
+                containers[0].state,
+                Some(bollard::models::ContainerSummaryStateEnum::RUNNING)
+            );
+            if !is_running {
+                self.docker
+                    .start_container(
+                        &container_name,
+                        None::<bollard::query_parameters::StartContainerOptions>,
+                    )
+                    .await
+                    .context("Failed to start imported PostgreSQL container")?;
+            }
+            self.wait_for_container_health(&self.docker, &container_name)
+                .await?;
+            let _ = config;
+            return Ok(());
+        }
 
         // Reconcile-on-start. The desired `archive_mode` is derived from
         // on-disk truth: `/var/lib/postgresql/walg.env` exists on the
@@ -3010,7 +3115,13 @@ impl ExternalService for PostgresService {
 
     async fn stop(&self) -> Result<()> {
         // Stop the container if Docker is available
-        let container_name = self.get_container_name();
+        let container_name = self
+            .config
+            .read()
+            .await
+            .as_ref()
+            .map(|config| self.get_live_container_name(config))
+            .unwrap_or_else(|| self.get_container_name());
 
         // Check if container exists before attempting to stop
         let containers = self
@@ -3113,8 +3224,14 @@ impl ExternalService for PostgresService {
             .get("password")
             .context("Missing password parameter")?;
 
-        // Always use container name and internal port for container-to-container communication
-        let effective_host = self.get_container_name();
+        // Always use container name and internal port for container-to-container
+        // communication. An imported service's real container name (stored raw
+        // in parameters, since the typed config isn't available here) wins over
+        // the derived one.
+        let effective_host = parameters
+            .get("container_name")
+            .cloned()
+            .unwrap_or_else(|| self.get_container_name());
         let effective_port = POSTGRES_INTERNAL_PORT.to_string();
 
         let url = format!(
@@ -3259,7 +3376,13 @@ impl ExternalService for PostgresService {
     }
 
     async fn get_current_docker_image(&self) -> Result<(String, String)> {
-        let container_name = self.get_container_name();
+        let container_name = self
+            .config
+            .read()
+            .await
+            .as_ref()
+            .map(|config| self.get_live_container_name(config))
+            .unwrap_or_else(|| self.get_container_name());
         let container = self
             .docker
             .inspect_container(
@@ -3311,6 +3434,15 @@ impl ExternalService for PostgresService {
                 anyhow::anyhow!("Failed to inspect container '{}': {}", container_id, e)
             })?;
 
+        // The real Docker container name — every operation on an imported
+        // service must target this, not the derived `postgres-{name}`.
+        let imported_container_name = container
+            .name
+            .as_deref()
+            .unwrap_or(&container_id)
+            .trim_start_matches('/')
+            .to_string();
+
         // Extract image name and version
         let image = container.config.and_then(|c| c.image).ok_or_else(|| {
             anyhow::anyhow!("Could not determine image for container '{}'", container_id)
@@ -3344,27 +3476,63 @@ impl ExternalService for PostgresService {
             .unwrap_or("5432")
             .to_string();
 
-        // Verify connection to the imported service
+        // Verify connection to the imported service. Connects directly with
+        // `.await` on the current runtime — spinning up a nested
+        // `tokio::runtime::Runtime` and calling `block_on` here panics with
+        // "Cannot start a runtime from within a runtime", since this
+        // `async fn` is already driven by one.
         let connection_url = format!(
-            "postgresql://{}:{}@{}:{}/{}",
-            username, password, "localhost", port, database
+            "postgresql://{}:{}@localhost:{}/{}",
+            urlencoding::encode(&username),
+            urlencoding::encode(&password),
+            port,
+            urlencoding::encode(&database)
         );
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&connection_url)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to connect to PostgreSQL at localhost:{} with provided credentials: {}",
+                    port,
+                    e
+                )
+            })?;
+        pool.close().await;
+        info!("Successfully verified PostgreSQL connection for import");
 
-        match sqlx::postgres::PgConnectOptions::from_str(&connection_url)
-            .ok()
-            .and_then(|_opts| {
-                tokio::runtime::Runtime::new()
-                    .ok()
-                    .and_then(|rt| rt.block_on(sqlx::PgPool::connect(&connection_url)).ok())
-            }) {
-            Some(_) => {
-                info!("Successfully verified PostgreSQL connection for import");
+        let network_ready = match ensure_network_exists(&self.docker).await {
+            Ok(()) => true,
+            Err(e) => {
+                warn!(
+                    "Failed to ensure Temps Docker network before PostgreSQL import attach: {:?}",
+                    e
+                );
+                false
             }
-            None => {
-                return Err(anyhow::anyhow!(
-                    "Failed to connect to PostgreSQL at {}:{} with provided credentials. Verify host, port, username, and password.",
-                    "localhost", port
-                ));
+        };
+        if network_ready {
+            let network_name = temps_core::NETWORK_NAME.as_str();
+            let request = bollard::models::NetworkConnectRequest {
+                container: container_id.clone(),
+                ..Default::default()
+            };
+            match self.docker.connect_network(network_name, request).await {
+                Ok(()) => info!(
+                    "Attached imported PostgreSQL container '{}' to {}",
+                    imported_container_name, network_name
+                ),
+                Err(bollard::errors::Error::DockerResponseServerError {
+                    status_code: 403, ..
+                }) => debug!(
+                    "Imported PostgreSQL container '{}' is already attached to {}",
+                    imported_container_name, network_name
+                ),
+                Err(e) => warn!(
+                    "Failed to attach imported PostgreSQL container '{}' to {}: {}",
+                    imported_container_name, network_name, e
+                ),
             }
         }
 
@@ -3382,7 +3550,7 @@ impl ExternalService for PostgresService {
                 "max_connections": "20",
                 "ssl_mode": "disable",
                 "docker_image": image,
-                "container_id": container_id,
+                "container_name": imported_container_name,
             }),
         };
 
@@ -3669,6 +3837,7 @@ mod tests {
             max_connections: default_max_connections(),
             ssl_mode: default_ssl_mode(),
             docker_image: None,
+            container_name: None,
         };
 
         let runtime_config: PostgresConfig = config.into();
@@ -3695,6 +3864,7 @@ mod tests {
             max_connections: 50,
             ssl_mode: Some("disable".to_string()),
             docker_image: Some("timescale/timescaledb-ha:pg18".to_string()),
+            container_name: None,
         };
 
         let runtime_config: PostgresConfig = config.into();
@@ -4003,6 +4173,7 @@ mod tests {
             max_connections: 100,
             ssl_mode: Some("disable".to_string()),
             docker_image: Some("gotempsh/postgres-walg:18-bookworm".to_string()),
+            container_name: None,
         };
 
         let downgrade_config = PostgresInputConfig {
@@ -4014,6 +4185,7 @@ mod tests {
             max_connections: 100,
             ssl_mode: Some("disable".to_string()),
             docker_image: Some("gotempsh/postgres-walg:17-bookworm".to_string()),
+            container_name: None,
         };
 
         let old_version =
@@ -4045,6 +4217,7 @@ mod tests {
             max_connections: 100,
             ssl_mode: Some("disable".to_string()),
             docker_image: Some("gotempsh/postgres-walg:17-bookworm".to_string()),
+            container_name: None,
         };
 
         let v18_config = PostgresInputConfig {
@@ -4056,6 +4229,7 @@ mod tests {
             max_connections: 100,
             ssl_mode: Some("disable".to_string()),
             docker_image: Some("gotempsh/postgres-walg:18-bookworm".to_string()),
+            container_name: None,
         };
 
         // Convert to runtime configs

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -5465,6 +5465,7 @@ mod tests {
             health_metadata: None,
             metrics_enabled: false,
             default_backup_provisioned: false,
+            container_name: None,
         };
         // Build a MockDatabase for the `pool` slot — restore_pitr for
         // Postgres doesn't touch it in the legacy-reject path.

--- a/crates/temps-providers/src/externalsvc/redis.rs
+++ b/crates/temps-providers/src/externalsvc/redis.rs
@@ -55,6 +55,17 @@ pub struct RedisInputConfig {
     #[serde(default = "default_docker_image")]
     #[schemars(example = "example_docker_image", default = "default_docker_image")]
     pub docker_image: String,
+
+    /// Real Docker container name when this service was imported from an
+    /// existing Redis-compatible container (set by `import_from_container`,
+    /// never user-editable — omitted from the create form). Overrides the
+    /// derived `redis-{name}` container name so internal addressing targets
+    /// the actual pre-existing container instead of a synthesized name that
+    /// doesn't exist. Mirrors the MariaDB/Postgres fix for the same class of
+    /// bug.
+    #[serde(default, deserialize_with = "deserialize_optional_non_empty")]
+    #[schemars(skip)]
+    pub container_name: Option<String>,
 }
 
 /// Internal runtime configuration for Redis service
@@ -65,6 +76,10 @@ pub struct RedisConfig {
     pub port: String,
     pub password: String,
     pub docker_image: String,
+    /// Real container name for imported services — see
+    /// `RedisInputConfig::container_name`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_name: Option<String>,
 }
 
 impl From<RedisInputConfig> for RedisConfig {
@@ -93,6 +108,7 @@ impl From<RedisInputConfig> for RedisConfig {
             }),
             password,
             docker_image: input.docker_image,
+            container_name: input.container_name,
         }
     }
 }
@@ -112,6 +128,16 @@ where
         }
         _ => None,
     })
+}
+
+/// Treats a blank string the same as an absent value — see
+/// `RedisInputConfig::container_name`.
+fn deserialize_optional_non_empty<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let opt: Option<String> = Option::deserialize(deserializer)?;
+    Ok(opt.filter(|s| !s.is_empty()))
 }
 
 fn default_host() -> String {
@@ -225,6 +251,18 @@ impl RedisService {
 
     fn get_container_name(&self) -> String {
         format!("redis-{}", self.name)
+    }
+
+    /// The container this service actually runs in: the imported container's
+    /// real name when `config.container_name` is set, otherwise the derived
+    /// `redis-{name}`. Every operation that talks to the live container must
+    /// resolve through this, not `get_container_name()` directly, or it
+    /// targets a synthesized name that doesn't exist for imported services.
+    fn get_live_container_name(&self, config: &RedisConfig) -> String {
+        config
+            .container_name
+            .clone()
+            .unwrap_or_else(|| self.get_container_name())
     }
 
     /// Creates and starts the Redis container, retrying with a fresh host
@@ -496,9 +534,18 @@ impl RedisService {
                 .inspect_container(container_id, None::<InspectContainerOptions>)
                 .await?;
             if let Some(state) = info.state {
-                if state.status == Some(bollard::models::ContainerStateStatusEnum::RUNNING)
-                    && state.health.as_ref().and_then(|h| h.status.as_ref())
-                        == Some(&bollard::models::HealthStatusEnum::HEALTHY)
+                // Considered ready if it's running and either has a HEALTHY
+                // Docker healthcheck status or no healthcheck is defined at
+                // all (e.g. an imported container built from a vanilla image
+                // with no HEALTHCHECK directive — requiring an explicit
+                // HEALTHY here would spin until `max_wait` every time).
+                let is_running =
+                    state.status == Some(bollard::models::ContainerStateStatusEnum::RUNNING);
+                let health_status = state.health.as_ref().and_then(|h| h.status.as_ref());
+
+                if is_running
+                    && (health_status.is_none()
+                        || health_status == Some(&bollard::models::HealthStatusEnum::HEALTHY))
                 {
                     return Ok(());
                 }
@@ -677,7 +724,13 @@ impl RedisService {
         s3_credentials: &super::S3Credentials,
         walg_s3_prefix: &str,
     ) -> Result<()> {
-        let container_name = self.get_container_name();
+        let container_name = self
+            .config
+            .read()
+            .await
+            .as_ref()
+            .map(|config| self.get_live_container_name(config))
+            .unwrap_or_else(|| self.get_container_name());
 
         info!(
             "Restoring Redis from WAL-G backup (prefix: {}) in container '{}'",
@@ -978,7 +1031,13 @@ impl RedisService {
         // Read the backup data
         let backup_data = get_obj.body.collect().await?.to_vec();
 
-        let container_name = self.get_container_name();
+        let container_name = self
+            .config
+            .read()
+            .await
+            .as_ref()
+            .map(|config| self.get_live_container_name(config))
+            .unwrap_or_else(|| self.get_container_name());
 
         self.docker
             .stop_container(&container_name, None::<StopContainerOptions>)
@@ -1124,7 +1183,13 @@ impl RedisService {
         .exec_with_returning(pool)
         .await?;
 
-        let container_name = self.get_container_name();
+        let container_name = self
+            .config
+            .read()
+            .await
+            .as_ref()
+            .map(|config| self.get_live_container_name(config))
+            .unwrap_or_else(|| self.get_container_name());
         let temp_dir = tempfile::tempdir()?;
         let temp_path = temp_dir.path();
 
@@ -1254,7 +1319,10 @@ impl ExternalService for RedisService {
 
         if temps_core::DeploymentMode::is_docker() {
             // Docker mode: use container name and internal port
-            Ok((self.get_container_name(), REDIS_INTERNAL_PORT.to_string()))
+            Ok((
+                self.get_live_container_name(&config),
+                REDIS_INTERNAL_PORT.to_string(),
+            ))
         } else {
             // Baremetal mode: use localhost and exposed port
             Ok(("localhost".to_string(), config.port))
@@ -1298,17 +1366,24 @@ impl ExternalService for RedisService {
 
         info!("Redis init - config stored successfully");
 
-        // Create Docker container (but don't start it yet)
-        // Note: Connection will be established in start() method
-        self.create_container(
-            &self.docker,
-            &redis_config,
-            &redis_config.password,
-            &resource_limits,
-        )
-        .await?;
-
-        info!("Redis container created, connection will be established on start");
+        if redis_config.container_name.is_none() {
+            // Create Docker container (but don't start it yet)
+            // Note: Connection will be established in start() method
+            self.create_container(
+                &self.docker,
+                &redis_config,
+                &redis_config.password,
+                &resource_limits,
+            )
+            .await?;
+            info!("Redis container created, connection will be established on start");
+        } else {
+            info!(
+                "Redis service '{}' is imported from container '{}'; skipping container creation",
+                self.name,
+                self.get_live_container_name(&redis_config)
+            );
+        }
 
         // Serialize the full runtime config to save to database
         // This ensures auto-generated values (password, port) are persisted
@@ -1462,10 +1537,17 @@ impl ExternalService for RedisService {
             .ok_or_else(|| anyhow::anyhow!("Missing port parameter"))?;
         let password = parameters.get("password");
 
-        // Get effective host and port based on deployment mode
+        // Get effective host and port based on deployment mode. An imported
+        // service's real container name (stored raw in parameters, since the
+        // typed config isn't available here) wins over the derived one.
         let (effective_host, effective_port) = if temps_core::DeploymentMode::is_docker() {
-            // Docker mode: use container name and internal port
-            (self.get_container_name(), REDIS_INTERNAL_PORT.to_string())
+            (
+                parameters
+                    .get("container_name")
+                    .cloned()
+                    .unwrap_or_else(|| self.get_container_name()),
+                REDIS_INTERNAL_PORT.to_string(),
+            )
         } else {
             // Baremetal mode: use localhost and exposed port
             ("localhost".to_string(), port.clone())
@@ -1551,8 +1633,15 @@ impl ExternalService for RedisService {
 
         let mut env_vars = HashMap::new();
 
-        // Always use container name and internal port for container-to-container communication
-        let effective_host = self.get_container_name();
+        // Always use container name and internal port for container-to-container
+        // communication. An imported service's real container name wins over
+        // the derived one.
+        let effective_host = config
+            .parameters
+            .get("container_name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| self.get_container_name());
         let effective_port = REDIS_INTERNAL_PORT.to_string();
 
         // Database number (specific to this project/environment)
@@ -1592,7 +1681,11 @@ impl ExternalService for RedisService {
         Ok(env_vars)
     }
     async fn start(&self) -> Result<()> {
-        let container_name = self.get_container_name();
+        let existing_config = self.config.read().await.as_ref().cloned();
+        let container_name = existing_config
+            .as_ref()
+            .map(|config| self.get_live_container_name(config))
+            .unwrap_or_else(|| self.get_container_name());
         info!("Starting Redis container {}", container_name);
 
         let containers = self
@@ -1608,13 +1701,14 @@ impl ExternalService for RedisService {
             .await?;
 
         if containers.is_empty() {
-            let config = self
-                .config
-                .read()
-                .await
-                .as_ref()
-                .ok_or_else(|| anyhow::anyhow!("Redis configuration not found"))?
-                .clone();
+            let config =
+                existing_config.ok_or_else(|| anyhow::anyhow!("Redis configuration not found"))?;
+            if config.container_name.is_some() {
+                return Err(anyhow::anyhow!(
+                    "Imported Redis container '{}' not found",
+                    container_name
+                ));
+            }
             let limits = self.resource_limits.read().await.clone();
             self.create_container(&self.docker, &config, &config.password, &limits)
                 .await?;
@@ -1641,7 +1735,13 @@ impl ExternalService for RedisService {
         // No stored connections to clean up - they are created on-demand
 
         // Stop the container if Docker is available
-        let container_name = self.get_container_name();
+        let container_name = self
+            .config
+            .read()
+            .await
+            .as_ref()
+            .map(|config| self.get_live_container_name(config))
+            .unwrap_or_else(|| self.get_container_name());
         info!("Stopping Redis container {}", container_name);
 
         let containers = self
@@ -1733,8 +1833,13 @@ impl ExternalService for RedisService {
 
         let password = parameters.get("password");
 
-        // Always use container name and internal port for container-to-container communication
-        let effective_host = self.get_container_name();
+        // Always use container name and internal port for container-to-container
+        // communication. An imported service's real container name wins over
+        // the derived one.
+        let effective_host = parameters
+            .get("container_name")
+            .cloned()
+            .unwrap_or_else(|| self.get_container_name());
         let effective_port = REDIS_INTERNAL_PORT.to_string();
 
         let url = if let Some(pass) = password {
@@ -1787,7 +1892,8 @@ impl ExternalService for RedisService {
         use chrono::Utc;
         use sea_orm::*;
 
-        let container_name = self.get_container_name();
+        let redis_config = self.get_redis_config(service_config.clone())?;
+        let container_name = self.get_live_container_name(&redis_config);
 
         if !self.container_has_walg(&container_name).await {
             info!(
@@ -1933,7 +2039,13 @@ impl ExternalService for RedisService {
     }
 
     async fn get_current_docker_image(&self) -> Result<(String, String)> {
-        let container_name = self.get_container_name();
+        let container_name = self
+            .config
+            .read()
+            .await
+            .as_ref()
+            .map(|config| self.get_live_container_name(config))
+            .unwrap_or_else(|| self.get_container_name());
         let container = self
             .docker
             .inspect_container(
@@ -2019,6 +2131,15 @@ impl ExternalService for RedisService {
                 anyhow::anyhow!("Failed to inspect container '{}': {}", container_id, e)
             })?;
 
+        // The real Docker container name — every operation on an imported
+        // service must target this, not the derived `redis-{name}`.
+        let imported_container_name = container
+            .name
+            .as_deref()
+            .unwrap_or(&container_id)
+            .trim_start_matches('/')
+            .to_string();
+
         // Extract image name and version
         let image = container.config.and_then(|c| c.image).ok_or_else(|| {
             anyhow::anyhow!("Could not determine image for container '{}'", container_id)
@@ -2052,21 +2173,58 @@ impl ExternalService for RedisService {
             )
         };
 
-        match redis::Client::open(connection_url.as_str())
-            .ok()
-            .and_then(|client| {
-                tokio::runtime::Runtime::new()
-                    .ok()
-                    .and_then(|rt| rt.block_on(async { client.get_connection().ok() }))
-            }) {
-            Some(_) => {
-                info!("Successfully verified Redis connection for import");
+        // Connects directly with `.await` on the current runtime — spinning
+        // up a nested `tokio::runtime::Runtime` and calling `block_on` here
+        // panics with "Cannot start a runtime from within a runtime", since
+        // this `async fn` is already driven by one.
+        let client = redis::Client::open(connection_url.as_str())
+            .map_err(|e| anyhow::anyhow!("Invalid Redis connection URL: {}", e))?;
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            client.get_multiplexed_async_connection(),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("Redis connection timed out after 5 seconds"))?
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to connect to Redis at localhost:{} with provided credentials: {}",
+                port,
+                e
+            )
+        })?;
+        info!("Successfully verified Redis connection for import");
+
+        let network_ready = match ensure_network_exists(&self.docker).await {
+            Ok(()) => true,
+            Err(e) => {
+                warn!(
+                    "Failed to ensure Temps Docker network before Redis import attach: {:?}",
+                    e
+                );
+                false
             }
-            None => {
-                return Err(anyhow::anyhow!(
-                    "Failed to connect to Redis at localhost:{} with provided credentials. Verify port and password.",
-                    port
-                ));
+        };
+        if network_ready {
+            let network_name = temps_core::NETWORK_NAME.as_str();
+            let request = bollard::models::NetworkConnectRequest {
+                container: container_id.clone(),
+                ..Default::default()
+            };
+            match self.docker.connect_network(network_name, request).await {
+                Ok(()) => info!(
+                    "Attached imported Redis container '{}' to {}",
+                    imported_container_name, network_name
+                ),
+                Err(bollard::errors::Error::DockerResponseServerError {
+                    status_code: 403, ..
+                }) => debug!(
+                    "Imported Redis container '{}' is already attached to {}",
+                    imported_container_name, network_name
+                ),
+                Err(e) => warn!(
+                    "Failed to attach imported Redis container '{}' to {}: {}",
+                    imported_container_name, network_name, e
+                ),
             }
         }
 
@@ -2080,7 +2238,7 @@ impl ExternalService for RedisService {
                 "port": port,
                 "password": password,
                 "docker_image": image,
-                "container_id": container_id,
+                "container_name": imported_container_name,
             }),
         };
 
@@ -2213,6 +2371,7 @@ mod tests {
             port: Some("6379".to_string()),
             password: Some("mypassword".to_string()),
             docker_image: "gotempsh/redis-walg:8-bookworm".to_string(),
+            container_name: None,
         };
 
         // Convert to runtime config
@@ -2233,6 +2392,7 @@ mod tests {
             port: Some("6379".to_string()),
             password: Some("mypassword".to_string()),
             docker_image: "gotempsh/redis-walg:8-bookworm".to_string(),
+            container_name: None,
         };
 
         // Convert to runtime config
@@ -2253,6 +2413,7 @@ mod tests {
             port: Some("6379".to_string()),
             password: Some("mypassword".to_string()),
             docker_image: "redis".to_string(), // No tag
+            container_name: None,
         };
 
         // Convert to runtime config
@@ -2838,6 +2999,47 @@ mod tests {
 
         // Clean up
         unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
+    }
+
+    #[test]
+    fn test_get_effective_address_docker_mode_uses_imported_container_name() {
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe { std::env::set_var("DEPLOYMENT_MODE", "docker") };
+
+        let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
+        let service = RedisService::new("imported-svc".to_string(), docker);
+
+        let config = ServiceConfig {
+            name: "imported-svc".to_string(),
+            service_type: ServiceType::Redis,
+            version: None,
+            parameters: serde_json::json!({
+                "host": "localhost",
+                "port": "6380",
+                "password": "testpass",
+                "container_name": "legacy-redis",
+            }),
+        };
+
+        let (host, port) = service.get_effective_address(config).unwrap();
+        // The imported container name wins over the derived `redis-{name}`.
+        assert_eq!(host, "legacy-redis");
+        assert_eq!(port, "6379");
+
+        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
+    }
+
+    #[test]
+    fn test_container_name_is_not_a_user_input() {
+        // container_name is derived from the service name at creation time
+        // (`redis-{name}`), never supplied by the client — same as MariaDB
+        // (see mariadb.rs's identical test). The create form is generated
+        // from this schema, so the field must not appear in it.
+        let schema = serde_json::to_value(schemars::schema_for!(RedisInputConfig)).unwrap();
+        assert!(
+            !schema.to_string().contains("container_name"),
+            "container_name leaked into the Redis create schema"
+        );
     }
 
     #[test]

--- a/crates/temps-providers/src/externalsvc/s3.rs
+++ b/crates/temps-providers/src/externalsvc/s3.rs
@@ -60,6 +60,17 @@ pub struct S3InputConfig {
     #[serde(default = "default_image")]
     #[schemars(example = "example_image", default = "default_image")]
     pub docker_image: String,
+
+    /// Real Docker container name when this service was imported from an
+    /// existing MinIO/S3-compatible container (set by `import_from_container`,
+    /// never user-editable — omitted from the create form). Overrides the
+    /// derived `s3-{name}` container name so internal addressing targets the
+    /// actual pre-existing container instead of a synthesized name that
+    /// doesn't exist. Mirrors the MariaDB/Postgres/Redis/MongoDB fix for the
+    /// same class of bug.
+    #[serde(default, deserialize_with = "deserialize_optional_non_empty")]
+    #[schemars(skip)]
+    pub container_name: Option<String>,
 }
 
 /// Internal runtime configuration for S3/MinIO service
@@ -72,6 +83,10 @@ pub struct S3Config {
     pub host: String,
     pub region: String,
     pub docker_image: String,
+    /// Real container name for imported services — see
+    /// `S3InputConfig::container_name`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_name: Option<String>,
 }
 
 impl From<S3InputConfig> for S3Config {
@@ -87,6 +102,7 @@ impl From<S3InputConfig> for S3Config {
             host: input.host,
             region: input.region,
             docker_image: input.docker_image,
+            container_name: input.container_name,
         }
     }
 }
@@ -100,6 +116,16 @@ where
         Some(s) if !s.is_empty() => Some(s),
         _ => None,
     })
+}
+
+/// Treats a blank string the same as an absent value — see
+/// `S3InputConfig::container_name`.
+fn deserialize_optional_non_empty<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let opt: Option<String> = Option::deserialize(deserializer)?;
+    Ok(opt.filter(|s| !s.is_empty()))
 }
 fn default_region() -> String {
     "us-east-1".to_string()
@@ -193,6 +219,18 @@ impl S3Service {
 
     fn get_container_name(&self) -> String {
         format!("minio-{}", self.name)
+    }
+
+    /// The container this service actually runs in: the imported container's
+    /// real name when `config.container_name` is set, otherwise the derived
+    /// `minio-{name}`. Every operation that talks to the live container must
+    /// resolve through this, not `get_container_name()` directly, or it
+    /// targets a synthesized name that doesn't exist for imported services.
+    fn get_live_container_name(&self, config: &S3Config) -> String {
+        config
+            .container_name
+            .clone()
+            .unwrap_or_else(|| self.get_container_name())
     }
 
     /// Creates and starts the MinIO container, retrying with a fresh host
@@ -471,9 +509,18 @@ impl S3Service {
                 .inspect_container(container_id, None::<InspectContainerOptions>)
                 .await?;
             if let Some(state) = info.state {
-                if state.status == Some(bollard::models::ContainerStateStatusEnum::RUNNING)
-                    && state.health.as_ref().and_then(|h| h.status.as_ref())
-                        == Some(&bollard::models::HealthStatusEnum::HEALTHY)
+                // Considered ready if it's running and either has a HEALTHY
+                // Docker healthcheck status or no healthcheck is defined at
+                // all (e.g. an imported container from a vanilla image with
+                // no HEALTHCHECK directive — requiring an explicit HEALTHY
+                // here would spin until `max_wait` every time).
+                let is_running =
+                    state.status == Some(bollard::models::ContainerStateStatusEnum::RUNNING);
+                let health_status = state.health.as_ref().and_then(|h| h.status.as_ref());
+
+                if is_running
+                    && (health_status.is_none()
+                        || health_status == Some(&bollard::models::HealthStatusEnum::HEALTHY))
                 {
                     return Ok(());
                 }
@@ -648,7 +695,8 @@ impl S3Service {
     ) -> Result<HashMap<String, String>> {
         let mut env_vars = HashMap::new();
 
-        let effective_host = self.get_container_name();
+        let s3_config = self.get_s3_config(config.clone())?;
+        let effective_host = self.get_live_container_name(&s3_config);
         let effective_port = S3_INTERNAL_PORT.to_string();
 
         env_vars.insert("S3_BUCKET".to_string(), bucket_name.to_string());
@@ -694,7 +742,10 @@ impl ExternalService for S3Service {
 
         if temps_core::DeploymentMode::is_docker() {
             // Docker mode: use container name and internal port
-            Ok((self.get_container_name(), S3_INTERNAL_PORT.to_string()))
+            Ok((
+                self.get_live_container_name(&config),
+                S3_INTERNAL_PORT.to_string(),
+            ))
         } else {
             // Baremetal mode: use localhost and exposed port
             Ok(("localhost".to_string(), config.port))
@@ -732,9 +783,17 @@ impl ExternalService for S3Service {
         // Store runtime config
         *self.config.write().await = Some(s3_config.clone());
 
-        // Create Docker container
-        self.create_container(&self.docker, &s3_config, &resource_limits)
-            .await?;
+        if s3_config.container_name.is_none() {
+            // Create Docker container
+            self.create_container(&self.docker, &s3_config, &resource_limits)
+                .await?;
+        } else {
+            info!(
+                "S3/MinIO service '{}' is imported from container '{}'; skipping container creation",
+                self.name,
+                self.get_live_container_name(&s3_config)
+            );
+        }
 
         // Serialize the full runtime config to save to database
         // This ensures auto-generated values (keys, port) are persisted
@@ -894,7 +953,11 @@ impl ExternalService for S3Service {
 
     async fn start(&self) -> Result<()> {
         let docker = &self.docker;
-        let container_name = self.get_container_name();
+        let existing_config = self.config.read().await.as_ref().cloned();
+        let container_name = existing_config
+            .as_ref()
+            .map(|config| self.get_live_container_name(config))
+            .unwrap_or_else(|| self.get_container_name());
         info!("Starting MinIO container {}", container_name);
 
         let containers = docker
@@ -908,14 +971,43 @@ impl ExternalService for S3Service {
             }))
             .await?;
 
+        // Imported services never create a container: the real one already
+        // exists (we only attach + address it). Fail loudly if it's gone
+        // rather than silently synthesizing a fresh empty one.
+        if let Some(config) = existing_config
+            .as_ref()
+            .filter(|c| c.container_name.is_some())
+        {
+            if containers.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "Imported S3/MinIO container '{}' not found",
+                    container_name
+                ));
+            }
+            let is_running = matches!(
+                containers[0].state,
+                Some(bollard::models::ContainerSummaryStateEnum::RUNNING)
+            );
+            if !is_running {
+                docker
+                    .start_container(
+                        &container_name,
+                        None::<bollard::query_parameters::StartContainerOptions>,
+                    )
+                    .await
+                    .map_err(|e| {
+                        anyhow::anyhow!("Failed to start imported S3/MinIO container: {}", e)
+                    })?;
+            }
+            self.wait_for_container_health(docker, &container_name)
+                .await?;
+            let _ = config;
+            return Ok(());
+        }
+
         if containers.is_empty() {
-            let config = self
-                .config
-                .read()
-                .await
-                .as_ref()
-                .ok_or_else(|| anyhow::anyhow!("S3 configuration not found"))?
-                .clone();
+            let config =
+                existing_config.ok_or_else(|| anyhow::anyhow!("S3 configuration not found"))?;
             let limits = self.resource_limits.read().await.clone();
             self.create_container(docker, &config, &limits).await?;
         } else {
@@ -940,7 +1032,13 @@ impl ExternalService for S3Service {
 
         // Stop the container
         let docker = &self.docker;
-        let container_name = self.get_container_name();
+        let container_name = self
+            .config
+            .read()
+            .await
+            .as_ref()
+            .map(|config| self.get_live_container_name(config))
+            .unwrap_or_else(|| self.get_container_name());
         info!("Stopping MinIO container {}", container_name);
 
         let containers = docker
@@ -1058,8 +1156,14 @@ impl ExternalService for S3Service {
     ) -> Result<HashMap<String, String>> {
         let mut env_vars = HashMap::new();
 
-        // Always use container name and internal port for container-to-container communication
-        let effective_host = self.get_container_name();
+        // Always use container name and internal port for container-to-container
+        // communication. An imported service's real container name (stored raw
+        // in parameters, since the typed config isn't available here) wins over
+        // the derived one.
+        let effective_host = parameters
+            .get("container_name")
+            .cloned()
+            .unwrap_or_else(|| self.get_container_name());
         let effective_port = S3_INTERNAL_PORT.to_string();
 
         let endpoint = format!("http://{}:{}", effective_host, effective_port);
@@ -1094,8 +1198,14 @@ impl ExternalService for S3Service {
     ) -> Result<HashMap<String, String>> {
         let mut env_vars = HashMap::new();
 
-        // Always use container name and internal port for container-to-container communication
-        let effective_host = self.get_container_name();
+        // Always use container name and internal port for container-to-container
+        // communication. An imported service's real container name (stored raw
+        // in parameters, since the typed config isn't available here) wins over
+        // the derived one.
+        let effective_host = parameters
+            .get("container_name")
+            .cloned()
+            .unwrap_or_else(|| self.get_container_name());
         let effective_port = S3_INTERNAL_PORT.to_string();
 
         let access_key = parameters
@@ -2091,7 +2201,13 @@ impl ExternalService for S3Service {
     }
 
     async fn get_current_docker_image(&self) -> Result<(String, String)> {
-        let container_name = self.get_container_name();
+        let container_name = self
+            .config
+            .read()
+            .await
+            .as_ref()
+            .map(|config| self.get_live_container_name(config))
+            .unwrap_or_else(|| self.get_container_name());
         let container = self
             .docker
             .inspect_container(
@@ -2172,6 +2288,15 @@ impl ExternalService for S3Service {
                 anyhow::anyhow!("Failed to inspect container '{}': {}", container_id, e)
             })?;
 
+        // The real Docker container name — every operation on an imported
+        // service must target this, not the derived `minio-{name}`.
+        let imported_container_name = container
+            .name
+            .as_deref()
+            .unwrap_or(&container_id)
+            .trim_start_matches('/')
+            .to_string();
+
         // Extract image name and version
         let image = container.config.and_then(|c| c.image).ok_or_else(|| {
             anyhow::anyhow!("Could not determine image for container '{}'", container_id)
@@ -2204,41 +2329,82 @@ impl ExternalService for S3Service {
         // Build endpoint
         let endpoint = format!("http://localhost:{}", port);
 
-        // Verify connection to the imported service by attempting to list buckets
-        match tokio::runtime::Runtime::new().ok().and_then(|rt| {
-            rt.block_on(async {
-                let creds = aws_sdk_s3::config::Credentials::new(
-                    &access_key,
-                    &secret_key,
-                    None,
-                    None,
-                    "imported",
+        // Verify connection to the imported service by attempting to list
+        // buckets. Connects directly with `.await` on the current runtime —
+        // spinning up a nested `tokio::runtime::Runtime` and calling
+        // `block_on` here panics with "Cannot start a runtime from within a
+        // runtime", since this `async fn` is already driven by one.
+        let creds =
+            aws_sdk_s3::config::Credentials::new(&access_key, &secret_key, None, None, "imported");
+        let s3_client_config = aws_sdk_s3::config::Config::builder()
+            .credentials_provider(creds)
+            .endpoint_url(&endpoint)
+            .region(aws_sdk_s3::config::Region::new("us-east-1"))
+            .force_path_style(true)
+            .behavior_version_latest()
+            .build();
+        let client = aws_sdk_s3::Client::from_conf(s3_client_config);
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            client.list_buckets().send(),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("S3/MinIO connection timed out after 5 seconds"))?
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to connect to S3/MinIO at {} with provided credentials: {}",
+                endpoint,
+                e
+            )
+        })?;
+        info!("Successfully verified S3/MinIO connection for import");
+
+        let network_ready = match ensure_network_exists(&self.docker).await {
+            Ok(()) => true,
+            Err(e) => {
+                warn!(
+                    "Failed to ensure Temps Docker network before S3/MinIO import attach: {:?}",
+                    e
                 );
-
-                let config = aws_sdk_s3::config::Config::builder()
-                    .credentials_provider(creds)
-                    .endpoint_url(&endpoint)
-                    .build();
-
-                let client = aws_sdk_s3::Client::from_conf(config);
-                client.list_buckets().send().await.ok()
-            })
-        }) {
-            Some(_) => {
-                info!("Successfully verified S3/MinIO connection for import");
+                false
             }
-            None => {
-                return Err(anyhow::anyhow!(
-                    "Failed to connect to S3/MinIO at {} with provided credentials. Verify endpoint, access key, and secret key.",
-                    endpoint
-                ));
+        };
+        if network_ready {
+            let network_name = temps_core::NETWORK_NAME.as_str();
+            let request = bollard::models::NetworkConnectRequest {
+                container: container_id.clone(),
+                ..Default::default()
+            };
+            match self.docker.connect_network(network_name, request).await {
+                Ok(()) => info!(
+                    "Attached imported S3/MinIO container '{}' to {}",
+                    imported_container_name, network_name
+                ),
+                Err(bollard::errors::Error::DockerResponseServerError {
+                    status_code: 403, ..
+                }) => debug!(
+                    "Imported S3/MinIO container '{}' is already attached to {}",
+                    imported_container_name, network_name
+                ),
+                Err(e) => warn!(
+                    "Failed to attach imported S3/MinIO container '{}' to {}: {}",
+                    imported_container_name, network_name, e
+                ),
             }
         }
 
-        // Build the ServiceConfig for registration
+        // Register as `Minio`, NOT `S3`: only the `Minio` service type routes
+        // back to `S3Service` in `create_service_instance` (the `S3` type
+        // routes to `RustfsService`, which manages its own RustFS container
+        // and can't operate this imported MinIO container). Storing `S3` here
+        // would make every later start/stop/backup reload the service as a
+        // RustfsService against a synthesized `rustfs-{name}` container that
+        // doesn't exist. This branch is only reachable by importing a
+        // container as the `minio` type in the first place.
+        #[allow(deprecated)]
         let config = ServiceConfig {
             name: service_name,
-            service_type: ServiceType::S3,
+            service_type: ServiceType::Minio,
             version: Some(version),
             parameters: serde_json::json!({
                 "endpoint": endpoint,
@@ -2247,7 +2413,7 @@ impl ExternalService for S3Service {
                 "secret_key": secret_key,
                 "use_ssl": false,
                 "docker_image": image,
-                "container_id": container_id,
+                "container_name": imported_container_name,
             }),
         };
 
@@ -2359,6 +2525,7 @@ mod tests {
             host: "localhost".to_string(),
             region: "us-east-1".to_string(),
             docker_image: "minio/minio:RELEASE.2025-09-07T16-13-09Z".to_string(),
+            container_name: None,
         };
 
         // Convert to runtime config
@@ -2368,6 +2535,53 @@ mod tests {
         assert_eq!(
             runtime_config.docker_image,
             "minio/minio:RELEASE.2025-09-07T16-13-09Z"
+        );
+    }
+
+    #[test]
+    fn test_get_effective_address_docker_mode_uses_imported_container_name() {
+        let _lock = crate::externalsvc::DEPLOYMENT_MODE_MUTEX
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        unsafe { std::env::set_var("DEPLOYMENT_MODE", "docker") };
+
+        let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
+        let encryption_service =
+            Arc::new(EncryptionService::new("test_encryption_key_1234567890ab").unwrap());
+        let service = S3Service::new("imported-svc".to_string(), docker, encryption_service);
+
+        let config = ServiceConfig {
+            name: "imported-svc".to_string(),
+            service_type: ServiceType::S3,
+            version: None,
+            parameters: serde_json::json!({
+                "host": "localhost",
+                "port": "9000",
+                "access_key": "minioadmin",
+                "secret_key": "minioadmin",
+                "region": "us-east-1",
+                "container_name": "legacy-minio",
+            }),
+        };
+
+        let (host, port) = service.get_effective_address(config).unwrap();
+        // The imported container name wins over the derived `minio-{name}`.
+        assert_eq!(host, "legacy-minio");
+        assert_eq!(port, S3_INTERNAL_PORT);
+
+        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
+    }
+
+    #[test]
+    fn test_container_name_is_not_a_user_input() {
+        // container_name is derived from the service name at creation time
+        // (`minio-{name}`), never supplied by the client — same as MariaDB
+        // (see mariadb.rs's identical test). The create form is generated
+        // from this schema, so the field must not appear in it.
+        let schema = serde_json::to_value(schemars::schema_for!(S3InputConfig)).unwrap();
+        assert!(
+            !schema.to_string().contains("container_name"),
+            "container_name leaked into the S3/MinIO create schema"
         );
     }
 

--- a/crates/temps-providers/src/externalsvc/test_utils.rs
+++ b/crates/temps-providers/src/externalsvc/test_utils.rs
@@ -460,6 +460,7 @@ pub fn create_mock_external_service(
         health_metadata: None,
         metrics_enabled: false,
         default_backup_provisioned: false,
+        container_name: None,
     }
 }
 

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -8710,12 +8710,23 @@ echo "[restore] Pre-seed complete"
             .encrypt(config_json.as_bytes())
             .map_err(|e| anyhow::anyhow!("Failed to encrypt service configuration: {}", e))?;
 
+        // Plaintext real container name so the log collector can map the
+        // imported (label-less) container back to this service without
+        // decrypting `config`. Every provider's import_from_container stamps
+        // `container_name` into the parameters.
+        let imported_container_name = service_config
+            .parameters
+            .get("container_name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
         let external_service = external_services::ActiveModel {
             name: Set(service_config.name.clone()),
             service_type: Set(service_config.service_type.to_string()),
             version: Set(service_config.version.clone()),
             status: Set("running".to_string()),
             config: Set(Some(encrypted_config)),
+            container_name: Set(imported_container_name),
             ..Default::default()
         }
         .insert(self.db.as_ref())

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -7070,13 +7070,16 @@ echo "[restore] Pre-seed complete"
             // targets the real container instead of failing with
             // "configuration not found" and falling back to a full
             // re-initialize.
-            if matches!(
+            #[allow(deprecated)]
+            let needs_config_hydration = matches!(
                 service_type_enum,
                 ServiceType::Mariadb
                     | ServiceType::Postgres
                     | ServiceType::Redis
                     | ServiceType::Mongodb
-            ) {
+                    | ServiceType::Minio
+            );
+            if needs_config_hydration {
                 let parameters = self.get_service_parameters(service_id).await?;
                 if parameters.contains_key("container_name") {
                     let service_config = ServiceConfig {
@@ -7229,13 +7232,16 @@ echo "[restore] Pre-seed complete"
                 &parameters,
             )?;
 
-            if matches!(
+            #[allow(deprecated)]
+            let needs_config_hydration = matches!(
                 service_type_enum,
                 ServiceType::Mariadb
                     | ServiceType::Postgres
                     | ServiceType::Redis
                     | ServiceType::Mongodb
-            ) {
+                    | ServiceType::Minio
+            );
+            if needs_config_hydration {
                 let parameters = self.get_service_parameters(service_id).await?;
                 if parameters.contains_key("container_name") {
                     let service_config = ServiceConfig {
@@ -8552,7 +8558,11 @@ echo "[restore] Pre-seed complete"
 
         for (key, value) in &request.parameters {
             match key.as_str() {
-                "username" | "password" | "database" | "root_password" => {
+                // S3/MinIO import reads access_key/secret_key from `credentials`
+                // (not additional_config) — without them here, the S3 provider
+                // rejects every import with "Access key is required".
+                "username" | "password" | "database" | "root_password" | "access_key"
+                | "secret_key" => {
                     if let Some(str_value) = value.as_str() {
                         credentials.insert(key.clone(), str_value.to_string());
                     }

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -7072,7 +7072,10 @@ echo "[restore] Pre-seed complete"
             // re-initialize.
             if matches!(
                 service_type_enum,
-                ServiceType::Mariadb | ServiceType::Postgres
+                ServiceType::Mariadb
+                    | ServiceType::Postgres
+                    | ServiceType::Redis
+                    | ServiceType::Mongodb
             ) {
                 let parameters = self.get_service_parameters(service_id).await?;
                 if parameters.contains_key("container_name") {
@@ -7228,7 +7231,10 @@ echo "[restore] Pre-seed complete"
 
             if matches!(
                 service_type_enum,
-                ServiceType::Mariadb | ServiceType::Postgres
+                ServiceType::Mariadb
+                    | ServiceType::Postgres
+                    | ServiceType::Redis
+                    | ServiceType::Mongodb
             ) {
                 let parameters = self.get_service_parameters(service_id).await?;
                 if parameters.contains_key("container_name") {

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -7064,13 +7064,16 @@ echo "[restore] Pre-seed complete"
             )?;
 
             // A freshly-constructed instance has no in-memory config, so
-            // `start()` can't resolve an imported MariaDB service's real
-            // container name (it only lives in `config.container_name`).
-            // Hydrate it via `init()` first — same fix as `stop_service` — so
-            // `start()` targets the real container instead of failing with
-            // "MariaDB configuration not found" and falling back to a full
+            // `start()` can't resolve an imported service's real container
+            // name (it only lives in `config.container_name`). Hydrate it via
+            // `init()` first — same fix as `stop_service` — so `start()`
+            // targets the real container instead of failing with
+            // "configuration not found" and falling back to a full
             // re-initialize.
-            if service_type_enum == ServiceType::Mariadb {
+            if matches!(
+                service_type_enum,
+                ServiceType::Mariadb | ServiceType::Postgres
+            ) {
                 let parameters = self.get_service_parameters(service_id).await?;
                 if parameters.contains_key("container_name") {
                     let service_config = ServiceConfig {
@@ -7087,8 +7090,8 @@ echo "[restore] Pre-seed complete"
                         ExternalServiceError::StartFailed {
                             id: service_id,
                             reason: format!(
-                                "Failed to initialize imported MariaDB service before start: {}",
-                                e
+                                "Failed to initialize imported {} service before start: {}",
+                                service_type_enum, e
                             ),
                         }
                     })?;
@@ -7223,7 +7226,10 @@ echo "[restore] Pre-seed complete"
                 &parameters,
             )?;
 
-            if service_type_enum == ServiceType::Mariadb {
+            if matches!(
+                service_type_enum,
+                ServiceType::Mariadb | ServiceType::Postgres
+            ) {
                 let parameters = self.get_service_parameters(service_id).await?;
                 if parameters.contains_key("container_name") {
                     let service_config = ServiceConfig {
@@ -7240,8 +7246,8 @@ echo "[restore] Pre-seed complete"
                         ExternalServiceError::StopFailed {
                             id: service_id,
                             reason: format!(
-                                "Failed to initialize imported MariaDB service before stop: {}",
-                                e
+                                "Failed to initialize imported {} service before stop: {}",
+                                service_type_enum, e
                             ),
                         }
                     })?;

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -7063,6 +7063,38 @@ echo "[restore] Pre-seed complete"
                 &parameters,
             )?;
 
+            // A freshly-constructed instance has no in-memory config, so
+            // `start()` can't resolve an imported MariaDB service's real
+            // container name (it only lives in `config.container_name`).
+            // Hydrate it via `init()` first — same fix as `stop_service` — so
+            // `start()` targets the real container instead of failing with
+            // "MariaDB configuration not found" and falling back to a full
+            // re-initialize.
+            if service_type_enum == ServiceType::Mariadb {
+                let parameters = self.get_service_parameters(service_id).await?;
+                if parameters.contains_key("container_name") {
+                    let service_config = ServiceConfig {
+                        name: service.name.clone(),
+                        service_type: service_type_enum,
+                        version: service.version.clone(),
+                        parameters: serde_json::to_value(parameters).map_err(|e| {
+                            ExternalServiceError::InternalError {
+                                reason: format!("Failed to serialize parameters: {}", e),
+                            }
+                        })?,
+                    };
+                    service_instance.init(service_config).await.map_err(|e| {
+                        ExternalServiceError::StartFailed {
+                            id: service_id,
+                            reason: format!(
+                                "Failed to initialize imported MariaDB service before start: {}",
+                                e
+                            ),
+                        }
+                    })?;
+                }
+            }
+
             match service_instance.start().await {
                 Ok(()) => {}
                 Err(e) => {
@@ -7480,7 +7512,15 @@ echo "[restore] Pre-seed complete"
         // Use Docker container name and internal port directly — these match what
         // get_runtime_env_vars() puts in env var values (always Docker container names,
         // regardless of DeploymentMode). This is critical for cross-node env var rewriting.
-        let container_name = service_instance.get_docker_container_name();
+        // An imported service's real container name (stored raw in parameters, since
+        // get_docker_container_name() only knows the derived `{type}-{name}` form)
+        // wins over the derived one.
+        let container_name = service_config
+            .parameters
+            .get("container_name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| service_instance.get_docker_container_name());
         let internal_port = service_instance.get_docker_internal_port();
 
         // get_local_address returns "localhost:{host_port}" — we need the host port
@@ -8722,10 +8762,14 @@ echo "[restore] Pre-seed complete"
                 service_type,
                 &parameters,
             )?;
-            Ok(vec![(
-                "standalone".to_string(),
-                instance.get_docker_container_name(),
-            )])
+            // An imported service's real container name wins over the derived
+            // `{type}-{name}` one — see the identical pattern in `get_runtime_info`.
+            let container_name = parameters
+                .get("container_name")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| instance.get_docker_container_name());
+            Ok(vec![("standalone".to_string(), container_name)])
         }
     }
 

--- a/crates/temps-proxy/Cargo.toml
+++ b/crates/temps-proxy/Cargo.toml
@@ -82,4 +82,9 @@ tower = "0.4"
 anyhow = "1.0"
 lazy_static = "1.4"
 temps-presets = { path = "../temps-presets" }
-rcgen = { workspace = true }
+# Pinned below 0.14, matching temps-core's override — the 0.14.8 bump changed
+# `CertifiedKey`'s field from `key_pair` to `signing_key` and made `signed_by`
+# take a single `&Issuer` argument instead of `(&cert, &key)`, breaking
+# tls_cert_loader.rs's self-signed cert generation. Revert until this crate is
+# migrated to the 0.14 Issuer API alongside temps-core's node_pki.rs.
+rcgen = "0.13.2"

--- a/crates/temps-proxy/Cargo.toml
+++ b/crates/temps-proxy/Cargo.toml
@@ -82,9 +82,7 @@ tower = "0.4"
 anyhow = "1.0"
 lazy_static = "1.4"
 temps-presets = { path = "../temps-presets" }
-# Pinned below 0.14, matching temps-core's override — the 0.14.8 bump changed
-# `CertifiedKey`'s field from `key_pair` to `signing_key` and made `signed_by`
-# take a single `&Issuer` argument instead of `(&cert, &key)`, breaking
-# tls_cert_loader.rs's self-signed cert generation. Revert until this crate is
-# migrated to the 0.14 Issuer API alongside temps-core's node_pki.rs.
-rcgen = "0.13.2"
+# Uses the workspace 0.14.8; tls_cert_loader.rs was migrated to the 0.14
+# `Issuer`/`signing_key` API in #250 (merged from main), so the earlier
+# 0.13.2 pin (matching temps-core's) is no longer needed.
+rcgen = { workspace = true }

--- a/crates/temps-static-files/Cargo.toml
+++ b/crates/temps-static-files/Cargo.toml
@@ -15,3 +15,4 @@ utoipa = { workspace = true }
 
 temps-config = { path = "../temps-config" }
 temps-core = { path = "../temps-core" }
+temps-auth = { path = "../temps-auth" }

--- a/crates/temps-static-files/src/handler.rs
+++ b/crates/temps-static-files/src/handler.rs
@@ -10,6 +10,7 @@ use axum::{
     Router,
 };
 use std::sync::Arc;
+use temps_auth::{Permission, RequireAuth};
 use tracing::{debug, error};
 use utoipa::OpenApi;
 
@@ -41,19 +42,31 @@ pub struct FileApiDoc;
     tag = "Files",
     responses(
         (status = 200, description = "File content retrieved successfully", content_type = "application/octet-stream"),
-        (status = 403, description = "Access denied - path outside static directory"),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Access denied - path outside static directory or insufficient permissions"),
         (status = 404, description = "File not found"),
         (status = 500, description = "Internal server error")
     ),
     params(
         ("file_path" = String, Path, description = "Relative path to the file from static directory")
-    )
+    ),
+    security(("bearer_auth" = []))
 )]
 async fn get_file(
+    RequireAuth(auth): RequireAuth,
     Path(file_path): Path<String>,
     State(state): State<Arc<FileState>>,
 ) -> impl IntoResponse {
     debug!("GET /files/{}", file_path);
+
+    if !auth.has_permission(&Permission::FilesRead) {
+        error!("Insufficient permissions to read file: {}", file_path);
+        return (
+            StatusCode::FORBIDDEN,
+            [(header::CONTENT_TYPE, "text/plain")],
+            b"Insufficient permissions".to_vec(),
+        );
+    }
 
     match state.file_service.get_file(&file_path).await {
         Ok(content) => {

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -50,7 +50,7 @@
         "monaco-editor": "^0.55.1",
         "nanoid": "^5.1.16",
         "next-themes": "^0.4.6",
-        "react": "^19.1.1",
+        "react": "^19.2.7",
         "react-day-picker": "8.10.1",
         "react-dom": "^19.2.7",
         "react-hook-form": "^7.81.0",
@@ -1288,7 +1288,7 @@
 
     "rc9": ["rc9@3.0.1", "", { "dependencies": { "defu": "^6.1.6", "destr": "^2.0.5" } }, "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ=="],
 
-    "react": ["react@19.1.1", "", {}, "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ=="],
+    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "react-day-picker": ["react-day-picker@8.10.1", "", { "peerDependencies": { "date-fns": "^2.28.0 || ^3.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0" } }, "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA=="],
 
@@ -1591,6 +1591,8 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@temps-sdk/console-kit/react": ["react@19.1.1", "", {}, "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ=="],
 
     "@types/d3-interpolate/@types/d3-color": ["@types/d3-color@2.0.6", "", {}, "sha512-tbaFGDmJWHqnenvk3QGSvD3RVwr631BjKRD7Sc7VLRgrdX5mk5hTyoeBL6rXZaeoXzmZwIl1D2HPogEdt1rHBg=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -73,7 +73,7 @@
     "monaco-editor": "^0.55.1",
     "nanoid": "^5.1.16",
     "next-themes": "^0.4.6",
-    "react": "^19.1.1",
+    "react": "^19.2.7",
     "react-day-picker": "8.10.1",
     "react-dom": "^19.2.7",
     "react-hook-form": "^7.81.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -73,6 +73,11 @@ const ServiceDataBrowser = lazy(() =>
     default: m.ServiceDataBrowser,
   }))
 )
+const ServiceLogs = lazy(() =>
+  import('./pages/ServiceLogs').then((m) => ({
+    default: m.ServiceLogs,
+  }))
+)
 const ServiceRestore = lazy(() =>
   import('./pages/ServiceRestore').then((m) => ({
     default: m.ServiceRestore,
@@ -507,6 +512,7 @@ const FullAppRoutes = () => {
                 <Route path="/storage/:id" element={<ServiceDetail />} />
                 <Route path="/storage/:id/monitoring" element={<ServiceMonitoring />} />
                 <Route path="/storage/:id/browse" element={<ServiceDataBrowser />} />
+                <Route path="/storage/:id/logs" element={<ServiceLogs />} />
                 <Route path="/storage/:id/restore" element={<ServiceRestore />} />
                 <Route path="/storage/:id/upgrades/:upgradeId" element={<MajorUpgradeDetail />} />
                 <Route path="/storage/:id/members/add" element={<AddClusterMember />} />

--- a/web/src/hooks/useLogHistory.ts
+++ b/web/src/hooks/useLogHistory.ts
@@ -1,5 +1,9 @@
 import { client } from '@/api/client/client.gen'
-import { useQuery, keepPreviousData } from '@tanstack/react-query'
+import {
+  keepPreviousData,
+  useInfiniteQuery,
+  useQuery,
+} from '@tanstack/react-query'
 
 // ── Types matching the Rust SearchLogsResponse ─────────────────────────
 
@@ -81,6 +85,10 @@ export interface LogSearchParams {
   containerIds?: string[]
   /** Filter to specific worker nodes (node_id). Empty/undefined = all nodes. */
   nodeIds?: number[]
+  /** Bump to force a brand-new query (busts the infinite-query cache so the
+      viewer collapses back to a single newest page and re-tails). Ignored by
+      the plain {@link useLogHistory} hook. */
+  refreshKey?: number
 }
 
 // ── API call ───────────────────────────────────────────────────────────
@@ -140,5 +148,50 @@ export function useLogHistory(params: LogSearchParams, enabled = true) {
     enabled: enabled && (!!params.projectId || params.externalServiceId != null),
     staleTime: 1000 * 30, // 30 seconds
     placeholderData: keepPreviousData,
+  })
+}
+
+/**
+ * Infinite/tailing variant of {@link useLogHistory} for terminal-style viewers.
+ *
+ * The server bounds the first page (no cursor) to the *newest* `pageSize`
+ * matches and returns them oldest→newest, so the caller can render newest at
+ * the bottom and scroll to it on load. Each `fetchNextPage()` walks `next_cursor`
+ * into strictly *older* lines — the caller prepends those at the top. Pages are
+ * therefore concatenated as `[...pages].reverse().flatMap(p => p.lines)` to get
+ * a single fully-ascending rope (oldest loaded at the top, newest at the bottom).
+ *
+ * Changing any filter (or bumping `refreshKey`) resets to a fresh newest page.
+ */
+export function useLogHistoryInfinite(
+  params: Omit<LogSearchParams, 'cursor'>,
+  enabled = true
+) {
+  return useInfiniteQuery({
+    queryKey: [
+      'log-history-infinite',
+      params.projectId,
+      params.externalServiceId,
+      params.startTime,
+      params.endTime,
+      params.levels,
+      params.services,
+      params.envs,
+      params.text,
+      params.pageSize,
+      params.contextLines,
+      params.deployId,
+      params.containerIds,
+      params.nodeIds,
+      params.refreshKey,
+    ],
+    queryFn: ({ pageParam }) =>
+      searchLogs({ ...params, cursor: pageParam ?? undefined }),
+    initialPageParam: undefined as string | undefined,
+    // lastPage is the most recently fetched (oldest) page; its next_cursor
+    // points at the next-older page. Undefined stops the "load older" walk.
+    getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
+    enabled: enabled && (!!params.projectId || params.externalServiceId != null),
+    staleTime: 1000 * 30,
   })
 }

--- a/web/src/hooks/useLogHistory.ts
+++ b/web/src/hooks/useLogHistory.ts
@@ -60,6 +60,11 @@ export interface SearchLogsResponse {
 
 export interface LogSearchParams {
   projectId: number
+  /**
+   * When set, search an imported/managed external service's logs instead of a
+   * project's. `projectId` is ignored server-side in this mode.
+   */
+  externalServiceId?: number
   startTime?: string
   endTime?: string
   levels?: LogLevel[]
@@ -85,6 +90,8 @@ async function searchLogs(params: LogSearchParams): Promise<SearchLogsResponse> 
     project_id: params.projectId,
   }
 
+  if (params.externalServiceId != null)
+    body.external_service_id = params.externalServiceId
   if (params.startTime) body.start_time = params.startTime
   if (params.endTime) body.end_time = params.endTime
   if (params.levels?.length) body.levels = params.levels
@@ -115,6 +122,7 @@ export function useLogHistory(params: LogSearchParams, enabled = true) {
     queryKey: [
       'log-history',
       params.projectId,
+      params.externalServiceId,
       params.startTime,
       params.endTime,
       params.levels,
@@ -129,7 +137,7 @@ export function useLogHistory(params: LogSearchParams, enabled = true) {
       params.nodeIds,
     ],
     queryFn: () => searchLogs(params),
-    enabled: enabled && !!params.projectId,
+    enabled: enabled && (!!params.projectId || params.externalServiceId != null),
     staleTime: 1000 * 30, // 30 seconds
     placeholderData: keepPreviousData,
   })

--- a/web/src/pages/ServiceDetail.tsx
+++ b/web/src/pages/ServiceDetail.tsx
@@ -97,6 +97,7 @@ import {
   Radio,
   RefreshCcw,
   RotateCcw,
+  ScrollText,
   Server,
   Trash2,
   XCircle,
@@ -734,6 +735,12 @@ export function ServiceDetail() {
               <Button variant="outline" size="sm" className="gap-2">
                 <Database className="h-4 w-4" />
                 <span className="hidden sm:inline">Browse Data</span>
+              </Button>
+            </Link>
+            <Link to={`/storage/${id}/logs`}>
+              <Button variant="outline" size="sm" className="gap-2">
+                <ScrollText className="h-4 w-4" />
+                <span className="hidden sm:inline">Logs</span>
               </Button>
             </Link>
             <DropdownMenu>

--- a/web/src/pages/ServiceLogs.tsx
+++ b/web/src/pages/ServiceLogs.tsx
@@ -9,17 +9,24 @@ import { TimeAgo } from '@/components/utils/TimeAgo'
 import {
   type LogLevel,
   type LogSearchLine,
-  useLogHistory,
+  useLogHistoryInfinite,
 } from '@/hooks/useLogHistory'
 import { useQuery } from '@tanstack/react-query'
 import {
   ArrowLeft,
   Database,
+  Loader2,
   RefreshCw,
   ScrollText,
   Server,
 } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { Link, useParams } from 'react-router-dom'
 
 /** Tailwind classes per normalized level — mirrors the deployment log viewer. */
@@ -33,6 +40,13 @@ const LEVEL_CLASS: Record<LogLevel, string> = {
 
 const LEVELS: LogLevel[] = ['ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE']
 
+/** Lines fetched per page. The viewer tails the newest page on load and walks
+    older pages on scroll-to-top, so we deliberately do NOT load everything. */
+const PAGE_SIZE = 200
+
+/** Distance (px) from the top that triggers loading the next-older page. */
+const LOAD_OLDER_THRESHOLD = 48
+
 function formatTs(ts: string): string {
   const d = new Date(ts)
   if (Number.isNaN(d.getTime())) return ts
@@ -45,6 +59,10 @@ function formatTs(ts: string): string {
  * search pipeline as application/deployment logs, scoped by
  * `external_service_id` instead of a project. Wears the same header shell as
  * the service detail page so it reads as one app.
+ *
+ * The log panel tails to the newest lines on load (like a terminal) and lazily
+ * pages *older* lines in as the operator scrolls to the top, preserving scroll
+ * position across each prepend so the viewport never jumps.
  */
 export function ServiceLogs() {
   const { id } = useParams<{ id: string }>()
@@ -57,34 +75,117 @@ export function ServiceLogs() {
 
   const [text, setText] = useState('')
   const [activeLevels, setActiveLevels] = useState<LogLevel[]>([])
+  // Bumped by Refresh to collapse back to a single newest page and re-tail.
+  const [refreshKey, setRefreshKey] = useState(0)
 
-  // Look back 24h by default — matches the service history window operators expect.
+  // Look back 24h by default — matches the service history window operators
+  // expect. Memoized so it stays stable across renders (the pagination window
+  // must not shift under the cursor).
   const startTime = useMemo(
     () => new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
     []
   )
 
-  const { data, isLoading, isFetching, error, refetch } = useLogHistory(
+  const levels = activeLevels.length ? activeLevels : undefined
+  const trimmedText = text.trim() || undefined
+
+  const {
+    data,
+    isLoading,
+    isFetching,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    error,
+  } = useLogHistoryInfinite(
     {
       // projectId is ignored server-side when externalServiceId is set.
       projectId: 0,
       externalServiceId: serviceId,
       startTime,
-      levels: activeLevels.length ? activeLevels : undefined,
-      text: text.trim() || undefined,
-      pageSize: 500,
+      levels,
+      text: trimmedText,
+      pageSize: PAGE_SIZE,
+      refreshKey,
     },
     !Number.isNaN(serviceId)
   )
 
-  const lines: LogSearchLine[] = data?.lines ?? []
+  // Pages come newest-first (page 0 = newest). Reverse so the oldest loaded
+  // page sits at the top and the newest line lands at the bottom of the rope.
+  const lines: LogSearchLine[] = useMemo(() => {
+    const pages = data?.pages ?? []
+    return [...pages].reverse().flatMap((p) => p.lines)
+  }, [data])
+
   const svc = service?.service
+
+  // ── Scroll management: tail-on-load + preserve-position-on-prepend ──────
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+  // How many pages were rendered last commit — lets us distinguish the first
+  // page (0→1, tail to bottom) from an older-page prepend (N→N+1, restore).
+  const renderedPagesRef = useRef(0)
+  // scrollHeight + scrollTop captured just before a fetchNextPage() so we can
+  // re-anchor the viewport exactly after older lines prepend at the top.
+  const pendingRestore = useRef<{ height: number; top: number } | null>(null)
+
+  const pageCount = data?.pages.length ?? 0
+
+  // A fresh query (filters changed or Refresh pressed) must re-tail from the
+  // bottom. Reset the page counter whenever the query identity changes; this
+  // effect is declared first so it runs before the scroll effect below.
+  const querySig = `${serviceId}|${trimmedText ?? ''}|${
+    levels?.join(',') ?? ''
+  }|${refreshKey}`
+  useLayoutEffect(() => {
+    renderedPagesRef.current = 0
+    pendingRestore.current = null
+  }, [querySig])
+
+  useLayoutEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const prev = renderedPagesRef.current
+    if (pageCount > prev) {
+      if (prev === 0) {
+        // First page of a fresh query → tail to the newest line.
+        el.scrollTop = el.scrollHeight
+      } else if (pendingRestore.current) {
+        // Older page prepended → re-anchor the viewport on the line the user
+        // was reading. New content added above shifts everything down by the
+        // scrollHeight delta; offset scrollTop by exactly that to hold still.
+        // (overflow-anchor:none on the container disables the browser's own
+        // anchoring so this manual math is the sole authority.)
+        const { height, top } = pendingRestore.current
+        el.scrollTop = top + (el.scrollHeight - height)
+        pendingRestore.current = null
+      }
+      renderedPagesRef.current = pageCount
+    }
+  }, [pageCount])
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    if (
+      el.scrollTop <= LOAD_OLDER_THRESHOLD &&
+      hasNextPage &&
+      !isFetchingNextPage
+    ) {
+      // Snapshot height+top so the prepend effect can restore the anchor.
+      pendingRestore.current = { height: el.scrollHeight, top: el.scrollTop }
+      fetchNextPage()
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
 
   function toggleLevel(level: LogLevel) {
     setActiveLevels((prev) =>
       prev.includes(level) ? prev.filter((l) => l !== level) : [...prev, level]
     )
   }
+
+  // Refresh spins only for a full reload, not for background older-page loads.
+  const refreshing = isFetching && !isFetchingNextPage
 
   return (
     <div className="flex-1 overflow-auto">
@@ -167,11 +268,11 @@ export function ServiceLogs() {
               variant="outline"
               size="sm"
               className="gap-2"
-              onClick={() => refetch()}
-              disabled={isFetching}
+              onClick={() => setRefreshKey((k) => k + 1)}
+              disabled={refreshing}
             >
               <RefreshCw
-                className={`h-4 w-4 ${isFetching ? 'animate-spin' : ''}`}
+                className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`}
               />
               <span className="hidden sm:inline">Refresh</span>
             </Button>
@@ -200,11 +301,12 @@ export function ServiceLogs() {
           </div>
           <span className="text-xs text-muted-foreground sm:ml-auto">
             Last 24h · {lines.length} line{lines.length === 1 ? '' : 's'}
+            {hasNextPage ? '+' : ''}
           </span>
         </div>
 
-        {/* Log panel — bounded height + its own scrollbar so the page chrome
-            (header/filter) stays put and long output scrolls inside. */}
+        {/* Log panel — bounded height + its own scrollbar. Tails to the newest
+            line on load; scrolling to the top lazily pages in older lines. */}
         {error ? (
           <div className="rounded-md border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
             Failed to load logs: {(error as Error).message}
@@ -222,8 +324,27 @@ export function ServiceLogs() {
           </div>
         ) : (
           <div className="rounded-md border bg-muted/30">
-            <div className="max-h-[calc(100vh-19rem)] overflow-auto">
-              <pre className="min-w-full p-3 font-mono text-xs leading-relaxed">
+            <div
+              ref={scrollRef}
+              onScroll={handleScroll}
+              className="max-h-[calc(100vh-19rem)] overflow-auto [overflow-anchor:none]"
+            >
+              {/* Top affordance for the "load older" walk. */}
+              {isFetchingNextPage ? (
+                <div className="flex items-center justify-center gap-2 py-2 text-xs text-muted-foreground">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  Loading older logs…
+                </div>
+              ) : hasNextPage ? (
+                <div className="py-1.5 text-center text-xs text-muted-foreground/70">
+                  Scroll up to load older logs
+                </div>
+              ) : (
+                <div className="py-1.5 text-center text-xs text-muted-foreground/50">
+                  Beginning of the last 24 hours
+                </div>
+              )}
+              <pre className="min-w-full px-3 pb-3 font-mono text-xs leading-relaxed">
                 {lines.map((line, i) => (
                   <div
                     key={`${line.chunk_id}-${line.line_offset}-${i}`}

--- a/web/src/pages/ServiceLogs.tsx
+++ b/web/src/pages/ServiceLogs.tsx
@@ -1,0 +1,169 @@
+import { getServiceOptions } from '@/api/client/@tanstack/react-query.gen'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  type LogLevel,
+  type LogSearchLine,
+  useLogHistory,
+} from '@/hooks/useLogHistory'
+import { useQuery } from '@tanstack/react-query'
+import { ArrowLeft, RefreshCw, ScrollText } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+
+/** Tailwind classes per normalized level — mirrors the deployment log viewer. */
+const LEVEL_CLASS: Record<LogLevel, string> = {
+  ERROR: 'text-red-500',
+  WARN: 'text-amber-500',
+  INFO: 'text-foreground',
+  DEBUG: 'text-muted-foreground',
+  TRACE: 'text-muted-foreground/70',
+}
+
+const LEVELS: LogLevel[] = ['ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE']
+
+function formatTs(ts: string): string {
+  const d = new Date(ts)
+  if (Number.isNaN(d.getTime())) return ts
+  return d.toISOString().replace('T', ' ').replace('Z', '')
+}
+
+/**
+ * Persisted, searchable log history for an imported/managed external service
+ * (Postgres, MariaDB, Redis, MongoDB, MinIO). Reuses the same log-aggregator
+ * search pipeline as application/deployment logs, scoped by
+ * `external_service_id` instead of a project.
+ */
+export function ServiceLogs() {
+  const { id } = useParams<{ id: string }>()
+  const serviceId = id ? parseInt(id, 10) : NaN
+
+  const { data: service } = useQuery({
+    ...getServiceOptions({ path: { id: serviceId } }),
+    enabled: !Number.isNaN(serviceId),
+  })
+
+  const [text, setText] = useState('')
+  const [activeLevels, setActiveLevels] = useState<LogLevel[]>([])
+
+  // Look back 24h by default — matches the service history window operators expect.
+  const startTime = useMemo(
+    () => new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+    []
+  )
+
+  const { data, isLoading, isFetching, error, refetch } = useLogHistory(
+    {
+      // projectId is ignored server-side when externalServiceId is set.
+      projectId: 0,
+      externalServiceId: serviceId,
+      startTime,
+      levels: activeLevels.length ? activeLevels : undefined,
+      text: text.trim() || undefined,
+      pageSize: 500,
+    },
+    !Number.isNaN(serviceId)
+  )
+
+  const lines: LogSearchLine[] = data?.lines ?? []
+  const serviceName = service?.service?.name ?? id
+
+  function toggleLevel(level: LogLevel) {
+    setActiveLevels((prev) =>
+      prev.includes(level) ? prev.filter((l) => l !== level) : [...prev, level]
+    )
+  }
+
+  return (
+    <div className="container mx-auto max-w-5xl px-4 py-6">
+      <div className="mb-4 flex items-center gap-2">
+        <Link to={`/storage/${id}`}>
+          <Button variant="ghost" size="sm" className="gap-2">
+            <ArrowLeft className="h-4 w-4" />
+            <span className="hidden sm:inline">Back</span>
+          </Button>
+        </Link>
+        <ScrollText className="h-5 w-5 text-muted-foreground" />
+        <h1 className="text-lg font-medium">
+          Logs
+          {serviceName ? (
+            <span className="text-muted-foreground"> — {serviceName}</span>
+          ) : null}
+        </h1>
+        <Button
+          variant="outline"
+          size="sm"
+          className="ml-auto gap-2"
+          onClick={() => refetch()}
+          disabled={isFetching}
+        >
+          <RefreshCw
+            className={`h-4 w-4 ${isFetching ? 'animate-spin' : ''}`}
+          />
+          <span className="hidden sm:inline">Refresh</span>
+        </Button>
+      </div>
+
+      <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:flex-wrap">
+        <Input
+          placeholder="Filter logs (text search)…"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          className="w-full sm:w-[320px]"
+        />
+        <div className="flex flex-wrap gap-1">
+          {LEVELS.map((level) => (
+            <Badge
+              key={level}
+              variant={activeLevels.includes(level) ? 'default' : 'outline'}
+              className="cursor-pointer select-none"
+              onClick={() => toggleLevel(level)}
+            >
+              {level}
+            </Badge>
+          ))}
+        </div>
+        <span className="text-xs text-muted-foreground sm:ml-auto">
+          Last 24h · {lines.length} line{lines.length === 1 ? '' : 's'}
+        </span>
+      </div>
+
+      {error ? (
+        <div className="rounded-md border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          Failed to load logs: {(error as Error).message}
+        </div>
+      ) : isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 12 }).map((_, i) => (
+            <Skeleton key={i} className="h-5 w-full" />
+          ))}
+        </div>
+      ) : lines.length === 0 ? (
+        <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
+          No logs found in the last 24 hours. Logs appear here once the service
+          container emits output.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-md border bg-muted/30">
+          <pre className="min-w-full p-3 font-mono text-xs leading-relaxed">
+            {lines.map((line, i) => (
+              <div key={`${line.chunk_id}-${line.line_offset}-${i}`} className="flex gap-3">
+                <span className="shrink-0 text-muted-foreground/70">
+                  {formatTs(line.timestamp)}
+                </span>
+                <span className={`shrink-0 w-12 ${LEVEL_CLASS[line.level]}`}>
+                  {line.level}
+                </span>
+                <span className={`whitespace-pre-wrap break-all ${LEVEL_CLASS[line.level]}`}>
+                  {line.message}
+                </span>
+              </div>
+            ))}
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/ServiceLogs.tsx
+++ b/web/src/pages/ServiceLogs.tsx
@@ -2,14 +2,23 @@ import { getServiceOptions } from '@/api/client/@tanstack/react-query.gen'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { ServiceHealthBadge } from '@/components/storage/ServiceHealthCard'
+import { ServiceLogo } from '@/components/ui/service-logo'
 import { Skeleton } from '@/components/ui/skeleton'
+import { TimeAgo } from '@/components/utils/TimeAgo'
 import {
   type LogLevel,
   type LogSearchLine,
   useLogHistory,
 } from '@/hooks/useLogHistory'
 import { useQuery } from '@tanstack/react-query'
-import { ArrowLeft, RefreshCw, ScrollText } from 'lucide-react'
+import {
+  ArrowLeft,
+  Database,
+  RefreshCw,
+  ScrollText,
+  Server,
+} from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 
@@ -34,13 +43,14 @@ function formatTs(ts: string): string {
  * Persisted, searchable log history for an imported/managed external service
  * (Postgres, MariaDB, Redis, MongoDB, MinIO). Reuses the same log-aggregator
  * search pipeline as application/deployment logs, scoped by
- * `external_service_id` instead of a project.
+ * `external_service_id` instead of a project. Wears the same header shell as
+ * the service detail page so it reads as one app.
  */
 export function ServiceLogs() {
   const { id } = useParams<{ id: string }>()
   const serviceId = id ? parseInt(id, 10) : NaN
 
-  const { data: service } = useQuery({
+  const { data: service, isLoading: serviceLoading } = useQuery({
     ...getServiceOptions({ path: { id: serviceId } }),
     enabled: !Number.isNaN(serviceId),
   })
@@ -68,7 +78,7 @@ export function ServiceLogs() {
   )
 
   const lines: LogSearchLine[] = data?.lines ?? []
-  const serviceName = service?.service?.name ?? id
+  const svc = service?.service
 
   function toggleLevel(level: LogLevel) {
     setActiveLevels((prev) =>
@@ -77,93 +87,168 @@ export function ServiceLogs() {
   }
 
   return (
-    <div className="container mx-auto max-w-5xl px-4 py-6">
-      <div className="mb-4 flex items-center gap-2">
-        <Link to={`/storage/${id}`}>
-          <Button variant="ghost" size="sm" className="gap-2">
-            <ArrowLeft className="h-4 w-4" />
-            <span className="hidden sm:inline">Back</span>
-          </Button>
-        </Link>
-        <ScrollText className="h-5 w-5 text-muted-foreground" />
-        <h1 className="text-lg font-medium">
-          Logs
-          {serviceName ? (
-            <span className="text-muted-foreground"> — {serviceName}</span>
-          ) : null}
-        </h1>
-        <Button
-          variant="outline"
-          size="sm"
-          className="ml-auto gap-2"
-          onClick={() => refetch()}
-          disabled={isFetching}
-        >
-          <RefreshCw
-            className={`h-4 w-4 ${isFetching ? 'animate-spin' : ''}`}
-          />
-          <span className="hidden sm:inline">Refresh</span>
-        </Button>
-      </div>
-
-      <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:flex-wrap">
-        <Input
-          placeholder="Filter logs (text search)…"
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          className="w-full sm:w-[320px]"
-        />
-        <div className="flex flex-wrap gap-1">
-          {LEVELS.map((level) => (
-            <Badge
-              key={level}
-              variant={activeLevels.includes(level) ? 'default' : 'outline'}
-              className="cursor-pointer select-none"
-              onClick={() => toggleLevel(level)}
-            >
-              {level}
-            </Badge>
-          ))}
-        </div>
-        <span className="text-xs text-muted-foreground sm:ml-auto">
-          Last 24h · {lines.length} line{lines.length === 1 ? '' : 's'}
-        </span>
-      </div>
-
-      {error ? (
-        <div className="rounded-md border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
-          Failed to load logs: {(error as Error).message}
-        </div>
-      ) : isLoading ? (
-        <div className="space-y-2">
-          {Array.from({ length: 12 }).map((_, i) => (
-            <Skeleton key={i} className="h-5 w-full" />
-          ))}
-        </div>
-      ) : lines.length === 0 ? (
-        <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
-          No logs found in the last 24 hours. Logs appear here once the service
-          container emits output.
-        </div>
-      ) : (
-        <div className="overflow-x-auto rounded-md border bg-muted/30">
-          <pre className="min-w-full p-3 font-mono text-xs leading-relaxed">
-            {lines.map((line, i) => (
-              <div key={`${line.chunk_id}-${line.line_offset}-${i}`} className="flex gap-3">
-                <span className="shrink-0 text-muted-foreground/70">
-                  {formatTs(line.timestamp)}
-                </span>
-                <span className={`shrink-0 w-12 ${LEVEL_CLASS[line.level]}`}>
-                  {line.level}
-                </span>
-                <span className={`whitespace-pre-wrap break-all ${LEVEL_CLASS[line.level]}`}>
-                  {line.message}
-                </span>
+    <div className="flex-1 overflow-auto">
+      <div className="p-4 space-y-6 md:p-6">
+        {/* Header — mirrors ServiceDetail so the Logs view reads as one app. */}
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <Link to={`/storage/${id}`}>
+              <Button variant="ghost" size="icon">
+                <ArrowLeft className="h-4 w-4" />
+              </Button>
+            </Link>
+            {svc ? (
+              <ServiceLogo service={svc.service_type} className="h-8 w-8" />
+            ) : (
+              <ScrollText className="h-8 w-8 text-muted-foreground" />
+            )}
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-2 flex-wrap">
+                <h1 className="text-xl font-semibold sm:text-2xl">
+                  {svc?.name ?? id}
+                </h1>
+                {svc ? (
+                  <>
+                    <Badge
+                      variant={
+                        svc.status === 'running'
+                          ? 'default'
+                          : svc.status === 'stopped'
+                            ? 'secondary'
+                            : 'outline'
+                      }
+                      className="capitalize"
+                    >
+                      {svc.status}
+                    </Badge>
+                    {svc.status === 'running' ? (
+                      <ServiceHealthBadge serviceId={serviceId} />
+                    ) : null}
+                    <Badge variant="outline" className="gap-1.5">
+                      <ServiceLogo
+                        service={svc.service_type}
+                        className="h-3 w-3"
+                      />
+                      {svc.service_type}
+                    </Badge>
+                  </>
+                ) : null}
+                <Badge variant="outline" className="gap-1.5">
+                  <ScrollText className="h-3 w-3" />
+                  Logs
+                </Badge>
               </div>
-            ))}
-          </pre>
+              {svc ? (
+                <p className="text-sm text-muted-foreground">
+                  Created <TimeAgo date={svc.created_at} />
+                </p>
+              ) : null}
+            </div>
+          </div>
+
+          {/* Same action row as the detail page; Monitoring/Browse Data link
+              back out, and Refresh replaces the kebab for this view. */}
+          <div className="flex items-center gap-2 self-start sm:self-auto flex-wrap">
+            {svc?.status === 'running' ? (
+              <Link to={`/storage/${id}/monitoring`}>
+                <Button variant="outline" size="sm" className="gap-2">
+                  <Server className="h-4 w-4" />
+                  <span className="hidden sm:inline">Monitoring</span>
+                </Button>
+              </Link>
+            ) : null}
+            <Link to={`/storage/${id}/browse`}>
+              <Button variant="outline" size="sm" className="gap-2">
+                <Database className="h-4 w-4" />
+                <span className="hidden sm:inline">Browse Data</span>
+              </Button>
+            </Link>
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-2"
+              onClick={() => refetch()}
+              disabled={isFetching}
+            >
+              <RefreshCw
+                className={`h-4 w-4 ${isFetching ? 'animate-spin' : ''}`}
+              />
+              <span className="hidden sm:inline">Refresh</span>
+            </Button>
+          </div>
         </div>
-      )}
+
+        {/* Filter bar */}
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:flex-wrap">
+          <Input
+            placeholder="Filter logs (text search)…"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            className="w-full sm:w-[320px]"
+          />
+          <div className="flex flex-wrap gap-1">
+            {LEVELS.map((level) => (
+              <Badge
+                key={level}
+                variant={activeLevels.includes(level) ? 'default' : 'outline'}
+                className="cursor-pointer select-none"
+                onClick={() => toggleLevel(level)}
+              >
+                {level}
+              </Badge>
+            ))}
+          </div>
+          <span className="text-xs text-muted-foreground sm:ml-auto">
+            Last 24h · {lines.length} line{lines.length === 1 ? '' : 's'}
+          </span>
+        </div>
+
+        {/* Log panel — bounded height + its own scrollbar so the page chrome
+            (header/filter) stays put and long output scrolls inside. */}
+        {error ? (
+          <div className="rounded-md border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+            Failed to load logs: {(error as Error).message}
+          </div>
+        ) : isLoading || serviceLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 12 }).map((_, i) => (
+              <Skeleton key={i} className="h-5 w-full" />
+            ))}
+          </div>
+        ) : lines.length === 0 ? (
+          <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
+            No logs found in the last 24 hours. Logs appear here once the
+            service container emits output.
+          </div>
+        ) : (
+          <div className="rounded-md border bg-muted/30">
+            <div className="max-h-[calc(100vh-19rem)] overflow-auto">
+              <pre className="min-w-full p-3 font-mono text-xs leading-relaxed">
+                {lines.map((line, i) => (
+                  <div
+                    key={`${line.chunk_id}-${line.line_offset}-${i}`}
+                    className="flex gap-3 border-b border-border/40 py-0.5 last:border-0"
+                  >
+                    <span className="shrink-0 text-muted-foreground/70">
+                      {formatTs(line.timestamp)}
+                    </span>
+                    <span
+                      className={`shrink-0 w-12 ${LEVEL_CLASS[line.level]}`}
+                    >
+                      {line.level}
+                    </span>
+                    <span
+                      className={`whitespace-pre-wrap break-all ${LEVEL_CLASS[line.level]}`}
+                    >
+                      {line.message}
+                    </span>
+                  </div>
+                ))}
+              </pre>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Started from a user question about why the AI chat couldn't filter analytics visitors by country. Reviewing the AI chat's tool allowlist (a deliberate opt-in security boundary, since many GET endpoints return decrypted secrets) surfaced a broader gap, and auditing it surfaced real unauthenticated-access bugs unrelated to the original ask.

- **`fix(security)`** — Several admin-router handlers had **no auth at all**, reachable by any unauthenticated internet caller:
  - `temps-analytics-session-replay`: all 7 admin handlers, including **delete** and **inject-events** mutations, and full rrweb session-recording playback.
  - `temps-analytics-performance`: 4 handlers, cross-tenant Core Web Vitals reads.
  - `temps-static-files`: internal files (deployment screenshots) for every project.
  - `temps-geo`: unauthenticated GeoIP lookup proxy.
  - `temps-git` public-repo browsing was silently spending the server's own GitHub OAuth token on anonymous callers (quota-exhaustion risk) — now only reused for authenticated sessions.
  - Also pins `temps-proxy`'s `rcgen` to 0.13.2 (matching `temps-core`'s existing override) — needed to get a consistent `Cargo.lock` for the new `temps-auth` edges added by the fixes above; without it `tls_cert_loader.rs` breaks the same way `node_pki.rs` did against rcgen 0.14.8.

- **`feat(ai-chat)`** — Expands the AI chat's read-only tool allowlist from 9 to 208 entries (33 more analytics ops, ~85 across auth/webhooks/KV/blob/email/git/agents/AI Gateway/status-page/vuln-scans). Every addition was checked against its actual response DTO, not its name — a few suspicious-sounding ones (`list_provider_keys`, `list_connections`, `list_oidc_providers`) were individually verified to return only masked data. Still excludes anything that returns decrypted secrets or raw session/DOM capture.

- **`chore`** — Bundles unrelated pre-existing uncommitted work found in the working tree: a MariaDB `container_name` bugfix, a not-yet-wired-in node-metrics collector extraction, and a React patch bump.

## Test plan
- [x] `cargo check --lib --workspace` — 0 errors
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --lib -p temps-analytics-session-replay` — 12/12
- [x] `cargo test --lib -p temps-geo` — 5/5
- [x] `cargo test --lib -p temps-git` — 49/49
- [ ] Manual smoke test of `/session-replays`, `/performance/metrics`, `/files/{path}`, `/geo/{ip}` now returning 401 without a session