### PR TITLE
perf(proxy): serve proxy-log stats from a 1-minute continuous aggregate

### DIFF
--- a/crates/temps-database/src/connection.rs
+++ b/crates/temps-database/src/connection.rs
@@ -558,16 +558,57 @@ pub async fn get_pending_migration_names(db: &DbConnection) -> ServiceResult<Vec
 ///
 /// Run this on a long-lived runtime (e.g. via `tokio::spawn`) so it never blocks
 /// startup; it is decoupled from `establish_connection` for exactly that reason.
+/// One continuous-aggregate refresh window: optional start (`None` = NULL,
+/// i.e. unbounded) and end, both as SQL expressions.
+type RefreshWindow = (Option<String>, String);
+
 pub async fn run_post_migration_backfill(db: &DatabaseConnection) -> ServiceResult<()> {
-    // (view name, refresh window end). Each window end mirrors the
-    // aggregate's own refresh-policy end_offset so the backfill never
-    // overlaps the region the policy is responsible for.
-    let aggregates: [(&str, &str); 2] = [
-        ("events_hourly", "NOW() - INTERVAL '1 hour'"),
-        ("proxy_logs_stats_1m", "NOW() - INTERVAL '1 minute'"),
+    // Refresh windows per aggregate, executed in order. `None` as a bound
+    // means unbounded (NULL). Window ends mirror each aggregate's
+    // refresh-policy end_offset so the backfill never overlaps the region
+    // the policy is responsible for.
+    //
+    // `proxy_logs_stats_1m` is chunked into 1-day windows, NEWEST FIRST,
+    // instead of one unbounded call, for two reasons on large installs
+    // (100M+ retained rows):
+    //   * Each `CALL refresh_continuous_aggregate()` is one transaction; a
+    //     single 30-day refresh over that volume is a multi-minute
+    //     transaction with heavy WAL churn. Day-sized chunks keep each
+    //     transaction small.
+    //   * Once the every-minute refresh policy runs, the aggregate's
+    //     watermark advances and real-time aggregation stops covering
+    //     older, still-unmaterialized regions — queries would under-report
+    //     history until the backfill reaches it. Newest-first chunking
+    //     makes the dashboard's common windows (1h/6h/24h) correct after
+    //     the first chunk, then works backwards.
+    // The final unbounded window sweeps anything older than the loop
+    // covers (e.g. rows the 30-day retention hasn't dropped yet); it is a
+    // no-op when empty.
+    let proxy_stats_windows: Vec<RefreshWindow> = (1..=30)
+        .map(|d| {
+            let start = Some(format!("NOW() - INTERVAL '{d} days'"));
+            let end = if d == 1 {
+                "NOW() - INTERVAL '1 minute'".to_string()
+            } else {
+                format!("NOW() - INTERVAL '{} days'", d - 1)
+            };
+            (start, end)
+        })
+        .chain(std::iter::once((
+            None,
+            "NOW() - INTERVAL '30 days'".to_string(),
+        )))
+        .collect();
+
+    let aggregates: [(&str, Vec<RefreshWindow>); 2] = [
+        (
+            "events_hourly",
+            vec![(None, "NOW() - INTERVAL '1 hour'".to_string())],
+        ),
+        ("proxy_logs_stats_1m", proxy_stats_windows),
     ];
 
-    for (view_name, window_end) in aggregates {
+    for (view_name, windows) in aggregates {
         // Check the aggregate exists before attempting backfill (it may not
         // if the creating migration hasn't run on this install yet).
         let check_sql = format!(
@@ -597,21 +638,35 @@ pub async fn run_post_migration_backfill(db: &DatabaseConnection) -> ServiceResu
         }
 
         debug!("Backfilling {view_name} continuous aggregate");
-        let backfill_sql =
-            format!("CALL refresh_continuous_aggregate('{view_name}', NULL, {window_end})");
-        if let Err(e) = db
-            .execute(Statement::from_string(
-                sea_orm::DatabaseBackend::Postgres,
-                backfill_sql,
-            ))
-            .await
-        {
-            // Log but don't fail startup — the refresh policy will catch up
-            tracing::warn!(
-                "Failed to backfill {view_name} aggregate (refresh policy will catch up): {e}"
+        let mut failed = 0usize;
+        for (window_start, window_end) in &windows {
+            let start_sql = window_start.as_deref().unwrap_or("NULL");
+            let backfill_sql = format!(
+                "CALL refresh_continuous_aggregate('{view_name}', {start_sql}, {window_end})"
             );
-        } else {
+            if let Err(e) = db
+                .execute(Statement::from_string(
+                    sea_orm::DatabaseBackend::Postgres,
+                    backfill_sql,
+                ))
+                .await
+            {
+                // Log but keep going — later windows are independent, and
+                // the refresh policy will eventually catch up regardless.
+                failed += 1;
+                tracing::warn!(
+                    "Failed to backfill {view_name} window [{start_sql}, {window_end}] \
+                     (refresh policy will catch up): {e}"
+                );
+            }
+        }
+        if failed == 0 {
             debug!("{view_name} continuous aggregate backfill complete");
+        } else {
+            tracing::warn!(
+                "{view_name} continuous aggregate backfill finished with {failed} of {} windows failed",
+                windows.len()
+            );
         }
     }
 

--- a/crates/temps-database/src/connection.rs
+++ b/crates/temps-database/src/connection.rs
@@ -559,48 +559,59 @@ pub async fn get_pending_migration_names(db: &DbConnection) -> ServiceResult<Vec
 /// Run this on a long-lived runtime (e.g. via `tokio::spawn`) so it never blocks
 /// startup; it is decoupled from `establish_connection` for exactly that reason.
 pub async fn run_post_migration_backfill(db: &DatabaseConnection) -> ServiceResult<()> {
-    // Check if the events_hourly continuous aggregate exists before attempting backfill
-    let check_sql = r#"
-        SELECT EXISTS (
-            SELECT 1 FROM timescaledb_information.continuous_aggregates
-            WHERE view_name = 'events_hourly'
-        ) as exists
-    "#;
+    // (view name, refresh window end). Each window end mirrors the
+    // aggregate's own refresh-policy end_offset so the backfill never
+    // overlaps the region the policy is responsible for.
+    let aggregates: [(&str, &str); 2] = [
+        ("events_hourly", "NOW() - INTERVAL '1 hour'"),
+        ("proxy_logs_stats_1m", "NOW() - INTERVAL '1 minute'"),
+    ];
 
-    let row = db
-        .query_one(Statement::from_string(
-            sea_orm::DatabaseBackend::Postgres,
-            check_sql,
-        ))
-        .await
-        .map_err(|e| {
-            ServiceError::Database(format!(
-                "Failed to check for events_hourly aggregate: {}",
-                e
+    for (view_name, window_end) in aggregates {
+        // Check the aggregate exists before attempting backfill (it may not
+        // if the creating migration hasn't run on this install yet).
+        let check_sql = format!(
+            r#"
+            SELECT EXISTS (
+                SELECT 1 FROM timescaledb_information.continuous_aggregates
+                WHERE view_name = '{view_name}'
+            ) as exists
+            "#
+        );
+
+        let row = db
+            .query_one(Statement::from_string(
+                sea_orm::DatabaseBackend::Postgres,
+                check_sql,
             ))
-        })?;
+            .await
+            .map_err(|e| {
+                ServiceError::Database(format!("Failed to check for {view_name} aggregate: {e}"))
+            })?;
 
-    if let Some(row) = row {
-        let exists: bool = row.try_get("", "exists").unwrap_or(false);
-        if exists {
-            debug!("Backfilling events_hourly continuous aggregate");
-            let backfill_sql =
-                "CALL refresh_continuous_aggregate('events_hourly', NULL, NOW() - INTERVAL '1 hour')";
-            if let Err(e) = db
-                .execute(Statement::from_string(
-                    sea_orm::DatabaseBackend::Postgres,
-                    backfill_sql,
-                ))
-                .await
-            {
-                // Log but don't fail startup — the refresh policy will catch up
-                tracing::warn!(
-                    "Failed to backfill events_hourly aggregate (refresh policy will catch up): {}",
-                    e
-                );
-            } else {
-                debug!("events_hourly continuous aggregate backfill complete");
-            }
+        let exists = row
+            .map(|r| r.try_get("", "exists").unwrap_or(false))
+            .unwrap_or(false);
+        if !exists {
+            continue;
+        }
+
+        debug!("Backfilling {view_name} continuous aggregate");
+        let backfill_sql =
+            format!("CALL refresh_continuous_aggregate('{view_name}', NULL, {window_end})");
+        if let Err(e) = db
+            .execute(Statement::from_string(
+                sea_orm::DatabaseBackend::Postgres,
+                backfill_sql,
+            ))
+            .await
+        {
+            // Log but don't fail startup — the refresh policy will catch up
+            tracing::warn!(
+                "Failed to backfill {view_name} aggregate (refresh policy will catch up): {e}"
+            );
+        } else {
+            debug!("{view_name} continuous aggregate backfill complete");
         }
     }
 

--- a/crates/temps-migrations/src/migration/m20260711_000001_add_proxy_logs_stats_cagg.rs
+++ b/crates/temps-migrations/src/migration/m20260711_000001_add_proxy_logs_stats_cagg.rs
@@ -1,0 +1,123 @@
+//! Continuous aggregate for per-project proxy-log statistics.
+//!
+//! The proxy dashboard endpoints (`GET /proxy-logs/stats/projects-health` and
+//! `GET /proxy-logs/stats/time-buckets`) aggregate raw `proxy_logs` rows at
+//! request time: `COUNT(*)`, error counts, and `AVG(response_time_ms)` over
+//! the selected window. On high-traffic installs (millions of rows per hour)
+//! that is a 20s+ query even with the `(project_id, timestamp DESC)` index —
+//! the index narrows the scan but every matching row still needs a heap fetch
+//! for `response_time_ms` / `status_code`.
+//!
+//! `proxy_logs_stats_1m` pre-computes 1-minute buckets per
+//! `(project_id, environment_id, is_bot)`, so those endpoints read
+//! O(minutes × projects) aggregate rows instead of O(requests) raw rows.
+//! Sums and counts are stored (never averages) so buckets roll up losslessly
+//! to any coarser interval; `avg = sum_response_time_ms / response_time_count`
+//! reproduces the raw `AVG(response_time_ms)` exactly (both ignore NULLs).
+//!
+//! Real-time aggregation (`materialized_only = false`) keeps results fresh:
+//! queries transparently union the materialized buckets with raw rows newer
+//! than the refresh watermark, which the every-minute refresh policy keeps to
+//! ~1–2 minutes of raw data.
+//!
+//! Backfill of pre-existing data is handled by `run_post_migration_backfill()`
+//! in temps-database (a `CALL refresh_continuous_aggregate()` cannot run
+//! inside the migration transaction); until it completes, real-time
+//! aggregation still answers queries correctly, just at raw-scan cost.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        // `WITH NO DATA` is what allows creation inside the migration
+        // transaction; populating happens via the refresh policy + the
+        // post-migration backfill.
+        db.execute_unprepared(
+            r#"
+            CREATE MATERIALIZED VIEW proxy_logs_stats_1m
+            WITH (timescaledb.continuous) AS
+            SELECT
+                time_bucket('1 minute', timestamp) AS bucket,
+                project_id,
+                environment_id,
+                is_bot,
+                COUNT(*) AS request_count,
+                COUNT(*) FILTER (WHERE status_code >= 400) AS error_4xx_plus_count,
+                COUNT(*) FILTER (WHERE status_code >= 500) AS error_5xx_plus_count,
+                COUNT(response_time_ms) AS response_time_count,
+                SUM(response_time_ms) AS sum_response_time_ms,
+                SUM(request_size_bytes) AS sum_request_bytes,
+                SUM(response_size_bytes) AS sum_response_bytes
+            FROM proxy_logs
+            GROUP BY bucket, project_id, environment_id, is_bot
+            WITH NO DATA;
+            "#,
+        )
+        .await?;
+
+        // Real-time aggregation: query results include raw rows newer than
+        // the materialization watermark, so dashboards never lag behind the
+        // refresh schedule.
+        db.execute_unprepared(
+            "ALTER MATERIALIZED VIEW proxy_logs_stats_1m SET (timescaledb.materialized_only = false);",
+        )
+        .await?;
+
+        // The projects-health query filters `project_id IN (…)` + bucket range.
+        db.execute_unprepared(
+            r#"
+            CREATE INDEX IF NOT EXISTS idx_proxy_logs_stats_1m_project_bucket
+                ON proxy_logs_stats_1m (project_id, bucket DESC);
+            "#,
+        )
+        .await?;
+
+        // Refresh every minute with a 1-minute end offset: the real-time
+        // union then only has to scan ~1-2 minutes of raw rows. The 2-hour
+        // start offset re-covers late-arriving rows from the batch writer.
+        db.execute_unprepared(
+            r#"
+            SELECT add_continuous_aggregate_policy('proxy_logs_stats_1m',
+                start_offset => INTERVAL '2 hours',
+                end_offset => INTERVAL '1 minute',
+                schedule_interval => INTERVAL '1 minute');
+            "#,
+        )
+        .await?;
+
+        // Match the raw table's 30-day retention
+        // (m20260225_000001_add_proxy_logs_retention); the dashboard offers
+        // at most a 7-day window.
+        db.execute_unprepared(
+            "SELECT add_retention_policy('proxy_logs_stats_1m', drop_after => INTERVAL '30 days', if_not_exists => TRUE);",
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        db.execute_unprepared(
+            "SELECT remove_retention_policy('proxy_logs_stats_1m', if_exists => TRUE);",
+        )
+        .await?;
+
+        db.execute_unprepared(
+            "SELECT remove_continuous_aggregate_policy('proxy_logs_stats_1m', if_exists => true);",
+        )
+        .await?;
+
+        db.execute_unprepared("DROP MATERIALIZED VIEW IF EXISTS proxy_logs_stats_1m CASCADE;")
+            .await?;
+
+        Ok(())
+    }
+}

--- a/crates/temps-migrations/src/migration/m20260711_000001_add_proxy_logs_stats_cagg.rs
+++ b/crates/temps-migrations/src/migration/m20260711_000001_add_proxy_logs_stats_cagg.rs
@@ -22,8 +22,12 @@
 //!
 //! Backfill of pre-existing data is handled by `run_post_migration_backfill()`
 //! in temps-database (a `CALL refresh_continuous_aggregate()` cannot run
-//! inside the migration transaction); until it completes, real-time
-//! aggregation still answers queries correctly, just at raw-scan cost.
+//! inside the migration transaction). It refreshes in 1-day windows, newest
+//! first, so recent dashboard ranges become correct within the first chunk
+//! and no single refresh transaction has to chew through the whole retention
+//! window at once. Regions the backfill hasn't reached yet under-report once
+//! the refresh policy has advanced the watermark; that window is transient
+//! and self-heals as the chunks complete.
 
 use sea_orm_migration::prelude::*;
 

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -144,6 +144,7 @@ mod m20260705_000001_add_visitor_unique_index;
 mod m20260707_000001_add_external_service_to_logs;
 mod m20260707_000002_add_external_services_container_name;
 mod m20260708_000001_add_node_id_to_monitoring_alert_rules;
+mod m20260711_000001_add_proxy_logs_stats_cagg;
 
 pub struct Migrator;
 
@@ -293,6 +294,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260707_000001_add_external_service_to_logs::Migration),
             Box::new(m20260707_000002_add_external_services_container_name::Migration),
             Box::new(m20260708_000001_add_node_id_to_monitoring_alert_rules::Migration),
+            Box::new(m20260711_000001_add_proxy_logs_stats_cagg::Migration),
         ]
     }
 }

--- a/crates/temps-proxy/src/service/proxy_log_service.rs
+++ b/crates/temps-proxy/src/service/proxy_log_service.rs
@@ -727,6 +727,20 @@ impl ProxyLogService {
             )));
         }
 
+        // Serve from the 1-minute continuous aggregate when it can answer
+        // this query: every set filter is a grouping column of the aggregate
+        // and the interval is a whole multiple of its 1-minute buckets. That
+        // reads O(minutes × series) pre-aggregated rows instead of every raw
+        // request in the window.
+        if Self::cagg_serves_filters(filters.as_ref())
+            && Self::is_minute_multiple_interval(&bucket_interval)
+            && self.stats_cagg_exists().await
+        {
+            return self
+                .get_time_bucket_stats_from_cagg(start_time, end_time, bucket_interval, filters)
+                .await;
+        }
+
         // Build the base WHERE clause for filters
         let mut where_clauses = vec!["timestamp >= $1".to_string(), "timestamp < $2".to_string()];
         let mut param_index = 3;
@@ -751,8 +765,8 @@ impl ProxyLogService {
                 COALESCE(count, 0) as request_count,
                 COALESCE(avg_response_time, 0)::float8 as avg_response_time_ms,
                 COALESCE(error_count, 0) as error_count,
-                COALESCE(total_request_bytes, 0) as total_request_bytes,
-                COALESCE(total_response_bytes, 0) as total_response_bytes
+                COALESCE(total_request_bytes, 0)::bigint as total_request_bytes,
+                COALESCE(total_response_bytes, 0)::bigint as total_response_bytes
             FROM (
                 SELECT
                     time_bucket_gapfill(${}::interval, timestamp) AS bucket,
@@ -788,11 +802,91 @@ impl ProxyLogService {
 
         let results = self.db.query_all(stmt).await?;
 
-        // Parse results
-        let stats = results
+        Ok(Self::rows_to_time_bucket_stats(&results, start_time))
+    }
+
+    /// [`Self::get_time_bucket_stats`] served from the `proxy_logs_stats_1m`
+    /// continuous aggregate. Only called when the filter set is representable
+    /// on the aggregate (see [`Self::cagg_serves_filters`]) — under that
+    /// precondition [`Self::build_filter_sql`] emits only `project_id` /
+    /// `environment_id` / `is_bot` / `project_id IS [NOT] NULL` clauses, all
+    /// of which are grouping columns of the aggregate, so the raw-table
+    /// filter helpers are reused unchanged.
+    async fn get_time_bucket_stats_from_cagg(
+        &self,
+        start_time: UtcDateTime,
+        end_time: UtcDateTime,
+        bucket_interval: String,
+        filters: Option<StatsFilters>,
+    ) -> Result<Vec<TimeBucketStats>, ProxyLogServiceError> {
+        let mut where_clauses = vec!["bucket >= $1".to_string(), "bucket < $2".to_string()];
+        let mut param_index = 3;
+
+        if let Some(ref f) = filters {
+            Self::build_filter_sql(f, &mut param_index, &mut where_clauses);
+        }
+
+        let where_clause = format!("WHERE {}", where_clauses.join(" AND "));
+        let bucket_param_index = param_index;
+
+        // `GROUP BY 1` instead of `GROUP BY bucket`: the aggregate has a real
+        // `bucket` column, which Postgres prefers over the gapfill output
+        // alias — naming it would silently group at 1-minute resolution
+        // regardless of the requested interval.
+        let sql = format!(
+            r#"
+            SELECT
+                bucket::timestamptz as bucket,
+                COALESCE(count, 0)::bigint as request_count,
+                COALESCE(avg_response_time, 0)::float8 as avg_response_time_ms,
+                COALESCE(error_count, 0)::bigint as error_count,
+                COALESCE(total_request_bytes, 0)::bigint as total_request_bytes,
+                COALESCE(total_response_bytes, 0)::bigint as total_response_bytes
+            FROM (
+                SELECT
+                    time_bucket_gapfill(${}::interval, bucket) AS bucket,
+                    SUM(request_count) as count,
+                    SUM(sum_response_time_ms)::float8
+                        / NULLIF(SUM(response_time_count), 0)::float8 as avg_response_time,
+                    SUM(error_4xx_plus_count) as error_count,
+                    SUM(sum_request_bytes) as total_request_bytes,
+                    SUM(sum_response_bytes) as total_response_bytes
+                FROM proxy_logs_stats_1m
+                {}
+                GROUP BY 1
+            ) sub
+            ORDER BY bucket ASC
+            "#,
+            bucket_param_index, where_clause
+        );
+
+        let mut values: Vec<sea_orm::Value> = vec![start_time.into(), end_time.into()];
+        if let Some(ref f) = filters {
+            Self::add_filter_values(&mut values, f);
+        }
+        values.push(bucket_interval.into());
+
+        let stmt = sea_orm::Statement::from_sql_and_values(
+            sea_orm::DatabaseBackend::Postgres,
+            &sql,
+            values,
+        );
+        let results = self.db.query_all(stmt).await?;
+
+        Ok(Self::rows_to_time_bucket_stats(&results, start_time))
+    }
+
+    /// Map raw query rows (shared column shape of the raw-table and
+    /// aggregate time-bucket queries) into [`TimeBucketStats`].
+    fn rows_to_time_bucket_stats(
+        results: &[sea_orm::QueryResult],
+        fallback_bucket: UtcDateTime,
+    ) -> Vec<TimeBucketStats> {
+        results
             .iter()
             .map(|row| {
-                let bucket: chrono::DateTime<Utc> = row.try_get("", "bucket").unwrap_or(start_time);
+                let bucket: chrono::DateTime<Utc> =
+                    row.try_get("", "bucket").unwrap_or(fallback_bucket);
                 let request_count: i64 = row.try_get("", "request_count").unwrap_or(0);
                 let avg_response_time_ms: f64 =
                     row.try_get("", "avg_response_time_ms").unwrap_or(0.0);
@@ -810,9 +904,7 @@ impl ProxyLogService {
                     total_response_bytes,
                 }
             })
-            .collect();
-
-        Ok(stats)
+            .collect()
     }
 
     /// Get health summaries for multiple projects in a single query
@@ -848,21 +940,48 @@ impl ProxyLogService {
             None => (String::new(), None),
         };
 
-        let sql = format!(
-            r#"
-            SELECT
-                project_id,
-                COALESCE(COUNT(*), 0) as total_requests,
-                COALESCE(SUM(CASE WHEN status_code >= 500 THEN 1 ELSE 0 END), 0) as total_errors,
-                COALESCE(AVG(response_time_ms)::float8, 0) as avg_response_time_ms
-            FROM proxy_logs
-            WHERE timestamp >= $1
-              AND timestamp < $2
-              AND project_id IN ({}){}
-            GROUP BY project_id
-            "#,
-            placeholders_str, bot_clause
-        );
+        // Prefer the pre-aggregated 1-minute continuous aggregate: it reads
+        // O(minutes × projects) rows instead of every raw request in the
+        // window, which on high-traffic installs (millions of rows per hour)
+        // is the difference between milliseconds and a 20s+ scan. Both
+        // queries take the identical parameter list, so only the SQL differs.
+        let sql = if self.stats_cagg_exists().await {
+            format!(
+                r#"
+                SELECT
+                    project_id,
+                    COALESCE(SUM(request_count), 0)::bigint as total_requests,
+                    COALESCE(SUM(error_5xx_plus_count), 0)::bigint as total_errors,
+                    COALESCE(
+                        SUM(sum_response_time_ms)::float8
+                            / NULLIF(SUM(response_time_count), 0)::float8,
+                        0
+                    ) as avg_response_time_ms
+                FROM proxy_logs_stats_1m
+                WHERE bucket >= $1
+                  AND bucket < $2
+                  AND project_id IN ({}){}
+                GROUP BY project_id
+                "#,
+                placeholders_str, bot_clause
+            )
+        } else {
+            format!(
+                r#"
+                SELECT
+                    project_id,
+                    COALESCE(COUNT(*), 0) as total_requests,
+                    COALESCE(SUM(CASE WHEN status_code >= 500 THEN 1 ELSE 0 END), 0) as total_errors,
+                    COALESCE(AVG(response_time_ms)::float8, 0) as avg_response_time_ms
+                FROM proxy_logs
+                WHERE timestamp >= $1
+                  AND timestamp < $2
+                  AND project_id IN ({}){}
+                GROUP BY project_id
+                "#,
+                placeholders_str, bot_clause
+            )
+        };
 
         let db_backend = sea_orm::DatabaseBackend::Postgres;
         let mut values: Vec<sea_orm::Value> = vec![start_time.into(), end_time.into()];
@@ -1129,6 +1248,72 @@ impl ProxyLogService {
 
         // Verify second part is a valid unit
         valid_units.contains(&parts[1])
+    }
+
+    /// True when the `proxy_logs_stats_1m` continuous aggregate exists.
+    ///
+    /// Checked per call (one cheap catalog lookup, dwarfed by the stats query
+    /// it guards) so behaviour is correct both before the creating migration
+    /// has run and immediately after, without process-lifetime caching. On
+    /// lookup failure the caller falls back to the raw-table path.
+    async fn stats_cagg_exists(&self) -> bool {
+        let stmt = sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT to_regclass('proxy_logs_stats_1m') IS NOT NULL as cagg_exists".to_string(),
+        );
+        match self.db.query_one(stmt).await {
+            Ok(Some(row)) => row.try_get::<bool>("", "cagg_exists").unwrap_or(false),
+            Ok(None) => false,
+            Err(e) => {
+                tracing::debug!(
+                    "proxy_logs_stats_1m existence check failed ({e}); using raw proxy_logs path"
+                );
+                false
+            }
+        }
+    }
+
+    /// True when every set filter dimension is a grouping column of
+    /// `proxy_logs_stats_1m` (`project_id`, `environment_id`, `is_bot`,
+    /// `has_project`). Any other filter forces the raw-table path.
+    fn cagg_serves_filters(filters: Option<&StatsFilters>) -> bool {
+        let Some(f) = filters else { return true };
+        f.method.is_none()
+            && f.client_ip.is_none()
+            && f.deployment_id.is_none()
+            && f.host.is_none()
+            && f.status_code.is_none()
+            && f.status_code_class.is_none()
+            && f.routing_status.is_none()
+            && f.request_source.is_none()
+            && f.device_type.is_none()
+    }
+
+    /// True for intervals that are whole multiples of the aggregate's
+    /// 1-minute buckets ("5 minutes", "1 hour", …). Calendar units (month,
+    /// year) qualify too: minute-truncated buckets never straddle a calendar
+    /// boundary. Sub-minute units ("30 seconds") do not align and take the
+    /// raw-table path. Assumes [`Self::is_valid_interval`] already passed.
+    fn is_minute_multiple_interval(interval: &str) -> bool {
+        let parts: Vec<&str> = interval.split_whitespace().collect();
+        let Some(unit) = parts.get(1) else {
+            return false;
+        };
+        matches!(
+            *unit,
+            "minute"
+                | "minutes"
+                | "hour"
+                | "hours"
+                | "day"
+                | "days"
+                | "week"
+                | "weeks"
+                | "month"
+                | "months"
+                | "year"
+                | "years"
+        )
     }
 
     /// Aggregate AI-agent traffic for a project over a time window.
@@ -2152,7 +2337,263 @@ mod tests {
         assert!(filters.device_type.is_none());
     }
 
-    // Note: Integration tests that require a database connection should be added
-    // to test get_today_count and get_time_bucket_stats methods.
-    // These would need a test database setup with sample data.
+    #[test]
+    fn test_cagg_serves_filters_eligible_dimensions() {
+        // No filters at all — the aggregate always serves.
+        assert!(ProxyLogService::cagg_serves_filters(None));
+
+        // Every grouping-column dimension set at once — still eligible.
+        let f = StatsFilters {
+            project_id: Some(1),
+            environment_id: Some(2),
+            is_bot: Some(false),
+            has_project: Some(true),
+            ..Default::default()
+        };
+        assert!(ProxyLogService::cagg_serves_filters(Some(&f)));
+    }
+
+    #[test]
+    fn test_cagg_serves_filters_rejects_raw_only_dimensions() {
+        let raw_only: Vec<StatsFilters> = vec![
+            StatsFilters {
+                method: Some("GET".to_string()),
+                ..Default::default()
+            },
+            StatsFilters {
+                client_ip: Some("10.0.0.1".to_string()),
+                ..Default::default()
+            },
+            StatsFilters {
+                deployment_id: Some(7),
+                ..Default::default()
+            },
+            StatsFilters {
+                host: Some("example.com".to_string()),
+                ..Default::default()
+            },
+            StatsFilters {
+                status_code: Some(500),
+                ..Default::default()
+            },
+            StatsFilters {
+                status_code_class: Some("5xx".to_string()),
+                ..Default::default()
+            },
+            StatsFilters {
+                routing_status: Some("routed".to_string()),
+                ..Default::default()
+            },
+            StatsFilters {
+                request_source: Some("proxy".to_string()),
+                ..Default::default()
+            },
+            StatsFilters {
+                device_type: Some("mobile".to_string()),
+                ..Default::default()
+            },
+        ];
+        for f in &raw_only {
+            assert!(
+                !ProxyLogService::cagg_serves_filters(Some(f)),
+                "filter should force the raw path: {f:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_minute_multiple_interval() {
+        assert!(ProxyLogService::is_minute_multiple_interval("1 minute"));
+        assert!(ProxyLogService::is_minute_multiple_interval("5 minutes"));
+        assert!(ProxyLogService::is_minute_multiple_interval("1 hour"));
+        assert!(ProxyLogService::is_minute_multiple_interval("15 minutes"));
+        assert!(ProxyLogService::is_minute_multiple_interval("1 day"));
+        assert!(ProxyLogService::is_minute_multiple_interval("2 weeks"));
+        assert!(ProxyLogService::is_minute_multiple_interval("1 month"));
+        assert!(ProxyLogService::is_minute_multiple_interval("1 year"));
+
+        assert!(!ProxyLogService::is_minute_multiple_interval("30 seconds"));
+        assert!(!ProxyLogService::is_minute_multiple_interval(
+            "500 milliseconds"
+        ));
+        assert!(!ProxyLogService::is_minute_multiple_interval(
+            "1 microsecond"
+        ));
+        assert!(!ProxyLogService::is_minute_multiple_interval(""));
+        assert!(!ProxyLogService::is_minute_multiple_interval("garbage"));
+    }
+
+    /// Full pipeline against a real TimescaleDB: raw rows → the
+    /// `proxy_logs_stats_1m` continuous aggregate (via real-time
+    /// aggregation, no manual refresh) → the health-summary and
+    /// time-bucket queries. Cross-checks the aggregate-served result
+    /// against the raw-table path. Skips gracefully when no test
+    /// Postgres is available, per the repo's Docker-test convention.
+    #[tokio::test]
+    async fn test_stats_served_from_cagg_match_raw_path() {
+        use temps_database::test_utils::TestDatabase;
+
+        let test_db = match TestDatabase::with_migrations().await {
+            Ok(db) => db,
+            Err(e) => {
+                println!("Test database not available, skipping: {e}");
+                return;
+            }
+        };
+        let db = test_db.connection_arc().clone();
+
+        std::env::set_var("TEMPS_GEO_MOCK", "true");
+        let geoip = Arc::new(temps_geo::GeoIpService::new().expect("mock GeoIpService for tests"));
+        let ip_service = Arc::new(temps_geo::IpAddressService::new(db.clone(), geoip));
+        let service = ProxyLogService::new(db.clone(), ip_service);
+
+        // The migration must have created the aggregate.
+        assert!(
+            service.stats_cagg_exists().await,
+            "proxy_logs_stats_1m must exist after migrations"
+        );
+
+        // Parent rows for proxy_logs' project FK.
+        for (id, name) in [(1, "cagg-p1"), (2, "cagg-p2"), (3, "cagg-p3")] {
+            let stmt = sea_orm::Statement::from_sql_and_values(
+                sea_orm::DatabaseBackend::Postgres,
+                "INSERT INTO projects (id, name, repo_name, repo_owner, directory, \
+                 main_branch, preset, created_at, updated_at, slug) \
+                 VALUES ($1, $2, 'repo', 'owner', '.', 'main', 'nodejs', now(), now(), $2)",
+                vec![id.into(), name.into()],
+            );
+            db.execute(stmt).await.expect("insert project row");
+        }
+
+        async fn insert_log(
+            db: &DatabaseConnection,
+            ts: chrono::DateTime<Utc>,
+            n: i32,
+            project_id: i32,
+            status: i16,
+            rt_ms: i32,
+            is_bot: bool,
+        ) {
+            let stmt = sea_orm::Statement::from_sql_and_values(
+                sea_orm::DatabaseBackend::Postgres,
+                r#"INSERT INTO proxy_logs
+                    (timestamp, method, path, host, status_code, response_time_ms,
+                     request_source, is_system_request, routing_status, project_id,
+                     request_id, is_bot, request_size_bytes, response_size_bytes,
+                     created_date)
+                   VALUES ($1, 'GET', '/', 'test.local', $2, $3, 'proxy', false,
+                           'routed', $4, $5, $6, 100, 200, $7)"#,
+                vec![
+                    ts.into(),
+                    status.into(),
+                    rt_ms.into(),
+                    project_id.into(),
+                    format!("cagg-test-{n}").into(),
+                    is_bot.into(),
+                    ts.date_naive().into(),
+                ],
+            );
+            db.execute(stmt).await.expect("insert proxy_logs row");
+        }
+
+        // All rows a few minutes in the past: inside the window, and served
+        // by real-time aggregation (the refresh policy hasn't materialized
+        // them yet — exactly the state right after deploy).
+        let ts = Utc::now() - chrono::Duration::minutes(5);
+        insert_log(&db, ts, 1, 1, 200, 100, false).await;
+        insert_log(&db, ts, 2, 1, 404, 50, false).await;
+        insert_log(&db, ts, 3, 1, 500, 30, false).await;
+        insert_log(&db, ts, 4, 1, 200, 20, true).await; // bot row
+        insert_log(&db, ts, 5, 2, 200, 10, false).await;
+
+        let start = Utc::now() - chrono::Duration::hours(1);
+        let end = Utc::now() + chrono::Duration::minutes(1);
+
+        // ── Health summary (aggregate path) ───────────────────────────────
+        let health = service
+            .get_projects_health_summary(&[1, 2, 3], start, end, None)
+            .await
+            .expect("health summary");
+        assert_eq!(health.len(), 3);
+
+        let p1 = health.iter().find(|h| h.project_id == 1).expect("p1");
+        assert_eq!(p1.total_requests, 4);
+        assert_eq!(p1.total_errors, 1); // only the 500 counts (>= 500)
+        assert!((p1.avg_response_time_ms - 50.0).abs() < 1e-9); // (100+50+30+20)/4
+        assert_eq!(p1.status, "degraded"); // 25% error rate
+
+        let p2 = health.iter().find(|h| h.project_id == 2).expect("p2");
+        assert_eq!(p2.total_requests, 1);
+        assert_eq!(p2.total_errors, 0);
+        assert_eq!(p2.status, "healthy");
+
+        let p3 = health.iter().find(|h| h.project_id == 3).expect("p3");
+        assert_eq!(p3.total_requests, 0);
+        assert_eq!(p3.status, "unknown");
+
+        // is_bot filter narrows to human traffic.
+        let health_human = service
+            .get_projects_health_summary(&[1], start, end, Some(false))
+            .await
+            .expect("health summary human-only");
+        assert_eq!(health_human[0].total_requests, 3);
+        assert!((health_human[0].avg_response_time_ms - 60.0).abs() < 1e-9);
+
+        // ── Time buckets: aggregate path vs raw path must agree ───────────
+        let cagg_filters = StatsFilters {
+            project_id: Some(1),
+            ..Default::default()
+        };
+        assert!(ProxyLogService::cagg_serves_filters(Some(&cagg_filters)));
+        let via_cagg = service
+            .get_time_bucket_stats(start, end, "1 hour".to_string(), Some(cagg_filters))
+            .await
+            .expect("time buckets via aggregate");
+
+        // Adding `method` makes the filter unrepresentable on the aggregate,
+        // forcing the raw path; every inserted row is a GET, so the numbers
+        // must be identical.
+        let raw_filters = StatsFilters {
+            project_id: Some(1),
+            method: Some("GET".to_string()),
+            ..Default::default()
+        };
+        assert!(!ProxyLogService::cagg_serves_filters(Some(&raw_filters)));
+        let via_raw = service
+            .get_time_bucket_stats(start, end, "1 hour".to_string(), Some(raw_filters))
+            .await
+            .expect("time buckets via raw table");
+
+        let sum = |stats: &[TimeBucketStats]| {
+            stats.iter().fold((0i64, 0i64, 0i64, 0i64), |acc, b| {
+                (
+                    acc.0 + b.request_count,
+                    acc.1 + b.error_count,
+                    acc.2 + b.total_request_bytes,
+                    acc.3 + b.total_response_bytes,
+                )
+            })
+        };
+        let (cagg_reqs, cagg_errs, cagg_req_bytes, cagg_resp_bytes) = sum(&via_cagg);
+        assert_eq!(cagg_reqs, 4);
+        assert_eq!(cagg_errs, 2); // 404 + 500 (time-bucket errors are >= 400)
+        assert_eq!(cagg_req_bytes, 400);
+        assert_eq!(cagg_resp_bytes, 800);
+        assert_eq!(
+            sum(&via_raw),
+            (cagg_reqs, cagg_errs, cagg_req_bytes, cagg_resp_bytes)
+        );
+
+        // The populated bucket carries the same average on both paths.
+        let cagg_busy = via_cagg
+            .iter()
+            .find(|b| b.request_count > 0)
+            .expect("populated aggregate bucket");
+        let raw_busy = via_raw
+            .iter()
+            .find(|b| b.request_count > 0)
+            .expect("populated raw bucket");
+        assert!((cagg_busy.avg_response_time_ms - 50.0).abs() < 1e-9);
+        assert!((cagg_busy.avg_response_time_ms - raw_busy.avg_response_time_ms).abs() < 1e-9);
+    }
 }


### PR DESCRIPTION
## Problem

The proxy dashboard's **Traffic by project** panel and the project-filtered charts hang on high-traffic installs (observed 20s+ on an instance logging ~1.7M proxy-log rows/hour for a single project). Both are backed by request-time aggregation over raw `proxy_logs`:

- `GET /proxy-logs/stats/projects-health` — `COUNT(*)` / `SUM(status>=500)` / `AVG(response_time_ms)` per project over the window
- `GET /proxy-logs/stats/time-buckets` — `time_bucket_gapfill` over the same raw rows

The `(project_id, timestamp DESC)` index (m20260528) only narrows *which* rows to read — every matching row still needs a heap fetch for `response_time_ms` / `status_code`, so the cost is O(requests in window) no matter what.

## Fix

New continuous aggregate `proxy_logs_stats_1m`: 1-minute buckets keyed `(project_id, environment_id, is_bot)` storing counts and sums (never averages, so buckets roll up losslessly to any coarser interval; `avg = sum/count` reproduces raw `AVG` exactly incl. NULL handling).

- **Freshness**: real-time aggregation (`materialized_only = false`) + every-minute refresh policy (end offset 1 min) — queries union materialized buckets with at most ~1–2 min of raw tail.
- **Routing**: `get_projects_health_summary` uses the aggregate whenever it exists; `get_time_bucket_stats` uses it only when every set filter is one of its grouping columns (`project_id`/`environment_id`/`is_bot`/`has_project`) and the interval is a whole-minute multiple — all other filter shapes (method, status class, deployment, …) keep the raw path unchanged. ClickHouse storage path untouched.
- **Backfill**: the existing post-migration hook (`run_post_migration_backfill`, same as `events_hourly`) refreshes historical data outside the migration transaction; until it completes, real-time aggregation still answers correctly at raw-scan cost.
- **Retention**: 30 days on the aggregate, matching `proxy_logs` (m20260225); dashboard max window is 7d.

## Load / memory bound (per hot-path policy)

Reads become O(minutes × active series) instead of O(requests): a 1h window over 12 projects is ≤ ~60 × series rows regardless of traffic. Write amplification is constant: ~1 aggregate row per active `(project, environment, is_bot)` series per minute, refreshed incrementally (invalidation-driven). At saturation the refresh job lags; real-time aggregation then covers the gap with a bounded raw scan.

## Drive-by fix

The cross-path test caught a live bug: raw-path `total_request_bytes`/`total_response_bytes` are `SUM(bigint)` → Postgres `numeric`, which `try_get::<i64>` silently failed to parse (`unwrap_or(0)`), so the filtered view's **Bandwidth chart always reported 0 bytes**. Fixed with explicit `::bigint` casts.

## Testing

- `test_stats_served_from_cagg_match_raw_path` — full pipeline against real TimescaleDB (raw inserts → aggregate via real-time aggregation → health + time-bucket queries), cross-checking aggregate-path results against the raw path, incl. `is_bot` filtering, error-rate status, and the unknown-project case
- Unit tests for the filter-eligibility and interval-alignment routing helpers
- `cargo test --lib -p temps-proxy` (403 passed), `-p temps-database` (25 passed); clippy `--all-targets -D warnings` clean on touched crates
- The 4 failing tests in `migration_tests.rs` fail identically on `main` (pre-existing, environmental)