### PR TITLE
docs: require new features to scale on small resources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,24 @@ setting can only have one value per running process, ever". Almost
 nothing meets that bar. If you're tempted to add `TEMPS_FOO_BAR=1`,
 ask first whether `entity.foo_bar bool` would do the job.
 
+## New features must scale on small resources
+
+Temps runs as a single binary on small machines (reference: 3 vCPU /
+4 GB RAM) while the proxy path may see 100k+ req/s. Every new feature
+must be designed for that from the start — efficiency is a
+requirement, not a follow-up optimization. The full rules live in
+[`CLAUDE.md` → Scalability & Efficiency](./CLAUDE.md#scalability--efficiency);
+the short version:
+
+- Classify your code: **hot path** (per-request/per-event) vs
+  **control plane** (handlers, background jobs).
+- Hot path: no locks, no per-operation I/O, no unbounded channels or
+  cardinality — aggregate with atomics and flush in batches.
+- Everywhere: stream instead of buffering unbounded data, batch DB
+  writes, make background loops O(changes) not O(total rows).
+- PRs touching the hot path or high-volume data flows must state
+  expected load, memory bound, and behaviour at saturation.
+
 ## Don't sweep unrelated dirty files into your commits
 
 If you arrive at a working tree that's already dirty (because a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Guidance for Claude Code when working with the Temps codebase.
 - Give each component its own copy of shared dependencies (Arc clones) -- never share via accessor methods
 - Use `require_service` in plugins for dependencies the app can't function without
 - Let the user configure and control their setup -- show status, give instructions, don't do things silently on their behalf
+- Design new features to be scalable on a small resource footprint -- see [Scalability & Efficiency](#scalability--efficiency)
 
 ---
 
@@ -241,6 +242,35 @@ All error responses follow this JSON structure:
   "instance": "/backups/42"
 }
 ```
+
+---
+
+## Scalability & Efficiency
+
+Temps is a single binary that operators run on small machines (the reference deployment is a Hetzner cpx22: 3 vCPU / 4 GB RAM) while the proxy path may serve very high request rates. **Every new feature must be designed to scale on a small number of resources and be as efficient as possible.** This is a requirement for new functionality, not an optimization to defer.
+
+### Hot path vs. control plane
+
+Classify every piece of new code. The bar differs by an order of magnitude:
+
+- **Hot path** (per-request in `temps-proxy`/`temps-edge`, per-event in analytics/error ingest, per-sample in metrics collection): assume 100k+ ops/s. No locks, no allocations you can avoid, no I/O.
+- **Control plane** (handlers, services, background jobs): normal service rules apply, but still bounded memory and no unbounded fan-out.
+
+### Hot-path rules
+
+- **No synchronous I/O and no per-operation network/DB/disk calls.** Never write a row, send an HTTP request, or log to an external store per request. Aggregate in memory (atomics, sharded counters) and flush on an interval, or push into a bounded channel consumed by a background batcher.
+- **No `Mutex`/`RwLock` on the request path.** Prefer atomics (`AtomicU64`, prometheus-style counters/histograms which are atomic internally), `arc-swap`/`ArcSwap` for rarely-updated shared config (already the pattern for route tables), thread-locals, or sharded state. A single contended lock at 100k req/s serializes all cores.
+- **Bounded channels with explicit overflow policy.** Any `mpsc` fed by the hot path must be bounded, and the send must be `try_send` with a documented drop/degrade policy (count drops in a metric). An unbounded channel is a memory leak with a delay; a blocking send is a proxy stall.
+- **Bounded label/key cardinality.** Metrics, caches, and maps keyed by request attributes must use bounded dimensions (status class, not full URL; project ID only if project count is bounded). Unbounded cardinality is an OOM on a 4 GB box.
+- **Avoid per-request allocation and serialization** where practical: reuse buffers, prefer `&str`/`Bytes` over `String` clones, don't `serde_json::to_string` on the request path.
+
+### Everywhere rules
+
+- **Constant memory over per-item memory.** Streaming/chunked processing for anything unbounded (log tails, backups, exports). Never load an unbounded set into a `Vec`.
+- **Batch writes.** Inserts into ClickHouse/TimescaleDB/Postgres from high-volume producers must be batched with a max-size + max-age flush, never row-at-a-time.
+- **Pull over push for telemetry.** Prefer scrape/interval collection (existing `MetricsScraper` pattern) over per-event emission.
+- **Background loops must be O(changes), not O(total).** Reconciliation/polling loops should query deltas (updated_at cursors, NOTIFY) rather than rescanning entire tables each tick.
+- **Justify it in the PR.** For any feature touching the hot path or a high-volume data flow, the PR description must state the expected load, the memory bound, and what happens at saturation (drop, degrade, backpressure).
 
 ---
 


### PR DESCRIPTION
Adds a **Scalability & Efficiency** requirement for all new functionality, per discussion about proxy metrics at 100k req/s.

- `CLAUDE.md`: new section with hot-path vs control-plane classification and concrete rules (no locks/per-op I/O on the hot path, bounded channels + cardinality, batch writes, O(changes) background loops, saturation behaviour stated in PRs). Added to the ALWAYS list.
- `AGENTS.md`: short process summary pointing at the CLAUDE.md section.

Docs-only — will apply `skip-changelog`.