### PR TITLE
fix(auth): enforce privilege ceiling on custom API key permissions

### DIFF
--- a/crates/temps-auth/src/apikey_handler.rs
+++ b/crates/temps-auth/src/apikey_handler.rs
@@ -17,7 +17,7 @@ use crate::apikey_handler_types::{
     ApiKeyListResponse, ApiKeyResponse, CreateApiKeyRequest, CreateApiKeyResponse,
     UpdateApiKeyRequest,
 };
-use crate::audit::ApiKeyRotatedAudit;
+use crate::audit::{ApiKeyCreatedAudit, ApiKeyRotatedAudit};
 use crate::{
     apikey_service::ApiKeyService,
     apikey_types::{get_available_permissions, AvailablePermissions},
@@ -35,6 +35,44 @@ pub struct ApiKeyState {
     pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
     /// Audit logger for write operations (e.g. key rotation)
     pub audit_service: Arc<dyn temps_core::AuditLogger>,
+}
+
+/// Privilege-escalation ceiling: a custom-permission API key must never
+/// grant more than the creating user's own effective permissions.
+///
+/// Without this check, any role holding `ApiKeysCreate` (e.g. the standard
+/// `Role::User`) could mint a key carrying `Permission::SystemAdmin` or any
+/// other permission outside its own role — a full privilege escalation,
+/// since `ApiKeyService::create_api_key` only validates that the requested
+/// permission strings parse, not that the requester holds them. Unparsable
+/// strings are left to that existing validation, which returns 400.
+fn enforce_custom_permission_ceiling(
+    auth: &crate::context::AuthContext,
+    request: &CreateApiKeyRequest,
+) -> Result<(), Problem> {
+    if request.role_type != "custom" {
+        return Ok(());
+    }
+    let Some(ref permissions) = request.permissions else {
+        return Ok(());
+    };
+    for perm_str in permissions {
+        if let Some(perm) = crate::permissions::Permission::from_str(perm_str) {
+            if !auth.has_permission(&perm) {
+                return Err(
+                    temps_core::error_builder::ErrorBuilder::new(StatusCode::FORBIDDEN)
+                        .type_("https://temps.sh/probs/permission-ceiling-exceeded")
+                        .title("Forbidden")
+                        .detail(format!(
+                            "Cannot grant permission '{perm_str}': it exceeds your own permissions"
+                        ))
+                        .value("error_code", "PERMISSION_CEILING_EXCEEDED")
+                        .build(),
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 #[utoipa::path(
@@ -57,15 +95,40 @@ pub struct ApiKeyState {
 pub async fn create_api_key(
     RequireAuth(auth): RequireAuth,
     State(state): State<Arc<ApiKeyState>>,
+    Extension(metadata): Extension<RequestMetadata>,
     Json(request): Json<CreateApiKeyRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ApiKeysCreate);
+
+    enforce_custom_permission_ceiling(&auth, &request)?;
+
+    // Capture audit fields before request is moved into the service call.
+    let role_type = request.role_type.clone();
+    let permissions = request.permissions.clone();
 
     let api_key = state
         .api_key_service
         .create_api_key(auth.user_id(), request.into())
         .await
         .map_err(|e| e.to_problem())?;
+
+    let audit = ApiKeyCreatedAudit {
+        context: AuditContext {
+            user_id: auth.user_id(),
+            ip_address: Some(metadata.ip_address.clone()),
+            user_agent: metadata.user_agent.clone(),
+        },
+        api_key_id: api_key.id,
+        api_key_name: api_key.name.clone(),
+        role_type,
+        permissions,
+    };
+    if let Err(e) = state.audit_service.create_audit_log(&audit).await {
+        error!(
+            "Failed to create audit log for API key {} creation: {}",
+            api_key.id, e
+        );
+    }
 
     state.telemetry.report(temps_core::TelemetryEvent::new(
         temps_core::TelemetryEventKind::ApiKeyCreated,
@@ -392,3 +455,101 @@ pub async fn get_api_key_permissions(RequireAuth(_auth): RequireAuth) -> impl In
     )
 )]
 pub struct ApiKeyApiDoc;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use temps_entities::users;
+
+    use crate::context::AuthContext;
+    use crate::permissions::Role;
+
+    fn test_user(id: i32) -> users::Model {
+        let now = Utc::now();
+        users::Model {
+            id,
+            name: "Test User".to_string(),
+            email: format!("user{}@example.com", id),
+            password_hash: None,
+            email_verified: true,
+            email_verification_token: None,
+            email_verification_expires: None,
+            password_reset_token: None,
+            password_reset_expires: None,
+            deleted_at: None,
+            mfa_secret: None,
+            mfa_enabled: false,
+            mfa_recovery_codes: None,
+            oidc_subject: None,
+            oidc_provider_id: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn user_auth(role: Role) -> AuthContext {
+        AuthContext::new_session(test_user(42), role)
+    }
+
+    fn custom_request(permissions: Vec<&str>) -> CreateApiKeyRequest {
+        CreateApiKeyRequest {
+            name: "test-key".to_string(),
+            role_type: "custom".to_string(),
+            permissions: Some(permissions.into_iter().map(String::from).collect()),
+            expires_at: None,
+        }
+    }
+
+    /// `Role::User` does not hold `Permission::SystemAdmin` — this is the
+    /// exact escalation path that motivated this check (see finding logged
+    /// during ADR 0008 research).
+    #[test]
+    fn custom_role_cannot_grant_permission_actor_does_not_hold() {
+        let auth = user_auth(Role::User);
+        let req = custom_request(vec!["system:admin"]);
+        let err = enforce_custom_permission_ceiling(&auth, &req).unwrap_err();
+        assert_eq!(err.status_code, StatusCode::FORBIDDEN);
+    }
+
+    /// `Role::User` does hold `ProjectsRead` — a custom key scoped to a
+    /// subset of the actor's own permissions must succeed.
+    #[test]
+    fn custom_role_can_grant_permission_actor_holds() {
+        let auth = user_auth(Role::User);
+        let req = custom_request(vec!["projects:read"]);
+        assert!(enforce_custom_permission_ceiling(&auth, &req).is_ok());
+    }
+
+    /// `Role::Admin` holds every permission, including `SystemAdmin` —
+    /// confirms the check is a real ceiling, not a blanket denial.
+    #[test]
+    fn admin_can_grant_any_permission() {
+        let auth = user_auth(Role::Admin);
+        let req = custom_request(vec!["system:admin", "users:delete"]);
+        assert!(enforce_custom_permission_ceiling(&auth, &req).is_ok());
+    }
+
+    /// Non-custom role types (predefined roles) bypass the ceiling check
+    /// entirely — they don't carry an arbitrary permission list to bound.
+    #[test]
+    fn predefined_role_type_skips_ceiling_check() {
+        let auth = user_auth(Role::User);
+        let req = CreateApiKeyRequest {
+            name: "test-key".to_string(),
+            role_type: "admin".to_string(),
+            permissions: None,
+            expires_at: None,
+        };
+        assert!(enforce_custom_permission_ceiling(&auth, &req).is_ok());
+    }
+
+    /// An unparsable permission string is left to the service layer's
+    /// existing validation (400), not rejected here as a ceiling violation.
+    #[test]
+    fn unparsable_permission_string_is_not_a_ceiling_violation() {
+        let auth = user_auth(Role::User);
+        let req = custom_request(vec!["not-a-real-permission"]);
+        assert!(enforce_custom_permission_ceiling(&auth, &req).is_ok());
+    }
+}

--- a/crates/temps-auth/src/apikey_handler.rs
+++ b/crates/temps-auth/src/apikey_handler.rs
@@ -37,42 +37,60 @@ pub struct ApiKeyState {
     pub audit_service: Arc<dyn temps_core::AuditLogger>,
 }
 
-/// Privilege-escalation ceiling: a custom-permission API key must never
-/// grant more than the creating user's own effective permissions.
+/// Privilege-escalation ceiling: an API key must never grant more than the
+/// creating user's own effective permissions — whether requested as an
+/// explicit `role_type: "custom"` permission list, or as a predefined role
+/// name (`role_type: "admin"`, `"platform_admin"`, etc.).
 ///
 /// Without this check, any role holding `ApiKeysCreate` (e.g. the standard
 /// `Role::User`) could mint a key carrying `Permission::SystemAdmin` or any
 /// other permission outside its own role — a full privilege escalation,
-/// since `ApiKeyService::create_api_key` only validates that the requested
-/// permission strings parse, not that the requester holds them. Unparsable
-/// strings are left to that existing validation, which returns 400.
-fn enforce_custom_permission_ceiling(
+/// since `ApiKeyService::create_api_key` only validates that requested
+/// custom permission strings parse, and for predefined roles only that the
+/// role name is one of the known roles — neither path checks that the
+/// requester actually holds the permissions being granted. Unparsable
+/// custom permission strings and unrecognized role names are left to that
+/// existing validation, which returns 400.
+fn enforce_permission_ceiling(
     auth: &crate::context::AuthContext,
     request: &CreateApiKeyRequest,
 ) -> Result<(), Problem> {
-    if request.role_type != "custom" {
+    if request.role_type == "custom" {
+        let Some(ref permissions) = request.permissions else {
+            return Ok(());
+        };
+        for perm_str in permissions {
+            if let Some(perm) = crate::permissions::Permission::from_str(perm_str) {
+                if !auth.has_permission(&perm) {
+                    return Err(permission_ceiling_exceeded(perm_str));
+                }
+            }
+        }
         return Ok(());
     }
-    let Some(ref permissions) = request.permissions else {
-        return Ok(());
-    };
-    for perm_str in permissions {
-        if let Some(perm) = crate::permissions::Permission::from_str(perm_str) {
-            if !auth.has_permission(&perm) {
-                return Err(
-                    temps_core::error_builder::ErrorBuilder::new(StatusCode::FORBIDDEN)
-                        .type_("https://temps.sh/probs/permission-ceiling-exceeded")
-                        .title("Forbidden")
-                        .detail(format!(
-                            "Cannot grant permission '{perm_str}': it exceeds your own permissions"
-                        ))
-                        .value("error_code", "PERMISSION_CEILING_EXCEEDED")
-                        .build(),
-                );
+
+    // Predefined role type: the minted key inherits that role's ENTIRE
+    // permission set, so every permission the role carries must also be
+    // held by the requester — not just some of them.
+    if let Some(role) = crate::permissions::Role::from_str(&request.role_type) {
+        for perm in role.permissions() {
+            if !auth.has_permission(perm) {
+                return Err(permission_ceiling_exceeded(&perm.to_string()));
             }
         }
     }
     Ok(())
+}
+
+fn permission_ceiling_exceeded(perm_str: &str) -> Problem {
+    temps_core::error_builder::ErrorBuilder::new(StatusCode::FORBIDDEN)
+        .type_("https://temps.sh/probs/permission-ceiling-exceeded")
+        .title("Forbidden")
+        .detail(format!(
+            "Cannot grant permission '{perm_str}': it exceeds your own permissions"
+        ))
+        .value("error_code", "PERMISSION_CEILING_EXCEEDED")
+        .build()
 }
 
 #[utoipa::path(
@@ -100,7 +118,7 @@ pub async fn create_api_key(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ApiKeysCreate);
 
-    enforce_custom_permission_ceiling(&auth, &request)?;
+    enforce_permission_ceiling(&auth, &request)?;
 
     // Capture audit fields before request is moved into the service call.
     let role_type = request.role_type.clone();
@@ -508,7 +526,7 @@ mod tests {
     fn custom_role_cannot_grant_permission_actor_does_not_hold() {
         let auth = user_auth(Role::User);
         let req = custom_request(vec!["system:admin"]);
-        let err = enforce_custom_permission_ceiling(&auth, &req).unwrap_err();
+        let err = enforce_permission_ceiling(&auth, &req).unwrap_err();
         assert_eq!(err.status_code, StatusCode::FORBIDDEN);
     }
 
@@ -518,7 +536,7 @@ mod tests {
     fn custom_role_can_grant_permission_actor_holds() {
         let auth = user_auth(Role::User);
         let req = custom_request(vec!["projects:read"]);
-        assert!(enforce_custom_permission_ceiling(&auth, &req).is_ok());
+        assert!(enforce_permission_ceiling(&auth, &req).is_ok());
     }
 
     /// `Role::Admin` holds every permission, including `SystemAdmin` —
@@ -527,21 +545,57 @@ mod tests {
     fn admin_can_grant_any_permission() {
         let auth = user_auth(Role::Admin);
         let req = custom_request(vec!["system:admin", "users:delete"]);
-        assert!(enforce_custom_permission_ceiling(&auth, &req).is_ok());
+        assert!(enforce_permission_ceiling(&auth, &req).is_ok());
     }
 
-    /// Non-custom role types (predefined roles) bypass the ceiling check
-    /// entirely — they don't carry an arbitrary permission list to bound.
-    #[test]
-    fn predefined_role_type_skips_ceiling_check() {
-        let auth = user_auth(Role::User);
-        let req = CreateApiKeyRequest {
+    fn predefined_request(role_type: &str) -> CreateApiKeyRequest {
+        CreateApiKeyRequest {
             name: "test-key".to_string(),
-            role_type: "admin".to_string(),
+            role_type: role_type.to_string(),
             permissions: None,
             expires_at: None,
-        };
-        assert!(enforce_custom_permission_ceiling(&auth, &req).is_ok());
+        }
+    }
+
+    /// `Role::User` does not hold every permission `Role::Admin` carries —
+    /// self-minting a key with `role_type: "admin"` is the predefined-role
+    /// counterpart of the custom-permission escalation above, and must be
+    /// denied the same way.
+    #[test]
+    fn predefined_role_type_cannot_grant_role_actor_does_not_hold() {
+        let auth = user_auth(Role::User);
+        let req = predefined_request("admin");
+        let err = enforce_permission_ceiling(&auth, &req).unwrap_err();
+        assert_eq!(err.status_code, StatusCode::FORBIDDEN);
+    }
+
+    /// A user requesting a predefined role that is a subset of (or equal
+    /// to) their own permissions — the common case of a `Role::User`
+    /// minting a `role_type: "user"` key — must succeed.
+    #[test]
+    fn predefined_role_type_can_grant_role_actor_holds() {
+        let auth = user_auth(Role::User);
+        let req = predefined_request("user");
+        assert!(enforce_permission_ceiling(&auth, &req).is_ok());
+    }
+
+    /// `Role::Admin` holds every permission, including everything
+    /// `Role::Admin` itself carries — confirms the predefined-role check is
+    /// a real ceiling, not a blanket denial.
+    #[test]
+    fn admin_can_grant_predefined_admin_role() {
+        let auth = user_auth(Role::Admin);
+        let req = predefined_request("admin");
+        assert!(enforce_permission_ceiling(&auth, &req).is_ok());
+    }
+
+    /// An unrecognized role name is left to the service layer's existing
+    /// validation (400), not rejected here as a ceiling violation.
+    #[test]
+    fn unrecognized_role_type_is_not_a_ceiling_violation() {
+        let auth = user_auth(Role::User);
+        let req = predefined_request("not-a-real-role");
+        assert!(enforce_permission_ceiling(&auth, &req).is_ok());
     }
 
     /// An unparsable permission string is left to the service layer's
@@ -550,6 +604,6 @@ mod tests {
     fn unparsable_permission_string_is_not_a_ceiling_violation() {
         let auth = user_auth(Role::User);
         let req = custom_request(vec!["not-a-real-permission"]);
-        assert!(enforce_custom_permission_ceiling(&auth, &req).is_ok());
+        assert!(enforce_permission_ceiling(&auth, &req).is_ok());
     }
 }

--- a/crates/temps-auth/src/audit.rs
+++ b/crates/temps-auth/src/audit.rs
@@ -133,6 +133,19 @@ pub struct EmailVerifiedAudit {
     pub email: String,
 }
 
+// API key creation audit. Custom-permission keys are the highest-impact
+// variant -- capturing role_type and the granted permission strings lets an
+// auditor spot an over-broad grant after the fact without needing to
+// correlate against the key's current (mutable) state.
+#[derive(Debug, Clone, Serialize)]
+pub struct ApiKeyCreatedAudit {
+    pub context: AuditContext,
+    pub api_key_id: i32,
+    pub api_key_name: String,
+    pub role_type: String,
+    pub permissions: Option<Vec<String>>,
+}
+
 // API key rotation audit. Rotation invalidates the old secret and mints a new
 // one for the same key record -- an auditor needs the key's id/name to tie
 // this event to the credential's lifecycle without seeing the secret itself.
@@ -530,6 +543,29 @@ impl AuditOperation for PasswordChangedAudit {
 impl AuditOperation for EmailVerifiedAudit {
     fn operation_type(&self) -> String {
         "EMAIL_VERIFIED".to_string()
+    }
+
+    fn user_id(&self) -> i32 {
+        self.context.user_id
+    }
+
+    fn ip_address(&self) -> Option<String> {
+        self.context.ip_address.clone()
+    }
+
+    fn user_agent(&self) -> &str {
+        &self.context.user_agent
+    }
+
+    fn serialize(&self) -> Result<String> {
+        serde_json::to_string(self)
+            .map_err(|e| anyhow::anyhow!("Failed to serialize audit operation {}", e))
+    }
+}
+
+impl AuditOperation for ApiKeyCreatedAudit {
+    fn operation_type(&self) -> String {
+        "API_KEY_CREATED".to_string()
     }
 
     fn user_id(&self) -> i32 {


### PR DESCRIPTION
## Summary

**CRITICAL — please review before merging.** `POST /api-keys` had no check that requested permissions were a subset of the creating user's own permissions, for **either** way of requesting elevated access:

1. `role_type: "custom", permissions: ["system:admin", ...]` — the service layer only validated that each permission string parsed into a valid `Permission` variant.
2. `role_type: "admin"` (or any other predefined role) — the service layer only validated that the role name was one of the known roles.

Any authenticated user whose role holds `ApiKeysCreate` (which includes the standard, default `Role::User`) could call this endpoint either way and receive back a fully functional API key with permissions their own account never had — a full privilege escalation via a single API call. The predefined-role path (2) is if anything the more severe of the two: no permission enumeration needed, just `role_type: "admin"`.

- Adds `enforce_permission_ceiling()` in `apikey_handler.rs` (originally `enforce_custom_permission_ceiling`, renamed and extended once the predefined-role gap was found live-testing this PR), called after the existing `permission_guard!(auth, ApiKeysCreate)` and before the service call.
  - For `role_type == "custom"`: every requested permission that parses is checked against `auth.has_permission(...)`.
  - For a predefined `role_type`: every permission that role carries (`Role::permissions()`) is checked against `auth.has_permission(...)` — the actor must already hold the role's *entire* permission set, not just some of it.
  - Either way, the first permission the actor doesn't hold returns 403 `PERMISSION_CEILING_EXCEEDED`. Unparseable custom permission strings and unrecognized role names still fall through to the service layer's existing 400.
- Scoped to the HTTP handler only. `ApiKeyService::create_api_key`'s other two callers — the local `temps api-key` CLI (already root-equivalent: direct DB access) and the CLI device-flow approval (always mints a key matching the *approving user's own* role, never custom) — are outside this ceiling's threat model and were left untouched.
- Adds an audit log entry for key creation (`ApiKeyCreatedAudit`), matching the existing pattern already used for key rotation — creation previously had none.
- `PATCH /api-keys/{id}` was checked as a possible bypass (rotate an existing key's `role_type` post-creation) — confirmed not exploitable, `update_api_key` never sets `role_type` from `UpdateApiKeyRequest`.

Found while researching an unrelated ADR (Custom Roles design work) and cross-checking the claim that "API key creation already enforces a permission ceiling" — it didn't. The predefined-role gap was found live-testing this PR's own fix in an isolated worktree/DB/port sandbox, via both direct API calls and the actual Create API Key UI.

Security-reviewed by a dedicated security-auditor pass on the original custom-permission fix: **PASS**, no new issues introduced. That review also surfaced a few small pre-existing/adjacent issues (no audit log on creation — now fixed here; a dead `permissions` field on the update endpoint that's silently ignored; `Permission::all()` missing one variant) — tracked separately, not blocking this fix.

## Test plan
- [x] `cargo check --lib` (workspace) — clean
- [x] `cargo test --lib -p temps-auth` — 9 tests in `apikey_handler::tests` covering both the custom-permission ceiling (escalation denied, in-ceiling grant allowed, admin can grant anything, unparseable string isn't a violation) and the predefined-role ceiling (escalation denied, in-ceiling role allowed, admin can grant admin, unrecognized role name isn't a violation)
- [x] `cargo clippy -p temps-auth -- -D warnings` (real clippy, not the rtk-wrapped one) — clean
- [x] Manual verification against a running instance — done, in an isolated worktree + isolated Postgres (`timescale/timescaledb-ha:pg18`) + non-default ports (8085/8086/8446/3002), so as not to disturb other local dev instances:
  - Direct API: `Role::User` session → `POST /api-keys {role_type:"custom", permissions:["system:admin"]}` → 403 `PERMISSION_CEILING_EXCEEDED`; `POST /api-keys {role_type:"admin"}` → 403 (previously 201, this fix's new coverage); in-ceiling grants (`projects:read`, `role_type:"user"`) → 201 with correct `ApiKeyCreatedAudit` row.
  - UI: same `system:admin` escalation attempt through the actual Create API Key wizard → clean "Forbidden" toast with the exact ceiling-exceeded message, no key value ever displayed, no orphan row left in the API Keys list.
