### PR TITLE
feat(deployments): add SecretsManagerResolver OSS extension seam

### DIFF
--- a/crates/temps-core/src/lib.rs
+++ b/crates/temps-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod openapi;
 pub mod plugin;
 pub mod problemdetails;
 pub mod retry;
+pub mod secrets_manager;
 pub mod telemetry;
 pub mod tls;
 pub mod traces;
@@ -50,6 +51,7 @@ pub use error::*;
 pub use error_builder::*;
 pub use jobs::*;
 pub use on_demand::*;
+pub use secrets_manager::SecretsManagerResolver;
 pub use telemetry::{NoopTelemetryReporter, TelemetryEvent, TelemetryEventKind, TelemetryReporter};
 pub use traces::{
     TraceQueryFilter, TraceReader, TraceReaderError, TraceSpanDto, TraceSpanEventDto,

--- a/crates/temps-core/src/secrets_manager.rs
+++ b/crates/temps-core/src/secrets_manager.rs
@@ -1,0 +1,55 @@
+//! OSS extension point for deploy-time secrets injection.
+//!
+//! This trait avoids a circular dependency between `temps-deployments` (which
+//! orchestrates workflow planning) and any future EE crate that implements a
+//! secrets-manager integration. `temps-deployments` depends on `temps-core`
+//! (not on the EE crate); the EE plugin registers an implementation and
+//! `DeploymentsPlugin` retrieves it via the optional service registry.
+//!
+//! The design is modeled on [`crate::env_vars_provider::ProjectEnvVarsProvider`]:
+//! one file per trait, same error-boxing style, same file-per-trait convention.
+
+use async_trait::async_trait;
+use std::collections::HashMap;
+
+/// OSS extension point for deployer-time secret injection.
+///
+/// OSS never implements this trait. An EE plugin registers a concrete
+/// implementation via `context.register_service(resolver)` only when the
+/// `SecretsManagerIntegrations` feature is licensed.
+/// `DeploymentsPlugin` retrieves it with
+/// `context.get_service::<dyn SecretsManagerResolver>()`
+/// (never `require_service`) inside `initialize_plugin_services`, so the OSS
+/// binary is a strict no-op when nothing is registered.
+///
+/// # Fail-closed contract
+///
+/// Errors returned here are **fail-closed**: `WorkflowPlanner` treats any
+/// `Err` as a hard deployment failure and surfaces the error in the
+/// deployment log. An implementation MUST return `Err` when a bound secret
+/// cannot be retrieved rather than returning an empty or placeholder value.
+/// "Fail-open" behaviour (silently omitting a binding, returning an empty
+/// string, or falling back to a stale cached value) is explicitly prohibited.
+#[async_trait]
+pub trait SecretsManagerResolver: Send + Sync {
+    /// Resolve every secret bound to this project+environment combination
+    /// and return them as a flat `env_key → plaintext_value` map.
+    ///
+    /// Unlike [`crate::env_vars_provider::ProjectEnvVarsProvider::get_project_integration_env_vars`]
+    /// which accepts `Option<i32>` for `environment_id`, this method always
+    /// receives a concrete environment: deploy-time injection always operates
+    /// in a specific environment.
+    ///
+    /// # Fail-closed contract
+    ///
+    /// If any single binding cannot be resolved (provider unreachable,
+    /// path not found, authentication failure), return `Err`. The caller
+    /// (`WorkflowPlanner::gather_environment_variables`) will surface the
+    /// error in the deployment log and abort. Never return `Ok` with a
+    /// partial map that silently omits a binding.
+    async fn resolve_secrets_for_deployment(
+        &self,
+        project_id: i32,
+        environment_id: i32,
+    ) -> Result<HashMap<String, String>, Box<dyn std::error::Error + Send + Sync>>;
+}

--- a/crates/temps-deployments/src/plugin.rs
+++ b/crates/temps-deployments/src/plugin.rs
@@ -10,7 +10,8 @@ use utoipa::{openapi::OpenApi, OpenApi as UtoimaOpenApi};
 use crate::{
     handlers,
     services::{
-        DeploymentGateSlot, DeploymentService, JobProcessorService, WorkflowExecutionService,
+        DeploymentGateSlot, DeploymentService, JobProcessorService, SecretsResolverSlot,
+        WorkflowExecutionService,
     },
     WorkflowPlanner,
 };
@@ -26,12 +27,19 @@ pub struct DeploymentsPlugin {
     /// order, and this plugin registers (and starts its processor) before
     /// any later-registered plugin gets a chance to provide a gate.
     deployment_gate_slot: tokio::sync::OnceCell<DeploymentGateSlot>,
+    /// Handle to the `WorkflowPlanner`'s `secrets_resolver` slot, captured
+    /// before the planner is moved into the background task. Uses the same
+    /// two-phase handoff pattern as `deployment_gate_slot`: the actual EE
+    /// resolver is written in `initialize_plugin_services` once every plugin
+    /// has registered.  Remains `None` on OSS-only builds — a strict no-op.
+    secrets_resolver_slot: tokio::sync::OnceCell<SecretsResolverSlot>,
 }
 
 impl DeploymentsPlugin {
     pub fn new() -> Self {
         Self {
             deployment_gate_slot: tokio::sync::OnceCell::new(),
+            secrets_resolver_slot: tokio::sync::OnceCell::new(),
         }
     }
 }
@@ -261,6 +269,15 @@ impl TempsPlugin for DeploymentsPlugin {
                 encryption_service,
             ));
 
