### PR TITLE
fix(deps): unbreak build — pin aws-smithy (schema 0.1.0) and revert sqlx to 0.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,38 @@ updates:
     labels:
       - "dependencies"
       - "rust"
+    ignore:
+      # Keep sqlx aligned with sea-orm 1.1 (which requires sqlx ^0.8). A minor
+      # bump to 0.9 splits the graph into two sqlx versions, and 0.9's
+      # SqlSafeStr guard breaks our dynamic queries. Patch bumps within 0.8 are
+      # still allowed. Revisit when we move to sea-orm 2.0 (stable).
+      - dependency-name: "sqlx"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      # sea-orm 2.0 (major) is still pre-release and pulls sqlx 0.9; hold on 1.1.
+      - dependency-name: "sea-orm"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "sea-orm-migration"
+        update-types:
+          - "version-update:semver-major"
+      # sea-schema minor/major bumps drift ahead of the pinned sea-orm line.
+      - dependency-name: "sea-schema"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      # aws-config 1.8.17 / aws-sdk-s3 1.134.0 pin aws-smithy-schema ^0.1.0. A
+      # minor bump of these smithy crates pulls aws-smithy-schema 0.2.0 and
+      # breaks aws-config's compile (SharedClientProtocol type mismatch).
+      - dependency-name: "aws-smithy-runtime"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "aws-types"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
     groups:
       # Patch/minor bumps are low-risk and numerous across 51 crates; batching
       # them into one PR keeps the review queue sane. Majors are left

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,11 +698,11 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-schema 0.1.0",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
@@ -762,7 +762,7 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -792,9 +792,9 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http",
  "aws-smithy-json",
- "aws-smithy-observability 0.2.6",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -825,9 +825,9 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http",
  "aws-smithy-json",
- "aws-smithy-observability 0.2.6",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -849,9 +849,9 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http",
  "aws-smithy-json",
- "aws-smithy-observability 0.2.6",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -873,9 +873,9 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http",
  "aws-smithy-json",
- "aws-smithy-observability 0.2.6",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -897,9 +897,9 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http",
  "aws-smithy-json",
- "aws-smithy-observability 0.2.6",
+ "aws-smithy-observability",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -921,7 +921,7 @@ checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -957,7 +957,7 @@ version = "0.64.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e8e65f4f81fcccdeb6c3eca2af17ac21d421a1786a26a394aecf421d616d3a"
 dependencies = [
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http",
  "aws-smithy-types",
  "bytes",
  "crc-fast",
@@ -1006,27 +1006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-http"
-version = "0.64.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
- "http-body-util",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
 name = "aws-smithy-http-client"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,7 +1036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
 dependencies = [
  "aws-smithy-runtime-api",
- "aws-smithy-schema 0.1.0",
+ "aws-smithy-schema",
  "aws-smithy-types",
 ]
 
@@ -1066,15 +1045,6 @@ name = "aws-smithy-observability"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
-dependencies = [
- "aws-smithy-runtime-api",
-]
-
-[[package]]
-name = "aws-smithy-observability"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
@@ -1091,16 +1061,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.12.0"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea94a9ff8464016338c851e24b472d7131c388c88898a502e781815b2ee6045"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http 0.64.0",
+ "aws-smithy-http",
  "aws-smithy-http-client",
- "aws-smithy-observability 0.3.0",
+ "aws-smithy-observability",
  "aws-smithy-runtime-api",
- "aws-smithy-schema 0.2.0",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
@@ -1156,17 +1126,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-schema"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "http 1.4.2",
-]
-
-[[package]]
 name = "aws-smithy-types"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,14 +1162,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.4.0"
+version = "1.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e957a6c6dbce82b7a91f44231c09273159703769f447cbe85e854dfe9cf67f86"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
- "aws-smithy-schema 0.2.0",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -2303,7 +2262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3272,7 +3231,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4695,7 +4654,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -6512,7 +6471,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6644,7 +6603,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.2",
@@ -7415,7 +7374,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sfv",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "strum",
  "strum_macros",
  "tokio",
