### PR TITLE
feat(otel,proxy): parameterize ClickHouse retention via per-row retention_days

### DIFF
--- a/crates/temps-cli/src/commands/ch_backfill_domains.rs
+++ b/crates/temps-cli/src/commands/ch_backfill_domains.rs
@@ -550,6 +550,7 @@ mod proxy_logs {
             error_group_id: r.error_group_id,
             // Source timestamp ms as the dedup version — stable across re-runs.
             _version: ms as u64,
+            retention_days: temps_core::RetentionTable::ProxyLogs.default_days(),
         }
     }
 
@@ -671,6 +672,7 @@ mod traces {
             events: r.events.clone().unwrap_or_else(|| "[]".into()),
             // Source start_time ms as the dedup version — stable across re-runs.
             _version: r.start_time.timestamp_millis() as u64,
+            retention_days: temps_core::RetentionTable::Spans.default_days(),
         }
     }
 

--- a/crates/temps-core/src/lib.rs
+++ b/crates/temps-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod openapi;
 pub mod plugin;
 pub mod problemdetails;
 pub mod project_access;
+pub mod retention;
 pub mod retry;
 pub mod secrets_manager;
 pub mod telemetry;
@@ -53,6 +54,7 @@ pub use error_builder::*;
 pub use jobs::*;
 pub use on_demand::*;
 pub use project_access::ProjectAccessChecker;
+pub use retention::{FixedRetentionResolver, RetentionResolver, RetentionTable};
 pub use secrets_manager::SecretsManagerResolver;
 pub use telemetry::{NoopTelemetryReporter, TelemetryEvent, TelemetryEventKind, TelemetryReporter};
 pub use traces::{

--- a/crates/temps-core/src/lib.rs
+++ b/crates/temps-core/src/lib.rs
@@ -54,7 +54,9 @@ pub use error_builder::*;
 pub use jobs::*;
 pub use on_demand::*;
 pub use project_access::ProjectAccessChecker;
-pub use retention::{FixedRetentionResolver, RetentionResolver, RetentionTable};
+pub use retention::{
+    FixedRetentionResolver, RetentionResolver, RetentionResolverSlot, RetentionTable,
+};
 pub use secrets_manager::SecretsManagerResolver;
 pub use telemetry::{NoopTelemetryReporter, TelemetryEvent, TelemetryEventKind, TelemetryReporter};
 pub use traces::{

--- a/crates/temps-core/src/retention.rs
+++ b/crates/temps-core/src/retention.rs
@@ -12,6 +12,14 @@
 //! Any expensive lookup (Postgres, external service) must be driven by a
 //! background refresh task in the implementing type; the result must be cached
 //! so that individual `resolve` calls do no I/O.
+//!
+//! [`RetentionResolverSlot`] exists because `register_services` runs in
+//! plugin-registration order: the ClickHouse storage backends are constructed
+//! (and their resolver captured) before a later-registered plugin gets a
+//! chance to provide one (see `OtelPlugin`/`ProxyPlugin` in their respective
+//! crates — the same two-phase handoff `DeploymentGate` uses via
+//! `deployment_gate_slot`, adapted to a lock-free `ArcSwap` since `resolve`
+//! must stay synchronous).
 
 /// Which ClickHouse table a retention-days resolution is for.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -76,6 +84,38 @@ impl RetentionResolver for FixedRetentionResolver {
     }
 }
 
