### PR TITLE
feat(auth): project-scoped permission narrowing (project_permission_guard!)

### DIFF
--- a/crates/temps-auth/src/permission_guard.rs
+++ b/crates/temps-auth/src/permission_guard.rs
@@ -217,6 +217,147 @@ macro_rules! project_access_guard {
     };
 }
 
+/// Guard that enforces a *specific* permission within a project's team-scoped
+/// access grant, narrowing what [`permission_guard!`] alone allows.
+///
+/// `permission_guard!` proves the caller's **instance-wide** role has this
+/// permission at all; `project_access_guard!` proves the caller can touch
+/// this **project** at all, but not which actions. Neither answers "does
+/// this user's *role on this specific project* include this permission" —
+/// e.g. a project team member granted a read-only role should not be able to
+/// deploy, even though their instance-wide role and their team membership
+/// both otherwise check out. This macro is the seam that closes that gap.
+///
+/// This macro is **self-contained**: it performs the instance-wide
+/// permission check *and* the project-scoped narrowing in one call, so a
+/// single invocation is the complete gate for a project-scoped, permissioned
+/// action. Do not also call [`permission_guard!`] for the same permission in
+/// the same handler — that would be redundant, not incorrect, but this macro
+/// already does it.
+///
+/// **Call order** in a handler that needs it (replaces the
+/// `permission_guard!` + `project_access_guard!` pair for handlers that need
+/// permission-specific project narrowing; `project_scope_guard!` for
+/// deployment-token IDOR is unaffected and still runs separately):
+///
+/// ```ignore
+/// project_permission_guard!(auth, DeploymentsCreate, project_id, checker); // 1+3 combined
+/// project_scope_guard!(auth, project_id);                                 // 2. deployment-token IDOR
+/// ```
+///
+/// `checker` is the same `Option<Arc<dyn temps_core::ProjectAccessChecker>>`
+/// field `project_access_guard!` takes.
+///
+/// **Precedence — final = instance-wide ∩ project-scoped.** A project role
+/// can only ever *remove* permissions the instance-wide role already grants;
+/// it can never add one. Concretely:
+///
+/// 1. Instance-wide ceiling first — identical to `permission_guard!`. A
+///    caller whose instance-wide role lacks the permission is rejected here,
+///    before any project-scoped lookup — the existing instance-wide
+///    behaviour (e.g. a `user`-role account getting 403 on delete
+///    operations) is unchanged.
+/// 2. Deployment tokens skip project-scoped narrowing (governed by
+///    `project_scope_guard!` instead, and carry no user identity to resolve
+///    project-scoped permissions for) — same as `project_access_guard!`.
+/// 3. Instance Admin / PlatformAdmin bypass project-scoped narrowing
+///    entirely — same bypass `project_access_guard!` grants, for the same
+///    reason (an instance admin who is not a team member must not be locked
+///    out).
+/// 4. Otherwise, `checker.effective_project_permissions(user_id, project_id)`
+///    is consulted:
+///    - `Ok(None)` → unrestricted from this checker's perspective (no plugin
+///      registered, or the project has no team grants) — the instance-wide
+///      result from step 1 stands.
+///    - `Ok(Some(perms))` → the permission must be present in `perms`, else
+///      403. An empty `perms` denies every project-scoped permission.
+///    - `Err(_)` → fail-closed, 500. Never a silent allow.
+#[macro_export]
+macro_rules! project_permission_guard {
+    ($auth:expr, $permission:ident, $project_id:expr, $checker:expr) => {{
+        // Step 1: instance-wide ceiling — identical to permission_guard!.
+        if !$auth.has_permission(&$crate::permissions::Permission::$permission) {
+            return Err(temps_core::error_builder::ErrorBuilder::new(
+                ::axum::http::StatusCode::FORBIDDEN,
+            )
+            .type_("https://temps.sh/probs/insufficient-permissions")
+            .title("Insufficient Permissions")
+            .detail(format!(
+                "This operation requires the {} permission",
+                $crate::permissions::Permission::$permission.to_string()
+            ))
+            .value(
+                "required_permission",
+                $crate::permissions::Permission::$permission.to_string(),
+            )
+            .value("user_role", $auth.effective_role.to_string())
+            .build());
+        }
+
+        // Deployment tokens are governed by project_scope_guard! instead and
+        // carry no user identity — skip project-scoped narrowing entirely.
+        if !$auth.is_deployment_token() {
+            // Instance administrators are never restricted by team membership.
+            if !($auth.is_admin()
+                || $auth.has_role(&$crate::permissions::Role::PlatformAdmin))
+            {
+                if let Some(ref __checker) = $checker {
+                    if let Some(__user_id) = $auth.user_id_opt() {
+                        match __checker
+                            .effective_project_permissions(__user_id, $project_id)
+                            .await
+                        {
+                            // No opinion from this checker — instance-wide result stands.
+                            Ok(None) => {}
+                            Ok(Some(__perms)) => {
+                                let __required =
+                                    $crate::permissions::Permission::$permission.to_string();
+                                if !__perms.iter().any(|__p| __p == &__required) {
+                                    return Err(temps_core::error_builder::ErrorBuilder::new(
+                                        ::axum::http::StatusCode::FORBIDDEN,
+                                    )
+                                    .type_("https://temps.sh/probs/project-permission-denied")
+                                    .title("Project Permission Denied")
+                                    .detail(format!(
+                                        "Your role on this project does not include the {} \
+                                         permission",
+                                        __required
+                                    ))
+                                    .value("required_permission", __required)
+                                    .build());
+                                }
+                            }
+                            Err(__e) => {
+                                ::tracing::error!(
+                                    project_id = $project_id,
+                                    user_id = __user_id,
+                                    error = %__e,
+                                    "ProjectAccessChecker::effective_project_permissions \
+                                     infrastructure failure — denying access"
+                                );
+                                return Err(temps_core::error_builder::ErrorBuilder::new(
+                                    ::axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                                )
+                                .type_("https://temps.sh/probs/project-permission-check-failed")
+                                .title("Project Permission Check Failed")
+                                .detail(
+                                    "Could not verify project permissions; please try again",
+                                )
+                                .build());
+                            }
+                        }
+                    }
+                    // user_id_opt() == None here is impossible: deployment tokens
+                    // (the only non-user auth source) are filtered by the outer
+                    // is_deployment_token() check above.
+                }
+                // checker is None → no plugin registered → no-op beyond step 1.
+            }
+            // Admin / PlatformAdmin → unrestricted beyond step 1.
+        }
+    }};
+}
+
 /// Alias for permission_guard! macro for backwards compatibility
 ///
 /// Usage in handler:
