### PR TITLE
fix(metrics): checkpoint stats query fails to parse on PG17+

### DIFF
--- a/crates/temps-metrics/src/collector/postgres.rs
+++ b/crates/temps-metrics/src/collector/postgres.rs
@@ -620,23 +620,43 @@ async fn collect_metrics(
     // 4. Checkpoint counts (Counter)
     // PG17+ moved checkpoint stats to pg_stat_checkpointer; fall back to
     // pg_stat_bgwriter on older versions.
+    //
+    // This can't be done as a single UNION ALL query: Postgres resolves
+    // column references in every arm of a UNION at parse time, so an arm
+    // referencing pg_stat_bgwriter.checkpoints_timed/checkpoints_req fails
+    // to parse on PG17+ (where those columns were dropped) even though a
+    // `WHERE NOT EXISTS` would have skipped it at runtime. Check which view
+    // exists first, then issue only the matching query.
     // -------------------------------------------------------------------------
     {
-        let rows = client
-            .query(
-                "SELECT num_timed, num_requested \
-                 FROM pg_stat_checkpointer \
-                 UNION ALL \
-                 SELECT checkpoints_timed, checkpoints_req \
-                 FROM pg_stat_bgwriter \
-                 WHERE NOT EXISTS (SELECT 1 FROM pg_stat_checkpointer) \
-                 LIMIT 1",
+        let has_checkpointer_view = client
+            .query_one(
+                "SELECT to_regclass('pg_stat_checkpointer') IS NOT NULL",
                 &[],
             )
             .await
-            // If both views fail (very old PG), skip gracefully rather than
-            // aborting the entire collection cycle.
-            .unwrap_or_default();
+            .map(|row| row.get::<_, bool>(0))
+            .unwrap_or(false);
+
+        let query_result = if has_checkpointer_view {
+            client
+                .query(
+                    "SELECT num_timed, num_requested FROM pg_stat_checkpointer",
+                    &[],
+                )
+                .await
+        } else {
+            client
+                .query(
+                    "SELECT checkpoints_timed, checkpoints_req FROM pg_stat_bgwriter",
+                    &[],
+                )
+                .await
+        };
+
+        // If both views fail (very old PG), skip gracefully rather than
+        // aborting the entire collection cycle.
+        let rows = query_result.unwrap_or_default();
 
         if let Some(row) = rows.first() {
             let timed: i64 = row.get(0);


### PR DESCRIPTION
## Summary
- The Postgres metrics collector's checkpoint-stats query used a single `UNION ALL` to try `pg_stat_checkpointer` (PG17+) and fall back to `pg_stat_bgwriter` (older versions) in one statement, gated by `WHERE NOT EXISTS`.
- Postgres resolves column references in *every* arm of a `UNION` at parse time, regardless of which arm the `WHERE NOT EXISTS` would select at runtime. On PG17+, `pg_stat_bgwriter.checkpoints_timed`/`checkpoints_req` no longer exist (moved to `pg_stat_checkpointer.num_timed`/`num_requested`), so the whole statement failed to parse.
- Observed in prod: `ERROR: column "checkpoints_timed" does not exist` logged every scrape cycle (~30s), and `pg.checkpoints_timed_total`/`pg.checkpoints_req_total`/`pg.checkpoint_rate` silently missing from dashboards on PG17+ since the query returned zero rows via `unwrap_or_default()`.
- Fix: check `pg_stat_checkpointer`'s existence via `to_regclass()` first, then issue only the single matching query — no more UNION across schema versions.

## Test plan
- [x] `cargo check --lib -p temps-metrics` — no errors in `postgres.rs` (crate-wide check is blocked by a pre-existing, unrelated `bson` version-mismatch error in `mongodb.rs`, confirmed present on `origin/main` before this change too)
- [ ] Regression test tracked separately (stacked PR) using a real PG17 container to assert the query no longer errors