+            // Capture the secrets-resolver handle BEFORE moving workflow_planner
+            // into the job processor.  This is the two-phase handoff: the actual
+            // EE resolver (if any) is written into this slot in
+            // initialize_plugin_services, which runs only after every plugin has
+            // registered its services.  Any EE plugin that registers a
+            // SecretsManagerResolver will register AFTER this plugin, so looking
+            // it up here with get_service would always return None.
+            let secrets_resolver_handle = workflow_planner.secrets_resolver_handle();
+
             // Clone workflow_execution_service before passing to job processor
             // (the job processor takes ownership, but we need to register it too)
             let workflow_execution_service_for_processor = workflow_execution_service.clone();
@@ -283,6 +300,14 @@ impl TempsPlugin for DeploymentsPlugin {
             if self
                 .deployment_gate_slot
                 .set(job_processor.deployment_gate_handle())
+                .is_err()
+            {
+                unreachable!("register_services runs exactly once per plugin instance");
+            }
+
+            if self
+                .secrets_resolver_slot
+                .set(secrets_resolver_handle)
                 .is_err()
             {
                 unreachable!("register_services runs exactly once per plugin instance");
@@ -329,6 +354,20 @@ impl TempsPlugin for DeploymentsPlugin {
                     tracing::debug!("Deployment gate wired into job processor");
                 }
             }
+
+            // Wire the optional EE-provided SecretsManagerResolver into the
+            // WorkflowPlanner.  Uses get_service (not require_service) so that
+            // OSS-only builds — where no EE plugin registers the resolver —
+            // continue to work without secrets support (strict no-op).
+            if let Some(slot) = self.secrets_resolver_slot.get() {
+                if let Some(resolver) =
+                    context.get_service::<dyn temps_core::SecretsManagerResolver>()
+                {
+                    *slot.write().await = Some(resolver);
+                    tracing::debug!("SecretsManagerResolver wired into WorkflowPlanner");
+                }
+            }
+
             Ok(())
         })
     }
@@ -370,6 +409,26 @@ impl TempsPlugin for DeploymentsPlugin {
             dsn_service,
             encryption_service,
         ));
+
+        // Wire the SecretsManagerResolver into this secondary WorkflowPlanner
+        // (used for the remote-deployment handlers). configure_routes runs
+        // after initialize_plugin_services, so the resolver is already in the
+        // service registry if an EE plugin provided one.  The lock is freshly
+        // created and uncontested, so try_write() always succeeds here.
+        if let Some(resolver) = context.get_service::<dyn temps_core::SecretsManagerResolver>() {
+            match workflow_planner.secrets_resolver_handle().try_write() {
+                Ok(mut guard) => {
+                    *guard = Some(resolver);
+                    tracing::debug!("SecretsManagerResolver wired into secondary WorkflowPlanner");
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        "Could not acquire secrets resolver slot in configure_routes; \
+                         secrets-manager bindings will be unavailable for remote deployments"
+                    );
+                }
+            }
+        }
 
         // Get WorkflowExecutionService
         let workflow_executor = context.require_service::<WorkflowExecutionService>();

--- a/crates/temps-deployments/src/services/workflow_planner.rs
+++ b/crates/temps-deployments/src/services/workflow_planner.rs
@@ -5,10 +5,20 @@
 use sea_orm::{ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set};
 use serde_json;
 use std::sync::Arc;
