### PR TITLE
fix(git): constant-time comparison for GitHub webhook HMAC signatures

### DIFF
--- a/crates/temps-git/src/services/github.rs
+++ b/crates/temps-git/src/services/github.rs
@@ -1413,7 +1413,14 @@ impl GithubAppService {
             let code_bytes = result.into_bytes();
             let expected_signature = format!("sha256={}", hex::encode(code_bytes));
 
-            if original_signature == expected_signature {
+            // Constant-time comparison to avoid a timing side-channel that could
+            // leak the expected signature byte-by-byte (security review finding #14).
+            use subtle::ConstantTimeEq;
+            if original_signature
+                .as_bytes()
+                .ct_eq(expected_signature.as_bytes())
+                .into()
+            {
                 debug!("Valid signature for GitHub App: {}", github_app.name);
                 return Ok(());
             }

--- a/crates/temps-git/src/services/github_provider.rs
+++ b/crates/temps-git/src/services/github_provider.rs
@@ -1460,17 +1460,8 @@ impl GitProviderService for GitHubProvider {
         signature: &str,
         secret: &str,
     ) -> Result<bool, GitProviderError> {
-        use hmac::{Hmac, KeyInit, Mac};
-        use sha2::Sha256;
-
-        // GitHub uses HMAC-SHA256 for webhook signatures
-        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes())
-            .map_err(|e| GitProviderError::Other(format!("Invalid secret key: {}", e)))?;
-
-        mac.update(payload);
-
-        let expected = format!("sha256={}", hex::encode(mac.finalize().into_bytes()));
-        Ok(signature == expected)
+        github_webhook_signature_matches(payload, signature, secret)
+            .map_err(GitProviderError::Other)
     }
 
     async fn get_user(&self, access_token: &str) -> Result<User, GitProviderError> {
@@ -2719,5 +2710,57 @@ mod list_directory_tests {
         assert_eq!(entries[0].name, "Cargo.toml");
         assert!(!entries[0].is_dir);
         assert_eq!(entries[0].size, Some(1024));
+    }
+}
+
+/// Verify a GitHub `X-Hub-Signature-256` HMAC-SHA256 webhook signature.
+///
+/// The comparison is **constant-time** (`subtle::ConstantTimeEq`) to avoid a
+/// timing side-channel that could leak the expected signature byte-by-byte
+/// (security review finding #14). Factored out as a free function so the
+/// verification logic can be unit-tested with a known vector.
+fn github_webhook_signature_matches(
+    payload: &[u8],
+    signature: &str,
+    secret: &str,
+) -> Result<bool, String> {
+    use hmac::{Hmac, KeyInit, Mac};
+    use sha2::Sha256;
+    use subtle::ConstantTimeEq;
+
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes())
+        .map_err(|e| format!("Invalid secret key: {}", e))?;
+    mac.update(payload);
+    let expected = format!("sha256={}", hex::encode(mac.finalize().into_bytes()));
+    Ok(signature.as_bytes().ct_eq(expected.as_bytes()).into())
+}
+
+#[cfg(test)]
+mod signature_tests {
+    use super::github_webhook_signature_matches;
+
+    // Known HMAC-SHA256 vector (GitHub's documented example):
+    // secret "It's a Secret to Everybody", payload "Hello, World!".
+    const SECRET: &str = "It's a Secret to Everybody";
+    const PAYLOAD: &[u8] = b"Hello, World!";
+    const VALID: &str = "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17";
+
+    #[test]
+    fn valid_signature_matches() {
+        assert!(github_webhook_signature_matches(PAYLOAD, VALID, SECRET).unwrap());
+    }
+
+    #[test]
+    fn tampered_signature_is_rejected() {
+        let mut bad = VALID.to_string();
+        bad.pop();
+        bad.push('0');
+        assert!(!github_webhook_signature_matches(PAYLOAD, &bad, SECRET).unwrap());
+    }
+
+    #[test]
+    fn wrong_length_signature_is_rejected() {
+        // ct_eq handles unequal lengths without panicking and returns false.
+        assert!(!github_webhook_signature_matches(PAYLOAD, "sha256=deadbeef", SECRET).unwrap());
     }
 }


### PR DESCRIPTION
## Security review finding #14 — Non-constant-time webhook HMAC comparison (Low)

**Location:** `crates/temps-git/src/services/github.rs`, `crates/temps-git/src/services/github_provider.rs`

GitHub webhook signature validation compared the expected and provided HMAC-SHA256 signatures with string `==`, a timing side-channel that could leak the expected signature byte-by-byte. The generic/bitbucket paths already use `subtle::ConstantTimeEq`.

## Fix

Both sites now compare with `subtle::ConstantTimeEq`. The `github_provider` comparison is extracted into a testable free function `github_webhook_signature_matches`.

## Verification (regression tests only)

`cargo test -p temps-git --lib signature_tests` — 3 pass against GitHub's documented HMAC vector: valid signature accepted, tampered and wrong-length rejected. `cargo clippy -p temps-git --all-targets -- -D warnings` clean.

> CI note: this branch was cut from `main` before the dependency-skew fix (#333); it needs #333 merged (or `main` merged in) for a green build.