### PR TITLE
fix: repair rcgen 0.14 API breaks on main

### DIFF
--- a/crates/temps-core/src/node_pki.rs
+++ b/crates/temps-core/src/node_pki.rs
@@ -16,9 +16,10 @@
 //! Wiring it into the agent's TLS listener, the control-plane client, and the
 //! enrollment handshake happens in the respective crates.
 
+use rcgen::string::Ia5String;
 use rcgen::{
     BasicConstraints, CertificateParams, CertificateSigningRequestParams, DistinguishedName,
-    DnType, ExtendedKeyUsagePurpose, Ia5String, IsCa, KeyPair, KeyUsagePurpose, SanType,
+    DnType, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair, KeyUsagePurpose, SanType,
 };
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -167,14 +168,10 @@ pub fn sign_node_csr(
         context: "CA key".into(),
         reason: e.to_string(),
     })?;
-    let ca_params =
-        CertificateParams::from_ca_cert_pem(ca_cert_pem).map_err(|e| PkiError::PemParse {
-            context: "CA certificate".into(),
-            reason: e.to_string(),
-        })?;
-    let ca_cert = ca_params
-        .self_signed(&ca_key)
-        .map_err(|e| PkiError::CertBuild(e.to_string()))?;
+    let issuer = Issuer::from_ca_cert_pem(ca_cert_pem, ca_key).map_err(|e| PkiError::PemParse {
+        context: "CA certificate".into(),
+        reason: e.to_string(),
+    })?;
 
     // Parse the CSR; constrain the leaf to client+server auth.
     let mut csr =
@@ -202,11 +199,9 @@ pub fn sign_node_csr(
     }
     csr.params.subject_alt_names = sans;
 
-    let leaf = csr
-        .signed_by(&ca_cert, &ca_key)
-        .map_err(|e| PkiError::CsrSign {
-            reason: e.to_string(),
-        })?;
+    let leaf = csr.signed_by(&issuer).map_err(|e| PkiError::CsrSign {
+        reason: e.to_string(),
+    })?;
 
     let cert_pem = leaf.pem();
     let fingerprint = {

--- a/crates/temps-proxy/src/tls_cert_loader.rs
+++ b/crates/temps-proxy/src/tls_cert_loader.rs
@@ -493,11 +493,11 @@ mod tests {
     /// `domain` using rcgen + the test EncryptionService. Returns
     /// `(cert_pem, encrypted_key_pem)` ready to embed in a mock [`domains::Model`].
     fn make_test_cert(domain: &str, enc: &temps_core::EncryptionService) -> (String, String) {
-        let rcgen::CertifiedKey { cert, key_pair } =
+        let rcgen::CertifiedKey { cert, signing_key } =
             rcgen::generate_simple_self_signed(vec![domain.to_string()])
                 .expect("rcgen should generate a test certificate");
         let cert_pem = cert.pem();
-        let key_pem = key_pair.serialize_pem();
+        let key_pem = signing_key.serialize_pem();
         let encrypted_key = enc.encrypt_string(&key_pem).expect("encrypt test key");
         (cert_pem, encrypted_key)
     }


### PR DESCRIPTION
## Summary
- `main` currently fails `cargo check --lib --workspace` and `cargo clippy --workspace --all-targets` due to leftover rcgen 0.14 API breaks that #247 (dependency-bump compilation fix) didn't cover.
- `crates/temps-core/src/node_pki.rs`: `CertificateParams::from_ca_cert_pem` was removed and `CertificateSigningRequestParams::signed_by` now takes a single `&Issuer<impl SigningKey>` instead of separate cert+key args. Rebuilt the CA issuer via `Issuer::from_ca_cert_pem(ca_cert_pem, ca_key)` and sign the CSR through it. Also `Ia5String` is no longer re-exported at the crate root — imported from `rcgen::string` instead.
- `crates/temps-proxy/src/tls_cert_loader.rs` (test helper): `rcgen::CertifiedKey`'s `key_pair` field was renamed to `signing_key` — only surfaced under `--all-targets` since it's in a `#[cfg(test)]` block.

## Test plan
- [x] `cargo check --lib --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (matches pre-commit hook)
- [x] `cargo test --lib -p temps-core node_pki` — 5/5 pass, including the worker-supplied-SAN-rejection security test (`test_sign_overwrites_worker_supplied_sans`)