### PR TITLE
feat(email): dedup shared email UI helpers, working event filters, per-domain delivery stats

### DIFF
--- a/web/src/components/email/EmailAnalytics.tsx
+++ b/web/src/components/email/EmailAnalytics.tsx
@@ -30,7 +30,6 @@ import {
   ChevronRight,
   Eye,
   Globe,
-  Mail,
   MailWarning,
   Monitor,
   MousePointerClick,
@@ -39,6 +38,8 @@ import {
 } from 'lucide-react'
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { EventBadge } from './shared'
+import { parseUserAgent } from './sharedUtils'
 
 // Types
 interface EmailEventStats {
@@ -132,57 +133,6 @@ function RateCard({
       </CardContent>
     </Card>
   )
-}
-
-function EventIcon({ type }: { type: string }) {
-  switch (type) {
-    case 'open':
-    case 'opened':
-      return <Eye className="h-3.5 w-3.5 text-blue-500" />
-    case 'click':
-    case 'clicked':
-      return <MousePointerClick className="h-3.5 w-3.5 text-green-500" />
-    case 'delivered':
-      return <Send className="h-3.5 w-3.5 text-emerald-500" />
-    case 'bounced':
-      return <MailWarning className="h-3.5 w-3.5 text-red-500" />
-    case 'complained':
-      return <AlertTriangle className="h-3.5 w-3.5 text-orange-500" />
-    default:
-      return <Mail className="h-3.5 w-3.5 text-muted-foreground" />
-  }
-}
-
-function EventBadge({ type }: { type: string }) {
-  const config: Record<string, { variant: 'default' | 'secondary' | 'destructive' | 'outline'; label: string }> = {
-    opened: { variant: 'secondary', label: 'Opened' },
-    clicked: { variant: 'default', label: 'Clicked' },
-    delivered: { variant: 'outline', label: 'Delivered' },
-    bounced: { variant: 'destructive', label: 'Bounced' },
-    complained: { variant: 'destructive', label: 'Complained' },
-  }
-
-  const c = config[type] || { variant: 'outline' as const, label: type }
-
-  return (
-    <Badge variant={c.variant} className="gap-1 text-xs">
-      <EventIcon type={type} />
-      {c.label}
-    </Badge>
-  )
-}
-
-function parseUserAgent(ua: string): string {
-  if (ua.includes('Gmail')) return 'Gmail'
-  if (ua.includes('Yahoo')) return 'Yahoo Mail'
-  if (ua.includes('Outlook') || ua.includes('Microsoft')) return 'Outlook'
-  if (ua.includes('Thunderbird')) return 'Thunderbird'
-  if (ua.includes('Apple Mail') || ua.includes('AppleWebKit')) return 'Apple Mail'
-  if (ua.includes('Chrome')) return 'Chrome'
-  if (ua.includes('Firefox')) return 'Firefox'
-  if (ua.includes('Safari')) return 'Safari'
-  if (ua.length > 50) return ua.substring(0, 50) + '...'
-  return ua
 }
 
 export function EmailAnalytics() {
@@ -348,7 +298,7 @@ export function EmailAnalytics() {
                         onClick={() => navigate(`/email/${event.email_id}`)}
                       >
                         <TableCell>
-                          <EventBadge type={event.event_type} />
+                          <EventBadge type={event.event_type} iconClassName="h-3.5 w-3.5" />
                         </TableCell>
                         <TableCell className="hidden md:table-cell">
                           {event.recipient ? (

--- a/web/src/components/email/EmailAnalytics.tsx
+++ b/web/src/components/email/EmailAnalytics.tsx
@@ -262,8 +262,11 @@ export function EmailAnalytics() {
               <SelectContent>
                 <SelectItem value="all">All events</SelectItem>
                 <SelectItem value="delivered">Delivered</SelectItem>
-                <SelectItem value="opened">Opened</SelectItem>
-                <SelectItem value="clicked">Clicked</SelectItem>
+                {/* Stored event_type values are "open"/"click" — see
+                    tracking_service.rs record_open/record_click. The endpoint
+                    filters by exact match, so these values must match storage. */}
+                <SelectItem value="open">Opened</SelectItem>
+                <SelectItem value="click">Clicked</SelectItem>
                 <SelectItem value="bounced">Bounced</SelectItem>
                 <SelectItem value="complained">Complained</SelectItem>
               </SelectContent>

--- a/web/src/components/email/EmailDomainsManagement.tsx
+++ b/web/src/components/email/EmailDomainsManagement.tsx
@@ -78,6 +78,7 @@ import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import { z } from 'zod'
+import { problemMessage } from './sharedUtils'
 
 // Types
 type DnsRecordStatus = 'unknown' | 'verified' | 'pending' | 'failed'
@@ -98,16 +99,6 @@ const createDomainSchema = z.object({
 })
 
 type CreateDomainFormData = z.infer<typeof createDomainSchema>
-
-function problemMessage(error: unknown, fallback: string): string {
-  if (error && typeof error === 'object' && 'detail' in error) {
-    const detail = (error as { detail?: unknown }).detail
-    if (typeof detail === 'string' && detail.length > 0) {
-      return detail
-    }
-  }
-  return fallback
-}
 
 // API functions
 async function listEmailDomains(): Promise<EmailDomain[]> {

--- a/web/src/components/email/EmailEventTimeline.tsx
+++ b/web/src/components/email/EmailEventTimeline.tsx
@@ -14,18 +14,15 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { useQuery } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import {
-  AlertTriangle,
   ChevronLeft,
   ChevronRight,
-  Eye,
   Globe,
   Mail,
-  MailWarning,
   Monitor,
-  MousePointerClick,
-  Send,
 } from 'lucide-react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
+import { EventBadge, EventIcon } from './shared'
+import { parseUserAgent } from './sharedUtils'
 
 interface EmailEvent {
   id: number
@@ -39,96 +36,23 @@ interface EmailEvent {
   created_at: string
 }
 
-interface PaginatedEmailEvents {
-  events: EmailEvent[]
-  total: number
-  page: number
-  page_size: number
-}
-
-async function fetchEmailEvents(
-  emailId: string,
-  params: { event_type?: string; page?: number; page_size?: number }
-): Promise<PaginatedEmailEvents> {
+// NOTE: the `/emails/{id}/tracking/events` endpoint (temps-email's
+// `get_email_events` handler / `EventsQuery`) only supports an `event_type`
+// filter — it has no `page`/`page_size` params and always returns the full
+// event list for the email. Unlike EmailAnalytics.tsx's `fetchAllEvents`
+// (which hits the paginated `/emails/events` endpoint), there is currently
+// no server-side pagination available for a single email's event history.
+// We fetch the full list once per (emailId, eventType) — bounded by the
+// number of tracking events for one email — and paginate over it
+// client-side, without keeping `page` in the query key so switching pages
+// doesn't trigger a redundant network refetch of the same data.
+async function fetchEmailEvents(emailId: string, eventType?: string): Promise<EmailEvent[]> {
   const searchParams = new URLSearchParams()
-  if (params.event_type) searchParams.set('event_type', params.event_type)
+  if (eventType) searchParams.set('event_type', eventType)
 
   const response = await fetch(`/api/emails/${emailId}/tracking/events?${searchParams}`)
   if (!response.ok) throw new Error('Failed to fetch email events')
-  const events: EmailEvent[] = await response.json()
-
-  // Backend returns a flat array; apply client-side pagination
-  const page = params.page ?? 1
-  const pageSize = params.page_size ?? 20
-  const start = (page - 1) * pageSize
-  const paged = events.slice(start, start + pageSize)
-
-  return {
-    events: paged,
-    total: events.length,
-    page,
-    page_size: pageSize,
-  }
-}
-
-function EventIcon({ type }: { type: string }) {
-  switch (type) {
-    case 'open':
-    case 'opened':
-      return <Eye className="h-4 w-4 text-blue-500" />
-    case 'click':
-    case 'clicked':
-      return <MousePointerClick className="h-4 w-4 text-green-500" />
-    case 'delivered':
-      return <Send className="h-4 w-4 text-emerald-500" />
-    case 'bounced':
-      return <MailWarning className="h-4 w-4 text-red-500" />
-    case 'complained':
-      return <AlertTriangle className="h-4 w-4 text-orange-500" />
-    default:
-      return <Mail className="h-4 w-4 text-muted-foreground" />
-  }
-}
-
-function EventBadge({ type }: { type: string }) {
-  const variants: Record<string, { variant: 'default' | 'secondary' | 'destructive' | 'outline'; label: string }> = {
-    open: { variant: 'secondary', label: 'Opened' },
-    opened: { variant: 'secondary', label: 'Opened' },
-    click: { variant: 'default', label: 'Clicked' },
-    clicked: { variant: 'default', label: 'Clicked' },
-    delivered: { variant: 'outline', label: 'Delivered' },
-    bounced: { variant: 'destructive', label: 'Bounced' },
-    complained: { variant: 'destructive', label: 'Complained' },
-  }
-
-  const config = variants[type] || { variant: 'outline' as const, label: type }
-
-  return (
-    <Badge variant={config.variant} className="gap-1 text-xs">
-      <EventIcon type={type} />
-      {config.label}
-    </Badge>
-  )
-}
-
-function parseUserAgent(ua: string): string {
-  // Email image proxies (check first — they masquerade as browsers)
-  if (ua.includes('GoogleImageProxy') || ua.includes('ggpht.com')) return 'Gmail (Google Proxy)'
-  if (ua.includes('YahooMailProxy')) return 'Yahoo Mail (Proxy)'
-  if (ua.includes('Outlook-iOS') || ua.includes('Outlook-Android')) return 'Outlook Mobile'
-  // Email clients
-  if (ua.includes('Gmail')) return 'Gmail'
-  if (ua.includes('Yahoo')) return 'Yahoo Mail'
-  if (ua.includes('Outlook') || ua.includes('Microsoft')) return 'Outlook'
-  if (ua.includes('Thunderbird')) return 'Thunderbird'
-  if (ua.includes('Apple Mail')) return 'Apple Mail'
-  // Browsers
-  if (ua.includes('Chrome') && !ua.includes('Chromium')) return 'Chrome'
-  if (ua.includes('Firefox')) return 'Firefox'
-  if (ua.includes('Safari') && !ua.includes('Chrome')) return 'Safari'
-  if (ua.includes('AppleWebKit')) return 'WebKit'
-  if (ua.length > 50) return ua.substring(0, 50) + '...'
-  return ua
+  return response.json()
 }
 
 export function EmailEventTimeline({ emailId }: { emailId: string }) {
@@ -136,17 +60,25 @@ export function EmailEventTimeline({ emailId }: { emailId: string }) {
   const [page, setPage] = useState(1)
   const pageSize = 20
 
-  const { data, isLoading, error } = useQuery({
-    queryKey: ['email-events', emailId, eventType, page],
-    queryFn: () =>
-      fetchEmailEvents(emailId, {
-        event_type: eventType,
-        page,
-        page_size: pageSize,
-      }),
+  const {
+    data: events,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['email-events', emailId, eventType],
+    queryFn: () => fetchEmailEvents(emailId, eventType),
   })
 
-  const totalPages = data ? Math.ceil(data.total / pageSize) : 0
+  const total = events?.length ?? 0
+  const totalPages = Math.ceil(total / pageSize)
+  const data = useMemo(() => {
+    if (!events) return undefined
+    const start = (page - 1) * pageSize
+    return {
+      events: events.slice(start, start + pageSize),
+      total,
+    }
+  }, [events, page, total])
 
   if (isLoading) {
     return (
@@ -207,8 +139,8 @@ export function EmailEventTimeline({ emailId }: { emailId: string }) {
             <SelectContent>
               <SelectItem value="all">All events</SelectItem>
               <SelectItem value="delivered">Delivered</SelectItem>
-              <SelectItem value="open">Opened</SelectItem>
-              <SelectItem value="click">Clicked</SelectItem>
+              <SelectItem value="opened">Opened</SelectItem>
+              <SelectItem value="clicked">Clicked</SelectItem>
               <SelectItem value="bounced">Bounced</SelectItem>
               <SelectItem value="complained">Complained</SelectItem>
             </SelectContent>

--- a/web/src/components/email/EmailEventTimeline.tsx
+++ b/web/src/components/email/EmailEventTimeline.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { getEmailEvents, type TrackingEventResponse } from '@/api/client'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -17,24 +18,11 @@ import {
   ChevronLeft,
   ChevronRight,
   Globe,
-  Mail,
   Monitor,
 } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { EventBadge, EventIcon } from './shared'
-import { parseUserAgent } from './sharedUtils'
-
-interface EmailEvent {
-  id: number
-  email_id: string
-  event_type: string
-  provider_message_id: string | null
-  recipient: string | null
-  metadata: Record<string, unknown> | null
-  ip_address: string | null
-  user_agent: string | null
-  created_at: string
-}
+import { parseUserAgent, problemMessage } from './sharedUtils'
 
 // NOTE: the `/emails/{id}/tracking/events` endpoint (temps-email's
 // `get_email_events` handler / `EventsQuery`) only supports an `event_type`
@@ -46,13 +34,18 @@ interface EmailEvent {
 // number of tracking events for one email — and paginate over it
 // client-side, without keeping `page` in the query key so switching pages
 // doesn't trigger a redundant network refetch of the same data.
-async function fetchEmailEvents(emailId: string, eventType?: string): Promise<EmailEvent[]> {
-  const searchParams = new URLSearchParams()
-  if (eventType) searchParams.set('event_type', eventType)
-
-  const response = await fetch(`/api/emails/${emailId}/tracking/events?${searchParams}`)
-  if (!response.ok) throw new Error('Failed to fetch email events')
-  return response.json()
+async function fetchEmailEvents(
+  emailId: string,
+  eventType?: string
+): Promise<TrackingEventResponse[]> {
+  const response = await getEmailEvents({
+    path: { id: emailId },
+    query: eventType ? { event_type: eventType } : undefined,
+  })
+  if (response.error || !response.data) {
+    throw new Error(problemMessage(response.error, 'Failed to fetch email events'))
+  }
+  return response.data
 }
 
 export function EmailEventTimeline({ emailId }: { emailId: string }) {
@@ -108,7 +101,9 @@ export function EmailEventTimeline({ emailId }: { emailId: string }) {
           <CardTitle className="text-base">Activity</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-muted-foreground">Failed to load events.</p>
+          <p className="text-sm text-muted-foreground">
+            {error instanceof Error ? error.message : 'Failed to load events.'}
+          </p>
         </CardContent>
       </Card>
     )
@@ -139,8 +134,11 @@ export function EmailEventTimeline({ emailId }: { emailId: string }) {
             <SelectContent>
               <SelectItem value="all">All events</SelectItem>
               <SelectItem value="delivered">Delivered</SelectItem>
-              <SelectItem value="opened">Opened</SelectItem>
-              <SelectItem value="clicked">Clicked</SelectItem>
+              {/* Stored event_type values are "open"/"click" — see
+                  tracking_service.rs record_open/record_click. The endpoint
+                  filters by exact match, so these values must match storage. */}
+              <SelectItem value="open">Opened</SelectItem>
+              <SelectItem value="click">Clicked</SelectItem>
               <SelectItem value="bounced">Bounced</SelectItem>
               <SelectItem value="complained">Complained</SelectItem>
             </SelectContent>
@@ -179,17 +177,10 @@ export function EmailEventTimeline({ emailId }: { emailId: string }) {
                   </div>
 
                   <div className="flex items-center gap-3 text-xs text-muted-foreground flex-wrap">
-                    {(event.event_type === 'click' || event.event_type === 'clicked') && !!event.metadata?.url && (
+                    {event.link_url && (
                       <span className="flex items-center gap-1 truncate max-w-[300px]">
                         <Globe className="h-3 w-3 shrink-0" />
-                        <span className="truncate">{String(event.metadata!.url)}</span>
-                      </span>
-                    )}
-
-                    {event.recipient && (
-                      <span className="flex items-center gap-1">
-                        <Mail className="h-3 w-3 shrink-0" />
-                        {event.recipient}
+                        <span className="truncate">{event.link_url}</span>
                       </span>
                     )}
 
@@ -208,24 +199,6 @@ export function EmailEventTimeline({ emailId }: { emailId: string }) {
                     )}
                   </div>
 
-                  {/* Bounce/complaint metadata */}
-                  {(event.event_type === 'bounced' || event.event_type === 'complained') &&
-                    event.metadata != null && (
-                      <div className="text-xs bg-muted/50 rounded p-2 mt-1">
-                        {!!event.metadata.bounce_type && (
-                          <span>
-                            Type: <strong>{String(event.metadata.bounce_type)}</strong>
-                            {event.metadata.bounce_sub_type != null &&
-                              ` (${String(event.metadata.bounce_sub_type)})`}
-                          </span>
-                        )}
-                        {!!event.metadata.complaint_type && (
-                          <span>
-                            Type: <strong>{String(event.metadata.complaint_type)}</strong>
-                          </span>
-                        )}
-                      </div>
-                    )}
                 </div>
               </div>
             ))}

--- a/web/src/components/email/EmailProvidersManagement.tsx
+++ b/web/src/components/email/EmailProvidersManagement.tsx
@@ -59,6 +59,7 @@ import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import { z } from 'zod'
+import { problemMessage } from './sharedUtils'
 
 // Types for email providers — alias over SDK response
 type EmailProvider = EmailProviderResponse
@@ -127,16 +128,6 @@ const createProviderSchema = z.object({
 })
 
 type CreateProviderFormData = z.infer<typeof createProviderSchema>
-
-function problemMessage(error: unknown, fallback: string): string {
-  if (error && typeof error === 'object' && 'detail' in error) {
-    const detail = (error as { detail?: unknown }).detail
-    if (typeof detail === 'string' && detail.length > 0) {
-      return detail
-    }
-  }
-  return fallback
-}
 
 async function listEmailProviders(): Promise<EmailProvider[]> {
   const response = await listProviders2()

--- a/web/src/components/email/EmailsSentList.tsx
+++ b/web/src/components/email/EmailsSentList.tsx
@@ -8,11 +8,9 @@ import {
   type EmailStatsResponse,
   type PaginatedEmailsResponse,
 } from '@/api/client'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { EmptyState } from '@/components/ui/empty-state'
-import { Input } from '@/components/ui/input'
 import {
   Select,
   SelectContent,
@@ -32,7 +30,6 @@ import {
 import { useQuery } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
 import {
-  AlertCircle,
   Archive,
   CheckCircle2,
   ChevronLeft,
@@ -42,25 +39,16 @@ import {
   Mail,
   MailX,
   MousePointerClick,
-  Search,
 } from 'lucide-react'
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { StatusBadge } from './shared'
+import { problemMessage } from './sharedUtils'
 
 // Types (aliases over SDK)
 type PaginatedEmails = PaginatedEmailsResponse
 type EmailStats = EmailStatsResponse
 type EmailDomain = EmailDomainResponse
-
-function problemMessage(error: unknown, fallback: string): string {
-  if (error && typeof error === 'object' && 'detail' in error) {
-    const detail = (error as { detail?: unknown }).detail
-    if (typeof detail === 'string' && detail.length > 0) {
-      return detail
-    }
-  }
-  return fallback
-}
 
 async function fetchEmails(params: {
   domain_id?: number
@@ -91,41 +79,6 @@ async function listEmailDomains(): Promise<EmailDomain[]> {
     throw new Error(problemMessage(response.error, 'Failed to fetch email domains'))
   }
   return response.data ?? []
-}
-
-function StatusBadge({ status }: { status: string }) {
-  switch (status) {
-    case 'sent':
-      return (
-        <Badge variant="default" className="gap-1">
-          <CheckCircle2 className="h-3 w-3" />
-          Sent
-        </Badge>
-      )
-    case 'queued':
-      return (
-        <Badge variant="secondary" className="gap-1">
-          <Clock className="h-3 w-3" />
-          Queued
-        </Badge>
-      )
-    case 'failed':
-      return (
-        <Badge variant="destructive" className="gap-1">
-          <AlertCircle className="h-3 w-3" />
-          Failed
-        </Badge>
-      )
-    case 'captured':
-      return (
-        <Badge variant="outline" className="gap-1 border-blue-500 text-blue-600">
-          <Archive className="h-3 w-3" />
-          Captured
-        </Badge>
-      )
-    default:
-      return <Badge variant="outline">{status}</Badge>
-  }
 }
 
 function StatsCard({
@@ -266,17 +219,7 @@ export function EmailsSentList() {
       )}
 
       {/* Filters */}
-      <div className="flex flex-col sm:flex-row gap-4">
-        <div className="flex-1">
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-            <Input
-              placeholder="Search emails..."
-              className="pl-9"
-              disabled
-            />
-          </div>
-        </div>
+      <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
         <Select
           value={filters.domain_id?.toString() ?? 'all'}
           onValueChange={(value) =>

--- a/web/src/components/email/shared.tsx
+++ b/web/src/components/email/shared.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+// Shared display components for the email management UI.
+// Extracted from EmailsSentList / EmailDetail (StatusBadge) and
+// EmailEventTimeline / EmailAnalytics (EventIcon / EventBadge) to avoid
+// copy-pasted logic drifting out of sync.
+
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+import {
+  AlertCircle,
+  AlertTriangle,
+  Archive,
+  CheckCircle2,
+  Clock,
+  Eye,
+  Mail,
+  MailWarning,
+  MousePointerClick,
+  Send,
+} from 'lucide-react'
+
+export function StatusBadge({ status }: { status: string }) {
+  switch (status) {
+    case 'sent':
+      return (
+        <Badge variant="default" className="gap-1">
+          <CheckCircle2 className="h-3 w-3" />
+          Sent
+        </Badge>
+      )
+    case 'queued':
+      return (
+        <Badge variant="secondary" className="gap-1">
+          <Clock className="h-3 w-3" />
+          Queued
+        </Badge>
+      )
+    case 'failed':
+      return (
+        <Badge variant="destructive" className="gap-1">
+          <AlertCircle className="h-3 w-3" />
+          Failed
+        </Badge>
+      )
+    case 'captured':
+      return (
+        <Badge variant="outline" className="gap-1 border-blue-500 text-blue-600">
+          <Archive className="h-3 w-3" />
+          Captured
+        </Badge>
+      )
+    default:
+      return <Badge variant="outline">{status}</Badge>
+  }
+}
+
+// Canonical event-type -> icon mapping. This is the more complete of the two
+// copies that previously existed (EmailEventTimeline's), which correctly
+// recognizes Gmail/Yahoo proxy user-agents further down in parseUserAgent;
+// kept here alongside EventBadge since they're always used together.
+export function EventIcon({
+  type,
+  className = 'h-4 w-4',
+}: {
+  type: string
+  className?: string
+}) {
+  switch (type) {
+    case 'open':
+    case 'opened':
+      return <Eye className={cn(className, 'text-blue-500')} />
+    case 'click':
+    case 'clicked':
+      return <MousePointerClick className={cn(className, 'text-green-500')} />
+    case 'delivered':
+      return <Send className={cn(className, 'text-emerald-500')} />
+    case 'bounced':
+      return <MailWarning className={cn(className, 'text-red-500')} />
+    case 'complained':
+      return <AlertTriangle className={cn(className, 'text-orange-500')} />
+    default:
+      return <Mail className={cn(className, 'text-muted-foreground')} />
+  }
+}
+
+const EVENT_BADGE_CONFIG: Record<
+  string,
+  { variant: 'default' | 'secondary' | 'destructive' | 'outline'; label: string }
+> = {
+  open: { variant: 'secondary', label: 'Opened' },
+  opened: { variant: 'secondary', label: 'Opened' },
+  click: { variant: 'default', label: 'Clicked' },
+  clicked: { variant: 'default', label: 'Clicked' },
+  delivered: { variant: 'outline', label: 'Delivered' },
+  bounced: { variant: 'destructive', label: 'Bounced' },
+  complained: { variant: 'destructive', label: 'Complained' },
+}
+
+export function EventBadge({
+  type,
+  iconClassName,
+}: {
+  type: string
+  iconClassName?: string
+}) {
+  const config = EVENT_BADGE_CONFIG[type] || { variant: 'outline' as const, label: type }
+
+  return (
+    <Badge variant={config.variant} className="gap-1 text-xs">
+      <EventIcon type={type} className={iconClassName} />
+      {config.label}
+    </Badge>
+  )
+}

--- a/web/src/components/email/sharedUtils.ts
+++ b/web/src/components/email/sharedUtils.ts
@@ -1,0 +1,34 @@
+// Shared pure helpers for the email management UI.
+// Extracted from EmailsSentList / EmailDetail / EmailDomainsManagement /
+// EmailDomainDetail / EmailProvidersManagement / EmailEventTimeline /
+// EmailAnalytics to avoid copy-pasted logic drifting out of sync.
+
+export function problemMessage(error: unknown, fallback: string): string {
+  if (error && typeof error === 'object' && 'detail' in error) {
+    const detail = (error as { detail?: unknown }).detail
+    if (typeof detail === 'string' && detail.length > 0) {
+      return detail
+    }
+  }
+  return fallback
+}
+
+export function parseUserAgent(ua: string): string {
+  // Email image proxies (check first — they masquerade as browsers)
+  if (ua.includes('GoogleImageProxy') || ua.includes('ggpht.com')) return 'Gmail (Google Proxy)'
+  if (ua.includes('YahooMailProxy')) return 'Yahoo Mail (Proxy)'
+  if (ua.includes('Outlook-iOS') || ua.includes('Outlook-Android')) return 'Outlook Mobile'
+  // Email clients
+  if (ua.includes('Gmail')) return 'Gmail'
+  if (ua.includes('Yahoo')) return 'Yahoo Mail'
+  if (ua.includes('Outlook') || ua.includes('Microsoft')) return 'Outlook'
+  if (ua.includes('Thunderbird')) return 'Thunderbird'
+  if (ua.includes('Apple Mail')) return 'Apple Mail'
+  // Browsers
+  if (ua.includes('Chrome') && !ua.includes('Chromium')) return 'Chrome'
+  if (ua.includes('Firefox')) return 'Firefox'
+  if (ua.includes('Safari') && !ua.includes('Chrome')) return 'Safari'
+  if (ua.includes('AppleWebKit')) return 'WebKit'
+  if (ua.length > 50) return ua.substring(0, 50) + '...'
+  return ua
+}

--- a/web/src/pages/EmailDetail.tsx
+++ b/web/src/pages/EmailDetail.tsx
@@ -4,6 +4,7 @@ import { getEmailOptions } from '@/api/client/@tanstack/react-query.gen'
 import { client } from '@/api/client/client.gen'
 import { EmailResponse } from '@/api/client/types.gen'
 import { EmailEventTimeline } from '@/components/email/EmailEventTimeline'
+import { StatusBadge } from '@/components/email/shared'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -16,10 +17,7 @@ import { useQuery } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import {
   AlertCircle,
-  Archive,
   ArrowLeft,
-  CheckCircle2,
-  Clock,
   Code,
   Eye,
   FileText,
@@ -29,41 +27,6 @@ import {
 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
-
-function StatusBadge({ status }: { status: string }) {
-  switch (status) {
-    case 'sent':
-      return (
-        <Badge variant="default" className="gap-1">
-          <CheckCircle2 className="h-3 w-3" />
-          Sent
-        </Badge>
-      )
-    case 'queued':
-      return (
-        <Badge variant="secondary" className="gap-1">
-          <Clock className="h-3 w-3" />
-          Queued
-        </Badge>
-      )
-    case 'failed':
-      return (
-        <Badge variant="destructive" className="gap-1">
-          <AlertCircle className="h-3 w-3" />
-          Failed
-        </Badge>
-      )
-    case 'captured':
-      return (
-        <Badge variant="outline" className="gap-1 border-blue-500 text-blue-600">
-          <Archive className="h-3 w-3" />
-          Captured
-        </Badge>
-      )
-    default:
-      return <Badge variant="outline">{status}</Badge>
-  }
-}
 
 function HeadersDisplay({ headers }: { headers: Record<string, string> | null | undefined }) {
   if (!headers || Object.keys(headers).length === 0) {

--- a/web/src/pages/EmailDomainDetail.tsx
+++ b/web/src/pages/EmailDomainDetail.tsx
@@ -3,6 +3,7 @@
 import {
   deleteEmailDomain,
   getDomain,
+  getEmailStats,
   listDnsProviders,
   listEmailProviders,
   setupDns,
@@ -10,6 +11,7 @@ import {
   type DnsProviderResponse,
   type EmailDomainWithDnsResponse,
   type EmailProviderResponse,
+  type EmailStatsResponse,
   type SetupDnsResponse,
 } from '@/api/client'
 import {
@@ -59,10 +61,14 @@ import { cn } from '@/lib/utils'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   AlertCircle,
+  Archive,
   ArrowLeft,
   CheckCircle2,
+  Clock,
   Globe,
   Loader2,
+  Mail,
+  MailX,
   RefreshCw,
   Settings2,
   Trash2,
@@ -71,16 +77,7 @@ import {
 import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { toast } from 'sonner'
-
-function problemMessage(error: unknown, fallback: string): string {
-  if (error && typeof error === 'object' && 'detail' in error) {
-    const detail = (error as { detail?: unknown }).detail
-    if (typeof detail === 'string' && detail.length > 0) {
-      return detail
-    }
-  }
-  return fallback
-}
+import { problemMessage } from '@/components/email/sharedUtils'
 
 async function fetchDomain(id: number): Promise<EmailDomainWithDnsResponse> {
   const response = await getDomain({ path: { id } })
@@ -106,6 +103,58 @@ async function fetchDnsProviders(): Promise<DnsProviderResponse[]> {
   return response.data ?? []
 }
 
+// NOTE: EmailAnalytics.tsx's bounce/complaint/open/click *rate* stats come
+// from `/emails/events/stats` (get_global_event_stats), which has no
+// domain_id filter at all (global-only). `getEmailStats` (/emails/stats,
+// used by EmailsSentList.tsx) does support a domain_id filter, so that's
+// what we use here for domain-scoped delivery stats.
+async function fetchEmailStats(domainId: number): Promise<EmailStatsResponse> {
+  const response = await getEmailStats({ query: { domain_id: domainId } })
+  if (response.error || !response.data) {
+    throw new Error(problemMessage(response.error, 'Failed to fetch email stats'))
+  }
+  return response.data
+}
+
+function StatCard({
+  title,
+  value,
+  icon: Icon,
+}: {
+  title: string
+  value: number
+  icon: React.ComponentType<{ className?: string }>
+}) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        <Icon className="h-4 w-4 text-muted-foreground" />
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{value.toLocaleString()}</div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function StatsSkeleton() {
+  return (
+    <div className="grid gap-4 grid-cols-2 md:grid-cols-5">
+      {[1, 2, 3, 4, 5].map((i) => (
+        <Card key={i}>
+          <CardHeader className="pb-2">
+            <Skeleton className="h-4 w-16" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-12" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}
+
 export function EmailDomainDetail() {
   const { id: idParam } = useParams<{ id: string }>()
   const id = idParam ? parseInt(idParam, 10) : undefined
@@ -123,6 +172,12 @@ export function EmailDomainDetail() {
   } = useQuery({
     queryKey: ['email-domain', id],
     queryFn: () => fetchDomain(id!),
+    enabled: !!id,
+  })
+
+  const { data: emailStats, isLoading: isLoadingStats } = useQuery({
+    queryKey: ['email-stats', id],
+    queryFn: () => fetchEmailStats(id!),
     enabled: !!id,
   })
 
@@ -423,6 +478,21 @@ export function EmailDomainDetail() {
               {domain.verification_error}
             </AlertDescription>
           </Alert>
+        )}
+
+        {/* Deliverability stats for this domain */}
+        {isLoadingStats ? (
+          <StatsSkeleton />
+        ) : (
+          emailStats && (
+            <div className="grid gap-4 grid-cols-2 md:grid-cols-5">
+              <StatCard title="Total Emails" value={emailStats.total} icon={Mail} />
+              <StatCard title="Sent" value={emailStats.sent} icon={CheckCircle2} />
+              <StatCard title="Captured" value={emailStats.captured} icon={Archive} />
+              <StatCard title="Queued" value={emailStats.queued} icon={Clock} />
+              <StatCard title="Failed" value={emailStats.failed} icon={MailX} />
+            </div>
+          )
         )}
 
         {/* Two-column layout: DNS setup on left, overview on right */}

--- a/web/src/pages/EmailDomainDetail.tsx
+++ b/web/src/pages/EmailDomainDetail.tsx
@@ -175,7 +175,11 @@ export function EmailDomainDetail() {
     enabled: !!id,
   })
 
-  const { data: emailStats, isLoading: isLoadingStats } = useQuery({
+  const {
+    data: emailStats,
+    isLoading: isLoadingStats,
+    error: statsError,
+  } = useQuery({
     queryKey: ['email-stats', id],
     queryFn: () => fetchEmailStats(id!),
     enabled: !!id,
@@ -480,9 +484,19 @@ export function EmailDomainDetail() {
           </Alert>
         )}
 
-        {/* Deliverability stats for this domain */}
+        {/* Delivery status stats for this domain */}
         {isLoadingStats ? (
           <StatsSkeleton />
+        ) : statsError ? (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Failed to load email stats</AlertTitle>
+            <AlertDescription>
+              {statsError instanceof Error
+                ? statsError.message
+                : 'Could not fetch delivery stats for this domain.'}
+            </AlertDescription>
+          </Alert>
         ) : (
           emailStats && (
             <div className="grid gap-4 grid-cols-2 md:grid-cols-5">


### PR DESCRIPTION
## Summary

Independent of the other email-hardening PRs — touches only `web/src/components/email/*` and `web/src/pages/EmailDetail.tsx`/`EmailDomainDetail.tsx`.

- Dedup: shared badge/formatting helpers (`StatusBadge`, `EventIcon`, `EventBadge`, `problemMessage`, `parseUserAgent`) extracted into `shared.tsx`/`sharedUtils.ts`, used across `EmailAnalytics`, `EmailDomainsManagement`, `EmailEventTimeline`, `EmailProvidersManagement`, `EmailsSentList`, `EmailDetail`, and `EmailDomainDetail`. Each extraction keeps the more complete of the previously duplicated copies (proxy user-agent detection, both event-type spellings).
- Fix: the Opened/Clicked event-type filters (email timeline + analytics page) now send the stored `open`/`click` values — they previously sent `opened`/`clicked`, which never match, so those filters always returned an empty list.
- `EmailEventTimeline` now uses the generated SDK (`getEmailEvents`) instead of a hand-rolled `fetch`, renders the real `link_url` for click events (previously read a `metadata.url` field the endpoint never returns), and paginates client-side without refetching per page.
- Per-domain delivery status stats block (total / sent / captured / queued / failed) on the domain detail page, with skeleton loading and an error alert on failure. Note: these are send-status counts, not open/bounce rates — `/emails/events/stats` has no `domain_id` filter yet.
- Removed the permanently disabled search input from the sent-emails list: the backend `ListEmailsQuery` has no search param, so the box was dead UI. Real search needs a backend query param first.

## Test plan

- [x] `tsc --noEmit` — clean
- [ ] Manual click-through in a running dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)