### PR TITLE
fix(analytics): exclude bots and datacenter IPs from live-visitors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,19 @@ RUN if [ -f GeoLite2-City.mmdb ]; then \
       echo "Note: GeoLite2 database not found in repository. Geolocation features will be disabled."; \
     fi
 
+# Copy GeoLite2 ASN database if available (optional -- powers hosting/VPS-provider
+# detection for datacenter traffic spoofing a real browser user-agent; when absent,
+# that detection silently disables and city/country geolocation still works)
+RUN if [ -f GeoLite2-ASN.mmdb ]; then \
+      cp GeoLite2-ASN.mmdb /app/data/GeoLite2-ASN.mmdb && \
+      chown appuser:appgroup /app/data/GeoLite2-ASN.mmdb; \
+    elif [ -f crates/temps-cli/GeoLite2-ASN.mmdb ]; then \
+      cp crates/temps-cli/GeoLite2-ASN.mmdb /app/data/GeoLite2-ASN.mmdb && \
+      chown appuser:appgroup /app/data/GeoLite2-ASN.mmdb; \
+    else \
+      echo "Note: GeoLite2 ASN database not found in repository. Hosting-provider detection will be disabled."; \
+    fi
+
 # Set permissions
 RUN chmod -R 755 /app/data
 
@@ -218,3 +231,7 @@ CMD ["/app/temps", "serve"]
 #   Download from: https://www.maxmind.com/en/geolite2/geolite2-free-data-sources
 # - Geolocation features will be disabled if database is missing (non-fatal)
 #   The application will continue to run normally with a warning in logs
+# - GeoLite2-ASN.mmdb (same download page) is also optional and follows the same
+#   placement/mount rules. It powers hosting/VPS-provider detection used to keep
+#   scraper/bot traffic out of the live-visitors view. Without it, that detection
+#   is disabled (non-fatal) but city/country geolocation is unaffected.

--- a/crates/temps-analytics/src/analytics.rs
+++ b/crates/temps-analytics/src/analytics.rs
@@ -2805,6 +2805,8 @@ WHERE project_id = $1
             WHERE v.project_id = $1
               AND ($2::int IS NULL OR v.environment_id = $2)
               AND v.last_seen >= NOW() - INTERVAL '1 minute' * $3
+              AND v.is_crawler = false
+              AND COALESCE(ig.is_hosting_provider, false) = false
             ORDER BY v.last_seen DESC
         "#;
 

--- a/crates/temps-entities/src/ip_geolocations.rs
+++ b/crates/temps-entities/src/ip_geolocations.rs
@@ -18,6 +18,8 @@ pub struct Model {
     pub country_code: Option<String>,
     pub timezone: Option<String>,
     pub is_eu: bool,
+    pub asn_org: Option<String>,
+    pub is_hosting_provider: Option<bool>,
     pub created_at: DBDateTime,
     pub updated_at: DBDateTime,
 }