+/// Deferred-registration handle for a [`RetentionResolver`].
+///
+/// Constructed with [`FixedRetentionResolver`] loaded by default and handed
+/// to a storage backend immediately at construction time (as
+/// `Arc<dyn RetentionResolver>`, via unsized coercion — this type itself
+/// implements the trait). Once every plugin has finished `register_services`,
+/// whichever plugin owns the slot calls [`Self::set`] from
+/// `initialize_plugin_services` if a plugin registered an alternative
+/// resolver — see the module-level note for why this indirection exists.
+/// `resolve` reads are lock-free (`ArcSwap::load`).
+pub struct RetentionResolverSlot(arc_swap::ArcSwap<std::sync::Arc<dyn RetentionResolver>>);
+
+impl RetentionResolverSlot {
+    /// Start with [`FixedRetentionResolver`] loaded.
+    pub fn new_default() -> Self {
+        Self(arc_swap::ArcSwap::new(std::sync::Arc::new(
+            std::sync::Arc::new(FixedRetentionResolver) as std::sync::Arc<dyn RetentionResolver>,
+        )))
+    }
+
+    /// Swap in a resolver provided by a licensed plugin.
+    pub fn set(&self, resolver: std::sync::Arc<dyn RetentionResolver>) {
+        self.0.store(std::sync::Arc::new(resolver));
+    }
+}
+
+impl RetentionResolver for RetentionResolverSlot {
+    fn resolve(&self, project_id: i32, table: RetentionTable) -> u16 {
+        self.0.load().resolve(project_id, table)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -94,5 +134,27 @@ mod tests {
     fn retention_table_default_days() {
         assert_eq!(RetentionTable::Spans.default_days(), 90);
         assert_eq!(RetentionTable::ProxyLogs.default_days(), 30);
+    }
+
+    struct AlwaysSeven;
+    impl RetentionResolver for AlwaysSeven {
+        fn resolve(&self, _project_id: i32, _table: RetentionTable) -> u16 {
+            7
+        }
+    }
+
+    #[test]
+    fn slot_defaults_to_fixed_resolver() {
+        let slot = RetentionResolverSlot::new_default();
+        assert_eq!(slot.resolve(1, RetentionTable::Spans), 90);
+        assert_eq!(slot.resolve(1, RetentionTable::ProxyLogs), 30);
+    }
+
+    #[test]
+    fn slot_set_overrides_the_default() {
+        let slot = RetentionResolverSlot::new_default();
+        slot.set(std::sync::Arc::new(AlwaysSeven));
+        assert_eq!(slot.resolve(1, RetentionTable::Spans), 7);
+        assert_eq!(slot.resolve(1, RetentionTable::ProxyLogs), 7);
     }
 }

--- a/crates/temps-core/src/retention.rs
+++ b/crates/temps-core/src/retention.rs
@@ -1,0 +1,98 @@
+//! Extension point for per-project ClickHouse retention resolution.
+//!
+//! OSS registers [`FixedRetentionResolver`] at startup, which always returns
+//! the ClickHouse table default. A plugin (e.g. one implementing per-project
+//! data retention policies) can supply an alternative implementation — callers
+//! pass an `Arc<dyn RetentionResolver>` received at construction time and the
+//! plugin overrides the default by registering its implementation via the
+//! service registry before the storage backends are wired up.
+//!
+//! `resolve` is called on the ingest path (once per row in a batch, not once
+//! per HTTP request) and must be synchronous and lock-free on the read path.
+//! Any expensive lookup (Postgres, external service) must be driven by a
+//! background refresh task in the implementing type; the result must be cached
+//! so that individual `resolve` calls do no I/O.
+
+/// Which ClickHouse table a retention-days resolution is for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RetentionTable {
+    /// OTel spans table (`spans`). Default TTL: 90 days.
+    Spans,
+    /// Proxy / request-log table (`proxy_logs`). Default TTL: 30 days.
+    ProxyLogs,
+}
+
+impl RetentionTable {
+    /// The table-level TTL constant in days.
+    ///
+    /// Matches the `DEFAULT` in the `ADD COLUMN … retention_days` migration
+    /// and the prior hardcoded `INTERVAL` in the original DDL. Used by
+    /// [`FixedRetentionResolver`] and as a fallback for rows that have no
+    /// project context (e.g. unrouted proxy requests).
+    pub fn default_days(self) -> u16 {
+        match self {
+            Self::Spans => 90,
+            Self::ProxyLogs => 30,
+        }
+    }
+}
+
+/// Extension point for resolving the effective `retention_days` to stamp onto
+/// an ingested ClickHouse row.
+///
+/// OSS registers [`FixedRetentionResolver`] at startup, which always returns
+/// [`RetentionTable::default_days`] regardless of `project_id`. A plugin (e.g.
+/// one implementing per-project data retention policies) registers an
+/// implementation via the service registry — `context.register_service(resolver)`
+/// — only when appropriate (e.g. gated by its own licensing check). Storage
+/// backends receive the resolver at construction time as
+/// `Arc<dyn RetentionResolver>`, so a plugin-free binary uses the fixed
+/// default unconditionally and the ClickHouse rows self-expire at the
+/// table-level TTL without any configuration.
+pub trait RetentionResolver: Send + Sync {
+    /// Return the effective `retention_days` for `project_id` in `table`.
+    ///
+    /// The returned value is written into the `retention_days` column of each
+    /// new row, where it drives the per-row TTL expression
+    /// `toDateTime(<time_col>) + toIntervalDay(retention_days)`.
+    ///
+    /// Implementations must be synchronous and must not perform I/O — see the
+    /// module-level note.
+    fn resolve(&self, project_id: i32, table: RetentionTable) -> u16;
+}
+
+/// Default [`RetentionResolver`] that returns the ClickHouse table-level
+/// default for every project.
+///
+/// Registered at startup when no overriding implementation is present.
+/// Callers with no project context (e.g. unrouted proxy requests where
+/// `project_id` is `NULL`) should use [`RetentionTable::default_days`]
+/// directly rather than passing a fabricated project ID to this resolver.
+pub struct FixedRetentionResolver;
+
+impl RetentionResolver for FixedRetentionResolver {
+    fn resolve(&self, _project_id: i32, table: RetentionTable) -> u16 {
+        table.default_days()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_resolver_returns_table_defaults() {
+        let r = FixedRetentionResolver;
+        assert_eq!(r.resolve(1, RetentionTable::Spans), 90);
+        assert_eq!(r.resolve(1, RetentionTable::ProxyLogs), 30);
+        // project_id is ignored
+        assert_eq!(r.resolve(99999, RetentionTable::Spans), 90);
+        assert_eq!(r.resolve(0, RetentionTable::ProxyLogs), 30);
+    }
+
+    #[test]
+    fn retention_table_default_days() {
+        assert_eq!(RetentionTable::Spans.default_days(), 90);
+        assert_eq!(RetentionTable::ProxyLogs.default_days(), 30);
+    }
+}

--- a/crates/temps-otel/migrations/clickhouse/0004_retention_days.sql
+++ b/crates/temps-otel/migrations/clickhouse/0004_retention_days.sql
@@ -1,0 +1,5 @@
+-- Add retention_days to spans so each row carries its own TTL value.
+-- The DEFAULT (90) equals the prior hardcoded INTERVAL, so existing rows
+-- are unaffected: their effective expiry does not change until the TTL
+-- expression is updated by 0005_retention_ttl.sql.
+ALTER TABLE spans ADD COLUMN IF NOT EXISTS retention_days UInt16 DEFAULT 90

--- a/crates/temps-otel/migrations/clickhouse/0005_retention_ttl.sql
+++ b/crates/temps-otel/migrations/clickhouse/0005_retention_ttl.sql
@@ -1,0 +1,6 @@
+-- Replace the fixed 90-day TTL with a per-row expression driven by the
+-- retention_days column added in 0004_retention_days.sql.  This is a
+-- metadata-only operation in ClickHouse; existing rows are not re-scanned
+-- immediately.  Rows whose retention_days DEFAULT is 90 continue to expire
+-- at the same horizon as before.
+ALTER TABLE spans MODIFY TTL toDateTime(start_time) + toIntervalDay(retention_days)

--- a/crates/temps-otel/src/plugin.rs
+++ b/crates/temps-otel/src/plugin.rs
@@ -270,11 +270,23 @@ pub struct OtelApiDoc;
 // ── Plugin ──────────────────────────────────────────────────────────
 
 /// OTel Plugin for Temps.
-pub struct OtelPlugin;
+pub struct OtelPlugin {
+    /// Handle to the ClickHouse storage's `RetentionResolver` slot, captured
+    /// in `register_services` (before the storage is moved into `Arc<dyn
+    /// OtelStorage>`) and written into from `initialize_plugin_services`,
+    /// which runs only after every plugin has registered its services.
+    /// `register_services` runs in plugin-registration order and this plugin
+    /// registers before any later-registered plugin (e.g. one implementing
+    /// per-project retention) gets a chance to provide a resolver — same
+    /// two-phase handoff `DeploymentsPlugin` uses for `DeploymentGate`.
+    retention_resolver_slot: tokio::sync::OnceCell<Arc<temps_core::RetentionResolverSlot>>,
+}
 
 impl OtelPlugin {
     pub fn new() -> Self {
-        Self
+        Self {
+            retention_resolver_slot: tokio::sync::OnceCell::new(),
+        }
     }
 }
 
@@ -357,16 +369,17 @@ impl TempsPlugin for OtelPlugin {
                     database = %ch_cfg.database,
                     "ClickHouse OTel backend enabled (ADR-016) — applying migrations"
                 );
-                // A plugin (e.g. one implementing per-project data retention
-                // policies) registers an alternative implementation; a
-                // plugin-free binary falls back to the fixed default.
-                let retention_resolver = context
-                    .get_service::<dyn temps_core::RetentionResolver>()
-                    .unwrap_or_else(|| Arc::new(temps_core::FixedRetentionResolver));
+                // Slot defaults to FixedRetentionResolver; a plugin (e.g. one
+                // implementing per-project data retention policies) is wired
+                // in later from `initialize_plugin_services` — see the
+                // `retention_resolver_slot` field doc for why a direct
+                // `get_service` call here would never find it.
+                let retention_slot = Arc::new(temps_core::RetentionResolverSlot::new_default());
+                let _ = self.retention_resolver_slot.set(retention_slot.clone());
                 let ch_storage = Arc::new(ClickHouseOtelStorage::new(
                     ch_cfg.clone(),
                     timescale_storage,
-                    retention_resolver,
+                    retention_slot as Arc<dyn temps_core::RetentionResolver>,
                 ));
                 // Run migrations in a background task so plugin init
                 // returns promptly. If migrations fail, the first
@@ -671,6 +684,25 @@ impl TempsPlugin for OtelPlugin {
         })
     }
 
