### PR TITLE
ci(release): cut macOS/web build time in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -564,6 +564,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # workflow_dispatch dry-runs must not mint a real Release object
+          # under the dispatched branch name — everything above this step
+          # (artifact download, formula/checksum/notes generation) still
+          # runs and is inspectable in the job logs/artifacts.
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.dry_run }}" == "true" ]]; then
+            echo "Dry-run (workflow_dispatch): skipping actual GitHub Release creation for ${{ github.ref_name }}"
+            exit 0
+          fi
+
           echo "Creating release ${{ github.ref_name }}..."
 
           if [[ "${{ steps.channel.outputs.is_prerelease }}" == "true" ]]; then
@@ -661,7 +670,12 @@ jobs:
           context: .
           file: ./Dockerfile.release
           platforms: ${{ matrix.platform }}
-          push: true
+          # Dry-run: build but don't push. Same guard used by the sandbox
+          # and preview-gateway image jobs below — without it, every
+          # workflow_dispatch (dry-run or not) overwrites the real
+          # `:beta-<platform>` tags, which create-docker-manifest then
+          # merges into the `:beta` channel operators pin to.
+          push: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
           # Per-platform intermediate tags. The manifest-merge job below
           # combines amd64+arm64 into the final multi-arch refs. Channel tag
           # (`latest` for stable, `beta` for prereleases) keeps stable users
@@ -681,6 +695,10 @@ jobs:
   create-docker-manifest:
     name: Create Docker Manifest
     needs: [build-and-push-docker, create-release]
+    # Merges per-platform tags that build-and-push-docker only pushes on a
+    # real run. On a workflow_dispatch dry-run those source tags don't
+    # exist, so skip the merge too (would otherwise fail on a missing tag).
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,29 +26,25 @@ permissions:
   packages: write
 
 jobs:
-  build-linux-amd64:
-    name: Build Linux AMD64
+  build-web-assets:
+    name: Build web assets (WASM + dist)
+    # The web console + captcha WASM are pure static output with no
+    # platform/arch dependency, but crates/temps-cli/build.rs rebuilds them
+    # on every `cargo build --release` invocation. Build them once here and
+    # hand the compiled dist/ to each platform job (via SKIP_WEB_BUILD)
+    # instead of paying bun install + wasm-pack + rsbuild build 4x — the
+    # most expensive repeat was the macOS Intel job's wasm-pack step alone
+    # (7m26s on the last release), on top of a redundant rsbuild build in
+    # each of the other 3 jobs.
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake pkg-config libssl-dev protobuf-compiler
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-unknown-linux-gnu
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: linux-amd64-release
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
@@ -74,10 +70,56 @@ jobs:
           cd crates/temps-captcha-wasm
           bun run build
 
+      - name: Build web dist
+        run: |
+          cd web
+          bun run build
+        env:
+          RSBUILD_OUTPUT_PATH: ${{ github.workspace }}/crates/temps-cli/dist
+          TEMPS_VERSION: ${{ github.ref_name }}
+
+      - name: Upload web dist artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: web-dist
+          path: crates/temps-cli/dist
+          retention-days: 1
+
+  build-linux-amd64:
+    name: Build Linux AMD64
+    needs: build-web-assets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake pkg-config libssl-dev protobuf-compiler
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: linux-amd64-release
+
+      - name: Download web dist artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: web-dist
+          path: crates/temps-cli/dist
+
       - name: Build release binary
         run: cargo build --release --bin temps
         env:
-          FORCE_WEB_BUILD: 1
+          SKIP_WEB_BUILD: 1
           CARGO_INCREMENTAL: 0
           TEMPS_VERSION: ${{ github.ref_name }}
 
@@ -112,6 +154,7 @@ jobs:
 
   build-linux-arm64:
     name: Build Linux ARM64
+    needs: build-web-assets
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
@@ -134,34 +177,16 @@ jobs:
         with:
           key: linux-arm64-release
 
-      - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Download web dist artifact
+        uses: actions/download-artifact@v8
         with:
