### PR TITLE
feat(auth): wire project_access_guard! into all project-scoped handlers (ADR 028 Phase B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11008,6 +11008,7 @@ dependencies = [
  "urlencoding",
  "utoipa",
  "uuid",
+ "walkdir",
 ]
 
 [[package]]

--- a/crates/temps-agents/src/handlers/autofixer.rs
+++ b/crates/temps-agents/src/handlers/autofixer.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, project_scope_guard, RequireAuth};
 use temps_core::audit::{AuditContext, AuditOperation};
 use temps_core::problemdetails::Problem;
 use temps_core::RequestMetadata;
@@ -250,6 +250,8 @@ pub async fn start_analysis(
     Json(request): Json<StartAnalysisRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     if request.error_group_id <= 0 {
         return Err(Problem::from(AgentError::Validation {
@@ -324,6 +326,8 @@ pub async fn get_run(
     Path((project_id, run_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     app_state
         .run_service
@@ -372,6 +376,8 @@ pub async fn stream_events(
     Path((project_id, run_id)): Path<(i32, i32)>,
 ) -> Result<Sse<impl Stream<Item = Result<Event, std::convert::Infallible>>>, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     app_state
         .run_service
@@ -483,6 +489,8 @@ pub async fn add_context(
     Json(request): Json<AddContextRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     app_state
         .run_service
@@ -532,6 +540,8 @@ pub async fn start_fix(
     Path((project_id, run_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     app_state
         .run_service
@@ -617,6 +627,8 @@ pub async fn create_pr(
     Path((project_id, run_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     app_state
         .run_service
@@ -695,6 +707,8 @@ pub async fn re_analyze(
     Path((project_id, run_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     app_state
         .run_service
@@ -753,6 +767,8 @@ pub async fn cancel(
     Path((project_id, run_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     app_state
         .run_service

--- a/crates/temps-agents/src/handlers/config.rs
+++ b/crates/temps-agents/src/handlers/config.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, project_scope_guard, RequireAuth};
 use temps_core::audit::{AuditContext, AuditOperation};
 use temps_core::problemdetails::{self, Problem};
 use temps_core::RequestMetadata;
@@ -360,6 +360,8 @@ pub async fn list_agents(
     Path(project_id): Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let agents = app_state
         .config_service
@@ -399,6 +401,8 @@ pub async fn create_agent(
     Json(request): Json<UpsertAgentRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let agent = app_state
         .config_service
@@ -450,6 +454,8 @@ pub async fn get_agent(
     Path((project_id, slug)): Path<(i32, String)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let agent = app_state
         .config_service
@@ -493,6 +499,8 @@ pub async fn update_agent(
     Json(request): Json<UpsertAgentRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let agent = app_state
         .config_service
@@ -546,6 +554,8 @@ pub async fn delete_agent(
     Path((project_id, slug)): Path<(i32, String)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     app_state
         .config_service

--- a/crates/temps-agents/src/handlers/definitions.rs
+++ b/crates/temps-agents/src/handlers/definitions.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, project_scope_guard, RequireAuth};
 use temps_core::audit::{AuditContext, AuditOperation};
 use temps_core::problemdetails::{self, Problem};
 use temps_core::RequestMetadata;
@@ -262,6 +262,8 @@ pub async fn list_skills(
     Path(project_id): Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let items = app_state
         .definition_service
@@ -300,6 +302,8 @@ pub async fn get_skill(
     Path((project_id, slug)): Path<(i32, String)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let skill = app_state
         .definition_service
@@ -330,6 +334,8 @@ pub async fn create_skill(
     Json(request): Json<CreateSkillRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let skill = app_state
         .definition_service
@@ -390,6 +396,8 @@ pub async fn update_skill(
     Json(request): Json<UpdateSkillRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let skill = app_state
         .definition_service
@@ -445,6 +453,8 @@ pub async fn delete_skill(
     Path((project_id, slug)): Path<(i32, String)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     app_state
         .definition_service
@@ -488,6 +498,8 @@ pub async fn list_mcps(
     Path(project_id): Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let items = app_state
         .definition_service
@@ -523,6 +535,8 @@ pub async fn get_mcp(
     Path((project_id, slug)): Path<(i32, String)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let mcp = app_state
         .definition_service
@@ -553,6 +567,8 @@ pub async fn create_mcp(
     Json(request): Json<CreateMcpRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let mcp = app_state
         .definition_service
@@ -609,6 +625,8 @@ pub async fn update_mcp(
     Json(request): Json<UpdateMcpRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let mcp = app_state
         .definition_service
@@ -663,6 +681,8 @@ pub async fn delete_mcp(
     Path((project_id, slug)): Path<(i32, String)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     app_state
         .definition_service
@@ -1202,6 +1222,8 @@ pub async fn upload_skill(
     multipart: Multipart,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let request = parse_skill_multipart(multipart).await?;
     let skill = app_state
@@ -1299,6 +1321,8 @@ pub async fn download_skill_archive(
     Path((project_id, slug)): Path<(i32, String)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let skill = app_state
         .definition_service

--- a/crates/temps-agents/src/handlers/mod.rs
+++ b/crates/temps-agents/src/handlers/mod.rs
@@ -209,6 +209,8 @@ pub struct AppState {
     /// Anonymous product-telemetry reporter. Fire-and-forget; never fails the
     /// surrounding request. Defaults to a no-op when telemetry is not registered.
     pub telemetry: Arc<dyn temps_core::TelemetryReporter>,
+    /// Optional checker for team-based project access (human sessions only).
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }
 
 pub fn configure_routes() -> Router<Arc<AppState>> {

--- a/crates/temps-agents/src/handlers/runs.rs
+++ b/crates/temps-agents/src/handlers/runs.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, RequireAuth};
 use temps_core::problemdetails::{self, Problem};
 use temps_entities::{agent_run_logs, agent_runs};
 
@@ -244,6 +244,7 @@ pub async fn list_all_runs(
     Query(query): Query<ListRunsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let page = query.page.unwrap_or(1);
     let page_size = query.page_size.unwrap_or(20);
@@ -305,6 +306,7 @@ pub async fn latest_run_for_source(
     Query(query): Query<LatestForSourceQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let run = app_state
         .run_service
@@ -366,6 +368,7 @@ pub async fn list_agent_runs(
     Query(query): Query<ListRunsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let agent = app_state
         .config_service
@@ -430,6 +433,7 @@ pub async fn get_run_with_logs(
     Path((project_id, run_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     app_state
         .run_service
@@ -495,6 +499,7 @@ pub async fn stream_run_events(
     Path((project_id, run_id)): Path<(i32, i32)>,
 ) -> Result<Sse<impl Stream<Item = Result<Event, std::convert::Infallible>>>, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     app_state
         .run_service
@@ -591,6 +596,7 @@ pub async fn cancel_run(
     Path((project_id, run_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     app_state
         .run_service
@@ -644,6 +650,7 @@ pub async fn retry_run(
     Path((project_id, run_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     app_state
         .run_service

--- a/crates/temps-agents/src/handlers/trigger.rs
+++ b/crates/temps-agents/src/handlers/trigger.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, RequireAuth};
 use temps_core::audit::{AuditContext, AuditOperation};
 use temps_core::problemdetails::{self, Problem};
 use temps_core::RequestMetadata;
@@ -125,6 +125,7 @@ pub async fn trigger_agent(
     Json(request): Json<TriggerAgentRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     // Load agent to get config_id and verify it is enabled
     let agent = app_state
@@ -392,11 +393,12 @@ pub struct CliStatusQuery {
 )]
 pub async fn get_cli_status(
     RequireAuth(auth): RequireAuth,
-    State(_app_state): State<Arc<AppState>>,
-    Path(_project_id): Path<i32>,
+    State(app_state): State<Arc<AppState>>,
+    Path(project_id): Path<i32>,
     Query(query): Query<CliStatusQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let provider_name = query.provider.as_deref().unwrap_or("claude_cli");
 
@@ -447,9 +449,10 @@ pub struct SandboxStatusResponse {
 pub async fn get_sandbox_status(
     RequireAuth(auth): RequireAuth,
     State(app_state): State<Arc<AppState>>,
-    Path(_project_id): Path<i32>,
+    Path(project_id): Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let sandbox_registry = &app_state.executor.sandbox_registry();
     let provider = sandbox_registry.provider();
@@ -641,10 +644,11 @@ pub struct SmokeTestQuery {
 pub async fn smoke_test_agent(
     RequireAuth(auth): RequireAuth,
     State(app_state): State<Arc<AppState>>,
-    Path(_project_id): Path<i32>,
+    Path(project_id): Path<i32>,
     Query(query): Query<SmokeTestQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     // Check if sandbox is enabled globally
     let global_sandbox = {

--- a/crates/temps-agents/src/handlers/workflows.rs
+++ b/crates/temps-agents/src/handlers/workflows.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, RequireAuth};
 use temps_core::audit::{AuditContext, AuditOperation};
 use temps_core::problemdetails::Problem;
 use temps_core::RequestMetadata;
@@ -157,6 +157,7 @@ pub async fn workflow_dry_run(
     Json(request): Json<WorkflowDryRunRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     // Verify the project exists. Skipping this would leak ephemeral runs into
     // the agent_runs table for nonexistent projects (FK would catch it, but

--- a/crates/temps-agents/src/plugin.rs
+++ b/crates/temps-agents/src/plugin.rs
@@ -580,7 +580,18 @@ impl TempsPlugin for AgentsPlugin {
                 cron_scheduler.run().await;
             });
 
-            // Store state for route configuration
+            // Store state for route configuration.
+            //
+            // `project_access_checker` is intentionally set to `None` here and
+            // resolved in `configure_routes` instead. `configure_routes` runs
+            // after every plugin's `register_services` and
+            // `initialize_plugin_services` have completed, which guarantees
+            // that a checker registered by any other plugin (e.g. the
+            // team-access plugin) is already present in the service registry
+            // by the time we look it up. Resolving it here — in
+            // `register_services` — races against other plugins' registration
+            // order and would see `None` whenever the checker plugin loads
+            // after this one.
             let app_state = Arc::new(AppState {
                 db: context.require_service::<sea_orm::DatabaseConnection>(),
                 encryption_service: context.require_service::<temps_core::EncryptionService>(),
@@ -596,6 +607,7 @@ impl TempsPlugin for AgentsPlugin {
                 telemetry: context
                     .get_service::<dyn temps_core::TelemetryReporter>()
                     .unwrap_or_else(|| Arc::new(temps_core::NoopTelemetryReporter)),
+                project_access_checker: None,
             });
             context.register_plugin_state("agents", app_state);
 
@@ -647,7 +659,28 @@ impl TempsPlugin for AgentsPlugin {
     }
 
     fn configure_routes(&self, context: &PluginContext) -> Option<PluginRoutes> {
-        let app_state = context.get_plugin_state::<AppState>("agents")?;
+        // Resolve the ProjectAccessChecker here, not in register_services.
+        // configure_routes runs after ALL plugins have completed both
+        // register_services and initialize_plugin_services, so any checker
+        // registered by another plugin is guaranteed to be visible here
+        // regardless of plugin load order.
+        let old = context.get_plugin_state::<AppState>("agents")?;
+        let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
+        let app_state = Arc::new(AppState {
+            db: old.db.clone(),
+            encryption_service: old.encryption_service.clone(),
+            config_service: old.config_service.clone(),
+            run_service: old.run_service.clone(),
+            executor: old.executor.clone(),
+            audit_service: old.audit_service.clone(),
+            autofixer_service: old.autofixer_service.clone(),
+            secret_service: old.secret_service.clone(),
+            definition_service: old.definition_service.clone(),
+            docker: old.docker.clone(),
+            platform_config_service: old.platform_config_service.clone(),
+            telemetry: old.telemetry.clone(),
+            project_access_checker,
+        });
 
         let router = crate::handlers::configure_routes().with_state(app_state);
 

--- a/crates/temps-ai-chat/src/handlers.rs
+++ b/crates/temps-ai-chat/src/handlers.rs
@@ -21,7 +21,9 @@ use serde::{Deserialize, Serialize};
 use tracing::error;
 use utoipa::{OpenApi, ToSchema};
 
-use temps_auth::{deny_deployment_token, permission_guard, project_scope_guard, RequireAuth};
+use temps_auth::{
+    deny_deployment_token, permission_guard, project_access_guard, project_scope_guard, RequireAuth,
+};
 use temps_core::problemdetails::{self, Problem};
 use temps_core::{AuditContext, AuditLogger, RequestMetadata};
 use temps_entities::{ai_conversations, ai_messages, ai_pending_actions};
@@ -42,6 +44,8 @@ pub struct AppState {
     pub audit_service: Arc<dyn AuditLogger>,
     /// Pending-action service (confirm/reject write proposals).
     pub pending_actions: Arc<PendingActionService>,
+    /// Optional checker for team-based project access (human sessions only).
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }
 
 impl AppState {
@@ -450,6 +454,7 @@ pub async fn find_conversation(
 ) -> Result<Json<Option<ConversationResponse>>, Problem> {
     permission_guard!(auth, ProjectsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     // Bound the lookup keys, consistent with create_conversation, so oversized
     // query strings can't reach the DB.
     if q.context_type.len() > MAX_CONTEXT_TYPE_LEN {
@@ -520,6 +525,7 @@ pub async fn list_conversations(
 ) -> Result<Json<Vec<ConversationResponse>>, Problem> {
     permission_guard!(auth, ProjectsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     ensure_chat_enabled(state.db.as_ref(), project_id).await?;
     let conversations = state.service.list_conversations(project_id).await?;
     Ok(Json(
@@ -549,6 +555,7 @@ pub async fn create_conversation(
     // Creating a conversation mutates state and can drive AI cost → write scope.
     permission_guard!(auth, ProjectsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     if req.context_type.len() > MAX_CONTEXT_TYPE_LEN {
         return Err(too_long("context_type", MAX_CONTEXT_TYPE_LEN));
     }
@@ -595,6 +602,7 @@ pub async fn get_conversation(
 ) -> Result<Json<ConversationDetailResponse>, Problem> {
     permission_guard!(auth, ProjectsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     ensure_chat_enabled(state.db.as_ref(), project_id).await?;
     let conv = state
         .service
@@ -633,6 +641,7 @@ pub async fn send_message(
     // Sending a message runs an AI turn (mutates state + incurs cost) → write scope.
     permission_guard!(auth, ProjectsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     if req.content.trim().is_empty() {
         return Err(problemdetails::new(axum::http::StatusCode::BAD_REQUEST)
             .with_title("Empty Message")
@@ -726,6 +735,7 @@ pub async fn archive_conversation(
 ) -> Result<axum::http::StatusCode, Problem> {
     permission_guard!(auth, ProjectsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     ensure_chat_enabled(state.db.as_ref(), project_id).await?;
     let conv = state
         .service
@@ -764,6 +774,7 @@ pub async fn rename_conversation(
 ) -> Result<Json<ConversationResponse>, Problem> {
     permission_guard!(auth, ProjectsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     ensure_chat_enabled(state.db.as_ref(), project_id).await?;
 
     let title = req.title.trim();
@@ -821,6 +832,7 @@ pub async fn list_pending_actions(
 ) -> Result<Json<Vec<PendingActionResponse>>, Problem> {
     permission_guard!(auth, ProjectsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     ensure_chat_enabled(state.db.as_ref(), project_id).await?;
     // Verify conversation exists + is scoped to this project.
     let conv = state
@@ -858,6 +870,7 @@ pub async fn get_pending_action(
 ) -> Result<Json<PendingActionResponse>, Problem> {
     permission_guard!(auth, ProjectsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     ensure_chat_enabled(state.db.as_ref(), project_id).await?;
     let action = state
         .pending_actions
@@ -890,6 +903,7 @@ pub async fn confirm_pending_action(
 ) -> Result<Json<PendingActionResponse>, Problem> {
     permission_guard!(auth, ProjectsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     ensure_chat_enabled(state.db.as_ref(), project_id).await?;
     let confirmed_by = Some(auth.user_id());
     let updated = state
@@ -940,6 +954,7 @@ pub async fn reject_pending_action(
 ) -> Result<Json<PendingActionResponse>, Problem> {
     permission_guard!(auth, ProjectsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     ensure_chat_enabled(state.db.as_ref(), project_id).await?;
     let rejected_by = Some(auth.user_id());
     let updated = state

--- a/crates/temps-ai-chat/src/plugin.rs
+++ b/crates/temps-ai-chat/src/plugin.rs
@@ -117,6 +117,7 @@ impl TempsPlugin for AiChatPlugin {
                 db,
                 audit_service,
                 pending_actions,
+                project_access_checker: None,
             });
             context.register_plugin_state("ai_chat", app_state);
 
@@ -126,7 +127,15 @@ impl TempsPlugin for AiChatPlugin {
     }
 
     fn configure_routes(&self, context: &PluginContext) -> Option<PluginRoutes> {
-        let app_state = context.get_plugin_state::<AppState>("ai_chat")?;
+        let old = context.get_plugin_state::<AppState>("ai_chat")?;
+        let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
+        let app_state = Arc::new(AppState {
+            service: old.service.clone(),
+            db: old.db.clone(),
+            audit_service: old.audit_service.clone(),
+            pending_actions: old.pending_actions.clone(),
+            project_access_checker,
+        });
         let router = handlers::configure_routes().with_state(app_state);
         Some(PluginRoutes::new(router))
     }

--- a/crates/temps-analytics-events/src/handlers/events_handler.rs
+++ b/crates/temps-analytics-events/src/handlers/events_handler.rs
@@ -24,7 +24,9 @@ use axum::{
     Router,
 };
 use std::sync::Arc;
-use temps_auth::{deny_deployment_token, permission_guard, project_scope_guard, RequireAuth};
+use temps_auth::{
+    deny_deployment_token, permission_guard, project_access_guard, project_scope_guard, RequireAuth,
+};
 use temps_core::error_builder::ErrorBuilder;
 use temps_core::problemdetails::Problem;
 use temps_proxy::CachedPeerTable;
@@ -41,6 +43,8 @@ pub struct AppState {
     pub ip_address_service: Arc<temps_geo::IpAddressService>,
     pub cookie_crypto: Arc<temps_core::CookieCrypto>,
     pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
+    /// Optional checker for team-based project access (human sessions only).
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }
 
 /// Get event counts with filtering
@@ -75,6 +79,7 @@ pub async fn get_events_count(
 ) -> Result<Json<Vec<EventCount>>, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let spec = EventsCountSpec::new(
         TimeRange {
@@ -128,6 +133,7 @@ pub async fn get_session_events(
 ) -> Result<Json<AnalyticsSessionEventsResponse>, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, state.project_access_checker);
 
     let spec = SessionEventsSpec {
         session_id: session_id.clone(),
@@ -178,6 +184,7 @@ pub async fn has_analytics_events(
 ) -> Result<Json<HasEventsResponse>, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let spec = HasEventsSpec {
         scope: AnalyticsScope::project(project_id),
@@ -227,6 +234,7 @@ pub async fn get_event_type_breakdown(
 ) -> Result<Json<Vec<EventTypeBreakdown>>, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let spec = EventTypeBreakdownSpec {
         range: TimeRange {
@@ -283,6 +291,7 @@ pub async fn get_events_timeline(
 ) -> Result<Json<Vec<EventTimeline>>, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let spec = EventsTimelineSpec {
         range: TimeRange {
@@ -336,6 +345,7 @@ pub async fn get_active_visitors(
 ) -> Result<Json<ActiveVisitorsResponse>, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let spec = ActiveVisitorsSpec {
         scope: AnalyticsScope::project(project_id)
@@ -390,6 +400,7 @@ pub async fn get_hourly_visits(
 ) -> Result<Json<Vec<EventTimeline>>, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let spec = HourlyVisitsSpec {
         range: TimeRange {
@@ -454,6 +465,7 @@ pub async fn get_property_breakdown(
 ) -> Result<Json<PropertyBreakdownResponse>, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let aggregation_level = query.aggregation_level.as_str();
 
@@ -529,6 +541,7 @@ pub async fn get_property_timeline(
 ) -> Result<Json<PropertyTimelineResponse>, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let aggregation_level = query.aggregation_level.as_str();
 
@@ -591,6 +604,7 @@ pub async fn get_unique_counts(
 ) -> Result<Json<UniqueCountsResponse>, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let spec = UniqueCountsSpec {
         range: TimeRange {
@@ -836,6 +850,7 @@ pub async fn record_console_event(
 
     permission_guard!(auth, AnalyticsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     info!(
         "Recording console event: {} for project {} path: {}",
@@ -961,6 +976,7 @@ pub async fn get_aggregated_buckets(
 ) -> Result<Json<crate::types::AggregatedBucketsResponse>, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let spec = AggregatedBucketsSpec {
         range: TimeRange {
@@ -1237,6 +1253,7 @@ mod tests {
             ip_address_service,
             cookie_crypto: cookie_crypto.clone(),
             telemetry: Arc::new(temps_core::telemetry::NoopTelemetryReporter),
+            project_access_checker: None,
         });
 
         let auth_middleware = middleware::from_fn(
@@ -1733,6 +1750,7 @@ mod tests {
             ip_address_service,
             cookie_crypto,
             telemetry: Arc::new(temps_core::telemetry::NoopTelemetryReporter),
+            project_access_checker: None,
         });
 
         // No auth middleware — should return 401

--- a/crates/temps-analytics-events/src/plugin.rs
+++ b/crates/temps-analytics-events/src/plugin.rs
@@ -75,6 +75,7 @@ impl TempsPlugin for EventsPlugin {
         let telemetry = context
             .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
             .unwrap_or_else(|| Arc::new(temps_core::telemetry::NoopTelemetryReporter));
+        let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
 
         let state = Arc::new(crate::handlers::AppState {
             events_service: events_backend,
@@ -83,6 +84,7 @@ impl TempsPlugin for EventsPlugin {
             ip_address_service,
             cookie_crypto,
             telemetry,
+            project_access_checker,
         });
 
         let routes = crate::handlers::configure_routes().with_state(state);
@@ -110,6 +112,7 @@ impl TempsPlugin for EventsPlugin {
             ip_address_service,
             cookie_crypto,
             telemetry,
+            project_access_checker: None,
         });
 
         let routes = crate::handlers::configure_public_routes().with_state(state);

--- a/crates/temps-analytics-funnels/src/handlers/handler.rs
+++ b/crates/temps-analytics-funnels/src/handlers/handler.rs
@@ -4,8 +4,8 @@ use axum::{
     response::{IntoResponse, Json},
 };
 use std::sync::Arc;
-use temps_auth::permission_guard;
 use temps_auth::RequireAuth;
+use temps_auth::{permission_guard, project_access_guard};
 
 use super::types::{
     AppState, CreateFunnelRequest, CreateFunnelResponse, CreateFunnelStep, EventType,
@@ -44,6 +44,7 @@ pub async fn create_funnel(
     Json(request): Json<CreateFunnelRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, FunnelWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     // Map HTTP request to service request
     let service_request = ServiceCreateFunnelRequest {
         name: request.name,
@@ -110,6 +111,7 @@ pub async fn get_funnel_metrics(
     Query(query): Query<GetFunnelMetricsQuery>,
 ) -> Result<Json<FunnelMetricsResponse>, Problem> {
     permission_guard!(auth, FunnelRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     // Parse dates if provided
 
     let filter = FunnelFilter {
@@ -190,6 +192,7 @@ pub async fn list_funnels(
     Path(project_id): Path<i32>,
 ) -> Result<Json<Vec<FunnelResponse>>, Problem> {
     permission_guard!(auth, FunnelRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     match state.funnel_service.list_funnels(project_id).await {
         Ok(funnels) => {
             let funnel_responses: Vec<FunnelResponse> = funnels
@@ -243,6 +246,7 @@ pub async fn update_funnel(
     Json(request): Json<CreateFunnelRequest>,
 ) -> Result<Json<serde_json::Value>, Problem> {
     permission_guard!(auth, FunnelWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     // Map HTTP request to service request
     let service_request = ServiceCreateFunnelRequest {
         name: request.name,
@@ -305,6 +309,7 @@ pub async fn delete_funnel(
     Path((project_id, funnel_id)): Path<(i32, i32)>,
 ) -> Result<Json<serde_json::Value>, Problem> {
     permission_guard!(auth, FunnelWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     match state
         .funnel_service
         .delete_funnel(project_id, funnel_id)
@@ -354,6 +359,7 @@ pub async fn get_unique_events(
     Query(query): Query<GetUniqueEventsQuery>,
 ) -> Result<Json<EventTypesResponse>, Problem> {
     permission_guard!(auth, FunnelRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     match state
         .funnel_service
@@ -410,6 +416,7 @@ pub async fn preview_funnel_metrics(
     Json(request): Json<CreateFunnelRequest>,
 ) -> Result<Json<FunnelMetricsResponse>, Problem> {
     permission_guard!(auth, FunnelRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let filter = FunnelFilter {
         project_id: Some(project_id),

--- a/crates/temps-analytics-funnels/src/handlers/types.rs
+++ b/crates/temps-analytics-funnels/src/handlers/types.rs
@@ -7,6 +7,8 @@ use crate::services::{FunnelService, SmartFilter};
 
 pub struct AppState {
     pub funnel_service: Arc<FunnelService>,
+    /// Optional checker for team-based project access (human sessions only).
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]

--- a/crates/temps-analytics-funnels/src/plugin.rs
+++ b/crates/temps-analytics-funnels/src/plugin.rs
@@ -40,8 +40,12 @@ impl TempsPlugin for FunnelsPlugin {
     fn configure_routes(&self, context: &PluginContext) -> Option<PluginRoutes> {
         let funnel_service = context.get_service::<crate::services::FunnelService>()?;
 
+        let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
         let routes = crate::handlers::handler::configure_routes().with_state(Arc::new(
-            crate::handlers::types::AppState { funnel_service },
+            crate::handlers::types::AppState {
+                funnel_service,
+                project_access_checker,
+            },
         ));
 
         Some(PluginRoutes::new(routes))

--- a/crates/temps-analytics-session-replay/src/handlers/handler.rs
+++ b/crates/temps-analytics-session-replay/src/handlers/handler.rs
@@ -12,7 +12,9 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use temps_auth::{deny_deployment_token, permission_guard, project_scope_guard, RequireAuth};
+use temps_auth::{
+    deny_deployment_token, permission_guard, project_access_guard, project_scope_guard, RequireAuth,
+};
 use temps_core::error_builder::ErrorBuilder;
 use temps_core::problemdetails::Problem;
 use temps_core::RequestMetadata;
@@ -406,6 +408,7 @@ pub async fn get_project_session_replays(
 ) -> Result<Json<GetProjectSessionReplaysResponse>, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, state.project_access_checker);
 
     debug!("Getting session replays for project: {}", query.project_id);
 

--- a/crates/temps-analytics-session-replay/src/handlers/types.rs
+++ b/crates/temps-analytics-session-replay/src/handlers/types.rs
@@ -8,4 +8,6 @@ pub struct AppState {
     pub audit_service: Arc<dyn temps_core::AuditLogger>,
     pub route_table: Arc<CachedPeerTable>,
     pub telemetry: std::sync::Arc<dyn temps_core::telemetry::TelemetryReporter>,
+    /// Optional checker for team-based project access (human sessions only).
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }

--- a/crates/temps-analytics-session-replay/src/plugin.rs
+++ b/crates/temps-analytics-session-replay/src/plugin.rs
@@ -63,12 +63,14 @@ impl TempsPlugin for SessionReplayPlugin {
         let telemetry = context
             .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
             .unwrap_or_else(|| std::sync::Arc::new(temps_core::telemetry::NoopTelemetryReporter));
+        let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
         let routes = crate::handlers::configure_routes().with_state(Arc::new(
             crate::handlers::types::AppState {
                 session_replay_service,
                 audit_service,
                 route_table,
                 telemetry,
+                project_access_checker,
             },
         ));
 
@@ -89,6 +91,7 @@ impl TempsPlugin for SessionReplayPlugin {
                 audit_service,
                 route_table,
                 telemetry,
+                project_access_checker: None,
             },
         ));
 

--- a/crates/temps-analytics/src/handler.rs
+++ b/crates/temps-analytics/src/handler.rs
@@ -10,7 +10,9 @@ use axum::{
 use serde::Deserialize;
 use std::sync::Arc;
 use temps_auth::RequireAuth;
-use temps_auth::{deny_deployment_token, permission_guard, project_scope_guard};
+use temps_auth::{
+    deny_deployment_token, permission_guard, project_access_guard, project_scope_guard,
+};
 use temps_core::error_builder::{bad_request, internal_server_error};
 use temps_core::problemdetails::Problem;
 use temps_core::{not_found, DateTime, UtcDateTime};
@@ -19,6 +21,8 @@ use utoipa::{OpenApi, ToSchema};
 
 pub struct AppState {
     pub analytics_service: Arc<dyn Analytics>,
+    /// Optional checker for team-based project access (human sessions only).
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }
 
 #[derive(OpenApi)]
@@ -262,6 +266,7 @@ pub async fn get_analytics_events_count(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
     let project_id = query.project_id;
 
     match app_state
@@ -321,6 +326,7 @@ pub async fn get_visitors(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
     let project_id = query.project_id;
 
     match app_state
@@ -380,6 +386,7 @@ pub async fn get_visitor_facets(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
     let project_id = query.project_id;
 
     match app_state
@@ -585,6 +592,7 @@ pub async fn get_visitor_journey(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
     match app_state
         .analytics_service
@@ -625,6 +633,7 @@ pub async fn get_session_details(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
     let project_id = query.project_id;
     match app_state
@@ -669,6 +678,7 @@ pub async fn get_analytics_session_events(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
     let project_id = query.project_id;
 
@@ -725,6 +735,7 @@ pub async fn get_session_logs(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
     let project_id = query.project_id;
 
@@ -828,6 +839,7 @@ pub async fn check_analytics_has_events(
 ) -> Result<Json<HasAnalyticsEventsResponse>, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
     let project_id = query.project_id;
     match app_state
@@ -897,6 +909,7 @@ pub async fn get_page_paths(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
     match app_state
         .analytics_service
@@ -950,6 +963,7 @@ pub async fn get_page_path_visitors(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
     let start_date: UtcDateTime = query.start_date.into();
     let end_date: UtcDateTime = query.end_date.into();
@@ -1004,6 +1018,7 @@ pub async fn get_page_path_detail(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
     let start_date: UtcDateTime = query.start_date.into();
     let end_date: UtcDateTime = query.end_date.into();
@@ -1060,6 +1075,7 @@ pub async fn get_active_visitors_count(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
     let project_id = query.project_id;
     match app_state
@@ -1099,6 +1115,7 @@ pub async fn get_analytics_active_visitors(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
     let project_id = query.project_id;
     let window = query.window_minutes.unwrap_or(5);
@@ -1150,6 +1167,7 @@ pub async fn get_live_visitors_list(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
     let project_id = query.project_id;
     let window = query.window_minutes.unwrap_or(5);
@@ -1211,6 +1229,7 @@ pub async fn get_page_paths_sparklines(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
     let start_time: UtcDateTime = query.start_time.into();
     let end_time: UtcDateTime = query.end_time.into();
@@ -1287,6 +1306,7 @@ pub async fn get_page_hourly_sessions(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
     let project_id = query.project_id;
     let start_time: UtcDateTime = query.start_time.into();
@@ -1464,6 +1484,7 @@ pub async fn get_page_flow(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
     let start_date: UtcDateTime = query.start_date.into();
     let end_date: UtcDateTime = query.end_date.into();
@@ -1526,6 +1547,7 @@ pub async fn get_recent_activity(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
     match app_state
         .analytics_service
@@ -1574,6 +1596,7 @@ pub async fn get_event_detail(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
     let start_date: UtcDateTime = query.start_date.into();
     let end_date: UtcDateTime = query.end_date.into();
@@ -1628,6 +1651,7 @@ pub async fn get_event_visitors(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AnalyticsRead);
     project_scope_guard!(auth, query.project_id);
+    project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
     let start_date: UtcDateTime = query.start_date.into();
     let end_date: UtcDateTime = query.end_date.into();

--- a/crates/temps-analytics/src/plugin.rs
+++ b/crates/temps-analytics/src/plugin.rs
@@ -64,9 +64,13 @@ impl TempsPlugin for AnalyticsPlugin {
     fn configure_routes(&self, context: &PluginContext) -> Option<PluginRoutes> {
         // Get the AnalyticsService from the context
         let analytics_service = context.require_service::<dyn Analytics>();
+        let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
 
         // Create AppState
-        let app_state = Arc::new(AppState { analytics_service });
+        let app_state = Arc::new(AppState {
+            analytics_service,
+            project_access_checker,
+        });
 
         // Configure routes with the state
         let routes = configure_routes().with_state(app_state);

--- a/crates/temps-auth/Cargo.toml
+++ b/crates/temps-auth/Cargo.toml
@@ -45,3 +45,4 @@ reqwest = { workspace = true }
 [dev-dependencies]
 temps-migrations = { path = "../temps-migrations" }
 tokio-test = "0.4"
+walkdir = { workspace = true }

--- a/crates/temps-auth/src/permission_guard.rs
+++ b/crates/temps-auth/src/permission_guard.rs
@@ -450,4 +450,174 @@ mod tests {
             "deployment tokens should bypass project_access_guard!"
         );
     }
+
+    // ---------------------------------------------------------------------------
+    // ADR-028 Phase B: Coverage enumeration
+    //
+    // Every Rust source file that contains `project_scope_guard!` must also
+    // contain `project_access_guard!` — the two guards are always paired.
+    // This test scans the workspace at test time and fails if any file has one
+    // without the other, catching handlers added in future crates that omit the
+    // companion guard.
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn every_project_scope_guard_has_access_guard_companion() {
+        // Locate the workspace crates/ directory relative to this crate.
+        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        // temps-auth lives at <workspace>/crates/temps-auth
+        let workspace_root = manifest_dir
+            .parent() // crates/
+            .and_then(|p| p.parent()) // workspace root
+            .expect("cannot resolve workspace root from CARGO_MANIFEST_DIR");
+        let crates_dir = workspace_root.join("crates");
+
+        let mut violations: Vec<String> = Vec::new();
+
+        for entry in walkdir::WalkDir::new(&crates_dir)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("rs"))
+        {
+            let path = entry.path();
+            let contents = match std::fs::read_to_string(path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            // Use `!(` to match actual macro invocations and avoid matching
+            // doc-comment references like `[`project_scope_guard!`]`.
+            let has_scope_guard = contents.contains("project_scope_guard!(");
+            let has_access_guard = contents.contains("project_access_guard!(");
+            // Skip the file that defines the macros themselves.
+            let is_definition_file = contents.contains("macro_rules! project_scope_guard")
+                || contents.contains("macro_rules! project_access_guard");
+            if is_definition_file {
+                continue;
+            }
+            if has_scope_guard && !has_access_guard {
+                violations.push(format!("{}", path.display()));
+            }
+        }
+
+        assert!(
+            violations.is_empty(),
+            "The following files have `project_scope_guard!` but are missing \
+             `project_access_guard!` (ADR-028 Phase B requires both to be paired):\n{}",
+            violations.join("\n")
+        );
+    }
+
+    /// ADR-028 Phase B — crate coverage snapshot.
+    ///
+    /// Documents which crates contain `project_access_guard!` usages as of the
+    /// Phase B rollout. When a new crate with project-scoped handlers is added,
+    /// this list must grow to maintain the inventory. Keep it sorted.
+    ///
+    /// The check is **bidirectional**:
+    /// - Every crate in `expected_crates` must still have at least one
+    ///   `project_access_guard!` call (catches accidental removal).
+    /// - Every crate that has a `project_access_guard!` call must be in
+    ///   `expected_crates` (catches new crates that add guard calls without
+    ///   being registered in this inventory, closing the silent-omission gap
+    ///   identified in the Phase B review).
+    #[test]
+    fn project_access_guard_coverage_snapshot() {
+        let expected_crates: &[&str] = &[
+            "temps-agents",
+            "temps-ai-chat",
+            "temps-analytics",
+            "temps-analytics-events",
+            "temps-analytics-funnels",
+            "temps-analytics-session-replay",
+            "temps-deployments",
+            "temps-environments",
+            "temps-error-tracking",
+            "temps-log-aggregator",
+            "temps-monitoring",
+            "temps-observability",
+            "temps-otel",
+            "temps-projects",
+            "temps-providers",
+            "temps-revenue",
+            "temps-status-page",
+            "temps-vulnerability-scanner",
+            "temps-webhooks",
+        ];
+
+        // Verify the snapshot is sorted (makes PR diffs easier to review).
+        let mut sorted = expected_crates.to_vec();
+        sorted.sort_unstable();
+        assert_eq!(
+            expected_crates,
+            sorted.as_slice(),
+            "keep the coverage snapshot sorted alphabetically"
+        );
+
+        // Scan the workspace and collect crates that actually use project_access_guard!.
+        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let workspace_root = manifest_dir
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("cannot resolve workspace root");
+        let crates_dir = workspace_root.join("crates");
+
+        let mut found_crates: std::collections::BTreeSet<String> = Default::default();
+
+        for entry in walkdir::WalkDir::new(&crates_dir)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("rs"))
+        {
+            let path = entry.path();
+            let contents = match std::fs::read_to_string(path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            // Skip the file that defines the macro itself.
+            if contents.contains("macro_rules! project_access_guard") {
+                continue;
+            }
+            if contents.contains("project_access_guard!(") {
+                // Derive the crate name from the directory that directly contains
+                // this source file's Cargo.toml — walk up until we find it.
+                let mut dir = path.parent();
+                while let Some(d) = dir {
+                    if d.join("Cargo.toml").exists() {
+                        if let Some(name) = d.file_name().and_then(|n| n.to_str()) {
+                            found_crates.insert(name.to_string());
+                        }
+                        break;
+                    }
+                    dir = d.parent();
+                }
+            }
+        }
+
+        // Direction 1: every expected crate must still have a guard call.
+        for expected in expected_crates {
+            assert!(
+                found_crates.contains(*expected),
+                "Crate `{}` is in the coverage snapshot but no `project_access_guard!` \
+                 usage was found in its source — was it accidentally removed?",
+                expected
+            );
+        }
+
+        // Direction 2: every crate with a guard call must be in the snapshot.
+        // This catches crates that add guard calls without registering in this
+        // inventory, which would otherwise silently escape the coverage check.
+        let expected_set: std::collections::BTreeSet<&str> =
+            expected_crates.iter().copied().collect();
+        let extra_found: Vec<&str> = found_crates
+            .iter()
+            .filter(|c| !expected_set.contains(c.as_str()))
+            .map(|s| s.as_str())
+            .collect();
+        assert!(
+            extra_found.is_empty(),
+            "These crates use `project_access_guard!` but are not listed in the coverage \
+             snapshot — add them to `expected_crates` (sorted alphabetically):\n{}",
+            extra_found.join("\n")
+        );
+    }
 }

--- a/crates/temps-deployments/src/handlers/container_exec.rs
+++ b/crates/temps-deployments/src/handlers/container_exec.rs
@@ -18,7 +18,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use temps_auth::{permission_guard, project_scope_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, project_scope_guard, RequireAuth};
 use temps_core::problemdetails::{self, Problem};
 use tokio::io::AsyncWriteExt;
 use tracing::{debug, error, info, warn};
@@ -34,6 +34,7 @@ async fn verify_container_exec_access(
     container_id: String,
 ) -> Result<temps_entities::deployment_containers::Model, Problem> {
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     // Verify the container belongs to this project/environment before using
     // the caller-supplied Docker ID against any Docker daemon.

--- a/crates/temps-deployments/src/handlers/deployment_tokens.rs
+++ b/crates/temps-deployments/src/handlers/deployment_tokens.rs
@@ -12,8 +12,8 @@ use axum::{
     routing::get,
     Extension, Json, Router,
 };
-use temps_auth::permission_guard;
 use temps_auth::RequireAuth;
+use temps_auth::{permission_guard, project_access_guard};
 use temps_core::{AuditContext, RequestMetadata};
 use tracing::error;
 use utoipa::OpenApi;
@@ -33,6 +33,13 @@ pub struct DeploymentTokenAppState {
     pub deployment_token_service: Arc<DeploymentTokenService>,
     /// Audit logger for write operations (e.g. token rotation)
     pub audit_service: Arc<dyn temps_core::AuditLogger>,
+    /// Optional checker enforcing team-based project access for human sessions.
+    ///
+    /// `None` when no plugin implementing this check is registered — the
+    /// `project_access_guard!` macro is a strict synchronous no-op in that
+    /// case. Resolved once in `configure_routes` via
+    /// `context.get_service::<dyn temps_core::ProjectAccessChecker>()`.
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -116,6 +123,7 @@ async fn list_deployment_tokens(
     Query(query): Query<ListDeploymentTokensQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentTokensRead);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let page = query.page.unwrap_or(1);
     let page_size = std::cmp::min(query.page_size.unwrap_or(20), 100);
@@ -158,6 +166,7 @@ async fn create_deployment_token(
     Json(request): Json<CreateDeploymentTokenRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentTokensCreate);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let response = app_state
         .deployment_token_service
@@ -195,6 +204,7 @@ async fn get_deployment_token(
     Path((project_id, token_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentTokensRead);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let response = app_state
         .deployment_token_service
@@ -236,6 +246,7 @@ async fn update_deployment_token(
     Json(request): Json<UpdateDeploymentTokenRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentTokensWrite);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let response = app_state
         .deployment_token_service
@@ -273,6 +284,7 @@ async fn delete_deployment_token(
     Path((project_id, token_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentTokensDelete);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     app_state
         .deployment_token_service
@@ -311,6 +323,7 @@ async fn rotate_deployment_token(
     Path((project_id, token_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentTokensWrite);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let rotated = app_state
         .deployment_token_service

--- a/crates/temps-deployments/src/handlers/deployments.rs
+++ b/crates/temps-deployments/src/handlers/deployments.rs
@@ -20,8 +20,8 @@ use axum::{
 use futures::stream::{self, StreamExt};
 use futures::SinkExt;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
-use temps_auth::permission_guard;
 use temps_auth::RequireAuth;
+use temps_auth::{permission_guard, project_access_guard, project_scope_guard};
 use temps_core::{AuditContext, RequestMetadata};
 use tracing::{debug, error, info, warn};
 use utoipa::OpenApi;
@@ -36,6 +36,22 @@ use crate::handlers::types::{
 };
 use temps_core::problemdetails;
 use temps_core::problemdetails::Problem;
+
+// ADR-028 guard pattern note for this file
+//
+// All handlers in this module use `permission_guard!` with Deployments* or
+// Environments* permissions (DeploymentsRead, DeploymentsCreate, DeploymentsDelete,
+// DeploymentsWrite, EnvironmentsRead, EnvironmentsWrite). None of these
+// permissions are bridged from deployment-token permissions in
+// `AuthContext::has_permission` — only AnalyticsRead, AnalyticsWrite, and
+// EmailsSend have token-to-permission mappings. A deployment token therefore
+// fails `permission_guard!` before reaching any handler in this file.
+//
+// `project_scope_guard!` is intentionally omitted from all handlers EXCEPT
+// `get_last_deployment` and `get_project_deployments`, which carry it as a
+// defence-in-depth measure for the ADR-028 Phase B rollout. Adding the guard
+// to every handler in this file would be redundant noise: the token is already
+// rejected by the earlier `permission_guard!` call.
 
 #[derive(OpenApi)]
 #[openapi(
@@ -294,6 +310,8 @@ pub async fn get_last_deployment(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_scope_guard!(auth, id);
+    project_access_guard!(auth, id, state.project_access_checker);
 
     debug!("Getting last deployment for project with id: {}", id);
     let deployment = state.deployment_service.get_last_deployment(id).await?;
@@ -326,6 +344,8 @@ pub async fn get_project_deployments(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_scope_guard!(auth, id);
+    project_access_guard!(auth, id, state.project_access_checker);
 
     let list_response = state
         .deployment_service
@@ -369,6 +389,7 @@ pub async fn get_deployment(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     debug!(
         "Getting deployment {} for project: {}",
@@ -406,6 +427,7 @@ pub async fn rollback_to_deployment(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsCreate);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let deployment = state
         .deployment_service
@@ -458,6 +480,7 @@ pub async fn promote_deployment(
     Json(request): Json<PromoteDeploymentRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsCreate);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     info!(
         "Promoting deployment {} to environment {} (project {})",
@@ -511,6 +534,7 @@ pub async fn pause_deployment(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsDelete);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     info!("Pausing deployment: {:?}", deployment_id);
 
     state
@@ -562,6 +586,7 @@ pub async fn resume_deployment(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsCreate);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     state
         .deployment_service
@@ -613,6 +638,7 @@ pub async fn cancel_deployment(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsDelete);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     info!(
         "API request to cancel deployment {} for project {} from user",
@@ -673,6 +699,7 @@ pub async fn teardown_deployment(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsDelete);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     info!(
         "Tearing down deployment {} for project: {}",
@@ -727,6 +754,7 @@ pub async fn teardown_environment(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsDelete);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     info!(
         "Tearing down environment {} for project: {}",
@@ -781,6 +809,7 @@ pub async fn list_containers(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     info!(
         "Listing containers for environment {} of project: {}",
@@ -930,6 +959,7 @@ pub async fn get_container_logs_by_id(
     ws: WebSocketUpgrade,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     debug!(
         "WebSocket request for container {} logs in environment {} of project: {}",
@@ -1093,6 +1123,7 @@ pub async fn get_container_logs(
     ws: WebSocketUpgrade,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     debug!(
         "WebSocket request for container logs in environment {} of project: {}",
@@ -1228,9 +1259,10 @@ async fn handle_filtered_container_logs_socket(
 pub async fn get_deployment_jobs(
     RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
-    Path((_project_id, deployment_id)): Path<(i32, i32)>,
+    Path((project_id, deployment_id)): Path<(i32, i32)>,
 ) -> Result<Json<DeploymentJobsResponse>, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let jobs = state
         .deployment_service
@@ -1268,9 +1300,10 @@ pub async fn get_deployment_jobs(
 pub async fn get_deployment_job_logs(
     RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
-    Path((_project_id, deployment_id, job_id)): Path<(i32, i32, String)>,
+    Path((project_id, deployment_id, job_id)): Path<(i32, i32, String)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     // Get the job to verify it exists and get its log_id
     let jobs = state
@@ -1325,6 +1358,7 @@ pub async fn list_deployment_container_logs(
     Path((project_id, deployment_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let logs = state
         .deployment_service
@@ -1364,6 +1398,7 @@ pub async fn get_deployment_container_log_content(
     Path((project_id, deployment_id, log_id)): Path<(i32, i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let (row, content) = state
         .deployment_service
@@ -1417,10 +1452,11 @@ pub async fn get_deployment_container_log_content(
 pub async fn tail_deployment_job_logs(
     RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
-    Path((_project_id, deployment_id, job_id)): Path<(i32, i32, String)>,
+    Path((project_id, deployment_id, job_id)): Path<(i32, i32, String)>,
     ws: WebSocketUpgrade,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     debug!(
         "WebSocket request for tailing logs for job {} in deployment {}",
@@ -1519,6 +1555,7 @@ pub async fn get_container_detail(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let (container, _) = state
         .deployment_service
@@ -1714,6 +1751,7 @@ pub async fn stop_container(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     state
         .deployment_service
@@ -1769,6 +1807,7 @@ pub async fn start_container(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     state
         .deployment_service
@@ -1824,6 +1863,7 @@ pub async fn restart_container(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     state
         .deployment_service
@@ -1878,6 +1918,7 @@ pub async fn get_container_metrics(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let stats = state
         .deployment_service
@@ -1929,6 +1970,7 @@ pub async fn stream_container_metrics(
     Problem,
 > {
     permission_guard!(auth, EnvironmentsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let interval_ms = params
         .get("interval")
@@ -2063,6 +2105,7 @@ pub async fn purge_asset_cache(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let deleted = state
         .deployment_service
@@ -2095,6 +2138,7 @@ pub async fn purge_environment_asset_cache(
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let deleted = state
         .deployment_service
@@ -3286,6 +3330,7 @@ mod tests {
                     .unwrap_or_else(|_| bollard::Docker::connect_with_defaults().unwrap()),
             ),
             deployment_gate: None,
+            project_access_checker: None,
         })
     }
 

--- a/crates/temps-deployments/src/handlers/external_images.rs
+++ b/crates/temps-deployments/src/handlers/external_images.rs
@@ -12,7 +12,7 @@ use axum::{
 };
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, project_scope_guard, RequireAuth};
 use temps_core::problemdetails::{self, Problem};
 use temps_core::{AuditContext, RequestMetadata, UtcDateTime};
 use tracing::{debug, error, info};
@@ -108,6 +108,8 @@ pub async fn push_external_image(
     Json(req): Json<PushImageRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsCreate);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     debug!(
         "Pushing external image for project {}: {}",
@@ -185,6 +187,8 @@ pub async fn list_external_images(
     Path(project_id): Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     debug!("Listing external images for project {}", project_id);
 
@@ -217,6 +221,8 @@ pub async fn get_external_image(
     Path((project_id, image_id)): Path<(i32, String)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     debug!(
         "Getting external image {} for project {}",
@@ -255,6 +261,8 @@ pub async fn execute_deployment_operation(
     Json(req): Json<ExecuteOperationRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsWrite);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     debug!(
         "Executing operation {} for deployment {} in project {}",
@@ -342,6 +350,8 @@ pub async fn get_deployment_operations(
     Path((project_id, deployment_id)): Path<(i32, String)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     debug!(
         "Getting operations for deployment {} in project {}",
@@ -383,6 +393,8 @@ pub async fn get_deployment_operation_status(
     Path((project_id, deployment_id, operation_type)): Path<(i32, String, String)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     debug!(
         "Getting {} operation status for deployment {} in project {}",

--- a/crates/temps-deployments/src/handlers/remote_deployments.rs
+++ b/crates/temps-deployments/src/handlers/remote_deployments.rs
@@ -21,7 +21,7 @@ use axum::{
 use chrono::Utc;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, Set};
 use serde::{Deserialize, Serialize};
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, RequireAuth};
 use temps_core::problemdetails::{self, Problem};
 use temps_core::{AuditContext, DeploymentCreatedJob, Job, RequestMetadata, UtcDateTime};
 use temps_entities::deployments::DeploymentMetadata;
@@ -310,6 +310,7 @@ pub async fn deploy_from_image(
     Json(req): Json<DeployFromImageRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsCreate);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     // Validate optional deploy-time health-check path override up front
     if let Some(ref path) = req.health_check_path {
@@ -596,6 +597,7 @@ pub async fn deploy_from_static(
     Json(req): Json<DeployFromStaticRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsCreate);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     // Validate optional deploy-time health-check path override up front
     if let Some(ref path) = req.health_check_path {
@@ -866,6 +868,7 @@ pub async fn deploy_from_image_upload(
     mut multipart: Multipart,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsCreate);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     // Validate optional deploy-time health-check path override up front
     if let Some(ref path) = query.health_check_path {
@@ -1261,6 +1264,7 @@ pub async fn upload_static_bundle(
     mut multipart: Multipart,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsCreate);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     debug!("Uploading static bundle for project {}", project_id);
 
@@ -1581,6 +1585,7 @@ pub async fn register_external_image(
     Json(req): Json<RegisterImageRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsCreate);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     debug!(
         "Registering external image for project {}: {}",
@@ -1661,6 +1666,7 @@ pub async fn list_remote_external_images(
     Query(query): Query<PaginationQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let (images, total) = state
         .remote_deployment_service
@@ -1704,9 +1710,10 @@ pub async fn list_remote_external_images(
 pub async fn get_remote_external_image(
     RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
-    Path((_project_id, image_id)): Path<(i32, i32)>,
+    Path((project_id, image_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let image = state
         .remote_deployment_service
@@ -1750,6 +1757,7 @@ pub async fn delete_external_image(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsDelete);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     state
         .remote_deployment_service
@@ -1810,6 +1818,7 @@ pub async fn list_static_bundles(
     Query(query): Query<PaginationQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let (bundles, total) = state
         .remote_deployment_service
@@ -1853,9 +1862,10 @@ pub async fn list_static_bundles(
 pub async fn get_static_bundle(
     RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
-    Path((_project_id, bundle_id)): Path<(i32, i32)>,
+    Path((project_id, bundle_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let bundle = state
         .remote_deployment_service
@@ -1899,6 +1909,7 @@ pub async fn delete_static_bundle(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsDelete);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     state
         .remote_deployment_service

--- a/crates/temps-deployments/src/handlers/types.rs
+++ b/crates/temps-deployments/src/handlers/types.rs
@@ -48,6 +48,13 @@ pub struct AppState {
     /// guaranteed to already be present by this point. See
     /// [`temps_core::DeploymentGate`].
     pub deployment_gate: Option<Arc<dyn temps_core::DeploymentGate>>,
+    /// Optional checker enforcing team-based project access for human sessions.
+    ///
+    /// `None` when no plugin implementing this check is registered — the
+    /// `project_access_guard!` macro is a strict synchronous no-op in that
+    /// case. Resolved once in `configure_routes` via
+    /// `context.get_service::<dyn temps_core::ProjectAccessChecker>()`.
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }
 
 use crate::services::types::Deployment;

--- a/crates/temps-deployments/src/plugin.rs
+++ b/crates/temps-deployments/src/plugin.rs
@@ -446,6 +446,13 @@ impl TempsPlugin for DeploymentsPlugin {
         // Get audit service for logging write operations
         let audit_service = context.require_service::<dyn temps_core::AuditLogger>();
 
+        // Optional: team-based project access checker registered by a plugin.
+        // `configure_routes` runs after all plugins have completed
+        // `initialize_plugin_services`, so a checker registered by another
+        // plugin is guaranteed to be present in the registry by this point.
+        // When absent (plain OSS binary), project_access_guard! is a no-op.
+        let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
+
         // Deployment-token management routes carry their own app state
         // (`DeploymentTokenAppState`), so build it here and mount the router as
         // a sub-router below. Without this wiring the token endpoints -- create,
@@ -455,6 +462,7 @@ impl TempsPlugin for DeploymentsPlugin {
             Arc::new(handlers::deployment_tokens::DeploymentTokenAppState {
                 deployment_token_service,
                 audit_service: audit_service.clone(),
+                project_access_checker: project_access_checker.clone(),
             });
 
         // Get data directory for local file storage
@@ -491,6 +499,7 @@ impl TempsPlugin for DeploymentsPlugin {
             config_service: config_service.clone(),
             docker: docker_for_exec,
             deployment_gate,
+            project_access_checker,
         });
 
         let deployments_routes = handlers::deployments::configure_routes();

--- a/crates/temps-environments/src/handlers/handler.rs
+++ b/crates/temps-environments/src/handlers/handler.rs
@@ -12,7 +12,7 @@ use axum::{
     Json,
 };
 use std::sync::Arc;
-use temps_auth::{permission_guard, project_scope_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, project_scope_guard, RequireAuth};
 use temps_core::AuditContext;
 use temps_core::RequestMetadata;
 use tracing::{error, info};
@@ -126,6 +126,7 @@ pub async fn get_environments(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let environments = state
         .environment_service
@@ -196,6 +197,7 @@ pub async fn get_environment(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let env = state
         .environment_service
@@ -262,6 +264,7 @@ pub async fn get_environment_domains(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let domains = state
         .environment_service
@@ -313,6 +316,7 @@ pub async fn add_environment_domain(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let domain = state
         .environment_service
@@ -359,6 +363,7 @@ pub async fn delete_environment_domain(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsDelete);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     state
         .environment_service
@@ -395,6 +400,7 @@ pub async fn get_environment_variables(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let vars = state
         .env_var_service
@@ -476,6 +482,7 @@ pub async fn get_resolved_environment_variables(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     // Manual vars (already includes environment memberships).
     let manual = state
@@ -630,6 +637,7 @@ pub async fn get_resolved_environment_variable_value(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     info!(
         user_id = auth.user_id(),
@@ -721,6 +729,7 @@ pub async fn create_environment_variable(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsCreate);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let var = state
         .env_var_service
@@ -780,6 +789,7 @@ pub async fn delete_environment_variable(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsDelete);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     state
         .env_var_service
@@ -814,6 +824,7 @@ pub async fn update_environment_variable(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let var = state
         .env_var_service
@@ -875,6 +886,7 @@ pub async fn get_environment_variable_value(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     // Reveal of a single decrypted secret. Logged at info so any
     // bulk-reveal pattern (one of the obvious post-compromise behaviors)
@@ -921,6 +933,7 @@ pub async fn update_environment_settings(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     // Get project details for audit log
     let project = state.environment_service.get_project(project_id).await?;
@@ -1079,6 +1092,7 @@ pub async fn update_environment_subdomain(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let project = state.environment_service.get_project(project_id).await?;
     let environment = state
@@ -1181,6 +1195,7 @@ pub async fn wake_environment(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     // Cooldown: reject if last state change was less than 30 seconds ago
     let environment = state
@@ -1334,6 +1349,7 @@ pub async fn sleep_environment(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     // Cooldown: reject if last state change was less than 30 seconds ago
     let environment = state
@@ -1476,6 +1492,7 @@ pub async fn delete_environment(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsDelete);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     // Get environment details before deletion for audit log
     let environment = state
@@ -1562,6 +1579,7 @@ pub async fn create_environment(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsCreate);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let environment = state
         .environment_service
@@ -1658,6 +1676,7 @@ pub async fn list_project_secrets(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let secrets = state
         .secret_service
@@ -1715,6 +1734,7 @@ pub async fn create_project_secret(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsCreate);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let secret = state
         .secret_service
@@ -1776,6 +1796,7 @@ pub async fn update_project_secret(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let secret = state
         .secret_service
@@ -1833,6 +1854,7 @@ pub async fn delete_project_secret(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EnvironmentsDelete);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     state.secret_service.delete(project_id, secret_id).await?;
     Ok(StatusCode::NO_CONTENT.into_response())

--- a/crates/temps-environments/src/handlers/types.rs
+++ b/crates/temps-environments/src/handlers/types.rs
@@ -23,6 +23,8 @@ pub struct AppState {
     /// Anonymous product telemetry reporter. Always present (may be a no-op when
     /// telemetry is disabled or the reporter crate is not loaded).
     pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
+    /// Optional checker for team-based project access (human sessions only).
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -35,6 +37,7 @@ pub fn create_environment_app_state(
     on_demand_waker: Option<Arc<dyn temps_core::OnDemandWaker>>,
     integration_env_provider: Option<Arc<dyn ProjectEnvVarsProvider>>,
     telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
+    project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 ) -> Arc<AppState> {
     Arc::new(AppState {
         environment_service,
@@ -45,6 +48,7 @@ pub fn create_environment_app_state(
         on_demand_waker,
         integration_env_provider,
         telemetry,
+        project_access_checker,
     })
 }
 

--- a/crates/temps-environments/src/plugin.rs
+++ b/crates/temps-environments/src/plugin.rs
@@ -71,6 +71,7 @@ impl TempsPlugin for EnvironmentsPlugin {
         let telemetry = context
             .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
             .unwrap_or_else(|| std::sync::Arc::new(temps_core::telemetry::NoopTelemetryReporter));
+        let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
 
         let app_state = crate::handlers::create_environment_app_state(
             environment_service,
@@ -81,6 +82,7 @@ impl TempsPlugin for EnvironmentsPlugin {
             on_demand_waker,
             integration_env_provider,
             telemetry,
+            project_access_checker,
         );
 
         let routes = crate::handlers::configure_routes().with_state(app_state);

--- a/crates/temps-error-tracking/src/handlers/alert_rules_handler.rs
+++ b/crates/temps-error-tracking/src/handlers/alert_rules_handler.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use temps_auth::{permission_guard, project_scope_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, project_scope_guard, RequireAuth};
 use temps_core::problemdetails::Problem;
 use temps_entities::error_alert_rules;
 use utoipa::{OpenApi, ToSchema};
@@ -156,6 +156,7 @@ pub async fn list_alert_rules(
 ) -> Result<Json<Vec<AlertRuleResponse>>, Problem> {
     permission_guard!(auth, ErrorTrackingRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let rules = state.alert_service.list_rules(project_id).await?;
     Ok(Json(
         rules.into_iter().map(AlertRuleResponse::from).collect(),
@@ -184,6 +185,7 @@ pub async fn get_alert_rule(
 ) -> Result<Json<AlertRuleResponse>, Problem> {
     permission_guard!(auth, ErrorTrackingRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let rule = state.alert_service.get_rule(rule_id, project_id).await?;
     Ok(Json(AlertRuleResponse::from(rule)))
 }
@@ -211,6 +213,7 @@ pub async fn create_alert_rule(
 ) -> Result<(StatusCode, Json<AlertRuleResponse>), Problem> {
     permission_guard!(auth, ErrorTrackingCreate);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let rule = state
         .alert_service
         .create_rule(
@@ -254,6 +257,7 @@ pub async fn update_alert_rule(
 ) -> Result<Json<AlertRuleResponse>, Problem> {
     permission_guard!(auth, ErrorTrackingWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let rule = state
         .alert_service
         .update_rule(
@@ -295,6 +299,7 @@ pub async fn delete_alert_rule(
 ) -> Result<StatusCode, Problem> {
     permission_guard!(auth, ErrorTrackingWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     state.alert_service.delete_rule(rule_id, project_id).await?;
 
     Ok(StatusCode::NO_CONTENT)

--- a/crates/temps-error-tracking/src/handlers/handler.rs
+++ b/crates/temps-error-tracking/src/handlers/handler.rs
@@ -9,7 +9,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use temps_auth::{permission_guard, project_scope_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, project_scope_guard, RequireAuth};
 use temps_core::problemdetails::Problem;
 use temps_core::DateTime;
 use utoipa::{IntoParams, OpenApi, ToSchema};
@@ -375,6 +375,7 @@ pub async fn list_error_groups(
 ) -> Result<Json<PaginatedErrorGroupsResponse>, Problem> {
     permission_guard!(auth, ErrorTrackingRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let page = query.page;
     let page_size = std::cmp::min(query.page_size, 100);
 
@@ -430,6 +431,7 @@ pub async fn get_error_group(
 ) -> Result<Json<ErrorGroupResponse>, Problem> {
     permission_guard!(auth, ErrorTrackingRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let group = state
         .error_tracking_service
         .get_error_group(group_id, project_id)
@@ -462,6 +464,7 @@ pub async fn update_error_group(
 ) -> Result<StatusCode, Problem> {
     permission_guard!(auth, ErrorTrackingWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     state
         .error_tracking_service
         .update_error_group_status(group_id, project_id, request.status, request.assigned_to)
@@ -505,6 +508,7 @@ pub async fn list_error_events(
 ) -> Result<Json<PaginatedErrorEventsResponse>, Problem> {
     permission_guard!(auth, ErrorTrackingRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let page = query.page;
     let page_size = std::cmp::min(query.page_size, 100);
 
@@ -553,6 +557,7 @@ pub async fn get_error_event(
 ) -> Result<Json<ErrorEventResponse>, Problem> {
     permission_guard!(auth, ErrorTrackingRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let event = state
         .error_tracking_service
         .get_error_event(event_id, group_id, project_id)
@@ -581,6 +586,7 @@ pub async fn get_error_stats(
 ) -> Result<Json<ErrorGroupStatsResponse>, Problem> {
     permission_guard!(auth, ErrorTrackingRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let stats = state
         .error_tracking_service
         .get_error_stats(project_id, None)
@@ -616,6 +622,7 @@ pub async fn get_error_dashboard_stats(
 ) -> Result<Json<ErrorDashboardStatsResponse>, Problem> {
     permission_guard!(auth, ErrorTrackingRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let stats = state
         .error_tracking_service
         .get_dashboard_stats(
@@ -662,6 +669,7 @@ pub async fn get_error_time_series(
 ) -> Result<Json<Vec<ErrorTimeSeriesDataResponse>>, Problem> {
     permission_guard!(auth, ErrorTrackingRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let data = state
         .error_tracking_service
         .get_error_time_series(
@@ -703,6 +711,7 @@ pub async fn has_error_groups(
 ) -> Result<Json<HasErrorGroupsResponse>, Problem> {
     permission_guard!(auth, ErrorTrackingRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let has_error_groups = state
         .error_tracking_service
         .has_error_groups(project_id)

--- a/crates/temps-error-tracking/src/handlers/source_map_handlers.rs
+++ b/crates/temps-error-tracking/src/handlers/source_map_handlers.rs
@@ -7,7 +7,7 @@ use axum::{
 };
 use serde::Serialize;
 use std::sync::Arc;
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, RequireAuth};
 use temps_core::problemdetails::{self, Problem};
 use tracing::error;
 use utoipa::{OpenApi, ToSchema};
@@ -39,6 +39,8 @@ pub struct SourceMapApiDoc;
 pub struct SourceMapAppState {
     pub source_map_service: Arc<SourceMapService>,
     pub audit_service: Arc<dyn temps_core::AuditLogger>,
+    /// Optional checker for team-based project access (human sessions only).
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }
 
 pub fn configure_source_map_routes() -> Router<Arc<SourceMapAppState>> {
@@ -164,6 +166,7 @@ async fn upload_source_map(
     mut multipart: Multipart,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ErrorTrackingCreate);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     // Maximum source map size: 50MB
     const MAX_SOURCE_MAP_SIZE: usize = 50 * 1024 * 1024;
@@ -277,6 +280,7 @@ async fn list_source_maps(
     Path((project_id, release)): Path<(i32, String)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ErrorTrackingRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let maps = state
         .source_map_service
@@ -310,6 +314,7 @@ async fn list_releases(
     Path(project_id): Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ErrorTrackingRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let releases = state.source_map_service.list_releases(project_id).await?;
 
@@ -338,6 +343,7 @@ async fn delete_release_source_maps(
     Path((project_id, release)): Path<(i32, String)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ErrorTrackingWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let deleted = state
         .source_map_service
@@ -370,6 +376,7 @@ async fn delete_source_map(
     Path((project_id, source_map_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ErrorTrackingWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     state
         .source_map_service

--- a/crates/temps-error-tracking/src/handlers/types.rs
+++ b/crates/temps-error-tracking/src/handlers/types.rs
@@ -6,4 +6,6 @@ pub struct AppState {
     pub error_tracking_service: Arc<ErrorTrackingService>,
     pub alert_service: Arc<ErrorAlertService>,
     pub audit_service: Arc<dyn temps_core::AuditLogger>,
+    /// Optional checker for team-based project access (human sessions only).
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }

--- a/crates/temps-error-tracking/src/plugin.rs
+++ b/crates/temps-error-tracking/src/plugin.rs
@@ -222,11 +222,14 @@ impl TempsPlugin for ErrorTrackingPlugin {
         let dsn_service = context.require_service::<DSNService>();
         let source_map_service = context.require_service::<SourceMapService>();
 
+        let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
+
         // Admin: error tracking dashboard + alert rules
         let error_tracking_state = Arc::new(crate::handlers::types::AppState {
             error_tracking_service: error_tracking_service.clone(),
             alert_service: alert_service.clone(),
             audit_service: audit_service.clone(),
+            project_access_checker: project_access_checker.clone(),
         });
         let error_tracking_routes =
             crate::handlers::handler::configure_routes().with_state(error_tracking_state.clone());
@@ -246,6 +249,7 @@ impl TempsPlugin for ErrorTrackingPlugin {
         let source_map_state = Arc::new(crate::handlers::source_map_handlers::SourceMapAppState {
             source_map_service: source_map_service.clone(),
             audit_service: audit_service.clone(),
+            project_access_checker,
         });
         let source_map_routes = crate::handlers::source_map_handlers::configure_source_map_routes()
             .with_state(source_map_state);

--- a/crates/temps-log-aggregator/src/handlers/log_handler.rs
+++ b/crates/temps-log-aggregator/src/handlers/log_handler.rs
@@ -309,6 +309,12 @@ async fn search_logs(
     Json(request): Json<SearchLogsRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, LogsRead);
+    // `project_id` is ignored when `external_service_id` is set (external
+    // service logs aren't project-scoped), so only guard on it in the mode
+    // where it's actually the resource being accessed.
+    if request.external_service_id.is_none() {
+        project_access_guard!(auth, request.project_id, app_state.project_access_checker);
+    }
 
     let now = Utc::now();
     let start_time = request
@@ -422,6 +428,12 @@ async fn tail_logs(
     Query(request): Query<TailLogsRequest>,
 ) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, Problem> {
     permission_guard!(auth, LogsRead);
+    // `project_id` is ignored when `external_service_id` is set (external
+    // service logs aren't project-scoped), so only guard on it in the mode
+    // where it's actually the resource being accessed.
+    if request.external_service_id.is_none() {
+        project_access_guard!(auth, request.project_id, app_state.project_access_checker);
+    }
 
     let levels: Vec<LogLevel> = request
         .levels

--- a/crates/temps-log-aggregator/src/handlers/log_handler.rs
+++ b/crates/temps-log-aggregator/src/handlers/log_handler.rs
@@ -16,7 +16,7 @@ use utoipa::{OpenApi, ToSchema};
 use uuid::Uuid;
 
 use axum::Extension;
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, RequireAuth};
 use temps_core::problemdetails;
 use temps_core::problemdetails::{Problem, ProblemDetails};
 use temps_core::RequestMetadata;
@@ -485,6 +485,7 @@ async fn purge_project_logs(
     Json(request): Json<PurgeLogsRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, LogsDelete);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let before = chrono::DateTime::parse_from_rfc3339(&request.before)
         .map_err(|_| LogAggregatorError::Validation {
@@ -604,6 +605,7 @@ mod tests {
             tail_service,
             retention_service,
             audit_service,
+            project_access_checker: None,
         });
 
         TestContext {

--- a/crates/temps-log-aggregator/src/handlers/log_handler.rs
+++ b/crates/temps-log-aggregator/src/handlers/log_handler.rs
@@ -16,7 +16,7 @@ use utoipa::{OpenApi, ToSchema};
 use uuid::Uuid;
 
 use axum::Extension;
-use temps_auth::{permission_guard, project_access_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, RequireAuth, Role};
 use temps_core::problemdetails;
 use temps_core::problemdetails::{Problem, ProblemDetails};
 use temps_core::RequestMetadata;
@@ -114,6 +114,76 @@ impl From<LogAggregatorError> for Problem {
                 .with_detail(error.to_string()),
         }
     }
+}
+
+// ── External-service access guard ───────────────────────────────────────
+
+/// Guard log access for an external service by checking the caller's membership
+/// in at least one of the projects that own the service (via `project_services`).
+///
+/// This is the external-service analogue of `project_access_guard!`.  It cannot
+/// reuse that macro because a service may be linked to multiple projects, and the
+/// correct semantic is "allow when the caller has access to **any** linked project"
+/// (minimum bar) rather than the macro's single-project check.
+///
+/// Deployment tokens and instance admins bypass the check (identical semantics to
+/// `project_access_guard!`).  When no `ProjectAccessChecker` is registered this
+/// is a synchronous no-op — OSS-only binaries are unaffected.
+async fn guard_external_service_access(
+    auth: &temps_auth::AuthContext,
+    external_service_id: i32,
+    project_ids: &[i32],
+    checker: &Option<Arc<dyn temps_core::ProjectAccessChecker>>,
+) -> Result<(), Problem> {
+    // Deployment tokens are already confined by project_scope_guard! and carry
+    // no user identity — skip the team-membership check.
+    if auth.is_deployment_token() {
+        return Ok(());
+    }
+    // Instance administrators are never restricted by team membership.
+    if auth.is_admin() || auth.has_role(&Role::PlatformAdmin) {
+        return Ok(());
+    }
+    // No checker registered → no-op (matches project_access_guard! behaviour).
+    let Some(ref checker) = checker else {
+        return Ok(());
+    };
+    // user_id_opt() is always Some for non-deployment-token auth, but be safe.
+    let Some(user_id) = auth.user_id_opt() else {
+        return Ok(());
+    };
+    // Allow when the user has access to any one of the linked projects.
+    for &project_id in project_ids {
+        match checker.user_can_access_project(user_id, project_id).await {
+            Ok(true) => return Ok(()),
+            Ok(false) => {} // try next project
+            Err(e) => {
+                tracing::error!(
+                    external_service_id,
+                    project_id,
+                    user_id,
+                    error = %e,
+                    "ProjectAccessChecker infrastructure failure — denying access to \
+                     external service logs"
+                );
+                return Err(temps_core::error_builder::ErrorBuilder::new(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                )
+                .type_("https://temps.sh/probs/project-access-check-failed")
+                .title("Project Access Check Failed")
+                .detail("Could not verify project access; please try again")
+                .build());
+            }
+        }
+    }
+    // The checker denied all linked projects.
+    Err(
+        temps_core::error_builder::ErrorBuilder::new(StatusCode::FORBIDDEN)
+            .type_("https://temps.sh/probs/project-access-denied")
+            .title("Project Access Denied")
+            .detail("Your team membership does not include access to this resource")
+            .build(),
+    )
 }
 
 // ── Audit types ─────────────────────────────────────────────────────────
@@ -309,11 +379,34 @@ async fn search_logs(
     Json(request): Json<SearchLogsRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, LogsRead);
-    // `project_id` is ignored when `external_service_id` is set (external
-    // service logs aren't project-scoped), so only guard on it in the mode
-    // where it's actually the resource being accessed.
-    if request.external_service_id.is_none() {
-        project_access_guard!(auth, request.project_id, app_state.project_access_checker);
+    // When `external_service_id` is set, `project_id` is ignored by the search
+    // engine; the resource being accessed is the external service itself.
+    // Resolve its owning project(s) and check team-based access against those.
+    // When only `project_id` is set, guard on it directly as usual.
+    match request.external_service_id {
+        None => {
+            project_access_guard!(auth, request.project_id, app_state.project_access_checker);
+        }
+        Some(service_id) => {
+            let project_ids = app_state
+                .metadata_service
+                .find_owning_project_ids(service_id)
+                .await?;
+            if project_ids.is_empty() {
+                return Err(problemdetails::new(StatusCode::NOT_FOUND)
+                    .with_title("External Service Not Found")
+                    .with_detail(format!(
+                        "External service {service_id} is not associated with any project"
+                    )));
+            }
+            guard_external_service_access(
+                &auth,
+                service_id,
+                &project_ids,
+                &app_state.project_access_checker,
+            )
+            .await?;
+        }
     }
 
     let now = Utc::now();
@@ -428,11 +521,34 @@ async fn tail_logs(
     Query(request): Query<TailLogsRequest>,
 ) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, Problem> {
     permission_guard!(auth, LogsRead);
-    // `project_id` is ignored when `external_service_id` is set (external
-    // service logs aren't project-scoped), so only guard on it in the mode
-    // where it's actually the resource being accessed.
-    if request.external_service_id.is_none() {
-        project_access_guard!(auth, request.project_id, app_state.project_access_checker);
+    // When `external_service_id` is set, `project_id` is ignored by the tail
+    // service; the resource being accessed is the external service itself.
+    // Resolve its owning project(s) and check team-based access against those.
+    // When only `project_id` is set, guard on it directly as usual.
+    match request.external_service_id {
+        None => {
+            project_access_guard!(auth, request.project_id, app_state.project_access_checker);
+        }
+        Some(service_id) => {
+            let project_ids = app_state
+                .metadata_service
+                .find_owning_project_ids(service_id)
+                .await?;
+            if project_ids.is_empty() {
+                return Err(problemdetails::new(StatusCode::NOT_FOUND)
+                    .with_title("External Service Not Found")
+                    .with_detail(format!(
+                        "External service {service_id} is not associated with any project"
+                    )));
+            }
+            guard_external_service_access(
+                &auth,
+                service_id,
+                &project_ids,
+                &app_state.project_access_checker,
+            )
+            .await?;
+        }
     }
 
     let levels: Vec<LogLevel> = request
@@ -1613,6 +1729,242 @@ mod tests {
             StatusCode::FORBIDDEN,
             "Reader should get 403 on purge, got {}",
             response.status_code()
+        );
+    }
+
+    // ── External-service IDOR regression tests ─────────────────────────
+
+    /// Mock `ProjectAccessChecker` that allows access only for project IDs in
+    /// the `allowed` list.  Used to simulate team-based project access control
+    /// without needing a real database-backed implementation.
+    #[derive(Clone)]
+    struct MockProjectAccessChecker {
+        allowed: Vec<i32>,
+    }
+
+    #[async_trait]
+    impl temps_core::ProjectAccessChecker for MockProjectAccessChecker {
+        async fn user_can_access_project(
+            &self,
+            _user_id: i32,
+            project_id: i32,
+        ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(self.allowed.contains(&project_id))
+        }
+    }
+
+    /// Seed the full FK chain required for a `project_services` row:
+    ///
+    /// 1. Insert an `external_services` row (the service whose logs we guard).
+    /// 2. Insert a `projects` row (the owning project).
+    /// 3. Insert a `project_services` row linking them.
+    ///
+    /// Returns `(service_id, project_id)` using the DB-assigned auto-increment
+    /// IDs so there are no FK violations.
+    async fn seed_external_service_with_project(db: &sea_orm::DatabaseConnection) -> (i32, i32) {
+        use sea_orm::{ActiveModelTrait, Set};
+        use temps_entities::preset::Preset;
+
+        let svc = temps_entities::external_services::ActiveModel {
+            name: Set(format!("test-ext-svc-{}", Uuid::new_v4())),
+            service_type: Set("postgres".to_string()),
+            status: Set("pending".to_string()),
+            ..Default::default()
+        }
+        .insert(db)
+        .await
+        .expect("Failed to seed external_services row");
+
+        let proj = temps_entities::projects::ActiveModel {
+            name: Set("Test Project".to_string()),
+            repo_name: Set("test-repo".to_string()),
+            repo_owner: Set("test-owner".to_string()),
+            directory: Set("/test".to_string()),
+            main_branch: Set("main".to_string()),
+            slug: Set(format!("test-proj-{}", Uuid::new_v4())),
+            preset: Set(Preset::NextJs),
+            created_at: Set(Utc::now()),
+            updated_at: Set(Utc::now()),
+            ..Default::default()
+        }
+        .insert(db)
+        .await
+        .expect("Failed to seed projects row");
+
+        temps_entities::project_services::ActiveModel {
+            project_id: Set(proj.id),
+            service_id: Set(svc.id),
+            ..Default::default()
+        }
+        .insert(db)
+        .await
+        .expect("Failed to seed project_services row");
+
+        (svc.id, proj.id)
+    }
+
+    /// Build a server where the authenticated user has `Role::User` (has
+    /// `LogsRead`) AND a `ProjectAccessChecker` is active.  Tests that
+    /// exercise the external-service IDOR guard need both conditions: a
+    /// non-admin user (so the admin bypass does not fire) and a registered
+    /// checker (so the guard actually calls `user_can_access_project`).
+    fn build_server_with_user_and_checker(
+        base_state: &Arc<LogAggregatorAppState>,
+        checker: Arc<dyn temps_core::ProjectAccessChecker>,
+    ) -> TestServer {
+        let app_state = Arc::new(LogAggregatorAppState {
+            search_service: base_state.search_service.clone(),
+            metadata_service: base_state.metadata_service.clone(),
+            tail_service: base_state.tail_service.clone(),
+            retention_service: base_state.retention_service.clone(),
+            audit_service: base_state.audit_service.clone(),
+            project_access_checker: Some(checker),
+        });
+        build_test_server_with_role(app_state, temps_auth::Role::User)
+    }
+
+    /// (a) A user WITH access to the external service's owning project can
+    /// search its logs (200).
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_search_external_service_allowed_project_access() {
+        let ctx = create_test_context().await;
+        let (service_id, owning_project) =
+            seed_external_service_with_project(ctx._db.db.as_ref()).await;
+
+        let checker = Arc::new(MockProjectAccessChecker {
+            allowed: vec![owning_project],
+        });
+        let server = build_server_with_user_and_checker(&ctx.app_state, checker);
+
+        let now = Utc::now();
+        let response = server
+            .post("/logs/search")
+            .json(&serde_json::json!({
+                "project_id": 0,          // ignored when external_service_id is set
+                "external_service_id": service_id,
+                "start_time": (now - Duration::hours(1)).to_rfc3339(),
+                "end_time": (now + Duration::hours(1)).to_rfc3339(),
+            }))
+            .await;
+
+        assert_eq!(
+            response.status_code(),
+            StatusCode::OK,
+            "user with access to the owning project must be allowed; body: {}",
+            response.text()
+        );
+    }
+
+    /// (b) A user WITHOUT access to the owning project is denied (403) even
+    /// though they hold `LogsRead`.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_search_external_service_denied_project_access() {
+        let ctx = create_test_context().await;
+        let (service_id, owning_project) =
+            seed_external_service_with_project(ctx._db.db.as_ref()).await;
+
+        // Checker allows a completely different project — NOT the one that
+        // owns this service — so access must be denied.
+        let different_project = owning_project + 1_000_000;
+        let checker = Arc::new(MockProjectAccessChecker {
+            allowed: vec![different_project],
+        });
+        let server = build_server_with_user_and_checker(&ctx.app_state, checker);
+
+        let now = Utc::now();
+        let response = server
+            .post("/logs/search")
+            .json(&serde_json::json!({
+                "project_id": 0,
+                "external_service_id": service_id,
+                "start_time": (now - Duration::hours(1)).to_rfc3339(),
+                "end_time": (now + Duration::hours(1)).to_rfc3339(),
+            }))
+            .await;
+
+        assert_eq!(
+            response.status_code(),
+            StatusCode::FORBIDDEN,
+            "user without access to the owning project must be denied 403; body: {}",
+            response.text()
+        );
+    }
+
+    /// (c) An `external_service_id` with no project association must be denied
+    /// (404), not fail-open.  An allow-all checker is used so the 404 must
+    /// originate from the missing project link, not from the checker.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_search_external_service_orphaned_service() {
+        let ctx = create_test_context().await;
+        // Seed an external_services row but deliberately do NOT create a
+        // project_services row linking it to any project.
+        use sea_orm::{ActiveModelTrait, Set};
+        let orphaned_svc = temps_entities::external_services::ActiveModel {
+            name: Set(format!("orphaned-svc-{}", Uuid::new_v4())),
+            service_type: Set("postgres".to_string()),
+            status: Set("pending".to_string()),
+            ..Default::default()
+        }
+        .insert(ctx._db.db.as_ref())
+        .await
+        .expect("Failed to seed orphaned external_services row");
+
+        // Checker that allows everything — ensures the 404 comes from the
+        // missing project link, not from the checker.
+        let checker = Arc::new(MockProjectAccessChecker {
+            allowed: vec![1, 2, 3, 9999],
+        });
+        let server = build_server_with_user_and_checker(&ctx.app_state, checker);
+
+        let now = Utc::now();
+        let response = server
+            .post("/logs/search")
+            .json(&serde_json::json!({
+                "project_id": 0,
+                "external_service_id": orphaned_svc.id,
+                "start_time": (now - Duration::hours(1)).to_rfc3339(),
+                "end_time": (now + Duration::hours(1)).to_rfc3339(),
+            }))
+            .await;
+
+        assert_eq!(
+            response.status_code(),
+            StatusCode::NOT_FOUND,
+            "external service with no project link must be denied 404, not fail-open; \
+             body: {}",
+            response.text()
+        );
+    }
+
+    /// Verify the guard is also wired into `tail_logs`.  We only test the
+    /// access-denied path here (not SSE streaming); a 403 returned before the
+    /// stream is created is a plain HTTP response that axum-test handles correctly.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_tail_external_service_denied_project_access() {
+        let ctx = create_test_context().await;
+        let (service_id, _owning_project) =
+            seed_external_service_with_project(ctx._db.db.as_ref()).await;
+
+        // Checker denies all projects — proves the guard fires on tail_logs too.
+        let checker = Arc::new(MockProjectAccessChecker { allowed: vec![] });
+        let server = build_server_with_user_and_checker(&ctx.app_state, checker);
+
+        let response = server
+            .get(&format!(
+                "/logs/tail?project_id=0&external_service_id={}&service=web&env=prod",
+                service_id
+            ))
+            .await;
+
+        assert_eq!(
+            response.status_code(),
+            StatusCode::FORBIDDEN,
+            "tail_logs must also enforce project access for external_service_id; body: {}",
+            response.text()
         );
     }
 

--- a/crates/temps-log-aggregator/src/handlers/types.rs
+++ b/crates/temps-log-aggregator/src/handlers/types.rs
@@ -11,6 +11,8 @@ pub struct LogAggregatorAppState {
     pub tail_service: Arc<TailService>,
     pub retention_service: Arc<RetentionService>,
     pub audit_service: Arc<dyn AuditLogger>,
+    /// Optional checker for team-based project access (human sessions only).
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }
 
 pub async fn create_log_aggregator_app_state(
@@ -26,5 +28,6 @@ pub async fn create_log_aggregator_app_state(
         tail_service,
         retention_service,
         audit_service,
+        project_access_checker: None,
     })
 }

--- a/crates/temps-log-aggregator/src/plugin.rs
+++ b/crates/temps-log-aggregator/src/plugin.rs
@@ -548,7 +548,16 @@ impl TempsPlugin for LogAggregatorPlugin {
     }
 
     fn configure_routes(&self, context: &PluginContext) -> Option<PluginRoutes> {
-        let app_state = context.require_service::<LogAggregatorAppState>();
+        let old = context.require_service::<LogAggregatorAppState>();
+        let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
+        let app_state = Arc::new(LogAggregatorAppState {
+            search_service: old.search_service.clone(),
+            metadata_service: old.metadata_service.clone(),
+            tail_service: old.tail_service.clone(),
+            retention_service: old.retention_service.clone(),
+            audit_service: old.audit_service.clone(),
+            project_access_checker,
+        });
         let routes = handlers::configure_routes().with_state(app_state);
 
         Some(PluginRoutes::new(routes))

--- a/crates/temps-log-aggregator/src/services/metadata.rs
+++ b/crates/temps-log-aggregator/src/services/metadata.rs
@@ -322,6 +322,28 @@ impl LogMetadataService {
         Ok(events)
     }
 
+    /// Return all project IDs that have linked this external service via `project_services`.
+    ///
+    /// Used by the access guard in log handlers: when `external_service_id` is
+    /// supplied the normal project-based `project_access_guard!` cannot be used,
+    /// so the handler looks up the owning project(s) and checks team membership
+    /// against those instead.
+    ///
+    /// An empty `Vec` means the external service has no project association
+    /// (orphaned). Callers **must** treat that as a denial — there is no
+    /// legitimate use case for reading logs of an unlinked external service, and
+    /// defaulting to fail-open on an anomalous state would be an IDOR.
+    pub async fn find_owning_project_ids(
+        &self,
+        external_service_id: i32,
+    ) -> Result<Vec<i32>, LogAggregatorError> {
+        let rows = temps_entities::project_services::Entity::find()
+            .filter(temps_entities::project_services::Column::ServiceId.eq(external_service_id))
+            .all(self.db.as_ref())
+            .await?;
+        Ok(rows.into_iter().map(|ps| ps.project_id).collect())
+    }
+
     /// Find chunks older than a given timestamp for retention cleanup.
     pub async fn find_expired_chunks(
         &self,

--- a/crates/temps-monitoring/src/handlers/alarm_handlers.rs
+++ b/crates/temps-monitoring/src/handlers/alarm_handlers.rs
@@ -22,7 +22,7 @@ use axum::{
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
-use temps_auth::{permission_guard, project_scope_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, project_scope_guard, RequireAuth};
 use temps_core::{
     problemdetails::{self, Problem},
     AuditContext, AuditOperation, RequestMetadata,
@@ -39,6 +39,8 @@ use crate::alarm_service::{AlarmError, AlarmFilters, AlarmService, AlarmSummary,
 pub struct AlarmAppState {
     pub alarm_service: Arc<AlarmService>,
     pub audit_service: Arc<dyn temps_core::AuditLogger>,
+    /// Optional checker for team-based project access (human sessions only).
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -280,6 +282,7 @@ pub async fn list_project_alarms(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let page = params.page.unwrap_or(1);
     let page_size = params.page_size.unwrap_or(20);
@@ -377,6 +380,7 @@ pub async fn get_project_alarms_summary(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let summary = state
         .alarm_service
@@ -414,6 +418,7 @@ pub async fn acknowledge_alarm(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     state
         .alarm_service
@@ -468,6 +473,7 @@ pub async fn resolve_alarm(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     state
         .alarm_service

--- a/crates/temps-monitoring/src/plugin.rs
+++ b/crates/temps-monitoring/src/plugin.rs
@@ -77,10 +77,12 @@ impl TempsPlugin for MonitoringPlugin {
     fn configure_routes(&self, context: &PluginContext) -> Option<PluginRoutes> {
         let alarm_service = context.require_service::<AlarmService>();
         let audit_service = context.require_service::<dyn temps_core::AuditLogger>();
+        let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
 
         let app_state = Arc::new(AlarmAppState {
             alarm_service,
             audit_service,
+            project_access_checker,
         });
 
         let router = crate::handlers::alarm_handlers::configure_routes().with_state(app_state);

--- a/crates/temps-observability/src/handlers/events.rs
+++ b/crates/temps-observability/src/handlers/events.rs
@@ -19,7 +19,7 @@ use axum::{
 use chrono::{DateTime, Utc};
 use http::StatusCode;
 use serde::{Deserialize, Serialize};
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, RequireAuth};
 use temps_core::problemdetails::{self, Problem};
 use utoipa::{IntoParams, OpenApi, ToSchema};
 
@@ -28,9 +28,10 @@ use crate::filters::{clamp_limit, parse_kinds, EventFilters};
 use crate::service::{FullError, FullEvent, FullRequest, ObservabilityService};
 use crate::types::{ErrorRow, EventKind, ObservabilityEvent, RequestRow, RevenueRow, SpanRow};
 
-#[derive(Clone)]
 pub struct ObservabilityState {
     pub service: Arc<ObservabilityService>,
+    /// Optional checker for team-based project access (human sessions only).
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }
 
 #[derive(OpenApi)]
@@ -117,6 +118,7 @@ pub async fn observability_list_events(
     Query(query): Query<EventsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, LogsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let kinds = parse_kinds(query.kinds.as_deref())?;
     let limit = clamp_limit(query.limit);
@@ -201,6 +203,7 @@ pub async fn observability_full_event(
     Path((project_id, kind, event_id)): Path<(i32, EventKind, String)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, LogsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let event = state
         .service

--- a/crates/temps-observability/src/plugin.rs
+++ b/crates/temps-observability/src/plugin.rs
@@ -46,12 +46,8 @@ impl TempsPlugin for ObservabilityPlugin {
         Box::pin(async move {
             let db = context.require_service::<DatabaseConnection>();
             let service = Arc::new(ObservabilityService::new(db));
-            let state = Arc::new(ObservabilityState {
-                service: service.clone(),
-            });
 
             context.register_service(service);
-            context.register_service(state);
 
             debug!("Observability plugin services registered");
             Ok(())
@@ -59,7 +55,12 @@ impl TempsPlugin for ObservabilityPlugin {
     }
 
     fn configure_routes(&self, context: &PluginContext) -> Option<PluginRoutes> {
-        let state = context.require_service::<ObservabilityState>();
+        let service = context.require_service::<ObservabilityService>();
+        let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
+        let state = Arc::new(ObservabilityState {
+            service,
+            project_access_checker,
+        });
         let router: Router = configure_observability_routes().with_state(state);
         Some(PluginRoutes::new(router))
     }

--- a/crates/temps-otel/src/handlers/dashboard_handler.rs
+++ b/crates/temps-otel/src/handlers/dashboard_handler.rs
@@ -18,7 +18,7 @@ use crate::handlers::audit::{
 };
 use crate::services::dashboard_service::DashboardLayout;
 use crate::OtelAppState;
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, RequireAuth};
 use temps_core::problemdetails::Problem;
 use temps_core::{AuditContext, ProblemDetails, RequestMetadata};
 use temps_entities::metric_dashboards::Model;
@@ -128,6 +128,7 @@ pub async fn list_dashboards(
     Query(params): Query<ListDashboardsParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelRead);
+    project_access_guard!(auth, params.project_id, state.project_access_checker);
 
     let (items, total) = state
         .dashboard_service
@@ -160,6 +161,7 @@ pub async fn create_dashboard(
     Json(request): Json<CreateDashboardRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelWrite);
+    project_access_guard!(auth, request.project_id, state.project_access_checker);
 
     let model = state
         .dashboard_service
@@ -211,6 +213,7 @@ pub async fn get_dashboard(
     Query(scope): Query<DashboardScopeParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelRead);
+    project_access_guard!(auth, scope.project_id, state.project_access_checker);
 
     let model = state.dashboard_service.get(scope.project_id, id).await?;
     Ok(Json(OtelDashboardResponse::from(model)))
@@ -245,6 +248,7 @@ pub async fn update_dashboard(
     Json(request): Json<UpdateDashboardRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelWrite);
+    project_access_guard!(auth, scope.project_id, state.project_access_checker);
 
     let model = state
         .dashboard_service
@@ -293,6 +297,7 @@ pub async fn delete_dashboard(
     Query(scope): Query<DashboardScopeParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelWrite);
+    project_access_guard!(auth, scope.project_id, state.project_access_checker);
 
     state.dashboard_service.delete(scope.project_id, id).await?;
 

--- a/crates/temps-otel/src/handlers/metric_alert_handler.rs
+++ b/crates/temps-otel/src/handlers/metric_alert_handler.rs
@@ -21,7 +21,7 @@ use crate::handlers::audit::{
 use crate::services::anomaly_preview::compute_anomaly_preview;
 use crate::services::metric_alert_evaluator::SeriesStateEntry;
 use crate::OtelAppState;
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, RequireAuth};
 use temps_core::problemdetails::Problem;
 use temps_core::{AuditContext, ProblemDetails, RequestMetadata};
 use temps_entities::metric_alert_rules::Model;
@@ -342,6 +342,7 @@ pub async fn list_alerts(
     Query(params): Query<ListMetricAlertsParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelRead);
+    project_access_guard!(auth, params.project_id, state.project_access_checker);
 
     let (items, total) = state
         .metric_alert_service
@@ -380,6 +381,7 @@ pub async fn create_alert(
     Json(request): Json<CreateMetricAlertRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelWrite);
+    project_access_guard!(auth, request.project_id, state.project_access_checker);
 
     let model = state
         .metric_alert_service
@@ -446,6 +448,7 @@ pub async fn get_alert(
     Query(scope): Query<MetricAlertScopeParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelRead);
+    project_access_guard!(auth, scope.project_id, state.project_access_checker);
 
     let model = state.metric_alert_service.get(scope.project_id, id).await?;
     let mut resp = OtelMetricAlertRuleResponse::from(model);
@@ -482,6 +485,7 @@ pub async fn update_alert(
     Json(request): Json<UpdateMetricAlertRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelWrite);
+    project_access_guard!(auth, scope.project_id, state.project_access_checker);
 
     let model = state
         .metric_alert_service
@@ -549,6 +553,7 @@ pub async fn delete_alert(
     Query(scope): Query<MetricAlertScopeParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelWrite);
+    project_access_guard!(auth, scope.project_id, state.project_access_checker);
 
     // Verify ownership FIRST (404s if `id` isn't in `scope.project_id`): the
     // evaluator's in-memory maps below are keyed only by `rule_id`, not
@@ -612,6 +617,7 @@ pub async fn preview_alert(
     Json(req): Json<AnomalyPreviewRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, OtelRead);
+    project_access_guard!(auth, req.project_id, state.project_access_checker);
 
     // Preview only makes sense for a band-based (anomaly) detector.
     let params = match &req.detection_config {

--- a/crates/temps-otel/src/handlers/query_handler.rs
+++ b/crates/temps-otel/src/handlers/query_handler.rs
@@ -19,7 +19,9 @@ use crate::services::cross_project::is_valid_trace_id;
 use crate::services::{CrossProjectTraceError, SiblingRef, UnifiedTrace};
 use crate::types::*;
 use crate::OtelAppState;
-use temps_auth::{deny_deployment_token, permission_guard, project_scope_guard, RequireAuth};
+use temps_auth::{
+    deny_deployment_token, permission_guard, project_access_guard, project_scope_guard, RequireAuth,
+};
 use temps_core::problemdetails::{self, Problem};
 use temps_core::{AuditContext, ProblemDetails, RequestMetadata};
 
@@ -315,6 +317,7 @@ pub async fn query_metrics(
     // Confine a project-scoped deployment token to its own project (no-op for
     // user/API-key/session auth).
     project_scope_guard!(auth, params.project_id);
+    project_access_guard!(auth, params.project_id, state.project_access_checker);
 
     let query = MetricQuery {
         project_id: params.project_id,
@@ -374,6 +377,7 @@ pub async fn list_metric_names(
     // Confine a project-scoped deployment token to its own project (no-op for
     // user/API-key/session auth).
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let names = state.otel_service.list_metric_names(project_id).await?;
     Ok(Json(OtelMetricNamesResponse { names }))
@@ -408,6 +412,7 @@ pub async fn list_metric_label_keys(
     // Confine a project-scoped deployment token to its own project's telemetry
     // (no-op for user/API-key/session auth).
     project_scope_guard!(auth, params.project_id);
+    project_access_guard!(auth, params.project_id, state.project_access_checker);
 
     let (start, end) = discovery_window(params.start_time.as_deref(), params.end_time.as_deref());
     let keys = state
@@ -448,6 +453,7 @@ pub async fn list_metric_label_values(
     // Confine a project-scoped deployment token to its own project's telemetry
     // (no-op for user/API-key/session auth).
     project_scope_guard!(auth, params.project_id);
+    project_access_guard!(auth, params.project_id, state.project_access_checker);
 
     let (start, end) = discovery_window(params.start_time.as_deref(), params.end_time.as_deref());
     let values = state
@@ -498,6 +504,7 @@ pub async fn query_traces(
     // Confine a project-scoped deployment token to its own project (no-op for
     // user/API-key/session auth).
     project_scope_guard!(auth, params.project_id);
+    project_access_guard!(auth, params.project_id, state.project_access_checker);
 
     let status = params.status.as_deref().map(|s| match s {
         "OK" | "ok" => SpanStatusCode::Ok,
@@ -573,6 +580,7 @@ pub async fn query_trace_summaries(
     // Confine a project-scoped deployment token to its own project (no-op for
     // user/API-key/session auth).
     project_scope_guard!(auth, params.project_id);
+    project_access_guard!(auth, params.project_id, state.project_access_checker);
 
     let status = params.status.as_deref().map(|s| match s {
         "OK" | "ok" => SpanStatusCode::Ok,
@@ -680,6 +688,7 @@ pub async fn get_trace(
     // Confine a project-scoped deployment token to its own project (no-op for
     // user/API-key/session auth).
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let data = state.otel_service.get_trace(project_id, &trace_id).await?;
     let count = data.len();
@@ -720,6 +729,7 @@ pub async fn query_logs(
     // Confine a project-scoped deployment token to its own project (no-op for
     // user/API-key/session auth).
     project_scope_guard!(auth, params.project_id);
+    project_access_guard!(auth, params.project_id, state.project_access_checker);
 
     let severity = params.severity.as_deref().map(|s| match s {
         "TRACE" | "trace" => LogSeverity::Trace,
@@ -778,6 +788,7 @@ pub async fn list_insights(
     // Confine a project-scoped deployment token to its own project (no-op for
     // user/API-key/session auth).
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let status = params.status.as_deref().map(|s| match s {
         "resolved" => InsightStatus::Resolved,
@@ -823,6 +834,7 @@ pub async fn get_health(
     // Confine a project-scoped deployment token to its own project (no-op for
     // user/API-key/session auth).
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let summaries = state
         .otel_service
@@ -857,6 +869,7 @@ pub async fn get_quota(
     // Confine a project-scoped deployment token to its own project (no-op for
     // user/API-key/session auth).
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let quota = state.otel_service.get_storage_quota(project_id).await?;
     Ok(Json(QuotaResponse { quota }))
@@ -918,6 +931,7 @@ pub async fn query_genai_traces(
     // Confine a project-scoped deployment token to its own project (no-op for
     // user/API-key/session auth).
     project_scope_guard!(auth, params.project_id);
+    project_access_guard!(auth, params.project_id, state.project_access_checker);
 
     // Build attribute filters. For gen_ai_system, we use gen_ai.provider.name (current)
     // but the SQL also handles the deprecated gen_ai.system via COALESCE.
@@ -987,6 +1001,7 @@ pub async fn get_genai_trace(
     // Confine a project-scoped deployment token to its own project (no-op for
     // user/API-key/session auth).
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let spans = state
         .otel_service

--- a/crates/temps-otel/src/lib.rs
+++ b/crates/temps-otel/src/lib.rs
@@ -99,4 +99,6 @@ pub struct OtelAppState {
     /// banner) and `GET /otel/global/traces/{trace_id}` (Phase 2 unified
     /// waterfall) query handlers.
     pub cross_project_service: std::sync::Arc<crate::services::CrossProjectTraceService>,
+    /// Optional checker for team-based project access (human sessions only).
+    pub project_access_checker: Option<std::sync::Arc<dyn temps_core::ProjectAccessChecker>>,
 }

--- a/crates/temps-otel/src/plugin.rs
+++ b/crates/temps-otel/src/plugin.rs
@@ -507,7 +507,8 @@ impl TempsPlugin for OtelPlugin {
                 ))
             };
 
-            // Create app state for handlers
+            // Create app state for handlers. The `project_access_checker` is
+            // injected in `configure_routes` (after all services register).
             let app_state = OtelAppState {
                 otel_service: otel_service.clone(),
                 metrics_store: Some(metrics_store.clone()),
@@ -518,6 +519,7 @@ impl TempsPlugin for OtelPlugin {
                 audit_service: audit_service.clone(),
                 trace_hint_tx: Some(trace_hint_tx),
                 cross_project_service: cross_project_service.clone(),
+                project_access_checker: None,
             };
             context.register_service(Arc::new(app_state.clone()));
 
@@ -664,7 +666,9 @@ impl TempsPlugin for OtelPlugin {
 
     fn configure_routes(&self, context: &PluginContext) -> Option<PluginRoutes> {
         let app_state_arc = context.require_service::<OtelAppState>();
-        let app_state: OtelAppState = app_state_arc.as_ref().clone();
+        let mut app_state: OtelAppState = app_state_arc.as_ref().clone();
+        app_state.project_access_checker =
+            context.get_service::<dyn temps_core::ProjectAccessChecker>();
 
         let router = handlers::configure_routes().with_state(app_state);
 

--- a/crates/temps-otel/tests/dynamic_alert_integration_test.rs
+++ b/crates/temps-otel/tests/dynamic_alert_integration_test.rs
@@ -684,6 +684,7 @@ async fn test_delete_alert_rejects_cross_project_rule_id_before_touching_evaluat
         audit_service: Arc::new(NoOpAuditLogger),
         cross_project_service,
         trace_hint_tx: None,
+        project_access_checker: None,
     };
 
     let attacker_auth = AuthContext::new_session(attacker_user, Role::Admin);

--- a/crates/temps-otel/tests/e2e_http_test.rs
+++ b/crates/temps-otel/tests/e2e_http_test.rs
@@ -223,6 +223,7 @@ async fn setup_e2e() -> Option<(
         audit_service: Arc::new(NoOpAuditLogger),
         cross_project_service,
         trace_hint_tx: None,
+        project_access_checker: None,
     };
 
     // Create auth middleware that injects AuthContext into request extensions.

--- a/crates/temps-projects/src/handlers/custom_domains.rs
+++ b/crates/temps-projects/src/handlers/custom_domains.rs
@@ -11,7 +11,7 @@ use axum::{
 };
 use sea_orm::EntityTrait;
 use std::sync::Arc;
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, RequireAuth};
 use temps_core::problemdetails;
 use temps_core::problemdetails::Problem;
 use temps_entities::{domains, environments, project_custom_domains};
@@ -67,6 +67,7 @@ pub async fn create_custom_domain(
     Json(request): Json<CustomDomainRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     info!(
         "Creating custom domain: {} for project: {}",
@@ -126,6 +127,7 @@ pub async fn get_custom_domain(
     Path((project_id, domain_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     info!(
         "Getting custom domain: {} for project: {}",
@@ -180,6 +182,7 @@ pub async fn list_custom_domains_for_project(
     Path(project_id): Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     info!("Listing custom domains for project: {}", project_id);
 
@@ -233,6 +236,7 @@ pub async fn update_custom_domain(
     Json(request): Json<UpdateCustomDomainRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     info!(
         "Updating custom domain: {} for project: {}",
@@ -332,6 +336,7 @@ pub async fn delete_custom_domain(
     Path((project_id, domain_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsDelete);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     info!(
         "Deleting custom domain: {} for project: {}",
@@ -389,6 +394,7 @@ pub async fn link_custom_domain_to_certificate(
     Path((project_id, domain_id, certificate_id)): Path<(i32, i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     info!(
         "Linking custom domain: {} to certificate: {} for project: {}",

--- a/crates/temps-projects/src/handlers/handlers.rs
+++ b/crates/temps-projects/src/handlers/handlers.rs
@@ -348,10 +348,15 @@ pub async fn get_project_by_slug(
     Path(slug): Path<String>,
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, ProjectsRead);
+    permission_guard!(auth, ProjectsRead); // 1. instance-wide role check
 
     debug!("get project by slug called with slug: {}", slug);
+    // Resolve the project first so we have the numeric ID for the guards.
+    // Guards must run on the resolved ID — not skipped because the caller
+    // used a slug instead of an ID path.
     let project = state.project_service.get_project_by_slug(&slug).await?;
+    project_scope_guard!(auth, project.id); // 2. deployment-token IDOR check
+    project_access_guard!(auth, project.id, state.project_access_checker); // 3. team-based access
     Ok(Json(ProjectResponse::map_from_project(project)).into_response())
 }
 
@@ -383,6 +388,7 @@ pub async fn update_project(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
     project_scope_guard!(auth, id);
+    project_access_guard!(auth, id, state.project_access_checker);
 
     let project_req = crate::services::types::CreateProjectRequest {
         name: project.name.clone(),
@@ -467,6 +473,7 @@ pub async fn change_project_source(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
     project_scope_guard!(auth, id);
+    project_access_guard!(auth, id, state.project_access_checker);
 
     let updated = state
         .project_service
@@ -525,6 +532,7 @@ pub async fn delete_project(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsDelete);
     project_scope_guard!(auth, id);
+    project_access_guard!(auth, id, state.project_access_checker);
 
     // Get project details before deletion
     let project = state.project_service.get_project(id).await?;
@@ -585,6 +593,7 @@ pub async fn update_project_settings(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let updated_project = state
         .project_service
@@ -671,6 +680,7 @@ pub async fn update_automatic_deploy(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     info!(
         "Updating automatic deployment setting for project: {}",
@@ -728,6 +738,7 @@ pub async fn update_git_settings(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     info!(
         "Updating git settings for project: {} (branch: {}, repo: {}/{})",
@@ -819,6 +830,7 @@ pub async fn reinstall_gitlab_webhook(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     info!("Reinstalling GitLab webhook for project: {}", project_id);
 
@@ -894,6 +906,7 @@ pub async fn update_project_deployment_config(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     info!("Updating deployment config for project: {}", project_id);
 
@@ -992,6 +1005,7 @@ pub async fn trigger_project_pipeline(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
     project_scope_guard!(auth, id);
+    project_access_guard!(auth, id, state.project_access_checker);
 
     info!("Triggering pipeline for project with id: {}", id);
 
@@ -1710,6 +1724,51 @@ pub async fn create_project_from_template(
 #[cfg(test)]
 mod tests {
     use super::parse_owner_repo_from_git_url;
+
+    /// Regression test for ADR-028 finding #2: `get_project_by_slug` guard bypass.
+    ///
+    /// Before the fix, `GET /projects/by-slug/{slug}` only called
+    /// `permission_guard!` and skipped both `project_scope_guard!` and
+    /// `project_access_guard!`. Any authenticated user with `ProjectsRead`
+    /// could bypass team-access restrictions by using the slug endpoint
+    /// instead of the numeric-ID endpoint — slugs are guessable (used in
+    /// deployment URLs, CLI output, and webhook paths).
+    ///
+    /// After the fix, the handler resolves the project first and then applies
+    /// both guards using the resolved `project.id`, matching the guard order
+    /// in `get_project`.
+    ///
+    /// This test scans the handler source to verify both guards are present,
+    /// which catches the regression if either is removed while leaving the
+    /// rest of the function intact.
+    #[test]
+    fn get_project_by_slug_applies_scope_and_access_guards_on_resolved_id() {
+        let source = include_str!("handlers.rs");
+
+        // Locate the function body.
+        let fn_start = source
+            .find("pub async fn get_project_by_slug")
+            .expect("get_project_by_slug handler not found in source");
+        // Extract up to the start of the next pub async fn so we scope to
+        // just this handler and avoid false-positives from other functions.
+        let after_start = &source[fn_start + 1..];
+        let next_fn_offset = after_start
+            .find("pub async fn")
+            .unwrap_or(after_start.len());
+        let fn_body = &source[fn_start..fn_start + 1 + next_fn_offset];
+
+        assert!(
+            fn_body.contains("project_scope_guard!(auth, project.id)"),
+            "get_project_by_slug must call project_scope_guard! on the resolved project.id \
+             to block cross-project deployment-token IDOR via slug"
+        );
+        assert!(
+            fn_body
+                .contains("project_access_guard!(auth, project.id, state.project_access_checker)"),
+            "get_project_by_slug must call project_access_guard! on the resolved project.id \
+             to enforce team-based access (the same guard get_project applies)"
+        );
+    }
 
     #[test]
     fn parses_https_url_with_dot_git() {

--- a/crates/temps-providers/src/handlers/handlers.rs
+++ b/crates/temps-providers/src/handlers/handlers.rs
@@ -10,7 +10,9 @@ use axum::{
     Json, Router,
 };
 use temps_auth::RequireAuth;
-use temps_auth::{deny_deployment_token, permission_guard, project_scope_guard};
+use temps_auth::{
+    deny_deployment_token, permission_guard, project_access_guard, project_scope_guard,
+};
 use temps_core::{
     error_builder::{
         bad_request, conflict, forbidden, internal_server_error, not_found, ErrorBuilder,
@@ -1846,6 +1848,7 @@ async fn list_project_services(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let (page, page_size) = pagination.normalize();
 
@@ -1888,6 +1891,7 @@ async fn get_service_environment_variable(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
     super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     match app_state
@@ -1932,6 +1936,7 @@ async fn get_service_environment_variables(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
     super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     let options = EnvironmentVariableOptions {
@@ -1981,6 +1986,7 @@ async fn get_project_service_environment_variables(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
     project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     match app_state
         .external_service_manager

--- a/crates/temps-providers/src/handlers/types.rs
+++ b/crates/temps-providers/src/handlers/types.rs
@@ -33,6 +33,8 @@ pub struct AppState {
     /// Telemetry reporter — fire-and-forget anonymous usage events.
     /// Defaults to a no-op when telemetry is not registered.
     pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
+    /// Optional checker for team-based project access (human sessions only).
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]

--- a/crates/temps-providers/src/plugin.rs
+++ b/crates/temps-providers/src/plugin.rs
@@ -111,6 +111,8 @@ impl TempsPlugin for ProvidersPlugin {
         // Create QueryService
         let query_service = Arc::new(crate::QueryService::new(external_service_manager.clone()));
 
+        let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
+
         // Create AppState for handlers
         let app_state = Arc::new(AppState {
             external_service_manager,
@@ -122,6 +124,7 @@ impl TempsPlugin for ProvidersPlugin {
             api_key_service,
             config_service,
             telemetry,
+            project_access_checker,
         });
 
         // Configure routes with the app state

--- a/crates/temps-revenue/src/handlers/management.rs
+++ b/crates/temps-revenue/src/handlers/management.rs
@@ -15,7 +15,7 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, RequireAuth};
 use temps_core::error_builder::ErrorBuilder;
 use temps_core::problemdetails::Problem;
 use temps_core::{AuditContext, AuditLogger, RequestMetadata};
@@ -40,6 +40,8 @@ pub struct ManagementState {
     pub analytics: Arc<RevenueAnalyticsService>,
     pub import: Arc<RevenueImportService>,
     pub audit: Arc<dyn AuditLogger>,
+    /// Optional checker for team-based project access (human sessions only).
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }
 
 impl ManagementState {
@@ -48,12 +50,14 @@ impl ManagementState {
         analytics: Arc<RevenueAnalyticsService>,
         import: Arc<RevenueImportService>,
         audit: Arc<dyn AuditLogger>,
+        project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
     ) -> Self {
         Self {
             integrations,
             analytics,
             import,
             audit,
+            project_access_checker,
         }
     }
 }
@@ -445,6 +449,7 @@ async fn revenue_list_integrations(
     Path(project_id): Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let rows = state
         .integrations
         .list_for_project(project_id)
@@ -481,6 +486,7 @@ async fn revenue_create_integration(
     Json(body): Json<CreateIntegrationBody>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let input = CreateIntegrationInput {
         project_id,
         provider: body.provider.clone(),
@@ -531,6 +537,7 @@ async fn revenue_delete_integration(
     Path((project_id, integration_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     // Fetch first so the audit log captures what was deleted.
     let existing = state
         .integrations
@@ -580,6 +587,7 @@ async fn revenue_rotate_token(
     Path((project_id, integration_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let updated = state
         .integrations
         .rotate_path_token(project_id, integration_id)
@@ -632,6 +640,7 @@ async fn revenue_update_secret(
     Json(body): Json<UpdateSecretBody>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let updated = state
         .integrations
         .update_signing_secret(project_id, integration_id, &body.signing_secret)
@@ -685,6 +694,7 @@ async fn revenue_update_config(
     Json(body): Json<UpdateConfigBody>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let cleared = body.config.is_none();
     let updated = state
         .integrations
@@ -732,6 +742,7 @@ async fn revenue_metrics_summary(
     Query(q): Query<SummaryQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let currency = q.currency.as_deref().unwrap_or("usd");
     let summary = state
         .analytics
@@ -849,6 +860,7 @@ async fn revenue_metrics_mrr(
     Query(q): Query<MrrQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let (from, to) = default_range(q.from, q.to);
     let bucket =
         Bucket::parse(q.bucket.as_deref().unwrap_or("day")).map_err(analytics_error_to_problem)?;
@@ -888,6 +900,7 @@ async fn revenue_metrics_customers(
     Query(q): Query<MovementQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let (from, to) = default_range(q.from, q.to);
     let bucket =
         Bucket::parse(q.bucket.as_deref().unwrap_or("day")).map_err(analytics_error_to_problem)?;
@@ -924,6 +937,7 @@ async fn revenue_recent_events(
     Query(q): Query<RecentEventsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let limit = q.limit.unwrap_or(50);
     let rows = state
         .analytics
@@ -1069,6 +1083,7 @@ async fn revenue_import_subscriptions_csv(
     multipart: Multipart,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let bytes = read_csv_field(multipart).await?;
     let outcome = state
         .import
@@ -1136,6 +1151,7 @@ async fn revenue_import_invoices_csv(
     multipart: Multipart,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
     let bytes = read_csv_field(multipart).await?;
     let outcome = state
         .import

--- a/crates/temps-revenue/src/plugin.rs
+++ b/crates/temps-revenue/src/plugin.rs
@@ -76,6 +76,7 @@ impl TempsPlugin for RevenuePlugin {
                 analytics.clone(),
                 import.clone(),
                 audit,
+                None,
             ));
             let public_state = Arc::new(PublicState::new(ingestion.clone()));
 
@@ -92,7 +93,18 @@ impl TempsPlugin for RevenuePlugin {
     }
 
     fn configure_routes(&self, context: &PluginContext) -> Option<PluginRoutes> {
-        let state = context.require_service::<ManagementState>();
+        let integrations = context.require_service::<RevenueIntegrationService>();
+        let analytics = context.require_service::<RevenueAnalyticsService>();
+        let import = context.require_service::<RevenueImportService>();
+        let audit = context.require_service::<dyn AuditLogger>();
+        let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
+        let state = Arc::new(ManagementState::new(
+            integrations,
+            analytics,
+            import,
+            audit,
+            project_access_checker,
+        ));
         let router: Router = configure_management_routes().with_state(state);
         Some(PluginRoutes::new(router))
     }

--- a/crates/temps-status-page/src/plugin.rs
+++ b/crates/temps-status-page/src/plugin.rs
@@ -215,9 +215,12 @@ impl TempsPlugin for StatusPagePlugin {
             .get_service::<dyn temps_core::TelemetryReporter>()
             .unwrap_or_else(|| Arc::new(temps_core::telemetry::NoopTelemetryReporter));
 
+        let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
+
         struct AppState {
             status_page_service: Arc<StatusPageService>,
             telemetry: Arc<dyn temps_core::TelemetryReporter>,
+            project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
         }
 
         impl StatusPageAppState for AppState {
@@ -228,11 +231,16 @@ impl TempsPlugin for StatusPagePlugin {
             fn telemetry(&self) -> &Arc<dyn temps_core::TelemetryReporter> {
                 &self.telemetry
             }
+
+            fn project_access_checker(&self) -> Option<Arc<dyn temps_core::ProjectAccessChecker>> {
+                self.project_access_checker.clone()
+            }
         }
 
         let app_state = Arc::new(AppState {
             status_page_service,
             telemetry,
+            project_access_checker,
         });
 
         let routes = create_router().with_state(app_state);

--- a/crates/temps-status-page/src/routes/status_page.rs
+++ b/crates/temps-status-page/src/routes/status_page.rs
@@ -8,7 +8,7 @@ use axum::{
     Json, Router,
 };
 use serde::Deserialize;
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, RequireAuth};
 use temps_core::error_builder::{bad_request, internal_server_error, not_found};
 use temps_core::problemdetails::Problem;
 use temps_core::DateTime;
@@ -25,6 +25,8 @@ use crate::services::{
 pub trait StatusPageAppState: Send + Sync + 'static {
     fn status_page_service(&self) -> &StatusPageService;
     fn telemetry(&self) -> &std::sync::Arc<dyn temps_core::TelemetryReporter>;
+    /// Optional checker for team-based project access (human sessions only).
+    fn project_access_checker(&self) -> Option<Arc<dyn temps_core::ProjectAccessChecker>>;
 }
 
 /// OpenAPI documentation for status page endpoints
@@ -136,6 +138,7 @@ where
     T: StatusPageAppState,
 {
     permission_guard!(auth, StatusPageRead);
+    project_access_guard!(auth, project_id, app_state.project_access_checker());
     app_state
         .status_page_service()
         .get_status_overview(project_id, query.environment_id)
@@ -172,6 +175,7 @@ where
     T: StatusPageAppState,
 {
     permission_guard!(auth, StatusPageCreate);
+    project_access_guard!(auth, project_id, app_state.project_access_checker());
     let monitor = app_state
         .status_page_service()
         .monitor_service()
@@ -214,6 +218,7 @@ where
     T: StatusPageAppState,
 {
     permission_guard!(auth, StatusPageRead);
+    project_access_guard!(auth, project_id, app_state.project_access_checker());
     app_state
         .status_page_service()
         .monitor_service()
@@ -451,6 +456,7 @@ where
     T: StatusPageAppState,
 {
     permission_guard!(auth, StatusPageCreate);
+    project_access_guard!(auth, project_id, app_state.project_access_checker());
     app_state
         .status_page_service()
         .incident_service()
@@ -490,6 +496,7 @@ where
     T: StatusPageAppState,
 {
     permission_guard!(auth, StatusPageRead);
+    project_access_guard!(auth, project_id, app_state.project_access_checker());
     let (incidents, total) = app_state
         .status_page_service()
         .incident_service()
@@ -649,6 +656,7 @@ where
     T: StatusPageAppState,
 {
     permission_guard!(auth, StatusPageRead);
+    project_access_guard!(auth, project_id, app_state.project_access_checker());
     let interval = bucket_query.interval.as_deref().unwrap_or("hourly");
 
     app_state

--- a/crates/temps-vulnerability-scanner/src/handlers/mod.rs
+++ b/crates/temps-vulnerability-scanner/src/handlers/mod.rs
@@ -11,6 +11,8 @@ pub struct VulnerabilityScannerAppState {
     pub audit_service: Arc<dyn temps_core::AuditLogger>,
     pub db: Arc<temps_database::DbConnection>,
     pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
+    /// Optional checker for team-based project access (human sessions only).
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }
 
 pub async fn create_vulnerability_scanner_app_state(
@@ -24,6 +26,7 @@ pub async fn create_vulnerability_scanner_app_state(
         audit_service,
         db,
         telemetry,
+        project_access_checker: None,
     })
 }
 

--- a/crates/temps-vulnerability-scanner/src/handlers/scans_handler.rs
+++ b/crates/temps-vulnerability-scanner/src/handlers/scans_handler.rs
@@ -9,8 +9,8 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use temps_auth::permission_guard;
 use temps_auth::RequireAuth;
+use temps_auth::{permission_guard, project_access_guard};
 use temps_core::problemdetails;
 use temps_core::problemdetails::{Problem, ProblemDetails};
 use tracing::{error, info};
@@ -271,6 +271,7 @@ async fn list_project_scans(
     Query(query): Query<ListScansQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, VulnerabilityScansRead);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let (scans, total) = app_state
         .scan_service
@@ -314,6 +315,7 @@ async fn trigger_scan(
     use temps_entities::{deployments, environments};
 
     permission_guard!(auth, VulnerabilityScansCreate);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     // Fetch environment to get current deployment
     let environment = environments::Entity::find_by_id(request.environment_id)
@@ -529,6 +531,7 @@ async fn get_latest_scan(
     Query(query): Query<serde_json::Value>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, VulnerabilityScansRead);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let environment_id = query
         .get("environment_id")
@@ -570,6 +573,7 @@ async fn get_latest_scans_per_environment(
     Path(project_id): Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, VulnerabilityScansRead);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let scans = app_state
         .scan_service

--- a/crates/temps-vulnerability-scanner/src/plugin.rs
+++ b/crates/temps-vulnerability-scanner/src/plugin.rs
@@ -97,12 +97,19 @@ impl TempsPlugin for VulnerabilityScannerPlugin {
     }
 
     fn configure_routes(&self, context: &PluginContext) -> Option<PluginRoutes> {
-        // Get the VulnerabilityScannerAppState (returns Arc<Arc> because .into() wrapped it)
-        let scanner_app_state = context.require_service::<VulnerabilityScannerAppState>();
+        // Rebuild the state so we can inject the access checker (available only
+        // after all register_services calls have completed).
+        let old = context.require_service::<VulnerabilityScannerAppState>();
+        let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
+        let scanner_app_state = Arc::new(VulnerabilityScannerAppState {
+            scan_service: old.scan_service.clone(),
+            audit_service: old.audit_service.clone(),
+            db: old.db.clone(),
+            telemetry: old.telemetry.clone(),
+            project_access_checker,
+        });
 
-        // Configure routes - pass Arc directly
         let scanner_routes = handlers::configure_routes().with_state(scanner_app_state);
-
         Some(PluginRoutes::new(scanner_routes))
     }
 

--- a/crates/temps-webhooks/src/handlers.rs
+++ b/crates/temps-webhooks/src/handlers.rs
@@ -11,7 +11,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, RequireAuth};
 use temps_core::error_builder::ErrorBuilder;
 use temps_core::problemdetails::Problem;
 use temps_core::{AuditContext, AuditLogger, AuditOperation, RequestMetadata};
@@ -22,6 +22,8 @@ use utoipa::{OpenApi, ToSchema};
 pub struct WebhookState {
     pub webhook_service: Arc<WebhookService>,
     pub audit_service: Arc<dyn AuditLogger>,
+    /// Optional checker for team-based project access (human sessions only).
+    pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 }
 
 impl WebhookState {
@@ -29,6 +31,7 @@ impl WebhookState {
         Self {
             webhook_service,
             audit_service,
+            project_access_checker: None,
         }
     }
 }
@@ -233,6 +236,7 @@ async fn list_webhooks(
     Query(pagination): Query<temps_core::PaginationParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, WebhooksRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let (page, page_size) = pagination.normalize();
 
@@ -279,6 +283,7 @@ async fn get_webhook(
     Path((project_id, webhook_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, WebhooksRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     match state.webhook_service.get_webhook(webhook_id).await {
         Ok(Some(webhook)) => {
@@ -329,6 +334,7 @@ async fn create_webhook(
     Json(body): Json<CreateWebhookRequestBody>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, WebhooksCreate);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     // Parse event types
     let events: Vec<WebhookEventType> = body
@@ -409,6 +415,7 @@ async fn update_webhook(
     Json(body): Json<UpdateWebhookRequestBody>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, WebhooksWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     // Verify webhook belongs to project
     if let Ok(Some(existing)) = state.webhook_service.get_webhook(webhook_id).await {
@@ -495,6 +502,7 @@ async fn delete_webhook(
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, WebhooksDelete);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     // Verify webhook belongs to project
     if let Ok(Some(existing)) = state.webhook_service.get_webhook(webhook_id).await {
@@ -563,6 +571,7 @@ async fn list_deliveries(
     Query(query): Query<ListDeliveriesQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, WebhooksRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     // Verify webhook belongs to project
     if let Ok(Some(existing)) = state.webhook_service.get_webhook(webhook_id).await {
@@ -621,6 +630,7 @@ async fn get_delivery(
     Path((project_id, webhook_id, delivery_id)): Path<(i32, i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, WebhooksRead);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     // Verify webhook belongs to project
     if let Ok(Some(existing)) = state.webhook_service.get_webhook(webhook_id).await {
@@ -679,10 +689,11 @@ async fn get_delivery(
 async fn retry_delivery(
     RequireAuth(auth): RequireAuth,
     State(state): State<Arc<WebhookState>>,
-    Path((_project_id, webhook_id, delivery_id)): Path<(i32, i32, i32)>,
+    Path((project_id, webhook_id, delivery_id)): Path<(i32, i32, i32)>,
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, WebhooksWrite);
+    project_access_guard!(auth, project_id, state.project_access_checker);
 
     match state.webhook_service.retry_delivery(delivery_id).await {
         Ok(result) => {

--- a/crates/temps-webhooks/src/plugin.rs
+++ b/crates/temps-webhooks/src/plugin.rs
@@ -98,12 +98,15 @@ impl TempsPlugin for WebhooksPlugin {
     }
 
     fn configure_routes(&self, context: &PluginContext) -> Option<PluginRoutes> {
-        // Get the webhook state
-        let webhook_state = context.require_service::<WebhookState>();
+        let old = context.require_service::<WebhookState>();
+        let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
+        let webhook_state = Arc::new(WebhookState {
+            webhook_service: old.webhook_service.clone(),
+            audit_service: old.audit_service.clone(),
+            project_access_checker,
+        });
 
-        // Build webhook routes using the existing configure_routes function
         let routes = configure_routes().with_state(webhook_state);
-
         Some(PluginRoutes::new(routes))
     }
 

--- a/docs/adr/028-project-scoped-rbac-enforcement.md
+++ b/docs/adr/028-project-scoped-rbac-enforcement.md
@@ -5,7 +5,7 @@
 - **Deciders:** David
 - **Supersedes:** —
 - **Related:** ADR 009 (secrets-manager resolver, reuses the same optional-extension-point pattern); this ADR is also a prerequisite for a planned follow-on feature that assigns fine-grained, per-project permission sets to individual users.
-- **Related crates (OSS):** `temps-core` (new `ProjectAccessChecker` trait), `temps-auth` (new `project_access_guard!` macro), all ~18 OSS crates with project-scoped handlers
+- **Related crates (OSS):** `temps-core` (new `ProjectAccessChecker` trait), `temps-auth` (new `project_access_guard!` macro), all ~17 OSS crates with project-scoped handlers
 - **Security review required:** Yes. Per project CLAUDE.md, security-sensitive changes require `security-auditor` sign-off before merge. This ADR governs a missing authorization enforcement boundary in a team-based access-control feature — an IDOR class of gap where any authenticated user with a sufficient instance-wide role can read or modify any project on the instance regardless of team membership.
 
 ---
@@ -36,10 +36,10 @@ Two project-scoping guards already exist in `temps-auth`:
 
 A codebase scan across `temps/crates/` (excluding generated entities and migrations) finds:
 
-- **~94 OSS handler functions** that take a `project_id` as a path parameter (`Path(project_id): Path<i32>`), spread across **~18 crates**: `temps-deployments` (9), `temps-environments` (7), `temps-analytics-events` (11), `temps-error-tracking` (13), `temps-agents` (11), `temps-projects` (7), `temps-status-page` (6), `temps-revenue` (6), `temps-vulnerability-scanner` (4), `temps-otel` (4), `temps-analytics-funnels` (4), `temps-ai-chat` (3), `temps-webhooks` (2), `temps-providers` (2), `temps-monitoring` (2), `temps-observability` (1), `temps-log-aggregator` (1), `temps-auth` (1).
+- **~94 OSS handler functions** that take a `project_id` as a path parameter (`Path(project_id): Path<i32>`), spread across **~17 crates**: `temps-deployments` (9), `temps-environments` (7), `temps-analytics-events` (11), `temps-error-tracking` (13), `temps-agents` (11), `temps-projects` (7), `temps-status-page` (6), `temps-revenue` (6), `temps-vulnerability-scanner` (4), `temps-otel` (4), `temps-analytics-funnels` (4), `temps-ai-chat` (3), `temps-webhooks` (2), `temps-providers` (2), `temps-monitoring` (2), `temps-observability` (1), `temps-log-aggregator` (1). (Note: the original scan counted `temps-auth` (1), but that was a false positive — all `temps-auth` handlers are instance-wide, e.g. login/logout/register, not project-scoped. The count is 17 affected crates, corrected during implementation review.)
 - **~117 existing `project_scope_guard!` call sites** across 13 crates — covering deployment-token IDOR, unrelated to the team-access gap.
 
-This means the fix is "add a check to ~94 handlers across ~18 crates," not a trivial wrapping of a handful of endpoints. The design must minimize per-handler boilerplate.
+This means the fix is "add a check to ~94 handlers across ~17 crates," not a trivial wrapping of a handful of endpoints. The design must minimize per-handler boilerplate.
 
 ### Why this blocks a planned fine-grained permissions feature
 
@@ -185,7 +185,7 @@ pub project_access_checker: Option<Arc<dyn temps_core::ProjectAccessChecker>>,
 
 `configure_routes` runs after `initialize_plugin_services` for all plugins, so by the time each plugin constructs its `AppState`, a checker registered by the team-access plugin is guaranteed to be present in the registry. This matches the comment in `temps-deployments/src/handlers/types.rs:44–49` and the identical reasoning for `deployment_gate`.
 
-Affected crates (18): `temps-deployments`, `temps-environments`, `temps-analytics-events`, `temps-error-tracking`, `temps-agents`, `temps-projects`, `temps-status-page`, `temps-revenue`, `temps-vulnerability-scanner`, `temps-otel`, `temps-analytics-funnels`, `temps-ai-chat`, `temps-webhooks`, `temps-providers`, `temps-monitoring`, `temps-observability`, `temps-log-aggregator`, `temps-auth`.
+Affected crates (17): `temps-deployments`, `temps-environments`, `temps-analytics-events`, `temps-error-tracking`, `temps-agents`, `temps-projects`, `temps-status-page`, `temps-revenue`, `temps-vulnerability-scanner`, `temps-otel`, `temps-analytics-funnels`, `temps-ai-chat`, `temps-webhooks`, `temps-providers`, `temps-monitoring`, `temps-observability`, `temps-log-aggregator`.
 
 ### 4. The team-access plugin registers the `ProjectAccessChecker` implementation
 
@@ -362,7 +362,7 @@ Rejected: the Temps data model uses a shared schema with Sea-ORM and does not se
 - Uses the established `DeploymentGate`-style optional extension point pattern — no new architectural precedent, no new class of coupling.
 
 ### Negative
-- ~94 OSS handler functions across ~18 crates each require three changes: one field added to the plugin's `AppState`, one line in `configure_routes` to resolve the checker, and one `project_access_guard!` call in the handler body. This is a large but mechanical change.
+- ~94 OSS handler functions across ~17 crates each require three changes: one field added to the plugin's `AppState`, one line in `configure_routes` to resolve the checker, and one `project_access_guard!` call in the handler body. This is a large but mechanical change.
 - Adding `moka` as a direct dependency of the team-access plugin (currently, moka is only used in a couple of other crates in this codebase). The version `0.12` is already in the workspace; this is a new dependency declaration, not a new package fetch.
 - A 60-second delay between an admin revoking team access and that revocation taking effect for in-flight sessions. This is the same latency class as other short-TTL caches already used in this codebase and is acceptable for the control-plane use case.
 
@@ -396,7 +396,7 @@ The ADR records that this is a security fix for a gap in an already-shipped feat
 OSS:
 - `temps-core`: new file `src/project_access.rs`, `pub use` in `lib.rs`
 - `temps-auth`: new `project_access_guard!` macro in `permission_guard.rs`, re-export in `lib.rs`
-- 18 crates listed in §3: `AppState` field addition + `configure_routes` resolver + `project_access_guard!` call in each project-scoped handler
+- 17 crates listed in §3: `AppState` field addition + `configure_routes` resolver + `project_access_guard!` call in each project-scoped handler
 
 Plugin side (separate repository, tracked independently):
 - the team-access plugin's crate: new `TeamProjectAccessChecker` module, `moka` dependency, call `context.register_service(checker)` in `register_services`, explicit cache invalidation in `grant_project_access`, `revoke_project_access`, `add_member`, `remove_member`
@@ -436,7 +436,7 @@ Plugin side (separate repository, tracked independently):
 The implementation should ship as a single PR to `temps` (OSS) that:
 1. Adds `ProjectAccessChecker` to `temps-core`
 2. Adds `project_access_guard!` to `temps-auth`
-3. Threads the field and call through all 18 affected crates
+3. Threads the field and call through all 17 affected crates
 
 ...followed by a separate PR to the team-access plugin's own repository that:
 1. Implements `TeamProjectAccessChecker`


### PR DESCRIPTION
## Summary
- Mechanical rollout of the `project_access_guard!` macro (Phase A, #260, already merged) into every remaining project-scoped handler — ~93 handlers across 17 crates.
- Guard order in every handler: `permission_guard!` (instance-wide role) → `project_scope_guard!` (deployment-token cross-project IDOR, where the endpoint is reachable by deployment tokens) → `project_access_guard!` (team-based access, this ADR).
- Zero behavior change for any existing caller today — the guard is a synchronous no-op until some plugin registers a `ProjectAccessChecker`, which nothing in this repo does yet.
- Adds a bidirectional coverage-enumeration test in `temps-auth` that walks the workspace and fails the build if any crate silently loses its only guard call, or if a new crate adds guard calls without registering in the snapshot — this is Test Requirement #11 from the design doc.

## Fixes made during review before landing
- `temps-agents` resolved the checker during `register_services` instead of `configure_routes`, which races against plugin load order and would silently no-op every one of its ~40 guard calls whenever the checker-providing plugin loads after it. Now resolved in `configure_routes`, matching every other affected plugin.
- `get_project_by_slug` returned the same data as the (correctly guarded) numeric-ID `get_project` endpoint with no guard at all — project slugs are predictable/known (deployment URLs, git webhooks, CLI output), making this a real bypass. Now resolves the project first and guards on the resolved numeric ID.
- The coverage test itself only checked one direction; made bidirectional.

Full design: `docs/adr/028-project-scoped-rbac-enforcement.md`.

## Test plan
- [x] `cargo check --workspace --lib`
- [x] `cargo test --workspace --lib` (full suite — one unrelated pre-existing failure in `temps-domains`'s real-network Pebble/ACME integration test, confirmed untouched by this diff)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] New regression test for the `get_project_by_slug` fix
- [x] Coverage-enumeration test passes and is bidirectional