### PR TITLE
feat(dns): add Pebble challtestsrv-backed DNS provider for local testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11449,6 +11449,7 @@ dependencies = [
  "sea-orm",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2 0.10.9",
  "sha2 0.11.0",
  "temps-auth",

--- a/crates/temps-core/src/url_validation.rs
+++ b/crates/temps-core/src/url_validation.rs
@@ -44,6 +44,9 @@ pub enum UrlValidationError {
 
     #[error("Domain resolves to a blocked IP address")]
     DomainResolvesToBlockedIp,
+
+    #[error("URL must resolve to a loopback or private address (this is a local-only tool)")]
+    NotLocalOrPrivate,
 }
 
 /// Validates a URL for external webhook/HTTP requests
@@ -105,6 +108,112 @@ pub fn validate_external_url(url: &str) -> Result<Url, UrlValidationError> {
     }
 
     Ok(parsed)
+}
+
+/// Validates a URL for LOCAL-ONLY tools that must never reach the public
+/// internet or cloud metadata services (e.g. a dev-only DNS provider whose
+/// "API" is actually a loopback test server). This is the inverse of
+/// [`validate_external_url`]: it REQUIRES the host to be loopback or RFC 1918
+/// private, and rejects everything else -- including link-local (where cloud
+/// metadata endpoints live) and public addresses.
+///
+/// Like `validate_external_url`, this only definitively validates literal
+/// IPs and `localhost`. For a non-literal hostname, callers MUST also await
+/// [`validate_loopback_or_private_domain_async`] to resolve and check the
+/// actual IP(s) -- mirrors the `validate_external_url` +
+/// `validate_domain_async` composition already used by the webhook service.
+///
+/// # Examples
+///
+/// ```
+/// use temps_core::url_validation::validate_loopback_or_private_url;
+///
+/// // Valid: loopback
+/// assert!(validate_loopback_or_private_url("http://127.0.0.1:8055").is_ok());
+/// assert!(validate_loopback_or_private_url("http://localhost:8055").is_ok());
+///
+/// // Valid: RFC 1918 private
+/// assert!(validate_loopback_or_private_url("http://192.168.1.10:8055").is_ok());
+///
+/// // Invalid: public address
+/// assert!(validate_loopback_or_private_url("http://8.8.8.8").is_err());
+///
+/// // Invalid: cloud metadata (link-local, not private)
+/// assert!(validate_loopback_or_private_url("http://169.254.169.254").is_err());
+/// ```
+pub fn validate_loopback_or_private_url(url: &str) -> Result<Url, UrlValidationError> {
+    let parsed =
+        Url::parse(url).map_err(|e| UrlValidationError::InvalidFormat(format!("{}", e)))?;
+
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(UrlValidationError::InvalidScheme);
+    }
+
+    if let Some(host) = parsed.host() {
+        match host {
+            url::Host::Ipv4(ip) => {
+                if !(ip.is_loopback() || ip.is_private()) {
+                    return Err(UrlValidationError::NotLocalOrPrivate);
+                }
+            }
+            url::Host::Ipv6(ip) => {
+                if !(ip.is_loopback() || is_unique_local_ipv6(&ip)) {
+                    return Err(UrlValidationError::NotLocalOrPrivate);
+                }
+            }
+            url::Host::Domain(_domain) => {
+                // A hostname isn't inherently unsafe -- only its resolved
+                // IP is. Full validation happens in the async resolver;
+                // don't reject here (mirrors validate_external_url).
+            }
+        }
+    } else {
+        return Err(UrlValidationError::InvalidFormat(
+            "URL must have a valid host".to_string(),
+        ));
+    }
+
+    Ok(parsed)
+}
+
+/// Asynchronous DNS resolution and validation for [`validate_loopback_or_private_url`]'s
+/// domain-name case: resolves `domain` and requires every resolved IP to be
+/// loopback or RFC 1918 private, rejecting the domain if any resolved IP is
+/// public, link-local, or otherwise not local.
+pub async fn validate_loopback_or_private_domain_async(
+    domain: &str,
+) -> Result<(), UrlValidationError> {
+    let lookup_result = tokio::net::lookup_host(format!("{}:443", domain)).await;
+
+    let addrs = match lookup_result {
+        Ok(addrs) => addrs,
+        Err(e) => {
+            return Err(UrlValidationError::DnsResolutionFailed(format!(
+                "Failed to resolve {}: {}",
+                domain, e
+            )));
+        }
+    };
+
+    let mut has_valid_ip = false;
+    for addr in addrs {
+        let is_local_or_private = match addr.ip() {
+            IpAddr::V4(ip) => ip.is_loopback() || ip.is_private(),
+            IpAddr::V6(ip) => ip.is_loopback() || is_unique_local_ipv6(&ip),
+        };
+        if !is_local_or_private {
+            return Err(UrlValidationError::NotLocalOrPrivate);
+        }
+        has_valid_ip = true;
+    }
+
+    if !has_valid_ip {
+        return Err(UrlValidationError::DnsResolutionFailed(
+            "No valid IP addresses found for domain".to_string(),
+        ));
+    }
+
+    Ok(())
 }
 
 /// Validates an IPv4 address for external access
