### PR TITLE
feat(skills): add estimate-temps-savings skill

### DIFF
--- a/docs/features/skills/page.mdx
+++ b/docs/features/skills/page.mdx
@@ -13,6 +13,7 @@ export const sections = [
   { title: "Install All Skills", id: "install-all" },
   { title: "Install a Specific Skill", id: "install-specific" },
   { title: "Available Skills", id: "available-skills" },
+  { title: "estimate-temps-savings", id: "estimate-temps-savings" },
   { title: "deploy-to-temps", id: "deploy-to-temps" },
   { title: "temps-cli", id: "temps-cli" },
   { title: "temps-platform-setup", id: "temps-platform-setup" },
@@ -31,7 +32,7 @@ Give your AI coding agent deep knowledge about Temps. Skills are structured guid
 
 ## Overview {{ anchor: true, id: 'overview' }}
 
-Temps ships with **8 skills** that work with AI coding tools like Claude Code, Cursor, Windsurf, Cline, and any agent that supports the skills protocol. Each skill is a curated set of instructions, code examples, and reference material that the AI loads when it recognizes a relevant task.
+Temps ships with **9 skills** that work with AI coding tools like Claude Code, Cursor, Windsurf, Cline, and any agent that supports the skills protocol. Each skill is a curated set of instructions, code examples, and reference material that the AI loads when it recognizes a relevant task.
 
 For example, if you tell your AI agent "deploy my app to Temps", and the `deploy-to-temps` skill is installed, the agent already knows the exact CLI commands, framework detection logic, Dockerfile patterns, and troubleshooting steps -- without you having to explain anything.
 
@@ -71,6 +72,7 @@ Select skills to install (space to toggle)
   ◻ add-react-analytics
   ◻ add-session-recording
   ◻ deploy-to-temps
+  ◻ estimate-temps-savings
   ◻ temps-cli
   ◻ temps-mcp-setup
   ◻ temps-platform-setup
@@ -99,6 +101,7 @@ Replace `deploy-to-temps` with any skill name from the list below.
 
 | Skill                                             | Description                                                   | Triggers on                           |
 | ------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------- |
+| [`estimate-temps-savings`](#estimate-temps-savings) | Audit your SaaS stack and calculate what Temps would save you | "how much would I save", "audit my stack" |
 | [`deploy-to-temps`](#deploy-to-temps)             | Deploy applications with auto-detection and CI/CD             | "deploy to temps", "temps deployment" |
 | [`temps-cli`](#temps-cli)                         | Complete reference for all 54+ CLI commands                   | "temps cli", "temps command"          |
 | [`temps-platform-setup`](#temps-platform-setup)   | Install and configure Temps on a server                       | "install temps", "setup temps"        |
@@ -107,6 +110,38 @@ Replace `deploy-to-temps` with any skill name from the list below.
 | [`add-session-recording`](#add-session-recording) | Add privacy-aware session recording with rrweb                | "session recording", "session replay" |
 | [`add-node-sdk`](#add-node-sdk)                   | Integrate KV storage, blob storage, and server-side analytics | "temps node sdk", "temps kv"          |
 | [`add-custom-domain`](#add-custom-domain)         | Configure domains with automatic SSL/TLS                      | "custom domain", "ssl certificate"    |
+
+---
+
+## estimate-temps-savings {{ anchor: true, id: 'estimate-temps-savings' }}
+
+Audit a project's infrastructure and SaaS stack, then get a cost report showing current spend versus running Temps -- detected straight from your codebase, no forms to fill in.
+
+```bash
+npx skills add gotempsh/temps --skill estimate-temps-savings
+```
+
+<Properties>
+  <Property name="Stack Detection">
+    Finds hosting (Vercel, Netlify, Railway, Heroku), analytics (PostHog,
+    Plausible, Mixpanel), error tracking (Sentry, Bugsnag), session replay
+    (LogRocket, FullStory, Hotjar), uptime monitors, managed databases, and
+    email providers from dependencies, config files, and env var key names --
+    without ever reading secret values.
+  </Property>
+  <Property name="Honest Pricing">
+    Bundled list-price reference for 40+ tools. Reports low-to-typical ranges,
+    counts free tiers as $0, and tells you when Temps will not save you money.
+  </Property>
+  <Property name="Savings Report">
+    Current spend vs. self-hosted Temps (~€8/mo Hetzner) or Temps Cloud, yearly
+    savings, and what Temps does not replace (edge CDN, deep APM).
+  </Property>
+  <Property name="Migration Plan">
+    Suggested migration order starting with zero-risk parallel swaps, with
+    pointers to the matching Temps skills for each step.
+  </Property>
+</Properties>
 
 ---
 

--- a/skills/estimate-temps-savings/SKILL.md
+++ b/skills/estimate-temps-savings/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: estimate-temps-savings
+description: |
+  Audit a project's infrastructure and SaaS stack, then produce a cost report showing what the user currently pays and what they would save by consolidating onto Temps (self-hosted or Temps Cloud). Detects hosting platforms (Vercel, Netlify, Railway, Render, Heroku, Fly.io), analytics (PostHog, Plausible, Mixpanel, Amplitude, Fathom), error tracking (Sentry, Bugsnag, Rollbar, Honeybadger), session replay (LogRocket, FullStory, Hotjar, Highlight), uptime monitoring (Pingdom, UptimeRobot, Better Stack, Checkly), managed databases (Supabase, Neon, PlanetScale, MongoDB Atlas, Upstash, RDS), and transactional email (SendGrid, Postmark, Resend, Mailgun) from dependencies, config files, and env var names. Use when the user wants to: (1) Know how much they would save by switching to Temps, (2) Audit their SaaS/infrastructure spend, (3) Compare their current stack's cost against self-hosting, (4) Decide whether Temps is worth it, (5) Build a business case for consolidating tools. Triggers: "how much would I save", "temps savings", "cost comparison", "audit my stack", "am I overpaying", "saas spend", "calculate savings", "is temps cheaper".
+---
+
+# Estimate Temps Savings
+
+Scan the current project, detect every paid SaaS tool it depends on, estimate the monthly bill, and show the delta against running Temps instead. The output is a savings report the user can act on (or show their team).
+
+Temps is a self-hosted PaaS that replaces the deployment platform, web analytics, session replay, error tracking, uptime monitoring, managed databases, and transactional email relay with a single binary. Self-hosting is free (you pay only for the server); Temps Cloud is a managed server at cost + 30% (from ~$6/mo).
+
+## Ground Rules
+
+1. **Never read or print secret values.** Detection uses dependency names, config file presence, env var **key names**, and the **hostname** of connection strings only. If you must open a `.env*` file, extract key names (`cut -d= -f1`) — never echo values into the report or your reasoning.
+2. **No vanity math.** Only count tools you actually detected. If a tool has a free tier the user likely fits in (e.g. Google Analytics, small Sentry dev plan), say so and count $0 or a range starting at $0. An inflated savings number destroys trust; an honest one converts.
+3. **Ranges, not fake precision.** You don't know the user's plan. Report low/typical estimates and label them as list-price estimates. If exact numbers matter, tell the user which invoices to check.
+4. **Be honest about what Temps does NOT replace** (see the "Not replaced" section below). Always include it in the report.
+
+## Step 1 — Detect the Stack
+
+Run these checks from the project root. Check dependency manifests (`package.json`, `requirements.txt`, `pyproject.toml`, `Gemfile`, `go.mod`, `Cargo.toml`), config files, CI workflows (`.github/workflows/`), and env var key names in `.env*`, `.env.example`, `docker-compose*.yml`, and IaC files.
+
+| Category | Signal → Tool |
+|---|---|
+| **Hosting** | `vercel.json` or `.vercel/` → Vercel · `netlify.toml` → Netlify · `railway.json`/`railway.toml` → Railway · `render.yaml` → Render · `fly.toml` → Fly.io · `Procfile` + no Dockerfile → Heroku · `amplify.yml` → AWS Amplify |
+| **Analytics** | `posthog-js`/`posthog-node` → PostHog · `plausible-tracker` or plausible.io script tag → Plausible · `mixpanel-browser` → Mixpanel · `@amplitude/*` → Amplitude · `fathom-client` → Fathom · `@segment/analytics-*` → Segment · `@vercel/analytics` → Vercel Analytics |
+| **Error tracking** | `@sentry/*`, `sentry.properties`, `sentry-sdk` → Sentry · `@bugsnag/*` → Bugsnag · `rollbar` → Rollbar · `@honeybadger-io/*` → Honeybadger |
+| **Session replay** | `logrocket` → LogRocket · `@fullstory/browser` → FullStory · Hotjar script tag / `HOTJAR_ID` → Hotjar · `@highlight-run/*` → Highlight · PostHog with `session_recording` config → PostHog Replay |
+| **Uptime / status** | `checkly.config.ts` → Checkly · env keys or CI mentioning Pingdom / UptimeRobot / Better Stack (BetterUptime) / Statuspage |
+| **Managed DB / cache** | `@supabase/supabase-js` or `supabase.co` host → Supabase · `@neondatabase/serverless` or `neon.tech` host → Neon · `@planetscale/database` or `psdb.cloud` host → PlanetScale · `mongodb+srv://` or `mongodb.net` host → MongoDB Atlas · `@upstash/redis` or `upstash.io` host → Upstash · `rds.amazonaws.com` host → AWS RDS · `redns.redis-cloud.com` host → Redis Cloud |
+| **Transactional email** | `@sendgrid/mail` / `SENDGRID_API_KEY` → SendGrid · `postmark` / `POSTMARK_SERVER_TOKEN` → Postmark · `resend` / `RESEND_API_KEY` → Resend · `mailgun.js` / `MAILGUN_API_KEY` → Mailgun · `email-smtp.*.amazonaws.com` → AWS SES (already cheap — flag, don't count) |
+| **Observability (partial)** | `DD_API_KEY`/`datadog` → Datadog · `NEW_RELIC_LICENSE_KEY` → New Relic (Temps covers logs/metrics/traces basics — count partially, note the caveat) |
+
+Env key names worth grepping for: `SENTRY_DSN`, `NEXT_PUBLIC_POSTHOG_KEY`, `MIXPANEL_TOKEN`, `AMPLITUDE_API_KEY`, `SEGMENT_WRITE_KEY`, `LOGROCKET_APP_ID`, `DATABASE_URL`, `REDIS_URL`, `MONGODB_URI`, `UPSTASH_REDIS_REST_URL`, `VERCEL_TOKEN`, `NETLIFY_AUTH_TOKEN`, `RAILWAY_TOKEN`, `FLY_API_TOKEN`.
+
+Multi-repo note: if the user says this is one of several apps, ask how many apps/environments share these tools — per-seat and per-project pricing multiplies.
+
+## Step 2 — Ask for Usage (only what's needed)
+
+Ask ONLY about categories you detected, in one batch. Every question needs a default so the user can answer "don't know":
+
+- Team seats with dashboard access (drives Vercel/Netlify per-seat) — default 2
+- Monthly pageviews or analytics events — default 100k pageviews
+- Errors/month sent to error tracking — default within Sentry Team tier
+- Session recordings/month — default 5k
+- Emails sent/month — default 20k
+- Number of uptime monitors — default 10
+- Databases/branches in use — default 1 production DB
+
+If the user answers "just estimate it", use the defaults and the **typical** column from the pricing reference.
+
+## Step 3 — Price It
+
+Load `references/pricing.md` (bundled with this skill) for list prices per tool and tier. For each detected tool, pick the tier matching the usage answers and record a **low–typical** monthly range. Prices there are list prices as of early 2026 — if the user needs invoice-grade accuracy, tell them to check their billing pages; do not present the estimate as exact.
+
+Temps side of the ledger:
+
+| Option | Monthly cost | Notes |
+|---|---|---|
+| Self-hosted Temps | server only: **€4–15/mo** (reference: Hetzner CPX22, 3 vCPU / 4 GB, ~€8/mo, 20 TB traffic included) | Temps itself is free. One server runs deploys + analytics + replay + errors + uptime + DBs for typical startup workloads. |
+| Temps Cloud | **from ~$6/mo** | Managed Hetzner server at cost + 30%. No per-seat, per-event, or per-error pricing. |
+| Email sending | ~$0.10 per 1,000 via your own AWS SES/Scaleway | Temps relays through your provider at cost — the SaaS markup disappears, not the sending fee. |
+
+Unlimited seats, projects, and environments on both options — when the user has >2 seats on per-seat tools, this is usually the biggest line item; show it.
+
+## Step 4 — Produce the Report
+
+Output this structure (markdown):
+
+```markdown
+# Temps Savings Estimate — <project name>
+
+## Detected stack
+| Tool | Evidence | Est. monthly (low–typical) |
+|---|---|---|
+| Vercel Pro | vercel.json, 3 team seats | $60–$95 |
+| Sentry Team | @sentry/nextjs, SENTRY_DSN in .env.example | $26–$45 |
+| ...
+
+**Current estimated spend: $X–$Y/mo ($12X–$12Y/yr)**
+
+## With Temps
+| Option | Monthly | Yearly |
+|---|---|---|
+| Self-hosted (Hetzner CPX22) | ~€8 | ~€96 |
+| Temps Cloud | from ~$6 + server size | ... |
+
+**Estimated savings: $A–$B per year (~N% of current spend)**
+
+## What Temps does NOT replace
+- <honest list, see below>
+
+## Suggested migration order
+1. <lowest-risk, highest-saving first>
+
+## Next steps
+- `npx skills add gotempsh/temps --skill deploy-to-temps` — migrate hosting
+- `npx skills add gotempsh/temps --skill add-react-analytics` — replace analytics
+- ...
+```
+
+Rules for the report:
+- Sort detected tools by estimated cost, highest first.
+- Migration order: start with additive, zero-risk swaps (analytics, error tracking — run both in parallel), end with hosting/database moves.
+- If total detected spend is under ~$15/mo, say plainly that Temps won't save them meaningful money today — the pitch is then about avoiding the future bill and owning the data, not savings. Do not manufacture a number.
+
+## Not Replaced (always disclose)
+
+- **Global edge network / CDN PoPs** — Temps serves from your server(s); Vercel/Netlify's worldwide edge is not matched by a single region (Temps supports multi-node, but that's more servers, not a 100-PoP CDN).
+- **Serverless/edge function runtimes** — Vercel Edge Functions, ISR-specific behaviors, and Cloudflare Workers need porting to containerized apps.
+- **Deep APM** — Datadog/New Relic profiling depth exceeds Temps' built-in logs/metrics/traces; count these as partial replacements.
+- **Email deliverability infrastructure** — Temps relays via your SES/Scaleway account; sending fees and domain reputation work remain yours.
+- **Ops responsibility** — self-hosting means you own updates and backups (Temps automates both, but it's your pager). Temps Cloud narrows this gap.
+
+## Troubleshooting
+
+- **Nothing detected:** the project may use tools configured outside the repo (dashboards, DNS-level scripts). Ask the user directly: "What do you currently pay for hosting, analytics, error tracking, and databases?" and build the table from their answers.
+- **Monorepo:** run detection per app directory; dedupe tools that share one subscription.
+- **User disputes a price:** trust their invoice over the reference table, update the row, and note "user-provided" in the Evidence column.

--- a/skills/estimate-temps-savings/references/pricing.md
+++ b/skills/estimate-temps-savings/references/pricing.md
@@ -1,0 +1,102 @@
+# SaaS List-Price Reference
+
+List prices as of **early 2026**, USD unless noted. These drift — treat as estimates, and prefer the user's actual invoice when they have one. "Typical" assumes a small team (2–5 seats) at the default usage from Step 2 of the skill.
+
+## Hosting / Deployment
+
+| Tool | Entry paid tier | Typical small-team monthly | Pricing model |
+|---|---|---|---|
+| Vercel | Pro $20/seat | $40–$100 | Per-seat + usage (1 TB fast data transfer included, ~$0.15/GB after; function duration billed) |
+| Netlify | Pro $19/seat | $38–$80 | Per-seat + bandwidth overages ($55/100GB after 1TB) |
+| Heroku | Basic dyno $7 | $25–$75 | Per-dyno; Standard-1X $25; Postgres Basic $9, Standard-0 $50 |
+| Railway | usage, ~$5 min | $10–$40 | Per-resource usage (vCPU/GB-hour) |
+| Render | $7–$25/service | $15–$60 | Per-service instances + managed Postgres from $19 |
+| Fly.io | usage | $10–$50 | Per-VM usage + volumes + egress |
+| AWS Amplify | usage | $10–$40 | Build minutes + hosting + egress |
+
+## Web Analytics
+
+| Tool | Free tier | Typical monthly | Model |
+|---|---|---|---|
+| PostHog (analytics) | 1M events/mo | $0–$60 | ~$0.00031/event after free tier, decreasing with volume |
+| Plausible | none (30-day trial) | $9 (10k views) / $19 (100k) / $69 (1M) | Pageview tiers |
+| Fathom | none | $15 (100k views) → $25 (200k) | Pageview tiers |
+| Mixpanel | generous free (up to ~20M events) | $0–$28+ | Event-based; Growth from ~$28 |
+| Amplitude | 50k MTU free | $0–$61+ | Plus from $61 |
+| Segment (CDP) | 1k visitors free | $120+ | Team plan $120; scales fast with MTU |
+| Vercel Analytics | basic included on Pro | $10–$50 | Plus $10/mo + per-event over 25k |
+| Google Analytics | free | $0 | Don't count as savings |
+
+## Error Tracking
+
+| Tool | Free tier | Typical monthly | Model |
+|---|---|---|---|
+| Sentry | 5k errors (dev) | $26 (Team) – $80 (Business) | Volume-based; overages per error/span/replay |
+| Bugsnag | 7.5k events free | $59+ | Event volume |
+| Rollbar | 5k events free | $41+ (Essentials) | Event volume |
+| Honeybadger | 1k errors free | $26+ | Tiered |
+
+## Session Replay
+
+| Tool | Free tier | Typical monthly | Model |
+|---|---|---|---|
+| LogRocket | 1k sessions free | $69–$350 | Per-session tiers |
+| FullStory | limited free | $250–$800+ (quote) | Enterprise quotes; rarely under $250 |
+| Hotjar | 35 daily sessions free | $32 (Plus) – $80 (Business) | Daily session tiers |
+| Highlight.io | 500 sessions free | $50–$150 | Usage |
+| PostHog Replay | 5k recordings/mo free | $0–$50 | ~$0.005/recording after free |
+
+## Uptime Monitoring / Status Pages
+
+| Tool | Free tier | Typical monthly | Model |
+|---|---|---|---|
+| Pingdom | none | $10–$15 (Synthetic starter) | Per-monitor bundles |
+| UptimeRobot | 50 monitors @ 5min | $0–$29 | Solo $7, Team $29 |
+| Better Stack | 10 monitors free | $0–$29+ | Per-monitor + team |
+| Checkly | 10k API checks free | $40+ (Team) | Check-run volume |
+| Atlassian Statuspage | limited free | $29–$99 | Page tiers |
+
+## Managed Databases / Cache / Storage
+
+| Tool | Free tier | Typical monthly | Model |
+|---|---|---|---|
+| Supabase | 500MB free | $25 (Pro) + usage | Per-project + compute add-ons |
+| Neon | 0.5GB free | $19 (Launch) – $69 (Scale) | Compute-hours + storage |
+| PlanetScale | none (removed 2024) | $39+ (Scaler Pro) | Per-branch compute |
+| MongoDB Atlas | M0 free | $57+ (M10 dedicated) | Instance size |
+| AWS RDS | none | $13–$60 (t4g.micro–small + storage) | Instance-hours + storage + I/O |
+| Upstash Redis | 10k cmd/day free | $0–$20 | Per-request |
+| Redis Cloud | 30MB free | $5–$50 | Fixed tiers |
+
+Temps equivalents: managed Postgres/TimescaleDB, MySQL/MariaDB, MongoDB, Redis, and S3-compatible storage as containers on your server — cost is included in the server. Honesty note: a $6 VPS is not an HA multi-AZ RDS cluster; if the user runs production HA today, compare against a bigger multi-node Temps setup, not the minimum.
+
+## Transactional Email
+
+| Tool | Free tier | Typical monthly | Model |
+|---|---|---|---|
+| SendGrid | 100/day free | $19.95 (50k emails) | Volume tiers |
+| Postmark | 100/mo free | $15 (10k) – $55 (125k) | Volume tiers |
+| Resend | 3k/mo free | $20 (50k) | Volume tiers |
+| Mailgun | 100/day free | $35 (50k, Foundation) | Volume tiers |
+| AWS SES | 62k free from EC2 | ~$0.10 per 1,000 | Already at cost — flag as "keep, route through Temps" |
+
+Temps relays through the user's own SES/Scaleway account, so replacing e.g. Postmark 125k ($55) with SES via Temps (~$12.50) is a real line item.
+
+## Observability (partial replacement only)
+
+| Tool | Typical monthly | Caveat |
+|---|---|---|
+| Datadog | $15/host + $0.10/1k spans + RUM per-session | Temps covers logs, metrics, traces, and RUM basics; deep APM/profiling is not matched — count 30–60% of the bill, say so |
+| New Relic | usage (100GB free) | Same caveat |
+
+## Temps Cost Side
+
+| Item | Cost |
+|---|---|
+| Temps (software) | $0 — FSL-licensed, self-host free |
+| Hetzner CX22 (2 vCPU / 4 GB) | ~€3.79/mo |
+| Hetzner CPX22 (3 vCPU / 4 GB) — reference deployment | ~€8/mo |
+| Hetzner CPX32 (4 vCPU / 8 GB) | ~€15/mo |
+| Included traffic | 20 TB/mo (Hetzner) — compare against per-GB egress on Vercel/Netlify |
+| Temps Cloud | server cost + 30%, from ~$6/mo |
+| Seats / projects / environments / events / errors / recordings | unlimited, $0 |


### PR DESCRIPTION
## Summary

Adds a new user-facing AI skill, `estimate-temps-savings`, installable via:

```bash
npx skills add gotempsh/temps --skill estimate-temps-savings
```

When a user asks their AI agent *"how much would I save with Temps?"*, the agent:

1. **Detects the paid stack** from dependency manifests, config files (`vercel.json`, `fly.toml`, `render.yaml`, ...), and env var **key names** — hosting, analytics, error tracking, session replay, uptime monitoring, managed databases, and transactional email. Hard rule: never read or print secret values.
2. **Asks one batch of usage questions** (seats, pageviews, errors/month, ...), each with a default so "just estimate it" works.
3. **Prices each tool** from a bundled list-price reference (`references/pricing.md`, 40+ tools, dated early 2026) and compares against self-hosted Temps (~€8/mo Hetzner CPX22) or Temps Cloud.
4. **Outputs a savings report**: detected tools sorted by cost, yearly savings range, suggested migration order (zero-risk parallel swaps first), and pointers to the matching Temps skills.

## Design choices

- **Honesty as a rule**: free tiers count as $0, ranges instead of fake precision, an explicit "what Temps does NOT replace" section (edge CDN, deep APM, serverless runtimes), and if detected spend is under ~$15/mo the skill must say Temps won't save meaningful money today rather than manufacture a number. This skill doubles as a sales asset — an inflated estimate would poison trust with exactly the audience Temps targets.
- **Privacy**: detection is restricted to key names and connection-string hostnames.

## Changes

- `skills/estimate-temps-savings/SKILL.md` — the agent workflow
- `skills/estimate-temps-savings/references/pricing.md` — list-price reference
- `docs/features/skills/page.mdx` — docs registration (section, table row, selector list, 8→9 count)

Docs + markdown only; no Rust or web code touched.