### PR TITLE
fix(proxy): track real body bytes for request/response bandwidth

### DIFF
--- a/crates/temps-proxy/src/proxy.rs
+++ b/crates/temps-proxy/src/proxy.rs
@@ -389,6 +389,11 @@ pub struct ProxyContext {
     /// unlike the `Content-Length` header, this is always populated even for
     /// chunked-encoded request bodies.
     pub client_body_bytes_received: usize,
+    /// Proxy log entry built in `log_request` (response-header time), held
+    /// here rather than sent immediately because `upstream_body_bytes_received`
+    /// isn't fully accumulated until the response body finishes streaming.
+    /// The `logging` hook patches in the final byte count and sends it.
+    pub pending_proxy_log: Option<CreateProxyLogRequest>,
     /// Whether the client requested a Markdown response via `Accept: text/markdown`
     pub wants_markdown: bool,
     /// Accumulated body bytes for HTML-to-Markdown conversion
@@ -1348,7 +1353,7 @@ impl LoadBalancer {
         &self,
         _session: &PingoraSession,
         upstream_response: &ResponseHeader,
-        ctx: &ProxyContext,
+        ctx: &mut ProxyContext,
     ) -> Result<()> {
         // Skip logging for internal temps API routes
         if ctx.path.starts_with(ROUTE_PREFIX_TEMPS) {
@@ -1359,11 +1364,11 @@ impl LoadBalancer {
 
         // Asynchronously log to proxy_logs table via batch writer (skip static assets)
         if Self::should_log_request(&ctx.path) {
-            // Prefer bytes actually streamed through the proxy (accumulated in
-            // request_body_filter/response_body_filter) — Content-Length is
-            // absent for chunked/streamed bodies, which are common and would
-            // otherwise always log as 0. Fall back to Content-Length only for
-            // requests whose body never reached the filter (e.g. HEAD).
+            // Request body has already fully streamed through request_body_filter
+            // by the time response headers arrive (the client finishes sending
+            // before the upstream replies), so the accumulated count is reliable
+            // here. Fall back to Content-Length only for bodies that never
+            // reached the filter (e.g. HEAD).
             let request_size = if ctx.client_body_bytes_received > 0 {
                 Some(ctx.client_body_bytes_received as i64)
             } else {
@@ -1373,14 +1378,17 @@ impl LoadBalancer {
                     .and_then(|v| v.parse::<i64>().ok())
             };
 
-            let response_size = if ctx.upstream_body_bytes_received > 0 {
-                Some(ctx.upstream_body_bytes_received as i64)
-            } else {
-                ctx.response_headers
-                    .as_ref()
-                    .and_then(|h| h.get("content-length"))
-                    .and_then(|v| v.parse::<i64>().ok())
-            };
+            // This function runs when response *headers* arrive — the response
+            // body hasn't streamed through response_body_filter yet, so
+            // upstream_body_bytes_received is always 0 here. Content-Length is
+            // the best information available now; the `logging` hook (true
+            // end-of-request, after the body has fully streamed) overwrites
+            // this with the accumulated byte count before the entry is sent.
+            let response_size = ctx
+                .response_headers
+                .as_ref()
+                .and_then(|h| h.get("content-length"))
+                .and_then(|v| v.parse::<i64>().ok());
 
             // Extract cache status from response headers
             let cache_status = ctx
@@ -1436,10 +1444,10 @@ impl LoadBalancer {
                 error_group_id: None,
             };
 
-            // Non-blocking enqueue; sheds the entry when the writer is behind.
-            // Never spawn-and-await a send here: each parked send future pins
-            // the full log struct and the task list becomes an unbounded queue.
-            self.proxy_log_handle.send_or_drop(proxy_log_request);
+            // Stash rather than send: the `logging` hook fires after the
+            // response body has fully streamed and patches response_size_bytes
+            // with the accurate accumulated count before enqueueing.
+            ctx.pending_proxy_log = Some(proxy_log_request);
         }
 
         Ok(())
@@ -2299,6 +2307,7 @@ impl ProxyHttp for LoadBalancer {
             sni_hostname: None,
             upstream_body_bytes_received: 0,
             client_body_bytes_received: 0,
+            pending_proxy_log: None,
             wants_markdown: false,
             markdown_buffer: Vec::new(),
             upstream_connect_tries: 0,
@@ -4362,6 +4371,18 @@ impl ProxyHttp for LoadBalancer {
             ctx.upstream_response_time_ms,
             destination,
         );
+
+        // The response body has now fully streamed through response_body_filter
+        // (this hook fires in Pingora's finish(), after every body task), so
+        // upstream_body_bytes_received holds the real byte count. Patch it into
+        // the entry log_request stashed at header-time and send it now — this
+        // is the only place a proxied response's byte count is accurate.
+        if let Some(mut pending) = ctx.pending_proxy_log.take() {
+            if ctx.upstream_body_bytes_received > 0 {
+                pending.response_size_bytes = Some(ctx.upstream_body_bytes_received as i64);
+            }
+            self.proxy_log_handle.send_or_drop(pending);
+        }
     }
 }
 
@@ -4649,6 +4670,7 @@ mod markdown_tests {
             sni_hostname: None,
             upstream_body_bytes_received: 0,
             client_body_bytes_received: 0,
+            pending_proxy_log: None,
             wants_markdown: false,
             markdown_buffer: Vec::new(),
             upstream_connect_tries: 0,
@@ -5191,6 +5213,7 @@ mod markdown_pipeline_tests {
             sni_hostname: None,
             upstream_body_bytes_received: 0,
             client_body_bytes_received: 0,
+            pending_proxy_log: None,
             wants_markdown: false,
             markdown_buffer: Vec::new(),
             upstream_connect_tries: 0,

--- a/crates/temps-proxy/src/proxy.rs
+++ b/crates/temps-proxy/src/proxy.rs
@@ -379,8 +379,16 @@ pub struct ProxyContext {
     pub tls_cipher: Option<String>,
     /// SNI hostname from TLS handshake (for SNI-based routing)
     pub sni_hostname: Option<String>,
-    /// Upstream response body bytes received (tracked by Pingora 0.8.0)
+    /// Upstream response body bytes actually forwarded to the client,
+    /// accumulated per-chunk in `response_body_filter`. Authoritative source
+    /// for response bandwidth — unlike the `Content-Length` header, this is
+    /// always populated even for chunked/streamed responses.
     pub upstream_body_bytes_received: usize,
+    /// Client request body bytes received, accumulated per-chunk in
+    /// `request_body_filter`. Authoritative source for request bandwidth —
+    /// unlike the `Content-Length` header, this is always populated even for
+    /// chunked-encoded request bodies.
+    pub client_body_bytes_received: usize,
     /// Whether the client requested a Markdown response via `Accept: text/markdown`
     pub wants_markdown: bool,
     /// Accumulated body bytes for HTML-to-Markdown conversion
@@ -1351,19 +1359,28 @@ impl LoadBalancer {
 
         // Asynchronously log to proxy_logs table via batch writer (skip static assets)
         if Self::should_log_request(&ctx.path) {
-            // Extract request size from Content-Length header
-            let request_size = ctx
-                .request_headers
-                .as_ref()
-                .and_then(|h| h.get("content-length"))
-                .and_then(|v| v.parse::<i64>().ok());
+            // Prefer bytes actually streamed through the proxy (accumulated in
+            // request_body_filter/response_body_filter) — Content-Length is
+            // absent for chunked/streamed bodies, which are common and would
+            // otherwise always log as 0. Fall back to Content-Length only for
+            // requests whose body never reached the filter (e.g. HEAD).
+            let request_size = if ctx.client_body_bytes_received > 0 {
+                Some(ctx.client_body_bytes_received as i64)
+            } else {
+                ctx.request_headers
+                    .as_ref()
+                    .and_then(|h| h.get("content-length"))
+                    .and_then(|v| v.parse::<i64>().ok())
+            };
 
-            // Extract response size from Content-Length header
-            let response_size = ctx
-                .response_headers
-                .as_ref()
-                .and_then(|h| h.get("content-length"))
-                .and_then(|v| v.parse::<i64>().ok());
+            let response_size = if ctx.upstream_body_bytes_received > 0 {
+                Some(ctx.upstream_body_bytes_received as i64)
+            } else {
+                ctx.response_headers
+                    .as_ref()
+                    .and_then(|h| h.get("content-length"))
+                    .and_then(|v| v.parse::<i64>().ok())
+            };
 
             // Extract cache status from response headers
             let cache_status = ctx
@@ -2142,6 +2159,102 @@ fn ephemeral_redirect_location(
     Some(location)
 }
 
+/// Core response-body-filter logic (SSE/WebSocket passthrough, buffered
+/// Markdown conversion, default passthrough). Split out as a free function
+/// so `response_body_filter` can wrap it with byte-counting that applies
+/// uniformly to every exit path — see `ProxyContext::upstream_body_bytes_received`.
+fn response_body_filter_inner(
+    body: &mut Option<Bytes>,
+    end_of_stream: bool,
+    ctx: &mut ProxyContext,
+) -> Result<Option<std::time::Duration>> {
+    // For SSE or WebSocket responses, pass through immediately without buffering
+    if ctx.is_sse || ctx.is_websocket {
+        if let Some(chunk) = body {
+            let stream_type = if ctx.is_sse { "SSE" } else { "WebSocket" };
+            debug!("Streaming {} chunk: {} bytes", stream_type, chunk.len());
+        }
+        return Ok(None);
+    }
+
+    // HTML-to-Markdown conversion: buffer chunks, convert on end_of_stream.
+    if ctx.wants_markdown {
+        if let Some(chunk) = body.take() {
+            // Enforce 2 MB limit — mirrors Cloudflare's Markdown for Agents constraint.
+            if ctx.markdown_buffer.len() + chunk.len() > MAX_MARKDOWN_BODY_BYTES {
+                warn!(
+                    "Response body exceeds 2 MB markdown conversion limit for path={}, \
+                     falling back to passthrough",
+                    ctx.path
+                );
+                // Disable markdown, flush the buffer + current chunk as-is.
+                ctx.wants_markdown = false;
+                let mut flushed = std::mem::take(&mut ctx.markdown_buffer);
+                flushed.extend_from_slice(&chunk);
+                *body = Some(Bytes::from(flushed));
+                return Ok(None);
+            }
+            ctx.markdown_buffer.extend_from_slice(&chunk);
+        }
+
+        if end_of_stream {
+            let html = String::from_utf8_lossy(&ctx.markdown_buffer);
+            // Parse the document once — reuse it for both meta extraction
+            // and content extraction.
+            let document = scraper::Html::parse_document(&html);
+            let meta = extract_page_meta(&document);
+            // Extract <main> (or <body> fallback), stripping script/style.
+            let content = extract_content_html(&document);
+            let markdown = match htmd::convert(&content) {
+                Ok(md) => md,
+                Err(e) => {
+                    warn!(
+                        "HTML-to-Markdown conversion failed for path={}: {}",
+                        ctx.path, e
+                    );
+                    // Fall back to the original HTML bytes so the client gets something.
+                    let original = std::mem::take(&mut ctx.markdown_buffer);
+                    *body = Some(Bytes::from(original));
+                    return Ok(None);
+                }
+            };
+
+            let token_estimate = estimate_markdown_tokens(&markdown);
+            debug!(
+                "Markdown conversion complete for path={}: {} bytes, ~{} tokens",
+                ctx.path,
+                markdown.len(),
+                token_estimate
+            );
+
+            // The x-markdown-tokens header must be a trailer because the response
+            // headers have already been sent. Pingora does not support HTTP trailers
+            // for regular HTTP/1.1 clients, so we log the value and skip injecting it
+            // into headers here — the header is set in response_filter instead via
+            // a sentinel value once we know the body size upfront (not possible when
+            // streaming).  Best-effort: we set it here anyway; Pingora will silently
+            // drop it if trailers are unsupported.
+            // Note: if you need reliable x-markdown-tokens delivery, switch to a
+            // buffered response pattern (write_response_* directly in request_filter).
+
+            // Prepend YAML front-matter built from <head> meta tags,
+            // matching Cloudflare's Markdown for Agents output format.
+            let final_markdown = match meta.to_frontmatter() {
+                Some(fm) => fm + &markdown,
+                None => markdown,
+            };
+
+            ctx.markdown_buffer = Vec::new(); // free memory
+            *body = Some(Bytes::from(final_markdown));
+        }
+        // Suppress intermediate chunks — only emit on end_of_stream.
+        return Ok(None);
+    }
+
+    // Default: pass all responses through without buffering
+    Ok(None)
+}
+
 #[async_trait]
 impl ProxyHttp for LoadBalancer {
     type CTX = ProxyContext;
@@ -2185,6 +2298,7 @@ impl ProxyHttp for LoadBalancer {
             tls_cipher: None,
             sni_hostname: None,
             upstream_body_bytes_received: 0,
+            client_body_bytes_received: 0,
             wants_markdown: false,
             markdown_buffer: Vec::new(),
             upstream_connect_tries: 0,
@@ -3771,6 +3885,30 @@ impl ProxyHttp for LoadBalancer {
         Ok(())
     }
 
+    /// Accumulate request body bytes as they stream in. The only reliable
+    /// way to measure upload size — chunked-encoded request bodies carry no
+    /// `Content-Length` header and would otherwise log as 0 (see `log_request`).
+    async fn request_body_filter(
+        &self,
+        _session: &mut PingoraSession,
+        body: &mut Option<Bytes>,
+        _end_of_stream: bool,
+        ctx: &mut Self::CTX,
+    ) -> Result<()>
+    where
+        Self::CTX: Send + Sync,
+    {
+        if let Some(chunk) = body.as_ref() {
+            ctx.client_body_bytes_received += chunk.len();
+        }
+        Ok(())
+    }
+
+    /// Thin wrapper over `response_body_filter_inner` that accumulates the
+    /// bytes actually forwarded to the client on every exit path (passthrough,
+    /// SSE/WebSocket, and the buffered Markdown conversion below). Chunked
+    /// responses carry no `Content-Length` header, so this accumulated count
+    /// is the only reliable source for response bandwidth (see `log_request`).
     fn response_body_filter(
         &self,
         _session: &mut PingoraSession,
@@ -3781,91 +3919,11 @@ impl ProxyHttp for LoadBalancer {
     where
         Self::CTX: Send + Sync,
     {
-        // For SSE or WebSocket responses, pass through immediately without buffering
-        if ctx.is_sse || ctx.is_websocket {
-            if let Some(chunk) = body {
-                let stream_type = if ctx.is_sse { "SSE" } else { "WebSocket" };
-                debug!("Streaming {} chunk: {} bytes", stream_type, chunk.len());
-            }
-            return Ok(None);
+        let result = response_body_filter_inner(body, end_of_stream, ctx);
+        if let Some(chunk) = body.as_ref() {
+            ctx.upstream_body_bytes_received += chunk.len();
         }
-
-        // HTML-to-Markdown conversion: buffer chunks, convert on end_of_stream.
-        if ctx.wants_markdown {
-            if let Some(chunk) = body.take() {
-                // Enforce 2 MB limit — mirrors Cloudflare's Markdown for Agents constraint.
-                if ctx.markdown_buffer.len() + chunk.len() > MAX_MARKDOWN_BODY_BYTES {
-                    warn!(
-                        "Response body exceeds 2 MB markdown conversion limit for path={}, \
-                         falling back to passthrough",
-                        ctx.path
-                    );
-                    // Disable markdown, flush the buffer + current chunk as-is.
-                    ctx.wants_markdown = false;
-                    let mut flushed = std::mem::take(&mut ctx.markdown_buffer);
-                    flushed.extend_from_slice(&chunk);
-                    *body = Some(Bytes::from(flushed));
-                    return Ok(None);
-                }
-                ctx.markdown_buffer.extend_from_slice(&chunk);
-            }
-
-            if end_of_stream {
-                let html = String::from_utf8_lossy(&ctx.markdown_buffer);
-                // Parse the document once — reuse it for both meta extraction
-                // and content extraction.
-                let document = scraper::Html::parse_document(&html);
-                let meta = extract_page_meta(&document);
-                // Extract <main> (or <body> fallback), stripping script/style.
-                let content = extract_content_html(&document);
-                let markdown = match htmd::convert(&content) {
-                    Ok(md) => md,
-                    Err(e) => {
-                        warn!(
-                            "HTML-to-Markdown conversion failed for path={}: {}",
-                            ctx.path, e
-                        );
-                        // Fall back to the original HTML bytes so the client gets something.
-                        let original = std::mem::take(&mut ctx.markdown_buffer);
-                        *body = Some(Bytes::from(original));
-                        return Ok(None);
-                    }
-                };
-
-                let token_estimate = estimate_markdown_tokens(&markdown);
-                debug!(
-                    "Markdown conversion complete for path={}: {} bytes, ~{} tokens",
-                    ctx.path,
-                    markdown.len(),
-                    token_estimate
-                );
-
-                // The x-markdown-tokens header must be a trailer because the response
-                // headers have already been sent. Pingora does not support HTTP trailers
-                // for regular HTTP/1.1 clients, so we log the value and skip injecting it
-                // into headers here — the header is set in response_filter instead via
-                // a sentinel value once we know the body size upfront (not possible when
-                // streaming).  Best-effort: we set it here anyway; Pingora will silently
-                // drop it if trailers are unsupported.
-                // Note: if you need reliable x-markdown-tokens delivery, switch to a
-                // buffered response pattern (write_response_* directly in request_filter).
-
-                // Prepend YAML front-matter built from <head> meta tags,
-                // matching Cloudflare's Markdown for Agents output format.
-                let final_markdown = match meta.to_frontmatter() {
-                    Some(fm) => fm + &markdown,
-                    None => markdown,
-                };
-
-                ctx.markdown_buffer = Vec::new(); // free memory
-                *body = Some(Bytes::from(final_markdown));
-            }
-            // Suppress intermediate chunks — only emit on end_of_stream.
-            return Ok(None);
-        }
-
-        // Default: pass all responses through without buffering
-        Ok(None)
+        result
     }
 
     async fn response_filter(
@@ -4206,12 +4264,16 @@ impl ProxyHttp for LoadBalancer {
 
         // Asynchronously log failed proxy request (skip static assets)
         if Self::should_log_request(&ctx.path) {
-            // Extract request size from Content-Length header
-            let request_size = ctx
-                .request_headers
-                .as_ref()
-                .and_then(|h| h.get("content-length"))
-                .and_then(|v| v.parse::<i64>().ok());
+            // Prefer bytes actually received from the client (see log_request);
+            // fall back to Content-Length if the body never reached the filter.
+            let request_size = if ctx.client_body_bytes_received > 0 {
+                Some(ctx.client_body_bytes_received as i64)
+            } else {
+                ctx.request_headers
+                    .as_ref()
+                    .and_then(|h| h.get("content-length"))
+                    .and_then(|v| v.parse::<i64>().ok())
+            };
 
             // For failed requests, response size is the error message size
             let response_size = Some(SERVICE_UNAVAILABLE_BODY.len() as i64);
@@ -4586,6 +4648,7 @@ mod markdown_tests {
             tls_cipher: None,
             sni_hostname: None,
             upstream_body_bytes_received: 0,
+            client_body_bytes_received: 0,
             wants_markdown: false,
             markdown_buffer: Vec::new(),
             upstream_connect_tries: 0,
@@ -5127,6 +5190,7 @@ mod markdown_pipeline_tests {
             tls_cipher: None,
             sni_hostname: None,
             upstream_body_bytes_received: 0,
+            client_body_bytes_received: 0,
             wants_markdown: false,
             markdown_buffer: Vec::new(),
             upstream_connect_tries: 0,


### PR DESCRIPTION
## Summary
- The Proxy dashboard's "Bandwidth" panel (`/proxy`, per-project filtered view) always showed a flat 0 B line despite real traffic.
- Root cause: `total_request_bytes`/`total_response_bytes` were derived solely from the `Content-Length` header (`log_request`/`fail_to_proxy`). Chunked/streamed responses carry no `Content-Length` — a case this same file already explicitly detects and preserves (`is_chunked_response` in `response_filter`) — so for any backend that streams, bytes were always logged as `NULL` and summed to 0 in ClickHouse.
- There was also a dead scaffold for this: `ProxyContext::upstream_body_bytes_received` was declared and zero-initialized in three places but never incremented or read anywhere.
- Fix: accumulate actual body bytes per-chunk in `request_body_filter` (new override) and `response_body_filter` (now a thin wrapper around the existing logic, renamed `response_body_filter_inner`, so counting applies uniformly across every exit path — passthrough, SSE/WebSocket, buffered Markdown conversion). `log_request`/`fail_to_proxy` now prefer these accumulated counters, falling back to `Content-Length` only when a body never reached the filter (e.g. HEAD responses).
- Per-request counters on `ProxyContext`, no locks/atomics/extra I/O — Pingora already hands the chunk to these hooks regardless, so this is a couple of integer additions against work already happening on the hot path.

## Test plan
- [x] `cargo check --lib -p temps-proxy`
- [x] `cargo test --lib -p temps-proxy` (399 passed, 4 ignored)
- [x] `cargo clippy -p temps-proxy --lib --all-targets -- -D warnings` (clean, run via resolved binary, not rtk)
- [x] `cargo fmt -p temps-proxy -- --check` (clean)
- [ ] Manual: confirm the Bandwidth panel on `/proxy` (project-filtered view) shows nonzero bytes against a streaming/chunked backend