### PR TITLE
fix(providers): reject client-supplied internal-only fields on external-service create

### DIFF
--- a/crates/temps-providers/src/externalsvc/mariadb.rs
+++ b/crates/temps-providers/src/externalsvc/mariadb.rs
@@ -4710,4 +4710,37 @@ mod tests {
             "container_name leaked into the MariaDB create schema"
         );
     }
+
+    /// Regression guard for the cross-tenant IDOR: a client-supplied
+    /// `container_name` in a create request would make every subsequent Docker
+    /// operation (start, exec, backup, restore) target that named container
+    /// instead of creating a new one. Because Docker names are global and
+    /// predictable (`mariadb-{slug}`), this lets a tenant redirect operations
+    /// to a different tenant's live database container.
+    ///
+    /// The schema-level `#[schemars(skip)]` only hides the field from the UI
+    /// form — it does NOT stop `serde_json::from_value` from deserialising a
+    /// client-supplied value. `validate_for_creation` must reject it explicitly.
+    #[test]
+    fn test_container_name_rejected_by_validate_for_creation() {
+        use crate::parameter_strategies::MariaDbParameterStrategy;
+        let strategy = MariaDbParameterStrategy;
+        let mut params = std::collections::HashMap::new();
+        params.insert(
+            "container_name".to_string(),
+            serde_json::Value::String("mariadb-victim-slug".to_string()),
+        );
+        let result = crate::parameter_strategies::ParameterStrategy::validate_for_creation(
+            &strategy, &params,
+        );
+        assert!(
+            result.is_err(),
+            "validate_for_creation must reject a client-supplied container_name"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("container_name"),
+            "error message should mention 'container_name', got: {err}"
+        );
+    }
 }

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -5279,6 +5279,47 @@ mod tests {
         );
     }
 
+    /// Regression guard for the cross-tenant IDOR: a client-supplied
+    /// `container_name` in a create request would make every subsequent Docker
+    /// operation (start, exec, backup, restore) target that named container
+    /// instead of creating a new one. Because Docker names are global and
+    /// predictable (`postgres-{slug}`), this lets a tenant redirect operations
+    /// to a different tenant's live database container.
+    ///
+    /// The schema-level `#[schemars(skip)]` only hides the field from the UI
+    /// form — it does NOT stop `serde_json::from_value` from deserialising a
+    /// client-supplied value. `validate_for_creation` must reject it explicitly.
+    #[test]
+    fn test_container_name_rejected_by_validate_for_creation() {
+        use crate::parameter_strategies::PostgresParameterStrategy;
+        let strategy = PostgresParameterStrategy;
+        let mut params = std::collections::HashMap::new();
+        params.insert(
+            "database".to_string(),
+            serde_json::Value::String("mydb".to_string()),
+        );
+        params.insert(
+            "username".to_string(),
+            serde_json::Value::String("myuser".to_string()),
+        );
+        params.insert(
+            "container_name".to_string(),
+            serde_json::Value::String("postgres-victim-slug".to_string()),
+        );
+        let result = crate::parameter_strategies::ParameterStrategy::validate_for_creation(
+            &strategy, &params,
+        );
+        assert!(
+            result.is_err(),
+            "validate_for_creation must reject a client-supplied container_name"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("container_name"),
+            "error message should mention 'container_name', got: {err}"
+        );
+    }
+
     #[test]
     fn test_get_environment_variables_always_uses_container_name() {
         // get_environment_variables always uses container name and internal port

--- a/crates/temps-providers/src/parameter_strategies.rs
+++ b/crates/temps-providers/src/parameter_strategies.rs
@@ -213,6 +213,25 @@ fn validate_service_resource_limits(params: &HashMap<String, JsonValue>) -> Resu
         .map_err(|e| format!("invalid 'resources' block: {}", e))
 }
 
