### PR TITLE
perf(otel): cache storage quota checks to cut ingest DB load

### DIFF
--- a/crates/temps-otel/src/ingest/mod.rs
+++ b/crates/temps-otel/src/ingest/mod.rs
@@ -5,5 +5,6 @@
 
 pub mod auth;
 pub mod decode;
+pub mod quota_cache;
 pub mod rate_limit;
 pub mod sampler;

--- a/crates/temps-otel/src/ingest/quota_cache.rs
+++ b/crates/temps-otel/src/ingest/quota_cache.rs
@@ -1,0 +1,131 @@
+//! Per-project storage quota cache for OTel ingest.
+//!
+//! `get_storage_quota` runs exact `COUNT(*)` scans over three hypertables
+//! (`otel_metrics`, `otel_spans`, `otel_log_events`) filtered by `project_id`.
+//! Storage usage changes slowly (bytes accrue over minutes/hours), so paying
+//! for that scan on every single ingest request is wasted DB load — under
+//! high ingest volume it saturates TimescaleDB and drives up CPU. This cache
+//! lets `OtelService::check_quota` reuse the last result for a short TTL
+//! instead of re-querying per request.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use crate::types::StorageQuota;
+
+/// How long a cached quota result stays valid before the next check
+/// triggers a fresh DB query. Storage usage doesn't need per-request
+/// precision — a project that just crossed its limit will be caught
+/// within this window.
+pub const QUOTA_CACHE_TTL: Duration = Duration::from_secs(30);
+
+struct CacheEntry {
+    quota: StorageQuota,
+    checked_at: Instant,
+}
+
+/// Per-project TTL cache of the last computed [`StorageQuota`].
+pub struct QuotaCache {
+    ttl: Duration,
+    entries: Mutex<HashMap<i32, CacheEntry>>,
+}
+
+impl QuotaCache {
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            ttl,
+            entries: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Return the cached quota for `project_id` if it's still within the
+    /// TTL, otherwise `None` so the caller can fetch a fresh value.
+    pub fn get(&self, project_id: i32) -> Option<StorageQuota> {
+        let entries = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        let entry = entries.get(&project_id)?;
+        if entry.checked_at.elapsed() < self.ttl {
+            Some(entry.quota.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Store a freshly fetched quota, replacing any prior entry.
+    pub fn put(&self, project_id: i32, quota: StorageQuota) {
+        let mut entries = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        entries.insert(
+            project_id,
+            CacheEntry {
+                quota,
+                checked_at: Instant::now(),
+            },
+        );
+    }
+
+    /// Drop entries older than twice the TTL to prevent unbounded growth
+    /// from projects that stop sending data.
+    pub fn cleanup_expired(&self) {
+        let mut entries = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        let ttl = self.ttl;
+        entries.retain(|_, e| e.checked_at.elapsed() < ttl * 2);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn quota(project_id: i32, usage_pct: f64) -> StorageQuota {
+        StorageQuota {
+            project_id,
+            metrics_bytes: 0,
+            traces_bytes: 0,
+            logs_bytes: 0,
+            total_bytes: 0,
+            limit_bytes: 1_000_000,
+            usage_pct,
+        }
+    }
+
+    #[test]
+    fn test_miss_when_empty() {
+        let cache = QuotaCache::new(Duration::from_secs(60));
+        assert!(cache.get(1).is_none());
+    }
+
+    #[test]
+    fn test_hit_within_ttl() {
+        let cache = QuotaCache::new(Duration::from_secs(60));
+        cache.put(1, quota(1, 42.0));
+        let hit = cache.get(1).expect("should be cached");
+        assert_eq!(hit.usage_pct, 42.0);
+    }
+
+    #[test]
+    fn test_miss_after_ttl_expires() {
+        let cache = QuotaCache::new(Duration::from_millis(1));
+        cache.put(1, quota(1, 42.0));
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(cache.get(1).is_none());
+    }
+
+    #[test]
+    fn test_per_project_isolation() {
+        let cache = QuotaCache::new(Duration::from_secs(60));
+        cache.put(1, quota(1, 10.0));
+        assert!(cache.get(2).is_none());
+    }
+
+    #[test]
+    fn test_cleanup_expired_removes_stale_entries() {
+        let cache = QuotaCache::new(Duration::from_millis(1));
+        cache.put(1, quota(1, 10.0));
+        std::thread::sleep(Duration::from_millis(10));
+        cache.cleanup_expired();
+        // Internal map should no longer hold the entry; a subsequent get
+        // still misses (already true pre-cleanup), but this exercises the
+        // retain path without panicking.
+        assert!(cache.get(1).is_none());
+    }
+}

--- a/crates/temps-otel/src/services/otel_service.rs
+++ b/crates/temps-otel/src/services/otel_service.rs
@@ -12,6 +12,7 @@ use tracing::{error, warn};
 
 use crate::error::OtelError;
 use crate::ingest::auth::{IngestAuth, OtelAuthService, ProjectAuth};
+use crate::ingest::quota_cache::{QuotaCache, QUOTA_CACHE_TTL};
 use crate::ingest::rate_limit::RateLimiter;
 use crate::storage::OtelStorage;
 use crate::types::*;
@@ -28,6 +29,10 @@ pub struct OtelService {
     /// container pushes every ~10–30s), so the ceiling exists only to cap a
     /// runaway/compromised exporter, not to shape normal traffic.
     service_rate_limiter: Arc<RateLimiter>,
+    /// TTL cache of per-project storage quota, avoiding a `COUNT(*)` scan
+    /// over the OTel hypertables on every ingest request. See
+    /// [`crate::ingest::quota_cache`].
+    quota_cache: Arc<QuotaCache>,
     stats: PipelineStatsAtomic,
 }
 
@@ -85,6 +90,7 @@ impl OtelService {
                 SERVICE_INGEST_MAX_REQUESTS,
                 SERVICE_INGEST_WINDOW,
             )),
+            quota_cache: Arc::new(QuotaCache::new(QUOTA_CACHE_TTL)),
             stats: PipelineStatsAtomic::default(),
         }
     }
@@ -141,9 +147,23 @@ impl OtelService {
     }
 
     /// Check storage quota for a project.
+    ///
+    /// Storage quota is backed by an exact `COUNT(*)` scan over the OTel
+    /// hypertables (see `TimescaleDbStorage::get_storage_quota`), which is
+    /// too expensive to run on every ingest request under load. Reuse the
+    /// cached result within [`QUOTA_CACHE_TTL`] and only hit storage once
+    /// that expires.
     pub async fn check_quota(&self, project_id: i32) -> Result<(), OtelError> {
-        if self.storage.check_quota(project_id).await? {
-            let quota = self.storage.get_storage_quota(project_id).await?;
+        let quota = match self.quota_cache.get(project_id) {
+            Some(quota) => quota,
+            None => {
+                let quota = self.storage.get_storage_quota(project_id).await?;
+                self.quota_cache.put(project_id, quota.clone());
+                quota
+            }
+        };
+
+        if quota.usage_pct >= 100.0 {
             return Err(OtelError::QuotaExceeded {
                 project_id,
                 used_bytes: quota.total_bytes,
@@ -777,6 +797,60 @@ mod tests {
         assert!(svc.check_rate_limit(1).is_ok());
         assert!(svc.check_rate_limit(1).is_ok());
         assert!(svc.check_rate_limit(1).is_err());
+    }
+
+    // ── quota check caching (avoid per-request COUNT(*) under load) ────────
+
+    #[tokio::test]
+    async fn test_check_quota_reuses_cached_result_within_ttl() {
+        let (svc, storage) = make_service(MockOtelStorage::new());
+
+        for _ in 0..5 {
+            assert!(svc.check_quota(1).await.is_ok());
+        }
+
+        // 5 checks for the same project should only hit storage once — the
+        // rest are served from the quota cache.
+        assert_eq!(storage.get_storage_quota_call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_check_quota_is_cached_per_project() {
+        let (svc, storage) = make_service(MockOtelStorage::new());
+
+        assert!(svc.check_quota(1).await.is_ok());
+        assert!(svc.check_quota(2).await.is_ok());
+        assert!(svc.check_quota(1).await.is_ok());
+        assert!(svc.check_quota(2).await.is_ok());
+
+        // Each distinct project gets its own cache entry, so two projects
+        // still means exactly two storage calls, not four.
+        assert_eq!(storage.get_storage_quota_call_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_check_quota_rejects_when_over_limit() {
+        let mock = MockOtelStorage::new();
+        *mock.quota_override.lock().unwrap() = Some(StorageQuota {
+            project_id: 42,
+            metrics_bytes: 0,
+            traces_bytes: 0,
+            logs_bytes: 0,
+            total_bytes: 200,
+            limit_bytes: 100,
+            usage_pct: 200.0,
+        });
+        let (svc, _storage) = make_service(mock);
+
+        let result = svc.check_quota(42).await;
+        assert!(matches!(
+            result,
+            Err(OtelError::QuotaExceeded {
+                project_id: 42,
+                used_bytes: 200,
+                limit_bytes: 100,
+            })
+        ));
     }
 
     #[tokio::test]

--- a/crates/temps-otel/src/test_support.rs
+++ b/crates/temps-otel/src/test_support.rs
@@ -28,6 +28,12 @@ pub struct MockOtelStorage {
     pub fail_store_spans: Arc<Mutex<Option<String>>>,
     /// If set, archive_logs will return this error.
     pub fail_archive_logs: Arc<Mutex<Option<String>>>,
+    /// Counts calls to `get_storage_quota`, so tests can assert on
+    /// caching behavior in callers like `OtelService::check_quota`.
+    pub get_storage_quota_calls: Arc<Mutex<u32>>,
+    /// Overrides `get_storage_quota`'s `usage_pct`/`total_bytes`/`limit_bytes`
+    /// for tests that need to simulate a project over its quota.
+    pub quota_override: Arc<Mutex<Option<StorageQuota>>>,
 }
 
 impl MockOtelStorage {
@@ -53,6 +59,11 @@ impl MockOtelStorage {
     /// Return all archived logs (S3 path).
     pub fn stored_archived_logs(&self) -> Vec<LogRecord> {
         self.archived_logs.lock().unwrap().clone()
+    }
+
+    /// Number of times `get_storage_quota` has been called.
+    pub fn get_storage_quota_call_count(&self) -> u32 {
+        *self.get_storage_quota_calls.lock().unwrap()
     }
 }
 
@@ -301,6 +312,10 @@ impl OtelStorage for MockOtelStorage {
     }
 
     async fn get_storage_quota(&self, project_id: i32) -> StorageResult<StorageQuota> {
+        *self.get_storage_quota_calls.lock().unwrap() += 1;
+        if let Some(quota) = self.quota_override.lock().unwrap().clone() {
+            return Ok(quota);
+        }
         Ok(StorageQuota {
             project_id,
             metrics_bytes: 0,


### PR DESCRIPTION
## Summary
- `OtelService::check_quota` was called on every metrics/traces/logs ingest request (3 call sites in `ingest_handler.rs`) and ran `get_storage_quota`, which does an **exact `COUNT(*)` scan over three TimescaleDB hypertables** (`otel_metrics`, `otel_spans`, `otel_log_events`), filtered by `project_id`, plus `pg_total_relation_size` lookups — on every single request. Under high ingest volume this saturates TimescaleDB and drives CPU up.
- Added a per-project TTL cache (`QuotaCache`, 30s, mirrors the existing `RateLimiter` pattern already used on this same hot path) so `check_quota` reuses the last computed quota instead of re-querying storage per request.
- The cache sits above the storage trait abstraction, so it also caps query volume for **ClickHouse-backed projects** — `ClickHouseStorage::get_storage_quota`/`check_quota` still delegate to the underlying TimescaleDB query today (quota accounting has no native ClickHouse path yet), so this fix helps both backends equally until that's addressed separately.
- Also collapsed the old double query on the over-quota path (`check_quota()` then a second `get_storage_quota()` call just to build the error) into a single cached fetch reused for both the pass/fail check and the error detail.

## Test plan
- [x] `cargo check --lib -p temps-otel`
- [x] `cargo clippy -p temps-otel --lib --tests -- -D warnings` (bypassing the rtk wrapper per project policy)
- [x] `cargo test --lib -p temps-otel` — 408 passed, 0 failed
- [x] New tests: cache hit reuses result across repeated calls (`test_check_quota_reuses_cached_result_within_ttl`), cache is isolated per project (`test_check_quota_is_cached_per_project`), over-quota still rejects correctly (`test_check_quota_rejects_when_over_limit`)