@@ -7497,7 +7456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6705a26ad89d241a989a5395641931ba37076f5ab5fbd19ee92402414a43af32"
 dependencies = [
  "arrayvec",
- "hashbrown 0.17.1",
+ "hashbrown 0.12.3",
  "parking_lot",
  "rand 0.8.6",
 ]
@@ -8095,7 +8054,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8132,9 +8091,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11134,7 +11093,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
- "sqlx 0.9.0",
+ "sqlx 0.8.6",
  "tempfile",
  "temps-auth",
  "temps-backup-core",
@@ -11353,7 +11312,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.11.0",
- "sqlx 0.9.0",
+ "sqlx 0.8.6",
  "sysinfo 0.33.1",
  "temps-auth",
  "temps-core",
@@ -12588,7 +12547,7 @@ dependencies = [
  "sea-orm",
  "serde",
  "serde_json",
- "sqlx 0.9.0",
+ "sqlx 0.8.6",
  "tar",
  "tempfile",
  "temps-auth",
@@ -12864,7 +12823,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "sqlx 0.9.0",
+ "sqlx 0.8.6",
  "subtle",
  "temps-core",
  "temps-database",
@@ -15324,7 +15283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,9 @@ sea-orm-migration = { version = "1.1", features = [
     "sqlx-postgres",
     "runtime-tokio-rustls"
 ] }
-sqlx = { version = "0.9.0", features = ["postgres", "mysql", "runtime-tokio"] }
+# Pinned to 0.8 to match sea-orm 1.1's sqlx: a direct 0.9 dep splits the graph
+# into two sqlx versions and 0.9's SqlSafeStr guard breaks our dynamic queries.
+sqlx = { version = "0.8", features = ["postgres", "mysql", "runtime-tokio"] }
 rusqlite = { version = "0.32.0", features = ["bundled", "trace"] }
 
 # ============================================================================


### PR DESCRIPTION
## Fix the CI build breaks introduced by recent dependency bumps

Two independent version-skew problems left `main` non-compiling. This PR restores a green build and should land **before** the in-flight security PRs (they all inherit this break).

### 1. `aws-smithy-schema` 0.1.0 / 0.2.0 split → `aws-config` fails to compile

```
error[E0308]: mismatched types
  builder.set_protocol(self.protocol);
          expected `SharedClientProtocol` (aws-smithy-schema 0.2.0),
          found    `SharedClientProtocol` (aws-smithy-schema 0.1.0)
note: there are multiple different versions of crate `aws_smithy_schema`
```

`aws-config 1.8.17` and `aws-sdk-s3 1.134.0` both require `aws-smithy-runtime ^1.11.3`, `aws-types ^1.3.16`, and `aws-smithy-schema ^0.1.0`. Cargo resolved the caret ranges up to `aws-smithy-runtime 1.12.0` / `aws-types 1.4.0`, which jumped to `aws-smithy-schema 0.2.0` — incompatible with aws-config's direct `^0.1.0`.

**Fix:** pin `aws-smithy-runtime → 1.11.3` and `aws-types → 1.3.16` (the last releases on schema `0.1.0`) in `Cargo.lock`. The graph now has a single `aws-smithy-schema 0.1.0`.

### 2. `sqlx` 0.9 split → `SqlSafeStr` breaks dynamic queries

The direct workspace `sqlx` dep was bumped to `0.9.0`, but `sea-orm 1.1` still uses `sqlx 0.8.6` — splitting the graph. sqlx 0.9's `SqlSafeStr` guard also broke our dynamic-query call sites in `temps-providers` (`mariadb_query.rs`, `mariadb_binlog_health.rs`).

**Fix:** revert the direct dep to `sqlx = "0.8"` to match sea-orm.

## Verification

- `cargo check --workspace` → exit 0 (was failing to compile).
- `cargo fmt --all --check` → clean.
- `cargo clippy -p temps-providers -p temps-blob --all-targets -- -D warnings` → clean.
- `aws-smithy-schema` is now a single `0.1.0` in the lock.