### PR TITLE
feat(analytics): add daily returning visitor metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Daily returning-visitor metric**: The analytics overview now reports visitors active in the selected period who were previously seen in the same project and environment, making daily audience retention visible across TimescaleDB and ClickHouse backends.
+
 ### Fixed
 
 - **No-op visitor deduplication migration**: `m20260705_000001_add_visitor_unique_index` now skips bulk foreign-key rewrites when no duplicate `(visitor_id, project_id)` pairs exist, preventing TimescaleDB from eagerly decompressing unrelated hypertable chunks and exceeding `timescaledb.max_tuples_decompressed_per_dml_transaction` during upgrades.

--- a/crates/temps-analytics-events/src/handlers/events_handler.rs
+++ b/crates/temps-analytics-events/src/handlers/events_handler.rs
@@ -583,7 +583,7 @@ pub async fn get_property_timeline(
         ("end_date" = String, Query, description = "End date in '%Y-%m-%d %H:%M:%S' format"),
         ("environment_id" = Option<i32>, Query, description = "Filter by environment ID"),
         ("deployment_id" = Option<i32>, Query, description = "Filter by deployment ID"),
-        ("metric" = String, Query, description = "Metric to count: 'sessions' (unique sessions), 'visitors' (unique visitors), or 'page_views' (total page views) (default: 'sessions')")
+        ("metric" = String, Query, description = "Metric to count: 'sessions' (unique sessions), 'visitors' (unique visitors), 'returning_visitors' (visitors seen before the range), or 'page_views' (total page views) (default: 'sessions')")
     ),
     responses(
         (status = 200, description = "Successfully retrieved count", body = UniqueCountsResponse),

--- a/crates/temps-analytics-events/src/services/clickhouse_backend.rs
+++ b/crates/temps-analytics-events/src/services/clickhouse_backend.rs
@@ -890,6 +890,59 @@ impl AnalyticsEvents for ClickHouseEventsBackend {
         &self,
         q: UniqueCountsSpec,
     ) -> Result<UniqueCountsResponse, EventsError> {
+        let env_filter_flag: i32 = q.scope.environment_id.map(|_| 1).unwrap_or(0);
+        let env_filter_value: i32 = q.scope.environment_id.unwrap_or(0);
+        let dep_filter_flag: i32 = q.scope.deployment_id.map(|_| 1).unwrap_or(0);
+        let dep_filter_value: i32 = q.scope.deployment_id.unwrap_or(0);
+        let start_ms = to_unix_milli(q.range.start);
+        let end_ms = to_unix_milli(q.range.end);
+
+        if q.metric == "returning_visitors" {
+            let sql = r#"
+                SELECT uniq(visitor_id) AS value
+                FROM events FINAL
+                WHERE project_id = ?
+                  AND timestamp >= fromUnixTimestamp64Milli(?)
+                  AND timestamp <= fromUnixTimestamp64Milli(?)
+                  AND visitor_id IS NOT NULL
+                  AND (? = 0 OR environment_id = ?)
+                  AND (? = 0 OR deployment_id = ?)
+                  AND visitor_id IN (
+                      SELECT visitor_id
+                      FROM events FINAL
+                      WHERE project_id = ?
+                        AND timestamp < fromUnixTimestamp64Milli(?)
+                        AND visitor_id IS NOT NULL
+                        AND (? = 0 OR environment_id = ?)
+                        AND (? = 0 OR deployment_id = ?)
+                  )
+            "#;
+
+            let row = self
+                .client
+                .query(sql)
+                .bind(q.scope.project_id)
+                .bind(start_ms)
+                .bind(end_ms)
+                .bind(env_filter_flag)
+                .bind(env_filter_value)
+                .bind(dep_filter_flag)
+                .bind(dep_filter_value)
+                .bind(q.scope.project_id)
+                .bind(start_ms)
+                .bind(env_filter_flag)
+                .bind(env_filter_value)
+                .bind(dep_filter_flag)
+                .bind(dep_filter_value)
+                .fetch_one::<ScalarU64>()
+                .await
+                .map_err(|e| ch_err("query_returning_visitors", e))?;
+
+            return Ok(UniqueCountsResponse {
+                count: row.value as i64,
+            });
+        }
+
         // The Timescale impl validates the metric here; do the same so behavior
         // is identical.
         let count_expr = match q.metric.as_str() {
@@ -898,17 +951,10 @@ impl AnalyticsEvents for ClickHouseEventsBackend {
             "page_views" | "paths" => "countIf(event_type = 'page_view')",
             other => {
                 return Err(EventsError::Validation(format!(
-                    "Invalid metric '{other}'. Valid options: sessions, visitors, page_views"
+                    "Invalid metric '{other}'. Valid options: sessions, visitors, returning_visitors, page_views"
                 )))
             }
         };
-
-        let env_filter_flag: i32 = q.scope.environment_id.map(|_| 1).unwrap_or(0);
-        let env_filter_value: i32 = q.scope.environment_id.unwrap_or(0);
-        let dep_filter_flag: i32 = q.scope.deployment_id.map(|_| 1).unwrap_or(0);
-        let dep_filter_value: i32 = q.scope.deployment_id.unwrap_or(0);
-        let start_ms = to_unix_milli(q.range.start);
-        let end_ms = to_unix_milli(q.range.end);
 
         let sql = format!(
             r#"
@@ -1496,11 +1542,21 @@ mod tests {
         let now = Utc::now();
         let t = |mins_ago: i64| (now - Duration::minutes(mins_ago)).timestamp_millis();
 
-        // Project 7, session A, visitor 100: 2 page_views + 1 signup.
+        // Project 7, visitor 100: 1 visit before the reporting range, then
+        // session A with 2 page_views + 1 signup inside it.
         // Project 7, session B, visitor 101: 1 page_view, 1 click.
         // Project 8, session C, visitor 102: 1 page_view (different project — must
         // not leak into project 7 queries).
         let rows = [
+            make_row(
+                7,
+                7,
+                "sess-prior",
+                Some(100),
+                "page_view",
+                "page_view",
+                t(180),
+            ),
             make_row(1, 7, "sess-a", Some(100), "page_view", "page_view", t(60)),
             make_row(2, 7, "sess-a", Some(100), "page_view", "page_view", t(50)),
             make_row(3, 7, "sess-a", Some(100), "signup", "signup", t(45)),
@@ -1630,6 +1686,18 @@ mod tests {
             .expect("query_unique_counts visitors");
         // 2 distinct visitor_ids on project 7 (100, 101).
         assert_eq!(visitors.count, 2);
+
+        // ---- query_unique_counts: returning visitors ----
+        let returning_visitors = backend
+            .query_unique_counts(UniqueCountsSpec {
+                range: full_range(),
+                scope: project_scope(7).with_deployment(None),
+                metric: "returning_visitors".to_string(),
+            })
+            .await
+            .expect("query_unique_counts returning_visitors");
+        // Visitor 100 has an event before the range; visitor 101 is new.
+        assert_eq!(returning_visitors.count, 1);
 
         // ---- query_unique_counts: page_views ----
         let pvs = backend

--- a/crates/temps-analytics-events/src/services/events_service.rs
+++ b/crates/temps-analytics-events/src/services/events_service.rs
@@ -972,6 +972,56 @@ WHERE project_id = $1
         deployment_id: Option<i32>,
         metric: String,
     ) -> Result<UniqueCountsResponse, EventsError> {
+        if metric == "returning_visitors" {
+            let query = r#"
+                WITH current_visitors AS (
+                    SELECT DISTINCT visitor_id
+                    FROM events
+                    WHERE project_id = $1
+                      AND timestamp >= $2::timestamp
+                      AND timestamp <= $3::timestamp
+                      AND visitor_id IS NOT NULL
+                      AND ($4::int IS NULL OR environment_id = $4)
+                      AND ($5::int IS NULL OR deployment_id = $5)
+                )
+                SELECT COUNT(*)::bigint AS count
+                FROM current_visitors cv
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM events previous
+                    WHERE previous.project_id = $1
+                      AND previous.visitor_id = cv.visitor_id
+                      AND previous.timestamp < $2::timestamp
+                      AND ($4::int IS NULL OR previous.environment_id = $4)
+                      AND ($5::int IS NULL OR previous.deployment_id = $5)
+                )
+            "#;
+
+            #[derive(FromQueryResult)]
+            struct ReturningVisitorsResult {
+                count: i64,
+            }
+
+            let params = vec![
+                project_id.into(),
+                start_date.into(),
+                end_date.into(),
+                environment_id.into(),
+                deployment_id.into(),
+            ];
+
+            let result = ReturningVisitorsResult::find_by_statement(
+                Statement::from_sql_and_values(DatabaseBackend::Postgres, query, params),
+            )
+            .one(self.db.as_ref())
+            .await?
+            .unwrap_or(ReturningVisitorsResult { count: 0 });
+
+            return Ok(UniqueCountsResponse {
+                count: result.count,
+            });
+        }
+
         // Determine what to count based on metric
         let count_expr = match metric.as_str() {
             "sessions" => {
@@ -983,7 +1033,7 @@ WHERE project_id = $1
             "page_views" | "paths" => "COUNT(*) FILTER (WHERE event_type = 'page_view')::bigint",
             _ => {
                 return Err(EventsError::Validation(format!(
-                    "Invalid metric '{}'. Valid options: sessions, visitors, page_views",
+                    "Invalid metric '{}'. Valid options: sessions, visitors, returning_visitors, page_views",
                     metric
                 )))
             }
@@ -2063,6 +2113,22 @@ mod tests {
     async fn create_test_events(_db: &DatabaseConnection) {
         // This test would require the events table schema
         // For now, this is a template for future tests
+    }
+
+    #[tokio::test]
+    async fn test_unique_counts_rejects_unknown_metric() {
+        let db = setup_test_db().await.unwrap();
+        let service = AnalyticsEventsService::new(Arc::new(db));
+        let start = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let end = Utc.with_ymd_and_hms(2024, 1, 2, 0, 0, 0).unwrap();
+
+        let result = service
+            .get_unique_counts(start, end, 1, None, None, "unknown".to_string())
+            .await;
+
+        assert!(
+            matches!(result, Err(EventsError::Validation(message)) if message.contains("returning_visitors"))
+        );
     }
 
     #[tokio::test]
@@ -3683,7 +3749,19 @@ mod tests {
         let project_a = make_project(&db, "trend-baseline").await;
         let env_a = make_environment(&db, project_a.id, "trend-baseline-env").await;
         let dep_a = make_deployment(&db, project_a.id, env_a.id, "trend-baseline-dep").await;
-        for i in 0..4 {
+        let returning_visitor =
+            make_visitor(&db, project_a.id, env_a.id, "a-returning", prev_ts).await;
+        make_page_view(
+            &db,
+            project_a.id,
+            env_a.id,
+            dep_a.id,
+            returning_visitor.id,
+            "a-returning-prev-session",
+            prev_ts,
+        )
+        .await;
+        for i in 1..4 {
             let v =
                 make_visitor(&db, project_a.id, env_a.id, &format!("a-prev-{i}"), prev_ts).await;
             make_page_view(
@@ -3697,7 +3775,17 @@ mod tests {
             )
             .await;
         }
-        for i in 0..6 {
+        make_page_view(
+            &db,
+            project_a.id,
+            env_a.id,
+            dep_a.id,
+            returning_visitor.id,
+            "a-returning-current-session",
+            curr_ts,
+        )
+        .await;
+        for i in 1..6 {
             let v =
                 make_visitor(&db, project_a.id, env_a.id, &format!("a-curr-{i}"), curr_ts).await;
             make_page_view(
@@ -3771,6 +3859,22 @@ mod tests {
             a.trend_percentage,
             Some(50.0),
             "trend must be the real (6-4)/4*100 ratio, not derived from a stale/empty aggregate"
+        );
+
+        let returning = service
+            .get_unique_counts(
+                start,
+                end,
+                project_a.id,
+                Some(env_a.id),
+                Some(dep_a.id),
+                "returning_visitors".to_string(),
+            )
+            .await
+            .expect("get returning visitors");
+        assert_eq!(
+            returning.count, 1,
+            "only the visitor with an event before the reporting range is returning"
         );
 
         let b = response

--- a/crates/temps-analytics-events/src/services/queries.rs
+++ b/crates/temps-analytics-events/src/services/queries.rs
@@ -211,8 +211,9 @@ pub struct HourlyVisitsSpec {
 pub struct UniqueCountsSpec {
     pub range: TimeRange,
     pub scope: AnalyticsScope,
-    /// What to count: `"sessions"`, `"visitors"`, `"events"`. The backend
-    /// validates and returns a Validation error for unknown values.
+    /// What to count: `"sessions"`, `"visitors"`, `"returning_visitors"`, or
+    /// `"page_views"`. The backend validates and returns a Validation error for
+    /// unknown values.
     pub metric: String,
 }
 

--- a/crates/temps-analytics-events/src/services/traits.rs
+++ b/crates/temps-analytics-events/src/services/traits.rs
@@ -77,7 +77,7 @@ pub trait AnalyticsEvents: Send + Sync {
         q: HourlyVisitsSpec,
     ) -> Result<Vec<EventTimeline>, EventsError>;
 
-    /// Unique sessions/visitors counts.
+    /// Unique sessions, visitors, returning visitors, or page-view counts.
     async fn query_unique_counts(
         &self,
         q: UniqueCountsSpec,

--- a/crates/temps-analytics-events/src/types/requests.rs
+++ b/crates/temps-analytics-events/src/types/requests.rs
@@ -321,7 +321,9 @@ pub struct UniqueCountsQuery {
     pub environment_id: Option<i32>,
     /// Optional deployment filter
     pub deployment_id: Option<i32>,
-    /// Metric to count: "sessions" (unique sessions), "visitors" (unique visitors), or "page_views" (total page views) (default: "sessions")
+    /// Metric to count: "sessions" (unique sessions), "visitors" (unique visitors),
+    /// "returning_visitors" (visitors seen before the range), or "page_views"
+    /// (total page views) (default: "sessions")
     #[serde(default = "default_metric")]
     pub metric: String,
 }

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -15450,7 +15450,9 @@ export type UniqueCountsQuery = {
      */
     environment_id?: number | null;
     /**
-     * Metric to count: "sessions" (unique sessions), "visitors" (unique visitors), or "page_views" (total page views) (default: "sessions")
+     * Metric to count: "sessions" (unique sessions), "visitors" (unique visitors),
+     * "returning_visitors" (visitors seen before the range), or "page_views"
+     * (total page views) (default: "sessions")
      */
     metric?: string;
     /**
@@ -40597,7 +40599,7 @@ export type GetUniqueCountsData = {
          */
         deployment_id?: number;
         /**
-         * Metric to count: 'sessions' (unique sessions), 'visitors' (unique visitors), or 'page_views' (total page views) (default: 'sessions')
+         * Metric to count: 'sessions' (unique sessions), 'visitors' (unique visitors), 'returning_visitors' (visitors seen before the range), or 'page_views' (total page views) (default: 'sessions')
          */
         metric: string;
     };

--- a/web/src/components/analytics/overview/AnalyticsMetrics.tsx
+++ b/web/src/components/analytics/overview/AnalyticsMetrics.tsx
@@ -2,13 +2,21 @@ import { getUniqueCountsOptions } from '@/api/client/@tanstack/react-query.gen'
 import { ProjectResponse } from '@/api/client/types.gen'
 
 import { useQuery } from '@tanstack/react-query'
-import { Users, UserRoundCheck, MousePointer, FileText } from 'lucide-react'
+import { Users, MousePointer, FileText, type LucideIcon } from 'lucide-react'
 
 interface AnalyticsMetricsProps {
   project: ProjectResponse
   startDate: Date | undefined
   endDate: Date | undefined
   environment: number | undefined
+}
+
+interface MetricCard {
+  label: string
+  value: number
+  icon: LucideIcon
+  secondary?: string
+  className?: string
 }
 
 export function AnalyticsMetrics({
@@ -92,42 +100,45 @@ export function AnalyticsMetrics({
     sessionsQuery.error ||
     pathsQuery.error
 
-  const metrics = [
+  const uniqueVisitors = visitorsQuery.data?.count ?? 0
+  const returningVisitors = returningVisitorsQuery.data?.count ?? 0
+  const returningPercentage =
+    uniqueVisitors > 0
+      ? Math.round((returningVisitors / uniqueVisitors) * 100)
+      : 0
+
+  const metrics: MetricCard[] = [
     {
       label: 'Unique Visitors',
-      value: visitorsQuery.data?.count ?? 0,
+      value: uniqueVisitors,
       icon: Users,
-      description: 'Total unique visitors',
-    },
-    {
-      label: 'Returning Visitors',
-      value: returningVisitorsQuery.data?.count ?? 0,
-      icon: UserRoundCheck,
-      description: 'Visitors seen before this period',
+      secondary: `${returningPercentage}% returning (${returningVisitors.toLocaleString()})`,
+      className: 'col-span-2 lg:col-span-1',
     },
     {
       label: 'Total Sessions',
       value: sessionsQuery.data?.count ?? 0,
       icon: MousePointer,
-      description: 'Total number of sessions',
     },
     {
       label: 'Unique Pages',
       value: pathsQuery.data?.count ?? 0,
       icon: FileText,
-      description: 'Total unique pages visited',
     },
   ]
 
-  const gridCols = 'grid-cols-2 lg:grid-cols-4'
-  const skeletonCount = 4
+  const gridCols = 'grid-cols-2 lg:grid-cols-3'
+  const skeletonCount = 3
 
   return (
     <>
       {isLoading ? (
         <div className={`grid ${gridCols} gap-3 sm:gap-4`}>
           {[...Array(skeletonCount)].map((_, i) => (
-            <div key={i} className="space-y-2 p-3 sm:p-4 rounded-lg border">
+            <div
+              key={i}
+              className={`space-y-2 p-3 sm:p-4 rounded-lg border ${i === 0 ? 'col-span-2 lg:col-span-1' : ''}`}
+            >
               <div className="h-4 w-20 bg-muted animate-pulse rounded" />
               <div className="h-8 w-16 bg-muted animate-pulse rounded" />
             </div>
@@ -141,34 +152,28 @@ export function AnalyticsMetrics({
         </div>
       ) : (
         <div className={`grid ${gridCols} gap-3 sm:gap-4`}>
-          {metrics.map((metric: any) => {
+          {metrics.map((metric) => {
             const Icon = metric.icon
-            const isComingSoon = metric.isComingSoon
             return (
               <div
                 key={metric.label}
-                className={`flex flex-col p-3 sm:p-4 rounded-lg border bg-card transition-colors ${
-                  isComingSoon
-                    ? 'border-dashed border-muted-foreground/30'
-                    : 'hover:bg-accent/50'
-                }`}
+                className={`flex flex-col p-3 sm:p-4 rounded-lg border bg-card transition-colors hover:bg-accent/50 ${metric.className ?? ''}`}
               >
                 <div className="flex items-center justify-between mb-1 sm:mb-2">
-                  <Icon
-                    className={`h-4 w-4 sm:h-5 sm:w-5 ${isComingSoon ? 'text-muted-foreground/50' : 'text-muted-foreground'}`}
-                  />
+                  <Icon className="h-4 w-4 sm:h-5 sm:w-5 text-muted-foreground" />
                 </div>
                 <div className="space-y-0.5 sm:space-y-1">
-                  <p
-                    className={`text-xl sm:text-2xl font-bold ${isComingSoon ? 'text-muted-foreground/50' : ''}`}
-                  >
-                    {typeof metric.value === 'number'
-                      ? metric.value.toLocaleString()
-                      : metric.value}
+                  <p className="text-xl sm:text-2xl font-bold">
+                    {metric.value.toLocaleString()}
                   </p>
                   <p className="text-xs sm:text-sm text-muted-foreground">
                     {metric.label}
                   </p>
+                  {metric.secondary && (
+                    <p className="text-xs font-medium text-muted-foreground/80">
+                      {metric.secondary}
+                    </p>
+                  )}
                 </div>
               </div>
             )

--- a/web/src/components/analytics/overview/AnalyticsMetrics.tsx
+++ b/web/src/components/analytics/overview/AnalyticsMetrics.tsx
@@ -2,7 +2,7 @@ import { getUniqueCountsOptions } from '@/api/client/@tanstack/react-query.gen'
 import { ProjectResponse } from '@/api/client/types.gen'
 
 import { useQuery } from '@tanstack/react-query'
-import { Users, MousePointer, FileText } from 'lucide-react'
+import { Users, UserRoundCheck, MousePointer, FileText } from 'lucide-react'
 
 interface AnalyticsMetricsProps {
   project: ProjectResponse
@@ -49,6 +49,22 @@ export function AnalyticsMetrics({
     enabled: !!startDate && !!endDate,
   })
 
+  // Fetch visitors who were seen before the selected range
+  const returningVisitorsQuery = useQuery({
+    ...getUniqueCountsOptions({
+      path: {
+        project_id: project.id,
+      },
+      query: {
+        start_date: startDate ? startDate.toISOString() : '',
+        end_date: endDate ? endDate.toISOString() : '',
+        environment_id: environment,
+        metric: 'returning_visitors',
+      },
+    }),
+    enabled: !!startDate && !!endDate,
+  })
+
   // Fetch unique paths
   const pathsQuery = useQuery({
     ...getUniqueCountsOptions({
@@ -66,9 +82,15 @@ export function AnalyticsMetrics({
   })
 
   const isLoading =
-    visitorsQuery.isLoading || sessionsQuery.isLoading || pathsQuery.isLoading
+    visitorsQuery.isLoading ||
+    returningVisitorsQuery.isLoading ||
+    sessionsQuery.isLoading ||
+    pathsQuery.isLoading
   const hasError =
-    visitorsQuery.error || sessionsQuery.error || pathsQuery.error
+    visitorsQuery.error ||
+    returningVisitorsQuery.error ||
+    sessionsQuery.error ||
+    pathsQuery.error
 
   const metrics = [
     {
@@ -76,6 +98,12 @@ export function AnalyticsMetrics({
       value: visitorsQuery.data?.count ?? 0,
       icon: Users,
       description: 'Total unique visitors',
+    },
+    {
+      label: 'Returning Visitors',
+      value: returningVisitorsQuery.data?.count ?? 0,
+      icon: UserRoundCheck,
+      description: 'Visitors seen before this period',
     },
     {
       label: 'Total Sessions',
@@ -91,8 +119,8 @@ export function AnalyticsMetrics({
     },
   ]
 
-  const gridCols = 'grid-cols-3'
-  const skeletonCount = 3
+  const gridCols = 'grid-cols-2 lg:grid-cols-4'
+  const skeletonCount = 4
 
   return (
     <>
@@ -138,7 +166,9 @@ export function AnalyticsMetrics({
                       ? metric.value.toLocaleString()
                       : metric.value}
                   </p>
-                  <p className="text-xs sm:text-sm text-muted-foreground">{metric.label}</p>
+                  <p className="text-xs sm:text-sm text-muted-foreground">
+                    {metric.label}
+                  </p>
                 </div>
               </div>
             )


### PR DESCRIPTION
## Summary

- add `returning_visitors` to the analytics unique-count metric for TimescaleDB and ClickHouse
- define a returning visitor as someone active in the selected range with an earlier event in the same project/environment/deployment scope
- show the metric as a fourth responsive card in the analytics overview
- regenerate the affected OpenAPI client documentation and add an Unreleased changelog entry

## Performance

This is a control-plane analytics query, not an ingestion or proxy hot-path change. The query first scopes current visitors to the selected project and range, then checks prior project-scoped history; no new writes, locks, channels, or unbounded in-memory aggregation are introduced.

## Tests

- `cargo test --lib -p temps-analytics-events` (55 passed, including TimescaleDB and ClickHouse regression coverage)
- `cargo check --lib`
- `cargo clippy --lib -- -D warnings`
- `eslint src/components/analytics/overview/AnalyticsMetrics.tsx`
- `tsc --noEmit`

Repository-wide `bun run lint` remains red on existing unrelated frontend errors (243 errors across files outside this PR); the changed component and full TypeScript check pass.