### PR TITLE
feat(web): add Let's Encrypt contact email to Settings page

### DIFF
--- a/crates/temps-config/src/handler.rs
+++ b/crates/temps-config/src/handler.rs
@@ -748,6 +748,50 @@ fn preserve_self_recorded_fields(incoming: &mut AppSettings, current: &AppSettin
     incoming.console_version = current.console_version.clone();
 }
 
+/// Trim and validate an optional URL setting (`external_url`/`internal_url`).
+/// A blank value (after trimming) means "unset" and is normalized to `None`
+/// rather than rejected -- `external_url` previously validated the raw
+/// `Some("")` a client sends for a cleared field and rejected it with
+/// "must start with http:// or https://", which made every settings save
+/// fail with a 400 on any instance that had never configured it. Kept as a
+/// small pure helper (shared by both URL fields) so the two can't drift
+/// apart again and the invariant is unit-testable.
+fn sanitize_optional_url(
+    field_label: &str,
+    url: Option<String>,
+) -> Result<Option<String>, Problem> {
+    let Some(raw) = url else {
+        return Ok(None);
+    };
+
+    let trimmed = raw.trim().trim_end_matches('/').to_string();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    if !trimmed.starts_with("http://") && !trimmed.starts_with("https://") {
+        return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
+            .detail(format!(
+                "{field_label} URL must start with http:// or https://"
+            ))
+            .build());
+    }
+    if trimmed.contains('#') || trimmed.contains('?') {
+        return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
+            .detail(format!(
+                "{field_label} URL must not contain '#' or '?' characters"
+            ))
+            .build());
+    }
+    if url::Url::parse(&trimmed).is_err() {
+        return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
+            .detail(format!("{field_label} URL is not a valid URL"))
+            .build());
+    }
+
+    Ok(Some(trimmed))
+}
+
 /// Update application settings
 #[utoipa::path(
     tag = "Settings",
@@ -927,50 +971,8 @@ async fn update_settings(
         }
     }
 
