### PR TITLE
perf(metrics): time-bound external-service latest-metric queries

### DIFF
--- a/crates/temps-metrics/src/store/clickhouse.rs
+++ b/crates/temps-metrics/src/store/clickhouse.rs
@@ -431,7 +431,7 @@ impl MetricsStore for ClickhouseMetricsStore {
             // read path expects.
             format!(
                 "SELECT \
-                   toUnixTimestamp(bucket) * 1000 AS bucket_ms, \
+                   toInt64(toUnixTimestamp(bucket)) * 1000 AS bucket_ms, \
                    greatest(bucket_max - lagInFrame(bucket_max, 1, bucket_max) \
                             OVER (ORDER BY bucket ASC), 0) AS avg_value \
                  FROM ( \
@@ -458,7 +458,7 @@ impl MetricsStore for ClickhouseMetricsStore {
             // yields a second-resolution `DateTime`; * 1000 gives the i64 ms.
             format!(
                 "SELECT \
-                   toUnixTimestamp(toStartOfInterval(time, INTERVAL {step} SECOND)) * 1000 AS bucket_ms, \
+                   toInt64(toUnixTimestamp(toStartOfInterval(time, INTERVAL {step} SECOND))) * 1000 AS bucket_ms, \
                    avg(value) AS avg_value \
                  FROM service_metrics FINAL \
                  WHERE source_kind = ? AND source_id = ? AND name = '{nm}' \
@@ -531,10 +531,20 @@ impl MetricsStore for ClickhouseMetricsStore {
             name_filter = format!(" AND name IN ({list})");
         }
 
+        // PERF: time-bounded so partition pruning and primary-key range
+        // pruning apply — `FINAL` over an unbounded WHERE dedup-merges up to
+        // the full TTL (90 days) of rows for the source on every request.
+        // Anchoring on the source's own max(time) (cheap: single column,
+        // primary-key prefix filter) keeps values visible when the scraper is
+        // paused/stale. With no rows, max(time) is epoch and the query is
+        // empty either way.
         let sql = format!(
             "SELECT name, value \
              FROM service_metrics FINAL \
              WHERE source_kind = ? AND source_id = ?{name_filter} \
+               AND time > (SELECT max(time) FROM service_metrics \
+                            WHERE source_kind = ? AND source_id = ?) \
+                          - INTERVAL 15 MINUTE \
              ORDER BY name, length(JSONExtractKeys(labels)) ASC, time DESC \
              LIMIT 1 BY name",
             name_filter = name_filter,
@@ -543,6 +553,8 @@ impl MetricsStore for ClickhouseMetricsStore {
         let rows = self
             .client
             .query(&sql)
+            .bind(filter.source_kind.as_str())
+            .bind(filter.source_id)
             .bind(filter.source_kind.as_str())
             .bind(filter.source_id)
             .fetch_all::<ChLatestRow>()
@@ -602,10 +614,15 @@ impl MetricsStore for ClickhouseMetricsStore {
 
         // label_key is bound (?) into JSONExtractString / JSONHas — never
         // interpolated.
+        // PERF: time-bounded for the same reason as `query_latest` — see the
+        // comment there for the max(time) anchor rationale.
         let sql = format!(
             "SELECT name, JSONExtractString(labels, ?) AS label_value, value \
              FROM service_metrics FINAL \
              WHERE source_kind = ? AND source_id = ? \
+               AND time > (SELECT max(time) FROM service_metrics \
+                            WHERE source_kind = ? AND source_id = ?) \
+                          - INTERVAL 15 MINUTE \
                AND name IN ({list}) \
                AND JSONHas(labels, ?) \
              ORDER BY name, label_value, time DESC \
@@ -617,6 +634,8 @@ impl MetricsStore for ClickhouseMetricsStore {
             .client
             .query(&sql)
             .bind(&filter.label_key)
+            .bind(filter.source_kind.as_str())
+            .bind(filter.source_id)
             .bind(filter.source_kind.as_str())
             .bind(filter.source_id)
             .bind(&filter.label_key)
@@ -708,11 +727,17 @@ impl ClickhouseMetricsStore {
         }
 
         // Validated metric name interpolated; source_kind/source_id bound.
+        // Time-bounded so partition/primary-key pruning applies (see
+        // query_latest); without it the ORDER BY time DESC sort reads the
+        // metric's full history before the LIMIT.
         let sql = format!(
             "SELECT min(k) AS min_keys FROM ( \
                SELECT length(JSONExtractKeys(labels)) AS k \
                FROM service_metrics \
                WHERE source_kind = ? AND source_id = ? AND name = '{nm}' \
+                 AND time > (SELECT max(time) FROM service_metrics \
+                              WHERE source_kind = ? AND source_id = ?) \
+                            - INTERVAL 15 MINUTE \
                ORDER BY time DESC LIMIT 64 \
              )",
             nm = name,
@@ -721,6 +746,8 @@ impl ClickhouseMetricsStore {
         match self
             .client
             .query(&sql)
+            .bind(source_kind)
+            .bind(source_id)
             .bind(source_kind)
             .bind(source_id)
             .fetch_one::<MinKeysRow>()

--- a/crates/temps-metrics/src/store/timescale.rs
+++ b/crates/temps-metrics/src/store/timescale.rs
@@ -16,6 +16,13 @@ use crate::store::{
 /// At ~300 bytes/row, 500 rows ≈ 150 KB — well inside safe limits.
 const BATCH_SIZE: usize = 500;
 
+/// Lookback window for "latest value" queries, anchored to the source's
+/// `service_metrics_status.last_received_at`. Wide enough to cover many scrape
+/// cycles (scrapes run every 10-30 s) plus clock skew between the scraper and
+/// the database, while keeping the scan to the most recent hypertable chunk
+/// instead of the source's full retention history.
+const LATEST_WINDOW: &str = "15 minutes";
+
 /// TimescaleDB-backed implementation of [`MetricsStore`].
 ///
 /// Writes are chunked into batches of at most [`BATCH_SIZE`] rows using
@@ -51,16 +58,22 @@ impl TimescaleMetricsStore {
         }
         // Look only at the most-recent ~64 rows: a single scrape writes all of a
         // metric's series at once, so the recent window contains every series.
+        // Time-bounded so TimescaleDB chunk exclusion applies (see query_latest).
         let sql = format!(
             "SELECT min(k)::bigint AS min_keys FROM ( \
                  SELECT (SELECT count(*) FROM jsonb_object_keys(labels)) AS k \
                  FROM service_metrics \
                  WHERE source_kind = '{sk}' AND source_id = {sid} AND name = '{nm}' \
+                   AND time > COALESCE( \
+                         (SELECT last_received_at FROM service_metrics_status \
+                           WHERE source_kind = '{sk}' AND source_id = {sid}), \
+                         now()) - interval '{window}' \
                  ORDER BY time DESC LIMIT 64 \
              ) recent",
             sk = escape_sql_string(source_kind),
             sid = source_id,
             nm = escape_sql_string(name),
+            window = LATEST_WINDOW,
         );
         match self
             .db
@@ -590,15 +603,29 @@ impl MetricsStore for TimescaleMetricsStore {
         // labels. So order by label-key count ascending, then by recency.
         // (An empty `{}` is just the zero-key case and still wins.) Metrics with
         // a single series are unaffected.
+        //
+        // PERF: the query MUST be time-bounded. The label-key-count ordering
+        // prevents the planner from satisfying `DISTINCT ON` with a backwards
+        // index scan, so without a bound this degenerates into a full scan of
+        // every chunk the source ever wrote (millions of rows at a 10-30s
+        // scrape interval) with the jsonb subquery evaluated per row. Bounding
+        // relative to `service_metrics_status.last_received_at` (O(1) row,
+        // upserted on every write_batch) keeps chunk exclusion active while
+        // still returning values for sources whose scraper is paused/stale.
         let sql = format!(
             "SELECT DISTINCT ON (name) name, value \
              FROM service_metrics \
              WHERE source_kind = '{source_kind}' \
                AND source_id = {source_id} \
+               AND time > COALESCE( \
+                     (SELECT last_received_at FROM service_metrics_status \
+                       WHERE source_kind = '{source_kind}' AND source_id = {source_id}), \
+                     now()) - interval '{window}' \
                {name_filter} \
              ORDER BY name, \
                       (SELECT count(*) FROM jsonb_object_keys(labels)) ASC, \
                       time DESC",
+            window = LATEST_WINDOW,
             source_kind = escape_sql_string(filter.source_kind.as_str()),
             source_id = filter.source_id,
             name_filter = name_filter,
@@ -674,15 +701,25 @@ impl MetricsStore for TimescaleMetricsStore {
         // carry the label key are considered (`labels ? key`), which excludes
         // the unlabelled instance-wide aggregate. The `DISTINCT ON` key is
         // (name, label_value) so each metric gets one value per label value.
+        //
+        // PERF: time-bounded for the same reason as `query_latest` — the
+        // `labels ? key` predicate and the label-value DISTINCT key defeat a
+        // backwards index scan, so an unbounded query scans the source's full
+        // retention history. See the comment there for the COALESCE fallback.
         let sql = format!(
             "SELECT DISTINCT ON (name, labels->>'{label_key}') \
                     name, labels->>'{label_key}' AS label_value, value \
              FROM service_metrics \
              WHERE source_kind = '{source_kind}' \
                AND source_id = {source_id} \
+               AND time > COALESCE( \
+                     (SELECT last_received_at FROM service_metrics_status \
+                       WHERE source_kind = '{source_kind}' AND source_id = {source_id}), \
+                     now()) - interval '{window}' \
                AND name = ANY(ARRAY[{names}]) \
                AND labels ? '{label_key}' \
              ORDER BY name, labels->>'{label_key}', time DESC",
+            window = LATEST_WINDOW,
             label_key = label_key,
             source_kind = escape_sql_string(filter.source_kind.as_str()),
             source_id = filter.source_id,


### PR DESCRIPTION
## Problem
`GET /external-services/{id}/metrics/latest` and `/metrics/by-database` were very slow for services with metrics history. `query_latest`, `query_latest_by_label`, and `min_label_key_count` scanned the source's **entire retention history**: the label-key-count ordering (and the `labels ? key` predicate) prevent the planner from satisfying `DISTINCT ON` with a backwards index scan, so every chunk is read and the `jsonb_object_keys` correlated subquery is evaluated per row. At a 10–30s scrape interval that's millions of rows per request.

## Fix
Time-bound the scan to a 15-minute window anchored to `service_metrics_status.last_received_at` — an O(1) row upserted on every `write_batch` — so TimescaleDB chunk exclusion applies while stale/paused scrapers still return their last values. `COALESCE(..., now())` covers a missing status row.

## Verification
Seeded a source with **3.6M rows** (30 days @ 15s, 13 metrics, 8 per-`datname` series) in a local TimescaleDB:

| Query | Before | After |
|---|---|---|
| `query_latest` (EXPLAIN ANALYZE) | 5628 ms | 6 ms |
| `query_latest_by_label` (EXPLAIN ANALYZE) | 1916 ms | 1.3 ms |
| End-to-end via `TimescaleMetricsStore` | — | 13 ms / 11 ms |

Identical result sets before/after (13 metrics; 8 labelled series). All 99 `temps-metrics` unit tests pass.

## Load/saturation note
Read-path only; no new writes. Worst case per request drops from O(full retention) rows to O(15 min window).