--- a/crates/temps-entities/src/ip_geolocations.rs
+++ b/crates/temps-entities/src/ip_geolocations.rs
@@ -18,6 +18,9 @@ pub struct Model {
     pub country_code: Option<String>,
     pub timezone: Option<String>,
     pub is_eu: bool,
+    /// The ASN organization name (e.g. "Hetzner Online GmbH"). Maps to the `asn`
+    /// column, which existed in the schema unused/unmapped before this field.
+    #[sea_orm(column_name = "asn")]
     pub asn_org: Option<String>,
     pub is_hosting_provider: Option<bool>,
     pub created_at: DBDateTime,

--- a/crates/temps-geo/src/geoip_service.rs
+++ b/crates/temps-geo/src/geoip_service.rs
@@ -3,7 +3,7 @@ use rand::seq::SliceRandom;
 use serde::Serialize;
 use std::net::IpAddr;
 use thiserror::Error;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 #[derive(Debug, Serialize, Clone)]
 pub struct GeoLocation {
@@ -15,6 +15,60 @@ pub struct GeoLocation {
     pub region: Option<String>,
     pub timezone: Option<String>,
     pub is_eu: bool,
+    /// The organization that owns the ASN this IP belongs to (e.g. "Hetzner Online GmbH").
+    /// `None` when the ASN database isn't available or the ASN has no organization on file.
+    pub asn_org: Option<String>,
+    /// Best-effort heuristic: does `asn_org` match a known hosting/cloud/VPS provider
+    /// pattern? Datacenter IPs are never real end-user visitors, so this flags traffic
+    /// (often scrapers spoofing a real browser user-agent) that the user-agent-based
+    /// bot detector in temps-analytics-events can't catch. `None` when the ASN database
+    /// isn't available (can't tell either way).
+    pub is_hosting_provider: Option<bool>,
+}
+
+/// Substring patterns (lowercased) matched against an ASN organization name to
+/// flag traffic originating from hosting/cloud/VPS providers rather than
+/// residential or mobile ISPs. Best-effort: a legitimate visitor tunneling
+/// through a corporate VPN hosted on one of these providers would also match,
+/// so this is a signal for the live-visitors view, not a hard security boundary.
+const HOSTING_ORG_PATTERNS: &[&str] = &[
+    "hosting",
+    "vps",
+    "datacenter",
+    "data center",
+    "colocation",
+    "cloud",
+    "server",
+    "amazon",
+    "aws",
+    "google cloud",
+    "microsoft azure",
+    "digitalocean",
+    "linode",
+    "vultr",
+    "ovh",
+    "hetzner",
+    "leaseweb",
+    "scaleway",
+    "contabo",
+    "packet",
+    "equinix",
+    "choopa",
+    "he.net",
+    "hurricane electric",
+    "subnet digital",
+    "americancloud",
+];
+
+/// Detect whether an ASN organization name belongs to a known hosting/cloud/VPS
+/// provider. Returns `false` for an empty name rather than matching everything.
+fn is_hosting_org(org: &str) -> bool {
+    let trimmed = org.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let lower = trimmed.to_lowercase();
+    HOSTING_ORG_PATTERNS.iter().any(|pat| lower.contains(pat))
 }
 
 #[derive(Error, Debug)]
@@ -126,7 +180,7 @@ const MOCK_CITIES: &[MockCity] = &[
 ];
 
 pub enum GeoIpService {
-    MaxMind(MaxMindGeoIpService),
+    MaxMind(Box<MaxMindGeoIpService>),
     Mock(MockGeoIpService),
 }
 
@@ -151,7 +205,31 @@ impl GeoIpService {
                 e
             ))
         })?;
