### PR TITLE
perf(auth): throttle last_used_at writes on every authenticated request

### DIFF
--- a/crates/temps-auth/src/apikey_service.rs
+++ b/crates/temps-auth/src/apikey_service.rs
@@ -166,11 +166,20 @@ impl ApiKeyServiceError {
 
 pub struct ApiKeyService {
     db: Arc<DbConnection>,
+    /// Throttles `last_used_at` writes so repeated validations of the same
+    /// key within the window skip the DB write entirely. See
+    /// [`crate::last_used_throttle`].
+    last_used_throttle: crate::last_used_throttle::LastUsedThrottle,
 }
 
 impl ApiKeyService {
     pub fn new(db: Arc<DbConnection>) -> Self {
-        Self { db }
+        Self {
+            db,
+            last_used_throttle: crate::last_used_throttle::LastUsedThrottle::new(
+                crate::last_used_throttle::LAST_USED_UPDATE_INTERVAL,
+            ),
+        }
     }
 
     pub async fn create_api_key(
@@ -439,10 +448,13 @@ impl ApiKeyService {
             (Some(role), None)
         };
 
-        // Update last_used_at
-        let mut api_key_active: ApiKeyActiveModel = api_key_model.clone().into();
-        api_key_active.last_used_at = Set(Some(Utc::now()));
-        let _ = api_key_active.update(self.db.as_ref()).await; // Don't fail if this fails
+        // Update last_used_at, throttled so repeated validations of the
+        // same key within LAST_USED_UPDATE_INTERVAL skip the DB write.
+        if self.last_used_throttle.should_update(api_key_model.id) {
+            let mut api_key_active: ApiKeyActiveModel = api_key_model.clone().into();
+            api_key_active.last_used_at = Set(Some(Utc::now()));
+            let _ = api_key_active.update(self.db.as_ref()).await; // Don't fail if this fails
+        }
 
         Ok((
             user,
@@ -1290,6 +1302,57 @@ mod tests {
             .unwrap();
 
         assert!(api_key.last_used_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_validate_api_key_repeat_call_skips_last_used_update() {
+        let (db, api_key_service, user) = setup_test_env().await;
+
+        let request = CreateApiKeyRequest {
+            name: "Throttled Usage Key".to_string(),
+            role_type: "admin".to_string(),
+            permissions: None,
+            expires_at: None,
+        };
+
+        let create_response = api_key_service
+            .create_api_key(user.id, request)
+            .await
+            .unwrap();
+
+        api_key_service
+            .validate_api_key(&create_response.api_key)
+            .await
+            .unwrap();
+
+        let after_first_call = api_keys::Entity::find_by_id(create_response.id)
+            .one(db.db.as_ref())
+            .await
+            .unwrap()
+            .unwrap()
+            .last_used_at
+            .expect("first validation should write last_used_at");
+
+        // Immediately validate again — within LAST_USED_UPDATE_INTERVAL, the
+        // throttle should skip the write entirely, so last_used_at must be
+        // byte-identical to what the first call wrote.
+        api_key_service
+            .validate_api_key(&create_response.api_key)
+            .await
+            .unwrap();
+
+        let after_second_call = api_keys::Entity::find_by_id(create_response.id)
+            .one(db.db.as_ref())
+            .await
+            .unwrap()
+            .unwrap()
+            .last_used_at
+            .expect("last_used_at should still be set");
+
+        assert_eq!(
+            after_first_call, after_second_call,
+            "second validate_api_key call within the throttle window must not rewrite last_used_at"
+        );
     }
 
     // Activation/Deactivation Tests

--- a/crates/temps-auth/src/deployment_token_service.rs
+++ b/crates/temps-auth/src/deployment_token_service.rs
@@ -10,7 +10,7 @@ use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use temps_database::DbConnection;
 use temps_entities::deployment_tokens::{
-    DeploymentTokenPermission, Entity as DeploymentTokenEntity,
+    DeploymentTokenPermission, Entity as DeploymentTokenEntity, Model as DeploymentTokenModel,
 };
 use thiserror::Error;
 use tracing::warn;
@@ -43,11 +43,20 @@ pub struct ValidatedDeploymentToken {
 
 pub struct DeploymentTokenValidationService {
     db: Arc<DbConnection>,
+    /// Throttles `last_used_at` writes so repeated validations of the same
+    /// token within the window skip the DB write entirely. See
+    /// [`crate::last_used_throttle`].
+    last_used_throttle: crate::last_used_throttle::LastUsedThrottle,
 }
 
 impl DeploymentTokenValidationService {
     pub fn new(db: Arc<DbConnection>) -> Self {
-        Self { db }
+        Self {
+            db,
+            last_used_throttle: crate::last_used_throttle::LastUsedThrottle::new(
+                crate::last_used_throttle::LAST_USED_UPDATE_INTERVAL,
+            ),
+        }
     }
 
     /// Validate a deployment token and return its details
@@ -102,8 +111,13 @@ impl DeploymentTokenValidationService {
             vec![]
         };
 
-        // Update last_used_at (fire and forget - don't fail validation if this fails)
-        let _ = self.update_last_used(token_model.id).await;
+        // Update last_used_at, throttled so repeated validations of the
+        // same token within LAST_USED_UPDATE_INTERVAL skip the DB write.
+        // Best-effort: errors are swallowed so a write failure never blocks
+        // validation.
+        if self.last_used_throttle.should_update(token_model.id) {
+            let _ = self.update_last_used(&token_model).await;
+        }
 
         Ok(ValidatedDeploymentToken {
             token_id: token_model.id,
@@ -115,27 +129,18 @@ impl DeploymentTokenValidationService {
         })
     }
 
-    /// Update the last_used_at timestamp
-    async fn update_last_used(&self, token_id: i32) -> Result<(), sea_orm::DbErr> {
+    /// Update the last_used_at timestamp, reusing the already-fetched
+    /// token row instead of re-querying it.
+    async fn update_last_used(
+        &self,
+        token_model: &DeploymentTokenModel,
+    ) -> Result<(), sea_orm::DbErr> {
         use sea_orm::{ActiveModelTrait, Set};
         use temps_entities::deployment_tokens::ActiveModel;
 
-        let mut token_active = ActiveModel {
-            id: Set(token_id),
-            ..Default::default()
-        };
-        token_active.last_used_at = Set(Some(Utc::now()));
-
-        // Use update, but we need to handle partial updates properly
-        // Actually, sea-orm requires all fields for update, so we need to fetch first
-        if let Some(existing) = DeploymentTokenEntity::find_by_id(token_id)
-            .one(self.db.as_ref())
-            .await?
-        {
-            let mut active: ActiveModel = existing.into();
-            active.last_used_at = Set(Some(Utc::now()));
-            active.update(self.db.as_ref()).await?;
-        }
+        let mut active: ActiveModel = token_model.clone().into();
+        active.last_used_at = Set(Some(Utc::now()));
+        active.update(self.db.as_ref()).await?;
 
         Ok(())
     }
@@ -367,47 +372,29 @@ mod tests {
         hasher.update(token.as_bytes());
         let token_hash = hex::encode(hasher.finalize());
 
+        let model = temps_entities::deployment_tokens::Model {
+            id: 42,
+            project_id: 100,
+            environment_id: Some(200),
+            deployment_id: None,
+            name: "valid-token".to_string(),
+            token_hash,
+            token_prefix,
+            permissions: Some(serde_json::json!(["visitors:enrich", "emails:send"])),
+            is_active: true,
+            expires_at: Some(expires_at),
+            last_used_at: None,
+            created_at: now,
+            updated_at: now,
+            created_by: Some(1),
+            encrypted_token: None,
+        };
+
+        // Postgres supports `UPDATE ... RETURNING`, so `ActiveModel::update`
+        // goes through the query path (not `execute`/exec_results) — one
+        // query batch for the lookup, one for the update-and-return-updated.
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results(vec![vec![temps_entities::deployment_tokens::Model {
-                id: 42,
-                project_id: 100,
-                environment_id: Some(200),
-                deployment_id: None,
-                name: "valid-token".to_string(),
-                token_hash,
-                token_prefix,
-                permissions: Some(serde_json::json!(["visitors:enrich", "emails:send"])),
-                is_active: true,
-                expires_at: Some(expires_at),
-                last_used_at: None,
-                created_at: now,
-                updated_at: now,
-                created_by: Some(1),
-                encrypted_token: None,
-            }]])
-            // For finding token again to update last_used_at
-            .append_query_results(vec![vec![temps_entities::deployment_tokens::Model {
-                id: 42,
-                project_id: 100,
-                environment_id: Some(200),
-                deployment_id: None,
-                name: "valid-token".to_string(),
-                token_hash: "hash".to_string(),
-                token_prefix: "dt_valid".to_string(),
-                permissions: Some(serde_json::json!(["visitors:enrich", "emails:send"])),
-                is_active: true,
-                expires_at: Some(expires_at),
-                last_used_at: None,
-                created_at: now,
-                updated_at: now,
-                created_by: Some(1),
-                encrypted_token: None,
-            }]])
-            // For the update
-            .append_exec_results(vec![MockExecResult {
-                last_insert_id: 42,
-                rows_affected: 1,
-            }])
+            .append_query_results(vec![vec![model.clone()], vec![model]])
             .into_connection();
 
         let service = create_service_with_mock(db);
@@ -421,6 +408,69 @@ mod tests {
         assert_eq!(validated.environment_id, Some(200));
         assert_eq!(validated.name, "valid-token");
         assert_eq!(validated.permissions.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_validate_token_repeat_call_skips_last_used_update() {
+        let now = chrono::Utc::now();
+        let expires_at = now + chrono::Duration::days(30);
+        let token = "dt_validtoken12345678";
+        let token_prefix: String = token.chars().take(8).collect();
+
+        let mut hasher = Sha256::new();
+        hasher.update(token.as_bytes());
+        let token_hash = hex::encode(hasher.finalize());
+
+        let model = || temps_entities::deployment_tokens::Model {
+            id: 42,
+            project_id: 100,
+            environment_id: Some(200),
+            deployment_id: None,
+            name: "valid-token".to_string(),
+            token_hash: token_hash.clone(),
+            token_prefix: token_prefix.clone(),
+            permissions: Some(serde_json::json!(["visitors:enrich", "emails:send"])),
+            is_active: true,
+            expires_at: Some(expires_at),
+            last_used_at: None,
+            created_at: now,
+            updated_at: now,
+            created_by: Some(1),
+            encrypted_token: None,
+        };
+
+        // Errors from the last_used_at write are swallowed by validate_token
+        // (`let _ = self.update_last_used(...).await;`), so a call
+        // succeeding doesn't prove a write was attempted or skipped —
+        // asserting on the mock's transaction log is the only reliable way
+        // to verify the throttle actually prevented a second write.
+        //
+        // Statements needed if the throttle works correctly: call 1's
+        // lookup, call 1's update-and-return-updated (RETURNING), call 2's
+        // lookup. Call 2's update must NOT happen — if it did, it would
+        // need a 4th query batch that isn't provided, and (since that
+        // statement is logged before the mock realizes its results buffer
+        // is empty) the transaction log would show 4 entries instead of 3.
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![vec![model()], vec![model()], vec![model()]])
+                .into_connection(),
+        );
+
+        let service = DeploymentTokenValidationService::new(db.clone());
+
+        assert!(service.validate_token(token).await.is_ok());
+        assert!(service.validate_token(token).await.is_ok());
+
+        drop(service);
+        let statement_count = Arc::try_unwrap(db)
+            .expect("service dropped, so this is the only remaining ref")
+            .into_transaction_log()
+            .len();
+        assert_eq!(
+            statement_count, 3,
+            "expected exactly 2 lookups + 1 throttled last_used_at write, got {statement_count} statements"
+        );
     }
 
     #[tokio::test]

--- a/crates/temps-auth/src/last_used_throttle.rs
+++ b/crates/temps-auth/src/last_used_throttle.rs
@@ -1,0 +1,90 @@
+//! Per-credential throttle for `last_used_at` bookkeeping writes.
+//!
+//! `ApiKeyService::validate_api_key` and `DeploymentTokenValidationService::validate_token`
+//! run on every authenticated request platform-wide and each write
+//! `last_used_at = NOW()` unconditionally. That timestamp is only ever shown
+//! as an informational "last used" display — it doesn't need per-request
+//! freshness — so paying for a DB write on every single request wastes load
+//! proportional to all authenticated traffic. This throttle lets callers skip
+//! the write entirely when one already happened recently for the same
+//! credential id, rather than just moving the write off the critical path.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// Minimum spacing between `last_used_at` writes for a single credential.
+/// `last_used_at` is a UI/audit display value, not a security or billing
+/// gate, so this can be far looser than e.g. the OTel quota cache's 30s
+/// window (`crates/temps-otel/src/ingest/quota_cache.rs`).
+pub const LAST_USED_UPDATE_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Tracks the last time `last_used_at` was written for each credential id
+/// (an `api_keys.id` or `deployment_tokens.id`), so repeat validations
+/// within `interval` can skip the write.
+pub struct LastUsedThrottle {
+    interval: Duration,
+    last_updates: Mutex<HashMap<i32, Instant>>,
+}
+
+impl LastUsedThrottle {
+    pub fn new(interval: Duration) -> Self {
+        Self {
+            interval,
+            last_updates: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Returns `true` if the caller should write `last_used_at` now (and
+    /// records that a write is about to happen), `false` if one already
+    /// happened within `interval` and this call can skip the DB write
+    /// entirely. Check-and-mark happens under one lock acquisition so
+    /// concurrent callers for the same id can't both decide to write.
+    pub fn should_update(&self, id: i32) -> bool {
+        let now = Instant::now();
+        let mut last_updates = self.last_updates.lock().unwrap_or_else(|e| e.into_inner());
+
+        match last_updates.get(&id) {
+            Some(last) if now.duration_since(*last) < self.interval => false,
+            _ => {
+                last_updates.insert(id, now);
+                true
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_first_call_updates() {
+        let throttle = LastUsedThrottle::new(Duration::from_secs(60));
+        assert!(throttle.should_update(1));
+    }
+
+    #[test]
+    fn test_immediate_repeat_call_skips() {
+        let throttle = LastUsedThrottle::new(Duration::from_secs(60));
+        assert!(throttle.should_update(1));
+        assert!(!throttle.should_update(1));
+    }
+
+    #[test]
+    fn test_updates_again_after_interval_elapses() {
+        let throttle = LastUsedThrottle::new(Duration::from_millis(1));
+        assert!(throttle.should_update(1));
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(throttle.should_update(1));
+    }
+
+    #[test]
+    fn test_distinct_ids_are_independent() {
+        let throttle = LastUsedThrottle::new(Duration::from_secs(60));
+        assert!(throttle.should_update(1));
+        assert!(throttle.should_update(2));
+        assert!(!throttle.should_update(1));
+        assert!(!throttle.should_update(2));
+    }
+}

--- a/crates/temps-auth/src/lib.rs
+++ b/crates/temps-auth/src/lib.rs
@@ -14,6 +14,7 @@ mod decorators;
 mod deployment_token_service;
 mod email_templates;
 pub mod handlers;
+mod last_used_throttle;
 mod macros;
 mod middleware;
 mod oidc_errors;


### PR DESCRIPTION
## Summary
- `ApiKeyService::validate_api_key` (`crates/temps-auth/src/apikey_service.rs`) and `DeploymentTokenValidationService::validate_token` (`crates/temps-auth/src/deployment_token_service.rs`) run on **every** `tk_`/`dt_` authenticated request platform-wide, via `AuthMiddleware`. Each unconditionally wrote `last_used_at = NOW()` to Postgres before returning — a purely informational "last used" display value that doesn't need per-request freshness, so this was wasted DB write load proportional to all authenticated traffic on the platform (not just OTel ingest, see #262).
- Added `LastUsedThrottle` (`crates/temps-auth/src/last_used_throttle.rs`), a per-credential-id TTL cache (5 min), mirroring the pattern already used for the OTel quota fix. Both services now skip the write entirely when one already happened recently, rather than just moving it off the critical path via `tokio::spawn` — spawning would still issue the same number of writes, just non-blocking; skipping actually reduces DB load, which is the real goal. The first call for any credential still writes synchronously, so `last_used_at` still gets set on first use.
- Also fixed `DeploymentTokenValidationService::update_last_used`, which re-fetched the token row via `find_by_id` even though the caller already had it in hand from the initial lookup (labeled "fire and forget" in a comment, but was actually `.await`ed, not spawned) — now reuses the already-fetched row directly, dropping a redundant `SELECT` on every write regardless of throttling.

## Test plan
- [x] `cargo check --lib -p temps-auth`
- [x] `cargo clippy -p temps-auth --lib --tests -- -D warnings` (direct binary, not through rtk)
- [x] `cargo test --lib -p temps-auth` — 239 passed, 0 failed
- [x] New test for the deployment-token path uses `MockDatabase`'s transaction log (not call-success) to verify the throttle, since errors from the write are swallowed by design and a broken throttle would still return `Ok` — confirmed this test fails (4 statements instead of 3) when the throttle is bypassed
- [x] New test for the API-key path uses a real `TestDatabase` round trip, asserting `last_used_at` is byte-identical across two immediate calls — confirmed this test fails when the throttle is bypassed