+/// `container_name` is an internal-only field set exclusively by each
+/// provider's `import_from_container()` (never through the public create
+/// API — see `*InputConfig::container_name` doc comments). A client
+/// supplying it at creation time could make Docker operations target an
+/// existing container instead of creating a new one — including another
+/// tenant's container, since Docker names are global and predictable
+/// (`{service}-{slug}`). `validate_for_update` already blocks this via its
+/// updateable-keys allowlist; this closes the matching gap on create.
+fn reject_client_supplied_container_name(
+    params: &HashMap<String, JsonValue>,
+) -> Result<(), String> {
+    if params.contains_key("container_name") {
+        return Err(
+            "'container_name' cannot be set by the client — it is assigned internally only when importing an existing container".to_string(),
+        );
+    }
+    Ok(())
+}
+
 /// Strategy for validating and managing parameters for a specific service type
 pub trait ParameterStrategy: Send + Sync {
     /// Validate parameters for service creation - ensures all required parameters are present
@@ -249,6 +268,7 @@ pub struct PostgresParameterStrategy;
 
 impl ParameterStrategy for PostgresParameterStrategy {
     fn validate_for_creation(&self, params: &HashMap<String, JsonValue>) -> Result<(), String> {
+        reject_client_supplied_container_name(params)?;
         if !params.contains_key("database") || is_empty_value(params.get("database")) {
             return Err("'database' is required for PostgreSQL".to_string());
         }
@@ -380,6 +400,7 @@ pub struct MariaDbParameterStrategy;
 
 impl ParameterStrategy for MariaDbParameterStrategy {
     fn validate_for_creation(&self, params: &HashMap<String, JsonValue>) -> Result<(), String> {
+        reject_client_supplied_container_name(params)?;
         validate_mariadb_credentials(params)?;
         mariadb_size_profile_from_params(params)?;
         validate_service_resource_limits(params)?;
@@ -549,7 +570,8 @@ impl ParameterStrategy for MariaDbParameterStrategy {
 pub struct RedisParameterStrategy;
 
 impl ParameterStrategy for RedisParameterStrategy {
-    fn validate_for_creation(&self, _params: &HashMap<String, JsonValue>) -> Result<(), String> {
+    fn validate_for_creation(&self, params: &HashMap<String, JsonValue>) -> Result<(), String> {
+        reject_client_supplied_container_name(params)?;
         // Redis doesn't require parameters for creation
         Ok(())
     }
@@ -642,7 +664,8 @@ impl ParameterStrategy for RedisParameterStrategy {
 pub struct S3ParameterStrategy;
 
 impl ParameterStrategy for S3ParameterStrategy {
-    fn validate_for_creation(&self, _params: &HashMap<String, JsonValue>) -> Result<(), String> {
+    fn validate_for_creation(&self, params: &HashMap<String, JsonValue>) -> Result<(), String> {
+        reject_client_supplied_container_name(params)?;
         // S3/RustFS doesn't require parameters for creation
         Ok(())
     }
@@ -811,7 +834,8 @@ impl ParameterStrategy for S3ParameterStrategy {
 pub struct MinioParameterStrategy;
 
 impl ParameterStrategy for MinioParameterStrategy {
-    fn validate_for_creation(&self, _params: &HashMap<String, JsonValue>) -> Result<(), String> {
+    fn validate_for_creation(&self, params: &HashMap<String, JsonValue>) -> Result<(), String> {
+        reject_client_supplied_container_name(params)?;
         // MinIO doesn't require parameters for creation
         Ok(())
     }
@@ -925,7 +949,8 @@ impl ParameterStrategy for MinioParameterStrategy {
 pub struct RustfsParameterStrategy;
 
 impl ParameterStrategy for RustfsParameterStrategy {
-    fn validate_for_creation(&self, _params: &HashMap<String, JsonValue>) -> Result<(), String> {
+    fn validate_for_creation(&self, params: &HashMap<String, JsonValue>) -> Result<(), String> {
+        reject_client_supplied_container_name(params)?;
         // RustFS doesn't require parameters for creation
         Ok(())
     }
@@ -1089,6 +1114,7 @@ pub struct MongodbParameterStrategy;
 
 impl ParameterStrategy for MongodbParameterStrategy {
     fn validate_for_creation(&self, params: &HashMap<String, JsonValue>) -> Result<(), String> {
+        reject_client_supplied_container_name(params)?;
         if !params.contains_key("database") || is_empty_value(params.get("database")) {
             return Err("'database' is required for MongoDB".to_string());
         }
@@ -1629,6 +1655,136 @@ mod tests {
 
         let ok = pg_params("postgres", "myapp", Some("strong_password_456!"));
         assert!(strategy.validate_for_creation(&ok).is_ok());
+    }
+
+    // ─── container_name IDOR guard ─────────────────────────────────────
+    //
+    // `container_name` is internal-only (set by `import_from_container()`).
+    // A client including it in a create request could redirect every Docker
+    // operation to an existing container — including a different tenant's,
+    // since Docker names are global and predictable (`{service}-{slug}`).
+    // These tests confirm that every strategy's `validate_for_creation`
+    // rejects the field before anything is persisted.
+
+    #[test]
+    fn postgres_rejects_client_supplied_container_name() {
+        let strategy = PostgresParameterStrategy;
+        let mut params = HashMap::new();
+        params.insert(
+            "database".to_string(),
+            JsonValue::String("mydb".to_string()),
+        );
+        params.insert(
+            "username".to_string(),
+            JsonValue::String("user".to_string()),
+        );
+        params.insert(
+            "container_name".to_string(),
+            JsonValue::String("postgres-victim-slug".to_string()),
+        );
+        let err = strategy.validate_for_creation(&params).unwrap_err();
+        assert!(
+            err.contains("container_name"),
+            "error should mention 'container_name', got: {err}"
+        );
+    }
+
+    #[test]
+    fn mariadb_rejects_client_supplied_container_name() {
+        let strategy = MariaDbParameterStrategy;
+        let mut params = HashMap::new();
+        params.insert(
+            "container_name".to_string(),
+            JsonValue::String("mariadb-victim-slug".to_string()),
+        );
+        let err = strategy.validate_for_creation(&params).unwrap_err();
+        assert!(
+            err.contains("container_name"),
+            "error should mention 'container_name', got: {err}"
+        );
+    }
+
+    #[test]
+    fn redis_rejects_client_supplied_container_name() {
+        let strategy = RedisParameterStrategy;
+        let mut params = HashMap::new();
+        params.insert(
+            "container_name".to_string(),
+            JsonValue::String("redis-victim-slug".to_string()),
+        );
+        let err = strategy.validate_for_creation(&params).unwrap_err();
+        assert!(
+            err.contains("container_name"),
+            "error should mention 'container_name', got: {err}"
+        );
+    }
+
+    #[test]
+    fn s3_rejects_client_supplied_container_name() {
+        let strategy = S3ParameterStrategy;
+        let mut params = HashMap::new();
+        params.insert(
+            "container_name".to_string(),
+            JsonValue::String("rustfs-victim-slug".to_string()),
+        );
+        let err = strategy.validate_for_creation(&params).unwrap_err();
+        assert!(
+            err.contains("container_name"),
+            "error should mention 'container_name', got: {err}"
+        );
+    }
+
+    #[test]
+    fn minio_rejects_client_supplied_container_name() {
+        let strategy = MinioParameterStrategy;
+        let mut params = HashMap::new();
+        params.insert(
+            "container_name".to_string(),
+            JsonValue::String("minio-victim-slug".to_string()),
+        );
+        let err = strategy.validate_for_creation(&params).unwrap_err();
+        assert!(
+            err.contains("container_name"),
+            "error should mention 'container_name', got: {err}"
+        );
+    }
+
+    #[test]
+    fn rustfs_rejects_client_supplied_container_name() {
+        let strategy = RustfsParameterStrategy;
+        let mut params = HashMap::new();
+        params.insert(
+            "container_name".to_string(),
+            JsonValue::String("rustfs-victim-slug".to_string()),
+        );
+        let err = strategy.validate_for_creation(&params).unwrap_err();
+        assert!(
+            err.contains("container_name"),
+            "error should mention 'container_name', got: {err}"
+        );
+    }
+
+    #[test]
+    fn mongodb_rejects_client_supplied_container_name() {
+        let strategy = MongodbParameterStrategy;
+        let mut params = HashMap::new();
+        params.insert(
+            "database".to_string(),
+            JsonValue::String("mydb".to_string()),
+        );
+        params.insert(
+            "username".to_string(),
+            JsonValue::String("user".to_string()),
+        );
+        params.insert(
+            "container_name".to_string(),
+            JsonValue::String("mongodb-victim-slug".to_string()),
+        );
+        let err = strategy.validate_for_creation(&params).unwrap_err();
+        assert!(
+            err.contains("container_name"),
+            "error should mention 'container_name', got: {err}"
+        );
     }
 
     /// Regression: the UI and the parameter schema both promise users that

--- a/crates/temps-providers/src/parameter_strategies.rs
+++ b/crates/temps-providers/src/parameter_strategies.rs
@@ -213,21 +213,36 @@ fn validate_service_resource_limits(params: &HashMap<String, JsonValue>) -> Resu
         .map_err(|e| format!("invalid 'resources' block: {}", e))
 }
 
-/// `container_name` is an internal-only field set exclusively by each
-/// provider's `import_from_container()` (never through the public create
-/// API — see `*InputConfig::container_name` doc comments). A client
-/// supplying it at creation time could make Docker operations target an
-/// existing container instead of creating a new one — including another
-/// tenant's container, since Docker names are global and predictable
-/// (`{service}-{slug}`). `validate_for_update` already blocks this via its
-/// updateable-keys allowlist; this closes the matching gap on create.
-fn reject_client_supplied_container_name(
+/// Reject a set of internal-only fields that must never arrive from the
+/// client on a create request.
+///
+/// Each key in `forbidden` maps to a field that is populated exclusively by
+/// server-side logic:
+///
+/// - `container_name` — set only by `import_from_container()`.  A client
+///   supplying it could redirect every Docker operation to an existing
+///   container — including another tenant's, since Docker names are global
+///   and predictable (`{service}-{slug}`).  This is an IDOR.
+///
+/// - `metrics_ingest_key` / `metrics_ingest_url` — set only by the internal
+///   `store_and_apply_ingest_key` path when metrics are enabled.  A client
+///   supplying both at creation time makes the RustFS container push OTLP
+///   metrics (with a client-controlled bearer token) to a client-controlled
+///   URL from inside the Docker bridge network — SSRF and metrics-stream
+///   poisoning.
+///
+/// `validate_for_update` already blocks these via its updateable-keys
+/// allowlist; this closes the matching gap on create.
+fn reject_internal_only_keys(
     params: &HashMap<String, JsonValue>,
+    forbidden: &[&str],
 ) -> Result<(), String> {
-    if params.contains_key("container_name") {
-        return Err(
-            "'container_name' cannot be set by the client — it is assigned internally only when importing an existing container".to_string(),
-        );
+    for &key in forbidden {
+        if params.contains_key(key) {
+            return Err(format!(
+                "'{key}' cannot be set by the client — it is assigned internally only"
+            ));
+        }
     }
     Ok(())
 }
@@ -268,7 +283,7 @@ pub struct PostgresParameterStrategy;
 
 impl ParameterStrategy for PostgresParameterStrategy {
     fn validate_for_creation(&self, params: &HashMap<String, JsonValue>) -> Result<(), String> {
-        reject_client_supplied_container_name(params)?;
+        reject_internal_only_keys(params, &["container_name"])?;
         if !params.contains_key("database") || is_empty_value(params.get("database")) {
             return Err("'database' is required for PostgreSQL".to_string());
         }
@@ -400,7 +415,7 @@ pub struct MariaDbParameterStrategy;
 
 impl ParameterStrategy for MariaDbParameterStrategy {
     fn validate_for_creation(&self, params: &HashMap<String, JsonValue>) -> Result<(), String> {
-        reject_client_supplied_container_name(params)?;
+        reject_internal_only_keys(params, &["container_name"])?;
         validate_mariadb_credentials(params)?;
         mariadb_size_profile_from_params(params)?;
         validate_service_resource_limits(params)?;
@@ -571,7 +586,7 @@ pub struct RedisParameterStrategy;
 
 impl ParameterStrategy for RedisParameterStrategy {
     fn validate_for_creation(&self, params: &HashMap<String, JsonValue>) -> Result<(), String> {
-        reject_client_supplied_container_name(params)?;
+        reject_internal_only_keys(params, &["container_name"])?;
         // Redis doesn't require parameters for creation
         Ok(())
     }
@@ -665,8 +680,16 @@ pub struct S3ParameterStrategy;
 
 impl ParameterStrategy for S3ParameterStrategy {
     fn validate_for_creation(&self, params: &HashMap<String, JsonValue>) -> Result<(), String> {
-        reject_client_supplied_container_name(params)?;
-        // S3/RustFS doesn't require parameters for creation
+        // service_type "s3" validates here but the container is created via
+        // RustfsService, which deserializes params into RustfsInputConfig.
+        // Reject all internal-only fields that RustfsInputConfig exposes so
+        // that neither the direct rustfs/blob path nor this s3 path can be
+        // used to supply a client-controlled OTLP target (SSRF) or bearer
+        // token (metrics-stream poisoning).
+        reject_internal_only_keys(
+            params,
+            &["container_name", "metrics_ingest_key", "metrics_ingest_url"],
+        )?;
         Ok(())
     }
 
@@ -835,7 +858,7 @@ pub struct MinioParameterStrategy;
 
 impl ParameterStrategy for MinioParameterStrategy {
     fn validate_for_creation(&self, params: &HashMap<String, JsonValue>) -> Result<(), String> {
-        reject_client_supplied_container_name(params)?;
+        reject_internal_only_keys(params, &["container_name"])?;
         // MinIO doesn't require parameters for creation
         Ok(())
     }
@@ -950,8 +973,10 @@ pub struct RustfsParameterStrategy;
 
 impl ParameterStrategy for RustfsParameterStrategy {
     fn validate_for_creation(&self, params: &HashMap<String, JsonValue>) -> Result<(), String> {
-        reject_client_supplied_container_name(params)?;
-        // RustFS doesn't require parameters for creation
+        reject_internal_only_keys(
+            params,
+            &["container_name", "metrics_ingest_key", "metrics_ingest_url"],
+        )?;
         Ok(())
     }
 
@@ -1114,7 +1139,7 @@ pub struct MongodbParameterStrategy;
 
 impl ParameterStrategy for MongodbParameterStrategy {
     fn validate_for_creation(&self, params: &HashMap<String, JsonValue>) -> Result<(), String> {
-        reject_client_supplied_container_name(params)?;
+        reject_internal_only_keys(params, &["container_name"])?;
         if !params.contains_key("database") || is_empty_value(params.get("database")) {
             return Err("'database' is required for MongoDB".to_string());
         }
@@ -1784,6 +1809,71 @@ mod tests {
         assert!(
             err.contains("container_name"),
             "error should mention 'container_name', got: {err}"
+        );
+    }
+
+    // ─── RustFS metrics-field SSRF / metrics-poisoning guard ──────────────
+    //
+    // `metrics_ingest_key` and `metrics_ingest_url` are internal-only fields
+    // on `RustfsInputConfig`. When both are present, `RustfsService::init()`
+    // sets `RUSTFS_OBS_METRIC_ENDPOINT` and
+    // `RUSTFS_OBS_ENDPOINT_METRICS_HEADERS` on the container, making it push
+    // OTLP metrics to a client-controlled URL with a client-controlled bearer
+    // token — SSRF from inside the Docker bridge network, and metrics-stream
+    // poisoning if the attacker holds another tenant's ingest key.
+    //
+    // The routing detail that makes the S3 test load-bearing: a create
+    // request with `service_type: "s3"` is validated by
+    // `S3ParameterStrategy::validate_for_creation` but the container is
+    // actually started via `RustfsService`, which deserializes the stored
+    // params HashMap into `RustfsInputConfig`.  Closing the guard only on
+    // `RustfsParameterStrategy` would leave the s3 path open.
+
+    #[test]
+    fn rustfs_rejects_client_supplied_metrics_ingest_key() {
+        let strategy = RustfsParameterStrategy;
+        let mut params = HashMap::new();
+        params.insert(
+            "metrics_ingest_key".to_string(),
+            JsonValue::String("si_attacker_controlled_key".to_string()),
+        );
+        let err = strategy.validate_for_creation(&params).unwrap_err();
+        assert!(
+            err.contains("metrics_ingest_key"),
+            "error should mention 'metrics_ingest_key', got: {err}"
+        );
+    }
+
+    #[test]
+    fn rustfs_rejects_client_supplied_metrics_ingest_url() {
+        let strategy = RustfsParameterStrategy;
+        let mut params = HashMap::new();
+        params.insert(
+            "metrics_ingest_url".to_string(),
+            JsonValue::String("http://attacker.internal/collect".to_string()),
+        );
+        let err = strategy.validate_for_creation(&params).unwrap_err();
+        assert!(
+            err.contains("metrics_ingest_url"),
+            "error should mention 'metrics_ingest_url', got: {err}"
+        );
+    }
+
+    /// The routing-bypass test: service_type "s3" goes through
+    /// `S3ParameterStrategy` but the container runs as `RustfsService`, so
+    /// the s3 strategy must also block the RustFS-specific internal fields.
+    #[test]
+    fn s3_rejects_client_supplied_metrics_ingest_key() {
+        let strategy = S3ParameterStrategy;
+        let mut params = HashMap::new();
+        params.insert(
+            "metrics_ingest_key".to_string(),
+            JsonValue::String("si_attacker_controlled_key".to_string()),
+        );
+        let err = strategy.validate_for_creation(&params).unwrap_err();
+        assert!(
+            err.contains("metrics_ingest_key"),
+            "error should mention 'metrics_ingest_key', got: {err}"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes a critical cross-tenant IDOR in external-service creation, plus a sibling SSRF/metrics-poisoning gap of the same class found during review.

Every external-service `*InputConfig` struct (Postgres, MariaDB, MongoDB, Redis, S3/RustFS) has internal-only fields meant to be set exclusively by server-side logic — never by the client:

- **`container_name`** — set only by each provider's `import_from_container()`, to point Docker operations at a pre-existing imported container.
- **`metrics_ingest_key` / `metrics_ingest_url`** (RustFS only) — set only by the internal ingest-key provisioning path, to configure where the container pushes OTLP metrics.

These fields are annotated `#[schemars(skip)]`, which only hides them from the create-form JSON schema shown in the UI — it does **not** stop `serde_json::from_value` from deserializing a client-supplied value for them. `validate_for_creation` (the gate before a create request's raw parameters are persisted) never checked for these keys at all; it only checked that required keys were present.

- **`container_name`**: since Docker container names are global and predictable (`{service}-{slug}`), a user creating a service in their own project could set `container_name` to another tenant's container name. Every subsequent Docker operation (start, backup, browse/exec, restore) would then target the victim's existing container instead of creating a new one — full cross-tenant compromise.
- **`metrics_ingest_key` / `metrics_ingest_url`**: a client supplying both makes the RustFS container push OTLP metrics — with a client-controlled bearer token — to a client-controlled URL from inside the Docker bridge network (SSRF), and can poison another tenant's metrics stream if the attacker already holds their key.

Notably, a create request with `service_type: "s3"` (the default managed-S3 backend) is validated by `S3ParameterStrategy`, but the actual container is created via `RustfsService`, which deserializes into `RustfsInputConfig` — so the metrics fields needed to be rejected on **both** the `rustfs`/`blob` path and the `s3` path.

`validate_for_update` already allowlists updateable keys and was never vulnerable to this — only `create` was unguarded.

## Fix

Added `reject_internal_only_keys(params, forbidden)` in `parameter_strategies.rs`, called as the first check in every `ParameterStrategy::validate_for_creation` impl with the appropriate forbidden-key list per service type. `import_from_container` and the internal ingest-key provisioning path are untouched — they don't go through `validate_for_creation`, so legitimate internal use of these fields is unaffected.

## Test plan

- [x] `cargo check --lib` — clean, 0 errors
- [x] New regression tests per strategy asserting `validate_for_creation` rejects each internal-only key, including the `s3`-strategy routing-bypass case for the RustFS metrics fields
- [x] `cargo test -p temps-providers parameter_strategies` — 34 passed
- [x] `cargo test -p temps-providers container_name` — 27 passed
- [x] Reviewed by `security-auditor` (found the RustFS metrics sibling gap, now also fixed in this PR)