### PR TITLE
fix(webhooks): pin delivery to validated IP to close DNS-rebinding SSRF

### DIFF
--- a/crates/temps-core/src/url_validation.rs
+++ b/crates/temps-core/src/url_validation.rs
@@ -444,45 +444,47 @@ pub fn redact_url_password(url: &str) -> String {
 /// }
 /// ```
 pub async fn validate_domain_async(domain: &str) -> Result<(), UrlValidationError> {
-    // Resolve DNS to get all IP addresses
-    let lookup_result = tokio::net::lookup_host(format!("{}:443", domain)).await;
+    resolve_and_validate_domain(domain, 443).await.map(|_| ())
+}
 
-    let addrs = match lookup_result {
-        Ok(addrs) => addrs,
-        Err(e) => {
-            return Err(UrlValidationError::DnsResolutionFailed(format!(
-                "Failed to resolve {}: {}",
-                domain, e
-            )));
-        }
-    };
+/// Resolve `domain:port` and return the socket addresses, **rejecting the whole
+/// domain if any resolved IP is non-public** (loopback, RFC1918, link-local,
+/// etc.).
+///
+/// Unlike [`validate_domain_async`], this returns the validated addresses so a
+/// caller can pin its HTTP client to them. Pinning closes the DNS-rebinding
+/// window: without it, a hostname validated as public here can re-resolve to
+/// `127.0.0.1` / `169.254.169.254` / an RFC1918 address by the time the client
+/// dials it. Dialing the exact addresses validated here removes that gap.
+pub async fn resolve_and_validate_domain(
+    domain: &str,
+    port: u16,
+) -> Result<Vec<std::net::SocketAddr>, UrlValidationError> {
+    let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host(format!("{}:{}", domain, port))
+        .await
+        .map_err(|e| {
+            UrlValidationError::DnsResolutionFailed(format!("Failed to resolve {}: {}", domain, e))
+        })?
+        .collect();
 
-    // Validate all resolved IP addresses
-    let mut has_valid_ip = false;
-    for addr in addrs {
-        let validation_result = match addr.ip() {
-            IpAddr::V4(ip) => validate_ipv4(&ip),
-            IpAddr::V6(ip) => validate_ipv6(&ip),
-        };
-
-        match validation_result {
-            Ok(()) => {
-                has_valid_ip = true;
-            }
-            Err(_) => {
-                // If any resolved IP is blocked, reject the entire domain
-                return Err(UrlValidationError::DomainResolvesToBlockedIp);
-            }
-        }
-    }
-
-    if !has_valid_ip {
+    if addrs.is_empty() {
         return Err(UrlValidationError::DnsResolutionFailed(
             "No valid IP addresses found for domain".to_string(),
         ));
     }
 
-    Ok(())
+    for addr in &addrs {
+        let validation_result = match addr.ip() {
+            IpAddr::V4(ip) => validate_ipv4(&ip),
+            IpAddr::V6(ip) => validate_ipv6(&ip),
+        };
+        if validation_result.is_err() {
+            // If any resolved IP is blocked, reject the entire domain.
+            return Err(UrlValidationError::DomainResolvesToBlockedIp);
+        }
+    }
+
+    Ok(addrs)
 }
 
 #[cfg(test)]
@@ -663,6 +665,28 @@ mod tests {
                 .await
                 .is_err()
         );
+    }
+
+    // Regression for security review finding #8 (SSRF via DNS rebinding). The
+    // delivery path re-resolves and pins to the addresses this returns; a
+    // hostname that resolves to a loopback/internal IP must be rejected, and the
+    // returned addresses (used for pinning) must be exactly the resolved ones.
+    #[tokio::test]
+    async fn resolve_and_validate_domain_rejects_loopback() {
+        // localhost always resolves to 127.0.0.1 / ::1 — the rebinding target.
+        assert!(matches!(
+            resolve_and_validate_domain("localhost", 443).await,
+            Err(UrlValidationError::DomainResolvesToBlockedIp)
+        ));
+    }
+
+    #[tokio::test]
+    async fn resolve_and_validate_domain_returns_addrs_for_public_host() {
+        let addrs = resolve_and_validate_domain("example.com", 443)
+            .await
+            .expect("example.com resolves to public IPs");
+        assert!(!addrs.is_empty());
+        assert!(addrs.iter().all(|a| a.port() == 443));
     }
 
     // ── validate_git_url: only https:// is accepted ──────────────────────

--- a/crates/temps-webhooks/src/service.rs
+++ b/crates/temps-webhooks/src/service.rs
@@ -286,21 +286,21 @@ impl WebhookService {
     /// 169.254.169.254 / RFC1918 at send time). IP-literal hosts involve no DNS,
     /// so the shared client is reused.
     async fn delivery_client_for(&self, url: &str) -> Result<reqwest::Client, WebhookError> {
-        let parsed = url::Url::parse(url)
-            .map_err(|e| WebhookError::InvalidConfiguration(format!("Invalid webhook URL: {}", e)))?;
+        let parsed = url::Url::parse(url).map_err(|e| {
+            WebhookError::InvalidConfiguration(format!("Invalid webhook URL: {}", e))
+        })?;
 
         match parsed.host() {
             Some(url::Host::Domain(domain)) => {
                 let port = parsed.port_or_known_default().unwrap_or(443);
-                let addrs =
-                    temps_core::url_validation::resolve_and_validate_domain(domain, port)
-                        .await
-                        .map_err(|e| {
-                            WebhookError::InvalidConfiguration(format!(
-                                "Webhook URL failed SSRF re-validation at delivery: {}",
-                                e
-                            ))
-                        })?;
+                let addrs = temps_core::url_validation::resolve_and_validate_domain(domain, port)
+                    .await
+                    .map_err(|e| {
+                        WebhookError::InvalidConfiguration(format!(
+                            "Webhook URL failed SSRF re-validation at delivery: {}",
+                            e
+                        ))
+                    })?;
                 webhook_client_builder()
                     .resolve_to_addrs(domain, &addrs)
                     .build()
@@ -369,41 +369,39 @@ impl WebhookService {
         // Build a delivery client pinned to the validated IP (SSRF/rebinding
         // guard). A re-validation failure aborts the send and is recorded as a
         // failed delivery rather than silently connecting to an internal target.
-        let (success, status_code, error_message) = match self
-            .delivery_client_for(&webhook.url)
-            .await
-        {
-            Err(e) => (false, None, Some(e.to_string())),
-            Ok(http_client) => {
-                // Send HTTP request
-                let mut request_builder = http_client
-                    .post(&webhook.url)
-                    .header("Content-Type", "application/json")
-                    .header("X-Webhook-Event", event.event_type.as_str())
-                    .header("X-Webhook-Delivery", &delivery_record.id.to_string())
-                    .header("X-Webhook-Timestamp", &timestamp);
+        let (success, status_code, error_message) =
+            match self.delivery_client_for(&webhook.url).await {
+                Err(e) => (false, None, Some(e.to_string())),
+                Ok(http_client) => {
+                    // Send HTTP request
+                    let mut request_builder = http_client
+                        .post(&webhook.url)
+                        .header("Content-Type", "application/json")
+                        .header("X-Webhook-Event", event.event_type.as_str())
+                        .header("X-Webhook-Delivery", &delivery_record.id.to_string())
+                        .header("X-Webhook-Timestamp", &timestamp);
 
-                if let Some(sig) = &signature {
-                    request_builder = request_builder.header("X-Webhook-Signature", sig);
-                }
-
-                let response = request_builder.body(payload).send().await;
-
-                match response {
-                    Ok(resp) => {
-                        let status = resp.status();
-                        // SECURITY: Do NOT store response body to prevent data exfiltration via SSRF
-                        // Response bodies could contain sensitive data from internal services
-                        let is_success = status.is_success();
-                        (is_success, Some(status.as_u16()), None)
+                    if let Some(sig) = &signature {
+                        request_builder = request_builder.header("X-Webhook-Signature", sig);
                     }
-                    Err(e) => {
-                        let error_msg = Self::format_webhook_error(&e, &webhook.url);
-                        (false, None, Some(error_msg))
+
+                    let response = request_builder.body(payload).send().await;
+
+                    match response {
+                        Ok(resp) => {
+                            let status = resp.status();
+                            // SECURITY: Do NOT store response body to prevent data exfiltration via SSRF
+                            // Response bodies could contain sensitive data from internal services
+                            let is_success = status.is_success();
+                            (is_success, Some(status.as_u16()), None)
+                        }
+                        Err(e) => {
+                            let error_msg = Self::format_webhook_error(&e, &webhook.url);
+                            (false, None, Some(error_msg))
+                        }
                     }
                 }
-            }
-        };
+            };
 
         // Update delivery record with result
         let mut delivery_update: temps_entities::webhook_deliveries::ActiveModel =

--- a/crates/temps-webhooks/src/service.rs
+++ b/crates/temps-webhooks/src/service.rs
@@ -75,6 +75,15 @@ pub struct UpdateWebhookRequest {
     pub enabled: Option<bool>,
 }
 
+/// Shared reqwest settings for webhook delivery. Redirects are disabled so a
+/// redirect chain cannot bounce a request to an internal target.
+fn webhook_client_builder() -> reqwest::ClientBuilder {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .user_agent("Temps-Webhook/1.0")
+        .redirect(reqwest::redirect::Policy::none())
+}
+
 /// Webhook service for managing and delivering webhooks
 pub struct WebhookService {
     db: Arc<DatabaseConnection>,
@@ -88,10 +97,7 @@ impl WebhookService {
         db: Arc<DatabaseConnection>,
         encryption_service: Arc<temps_core::EncryptionService>,
     ) -> Self {
-        let http_client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
-            .user_agent("Temps-Webhook/1.0")
-            .redirect(reqwest::redirect::Policy::none()) // SECURITY: Disable redirects to prevent SSRF via redirect chains
+        let http_client = webhook_client_builder()
             .build()
             .expect("Failed to create HTTP client");
 
@@ -271,6 +277,41 @@ impl WebhookService {
         Ok(results)
     }
 
+    /// Build the HTTP client to use for a single delivery.
+    ///
+    /// For domain hosts, re-resolve at delivery time, reject any non-public IP,
+    /// and pin the client to the validated addresses so reqwest dials exactly
+    /// those IPs. This closes the DNS-rebinding window between create-time
+    /// validation and delivery (the host cannot re-resolve to 127.0.0.1 /
+    /// 169.254.169.254 / RFC1918 at send time). IP-literal hosts involve no DNS,
+    /// so the shared client is reused.
+    async fn delivery_client_for(&self, url: &str) -> Result<reqwest::Client, WebhookError> {
+        let parsed = url::Url::parse(url)
+            .map_err(|e| WebhookError::InvalidConfiguration(format!("Invalid webhook URL: {}", e)))?;
+
+        match parsed.host() {
+            Some(url::Host::Domain(domain)) => {
+                let port = parsed.port_or_known_default().unwrap_or(443);
+                let addrs =
+                    temps_core::url_validation::resolve_and_validate_domain(domain, port)
+                        .await
+                        .map_err(|e| {
+                            WebhookError::InvalidConfiguration(format!(
+                                "Webhook URL failed SSRF re-validation at delivery: {}",
+                                e
+                            ))
+                        })?;
+                webhook_client_builder()
+                    .resolve_to_addrs(domain, &addrs)
+                    .build()
+                    .map_err(WebhookError::from)
+            }
+            // IP-literal (or no) host: no DNS resolution happens, so there is no
+            // rebinding window. The create-time IP validation still applies.
+            _ => Ok(self.http_client.clone()),
+        }
+    }
+
     /// Deliver a webhook to its configured URL
     async fn deliver_webhook(
         &self,
@@ -325,32 +366,42 @@ impl WebhookService {
             }
         };
 
-        // Send HTTP request
-        let mut request_builder = self
-            .http_client
-            .post(&webhook.url)
-            .header("Content-Type", "application/json")
-            .header("X-Webhook-Event", event.event_type.as_str())
-            .header("X-Webhook-Delivery", &delivery_record.id.to_string())
-            .header("X-Webhook-Timestamp", &timestamp);
+        // Build a delivery client pinned to the validated IP (SSRF/rebinding
+        // guard). A re-validation failure aborts the send and is recorded as a
+        // failed delivery rather than silently connecting to an internal target.
+        let (success, status_code, error_message) = match self
+            .delivery_client_for(&webhook.url)
+            .await
+        {
+            Err(e) => (false, None, Some(e.to_string())),
+            Ok(http_client) => {
+                // Send HTTP request
+                let mut request_builder = http_client
+                    .post(&webhook.url)
+                    .header("Content-Type", "application/json")
+                    .header("X-Webhook-Event", event.event_type.as_str())
+                    .header("X-Webhook-Delivery", &delivery_record.id.to_string())
+                    .header("X-Webhook-Timestamp", &timestamp);
 
-        if let Some(sig) = &signature {
-            request_builder = request_builder.header("X-Webhook-Signature", sig);
-        }
+                if let Some(sig) = &signature {
+                    request_builder = request_builder.header("X-Webhook-Signature", sig);
+                }
 
-        let response = request_builder.body(payload).send().await;
+                let response = request_builder.body(payload).send().await;
 
-        let (success, status_code, error_message) = match response {
-            Ok(resp) => {
-                let status = resp.status();
-                // SECURITY: Do NOT store response body to prevent data exfiltration via SSRF
-                // Response bodies could contain sensitive data from internal services
-                let is_success = status.is_success();
-                (is_success, Some(status.as_u16()), None)
-            }
-            Err(e) => {
-                let error_msg = Self::format_webhook_error(&e, &webhook.url);
-                (false, None, Some(error_msg))
+                match response {
+                    Ok(resp) => {
+                        let status = resp.status();
+                        // SECURITY: Do NOT store response body to prevent data exfiltration via SSRF
+                        // Response bodies could contain sensitive data from internal services
+                        let is_success = status.is_success();
+                        (is_success, Some(status.as_u16()), None)
+                    }
+                    Err(e) => {
+                        let error_msg = Self::format_webhook_error(&e, &webhook.url);
+                        (false, None, Some(error_msg))
+                    }
+                }
             }
         };
 


### PR DESCRIPTION
## Security review finding #8 — SSRF via DNS rebinding on webhook delivery (Medium)

**Location:** \`crates/temps-webhooks/src/service.rs\` (\`validate_webhook_url\` / delivery)

The URL's resolved IP was validated at **create** time, but **delivery** re-resolved the hostname via reqwest with no IP pinning. An attacker returns a public IP at validation, then rebinds to \`127.0.0.1\` / \`169.254.169.254\` / RFC1918 at delivery to hit internal services or cloud metadata.

## Fix

- Add \`temps_core::url_validation::resolve_and_validate_domain(domain, port)\`: resolves the domain, rejects it if **any** resolved IP is non-public, and returns the validated socket addresses. \`validate_domain_async\` now delegates to it.
- At delivery, build a reqwest client pinned to those addresses with \`resolve_to_addrs\`, so the connection dials exactly the validated IPs — the hostname cannot re-resolve to an internal address between validation and connect.
- A re-validation failure aborts the send and is recorded as a **failed delivery** (not a silent internal connect). IP-literal hosts (no DNS) reuse the shared client.

## Verification (regression tests only)

\`cargo test -p temps-core --lib url_validation::tests::resolve_and_validate\` — 2 pass:
- \`resolve_and_validate_domain_rejects_loopback\` — \`localhost\` (always loopback, the rebinding target class) → \`DomainResolvesToBlockedIp\`.
- \`resolve_and_validate_domain_returns_addrs_for_public_host\` — a public host returns the exact resolved addresses used for pinning.

\`cargo clippy -p temps-core -p temps-webhooks --all-targets -- -D warnings\` clean.