### PR TITLE
fix(otel): make otel_spans compression effective by dropping trace_id from segmentby

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12262,6 +12262,7 @@ dependencies = [
  "temps-entities",
  "testcontainers",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/temps-migrations/Cargo.toml
+++ b/crates/temps-migrations/Cargo.toml
@@ -12,6 +12,7 @@ temps-core = { path = "../temps-core" }
 temps-entities = { path = "../temps-entities" }
 sea-orm-migration = { workspace = true }
 sea-orm = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 testcontainers = { workspace = true }

--- a/crates/temps-migrations/src/migration/m20260714_000001_fix_otel_spans_compression_segmentby.rs
+++ b/crates/temps-migrations/src/migration/m20260714_000001_fix_otel_spans_compression_segmentby.rs
@@ -1,0 +1,84 @@
+//! Fix the `otel_spans` compression settings so compression is actually
+//! effective.
+//!
+//! The original DDL (`m20260225_000001_create_otel_tables`) declared
+//! `compress_segmentby = 'project_id,service_name,trace_id'`. `trace_id` is
+//! near-unique (one value per trace, a handful of spans each), so every
+//! compressed segment holds only a few rows instead of the up-to-1000-row
+//! batches TimescaleDB compression is built around. Measured on a
+//! representative 1M-span workload, the old settings compress ~707 B/span to
+//! only ~543 B/span (1.3x); dropping `trace_id` from segmentby yields
+//! ~63 B/span (11x).
+//!
+//! This migration is metadata-only and completes in milliseconds. However:
+//!
+//! * The new settings apply to chunks compressed **after** this migration.
+//!   Chunks that were already compressed keep the old (ineffective) layout
+//!   until they age out via the retention policy, or until an operator
+//!   manually runs `SELECT compress_chunk(c, recompress => true) FROM
+//!   show_chunks('otel_spans') c;`.
+//! * The **next run of the compression policy** may take a long time (hours
+//!   on large tables) and consume significant CPU and transient disk while it
+//!   works through the backlog of uncompressed chunks with the new settings.
+//!   This is background work; the server stays up while it runs.
+//!
+//! Trace-by-id lookups on compressed chunks can no longer seek directly to a
+//! `trace_id` segment after this change; the paired `get_trace` change bounds
+//! those scans by the trace's time window from `otel_trace_summaries` so
+//! chunk exclusion keeps them cheap.
+
+use sea_orm::DatabaseBackend;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() != DatabaseBackend::Postgres {
+            return Ok(());
+        }
+
+        tracing::warn!(
+            "Applying otel_spans compression fix: the ALTER itself is instant, but the next \
+             compression-policy run will recompress the uncompressed backlog with the new \
+             settings and may take a long time (hours on large tables) while using significant \
+             CPU. The server stays up; this is background work. Chunks compressed under the old \
+             settings keep the old layout until retention drops them or an operator recompresses \
+             them manually."
+        );
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "ALTER TABLE otel_spans SET (
+                    timescaledb.compress,
+                    timescaledb.compress_segmentby = 'project_id,service_name',
+                    timescaledb.compress_orderby = 'start_time DESC'
+                )",
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() != DatabaseBackend::Postgres {
+            return Ok(());
+        }
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "ALTER TABLE otel_spans SET (
+                    timescaledb.compress,
+                    timescaledb.compress_segmentby = 'project_id,service_name,trace_id',
+                    timescaledb.compress_orderby = 'start_time DESC'
+                )",
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -148,6 +148,7 @@ mod m20260711_000001_add_proxy_logs_stats_cagg;
 mod m20260711_000002_add_ip_geolocations_hosting_provider;
 mod m20260711_000003_add_visitor_non_crawler_partial_index;
 mod m20260713_000001_add_mfa_pending_to_sessions;
+mod m20260714_000001_fix_otel_spans_compression_segmentby;
 
 pub struct Migrator;
 
@@ -301,6 +302,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260711_000002_add_ip_geolocations_hosting_provider::Migration),
             Box::new(m20260711_000003_add_visitor_non_crawler_partial_index::Migration),
             Box::new(m20260713_000001_add_mfa_pending_to_sessions::Migration),
+            Box::new(m20260714_000001_fix_otel_spans_compression_segmentby::Migration),
         ]
     }
 }

