### PR TITLE
fix(proxy): harden preview cookie session handling

### DIFF
--- a/crates/temps-proxy/src/handler/preview_wall.rs
+++ b/crates/temps-proxy/src/handler/preview_wall.rs
@@ -61,15 +61,30 @@ pub fn generate_preview_form_html_labeled(
 /// Build an expired Set-Cookie header for a standalone sandbox logout.
 /// Matches the scope of the live cookie so the browser actually drops it.
 /// `secure` must match the scheme used when the live cookie was set.
+/// Expire the obsolete HTTPS host-only, unpartitioned variant.
+pub fn build_logout_cookie_sandbox_unpartitioned(public_id_suffix: &str) -> String {
+    format!(
+        "{}{}=; Path=/; HttpOnly; Secure; SameSite=None; Max-Age=0",
+        crate::preview_auth::PREVIEW_SANDBOX_COOKIE_PREFIX,
+        public_id_suffix,
+    )
+}
+
 pub fn build_logout_cookie_sandbox(
     public_id_suffix: &str,
     preview_domain: &str,
     secure: bool,
 ) -> String {
+    if secure {
+        return format!(
+            "{}{}=; Path=/; HttpOnly; Secure; SameSite=None; Partitioned; Max-Age=0",
+            crate::preview_auth::PREVIEW_SANDBOX_COOKIE_PREFIX,
+            public_id_suffix,
+        );
+    }
     let domain = preview_domain.trim_start_matches("*.");
-    let secure_attr = if secure { "; Secure" } else { "" };
     format!(
-        "{}{}=; Domain=.{domain}; Path=/; HttpOnly{secure_attr}; SameSite=Lax; Max-Age=0",
+        "{}{}=; Domain=.{domain}; Path=/; HttpOnly; SameSite=Lax; Max-Age=0",
         crate::preview_auth::PREVIEW_SANDBOX_COOKIE_PREFIX,
         public_id_suffix,
     )
@@ -146,12 +161,25 @@ mod tests {
     }
 
     #[test]
-    fn logout_cookie_has_max_age_zero_and_domain() {
+    fn secure_logout_cookie_matches_partitioned_host_only_scope() {
         let c = build_logout_cookie_sandbox("abc", "*.localho.st", true);
         assert!(c.starts_with("temps_preview_sbx_abc="));
-        assert!(c.contains("Domain=.localho.st"));
+        assert!(!c.contains("Domain="));
         assert!(c.contains("Max-Age=0"));
         assert!(c.contains("; Secure"));
+        assert!(c.contains("SameSite=None"));
+        assert!(c.contains("Partitioned"));
+    }
+
+    #[test]
+    fn unpartitioned_logout_cookie_targets_obsolete_https_scope() {
+        let c = build_logout_cookie_sandbox_unpartitioned("abc");
+        assert!(c.starts_with("temps_preview_sbx_abc="));
+        assert!(c.contains("; Secure"));
+        assert!(c.contains("SameSite=None"));
+        assert!(!c.contains("Partitioned"));
+        assert!(!c.contains("Domain="));
+        assert!(c.contains("Max-Age=0"));
     }
 
     #[test]

--- a/crates/temps-proxy/src/preview_auth.rs
+++ b/crates/temps-proxy/src/preview_auth.rs
@@ -39,6 +39,18 @@ pub const PREVIEW_SANDBOX_COOKIE_PREFIX: &str = "temps_preview_sbx_";
 /// immediately regardless of this TTL.
 pub const PREVIEW_COOKIE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 
+/// How close to expiry a valid preview cookie must be before it is renewed.
+/// Owner unlock bridges remain idempotent outside this window.
+pub const PREVIEW_COOKIE_REFRESH_WINDOW: Duration = Duration::from_secs(60 * 60);
+
+/// Lifetime of a scoped handoff minted by an authenticated control-plane
+/// route. This is only long enough to cross an auto-submit bridge; it
+/// is never forwarded to the sandbox and is exchanged for the normal preview
+/// cookie immediately.
+pub const PREVIEW_SESSION_GRANT_TTL: Duration = Duration::from_secs(60);
+
+const PREVIEW_SESSION_GRANT_VERSION: &str = "preview-session-v1";
+
 /// The local TCP address where the preview gateway listens. Pingora forwards
 /// authenticated preview requests to this peer.
 pub const PREVIEW_GATEWAY_PEER: &str = "127.0.0.1:8090";
@@ -174,39 +186,128 @@ pub fn verify_preview_cookie_subject(
     password_hash: &str,
     now: SystemTime,
 ) -> bool {
+    preview_cookie_remaining_ttl(crypto, cookie_value, subject, password_hash, now).is_some()
+}
+
+/// Return the remaining lifetime of a valid cookie for this sandbox and
+/// current password hash. Invalid, revoked, and expired cookies return `None`.
+pub fn preview_cookie_remaining_ttl(
+    crypto: &CookieCrypto,
+    cookie_value: &str,
+    subject: &str,
+    password_hash: &str,
+    now: SystemTime,
+) -> Option<Duration> {
     let Ok(plain) = crypto.decrypt(cookie_value) else {
-        return false;
+        return None;
     };
     let parts: Vec<&str> = plain.splitn(3, '|').collect();
     if parts.len() != 3 {
-        return false;
+        return None;
     }
     if parts[0] != subject {
-        return false;
+        return None;
     }
     if parts[1] != hash_fingerprint(password_hash) {
-        return false;
+        return None;
     }
     let Ok(exp) = parts[2].parse::<u64>() else {
+        return None;
+    };
+    let Ok(now_secs) = now.duration_since(UNIX_EPOCH) else {
+        return None;
+    };
+    exp.checked_sub(now_secs.as_secs()).map(Duration::from_secs)
+}
+
+/// Validate a short-lived platform-session handoff for one sandbox.
+///
+/// The API and proxy share `CookieCrypto`, so an authenticated API route can
+/// mint an AES-GCM authenticated payload without making the host-only Temps
+/// session cookie available to preview application code. The version prefix
+/// keeps grants domain-separated from every other encrypted cookie payload.
+pub fn verify_preview_session_grant(
+    crypto: &CookieCrypto,
+    grant: &str,
+    subject: &str,
+    now: SystemTime,
+) -> bool {
+    let Ok(plain) = crypto.decrypt(grant) else {
         return false;
     };
+    let mut parts = plain.split('|');
+    if parts.next() != Some(PREVIEW_SESSION_GRANT_VERSION) || parts.next() != Some(subject) {
+        return false;
+    }
+    let Some(exp) = parts.next().and_then(|value| value.parse::<u64>().ok()) else {
+        return false;
+    };
+    if parts.next().is_some() {
+        return false;
+    }
     let Ok(now_secs) = now.duration_since(UNIX_EPOCH) else {
         return false;
     };
     now_secs.as_secs() <= exp
 }
 
+/// Combine every HTTP Cookie header field into the equivalent cookie-pair
+/// sequence. HTTP/2 permits clients to split Cookie across multiple fields.
+pub fn combine_cookie_header_values<'a>(
+    headers: impl IntoIterator<Item = &'a str>,
+) -> Option<String> {
+    let values = headers.into_iter().collect::<Vec<_>>();
+    if values.is_empty() {
+        None
+    } else {
+        Some(values.join("; "))
+    }
+}
+
 /// Pull a single cookie value out of a `Cookie:` header by name.
 pub fn extract_cookie<'a>(cookie_header: &'a str, name: &str) -> Option<&'a str> {
+    extract_cookie_values(cookie_header, name)
+        .into_iter()
+        .next()
+}
+
+/// Return every cookie value with `name`, preserving header order.
+///
+/// Browsers can legitimately send duplicate names when an older parent-domain
+/// preview cookie coexists with the newer host-only partitioned cookie. Cookie
+/// ordering is not a security boundary, so authentication must accept any
+/// value that validates instead of blindly trusting the first one.
+pub fn extract_cookie_values<'a>(cookie_header: &'a str, name: &str) -> Vec<&'a str> {
+    let mut values = Vec::new();
     for pair in cookie_header.split(';') {
         let pair = pair.trim();
         if let Some((k, v)) = pair.split_once('=') {
             if k == name {
-                return Some(v);
+                values.push(v);
             }
         }
     }