@@ -386,6 +495,65 @@ mod tests {
         assert!(validate_external_url("https://example.com").is_ok());
         assert!(validate_external_url("http://example.com/webhook").is_ok());
         assert!(validate_external_url("https://api.github.com/webhooks").is_ok());
+    }
+
+    // ── validate_loopback_or_private_url: the inverse allow-list ─────────
+
+    #[test]
+    fn test_loopback_or_private_allows_loopback() {
+        assert!(validate_loopback_or_private_url("http://127.0.0.1:8055").is_ok());
+        assert!(validate_loopback_or_private_url("http://localhost:8055").is_ok());
+        assert!(validate_loopback_or_private_url("http://[::1]:8055").is_ok());
+    }
+
+    #[test]
+    fn test_loopback_or_private_allows_rfc1918_private() {
+        assert!(validate_loopback_or_private_url("http://10.0.0.5:8055").is_ok());
+        assert!(validate_loopback_or_private_url("http://172.20.0.3:8055").is_ok());
+        assert!(validate_loopback_or_private_url("http://192.168.1.10:8055").is_ok());
+    }
+
+    #[test]
+    fn test_loopback_or_private_rejects_public_ip() {
+        assert!(validate_loopback_or_private_url("http://8.8.8.8").is_err());
+        assert!(validate_loopback_or_private_url("http://1.1.1.1").is_err());
+    }
+
+    #[test]
+    fn test_loopback_or_private_rejects_cloud_metadata_and_link_local() {
+        // Cloud metadata lives in link-local space (169.254.0.0/16), which is
+        // neither loopback nor RFC 1918 private -- must stay rejected even
+        // though this validator's whole point is to allow "local" addresses.
+        assert!(validate_loopback_or_private_url("http://169.254.169.254").is_err());
+        assert!(validate_loopback_or_private_url("http://169.254.1.1").is_err());
+    }
+
+    #[test]
+    fn test_loopback_or_private_rejects_bad_scheme() {
+        assert!(validate_loopback_or_private_url("file:///etc/passwd").is_err());
+        assert!(validate_loopback_or_private_url("ftp://127.0.0.1").is_err());
+    }
+
+    #[test]
+    fn test_loopback_or_private_domain_name_passes_through_sync_check() {
+        // A non-literal hostname can't be judged synchronously -- the sync
+        // check must not reject it (that's what the async resolver is for).
+        assert!(validate_loopback_or_private_url("http://challtestsrv:8055").is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_loopback_or_private_domain_async_rejects_public_domain() {
+        // example.com resolves publicly -- must be rejected by the allow-list.
+        assert!(validate_loopback_or_private_domain_async("example.com")
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn test_loopback_or_private_domain_async_allows_localhost() {
+        assert!(validate_loopback_or_private_domain_async("localhost")
+            .await
+            .is_ok());
     }
 
     #[test]

--- a/crates/temps-dns/Cargo.toml
+++ b/crates/temps-dns/Cargo.toml
@@ -71,6 +71,7 @@ tokio-test = "0.4"
 testcontainers = { workspace = true }
 temps-migrations = { path = "../temps-migrations" }
 wiremock = "0.6"
+serial_test = "3.2"
 mockall = "0.13"
 # ADR-024 integration test: in-process DNS client to query the real
 # control-plane resolver over a UDP socket (mirrors temps-dns-resolver's

--- a/crates/temps-dns/src/handlers/mod.rs
+++ b/crates/temps-dns/src/handlers/mod.rs
@@ -26,7 +26,8 @@ use utoipa::{OpenApi, ToSchema};
 use crate::errors::DnsError;
 use crate::providers::{
     AzureCredentials, CloudflareCredentials, DigitalOceanCredentials, DnsProviderType, DnsRecord,
-    DnsZone, GcpCredentials, NamecheapCredentials, ProviderCredentials, Route53Credentials,
+    DnsZone, GcpCredentials, NamecheapCredentials, PebbleCredentials, ProviderCredentials,
+    Route53Credentials,
 };
 use crate::services::{
     AddManagedDomainRequest, CreateProviderRequest, DnsProviderService, DnsRecordService,
@@ -121,6 +122,11 @@ pub enum DnsProviderCredentials {
         #[schema(example = "my-resource-group")]
         resource_group: String,
     },
+    /// Pebble challtestsrv mock DNS (LOCAL DEV/TEST ONLY)
+    Pebble {
+        #[schema(example = "http://localhost:8055")]
+        management_url: String,
+    },
 }
 
 impl From<DnsProviderCredentials> for ProviderCredentials {
@@ -180,6 +186,9 @@ impl From<DnsProviderCredentials> for ProviderCredentials {
                 subscription_id,
                 resource_group,
             }),
+            DnsProviderCredentials::Pebble { management_url } => {
+                ProviderCredentials::Pebble(PebbleCredentials { management_url })
+            }
         }
     }
 }

--- a/crates/temps-dns/src/handlers/mod.rs
+++ b/crates/temps-dns/src/handlers/mod.rs
@@ -461,6 +461,11 @@ async fn get_dns_provider(
 }
 
 /// Update a DNS provider
+///
+/// If new credentials are supplied, they are tested before the update is
+/// persisted (same as creation) -- otherwise a provider's credentials (and,
+/// for Pebble, its target URL) could be swapped for something invalid or
+/// unsafe without ever going through validation.
 #[utoipa::path(
     tag = "DNS Providers",
     put,
@@ -483,13 +488,24 @@ async fn update_provider(
 ) -> Result<impl IntoResponse, Problem> {
     permission_check!(auth, Permission::SettingsWrite);
 
+    let credentials: Option<ProviderCredentials> = request.credentials.map(|c| c.into());
+
+    if let Some(credentials) = &credentials {
+        let existing = state.provider_service.get(id).await?;
+        let provider_type = DnsProviderType::from_str(&existing.provider_type)?;
+        state
+            .provider_service
+            .test_credentials(&provider_type, credentials)
+            .await?;
+    }
+
     let provider = state
         .provider_service
         .update(
             id,
             UpdateProviderRequest {
                 name: request.name,
-                credentials: request.credentials.map(|c| c.into()),
+                credentials,
                 description: request.description,
                 is_active: request.is_active,
             },

--- a/crates/temps-dns/src/lib.rs
+++ b/crates/temps-dns/src/lib.rs
@@ -51,7 +51,8 @@ pub use plugin::DnsPlugin;
 pub use providers::{
     CloudflareCredentials, CloudflareProvider, DnsProvider, DnsProviderCapabilities,
     DnsProviderType, DnsRecord, DnsRecordContent, DnsRecordRequest, DnsRecordType, DnsZone,
-    ManualDnsProvider, NamecheapCredentials, NamecheapProvider, ProviderCredentials,
+    ManualDnsProvider, NamecheapCredentials, NamecheapProvider, PebbleCredentials,
+    PebbleDnsProvider, ProviderCredentials,
 };
 pub use services::{
     ChangeSet, DeploymentDnsPublisher, DnsOperationResult, DnsProviderService, DnsRecordService,

--- a/crates/temps-dns/src/providers/credentials.rs
+++ b/crates/temps-dns/src/providers/credentials.rs
@@ -132,6 +132,20 @@ pub struct AzureCredentials {
     pub resource_group: String,
 }
 
+/// Pebble challtestsrv credentials (LOCAL DEV/TEST ONLY)
+///
+/// `pebble-challtestsrv` has no authentication -- the only thing needed is
+/// its management API base URL (default `http://localhost:8055` when run
+/// per the upstream Pebble docs). Never point this at anything but a local
+/// Pebble test setup: it has no zone ownership model and will claim it can
+/// manage any domain.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct PebbleCredentials {
+    /// Base URL of pebble-challtestsrv's management API
+    #[schema(example = "http://localhost:8055")]
+    pub management_url: String,
+}
+
 /// Unified provider credentials enum
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
@@ -142,6 +156,7 @@ pub enum ProviderCredentials {
     DigitalOcean(DigitalOceanCredentials),
     Gcp(GcpCredentials),
     Azure(AzureCredentials),
+    Pebble(PebbleCredentials),
 }
 
 impl ProviderCredentials {
@@ -194,6 +209,14 @@ impl ProviderCredentials {
                     "client_secret": "***",
                     "subscription_id": mask_string(&c.subscription_id),
                     "resource_group": c.resource_group.clone(),
+                })
+            }
+            ProviderCredentials::Pebble(c) => {
+                // No secret to mask -- the management URL is not sensitive
+                // (it only makes sense pointed at a local Pebble instance).
+                serde_json::json!({
+                    "type": "pebble",
+                    "management_url": c.management_url.clone(),
                 })
             }
         }

--- a/crates/temps-dns/src/providers/mod.rs
+++ b/crates/temps-dns/src/providers/mod.rs
@@ -9,6 +9,7 @@ pub mod credentials;
 pub mod digitalocean;
 pub mod gcp;
 pub mod namecheap;
+pub mod pebble;
 pub mod route53;
 pub mod traits;
 
@@ -17,11 +18,12 @@ pub use azure::AzureProvider;
 pub use cloudflare::CloudflareProvider;
 pub use credentials::{
     AzureCredentials, CloudflareCredentials, DigitalOceanCredentials, GcpCredentials,
-    NamecheapCredentials, ProviderCredentials, Route53Credentials,
+    NamecheapCredentials, PebbleCredentials, ProviderCredentials, Route53Credentials,
 };
 pub use digitalocean::DigitalOceanProvider;
 pub use gcp::GcpProvider;
 pub use namecheap::NamecheapProvider;
+pub use pebble::PebbleDnsProvider;
 pub use route53::Route53Provider;
 pub use traits::{
     DnsProvider, DnsProviderCapabilities, DnsProviderType, DnsRecord, DnsRecordContent,

--- a/crates/temps-dns/src/providers/pebble.rs
+++ b/crates/temps-dns/src/providers/pebble.rs
@@ -1,0 +1,389 @@
+//! Pebble challtestsrv-backed DNS provider (LOCAL DEV/TEST ONLY)
+//!
+//! Publishes DNS-01 challenge TXT records to `pebble-challtestsrv`'s
+//! management API instead of a real registrar, so DNS-01 auto-renewal
+//! (`TlsService::try_dns01_renewal_with_provider`) can be exercised end to
+//! end against a local Pebble ACME server -- no real domain or DNS account
+//! required. `pebble-challtestsrv` ships alongside Pebble in
+//! `ghcr.io/letsencrypt/pebble-challtestsrv` and exposes a write-only
+//! management API (`/set-txt`, `/clear-txt`) on port 8055 by default.
+//!
+//! NEVER point this at anything other than a local Pebble test setup: it
+//! has no zone-ownership model (`can_manage_domain` always returns `true`)
+//! and no authentication.
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Serialize;
+
+use super::credentials::PebbleCredentials;
+use super::traits::{
+    DnsProvider, DnsProviderCapabilities, DnsProviderType, DnsRecord, DnsRecordContent,
+    DnsRecordRequest, DnsRecordType, DnsZone,
+};
+use crate::errors::DnsError;
+
+#[derive(Serialize)]
+struct SetTxtRequest {
+    host: String,
+    value: String,
+}
+
+#[derive(Serialize)]
+struct ClearTxtRequest {
+    host: String,
+}
+
+/// DNS provider backed by `pebble-challtestsrv`'s mock DNS server.
+pub struct PebbleDnsProvider {
+    client: Client,
+    /// Base URL of `pebble-challtestsrv`'s management API, e.g.
+    /// `http://localhost:8055`.
+    management_url: String,
+}
+
+impl PebbleDnsProvider {
+    pub fn new(credentials: PebbleCredentials) -> Result<Self, DnsError> {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .map_err(|e| DnsError::ApiError(format!("Failed to create HTTP client: {}", e)))?;
+
+        Ok(Self {
+            client,
+            management_url: credentials.management_url.trim_end_matches('/').to_string(),
+        })
+    }
+
+    /// challtestsrv addresses records by fully-qualified, dot-terminated
+    /// host, e.g. `_acme-challenge.example.com.`. `name` is the record name
+    /// relative to `domain` (`"_acme-challenge"` or `"@"` for the apex).
+    fn fqdn(domain: &str, name: &str) -> String {
+        let host = if name.is_empty() || name == "@" {
+            domain.to_string()
+        } else {
+            format!("{}.{}", name, domain)
+        };
+        format!("{}.", host)
+    }
+
+    async fn set_txt(&self, host: &str, value: &str) -> Result<(), DnsError> {
+        let response = self
+            .client
+            .post(format!("{}/set-txt", self.management_url))
+            .json(&SetTxtRequest {
+                host: host.to_string(),
+                value: value.to_string(),
+            })
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(DnsError::ApiError(format!(
+                "challtestsrv /set-txt returned status {}: {}",
+                status, body
+            )));
+        }
+        Ok(())
+    }
+
+    async fn clear_txt(&self, host: &str) -> Result<(), DnsError> {
+        let response = self
+            .client
+            .post(format!("{}/clear-txt", self.management_url))
+            .json(&ClearTxtRequest {
+                host: host.to_string(),
+            })
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(DnsError::ApiError(format!(
+                "challtestsrv /clear-txt returned status {}: {}",
+                status, body
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl DnsProvider for PebbleDnsProvider {
+    fn provider_type(&self) -> DnsProviderType {
+        DnsProviderType::Pebble
+    }
+
+    fn capabilities(&self) -> DnsProviderCapabilities {
+        DnsProviderCapabilities {
+            txt_record: true,
+            wildcard: true,
+            ..Default::default()
+        }
+    }
+
+    async fn test_connection(&self) -> Result<bool, DnsError> {
+        // challtestsrv has no health endpoint; a throwaway set-txt/clear-txt
+        // round trip is the simplest liveness probe available.
+        let probe_host = "_temps-pebble-probe.invalid.";
+        self.set_txt(probe_host, "probe").await?;
+        self.clear_txt(probe_host).await?;
+        Ok(true)
+    }
+
+    async fn list_zones(&self) -> Result<Vec<DnsZone>, DnsError> {
+        // challtestsrv has no concept of zones -- it answers authoritatively
+        // for any hostname it has been told a record for.
+        Ok(vec![])
+    }
+
+    async fn get_zone(&self, domain: &str) -> Result<Option<DnsZone>, DnsError> {
+        Ok(Some(DnsZone {
+            id: domain.to_string(),
+            name: domain.to_string(),
+            status: "active".to_string(),
+            nameservers: vec![],
+            metadata: Default::default(),
+        }))
+    }
+
+    async fn can_manage_domain(&self, _domain: &str) -> bool {
+        // No zone-ownership model -- challtestsrv will serve records for any
+        // hostname it's told about. Restrict use to local Pebble testing.
+        true
+    }
+
+    async fn list_records(&self, _domain: &str) -> Result<Vec<DnsRecord>, DnsError> {
+        // challtestsrv's management API is write-only (set/clear); it has no
+        // "list" endpoint, so this always reports empty. remove_record() is
+        // overridden below rather than relying on the trait's default
+        // list-then-delete implementation, which would be a no-op here.
+        Ok(vec![])
+    }
+
+    async fn get_record(
+        &self,
+        _domain: &str,
+        _name: &str,
+        _record_type: DnsRecordType,
+    ) -> Result<Option<DnsRecord>, DnsError> {
+        Ok(None)
+    }
+
+    async fn create_record(
+        &self,
+        domain: &str,
+        request: DnsRecordRequest,
+    ) -> Result<DnsRecord, DnsError> {
+        let DnsRecordContent::TXT { content } = &request.content else {
+            return Err(DnsError::NotSupported(
+                "PebbleDnsProvider only supports TXT records (ACME DNS-01 challenges)".to_string(),
+            ));
+        };
+
+        let fqdn = Self::fqdn(domain, &request.name);
+        self.set_txt(&fqdn, content).await?;
+
+        Ok(DnsRecord {
+            id: Some(fqdn.clone()),
+            zone: domain.to_string(),
+            name: request.name,
+            fqdn,
+            content: request.content,
+            ttl: request.ttl.unwrap_or(60),
+            proxied: false,
+            metadata: Default::default(),
+        })
+    }
+
+    async fn update_record(
+        &self,
+        domain: &str,
+        _record_id: &str,
+        request: DnsRecordRequest,
+    ) -> Result<DnsRecord, DnsError> {
+        // challtestsrv's /set-txt overwrites the value for a host in place,
+        // so "update" is identical to "create".
+        self.create_record(domain, request).await
+    }
+
+    async fn delete_record(&self, _domain: &str, record_id: &str) -> Result<(), DnsError> {
+        // `record_id` is the FQDN we minted in create_record().
+        self.clear_txt(record_id).await
+    }
+
+    async fn remove_record(
+        &self,
+        domain: &str,
+        name: &str,
+        record_type: DnsRecordType,
+    ) -> Result<(), DnsError> {
+        if record_type != DnsRecordType::TXT {
+            return Ok(());
+        }
+        // The trait's default remove_record() lists then deletes by ID, but
+        // list_records() always returns empty here (challtestsrv has no read
+        // API) -- clear directly by the FQDN we'd have created instead.
+        let fqdn = Self::fqdn(domain, name);
+        self.clear_txt(&fqdn).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fqdn_appends_dot_and_joins_name() {
+        assert_eq!(
+            PebbleDnsProvider::fqdn("example.com", "_acme-challenge"),
+            "_acme-challenge.example.com."
+        );
+    }
+
+    #[test]
+    fn fqdn_treats_apex_marker_as_bare_domain() {
+        assert_eq!(PebbleDnsProvider::fqdn("example.com", "@"), "example.com.");
+        assert_eq!(PebbleDnsProvider::fqdn("example.com", ""), "example.com.");
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use wiremock::matchers::{body_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn provider_for(mock_server: &MockServer) -> PebbleDnsProvider {
+        PebbleDnsProvider::new(PebbleCredentials {
+            management_url: mock_server.uri(),
+        })
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn create_record_publishes_txt_via_set_txt() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/set-txt"))
+            .and(body_json(serde_json::json!({
+                "host": "_acme-challenge.example.com.",
+                "value": "token-value"
+            })))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&mock_server)
+            .await;
+
+        let provider = provider_for(&mock_server);
+        let record = provider
+            .create_record(
+                "example.com",
+                DnsRecordRequest {
+                    name: "_acme-challenge".to_string(),
+                    content: DnsRecordContent::TXT {
+                        content: "token-value".to_string(),
+                    },
+                    ttl: None,
+                    proxied: false,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(record.fqdn, "_acme-challenge.example.com.");
+    }
+
+    #[tokio::test]
+    async fn create_record_rejects_non_txt_content() {
+        let mock_server = MockServer::start().await;
+        let provider = provider_for(&mock_server);
+
+        let result = provider
+            .create_record(
+                "example.com",
+                DnsRecordRequest {
+                    name: "www".to_string(),
+                    content: DnsRecordContent::A {
+                        address: "192.0.2.1".to_string(),
+                    },
+                    ttl: None,
+                    proxied: false,
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(DnsError::NotSupported(_))));
+    }
+
+    #[tokio::test]
+    async fn remove_record_calls_clear_txt_directly_without_listing() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/clear-txt"))
+            .and(body_json(serde_json::json!({
+                "host": "_acme-challenge.example.com."
+            })))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&mock_server)
+            .await;
+
+        let provider = provider_for(&mock_server);
+        provider
+            .remove_record("example.com", "_acme-challenge", DnsRecordType::TXT)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn remove_record_is_noop_for_non_txt_types() {
+        let mock_server = MockServer::start().await;
+        // No mock registered for /clear-txt -- if the provider called it,
+        // wiremock would return a 404 and this test would fail.
+        let provider = provider_for(&mock_server);
+
+        provider
+            .remove_record("example.com", "www", DnsRecordType::A)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn set_txt_error_response_surfaces_as_api_error() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/set-txt"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .mount(&mock_server)
+            .await;
+
+        let provider = provider_for(&mock_server);
+        let result = provider
+            .create_record(
+                "example.com",
+                DnsRecordRequest {
+                    name: "_acme-challenge".to_string(),
+                    content: DnsRecordContent::TXT {
+                        content: "v".to_string(),
+                    },
+                    ttl: None,
+                    proxied: false,
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(DnsError::ApiError(_))));
+    }
+
+    #[tokio::test]
+    async fn can_manage_domain_always_true() {
+        let mock_server = MockServer::start().await;
+        let provider = provider_for(&mock_server);
+        assert!(provider.can_manage_domain("anything.example").await);
+    }
+}

--- a/crates/temps-dns/src/providers/pebble.rs
+++ b/crates/temps-dns/src/providers/pebble.rs
@@ -42,16 +42,46 @@ pub struct PebbleDnsProvider {
     management_url: String,
 }
 
+/// Env var that must be set to `1` for this provider to be constructible.
+///
+/// `PebbleDnsProvider` has no authentication and, unlike every other
+/// provider in this crate, is intentionally allowed to target loopback and
+/// private addresses -- it exists solely to drive a local Pebble test
+/// instance. Gating it behind an explicit opt-in keeps it out of production
+/// instances by default (mirrors the existing `ACME_INSECURE` precedent).
+const ALLOW_PEBBLE_PROVIDER_ENV: &str = "TEMPS_ALLOW_PEBBLE_PROVIDER";
+
 impl PebbleDnsProvider {
     pub fn new(credentials: PebbleCredentials) -> Result<Self, DnsError> {
+        if std::env::var(ALLOW_PEBBLE_PROVIDER_ENV).as_deref() != Ok("1") {
+            return Err(DnsError::Validation(format!(
+                "PebbleDnsProvider is disabled: it has no authentication and is intended only \
+                 for local ACME testing against a Pebble instance. Set {}=1 to enable it.",
+                ALLOW_PEBBLE_PROVIDER_ENV
+            )));
+        }
+
+        let management_url = credentials.management_url.trim_end_matches('/').to_string();
+
+        temps_core::url_validation::validate_loopback_or_private_url(&management_url).map_err(
+            |e| {
+                DnsError::Validation(format!(
+                    "Invalid Pebble management_url: {} (must be a loopback or private address -- \
+                     this provider only ever talks to a local Pebble instance)",
+                    e
+                ))
+            },
+        )?;
+
         let client = Client::builder()
             .timeout(std::time::Duration::from_secs(10))
+            .redirect(reqwest::redirect::Policy::none())
             .build()
             .map_err(|e| DnsError::ApiError(format!("Failed to create HTTP client: {}", e)))?;
 
         Ok(Self {
             client,
-            management_url: credentials.management_url.trim_end_matches('/').to_string(),
+            management_url,
         })
     }
 
@@ -81,9 +111,15 @@ impl PebbleDnsProvider {
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
+            tracing::debug!(
+                "challtestsrv /set-txt for host '{}' returned status {}: {}",
+                host,
+                status,
+                body.chars().take(500).collect::<String>()
+            );
             return Err(DnsError::ApiError(format!(
-                "challtestsrv /set-txt returned status {}: {}",
-                status, body
+                "challtestsrv /set-txt failed for host '{}' with status {}",
+                host, status
             )));
         }
         Ok(())
@@ -102,9 +138,15 @@ impl PebbleDnsProvider {
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
+            tracing::debug!(
+                "challtestsrv /clear-txt for host '{}' returned status {}: {}",
+                host,
+                status,
+                body.chars().take(500).collect::<String>()
+            );
             return Err(DnsError::ApiError(format!(
-                "challtestsrv /clear-txt returned status {}: {}",
-                status, body
+                "challtestsrv /clear-txt failed for host '{}' with status {}",
+                host, status
             )));
         }
         Ok(())
@@ -126,6 +168,24 @@ impl DnsProvider for PebbleDnsProvider {
     }
 
     async fn test_connection(&self) -> Result<bool, DnsError> {
+        // management_url's literal-IP case was already validated synchronously
+        // in new(); a hostname needs its resolved IPs checked here, same as
+        // validate_external_url/validate_domain_async's split in temps-webhooks.
+        if let Ok(parsed) = reqwest::Url::parse(&self.management_url) {
+            if let Some(host) = parsed.host_str() {
+                if host.parse::<std::net::IpAddr>().is_err() {
+                    temps_core::url_validation::validate_loopback_or_private_domain_async(host)
+                        .await
+                        .map_err(|e| {
+                            DnsError::Validation(format!(
+                                "Pebble management_url host '{}' failed validation: {}",
+                                host, e
+                            ))
+                        })?;
+                }
+            }
+        }
+
         // challtestsrv has no health endpoint; a throwaway set-txt/clear-txt
         // round trip is the simplest liveness probe available.
         let probe_host = "_temps-pebble-probe.invalid.";
@@ -235,6 +295,7 @@ impl DnsProvider for PebbleDnsProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn fqdn_appends_dot_and_joins_name() {
@@ -249,15 +310,55 @@ mod tests {
         assert_eq!(PebbleDnsProvider::fqdn("example.com", "@"), "example.com.");
         assert_eq!(PebbleDnsProvider::fqdn("example.com", ""), "example.com.");
     }
+
+    // These tests mutate the process-wide TEMPS_ALLOW_PEBBLE_PROVIDER env var,
+    // so they (and integration_tests, which also constructs providers) must
+    // not run concurrently with each other.
+    #[test]
+    #[serial(pebble_env_gate)]
+    fn new_rejects_when_gate_env_unset() {
+        std::env::remove_var(ALLOW_PEBBLE_PROVIDER_ENV);
+        let result = PebbleDnsProvider::new(PebbleCredentials {
+            management_url: "http://localhost:8055".to_string(),
+        });
+        assert!(matches!(result, Err(DnsError::Validation(_))));
+    }
+
+    #[test]
+    #[serial(pebble_env_gate)]
+    fn new_rejects_public_management_url_even_when_gated() {
+        std::env::set_var(ALLOW_PEBBLE_PROVIDER_ENV, "1");
+        let result = PebbleDnsProvider::new(PebbleCredentials {
+            management_url: "http://93.184.216.34:8055".to_string(),
+        });
+        std::env::remove_var(ALLOW_PEBBLE_PROVIDER_ENV);
+        assert!(matches!(result, Err(DnsError::Validation(_))));
+    }
+
+    #[test]
+    #[serial(pebble_env_gate)]
+    fn new_accepts_loopback_url_when_gated() {
+        std::env::set_var(ALLOW_PEBBLE_PROVIDER_ENV, "1");
+        let result = PebbleDnsProvider::new(PebbleCredentials {
+            management_url: "http://localhost:8055".to_string(),
+        });
+        std::env::remove_var(ALLOW_PEBBLE_PROVIDER_ENV);
+        assert!(result.is_ok());
+    }
 }
 
 #[cfg(test)]
 mod integration_tests {
     use super::*;
+    use serial_test::serial;
     use wiremock::matchers::{body_json, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn provider_for(mock_server: &MockServer) -> PebbleDnsProvider {
+        // Safety gate is opt-in (see ALLOW_PEBBLE_PROVIDER_ENV); these tests
+        // exercise the provider directly against a loopback wiremock server,
+        // which is exactly the intended use, so enable it for the process.
+        std::env::set_var(ALLOW_PEBBLE_PROVIDER_ENV, "1");
         PebbleDnsProvider::new(PebbleCredentials {
             management_url: mock_server.uri(),
         })
@@ -265,6 +366,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[serial(pebble_env_gate)]
     async fn create_record_publishes_txt_via_set_txt() {
         let mock_server = MockServer::start().await;
 
@@ -298,6 +400,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[serial(pebble_env_gate)]
     async fn create_record_rejects_non_txt_content() {
         let mock_server = MockServer::start().await;
         let provider = provider_for(&mock_server);
@@ -320,6 +423,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[serial(pebble_env_gate)]
     async fn remove_record_calls_clear_txt_directly_without_listing() {
         let mock_server = MockServer::start().await;
 
@@ -340,6 +444,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[serial(pebble_env_gate)]
     async fn remove_record_is_noop_for_non_txt_types() {
         let mock_server = MockServer::start().await;
         // No mock registered for /clear-txt -- if the provider called it,
@@ -353,6 +458,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[serial(pebble_env_gate)]
     async fn set_txt_error_response_surfaces_as_api_error() {
         let mock_server = MockServer::start().await;
 
@@ -381,6 +487,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[serial(pebble_env_gate)]
     async fn can_manage_domain_always_true() {
         let mock_server = MockServer::start().await;
         let provider = provider_for(&mock_server);

--- a/crates/temps-dns/src/providers/traits.rs
+++ b/crates/temps-dns/src/providers/traits.rs
@@ -29,6 +29,11 @@ pub enum DnsProviderType {
     Azure,
     /// Manual DNS (user sets records manually)
     Manual,
+    /// Pebble challtestsrv mock DNS (LOCAL DEV/TEST ONLY -- publishes to
+    /// `pebble-challtestsrv` instead of a real registrar, so DNS-01
+    /// auto-renewal can be exercised against a local Pebble ACME server with
+    /// no real domain or DNS account)
+    Pebble,
 }
 
 impl std::fmt::Display for DnsProviderType {
@@ -41,6 +46,7 @@ impl std::fmt::Display for DnsProviderType {
             DnsProviderType::Gcp => write!(f, "gcp"),
             DnsProviderType::Azure => write!(f, "azure"),
             DnsProviderType::Manual => write!(f, "manual"),
+            DnsProviderType::Pebble => write!(f, "pebble"),
         }
     }
 }
@@ -56,6 +62,7 @@ impl DnsProviderType {
             "gcp" | "google" | "googlecloud" | "google-cloud" => Ok(DnsProviderType::Gcp),
             "azure" | "az" => Ok(DnsProviderType::Azure),
             "manual" => Ok(DnsProviderType::Manual),
+            "pebble" | "challtestsrv" => Ok(DnsProviderType::Pebble),
             _ => Err(DnsError::InvalidProviderType(s.to_string())),
         }
     }
@@ -78,6 +85,7 @@ impl DnsProviderType {
                 ]
             }
             DnsProviderType::Manual => vec![],
+            DnsProviderType::Pebble => vec!["management_url"],
         }
     }
 
@@ -91,6 +99,7 @@ impl DnsProviderType {
             DnsProviderType::Gcp => vec![],
             DnsProviderType::Azure => vec![],
             DnsProviderType::Manual => vec![],
+            DnsProviderType::Pebble => vec![],
         }
     }
 }
@@ -553,6 +562,14 @@ mod tests {
             DnsProviderType::from_str("manual").unwrap(),
             DnsProviderType::Manual
         );
+        assert_eq!(
+            DnsProviderType::from_str("pebble").unwrap(),
+            DnsProviderType::Pebble
+        );
+        assert_eq!(
+            DnsProviderType::from_str("challtestsrv").unwrap(),
+            DnsProviderType::Pebble
+        );
         assert!(DnsProviderType::from_str("invalid").is_err());
     }
 
@@ -622,6 +639,7 @@ mod tests {
         assert_eq!(DnsProviderType::Gcp.to_string(), "gcp");
         assert_eq!(DnsProviderType::Azure.to_string(), "azure");
         assert_eq!(DnsProviderType::Manual.to_string(), "manual");
+        assert_eq!(DnsProviderType::Pebble.to_string(), "pebble");
     }
 
     #[test]
@@ -657,6 +675,10 @@ mod tests {
             ]
         );
         assert!(DnsProviderType::Manual.required_credentials().is_empty());
+        assert_eq!(
+            DnsProviderType::Pebble.required_credentials(),
+            vec!["management_url"]
+        );
     }
 
     #[test]

--- a/crates/temps-dns/src/services/provider_service.rs
+++ b/crates/temps-dns/src/services/provider_service.rs
@@ -18,7 +18,8 @@ use tracing::{debug, error, info};
 use crate::errors::DnsError;
 use crate::providers::{
     AzureProvider, CloudflareProvider, DigitalOceanProvider, DnsProvider, DnsProviderType,
-    GcpProvider, ManualDnsProvider, NamecheapProvider, ProviderCredentials, Route53Provider,
+    GcpProvider, ManualDnsProvider, NamecheapProvider, PebbleDnsProvider, ProviderCredentials,
+    Route53Provider,
 };
 
 /// Service for managing DNS providers
@@ -196,6 +197,21 @@ impl DnsProviderService {
                 debug!("Manual provider - skipping connection test");
                 return Ok(());
             }
+            DnsProviderType::Pebble => match credentials {
+                ProviderCredentials::Pebble(pebble_creds) => {
+                    let pebble_provider =
+                        PebbleDnsProvider::new(pebble_creds.clone()).map_err(|e| {
+                            error!("Failed to create Pebble provider for testing: {}", e);
+                            e
+                        })?;
+                    Box::new(pebble_provider)
+                }
+                _ => {
+                    return Err(DnsError::InvalidCredentials(
+                        "Expected Pebble credentials".to_string(),
+                    ))
+                }
+            },
         };
 
         // Test the connection
@@ -420,6 +436,22 @@ impl DnsProviderService {
                 }
             }
             DnsProviderType::Manual => Ok(Box::new(ManualDnsProvider::new())),
+            DnsProviderType::Pebble => {
+                let credentials: ProviderCredentials = serde_json::from_str(&credentials_json)?;
+                match credentials {
+                    ProviderCredentials::Pebble(pebble_creds) => {
+                        let pebble_provider =
+                            PebbleDnsProvider::new(pebble_creds).map_err(|e| {
+                                error!("Failed to create Pebble provider: {}", e);
+                                e
+                            })?;
+                        Ok(Box::new(pebble_provider))
+                    }
+                    _ => Err(DnsError::InvalidCredentials(
+                        "Expected Pebble credentials".to_string(),
+                    )),
+                }
+            }
         }
     }
 

--- a/crates/temps-sandbox/src/handlers/sandboxes.rs
+++ b/crates/temps-sandbox/src/handlers/sandboxes.rs
@@ -210,6 +210,11 @@ fn validate_seed_url(url: &str, kind: &str) -> Result<(), SandboxError> {
                 "host points to a private, loopback, or metadata address".to_string()
             }
             UrlValidationError::DnsResolutionFailed(m) => format!("dns: {m}"),
+            // Only ever returned by validate_loopback_or_private_url/_async
+            // (the inverse check used by local-only providers), never by
+            // validate_external_url -- unreachable here, kept explicit so
+            // this match stays exhaustive as the shared enum grows.
+            UrlValidationError::NotLocalOrPrivate => "unexpected validation error".to_string(),
         };
         SandboxError::Validation {
             message: format!("{kind} source: {detail}"),


### PR DESCRIPTION
## Summary

Adds a way to test DNS-01 certificate auto-renewal (`TlsService::try_dns01_renewal_with_provider`, shipped in #270) end-to-end locally, with fake Let's Encrypt, and no real domain or DNS account.

- New `DnsProviderType::Pebble` / `PebbleDnsProvider`: implements the standard `DnsProvider` trait, but publishes DNS-01 `_acme-challenge` TXT records to [`pebble-challtestsrv`](https://github.com/letsencrypt/pebble/tree/main/cmd/pebble-challtestsrv)'s management API (`/set-txt`, `/clear-txt`) instead of a real registrar.
- **LOCAL DEV/TEST ONLY** — clearly documented as such. `can_manage_domain` always returns `true` (challtestsrv has no zone-ownership model) and there's no authentication, just the challtestsrv management URL as the "credential". Never point this at anything but a local Pebble setup.
- Same trait, same `create_provider_instance` / `test_credentials` wiring as every other provider (Cloudflare, Route53, etc.) — no special-casing elsewhere in the DNS-provider system.

## How to use it (full local test loop)

```bash
# 1. Run Pebble + its DNS mock companion, wired together
docker network create pebble-test
docker run -d --name challtestsrv --network pebble-test -p 8055:8055 \
  ghcr.io/letsencrypt/pebble-challtestsrv:latest -defaultIPv6 ""
docker run -d --name pebble --network pebble-test -p 14000:14000 \
  ghcr.io/letsencrypt/pebble:latest \
  -config /test/config/pebble-config.json -dnsserver challtestsrv:8053

# 2. Point temps at Pebble instead of real Let's Encrypt (already-supported env vars)
ACME_DIRECTORY_URL=https://localhost:14000/dir ACME_INSECURE=1 \
  cargo run --bin temps -- serve ...

# 3. Register the Pebble DNS provider, mark a domain auto-managed, create a dns-01 domain
curl -X POST localhost:8080/api/dns-providers -H "Authorization: Bearer $API_KEY" -d '
  {"name":"Local Pebble","provider_type":"pebble",
   "credentials":{"type":"pebble","management_url":"http://localhost:8055"}}'
curl -X POST localhost:8080/api/dns-providers/{id}/domains -H "Authorization: Bearer $API_KEY" \
  -d '{"domain":"example.local","auto_manage":true}'
curl -X POST localhost:8080/api/dns-providers/{id}/domains/example.local/verify -H "Authorization: Bearer $API_KEY"
curl -X POST localhost:8080/api/domains -H "Authorization: Bearer $API_KEY" \
  -d '{"domain":"www.example.local","challenge_type":"dns-01"}'
```

From there, the background renewal scheduler (or an expiring cert) drives the exact same code path production auto-renewal uses — `request_challenge` → `setup_dns_txt_records` (via `PebbleDnsProvider`) → `complete_challenge` — validated by Pebble's real ACME VA against challtestsrv's DNS server.

## Test plan

- [x] `cargo test --lib -p temps-dns` — 234 passed (8 new: `pebble::tests` + `pebble::integration_tests`, wiremock-backed, covering TXT publish/clear, non-TXT rejection, error surfacing, `can_manage_domain`)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] **Live end-to-end verification**, not just unit tests: ran real `ghcr.io/letsencrypt/pebble` + `pebble-challtestsrv` containers, pointed a real `temps serve` at Pebble (`ACME_DIRECTORY_URL` + `ACME_INSECURE=1`), and drove the full flow via the actual HTTP API:
  1. `POST /api/dns-providers` with `provider_type: "pebble"` → succeeded (this calls `test_credentials` → `PebbleDnsProvider::test_connection()` first, so provider creation itself proves connectivity)
  2. Added + verified a managed domain (`auto_manage: true`)
  3. Created a domain with `challenge_type: "dns-01"`, called `setup-dns-challenge` against the Pebble provider — TXT record actually published to challtestsrv
  4. Finalized the order — Pebble validated via DNS and issued a real certificate chain (`CN=Pebble Intermediate CA`)
  5. Set `expiration_time` to 10 days out and restarted the server — the **background renewal scheduler** (not a manual API call) picked it up on its startup check, logged `🔄 Auto-renewing DNS-01 certificate for www.example.local via DNS provider Local Pebble`, auto-published a fresh TXT record, and completed: `✅ Successfully renewed certificate for www.example.local`