+    fn initialize_plugin_services<'a>(
+        &'a self,
+        context: &'a PluginContext,
+    ) -> Pin<Box<dyn Future<Output = Result<(), PluginError>> + Send + 'a>> {
+        Box::pin(async move {
+            // Runs after every plugin has registered its services, so this is
+            // the first point at which an optional plugin-provided
+            // RetentionResolver (e.g. from a plugin implementing per-project
+            // retention) can actually be found.
+            if let Some(slot) = self.retention_resolver_slot.get() {
+                if let Some(resolver) = context.get_service::<dyn temps_core::RetentionResolver>() {
+                    slot.set(resolver);
+                    debug!("otel: RetentionResolver wired in from a registered plugin");
+                }
+            }
+            Ok(())
+        })
+    }
+
     fn configure_routes(&self, context: &PluginContext) -> Option<PluginRoutes> {
         let app_state_arc = context.require_service::<OtelAppState>();
         let mut app_state: OtelAppState = app_state_arc.as_ref().clone();
@@ -741,7 +773,7 @@ mod tests {
 
     #[test]
     fn test_otel_plugin_default() {
-        let plugin = OtelPlugin;
+        let plugin = OtelPlugin::default();
         assert_eq!(plugin.name(), "otel");
     }
 

--- a/crates/temps-otel/src/plugin.rs
+++ b/crates/temps-otel/src/plugin.rs
@@ -360,6 +360,7 @@ impl TempsPlugin for OtelPlugin {
                 let ch_storage = Arc::new(ClickHouseOtelStorage::new(
                     ch_cfg.clone(),
                     timescale_storage,
+                    Arc::new(temps_core::FixedRetentionResolver),
                 ));
                 // Run migrations in a background task so plugin init
                 // returns promptly. If migrations fail, the first

--- a/crates/temps-otel/src/plugin.rs
+++ b/crates/temps-otel/src/plugin.rs
@@ -357,10 +357,16 @@ impl TempsPlugin for OtelPlugin {
                     database = %ch_cfg.database,
                     "ClickHouse OTel backend enabled (ADR-016) — applying migrations"
                 );
+                // A plugin (e.g. one implementing per-project data retention
+                // policies) registers an alternative implementation; a
+                // plugin-free binary falls back to the fixed default.
+                let retention_resolver = context
+                    .get_service::<dyn temps_core::RetentionResolver>()
+                    .unwrap_or_else(|| Arc::new(temps_core::FixedRetentionResolver));
                 let ch_storage = Arc::new(ClickHouseOtelStorage::new(
                     ch_cfg.clone(),
                     timescale_storage,
-                    Arc::new(temps_core::FixedRetentionResolver),
+                    retention_resolver,
                 ));
                 // Run migrations in a background task so plugin init
                 // returns promptly. If migrations fail, the first

--- a/crates/temps-otel/src/storage/clickhouse/migrations.rs
+++ b/crates/temps-otel/src/storage/clickhouse/migrations.rs
@@ -34,6 +34,14 @@ const MIGRATIONS: &[Migration] = &[
         name: "0003_metrics",
         sql: include_str!("../../../migrations/clickhouse/0003_metrics.sql"),
     },
+    Migration {
+        name: "0004_retention_days",
+        sql: include_str!("../../../migrations/clickhouse/0004_retention_days.sql"),
+    },
+    Migration {
+        name: "0005_retention_ttl",
+        sql: include_str!("../../../migrations/clickhouse/0005_retention_ttl.sql"),
+    },
 ];
 
 /// SQL for the migration tracking table. Created on first run.

--- a/crates/temps-otel/src/storage/clickhouse/mod.rs
+++ b/crates/temps-otel/src/storage/clickhouse/mod.rs
@@ -248,6 +248,15 @@ pub struct ChSpanRow {
     /// OTLP retries of the same span converge to one canonical row via
     /// ReplacingMergeTree (highest _version wins).
     pub _version: u64,
+
+    // ── Retention ───────────────────────────────────────────────────────────
+    /// retention_days  UInt16  DEFAULT 90
+    ///
+    /// Added by migration 0004_retention_days.sql — must remain the last
+    /// field so its position matches the DDL column order (positional binary
+    /// serialization). The TTL expression in 0005_retention_ttl.sql reads
+    /// this column: `toDateTime(start_time) + toIntervalDay(retention_days)`.
+    pub retention_days: u16,
 }
 
 // ── From<&SpanRecord> for ChSpanRow ────────────────────────────────────────
@@ -295,6 +304,9 @@ impl From<&SpanRecord> for ChSpanRow {
             attributes,
             events,
             _version: version,
+            // Callers that hold a RetentionResolver should override this field
+            // after construction. The fixed default matches the DDL DEFAULT.
+            retention_days: temps_core::RetentionTable::Spans.default_days(),
         }
     }
 }
