### PR TITLE
fix(domains): wire config/DNS services into TlsService for auto-renewal

### DIFF
--- a/crates/temps-agents/src/services/config_service.rs
+++ b/crates/temps-agents/src/services/config_service.rs
@@ -391,9 +391,7 @@ impl AgentConfigService {
                 trigger_config: Set(trigger_config),
                 prompt: Set(request.prompt),
                 ai_provider: Set(request.ai_provider.unwrap_or(default_provider)),
-                ai_model: Set(request
-                    .ai_model
-                    .and_then(|m| if m.is_empty() { None } else { Some(m) })),
+                ai_model: Set(request.ai_model.filter(|m| !m.is_empty())),
                 api_key_encrypted: Set(encrypted_key),
                 ai_provider_key_id: Set(request.ai_provider_key_id),
                 max_turns: Set(request.max_turns.unwrap_or(10)),
@@ -551,9 +549,7 @@ impl AgentConfigService {
             trigger_config: Set(trigger_config),
             prompt: Set(request.prompt),
             ai_provider: Set(request.ai_provider.unwrap_or(default_provider)),
-            ai_model: Set(request
-                .ai_model
-                .and_then(|m| if m.is_empty() { None } else { Some(m) })),
+            ai_model: Set(request.ai_model.filter(|m| !m.is_empty())),
             api_key_encrypted: Set(encrypted_key),
             ai_provider_key_id: Set(request.ai_provider_key_id),
             max_turns: Set(request.max_turns.unwrap_or(25)),

--- a/crates/temps-analytics/src/analytics.rs
+++ b/crates/temps-analytics/src/analytics.rs
@@ -1479,18 +1479,11 @@ impl Analytics for AnalyticsService {
         let mut total_events: i64 = 0;
         for row in event_rows {
             total_events += 1;
-            let time_on_page =
-                if row.event_type == "page_view" {
-                    row.computed_time_on_page.and_then(|t| {
-                        if t > 0 && t < 1800 {
-                            Some(t)
-                        } else {
-                            None
-                        }
-                    })
-                } else {
-                    None
-                };
+            let time_on_page = if row.event_type == "page_view" {
+                row.computed_time_on_page.filter(|&t| t > 0 && t < 1800)
+            } else {
+                None
+            };
 
             let event_data = if row.event_data == serde_json::json!({}) {
                 None

--- a/crates/temps-backup/src/engines/control_plane.rs
+++ b/crates/temps-backup/src/engines/control_plane.rs
@@ -139,7 +139,7 @@ impl BackupEngine for ControlPlaneEngine {
 
         let spec = OneShotSpec {
             image: image_tag,
-            name: format!("temps-cp-backup-{}", &backup_uuid),
+            name: format!("temps-cp-backup-{}", backup_uuid),
             engine: ENGINE_KEY,
             backup_id,
             entrypoint: vec!["sh".to_string(), "-c".to_string()],

--- a/crates/temps-backup/src/engines/mongodb.rs
+++ b/crates/temps-backup/src/engines/mongodb.rs
@@ -183,7 +183,7 @@ impl BackupEngine for MongodbEngine {
 
         let spec = OneShotSpec {
             image: MONGO_SIDECAR_IMAGE.to_string(),
-            name: format!("temps-mongodump-{}", &backup_uuid),
+            name: format!("temps-mongodump-{}", backup_uuid),
             engine: ENGINE_KEY,
             backup_id,
             entrypoint: vec!["sh".to_string(), "-c".to_string()],

--- a/crates/temps-backup/src/engines/postgres_pgdump.rs
+++ b/crates/temps-backup/src/engines/postgres_pgdump.rs
@@ -145,7 +145,7 @@ impl BackupEngine for PostgresPgDumpEngine {
 
         let spec = OneShotSpec {
             image: pg.docker_image.clone(),
-            name: format!("temps-pgdump-{}", &backup_uuid),
+            name: format!("temps-pgdump-{}", backup_uuid),
             engine: ENGINE_KEY,
             backup_id,
             entrypoint: vec!["sh".to_string(), "-c".to_string()],

--- a/crates/temps-backup/src/engines/redis.rs
+++ b/crates/temps-backup/src/engines/redis.rs
@@ -138,7 +138,7 @@ impl BackupEngine for RedisEngine {
 
         let spec = OneShotSpec {
             image: REDIS_SIDECAR_IMAGE.to_string(),
-            name: format!("temps-redis-backup-{}", &backup_uuid),
+            name: format!("temps-redis-backup-{}", backup_uuid),
             engine: ENGINE_KEY,
             backup_id,
             entrypoint: vec!["sh".to_string(), "-c".to_string()],

--- a/crates/temps-backup/src/engines/s3_mirror.rs
+++ b/crates/temps-backup/src/engines/s3_mirror.rs
@@ -184,7 +184,7 @@ impl BackupEngine for S3MirrorEngine {
 
         let spec = OneShotSpec {
             image: MC_IMAGE.to_string(),
-            name: format!("temps-s3mirror-{}", &backup_uuid),
+            name: format!("temps-s3mirror-{}", backup_uuid),
             engine: ENGINE_KEY,
             backup_id,
             entrypoint: vec!["sh".to_string(), "-c".to_string()],

--- a/crates/temps-domains/src/handlers/domain_handler.rs
+++ b/crates/temps-domains/src/handlers/domain_handler.rs
@@ -2021,7 +2021,7 @@ async fn setup_dns_challenge(
 }
 
 /// Extract the base domain from a full domain name (e.g., "sub.example.com" -> "example.com")
-fn extract_base_domain(domain: &str) -> String {
+pub(crate) fn extract_base_domain(domain: &str) -> String {
     // Handle wildcard domains
     let domain = domain.strip_prefix("*.").unwrap_or(domain);
 
@@ -2052,7 +2052,7 @@ fn acme_txt_record_name(base_domain: &str, name: &str) -> String {
 /// in the batch is created: a wildcard order publishes two TXT records under the same
 /// `_acme-challenge` name (one per authorization), so removing per-record (interleaved
 /// with creation) would delete a sibling record this same batch just created.
-async fn setup_dns_txt_records(
+pub(crate) async fn setup_dns_txt_records(
     provider: &dyn temps_dns::providers::DnsProvider,
     base_domain: &str,
     dns_txt_records: &[(String, String)],

--- a/crates/temps-domains/src/plugin.rs
+++ b/crates/temps-domains/src/plugin.rs
@@ -61,6 +61,16 @@ impl TempsPlugin for DomainsPlugin {
             let notification_service =
                 context.get_service::<dyn temps_core::notifications::NotificationService>();
 
+            // Required so background renewals can read `letsencrypt.email` (see
+            // `TlsService::get_acme_email`) -- without this, auto-renewal always fails
+            // with "User email is required" regardless of what's configured.
+            let config_service = context.require_service::<temps_config::ConfigService>();
+
+            // Get DnsProviderService (requires dns plugin to be registered first). Also
+            // wired into the TLS service so DNS-01 background renewals can auto-publish
+            // the challenge TXT record when a DNS provider manages the domain's zone.
+            let dns_provider_service = context.require_service::<DnsProviderService>();
+
             // Create domain service first so the TLS service can drive the order-based
             // ACME flow during background HTTP-01 renewals (keeps auto-renewals
             // recoverable from the UI). DomainService does not depend on TlsService, so
@@ -81,7 +91,9 @@ impl TempsPlugin for DomainsPlugin {
                     plugin_name: "domains".to_string(),
                     error: format!("Failed to create TLS service: {}", e),
                 })?
-                .with_domain_service(domain_service.clone());
+                .with_domain_service(domain_service.clone())
+                .with_config_service(config_service.clone())
+                .with_dns_provider_service(dns_provider_service.clone());
 
             // Add notification service if available
             if let Some(notif_service) = notification_service {
@@ -98,9 +110,6 @@ impl TempsPlugin for DomainsPlugin {
 
             // Note: Certificate renewal scheduler is started in console.rs
             // The scheduler handles both initial check and daily scheduled checks
-
-            // Get DnsProviderService (requires dns plugin to be registered first)
-            let dns_provider_service = context.require_service::<DnsProviderService>();
 
             // Get audit service
             let audit_service = context.require_service::<dyn temps_core::AuditLogger>();

--- a/crates/temps-domains/src/tls/service.rs
+++ b/crates/temps-domains/src/tls/service.rs
@@ -33,6 +33,12 @@ pub struct TlsService {
     /// validate immediately is recoverable from the certificate management UI via
     /// the "Verify & finalize" action, instead of silently expiring.
     domain_service: Option<Arc<crate::DomainService>>,
+    /// DNS provider service used to auto-publish the `_acme-challenge` TXT record
+    /// during background DNS-01 renewals when the certificate's base domain has an
+    /// `auto_manage`-enabled `dns_managed_domains` row. When absent, or when no
+    /// provider manages the domain, DNS-01 renewals fall back to the manual
+    /// "add this TXT record yourself" notification.
+    dns_provider_service: Option<Arc<temps_dns::services::DnsProviderService>>,
 }
 
 impl TlsService {
@@ -67,6 +73,7 @@ impl TlsService {
             config_service: None,
             db: None,
             domain_service: None,
+            dns_provider_service: None,
         }
     }
 
@@ -85,6 +92,14 @@ impl TlsService {
 
     pub fn with_db(mut self, db: Arc<temps_database::DbConnection>) -> Self {
         self.db = Some(db);
+        self
+    }
+
+    pub fn with_dns_provider_service(
+        mut self,
+        dns_provider_service: Arc<temps_dns::services::DnsProviderService>,
+    ) -> Self {
+        self.dns_provider_service = Some(dns_provider_service);
         self
     }
 
@@ -467,8 +482,12 @@ impl TlsService {
                     error: e.to_string(),
                     verification_method: cert.verification_method.clone(),
                 });
-                self.send_renewal_failure_notification(&cert.domain, &e.to_string())
-                    .await;
+                self.send_renewal_failure_notification(
+                    &cert.domain,
+                    &e.to_string(),
+                    &cert.verification_method,
+                )
+                .await;
                 return;
             }
         }
@@ -495,8 +514,12 @@ impl TlsService {
                     error: e.to_string(),
                     verification_method: cert.verification_method.clone(),
                 });
-                self.send_renewal_failure_notification(&cert.domain, &e.to_string())
-                    .await;
+                self.send_renewal_failure_notification(
+                    &cert.domain,
+                    &e.to_string(),
+                    &cert.verification_method,
+                )
+                .await;
             }
         }
     }
@@ -523,8 +546,12 @@ impl TlsService {
                     error: e.to_string(),
                     verification_method: cert.verification_method.clone(),
                 });
-                self.send_renewal_failure_notification(&cert.domain, &e.to_string())
-                    .await;
+                self.send_renewal_failure_notification(
+                    &cert.domain,
+                    &e.to_string(),
+                    &cert.verification_method,
+                )
+                .await;
                 return;
             }
         };
@@ -560,13 +587,37 @@ impl TlsService {
                     error: e.to_string(),
                     verification_method: cert.verification_method.clone(),
                 });
-                self.send_renewal_failure_notification(&cert.domain, &e.to_string())
-                    .await;
+                self.send_renewal_failure_notification(
+                    &cert.domain,
+                    &e.to_string(),
+                    &cert.verification_method,
+                )
+                .await;
             }
         }
     }
 
+    /// DNS-01 certificates auto-renew when a DNS provider manages the domain's zone
+    /// (`dns_managed_domains.auto_manage = true`); otherwise they fall back to the
+    /// "add this TXT record yourself" manual notification.
     async fn handle_dns01_notification(&self, cert: &Certificate, report: &mut RenewalReport) {
+        if let (Some(domain_service), Some(dns_provider_service)) = (
+            self.domain_service.clone(),
+            self.dns_provider_service.clone(),
+        ) {
+            if self
+                .try_dns01_renewal_with_provider(
+                    cert,
+                    &domain_service,
+                    &dns_provider_service,
+                    report,
+                )
+                .await
+            {
+                return;
+            }
+        }
+
         let days_remaining = cert.days_until_expiry();
 
         info!(
@@ -582,6 +633,194 @@ impl TlsService {
 
         // Send notification to user
         self.send_manual_renewal_notification(cert).await;
+    }
+
+    /// Order-based DNS-01 auto-renewal, attempted only when a verified, `auto_manage`
+    /// DNS provider covers the certificate's base domain (see
+    /// `DnsProviderService::find_provider_for_domain`). Mirrors
+    /// `handle_http01_renewal_order_based`: `request_challenge` creates and persists a
+    /// fresh ACME order, the DNS provider auto-publishes the `_acme-challenge` TXT
+    /// record(s) (same helper the manual "Setup DNS" endpoint uses), then
+    /// `complete_challenge` accepts the challenge and finalizes. On any failure the
+    /// order is left in place for a manual "Verify & finalize" retry from the UI.
+    ///
+    /// Returns `true` once a DNS provider was found for this domain (success or
+    /// failure is recorded on `report` either way) so the caller does not also send
+    /// the manual-renewal notification. Returns `false` when no provider manages the
+    /// domain, so the caller falls back to that manual flow.
+    async fn try_dns01_renewal_with_provider(
+        &self,
+        cert: &Certificate,
+        domain_service: &Arc<crate::DomainService>,
+        dns_provider_service: &Arc<temps_dns::services::DnsProviderService>,
+        report: &mut RenewalReport,
+    ) -> bool {
+        let (provider, _managed_domain) = match dns_provider_service
+            .find_provider_for_domain(&cert.domain)
+            .await
+        {
+            Ok(Some(found)) => found,
+            Ok(None) => return false,
+            Err(e) => {
+                warn!("Failed to look up DNS provider for {}: {}", cert.domain, e);
+                return false;
+            }
+        };
+
+        let provider_instance = match dns_provider_service.create_provider_instance(&provider) {
+            Ok(instance) => instance,
+            Err(e) => {
+                warn!(
+                    "Failed to initialize DNS provider {} for {}: {}",
+                    provider.name, cert.domain, e
+                );
+                return false;
+            }
+        };
+
+        let base_domain = crate::handlers::domain_handler::extract_base_domain(&cert.domain);
+
+        info!(
+            "🔄 Auto-renewing DNS-01 certificate for {} via DNS provider {}",
+            cert.domain, provider.name
+        );
+
+        let email = self.get_acme_email().await;
+
+        // Step 1: Create + persist a new ACME order (sets domain to `challenge_requested`).
+        let challenge = match domain_service.request_challenge(&cert.domain, &email).await {
+            Ok(challenge) => challenge,
+            Err(e) => {
+                error!(
+                    "❌ Failed to initiate DNS-01 renewal for {}: {}",
+                    cert.domain, e
+                );
+                report.renewal_failed.push(RenewalFailure {
+                    domain: cert.domain.clone(),
+                    error: e.to_string(),
+                    verification_method: cert.verification_method.clone(),
+                });
+                self.send_renewal_failure_notification(
+                    &cert.domain,
+                    &e.to_string(),
+                    &cert.verification_method,
+                )
+                .await;
+                return true;
+            }
+        };
+
+        // A cached/valid authorization can yield a certificate immediately.
+        if challenge.status == "completed" {
+            info!("✅ Successfully renewed certificate for {}", cert.domain);
+            report.auto_renewed.push(cert.domain.clone());
+            return true;
+        }
+
+        if challenge.txt_records.is_empty() {
+            let error_msg = "ACME order did not return any DNS TXT records".to_string();
+            error!(
+                "❌ DNS-01 renewal for {} failed: {}",
+                cert.domain, error_msg
+            );
+            report.renewal_failed.push(RenewalFailure {
+                domain: cert.domain.clone(),
+                error: error_msg.clone(),
+                verification_method: cert.verification_method.clone(),
+            });
+            self.send_renewal_failure_notification(
+                &cert.domain,
+                &error_msg,
+                &cert.verification_method,
+            )
+            .await;
+            return true;
+        }
+
+        // Step 2: Auto-publish the TXT record(s) via the configured DNS provider (same
+        // helper used by the manual "Setup DNS" endpoint).
+        let dns_txt_records: Vec<(String, String)> = challenge
+            .txt_records
+            .iter()
+            .map(|record| (record.name.clone(), record.value.clone()))
+            .collect();
+
+        let (results, records_created) = crate::handlers::domain_handler::setup_dns_txt_records(
+            provider_instance.as_ref(),
+            &base_domain,
+            &dns_txt_records,
+        )
+        .await;
+
+        if (records_created as usize) < dns_txt_records.len() {
+            let failed_detail = results
+                .iter()
+                .filter(|result| !result.success)
+                .map(|result| format!("{}: {}", result.name, result.message))
+                .collect::<Vec<_>>()
+                .join("; ");
+            let error_msg = format!(
+                "Failed to publish {} of {} DNS TXT record(s) via provider {}: {}",
+                dns_txt_records.len() - records_created as usize,
+                dns_txt_records.len(),
+                provider.name,
+                failed_detail
+            );
+            error!(
+                "❌ DNS-01 renewal for {} failed: {}",
+                cert.domain, error_msg
+            );
+            report.renewal_failed.push(RenewalFailure {
+                domain: cert.domain.clone(),
+                error: error_msg.clone(),
+                verification_method: cert.verification_method.clone(),
+            });
+            self.send_renewal_failure_notification(
+                &cert.domain,
+                &error_msg,
+                &cert.verification_method,
+            )
+            .await;
+            return true;
+        }
+
+        // Step 3: Give DNS a moment to propagate before asking Let's Encrypt to validate.
+        info!(
+            "Waiting for DNS propagation before validating DNS-01 challenge for {}...",
+            cert.domain
+        );
+        tokio::time::sleep(tokio::time::Duration::from_secs(30)).await;
+
+        // Step 4: Accept the challenge and finalize the persisted order.
+        match domain_service
+            .complete_challenge(&cert.domain, &email)
+            .await
+        {
+            Ok(_renewed) => {
+                info!("✅ Successfully renewed certificate for {}", cert.domain);
+                report.auto_renewed.push(cert.domain.clone());
+            }
+            Err(e) => {
+                // The order remains persisted (pending) and recoverable from the UI.
+                error!(
+                    "❌ Failed to complete DNS-01 renewal for {} (order left pending for manual retry): {}",
+                    cert.domain, e
+                );
+                report.renewal_failed.push(RenewalFailure {
+                    domain: cert.domain.clone(),
+                    error: e.to_string(),
+                    verification_method: cert.verification_method.clone(),
+                });
+                self.send_renewal_failure_notification(
+                    &cert.domain,
+                    &e.to_string(),
+                    &cert.verification_method,
+                )
+                .await;
+            }
+        }
+
+        true
     }
 
     async fn send_renewal_summary(&self, report: &RenewalReport) {
@@ -669,7 +908,12 @@ impl TlsService {
         }
     }
 
-    async fn send_renewal_failure_notification(&self, domain: &str, error: &str) {
+    async fn send_renewal_failure_notification(
+        &self,
+        domain: &str,
+        error: &str,
+        verification_method: &str,
+    ) {
         let Some(notif_service) = &self.notification_service else {
             return;
         };
@@ -688,7 +932,10 @@ impl TlsService {
             metadata: std::collections::HashMap::from([
                 ("domain".to_string(), domain.to_string()),
                 ("error".to_string(), error.to_string()),
-                ("verification_method".to_string(), "http-01".to_string()),
+                (
+                    "verification_method".to_string(),
+                    verification_method.to_string(),
+                ),
             ]),
             bypass_throttling: true,
         };
@@ -1970,5 +2217,66 @@ mod tests {
         assert!(not_found.is_none());
 
         println!("✅ ACME account persistence test passed!");
+    }
+
+    fn test_server_config() -> Arc<temps_config::ServerConfig> {
+        Arc::new(
+            temps_config::ServerConfig::new(
+                "127.0.0.1:3000".to_string(),
+                "postgres://test:test@localhost/test".to_string(),
+                None,
+                None,
+            )
+            .expect("failed to build test ServerConfig"),
+        )
+    }
+
+    /// Regression test for the auto-renewal bug: `TlsService` built without
+    /// `.with_config_service(...)` always resolves an empty ACME contact email
+    /// (`get_acme_email` returns `String::new()`), so every background renewal
+    /// failed with "User email is required for Let's Encrypt certificate
+    /// provisioning" even when an operator had configured `letsencrypt.email`.
+    #[tokio::test]
+    async fn test_get_acme_email_reads_configured_letsencrypt_email() {
+        let test_db = TestDatabase::with_migrations().await.unwrap();
+        let db = test_db.db.clone();
+        let encryption_service = Arc::new(temps_core::EncryptionService::new_from_password("test"));
+        let repo = Arc::new(DefaultCertificateRepository::new(
+            db.clone(),
+            encryption_service,
+        ));
+        let provider = Arc::new(MockCertificateProvider::new());
+
+        let config_service = Arc::new(temps_config::ConfigService::new(test_server_config(), db));
+        config_service
+            .update_settings(temps_core::AppSettings {
+                letsencrypt: temps_core::LetsEncryptSettings {
+                    email: Some("ops@example.com".to_string()),
+                    environment: "production".to_string(),
+                },
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let service = TlsService::new(repo, provider).with_config_service(config_service.clone());
+
+        assert_eq!(service.get_acme_email().await, "ops@example.com");
+    }
+
+    /// Without a wired `config_service` (the pre-fix state), the ACME contact
+    /// email must be empty, not a placeholder -- callers use emptiness to
+    /// refuse issuance rather than register a bogus contact.
+    #[tokio::test]
+    async fn test_get_acme_email_empty_without_config_service() {
+        let test_db = TestDatabase::with_migrations().await.unwrap();
+        let db = test_db.db.clone();
+        let encryption_service = Arc::new(temps_core::EncryptionService::new_from_password("test"));
+        let repo = Arc::new(DefaultCertificateRepository::new(db, encryption_service));
+        let provider = Arc::new(MockCertificateProvider::new());
+
+        let service = TlsService::new(repo, provider);
+
+        assert_eq!(service.get_acme_email().await, "");
     }
 }

--- a/crates/temps-sandbox/tests/vercel_compat.rs
+++ b/crates/temps-sandbox/tests/vercel_compat.rs
@@ -107,7 +107,7 @@ fn openapi_does_not_advertise_unknown_paths() {
     let expected: std::collections::HashSet<_> = expected_sdk_paths().into_iter().collect();
     let got = &api.paths.paths;
 
-    for (path, _) in got.iter() {
+    for path in got.keys() {
         assert!(
             expected.contains(path.as_str()),
             "OpenAPI doc exposes path '{}' not in the Vercel SDK surface — \


### PR DESCRIPTION
## Summary

- Fixes auto-renewal failing with `Invalid domain: User email is required for Let's Encrypt certificate provisioning` for **every** domain, regardless of what `letsencrypt.email` was configured to. Root cause: the domains plugin built `TlsService` without ever calling `.with_config_service(...)`, so `get_acme_email()` always resolved to an empty string.
- Adds DNS-01 auto-renewal: previously any `dns-01` certificate always fell back to a manual "add this TXT record yourself" notification, even with a DNS provider configured. Now, when the certificate's base domain has a verified, `auto_manage` DNS provider (`DnsProviderService::find_provider_for_domain`), renewal runs the same order-based ACME flow as HTTP-01, auto-publishing the `_acme-challenge` TXT record via that provider (reusing the helper the manual "Setup DNS" endpoint already uses). Domains without an auto-managed provider keep the existing manual-notification behavior.
- `send_renewal_failure_notification`'s metadata previously hardcoded `verification_method` to `"http-01"`; it now takes the actual method so DNS-01 failures aren't mislabeled.
- Also includes an unrelated `chore(lint)` commit fixing pre-existing clippy warnings (in `temps-analytics`, `temps-agents`, `temps-backup`, `temps-sandbox`) that were blocking the local pre-commit hook's workspace-wide clippy gate (CI's own clippy job is non-blocking, so these had accumulated over time).

## Test plan

- [x] `cargo check --lib` clean across the whole workspace
- [x] `cargo test --lib -p temps-domains -p temps-dns` — 279 tests pass (3 pebble-only tests skipped as expected), including two new regression tests: `test_get_acme_email_reads_configured_letsencrypt_email` and `test_get_acme_email_empty_without_config_service`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --lib -p temps-analytics -p temps-agents -p temps-backup` — no regressions from the mechanical lint fixes