-use temps_core::EncryptionService;
+use temps_core::{EncryptionService, SecretsManagerResolver};
 use temps_entities::{deployment_jobs, deployments, environments, projects, types::JobStatus};
 use temps_logs::LogService;
 use tracing::{debug, info};
+
+/// Shared slot type for the optional [`temps_core::SecretsManagerResolver`].
+///
+/// Mirrors the two-phase wiring pattern of
+/// [`super::job_processor::DeploymentGateSlot`]: the slot is captured from
+/// `WorkflowPlanner` inside `DeploymentsPlugin::register_services` (before the
+/// planner is moved into the background task) and written into from
+/// `DeploymentsPlugin::initialize_plugin_services` (which runs only after every
+/// plugin has registered its services).
+pub type SecretsResolverSlot = Arc<tokio::sync::RwLock<Option<Arc<dyn SecretsManagerResolver>>>>;
 #[derive(Debug, Clone)]
 pub struct JobDefinition {
     pub job_id: String,
@@ -32,6 +42,17 @@ pub struct WorkflowPlanner {
     dsn_service: Arc<temps_error_tracking::DSNService>,
     deployment_token_service: Arc<DeploymentTokenService>,
     encryption_service: Arc<EncryptionService>,
+    /// Optional EE-provided resolver for secrets-manager bindings.
+    ///
+    /// Held behind a shared lock — identical to the `deployment_gate` slot in
+    /// [`super::job_processor::JobProcessorService`] — so it can be wired in
+    /// by `DeploymentsPlugin::initialize_plugin_services` after this struct
+    /// has already been moved into a background task by `register_services`.
+    ///
+    /// `None` on OSS-only builds (strict no-op). When `Some`, any error from
+    /// [`SecretsManagerResolver::resolve_secrets_for_deployment`] aborts the
+    /// entire deployment (fail-closed).
+    secrets_resolver: SecretsResolverSlot,
 }
 
 impl WorkflowPlanner {
@@ -55,7 +76,19 @@ impl WorkflowPlanner {
             dsn_service,
             deployment_token_service,
             encryption_service,
+            secrets_resolver: Arc::new(tokio::sync::RwLock::new(None)),
         }
+    }
+
+    /// Returns a clone of the shared secrets-resolver slot.
+    ///
+    /// Call this **before** moving `self` into a spawned task so that
+    /// `DeploymentsPlugin::initialize_plugin_services` can write the EE
+    /// resolver into it after every plugin has registered. The background
+    /// task re-reads the slot on every deployment, so a resolver wired in
+    /// after startup still protects every subsequent deployment.
+    pub fn secrets_resolver_handle(&self) -> SecretsResolverSlot {
+        self.secrets_resolver.clone()
     }
 
     /// Gather all environment variables for a deployment
@@ -219,6 +252,71 @@ impl WorkflowPlanner {
             );
 
             return Err(anyhow::anyhow!(error_message));
+        }
+
+        // 2b. Secrets-manager bindings (EE only — strict no-op when resolver is absent).
+        //
+        // Placed between the external-service env vars (step 2, fail-closed) and the
+        // system-generated vars (Sentry DSN, deployment token, OTel — steps 3-5).
+        // Secrets-manager bindings are operator-controlled and may shadow manual env
+        // vars (step 1) or integration env vars (step 2). They can never shadow
+        // system-generated vars because those are injected in later steps, after
+        // this block completes.
+        {
+            // Clone the Arc and drop the read guard before awaiting, so the lock is
+            // not held across an await point.
+            let maybe_resolver = {
+                let guard = self.secrets_resolver.read().await;
+                guard.as_ref().cloned()
+            };
+
+            if let Some(resolver) = maybe_resolver {
+                match resolver
+                    .resolve_secrets_for_deployment(project.id, environment.id)
+                    .await
+                {
+                    Ok(secrets_map) => {
+                        // Log resolved keys only — never log values (S2 of ADR 0009).
+                        info!(
+                            "Resolved {} secret(s) for project {} environment {}: [{}]",
+                            secrets_map.len(),
+                            project.id,
+                            environment.id,
+                            secrets_map.keys().cloned().collect::<Vec<_>>().join(", ")
+                        );
+                        // Warn when a secrets-manager binding overwrites a value
+                        // that was already set by a manual or integration env var so
+                        // operators can detect unintended shadowing. System-generated
+                        // vars (Sentry, OTel, deployment token) are added in later
+                        // steps and are therefore never shadowed here.
+                        for key in secrets_map.keys() {
+                            if env_vars_map.contains_key(key.as_str()) {
+                                tracing::warn!(
+                                    "Secrets binding overwrites existing env var '{}' for \
+                                     project {} environment {}",
+                                    key,
+                                    project.id,
+                                    environment.id,
+                                );
+                            }
+                        }
+                        env_vars_map.extend(secrets_map);
+                    }
+                    Err(e) => {
+                        // Fail-closed: abort the entire deployment. This is the same
+                        // treatment applied to a failed external service in the block
+                        // above — no partial success, no silent empty-string fallback.
+                        return Err(anyhow::anyhow!(
+                            "Secrets-manager resolution failed for project {} environment {}: {}. \
+                             The deployment cannot proceed. \
+                             Verify provider connectivity and credentials.",
+                            project.id,
+                            environment.id,
+                            e,
+                        ));
+                    }
+                }
+            }
         }
 
         // 3. Get or create Sentry DSN for error tracking