-    // Validate and sanitize external_url
-    if let Some(ref mut ext_url) = settings.external_url {
-        *ext_url = ext_url.trim().to_string();
-        *ext_url = ext_url.trim_end_matches('/').to_string();
-        if !ext_url.starts_with("http://") && !ext_url.starts_with("https://") {
-            return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
-                .detail("External URL must start with http:// or https://")
-                .build());
-        }
-        if ext_url.contains('#') || ext_url.contains('?') {
-            return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
-                .detail("External URL must not contain '#' or '?' characters")
-                .build());
-        }
-        if url::Url::parse(ext_url).is_err() {
-            return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
-                .detail("External URL is not a valid URL")
-                .build());
-        }
-    }
-
-    // Validate and sanitize internal_url (same rules as external_url)
-    if let Some(ref mut int_url) = settings.internal_url {
-        *int_url = int_url.trim().trim_end_matches('/').to_string();
-        if int_url.is_empty() {
-            settings.internal_url = None;
-        } else {
-            if !int_url.starts_with("http://") && !int_url.starts_with("https://") {
-                return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
-                    .detail("Internal URL must start with http:// or https://")
-                    .build());
-            }
-            if int_url.contains('#') || int_url.contains('?') {
-                return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
-                    .detail("Internal URL must not contain '#' or '?' characters")
-                    .build());
-            }
-            if url::Url::parse(int_url).is_err() {
-                return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
-                    .detail("Internal URL is not a valid URL")
-                    .build());
-            }
-        }
-    }
+    settings.external_url = sanitize_optional_url("External", settings.external_url)?;
+    settings.internal_url = sanitize_optional_url("Internal", settings.internal_url)?;
 
     match app_state.config_service.update_settings(settings).await {
         Ok(_) => {
@@ -1272,6 +1274,50 @@ async fn refresh_route_table(
 mod tests {
     use super::*;
     use temps_core::{AgentSandboxSettings, AppSettings, ProviderConfig};
+
+    // Regression: a client round-tripping a never-configured external_url
+    // sends `Some("")` (the form's empty-string default), which previously
+    // fell through straight to the http/https prefix check and rejected
+    // every settings save with a 400 on any instance that had never set it.
+    #[test]
+    fn sanitize_optional_url_treats_blank_as_unset() {
+        assert_eq!(
+            sanitize_optional_url("External", Some(String::new())).unwrap(),
+            None
+        );
+        assert_eq!(
+            sanitize_optional_url("External", Some("   ".to_string())).unwrap(),
+            None
+        );
+        assert_eq!(sanitize_optional_url("External", None).unwrap(), None);
+    }
+
+    #[test]
+    fn sanitize_optional_url_trims_and_strips_trailing_slash() {
+        assert_eq!(
+            sanitize_optional_url("External", Some("  https://example.com/  ".to_string()))
+                .unwrap(),
+            Some("https://example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_optional_url_rejects_missing_scheme() {
+        let err = sanitize_optional_url("External", Some("example.com".to_string())).unwrap_err();
+        let detail = err.body.get("detail").and_then(|v| v.as_str()).unwrap();
+        assert!(detail.contains("must start with http:// or https://"));
+    }
+
+    #[test]
+    fn sanitize_optional_url_rejects_query_or_fragment() {
+        assert!(
+            sanitize_optional_url("External", Some("https://example.com?a=1".to_string())).is_err()
+        );
+        assert!(
+            sanitize_optional_url("External", Some("https://example.com#frag".to_string()))
+                .is_err()
+        );
+    }
 
     // Regression: the GET /api/settings response must surface agent_sandbox,
     // ai_config, preview_gateway, multi_node, and insecure_tls so the UI can

--- a/web/src/api/platformSettings.ts
+++ b/web/src/api/platformSettings.ts
@@ -197,7 +197,16 @@ export async function updatePlatformSettings(
     build_limits: updated.build_limits,
     monitoring: updated.monitoring,
   }
-  await updateSettings({ body })
+  const result = await updateSettings({ body })
+  if (result.error) {
+    // The generated client resolves (rather than throws) on non-2xx
+    // responses, so a failed save must be surfaced explicitly here —
+    // otherwise the caller sees a resolved promise and reports "saved"
+    // for a change that was actually rejected (e.g. a validation error).
+    const detail =
+      (result.error as { detail?: string })?.detail || 'Failed to save settings'
+    throw new Error(detail)
+  }
 
   // The PATCH endpoint returns only an ack message, so we hand back our
   // merged view. Callers that need the absolute server state should refetch.

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -33,6 +33,7 @@ import {
   Loader2,
   RefreshCw,
   Save,
+  ShieldCheck,
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
@@ -40,7 +41,11 @@ import { toast } from 'sonner'
 
 type SettingsFormData = Pick<
   PlatformSettings,
-  'external_url' | 'internal_url' | 'preview_domain' | 'screenshots'
+  | 'external_url'
+  | 'internal_url'
+  | 'preview_domain'
+  | 'screenshots'
+  | 'letsencrypt'
 >
 
 export function Settings() {
@@ -66,10 +71,18 @@ export function Settings() {
         provider: 'local',
         url: '',
       },
+      letsencrypt: {
+        email: '',
+        environment: 'production',
+      },
     },
   })
 
   const screenshots = useWatch({ control, name: 'screenshots' })
+  const letsencryptEnvironment = useWatch({
+    control,
+    name: 'letsencrypt.environment',
+  })
 
   useEffect(() => {
     setBreadcrumbs([{ label: 'Settings' }])
@@ -88,6 +101,10 @@ export function Settings() {
           provider: 'local',
           url: '',
         },
+        letsencrypt: {
+          email: settings.letsencrypt?.email || '',
+          environment: settings.letsencrypt?.environment || 'production',
+        },
       })
     }
   }, [settings, reset])
@@ -98,7 +115,10 @@ export function Settings() {
       reset(data)
       toast.success('Settings saved successfully')
     } catch (err: any) {
-      const detail = err?.body?.detail || err?.message || 'Failed to save settings. Please try again.'
+      const detail =
+        err?.body?.detail ||
+        err?.message ||
+        'Failed to save settings. Please try again.'
       toast.error(detail)
     }
   }
@@ -147,11 +167,16 @@ export function Settings() {
                   if (!value) return true // optional
                   const trimmed = value.trim()
                   if (!trimmed) return true
-                  if (!trimmed.startsWith('http://') && !trimmed.startsWith('https://'))
+                  if (
+                    !trimmed.startsWith('http://') &&
+                    !trimmed.startsWith('https://')
+                  )
                     return 'Must start with http:// or https://'
                   if (trimmed.includes('#') || trimmed.includes('?'))
                     return 'Must not contain # or ? characters'
-                  try { new URL(trimmed) } catch {
+                  try {
+                    new URL(trimmed)
+                  } catch {
                     return 'Must be a valid URL'
                   }
                   return true
@@ -159,7 +184,9 @@ export function Settings() {
               })}
             />
             {errors.external_url && (
-              <p className="text-sm text-destructive">{errors.external_url.message}</p>
+              <p className="text-sm text-destructive">
+                {errors.external_url.message}
+              </p>
             )}
             <p className="text-sm text-muted-foreground">
               Used for OAuth callbacks, webhooks, and external integrations
@@ -177,11 +204,16 @@ export function Settings() {
                   if (!value) return true // optional — falls back to default
                   const trimmed = value.trim()
                   if (!trimmed) return true
-                  if (!trimmed.startsWith('http://') && !trimmed.startsWith('https://'))
+                  if (
+                    !trimmed.startsWith('http://') &&
+                    !trimmed.startsWith('https://')
+                  )
                     return 'Must start with http:// or https://'
                   if (trimmed.includes('#') || trimmed.includes('?'))
                     return 'Must not contain # or ? characters'
-                  try { new URL(trimmed) } catch {
+                  try {
+                    new URL(trimmed)
+                  } catch {
                     return 'Must be a valid URL'
                   }
                   return true
@@ -189,12 +221,17 @@ export function Settings() {
               })}
             />
             {errors.internal_url && (
-              <p className="text-sm text-destructive">{errors.internal_url.message}</p>
+              <p className="text-sm text-destructive">
+                {errors.internal_url.message}
+              </p>
             )}
             <p className="text-sm text-muted-foreground">
               How service containers reach the Temps API from inside the Docker
               network (OTLP metrics ingest, agent callbacks). Leave blank to use{' '}
-              <code className="font-mono text-xs">http://host.docker.internal:&lt;proxy-port&gt;</code>.
+              <code className="font-mono text-xs">
+                http://host.docker.internal:&lt;proxy-port&gt;
+              </code>
+              .
             </p>
           </div>
         </CardContent>
@@ -222,6 +259,80 @@ export function Settings() {
             <p className="text-sm text-muted-foreground">
               Deployments will be accessible at subdomain.
               {settings?.preview_domain || 'localho.st'}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5" />
+            Let&apos;s Encrypt
+          </CardTitle>
+          <CardDescription>
+            Contact email for automatic TLS certificate issuance and renewal
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            <Label htmlFor="letsencrypt-email">Contact Email</Label>
+            <Input
+              id="letsencrypt-email"
+              type="email"
+              placeholder="ops@your-domain.com"
+              {...register('letsencrypt.email', {
+                validate: (value) => {
+                  if (!value) return true // optional, but renewals will fail without it
+                  const trimmed = value.trim()
+                  if (!trimmed) return true
+                  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed))
+                    return 'Must be a valid email address'
+                  return true
+                },
+              })}
+            />
+            {errors.letsencrypt?.email && (
+              <p className="text-sm text-destructive">
+                {errors.letsencrypt.email.message}
+              </p>
+            )}
+            {!settings?.letsencrypt?.email && (
+              <p className="text-sm text-amber-600 dark:text-amber-500">
+                No contact email configured — certificate issuance and automatic
+                renewal will fail until this is set.
+              </p>
+            )}
+            <p className="text-sm text-muted-foreground">
+              Let&apos;s Encrypt requires a real contact email to register an
+              ACME account. Used for all certificate provisioning and background
+              auto-renewal (HTTP-01 and DNS-01).
+            </p>
+          </div>
+
+          <div className="space-y-2 pt-4">
+            <Label htmlFor="letsencrypt-environment">Environment</Label>
+            <Select
+              value={letsencryptEnvironment}
+              onValueChange={(value: 'production' | 'staging') =>
+                setValue('letsencrypt.environment', value, {
+                  shouldDirty: true,
+                })
+              }
+            >
+              <SelectTrigger id="letsencrypt-environment">
+                <SelectValue placeholder="Select environment" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="production">Production</SelectItem>
+                <SelectItem value="staging">
+                  Staging (testing, avoids rate limits)
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-sm text-muted-foreground">
+              Staging certificates are not trusted by browsers — use only for
+              testing to avoid Let&apos;s Encrypt&apos;s production rate limits.
             </p>
           </div>
         </CardContent>