-        Ok(Self::MaxMind(MaxMindGeoIpService { reader }))
+
+        // ASN database is optional: hosting-provider detection degrades gracefully
+        // (asn_org/is_hosting_provider stay None) rather than failing startup when
+        // the operator hasn't provisioned it, same as the City database's own
+        // optional-file convention in Dockerfile/docker-compose.
+        let asn_db_path = std::env::current_dir()?.join("GeoLite2-ASN.mmdb");
+        let asn_reader = match maxminddb::Reader::open_readfile(&asn_db_path) {
+            Ok(reader) => {
+                info!("Loaded MaxMind ASN database from: {:?}", asn_db_path);
+                Some(reader)
+            }
+            Err(e) => {
+                warn!(
+                    "MaxMind ASN database not found at '{}' ({}); hosting-provider detection disabled",
+                    asn_db_path.display(),
+                    e
+                );
+                None
+            }
+        };
+
+        Ok(Self::MaxMind(Box::new(MaxMindGeoIpService {
+            reader,
+            asn_reader,
+        })))
     }
 
     pub async fn geolocate(&self, ip: IpAddr) -> Result<GeoLocation, GeoIpError> {
@@ -164,6 +242,7 @@ impl GeoIpService {
 
 pub struct MaxMindGeoIpService {
     reader: maxminddb::Reader<Vec<u8>>,
+    asn_reader: Option<maxminddb::Reader<Vec<u8>>>,
 }
 
 impl MaxMindGeoIpService {
@@ -177,7 +256,39 @@ impl MaxMindGeoIpService {
             .map_err(|e| GeoIpError::NotFound(format!("Failed to decode city data: {}", e)))?
             .ok_or_else(|| GeoIpError::NotFound(format!("No data found for IP: {}", ip)))?;
 
-        Ok(Self::extract_geo_location(&city_data))
+        let mut geo_location = Self::extract_geo_location(&city_data);
+        let (asn_org, is_hosting_provider) = self.lookup_asn(ip);
+        geo_location.asn_org = asn_org;
+        geo_location.is_hosting_provider = is_hosting_provider;
+
+        Ok(geo_location)
+    }
+
+    /// Look up the ASN organization for `ip` and classify it as a hosting
+    /// provider. Any lookup/decode failure degrades to `(None, None)` rather
+    /// than failing the whole geolocation — the City lookup already succeeded
+    /// and callers shouldn't lose city/country data over an optional signal.
+    fn lookup_asn(&self, ip: IpAddr) -> (Option<String>, Option<bool>) {
+        let Some(asn_reader) = &self.asn_reader else {
+            return (None, None);
+        };
+
+        let asn_data = match asn_reader
+            .lookup(ip)
+            .and_then(|result| result.decode::<geoip2::Asn>())
+        {
+            Ok(Some(data)) => data,
+            Ok(None) => return (None, Some(false)),
+            Err(e) => {
+                debug!("ASN lookup failed for IP {}: {}", ip, e);
+                return (None, None);
+            }
+        };
+
+        let org = asn_data.autonomous_system_organization.map(str::to_string);
+        let is_hosting = org.as_deref().map(is_hosting_org);
+
+        (org, is_hosting)
     }
 
     fn extract_geo_location(city_data: &geoip2::City<'_>) -> GeoLocation {
@@ -210,6 +321,8 @@ impl MaxMindGeoIpService {
             region,
             timezone,
             is_eu,
+            asn_org: None,
+            is_hosting_provider: None,
         }
     }
 }
@@ -246,6 +359,8 @@ impl MockGeoIpService {
             region: Some("Unknown".to_string()),
             timezone: Some("UTC".to_string()),
             is_eu: false,
+            asn_org: None,
+            is_hosting_provider: None,
         })
     }
 
@@ -264,6 +379,8 @@ impl MockGeoIpService {
             region: Some(mock_city.region.to_string()),
             timezone: Some(mock_city.timezone.to_string()),
             is_eu: mock_city.is_eu,
+            asn_org: None,
+            is_hosting_provider: None,
         })
     }
 
