### PR TITLE
feat(analytics-performance): read-time bot filtering for speed metrics

### DIFF
--- a/crates/temps-analytics-performance/src/handlers/handler.rs
+++ b/crates/temps-analytics-performance/src/handlers/handler.rs
@@ -63,6 +63,9 @@ pub struct PerformanceMetricsQuery {
     deployment_id: Option<i32>,
     /// Device type filter: "desktop" or "mobile"
     device_type: Option<String>,
+    /// Include crawler/datacenter (bot) samples. Defaults to false — bots
+    /// are excluded from the read view but always stored at ingest.
+    include_bots: Option<bool>,
     /// Segment filters (filter_path, filter_country, filter_region,
     /// filter_city, filter_browser, filter_operating_system) — flattened so
     /// each remains a top-level query string param.
@@ -79,6 +82,8 @@ pub struct GroupedPageMetricsQuery {
     deployment_id: Option<i32>,
     /// Device type filter: "desktop" or "mobile"
     device_type: Option<String>,
+    /// Include crawler/datacenter (bot) samples. Defaults to false.
+    include_bots: Option<bool>,
     // "path", "country", "region", "city", "device_type", "browser", "operating_system"
     group_by: String,
     /// Segment filters — same shape as `PerformanceMetricsQuery`.
@@ -203,6 +208,7 @@ pub fn configure_public_routes() -> Router<Arc<AppState>> {
         ("environment_id" = Option<i32>, Query, description = "Environment ID (optional)"),
         ("deployment_id" = Option<i32>, Query, description = "Deployment ID (optional)"),
         ("device_type" = Option<String>, Query, description = "Device type filter: desktop or mobile (optional)"),
+        ("include_bots" = Option<bool>, Query, description = "Include crawler/datacenter bot samples (default false)"),
         ("filter_path" = Option<String>, Query, description = "Filter to one page pathname (optional)"),
         ("filter_country" = Option<String>, Query, description = "Filter to one country (optional)"),
         ("filter_region" = Option<String>, Query, description = "Filter to one region (optional)"),
@@ -236,6 +242,7 @@ async fn get_performance_metrics(
             query.deployment_id,
             query.device_type,
             &query.segment,
+            query.include_bots.unwrap_or(false),
         )
         .await
     {
@@ -265,6 +272,7 @@ async fn get_performance_metrics(
         ("environment_id" = Option<i32>, Query, description = "Environment ID (optional)"),
         ("deployment_id" = Option<i32>, Query, description = "Deployment ID (optional)"),
         ("device_type" = Option<String>, Query, description = "Device type filter: desktop or mobile (optional)"),
+        ("include_bots" = Option<bool>, Query, description = "Include crawler/datacenter bot samples (default false)"),
         ("filter_path" = Option<String>, Query, description = "Filter to one page pathname (optional)"),
         ("filter_country" = Option<String>, Query, description = "Filter to one country (optional)"),
         ("filter_region" = Option<String>, Query, description = "Filter to one region (optional)"),
@@ -298,6 +306,7 @@ async fn get_metrics_over_time(
             query.deployment_id,
             query.device_type,
             &query.segment,
+            query.include_bots.unwrap_or(false),
         )
         .await
     {
@@ -328,6 +337,7 @@ async fn get_metrics_over_time(
         ("deployment_id" = Option<i32>, Query, description = "Deployment ID (optional)"),
         ("group_by" = String, Query, description = "Group by: path, country, region, city, device_type, browser, operating_system"),
         ("device_type" = Option<String>, Query, description = "Device type filter: desktop or mobile (optional)"),
+        ("include_bots" = Option<bool>, Query, description = "Include crawler/datacenter bot samples (default false)"),
         ("filter_path" = Option<String>, Query, description = "Filter to one page pathname (optional)"),
         ("filter_country" = Option<String>, Query, description = "Filter to one country (optional)"),
         ("filter_region" = Option<String>, Query, description = "Filter to one region (optional)"),
@@ -383,6 +393,7 @@ async fn get_grouped_page_metrics(
             query.deployment_id,
             query.device_type.clone(),
             &query.segment,
+            query.include_bots.unwrap_or(false),
             group_by,
         )
         .await

--- a/crates/temps-analytics-performance/src/services/service.rs
+++ b/crates/temps-analytics-performance/src/services/service.rs
@@ -254,7 +254,16 @@ impl PerformanceService {
     /// Build the WHERE clause and params shared by the performance read
     /// queries. All columns are qualified with the `pm.` alias so the clause
     /// works with or without the `ip_geolocations ig` join; the returned bool
-    /// says whether that join is required (any geographic filter present).
+    /// says whether that join is required (any geographic filter present, or
+    /// bot exclusion — which checks `ig.is_hosting_provider`).
+    ///
+    /// Unless `include_bots` is set, samples are excluded when the UA parsed
+    /// as a crawler (`pm.is_crawler`) or the IP belongs to a hosting provider
+    /// (`ig.is_hosting_provider`) — headless browsers in datacenters report
+    /// wildly unrepresentative timings but carry normal Chrome user agents,
+    /// so the ASN signal is the one that actually catches them. Nothing is
+    /// dropped at ingest; this is purely a read-time view.
+    #[allow(clippy::too_many_arguments)]
     fn build_where(
         project_id: i32,
         start_date: UtcDateTime,
@@ -263,12 +272,17 @@ impl PerformanceService {
         deployment_id: Option<i32>,
         device_type: Option<String>,
         filters: &SpeedSegmentFilters,
+        include_bots: bool,
     ) -> (String, Vec<sea_orm::Value>, bool) {
         let mut conditions = vec![
             "pm.project_id = $1".to_string(),
             "pm.recorded_at >= $2".to_string(),
             "pm.recorded_at <= $3".to_string(),
         ];
+        if !include_bots {
+            conditions.push("pm.is_crawler = false".to_string());
+            conditions.push("COALESCE(ig.is_hosting_provider, false) = false".to_string());
+        }
         let mut params: Vec<sea_orm::Value> =
             vec![project_id.into(), start_date.into(), end_date.into()];
         let mut idx = 3;
@@ -312,7 +326,8 @@ impl PerformanceService {
         push_eq("ig.region", &filters.filter_region);
         push_eq("ig.city", &filters.filter_city);
 
-        (conditions.join(" AND "), params, filters.needs_geo_join())
+        let needs_geo_join = filters.needs_geo_join() || !include_bots;
+        (conditions.join(" AND "), params, needs_geo_join)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -325,6 +340,7 @@ impl PerformanceService {
         deployment_id: Option<i32>,
         device_type: Option<String>,
         filters: &SpeedSegmentFilters,
+        include_bots: bool,
     ) -> Result<PerformanceMetricsResponse, PerformanceError> {
         let (where_clause, params, needs_geo_join) = Self::build_where(
             project_id,
@@ -334,6 +350,7 @@ impl PerformanceService {
             deployment_id,
             device_type,
             filters,
+            include_bots,
         );
         let geo_join = if needs_geo_join {
             "LEFT JOIN ip_geolocations ig ON pm.ip_address_id = ig.id"
@@ -501,6 +518,7 @@ impl PerformanceService {
         deployment_id: Option<i32>,
         device_type: Option<String>,
         filters: &SpeedSegmentFilters,
+        include_bots: bool,
     ) -> Result<MetricsOverTimeResponse, PerformanceError> {
         let (where_clause, params, needs_geo_join) = Self::build_where(
             project_id,
@@ -510,6 +528,7 @@ impl PerformanceService {
             deployment_id,
             device_type,
             filters,
+            include_bots,
         );
         let geo_join = if needs_geo_join {
             "LEFT JOIN ip_geolocations ig ON pm.ip_address_id = ig.id"
@@ -718,6 +737,7 @@ impl PerformanceService {
         deployment_id: Option<i32>,
         device_type: Option<String>,
         filters: &SpeedSegmentFilters,
+        include_bots: bool,
         group_by: GroupBy,
     ) -> Result<GroupedPageMetricsResponse, PerformanceError> {
         // Determine the grouping field and column. Non-geographic dimensions
@@ -733,6 +753,7 @@ impl PerformanceService {
             deployment_id,
             device_type,
             filters,
+            include_bots,
         );
         let needs_geo_join = group_needs_geo || filters_need_geo;
         let geo_join = if needs_geo_join {
@@ -763,7 +784,7 @@ impl PerformanceService {
                 COUNT(*) as events
             FROM performance_metrics pm
             {}
-            WHERE {} AND pm.is_crawler = false
+            WHERE {}
             GROUP BY {}
             HAVING COUNT(*) >= 1
             ORDER BY events DESC, group_key
@@ -1110,6 +1131,7 @@ mod tests {
             None,
             Some("desktop".to_string()),
             &filters,
+            true, // include bots so no geo join is forced by bot exclusion
         );
         assert!(!needs_geo, "pm-only filters must not require the geo join");
         assert!(clause.contains("pm.pathname = $6"));
@@ -1130,10 +1152,43 @@ mod tests {
             None,
             None,
             &geo_filters,
+            true,
         );
         assert!(needs_geo, "geo filters must request the geo join");
         assert!(clause.contains("ig.country = $4"));
         assert_eq!(params.len(), 4);
+    }
+
+    #[test]
+    fn test_build_where_excludes_bots_by_default() {
+        use chrono::Utc;
+        let (clause, _, needs_geo) = PerformanceService::build_where(
+            1,
+            Utc::now(),
+            Utc::now(),
+            None,
+            None,
+            None,
+            &SpeedSegmentFilters::default(),
+            false,
+        );
+        assert!(clause.contains("pm.is_crawler = false"));
+        assert!(clause.contains("COALESCE(ig.is_hosting_provider, false) = false"));
+        assert!(needs_geo, "bot exclusion checks ig. and needs the geo join");
+
+        let (clause, _, needs_geo) = PerformanceService::build_where(
+            1,
+            Utc::now(),
+            Utc::now(),
+            None,
+            None,
+            None,
+            &SpeedSegmentFilters::default(),
+            true,
+        );
+        assert!(!clause.contains("is_crawler"));
+        assert!(!clause.contains("is_hosting_provider"));
+        assert!(!needs_geo);
     }
 
     #[test]

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -7301,6 +7301,10 @@ export type GroupedPageMetricsQuery = SpeedSegmentFilters & {
     end_date: string;
     environment_id?: number | null;
     group_by: string;
+    /**
+     * Include crawler/datacenter (bot) samples. Defaults to false.
+     */
+    include_bots?: boolean | null;
     project_id: number;
     start_date: string;
 };
@@ -10540,6 +10544,11 @@ export type PerformanceMetricsQuery = SpeedSegmentFilters & {
     device_type?: string | null;
     end_date: string;
     environment_id?: number | null;
+    /**
+     * Include crawler/datacenter (bot) samples. Defaults to false — bots
+     * are excluded from the read view but always stored at ingest.
+     */
+    include_bots?: boolean | null;
     project_id: number;
     start_date: string;
 };
@@ -32276,6 +32285,10 @@ export type GetPerformanceMetricsData = {
          */
         device_type?: string;
         /**
+         * Include crawler/datacenter bot samples (default false)
+         */
+        include_bots?: boolean;
+        /**
          * Filter to one page pathname (optional)
          */
         filter_path?: string;
@@ -32361,6 +32374,10 @@ export type GetMetricsOverTimeData = {
          * Device type filter: desktop or mobile (optional)
          */
         device_type?: string;
+        /**
+         * Include crawler/datacenter bot samples (default false)
+         */
+        include_bots?: boolean;
         /**
          * Filter to one page pathname (optional)
          */
@@ -32451,6 +32468,10 @@ export type GetGroupedPageMetricsData = {
          * Device type filter: desktop or mobile (optional)
          */
         device_type?: string;
+        /**
+         * Include crawler/datacenter bot samples (default false)
+         */
+        include_bots?: boolean;
         /**
          * Filter to one page pathname (optional)
          */

--- a/web/src/components/project/ProjectSpeedInsights.tsx
+++ b/web/src/components/project/ProjectSpeedInsights.tsx
@@ -325,6 +325,7 @@ interface SpeedBreakdownCardProps {
   startDate: string
   endDate: string
   device: 'desktop' | 'mobile'
+  includeBots: boolean
   filters: SpeedFilters
   onFilter: (key: keyof SpeedFilters, value: string) => void
 }
@@ -335,6 +336,7 @@ function SpeedBreakdownCard({
   startDate,
   endDate,
   device,
+  includeBots,
   filters,
   onFilter,
 }: SpeedBreakdownCardProps) {
@@ -348,6 +350,7 @@ function SpeedBreakdownCard({
         project_id: projectId,
         environment_id: environmentId!,
         device_type: device,
+        include_bots: includeBots,
         group_by: dimension,
         ...filters,
       },
@@ -478,6 +481,9 @@ export function ProjectSpeedInsights({ project }: ProjectSpeedInsightsProps) {
   const [timeRange, setTimeRange] = useState('7d')
   const [activeMetric, setActiveMetric] = useState<MetricKey>('lcp')
   const [filters, setFilters] = useState<SpeedFilters>({})
+  // Bots (crawler UAs + datacenter IPs) are always stored at ingest but
+  // hidden from this page by default — they report unrepresentative timings.
+  const [includeBots, setIncludeBots] = useState(false)
 
   const addFilter = (key: keyof SpeedFilters, value: string) =>
     setFilters((prev) => ({ ...prev, [key]: value }))
@@ -546,6 +552,7 @@ export function ProjectSpeedInsights({ project }: ProjectSpeedInsightsProps) {
         project_id: project.id,
         environment_id: selectedEnvironment!,
         device_type: device,
+        include_bots: includeBots,
         ...filters,
       },
     }),
@@ -798,6 +805,19 @@ export function ProjectSpeedInsights({ project }: ProjectSpeedInsightsProps) {
             </SelectContent>
           </Select>
 
+          <Select
+            value={includeBots ? 'all' : 'human'}
+            onValueChange={(v) => setIncludeBots(v === 'all')}
+          >
+            <SelectTrigger className="h-8 w-[130px] text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="human">Human traffic</SelectItem>
+              <SelectItem value="all">All traffic</SelectItem>
+            </SelectContent>
+          </Select>
+
           <Button
             variant="outline"
             size="sm"
@@ -959,6 +979,7 @@ export function ProjectSpeedInsights({ project }: ProjectSpeedInsightsProps) {
             startDate={startDate}
             endDate={endDate}
             device={device}
+            includeBots={includeBots}
             filters={filters}
             onCountryClick={(country) => addFilter('filter_country', country)}
           />
@@ -970,6 +991,7 @@ export function ProjectSpeedInsights({ project }: ProjectSpeedInsightsProps) {
             startDate={startDate}
             endDate={endDate}
             device={device}
+            includeBots={includeBots}
             filters={filters}
             onFilter={addFilter}
           />

--- a/web/src/components/project/SpeedWorldMap.tsx
+++ b/web/src/components/project/SpeedWorldMap.tsx
@@ -72,6 +72,7 @@ interface SpeedWorldMapProps {
   startDate: string
   endDate: string
   device: 'desktop' | 'mobile'
+  includeBots: boolean
   filters: Record<string, string | undefined>
   onCountryClick: (country: string) => void
 }
@@ -89,6 +90,7 @@ export function SpeedWorldMap({
   startDate,
   endDate,
   device,
+  includeBots,
   filters,
   onCountryClick,
 }: SpeedWorldMapProps) {
@@ -103,6 +105,7 @@ export function SpeedWorldMap({
         project_id: projectId,
         environment_id: environmentId!,
         device_type: device,
+        include_bots: includeBots,
         group_by: 'country',
         ...filters,
       },


### PR DESCRIPTION
Stacked on #284 (world map). Completes the Speed page sequence: repair + geo + filters (#282) → map (#284) → **bot filtering (this)**.

## Approach: classify, don't drop

Nothing changes at ingest — every sample is still stored. The read endpoints gain `include_bots` (default `false`):

- `pm.is_crawler = false` (woothee UA classification, as before)
- `COALESCE(ig.is_hosting_provider, false) = false` — the ASN-based datacenter flag added for live visitors in #281. This is the signal that actually catches the problem cohort: headless Chrome on cloud VMs sends a normal Chrome UA but reports ~10s TTFBs (~28% of temps-landing samples)

## UI

A **Human traffic / All traffic** selector next to the time-range picker, applied to the score ring, p75 tiles, trend, world map and breakdown together. Default is Human traffic, so the dashboard reflects real users out of the box — while the bot view stays one click away.

## Behavior change worth noting

`/performance/metrics` and `/performance/metrics-over-time` previously included crawler samples (only the grouped endpoint filtered them). With the new default all three exclude crawler + datacenter samples unless `include_bots=true` — intended, but dashboard numbers will shift (for temps-landing, in the honest direction).

## Verification

- `cargo test --lib -p temps-analytics-performance` 6/6 (new tests pin the bot-exclusion clause and geo-join requirement); clippy `--all-targets -D warnings` clean; `tsc` + `rsbuild build` clean
- Live: flagged the seeded US IP as `is_hosting_provider` → the default view drops the US from the map/countries (only ES/DE remain); switching to All traffic restores it