### PR TITLE
chore(sdk): bump analytics-browser, kv, blob, node-sdk for npm publish

### DIFF
--- a/sdks/node/packages/analytics-browser/package.json
+++ b/sdks/node/packages/analytics-browser/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temps-sdk/analytics-browser",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"description": "Vanilla JS analytics SDK for Temps. Use as a script tag or import programmatically.",
 	"private": false,
 	"type": "module",

--- a/sdks/node/packages/blob/package.json
+++ b/sdks/node/packages/blob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temps-sdk/blob",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Blob storage SDK for the Temps platform",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/sdks/node/packages/kv/package.json
+++ b/sdks/node/packages/kv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temps-sdk/kv",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Key-Value store SDK for Temps platform",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/sdks/node/packages/node-sdk/package.json
+++ b/sdks/node/packages/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temps-sdk/node-sdk",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bumps ahead of an npm publish round:

- **analytics-browser 0.0.1 → 0.0.2** — the 0.0.1 tarball on npm is broken: it was published with raw `npm publish`, which leaked the literal `workspace:*` protocol for `@temps-sdk/analytics-core` (itself never published), so `npm install @temps-sdk/analytics-browser` fails. 0.0.2 will be published with `bun publish`, which rewrites `workspace:*` to the real version (verified via `bun pm pack` tarball inspection).
- **kv 0.0.3 → 0.0.4, blob 0.0.3 → 0.0.4, node-sdk 0.0.4 → 0.0.5** — npm versions collide with local; dependency-update commits landed since the last publish.

No code changes. All eight sdks/node packages build clean after the bumps.