### PR TITLE
fix(providers): persist actual bound port after container creation retry

### DIFF
--- a/crates/temps-providers/src/externalsvc/mongodb.rs
+++ b/crates/temps-providers/src/externalsvc/mongodb.rs
@@ -360,10 +360,15 @@ impl MongodbService {
     /// it). The container name is deterministic, so a failed attempt must be
     /// removed before retrying or the next attempt's "already exists" check
     /// short-circuits without picking a new port.
+    ///
+    /// `config` is taken by mutable reference so a retry's port change is
+    /// written back to the caller — otherwise the caller (and anything it
+    /// persists to the database) keeps referencing the original port even
+    /// though the container actually ended up bound to a different one.
     async fn create_container(
         &self,
         docker: &Docker,
-        config: &MongodbRuntimeConfig,
+        config: &mut MongodbRuntimeConfig,
         resource_limits: &ServiceResourceLimits,
     ) -> Result<()> {
         const MAX_ATTEMPTS: u32 = 3;
@@ -373,7 +378,10 @@ impl MongodbService {
                 .create_container_once(docker, &attempt_config, resource_limits)
                 .await
             {
-                Ok(()) => return Ok(()),
+                Ok(()) => {
+                    *config = attempt_config;
+                    return Ok(());
+                }
                 Err(e) if attempt < MAX_ATTEMPTS && is_port_conflict_error(&e.to_string()) => {
                     warn!(
                         "Port {} for MongoDB container was already allocated (attempt {}/{}), retrying with a fresh port: {}",
@@ -1879,7 +1887,7 @@ impl ExternalService for MongodbService {
             }))
             .await?;
 
-        let config =
+        let mut config =
             existing_config.ok_or_else(|| anyhow::anyhow!("MongoDB configuration not found"))?;
 
         // Imported services skip the replica-set drift-reconciliation path
@@ -1914,7 +1922,8 @@ impl ExternalService for MongodbService {
 
         let limits = self.resource_limits.read().await.clone();
         if containers.is_empty() {
-            self.create_container(docker, &config, &limits).await?;
+            self.create_container(docker, &mut config, &limits).await?;
+            *self.config.write().await = Some(config);
         } else {
             // If the persisted config now requires `--replSet` but the
             // existing container was created in standalone mode, restarting it
@@ -1958,7 +1967,8 @@ impl ExternalService for MongodbService {
                             e
                         )
                     })?;
-                self.create_container(docker, &config, &limits).await?;
+                self.create_container(docker, &mut config, &limits).await?;
+                *self.config.write().await = Some(config);
             } else {
                 docker
                     .start_container(
@@ -2449,7 +2459,7 @@ impl ExternalService for MongodbService {
         info!("Starting MongoDB upgrade");
 
         let _old_mongodb_config = self.get_mongodb_config(old_config)?;
-        let new_mongodb_config = self.get_mongodb_config(new_config)?;
+        let mut new_mongodb_config = self.get_mongodb_config(new_config)?;
 
         // Verify the new image can be pulled BEFORE stopping the old container
         info!(
@@ -2467,8 +2477,9 @@ impl ExternalService for MongodbService {
         // Create container with new image (keeping the same volume for data persistence)
         info!("Starting MongoDB container with new image");
         let limits = self.resource_limits.read().await.clone();
-        self.create_container(&self.docker, &new_mongodb_config, &limits)
+        self.create_container(&self.docker, &mut new_mongodb_config, &limits)
             .await?;
+        *self.config.write().await = Some(new_mongodb_config);
 
         info!("MongoDB upgrade completed successfully");
         Ok(())
@@ -3245,7 +3256,7 @@ mod tests {
         println!("Step 3: Starting MongoDB container...");
         let service = MongodbService::new(service_name.clone(), docker.clone());
 
-        let mongodb_config = MongodbRuntimeConfig {
+        let mut mongodb_config = MongodbRuntimeConfig {
             host: "localhost".to_string(),
             port: test_port.to_string(),
             database: database.to_string(),
@@ -3261,7 +3272,11 @@ mod tests {
 
         // Create and start MongoDB container
         service
-            .create_container(&docker, &mongodb_config, &ServiceResourceLimits::default())
+            .create_container(
+                &docker,
+                &mut mongodb_config,
+                &ServiceResourceLimits::default(),
+            )
             .await
             .expect("Failed to create MongoDB container");
         println!("✓ MongoDB container started and healthy");

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -378,10 +378,15 @@ impl PostgresService {
     /// it). The container name is deterministic, so a failed attempt must be
     /// removed before retrying or the next attempt's "already exists" check
     /// short-circuits without picking a new port.
+    ///
+    /// `config` is taken by mutable reference so a retry's port change is
+    /// written back to the caller — otherwise the caller (and anything it
+    /// persists to the database) keeps referencing the original port even
+    /// though the container actually ended up bound to a different one.
     async fn create_container(
         &self,
         docker: &Docker,
-        config: &PostgresConfig,
+        config: &mut PostgresConfig,
         resource_limits: &ServiceResourceLimits,
         enable_archiving: bool,
     ) -> Result<()> {
@@ -392,7 +397,10 @@ impl PostgresService {
                 .create_container_once(docker, &attempt_config, resource_limits, enable_archiving)
                 .await
             {
-                Ok(()) => return Ok(()),
+                Ok(()) => {
+                    *config = attempt_config;
+                    return Ok(());
+                }
                 Err(e) if attempt < MAX_ATTEMPTS && is_port_conflict_error(&e.to_string()) => {
                     warn!(
                         "Port {} for PostgreSQL container was already allocated (attempt {}/{}), retrying with a fresh port: {}",
@@ -969,7 +977,11 @@ impl PostgresService {
             })?;
 
         let limits = self.resource_limits.read().await.clone();
-        self.create_container(&self.docker, postgres_config, &limits, true)
+        // `postgres_config` is a caller-owned `&PostgresConfig` here (used
+        // only for this recreate, not persisted afterward), so retry port
+        // changes are applied to a local clone rather than threaded further.
+        let mut recreate_config = postgres_config.clone();
+        self.create_container(&self.docker, &mut recreate_config, &limits, true)
             .await?;
         self.docker
             .start_container(
@@ -2666,19 +2678,25 @@ impl ExternalService for PostgresService {
         }
 
         // Parse input config and transform to runtime config
-        let postgres_config = self.get_postgres_config(config)?;
+        let mut postgres_config = self.get_postgres_config(config)?;
 
         // Store runtime config and limits so `start()` can recreate the
-        // container with the same constraints if it has been removed.
+        // container with the same constraints if it has been removed. This
+        // gets overwritten below once the real container port is known.
         *self.config.write().await = Some(postgres_config.clone());
         *self.resource_limits.write().await = resource_limits.clone();
 
         if postgres_config.container_name.is_none() {
             // Create Docker container. New services always start with archiving
             // off — `enable_wal_archiving()` recreates with archiving on when
-            // WAL-G is later configured.
-            self.create_container(&self.docker, &postgres_config, &resource_limits, false)
+            // WAL-G is later configured. `create_container` may retry on a
+            // different host port than requested (see its docs); it writes
+            // that back into `postgres_config`, so everything below —
+            // `self.config` and the DB-persisted parameters — reflects the
+            // port the container is actually bound to.
+            self.create_container(&self.docker, &mut postgres_config, &resource_limits, false)
                 .await?;
+            *self.config.write().await = Some(postgres_config.clone());
         } else {
             info!(
                 "PostgreSQL service '{}' is imported from container '{}'; skipping container creation",
@@ -3061,7 +3079,7 @@ impl ExternalService for PostgresService {
         }
 
         if need_create {
-            let config = self
+            let mut config = self
                 .config
                 .read()
                 .await
@@ -3069,8 +3087,9 @@ impl ExternalService for PostgresService {
                 .ok_or_else(|| anyhow::anyhow!("PostgreSQL configuration not found"))?
                 .clone();
             let limits = self.resource_limits.read().await.clone();
-            self.create_container(&self.docker, &config, &limits, desired_enable_archiving)
+            self.create_container(&self.docker, &mut config, &limits, desired_enable_archiving)
                 .await?;
+            *self.config.write().await = Some(config);
         } else {
             // Container exists and CMD matches desired state. Just start it
             // if it isn't already running.
@@ -3292,7 +3311,7 @@ impl ExternalService for PostgresService {
 
     async fn upgrade(&self, old_config: ServiceConfig, new_config: ServiceConfig) -> Result<()> {
         let old_pg_config = self.get_postgres_config(old_config)?;
-        let new_pg_config = self.get_postgres_config(new_config)?;
+        let mut new_pg_config = self.get_postgres_config(new_config)?;
 
         // Extract version numbers from Docker images
         let old_version = Self::extract_postgres_version(&old_pg_config.docker_image)?;
@@ -3360,8 +3379,9 @@ impl ExternalService for PostgresService {
         // Preserve archiving state across the image swap by reading
         // `walg.env` from the existing volume — same rule as `start()`.
         let enable_archiving = self.compute_desired_enable_archiving().await;
-        self.create_container(&self.docker, &new_pg_config, &limits, enable_archiving)
+        self.create_container(&self.docker, &mut new_pg_config, &limits, enable_archiving)
             .await?;
+        *self.config.write().await = Some(new_pg_config);
         info!("PostgreSQL image swap completed successfully");
 
         Ok(())
@@ -3644,10 +3664,13 @@ impl ExternalService for PostgresService {
 
         // Create the new container+volume. Restored services start with
         // archiving off — the operator decides whether to wire WAL-G to the
-        // new service explicitly.
+        // new service explicitly. `create_container` writes any port-conflict
+        // retry back into `source_config`, so everything serialized below
+        // reflects the port the container actually bound to.
         new_service
-            .create_container(&self.docker, &source_config, &cloned_limits, false)
+            .create_container(&self.docker, &mut source_config, &cloned_limits, false)
             .await?;
+        *new_service.config.write().await = Some(source_config.clone());
 
         // Build a ServiceConfig that parses cleanly back into PostgresConfig.
         let new_service_config = ServiceConfig {
@@ -3748,8 +3771,9 @@ impl ExternalService for PostgresService {
             *new_service.config.write().await = Some(source_config.clone());
             *new_service.resource_limits.write().await = cloned_limits.clone();
             new_service
-                .create_container(&self.docker, &source_config, &cloned_limits, false)
+                .create_container(&self.docker, &mut source_config, &cloned_limits, false)
                 .await?;
+            *new_service.config.write().await = Some(source_config.clone());
 
             let new_service_config = ServiceConfig {
                 name: new_name.clone(),
@@ -4000,6 +4024,118 @@ mod tests {
         );
 
         // Cleanup
+        let _ = service.cleanup().await;
+    }
+
+    /// Regression test for a bug where `init()` persisted the *requested*
+    /// host port even when `create_container`'s retry-on-conflict logic
+    /// bound the container to a *different* port. Reported symptom: the
+    /// service's stored config (and DB-persisted connection info) showed
+    /// port 5441, but `docker ps` showed the container published on 5446 —
+    /// any client using the stored port couldn't connect.
+    ///
+    /// Reproduced deterministically by pre-occupying the requested port with
+    /// a plain `TcpListener` before calling `init()`, forcing Docker's own
+    /// bind to fail with "port is already allocated" and triggering the
+    /// exact retry path that used to lose track of the real port.
+    #[cfg(feature = "docker-tests")]
+    #[tokio::test]
+    async fn test_init_persists_actual_port_after_conflict_retry() {
+        let docker = match Docker::connect_with_local_defaults() {
+            Ok(d) => d,
+            Err(_) => {
+                println!("Docker not available, skipping");
+                return;
+            }
+        };
+        if docker.ping().await.is_err() {
+            println!("Docker not available, skipping");
+            return;
+        }
+
+        let requested_port = find_available_port(5432).expect("an OS-bindable port should exist");
+
+        // Hold the port so Docker's own bind fails with "port is already
+        // allocated" — the exact race `create_container`'s retry handles.
+        let _blocker = std::net::TcpListener::bind(("0.0.0.0", requested_port))
+            .expect("failed to occupy the port for the test");
+
+        let docker = Arc::new(docker);
+        let service = PostgresService::new("test-port-conflict-retry".to_string(), docker);
+
+        let config = ServiceConfig {
+            name: "test-postgres-conflict".to_string(),
+            service_type: super::ServiceType::Postgres,
+            version: None,
+            parameters: serde_json::json!({
+                "host": "localhost",
+                "port": requested_port.to_string(),
+                "database": "testdb",
+                "username": "testuser",
+                "password": "testpass123",
+                "max_connections": 100,
+                "ssl_mode": "disable",
+                "docker_image": "gotempsh/postgres-walg:18-bookworm"
+            }),
+        };
+
+        let inferred_params = service
+            .init(config)
+            .await
+            .expect("init should succeed by retrying on a fresh port");
+
+        let persisted_port: u16 = inferred_params
+            .get("port")
+            .expect("port should be present in inferred params")
+            .parse()
+            .expect("port should be numeric");
+
+        assert_ne!(
+            persisted_port, requested_port,
+            "persisted port must differ from the occupied port that forced a retry"
+        );
+
+        // The in-memory config used by start()/health checks must agree too.
+        let cached_port: u16 = service
+            .config
+            .read()
+            .await
+            .as_ref()
+            .expect("config should be set after init")
+            .port
+            .parse()
+            .expect("cached port should be numeric");
+        assert_eq!(
+            cached_port, persisted_port,
+            "cached config port must match what was persisted"
+        );
+
+        // And it must match the port the container is actually bound to.
+        let container_name = service.get_container_name();
+        let inspect = service
+            .docker
+            .inspect_container(
+                &container_name,
+                None::<bollard::query_parameters::InspectContainerOptions>,
+            )
+            .await
+            .expect("container should exist");
+        let bound_ports: Vec<u16> = inspect
+            .network_settings
+            .and_then(|ns| ns.ports)
+            .into_iter()
+            .flatten()
+            .filter_map(|(_, bindings)| bindings)
+            .flatten()
+            .filter_map(|b| b.host_port.and_then(|p| p.parse().ok()))
+            .collect();
+        assert!(
+            bound_ports.contains(&persisted_port),
+            "container's actual bound ports {:?} should include the persisted port {}",
+            bound_ports,
+            persisted_port
+        );
+
         let _ = service.cleanup().await;
     }
 

--- a/crates/temps-providers/src/externalsvc/redis.rs
+++ b/crates/temps-providers/src/externalsvc/redis.rs
@@ -271,10 +271,15 @@ impl RedisService {
     /// it). The container name is deterministic, so a failed attempt must be
     /// removed before retrying or the next attempt's "already exists" check
     /// short-circuits without picking a new port.
+    ///
+    /// `config` is taken by mutable reference so a retry's port change is
+    /// written back to the caller — otherwise the caller (and anything it
+    /// persists to the database) keeps referencing the original port even
+    /// though the container actually ended up bound to a different one.
     async fn create_container(
         &self,
         docker: &Docker,
-        config: &RedisConfig,
+        config: &mut RedisConfig,
         password: &str,
         resource_limits: &ServiceResourceLimits,
     ) -> Result<()> {
@@ -285,7 +290,10 @@ impl RedisService {
                 .create_container_once(docker, &attempt_config, password, resource_limits)
                 .await
             {
-                Ok(()) => return Ok(()),
+                Ok(()) => {
+                    *config = attempt_config;
+                    return Ok(());
+                }
                 Err(e) if attempt < MAX_ATTEMPTS && is_port_conflict_error(&e.to_string()) => {
                     warn!(
                         "Port {} for Redis container was already allocated (attempt {}/{}), retrying with a fresh port: {}",
@@ -1352,7 +1360,7 @@ impl ExternalService for RedisService {
         }
 
         // Parse input config and transform to runtime config
-        let redis_config = self.get_redis_config(config)?;
+        let mut redis_config = self.get_redis_config(config)?;
 
         info!(
             "Redis init - storing config: port={}, password_len={}",
@@ -1361,6 +1369,7 @@ impl ExternalService for RedisService {
         );
 
         // Store runtime config and limits so `start()` recreates correctly.
+        // Gets overwritten below once the real container port is known.
         *self.config.write().await = Some(redis_config.clone());
         *self.resource_limits.write().await = resource_limits.clone();
 
@@ -1368,14 +1377,15 @@ impl ExternalService for RedisService {
 
         if redis_config.container_name.is_none() {
             // Create Docker container (but don't start it yet)
-            // Note: Connection will be established in start() method
-            self.create_container(
-                &self.docker,
-                &redis_config,
-                &redis_config.password,
-                &resource_limits,
-            )
-            .await?;
+            // Note: Connection will be established in start() method.
+            // `create_container` may retry on a different host port than
+            // requested (see its docs); it writes that back into
+            // `redis_config`, so everything below reflects the port the
+            // container is actually bound to.
+            let password = redis_config.password.clone();
+            self.create_container(&self.docker, &mut redis_config, &password, &resource_limits)
+                .await?;
+            *self.config.write().await = Some(redis_config.clone());
             info!("Redis container created, connection will be established on start");
         } else {
             info!(
@@ -1701,7 +1711,7 @@ impl ExternalService for RedisService {
             .await?;
 
         if containers.is_empty() {
-            let config =
+            let mut config =
                 existing_config.ok_or_else(|| anyhow::anyhow!("Redis configuration not found"))?;
             if config.container_name.is_some() {
                 return Err(anyhow::anyhow!(
@@ -1710,8 +1720,10 @@ impl ExternalService for RedisService {
                 ));
             }
             let limits = self.resource_limits.read().await.clone();
-            self.create_container(&self.docker, &config, &config.password, &limits)
+            let password = config.password.clone();
+            self.create_container(&self.docker, &mut config, &password, &limits)
                 .await?;
+            *self.config.write().await = Some(config);
         } else {
             self.docker
                 .start_container(
@@ -2082,7 +2094,7 @@ impl ExternalService for RedisService {
         info!("Starting Redis upgrade");
 
         let _old_redis_config = self.get_redis_config(old_config)?;
-        let new_redis_config = self.get_redis_config(new_config)?;
+        let mut new_redis_config = self.get_redis_config(new_config)?;
 
         // Verify the new image can be pulled BEFORE stopping the old container
         info!(
@@ -2100,13 +2112,10 @@ impl ExternalService for RedisService {
         // Create container with new image (keeping the same volume for data persistence)
         info!("Starting Redis container with new image");
         let limits = self.resource_limits.read().await.clone();
-        self.create_container(
-            &self.docker,
-            &new_redis_config,
-            &new_redis_config.password,
-            &limits,
-        )
-        .await?;
+        let password = new_redis_config.password.clone();
+        self.create_container(&self.docker, &mut new_redis_config, &password, &limits)
+            .await?;
+        *self.config.write().await = Some(new_redis_config);
 
         info!("Redis upgrade completed successfully");
         Ok(())

--- a/crates/temps-providers/src/externalsvc/s3.rs
+++ b/crates/temps-providers/src/externalsvc/s3.rs
@@ -239,10 +239,15 @@ impl S3Service {
     /// it). The container name is deterministic, so a failed attempt must be
     /// removed before retrying or the next attempt's "already exists" check
     /// short-circuits without picking a new port.
+    ///
+    /// `config` is taken by mutable reference so a retry's port change is
+    /// written back to the caller — otherwise the caller (and anything it
+    /// persists to the database) keeps referencing the original port even
+    /// though the container actually ended up bound to a different one.
     async fn create_container(
         &self,
         docker: &Docker,
-        config: &S3Config,
+        config: &mut S3Config,
         resource_limits: &ServiceResourceLimits,
     ) -> Result<()> {
         const MAX_ATTEMPTS: u32 = 3;
@@ -252,7 +257,10 @@ impl S3Service {
                 .create_container_once(docker, &attempt_config, resource_limits)
                 .await
             {
-                Ok(()) => return Ok(()),
+                Ok(()) => {
+                    *config = attempt_config;
+                    return Ok(());
+                }
                 Err(e) if attempt < MAX_ATTEMPTS && is_port_conflict_error(&e.to_string()) => {
                     warn!(
                         "Port {} for MinIO container was already allocated (attempt {}/{}), retrying with a fresh port: {}",
@@ -774,19 +782,24 @@ impl ExternalService for S3Service {
         *self.resource_limits.write().await = resource_limits.clone();
 
         // Parse input config and transform to runtime config
-        let s3_config = self.get_s3_config(config)?;
+        let mut s3_config = self.get_s3_config(config)?;
         info!(
             "S3 runtime config (host={}, port={}, region={}, image={})",
             s3_config.host, s3_config.port, s3_config.region, s3_config.docker_image
         );
 
-        // Store runtime config
+        // Store runtime config. Gets overwritten below once the real
+        // container port is known.
         *self.config.write().await = Some(s3_config.clone());
 
         if s3_config.container_name.is_none() {
-            // Create Docker container
-            self.create_container(&self.docker, &s3_config, &resource_limits)
+            // Create Docker container. `create_container` may retry on a
+            // different host port than requested (see its docs); it writes
+            // that back into `s3_config`, so everything below reflects the
+            // port the container is actually bound to.
+            self.create_container(&self.docker, &mut s3_config, &resource_limits)
                 .await?;
+            *self.config.write().await = Some(s3_config.clone());
         } else {
             info!(
                 "S3/MinIO service '{}' is imported from container '{}'; skipping container creation",
@@ -1006,10 +1019,11 @@ impl ExternalService for S3Service {
         }
 
         if containers.is_empty() {
-            let config =
+            let mut config =
                 existing_config.ok_or_else(|| anyhow::anyhow!("S3 configuration not found"))?;
             let limits = self.resource_limits.read().await.clone();
-            self.create_container(docker, &config, &limits).await?;
+            self.create_container(docker, &mut config, &limits).await?;
+            *self.config.write().await = Some(config);
         } else {
             docker
                 .start_container(
@@ -1875,10 +1889,15 @@ impl ExternalService for S3Service {
         *new_service.resource_limits.write().await = cloned_limits.clone();
 
         // Provision the new container (image pull, volume, port binding, health check).
+        // `create_container` writes any port-conflict retry back into
+        // `new_config`, so the `mc mirror` connection below (and the final
+        // parameters returned to the orchestrator) target the port the
+        // container actually bound to.
         new_service
-            .create_container(&self.docker, &new_config, &cloned_limits)
+            .create_container(&self.docker, &mut new_config, &cloned_limits)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to create new S3/MinIO container: {}", e))?;
+        *new_service.config.write().await = Some(new_config.clone());
 
         // The orchestrator already decrypted these into the plaintext copy
         // of s3_source it hands us via RestoreContext. Passing them straight
@@ -2244,7 +2263,7 @@ impl ExternalService for S3Service {
         info!("Starting S3/MinIO upgrade");
 
         let _old_s3_config = self.get_s3_config(old_config)?;
-        let new_s3_config = self.get_s3_config(new_config)?;
+        let mut new_s3_config = self.get_s3_config(new_config)?;
 
         // Verify the new image can be pulled BEFORE stopping the old container
         info!(
@@ -2262,8 +2281,9 @@ impl ExternalService for S3Service {
         // Create container with new image (keeping the same volume for data persistence)
         info!("Starting S3/MinIO container with new image");
         let limits = self.resource_limits.read().await.clone();
-        self.create_container(&self.docker, &new_s3_config, &limits)
+        self.create_container(&self.docker, &mut new_s3_config, &limits)
             .await?;
+        *self.config.write().await = Some(new_s3_config);
 
         info!("S3/MinIO upgrade completed successfully");
         Ok(())


### PR DESCRIPTION
## Summary
- `create_container`'s port-conflict retry logic (added in e48308df to fix flaky CI) picked a fresh host port on a local `attempt_config` clone but never returned it to the caller. `init()`/`start()`/`upgrade()` then persisted the *originally-requested* port to `self.config` and the database, while Docker had actually bound the container to a *different* port — e.g. the UI/DB showing port 5441 while `docker ps` showed `127.0.0.1:5446->5432/tcp`.
- Same bug, same shape, in all four Docker-backed external services: Postgres, Redis, MongoDB, S3/MinIO.
- Fix: `create_container` now takes `config` by mutable reference and writes the winning attempt's port back into it on success. Updated every call site (`init`, `start`'s drift-reconcile path, `upgrade`'s image-swap path, and the two restore-to-new-service paths) to pass `&mut` and re-persist `self.config`/the serialized parameters after the call.
- Added a regression test (`test_init_persists_actual_port_after_conflict_retry` in `postgres.rs`, gated behind the `docker-tests` feature) that deterministically forces the conflict by pre-occupying the target port with a `TcpListener` before calling `init()`, then asserts the persisted port, the cached config port, and the container's actual `docker inspect` port all agree.

## Root cause
```rust
// before
async fn create_container(&self, docker: &Docker, config: &PostgresConfig, ...) -> Result<()> {
    let mut attempt_config = config.clone();
    for attempt in 1..=MAX_ATTEMPTS {
        match self.create_container_once(docker, &attempt_config, ...).await {
            Ok(()) => return Ok(()),   // attempt_config's corrected port is discarded here
            Err(e) if is_port_conflict_error(...) => {
                attempt_config.port = new_port.to_string(); // only the local clone changes
            }
            ...
        }
    }
}
```
`postgres_config`/`redis_config`/etc. in the caller kept the pre-retry port, which is what got serialized into `inferred_params` and written to the `external_services` row.

## Test plan
- [x] `cargo check --lib` / `cargo check --tests` clean for `temps-providers` (workspace-wide `cargo check --lib` also clean)
- [x] `cargo clippy -p temps-providers --lib --tests -- -D warnings` clean (run via the resolved binary, bypassing rtk per repo convention)
- [x] Added `test_init_persists_actual_port_after_conflict_retry`, compiles under `--features docker-tests`
- [ ] Run the new test against local Docker to confirm it passes (not yet executed in this session)