@@ -272,5 +389,39 @@ impl MockGeoIpService {
             IpAddr::V4(ipv4) => ipv4.is_private() || ipv4.is_link_local(),
             IpAddr::V6(ipv6) => ipv6.is_loopback() || ipv6.is_unique_local(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_known_hosting_orgs_detected() {
+        assert!(is_hosting_org("EGIHosting"));
+        assert!(is_hosting_org("Subnet Digital LLC (SDL-166)"));
+        assert!(is_hosting_org("Hetzner Online GmbH"));
+        assert!(is_hosting_org("Amazon.com, Inc."));
+        assert!(is_hosting_org("DigitalOcean, LLC"));
+        assert!(is_hosting_org("OVH SAS"));
+    }
+
+    #[test]
+    fn test_residential_isp_not_flagged() {
+        assert!(!is_hosting_org("Comcast Cable Communications, LLC"));
+        assert!(!is_hosting_org("Verizon Communications"));
+        assert!(!is_hosting_org("British Telecommunications PLC"));
+    }
+
+    #[test]
+    fn test_empty_org_not_flagged() {
+        assert!(!is_hosting_org(""));
+        assert!(!is_hosting_org("   "));
+    }
+
+    #[test]
+    fn test_case_insensitive_match() {
+        assert!(is_hosting_org("SUBNET DIGITAL LLC"));
+        assert!(is_hosting_org("subnet digital llc"));
     }
 }

--- a/crates/temps-geo/src/handlers.rs
+++ b/crates/temps-geo/src/handlers.rs
@@ -209,6 +209,8 @@ mod tests {
             region: Some("New York".to_string()),
             timezone: Some("America/New_York".to_string()),
             is_eu: false,
+            asn_org: None,
+            is_hosting_provider: None,
         };
 
         let response = GeoLocationResponse::from(("8.8.8.8".to_string(), location));

--- a/crates/temps-geo/src/ip_address_service.rs
+++ b/crates/temps-geo/src/ip_address_service.rs
@@ -118,6 +118,8 @@ impl IpAddressService {
             longitude: Set(geo_data.as_ref().and_then(|d| d.longitude)),
             timezone: Set(geo_data.as_ref().and_then(|d| d.timezone.clone())),
             is_eu: Set(geo_data.as_ref().map(|d| d.is_eu).unwrap_or(false)),
+            asn_org: Set(geo_data.as_ref().and_then(|d| d.asn_org.clone())),
+            is_hosting_provider: Set(geo_data.as_ref().and_then(|d| d.is_hosting_provider)),
             created_at: Set(now),
             updated_at: Set(now),
             ..Default::default()
@@ -170,6 +172,8 @@ impl IpAddressService {
         active_model.longitude = Set(geo_data.longitude);
         active_model.timezone = Set(geo_data.timezone);
         active_model.is_eu = Set(geo_data.is_eu);
+        active_model.asn_org = Set(geo_data.asn_org);
+        active_model.is_hosting_provider = Set(geo_data.is_hosting_provider);
         active_model.updated_at = Set(Utc::now());
 
         let updated = active_model

--- a/crates/temps-migrations/src/migration/m20260711_000002_add_ip_geolocations_hosting_provider.rs
+++ b/crates/temps-migrations/src/migration/m20260711_000002_add_ip_geolocations_hosting_provider.rs
@@ -1,14 +1,19 @@
-//! Add ASN organization + hosting-provider classification to `ip_geolocations`.
+//! Add hosting-provider classification to `ip_geolocations`.
 //!
 //! The live-visitors view was showing datacenter/scraper traffic as real human
 //! visitors: the existing bot detector only inspects the user-agent string, so
 //! traffic that spoofs a normal browser UA from a hosting/VPS IP sails through
-//! undetected. `asn_org` and `is_hosting_provider` are computed once per IP at
-//! geolocation time (via the optional GeoLite2-ASN database) and cached on this
-//! row like the rest of the geo data, so filtering on them at query time is free.
+//! undetected. `is_hosting_provider` is computed once per IP at geolocation
+//! time (via the optional GeoLite2-ASN database) and cached on this row like
+//! the rest of the geo data, so filtering on it at query time is free.
 //!
-//! Both columns are nullable: `is_hosting_provider = NULL` means "the ASN
-//! database wasn't available when this IP was resolved", not "confirmed human".
+//! `is_hosting_provider` is nullable: `NULL` means "the ASN database wasn't
+//! available when this IP was resolved", not "confirmed human".
+//!
+//! No new column for the ASN organization name: the initial schema
+//! (`m20250101_000001_initial_schema`) already created an `asn` text column
+//! on this table that was never wired up to the entity model or any code
+//! path. We reuse it here instead of adding a second, duplicate column.
 
 use sea_orm_migration::prelude::*;
 
@@ -23,7 +28,6 @@ impl MigrationTrait for Migration {
         db.execute_unprepared(
             r#"
             ALTER TABLE ip_geolocations
-                ADD COLUMN IF NOT EXISTS asn_org varchar,
                 ADD COLUMN IF NOT EXISTS is_hosting_provider boolean;
             "#,
         )
@@ -38,8 +42,7 @@ impl MigrationTrait for Migration {
         db.execute_unprepared(
             r#"
             ALTER TABLE ip_geolocations
-                DROP COLUMN IF EXISTS is_hosting_provider,
-                DROP COLUMN IF EXISTS asn_org;
+                DROP COLUMN IF EXISTS is_hosting_provider;
             "#,
         )
         .await?;

--- a/crates/temps-migrations/src/migration/m20260711_000002_add_ip_geolocations_hosting_provider.rs
+++ b/crates/temps-migrations/src/migration/m20260711_000002_add_ip_geolocations_hosting_provider.rs
@@ -1,0 +1,49 @@
+//! Add ASN organization + hosting-provider classification to `ip_geolocations`.
+//!
+//! The live-visitors view was showing datacenter/scraper traffic as real human
+//! visitors: the existing bot detector only inspects the user-agent string, so
+//! traffic that spoofs a normal browser UA from a hosting/VPS IP sails through
+//! undetected. `asn_org` and `is_hosting_provider` are computed once per IP at
+//! geolocation time (via the optional GeoLite2-ASN database) and cached on this
+//! row like the rest of the geo data, so filtering on them at query time is free.
+//!
+//! Both columns are nullable: `is_hosting_provider = NULL` means "the ASN
+//! database wasn't available when this IP was resolved", not "confirmed human".
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        db.execute_unprepared(
+            r#"
+            ALTER TABLE ip_geolocations
+                ADD COLUMN IF NOT EXISTS asn_org varchar,
+                ADD COLUMN IF NOT EXISTS is_hosting_provider boolean;
+            "#,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        db.execute_unprepared(
+            r#"
+            ALTER TABLE ip_geolocations
+                DROP COLUMN IF EXISTS is_hosting_provider,
+                DROP COLUMN IF EXISTS asn_org;
+            "#,
+        )
+        .await?;
+
+        Ok(())
+    }
+}

--- a/crates/temps-migrations/src/migration/m20260711_000003_add_visitor_non_crawler_partial_index.rs
+++ b/crates/temps-migrations/src/migration/m20260711_000003_add_visitor_non_crawler_partial_index.rs
@@ -1,0 +1,46 @@
+//! Partial index on `visitor` scoped to non-crawler rows.
+//!
+//! `idx_visitor_project_last_seen (project_id, last_seen DESC)` (added in
+//! `m20260214_000002_add_analytics_performance_indexes`) already anchors the
+//! main visitor-listing queries, but every one of them also carries a
+//! `v.is_crawler = false` predicate: unconditionally in `get_live_visitors`
+//! (polled every 2s from the live-visitors page), and whenever a caller of
+//! `get_visitors`/the facet queries passes `include_crawlers = false`. A plain
+//! composite index still has to fetch each matching row before discarding the
+//! crawler ones; a partial index excludes them from the index itself, so a
+//! table with meaningful bot/scraper volume (the exact situation that
+//! motivated this migration) doesn't pay to scan past them on every poll.
+//!
+//! This is additive to, not a replacement for, `idx_visitor_project_last_seen`:
+//! queries that legitimately want crawlers included (`include_crawlers` unset
+//! or `true`) still use the existing full index.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        db.execute_unprepared(
+            r#"CREATE INDEX IF NOT EXISTS idx_visitor_project_last_seen_non_crawler
+               ON visitor (project_id, last_seen DESC)
+               WHERE is_crawler = false"#,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        db.execute_unprepared("DROP INDEX IF EXISTS idx_visitor_project_last_seen_non_crawler")
+            .await?;
+
+        Ok(())
+    }
+}

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -146,6 +146,7 @@ mod m20260707_000002_add_external_services_container_name;
 mod m20260708_000001_add_node_id_to_monitoring_alert_rules;
 mod m20260711_000001_add_proxy_logs_stats_cagg;
 mod m20260711_000002_add_ip_geolocations_hosting_provider;
+mod m20260711_000003_add_visitor_non_crawler_partial_index;
 
 pub struct Migrator;
 
@@ -297,6 +298,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260708_000001_add_node_id_to_monitoring_alert_rules::Migration),
             Box::new(m20260711_000001_add_proxy_logs_stats_cagg::Migration),
             Box::new(m20260711_000002_add_ip_geolocations_hosting_provider::Migration),
