### PR TITLE
fix(web): adapt chart and replay types to recharts 3 and rrweb-player 2

### DIFF
--- a/web/src/components/metrics/AnomalyBacktest.tsx
+++ b/web/src/components/metrics/AnomalyBacktest.tsx
@@ -233,8 +233,8 @@ export function AnomalyBacktest({
               <Tooltip
                 contentStyle={{ fontSize: 11 }}
                 labelFormatter={(l) => formatBucketLabel(String(l))}
-                formatter={(v: number, name: string) =>
-                  name === 'band' ? null : [fmtNum(v), name]
+                formatter={(v, name) =>
+                  name === 'band' ? null : [fmtNum(Number(v)), name]
                 }
               />
             </ComposedChart>

--- a/web/src/components/session-replay/SessionReplayPlayer.tsx
+++ b/web/src/components/session-replay/SessionReplayPlayer.tsx
@@ -14,6 +14,14 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { format } from 'date-fns'
 import { SessionEventDto } from '@/api/client'
 
+// rrweb-player 2.x types `props.events` as `eventWithTime[]` (from @rrweb/types,
+// a transitive dependency), while the generated SDK ships event data as
+// `unknown`. Derive the event type from the player's own constructor so we
+// don't import from a package we don't directly depend on.
+type RRwebEvent = ConstructorParameters<
+  typeof rrwebPlayer
+>[0]['props']['events'][number]
+
 interface SessionReplayPlayerProps {
   events: SessionEventDto[]
   sessionData?: {
@@ -71,7 +79,7 @@ export function SessionReplayPlayer({
         playerRef.current = new rrwebPlayer({
           target: playerContainerRef.current,
           props: {
-            events: eventData.map((event) => event.data),
+            events: eventData.map((event) => event.data as RRwebEvent),
             width: width,
             height: height,
             autoPlay: false,

--- a/web/src/components/storage/MonitoringCard.tsx
+++ b/web/src/components/storage/MonitoringCard.tsx
@@ -923,8 +923,8 @@ function LiveMetrics({ serviceId, engine, latestMetrics }: LiveMetricsProps) {
                   labelStyle={TOOLTIP_LABEL_STYLE}
                   itemStyle={{ color: CHART_LINE_COLOR }}
                   cursor={{ stroke: 'rgba(128,128,128,0.3)', strokeWidth: 1 }}
-                  formatter={(v: number) => [
-                    formatMetricValue(selectedMetric, v),
+                  formatter={(v) => [
+                    formatMetricValue(selectedMetric, Number(v)),
                     labelForMetric(selectedMetric),
                   ]}
                 />

--- a/web/src/components/ui/chart.tsx
+++ b/web/src/components/ui/chart.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import * as RechartsPrimitive from 'recharts'
+import type { LegendPayload, TooltipContentProps } from 'recharts'
 
 import { cn } from '@/lib/utils'
 
@@ -107,8 +108,18 @@ const ChartTooltip = RechartsPrimitive.Tooltip
 
 const ChartTooltipContent = React.forwardRef<
   HTMLDivElement,
-  React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+  // recharts v3 injects the tooltip state (active, payload, label, ...) into the
+  // `content` element; they are optional here because the element is created
+  // without them (e.g. `content={<ChartTooltipContent />}`).
+  Partial<
+    Pick<
+      TooltipContentProps,
+      'active' | 'payload' | 'label' | 'labelFormatter' | 'formatter'
+    >
+  > &
     React.ComponentProps<'div'> & {
+      labelClassName?: string
+      color?: string
       hideLabel?: boolean
       hideIndicator?: boolean
       indicator?: 'line' | 'dot' | 'dashed'
@@ -195,7 +206,7 @@ const ChartTooltipContent = React.forwardRef<
 
             return (
               <div
-                key={item.dataKey}
+                key={`${key}-${index}`}
                 className={cn(
                   'flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground',
                   indicator === 'dot' && 'items-center'
@@ -263,11 +274,14 @@ const ChartLegend = RechartsPrimitive.Legend
 
 const ChartLegendContent = React.forwardRef<
   HTMLDivElement,
-  React.ComponentProps<'div'> &
-    Pick<RechartsPrimitive.LegendProps, 'payload' | 'verticalAlign'> & {
-      hideIcon?: boolean
-      nameKey?: string
-    }
+  // recharts v3 injects `payload` into the legend `content` element; optional
+  // for the same reason as ChartTooltipContent above.
+  React.ComponentProps<'div'> & {
+    payload?: LegendPayload[]
+    verticalAlign?: 'top' | 'middle' | 'bottom'
+    hideIcon?: boolean
+    nameKey?: string
+  }
 >(
   (
     { className, hideIcon = false, payload, verticalAlign = 'bottom', nameKey },

--- a/web/src/pages/ProxyMetrics.tsx
+++ b/web/src/pages/ProxyMetrics.tsx
@@ -427,10 +427,7 @@ function ChartPanel({
                   contentStyle={TOOLTIP_CONTENT_STYLE}
                   labelStyle={TOOLTIP_LABEL_STYLE}
                   cursor={{ stroke: 'rgba(128,128,128,0.3)', strokeWidth: 1 }}
-                  formatter={(v: number, name: string) => [
-                    valueFormatter(v),
-                    name,
-                  ]}
+                  formatter={(v, name) => [valueFormatter(Number(v)), name]}
                 />
                 {series.map((s) => (
                   <Line

--- a/web/src/pages/ServiceMonitoring.tsx
+++ b/web/src/pages/ServiceMonitoring.tsx
@@ -708,8 +708,8 @@ function MetricChart({ serviceId, metricName, range }: MetricChartProps) {
           labelStyle={TOOLTIP_LABEL_STYLE}
           itemStyle={{ color: CHART_LINE_COLOR }}
           cursor={{ stroke: 'rgba(128,128,128,0.3)', strokeWidth: 1 }}
-          formatter={(v: number) => [
-            formatMetricValue(metricName, v),
+          formatter={(v) => [
+            formatMetricValue(metricName, Number(v)),
             labelForMetric(metricName),
           ]}
         />


### PR DESCRIPTION
## Summary

Main CI is red: the **Web TypeScript Check** job fails since the Dependabot merges of recharts 2→3 (#214) and rrweb-player 1.0.0-alpha.4→2.1.0 (#212). This fixes all 18 type errors with no runtime behavior changes intended.

### Changes

- **`ui/chart.tsx`**: recharts v3 no longer exposes injected tooltip/legend state via `React.ComponentProps<typeof Tooltip>` / `LegendProps`. `ChartTooltipContent` now types those props via `Pick<TooltipContentProps, ...>` (made `Partial` since recharts injects them into the `content` element at render time), and `ChartLegendContent` uses the exported `LegendPayload[]`. `dataKey` can be a function in v3, so the per-item React key now derives from the resolved config key + index.
- **Tooltip `formatter` call sites** (`AnomalyBacktest`, `MonitoringCard`, `ProxyMetrics`, `ServiceMonitoring`): v3 passes `ValueType | undefined` instead of `number`; formatters now take the inferred type and coerce with `Number(v)`.
- **`SessionReplayPlayer.tsx`**: rrweb-player 2.x types `props.events` as `eventWithTime[]` while the generated SDK ships event payloads as `unknown`. The event type is derived from the player's constructor signature (avoids importing the transitive `@rrweb/types`).

## Verification

- `bunx tsc --noEmit` in `web/` passes (same command as the CI job).

Charts/tooltips/legends and the session-replay player are worth a visual smoke test on this branch since the underlying libraries had major-version bumps (that risk predates this PR — it landed with the dep merges).