@@ -896,6 +908,10 @@ pub struct ClickHouseOtelStorage {
     /// forwarded here verbatim. Phase 1 will replace span read delegation
     /// with native CH queries one method at a time.
     inner: Arc<TimescaleDbStorage>,
+    /// Resolves the per-project `retention_days` value stamped onto each
+    /// ingested span row. The default [`temps_core::FixedRetentionResolver`]
+    /// always returns 90; a plugin can register an alternative implementation.
+    resolver: Arc<dyn temps_core::RetentionResolver>,
 }
 
 impl ClickHouseOtelStorage {
@@ -906,13 +922,24 @@ impl ClickHouseOtelStorage {
     ///   methods and (during Phase 0) span reads. Callers typically pass
     ///   the same `Arc<TimescaleDbStorage>` they would have registered
     ///   without ClickHouse.
-    pub fn new(config: ClickHouseOtelConfig, inner: Arc<TimescaleDbStorage>) -> Self {
+    /// - `resolver`: resolves per-project `retention_days` at ingest time.
+    ///   Pass `Arc::new(FixedRetentionResolver)` unless a plugin has
+    ///   registered a project-aware implementation.
+    pub fn new(
+        config: ClickHouseOtelConfig,
+        inner: Arc<TimescaleDbStorage>,
+        resolver: Arc<dyn temps_core::RetentionResolver>,
+    ) -> Self {
         let ch = ::clickhouse::Client::default()
             .with_url(&config.url)
             .with_database(&config.database)
             .with_user(&config.user)
             .with_password(&config.password);
-        Self { ch, inner }
+        Self {
+            ch,
+            inner,
+            resolver,
+        }
     }
 
     /// Expose the raw ClickHouse client for migration runners / health checks.
@@ -952,7 +979,10 @@ impl OtelStorage for ClickHouseOtelStorage {
                 .map_err(|e| ch_ingest_err("store_spans (inserter setup)", e))?;
 
             for span in chunk {
-                let row = ChSpanRow::from(span);
+                let mut row = ChSpanRow::from(span);
+                row.retention_days = self
+                    .resolver
+                    .resolve(span.project_id, temps_core::RetentionTable::Spans);
                 inserter
                     .write(&row)
                     .await

--- a/crates/temps-otel/tests/clickhouse_storage_test.rs
+++ b/crates/temps-otel/tests/clickhouse_storage_test.rs
@@ -111,7 +111,8 @@ async fn setup() -> Option<(ClickHouseOtelStorage, Box<dyn std::any::Any + Send>
     let mock_db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
     let inner = Arc::new(TimescaleDbStorage::new(Arc::new(mock_db), None));
 
-    let storage = ClickHouseOtelStorage::new(config, inner);
+    let storage =
+        ClickHouseOtelStorage::new(config, inner, Arc::new(temps_core::FixedRetentionResolver));
     Some((storage, Box::new(container)))
 }
 

--- a/crates/temps-otel/tests/decode_to_store_test.rs
+++ b/crates/temps-otel/tests/decode_to_store_test.rs
@@ -226,7 +226,8 @@ async fn setup() -> Option<(
 
     let mock_db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
     let inner = Arc::new(TimescaleDbStorage::new(Arc::new(mock_db), None));
-    let storage = ClickHouseOtelStorage::new(config, inner);
+    let storage =
+        ClickHouseOtelStorage::new(config, inner, Arc::new(temps_core::FixedRetentionResolver));
 
     Some((storage, probe, Box::new(container)))
 }

--- a/crates/temps-proxy/migrations/clickhouse/0003_retention_days.sql
+++ b/crates/temps-proxy/migrations/clickhouse/0003_retention_days.sql
@@ -1,0 +1,5 @@
+-- Add retention_days to proxy_logs so each row carries its own TTL value.
+-- The DEFAULT (30) equals the prior hardcoded INTERVAL, so existing rows
+-- are unaffected: their effective expiry does not change until the TTL
+-- expression is updated by 0004_retention_ttl.sql.
+ALTER TABLE proxy_logs ADD COLUMN IF NOT EXISTS retention_days UInt16 DEFAULT 30

--- a/crates/temps-proxy/migrations/clickhouse/0004_retention_ttl.sql
+++ b/crates/temps-proxy/migrations/clickhouse/0004_retention_ttl.sql
@@ -1,0 +1,6 @@
+-- Replace the fixed 30-day TTL with a per-row expression driven by the
+-- retention_days column added in 0003_retention_days.sql.  This is a
+-- metadata-only operation in ClickHouse; existing rows are not re-scanned
+-- immediately.  Rows whose retention_days DEFAULT is 30 continue to expire
+-- at the same horizon as before.
+ALTER TABLE proxy_logs MODIFY TTL toDateTime(timestamp) + toIntervalDay(retention_days)

--- a/crates/temps-proxy/src/plugin.rs
+++ b/crates/temps-proxy/src/plugin.rs
@@ -16,7 +16,18 @@ use crate::{
     },
 };
 
-pub struct ProxyPlugin;
+pub struct ProxyPlugin {
+    /// Handle to the ClickHouse proxy-log storage's `RetentionResolver` slot,
+    /// captured in `register_services` (before the storage is moved into
+    /// `Arc<dyn ProxyLogStorage>`) and written into from
+    /// `initialize_plugin_services`, which runs only after every plugin has
+    /// registered its services. `register_services` runs in
+    /// plugin-registration order and this plugin registers before any
+    /// later-registered plugin (e.g. one implementing per-project retention)
+    /// gets a chance to provide a resolver — same two-phase handoff
+    /// `DeploymentsPlugin` uses for `DeploymentGate`.
+    retention_resolver_slot: tokio::sync::OnceCell<Arc<temps_core::RetentionResolverSlot>>,
+}
 
 impl TempsPlugin for ProxyPlugin {
     fn name(&self) -> &'static str {
@@ -48,11 +59,15 @@ impl TempsPlugin for ProxyPlugin {
                 .get_service::<temps_config::ConfigService>()
                 .map(|cs| cs.get_server_config());
 
-            // A plugin (e.g. one implementing per-project data retention
-            // policies) registers an alternative implementation; a plugin-free
-            // binary falls back to the fixed default inside
-            // `build_proxy_log_storage`.
-            let retention_resolver = context.get_service::<dyn temps_core::RetentionResolver>();
+            // Slot defaults to FixedRetentionResolver; a plugin (e.g. one
+            // implementing per-project data retention policies) is wired in
+            // later from `initialize_plugin_services` — see the
+            // `retention_resolver_slot` field doc for why a direct
+            // `get_service` call here would never find it (register_services
+            // runs in plugin-registration order and this plugin registers
+            // before any EE plugin gets a chance to register one).
+            let retention_slot = Arc::new(temps_core::RetentionResolverSlot::new_default());
+            let _ = self.retention_resolver_slot.set(retention_slot.clone());
 
             // Create LB service
             let lb_service = Arc::new(LbService::new(db.clone()));
@@ -66,7 +81,7 @@ impl TempsPlugin for ProxyPlugin {
                     &config,
                     db.clone(),
                     ip_service.clone(),
-                    retention_resolver,
+                    Some(retention_slot as Arc<dyn temps_core::RetentionResolver>),
                 ),
                 None => {
                     tracing::debug!(
@@ -102,6 +117,25 @@ impl TempsPlugin for ProxyPlugin {
             context.register_service(challenge_service);
 
             tracing::debug!("Proxy plugin services registered successfully");
+            Ok(())
+        })
+    }
+
+    fn initialize_plugin_services<'a>(
+        &'a self,
+        context: &'a PluginContext,
+    ) -> Pin<Box<dyn Future<Output = Result<(), PluginError>> + Send + 'a>> {
+        Box::pin(async move {
+            // Runs after every plugin has registered its services, so this is
+            // the first point at which an optional plugin-provided
+            // RetentionResolver (e.g. from a plugin implementing per-project
+            // retention) can actually be found.
+            if let Some(slot) = self.retention_resolver_slot.get() {
+                if let Some(resolver) = context.get_service::<dyn temps_core::RetentionResolver>() {
+                    slot.set(resolver);
+                    tracing::debug!("proxy: RetentionResolver wired in from a registered plugin");
+                }
+            }
             Ok(())
         })
     }
@@ -153,7 +187,9 @@ impl TempsPlugin for ProxyPlugin {
 
 impl ProxyPlugin {
     pub fn new() -> Self {
-        Self
+        Self {
+            retention_resolver_slot: tokio::sync::OnceCell::new(),
+        }
     }
 }
 

--- a/crates/temps-proxy/src/plugin.rs
+++ b/crates/temps-proxy/src/plugin.rs
@@ -48,6 +48,12 @@ impl TempsPlugin for ProxyPlugin {
                 .get_service::<temps_config::ConfigService>()
                 .map(|cs| cs.get_server_config());
 
+            // A plugin (e.g. one implementing per-project data retention
+            // policies) registers an alternative implementation; a plugin-free
+            // binary falls back to the fixed default inside
+            // `build_proxy_log_storage`.
+            let retention_resolver = context.get_service::<dyn temps_core::RetentionResolver>();
+
             // Create LB service
             let lb_service = Arc::new(LbService::new(db.clone()));
 
@@ -56,9 +62,12 @@ impl TempsPlugin for ProxyPlugin {
             // When ClickHouse is NOT configured this resolves to the default
             // TimescaleDB path with no behaviour change.
             let proxy_log_storage = match server_config {
-                Some(config) => {
-                    crate::storage::build_proxy_log_storage(&config, db.clone(), ip_service.clone())
-                }
+                Some(config) => crate::storage::build_proxy_log_storage(
+                    &config,
+                    db.clone(),
+                    ip_service.clone(),
+                    retention_resolver,
+                ),
                 None => {
                     tracing::debug!(
                         "Proxy plugin: ConfigService unavailable; proxy logs use the \

--- a/crates/temps-proxy/src/server.rs
+++ b/crates/temps-proxy/src/server.rs
@@ -268,8 +268,12 @@ pub fn setup_proxy_server(
     // backend the API read handlers use so writes and reads agree. The
     // ClickHouse client lives only in this background task — never the Pingora
     // hot path.
-    let proxy_log_storage =
-        crate::storage::build_proxy_log_storage(&config, db.clone(), ip_service.clone());
+    let proxy_log_storage = crate::storage::build_proxy_log_storage(
+        &config,
+        db.clone(),
+        ip_service.clone(),
+        context.get_service::<dyn temps_core::RetentionResolver>(),
+    );
 
     // Create batch writer for proxy logs and tracking events (bounded channels + background tasks)
     let (proxy_log_handle, tracking_handle, proxy_log_writer) =
@@ -540,8 +544,12 @@ pub fn create_proxy_service(
     // backend the API read handlers use so writes and reads agree. The
     // ClickHouse client lives only in this background task — never the Pingora
     // hot path.
-    let proxy_log_storage =
-        crate::storage::build_proxy_log_storage(&config, db.clone(), ip_service.clone());
+    let proxy_log_storage = crate::storage::build_proxy_log_storage(
+        &config,
+        db.clone(),
+        ip_service.clone(),
+        context.get_service::<dyn temps_core::RetentionResolver>(),
+    );
 
     // Create batch writer for proxy logs and tracking events (bounded channels + background tasks)
     let (proxy_log_handle, tracking_handle, proxy_log_writer) =

--- a/crates/temps-proxy/src/storage/clickhouse.rs
+++ b/crates/temps-proxy/src/storage/clickhouse.rs
@@ -44,6 +44,8 @@
 //!   strings. The known-agent IN list is server-derived from
 //!   `ai_agent_detector::known_agents()` and is bound as an array regardless.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use chrono::{TimeZone, Utc};
 use serde::{Deserialize, Serialize};
@@ -287,6 +289,13 @@ pub struct ChProxyLogRow {
     pub error_group_id: Option<i32>,
     /// _version UInt64 — Unix-ms dedup key for ReplacingMergeTree.
     pub _version: u64,
+    /// retention_days UInt16 DEFAULT 30
+    ///
+    /// Added by migration 0003_retention_days.sql — must remain the last
+    /// field so its position matches the DDL column order (positional binary
+    /// serialization). The TTL expression in 0004_retention_ttl.sql reads
+    /// this column: `toDateTime(timestamp) + toIntervalDay(retention_days)`.
+    pub retention_days: u16,
 }
 
 impl From<&CreateProxyLogRequest> for ChProxyLogRow {
@@ -351,6 +360,9 @@ impl From<&CreateProxyLogRequest> for ChProxyLogRow {
             trace_id: entry.trace_id.clone().unwrap_or_default(),
             error_group_id: entry.error_group_id,
             _version: now_ms as u64,
+            // Callers that hold a RetentionResolver should override this field
+            // after construction. The fixed default matches the DDL DEFAULT.
+            retention_days: temps_core::RetentionTable::ProxyLogs.default_days(),
         }
     }
 }
@@ -542,18 +554,29 @@ fn ms_to_rfc3339(ms: i64) -> String {
 /// [`super::clickhouse_migrations::apply_migrations`].
 pub struct ClickHouseProxyLogStore {
     client: ::clickhouse::Client,
+    /// Resolves the per-project `retention_days` value stamped onto each
+    /// ingested proxy log row. The default [`temps_core::FixedRetentionResolver`]
+    /// always returns 30; a plugin can register an alternative implementation.
+    resolver: Arc<dyn temps_core::RetentionResolver>,
 }
 
 impl ClickHouseProxyLogStore {
     /// Build a store from connection configuration. Does not validate
     /// connectivity.
-    pub fn new(config: ClickHouseProxyLogConfig) -> Self {
+    ///
+    /// `resolver` is called once per row in `write_batch` to populate
+    /// `retention_days`. Pass `Arc::new(FixedRetentionResolver)` unless a
+    /// plugin has registered a project-aware implementation.
+    pub fn new(
+        config: ClickHouseProxyLogConfig,
+        resolver: Arc<dyn temps_core::RetentionResolver>,
+    ) -> Self {
         let client = ::clickhouse::Client::default()
             .with_url(&config.url)
             .with_database(&config.database)
             .with_user(&config.user)
             .with_password(&config.password);
-        Self { client }
+        Self { client, resolver }
     }
 
     /// Borrow the underlying client (for migrations / health checks).
@@ -887,7 +910,16 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
                 })?;
 
             for entry in chunk {
-                let row = ChProxyLogRow::from(entry);
+                let mut row = ChProxyLogRow::from(entry);
+                // Unrouted requests have no project context; use the table
+                // default directly so the resolver is not called with a
+                // fabricated project ID.
+                row.retention_days = match entry.project_id {
+                    Some(pid) => self
+                        .resolver
+                        .resolve(pid, temps_core::RetentionTable::ProxyLogs),
+                    None => temps_core::RetentionTable::ProxyLogs.default_days(),
+                };
                 inserter
                     .write(&row)
                     .await
@@ -2058,12 +2090,10 @@ mod tests {
 
     #[tokio::test]
     async fn write_batch_empty_is_noop() {
-        let store = ClickHouseProxyLogStore::new(ClickHouseProxyLogConfig::new(
-            "http://127.0.0.1:1",
-            "otel",
-            "temps",
-            "temps_dev",
-        ));
+        let store = ClickHouseProxyLogStore::new(
+            ClickHouseProxyLogConfig::new("http://127.0.0.1:1", "otel", "temps", "temps_dev"),
+            Arc::new(temps_core::FixedRetentionResolver),
+        );
         assert!(store.write_batch(vec![]).await.is_ok());
     }
 
@@ -2071,12 +2101,10 @@ mod tests {
     async fn get_by_id_returns_none_under_clickhouse() {
         // No serial id in CH — get_by_id always resolves to None (404) without
         // any I/O, so an unreachable URL still succeeds.
-        let store = ClickHouseProxyLogStore::new(ClickHouseProxyLogConfig::new(
-            "http://127.0.0.1:1",
-            "otel",
-            "temps",
-            "temps_dev",
-        ));
+        let store = ClickHouseProxyLogStore::new(
+            ClickHouseProxyLogConfig::new("http://127.0.0.1:1", "otel", "temps", "temps_dev"),
+            Arc::new(temps_core::FixedRetentionResolver),
+        );
         assert!(store
             .get_by_id(42, None)
             .await
@@ -2086,12 +2114,10 @@ mod tests {
 
     #[tokio::test]
     async fn list_unknown_provider_short_circuits_without_io() {
-        let store = ClickHouseProxyLogStore::new(ClickHouseProxyLogConfig::new(
-            "http://127.0.0.1:1",
-            "otel",
-            "temps",
-            "temps_dev",
-        ));
+        let store = ClickHouseProxyLogStore::new(
+            ClickHouseProxyLogConfig::new("http://127.0.0.1:1", "otel", "temps", "temps_dev"),
+            Arc::new(temps_core::FixedRetentionResolver),
+        );
         let mut filters = empty_query();
         filters.ai_provider = Some("NopeNotReal".into());
         let (rows, total) = store

--- a/crates/temps-proxy/src/storage/clickhouse_migrations.rs
+++ b/crates/temps-proxy/src/storage/clickhouse_migrations.rs
@@ -41,6 +41,14 @@ const MIGRATIONS: &[Migration] = &[
         name: "0002_proxy_logs_codecs",
         sql: include_str!("../../migrations/clickhouse/0002_proxy_logs_codecs.sql"),
     },
+    Migration {
+        name: "0003_retention_days",
+        sql: include_str!("../../migrations/clickhouse/0003_retention_days.sql"),
+    },
+    Migration {
+        name: "0004_retention_ttl",
+        sql: include_str!("../../migrations/clickhouse/0004_retention_ttl.sql"),
+    },
 ];
 
 /// SQL for the migration tracking table. Created on first run.

--- a/crates/temps-proxy/src/storage/mod.rs
+++ b/crates/temps-proxy/src/storage/mod.rs
@@ -193,6 +193,7 @@ pub fn build_proxy_log_storage(
     config: &ServerConfig,
     db: Arc<DatabaseConnection>,
     ip_service: Arc<temps_geo::IpAddressService>,
+    resolver: Option<Arc<dyn temps_core::RetentionResolver>>,
 ) -> Arc<dyn ProxyLogStorage> {
     if config.is_clickhouse_enabled() {
         // is_clickhouse_enabled() guarantees all four fields are Some.
@@ -202,7 +203,11 @@ pub fn build_proxy_log_storage(
             config.clickhouse_user.clone().unwrap_or_default(),
             config.clickhouse_password.clone().unwrap_or_default(),
         );
-        let store = ClickHouseProxyLogStore::new(cfg, Arc::new(temps_core::FixedRetentionResolver));
+        // A plugin (e.g. one implementing per-project data retention
+        // policies) registers an alternative resolver via the service
+        // registry; a plugin-free binary falls back to the fixed default.
+        let resolver = resolver.unwrap_or_else(|| Arc::new(temps_core::FixedRetentionResolver));
+        let store = ClickHouseProxyLogStore::new(cfg, resolver);
 
         // Apply migrations off the startup path. Cloning the client is cheap
         // (Arc-backed internally).

--- a/crates/temps-proxy/src/storage/mod.rs
+++ b/crates/temps-proxy/src/storage/mod.rs
@@ -202,7 +202,7 @@ pub fn build_proxy_log_storage(
             config.clickhouse_user.clone().unwrap_or_default(),
             config.clickhouse_password.clone().unwrap_or_default(),
         );
-        let store = ClickHouseProxyLogStore::new(cfg);
+        let store = ClickHouseProxyLogStore::new(cfg, Arc::new(temps_core::FixedRetentionResolver));
 
         // Apply migrations off the startup path. Cloning the client is cheap
         // (Arc-backed internally).


### PR DESCRIPTION
## Summary
- Adds a `RetentionResolver` extension point (`temps-core`) so a plugin can override the fixed ClickHouse TTL for `spans`/`proxy_logs` on a per-project basis. OSS registers `FixedRetentionResolver` by default, which is behaviorally a no-op: it always returns the current hardcoded constants (90 days for spans, 30 for proxy_logs), so plugin-free instances are unaffected.
- Adds additive ClickHouse migrations (`retention_days UInt16` column + `MODIFY TTL` to reference it instead of a fixed `INTERVAL`) for both tables. Existing rows get a `DEFAULT` equal to the prior fixed interval, so no existing data is re-dated.
- `ChSpanRow`/`ChProxyLogRow` gain a trailing `retention_days` field (column order is load-bearing for positional binary serialization — appended last to match `ADD COLUMN` ordering).
- Ingest paths resolve the effective value per project at write time via the injected resolver; unrouted proxy requests (no `project_id`) use the fixed table default directly rather than a fabricated project ID.
- Updated the `ch_backfill_domains` CLI backfill tool's struct literals to populate the table default for historical rows.

## Test plan
- [x] `cargo check --lib` clean across `temps-core`, `temps-otel`, `temps-proxy`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (workspace-wide, matches pre-commit hook)
- [x] `cargo test --lib -p temps-core -p temps-otel -p temps-proxy` — 399+ passing, 0 failed
- [x] Pre-commit hooks (fmt, clippy, conventional commit) passed on the actual commit