### PR TITLE
perf: bound proxy-log and monitor-health hypertable lookups by time

### DIFF
--- a/crates/temps-proxy/src/handler/proxy_logs.rs
+++ b/crates/temps-proxy/src/handler/proxy_logs.rs
@@ -170,12 +170,24 @@ pub async fn get_proxy_logs(
     Ok(Json(response))
 }
 
+/// Query parameters for the single proxy-log lookup
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ProxyLogByIdQuery {
+    /// Event time of the log row (ISO 8601). When provided, the lookup is
+    /// bounded to the hypertable chunks around this instant instead of
+    /// scanning (and decompressing) the whole retention window. The list
+    /// endpoint already returns this value per row — always pass it when
+    /// navigating from a list.
+    pub timestamp: Option<DateTime>,
+}
+
 /// Get a single proxy log by ID
 #[utoipa::path(
     get,
     path = "/proxy-logs/{id}",
     params(
-        ("id" = i32, Path, description = "Proxy log ID")
+        ("id" = i32, Path, description = "Proxy log ID"),
+        ProxyLogByIdQuery
     ),
     responses(
         (status = 200, description = "Proxy log found", body = ProxyLogResponse),
@@ -187,9 +199,10 @@ pub async fn get_proxy_logs(
 pub async fn get_proxy_log_by_id(
     State(service): State<Arc<ProxyLogService>>,
     Path(id): Path<i32>,
+    Query(query): Query<ProxyLogByIdQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     let log = service
-        .get_by_id(id)
+        .get_by_id(id, query.timestamp.map(|t| t.into()))
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 

--- a/crates/temps-proxy/src/service/proxy_log_service.rs
+++ b/crates/temps-proxy/src/service/proxy_log_service.rs
@@ -620,14 +620,48 @@ impl ProxyLogService {
         .await
     }
 
-    /// Get a single proxy log by ID
+    /// Get a single proxy log by ID.
+    ///
+    /// `proxy_logs` is a TimescaleDB hypertable partitioned by `timestamp`
+    /// (1-day chunks, compressed after 7 days), so a bare `WHERE id = $1`
+    /// cannot exclude any chunk and must decompress every compressed chunk —
+    /// observed as multi-second lookups. When the caller knows the row's event
+    /// time (the list endpoint returns it), a ±1-day bound reduces the lookup
+    /// to the couple of chunks that can contain the row. Without a timestamp,
+    /// the recent uncompressed window is probed first and the unbounded scan
+    /// only runs as a last resort so bare deep-links keep resolving.
     pub async fn get_by_id(
         &self,
         id: i32,
+        timestamp: Option<UtcDateTime>,
     ) -> Result<Option<proxy_logs::Model>, ProxyLogServiceError> {
         if let Some(storage) = &self.storage {
-            return storage.get_by_id(id).await;
+            return storage.get_by_id(id, timestamp).await;
         }
+
+        if let Some(ts) = timestamp {
+            let log = proxy_logs::Entity::find()
+                .filter(proxy_logs::Column::Id.eq(id))
+                .filter(proxy_logs::Column::Timestamp.gte(ts - chrono::Duration::days(1)))
+                .filter(proxy_logs::Column::Timestamp.lte(ts + chrono::Duration::days(1)))
+                .one(self.db.as_ref())
+                .await?;
+            return Ok(log);
+        }
+
+        // Compression policy compresses chunks older than 7 days; probing the
+        // uncompressed window first keeps the common case (recent log, no
+        // timestamp supplied) off the decompression path.
+        let recent_cutoff = Utc::now() - chrono::Duration::days(7);
+        let log = proxy_logs::Entity::find()
+            .filter(proxy_logs::Column::Id.eq(id))
+            .filter(proxy_logs::Column::Timestamp.gte(recent_cutoff))
+            .one(self.db.as_ref())
+            .await?;
+        if log.is_some() {
+            return Ok(log);
+        }
+
         let log = proxy_logs::Entity::find_by_id(id)
             .one(self.db.as_ref())
             .await?;

--- a/crates/temps-proxy/src/storage/clickhouse.rs
+++ b/crates/temps-proxy/src/storage/clickhouse.rs
@@ -992,7 +992,11 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
         Ok((models, total))
     }
 
-    async fn get_by_id(&self, id: i32) -> Result<Option<proxy_logs::Model>, ProxyLogServiceError> {
+    async fn get_by_id(
+        &self,
+        id: i32,
+        _timestamp: Option<UtcDateTime>,
+    ) -> Result<Option<proxy_logs::Model>, ProxyLogServiceError> {
         // ClickHouse proxy_logs has no serial `id` column (see the schema note).
         // The list rows surface id=0 and the UI keys off request_id, so an
         // id-based lookup cannot resolve a CH row. Return None (404) rather than
@@ -2073,7 +2077,11 @@ mod tests {
             "temps",
             "temps_dev",
         ));
-        assert!(store.get_by_id(42).await.expect("no-io path").is_none());
+        assert!(store
+            .get_by_id(42, None)
+            .await
+            .expect("no-io path")
+            .is_none());
     }
 
     #[tokio::test]

--- a/crates/temps-proxy/src/storage/mod.rs
+++ b/crates/temps-proxy/src/storage/mod.rs
@@ -85,7 +85,16 @@ pub trait ProxyLogStorage: Send + Sync {
     ) -> Result<(Vec<proxy_logs::Model>, u64), ProxyLogServiceError>;
 
     /// Fetch a single proxy log by its serial id.
-    async fn get_by_id(&self, id: i32) -> Result<Option<proxy_logs::Model>, ProxyLogServiceError>;
+    ///
+    /// `timestamp` is the row's known event time (the list endpoint returns it
+    /// per row). On the TimescaleDB hypertable it bounds the lookup to the
+    /// chunks around that instant instead of scanning — and decompressing —
+    /// the entire retention window.
+    async fn get_by_id(
+        &self,
+        id: i32,
+        timestamp: Option<UtcDateTime>,
+    ) -> Result<Option<proxy_logs::Model>, ProxyLogServiceError>;
 
     /// Fetch a single proxy log by its (unique) request id, for tracing joins.
     async fn get_by_request_id(

--- a/crates/temps-proxy/src/storage/timescaledb.rs
+++ b/crates/temps-proxy/src/storage/timescaledb.rs
@@ -192,8 +192,12 @@ impl ProxyLogStorage for TimescaleDbProxyLogStore {
             .await
     }
 
-    async fn get_by_id(&self, id: i32) -> Result<Option<proxy_logs::Model>, ProxyLogServiceError> {
-        self.reader.get_by_id(id).await
+    async fn get_by_id(
+        &self,
+        id: i32,
+        timestamp: Option<UtcDateTime>,
+    ) -> Result<Option<proxy_logs::Model>, ProxyLogServiceError> {
+        self.reader.get_by_id(id, timestamp).await
     }
 
     async fn get_by_request_id(

--- a/crates/temps-status-page/src/services/monitor_service.rs
+++ b/crates/temps-status-page/src/services/monitor_service.rs
@@ -344,6 +344,16 @@ impl MonitorService {
         // Single query: for each project, get latest check status of production monitors.
         // Inlined subquery (no CTE) so Postgres can push predicates down.
         // LATERAL + LIMIT 1 uses idx_status_checks_monitor_time for index-only lookups.
+        //
+        // The `checked_at` lower bound is load-bearing: status_checks is a
+        // TimescaleDB hypertable (1-day chunks, 90-day retention, compressed
+        // after 30 days). Without a time predicate the planner cannot exclude
+        // any chunk, so the LIMIT 1 merge touches every chunk — including
+        // decompressing batches from every compressed one — per monitor. An
+        // active monitor's latest check is at most one check interval old
+        // (minutes), so a 1-day bound prunes to the newest chunks while a
+        // monitor whose checker has been dead for over a day correctly counts
+        // as not operational.
         let sql = format!(
             r#"
             SELECT
@@ -358,6 +368,7 @@ impl MonitorService {
                 SELECT sc.status
                 FROM status_checks sc
                 WHERE sc.monitor_id = sm.id
+                  AND sc.checked_at > NOW() - INTERVAL '1 day'
                 ORDER BY sc.checked_at DESC
                 LIMIT 1
             ) lc ON true

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -41274,7 +41274,16 @@ export type GetProxyLogByIdData = {
          */
         id: number;
     };
-    query?: never;
+    query?: {
+        /**
+         * Event time of the log row (ISO 8601). When provided, the lookup is
+         * bounded to the hypertable chunks around this instant instead of
+         * scanning (and decompressing) the whole retention window. The list
+         * endpoint already returns this value per row — always pass it when
+         * navigating from a list.
+         */
+        timestamp?: string | null;
+    };
     url: '/proxy-logs/{id}';
 };
 

--- a/web/src/components/analytics/AiCrawlerActivityFeed.tsx
+++ b/web/src/components/analytics/AiCrawlerActivityFeed.tsx
@@ -268,7 +268,7 @@ function FeedRow({ log }: { log: ProxyLogResponse }) {
 
   return (
     <Link
-      to={`/proxy-logs/${log.id}`}
+      to={`/proxy-logs/${log.id}?ts=${encodeURIComponent(log.timestamp)}`}
       className="flex items-center gap-3 px-3 py-2.5 text-sm transition-colors hover:bg-muted/50"
     >
       <AiAgentLogo provider={providerName} agent={log.bot_name} size={22} />

--- a/web/src/components/logs/ProxyLogsList.tsx
+++ b/web/src/components/logs/ProxyLogsList.tsx
@@ -38,7 +38,7 @@ import { useSearchParams } from 'react-router-dom'
 
 interface ProxyLogsListProps {
   project: ProjectResponse
-  onRowClick?: (logId: number, projectId: number) => void
+  onRowClick?: (logId: number, projectId: number, timestamp: string) => void
   showEnvironmentFilter?: boolean
 }
 
@@ -303,9 +303,13 @@ export default function ProxyLogsList({
     setPage(1)
   }
 
-  const handleRowClick = (logId: number, logProjectId: number) => {
+  const handleRowClick = (
+    logId: number,
+    logProjectId: number,
+    timestamp: string
+  ) => {
     if (onRowClick) {
-      onRowClick(logId, logProjectId)
+      onRowClick(logId, logProjectId, timestamp)
     }
   }
 
@@ -672,7 +676,11 @@ export default function ProxyLogsList({
                             onClick={() =>
                               onRowClick &&
                               log.project_id &&
-                              handleRowClick(log.id, log.project_id)
+                              handleRowClick(
+                                log.id,
+                                log.project_id,
+                                log.timestamp
+                              )
                             }
                           >
                             <TableCell className="tabular-nums text-muted-foreground">

--- a/web/src/components/proxy-logs/ProxyLogDetail.tsx
+++ b/web/src/components/proxy-logs/ProxyLogDetail.tsx
@@ -34,6 +34,12 @@ import {
 
 interface ProxyLogDetailProps {
   logId: number
+  /**
+   * Event time of the log row, forwarded from the list link. Bounds the
+   * backend's hypertable lookup; without it the lookup falls back to a
+   * wider (slower) scan.
+   */
+  timestamp?: string
 }
 
 function formatBytes(bytes: number | null | undefined): string {
@@ -56,7 +62,7 @@ function getDeviceIcon(deviceType: string | null | undefined) {
   }
 }
 
-export function ProxyLogDetail({ logId }: ProxyLogDetailProps) {
+export function ProxyLogDetail({ logId, timestamp }: ProxyLogDetailProps) {
   const {
     data: log,
     isLoading,
@@ -64,6 +70,7 @@ export function ProxyLogDetail({ logId }: ProxyLogDetailProps) {
   } = useQuery({
     ...getProxyLogByIdOptions({
       path: { id: logId },
+      query: timestamp ? { timestamp } : undefined,
     }),
   })
 

--- a/web/src/components/proxy-logs/ProxyLogsDataTable.tsx
+++ b/web/src/components/proxy-logs/ProxyLogsDataTable.tsx
@@ -1607,7 +1607,7 @@ function ProxyLogInlineDetail({ log }: { log: ProxyLogResponse }) {
       {/* Link to full detail page */}
       <div className="flex justify-end">
         <Link
-          to={`/proxy-logs/${log.id}`}
+          to={`/proxy-logs/${log.id}?ts=${encodeURIComponent(log.timestamp)}`}
           className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
           onClick={(e) => e.stopPropagation()}
         >

--- a/web/src/components/visitors/SessionDetail.tsx
+++ b/web/src/components/visitors/SessionDetail.tsx
@@ -524,7 +524,11 @@ export function SessionDetail({
                               className="cursor-pointer hover:bg-muted/50"
                               onClick={() =>
                                 navigate(
-                                  `/projects/${project.slug}/logs/${log.id}`
+                                  `/projects/${project.slug}/logs/${log.id}${
+                                    log.timestamp
+                                      ? `?ts=${encodeURIComponent(log.timestamp)}`
+                                      : ''
+                                  }`
                                 )
                               }
                             >

--- a/web/src/pages/ProxyLogDetail.tsx
+++ b/web/src/pages/ProxyLogDetail.tsx
@@ -4,13 +4,17 @@ import { useBreadcrumbs } from '@/contexts/BreadcrumbContext'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { ArrowLeft } from 'lucide-react'
 import { useEffect } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 
 export default function ProxyLogDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const { setBreadcrumbs } = useBreadcrumbs()
   const logId = parseInt(id || '0', 10)
+  // Row timestamp forwarded by list links; bounds the backend's hypertable
+  // lookup. Absent on bare deep-links, which fall back to a wider scan.
+  const ts = searchParams.get('ts') ?? undefined
 
   useEffect(() => {
     setBreadcrumbs([
@@ -64,7 +68,7 @@ export default function ProxyLogDetailPage() {
         </div>
 
         {/* Detail Component */}
-        <ProxyLogDetail logId={logId} />
+        <ProxyLogDetail logId={logId} timestamp={ts} />
       </div>
     </div>
   )

--- a/web/src/pages/RequestLogDetail.tsx
+++ b/web/src/pages/RequestLogDetail.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { getProxyLogByIdOptions } from '@/api/client/@tanstack/react-query.gen'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -26,6 +26,10 @@ export default function RequestLogDetail({
 }: RequestLogDetailProps) {
   const { logId } = useParams<{ logId: string }>()
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  // Row timestamp forwarded by the list; bounds the backend's hypertable
+  // lookup. Absent on bare deep-links, which fall back to a wider scan.
+  const ts = searchParams.get('ts')
 
   const {
     data: logDetail,
@@ -36,6 +40,7 @@ export default function RequestLogDetail({
       path: {
         id: parseInt(logId || '0'),
       },
+      query: ts ? { timestamp: ts } : undefined,
     }),
     enabled: !!logId,
   })

--- a/web/src/pages/RequestLogsList.tsx
+++ b/web/src/pages/RequestLogsList.tsx
@@ -11,8 +11,17 @@ export default function RequestLogsList({
 }: RequestLogsListProps) {
   const navigate = useNavigate()
 
-  const handleRowClick = (logId: number) => {
-    navigate(`/projects/${projectResponse.slug}/logs/${logId}`)
+  const handleRowClick = (
+    logId: number,
+    _projectId: number,
+    timestamp: string
+  ) => {
+    // The row's timestamp lets the detail endpoint bound its hypertable
+    // lookup to the right chunks instead of scanning the whole retention
+    // window.
+    navigate(
+      `/projects/${projectResponse.slug}/logs/${logId}?ts=${encodeURIComponent(timestamp)}`
+    )
   }
 
   return (


### PR DESCRIPTION
## Problem

Two endpoints were slow on production (`app.temps.kfs.es`):

- `GET /api/proxy-logs/{id}` (request-log detail page) — multi-second responses
- `GET /api/monitors-health/projects` — few-hundred-ms responses

Both had the same root cause: **queries against TimescaleDB hypertables with no time predicate**, so the planner cannot exclude any chunk and compressed chunks must be decompressed.

### proxy-logs/{id}
`proxy_logs` is a hypertable (1-day chunks × 4 space partitions, 30-day retention, compressed after 7 days with `segmentby = project_id`). `get_by_id` ran a bare `WHERE id = $1`: ~28 uncompressed chunks get cheap PK probes, but the ~90 compressed chunks have no btree index and no usable batch metadata for `id`, so each was **fully decompressed** — and Append walks oldest-first, so ~3 weeks of traffic decompress before reaching the recent chunk that has the row.

### monitors-health/projects
The per-monitor `LATERAL ... ORDER BY checked_at DESC LIMIT 1` over `status_checks` (90-day retention → up to ~360 chunks, ~240 compressed) had no `checked_at` bound; a `LIMIT 1` merge needs the first tuple from every chunk input, per monitor.

## Fix

- `GET /proxy-logs/{id}` accepts an optional `timestamp` query param; the lookup is bounded to a ±1-day window around it (single-chunk probe). Without it, the recent uncompressed 7-day window is probed first; the unbounded scan only runs as a last resort so bare deep-links keep resolving.
- All web list views (project request logs, global proxy logs table, AI crawler feed, session detail) forward the row's timestamp as `?ts=` to the detail routes and through to the API.
- The monitor-health LATERAL gets `checked_at > NOW() - INTERVAL '1 day'` — an active monitor's latest check is at most one check interval old; a monitor whose checker has been dead >1 day now correctly counts as not operational instead of reporting a stale status.

## Notes

- `web/src/api/client/types.gen.ts` is hand-synced to the new utoipa param; regenerating the SDK against a server running this branch produces the same shape.
- Load/behaviour at saturation: no new queries or writes; both changes strictly shrink existing read plans. The unbounded fallback remains only for deep-links to logs older than 7 days.
- Follow-ups worth separate PRs: `get_by_request_id` has the same unbounded pattern (plus no index on `request_id`); both hypertables use pointless 4-way space partitioning on a serial `id`, which quadruples chunk count — fixable for new installs in the initial migration.

## Testing

- `cargo check --all-targets -p temps-proxy -p temps-status-page` clean; real `cargo clippy -- -D warnings` clean
- `cargo test --lib`: 395 passed; 1 pre-existing environmental failure (`test_proxy_route_resolution` binds port 9000, occupied by Docker locally)
- `tsc --noEmit` clean