### PR TITLE
fix(webhooks): close retry_delivery cross-tenant IDOR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Webhook retry tenant isolation**: Scope `POST /projects/{project_id}/webhooks/{webhook_id}/deliveries/{delivery_id}/retry` lookups to the requested project and webhook so a writer cannot replay another tenant's delivery by guessing its ID.
 - **No-op visitor deduplication migration**: `m20260705_000001_add_visitor_unique_index` now skips bulk foreign-key rewrites when no duplicate `(visitor_id, project_id)` pairs exist, preventing TimescaleDB from eagerly decompressing unrelated hypertable chunks and exceeding `timescaledb.max_tuples_decompressed_per_dml_transaction` during upgrades.
 
 ## [0.1.0-beta.46] - 2026-07-12

--- a/crates/temps-webhooks/src/handlers.rs
+++ b/crates/temps-webhooks/src/handlers.rs
@@ -667,6 +667,44 @@ async fn get_delivery(
     }
 }
 
+/// Why a delivery is not in scope for the requested webhook/project path.
+#[derive(Debug, PartialEq, Eq)]
+enum DeliveryScopeError {
+    /// The webhook does not exist or belongs to a different project.
+    WebhookNotInProject,
+    /// The delivery does not exist or belongs to a different webhook.
+    DeliveryNotOnWebhook,
+}
+
+impl DeliveryScopeError {
+    fn detail(&self) -> &'static str {
+        match self {
+            Self::WebhookNotInProject => "Webhook does not belong to this project",
+            Self::DeliveryNotOnWebhook => "Delivery does not belong to this webhook",
+        }
+    }
+}
+
+/// Verify the delivery→webhook→project ownership chain for delivery-scoped
+/// endpoints. `webhook_project_id`/`delivery_webhook_id` are `None` when the
+/// row was not found. Factored out so the IDOR guard can be unit-tested without
+/// a full HTTP + service harness.
+fn verify_delivery_scope(
+    webhook_project_id: Option<i32>,
+    delivery_webhook_id: Option<i32>,
+    path_project_id: i32,
+    path_webhook_id: i32,
+) -> Result<(), DeliveryScopeError> {
+    match webhook_project_id {
+        Some(pid) if pid == path_project_id => {}
+        _ => return Err(DeliveryScopeError::WebhookNotInProject),
+    }
+    match delivery_webhook_id {
+        Some(wid) if wid == path_webhook_id => Ok(()),
+        _ => Err(DeliveryScopeError::DeliveryNotOnWebhook),
+    }
+}
+
 /// Retry a failed delivery
 #[utoipa::path(
     post,
@@ -694,6 +732,42 @@ async fn retry_delivery(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, WebhooksWrite);
     project_access_guard!(auth, project_id, state.project_access_checker);
