### PR TITLE
fix(auth): restrict audit:read to administration roles

### DIFF
--- a/crates/temps-audit/Cargo.toml
+++ b/crates/temps-audit/Cargo.toml
@@ -25,4 +25,5 @@ axum = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
+# `mock` powers MockDatabase for the handler authorization tests.
 sea-orm = { workspace = true, features = ["mock"] }

--- a/crates/temps-audit/src/handlers/handlers.rs
+++ b/crates/temps-audit/src/handlers/handlers.rs
@@ -42,6 +42,7 @@ pub fn configure_routes() -> Router<Arc<AppState>> {
     responses(
         (status = 200, description = "List of audit logs", body = Vec<AuditLogResponse>),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Insufficient permissions"),
         (status = 500, description = "Internal server error")
     ),
     security(("api_key" = []))
@@ -93,6 +94,7 @@ async fn list_audit_logs(
         (status = 200, description = "Audit log details", body = AuditLogResponse),
         (status = 404, description = "Audit log not found"),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Insufficient permissions"),
         (status = 500, description = "Internal server error")
     ),
     security(("api_key" = []))
@@ -121,6 +123,130 @@ async fn get_audit_log(
                     .detail(format!("Failed to get audit log: {}", e))
                     .build(),
             )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get_audit_log, list_audit_logs};