@@ -452,6 +593,251 @@ mod tests {
     }
 
     // ---------------------------------------------------------------------------
+    // project_permission_guard! tests (permission-specific project narrowing)
+    // ---------------------------------------------------------------------------
+
+    type EffectivePermissionsResult =
+        Result<Option<Vec<String>>, Box<dyn std::error::Error + Send + Sync>>;
+
+    /// A mock [`ProjectAccessChecker`] whose `effective_project_permissions`
+    /// result is configurable, for `project_permission_guard!` tests.
+    /// `user_can_access_project` is a trivial always-allow stub — these tests
+    /// never exercise it.
+    struct MockPermissionChecker {
+        result: fn() -> EffectivePermissionsResult,
+    }
+
+    impl MockPermissionChecker {
+        fn unrestricted() -> Arc<dyn ProjectAccessChecker> {
+            Arc::new(MockPermissionChecker {
+                result: || Ok(None),
+            })
+        }
+
+        fn with_perms(perms: &'static [&'static str]) -> Arc<dyn ProjectAccessChecker> {
+            // fn pointers can't capture `perms` by closure, so encode the two
+            // fixed sets this test file actually needs directly.
+            if perms == ["deployments:create"] {
+                Arc::new(MockPermissionChecker {
+                    result: || Ok(Some(vec!["deployments:create".to_string()])),
+                })
+            } else {
+                Arc::new(MockPermissionChecker {
+                    result: || Ok(Some(vec!["projects:read".to_string()])),
+                })
+            }
+        }
+
+        fn empty() -> Arc<dyn ProjectAccessChecker> {
+            Arc::new(MockPermissionChecker {
+                result: || Ok(Some(vec![])),
+            })
+        }
+
+        fn error() -> Arc<dyn ProjectAccessChecker> {
+            Arc::new(MockPermissionChecker {
+                result: || Err(Box::new(std::io::Error::other("simulated DB failure"))),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl ProjectAccessChecker for MockPermissionChecker {
+        async fn user_can_access_project(
+            &self,
+            _user_id: i32,
+            _project_id: i32,
+        ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(true)
+        }
+
+        async fn effective_project_permissions(
+            &self,
+            _user_id: i32,
+            _project_id: i32,
+        ) -> Result<Option<Vec<String>>, Box<dyn std::error::Error + Send + Sync>> {
+            (self.result)()
+        }
+    }
+
+    /// Runs `project_permission_guard!` requiring `DeploymentsCreate` and
+    /// returns `Ok(())` or `Err(Problem)`.
+    async fn run_permission_guard(
+        auth: &AuthContext,
+        project_id: i32,
+        checker: Option<Arc<dyn ProjectAccessChecker>>,
+    ) -> Result<(), Problem> {
+        project_permission_guard!(auth, DeploymentsCreate, project_id, checker);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn permission_guard_instance_ceiling_blocks_before_project_lookup() {
+        // Role::User lacks DeploymentsDelete outright — the instance-wide
+        // check must reject before any project-scoped lookup happens, exactly
+        // like permission_guard! does today.
+        let auth = user_auth(Role::User);
+        async fn run_delete_guard(
+            auth: &AuthContext,
+            project_id: i32,
+            checker: Option<Arc<dyn ProjectAccessChecker>>,
+        ) -> Result<(), Problem> {
+            project_permission_guard!(auth, DeploymentsDelete, project_id, checker);
+            Ok(())
+        }
+        // Even a checker that would grant everything must not matter — the
+        // instance ceiling is checked first.
+        let checker = Some(MockPermissionChecker::unrestricted());
+        let result = run_delete_guard(&auth, 1, checker).await;
+        let err = result.expect_err("instance-wide ceiling must reject before project lookup");
+        assert_eq!(err.status_code, axum::http::StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn permission_guard_viewer_blocked_from_deploy() {
+        // The reproduced hole: instance role `user` (has DeploymentsCreate
+        // instance-wide) + a project-scoped role whose resolved permission
+        // set does NOT include deployments:create → must be denied.
+        let auth = user_auth(Role::User);
+        let checker = Some(MockPermissionChecker::with_perms(&["projects:read"]));
+        let result = run_permission_guard(&auth, 1, checker).await;
+        let err = result.expect_err("a project role without deployments:create must be denied");
+        assert_eq!(err.status_code, axum::http::StatusCode::FORBIDDEN);
+        assert_eq!(
+            err.body.get("type").and_then(|v| v.as_str()),
+            Some("https://temps.sh/probs/project-permission-denied")
+        );
+    }
+
+    #[tokio::test]
+    async fn permission_guard_deployer_allowed_deploy() {
+        let auth = user_auth(Role::User);
+        let checker = Some(MockPermissionChecker::with_perms(&["deployments:create"]));
+        let result = run_permission_guard(&auth, 1, checker).await;
+        assert!(
+            result.is_ok(),
+            "a project role that includes deployments:create must be allowed"
+        );
+    }
+
+    #[tokio::test]
+    async fn permission_guard_empty_perms_denies() {
+        let auth = user_auth(Role::User);
+        let checker = Some(MockPermissionChecker::empty());
+        let result = run_permission_guard(&auth, 1, checker).await;
+        assert!(
+            result.is_err(),
+            "an empty project-scoped permission set must deny every action"
+        );
+    }
+
+    #[tokio::test]
+    async fn permission_guard_unrestricted_falls_through_to_instance_wide() {
+        // Ok(None) means "no opinion" — the instance-wide result (which
+        // already passed) stands.
+        let auth = user_auth(Role::User);
+        let checker = Some(MockPermissionChecker::unrestricted());
+        let result = run_permission_guard(&auth, 1, checker).await;
+        assert!(
+            result.is_ok(),
+            "Ok(None) must fall through to the instance-wide result"
+        );
+    }
+
+    #[tokio::test]
+    async fn permission_guard_resolver_error_returns_500() {
+        let auth = user_auth(Role::User);
+        let checker = Some(MockPermissionChecker::error());
+        let result = run_permission_guard(&auth, 1, checker).await;
+        let err = result.expect_err("infrastructure error must deny, never allow");
+        assert_eq!(
+            err.status_code,
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    #[tokio::test]
+    async fn permission_guard_no_checker_registered_is_instance_wide_only() {
+        let auth = user_auth(Role::User);
+        let result = run_permission_guard(&auth, 1, None).await;
+        assert!(
+            result.is_ok(),
+            "no checker registered must reduce to the instance-wide check only"
+        );
+    }
+
+    #[tokio::test]
+    async fn permission_guard_admin_bypasses_project_narrowing() {
+        let auth = user_auth(Role::Admin);
+        // Even a deny-everything checker must not block an instance admin.
+        let checker = Some(MockPermissionChecker::empty());
+        let result = run_permission_guard(&auth, 1, checker).await;
+        assert!(
+            result.is_ok(),
+            "instance Admin must bypass project narrowing"
+        );
+    }
+
+    #[tokio::test]
+    async fn permission_guard_platform_admin_bypasses_project_narrowing() {
+        // PlatformAdmin's instance-wide role deliberately excludes
+        // Deployments{Create,Write,Delete} (read-only on deployments) — use
+        // DeploymentsRead here so this test isolates the bypass behaviour
+        // instead of tripping the (correct, separate) instance-wide ceiling.
+        async fn run_read_guard(
+            auth: &AuthContext,
+            project_id: i32,
+            checker: Option<Arc<dyn ProjectAccessChecker>>,
+        ) -> Result<(), Problem> {
+            project_permission_guard!(auth, DeploymentsRead, project_id, checker);
+            Ok(())
+        }
+        let auth = user_auth(Role::PlatformAdmin);
+        let checker = Some(MockPermissionChecker::empty());
+        let result = run_read_guard(&auth, 1, checker).await;
+        assert!(
+            result.is_ok(),
+            "instance PlatformAdmin must bypass project narrowing"
+        );
+    }
+
+    #[tokio::test]
+    async fn permission_guard_deployment_token_bypasses_project_narrowing() {
+        // `AuthContext::has_permission` deliberately only bridges deployment
+        // tokens to a small explicit whitelist of `Permission` variants
+        // (AnalyticsRead/AnalyticsWrite/EmailsSend) — DeploymentsCreate is
+        // not one of them by design ("no implicit bridge from
+        // deployment-token permissions to general control-plane
+        // permissions"), so no deployment token can ever pass step 1 for
+        // that permission, with or without this macro. Use AnalyticsRead
+        // (one of the bridged permissions) so this test isolates what it's
+        // actually testing: that project-scoped narrowing is skipped for
+        // deployment tokens, once step 1 passes.
+        async fn run_analytics_guard(
+            auth: &AuthContext,
+            project_id: i32,
+            checker: Option<Arc<dyn ProjectAccessChecker>>,
+        ) -> Result<(), Problem> {
+            project_permission_guard!(auth, AnalyticsRead, project_id, checker);
+            Ok(())
+        }
+        let auth = AuthContext::new_deployment_token(
+            7,
+            None,
+            None,
+            1,
+            "deploy-token".to_string(),
+            vec![temps_entities::deployment_tokens::DeploymentTokenPermission::AnalyticsRead],
+        );
+        let checker = Some(MockPermissionChecker::empty());
+        let result = run_analytics_guard(&auth, 7, checker).await;
+        assert!(
+            result.is_ok(),
+            "deployment tokens are governed by project_scope_guard! instead"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
     // ADR-028 Phase B: Coverage enumeration
     //
     // Every Rust source file that contains `project_scope_guard!` must also
@@ -617,6 +1003,94 @@ mod tests {
             extra_found.is_empty(),
             "These crates use `project_access_guard!` but are not listed in the coverage \
              snapshot — add them to `expected_crates` (sorted alphabetically):\n{}",
+            extra_found.join("\n")
+        );
+    }
+
+    /// v1 coverage snapshot for `project_permission_guard!` (permission-specific
+    /// project narrowing, distinct from `project_access_guard!`'s coarser
+    /// "can touch this project at all" check).
+    ///
+    /// v1 deliberately covers only the highest-risk project-scoped actions
+    /// (deployment create/trigger, project delete/settings, environment
+    /// variable create/write/delete, domain create/write/delete) — see the
+    /// ADR for the full rationale on what's deferred and why. This test is
+    /// the "reviewed allowlist" that ADR calls for: it does NOT enumerate
+    /// every handler function (that's noted as a mechanical follow-up once
+    /// the seam is proven), but it does pin which CRATES are expected to use
+    /// the guard, the same granularity `project_access_guard_coverage_snapshot`
+    /// already uses. Bidirectional for the same reason that one is: catches
+    /// both accidental removal and silent, unreviewed expansion.
+    #[test]
+    fn project_permission_guard_coverage_snapshot() {
+        let expected_crates: &[&str] =
+            &["temps-deployments", "temps-environments", "temps-projects"];
+
+        let mut sorted = expected_crates.to_vec();
+        sorted.sort_unstable();
+        assert_eq!(
+            expected_crates,
+            sorted.as_slice(),
+            "keep the coverage snapshot sorted alphabetically"
+        );
+
+        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let workspace_root = manifest_dir
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("cannot resolve workspace root");
+        let crates_dir = workspace_root.join("crates");
+
+        let mut found_crates: std::collections::BTreeSet<String> = Default::default();
+
+        for entry in walkdir::WalkDir::new(&crates_dir)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("rs"))
+        {
+            let path = entry.path();
+            let contents = match std::fs::read_to_string(path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            if contents.contains("macro_rules! project_permission_guard") {
+                continue;
+            }
+            if contents.contains("project_permission_guard!(") {
+                let mut dir = path.parent();
+                while let Some(d) = dir {
+                    if d.join("Cargo.toml").exists() {
+                        if let Some(name) = d.file_name().and_then(|n| n.to_str()) {
+                            found_crates.insert(name.to_string());
+                        }
+                        break;
+                    }
+                    dir = d.parent();
+                }
+            }
+        }
+
+        for expected in expected_crates {
+            assert!(
+                found_crates.contains(*expected),
+                "Crate `{}` is in the project_permission_guard! coverage snapshot but no \
+                 usage was found in its source — was it accidentally removed?",
+                expected
+            );
+        }
+
+        let expected_set: std::collections::BTreeSet<&str> =
+            expected_crates.iter().copied().collect();
+        let extra_found: Vec<&str> = found_crates
+            .iter()
+            .filter(|c| !expected_set.contains(c.as_str()))
+            .map(|s| s.as_str())
+            .collect();
+        assert!(
+            extra_found.is_empty(),
+            "These crates use `project_permission_guard!` but are not listed in the coverage \
+             snapshot — add them to `expected_crates` (sorted alphabetically) after reviewing \
+             the new usage:\n{}",
             extra_found.join("\n")
         );
     }

--- a/crates/temps-auth/src/permission_guard.rs
+++ b/crates/temps-auth/src/permission_guard.rs
@@ -346,10 +346,24 @@ macro_rules! project_permission_guard {
                                 .build());
                             }
                         }
+                    } else {
+                        // user_id_opt() == None here is impossible today:
+                        // deployment tokens (the only non-user auth source) are
+                        // filtered by the outer is_deployment_token() check
+                        // above, and every other AuthSource carries a user. If
+                        // a future AuthSource variant broke that invariant,
+                        // fail closed rather than silently skipping the
+                        // project-scoped check.
+                        return Err(temps_core::error_builder::ErrorBuilder::new(
+                            ::axum::http::StatusCode::FORBIDDEN,
+                        )
+                        .type_("https://temps.sh/probs/insufficient-permissions")
+                        .title("Insufficient Permissions")
+                        .detail(
+                            "Could not resolve caller identity for project permission check",
+                        )
+                        .build());
                     }
-                    // user_id_opt() == None here is impossible: deployment tokens
-                    // (the only non-user auth source) are filtered by the outer
-                    // is_deployment_token() check above.
                 }
                 // checker is None → no plugin registered → no-op beyond step 1.
             }
@@ -615,11 +629,15 @@ mod tests {
         }
 
         fn with_perms(perms: &'static [&'static str]) -> Arc<dyn ProjectAccessChecker> {
-            // fn pointers can't capture `perms` by closure, so encode the two
+            // fn pointers can't capture `perms` by closure, so encode the
             // fixed sets this test file actually needs directly.
             if perms == ["deployments:create"] {
                 Arc::new(MockPermissionChecker {
                     result: || Ok(Some(vec!["deployments:create".to_string()])),
+                })
+            } else if perms == ["deployments:delete"] {
+                Arc::new(MockPermissionChecker {
+                    result: || Ok(Some(vec!["deployments:delete".to_string()])),
                 })
             } else {
                 Arc::new(MockPermissionChecker {
@@ -691,6 +709,40 @@ mod tests {
         let result = run_delete_guard(&auth, 1, checker).await;
         let err = result.expect_err("instance-wide ceiling must reject before project lookup");
         assert_eq!(err.status_code, axum::http::StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn permission_guard_project_grant_cannot_widen_past_instance_ceiling() {
+        // Narrowing-only invariant: a project-scoped checker can only ever
+        // remove permissions the instance-wide role grants, never add ones it
+        // didn't. Role::User lacks DeploymentsDelete outright (see
+        // permission_guard_instance_ceiling_blocks_before_project_lookup), so
+        // even a checker that explicitly grants "deployments:delete" at the
+        // project level must not resurrect it — step 1 rejects before the
+        // checker is ever consulted.
+        let auth = user_auth(Role::User);
+        async fn run_delete_guard(
+            auth: &AuthContext,
+            project_id: i32,
+            checker: Option<Arc<dyn ProjectAccessChecker>>,
+        ) -> Result<(), Problem> {
+            project_permission_guard!(auth, DeploymentsDelete, project_id, checker);
+            Ok(())
+        }
+        let checker = Some(MockPermissionChecker::with_perms(&["deployments:delete"]));
+        let result = run_delete_guard(&auth, 1, checker).await;
+        let err = result.expect_err(
+            "a project-level grant must never widen permissions past the instance ceiling",
+        );
+        assert_eq!(err.status_code, axum::http::StatusCode::FORBIDDEN);
+        // Must be the instance-wide rejection, proving the checker was never
+        // reached — not the project-scoped "project-permission-denied" type,
+        // which would imply the checker was consulted and (correctly) denied
+        // it there instead of at the ceiling.
+        assert_eq!(
+            err.body.get("type").and_then(|v| v.as_str()),
+            Some("https://temps.sh/probs/insufficient-permissions")
+        );
     }
 
     #[tokio::test]

--- a/crates/temps-core/src/project_access.rs
+++ b/crates/temps-core/src/project_access.rs
@@ -49,4 +49,38 @@ pub trait ProjectAccessChecker: Send + Sync {
         user_id: i32,
         project_id: i32,
     ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>>;
+
+    /// Returns the set of permission strings (matching
+    /// `temps_auth::permissions::Permission::to_string()`, e.g.
+    /// `"deployments:create"`) `user_id` holds *within* `project_id`, for
+    /// callers that need a specific-action check rather than the coarse
+    /// "can touch this project at all" answer `user_can_access_project`
+    /// gives. See [`project_permission_guard!`](temps_auth::project_permission_guard).
+    ///
+    /// # Semantics
+    ///
+    /// - `Ok(None)` — this checker has no project-scoped, per-permission
+    ///   opinion (the default): either no team-scoped permission model
+    ///   applies, or the project has zero access grants. The guard falls
+    ///   through to the instance-wide permission check only — this is what
+    ///   keeps a binary with no checker registered, or a binary whose
+    ///   checker hasn't overridden this method yet, behaviourally unchanged.
+    /// - `Ok(Some(perms))` — the exact permission strings the user holds in
+    ///   this project. An **empty** vec means "holds nothing here" — every
+    ///   project-scoped permission check denies, which is how a
+    ///   non-member's binary deny is expressed at this finer granularity.
+    /// - `Err(_)` — infrastructure failure. The caller treats this as a
+    ///   denial (fail-closed), never a silent allow — identical contract to
+    ///   `user_can_access_project`.
+    ///
+    /// Defaults to `Ok(None)` so existing implementations of this trait
+    /// (compiled against an older version of it) keep behaving exactly as
+    /// they do today without needing to implement this method.
+    async fn effective_project_permissions(
+        &self,
+        _user_id: i32,
+        _project_id: i32,
+    ) -> Result<Option<Vec<String>>, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(None)
+    }
 }

--- a/crates/temps-deployments/src/handlers/deployments.rs
+++ b/crates/temps-deployments/src/handlers/deployments.rs
@@ -21,7 +21,9 @@ use futures::stream::{self, StreamExt};
 use futures::SinkExt;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use temps_auth::RequireAuth;
-use temps_auth::{permission_guard, project_access_guard, project_scope_guard};
+use temps_auth::{
+    permission_guard, project_access_guard, project_permission_guard, project_scope_guard,
+};
 use temps_core::{AuditContext, RequestMetadata};
 use tracing::{debug, error, info, warn};
 use utoipa::OpenApi;
@@ -426,8 +428,12 @@ pub async fn rollback_to_deployment(
     RequireAuth(auth): RequireAuth,
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, DeploymentsCreate);
-    project_access_guard!(auth, project_id, state.project_access_checker);
+    project_permission_guard!(
+        auth,
+        DeploymentsCreate,
+        project_id,
+        state.project_access_checker
+    );
 
     let deployment = state
         .deployment_service
@@ -479,8 +485,12 @@ pub async fn promote_deployment(
     Extension(metadata): Extension<RequestMetadata>,
     Json(request): Json<PromoteDeploymentRequest>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, DeploymentsCreate);
-    project_access_guard!(auth, project_id, state.project_access_checker);
+    project_permission_guard!(
+        auth,
+        DeploymentsCreate,
+        project_id,
+        state.project_access_checker
+    );
 
     info!(
         "Promoting deployment {} to environment {} (project {})",
@@ -533,8 +543,12 @@ pub async fn pause_deployment(
     RequireAuth(auth): RequireAuth,
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, DeploymentsDelete);
-    project_access_guard!(auth, project_id, state.project_access_checker);
+    project_permission_guard!(
+        auth,
+        DeploymentsDelete,
+        project_id,
+        state.project_access_checker
+    );
     info!("Pausing deployment: {:?}", deployment_id);
 
     state
@@ -585,8 +599,12 @@ pub async fn resume_deployment(
     RequireAuth(auth): RequireAuth,
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, DeploymentsCreate);
-    project_access_guard!(auth, project_id, state.project_access_checker);
+    project_permission_guard!(
+        auth,
+        DeploymentsCreate,
+        project_id,
+        state.project_access_checker
+    );
 
     state
         .deployment_service
@@ -637,8 +655,12 @@ pub async fn cancel_deployment(
     RequireAuth(auth): RequireAuth,
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, DeploymentsDelete);
-    project_access_guard!(auth, project_id, state.project_access_checker);
+    project_permission_guard!(
+        auth,
+        DeploymentsDelete,
+        project_id,
+        state.project_access_checker
+    );
 
     info!(
         "API request to cancel deployment {} for project {} from user",
@@ -698,8 +720,12 @@ pub async fn teardown_deployment(
     RequireAuth(auth): RequireAuth,
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, DeploymentsDelete);
-    project_access_guard!(auth, project_id, state.project_access_checker);
+    project_permission_guard!(
+        auth,
+        DeploymentsDelete,
+        project_id,
+        state.project_access_checker
+    );
 
     info!(
         "Tearing down deployment {} for project: {}",
@@ -753,8 +779,12 @@ pub async fn teardown_environment(
     RequireAuth(auth): RequireAuth,
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, DeploymentsDelete);
-    project_access_guard!(auth, project_id, state.project_access_checker);
+    project_permission_guard!(
+        auth,
+        DeploymentsDelete,
+        project_id,
+        state.project_access_checker
+    );
 
     info!(
         "Tearing down environment {} for project: {}",

--- a/crates/temps-deployments/src/handlers/remote_deployments.rs
+++ b/crates/temps-deployments/src/handlers/remote_deployments.rs
@@ -21,7 +21,7 @@ use axum::{
 use chrono::Utc;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, Set};
 use serde::{Deserialize, Serialize};
-use temps_auth::{permission_guard, project_access_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, project_permission_guard, RequireAuth};
 use temps_core::problemdetails::{self, Problem};
 use temps_core::{AuditContext, DeploymentCreatedJob, Job, RequestMetadata, UtcDateTime};
 use temps_entities::deployments::DeploymentMetadata;
@@ -309,8 +309,12 @@ pub async fn deploy_from_image(
     Extension(metadata): Extension<RequestMetadata>,
     Json(req): Json<DeployFromImageRequest>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, DeploymentsCreate);
-    project_access_guard!(auth, project_id, state.project_access_checker);
+    project_permission_guard!(
+        auth,
+        DeploymentsCreate,
+        project_id,
+        state.project_access_checker
+    );
 
     // Validate optional deploy-time health-check path override up front
     if let Some(ref path) = req.health_check_path {
@@ -596,8 +600,12 @@ pub async fn deploy_from_static(
     Extension(metadata): Extension<RequestMetadata>,
     Json(req): Json<DeployFromStaticRequest>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, DeploymentsCreate);
-    project_access_guard!(auth, project_id, state.project_access_checker);
+    project_permission_guard!(
+        auth,
+        DeploymentsCreate,
+        project_id,
+        state.project_access_checker
+    );
 
     // Validate optional deploy-time health-check path override up front
     if let Some(ref path) = req.health_check_path {
@@ -867,8 +875,12 @@ pub async fn deploy_from_image_upload(
     Query(query): Query<DeployFromImageUploadQuery>,
     mut multipart: Multipart,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, DeploymentsCreate);
-    project_access_guard!(auth, project_id, state.project_access_checker);
+    project_permission_guard!(
+        auth,
+        DeploymentsCreate,
+        project_id,
+        state.project_access_checker
+    );
 
     // Validate optional deploy-time health-check path override up front
     if let Some(ref path) = query.health_check_path {
@@ -1263,8 +1275,12 @@ pub async fn upload_static_bundle(
     Extension(request_metadata): Extension<RequestMetadata>,
     mut multipart: Multipart,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, DeploymentsCreate);
-    project_access_guard!(auth, project_id, state.project_access_checker);
+    project_permission_guard!(
+        auth,
+        DeploymentsCreate,
+        project_id,
+        state.project_access_checker
+    );
 
     debug!("Uploading static bundle for project {}", project_id);
 

--- a/crates/temps-environments/src/handlers/handler.rs
+++ b/crates/temps-environments/src/handlers/handler.rs
@@ -12,7 +12,10 @@ use axum::{
     Json,
 };
 use std::sync::Arc;
-use temps_auth::{permission_guard, project_access_guard, project_scope_guard, RequireAuth};
+use temps_auth::{
+    permission_guard, project_access_guard, project_permission_guard, project_scope_guard,
+    RequireAuth,
+};
 use temps_core::AuditContext;
 use temps_core::RequestMetadata;
 use tracing::{error, info};
@@ -727,9 +730,13 @@ pub async fn create_environment_variable(
     RequireAuth(auth): RequireAuth,
     Json(request): Json<CreateEnvironmentVariableRequest>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, EnvironmentsCreate);
+    project_permission_guard!(
+        auth,
+        EnvironmentsCreate,
+        project_id,
+        state.project_access_checker
+    );
     project_scope_guard!(auth, project_id);
-    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let var = state
         .env_var_service
@@ -787,9 +794,13 @@ pub async fn delete_environment_variable(
     Path((project_id, var_id)): Path<(i32, i32)>,
     RequireAuth(auth): RequireAuth,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, EnvironmentsDelete);
+    project_permission_guard!(
+        auth,
+        EnvironmentsDelete,
+        project_id,
+        state.project_access_checker
+    );
     project_scope_guard!(auth, project_id);
-    project_access_guard!(auth, project_id, state.project_access_checker);
 
     state
         .env_var_service
@@ -822,9 +833,13 @@ pub async fn update_environment_variable(
     RequireAuth(auth): RequireAuth,
     Json(request): Json<UpdateEnvironmentVariableRequest>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, EnvironmentsWrite);
+    project_permission_guard!(
+        auth,
+        EnvironmentsWrite,
+        project_id,
+        state.project_access_checker
+    );
     project_scope_guard!(auth, project_id);
-    project_access_guard!(auth, project_id, state.project_access_checker);
 
     let var = state
         .env_var_service

--- a/crates/temps-projects/src/handlers/custom_domains.rs
+++ b/crates/temps-projects/src/handlers/custom_domains.rs
@@ -11,7 +11,7 @@ use axum::{
 };
 use sea_orm::EntityTrait;
 use std::sync::Arc;
-use temps_auth::{permission_guard, project_access_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, project_permission_guard, RequireAuth};
 use temps_core::problemdetails;
 use temps_core::problemdetails::Problem;
 use temps_entities::{domains, environments, project_custom_domains};
@@ -66,8 +66,12 @@ pub async fn create_custom_domain(
     Path(project_id): Path<i32>,
     Json(request): Json<CustomDomainRequest>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, ProjectsWrite);
-    project_access_guard!(auth, project_id, state.project_access_checker);
+    project_permission_guard!(
+        auth,
+        ProjectsWrite,
+        project_id,
+        state.project_access_checker
+    );
 
     info!(
         "Creating custom domain: {} for project: {}",
@@ -235,8 +239,12 @@ pub async fn update_custom_domain(
     Path((project_id, domain_id)): Path<(i32, i32)>,
     Json(request): Json<UpdateCustomDomainRequest>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, ProjectsWrite);
-    project_access_guard!(auth, project_id, state.project_access_checker);
+    project_permission_guard!(
+        auth,
+        ProjectsWrite,
+        project_id,
+        state.project_access_checker
+    );
 
     info!(
         "Updating custom domain: {} for project: {}",
@@ -335,8 +343,12 @@ pub async fn delete_custom_domain(
     State(state): State<Arc<AppState>>,
     Path((project_id, domain_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, ProjectsDelete);
-    project_access_guard!(auth, project_id, state.project_access_checker);
+    project_permission_guard!(
+        auth,
+        ProjectsDelete,
+        project_id,
+        state.project_access_checker
+    );
 
     info!(
         "Deleting custom domain: {} for project: {}",
@@ -393,8 +405,12 @@ pub async fn link_custom_domain_to_certificate(
     State(state): State<Arc<AppState>>,
     Path((project_id, domain_id, certificate_id)): Path<(i32, i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, ProjectsWrite);
-    project_access_guard!(auth, project_id, state.project_access_checker);
+    project_permission_guard!(
+        auth,
+        ProjectsWrite,
+        project_id,
+        state.project_access_checker
+    );
 
     info!(
         "Linking custom domain: {} to certificate: {} for project: {}",

--- a/crates/temps-projects/src/handlers/handlers.rs
+++ b/crates/temps-projects/src/handlers/handlers.rs
@@ -15,7 +15,9 @@ use axum::{
 };
 use std::sync::Arc;
 use temps_auth::RequireAuth;
-use temps_auth::{permission_guard, project_access_guard, project_scope_guard};
+use temps_auth::{
+    permission_guard, project_access_guard, project_permission_guard, project_scope_guard,
+};
 use temps_core::RequestMetadata;
 use tracing::{debug, error, info};
 
@@ -386,9 +388,8 @@ pub async fn update_project(
     Extension(metadata): Extension<RequestMetadata>,
     Json(project): Json<CreateProjectRequest>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, ProjectsWrite);
+    project_permission_guard!(auth, ProjectsWrite, id, state.project_access_checker);
     project_scope_guard!(auth, id);
-    project_access_guard!(auth, id, state.project_access_checker);
 
     let project_req = crate::services::types::CreateProjectRequest {
         name: project.name.clone(),
@@ -530,9 +531,8 @@ pub async fn delete_project(
     RequireAuth(auth): RequireAuth,
     Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, ProjectsDelete);
+    project_permission_guard!(auth, ProjectsDelete, id, state.project_access_checker);
     project_scope_guard!(auth, id);
-    project_access_guard!(auth, id, state.project_access_checker);
 
     // Get project details before deletion
     let project = state.project_service.get_project(id).await?;


### PR DESCRIPTION
## Summary

`project_access_guard!` answers a coarse question: can this user touch this project at all? It never checks *which actions* a project-scoped role should allow, so a role meant to be more restrictive than another currently has no actual enforcement once the binary "can access" answer is yes.

This adds a permission-specific companion guard, following the same optional-plugin seam `ProjectAccessChecker`/`project_access_guard!` already established:

- `ProjectAccessChecker` (`temps-core`) grows a default-`Ok(None)` `effective_project_permissions(user_id, project_id)` method returning the permission strings a user holds within a specific project. A plugin implementing project-scoped, per-role permission sets overrides it; the default keeps every existing implementation of this trait behaviourally unchanged — this binary is unaffected unless a plugin opts in.
- `project_permission_guard!(auth, Permission, project_id, checker)` (`temps-auth`) is self-contained: instance-wide ceiling first (identical to `permission_guard!`, so existing instance-role behaviour like `user`→403-on-delete is untouched), then admin/platform-admin bypass, then project-scoped narrowing via the checker.
- **Precedence is strict narrowing only** — final = instance-wide ∩ project-scoped. A project role can remove permissions the instance-wide role grants; it can never add one.

Wired into the highest-risk project-scoped write paths: deployment create/trigger/rollback/promote/pause/resume/teardown/cancel, project delete/settings, environment-variable create/write/delete, and custom domain create/update/delete/link. Read-only endpoints are intentionally untouched — narrower scope for this change, and a plugin with no per-permission opinion (`Ok(None)`) leaves them exactly as they behave today.

## Test plan

- [x] 20 new/updated unit tests in `temps-auth::permission_guard` (instance-ceiling precedence, narrowing, empty-permission deny, unrestricted fallthrough, resolver-error fail-closed, admin/platform-admin/deployment-token bypass, bidirectional crate-level coverage snapshot mirroring the existing `project_access_guard!` one)
- [x] `cargo check` clean across `temps-auth`, `temps-core`, `temps-deployments`, `temps-projects`, `temps-environments`
- [x] `cargo clippy --all-targets -- -D warnings` clean across the same crates
- [x] Full DB-backed integration test suite — ran locally (Docker outage resolved): `temps-auth`, `temps-core`, `temps-deployments`, `temps-projects`, `temps-environments`, 407 passed, 0 failed, 3 ignored (require Docker+network, unrelated to this change)
