### PR TITLE
fix(auth): prevent MFA challenge session from authenticating real requests

### DIFF
--- a/crates/temps-auth/src/auth_service.rs
+++ b/crates/temps-auth/src/auth_service.rs
@@ -101,6 +101,8 @@ impl AuthService {
             user_id: Set(user_id),
             session_token: Set(session_token.clone()),
             expires_at: Set(expires_at),
+            // Fully authenticated session, not an MFA challenge.
+            mfa_pending: Set(false),
             ..Default::default()
         };
 
@@ -122,6 +124,9 @@ impl AuthService {
         let count = temps_entities::sessions::Entity::find()
             .filter(temps_entities::sessions::Column::UserId.eq(user_id))
             .filter(temps_entities::sessions::Column::ExpiresAt.gt(Utc::now()))
+            // Pending MFA challenge rows are not real sessions -- excluding
+            // them keeps the concurrent-login audit signal honest.
+            .filter(temps_entities::sessions::Column::MfaPending.eq(false))
             .count(self.db.as_ref())
             .await?;
         Ok(count)
@@ -134,6 +139,9 @@ impl AuthService {
         let session = temps_entities::sessions::Entity::find()
             .filter(temps_entities::sessions::Column::SessionToken.eq(session_token))
             .filter(temps_entities::sessions::Column::ExpiresAt.gt(Utc::now()))
+            // A first-factor-only MFA challenge row must never authenticate a
+            // real request. Only `verify_mfa_challenge` may consume those.
+            .filter(temps_entities::sessions::Column::MfaPending.eq(false))
             .one(self.db.as_ref())
             .await?
             .ok_or_else(|| AuthError::NotFound("Session not found or expired".to_string()))?;
@@ -225,6 +233,9 @@ impl AuthService {
             user_id: Set(user_id),
             session_token: Set(session_token.clone()),
             expires_at: Set(expires_at),
+            // Mark this as a pending MFA challenge so it can never be replayed
+            // as a real session cookie -- `verify_session` rejects such rows.
+            mfa_pending: Set(true),
             ..Default::default()
         };
 
@@ -239,10 +250,13 @@ impl AuthService {
         session_token: &str,
         code: &str,
     ) -> Result<temps_entities::users::Model, AuthError> {
-        // Get the user from the temporary session
+        // Get the user from the temporary session. Require mfa_pending so a
+        // real (fully authenticated) session token can never be spent as an
+        // MFA challenge -- the discriminator cuts both ways.
         let session = temps_entities::sessions::Entity::find()
             .filter(temps_entities::sessions::Column::SessionToken.eq(session_token))
             .filter(temps_entities::sessions::Column::ExpiresAt.gt(Utc::now()))
+            .filter(temps_entities::sessions::Column::MfaPending.eq(true))
             .one(self.db.as_ref())
             .await?
             .ok_or_else(|| AuthError::GenericError("Invalid or expired session".to_string()))?;
@@ -1280,6 +1294,83 @@ mod tests {
         // Session should be valid
         let verified_user = auth_service.verify_session(&session_token).await.unwrap();
         assert_eq!(verified_user.id, user.id);
+    }
+
+    /// Regression: an MFA challenge token (first factor only) must never
+    /// authenticate a real request. Before the `mfa_pending` discriminator,
+    /// `create_mfa_session` inserted an ordinary `sessions` row and
+    /// `verify_session` accepted it, so replaying the `mfa_session` cookie as
+    /// the `session` cookie yielded a fully authenticated context without the
+    /// second factor.
+    #[tokio::test]
+    async fn test_mfa_pending_session_cannot_authenticate_via_verify_session() {
+        let (db, auth_service, _) = setup_test_env().await;
+        let user = create_test_user(&db.db, "mfabypass@example.com", "password").await;
+
+        // Token handed to the client as the `mfa_session` cookie.
+        let mfa_token = auth_service.create_mfa_session(user.id).await.unwrap();
+
+        // The attack: replay it on the normal session path.
+        let result = auth_service.verify_session(&mfa_token).await;
+        assert!(
+            result.is_err(),
+            "MFA challenge token must NOT authenticate a real request"
+        );
+        assert!(
+            matches!(result.unwrap_err(), AuthError::NotFound(_)),
+            "MFA challenge token should be indistinguishable from a missing session"
+        );
+
+        // Sanity: a genuine session on the same user still authenticates.
+        let real_token = auth_service.create_session(user.id).await.unwrap();
+        assert_eq!(
+            auth_service.verify_session(&real_token).await.unwrap().id,
+            user.id
+        );
+    }
+
+    /// Regression (symmetric): a real, fully authenticated session token must
+    /// not be consumable as an MFA challenge. `verify_mfa_challenge` filters on
+    /// `mfa_pending = true`, so a real token is rejected before the TOTP code
+    /// is ever checked.
+    #[tokio::test]
+    async fn test_real_session_cannot_be_used_as_mfa_challenge() {
+        let (db, auth_service, _) = setup_test_env().await;
+        let user = create_test_user(&db.db, "notachallenge@example.com", "password").await;
+
+        let real_token = auth_service.create_session(user.id).await.unwrap();
+
+        // Even with a bogus code, this must fail because the token is not a
+        // pending challenge -- not because the code is wrong.
+        let result = auth_service
+            .verify_mfa_challenge(&real_token, "000000")
+            .await;
+        assert!(
+            result.is_err(),
+            "A real session token must not be usable as an MFA challenge"
+        );
+    }
+
+    /// A pending MFA challenge row is not a real, active session, so it must
+    /// not inflate the concurrent-session count used for login auditing.
+    #[tokio::test]
+    async fn test_mfa_pending_session_not_counted_as_active() {
+        let (db, auth_service, _) = setup_test_env().await;
+        let user = create_test_user(&db.db, "activecount@example.com", "password").await;
+
+        auth_service.create_mfa_session(user.id).await.unwrap();
+        assert_eq!(
+            auth_service.count_active_sessions(user.id).await.unwrap(),
+            0,
+            "A pending MFA challenge must not count as an active session"
+        );
+
+        auth_service.create_session(user.id).await.unwrap();
+        assert_eq!(
+            auth_service.count_active_sessions(user.id).await.unwrap(),
+            1,
+            "Only the real session should be counted"
+        );
     }
 
     #[tokio::test]

--- a/crates/temps-auth/src/auth_service.rs
+++ b/crates/temps-auth/src/auth_service.rs
@@ -1304,7 +1304,9 @@ mod tests {
     /// second factor.
     #[tokio::test]
     async fn test_mfa_pending_session_cannot_authenticate_via_verify_session() {
-        let (db, auth_service, _) = setup_test_env().await;
+        let Some((db, auth_service)) = setup_test_env_with_mfa_setting(false).await else {
+            return;
+        };
         let user = create_test_user(&db.db, "mfabypass@example.com", "password").await;
 
         // Token handed to the client as the `mfa_session` cookie.
@@ -1335,19 +1337,23 @@ mod tests {
     /// is ever checked.
     #[tokio::test]
     async fn test_real_session_cannot_be_used_as_mfa_challenge() {
-        let (db, auth_service, _) = setup_test_env().await;
+        let Some((db, auth_service)) = setup_test_env_with_mfa_setting(false).await else {
+            return;
+        };
         let user = create_test_user(&db.db, "notachallenge@example.com", "password").await;
 
         let real_token = auth_service.create_session(user.id).await.unwrap();
 
-        // Even with a bogus code, this must fail because the token is not a
-        // pending challenge -- not because the code is wrong.
         let result = auth_service
             .verify_mfa_challenge(&real_token, "000000")
             .await;
         assert!(
-            result.is_err(),
-            "A real session token must not be usable as an MFA challenge"
+            matches!(
+                result,
+                Err(AuthError::GenericError(ref message))
+                    if message == "Invalid or expired session"
+            ),
+            "A real session token must be rejected before TOTP verification, got: {result:?}"
         );
     }
 
@@ -1355,7 +1361,9 @@ mod tests {
     /// not inflate the concurrent-session count used for login auditing.
     #[tokio::test]
     async fn test_mfa_pending_session_not_counted_as_active() {
-        let (db, auth_service, _) = setup_test_env().await;
+        let Some((db, auth_service)) = setup_test_env_with_mfa_setting(false).await else {
+            return;
+        };
         let user = create_test_user(&db.db, "activecount@example.com", "password").await;
 
         auth_service.create_mfa_session(user.id).await.unwrap();

--- a/crates/temps-entities/src/sessions.rs
+++ b/crates/temps-entities/src/sessions.rs
@@ -11,6 +11,11 @@ pub struct Model {
     #[serde(skip_serializing)]
     pub session_token: String,
     pub expires_at: DBDateTime,
+    /// True while this row is a first-factor-only MFA challenge awaiting TOTP
+    /// verification. Such rows must never authenticate a real request: only
+    /// `verify_mfa_challenge` may consume them, and `verify_session` filters
+    /// them out. A fully authenticated session has this set to false.
+    pub mfa_pending: bool,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/temps-migrations/src/migration/m20260713_000001_add_mfa_pending_to_sessions.rs
+++ b/crates/temps-migrations/src/migration/m20260713_000001_add_mfa_pending_to_sessions.rs
@@ -10,13 +10,30 @@
 //! This column lets `verify_session` reject challenge rows and
 //! `verify_mfa_challenge` reject real-session rows.
 //!
-//! Backfill note: existing rows default to FALSE. Real sessions are correctly
-//! treated as fully authenticated. Any in-flight MFA challenge rows at deploy
-//! time also become FALSE (i.e. promoted), but these live at most 5 minutes and
-//! require the caller to already hold the account password, so the exposure is
-//! negligible and self-clearing.
+//! Existing rows cannot be classified safely because the old schema did not
+//! distinguish real sessions from MFA challenges. The migration therefore
+//! revokes every existing session. The database default is `TRUE` so an older
+//! binary participating in a rolling upgrade fails closed when it omits the
+//! discriminator. The new binary writes `FALSE` explicitly only after full
+//! authentication. Users must sign in again after the upgrade, but no old or
+//! mixed-version challenge can be promoted into a real session.
 
 use sea_orm_migration::prelude::*;
+
+const UP_SQL: &str = r#"
+ALTER TABLE sessions
+ADD COLUMN IF NOT EXISTS mfa_pending BOOLEAN;
+
+-- Old rows are ambiguous: they may be authenticated sessions or MFA
+-- challenges. Revoking all of them is the only fail-closed backfill.
+DELETE FROM sessions;
+
+ALTER TABLE sessions
+ALTER COLUMN mfa_pending SET DEFAULT TRUE;
+
+ALTER TABLE sessions
+ALTER COLUMN mfa_pending SET NOT NULL;
+"#;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -26,13 +43,7 @@ impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         let db = manager.get_connection();
 
-        db.execute_unprepared(
-            r#"
-            ALTER TABLE sessions
-            ADD COLUMN IF NOT EXISTS mfa_pending BOOLEAN NOT NULL DEFAULT FALSE
-            "#,
-        )
-        .await?;
+        db.execute_unprepared(UP_SQL).await?;
 
         Ok(())
     }
@@ -48,5 +59,32 @@ impl MigrationTrait for Migration {
         .await?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UP_SQL;
+
+    #[test]
+    fn revokes_ambiguous_sessions_before_setting_authenticated_default() {
+        let delete_position = UP_SQL
+            .find("DELETE FROM sessions")
+            .expect("migration must revoke pre-upgrade sessions");
+        let default_position = UP_SQL
+            .find("ALTER COLUMN mfa_pending SET DEFAULT TRUE")
+            .expect("migration must default omitted session purpose to MFA-pending");
+        let not_null_position = UP_SQL
+            .find("ALTER COLUMN mfa_pending SET NOT NULL")
+            .expect("migration must make the discriminator mandatory");
+
+        assert!(
+            delete_position < default_position,
+            "ambiguous rows must be revoked before enforcing the fail-closed default"
+        );
+        assert!(
+            default_position < not_null_position,
+            "the default must be established before enforcing NOT NULL"
+        );
     }
 }

--- a/crates/temps-migrations/src/migration/m20260713_000001_add_mfa_pending_to_sessions.rs
+++ b/crates/temps-migrations/src/migration/m20260713_000001_add_mfa_pending_to_sessions.rs
@@ -1,0 +1,52 @@
+//! Migration to add `mfa_pending` to the sessions table.
+//!
+//! Closes an MFA-bypass: the temporary session created after the first factor
+//! (password) passes was inserted into the same `sessions` table as a fully
+//! authenticated session, distinguished only by a short expiry. `verify_session`
+//! accepted any non-expired row, so the `mfa_session` challenge cookie could be
+//! replayed as the `session` cookie to authenticate real requests without ever
+//! completing the second factor.
+//!
+//! This column lets `verify_session` reject challenge rows and
+//! `verify_mfa_challenge` reject real-session rows.
+//!
+//! Backfill note: existing rows default to FALSE. Real sessions are correctly
+//! treated as fully authenticated. Any in-flight MFA challenge rows at deploy
+//! time also become FALSE (i.e. promoted), but these live at most 5 minutes and
+//! require the caller to already hold the account password, so the exposure is
+//! negligible and self-clearing.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        db.execute_unprepared(
+            r#"
+            ALTER TABLE sessions
+            ADD COLUMN IF NOT EXISTS mfa_pending BOOLEAN NOT NULL DEFAULT FALSE
+            "#,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        db.execute_unprepared(
+            r#"
+            ALTER TABLE sessions DROP COLUMN IF EXISTS mfa_pending
+            "#,
+        )
+        .await?;
+
+        Ok(())
+    }
+}

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -147,6 +147,7 @@ mod m20260708_000001_add_node_id_to_monitoring_alert_rules;
 mod m20260711_000001_add_proxy_logs_stats_cagg;
 mod m20260711_000002_add_ip_geolocations_hosting_provider;
 mod m20260711_000003_add_visitor_non_crawler_partial_index;
+mod m20260713_000001_add_mfa_pending_to_sessions;
 
 pub struct Migrator;
 
@@ -299,6 +300,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260711_000001_add_proxy_logs_stats_cagg::Migration),
             Box::new(m20260711_000002_add_ip_geolocations_hosting_provider::Migration),
             Box::new(m20260711_000003_add_visitor_non_crawler_partial_index::Migration),
+            Box::new(m20260713_000001_add_mfa_pending_to_sessions::Migration),
         ]
     }
 }

--- a/crates/temps-migrations/tests/migration_tests.rs
+++ b/crates/temps-migrations/tests/migration_tests.rs
@@ -1671,3 +1671,123 @@ async fn test_observe_correlation_migration_survives_concurrent_retention() -> a
     );
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Regression test: the MFA session-purpose migration must fail closed.
+// Pre-upgrade rows are ambiguous, so all are revoked. An old binary may still
+// omit `mfa_pending` during a rolling upgrade; the database default must mark
+// such rows pending rather than authenticate them.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn test_mfa_pending_migration_revokes_ambiguous_sessions_and_defaults_closed(
+) -> anyhow::Result<()> {
+    if std::env::var("TEMPS_TEST_DATABASE_URL").is_ok() {
+        println!("⏭️  Skipping MFA session migration test: external database in use");
+        return Ok(());
+    }
+
+    let container = match GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_env_var("POSTGRES_DB", "postgres")
+        .with_env_var("POSTGRES_USER", "postgres")
+        .with_env_var("POSTGRES_PASSWORD", "postgres")
+        .with_env_var("POSTGRES_HOST_AUTH_METHOD", "trust")
+        .start()
+        .await
+    {
+        Ok(container) => container,
+        Err(error) => {
+            println!("⏭️  Skipping MFA session migration test: {error}");
+            return Ok(());
+        }
+    };
+    let port = container.get_host_port_ipv4(5432).await?;
+    let db_url = format!("postgresql://postgres:postgres@localhost:{port}/postgres");
+    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+    let db = connect_with_retries(&db_url).await?;
+
+    let target = "m20260713_000001_add_mfa_pending_to_sessions";
+    let pre_target_count = Migrator::migrations()
+        .iter()
+        .position(|migration| migration.name() == target)
+        .unwrap_or_else(|| panic!("migration {target} not found in Migrator"));
+    Migrator::up(&db, Some(pre_target_count as u32)).await?;
+
+    let user = db
+        .query_one(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "INSERT INTO users (name, email, created_at, updated_at) \
+             VALUES ('MFA migration user', 'mfa-migration@example.test', now(), now()) \
+             RETURNING id"
+                .to_string(),
+        ))
+        .await?
+        .expect("inserted user row");
+    let user_id: i32 = user.try_get("", "id")?;
+
+    db.execute_unprepared(&format!(
+        "INSERT INTO sessions (user_id, session_token, expires_at) VALUES \
+         ({user_id}, 'pre-upgrade-real', now() + INTERVAL '7 days'), \
+         ({user_id}, 'pre-upgrade-challenge', now() + INTERVAL '5 minutes')"
+    ))
+    .await?;
+
+    Migrator::up(&db, None).await?;
+
+    let remaining = db
+        .query_one(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT count(*)::int AS count FROM sessions".to_string(),
+        ))
+        .await?
+        .expect("session count row");
+    let remaining_count: i32 = remaining.try_get("", "count")?;
+    assert_eq!(
+        remaining_count, 0,
+        "all ambiguous pre-upgrade sessions must be revoked"
+    );
+
+    let column = db
+        .query_one(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT is_nullable, column_default \
+             FROM information_schema.columns \
+             WHERE table_schema = current_schema() \
+               AND table_name = 'sessions' \
+               AND column_name = 'mfa_pending'"
+                .to_string(),
+        ))
+        .await?
+        .expect("mfa_pending schema row");
+    let is_nullable: String = column.try_get("", "is_nullable")?;
+    let column_default: String = column.try_get("", "column_default")?;
+    assert_eq!(is_nullable, "NO", "mfa_pending must remain mandatory");
+    assert_eq!(
+        column_default, "true",
+        "omitted session purpose must default to MFA-pending"
+    );
+
+    let legacy_insert = db
+        .query_one(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            format!(
+                "INSERT INTO sessions (user_id, session_token, expires_at) \
+                 VALUES ({user_id}, 'mixed-version-challenge', now() + INTERVAL '5 minutes') \
+                 RETURNING mfa_pending"
+            ),
+        ))
+        .await?
+        .expect("legacy-style session insert");
+    let defaults_pending: bool = legacy_insert.try_get("", "mfa_pending")?;
+    assert!(
+        defaults_pending,
+        "a mixed-version insert that omits purpose must fail closed"
+    );
+
+    db.execute_unprepared(&format!(
+        "INSERT INTO sessions (user_id, session_token, expires_at, mfa_pending) \
+         VALUES ({user_id}, 'new-real-session', now() + INTERVAL '7 days', FALSE)"
+    ))
+    .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes an **authentication bypass of MFA**: the temporary session created after the first factor (password) passed was inserted into the same `sessions` table as a fully authenticated session, distinguished only by a 5-minute expiry. `verify_session` accepted **any** non-expired row, so an attacker who already has the password (exactly what MFA defends against) could:

