### PR TITLE
fix(proxy): isolate preview connection-pool by sandbox target

### DIFF
--- a/crates/temps-proxy/src/preview_auth.rs
+++ b/crates/temps-proxy/src/preview_auth.rs
@@ -67,6 +67,27 @@ impl PreviewHost {
     }
 }
 
+/// Derives a Pingora connection-pool partition key (`HttpPeer::group_key`)
+/// from a preview target. All preview traffic is forwarded through the same
+/// physical peer (`PREVIEW_GATEWAY_PEER`), so without a distinguishing
+/// `group_key`, every sandbox's requests look like the same logical peer to
+/// Pingora's connection pool: pooling is keyed by `Peer::reuse_hash()`
+/// (`HttpPeer`'s hash includes `group_key`, address, scheme, and SNI — see
+/// pingora-core's `upstreams/peer.rs`), and a pooled keep-alive connection
+/// opened while serving one sandbox can be handed back out to serve a
+/// different sandbox's request on a completely different hostname —
+/// silently splicing one app's bytes into another's response. Folding the
+/// target hex+port into `group_key` makes each sandbox+port combination its
+/// own pool partition, so a connection can never cross between them.
+pub fn preview_peer_group_key(host: &PreviewHost) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    host.hex.hash(&mut hasher);
+    host.port.hash(&mut hasher);
+    hasher.finish()
+}
+
 /// Parse a hostname against `ws-<hex>-<port>.<preview_domain>`.
 ///
 /// `preview_domain` may start with `*.` (wildcard form) — the leading `*.` is
@@ -508,6 +529,47 @@ mod tests {
         assert_ne!(hash_fingerprint(hash_a), hash_fingerprint(hash_b));
         assert_eq!(hash_fingerprint(hash_a), hash_fingerprint(hash_a));
         assert_eq!(hash_fingerprint(hash_a).len(), 16);
+    }
+
+    #[test]
+    fn preview_peer_group_key_differs_for_different_sandboxes() {
+        let a = PreviewHost {
+            hex: "7702c56bfb804b49".into(),
+            port: 3000,
+        };
+        let b = PreviewHost {
+            hex: "c5d8e38f791dbc40".into(),
+            port: 3000,
+        };
+        assert_ne!(preview_peer_group_key(&a), preview_peer_group_key(&b));
+    }
+
+    #[test]
+    fn preview_peer_group_key_differs_for_different_ports_same_sandbox() {
+        // Same sandbox, two different exposed ports (e.g. HMR websocket vs.
+        // the app's own HTTP port) must not share a pooled connection.
+        let http = PreviewHost {
+            hex: "7702c56bfb804b49".into(),
+            port: 3000,
+        };
+        let ws = PreviewHost {
+            hex: "7702c56bfb804b49".into(),
+            port: 3001,
+        };
+        assert_ne!(preview_peer_group_key(&http), preview_peer_group_key(&ws));
+    }
+
+    #[test]
+    fn preview_peer_group_key_stable_for_same_target() {
+        let a = PreviewHost {
+            hex: "7702c56bfb804b49".into(),
+            port: 3000,
+        };
+        let a2 = PreviewHost {
+            hex: "7702c56bfb804b49".into(),
+            port: 3000,
+        };
+        assert_eq!(preview_peer_group_key(&a), preview_peer_group_key(&a2));
     }
 
     #[test]

--- a/crates/temps-proxy/src/proxy.rs
+++ b/crates/temps-proxy/src/proxy.rs
@@ -24,8 +24,9 @@ use crate::handler::preview_wall::{
 use crate::on_demand::OnDemandManager;
 use crate::preview_auth::{
     build_set_cookie_sandbox, check_preview_auth, encode_preview_cookie_subject,
-    parse_preview_host, verify_argon2, PreviewAuthLimiter, PreviewAuthOutcome, PreviewHost,
-    PreviewSandboxLookup, SandboxLookupCache, PREVIEW_GATEWAY_PEER,
+    parse_preview_host, preview_peer_group_key, verify_argon2, PreviewAuthLimiter,
+    PreviewAuthOutcome, PreviewHost, PreviewSandboxLookup, SandboxLookupCache,
+    PREVIEW_GATEWAY_PEER,
 };
 use crate::service::cert_host_cache::CertHostCache;
 use crate::service::challenge_service::ChallengeService;
@@ -4044,8 +4045,16 @@ impl ProxyHttp for LoadBalancer {
         // Workspace preview gateway: skip the route table and forward straight
         // to the local gateway. The host header is preserved so the gateway
         // can decode `ws-<sid>-<port>` and pick the right sandbox container.
-        if ctx.preview_route.is_some() {
+        //
+        // Every preview target shares this same physical peer address, so
+        // `group_key` MUST be set per-target — otherwise Pingora's
+        // connection pool considers all sandboxes' requests interchangeable
+        // and can hand a connection opened for one sandbox back out to
+        // serve a different sandbox's request (see `preview_peer_group_key`
+        // doc comment for the full mechanism).
+        if let Some(host) = &ctx.preview_route {
             let mut peer = Box::new(HttpPeer::new(PREVIEW_GATEWAY_PEER, false, String::new()));
+            peer.group_key = preview_peer_group_key(host);
             peer.options.connection_timeout = Some(std::time::Duration::from_secs(5));
             peer.options.read_timeout = Some(io_timeout);
             peer.options.write_timeout = Some(io_timeout);


### PR DESCRIPTION
## Summary

- Every preview request (`ws-<sandbox-hex>-<port>.<preview-domain>`) is proxied through the same `HttpPeer` identity (`127.0.0.1:8090`, the singleton preview-gateway container), with no field distinguishing which sandbox/port it's actually for.
- Pingora pools upstream connections by peer identity (`Peer::reuse_hash()`), so a keep-alive connection opened while serving sandbox A's traffic is eligible to be handed back out to serve sandbox B's request — on a completely different hostname. The receiving `temps-preview-gateway` reads the `Host` header only once, at TCP-accept time, then does raw byte-splicing for the rest of that connection's life, so it never notices the mismatch.
- Net effect, live-reproduced: a browser hitting its own correctly-authenticated preview URL can intermittently receive a *different app's* response bytes, whenever two sandboxes have both had recent traffic.
- Fix: fold the parsed preview target's `hex`+`port` into `HttpPeer::group_key` — a field `pingora-core` provides specifically to isolate connection reuse between logically distinct peers that share one physical address ("Requests with different group keys cannot share connections with each other"). Each sandbox+port combination now gets its own pool partition.

## Test plan

- [x] `cargo test -p temps-proxy` — 399 passed, 0 failed
- [x] `cargo clippy -p temps-proxy --lib -- -D warnings` — clean
- [x] New unit tests for `preview_peer_group_key`: differs across sandboxes, differs across ports on the same sandbox, stable for the same target
- [x] Live-reproduced the original symptom on a local dev instance before diagnosing (two sandboxes with recent traffic served each other's content on their own preview hostnames)