--- a/crates/temps-otel/src/storage/timescaledb.rs
+++ b/crates/temps-otel/src/storage/timescaledb.rs
@@ -1487,6 +1487,56 @@ impl OtelStorage for TimescaleDbStorage {
         self.count_traces_from_table(query).await
     }
     async fn get_trace(&self, project_id: i32, trace_id: &str) -> StorageResult<Vec<SpanRecord>> {
+        // Two-phase lookup. Phase 1: fetch the trace's time window from
+        // otel_trace_summaries (PK lookup, O(1)). Phase 2: scan otel_spans
+        // bounded to that window so hypertable chunk exclusion prunes the
+        // scan to 1-2 chunks. Without the bound, this query touches every
+        // chunk in the retention window — and on compressed chunks (which
+        // have no B-tree indexes, and no trace_id segmentby since
+        // m20260714_000001) that means decompressing the project's entire
+        // history for one trace.
+        //
+        // The window is padded generously: spans of a trace can start before
+        // the summary's recorded start (late/out-of-order batches update it,
+        // but a reader can race the update) and child spans can outlive the
+        // root. A day of slack is negligible for chunk exclusion (chunks are
+        // 1 day) and safe for any realistic trace duration.
+        let window = self
+            .db
+            .query_one(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                "SELECT start_time, duration_ms FROM otel_trace_summaries
+                 WHERE project_id = $1 AND trace_id = $2",
+                vec![project_id.into(), trace_id.to_string().into()],
+            ))
+            .await?
+            .and_then(|row| {
+                let start: chrono::DateTime<chrono::Utc> = row.try_get("", "start_time").ok()?;
+                let duration_ms: f64 = row.try_get("", "duration_ms").unwrap_or(0.0);
+                let end = start + chrono::Duration::milliseconds(duration_ms.ceil() as i64);
+                Some((
+                    start - chrono::Duration::days(1),
+                    end + chrono::Duration::days(1),
+                ))
+            });
+
+        // No summary row means the trace is invisible in every list view (the
+        // list reads from otel_trace_summaries), so it can only be requested
+        // via a direct link. That happens for (a) an ingest race — the summary
+        // upsert in store_spans runs just after the span insert, (b) a
+        // transient, fail-soft summary upsert failure, or (c) legacy spans
+        // predating the summaries table. (a) and (b) are recent by nature, so
+        // fall back to a scan bounded to the last 7 days — the window in which
+        // chunks are still uncompressed and carry the trace_id B-tree index.
+        // Never scan unbounded: on compressed chunks a trace_id lookup has no
+        // index and no segmentby to seek on, so an unbounded fallback would
+        // decompress the project's entire history for any unknown trace_id
+        // (stale links, cross-project probes, or abuse).
+        let (from, to) = window.unwrap_or_else(|| {
+            let now = chrono::Utc::now();
+            (now - chrono::Duration::days(7), now)
+        });
+
         let sql = r#"
             SELECT project_id, deployment_id, service_name, service_version,
                    deployment_environment, trace_id, span_id, parent_span_id,
@@ -1494,15 +1544,22 @@ impl OtelStorage for TimescaleDbStorage {
                    status_code, status_message, attributes, events
             FROM otel_spans
             WHERE project_id = $1 AND trace_id = $2
+              AND start_time >= $3 AND start_time <= $4
             ORDER BY start_time ASC
         "#;
+        let values: Vec<sea_orm::Value> = vec![
+            project_id.into(),
+            trace_id.to_string().into(),
+            from.into(),
+            to.into(),
+        ];
 
         let results = self
             .db
             .query_all(Statement::from_sql_and_values(
                 DatabaseBackend::Postgres,
                 sql,
-                vec![project_id.into(), trace_id.to_string().into()],
+                values,
             ))
             .await?;
 
@@ -3961,5 +4018,83 @@ mod tests {
         // project_id(1) + k1(1) + v1(1) + k2(1) + v2(1) = 5 values
         assert_eq!(values.len(), 5);
         assert_eq!(next, 6);
+    }
+
+    /// When otel_trace_summaries has a row for the trace, the span scan must
+    /// be bounded by the trace's time window so hypertable chunk exclusion
+    /// applies (compressed chunks have no trace_id B-tree index).
+    #[tokio::test]
+    async fn get_trace_bounds_span_scan_when_summary_exists() {
+        use sea_orm::{DatabaseBackend, MockDatabase};
+        use std::collections::BTreeMap;
+
+        let start = chrono::Utc.with_ymd_and_hms(2026, 7, 10, 10, 0, 0).unwrap();
+        let summary_row: BTreeMap<&str, sea_orm::Value> = BTreeMap::from([
+            ("start_time", start.into()),
+            ("duration_ms", 1500.0_f64.into()),
+        ]);
+
+        let conn = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![summary_row]])
+                .append_query_results([Vec::<BTreeMap<&str, sea_orm::Value>>::new()])
+                .into_connection(),
+        );
+        let storage = TimescaleDbStorage::new(conn.clone(), None);
+
+        let spans = storage.get_trace(7, "abc123").await.unwrap();
+        assert!(spans.is_empty());
+
+        drop(storage);
+        let log = Arc::try_unwrap(conn)
+            .unwrap_or_else(|_| panic!("connection still shared"))
+            .into_transaction_log();
+        assert_eq!(log.len(), 2, "summary lookup + bounded span query");
+        let span_query = format!("{:?}", log[1]);
+        assert!(
+            span_query.contains("start_time >= $3"),
+            "span query must be time-bounded, got: {span_query}"
+        );
+        assert!(span_query.contains("start_time <= $4"));
+        // Window derived from the summary: start - 1 day .. start + duration + 1 day.
+        assert!(
+            span_query.contains("2026-07-09"),
+            "lower bound must come from the summary window, got: {span_query}"
+        );
+        assert!(span_query.contains("2026-07-11"));
+    }
+
+    /// Without a summary row (ingest race, fail-soft summary upsert failure,
+    /// or legacy spans predating summaries), get_trace must still bound the
+    /// scan — to the recent hot window — and never scan the full retention
+    /// range: on compressed chunks a trace_id lookup has no index to seek on,
+    /// so an unbounded fallback would decompress the project's entire history
+    /// for any unknown trace_id.
+    #[tokio::test]
+    async fn get_trace_falls_back_to_recent_window_without_summary() {
+        use sea_orm::{DatabaseBackend, MockDatabase};
+        use std::collections::BTreeMap;
+
+        let conn = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([Vec::<BTreeMap<&str, sea_orm::Value>>::new()])
+                .append_query_results([Vec::<BTreeMap<&str, sea_orm::Value>>::new()])
+                .into_connection(),
+        );
+        let storage = TimescaleDbStorage::new(conn.clone(), None);
+
+        let spans = storage.get_trace(7, "abc123").await.unwrap();
+        assert!(spans.is_empty());
+
+        drop(storage);
+        let log = Arc::try_unwrap(conn)
+            .unwrap_or_else(|_| panic!("connection still shared"))
+            .into_transaction_log();
+        assert_eq!(log.len(), 2, "summary lookup + fallback span query");
+        let span_query = format!("{:?}", log[1]);
+        assert!(
+            span_query.contains("start_time >= $3") && span_query.contains("start_time <= $4"),
+            "fallback query must be bounded to the recent window, got: {span_query}"
+        );
     }
 }