@@ -2618,5 +2716,193 @@ mod tests {
                 preset
             );
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // SecretsManagerResolver seam tests (ADR 0009 §Decision-2)
+    // -------------------------------------------------------------------------
+
+    /// A mock resolver that always returns an error, simulating a Vault outage
+    /// or misconfiguration.
+    struct FailingSecretsResolver {
+        message: String,
+    }
+
+    #[async_trait::async_trait]
+    impl temps_core::SecretsManagerResolver for FailingSecretsResolver {
+        async fn resolve_secrets_for_deployment(
+            &self,
+            _project_id: i32,
+            _environment_id: i32,
+        ) -> Result<
+            std::collections::HashMap<String, String>,
+            Box<dyn std::error::Error + Send + Sync>,
+        > {
+            Err(self.message.clone().into())
+        }
+    }
+
+    /// A mock resolver that returns a fixed set of secrets.
+    struct SucceedingSecretsResolver {
+        secrets: std::collections::HashMap<String, String>,
+    }
+
+    #[async_trait::async_trait]
+    impl temps_core::SecretsManagerResolver for SucceedingSecretsResolver {
+        async fn resolve_secrets_for_deployment(
+            &self,
+            _project_id: i32,
+            _environment_id: i32,
+        ) -> Result<
+            std::collections::HashMap<String, String>,
+            Box<dyn std::error::Error + Send + Sync>,
+        > {
+            Ok(self.secrets.clone())
+        }
+    }
+
+    /// ADR 0009 §S1: when the resolver returns `Err`, the entire deployment
+    /// must be aborted (fail-closed). `create_deployment_jobs` must propagate
+    /// the error rather than continuing with a partial or empty env-var map.
+    #[tokio::test]
+    async fn secrets_resolver_fail_closed_on_error() -> Result<(), Box<dyn std::error::Error>> {
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+        let log_service = Arc::new(LogService::new(std::env::temp_dir()));
+        let config_service = create_test_config_service(db.clone());
+        let dsn_service = create_test_dsn_service(db.clone());
+        let external_service_manager = create_test_external_service_manager(db.clone());
+        let planner = Arc::new(WorkflowPlanner::new(
+            db.clone(),
+            log_service,
+            external_service_manager,
+            config_service,
+            dsn_service,
+            create_test_encryption_service(),
+        ));
+
+        // Wire in a resolver that always fails.
+        let resolver: Arc<dyn temps_core::SecretsManagerResolver> =
+            Arc::new(FailingSecretsResolver {
+                message: "simulated Vault outage".to_string(),
+            });
+        *planner.secrets_resolver_handle().write().await = Some(resolver);
+
+        let (_project, _environment, deployment) =
+            create_test_project(db.as_ref(), Preset::NextJs).await?;
+
+        let result = planner.create_deployment_jobs(deployment.id).await;
+
+        assert!(
+            result.is_err(),
+            "create_deployment_jobs must fail when the secrets resolver returns Err (fail-closed)"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("Secrets-manager resolution failed"),
+            "error message must mention secrets-manager resolution failure; got: {err_msg}"
+        );
+        assert!(
+            err_msg.contains("simulated Vault outage"),
+            "error message must include the original resolver error; got: {err_msg}"
+        );
+
+        Ok(())
+    }
+
+    /// When the resolver returns `Ok`, deployment planning must succeed and the
+    /// resolved secrets must not appear in any error (they are merged silently
+    /// into the env-var map used by subsequent job-config assembly steps).
+    #[tokio::test]
+    async fn secrets_resolver_success_does_not_break_planning(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+        let log_service = Arc::new(LogService::new(std::env::temp_dir()));
+        let config_service = create_test_config_service(db.clone());
+        let dsn_service = create_test_dsn_service(db.clone());
+        let external_service_manager = create_test_external_service_manager(db.clone());
+        let planner = Arc::new(WorkflowPlanner::new(
+            db.clone(),
+            log_service,
+            external_service_manager,
+            config_service,
+            dsn_service,
+            create_test_encryption_service(),
+        ));
+
+        // Wire in a resolver that returns one secret.
+        let mut secrets = std::collections::HashMap::new();
+        secrets.insert("MY_API_KEY".to_string(), "super-secret-value".to_string());
+        let resolver: Arc<dyn temps_core::SecretsManagerResolver> =
+            Arc::new(SucceedingSecretsResolver { secrets });
+        *planner.secrets_resolver_handle().write().await = Some(resolver);
+
+        let (_project, _environment, deployment) =
+            create_test_project(db.as_ref(), Preset::NextJs).await?;
+
+        // Deployment planning must succeed when the resolver returns Ok.
+        let jobs = planner.create_deployment_jobs(deployment.id).await?;
+        assert!(
+            !jobs.is_empty(),
+            "create_deployment_jobs must succeed when the secrets resolver returns Ok"
+        );
+
+        Ok(())
+    }
+
+    /// ADR 0009 §Consequences (Positive): when no resolver is registered
+    /// (`None`), `create_deployment_jobs` must succeed with exactly the same
+    /// behaviour as before this seam was introduced — a strict no-op.
+    #[tokio::test]
+    async fn secrets_resolver_absent_is_strict_noop() -> Result<(), Box<dyn std::error::Error>> {
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+        let log_service = Arc::new(LogService::new(std::env::temp_dir()));
+        let config_service = create_test_config_service(db.clone());
+        let dsn_service = create_test_dsn_service(db.clone());
+        let external_service_manager = create_test_external_service_manager(db.clone());
+        // Create planner without wiring any resolver — slot stays None.
+        let planner = WorkflowPlanner::new(
+            db.clone(),
+            log_service,
+            external_service_manager,
+            config_service,
+            dsn_service,
+            create_test_encryption_service(),
+        );
+
+        // Verify the slot is indeed None.
+        assert!(
+            planner.secrets_resolver_handle().read().await.is_none(),
+            "slot must start as None"
+        );
+
+        let (_project, _environment, deployment) =
+            create_test_project(db.as_ref(), Preset::NextJs).await?;
+
+        // Deployment planning must succeed exactly as it did before ADR 0009.
+        let jobs = planner.create_deployment_jobs(deployment.id).await?;
+        assert!(
+            !jobs.is_empty(),
+            "create_deployment_jobs must succeed when no secrets resolver is registered"
+        );
+
+        // The standard set of jobs must still be created (unchanged pre-ADR behaviour).
+        let job_ids: Vec<String> = jobs.iter().map(|j| j.job_id.clone()).collect();
+        assert!(
+            job_ids.contains(&"download_repo".to_string()),
+            "download_repo job must still be planned when secrets resolver is absent"
+        );
+        assert!(
+            job_ids.contains(&"build_image".to_string()),
+            "build_image job must still be planned when secrets resolver is absent"
+        );
+        assert!(
+            job_ids.contains(&"deploy_container".to_string()),
+            "deploy_container job must still be planned when secrets resolver is absent"
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- New `temps_core::SecretsManagerResolver` trait, modeled on the existing `ProjectEnvVarsProvider` — a generic extension point that lets an optional plugin inject deploy-time secrets without this crate depending on any external secrets-manager integration.
- Wires an optional resolver into `WorkflowPlanner` using the same two-phase slot pattern already used for `DeploymentGate`: captured in `register_services`, wired in `initialize_plugin_services` via `context.get_service()` (never `require_service`), so a build with no resolver registered is a strict no-op.
- Extends `gather_environment_variables` with a **fail-closed** step between external-service env vars and the Sentry DSN: if a registered resolver returns `Err`, the whole deployment aborts with a clear error (never silently deploys with a missing secret). Resolved *keys* are logged, values never are.

## Test plan
- [x] `cargo check --workspace --lib`
- [x] `cargo test --lib -p temps-deployments secrets_resolver` (3 new tests: fail-closed on error, success path, absent-resolver strict no-op)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`