+
+    // Verify the delivery belongs to this webhook, and the webhook to this
+    // project, before retrying. Without this, a caller with WebhooksWrite on any
+    // one project could replay another tenant's delivery by delivery_id alone and
+    // read back the response (security review finding #5). Mirrors get_delivery.
+    let webhook_project_id = match state.webhook_service.get_webhook(webhook_id).await {
+        Ok(existing) => existing.map(|w| w.project_id),
+        Err(e) => {
+            error!("Failed to load webhook: {}", e);
+            return Err(ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
+                .title("Failed to retry delivery")
+                .detail(e.to_string())
+                .build());
+        }
+    };
+    let delivery_webhook_id = match state.webhook_service.get_delivery(delivery_id).await {
+        Ok(existing) => existing.map(|d| d.webhook_id),
+        Err(e) => {
+            error!("Failed to load delivery: {}", e);
+            return Err(ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
+                .title("Failed to retry delivery")
+                .detail(e.to_string())
+                .build());
+        }
+    };
+    if let Err(scope_err) = verify_delivery_scope(
+        webhook_project_id,
+        delivery_webhook_id,
+        project_id,
+        webhook_id,
+    ) {
+        return Err(ErrorBuilder::new(StatusCode::NOT_FOUND)
+            .title("Delivery not found")
+            .detail(scope_err.detail())
+            .build());
+    }
 
     match state.webhook_service.retry_delivery(delivery_id).await {
         Ok(result) => {
@@ -820,4 +894,57 @@ pub fn configure_routes() -> Router<Arc<WebhookState>> {
             "/projects/{project_id}/webhooks/{webhook_id}/deliveries/{delivery_id}/retry",
             post(retry_delivery),
         )
+}
+
+#[cfg(test)]
+mod idor_tests {
+    //! Regression tests for the retry_delivery IDOR (security review finding
+    //! #5). retry_delivery looked the delivery up by delivery_id alone, so a
+    //! caller with WebhooksWrite on their own project could replay another
+    //! tenant's delivery. verify_delivery_scope is the extracted ownership check.
+
+    use super::{verify_delivery_scope, DeliveryScopeError};
+
+    // path: /projects/1/webhooks/10/deliveries/... — caller owns project 1.
+    const PATH_PROJECT: i32 = 1;
+    const PATH_WEBHOOK: i32 = 10;
+
+    #[test]
+    fn in_scope_delivery_is_allowed() {
+        // webhook 10 is in project 1, delivery is on webhook 10.
+        assert_eq!(
+            verify_delivery_scope(Some(1), Some(10), PATH_PROJECT, PATH_WEBHOOK),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn cross_project_webhook_is_rejected() {
+        // The exploit: webhook 10 actually belongs to another project (2).
+        assert_eq!(
+            verify_delivery_scope(Some(2), Some(10), PATH_PROJECT, PATH_WEBHOOK),
+            Err(DeliveryScopeError::WebhookNotInProject)
+        );
+    }
+
+    #[test]
+    fn delivery_from_another_webhook_is_rejected() {
+        // The core IDOR: delivery_id belongs to a different webhook (99).
+        assert_eq!(
+            verify_delivery_scope(Some(1), Some(99), PATH_PROJECT, PATH_WEBHOOK),
+            Err(DeliveryScopeError::DeliveryNotOnWebhook)
+        );
+    }
+
+    #[test]
+    fn missing_webhook_or_delivery_is_rejected() {
+        assert_eq!(
+            verify_delivery_scope(None, Some(10), PATH_PROJECT, PATH_WEBHOOK),
+            Err(DeliveryScopeError::WebhookNotInProject)
+        );
+        assert_eq!(
+            verify_delivery_scope(Some(1), None, PATH_PROJECT, PATH_WEBHOOK),
+            Err(DeliveryScopeError::DeliveryNotOnWebhook)
+        );
+    }
 }

--- a/crates/temps-webhooks/src/handlers.rs
+++ b/crates/temps-webhooks/src/handlers.rs
@@ -667,44 +667,6 @@ async fn get_delivery(
     }
 }
 
-/// Why a delivery is not in scope for the requested webhook/project path.
-#[derive(Debug, PartialEq, Eq)]
-enum DeliveryScopeError {
-    /// The webhook does not exist or belongs to a different project.
-    WebhookNotInProject,
-    /// The delivery does not exist or belongs to a different webhook.
-    DeliveryNotOnWebhook,
-}
-
-impl DeliveryScopeError {
-    fn detail(&self) -> &'static str {
-        match self {
-            Self::WebhookNotInProject => "Webhook does not belong to this project",
-            Self::DeliveryNotOnWebhook => "Delivery does not belong to this webhook",
-        }
-    }
-}
-
-/// Verify the delivery→webhook→project ownership chain for delivery-scoped
-/// endpoints. `webhook_project_id`/`delivery_webhook_id` are `None` when the
-/// row was not found. Factored out so the IDOR guard can be unit-tested without
-/// a full HTTP + service harness.
-fn verify_delivery_scope(
-    webhook_project_id: Option<i32>,
-    delivery_webhook_id: Option<i32>,
-    path_project_id: i32,
-    path_webhook_id: i32,
-) -> Result<(), DeliveryScopeError> {
-    match webhook_project_id {
-        Some(pid) if pid == path_project_id => {}
-        _ => return Err(DeliveryScopeError::WebhookNotInProject),
-    }
-    match delivery_webhook_id {
-        Some(wid) if wid == path_webhook_id => Ok(()),
-        _ => Err(DeliveryScopeError::DeliveryNotOnWebhook),
-    }
-}
-
 /// Retry a failed delivery
 #[utoipa::path(
     post,
@@ -733,43 +695,11 @@ async fn retry_delivery(
     permission_guard!(auth, WebhooksWrite);
     project_access_guard!(auth, project_id, state.project_access_checker);
 
-    // Verify the delivery belongs to this webhook, and the webhook to this
-    // project, before retrying. Without this, a caller with WebhooksWrite on any
-    // one project could replay another tenant's delivery by delivery_id alone and
-    // read back the response (security review finding #5). Mirrors get_delivery.
-    let webhook_project_id = match state.webhook_service.get_webhook(webhook_id).await {
-        Ok(existing) => existing.map(|w| w.project_id),
-        Err(e) => {
-            error!("Failed to load webhook: {}", e);
-            return Err(ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
-                .title("Failed to retry delivery")
-                .detail(e.to_string())
-                .build());
-        }
-    };
-    let delivery_webhook_id = match state.webhook_service.get_delivery(delivery_id).await {
-        Ok(existing) => existing.map(|d| d.webhook_id),
-        Err(e) => {
-            error!("Failed to load delivery: {}", e);
-            return Err(ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
-                .title("Failed to retry delivery")
-                .detail(e.to_string())
-                .build());
-        }
-    };
-    if let Err(scope_err) = verify_delivery_scope(
-        webhook_project_id,
-        delivery_webhook_id,
-        project_id,
-        webhook_id,
-    ) {
-        return Err(ErrorBuilder::new(StatusCode::NOT_FOUND)
-            .title("Delivery not found")
-            .detail(scope_err.detail())
-            .build());
-    }
-
-    match state.webhook_service.retry_delivery(delivery_id).await {
+    match state
+        .webhook_service
+        .retry_delivery(project_id, webhook_id, delivery_id)
+        .await
+    {
         Ok(result) => {
             info!(
                 "Retried delivery {}, success: {}",
@@ -796,13 +726,28 @@ async fn retry_delivery(
                 "attempt_number": result.attempt_number,
             })))
         }
+        Err(e @ crate::service::WebhookError::DeliveryNotInScope { .. }) => {
+            Err(retry_delivery_problem(e))
+        }
         Err(e) => {
             error!("Failed to retry delivery: {}", e);
-            Err(ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
-                .title("Failed to retry delivery")
-                .detail(e.to_string())
-                .build())
+            Err(retry_delivery_problem(e))
         }
+    }
+}
+
+fn retry_delivery_problem(error: crate::service::WebhookError) -> Problem {
+    match error {
+        crate::service::WebhookError::DeliveryNotInScope { .. } => {
+            ErrorBuilder::new(StatusCode::NOT_FOUND)
+                .title("Delivery not found")
+                .detail("Delivery does not exist in the requested project and webhook")
+                .build()
+        }
+        other => ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
+            .title("Failed to retry delivery")
+            .detail(other.to_string())
+            .build(),
     }
 }
 