### PR DESCRIPTION
## Problem

`otel_spans` compression has been effectively a no-op since it shipped. The DDL in `m20260225_000001_create_otel_tables` set

```
compress_segmentby = 'project_id,service_name,trace_id'
```

`trace_id` is near-unique (one value per trace, a handful of spans each), so every compressed segment holds only a few rows instead of the up-to-1000-row batches TimescaleDB compression is designed around.

**Measured on a representative 1M-span workload** (14-span Express-style traces, realistic attributes; sizes include indexes):

| Configuration | Bytes/span | Ratio |
|---|---|---|
| Uncompressed | 707 B | — |
| Compressed, old segmentby (`…,trace_id`) | 543 B | 1.3× |
| Compressed, new segmentby (`project_id,service_name`) | **63 B** | **11×** |

On a real deployment this is the difference between ~490 GB and ~57 GB for the same retained spans.

## Changes

1. **`m20260714_000001_fix_otel_spans_compression_segmentby`** — `ALTER TABLE otel_spans SET (… compress_segmentby = 'project_id,service_name' …)`. Metadata-only, completes in milliseconds.
2. **`get_trace` two-phase lookup** (TimescaleDB backend) — compressed chunks have no B-tree indexes and, after this change, no `trace_id` segmentby to seek on, so the previously **unbounded** `WHERE project_id AND trace_id` scan could decompress a project's entire history for one trace. `get_trace` now:
   - fetches the trace's time window from `otel_trace_summaries` (PK lookup, O(1)) and bounds the span scan to it (±1 day slack), letting chunk exclusion prune the scan to 1–2 chunks;
   - when **no summary row exists** (ingest race, fail-soft summary-upsert failure, or legacy pre-summary spans), bounds the scan to the **last 7 days** — the uncompressed, `trace_id`-indexed hot window. The scan is **never unbounded**: an unbounded fallback would let any unknown trace_id (stale link, `cross_project` probe, or abuse) trigger a full-history decompression scan. A trace with no summary row is already invisible in every list view (the list reads from `otel_trace_summaries`), so returning empty for old summary-less traces is consistent with the rest of the product.

## ⚠️ Operator impact — this can take a long time

- The migration itself is **instant**, but the **next compression-policy run** recompresses the uncompressed backlog with the new settings. On large tables (hundreds of GB) this is **hours** of background CPU and transient disk usage. The server stays up throughout; a `tracing::warn!` at migration time says exactly this.
- Chunks **already compressed** under the old settings keep the old (ineffective) layout until they age out via retention, or until an operator manually runs:
  ```sql
  SELECT compress_chunk(c, recompress => true) FROM show_chunks('otel_spans') c;
  ```

## Testing

- Unit tests for both `get_trace` paths (summary-derived window; 7-day fallback window) via MockDatabase transaction-log assertions — `cargo test --lib -p temps-otel get_trace` ✅
- Two-phase semantics + chunk-exclusion EXPLAIN verified against a live TimescaleDB (pg18)
- The compression numbers above measured end-to-end on the same DDL
- `cargo clippy --lib -p temps-otel -p temps-migrations -- -D warnings` ✅
- Note: `cargo test -p temps-migrations` has 5 pre-existing failures on `origin/main` (`backup_jobs` relation missing / chunk not found, introduced by #336) — identical failures with and without this change.