+    use crate::handlers::types::{AppState, ListAuditLogsQuery};
+    use crate::services::AuditService;
+    use axum::extract::{Path, Query, State};
+    use axum::http::StatusCode;
+    use sea_orm::{DatabaseBackend, MockDatabase};
+    use std::sync::Arc;
+    use temps_auth::context::AuthContext;
+    use temps_auth::permissions::{Permission, Role};
+    use temps_auth::RequireAuth;
+    use temps_entities::users;
+    use temps_geo::{GeoIpService, IpAddressService, MockGeoIpService};
+
+    fn test_user() -> users::Model {
+        let now = chrono::Utc::now();
+        users::Model {
+            id: 1,
+            name: "Test User".to_string(),
+            email: "test@example.com".to_string(),
+            password_hash: None,
+            email_verified: true,
+            email_verification_token: None,
+            email_verification_expires: None,
+            password_reset_token: None,
+            password_reset_expires: None,
+            deleted_at: None,
+            mfa_secret: None,
+            mfa_enabled: false,
+            mfa_recovery_codes: None,
+            oidc_subject: None,
+            oidc_provider_id: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn app_state() -> Arc<AppState> {
+        let db = Arc::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+        let geoip = Arc::new(GeoIpService::Mock(MockGeoIpService::new()));
+        let ip_service = Arc::new(IpAddressService::new(db.clone(), geoip));
+        let audit_service = Arc::new(AuditService::new(db, ip_service));
+        Arc::new(AppState { audit_service })
+    }
+
+    fn empty_query() -> ListAuditLogsQuery {
+        ListAuditLogsQuery {
+            operation_type: None,
+            user_id: None,
+            from: None,
+            to: None,
+            limit: None,
+            offset: None,
+        }
+    }
+
+    /// Returns the Problem status if the handler rejected the request, or `None`
+    /// if it passed the `AuditRead` guard (and proceeded to the service).
+    async fn list_rejection_status(auth: AuthContext) -> Option<StatusCode> {
+        list_audit_logs(State(app_state()), RequireAuth(auth), Query(empty_query()))
+            .await
+            .err()
+            .map(|p| p.status_code)
+    }
+
+    async fn get_rejection_status(auth: AuthContext) -> Option<StatusCode> {
+        get_audit_log(State(app_state()), RequireAuth(auth), Path(1))
+            .await
+            .err()
+            .map(|p| p.status_code)
+    }
+
+    #[tokio::test]
+    async fn audit_endpoints_forbidden_for_low_privilege_roles() {
+        for role in [Role::User, Role::Reader] {
+            assert_eq!(
+                list_rejection_status(AuthContext::new_session(test_user(), role.clone())).await,
+                Some(StatusCode::FORBIDDEN),
+                "list_audit_logs must return 403 for {role:?}"
+            );
+            assert_eq!(
+                get_rejection_status(AuthContext::new_session(test_user(), role.clone())).await,
+                Some(StatusCode::FORBIDDEN),
+                "get_audit_log must return 403 for {role:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn audit_endpoints_pass_guard_for_administration_roles_and_scoped_key() {
+        // Administration roles, plus a custom API key explicitly carrying
+        // `audit:read`, must pass the permission guard. They then reach the
+        // service (which fails on the empty mock DB) -- the point is only that
+        // they are NOT rejected with 403.
+        let principals: Vec<Box<dyn Fn() -> AuthContext>> = vec![
+            Box::new(|| AuthContext::new_session(test_user(), Role::Admin)),
+            Box::new(|| AuthContext::new_session(test_user(), Role::PlatformAdmin)),
+            Box::new(|| {
+                AuthContext::new_api_key(
+                    test_user(),
+                    None,
+                    Some(vec![Permission::AuditRead]),
+                    "audit-scoped-key".to_string(),
+                    1,
+                )
+            }),
+        ];
+
+        for make_auth in principals {
+            assert_ne!(
+                list_rejection_status(make_auth()).await,
+                Some(StatusCode::FORBIDDEN),
+                "list_audit_logs must not 403 an audit:read principal"
+            );
+            assert_ne!(
+                get_rejection_status(make_auth()).await,
+                Some(StatusCode::FORBIDDEN),
+                "get_audit_log must not 403 an audit:read principal"
+            );
         }
     }
 }

--- a/crates/temps-auth/src/permissions.rs
+++ b/crates/temps-auth/src/permissions.rs
@@ -1341,27 +1341,6 @@ mod tests {
         assert!(Permission::all().contains(&Permission::SecretsRead));
     }
 
-    #[test]
-    fn test_audit_read_is_restricted_to_administration_roles() {
-        // The audit log is a platform-wide, security-sensitive view (every
-        // user's and admin's actions, IP addresses, emails). Only the
-        // administration roles may read it; lower-privilege roles must not (an
-        // operator can still grant `audit:read` to a specific API key).
-        assert!(Role::Admin.has_permission(&Permission::AuditRead));
-        assert!(Role::PlatformAdmin.has_permission(&Permission::AuditRead));
-        for role in [
-            Role::User,
-            Role::Reader,
-            Role::ApiReader,
-            Role::MetricsIngest,
-        ] {
-            assert!(
-                !role.has_permission(&Permission::AuditRead),
-                "role {role:?} must not hold audit:read"
-            );
-        }
-    }
-
     // Deployment token permission tests
     #[test]
     fn test_deployment_token_permissions_exist() {
@@ -1440,6 +1419,27 @@ mod tests {
         assert!(user_permissions.contains(&Permission::DeploymentTokensWrite));
         assert!(user_permissions.contains(&Permission::DeploymentTokensCreate));
         assert!(!user_permissions.contains(&Permission::DeploymentTokensDelete));
+    }
+
+    #[test]
+    fn test_audit_read_is_restricted_to_administration_roles() {
+        // The audit log is a platform-wide, security-sensitive view (every
+        // user's and admin's actions, IP addresses, emails). Only the
+        // administration roles may read it; lower-privilege roles must not (an
+        // operator can still grant `audit:read` to a specific API key).
+        assert!(Role::Admin.has_permission(&Permission::AuditRead));
+        assert!(Role::PlatformAdmin.has_permission(&Permission::AuditRead));
+        for role in [
+            Role::User,
+            Role::Reader,
+            Role::ApiReader,
+            Role::MetricsIngest,
+        ] {
+            assert!(
+                !role.has_permission(&Permission::AuditRead),
+                "role {role:?} must not hold audit:read"
+            );
+        }
     }
 
     #[test]

--- a/crates/temps-auth/src/permissions.rs
+++ b/crates/temps-auth/src/permissions.rs
@@ -1008,7 +1008,6 @@ impl Role {
                 Permission::ApiKeysRead,
                 Permission::ApiKeysWrite,
                 Permission::ApiKeysCreate,
-                Permission::AuditRead,
                 Permission::BackupsRead,
                 Permission::BackupsWrite,
                 Permission::BackupsCreate,
@@ -1101,7 +1100,6 @@ impl Role {
                 Permission::DomainsRead,
                 Permission::EnvironmentsRead,
                 Permission::AnalyticsRead,
-                Permission::AuditRead,
                 Permission::BackupsRead,
                 Permission::CronsRead,
                 Permission::ExternalServicesRead,
@@ -1341,6 +1339,27 @@ mod tests {
             Some(Permission::SecretsRead)
         );
         assert!(Permission::all().contains(&Permission::SecretsRead));
+    }
+
+    #[test]
+    fn test_audit_read_is_restricted_to_administration_roles() {
+        // The audit log is a platform-wide, security-sensitive view (every
+        // user's and admin's actions, IP addresses, emails). Only the
+        // administration roles may read it; lower-privilege roles must not (an
+        // operator can still grant `audit:read` to a specific API key).
+        assert!(Role::Admin.has_permission(&Permission::AuditRead));
+        assert!(Role::PlatformAdmin.has_permission(&Permission::AuditRead));
+        for role in [
+            Role::User,
+            Role::Reader,
+            Role::ApiReader,
+            Role::MetricsIngest,
+        ] {
+            assert!(
+                !role.has_permission(&Permission::AuditRead),
+                "role {role:?} must not hold audit:read"
+            );
+        }
     }
 
     // Deployment token permission tests

--- a/web/src/components/command/CommandPalette.tsx
+++ b/web/src/components/command/CommandPalette.tsx
@@ -15,6 +15,7 @@ import {
   CommandSeparator,
 } from '@/components/ui/command'
 import { usePluginsContext } from '@/contexts/PluginsContext'
+import { useCanViewAuditLogs } from '@/hooks/useAuditAccess'
 import { useFrecency } from '@/hooks/useFrecency'
 import { resolvePluginIcon } from '@/lib/pluginIcons'
 import { useQuery } from '@tanstack/react-query'
@@ -87,7 +88,14 @@ const mainNavItems: NavigationItem[] = [
     title: 'Sandboxes',
     url: '/sandboxes',
     icon: Box,
-    keywords: ['sandbox', 'sandboxes', 'workspace', 'shell', 'terminal', 'environment'],
+    keywords: [
+      'sandbox',
+      'sandboxes',
+      'workspace',
+      'shell',
+      'terminal',
+      'environment',
+    ],
   },
   {
     title: 'Create New Project',
@@ -105,7 +113,14 @@ const mainNavItems: NavigationItem[] = [
     title: 'Monitoring',
     url: '/monitoring',
     icon: Activity,
-    keywords: ['metrics', 'performance', 'analytics', 'stats', 'alerts', 'health'],
+    keywords: [
+      'metrics',
+      'performance',
+      'analytics',
+      'stats',
+      'alerts',
+      'health',
+    ],
   },
 ]
 
@@ -121,7 +136,14 @@ const settingsNavItems: NavigationItem[] = [
     title: 'Notification Providers',
     url: '/settings/notifications',
     icon: Bell,
-    keywords: ['alerts', 'notifications', 'providers', 'slack', 'email', 'webhook'],
+    keywords: [
+      'alerts',
+      'notifications',
+      'providers',
+      'slack',
+      'email',
+      'webhook',
+    ],
   },
   {
     title: 'Add Notification Provider',
@@ -197,25 +219,61 @@ const settingsNavItems: NavigationItem[] = [
     title: 'AI Gateway',
     url: '/ai-gateway',
     icon: Sparkles,
-    keywords: ['ai', 'llm', 'openai', 'anthropic', 'gateway', 'models', 'providers', 'chat', 'gpt', 'claude'],
+    keywords: [
+      'ai',
+      'llm',
+      'openai',
+      'anthropic',
+      'gateway',
+      'models',
+      'providers',
+      'chat',
+      'gpt',
+      'claude',
+    ],
   },
   {
     title: 'AI Workflows',
     url: '/agent-sandbox',
     icon: Bot,
-    keywords: ['ai', 'workflows', 'agents', 'sandbox', 'automation', 'autopilot'],
+    keywords: [
+      'ai',
+      'workflows',
+      'agents',
+      'sandbox',
+      'automation',
+      'autopilot',
+    ],
   },
   {
     title: 'Skills',
     url: '/skills',
     icon: Wand2,
-    keywords: ['skills', 'ai', 'agents', 'claude', 'instructions', 'prompts', 'global'],
+    keywords: [
+      'skills',
+      'ai',
+      'agents',
+      'claude',
+      'instructions',
+      'prompts',
+      'global',
+    ],
   },
   {
     title: 'MCP Servers',
     url: '/mcp-servers',
     icon: Server,
-    keywords: ['mcp', 'model', 'context', 'protocol', 'tools', 'servers', 'agents', 'claude', 'global'],
+    keywords: [
+      'mcp',
+      'model',
+      'context',
+      'protocol',
+      'tools',
+      'servers',
+      'agents',
+      'claude',
+      'global',
+    ],
   },
   {
     title: 'Git Providers',
@@ -317,7 +375,15 @@ const settingsNavItems: NavigationItem[] = [
     title: 'Metrics Monitoring',
     url: '/settings/metrics-monitoring',
     icon: BarChart3,
-    keywords: ['metrics', 'monitoring', 'thresholds', 'alerts', 'cpu', 'memory', 'resources'],
+    keywords: [
+      'metrics',
+      'monitoring',
+      'thresholds',
+      'alerts',
+      'cpu',
+      'memory',
+      'resources',
+    ],
   },
 ]
 
@@ -458,13 +524,28 @@ const projectNavItems: NavigationItem[] = [
     title: 'Traces',
     url: 'traces',
     icon: Workflow,
-    keywords: ['traces', 'opentelemetry', 'otel', 'spans', 'tracing', 'distributed'],
+    keywords: [
+      'traces',
+      'opentelemetry',
+      'otel',
+      'spans',
+      'tracing',
+      'distributed',
+    ],
   },
   {
     title: 'AI Crawlers',
     url: 'ai-crawlers',
     icon: Bot,
-    keywords: ['ai', 'crawlers', 'bots', 'gptbot', 'googlebot', 'scrapers', 'observe'],
+    keywords: [
+      'ai',
+      'crawlers',
+      'bots',
+      'gptbot',
+      'googlebot',
+      'scrapers',
+      'observe',
+    ],
   },
   {
     title: 'Project Settings',
@@ -530,19 +611,42 @@ const projectNavItems: NavigationItem[] = [
     title: 'Project MCP Servers',
     url: 'settings/mcp-servers',
     icon: Server,
-    keywords: ['mcp', 'model', 'context', 'protocol', 'tools', 'servers', 'project'],
+    keywords: [
+      'mcp',
+      'model',
+      'context',
+      'protocol',
+      'tools',
+      'servers',
+      'project',
+    ],
   },
   {
     title: 'Metrics',
     url: 'metrics',
     icon: BarChart3,
-    keywords: ['metrics', 'opentelemetry', 'otel', 'cpu', 'memory', 'resources', 'observe'],
+    keywords: [
+      'metrics',
+      'opentelemetry',
+      'otel',
+      'cpu',
+      'memory',
+      'resources',
+      'observe',
+    ],
   },
   {
     title: 'Observe',
     url: 'observe',
     icon: Activity,
-    keywords: ['observe', 'events', 'opentelemetry', 'otel', 'timeline', 'all events'],
+    keywords: [
+      'observe',
+      'events',
+      'opentelemetry',
+      'otel',
+      'timeline',
+      'all events',
+    ],
   },
   {
     title: 'Services',
@@ -566,7 +670,18 @@ const projectNavItems: NavigationItem[] = [
     title: 'AI Traces',
     url: 'ai-gateway',
     icon: Bot,
-    keywords: ['ai', 'traces', 'observability', 'llm', 'openai', 'anthropic', 'models', 'gateway', 'otel', 'gen_ai'],
+    keywords: [
+      'ai',
+      'traces',
+      'observability',
+      'llm',
+      'openai',
+      'anthropic',
+      'models',
+      'gateway',
+      'otel',
+      'gen_ai',
+    ],
   },
   {
     title: 'Agents',
@@ -711,12 +826,16 @@ export function CommandPalette() {
     [projectNavEntries]
   )
 
+  const canViewAuditLogs = useCanViewAuditLogs()
+
   // Create Fuse instances for fuzzy search
   const navFuse = useMemo(() => {
     const allNavItems = [
       ...mainNavItems.map((item) => ({ ...item, category: 'Navigation' })),
       ...settingsNavItems.map((item) => ({ ...item, category: 'Settings' })),
-      ...observeNavItems.map((item) => ({ ...item, category: 'Observe' })),
+      ...observeNavItems
+        .filter((item) => canViewAuditLogs || item.url !== '/audit-logs')
+        .map((item) => ({ ...item, category: 'Observe' })),
       ...accountNavItems.map((item) => ({ ...item, category: 'Account' })),
       ...pluginNavItems.map((item) => ({ ...item, category: 'Plugins' })),
     ]
@@ -746,7 +865,13 @@ export function CommandPalette() {
       shouldSort: true,
       minMatchCharLength: 1,
     })
-  }, [currentProjectSlug, currentProject, pluginNavItems, projectPluginNavItems])
+  }, [
+    currentProjectSlug,
+    currentProject,
+    pluginNavItems,
+    projectPluginNavItems,
+    canViewAuditLogs,
+  ])
 
   const projectsFuse = useMemo(() => {
     return new Fuse(projects, {
@@ -1030,7 +1155,11 @@ export function CommandPalette() {
       onOpenChange={setOpen}
       contentClassName="sm:max-w-2xl"
     >
-      <Command className="rounded-lg border shadow-md" loop shouldFilter={false}>
+      <Command
+        className="rounded-lg border shadow-md"
+        loop
+        shouldFilter={false}
+      >
         <CommandInput
           placeholder="Type a command or search..."
           value={search}

--- a/web/src/components/dashboard/Sidebar.tsx
+++ b/web/src/components/dashboard/Sidebar.tsx
@@ -76,6 +76,7 @@ import {
 import { getProjectBySlugOptions } from '@/api/client/@tanstack/react-query.gen'
 import { useAuth } from '@/contexts/AuthContext'
 import { useGettingStarted } from '@/hooks/useGettingStarted'
+import { useCanViewAuditLogs } from '@/hooks/useAuditAccess'
 import { usePluginsContext } from '@/contexts/PluginsContext'
 import { resolvePluginIcon } from '@/lib/pluginIcons'
 import { cn } from '@/lib/utils'
@@ -190,7 +191,11 @@ const settingsGroups: SettingsGroupDef[] = [
     label: 'Infrastructure',
     items: [
       { title: 'Load Balancer', url: '/settings/load-balancer', icon: Server },
-      { title: 'Docker Registry', url: '/settings/docker-registry', icon: Boxes },
+      {
+        title: 'Docker Registry',
+        url: '/settings/docker-registry',
+        icon: Boxes,
+      },
       { title: 'Build Limits', url: '/settings/build-limits', icon: Gauge },
       { title: 'Worker Nodes', url: '/settings/nodes', icon: Network },
       { title: 'Plugins', url: '/settings/plugins', icon: Puzzle },
@@ -201,8 +206,16 @@ const settingsGroups: SettingsGroupDef[] = [
     items: [
       { title: 'Security Headers', url: '/settings/security', icon: Shield },
       { title: 'Rate Limiting', url: '/settings/rate-limiting', icon: Monitor },
-      { title: 'Disk Monitoring', url: '/settings/disk-monitoring', icon: HardDrive },
-      { title: 'Metrics Monitoring', url: '/settings/metrics-monitoring', icon: BarChart3 },
+      {
+        title: 'Disk Monitoring',
+        url: '/settings/disk-monitoring',
+        icon: HardDrive,
+      },
+      {
+        title: 'Metrics Monitoring',
+        url: '/settings/metrics-monitoring',
+        icon: BarChart3,
+      },
     ],
   },
 ]
@@ -330,11 +343,10 @@ export default function AppSidebar() {
   //   anything else     → default workspace nav
   // /projects (the list) and /projects/new keep the default nav.
   const settingsMode = location.pathname.startsWith('/settings')
-  const projectMatch = location.pathname.match(
-    /^\/projects\/([^/]+)(?:\/.*)?$/
-  )
+  const projectMatch = location.pathname.match(/^\/projects\/([^/]+)(?:\/.*)?$/)
   const projectSlug =
-    projectMatch && !['new', 'import-wizard', 'import'].includes(projectMatch[1])
+    projectMatch &&
+    !['new', 'import-wizard', 'import'].includes(projectMatch[1])
       ? projectMatch[1]
       : null
 
@@ -396,18 +408,13 @@ export default function AppSidebar() {
         {showDefault ? (
           <DefaultNav
             pluginItems={pluginItems}
-            pinnedProjectSlug={
-              forceDefault && projectSlug ? projectSlug : null
-            }
+            pinnedProjectSlug={forceDefault && projectSlug ? projectSlug : null}
             onReturnToProject={() => setForceDefault(false)}
           />
         ) : settingsMode ? (
           <SettingsNav onBack={() => setForceDefault(true)} />
         ) : projectSlug ? (
-          <ProjectNav
-            slug={projectSlug}
-            onBack={() => setForceDefault(true)}
-          />
+          <ProjectNav slug={projectSlug} onBack={() => setForceDefault(true)} />
         ) : null}
       </SidebarContent>
       <SidebarFooter>
@@ -448,8 +455,7 @@ function NavSection({
       allUrls
         .filter(
           (url) =>
-            location.pathname === url ||
-            location.pathname.startsWith(url + '/')
+            location.pathname === url || location.pathname.startsWith(url + '/')
         )
         .reduce<string | null>(
           (best, url) =>
@@ -460,9 +466,7 @@ function NavSection({
   )
   return (
     <SidebarGroup
-      className={
-        compact ? '' : 'group-data-[collapsible=icon]:hidden'
-      }
+      className={compact ? '' : 'group-data-[collapsible=icon]:hidden'}
     >
       <SidebarGroupLabel className={compact ? 'hidden' : ''}>
         {label}
@@ -812,6 +816,10 @@ function DefaultNav({
   const flatItems = navWorkflow.filter((it) => !it.subItems?.length)
   const grouped = navWorkflow.filter((it) => it.subItems?.length)
   const { navItems: extraNavItems } = useConsoleExtensions()
+  const canViewAuditLogs = useCanViewAuditLogs()
+  const observabilityItems = canViewAuditLogs
+    ? navObservability
+    : navObservability.filter((it) => it.url !== '/audit-logs')
 
   return (
     <>
@@ -829,7 +837,7 @@ function DefaultNav({
           items={group.subItems!}
         />
       ))}
-      <NavSection label="Observe" items={navObservability} />
+      <NavSection label="Observe" items={observabilityItems} />
       <NavPlugins items={pluginItems} />
       <ExtensionNav items={extraNavItems} />
       <SidebarGroup className="mt-auto">
@@ -918,7 +926,11 @@ const projectBaseNav: ProjectNavItem[] = [
     ],
   },
   { title: 'Databases', url: 'storage', icon: Database },
-  { title: 'Environment Variables', url: 'environment-variables', icon: KeyRound },
+  {
+    title: 'Environment Variables',
+    url: 'environment-variables',
+    icon: KeyRound,
+  },
   { title: 'Domains', url: 'domains', icon: Globe },
   { title: 'Git', url: 'git', icon: GitFork },
   { title: 'Logs', url: 'runtime', icon: ScrollText },
@@ -965,13 +977,7 @@ const projectBaseNav: ProjectNavItem[] = [
   },
 ]
 
-function ProjectNav({
-  slug,
-  onBack,
-}: {
-  slug: string
-  onBack: () => void
-}) {
+function ProjectNav({ slug, onBack }: { slug: string; onBack: () => void }) {
   const { data: project } = useQuery({
     ...getProjectBySlugOptions({ path: { slug } }),
   })
@@ -1069,8 +1075,10 @@ function ProjectNav({
 
   const isActive = (url: string) => {
     const pathOnly = url.split('?')[0]
-    if (pathOnly === 'project') return activeRoute === '' || activeRoute === 'project'
-    if (pathOnly === 'environments') return activeRoute.startsWith('environments')
+    if (pathOnly === 'project')
+      return activeRoute === '' || activeRoute === 'project'
+    if (pathOnly === 'environments')
+      return activeRoute.startsWith('environments')
     return pathOnly === bestMatchUrl
   }
   const isParentActive = (item: ProjectNavItem) =>
@@ -1095,7 +1103,7 @@ function ProjectNav({
                       className={cn(
                         compact ? 'justify-center' : 'justify-start',
                         active &&
-                        'bg-sidebar-accent text-sidebar-accent-foreground'
+                          'bg-sidebar-accent text-sidebar-accent-foreground'
                       )}
                     >
                       <Link to={`/projects/${project.slug}/${sub.url}`}>
@@ -1135,7 +1143,7 @@ function ProjectNav({
                     className={cn(
                       compact ? 'justify-center' : 'justify-start',
                       active &&
-                      'bg-sidebar-accent text-sidebar-accent-foreground'
+                        'bg-sidebar-accent text-sidebar-accent-foreground'
                     )}
                   >
                     <Link to={`/projects/${project.slug}/${item.url}`}>
@@ -1155,7 +1163,7 @@ function ProjectNav({
                     className={cn(
                       compact ? 'justify-center' : 'justify-start',
                       active &&
-                      'bg-sidebar-accent text-sidebar-accent-foreground'
+                        'bg-sidebar-accent text-sidebar-accent-foreground'
                     )}
                   >
                     <item.icon />
@@ -1173,7 +1181,7 @@ function ProjectNav({
                     className={cn(
                       compact ? 'justify-center' : 'justify-start',
                       active &&
-                      'bg-sidebar-accent text-sidebar-accent-foreground'
+                        'bg-sidebar-accent text-sidebar-accent-foreground'
                     )}
                   >
                     <Link to={`/projects/${project.slug}/${item.url}`}>
@@ -1243,13 +1251,7 @@ function CurrentProjectPin({
 
 // Shared back-arrow header used by Settings, Project, and drill-down
 // sub-views. `onBack` is a state callback — it never navigates.
-function SwapHeader({
-  title,
-  onBack,
-}: {
-  title: string
-  onBack: () => void
-}) {
+function SwapHeader({ title, onBack }: { title: string; onBack: () => void }) {
   const { isMinimal, isMobile } = useSidebar()
   const compact = isMinimal && !isMobile
   if (compact) return null

--- a/web/src/hooks/useAuditAccess.ts
+++ b/web/src/hooks/useAuditAccess.ts
@@ -1,0 +1,18 @@
+import { useAuth } from '@/contexts/AuthContext'
+
+/**
+ * Roles that carry the `audit:read` permission (see
+ * `crates/temps-auth/src/permissions.rs`). The audit log is a platform-wide,
+ * security-sensitive view (it records every user's and admin's actions, IP
+ * addresses and emails), so only the administration roles may read it.
+ */
+const AUDIT_LOG_ROLES = ['admin', 'platform_admin']
+
+/**
+ * Whether the current user may view audit logs. Used to hide audit-log UI
+ * entry points so unauthorized roles never issue requests that would 403.
+ */
+export function useCanViewAuditLogs(): boolean {
+  const { user } = useAuth()
+  return !!user && AUDIT_LOG_ROLES.includes(user.role)
+}

--- a/web/src/pages/AuditLogs.tsx
+++ b/web/src/pages/AuditLogs.tsx
@@ -21,11 +21,13 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { useBreadcrumbs } from '@/contexts/BreadcrumbContext'
+import { useCanViewAuditLogs } from '@/hooks/useAuditAccess'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useQuery } from '@tanstack/react-query'
 import { ScrollText, X } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { DateRange } from 'react-day-picker'
+import { Navigate } from 'react-router-dom'
 
 const ITEMS_PER_PAGE = 20
 
@@ -71,7 +73,10 @@ const OPERATION_GROUPS: OperationGroup[] = [
       { value: 'PROJECT_UPDATED', label: 'Project Updated' },
       { value: 'PROJECT_DELETED', label: 'Project Deleted' },
       { value: 'PROJECT_SETTINGS_UPDATED', label: 'Project Settings Updated' },
-      { value: 'DEPLOYMENT_CONFIG_UPDATED', label: 'Deployment Config Updated' },
+      {
+        value: 'DEPLOYMENT_CONFIG_UPDATED',
+        label: 'Deployment Config Updated',
+      },
       { value: 'ENVIRONMENT_DELETED', label: 'Environment Deleted' },
       {
         value: 'ENVIRONMENT_SETTINGS_UPDATED',
@@ -116,9 +121,7 @@ const OPERATION_GROUPS: OperationGroup[] = [
   },
   {
     label: 'Containers',
-    operations: [
-      { value: 'CONTAINER_ACTION', label: 'Container Action' },
-    ],
+    operations: [{ value: 'CONTAINER_ACTION', label: 'Container Action' }],
   },
   {
     label: 'Workspaces',
@@ -298,6 +301,7 @@ const OPERATION_GROUPS: OperationGroup[] = [
 const ALL_FILTER = '__all__'
 
 export function AuditLogs() {
+  const canViewAuditLogs = useCanViewAuditLogs()
   const { setBreadcrumbs } = useBreadcrumbs()
   const [dateRange, setDateRange] = useState<DateRange | undefined>()
   const [operation, setOperation] = useState<string>(ALL_FILTER)
@@ -310,14 +314,15 @@ export function AuditLogs() {
 
   usePageTitle('Audit Logs')
 
-  const { data: users, isLoading: isLoadingUsers } = useQuery(
-    listUsersOptions({
+  const { data: users, isLoading: isLoadingUsers } = useQuery({
+    ...listUsersOptions({
       query: { include_deleted: false },
-    })
-  )
+    }),
+    enabled: canViewAuditLogs,
+  })
 
-  const { data, isLoading } = useQuery(
-    listAuditLogsOptions({
+  const { data, isLoading } = useQuery({
+    ...listAuditLogsOptions({
       query: {
         limit: ITEMS_PER_PAGE,
         offset: (page - 1) * ITEMS_PER_PAGE,
@@ -327,8 +332,9 @@ export function AuditLogs() {
         user_id:
           selectedUserId !== ALL_FILTER ? Number(selectedUserId) : undefined,
       },
-    })
-  )
+    }),
+    enabled: canViewAuditLogs,
+  })
 
   const hasMore = useMemo(() => data?.length === ITEMS_PER_PAGE, [data])
   const showEmptyState = useMemo(
@@ -374,6 +380,12 @@ export function AuditLogs() {
     setOperation(ALL_FILTER)
     setSelectedUserId(ALL_FILTER)
     setPage(1)
+  }
+
+  // Direct navigation guard: only the administration roles may read audit
+  // logs, so redirect anyone else away instead of surfacing 403s.
+  if (!canViewAuditLogs) {
+    return <Navigate to="/projects" replace />
   }
 
   return (
@@ -493,9 +505,7 @@ export function AuditLogs() {
                     audit_date={log.audit_date}
                     user={log.user ?? undefined}
                     ip_address={log.ip_address ?? undefined}
-                    data={
-                      log.data as Record<string, unknown> | undefined
-                    }
+                    data={log.data as Record<string, unknown> | undefined}
                   />
                 ))
               )}

--- a/web/src/pages/AuditLogs.tsx
+++ b/web/src/pages/AuditLogs.tsx
@@ -27,7 +27,7 @@ import { useQuery } from '@tanstack/react-query'
 import { ScrollText, X } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { DateRange } from 'react-day-picker'
-import { Navigate } from 'react-router-dom'
+import { Navigate } from 'react-router'
 
 const ITEMS_PER_PAGE = 20
 

--- a/web/src/pages/UserDetail.tsx
+++ b/web/src/pages/UserDetail.tsx
@@ -18,6 +18,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { useBreadcrumbs } from '@/contexts/BreadcrumbContext'
+import { useCanViewAuditLogs } from '@/hooks/useAuditAccess'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useQuery } from '@tanstack/react-query'
 import { format, formatDistanceToNow } from 'date-fns'
@@ -47,6 +48,7 @@ export function UserDetail() {
   const navigate = useNavigate()
   const { setBreadcrumbs } = useBreadcrumbs()
   const [page, setPage] = useState(1)
+  const canViewAuditLogs = useCanViewAuditLogs()
 
   const { data: users, isLoading: isLoadingUser } = useQuery(
     listUsersOptions({ query: { include_deleted: true } })
@@ -68,7 +70,7 @@ export function UserDetail() {
         to: undefined,
       },
     }),
-    enabled: Number.isFinite(parsedId),
+    enabled: Number.isFinite(parsedId) && canViewAuditLogs,
   })
 
   // Separate query for stats — pull a larger recent batch so we can
@@ -85,7 +87,7 @@ export function UserDetail() {
         to: undefined,
       },
     }),
-    enabled: Number.isFinite(parsedId),
+    enabled: Number.isFinite(parsedId) && canViewAuditLogs,
   })
 
   const stats = useMemo(() => {
@@ -118,8 +120,7 @@ export function UserDetail() {
     return { actions30d, failedLogins30d, lastLogin, lastActivity }
   }, [statsLogs])
 
-  const userDisplayName =
-    target?.user.name || target?.user.username || 'User'
+  const userDisplayName = target?.user.name || target?.user.username || 'User'
 
   useEffect(() => {
     setBreadcrumbs([
@@ -157,9 +158,7 @@ export function UserDetail() {
   }
 
   const lastLoginLocation = stats?.lastLogin
-    ? [stats.lastLogin.city, stats.lastLogin.country]
-        .filter(Boolean)
-        .join(', ')
+    ? [stats.lastLogin.city, stats.lastLogin.country].filter(Boolean).join(', ')
     : ''
 
   return (
@@ -272,9 +271,7 @@ export function UserDetail() {
           icon={<Calendar className="h-4 w-4" />}
           label="Member since"
           value={
-            target
-              ? format(new Date(target.user.created_at), 'PP')
-              : undefined
+            target ? format(new Date(target.user.created_at), 'PP') : undefined
           }
           hint={
             target
@@ -283,168 +280,179 @@ export function UserDetail() {
           }
           loading={isLoadingUser}
         />
-        <StatCard
-          icon={<LogIn className="h-4 w-4" />}
-          label="Last login"
-          value={
-            stats?.lastLogin
-              ? formatDistanceToNow(new Date(stats.lastLogin.at), {
-                  addSuffix: true,
-                })
-              : statsLogs
-              ? 'Never'
-              : undefined
-          }
-          hint={
-            stats?.lastLogin
-              ? lastLoginLocation ||
-                format(new Date(stats.lastLogin.at), 'PP p')
-              : undefined
-          }
-          loading={!statsLogs}
-        />
-        <StatCard
-          icon={<Activity className="h-4 w-4" />}
-          label="Actions (30d)"
-          value={
-            stats
-              ? stats.actions30d >= STATS_BATCH_SIZE
-                ? `${STATS_BATCH_SIZE}+`
-                : String(stats.actions30d)
-              : undefined
-          }
-          hint={
-            stats?.lastActivity
-              ? `last ${formatDistanceToNow(
-                  new Date(stats.lastActivity)
-                )} ago`
-              : undefined
-          }
-          loading={!statsLogs}
-        />
-        <StatCard
-          icon={
-            stats && stats.failedLogins30d > 0 ? (
-              <AlertTriangle className="h-4 w-4 text-amber-500" />
-            ) : (
-              <Clock className="h-4 w-4" />
-            )
-          }
-          label="Failed logins (30d)"
-          value={stats ? String(stats.failedLogins30d) : undefined}
-          hint={
-            stats && stats.failedLogins30d === 0
-              ? 'No failed attempts'
-              : undefined
-          }
-          tone={
-            stats && stats.failedLogins30d > 0 ? 'warning' : undefined
-          }
-          loading={!statsLogs}
-        />
-      </div>
-
-      {/* Audit log section — reuses AuditLogItemRow to match /audit rendering */}
-      <div className="space-y-3">
-        <div className="flex flex-col gap-1">
-          <h2 className="text-lg font-semibold">Audit logs</h2>
-          <p className="text-sm text-muted-foreground">
-            Actions performed by {userDisplayName}.
-          </p>
-        </div>
-
-        <Card>
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="w-8" />
-                  <TableHead className="w-[110px]">Type</TableHead>
-                  <TableHead>Operation</TableHead>
-                  <TableHead className="hidden md:table-cell">Actor</TableHead>
-                  <TableHead className="hidden lg:table-cell">Origin</TableHead>
-                  <TableHead className="text-right">When</TableHead>
-                  <TableHead className="w-8" />
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {isLoadingLogs ? (
-                  Array.from({ length: 6 }).map((_, i) => (
-                    <TableRow key={i}>
-                      <TableCell />
-                      <TableCell>
-                        <Skeleton className="h-5 w-16" />
-                      </TableCell>
-                      <TableCell>
-                        <Skeleton className="h-4 w-64" />
-                      </TableCell>
-                      <TableCell className="hidden md:table-cell">
-                        <Skeleton className="h-4 w-24" />
-                      </TableCell>
-                      <TableCell className="hidden lg:table-cell">
-                        <Skeleton className="h-4 w-32" />
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <Skeleton className="ml-auto h-4 w-32" />
-                      </TableCell>
-                      <TableCell />
-                    </TableRow>
-                  ))
-                ) : showEmptyState ? (
-                  <TableRow className="hover:bg-transparent">
-                    <TableCell colSpan={7} className="p-0">
-                      <EmptyState
-                        icon={ScrollText}
-                        title="No activity yet"
-                        description="Actions performed by this user will show up here."
-                      />
-                    </TableCell>
-                  </TableRow>
+        {canViewAuditLogs && (
+          <>
+            <StatCard
+              icon={<LogIn className="h-4 w-4" />}
+              label="Last login"
+              value={
+                stats?.lastLogin
+                  ? formatDistanceToNow(new Date(stats.lastLogin.at), {
+                      addSuffix: true,
+                    })
+                  : statsLogs
+                    ? 'Never'
+                    : undefined
+              }
+              hint={
+                stats?.lastLogin
+                  ? lastLoginLocation ||
+                    format(new Date(stats.lastLogin.at), 'PP p')
+                  : undefined
+              }
+              loading={!statsLogs}
+            />
+            <StatCard
+              icon={<Activity className="h-4 w-4" />}
+              label="Actions (30d)"
+              value={
+                stats
+                  ? stats.actions30d >= STATS_BATCH_SIZE
+                    ? `${STATS_BATCH_SIZE}+`
+                    : String(stats.actions30d)
+                  : undefined
+              }
+              hint={
+                stats?.lastActivity
+                  ? `last ${formatDistanceToNow(
+                      new Date(stats.lastActivity)
+                    )} ago`
+                  : undefined
+              }
+              loading={!statsLogs}
+            />
+            <StatCard
+              icon={
+                stats && stats.failedLogins30d > 0 ? (
+                  <AlertTriangle className="h-4 w-4 text-amber-500" />
                 ) : (
-                  logs?.map((log) => (
-                    <AuditLogItemRow
-                      key={log.id}
-                      id={log.id}
-                      operation_type={log.operation_type}
-                      audit_date={log.audit_date}
-                      user={log.user ?? undefined}
-                      ip_address={log.ip_address ?? undefined}
-                      data={log.data as Record<string, unknown> | undefined}
-                    />
-                  ))
-                )}
-              </TableBody>
-            </Table>
-          </div>
-        </Card>
-
-        {!showEmptyState && (
-          <div className="flex items-center justify-between">
-            <p className="text-sm text-muted-foreground">
-              Page {page}
-              {logs && ` · ${logs.length} result${logs.length === 1 ? '' : 's'}`}
-            </p>
-            <div className="flex gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setPage((p) => Math.max(1, p - 1))}
-                disabled={page === 1 || isLoadingLogs}
-              >
-                Previous
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setPage((p) => p + 1)}
-                disabled={!hasMore || isLoadingLogs}
-              >
-                Next
-              </Button>
-            </div>
-          </div>
+                  <Clock className="h-4 w-4" />
+                )
+              }
+              label="Failed logins (30d)"
+              value={stats ? String(stats.failedLogins30d) : undefined}
+              hint={
+                stats && stats.failedLogins30d === 0
+                  ? 'No failed attempts'
+                  : undefined
+              }
+              tone={stats && stats.failedLogins30d > 0 ? 'warning' : undefined}
+              loading={!statsLogs}
+            />
+          </>
         )}
       </div>
+
+      {/* Audit log section — reuses AuditLogItemRow to match /audit rendering.
+          Gated to audit-log viewers: only administration roles may read
+          another user's activity. */}
+      {canViewAuditLogs && (
+        <div className="space-y-3">
+          <div className="flex flex-col gap-1">
+            <h2 className="text-lg font-semibold">Audit logs</h2>
+            <p className="text-sm text-muted-foreground">
+              Actions performed by {userDisplayName}.
+            </p>
+          </div>
+
+          <Card>
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-8" />
+                    <TableHead className="w-[110px]">Type</TableHead>
+                    <TableHead>Operation</TableHead>
+                    <TableHead className="hidden md:table-cell">
+                      Actor
+                    </TableHead>
+                    <TableHead className="hidden lg:table-cell">
+                      Origin
+                    </TableHead>
+                    <TableHead className="text-right">When</TableHead>
+                    <TableHead className="w-8" />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {isLoadingLogs ? (
+                    Array.from({ length: 6 }).map((_, i) => (
+                      <TableRow key={i}>
+                        <TableCell />
+                        <TableCell>
+                          <Skeleton className="h-5 w-16" />
+                        </TableCell>
+                        <TableCell>
+                          <Skeleton className="h-4 w-64" />
+                        </TableCell>
+                        <TableCell className="hidden md:table-cell">
+                          <Skeleton className="h-4 w-24" />
+                        </TableCell>
+                        <TableCell className="hidden lg:table-cell">
+                          <Skeleton className="h-4 w-32" />
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <Skeleton className="ml-auto h-4 w-32" />
+                        </TableCell>
+                        <TableCell />
+                      </TableRow>
+                    ))
+                  ) : showEmptyState ? (
+                    <TableRow className="hover:bg-transparent">
+                      <TableCell colSpan={7} className="p-0">
+                        <EmptyState
+                          icon={ScrollText}
+                          title="No activity yet"
+                          description="Actions performed by this user will show up here."
+                        />
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    logs?.map((log) => (
+                      <AuditLogItemRow
+                        key={log.id}
+                        id={log.id}
+                        operation_type={log.operation_type}
+                        audit_date={log.audit_date}
+                        user={log.user ?? undefined}
+                        ip_address={log.ip_address ?? undefined}
+                        data={log.data as Record<string, unknown> | undefined}
+                      />
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          </Card>
+
+          {!showEmptyState && (
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-muted-foreground">
+                Page {page}
+                {logs &&
+                  ` · ${logs.length} result${logs.length === 1 ? '' : 's'}`}
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page === 1 || isLoadingLogs}
+                >
+                  Previous
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPage((p) => p + 1)}
+                  disabled={!hasMore || isLoadingLogs}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## What

Restricts the `audit:read` permission to the administration roles. The audit log is a platform-wide view (it records every user's and admin's actions, IP addresses, and emails), and its list endpoint accepts an arbitrary `user_id` filter with no per-caller scoping. `AuditRead` was granted to the low-privilege `User` and `Reader` roles in addition to `Admin`/`PlatformAdmin`, so far more principals could read the full trail than the data warrants.

## Change

- `permissions.rs`: remove `AuditRead` from the `User` and `Reader` role arms. It stays with `Admin` and `PlatformAdmin`, and — being permission-based — can still be granted to a specific API key when an operator wants to delegate audit access. The handler already gates on the permission, so no handler change is needed.
- Add a regression test asserting only the administration roles hold `audit:read`.

**Behavior change:** `User` and `Reader` roles no longer read the audit log.

## Tests

`cargo test --lib -p temps-auth` passes, including the new matrix test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)