### PR TITLE
feat(auth): add ProjectAccessChecker trait and project_access_guard! macro (ADR 028 Phase A)

### DIFF
--- a/crates/temps-auth/src/permission_guard.rs
+++ b/crates/temps-auth/src/permission_guard.rs
@@ -118,6 +118,105 @@ macro_rules! deny_deployment_token {
     };
 }
 
+/// Guard that enforces team-based project access for human sessions.
+///
+/// This is **distinct from** and **additional to** [`project_scope_guard!`], which
+/// handles deployment-token cross-project IDOR and is a no-op for human
+/// sessions. This macro enforces team-based access for those same human
+/// sessions, but only when a [`temps_core::ProjectAccessChecker`] has been
+/// registered (i.e. only when an optional plugin implementing that check is
+/// present).
+///
+/// **Call order** in every project-scoped handler:
+///
+/// ```ignore
+/// permission_guard!(auth, SomePermission);              // 1. instance-wide role
+/// project_scope_guard!(auth, project_id);               // 2. deployment-token IDOR
+/// project_access_guard!(auth, project_id, checker);     // 3. team-based access
+/// ```
+///
+/// `checker` is the `Option<Arc<dyn temps_core::ProjectAccessChecker>>` field
+/// stored on each handler plugin's `AppState`. It is resolved once during the
+/// plugin's `configure_routes` phase via
+/// `context.get_service::<dyn temps_core::ProjectAccessChecker>()`.
+///
+/// When `checker` is `None` (no plugin has registered a checker) this macro is
+/// a **synchronous no-op** with zero overhead — OSS-only binaries are unaffected.
+///
+/// **Admin bypass:** callers with `Role::Admin` or `Role::PlatformAdmin` skip
+/// the check entirely; instance administrators are never restricted by team
+/// membership.
+///
+/// **Deployment tokens** bypass this guard — they are already confined to their
+/// bound project by `project_scope_guard!` above and carry no user identity
+/// with which to look up team membership.
+///
+/// **Fail semantics:**
+/// - `Ok(true)` → allowed, continues.
+/// - `Ok(false)` → returns `Err` with HTTP 403 (`project-access-denied`).
+/// - `Err(_)` → infrastructure failure; returns `Err` with HTTP 500
+///   (`project-access-check-failed`). Fail-closed: a broken check must never
+///   silently allow access.
+#[macro_export]
+macro_rules! project_access_guard {
+    ($auth:expr, $project_id:expr, $checker:expr) => {
+        // Deployment tokens are already confined by project_scope_guard! and carry
+        // no user identity — skip the team-membership check entirely.
+        if !$auth.is_deployment_token() {
+            // Instance administrators are never restricted by team membership.
+            if !($auth.is_admin()
+                || $auth.has_role(&$crate::permissions::Role::PlatformAdmin))
+            {
+                if let Some(ref __checker) = $checker {
+                    if let Some(__user_id) = $auth.user_id_opt() {
+                        match __checker
+                            .user_can_access_project(__user_id, $project_id)
+                            .await
+                        {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                return Err(temps_core::error_builder::ErrorBuilder::new(
+                                    ::axum::http::StatusCode::FORBIDDEN,
+                                )
+                                .type_("https://temps.sh/probs/project-access-denied")
+                                .title("Project Access Denied")
+                                .detail(
+                                    "Your team membership does not include access to \
+                                     this project",
+                                )
+                                .build());
+                            }
+                            Err(__e) => {
+                                ::tracing::error!(
+                                    project_id = $project_id,
+                                    user_id = __user_id,
+                                    error = %__e,
+                                    "ProjectAccessChecker infrastructure failure \
+                                     — denying access"
+                                );
+                                return Err(temps_core::error_builder::ErrorBuilder::new(
+                                    ::axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                                )
+                                .type_("https://temps.sh/probs/project-access-check-failed")
+                                .title("Project Access Check Failed")
+                                .detail(
+                                    "Could not verify project access; please try again",
+                                )
+                                .build());
+                            }
+                        }
+                    }
+                    // user_id_opt() == None here is impossible: deployment tokens
+                    // (the only non-user auth source) are filtered by the outer
+                    // is_deployment_token() check above.
+                }
+                // checker is None → no plugin registered → no-op.
+            }
+            // Admin / PlatformAdmin → unrestricted, no check performed.
+        }
+    };
+}
+
 /// Alias for permission_guard! macro for backwards compatibility
 ///
 /// Usage in handler:
