### PR TITLE
fix(migrations): skip empty visitor deduplication rewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **No-op visitor deduplication migration**: `m20260705_000001_add_visitor_unique_index` now skips bulk foreign-key rewrites when no duplicate `(visitor_id, project_id)` pairs exist, preventing TimescaleDB from eagerly decompressing unrelated hypertable chunks and exceeding `timescaledb.max_tuples_decompressed_per_dml_transaction` during upgrades.
+
 ## [0.1.0-beta.46] - 2026-07-12
 
 ### Added

--- a/crates/temps-migrations/src/migration/m20260705_000001_add_visitor_unique_index.rs
+++ b/crates/temps-migrations/src/migration/m20260705_000001_add_visitor_unique_index.rs
@@ -1,3 +1,4 @@
+use sea_orm::Statement;
 use sea_orm_migration::prelude::*;
 
 /// Migration: add a UNIQUE index on visitor(visitor_id, project_id).
@@ -29,6 +30,12 @@ use sea_orm_migration::prelude::*;
 /// Down removes the index (does NOT restore deleted rows).
 pub struct Migration;
 
+const CREATE_UNIQUE_INDEX_SQL: &str = r#"
+    CREATE UNIQUE INDEX IF NOT EXISTS
+        visitor_visitor_id_project_id_key
+    ON visitor (visitor_id, project_id);
+"#;
+
 impl MigrationName for Migration {
     fn name(&self) -> &str {
         "m20260705_000001_add_visitor_unique_index"
@@ -38,6 +45,38 @@ impl MigrationName for Migration {
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let connection = manager.get_connection();
+        let duplicate_check = connection
+            .query_one(Statement::from_string(
+                manager.get_database_backend(),
+                r#"
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM visitor
+                    GROUP BY visitor_id, project_id
+                    HAVING COUNT(*) > 1
+                ) AS has_duplicates;
+                "#,
+            ))
+            .await?
+            .ok_or_else(|| {
+                DbErr::Custom(
+                    "m20260705_000001: duplicate visitor check returned no row".to_string(),
+                )
+            })?;
+        let has_duplicates: bool = duplicate_check.try_get("", "has_duplicates")?;
+
+        // TimescaleDB may decompress hypertable chunks eagerly for UPDATE even
+        // when the join source is empty. Avoid touching the eight referencing
+        // tables when the visitor table is already unique; otherwise a no-op
+        // migration can exceed the tuple-decompression safety limit.
+        if !has_duplicates {
+            connection
+                .execute_unprepared(CREATE_UNIQUE_INDEX_SQL)
+                .await?;
+            return Ok(());
+        }
+
         // Step 1: Re-point FK references from duplicate visitor rows to the
         // canonical (lowest-id) row for the same (visitor_id, project_id).
         // NULL FK refs first so we don't violate the FK constraint on delete.
@@ -246,13 +285,7 @@ impl MigrationTrait for Migration {
         // running this manually outside a transaction after the migration runs.
         manager
             .get_connection()
-            .execute_unprepared(
-                r#"
-                CREATE UNIQUE INDEX IF NOT EXISTS
-                    visitor_visitor_id_project_id_key
-                ON visitor (visitor_id, project_id);
-                "#,
-            )
+            .execute_unprepared(CREATE_UNIQUE_INDEX_SQL)
             .await?;
 
         Ok(())


### PR DESCRIPTION
## Summary

- check whether `visitor` actually contains duplicate `(visitor_id, project_id)` pairs before running the deduplication rewrites
- skip all eight foreign-key `UPDATE` statements when there is nothing to rewrite
- reuse the unique-index SQL in both the fast path and deduplication path

## Root cause

TimescaleDB can eagerly decompress hypertable chunks for an `UPDATE` even when its join source produces no rows. On an installation with no duplicate visitors, the migration's logically no-op rewrites still exceeded `timescaledb.max_tuples_decompressed_per_dml_transaction` and blocked the upgrade.

## Impact

Upgrades with already-unique visitor data now create the unique index directly without touching compressed analytics tables. Installations that do contain duplicates retain the existing deduplication and foreign-key repointing behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p temps-migrations --lib`
- `git diff --check`
- applied successfully against the affected TimescaleDB installation; all seven pending migrations completed and the upgraded server started healthy