-    None
+    values
+}
+
+/// Return true when no cookie candidate is valid with more than the refresh
+/// window remaining. Duplicate names are all considered.
+pub fn preview_cookie_needs_refresh(
+    crypto: &CookieCrypto,
+    cookie_header: Option<&str>,
+    cookie_name: &str,
+    subject: &str,
+    password_hash: &str,
+    now: SystemTime,
+) -> bool {
+    !cookie_header.is_some_and(|header| {
+        extract_cookie_values(header, cookie_name)
+            .iter()
+            .any(|value| {
+                preview_cookie_remaining_ttl(crypto, value, subject, password_hash, now)
+                    .is_some_and(|remaining| remaining > PREVIEW_COOKIE_REFRESH_WINDOW)
+            })
+    })
 }
 
 /// Build the `Set-Cookie` header for a sandbox preview cookie.
@@ -220,11 +321,27 @@ pub fn build_set_cookie_sandbox(
     // silently drop `Secure` cookies sent over plain HTTP, which would
     // completely break preview auth for self-hosted setups running without
     // TLS (e.g. `http://host.docker.internal:8080`).
-    let domain = preview_domain.trim_start_matches("*.");
-    let secure_attr = if secure { "; Secure" } else { "" };
+    // An authenticated unlock bridge may run inside a cross-site iframe.
+    // HTTPS previews therefore need an explicitly partitioned cookie;
+    // `SameSite=Lax` is omitted from iframe redirects by modern browsers.
+    // Plain HTTP cannot use SameSite=None or Partitioned because both require
+    // Secure, so retain the local/self-hosted Lax behavior there.
+    let scope_and_security = if secure {
+        // Host-only is the most interoperable CHIPS scope and is sufficient:
+        // the login POST and every request it unlocks use this exact host.
+        "; Secure; SameSite=None; Partitioned"
+    } else {
+        // HTTP cannot use CHIPS; retain the parent-domain scope used by local
+        // multi-port preview hosts.
+        let domain = preview_domain.trim_start_matches("*.");
+        return format!(
+            "{PREVIEW_SANDBOX_COOKIE_PREFIX}{public_id_suffix}={cookie_value}; Domain=.{domain}; Path=/; HttpOnly; SameSite=Lax; Max-Age={}",
+            PREVIEW_COOKIE_TTL.as_secs()
+        );
+    };
     let ttl = PREVIEW_COOKIE_TTL.as_secs();
     format!(
-        "{PREVIEW_SANDBOX_COOKIE_PREFIX}{public_id_suffix}={cookie_value}; Domain=.{domain}; Path=/; HttpOnly{secure_attr}; SameSite=Lax; Max-Age={ttl}"
+        "{PREVIEW_SANDBOX_COOKIE_PREFIX}{public_id_suffix}={cookie_value}; Path=/; HttpOnly{scope_and_security}; Max-Age={ttl}"
     )
 }
 