+            Box::new(m20260711_000003_add_visitor_non_crawler_partial_index::Migration),
         ]
     }
 }

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -145,6 +145,7 @@ mod m20260707_000001_add_external_service_to_logs;
 mod m20260707_000002_add_external_services_container_name;
 mod m20260708_000001_add_node_id_to_monitoring_alert_rules;
 mod m20260711_000001_add_proxy_logs_stats_cagg;
+mod m20260711_000002_add_ip_geolocations_hosting_provider;
 
 pub struct Migrator;
 
@@ -295,6 +296,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260707_000002_add_external_services_container_name::Migration),
             Box::new(m20260708_000001_add_node_id_to_monitoring_alert_rules::Migration),
             Box::new(m20260711_000001_add_proxy_logs_stats_cagg::Migration),
+            Box::new(m20260711_000002_add_ip_geolocations_hosting_provider::Migration),
         ]
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,9 @@ services:
       # Optional: Mount local GeoLite2 database
       # Uncomment and update path to your local database file
       # - ./GeoLite2-City.mmdb:/app/data/GeoLite2-City.mmdb:ro
+
+      # Optional: Mount local GeoLite2 ASN database (hosting/VPS-provider detection)
+      # - ./GeoLite2-ASN.mmdb:/app/data/GeoLite2-ASN.mmdb:ro
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- `get_live_visitors()` never filtered `v.is_crawler`, unlike `get_visitors()` — any UA-detected crawler (Googlebot, GPTBot, headless browsers, etc.) still showed up as a "Human Visitor" in the live-visitors view.
- Separately, traffic that spoofs a normal browser user-agent (e.g. real `Chrome/119...`) from a hosting/VPS IP was invisible to the existing UA-keyword bot detector entirely — this is what was actually inflating the count on `temps-landing-new`'s live-visitors page (verified via whois: sampled IPs resolved to EGIHosting / Subnet Digital LLC, both hosting providers, not residential ISPs).
- Added an **optional** GeoLite2-ASN lookup to `GeoIpService`: when present, each geolocated IP gets an ASN org name and a best-effort `is_hosting_provider` flag (keyword match against known hosting/cloud/VPS provider names). Both are computed once per IP and cached on `ip_geolocations` alongside the rest of the geo data (6h TTL cache already in place), so filtering on them at query time is free — no hot-path cost.
- `get_live_visitors()` now excludes `v.is_crawler = true` and `ig.is_hosting_provider = true`.
- The ASN database is optional and degrades gracefully (fields stay `NULL`, feature silently disabled with a log warning) when not provisioned — mirrors the existing `GeoLite2-City.mmdb` convention in `Dockerfile`/`docker-compose.yml`, which I extended for the new file.
- While wiring the new column I found the initial schema already had an unused `asn` text column on `ip_geolocations` (never mapped to the entity, never written by any code path). Reused it instead of adding a duplicate `asn_org` column — only `is_hosting_provider` is a genuinely new column.