1. `POST /api/auth/login` → receive `Set-Cookie: mfa_session=<E>`
2. Replay `<E>` as `Cookie: session=<E>` against any endpoint

…and obtain a fully authenticated context — **Admin included** — without ever producing a TOTP code. The two cookies are interchangeable ciphertext (same `CookieCrypto` key, no purpose binding), so no discriminator existed at the token, cookie, or row level. The OIDC MFA leg (`oidc_handler.rs`) shared the flaw via the same `create_mfa_session` / `verify_session` pair.

`require_mfa_for_admins` makes it *worse*, not better: forcing admins to enroll sets `mfa_enabled = true`, which is precisely the flag that routes login down the vulnerable `create_mfa_session` branch.

## Fix

Add a non-nullable `mfa_pending` discriminator column to `sessions`:

- `create_mfa_session` sets it `true`; `create_session` sets it `false`.
- `verify_session` and `count_active_sessions` filter `mfa_pending = false` — a challenge row can never authenticate a request or inflate the concurrent-session audit count.
- `verify_mfa_challenge` requires `mfa_pending = true` — a real session token cannot be spent as a challenge either. The discriminator cuts both ways.

The fix lives in the service layer, so it covers **both** the password and OIDC MFA legs.

### Migration / backfill

`ALTER TABLE sessions ADD COLUMN mfa_pending BOOLEAN NOT NULL DEFAULT FALSE`. Existing rows default to `false` (real sessions stay valid). Any in-flight MFA challenge row at deploy time also becomes `false` (i.e. promoted), but those live ≤5 min and require the caller to already hold the password — negligible, self-clearing exposure.

## Verification (reproduced locally on an isolated instance)

Ran the actual attack against a running `temps serve` before and after the fix:

| Step | Pre-fix | Post-fix |
|---|---|---|
| Replay `mfa_session` value as `session` cookie → `GET /api/user/me` | **200, authenticated as admin** (`role: admin`) | **401 Authentication Required** |
| Legitimate `POST /api/auth/verify-mfa` with valid TOTP → session | 200, works | 200, still works |

Plus 3 new unit tests (all passing):
- `test_mfa_pending_session_cannot_authenticate_via_verify_session`
- `test_real_session_cannot_be_used_as_mfa_challenge`
- `test_mfa_pending_session_not_counted_as_active`

## Notes for reviewers

I chose the discriminator-column approach over a separate `mfa_challenges` table for a contained, migration-safe hotfix. The tradeoff: a boolean defaulting to `false` means any *future* read path that forgets the `mfa_pending = false` filter silently reverts to the vulnerable behavior. This PR covers all three current read paths (`verify_session`, `count_active_sessions`, `verify_mfa_challenge`). If the team prefers the stronger structural guarantee, a follow-up can migrate challenge tokens to their own table so they have no representation in `sessions` at all.
