### PR TITLE
fix(metrics): temps-metrics fails to compile due to bson version mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12158,7 +12158,6 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
- "bson 3.1.0",
  "chrono",
  "clickhouse",
  "libc",

--- a/crates/temps-metrics/Cargo.toml
+++ b/crates/temps-metrics/Cargo.toml
@@ -29,9 +29,10 @@ temps-entities = { path = "../temps-entities" }
 # Postgres collector
 tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
 
-# MongoDB collector
+# MongoDB collector. Use mongodb's own re-exported `mongodb::bson` types
+# rather than a standalone `bson` dependency — a standalone version can drift
+# out of sync with whatever bson version `mongodb` pins internally.
 mongodb = "3.7.0"
-bson = "3.1"
 
 # Redis collector
 redis = { workspace = true }

--- a/crates/temps-metrics/src/collector/mongodb.rs
+++ b/crates/temps-metrics/src/collector/mongodb.rs
@@ -39,8 +39,8 @@
 //! the scraper loop is never blocked by a slow or unreachable MongoDB instance.
 
 use async_trait::async_trait;
-use bson::doc;
 use chrono::Utc;
+use mongodb::bson::doc;
 use mongodb::{options::ClientOptions, Client};
 use std::collections::HashMap;
 use tracing::{debug, warn};
@@ -146,7 +146,7 @@ async fn run_server_status(
 }
 
 /// Extract metric points from a `serverStatus` BSON document.
-fn extract_metrics(doc: &bson::Document, config: &CollectorConfig) -> Vec<MetricPoint> {
+fn extract_metrics(doc: &mongodb::bson::Document, config: &CollectorConfig) -> Vec<MetricPoint> {
     let mut points: Vec<MetricPoint> = Vec::with_capacity(16);
     let now = Utc::now();
 
@@ -400,11 +400,11 @@ fn extract_metrics(doc: &bson::Document, config: &CollectorConfig) -> Vec<Metric
 /// the underlying BSON type is `Int32`, `Int64`, or `Double`.
 ///
 /// Returns `None` if the field is absent or cannot be converted to `f64`.
-fn bson_to_f64(doc: &bson::Document, key: &str) -> Option<f64> {
+fn bson_to_f64(doc: &mongodb::bson::Document, key: &str) -> Option<f64> {
     match doc.get(key) {
-        Some(bson::Bson::Int32(v)) => Some(*v as f64),
-        Some(bson::Bson::Int64(v)) => Some(*v as f64),
-        Some(bson::Bson::Double(v)) => Some(*v),
+        Some(mongodb::bson::Bson::Int32(v)) => Some(*v as f64),
+        Some(mongodb::bson::Bson::Int64(v)) => Some(*v as f64),
+        Some(mongodb::bson::Bson::Double(v)) => Some(*v),
         _ => None,
     }
 }
@@ -413,7 +413,7 @@ fn bson_to_f64(doc: &bson::Document, key: &str) -> Option<f64> {
 mod tests {
     use super::*;
     use crate::store::SourceKind;
-    use bson::doc;
+    use mongodb::bson::doc;
     use std::time::Duration;
 
     fn make_config() -> CollectorConfig {


### PR DESCRIPTION
## Summary
- `temps-metrics/Cargo.toml` pinned a standalone `bson = "3.1"` dependency alongside `mongodb = "3.7.0"`, which internally requires bson 2.x.
- `mongodb.rs` used the standalone `bson` crate's `Document`/`Bson` types, but `mongodb::Database::run_command()` returns `mongodb::bson::Document` — nominally distinct from the standalone crate's type even though structurally identical. This has been failing `cargo check --lib -p temps-metrics` (and `--tests`) on `main` since the dependency bump.
- Root cause: dependabot PR #243 ("bump bson from 2.15.0 to 3.1.0") bumped the standalone dependency without visibility into the fact that `mongodb.rs` needs to match whatever bson version `mongodb` re-exports internally — a version-drift trap for any future dependabot bump of either crate.
- Discovered while working on #290 (checkpoint-stats query fix, also in `temps-metrics`) — that PR's diff is unrelated to this bug, but the crate wouldn't compile for CI regardless.

## Fix
- Switched `mongodb.rs` to `mongodb::bson::{doc, Document, Bson}` (the re-exported types, guaranteed consistent with whatever `mongodb` uses internally) instead of the standalone `bson` crate.
- Dropped the standalone `bson` dependency from `temps-metrics/Cargo.toml` entirely so this can't drift out of sync again on a future bump.

## Test plan
- [x] `cargo check --lib --tests -p temps-metrics` passes
- [x] `cargo test --lib -p temps-metrics` — 99 passed, 0 failed