@@ -460,6 +577,16 @@ impl SandboxLookupCache {
         self.cache.insert(key, result.clone()).await;
         result
     }
+
+    /// Bypass a possibly stale password-hash entry and replace it with the
+    /// current database value. Used only after a presented cookie fails the
+    /// cached fingerprint check, so the normal authenticated hot path remains
+    /// cache-only while freshly rotated/reconciled cookies work immediately.
+    pub async fn lookup_fresh(&self, hex: &str) -> PreviewSandboxLookup {
+        let result = lookup_sandbox(&self.db, hex).await;
+        self.cache.insert(hex.to_string(), result.clone()).await;
+        result
+    }
 }
 
 /// Run the preview auth check for a parsed preview host (cookie-only).
@@ -501,18 +628,53 @@ pub async fn check_preview_auth(
     let cookie_name = format!("{}{}", PREVIEW_SANDBOX_COOKIE_PREFIX, host.hex);
 
     if let Some(header) = cookie_header {
-        if let Some(value) = extract_cookie(header, &cookie_name) {
-            if verify_preview_cookie_subject(
-                crypto,
-                value,
-                &subject,
-                &stored_hash,
-                SystemTime::now(),
-            ) {
+        let values = extract_cookie_values(header, &cookie_name);
+        if !values.is_empty() {
+            let now = SystemTime::now();
+            if values.iter().any(|value| {
+                verify_preview_cookie_subject(crypto, value, &subject, &stored_hash, now)
+            }) {
                 limiter.record_success(client_ip, &host.hex);
                 return PreviewAuthOutcome::Allow { host };
             }
+
+            // Password reconciliation can mint a cookie against a new hash
+            // while another worker still holds the previous hash in its
+            // short-lived lookup cache. Refresh only on fingerprint failure;
+            // without this, a successful login can redirect straight back to
+            // the password wall until that cache expires.
+            if let PreviewSandboxLookup::Protected { password_hash } =
+                cache.lookup_fresh(&host.hex).await
+            {
+                if values.iter().any(|value| {
+                    verify_preview_cookie_subject(crypto, value, &subject, &password_hash, now)
+                }) {
+                    limiter.record_success(client_ip, &host.hex);
+                    return PreviewAuthOutcome::Allow { host };
+                }
+            }
+
+            debug!(
+                sandbox = %host.hex,
+                cookie_header_present = true,
+                named_cookie_present = true,
+                "preview-auth: presented cookie failed cached and fresh validation"
+            );
+        } else {
+            debug!(
+                sandbox = %host.hex,
+                cookie_header_present = true,
+                named_cookie_present = false,
+                "preview-auth: preview cookie missing from Cookie header"
+            );
         }
+    } else {
+        debug!(
+            sandbox = %host.hex,
+            cookie_header_present = false,
+            named_cookie_present = false,
+            "preview-auth: request has no Cookie header"
+        );
     }
 
     PreviewAuthOutcome::LoginRequired { host }
@@ -529,6 +691,113 @@ mod tests {
         assert_ne!(hash_fingerprint(hash_a), hash_fingerprint(hash_b));
         assert_eq!(hash_fingerprint(hash_a), hash_fingerprint(hash_a));
         assert_eq!(hash_fingerprint(hash_a).len(), 16);
+    }
+
+    #[test]
+    fn secure_preview_cookie_is_available_to_the_owner_iframe() {
+        let cookie = build_set_cookie_sandbox("abc", "opaque", "preview.example.com", true);
+        assert!(cookie.contains("; Secure; SameSite=None; Partitioned;"));
+        assert!(!cookie.contains("Domain="));
+    }
+
+    #[test]
+    fn http_preview_cookie_retains_local_lax_behavior() {
+        let cookie = build_set_cookie_sandbox("abc", "opaque", "localho.st", false);
+        assert!(cookie.contains("; SameSite=Lax;"));
+        assert!(cookie.contains("Domain=.localho.st"));
+        assert!(!cookie.contains("Secure"));
+        assert!(!cookie.contains("Partitioned"));
+    }
+
+    #[test]
+    fn duplicate_cookie_names_are_all_preserved_for_validation() {
+        let values = extract_cookie_values(
+            "other=1; temps_preview_sbx_abc=stale; temps_preview_sbx_abc=fresh",
+            "temps_preview_sbx_abc",
+        );
+        assert_eq!(values, vec!["stale", "fresh"]);
+    }
+
+    #[test]
+    fn split_cookie_header_fields_preserve_every_duplicate_candidate() {
+        let combined = combine_cookie_header_values([
+            "temps_preview_sbx_abc=stale",
+            "other=1; temps_preview_sbx_abc=fresh",
+        ])
+        .unwrap();
+        assert_eq!(
+            extract_cookie_values(&combined, "temps_preview_sbx_abc"),
+            vec!["stale", "fresh"]
+        );
+        assert!(combine_cookie_header_values(std::iter::empty()).is_none());
+    }
+
+    #[test]
+    fn preview_cookie_is_reused_until_it_enters_refresh_window() {
+        let crypto = CookieCrypto::new("default-32-byte-key-for-testing!").unwrap();
+        let issued_at = UNIX_EPOCH + Duration::from_secs(10_000);
+        let subject = "sbx_7702c56bfb804b49";
+        let password_hash = "current-password-hash";
+        let cookie =
+            encode_preview_cookie_subject(&crypto, subject, password_hash, issued_at).unwrap();
+        let cookie_name = "temps_preview_sbx_7702c56bfb804b49";
+        let header = format!("{cookie_name}={cookie}");
+
+        assert!(!preview_cookie_needs_refresh(
+            &crypto,
+            Some(&header),
+            cookie_name,
+            subject,
+            password_hash,
+            issued_at,
+        ));
+        assert!(preview_cookie_needs_refresh(
+            &crypto,
+            Some(&header),
+            cookie_name,
+            subject,
+            password_hash,
+            issued_at + PREVIEW_COOKIE_TTL - PREVIEW_COOKIE_REFRESH_WINDOW,
+        ));
+        assert!(preview_cookie_needs_refresh(
+            &crypto,
+            Some(&header),
+            cookie_name,
+            subject,
+            password_hash,
+            issued_at + PREVIEW_COOKIE_TTL + Duration::from_secs(1),
+        ));
+    }
+
+    #[test]
+    fn platform_session_grant_is_scoped_and_expires() {
+        let crypto = CookieCrypto::new("default-32-byte-key-for-testing!").unwrap();
+        let now = UNIX_EPOCH + Duration::from_secs(1_000);
+        let payload = format!(
+            "{}|sbx_7702c56bfb804b49|{}",
+            PREVIEW_SESSION_GRANT_VERSION,
+            1_000 + PREVIEW_SESSION_GRANT_TTL.as_secs()
+        );
+        let grant = crypto.encrypt(&payload).unwrap();
+
+        assert!(verify_preview_session_grant(
+            &crypto,
+            &grant,
+            "sbx_7702c56bfb804b49",
+            now
+        ));
+        assert!(!verify_preview_session_grant(
+            &crypto,
+            &grant,
+            "sbx_c5d8e38f791dbc40",
+            now
+        ));
+        assert!(!verify_preview_session_grant(
+            &crypto,
+            &grant,
+            "sbx_7702c56bfb804b49",
+            now + PREVIEW_SESSION_GRANT_TTL + Duration::from_secs(1)
+        ));
     }
 
     #[test]

--- a/crates/temps-proxy/src/proxy.rs
+++ b/crates/temps-proxy/src/proxy.rs
@@ -18,15 +18,16 @@
 //! branch was removed as part of `perf/remove-db-from-request-path` (WS1–WS6).
 
 use crate::handler::preview_wall::{
-    build_logout_cookie_sandbox, generate_preview_form_html_labeled, sanitize_next,
-    PREVIEW_LOGIN_PATH, PREVIEW_LOGOUT_PATH,
+    build_logout_cookie_sandbox, build_logout_cookie_sandbox_unpartitioned,
+    generate_preview_form_html_labeled, sanitize_next, PREVIEW_LOGIN_PATH, PREVIEW_LOGOUT_PATH,
 };
 use crate::on_demand::OnDemandManager;
 use crate::preview_auth::{
-    build_set_cookie_sandbox, check_preview_auth, encode_preview_cookie_subject,
-    parse_preview_host, preview_peer_group_key, verify_argon2, PreviewAuthLimiter,
-    PreviewAuthOutcome, PreviewHost, PreviewSandboxLookup, SandboxLookupCache,
-    PREVIEW_GATEWAY_PEER,
+    build_set_cookie_sandbox, check_preview_auth, combine_cookie_header_values,
+    encode_preview_cookie_subject, extract_cookie_values, parse_preview_host,
+    preview_cookie_needs_refresh, preview_peer_group_key, verify_argon2,
+    verify_preview_session_grant, PreviewAuthLimiter, PreviewAuthOutcome, PreviewHost,
+    PreviewSandboxLookup, SandboxLookupCache, PREVIEW_GATEWAY_PEER,
 };
 use crate::service::cert_host_cache::CertHostCache;
 use crate::service::challenge_service::ChallengeService;
@@ -2553,31 +2554,6 @@ impl ProxyHttp for LoadBalancer {
                     .clone()
                     .filter(|_| ctx.path == PREVIEW_LOGIN_PATH && ctx.method == "POST")
                 {
-                    if self.preview_auth_limiter.is_blocked(client_ip, &hex) {
-                        warn!(
-                            sandbox = %hex,
-                            client_ip = %client_ip,
-                            "preview-auth: sandbox login POST rate limited"
-                        );
-                        let mut response =
-                            ResponseHeader::build(StatusCode::TOO_MANY_REQUESTS, None)?;
-                        response.insert_header("Retry-After", "60")?;
-                        response.insert_header("Cache-Control", "no-store")?;
-                        response.insert_header("X-Request-ID", &ctx.request_id)?;
-                        response.insert_header("Content-Type", "text/plain; charset=utf-8")?;
-                        session
-                            .write_response_header(Box::new(response), false)
-                            .await?;
-                        session
-                            .write_response_body(
-                                Some(Bytes::from_static(b"Too many failed attempts\n")),
-                                true,
-                            )
-                            .await?;
-                        ctx.routing_status = "preview_rate_limited".to_string();
-                        return Ok(true);
-                    }
-
                     let stored_hash = match self.sandbox_lookup_cache.lookup(&hex).await {
                         PreviewSandboxLookup::Protected { password_hash } => password_hash,
                         PreviewSandboxLookup::Open => {
@@ -2628,6 +2604,11 @@ impl ProxyHttp for LoadBalancer {
                         .find(|(k, _)| k == "password")
                         .map(|(_, v)| v.as_str())
                         .unwrap_or("");
+                    let session_grant = params
+                        .iter()
+                        .find(|(k, _)| k == "session_grant")
+                        .map(|(_, v)| v.as_str())
+                        .unwrap_or("");
                     let next_raw = params
                         .iter()
                         .find(|(k, _)| k == "next")
@@ -2635,43 +2616,152 @@ impl ProxyHttp for LoadBalancer {
                         .unwrap_or("/");
                     let next = sanitize_next(next_raw);
 
-                    if verify_argon2(password, &stored_hash) {
+                    let subject = format!("sbx_{}", hex);
+                    let now = std::time::SystemTime::now();
+                    let valid_session_grant =
+                        verify_preview_session_grant(&self.crypto, session_grant, &subject, now);
+
+                    // A valid platform-session grant is not a password guess
+                    // and must remain usable even if this IP previously hit
+                    // the manual-login limiter.
+                    if !valid_session_grant && self.preview_auth_limiter.is_blocked(client_ip, &hex)
+                    {
+                        warn!(
+                            sandbox = %hex,
+                            client_ip = %client_ip,
+                            "preview-auth: sandbox login POST rate limited"
+                        );
+                        let mut response =
+                            ResponseHeader::build(StatusCode::TOO_MANY_REQUESTS, None)?;
+                        response.insert_header("Retry-After", "60")?;
+                        response.insert_header("Cache-Control", "no-store")?;
+                        response.insert_header("X-Request-ID", &ctx.request_id)?;
+                        response.insert_header("Content-Type", "text/plain; charset=utf-8")?;
+                        session
+                            .write_response_header(Box::new(response), false)
+                            .await?;
+                        session
+                            .write_response_body(
+                                Some(Bytes::from_static(b"Too many failed attempts\n")),
+                                true,
+                            )
+                            .await?;
+                        ctx.routing_status = "preview_rate_limited".to_string();
+                        return Ok(true);
+                    }
+
+                    // Password reconciliation can update the sandbox row
+                    // immediately while this worker still has the previous
+                    // hash in its short-lived lookup cache. The owner bridge
+                    // already has the new password, so retry against a fresh
+                    // row before showing a manual password wall.
+                    let verified_hash = if valid_session_grant
+                        || verify_argon2(password, &stored_hash)
+                    {
+                        Some(stored_hash)
+                    } else {
+                        match self.sandbox_lookup_cache.lookup_fresh(&hex).await {
+                            PreviewSandboxLookup::Protected { password_hash }
+                                if verify_argon2(password, &password_hash) =>
+                            {
+                                debug!(
+                                    sandbox = %hex,
+                                    "preview-auth: login succeeded after refreshing stale password hash"
+                                );
+                                Some(password_hash)
+                            }
+                            _ => None,
+                        }
+                    };
+
+                    if let Some(stored_hash) = verified_hash {
                         self.preview_auth_limiter.record_success(client_ip, &hex);
-                        let subject = format!("sbx_{}", hex);
-                        let Some(cookie_value) = encode_preview_cookie_subject(
+                        let cookie_name = format!("temps_preview_sbx_{}", hex);
+                        let cookie_values = session
+                            .req_header()
+                            .headers
+                            .get_all("cookie")
+                            .iter()
+                            .filter_map(|value| value.to_str().ok())
+                            .collect::<Vec<_>>();
+                        let cookie_header = combine_cookie_header_values(cookie_values);
+                        let cookie_needs_refresh = preview_cookie_needs_refresh(
                             &self.crypto,
+                            cookie_header.as_deref(),
+                            &cookie_name,
                             &subject,
                             &stored_hash,
-                            std::time::SystemTime::now(),
-                        ) else {
-                            error!("preview-auth: failed to encode sandbox preview cookie");
-                            let mut response =
-                                ResponseHeader::build(StatusCode::INTERNAL_SERVER_ERROR, None)?;
-                            response.insert_header("Cache-Control", "no-store")?;
-                            response.insert_header("X-Request-ID", &ctx.request_id)?;
-                            session
-                                .write_response_header(Box::new(response), false)
-                                .await?;
-                            session
-                                .write_response_body(
-                                    Some(Bytes::from_static(b"Cookie mint failed\n")),
-                                    true,
-                                )
-                                .await?;
-                            ctx.routing_status = "preview_cookie_error".to_string();
-                            return Ok(true);
-                        };
-                        let set_cookie = build_set_cookie_sandbox(
-                            &hex,
-                            &cookie_value,
-                            &settings.preview_domain,
-                            self.is_tls_connection(session),
+                            now,
                         );
+                        // Duplicate names indicate an obsolete cookie scope.
+                        // Mint the partitioned replacement before expiring the
+                        // old scopes so cleanup can never delete the only
+                        // healthy cookie.
+                        let has_duplicate_candidates =
+                            cookie_header.as_deref().is_some_and(|header| {
+                                extract_cookie_values(header, &cookie_name).len() > 1
+                            });
+                        let should_refresh_cookie =
+                            cookie_needs_refresh || has_duplicate_candidates;
 
-                        info!(sandbox = %hex, "preview-auth: sandbox login succeeded");
+                        let set_cookie = if !should_refresh_cookie {
+                            None
+                        } else {
+                            let Some(cookie_value) = encode_preview_cookie_subject(
+                                &self.crypto,
+                                &subject,
+                                &stored_hash,
+                                now,
+                            ) else {
+                                error!("preview-auth: failed to encode sandbox preview cookie");
+                                let mut response =
+                                    ResponseHeader::build(StatusCode::INTERNAL_SERVER_ERROR, None)?;
+                                response.insert_header("Cache-Control", "no-store")?;
+                                response.insert_header("X-Request-ID", &ctx.request_id)?;
+                                session
+                                    .write_response_header(Box::new(response), false)
+                                    .await?;
+                                session
+                                    .write_response_body(
+                                        Some(Bytes::from_static(b"Cookie mint failed\n")),
+                                        true,
+                                    )
+                                    .await?;
+                                ctx.routing_status = "preview_cookie_error".to_string();
+                                return Ok(true);
+                            };
+                            Some(build_set_cookie_sandbox(
+                                &hex,
+                                &cookie_value,
+                                &settings.preview_domain,
+                                self.is_tls_connection(session),
+                            ))
+                        };
+
+                        info!(
+                            sandbox = %hex,
+                            auth_kind = if valid_session_grant { "platform_session" } else { "password" },
+                            cookie_refreshed = should_refresh_cookie,
+                            "preview-auth: sandbox login succeeded"
+                        );
                         let mut response = ResponseHeader::build(303, None)?;
                         response.insert_header("Location", &next)?;
-                        response.insert_header("Set-Cookie", &set_cookie)?;
+                        if let Some(set_cookie) = &set_cookie {
+                            response.append_header("Set-Cookie", set_cookie)?;
+                        }
+                        // Expire both scopes used by older gateway versions.
+                        // Chrome can keep an unpartitioned host-only cookie and
+                        // a parent-domain cookie alongside the fresh CHIPS
+                        // cookie, sometimes emitting them in separate Cookie
+                        // header fields.
+                        if should_refresh_cookie && self.is_tls_connection(session) {
+                            let unpartitioned_cookie =
+                                build_logout_cookie_sandbox_unpartitioned(&hex);
+                            response.append_header("Set-Cookie", &unpartitioned_cookie)?;
+                            let legacy_cookie =
+                                build_logout_cookie_sandbox(&hex, &settings.preview_domain, false);
+                            response.append_header("Set-Cookie", &legacy_cookie)?;
+                        }
                         response.insert_header("Cache-Control", "no-store")?;
                         response.insert_header("X-Request-ID", &ctx.request_id)?;
                         session
@@ -2760,12 +2850,17 @@ impl ProxyHttp for LoadBalancer {
                 }
 
                 // ── Regular preview request: check cookie ─────────────────
-                let cookie_header = session
+                // HTTP/2 and some browser cookie stores may emit duplicate
+                // cookie names in separate Cookie header fields. Join every
+                // field so check_preview_auth can validate every candidate.
+                let cookie_values = session
                     .req_header()
                     .headers
-                    .get("cookie")
-                    .and_then(|h| h.to_str().ok())
-                    .map(|s| s.to_string());
+                    .get_all("cookie")
+                    .iter()
+                    .filter_map(|value| value.to_str().ok())
+                    .collect::<Vec<_>>();
+                let cookie_header = combine_cookie_header_values(cookie_values);
 
                 let outcome = check_preview_auth(
                     &self.sandbox_lookup_cache,


### PR DESCRIPTION
## Summary

- accept short-lived encrypted session grants scoped to a single preview sandbox
- use host-only partitioned cookies for HTTPS iframe previews while retaining the HTTP fallback
- validate duplicate cookie names across split Cookie header fields and refresh stale password-hash cache entries
- reuse healthy cookies, refresh them in the final hour, and replace duplicate or obsolete cookie scopes safely
- keep manual password attempts rate-limited while allowing valid session-grant exchanges

## Tests

- `cargo test -p temps-proxy preview_auth::tests` (26 passed)
- `cargo test -p temps-proxy handler::preview_wall::tests` (10 passed)