@@ -150,4 +249,205 @@ macro_rules! permission_check {
             .build());
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use chrono::Utc;
+    use temps_core::problemdetails::Problem;
+    use temps_core::ProjectAccessChecker;
+    use temps_entities::users;
+
+    use crate::context::AuthContext;
+    use crate::permissions::Role;
+
+    // ---------------------------------------------------------------------------
+    // Test helpers
+    // ---------------------------------------------------------------------------
+
+    fn test_user(id: i32) -> users::Model {
+        let now = Utc::now();
+        users::Model {
+            id,
+            name: "Test User".to_string(),
+            email: format!("user{}@example.com", id),
+            password_hash: None,
+            email_verified: true,
+            email_verification_token: None,
+            email_verification_expires: None,
+            password_reset_token: None,
+            password_reset_expires: None,
+            deleted_at: None,
+            mfa_secret: None,
+            mfa_enabled: false,
+            mfa_recovery_codes: None,
+            oidc_subject: None,
+            oidc_provider_id: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn user_auth(role: Role) -> AuthContext {
+        AuthContext::new_session(test_user(42), role)
+    }
+
+    fn deployment_token_auth() -> AuthContext {
+        AuthContext::new_deployment_token(
+            7,    // project_id
+            None, // environment_id
+            None, // deployment_id
+            1,    // token_id
+            "deploy-token".to_string(),
+            vec![],
+        )
+    }
+
+    /// A mock [`ProjectAccessChecker`] that returns a fixed outcome.
+    struct MockChecker {
+        result: fn() -> Result<bool, Box<dyn std::error::Error + Send + Sync>>,
+    }
+
+    impl MockChecker {
+        fn allow() -> Arc<dyn ProjectAccessChecker> {
+            Arc::new(MockChecker {
+                result: || Ok(true),
+            })
+        }
+
+        fn deny() -> Arc<dyn ProjectAccessChecker> {
+            Arc::new(MockChecker {
+                result: || Ok(false),
+            })
+        }
+
+        fn error() -> Arc<dyn ProjectAccessChecker> {
+            Arc::new(MockChecker {
+                result: || Err(Box::new(std::io::Error::other("simulated DB failure"))),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl ProjectAccessChecker for MockChecker {
+        async fn user_can_access_project(
+            &self,
+            _user_id: i32,
+            _project_id: i32,
+        ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+            (self.result)()
+        }
+    }
+
+    /// Runs the guard macro and returns `Ok(())` or `Err(Problem)`.
+    async fn run_guard(
+        auth: &AuthContext,
+        project_id: i32,
+        checker: Option<Arc<dyn ProjectAccessChecker>>,
+    ) -> Result<(), Problem> {
+        project_access_guard!(auth, project_id, checker);
+        Ok(())
+    }
+
+    // ---------------------------------------------------------------------------
+    // (a) No checker registered → no-op, request proceeds
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn no_checker_registered_is_noop() {
+        let auth = user_auth(Role::User);
+        let result = run_guard(&auth, 1, None).await;
+        assert!(result.is_ok(), "no checker should be a no-op");
+    }
+
+    // ---------------------------------------------------------------------------
+    // (b) Checker registered, checker returns Ok(true) → proceeds
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn checker_allow_proceeds() {
+        let auth = user_auth(Role::User);
+        let checker = Some(MockChecker::allow());
+        let result = run_guard(&auth, 1, checker).await;
+        assert!(result.is_ok(), "checker returning Ok(true) should allow");
+    }
+
+    // ---------------------------------------------------------------------------
+    // (c) Checker returns Ok(false) → 403
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn checker_deny_returns_403() {
+        let auth = user_auth(Role::User);
+        let checker = Some(MockChecker::deny());
+        let result = run_guard(&auth, 1, checker).await;
+        let err = result.expect_err("checker returning Ok(false) should deny");
+        assert_eq!(
+            err.status_code,
+            axum::http::StatusCode::FORBIDDEN,
+            "denial should be HTTP 403"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // (d) Checker returns Err → fail-closed, 500
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn checker_error_returns_500() {
+        let auth = user_auth(Role::User);
+        let checker = Some(MockChecker::error());
+        let result = run_guard(&auth, 1, checker).await;
+        let err = result.expect_err("infrastructure error should deny");
+        assert_eq!(
+            err.status_code,
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            "infrastructure failure should be HTTP 500"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // (e) Admin bypass — Role::Admin skips the checker entirely
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn admin_bypasses_checker() {
+        let auth = user_auth(Role::Admin);
+        // Even with a deny-all checker, Admin must not be blocked.
+        let checker = Some(MockChecker::deny());
+        let result = run_guard(&auth, 1, checker).await;
+        assert!(result.is_ok(), "Admin should bypass the checker");
+    }
+
+    // ---------------------------------------------------------------------------
+    // (f) PlatformAdmin bypass
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn platform_admin_bypasses_checker() {
+        let auth = user_auth(Role::PlatformAdmin);
+        let checker = Some(MockChecker::deny());
+        let result = run_guard(&auth, 1, checker).await;
+        assert!(result.is_ok(), "PlatformAdmin should bypass the checker");
+    }
+
+    // ---------------------------------------------------------------------------
+    // (g) Deployment token bypass — no checker call, no user identity lookup
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn deployment_token_bypasses_checker() {
+        let auth = deployment_token_auth();
+        // Deployment tokens are governed by project_scope_guard! instead;
+        // this guard must leave them untouched even with a deny-all checker.
+        let checker = Some(MockChecker::deny());
+        let result = run_guard(&auth, 7, checker).await;
+        assert!(
+            result.is_ok(),
+            "deployment tokens should bypass project_access_guard!"
+        );
+    }
 }

--- a/crates/temps-core/src/lib.rs
+++ b/crates/temps-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod on_demand;
 pub mod openapi;
 pub mod plugin;
 pub mod problemdetails;
+pub mod project_access;
 pub mod retry;
 pub mod secrets_manager;
 pub mod telemetry;
@@ -51,6 +52,7 @@ pub use error::*;
 pub use error_builder::*;
 pub use jobs::*;
 pub use on_demand::*;
+pub use project_access::ProjectAccessChecker;
 pub use secrets_manager::SecretsManagerResolver;
 pub use telemetry::{NoopTelemetryReporter, TelemetryEvent, TelemetryEventKind, TelemetryReporter};
 pub use traces::{

--- a/crates/temps-core/src/project_access.rs
+++ b/crates/temps-core/src/project_access.rs
@@ -1,0 +1,52 @@
+//! Extension point for team-based project access enforcement.
+//!
+//! See ADR 028 for the full design rationale.
+
+use async_trait::async_trait;
+
+/// OSS extension point for team-based project access enforcement.
+///
+/// OSS itself never implements this trait and has no concept of what
+/// governs project access — it just asks "may this user access this
+/// project?" A plugin (e.g. one implementing team-based project access)
+/// registers an implementation via `context.register_service(checker)`.
+/// Callers retrieve it with `context.get_service::<dyn ProjectAccessChecker>()`
+/// — never `require_service` — so the OSS binary is a strict no-op when
+/// nothing is registered, identical in spirit to [`crate::DeploymentGate`].
+///
+/// The check is **fail-closed** on infrastructure errors: if the implementation
+/// cannot reach its database it must return `Err`, never silently allow.
+/// This is distinct from the "fail-open when unconfigured" behaviour, which
+/// is a semantic property of the checker's own business logic when the plugin
+/// is present but no access grants have been configured yet.
+///
+/// # Semantics ("project-level access-grant" model)
+///
+/// The recommended implementation follows a two-step check:
+///
+/// 1. Does this project have any team-access grant rows? If **no** → allow
+///    (project is unrestricted; adding the first grant is the action that
+///    makes it team-gated).
+/// 2. Does this user belong to at least one team that has a grant for this
+///    project? If **yes** → allow. Otherwise → deny.
+///
+/// This ensures instances with the plugin present but no grants configured
+/// behave identically to a plain OSS binary (fail-open-when-unconfigured).
+///
+/// # Admin bypass
+///
+/// The [`project_access_guard!`](temps_auth::project_access_guard) macro
+/// short-circuits before calling this trait when the caller holds an
+/// instance-wide Admin or PlatformAdmin role. Implementations are not
+/// required to duplicate that check.
+#[async_trait]
+pub trait ProjectAccessChecker: Send + Sync {
+    /// Returns `Ok(true)` if `user_id` may access `project_id`, `Ok(false)`
+    /// if they may not, or `Err` if the check could not be completed
+    /// (infrastructure failure — the caller treats this as a denial).
+    async fn user_can_access_project(
+        &self,
+        user_id: i32,
+        project_id: i32,
+    ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>>;
+}

--- a/crates/temps-projects/src/handlers/handlers.rs
+++ b/crates/temps-projects/src/handlers/handlers.rs
@@ -15,7 +15,7 @@ use axum::{
 };
 use std::sync::Arc;
 use temps_auth::RequireAuth;
-use temps_auth::{permission_guard, project_scope_guard};
+use temps_auth::{permission_guard, project_access_guard, project_scope_guard};
 use temps_core::RequestMetadata;
 use tracing::{debug, error, info};
 
@@ -313,8 +313,9 @@ pub async fn get_project(
     Path(id): Path<i32>,
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, ProjectsRead);
-    project_scope_guard!(auth, id);
+    permission_guard!(auth, ProjectsRead); // 1. instance-wide role check
+    project_scope_guard!(auth, id); // 2. deployment-token IDOR check
+    project_access_guard!(auth, id, state.project_access_checker); // 3. team-based access
 
     info!("get project called with id: {}", id);
     let project = state

--- a/crates/temps-projects/src/handlers/types.rs
+++ b/crates/temps-projects/src/handlers/types.rs
@@ -21,6 +21,16 @@ pub struct AppState {
     pub audit_service: Arc<dyn AuditLogger>,
     pub template_service: Arc<TemplateService>,
     pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
+    /// Optional checker enforcing team-based project access for human sessions.
+    ///
+    /// `None` when no plugin implementing this check is registered — the
+    /// `project_access_guard!` macro is a strict synchronous no-op in that
+    /// case, matching the behaviour of `deployment_gate` in `temps-deployments`.
+    /// Resolved once in `configure_routes` via
+    /// `context.get_service::<dyn temps_core::ProjectAccessChecker>()`, which
+    /// is guaranteed to see all registered services because `configure_routes`
+    /// runs after every plugin's `initialize_plugin_services` has completed.
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }
 
 // Domain-related types

--- a/crates/temps-projects/src/plugin.rs
+++ b/crates/temps-projects/src/plugin.rs
@@ -77,12 +77,19 @@ impl TempsPlugin for ProjectsPlugin {
         let telemetry = context
             .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
             .unwrap_or_else(|| Arc::new(temps_core::telemetry::NoopTelemetryReporter));
+        // Optional: team-based project access checker registered by a plugin.
+        // `configure_routes` runs after all plugins have completed
+        // `initialize_plugin_services`, so a checker registered by another
+        // plugin is guaranteed to be present in the registry by this point.
+        // When absent (plain OSS binary), project_access_guard! is a no-op.
+        let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
         let app_state = Arc::new(crate::handlers::AppState {
             project_service,
             custom_domain_service,
             audit_service,
             template_service,
             telemetry,
+            project_access_checker,
         });
         let routes = crate::handlers::configure_routes().with_state(app_state);
         Some(PluginRoutes::new(routes))


### PR DESCRIPTION
## Summary
- New `temps_core::ProjectAccessChecker` optional extension point, following the exact same pattern as the existing `DeploymentGate`: the trait is defined here, a plugin registers a concrete implementation, `get_service` (never `require_service`) means a binary with nothing registered is a strict no-op.
- New `project_access_guard!` macro in `temps-auth`, called alongside the existing `permission_guard!`/`project_scope_guard!` in project-scoped handlers. Fail-open when a project has no access grants configured, fail-closed (500) on infrastructure errors, 403 on a genuine denial. Admin/platform-admin roles and deployment tokens bypass it.
- One demonstration call site (`get_project` in `temps-projects`, the simplest handler in the smallest affected crate) proving the trait, macro, and `AppState` wiring work end-to-end.
- This is Phase A only — foundation and one call site. The mechanical rollout across the other ~93 handlers in ~17 crates is tracked as a separate follow-up PR, per the design doc at `docs/adr/028-project-scoped-rbac-enforcement.md`.
- Zero behavior change for any existing caller: the guard is a synchronous no-op whenever nothing has registered a checker (true for every build today).

## Test plan
- [x] `cargo check --workspace --lib`
- [x] `cargo test --lib -p temps-auth` (7 new macro tests: no-op, fail-open, allow, deny, fail-closed, admin bypass, deployment-token bypass)
- [x] `cargo test --lib -p temps-core`
- [x] `cargo test --lib -p temps-projects`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`