### PR TITLE
fix(git): bind webhook tokens to projects

### DIFF
--- a/crates/temps-git/src/handlers/bitbucket.rs
+++ b/crates/temps-git/src/handlers/bitbucket.rs
@@ -231,28 +231,43 @@ async fn bitbucket_webhook_events(
         None
     };
 
-    // Dispatch through the existing push-event machinery (shared by push and PR).
-    let triggered = if let Err(e) = state
-        .git_provider_manager
-        .handle_push_event(
-            repo_owner.clone(),
-            repo_name.clone(),
-            branch.clone(),
-            tag.clone(),
-            commit_sha.clone(),
-        )
-        .await
-    {
-        error!(
+    let authorized_projects =
+        matched_projects_for_repository(matched_projects, repo_owner.as_str(), repo_name.as_str());
+
+    if authorized_projects.is_empty() {
+        warn!(
             hook_uuid = %hook_uuid,
             repo_owner = %repo_owner,
             repo_name = %repo_name,
-            event_key = %event_key,
-            "Failed to handle Bitbucket event: {:?}", e
+            "Bitbucket webhook token matched projects for a different repository — ignoring"
         );
-        0
-    } else {
-        matched_projects.len()
+        return axum::Json(BitbucketWebhookResponse {
+            message: "processed".to_string(),
+        });
+    }
+
+    // Dispatch only to projects authenticated by the matched delivery token.
+    let triggered = match state
+        .git_provider_manager
+        .handle_push_event_for_projects(
+            branch.clone(),
+            tag.clone(),
+            commit_sha.clone(),
+            authorized_projects,
+        )
+        .await
+    {
+        Ok(triggered) => triggered,
+        Err(e) => {
+            error!(
+                hook_uuid = %hook_uuid,
+                repo_owner = %repo_owner,
+                repo_name = %repo_name,
+                event_key = %event_key,
+                "Failed to handle Bitbucket event: {:?}", e
+            );
+            0
+        }
     };
 
     info!(
@@ -362,9 +377,78 @@ fn extract_push_ref_and_commit(payload: &serde_json::Value) -> (String, String) 
     (git_ref, commit_sha)
 }
 
+fn matched_projects_for_repository(
+    projects: Vec<temps_entities::projects::Model>,
+    repo_owner: &str,
+    repo_name: &str,
+) -> Vec<temps_entities::projects::Model> {
+    projects
+        .into_iter()
+        .filter(|project| {
+            project.repo_owner.eq_ignore_ascii_case(repo_owner)
+                && project.repo_name.eq_ignore_ascii_case(repo_name)
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_project(id: i32, repo_owner: &str, repo_name: &str) -> temps_entities::projects::Model {
+        let now = chrono::Utc::now();
+        temps_entities::projects::Model {
+            id,
+            name: format!("project-{id}"),
+            repo_name: repo_name.to_string(),
+            repo_owner: repo_owner.to_string(),
+            directory: "/".to_string(),
+            main_branch: "main".to_string(),
+            preset: temps_entities::preset::Preset::Vite,
+            preset_config: None,
+            deployment_config: None,
+            created_at: now,
+            updated_at: now,
+            slug: format!("project-{id}"),
+            is_deleted: false,
+            deleted_at: None,
+            last_deployment: None,
+            is_public_repo: false,
+            git_url: None,
+            git_provider_connection_id: None,
+            attack_mode: false,
+            ai_alert_summaries_enabled: None,
+            ai_debug_chat_enabled: None,
+            ai_write_actions_enabled: false,
+            cross_project_trace_sharing: true,
+            enable_preview_environments: false,
+            preview_envs_on_demand: false,
+            preview_envs_idle_timeout_seconds: 300,
+            preview_envs_wake_timeout_seconds: 30,
+            source_type: temps_entities::source_type::SourceType::Git,
+            gitlab_webhook_id: None,
+            gitlab_webhook_signing_token: None,
+            gitea_webhook_signing_token: None,
+            bitbucket_webhook_token: None,
+            bitbucket_webhook_hook_id: None,
+            generic_webhook_token: None,
+        }
+    }
+
+    #[test]
+    fn test_matched_projects_for_repository_filters_token_matches_by_repo() {
+        let projects = vec![
+            test_project(1, "attacker", "demo"),
+            test_project(2, "victim", "prod"),
+        ];
+
+        let authorized = matched_projects_for_repository(projects, "ATTACKER", "Demo");
+
+        assert_eq!(authorized.len(), 1);
+        assert_eq!(authorized[0].id, 1);
+        assert_eq!(authorized[0].repo_owner, "attacker");
+        assert_eq!(authorized[0].repo_name, "demo");
+    }
 
     // ── extract_push_ref_and_commit ───────────────────────────────────────────
 

--- a/crates/temps-git/src/handlers/generic.rs
+++ b/crates/temps-git/src/handlers/generic.rs
@@ -179,27 +179,49 @@ async fn generic_webhook_events(
     // Optional: extract repo owner/name from payload (best-effort).
     let (repo_owner, repo_name) = extract_repo_info(&payload);
 
-    // Dispatch through the existing push-event machinery.
-    let triggered = if let Err(e) = state
-        .git_provider_manager
-        .handle_push_event(
-            repo_owner.clone(),
-            repo_name.clone(),
-            branch.clone(),
-            tag.clone(),
-            commit_sha.clone(),
-        )
-        .await
-    {
-        error!(
+    // The secret delivery token is the primary project binding for Generic
+    // webhooks. When the payload also supplies a repository identity, narrow
+    // the token-matched set to it; otherwise retain the authenticated set so
+    // minimal generic payloads continue to work.
+    let authorized_projects = authorized_projects_for_repository_payload(
+        matched_projects,
+        repo_owner.as_str(),
+        repo_name.as_str(),
+    );
+
+    if authorized_projects.is_empty() {
+        warn!(
             delivery_id = %delivery_id,
             repo_owner = %repo_owner,
             repo_name = %repo_name,
-            "Failed to handle Generic webhook push event: {:?}", e
+            "Generic webhook token matched projects for a different repository — ignoring"
         );
-        0
-    } else {
-        matched_projects.len()
+        return axum::Json(GenericWebhookResponse {
+            message: "processed".to_string(),
+        });
+    }
+
+    // Dispatch only to projects authenticated by the matched delivery token.
+    let triggered = match state
+        .git_provider_manager
+        .handle_push_event_for_projects(
+            branch.clone(),
+            tag.clone(),
+            commit_sha.clone(),
+            authorized_projects,
+        )
+        .await
+    {
+        Ok(triggered) => triggered,
+        Err(e) => {
+            error!(
+                delivery_id = %delivery_id,
+                repo_owner = %repo_owner,
+                repo_name = %repo_name,
+                "Failed to handle Generic webhook push event: {:?}", e
+            );
+            0
+        }
     };
 
     info!(
@@ -298,9 +320,100 @@ fn extract_repo_info(payload: &serde_json::Value) -> (String, String) {
     (owner, name)
 }
 
+fn matched_projects_for_repository(
+    projects: Vec<temps_entities::projects::Model>,
+    repo_owner: &str,
+    repo_name: &str,
+) -> Vec<temps_entities::projects::Model> {
+    projects
+        .into_iter()
+        .filter(|project| {
+            project.repo_owner.eq_ignore_ascii_case(repo_owner)
+                && project.repo_name.eq_ignore_ascii_case(repo_name)
+        })
+        .collect()
+}
+
+fn authorized_projects_for_repository_payload(
+    projects: Vec<temps_entities::projects::Model>,
+    repo_owner: &str,
+    repo_name: &str,
+) -> Vec<temps_entities::projects::Model> {
+    if repo_owner.is_empty() || repo_name.is_empty() {
+        projects
+    } else {
+        matched_projects_for_repository(projects, repo_owner, repo_name)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_project(id: i32, repo_owner: &str, repo_name: &str) -> temps_entities::projects::Model {
+        let now = chrono::Utc::now();
+        temps_entities::projects::Model {
+            id,
+            name: format!("project-{id}"),
+            repo_name: repo_name.to_string(),
+            repo_owner: repo_owner.to_string(),
+            directory: "/".to_string(),
+            main_branch: "main".to_string(),
+            preset: temps_entities::preset::Preset::Vite,
+            preset_config: None,
+            deployment_config: None,
+            created_at: now,
+            updated_at: now,
+            slug: format!("project-{id}"),
+            is_deleted: false,
+            deleted_at: None,
+            last_deployment: None,
+            is_public_repo: false,
+            git_url: None,
+            git_provider_connection_id: None,
+            attack_mode: false,
+            ai_alert_summaries_enabled: None,
+            ai_debug_chat_enabled: None,
+            ai_write_actions_enabled: false,
+            cross_project_trace_sharing: true,
+            enable_preview_environments: false,
+            preview_envs_on_demand: false,
+            preview_envs_idle_timeout_seconds: 300,
+            preview_envs_wake_timeout_seconds: 30,
+            source_type: temps_entities::source_type::SourceType::Git,
+            gitlab_webhook_id: None,
+            gitlab_webhook_signing_token: None,
+            gitea_webhook_signing_token: None,
+            bitbucket_webhook_token: None,
+            bitbucket_webhook_hook_id: None,
+            generic_webhook_token: None,
+        }
+    }
+
+    #[test]
+    fn test_matched_projects_for_repository_filters_token_matches_by_repo() {
+        let projects = vec![
+            test_project(1, "attacker", "demo"),
+            test_project(2, "victim", "prod"),
+        ];
+
+        let authorized = matched_projects_for_repository(projects, "ATTACKER", "Demo");
+
+        assert_eq!(authorized.len(), 1);
+        assert_eq!(authorized[0].id, 1);
+        assert_eq!(authorized[0].repo_owner, "attacker");
+        assert_eq!(authorized[0].repo_name, "demo");
+    }
+
+    #[test]
+    fn test_missing_repository_metadata_keeps_token_matches() {
+        let projects = vec![test_project(1, "owner", "repo")];
+
+        let authorized = authorized_projects_for_repository_payload(projects, "", "");
+
+        assert_eq!(authorized.len(), 1);
+        assert_eq!(authorized[0].id, 1);
+    }
 
     // ── extract_commit_sha ────────────────────────────────────────────────────
 

--- a/crates/temps-git/src/services/git_provider_manager.rs
+++ b/crates/temps-git/src/services/git_provider_manager.rs
@@ -14,7 +14,7 @@ use super::git_provider::{
 };
 use temps_config::ConfigService;
 use temps_core::{JobQueue, UtcDateTime};
-use temps_entities::{git_provider_connections, git_providers, repositories};
+use temps_entities::{git_provider_connections, git_providers, projects, repositories};
 
 // OAuth scope constants
 const GITLAB_OAUTH_SCOPES: &str = "api read_api read_repository";
@@ -4301,9 +4301,6 @@ impl GitProviderManager {
         tag: Option<String>,
         commit: String,
     ) -> Result<(), GitProviderManagerError> {
-        use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
-        use temps_entities::projects;
-
         // Branch/tag deletions send the all-zeros "null SHA" in the `after`
         // field (GitHub, GitLab, and others all follow this Git convention).
         // There is no commit to deploy, so creating a deployment from it would
@@ -4331,24 +4328,61 @@ impl GitProviderManager {
                 GitProviderManagerError::DatabaseError(e)
             })?;
 
-        if matching_projects.is_empty() {
-            tracing::warn!(
-                "No projects found for repository {}/{}, skipping push event",
-                owner,
-                repo
+        self.queue_push_event_for_projects(branch, tag, commit, matching_projects)
+            .await
+            .map(|_| ())
+    }
+
+    /// Handle an authenticated push event for a pre-authorized set of projects.
+    ///
+    /// Secret-in-path webhook handlers must use this method after token lookup so
+    /// the authenticated token owner, not untrusted payload repository fields,
+    /// determines which projects can receive deployment jobs.
+    pub async fn handle_push_event_for_projects(
+        &self,
+        branch: Option<String>,
+        tag: Option<String>,
+        commit: String,
+        projects: Vec<projects::Model>,
+    ) -> Result<usize, GitProviderManagerError> {
+        self.queue_push_event_for_projects(branch, tag, commit, projects)
+            .await
+    }
+
+    async fn queue_push_event_for_projects(
+        &self,
+        branch: Option<String>,
+        tag: Option<String>,
+        commit: String,
+        matching_projects: Vec<projects::Model>,
+    ) -> Result<usize, GitProviderManagerError> {
+        // Branch/tag deletions send the all-zeros "null SHA" in the `after`
+        // field. There is no commit to deploy, so skip them before queueing.
+        if commit.is_empty() || commit.chars().all(|c| c == '0') {
+            tracing::info!(
+                "Ignoring push event with null SHA (branch/tag deletion), branch: {:?}, tag: {:?}",
+                branch,
+                tag
             );
-            return Ok(());
+            return Ok(0);
+        }
+
+        if matching_projects.is_empty() {
+            tracing::warn!("No authorized projects found, skipping push event");
+            return Ok(0);
         }
 
         tracing::info!(
-            "Found {} projects for repository {}/{}, queueing push events",
-            matching_projects.len(),
-            owner,
-            repo
+            "Found {} authorized projects, queueing push events",
+            matching_projects.len()
         );
+
+        let triggered = matching_projects.len();
 
         // Queue a GitPushEventJob for each project
         for project in matching_projects {
+            let owner = project.repo_owner.clone();
+            let repo = project.repo_name.clone();
             let push_job = temps_core::GitPushEventJob {
                 owner: owner.clone(),
                 repo: repo.clone(),
@@ -4384,7 +4418,7 @@ impl GitProviderManager {
             }
         }
 
-        Ok(())
+        Ok(triggered)
     }
 
     /// Push files to a repository using native git operations (git2 library)


### PR DESCRIPTION
## Summary

Bitbucket and Generic secret-in-path webhooks authenticated that a delivery token existed, but their push dispatch path could re-query or queue using repository fields supplied by the payload. This binds dispatch to the projects that own the matched token.

## Security behavior

- Filters Bitbucket token matches against the payload repository identity, case-insensitively.
- For Generic webhooks, narrows token matches when repository metadata is present while retaining the token-authenticated projects for valid minimal payloads.
- Dispatches only a pre-authorized set of project rows.
- Derives every queued job owner/repository from the authenticated project row, never from attacker-controlled payload fields.
- Returns the same processed response when a valid token does not authorize the named repository, avoiding an authorization oracle.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p temps-git --lib`
- `cargo test -p temps-git token_matches --lib` (4 passed)

The regression coverage exercises cross-project filtering, case-insensitive repository identity, Generic payloads without repository metadata, and constant-time delivery-token matching.