@@ -312,8 +423,9 @@ export function Settings() {
             Route Table
           </CardTitle>
           <CardDescription>
-            Manually refresh the proxy route table from the database. Use this if
-            routes appear out of sync after deployments or configuration changes.
+            Manually refresh the proxy route table from the database. Use this
+            if routes appear out of sync after deployments or configuration
+            changes.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -329,8 +441,7 @@ export function Settings() {
                   security: [{ scheme: 'bearer', type: 'http' }],
                 })
                 const data = response.data as
-                  | { route_count: number; message: string }
-                  | undefined
+                  { route_count: number; message: string } | undefined
                 toast.success(
                   data?.message || 'Route table refreshed successfully'
                 )
@@ -362,7 +473,11 @@ export function Settings() {
             <p className="text-sm text-muted-foreground">
               You have unsaved changes
             </p>
-            <Button type="submit" disabled={isSubmitting} className="w-full sm:w-auto">
+            <Button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full sm:w-auto"
+            >
               {isSubmitting ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />


### PR DESCRIPTION
## Summary

Follow-up to #270. That PR fixed auto-renewal always failing with "User email is required for Let's Encrypt certificate provisioning" (a wiring bug), but while testing the fix live it turned out there's **no way to configure or view the ACME contact email from the dashboard at all** — only via `temps setup --letsencrypt-email` at initial install, or a raw API call. The renewal-failure notification literally says "Please renew this certificate manually in the Temps dashboard," but the dashboard had no control for the one thing actually required to unblock it.

- Adds a **"Let's Encrypt"** card to the Settings page: contact-email input (client-validated, optional but warns clearly when unset), and an environment selector (production/staging, matching the `--letsencrypt-staging` CLI flag).
- Reuses the existing `updatePlatformSettings()` merge-then-send flow, so saving from this page can't clobber unrelated settings.

## Bugs found and fixed along the way

Both surfaced while manually verifying the new field actually persists end-to-end (via a live save through the running app), and are unrelated to the new field itself:

1. **`PUT /settings` rejected a blank `external_url`.** The client sends `Some("")` for a never-configured field; `external_url`'s validation checked the raw string against `starts_with("http://"...)` without first checking for empty, so it failed with `400 "External URL must start with http:// or https://"`. `internal_url`'s handler already had the correct `is_empty() -> None` branch right next to it — `external_url` was just missing it. **Every settings save failed on any instance that had never set an external URL** (i.e. most fresh installs). Fixed by extracting a shared `sanitize_optional_url()` helper used by both fields, with unit tests.
2. **Failed saves were silently reported as successful.** `web/src/api/platformSettings.ts` never checked the generated API client's `{data, error}` result on the PUT call (the client resolves rather than throws on non-2xx by default) — so bug #1's 400 was swallowed and the UI toasted "Settings saved successfully" while nothing persisted. Now throws with the server's detail message, surfaced by the existing catch handler in `Settings.tsx`.

Together these meant the Let's Encrypt email (or any other setting) could be typed in, "saved" with a success toast, and silently discarded — confirmed live: DB `letsencrypt.email` stayed `null` after a "successful" save until both were fixed.

## Test plan

- [x] `cargo test --lib -p temps-config` — 29 passed, including 4 new tests for `sanitize_optional_url` (blank→None, trim/trailing-slash, missing scheme rejected, query/fragment rejected)
- [x] `cargo clippy --lib -p temps-config --all-targets -- -D warnings` clean
- [x] `tsc --noEmit` and `eslint` clean on both changed web files
- [x] Live-tested end-to-end against a running dev server + Postgres: logged in, filled the Contact Email field, saved, verified the toast reflected the *real* backend response, confirmed the value round-trips correctly in the DB (`select data->'letsencrypt' from settings`) and survives a cold page reload