### PR TITLE
fix(proxy): thread a shared RetentionResolver into the live Pingora proxy

### DIFF
--- a/crates/temps-cli/src/commands/proxy.rs
+++ b/crates/temps-cli/src/commands/proxy.rs
@@ -507,6 +507,9 @@ impl ProxyCommand {
             config.clone(),
             on_demand_manager, // wired in split mode (ADR-017 Phase 2); None if Docker unavailable
             admin_gate_handle,
+            // This standalone `temps proxy` process never loads EE plugins —
+            // there is no console here to register an alternative resolver.
+            Arc::new(temps_core::FixedRetentionResolver),
         ) {
             Ok(_) => {
                 info!("Proxy server exited");

--- a/crates/temps-cli/src/commands/proxy.rs
+++ b/crates/temps-cli/src/commands/proxy.rs
@@ -507,8 +507,9 @@ impl ProxyCommand {
             config.clone(),
             on_demand_manager, // wired in split mode (ADR-017 Phase 2); None if Docker unavailable
             admin_gate_handle,
-            // This standalone `temps proxy` process never loads EE plugins —
-            // there is no console here to register an alternative resolver.
+            // This standalone `temps proxy` process never loads a console or
+            // its plugins — there is nothing here to register an alternative
+            // resolver.
             Arc::new(temps_core::FixedRetentionResolver),
         ) {
             Ok(_) => {

--- a/crates/temps-cli/src/commands/serve/console.rs
+++ b/crates/temps-cli/src/commands/serve/console.rs
@@ -865,6 +865,15 @@ pub struct ConsoleApiParams {
     /// Pre-built admin-gate handle. When `None`, the console derives one
     /// from the freshly-constructed service above.
     pub admin_gate_handle: Option<temps_core::admin_gate::AdminGateHandle>,
+    /// Shared retention-resolver slot (see `temps_core::retention`). Owned by
+    /// the caller (`commands/serve/mod.rs`) so the SAME instance can also be
+    /// handed to `start_proxy_server` — the live Pingora proxy builds its own
+    /// isolated plugin context (`temps-proxy/src/server.rs::setup_proxy_plugins`,
+    /// only `ConfigPlugin`+`GeoPlugin`) and can never see a resolver registered
+    /// here via the console's plugin manager otherwise. Pre-registered into the
+    /// service registry below (before any plugin's `register_services` runs) so
+    /// `ProxyPlugin` uses this exact object rather than creating its own.
+    pub retention_resolver_slot: Arc<temps_core::RetentionResolverSlot>,
 }
 
 /// Build a ClickHouse-backed metrics store from the server config, or `None`
@@ -1273,6 +1282,7 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
         extra_plugins,
         admin_gate_service: provided_admin_gate_service,
         admin_gate_handle: provided_admin_gate_handle,
+        retention_resolver_slot,
     } = params;
 
     // Readiness flag for the `/readyz` probe. Starts `false` (not ready) and is
@@ -1354,6 +1364,10 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
     service_context.register_service(encryption_service.clone());
     service_context.register_service(cookie_crypto.clone());
     service_context.register_service(docker.clone());
+    // Pre-registered before any plugin runs so ProxyPlugin uses this exact
+    // slot instance instead of creating its own — see the field doc on
+    // `ConsoleApiParams::retention_resolver_slot`.
+    service_context.register_service(retention_resolver_slot.clone());
 
     // Register the shared route table (created in serve/mod.rs)
     // This is used by analytics-events and other plugins that need to resolve hosts

--- a/crates/temps-cli/src/commands/serve/console.rs
+++ b/crates/temps-cli/src/commands/serve/console.rs
@@ -873,6 +873,21 @@ pub struct ConsoleApiParams {
     /// here via the console's plugin manager otherwise. Pre-registered into the
     /// service registry below (before any plugin's `register_services` runs) so
     /// `ProxyPlugin` uses this exact object rather than creating its own.
+    ///
+    /// **Security guardrail — shared-slot pattern:**
+    /// This is the only object that is deliberately pre-registered in the
+    /// console's service registry AND passed directly to `start_proxy_server` as
+    /// a constructor argument. That cross-context sharing is necessary here
+    /// because the Pingora proxy runs in a wholly separate plugin context and
+    /// cannot reach anything registered in the console's registry.
+    ///
+    /// This pattern MUST NOT be used for any object that affects the proxy's
+    /// security decisions (authentication, TLS/cert issuance, IP blocklists,
+    /// rate limiting, or routing). It is acceptable for `RetentionResolverSlot`
+    /// exclusively because its sole effect is a per-row metadata value
+    /// (`retention_days`) with no bearing on request routing, authorization, or
+    /// connection handling. Any future object shared this same way requires an
+    /// explicit security review before being added here.
     pub retention_resolver_slot: Arc<temps_core::RetentionResolverSlot>,
 }
 

--- a/crates/temps-cli/src/commands/serve/mod.rs
+++ b/crates/temps-cli/src/commands/serve/mod.rs
@@ -476,6 +476,15 @@ impl ServeCommand {
         // the proxy is a wholly separate bootstrap, so neither side can reach
         // the other's service registry — this slot is the one thing shared
         // across both.
+        //
+        // **Security guardrail — shared-slot pattern:** this cross-context
+        // sharing is permissible for `RetentionResolverSlot` only because its
+        // sole effect is a per-row metadata value (`retention_days`) with no
+        // bearing on request routing, authorization, or connection handling.
+        // Do NOT add new objects to this pattern without an explicit security
+        // review: any object that influences auth, TLS/cert issuance, IP
+        // blocklists, or rate limiting MUST NOT be shared across plugin
+        // contexts this way.
         let retention_resolver_slot = Arc::new(temps_core::RetentionResolverSlot::new_default());
 
         // Build the console params once; both roles consume them.

--- a/crates/temps-cli/src/commands/serve/mod.rs
+++ b/crates/temps-cli/src/commands/serve/mod.rs
@@ -465,6 +465,19 @@ impl ServeCommand {
             );
         }
 
+        // Shared retention-resolver slot: constructed ONCE here (before either
+        // the console or the proxy bootstraps begin) so both see the same
+        // object. The console's ProxyPlugin looks this up via the service
+        // registry and swaps in a plugin-provided resolver once one registers;
+        // the proxy (started separately below, own isolated plugin context)
+        // gets a direct clone as a function parameter since it can never see
+        // anything registered in the console's registry. See ADR 0017
+        // follow-up: register_services runs in plugin-registration order and
+        // the proxy is a wholly separate bootstrap, so neither side can reach
+        // the other's service registry — this slot is the one thing shared
+        // across both.
+        let retention_resolver_slot = Arc::new(temps_core::RetentionResolverSlot::new_default());
+
         // Build the console params once; both roles consume them.
         let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
         let params = console::ConsoleApiParams {
@@ -482,6 +495,7 @@ impl ServeCommand {
             extra_plugins,
             admin_gate_service: Some(admin_gate_service),
             admin_gate_handle: Some(admin_gate_handle.clone()),
+            retention_resolver_slot: retention_resolver_slot.clone(),
         };
 
         if self.role == ServeRole::Console {
@@ -572,6 +586,7 @@ impl ServeCommand {
             self.disable_https_redirect,
             on_demand_manager,
             Some(admin_gate_handle),
+            retention_resolver_slot as Arc<dyn temps_core::RetentionResolver>,
         )
     }
 }

--- a/crates/temps-cli/src/commands/serve/proxy.rs
+++ b/crates/temps-cli/src/commands/serve/proxy.rs
@@ -90,6 +90,7 @@ pub fn start_proxy_server(
     disable_https_redirect: bool,
     on_demand_manager: Option<Arc<OnDemandManager>>,
     admin_gate: Option<temps_core::admin_gate::AdminGateHandle>,
+    retention_resolver: Arc<dyn temps_core::RetentionResolver>,
 ) -> anyhow::Result<()> {
     let console_address = config.console_address.clone();
     // Create tokio runtime to fetch preview_domain from config service
@@ -229,6 +230,7 @@ pub fn start_proxy_server(
         config.clone(),
         on_demand_manager,
         admin_gate,
+        retention_resolver,
     ) {
         Ok(_) => {
             info!("Proxy server exited");

--- a/crates/temps-core/src/retention.rs
+++ b/crates/temps-core/src/retention.rs
@@ -99,7 +99,7 @@ impl RetentionResolver for FixedRetentionResolver {
 /// effect. A second caller cannot silently overwrite a resolver that was
 /// already installed — the call is a no-op and returns `false`. This
 /// prevents a buggy or late-registered plugin from replacing a correctly
-/// wired EE-provided resolver after the fact.
+/// wired resolver after the fact.
 pub struct RetentionResolverSlot {
     resolver: arc_swap::ArcSwap<std::sync::Arc<dyn RetentionResolver>>,
     /// Flipped to `true` by the first successful [`Self::set`] call.
@@ -118,7 +118,7 @@ impl RetentionResolverSlot {
         }
     }
 
-    /// Swap in a resolver provided by a licensed plugin, but only once.
+    /// Swap in a resolver provided by a plugin, but only once.
     ///
     /// A resolver that has already been set (by a prior `set()` call) cannot
     /// be silently overwritten by a second plugin. Returns `true` if the swap

--- a/crates/temps-core/src/retention.rs
+++ b/crates/temps-core/src/retention.rs
@@ -94,25 +94,58 @@ impl RetentionResolver for FixedRetentionResolver {
 /// `initialize_plugin_services` if a plugin registered an alternative
 /// resolver — see the module-level note for why this indirection exists.
 /// `resolve` reads are lock-free (`ArcSwap::load`).
-pub struct RetentionResolverSlot(arc_swap::ArcSwap<std::sync::Arc<dyn RetentionResolver>>);
+///
+/// **Write-once semantics:** only the first call to [`Self::set`] takes
+/// effect. A second caller cannot silently overwrite a resolver that was
+/// already installed — the call is a no-op and returns `false`. This
+/// prevents a buggy or late-registered plugin from replacing a correctly
+/// wired EE-provided resolver after the fact.
+pub struct RetentionResolverSlot {
+    resolver: arc_swap::ArcSwap<std::sync::Arc<dyn RetentionResolver>>,
+    /// Flipped to `true` by the first successful [`Self::set`] call.
+    claimed: std::sync::atomic::AtomicBool,
+}
 
 impl RetentionResolverSlot {
     /// Start with [`FixedRetentionResolver`] loaded.
     pub fn new_default() -> Self {
-        Self(arc_swap::ArcSwap::new(std::sync::Arc::new(
-            std::sync::Arc::new(FixedRetentionResolver) as std::sync::Arc<dyn RetentionResolver>,
-        )))
+        Self {
+            resolver: arc_swap::ArcSwap::new(std::sync::Arc::new(std::sync::Arc::new(
+                FixedRetentionResolver,
+            )
+                as std::sync::Arc<dyn RetentionResolver>)),
+            claimed: std::sync::atomic::AtomicBool::new(false),
+        }
     }
 
-    /// Swap in a resolver provided by a licensed plugin.
-    pub fn set(&self, resolver: std::sync::Arc<dyn RetentionResolver>) {
-        self.0.store(std::sync::Arc::new(resolver));
+    /// Swap in a resolver provided by a licensed plugin, but only once.
+    ///
+    /// A resolver that has already been set (by a prior `set()` call) cannot
+    /// be silently overwritten by a second plugin. Returns `true` if the swap
+    /// was applied, `false` if a resolver was already set and this call was a
+    /// no-op.
+    pub fn set(&self, resolver: std::sync::Arc<dyn RetentionResolver>) -> bool {
+        if self
+            .claimed
+            .compare_exchange(
+                false,
+                true,
+                std::sync::atomic::Ordering::SeqCst,
+                std::sync::atomic::Ordering::SeqCst,
+            )
+            .is_ok()
+        {
+            self.resolver.store(std::sync::Arc::new(resolver));
+            true
+        } else {
+            false
+        }
     }
 }
 
 impl RetentionResolver for RetentionResolverSlot {
     fn resolve(&self, project_id: i32, table: RetentionTable) -> u16 {
-        self.0.load().resolve(project_id, table)
+        self.resolver.load().resolve(project_id, table)
     }
 }
 
@@ -153,8 +186,42 @@ mod tests {
     #[test]
     fn slot_set_overrides_the_default() {
         let slot = RetentionResolverSlot::new_default();
-        slot.set(std::sync::Arc::new(AlwaysSeven));
+        let swapped = slot.set(std::sync::Arc::new(AlwaysSeven));
+        assert!(swapped, "first set() must return true");
         assert_eq!(slot.resolve(1, RetentionTable::Spans), 7);
         assert_eq!(slot.resolve(1, RetentionTable::ProxyLogs), 7);
+    }
+
+    struct AlwaysForty;
+    impl RetentionResolver for AlwaysForty {
+        fn resolve(&self, _project_id: i32, _table: RetentionTable) -> u16 {
+            40
+        }
+    }
+
+    #[test]
+    fn slot_second_set_is_noop() {
+        let slot = RetentionResolverSlot::new_default();
+
+        // First set: succeeds and resolver is active.
+        let first = slot.set(std::sync::Arc::new(AlwaysSeven));
+        assert!(first, "first set() must return true");
+        assert_eq!(slot.resolve(1, RetentionTable::Spans), 7);
+
+        // Second set: must be a no-op — returns false, resolver unchanged.
+        let second = slot.set(std::sync::Arc::new(AlwaysForty));
+        assert!(!second, "second set() must return false (write-once)");
+
+        // The FIRST resolver is still active; AlwaysForty must not have taken effect.
+        assert_eq!(
+            slot.resolve(1, RetentionTable::Spans),
+            7,
+            "resolver must remain AlwaysSeven after rejected second set()"
+        );
+        assert_eq!(
+            slot.resolve(1, RetentionTable::ProxyLogs),
+            7,
+            "resolver must remain AlwaysSeven after rejected second set()"
+        );
     }
 }

--- a/crates/temps-otel/src/plugin.rs
+++ b/crates/temps-otel/src/plugin.rs
@@ -695,8 +695,15 @@ impl TempsPlugin for OtelPlugin {
             // retention) can actually be found.
             if let Some(slot) = self.retention_resolver_slot.get() {
                 if let Some(resolver) = context.get_service::<dyn temps_core::RetentionResolver>() {
-                    slot.set(resolver);
-                    debug!("otel: RetentionResolver wired in from a registered plugin");
+                    if slot.set(resolver) {
+                        debug!("otel: RetentionResolver wired in from a registered plugin");
+                    } else {
+                        tracing::warn!(
+                            "otel: RetentionResolver slot was already claimed; \
+                             this plugin's resolver was NOT installed. \
+                             Check plugin registration order."
+                        );
+                    }
                 }
             }
             Ok(())

--- a/crates/temps-proxy/src/integration_test.rs
+++ b/crates/temps-proxy/src/integration_test.rs
@@ -45,6 +45,7 @@ mod integration_tests {
             create_crypto_cookie_crypto(),
             route_table,
             config,
+            Arc::new(temps_core::FixedRetentionResolver),
         )?;
 
         // Verify the proxy service was created successfully
@@ -91,6 +92,7 @@ mod integration_tests {
             create_crypto_cookie_crypto(),
             route_table,
             config,
+            Arc::new(temps_core::FixedRetentionResolver),
         )?;
 
         // Test custom route resolution
@@ -132,6 +134,7 @@ mod integration_tests {
             create_crypto_cookie_crypto(),
             route_table,
             config,
+            Arc::new(temps_core::FixedRetentionResolver),
         )?;
 
         // Test project context resolution

--- a/crates/temps-proxy/src/plugin.rs
+++ b/crates/temps-proxy/src/plugin.rs
@@ -134,8 +134,17 @@ impl TempsPlugin for ProxyPlugin {
             // retention) can actually be found.
             if let Some(slot) = self.retention_resolver_slot.get() {
                 if let Some(resolver) = context.get_service::<dyn temps_core::RetentionResolver>() {
-                    slot.set(resolver);
-                    tracing::debug!("proxy: RetentionResolver wired in from a registered plugin");
+                    if slot.set(resolver) {
+                        tracing::debug!(
+                            "proxy: RetentionResolver wired in from a registered plugin"
+                        );
+                    } else {
+                        tracing::warn!(
+                            "proxy: RetentionResolver slot was already claimed; \
+                             this plugin's resolver was NOT installed. \
+                             Check plugin registration order."
+                        );
+                    }
                 }
             }
             Ok(())

--- a/crates/temps-proxy/src/plugin.rs
+++ b/crates/temps-proxy/src/plugin.rs
@@ -67,7 +67,7 @@ impl TempsPlugin for ProxyPlugin {
             // anything registered here. A plugin (e.g. one implementing
             // per-project data retention policies) is wired in later from
             // `initialize_plugin_services`, once every plugin (including a
-            // later-registered EE plugin) has finished registering.
+            // later-registered plugin) has finished registering.
             let retention_slot = context.require_service::<temps_core::RetentionResolverSlot>();
             let _ = self.retention_resolver_slot.set(retention_slot.clone());
 

--- a/crates/temps-proxy/src/plugin.rs
+++ b/crates/temps-proxy/src/plugin.rs
@@ -59,14 +59,16 @@ impl TempsPlugin for ProxyPlugin {
                 .get_service::<temps_config::ConfigService>()
                 .map(|cs| cs.get_server_config());
 
-            // Slot defaults to FixedRetentionResolver; a plugin (e.g. one
-            // implementing per-project data retention policies) is wired in
-            // later from `initialize_plugin_services` — see the
-            // `retention_resolver_slot` field doc for why a direct
-            // `get_service` call here would never find it (register_services
-            // runs in plugin-registration order and this plugin registers
-            // before any EE plugin gets a chance to register one).
-            let retention_slot = Arc::new(temps_core::RetentionResolverSlot::new_default());
+            // Pre-registered by the top-level `temps serve` orchestrator
+            // (commands/serve/mod.rs) BEFORE any plugin's `register_services`
+            // runs, specifically so this exact slot instance can also be
+            // handed directly to `start_proxy_server` — the live Pingora
+            // proxy builds its own isolated plugin context that can never see
+            // anything registered here. A plugin (e.g. one implementing
+            // per-project data retention policies) is wired in later from
+            // `initialize_plugin_services`, once every plugin (including a
+            // later-registered EE plugin) has finished registering.
+            let retention_slot = context.require_service::<temps_core::RetentionResolverSlot>();
             let _ = self.retention_resolver_slot.set(retention_slot.clone());
 
             // Create LB service
@@ -81,7 +83,7 @@ impl TempsPlugin for ProxyPlugin {
                     &config,
                     db.clone(),
                     ip_service.clone(),
-                    Some(retention_slot as Arc<dyn temps_core::RetentionResolver>),
+                    retention_slot as Arc<dyn temps_core::RetentionResolver>,
                 ),
                 None => {
                     tracing::debug!(
@@ -222,6 +224,11 @@ mod tests {
             geo_ip_service,
         ));
         context.register_service(ip_service);
+
+        // Pre-registered by the top-level `temps serve` orchestrator in real
+        // boot (commands/serve/mod.rs), before any plugin's register_services
+        // runs — see the `retention_resolver_slot` field doc.
+        context.register_service(Arc::new(temps_core::RetentionResolverSlot::new_default()));
 
         // No ConfigService is registered here: the plugin reads it via
         // `get_service` and, when absent, selects the default TimescaleDB

--- a/crates/temps-proxy/src/server.rs
+++ b/crates/temps-proxy/src/server.rs
@@ -229,9 +229,9 @@ pub fn setup_proxy_server(
     admin_gate: Option<temps_core::admin_gate::AdminGateHandle>,
     // Passed in directly rather than looked up via `context.get_service`:
     // `setup_proxy_plugins` below only ever registers ConfigPlugin+GeoPlugin,
-    // so a plugin-registered resolver (e.g. from an EE retention-policy
-    // plugin) would never be visible through that isolated context. The
-    // caller (single-binary `temps serve`) passes the same
+    // so a plugin-registered resolver (e.g. from a plugin implementing
+    // per-project retention policies) would never be visible through that
+    // isolated context. The caller (single-binary `temps serve`) passes the same
     // `RetentionResolverSlot` the console's `ProxyPlugin` uses; the
     // standalone `temps proxy` binary (no console, ever) passes a fixed
     // default.

--- a/crates/temps-proxy/src/server.rs
+++ b/crates/temps-proxy/src/server.rs
@@ -227,6 +227,15 @@ pub fn setup_proxy_server(
     config: Arc<ServerConfig>,
     on_demand_manager: Option<Arc<crate::on_demand::OnDemandManager>>,
     admin_gate: Option<temps_core::admin_gate::AdminGateHandle>,
+    // Passed in directly rather than looked up via `context.get_service`:
+    // `setup_proxy_plugins` below only ever registers ConfigPlugin+GeoPlugin,
+    // so a plugin-registered resolver (e.g. from an EE retention-policy
+    // plugin) would never be visible through that isolated context. The
+    // caller (single-binary `temps serve`) passes the same
+    // `RetentionResolverSlot` the console's `ProxyPlugin` uses; the
+    // standalone `temps proxy` binary (no console, ever) passes a fixed
+    // default.
+    retention_resolver: Arc<dyn temps_core::RetentionResolver>,
 ) -> Result<()> {
     // Setup plugin system (async operation in sync context)
     let context = tokio::runtime::Runtime::new()?
@@ -272,7 +281,7 @@ pub fn setup_proxy_server(
         &config,
         db.clone(),
         ip_service.clone(),
-        context.get_service::<dyn temps_core::RetentionResolver>(),
+        retention_resolver.clone(),
     );
 
     // Create batch writer for proxy logs and tracking events (bounded channels + background tasks)
@@ -508,6 +517,7 @@ pub fn create_proxy_service(
     crypto: Arc<temps_core::CookieCrypto>,
     route_table: Arc<CachedPeerTable>,
     config: Arc<ServerConfig>,
+    retention_resolver: Arc<dyn temps_core::RetentionResolver>,
 ) -> Result<LoadBalancer> {
     // Setup plugin system (async operation in sync context)
     let context = tokio::runtime::Runtime::new()?
@@ -548,7 +558,7 @@ pub fn create_proxy_service(
         &config,
         db.clone(),
         ip_service.clone(),
-        context.get_service::<dyn temps_core::RetentionResolver>(),
+        retention_resolver.clone(),
     );
 
     // Create batch writer for proxy logs and tracking events (bounded channels + background tasks)

--- a/crates/temps-proxy/src/storage/mod.rs
+++ b/crates/temps-proxy/src/storage/mod.rs
@@ -193,7 +193,7 @@ pub fn build_proxy_log_storage(
     config: &ServerConfig,
     db: Arc<DatabaseConnection>,
     ip_service: Arc<temps_geo::IpAddressService>,
-    resolver: Option<Arc<dyn temps_core::RetentionResolver>>,
+    resolver: Arc<dyn temps_core::RetentionResolver>,
 ) -> Arc<dyn ProxyLogStorage> {
     if config.is_clickhouse_enabled() {
         // is_clickhouse_enabled() guarantees all four fields are Some.
@@ -203,10 +203,6 @@ pub fn build_proxy_log_storage(
             config.clickhouse_user.clone().unwrap_or_default(),
             config.clickhouse_password.clone().unwrap_or_default(),
         );
-        // A plugin (e.g. one implementing per-project data retention
-        // policies) registers an alternative resolver via the service
-        // registry; a plugin-free binary falls back to the fixed default.
-        let resolver = resolver.unwrap_or_else(|| Arc::new(temps_core::FixedRetentionResolver));
         let store = ClickHouseProxyLogStore::new(cfg, resolver);
 
         // Apply migrations off the startup path. Cloning the client is cheap


### PR DESCRIPTION
## Summary

Follow-up to #279 (ADR 0017, per-project ClickHouse retention). Testing that PR against a live server surfaced a real bug: a plugin-provided retention override silently never took effect on real proxy traffic.

**Root cause:** the live Pingora proxy (single-binary `temps serve`, the default `--role=all` mode) does not start through the console's plugin manager — where `ProxyPlugin` and any plugin implementing per-project retention policies register a resolver. It starts through a separate, parallel bootstrap (`temps-proxy/src/server.rs::setup_proxy_server`/`create_proxy_service`), each building their own isolated plugin context (`ConfigPlugin`+`GeoPlugin` only) — deliberate, so proxied traffic keeps flowing even if the console fails to start. A resolver registered via the console's plugin manager is structurally invisible to that isolated context, so the actual write path always fell back to the fixed default.

Verified live against a real ClickHouse instance: a plugin-provided override sat stale for 6+ minutes (well past its cache-refresh window) before this fix, and took effect immediately after.

## Fix

- One shared `Arc<RetentionResolverSlot>` constructed once in `commands/serve/mod.rs`, before either the console or proxy bootstrap begins.
- Pre-registered into the console's service registry so `ProxyPlugin` uses this exact instance instead of creating its own.
- Threaded as an explicit parameter through `start_proxy_server` → `setup_proxy_server`/`create_proxy_service` → `build_proxy_log_storage`, since the proxy's isolated context can never see anything registered in the console's registry.
- `build_proxy_log_storage`'s resolver parameter is no longer `Option` — every caller now always has something to provide (the standalone `temps proxy` binary, which never has a console, passes a fixed default).

## Test plan

- [x] `cargo check --all-targets` clean for `temps-cli`, `temps-proxy`
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib -p temps-proxy` — 403 passed, 0 failed (one test updated for the new required service)
- [x] `cargo test --lib -p temps-cli` — 122 passed, 0 failed
- [x] **Live verification**: ran the full binary with a real ClickHouse container, set a per-project retention override via the API, generated real proxy traffic, and confirmed ClickHouse rows show the configured `retention_days` (not the fixed default) after the fix — confirmed broken before, fixed after, on the same running instance