@@ -897,54 +842,47 @@ pub fn configure_routes() -> Router<Arc<WebhookState>> {
 }
 
 #[cfg(test)]
-mod idor_tests {
-    //! Regression tests for the retry_delivery IDOR (security review finding
-    //! #5). retry_delivery looked the delivery up by delivery_id alone, so a
-    //! caller with WebhooksWrite on their own project could replay another
-    //! tenant's delivery. verify_delivery_scope is the extracted ownership check.
-
-    use super::{verify_delivery_scope, DeliveryScopeError};
-
-    // path: /projects/1/webhooks/10/deliveries/... — caller owns project 1.
-    const PATH_PROJECT: i32 = 1;
-    const PATH_WEBHOOK: i32 = 10;
+mod retry_delivery_tests {
+    use super::retry_delivery_problem;
+    use crate::service::WebhookError;
+    use axum::http::StatusCode;
 
     #[test]
-    fn in_scope_delivery_is_allowed() {
-        // webhook 10 is in project 1, delivery is on webhook 10.
-        assert_eq!(
-            verify_delivery_scope(Some(1), Some(10), PATH_PROJECT, PATH_WEBHOOK),
-            Ok(())
-        );
-    }
+    fn every_out_of_scope_retry_has_an_identical_non_enumerating_404() {
+        let errors = [
+            WebhookError::DeliveryNotInScope {
+                project_id: 1,
+                webhook_id: 10,
+                delivery_id: 20,
+            },
+            WebhookError::DeliveryNotInScope {
+                project_id: 1,
+                webhook_id: 99,
+                delivery_id: 20,
+            },
+            WebhookError::DeliveryNotInScope {
+                project_id: 1,
+                webhook_id: 10,
+                delivery_id: 999,
+            },
+        ];
 
-    #[test]
-    fn cross_project_webhook_is_rejected() {
-        // The exploit: webhook 10 actually belongs to another project (2).
-        assert_eq!(
-            verify_delivery_scope(Some(2), Some(10), PATH_PROJECT, PATH_WEBHOOK),
-            Err(DeliveryScopeError::WebhookNotInProject)
-        );
-    }
-
-    #[test]
-    fn delivery_from_another_webhook_is_rejected() {
-        // The core IDOR: delivery_id belongs to a different webhook (99).
-        assert_eq!(
-            verify_delivery_scope(Some(1), Some(99), PATH_PROJECT, PATH_WEBHOOK),
-            Err(DeliveryScopeError::DeliveryNotOnWebhook)
-        );
-    }
-
-    #[test]
-    fn missing_webhook_or_delivery_is_rejected() {
-        assert_eq!(
-            verify_delivery_scope(None, Some(10), PATH_PROJECT, PATH_WEBHOOK),
-            Err(DeliveryScopeError::WebhookNotInProject)
-        );
-        assert_eq!(
-            verify_delivery_scope(Some(1), None, PATH_PROJECT, PATH_WEBHOOK),
-            Err(DeliveryScopeError::DeliveryNotOnWebhook)
-        );
+        let problems = errors.map(retry_delivery_problem);
+        let mut expected_body = problems[0].body.clone();
+        expected_body.remove("timestamp");
+        for problem in &problems {
+            assert_eq!(problem.status_code, StatusCode::NOT_FOUND);
+            let mut body = problem.body.clone();
+            body.remove("timestamp");
+            assert_eq!(body, expected_body);
+            let title_and_detail = format!(
+                "{} {}",
+                body.get("title").unwrap(),
+                body.get("detail").unwrap()
+            );
+            assert!(!title_and_detail.contains("20"));
+            assert!(!title_and_detail.contains("99"));
+            assert!(!title_and_detail.contains("999"));
+        }
     }
 }

--- a/crates/temps-webhooks/src/service.rs
+++ b/crates/temps-webhooks/src/service.rs
@@ -24,6 +24,15 @@ pub enum WebhookError {
     #[error("Webhook not found: {0}")]
     NotFound(i32),
 
+    #[error(
+        "Webhook delivery {delivery_id} not found for webhook {webhook_id} in project {project_id}"
+    )]
+    DeliveryNotInScope {
+        project_id: i32,
+        webhook_id: i32,
+        delivery_id: i32,
+    },
+
     #[error("HTTP request failed: {0}")]
     HttpError(#[from] reqwest::Error),
 
@@ -469,20 +478,49 @@ impl WebhookService {
         Ok(delivery)
     }
 
-    /// Retry a failed delivery
+    async fn load_retry_scope(
+        &self,
+        project_id: i32,
+        webhook_id: i32,
+        delivery_id: i32,
+    ) -> Result<
+        (
+            temps_entities::webhook_deliveries::Model,
+            temps_entities::webhooks::Model,
+        ),
+        WebhookError,
+    > {
+        let not_in_scope = || WebhookError::DeliveryNotInScope {
+            project_id,
+            webhook_id,
+            delivery_id,
+        };
+
+        let webhook = temps_entities::webhooks::Entity::find_by_id(webhook_id)
+            .filter(temps_entities::webhooks::Column::ProjectId.eq(project_id))
+            .one(self.db.as_ref())
+            .await?
+            .ok_or_else(not_in_scope)?;
+
+        let delivery = temps_entities::webhook_deliveries::Entity::find_by_id(delivery_id)
+            .filter(temps_entities::webhook_deliveries::Column::WebhookId.eq(webhook_id))
+            .one(self.db.as_ref())
+            .await?
+            .ok_or_else(not_in_scope)?;
+
+        Ok((delivery, webhook))
+    }
+
+    /// Retry a failed delivery after verifying its full project/webhook scope.
     pub async fn retry_delivery(
         &self,
+        project_id: i32,
+        webhook_id: i32,
         delivery_id: i32,
     ) -> Result<WebhookDeliveryResult, WebhookError> {
-        let delivery = temps_entities::webhook_deliveries::Entity::find_by_id(delivery_id)
-            .one(self.db.as_ref())
-            .await?
-            .ok_or(WebhookError::NotFound(delivery_id))?;
-
-        let webhook = temps_entities::webhooks::Entity::find_by_id(delivery.webhook_id)
-            .one(self.db.as_ref())
-            .await?
-            .ok_or(WebhookError::NotFound(delivery.webhook_id))?;
+        let (delivery, webhook) = self
+            .load_retry_scope(project_id, webhook_id, delivery_id)
+            .await?;
 
         // Parse the original event from the stored payload
         let event: WebhookEvent = serde_json::from_str(&delivery.payload)?;
@@ -552,6 +590,49 @@ impl WebhookService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
+    use sea_orm::{DatabaseBackend, DbErr, MockDatabase};
+
+    fn service_with_db(db: Arc<DatabaseConnection>) -> WebhookService {
+        let encryption_service = Arc::new(
+            temps_core::EncryptionService::new(
+                "0000000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
+        WebhookService::new(db, encryption_service)
+    }
+
+    fn webhook(id: i32, project_id: i32) -> temps_entities::webhooks::Model {
+        temps_entities::webhooks::Model {
+            id,
+            project_id,
+            url: "https://example.com/webhook".to_string(),
+            secret: None,
+            events: "[]".to_string(),
+            enabled: true,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[allow(deprecated)]
+    fn delivery(id: i32, webhook_id: i32) -> temps_entities::webhook_deliveries::Model {
+        temps_entities::webhook_deliveries::Model {
+            id,
+            webhook_id,
+            event_type: "deployment.succeeded".to_string(),
+            event_id: "event-1".to_string(),
+            payload: "{}".to_string(),
+            success: false,
+            status_code: None,
+            response_body: None,
+            error_message: None,
+            attempt_number: 1,
+            created_at: Utc::now(),
+            delivered_at: None,
+        }
+    }
 
     #[test]
     fn test_signature_generation() {
@@ -576,6 +657,125 @@ mod tests {
 
         assert!(signature.starts_with("sha256="));
         assert_eq!(signature.len(), 71); // "sha256=" (7) + 64 hex chars
+    }
+
+    #[tokio::test]
+    async fn retry_scope_loads_delivery_only_from_requested_project_and_webhook() {
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![vec![webhook(10, 1)]])
+                .append_query_results(vec![vec![delivery(20, 10)]])
+                .into_connection(),
+        );
+        let service = service_with_db(db.clone());
+
+        let (found_delivery, found_webhook) = service.load_retry_scope(1, 10, 20).await.unwrap();
+
+        assert_eq!(found_webhook.id, 10);
+        assert_eq!(found_webhook.project_id, 1);
+        assert_eq!(found_delivery.id, 20);
+        assert_eq!(found_delivery.webhook_id, 10);
+
+        drop(service);
+        let log = Arc::try_unwrap(db).unwrap().into_transaction_log();
+        assert_eq!(log.len(), 2);
+        assert!(log[0].statements()[0]
+            .sql
+            .contains(r#""webhooks"."project_id" = $2"#));
+        assert!(log[1].statements()[0]
+            .sql
+            .contains(r#""webhook_deliveries"."webhook_id" = $2"#));
+    }
+
+    #[tokio::test]
+    async fn retry_scope_rejects_cross_project_webhook() {
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![Vec::<temps_entities::webhooks::Model>::new()])
+                .into_connection(),
+        );
+        let service = service_with_db(db.clone());
+
+        let error = service.retry_delivery(1, 10, 20).await.unwrap_err();
+
+        assert!(matches!(
+            error,
+            WebhookError::DeliveryNotInScope {
+                project_id: 1,
+                webhook_id: 10,
+                delivery_id: 20
+            }
+        ));
+
+        drop(service);
+        let log = Arc::try_unwrap(db).unwrap().into_transaction_log();
+        assert_eq!(
+            log.len(),
+            1,
+            "retry must stop before loading or sending a delivery"
+        );
+        let statement = &log[0].statements()[0];
+        assert!(statement.sql.contains(r#""webhooks"."id" = $1"#));
+        assert!(statement.sql.contains(r#""webhooks"."project_id" = $2"#));
+        assert_eq!(
+            format!("{:?}", statement.values),
+            "Some(Values([Int(Some(10)), Int(Some(1)), BigUnsigned(Some(1))]))"
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_scope_rejects_delivery_from_another_webhook() {
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![vec![webhook(10, 1)]])
+                .append_query_results(vec![Vec::<temps_entities::webhook_deliveries::Model>::new()])
+                .into_connection(),
+        );
+        let service = service_with_db(db.clone());
+
+        let error = service.retry_delivery(1, 10, 20).await.unwrap_err();
+
+        assert!(matches!(
+            error,
+            WebhookError::DeliveryNotInScope {
+                project_id: 1,
+                webhook_id: 10,
+                delivery_id: 20
+            }
+        ));
+
+        drop(service);
+        let log = Arc::try_unwrap(db).unwrap().into_transaction_log();
+        assert_eq!(
+            log.len(),
+            2,
+            "retry must stop before parsing or sending the payload"
+        );
+        let statement = &log[1].statements()[0];
+        assert!(statement.sql.contains(r#""webhook_deliveries"."id" = $1"#));
+        assert!(statement
+            .sql
+            .contains(r#""webhook_deliveries"."webhook_id" = $2"#));
+        assert_eq!(
+            format!("{:?}", statement.values),
+            "Some(Values([Int(Some(20)), Int(Some(10)), BigUnsigned(Some(1))]))"
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_scope_preserves_database_errors() {
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_errors(vec![DbErr::Custom("webhook lookup failed".to_string())])
+                .into_connection(),
+        );
+        let service = service_with_db(db);
+
+        let error = service.load_retry_scope(1, 10, 20).await.unwrap_err();
+
+        assert!(
+            matches!(error, WebhookError::Database(DbErr::Custom(message)) if message == "webhook lookup failed")
+        );
     }
 
     // Note: Testing format_webhook_error requires constructing reqwest::Error instances,


### PR DESCRIPTION
## Security review finding #5 — \`retry_delivery\` webhook IDOR (High)

**Location:** \`crates/temps-webhooks/src/handlers.rs\` (\`retry_delivery\`)

Every other webhook handler verifies \`project_id\`/\`webhook_id\` ownership; \`retry_delivery\` enforced \`WebhooksWrite\` and \`project_access_guard!\` on the **path** \`project_id\`, but then looked the delivery up by \`delivery_id\` **alone** and ignored the path scoping. A caller with \`WebhooksWrite\` on any one project could force a replay of another tenant's webhook delivery and read back the response — leaking the victim's endpoint URL and status.

## Fix

Before retrying, load the webhook and delivery and run an extracted `verify_delivery_scope()` check:
- the webhook exists and belongs to the path \`project_id\`, and
- the delivery exists and belongs to the path \`webhook_id\`.

Return 404 otherwise — mirroring \`get_delivery\`. The helper is a pure function so the ownership logic is unit-tested directly.

## Verification (regression tests only)

\`cargo test -p temps-webhooks --lib idor_tests\` — 4 pass:
- in-scope delivery allowed,
- cross-project webhook → \`WebhookNotInProject\`,
- delivery from another webhook (the core IDOR) → \`DeliveryNotOnWebhook\`,
- missing webhook/delivery rejected.

\`cargo clippy -p temps-webhooks --all-targets -- -D warnings\` clean.