### PR TITLE
perf(otel): make storage quota opt-in, disabled by default

### DIFF
--- a/crates/temps-otel/src/plugin.rs
+++ b/crates/temps-otel/src/plugin.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use temps_core::plugin::{
     PluginContext, PluginError, PluginRoutes, ServiceRegistrationContext, TempsPlugin,
 };
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 use utoipa::openapi::OpenApi;
 use utoipa::OpenApi as OpenApiTrait;
 
@@ -120,9 +120,16 @@ impl OtelConfig {
             }
         }
         if let Ok(v) = std::env::var("TEMPS_OTEL_QUOTA_GB") {
-            if let Ok(gb) = v.parse::<u64>() {
+            match v.parse::<u64>() {
                 // 0 keeps quotas disabled, same as leaving the var unset.
-                config.quota_bytes_per_project = (gb > 0).then(|| gb * 1024 * 1024 * 1024);
+                Ok(gb) => {
+                    config.quota_bytes_per_project = (gb > 0).then(|| gb * 1024 * 1024 * 1024)
+                }
+                Err(_) => warn!(
+                    value = %v,
+                    "TEMPS_OTEL_QUOTA_GB is set but is not a non-negative integer; \
+                     storage quota stays disabled"
+                ),
             }
         }
         if let Ok(v) = std::env::var("TEMPS_OTEL_ENABLE_HEALTH_COMPUTE") {

--- a/crates/temps-otel/src/plugin.rs
+++ b/crates/temps-otel/src/plugin.rs
@@ -51,8 +51,10 @@ pub struct OtelConfig {
     pub rate_limit_requests: u32,
     pub rate_limit_window_secs: u64,
 
-    // Quota
-    pub quota_bytes_per_project: u64,
+    // Quota. `None` (the default) disables per-project storage quotas
+    // entirely — ingest skips the quota check and its expensive per-project
+    // usage estimate. Set `TEMPS_OTEL_QUOTA_GB` to opt in.
+    pub quota_bytes_per_project: Option<u64>,
 
     // Background tasks
     pub enable_health_compute: bool,
@@ -72,7 +74,7 @@ impl Default for OtelConfig {
             retention_check_interval_secs: 3600, // 1 hour
             rate_limit_requests: 1000,
             rate_limit_window_secs: 60,
-            quota_bytes_per_project: 10 * 1024 * 1024 * 1024, // 10 GB
+            quota_bytes_per_project: None, // quota disabled unless configured
             enable_health_compute: true,
             enable_anomaly_detection: true,
         }
@@ -119,7 +121,8 @@ impl OtelConfig {
         }
         if let Ok(v) = std::env::var("TEMPS_OTEL_QUOTA_GB") {
             if let Ok(gb) = v.parse::<u64>() {
-                config.quota_bytes_per_project = gb * 1024 * 1024 * 1024;
+                // 0 keeps quotas disabled, same as leaving the var unset.
+                config.quota_bytes_per_project = (gb > 0).then(|| gb * 1024 * 1024 * 1024);
             }
         }
         if let Ok(v) = std::env::var("TEMPS_OTEL_ENABLE_HEALTH_COMPUTE") {
@@ -790,7 +793,7 @@ mod tests {
         assert_eq!(config.retention_days, 7);
         assert_eq!(config.rate_limit_requests, 1000);
         assert_eq!(config.rate_limit_window_secs, 60);
-        assert_eq!(config.quota_bytes_per_project, 10 * 1024 * 1024 * 1024);
+        assert_eq!(config.quota_bytes_per_project, None);
         assert!(!config.has_s3_config());
         assert!(config.enable_health_compute);
         assert!(config.enable_anomaly_detection);

--- a/crates/temps-otel/src/storage/timescaledb.rs
+++ b/crates/temps-otel/src/storage/timescaledb.rs
@@ -2219,6 +2219,23 @@ impl OtelStorage for TimescaleDbStorage {
     }
 
     async fn get_storage_quota(&self, project_id: i32) -> StorageResult<StorageQuota> {
+        // Quota is opt-in. With no limit configured, skip the usage estimate
+        // entirely and report zeros: this method sits on the ingest hot path
+        // (`OtelService::check_quota` calls it on every quota-cache miss), and
+        // its three per-project COUNT(*) hypertable scans are far too
+        // expensive to pay for a limit that is never enforced.
+        let Some(limit_bytes) = self.quota_bytes_per_project else {
+            return Ok(StorageQuota {
+                project_id,
+                metrics_bytes: 0,
+                traces_bytes: 0,
+                logs_bytes: 0,
+                total_bytes: 0,
+                limit_bytes: 0,
+                usage_pct: 0.0,
+            });
+        };
+
         // Per-project storage is estimated as
         //   table_size * (rows for project / total rows in table).
         // The per-project numerator must be exact, but the whole-table
@@ -2259,7 +2276,6 @@ impl OtelStorage for TimescaleDbStorage {
             None => 0,
         };
 
-        let limit_bytes: u64 = self.quota_bytes_per_project.unwrap_or(0);
         let usage_pct = if limit_bytes > 0 {
             (total_bytes as f64 / limit_bytes as f64) * 100.0
         } else {
@@ -2278,13 +2294,8 @@ impl OtelStorage for TimescaleDbStorage {
     }
 
     async fn check_quota(&self, project_id: i32) -> StorageResult<bool> {
-        // Quota is opt-in. With no limit configured, skip the per-project
-        // usage estimate entirely — it runs on every ingest request and its
-        // three per-project COUNT(*) hypertable scans are far too expensive
-        // to pay for a check whose answer is always "not exceeded".
-        if self.quota_bytes_per_project.is_none() {
-            return Ok(false);
-        }
+        // With no quota configured, get_storage_quota short-circuits to zeros
+        // without touching the database, so this is always "not exceeded".
         let quota = self.get_storage_quota(project_id).await?;
         Ok(quota.usage_pct >= 100.0)
     }

--- a/crates/temps-otel/src/storage/timescaledb.rs
+++ b/crates/temps-otel/src/storage/timescaledb.rs
@@ -119,7 +119,9 @@ pub struct TimescaleDbStorage {
     /// rationale.
     #[allow(dead_code)]
     retention_days: u32,
-    quota_bytes_per_project: u64,
+    /// Per-project storage quota. `None` disables quota enforcement: ingest
+    /// never runs the per-project usage estimate (see `get_storage_quota`).
+    quota_bytes_per_project: Option<u64>,
 }
 
 /// S3 log archiver configuration.
@@ -235,7 +237,7 @@ impl TimescaleDbStorage {
             db,
             s3_client,
             retention_days: 7,
-            quota_bytes_per_project: 10 * 1024 * 1024 * 1024,
+            quota_bytes_per_project: None,
         }
     }
 
@@ -244,7 +246,7 @@ impl TimescaleDbStorage {
         db: Arc<DatabaseConnection>,
         s3_client: Option<Arc<S3LogArchiver>>,
         retention_days: u32,
-        quota_bytes_per_project: u64,
+        quota_bytes_per_project: Option<u64>,
     ) -> Self {
         Self {
             db,
@@ -2257,7 +2259,7 @@ impl OtelStorage for TimescaleDbStorage {
             None => 0,
         };
 
-        let limit_bytes: u64 = self.quota_bytes_per_project;
+        let limit_bytes: u64 = self.quota_bytes_per_project.unwrap_or(0);
         let usage_pct = if limit_bytes > 0 {
             (total_bytes as f64 / limit_bytes as f64) * 100.0
         } else {
@@ -2276,6 +2278,13 @@ impl OtelStorage for TimescaleDbStorage {
     }
 
     async fn check_quota(&self, project_id: i32) -> StorageResult<bool> {
+        // Quota is opt-in. With no limit configured, skip the per-project
+        // usage estimate entirely — it runs on every ingest request and its
+        // three per-project COUNT(*) hypertable scans are far too expensive
+        // to pay for a check whose answer is always "not exceeded".
+        if self.quota_bytes_per_project.is_none() {
+            return Ok(false);
+        }
         let quota = self.get_storage_quota(project_id).await?;
         Ok(quota.usage_pct >= 100.0)
     }

--- a/crates/temps-otel/tests/timescaledb_storage_test.rs
+++ b/crates/temps-otel/tests/timescaledb_storage_test.rs
@@ -485,12 +485,22 @@ async fn test_storage_quota() {
         return;
     };
 
+    // Default storage has no quota configured: usage is still reported but
+    // there is no limit, and check_quota short-circuits to "not exceeded".
     let quota = storage.get_storage_quota(1).await.unwrap();
     assert_eq!(quota.project_id, 1);
-    assert_eq!(quota.limit_bytes, 10 * 1024 * 1024 * 1024); // 10 GB
-    assert!(quota.usage_pct >= 0.0);
+    assert_eq!(quota.limit_bytes, 0);
+    assert_eq!(quota.usage_pct, 0.0);
 
     let exceeded = storage.check_quota(1).await.unwrap();
+    assert!(!exceeded);
+
+    // With an explicit quota, the check runs for real against a fresh DB.
+    let storage_with_quota =
+        TimescaleDbStorage::with_config(_db.db.clone(), None, 7, Some(10 * 1024 * 1024 * 1024));
+    let quota = storage_with_quota.get_storage_quota(1).await.unwrap();
+    assert_eq!(quota.limit_bytes, 10 * 1024 * 1024 * 1024);
+    let exceeded = storage_with_quota.check_quota(1).await.unwrap();
     assert!(!exceeded); // Fresh DB, should not be exceeded
 }
 

--- a/crates/temps-otel/tests/timescaledb_storage_test.rs
+++ b/crates/temps-otel/tests/timescaledb_storage_test.rs
@@ -485,8 +485,8 @@ async fn test_storage_quota() {
         return;
     };
 
-    // Default storage has no quota configured: usage is still reported but
-    // there is no limit, and check_quota short-circuits to "not exceeded".
+    // Default storage has no quota configured: the estimate short-circuits
+    // to zeros and check_quota reports "not exceeded".
     let quota = storage.get_storage_quota(1).await.unwrap();
     assert_eq!(quota.project_id, 1);
     assert_eq!(quota.limit_bytes, 0);
@@ -502,6 +502,27 @@ async fn test_storage_quota() {
     assert_eq!(quota.limit_bytes, 10 * 1024 * 1024 * 1024);
     let exceeded = storage_with_quota.check_quota(1).await.unwrap();
     assert!(!exceeded); // Fresh DB, should not be exceeded
+}
+
+#[tokio::test]
+async fn test_get_storage_quota_disabled_skips_database() {
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    // No query results are prepared, so any database access would error.
+    // With no quota configured, the usage estimate must short-circuit
+    // without touching the database — this is the ingest hot path
+    // (`OtelService::check_quota` calls `get_storage_quota` on every
+    // quota-cache miss).
+    let mock_db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+    let storage = TimescaleDbStorage::new(std::sync::Arc::new(mock_db), None);
+
+    let quota = storage.get_storage_quota(1).await.unwrap();
+    assert_eq!(quota.total_bytes, 0);
+    assert_eq!(quota.limit_bytes, 0);
+    assert_eq!(quota.usage_pct, 0.0);
+
+    let exceeded = storage.check_quota(1).await.unwrap();
+    assert!(!exceeded);
 }
 
 // ── Retention is a no-op (Timescale's policy is the source of truth) ─


### PR DESCRIPTION
## Problem

`check_quota()` runs on **every** OTLP metrics/spans/logs ingest request. It is fronted by a 30s `QuotaCache` (#262), but the underlying per-project usage estimate — three `COUNT(*)` scans over the `otel_metrics`, `otel_spans`, and `otel_log_events` hypertables plus `pg_total_relation_size` lookups — can take 90+ seconds under load, longer than the cache TTL, and the cache has no in-flight dedup. Result: a query stampede. A beta.45 install showed ~60 concurrent copies of this query in `pg_stat_activity`, saturating TimescaleDB.

## Fix

Quota enforcement is now **opt-in**:

- `quota_bytes_per_project` is `Option<u64>`, default `None` (no quota).
- With no quota configured, `get_storage_quota` short-circuits to zeros **without touching the database**. The guard lives in `get_storage_quota` (not `check_quota`) because the ingest hot path is `OtelService::check_quota` → quota cache → `get_storage_quota`; this covers ingest, cache refills, and the `GET /otel/quota/{project_id}` endpoint (which now reports zeros when disabled).
- `TEMPS_OTEL_QUOTA_GB` (> 0) opts back in; `0` or unset means unmetered. An unparseable value now logs a `warn!` instead of silently leaving quota disabled.

## Security notes (security-auditor pass: PASS_WITH_NOTES)

- Ingest still requires authentication and is bounded by the per-project rate limiter (default 1000 req/60s) and native TimescaleDB retention (90 days), so disk growth stays bounded: worst case ≈ rate limit × body size × retention.
- **Multi-tenant / Temps Cloud operators should set `TEMPS_OTEL_QUOTA_GB`** — without it a single noisy project's telemetry is only bounded by rate limit × retention.

## Testing

- `cargo check --lib -p temps-otel` clean; fmt + clippy pre-commit hooks pass
- Plugin config unit tests updated and passing
- `test_storage_quota` covers both the disabled default and an explicit `Some(10 GiB)` quota
- New `test_get_storage_quota_disabled_skips_database`: MockDatabase with no prepared results proves the disabled path performs **zero** DB access