## Indexes
- The join to `ip_geolocations` is `ON v.ip_address_id = ig.id` — a primary-key lookup, already indexed — so filtering on `ig.is_hosting_provider` afterward is O(1) per already-joined row, not a search predicate. No index needed there.
- `get_live_visitors` is polled every 2s from the live-visitors page and now unconditionally filters `v.is_crawler = false`; `get_visitors`/the facet queries carry the same predicate whenever `include_crawlers = false`. The existing `idx_visitor_project_last_seen (project_id, last_seen DESC)` index still has to fetch and discard crawler rows before that filter applies. Added `idx_visitor_project_last_seen_non_crawler`, a **partial index** scoped to `WHERE is_crawler = false`, so Postgres skips bot rows at the index level on this hot, frequently-polled path — additive to the existing index, which queries wanting crawlers included still use.

## Test plan
- [x] `cargo check --lib` (workspace-wide): 0 errors
- [x] `cargo test --lib` for `temps-geo`, `temps-analytics`, `temps-entities`, `temps-migrations`: 74 passed
- [x] `cargo clippy --lib --tests -- -D warnings` (via resolved binary, not rtk) for touched crates: clean
- [x] New unit tests for the hosting-org heuristic (`temps-geo/src/geoip_service.rs`), covering known hosting orgs (including the two found in this incident), residential ISPs (not flagged), empty input, and case-insensitivity