-          bun-version: latest
-
-      - name: Cache Bun dependencies
-        uses: actions/cache@v6
-        with:
-          path: web/node_modules
-          key: ${{ runner.os }}-arm64-bun-${{ hashFiles('web/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-arm64-bun-
-
-      - name: Install web dependencies
-        run: |
-          cd web
-          bun install
-
-      - name: Install wasm-pack and Build WASM
-        run: |
-          cargo install wasm-pack
-          cd crates/temps-captcha-wasm
-          bun run build
+          name: web-dist
+          path: crates/temps-cli/dist
 
       - name: Build release binary
         run: cargo build --release --bin temps
         env:
-          FORCE_WEB_BUILD: 1
+          SKIP_WEB_BUILD: 1
           CARGO_INCREMENTAL: 0
           TEMPS_VERSION: ${{ github.ref_name }}
           # jemalloc bakes max page size at build time; aarch64 kernels vary
@@ -199,7 +224,17 @@ jobs:
 
   build-darwin-amd64:
     name: Build macOS AMD64
-    runs-on: macos-15-intel
+    needs: build-web-assets
+    # Cross-compiled from Apple Silicon (same host as build-darwin-arm64),
+    # not run natively on Intel hardware. GitHub's Intel macOS pool is
+    # smaller/older and measured ~2x the wall-clock of the arm64 pool for
+    # this job (72m46s vs 40m52s on the last release). x86_64-apple-darwin is
+    # a well-supported cross target from an aarch64-apple-darwin host: the
+    # same Xcode toolchain/SDK provides both arch slices, and this
+    # workspace's native deps (openssl via openssl-src, jemalloc via cc-rs)
+    # build from source per-target rather than linking a host-arch system
+    # lib, so there's no arch-mismatch risk at link time.
+    runs-on: macos-14
     permissions:
       contents: write
     steps:
@@ -216,37 +251,19 @@ jobs:
         with:
           key: darwin-amd64-release
 
-      - name: Install Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Cache Bun dependencies
-        uses: actions/cache@v6
-        with:
-          path: web/node_modules
-          key: ${{ runner.os }}-bun-${{ hashFiles('web/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
-
-      - name: Install web dependencies
-        run: |
-          cd web
-          bun install
-
       - name: Install system dependencies
         run: brew install protobuf
 
-      - name: Install wasm-pack and Build WASM
-        run: |
-          cargo install wasm-pack
-          cd crates/temps-captcha-wasm
-          bun run build
+      - name: Download web dist artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: web-dist
+          path: crates/temps-cli/dist
 
       - name: Build release binary
         run: cargo build --release --bin temps --target x86_64-apple-darwin
         env:
-          FORCE_WEB_BUILD: 1
+          SKIP_WEB_BUILD: 1
           CARGO_INCREMENTAL: 0
           TEMPS_VERSION: ${{ github.ref_name }}
 
@@ -281,6 +298,7 @@ jobs:
 
   build-darwin-arm64:
     name: Build macOS ARM64
+    needs: build-web-assets
     runs-on: macos-14
     permissions:
       contents: write
@@ -293,32 +311,14 @@ jobs:
         with:
           targets: aarch64-apple-darwin
 
-      - name: Install Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Cache Bun dependencies
-        uses: actions/cache@v6
-        with:
-          path: web/node_modules
-          key: ${{ runner.os }}-bun-${{ hashFiles('web/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
-
-      - name: Install web dependencies
-        run: |
-          cd web
-          bun install
-
       - name: Install system dependencies
         run: brew install protobuf
 
-      - name: Install wasm-pack and Build WASM
-        run: |
-          cargo install wasm-pack
-          cd crates/temps-captcha-wasm
-          bun run build
+      - name: Download web dist artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: web-dist
+          path: crates/temps-cli/dist
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
@@ -328,7 +328,7 @@ jobs:
       - name: Build release binary
         run: cargo build --release --bin temps --target aarch64-apple-darwin
         env:
-          FORCE_WEB_BUILD: 1
+          SKIP_WEB_BUILD: 1
           CARGO_INCREMENTAL: 0
           TEMPS_VERSION: ${{ github.ref_name }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -434,7 +434,16 @@ jobs:
 
       - name: Generate Homebrew formula
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          # workflow_dispatch runs against a branch, not a tag, so GITHUB_REF
+          # is refs/heads/<branch> and the prefix-strip below leaves it
+          # untouched -- if the branch name contains a `/` (as most do),
+          # that lands in VERSION and breaks the `sed -e "s/.../.../"` call
+          # below (VERSION's `/` collides with sed's own delimiter).
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="dryrun-${{ github.run_id }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
           SHA256_LINUX_AMD64=$(awk '{print $1}' release/temps-linux-amd64.tar.gz.sha256)
           SHA256_LINUX_ARM64=$(awk '{print $1}' release/temps-linux-arm64.tar.gz.sha256)
           SHA256_DARWIN_AMD64=$(awk '{print $1}' release/temps-darwin-amd64.tar.gz.sha256)
@@ -653,7 +662,15 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          # See the matching comment in create-release's "Generate Homebrew
+          # formula" step: workflow_dispatch runs against a branch ref, so
+          # this would otherwise leave a `/`-containing string in VERSION,
+          # which is invalid in a Docker tag component.
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="dryrun-${{ github.run_id }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"
 
@@ -714,7 +731,15 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          # See the matching comment in create-release's "Generate Homebrew
+          # formula" step: workflow_dispatch runs against a branch ref, so
+          # this would otherwise leave a `/`-containing string in VERSION,
+          # which is invalid in a Docker tag component.
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="dryrun-${{ github.run_id }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"
 


### PR DESCRIPTION
## Summary
- `build-darwin-amd64` cross-compiles `x86_64-apple-darwin` from an Apple Silicon runner (`macos-14`) instead of running natively on `macos-15-intel`. On the last real release (`v0.1.0-beta.42`), the Intel job took 72m46s vs 40m52s for the arm64 job — GitHub's Intel macOS pool is smaller/older hardware. `openssl` (via `openssl-src`, vendored) and `jemalloc` (via `cc-rs`) already build from source per-target, so there's no system-lib arch-mismatch risk cross-linking. **Validated: the cross-compiled job completed in 42m33s in the dry-run below, and the resulting binary runs correctly.**
- Added a `build-web-assets` job that builds the web console `dist/` + captcha WASM **once** (on `ubuntu-latest`) and uploads it as an artifact, instead of each of the 4 platform jobs independently running `bun install` + `wasm-pack` + `rsbuild build` for identical, platform-independent output. Each platform job now downloads the artifact and sets `SKIP_WEB_BUILD=1` so `crates/temps-cli/build.rs` embeds the pre-built `dist/` instead of rebuilding it. Measured redundant cost of the wasm-pack step alone (per job, last release): Linux amd64 1m55s, Linux arm64 1m33s, macOS arm64 3m19s, macOS Intel 7m26s — now paid once instead of 4x.
- **Three follow-on fixes, all found by actually running `workflow_dispatch --dry_run` to validate the above** (all pre-existing bugs, unrelated to the perf change, but blocking a safe/complete dry-run):
  1. `create-release` always called `gh release create`, so a dry-run against a branch would mint a real GitHub Release named after that branch.
  2. `build-and-push-docker`'s `push` was hardcoded `true` (unlike the sandbox/gateway image jobs, which already gate on `dry_run`), so *any* `workflow_dispatch` — dry-run or not — overwrote the real `ghcr.io/.../temps:beta-linux-{amd64,arm64}` tags, which `create-docker-manifest` then merges into the `:beta` channel tag operators can pin to.
  3. `VERSION="${GITHUB_REF#refs/tags/v}"` (3 call sites) only strips the tag prefix on a real tag push; on `workflow_dispatch` it left a `/`-containing branch ref in `VERSION`, which crashed `sed` in the Homebrew formula step and would've produced invalid Docker tags in the other two sites.

Expected effect: total release wall-clock drops from ~72m (bounded by the old Intel job) to ~42m (bounded by the darwin jobs, both now similar), plus removes ~14min of aggregate redundant CI compute across the 4 platform jobs.

## Test plan
- [x] YAML validated locally
- [x] Validated end-to-end via `workflow_dispatch --dry_run=true`:
  - First run ([29087021926](https://github.com/gotempsh/temps/actions/runs/29087021926)): all 4 platform builds + web-assets succeeded (darwin-amd64 cross-compiled in 42m33s, darwin-arm64 in 43m12s); surfaced the `create-release`/`build-and-push-docker`/VERSION bugs above.
  - Second run ([29089590515](https://github.com/gotempsh/temps/actions/runs/29089590515), after fixing those): **fully green**, all 16 jobs succeeded, `Create Docker Manifest` correctly `skipped`. Confirmed via logs that `create-release` hit the dry-run guard and did not call `gh release create`. Confirmed via `gh release list` that no spurious release exists on the repo.
- [x] Confirmed `temps --version` works on the cross-compiled macOS amd64 binary: downloaded the artifact, verified its sha256, confirmed via `file` it's a genuine `Mach-O 64-bit executable x86_64`, and ran it under Rosetta — `temps-cli 0.1.0-beta.43-0d954d8 built 2026-07-10 11:16:53 UTC`.