### PR TITLE
feat(observability): compress immutable telemetry after 24h

### DIFF
--- a/crates/temps-config/src/handler.rs
+++ b/crates/temps-config/src/handler.rs
@@ -16,8 +16,9 @@ use temps_core::error_builder::ErrorBuilder;
 use temps_core::{
     problemdetails::Problem, AiConfigSettings, AppSettings, AuditContext, AuditLogger,
     AuditOperation, BuildLimitsSettings, ClusterDnsSettings, ContainerLogSettings,
-    DiskSpaceAlertSettings, LetsEncryptSettings, MetricsStoreKind, PublicHostnameStrategy,
-    RateLimitSettings, RequestMetadata, ScreenshotSettings, SecurityHeadersSettings,
+    DiskSpaceAlertSettings, LetsEncryptSettings, MetricsStoreKind,
+    ObservabilityCompressionSettings, PublicHostnameStrategy, RateLimitSettings, RequestMetadata,
+    ScreenshotSettings, SecurityHeadersSettings,
 };
 use tracing::{error, info};
 use utoipa::{OpenApi, ToSchema};
@@ -126,6 +127,9 @@ pub struct AppSettingsResponse {
 
     // Metrics monitoring settings (clickhouse_url masked)
     pub monitoring: MonitoringSettingsMasked,
+
+    /// TimescaleDB compression delays for immutable proxy logs and OTel spans.
+    pub observability_compression: ObservabilityCompressionSettings,
 
     /// The storage backend the runtime is **actually** using for metrics,
     /// after reconciling the `monitoring.store` toggle with the server's
@@ -352,6 +356,7 @@ impl From<AppSettings> for AppSettingsResponse {
             // the ClickHouse env-var state is known (via `with_effective_store`).
             effective_metrics_store: settings.monitoring.store.clone(),
             monitoring: MonitoringSettingsMasked::from(settings.monitoring),
+            observability_compression: settings.observability_compression,
             insecure_tls: settings.insecure_tls,
             setup_complete: settings.setup_complete,
             require_mfa_for_admins: settings.require_mfa_for_admins,
@@ -410,6 +415,7 @@ impl AppSettingsResponse {
         PreviewGatewaySettingsMasked,
         MultiNodeSettingsMasked,
         MonitoringSettingsMasked,
+        ObservabilityCompressionSettings,
         MetricsStoreKind,
         SettingsUpdateResponse,
         GenerateJoinTokenResponse,
@@ -876,6 +882,22 @@ fn sanitize_optional_url(
     Ok(Some(trimmed))
 }
 
+fn validate_observability_compression(
+    compression: &ObservabilityCompressionSettings,
+) -> Result<(), Problem> {
+    if !(1..=720).contains(&compression.proxy_logs_after_hours) {
+        return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
+            .detail("observability_compression.proxy_logs_after_hours must be between 1 and 720")
+            .build());
+    }
+    if !(1..=2160).contains(&compression.otel_spans_after_hours) {
+        return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
+            .detail("observability_compression.otel_spans_after_hours must be between 1 and 2160")
+            .build());
+    }
+    Ok(())
+}
+
 /// Normalize the edge target: trim whitespace and treat an empty string as
 /// `None` so an operator clearing the field disables DNS record sync.
 fn normalize_edge_target(settings: &mut AppSettings) {
@@ -1065,6 +1087,8 @@ async fn update_settings(
             }
         }
     }
+
+    validate_observability_compression(&settings.observability_compression)?;
 
     settings.external_url = sanitize_optional_url("External", settings.external_url)?;
     settings.internal_url = sanitize_optional_url("Internal", settings.internal_url)?;
@@ -1460,6 +1484,42 @@ mod tests {
         );
     }
 
+    #[test]
+    fn observability_compression_validation_accepts_supported_boundaries() {
+        assert!(
+            validate_observability_compression(&ObservabilityCompressionSettings {
+                proxy_logs_after_hours: 1,
+                otel_spans_after_hours: 1,
+            })
+            .is_ok()
+        );
+        assert!(
+            validate_observability_compression(&ObservabilityCompressionSettings {
+                proxy_logs_after_hours: 720,
+                otel_spans_after_hours: 2160,
+            })
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn observability_compression_validation_rejects_zero_and_over_retention() {
+        assert!(
+            validate_observability_compression(&ObservabilityCompressionSettings {
+                proxy_logs_after_hours: 0,
+                otel_spans_after_hours: 24,
+            })
+            .is_err()
+        );
+        assert!(
+            validate_observability_compression(&ObservabilityCompressionSettings {
+                proxy_logs_after_hours: 24,
+                otel_spans_after_hours: 2161,
+            })
+            .is_err()
+        );
+    }
+
     // Regression: the GET /api/settings response must surface agent_sandbox,
     // ai_config, preview_gateway, multi_node, and insecure_tls so the UI can
     // render (and round-trip) resource/runtime/network settings. An earlier
@@ -1569,6 +1629,24 @@ mod tests {
         assert!(!json.contains("ch-pass"));
         assert!(!json.contains("clickhouse:8123"));
         assert!(json.contains("\"clickhouse_url_set\":true"));
+    }
+
+    #[test]
+    fn response_surfaces_observability_compression_settings() {
+        let mut settings = AppSettings::default();
+        settings.observability_compression.proxy_logs_after_hours = 12;
+        settings.observability_compression.otel_spans_after_hours = 48;
+
+        let response = AppSettingsResponse::from(settings);
+
+        assert_eq!(
+            response.observability_compression.proxy_logs_after_hours,
+            12
+        );
+        assert_eq!(
+            response.observability_compression.otel_spans_after_hours,
+            48
+        );
     }
 
     // The effective metrics store reconciles the `store` toggle with the

--- a/crates/temps-config/src/handler.rs
+++ b/crates/temps-config/src/handler.rs
@@ -17,8 +17,8 @@ use temps_core::{
     problemdetails::Problem, AiConfigSettings, AppSettings, AuditContext, AuditLogger,
     AuditOperation, BuildLimitsSettings, ClusterDnsSettings, ContainerLogSettings,
     DiskSpaceAlertSettings, LetsEncryptSettings, MetricsStoreKind,
-    ObservabilityCompressionSettings, PublicHostnameStrategy, RateLimitSettings, RequestMetadata,
-    ScreenshotSettings, SecurityHeadersSettings,
+    ObservabilityCompressionSettings, ObservabilityRetentionSettings, PublicHostnameStrategy,
+    RateLimitSettings, RequestMetadata, ScreenshotSettings, SecurityHeadersSettings,
 };
 use tracing::{error, info};
 use utoipa::{OpenApi, ToSchema};
@@ -130,6 +130,9 @@ pub struct AppSettingsResponse {
 
     /// TimescaleDB compression delays for immutable proxy logs and OTel spans.
     pub observability_compression: ObservabilityCompressionSettings,
+
+    /// Retention windows for raw proxy logs and OpenTelemetry data.
+    pub observability_retention: ObservabilityRetentionSettings,
 
     /// The storage backend the runtime is **actually** using for metrics,
     /// after reconciling the `monitoring.store` toggle with the server's
@@ -364,6 +367,7 @@ impl From<AppSettings> for AppSettingsResponse {
             effective_observability_store: MetricsStoreKind::TimescaleDb,
             monitoring: MonitoringSettingsMasked::from(settings.monitoring),
             observability_compression: settings.observability_compression,
+            observability_retention: settings.observability_retention,
             insecure_tls: settings.insecure_tls,
             setup_complete: settings.setup_complete,
             require_mfa_for_admins: settings.require_mfa_for_admins,
@@ -428,6 +432,7 @@ impl AppSettingsResponse {
         MultiNodeSettingsMasked,
         MonitoringSettingsMasked,
         ObservabilityCompressionSettings,
+        ObservabilityRetentionSettings,
         MetricsStoreKind,
         SettingsUpdateResponse,
         GenerateJoinTokenResponse,
@@ -910,6 +915,27 @@ fn validate_observability_compression(
     Ok(())
 }
 
+fn validate_observability_retention(
+    retention: &ObservabilityRetentionSettings,
+) -> Result<(), Problem> {
+    let values = [
+        ("proxy_logs_days", retention.proxy_logs_days),
+        ("otel_spans_days", retention.otel_spans_days),
+        ("otel_logs_days", retention.otel_logs_days),
+        ("otel_metrics_days", retention.otel_metrics_days),
+    ];
+    for (field, days) in values {
+        if !(1..=3650).contains(&days) {
+            return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
+                .detail(format!(
+                    "observability_retention.{field} must be between 1 and 3650"
+                ))
+                .build());
+        }
+    }
+    Ok(())
+}
+
 /// Normalize the edge target: trim whitespace and treat an empty string as
 /// `None` so an operator clearing the field disables DNS record sync.
 fn normalize_edge_target(settings: &mut AppSettings) {
@@ -1101,6 +1127,7 @@ async fn update_settings(
     }
 
     validate_observability_compression(&settings.observability_compression)?;
+    validate_observability_retention(&settings.observability_retention)?;
 
     settings.external_url = sanitize_optional_url("External", settings.external_url)?;
     settings.internal_url = sanitize_optional_url("Internal", settings.internal_url)?;
@@ -1532,6 +1559,34 @@ mod tests {
         );
     }
 
+    #[test]
+    fn observability_retention_validation_accepts_supported_boundaries() {
+        assert!(
+            validate_observability_retention(&ObservabilityRetentionSettings {
+                proxy_logs_days: 1,
+                otel_spans_days: 3650,
+                otel_logs_days: 90,
+                otel_metrics_days: 90,
+            })
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn observability_retention_validation_rejects_invalid_table_window() {
+        let error = validate_observability_retention(&ObservabilityRetentionSettings {
+            proxy_logs_days: 30,
+            otel_spans_days: 90,
+            otel_logs_days: 0,
+            otel_metrics_days: 90,
+        })
+        .expect_err("zero-day retention must be rejected");
+        assert_eq!(
+            error.body.get("detail").and_then(|value| value.as_str()),
+            Some("observability_retention.otel_logs_days must be between 1 and 3650")
+        );
+    }
+
     // Regression: the GET /api/settings response must surface agent_sandbox,
     // ai_config, preview_gateway, multi_node, and insecure_tls so the UI can
     // render (and round-trip) resource/runtime/network settings. An earlier
@@ -1659,6 +1714,20 @@ mod tests {
             response.observability_compression.otel_spans_after_hours,
             48
         );
+    }
+
+    #[test]
+    fn response_surfaces_observability_retention_settings() {
+        let mut settings = AppSettings::default();
+        settings.observability_retention.proxy_logs_days = 14;
+        settings.observability_retention.otel_spans_days = 60;
+
+        let response = AppSettingsResponse::from(settings);
+
+        assert_eq!(response.observability_retention.proxy_logs_days, 14);
+        assert_eq!(response.observability_retention.otel_spans_days, 60);
+        assert_eq!(response.observability_retention.otel_logs_days, 90);
+        assert_eq!(response.observability_retention.otel_metrics_days, 90);
     }
 
     // The effective metrics store reconciles the `store` toggle with the

--- a/crates/temps-config/src/handler.rs
+++ b/crates/temps-config/src/handler.rs
@@ -140,6 +140,12 @@ pub struct AppSettingsResponse {
     /// effective backend and warns when it diverges from the configured store.
     pub effective_metrics_store: MetricsStoreKind,
 
+    /// Storage backend actually used for proxy logs and OTel spans. Unlike
+    /// metrics, these domains switch to ClickHouse whenever the server-level
+    /// ClickHouse connection is configured; they do not use the monitoring
+    /// store toggle.
+    pub effective_observability_store: MetricsStoreKind,
+
     // Outbound TLS verification toggle
     pub insecure_tls: bool,
 
@@ -355,6 +361,7 @@ impl From<AppSettings> for AppSettingsResponse {
             // the handler overrides it with the runtime-reconciled value once
             // the ClickHouse env-var state is known (via `with_effective_store`).
             effective_metrics_store: settings.monitoring.store.clone(),
+            effective_observability_store: MetricsStoreKind::TimescaleDb,
             monitoring: MonitoringSettingsMasked::from(settings.monitoring),
             observability_compression: settings.observability_compression,
             insecure_tls: settings.insecure_tls,
@@ -380,6 +387,11 @@ impl AppSettingsResponse {
             } else {
                 MetricsStoreKind::TimescaleDb
             };
+        self.effective_observability_store = if clickhouse_enabled {
+            MetricsStoreKind::ClickHouse
+        } else {
+            MetricsStoreKind::TimescaleDb
+        };
         self
     }
 }
@@ -1663,11 +1675,19 @@ mod tests {
             MetricsStoreKind::TimescaleDb,
             "ClickHouse selected but env vars unset must fall back to TimescaleDB"
         );
+        assert_eq!(
+            response.effective_observability_store,
+            MetricsStoreKind::TimescaleDb
+        );
 
         // store=click_house AND env vars configured → runtime uses ClickHouse.
         let response = AppSettingsResponse::from(settings).with_effective_store(true);
         assert_eq!(
             response.effective_metrics_store,
+            MetricsStoreKind::ClickHouse
+        );
+        assert_eq!(
+            response.effective_observability_store,
             MetricsStoreKind::ClickHouse
         );
 
@@ -1676,6 +1696,11 @@ mod tests {
         assert_eq!(
             response.effective_metrics_store,
             MetricsStoreKind::TimescaleDb
+        );
+        assert_eq!(
+            response.effective_observability_store,
+            MetricsStoreKind::ClickHouse,
+            "proxy logs and spans use ClickHouse whenever its server config is available"
         );
     }
 

--- a/crates/temps-config/src/service.rs
+++ b/crates/temps-config/src/service.rs
@@ -1,5 +1,7 @@
 use chrono::Utc;
-use sea_orm::{ActiveModelTrait, DatabaseBackend, EntityTrait, Set};
+use sea_orm::{
+    ActiveModelTrait, ConnectionTrait, DatabaseBackend, EntityTrait, Set, TransactionTrait,
+};
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -38,6 +40,45 @@ pub enum ConfigServiceError {
 
     #[error("Serialization error: {0}")]
     Serialization(String),
+
+    #[error(
+        "Failed to set TimescaleDB compression policy for {table} to {after_hours} hours: {source}"
+    )]
+    CompressionPolicyUpdate {
+        table: &'static str,
+        after_hours: u32,
+        #[source]
+        source: sea_orm::DbErr,
+    },
+}
+
+fn compression_policy_sql(table: &'static str, after_hours: u32) -> String {
+    format!(
+        "SELECT remove_compression_policy('{table}', if_exists => TRUE); \
+         SELECT add_compression_policy(\
+             '{table}', \
+             compress_after => make_interval(hours => {after_hours}), \
+             if_not_exists => TRUE\
+         )"
+    )
+}
+
+async fn replace_compression_policy<C>(
+    db: &C,
+    table: &'static str,
+    after_hours: u32,
+) -> Result<(), ConfigServiceError>
+where
+    C: ConnectionTrait,
+{
+    db.execute_unprepared(&compression_policy_sql(table, after_hours))
+        .await
+        .map_err(|source| ConfigServiceError::CompressionPolicyUpdate {
+            table,
+            after_hours,
+            source,
+        })?;
+    Ok(())
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -612,22 +653,38 @@ impl ConfigService {
     /// Update the application settings
     pub async fn update_settings(&self, settings: AppSettings) -> Result<(), ConfigServiceError> {
         let now = Utc::now();
-        // Refresh the TLS opt-in cache as soon as the operator toggles it
-        // in the settings UI; otherwise the change wouldn't take effect
-        // until the next get_settings() call.
-        temps_core::tls::set_insecure_tls(settings.insecure_tls);
+
+        // Persist the settings and replace changed TimescaleDB policies in one
+        // transaction. A policy error therefore cannot leave the API reporting
+        // a delay that the database did not actually apply (or vice versa).
+        let txn = self.db.begin().await?;
 
         // Check if record exists
-        let existing = settings::Entity::find_by_id(1)
-            .one(self.db.as_ref())
-            .await?;
+        let existing = settings::Entity::find_by_id(1).one(&txn).await?;
+
+        let previous_compression = existing
+            .as_ref()
+            .map(|model| AppSettings::from_json(model.data.clone()).observability_compression)
+            .unwrap_or_default();
+
+        if self.db.get_database_backend() == DatabaseBackend::Postgres {
+            let compression = &settings.observability_compression;
+            if compression.proxy_logs_after_hours != previous_compression.proxy_logs_after_hours {
+                replace_compression_policy(&txn, "proxy_logs", compression.proxy_logs_after_hours)
+                    .await?;
+            }
+            if compression.otel_spans_after_hours != previous_compression.otel_spans_after_hours {
+                replace_compression_policy(&txn, "otel_spans", compression.otel_spans_after_hours)
+                    .await?;
+            }
+        }
 
         if let Some(existing_model) = existing {
             // Update existing settings
             let mut active_model: settings::ActiveModel = existing_model.into();
             active_model.data = Set(settings.to_json());
             active_model.updated_at = Set(now);
-            active_model.update(self.db.as_ref()).await?;
+            active_model.update(&txn).await?;
         } else {
             // Create new settings
             let new_settings = settings::ActiveModel {
@@ -636,8 +693,15 @@ impl ConfigService {
                 created_at: Set(now),
                 updated_at: Set(now),
             };
-            new_settings.insert(self.db.as_ref()).await?;
+            new_settings.insert(&txn).await?;
         }
+
+        txn.commit().await?;
+
+        // Publish runtime settings only after the transaction commits. A
+        // failed policy replacement must not partially apply an unrelated TLS
+        // toggle in memory while the persisted settings remain unchanged.
+        temps_core::tls::set_insecure_tls(settings.insecure_tls);
 
         // Write-through: refresh the cache with the just-written value so an
         // admin's change takes effect immediately in this process, rather than
@@ -972,6 +1036,14 @@ mod tests {
         }
     }
 
+    #[test]
+    fn compression_policy_sql_uses_an_integer_interval_and_idempotent_replace() {
+        let sql = compression_policy_sql("proxy_logs", 24);
+        assert!(sql.contains("remove_compression_policy('proxy_logs', if_exists => TRUE)"));
+        assert!(sql.contains("make_interval(hours => 24)"));
+        assert!(sql.contains("if_not_exists => TRUE"));
+    }
+
     // The proxy reads settings on the per-request hot path, so get_settings()
     // must serve from the in-memory cache and NOT hit the DB every call.
     #[tokio::test]
@@ -1043,6 +1115,66 @@ mod tests {
             "new.example.com",
             "update_settings must write through to the cache"
         );
+    }
+
+    #[tokio::test]
+    async fn update_settings_applies_changed_observability_compression_policies() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![
+                vec![settings_row("logs.example.com")],
+                vec![settings_row("logs.example.com")],
+                vec![settings_row("logs.example.com")],
+            ])
+            // proxy policy, span policy, settings row update
+            .append_exec_results(vec![
+                sea_orm::MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                },
+                sea_orm::MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                },
+                sea_orm::MockExecResult {
+                    last_insert_id: 1,
+                    rows_affected: 1,
+                },
+            ])
+            .into_connection();
+        let svc = ConfigService::new(test_config(), Arc::new(db));
+        let mut updated = AppSettings::default();
+        updated.observability_compression.proxy_logs_after_hours = 12;
+        updated.observability_compression.otel_spans_after_hours = 48;
+
+        svc.update_settings(updated.clone())
+            .await
+            .expect("changed compression policies should be applied transactionally");
+
+        let cached = svc.get_settings().await.expect("updated settings cache");
+        assert_eq!(
+            cached.observability_compression,
+            updated.observability_compression
+        );
+    }
+
+    #[tokio::test]
+    async fn compression_policy_errors_include_table_and_requested_delay() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_errors(vec![sea_orm::DbErr::Custom("Timescale job error".into())])
+            .into_connection();
+
+        let error = replace_compression_policy(&db, "otel_spans", 12)
+            .await
+            .expect_err("policy error should be returned");
+
+        assert!(matches!(
+            error,
+            ConfigServiceError::CompressionPolicyUpdate {
+                table: "otel_spans",
+                after_hours: 12,
+                ..
+            }
+        ));
     }
 
     // A settings_change NOTIFY must force the next get_settings() to re-read

--- a/crates/temps-config/src/service.rs
+++ b/crates/temps-config/src/service.rs
@@ -50,6 +50,16 @@ pub enum ConfigServiceError {
         #[source]
         source: sea_orm::DbErr,
     },
+
+    #[error(
+        "Failed to set TimescaleDB retention policy for {table} to {after_days} days: {source}"
+    )]
+    RetentionPolicyUpdate {
+        table: &'static str,
+        after_days: u32,
+        #[source]
+        source: sea_orm::DbErr,
+    },
 }
 
 fn compression_policy_sql(table: &'static str, after_hours: u32) -> String {
@@ -76,6 +86,35 @@ where
         .map_err(|source| ConfigServiceError::CompressionPolicyUpdate {
             table,
             after_hours,
+            source,
+        })?;
+    Ok(())
+}
+
+fn retention_policy_sql(table: &'static str, after_days: u32) -> String {
+    format!(
+        "SELECT remove_retention_policy('{table}', if_exists => TRUE); \
+         SELECT add_retention_policy(\
+             '{table}', \
+             drop_after => make_interval(days => {after_days}), \
+             if_not_exists => TRUE\
+         )"
+    )
+}
+
+async fn replace_retention_policy<C>(
+    db: &C,
+    table: &'static str,
+    after_days: u32,
+) -> Result<(), ConfigServiceError>
+where
+    C: ConnectionTrait,
+{
+    db.execute_unprepared(&retention_policy_sql(table, after_days))
+        .await
+        .map_err(|source| ConfigServiceError::RetentionPolicyUpdate {
+            table,
+            after_days,
             source,
         })?;
     Ok(())
@@ -666,6 +705,10 @@ impl ConfigService {
             .as_ref()
             .map(|model| AppSettings::from_json(model.data.clone()).observability_compression)
             .unwrap_or_default();
+        let previous_retention = existing
+            .as_ref()
+            .map(|model| AppSettings::from_json(model.data.clone()).observability_retention)
+            .unwrap_or_default();
 
         if self.db.get_database_backend() == DatabaseBackend::Postgres {
             let compression = &settings.observability_compression;
@@ -676,6 +719,35 @@ impl ConfigService {
             if compression.otel_spans_after_hours != previous_compression.otel_spans_after_hours {
                 replace_compression_policy(&txn, "otel_spans", compression.otel_spans_after_hours)
                     .await?;
+            }
+
+            let retention = &settings.observability_retention;
+            let policies = [
+                (
+                    "proxy_logs",
+                    retention.proxy_logs_days,
+                    previous_retention.proxy_logs_days,
+                ),
+                (
+                    "otel_spans",
+                    retention.otel_spans_days,
+                    previous_retention.otel_spans_days,
+                ),
+                (
+                    "otel_log_events",
+                    retention.otel_logs_days,
+                    previous_retention.otel_logs_days,
+                ),
+                (
+                    "otel_metrics",
+                    retention.otel_metrics_days,
+                    previous_retention.otel_metrics_days,
+                ),
+            ];
+            for (table, after_days, previous_days) in policies {
+                if after_days != previous_days {
+                    replace_retention_policy(&txn, table, after_days).await?;
+                }
             }
         }
 
@@ -1044,6 +1116,14 @@ mod tests {
         assert!(sql.contains("if_not_exists => TRUE"));
     }
 
+    #[test]
+    fn retention_policy_sql_uses_an_integer_interval_and_idempotent_replace() {
+        let sql = retention_policy_sql("otel_spans", 90);
+        assert!(sql.contains("remove_retention_policy('otel_spans', if_exists => TRUE)"));
+        assert!(sql.contains("make_interval(days => 90)"));
+        assert!(sql.contains("if_not_exists => TRUE"));
+    }
+
     // The proxy reads settings on the per-request hot path, so get_settings()
     // must serve from the in-memory cache and NOT hit the DB every call.
     #[tokio::test]
@@ -1172,6 +1252,61 @@ mod tests {
             ConfigServiceError::CompressionPolicyUpdate {
                 table: "otel_spans",
                 after_hours: 12,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn update_settings_applies_changed_observability_retention_policies() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![
+                vec![settings_row("retention.example.com")],
+                vec![settings_row("retention.example.com")],
+                vec![settings_row("retention.example.com")],
+            ])
+            // Four telemetry retention policies, then the settings row update.
+            .append_exec_results(vec![
+                sea_orm::MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                };
+                5
+            ])
+            .into_connection();
+        let svc = ConfigService::new(test_config(), Arc::new(db));
+        let mut updated = AppSettings::default();
+        updated.observability_retention.proxy_logs_days = 14;
+        updated.observability_retention.otel_spans_days = 60;
+        updated.observability_retention.otel_logs_days = 45;
+        updated.observability_retention.otel_metrics_days = 30;
+
+        svc.update_settings(updated.clone())
+            .await
+            .expect("changed retention policies should be applied transactionally");
+
+        let cached = svc.get_settings().await.expect("updated settings cache");
+        assert_eq!(
+            cached.observability_retention,
+            updated.observability_retention
+        );
+    }
+
+    #[tokio::test]
+    async fn retention_policy_errors_include_table_and_requested_window() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_errors(vec![sea_orm::DbErr::Custom("Timescale job error".into())])
+            .into_connection();
+
+        let error = replace_retention_policy(&db, "otel_log_events", 45)
+            .await
+            .expect_err("policy error should be returned");
+
+        assert!(matches!(
+            error,
+            ConfigServiceError::RetentionPolicyUpdate {
+                table: "otel_log_events",
+                after_days: 45,
                 ..
             }
         ));

--- a/crates/temps-core/src/app_settings.rs
+++ b/crates/temps-core/src/app_settings.rs
@@ -85,6 +85,10 @@ pub struct AppSettings {
     /// scrape interval, and tiered retention windows.
     pub monitoring: MonitoringSettings,
 
+    /// TimescaleDB compression delays for immutable observability data.
+    /// Changes are applied at runtime by the Settings API.
+    pub observability_compression: ObservabilityCompressionSettings,
+
     /// Set to `true` by `temps setup` (all modes) once initial configuration
     /// has been applied. The web onboarding wizard reads this from the server
     /// and skips itself when true, preventing the "Configure Base Domain" wall
@@ -700,6 +704,31 @@ pub struct MonitoringSettings {
     pub clickhouse_url: Option<String>,
 }
 
+/// TimescaleDB compression policy configuration for append-only observability
+/// tables. Values are expressed in hours so operators can choose sub-day
+/// windows while keeping the API representation unambiguous.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(default)]
+pub struct ObservabilityCompressionSettings {
+    /// Compress proxy-log chunks after this many hours. Defaults to 24 hours.
+    #[schema(minimum = 1, maximum = 720, example = 24)]
+    pub proxy_logs_after_hours: u32,
+
+    /// Compress OpenTelemetry span chunks after this many hours. Defaults to
+    /// 24 hours.
+    #[schema(minimum = 1, maximum = 2160, example = 24)]
+    pub otel_spans_after_hours: u32,
+}
+
+impl Default for ObservabilityCompressionSettings {
+    fn default() -> Self {
+        Self {
+            proxy_logs_after_hours: 24,
+            otel_spans_after_hours: 24,
+        }
+    }
+}
+
 impl Default for MonitoringSettings {
     fn default() -> Self {
         Self {
@@ -739,6 +768,7 @@ impl Default for AppSettings {
             build_limits: BuildLimitsSettings::default(),
             cluster_dns: ClusterDnsSettings::default(),
             monitoring: MonitoringSettings::default(),
+            observability_compression: ObservabilityCompressionSettings::default(),
             setup_complete: false,
             require_mfa_for_admins: false,
             console_version: None,
@@ -1065,5 +1095,34 @@ mod tests {
         let json = s.to_json();
         let back = AppSettings::from_json(json);
         assert!(back.require_mfa_for_admins);
+    }
+
+    #[test]
+    fn observability_compression_defaults_to_24_hours() {
+        let compression = ObservabilityCompressionSettings::default();
+        assert_eq!(compression.proxy_logs_after_hours, 24);
+        assert_eq!(compression.otel_spans_after_hours, 24);
+    }
+
+    #[test]
+    fn legacy_settings_get_24_hour_observability_compression_defaults() {
+        let parsed = AppSettings::from_json(serde_json::json!({
+            "external_url": "https://paas.example.com",
+            "preview_domain": "localho.st"
+        }));
+
+        assert_eq!(parsed.observability_compression.proxy_logs_after_hours, 24);
+        assert_eq!(parsed.observability_compression.otel_spans_after_hours, 24);
+    }
+
+    #[test]
+    fn observability_compression_round_trips_through_json() {
+        let mut settings = AppSettings::default();
+        settings.observability_compression.proxy_logs_after_hours = 12;
+        settings.observability_compression.otel_spans_after_hours = 48;
+
+        let parsed = AppSettings::from_json(settings.to_json());
+        assert_eq!(parsed.observability_compression.proxy_logs_after_hours, 12);
+        assert_eq!(parsed.observability_compression.otel_spans_after_hours, 48);
     }
 }

--- a/crates/temps-core/src/app_settings.rs
+++ b/crates/temps-core/src/app_settings.rs
@@ -89,6 +89,10 @@ pub struct AppSettings {
     /// Changes are applied at runtime by the Settings API.
     pub observability_compression: ObservabilityCompressionSettings,
 
+    /// Retention windows for raw proxy and OpenTelemetry telemetry.
+    /// TimescaleDB policies are updated at runtime by the Settings API.
+    pub observability_retention: ObservabilityRetentionSettings,
+
     /// Set to `true` by `temps setup` (all modes) once initial configuration
     /// has been applied. The web onboarding wizard reads this from the server
     /// and skips itself when true, preventing the "Configure Base Domain" wall
@@ -729,6 +733,40 @@ impl Default for ObservabilityCompressionSettings {
     }
 }
 
+/// Retention policy configuration for raw observability tables. Values are in
+/// days. The Settings API applies them to TimescaleDB; ClickHouse-backed proxy
+/// logs and spans retain their storage-level per-row TTL behavior.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(default)]
+pub struct ObservabilityRetentionSettings {
+    /// Retain proxy request logs for this many days.
+    #[schema(minimum = 1, maximum = 3650, example = 30)]
+    pub proxy_logs_days: u32,
+
+    /// Retain OpenTelemetry spans (traces) for this many days.
+    #[schema(minimum = 1, maximum = 3650, example = 90)]
+    pub otel_spans_days: u32,
+
+    /// Retain OpenTelemetry log events for this many days.
+    #[schema(minimum = 1, maximum = 3650, example = 90)]
+    pub otel_logs_days: u32,
+
+    /// Retain OpenTelemetry metric points for this many days.
+    #[schema(minimum = 1, maximum = 3650, example = 90)]
+    pub otel_metrics_days: u32,
+}
+
+impl Default for ObservabilityRetentionSettings {
+    fn default() -> Self {
+        Self {
+            proxy_logs_days: 30,
+            otel_spans_days: 90,
+            otel_logs_days: 90,
+            otel_metrics_days: 90,
+        }
+    }
+}
+
 impl Default for MonitoringSettings {
     fn default() -> Self {
         Self {
@@ -769,6 +807,7 @@ impl Default for AppSettings {
             cluster_dns: ClusterDnsSettings::default(),
             monitoring: MonitoringSettings::default(),
             observability_compression: ObservabilityCompressionSettings::default(),
+            observability_retention: ObservabilityRetentionSettings::default(),
             setup_complete: false,
             require_mfa_for_admins: false,
             console_version: None,
@@ -1005,6 +1044,37 @@ mod tests {
         assert!(
             !parsed.cluster_dns.enabled,
             "cluster_dns must default to disabled when deserializing a legacy settings row"
+        );
+    }
+
+    #[test]
+    fn legacy_settings_json_uses_observability_retention_defaults() {
+        let parsed = AppSettings::from_json(serde_json::json!({
+            "external_url": "https://paas.example.com",
+            "preview_domain": "localho.st"
+        }));
+
+        assert_eq!(
+            parsed.observability_retention,
+            ObservabilityRetentionSettings::default()
+        );
+        assert_eq!(parsed.observability_retention.proxy_logs_days, 30);
+        assert_eq!(parsed.observability_retention.otel_spans_days, 90);
+    }
+
+    #[test]
+    fn observability_retention_round_trips_through_json() {
+        let mut settings = AppSettings::default();
+        settings.observability_retention.proxy_logs_days = 14;
+        settings.observability_retention.otel_spans_days = 60;
+        settings.observability_retention.otel_logs_days = 45;
+        settings.observability_retention.otel_metrics_days = 30;
+
+        let parsed = AppSettings::from_json(settings.to_json());
+
+        assert_eq!(
+            parsed.observability_retention,
+            settings.observability_retention
         );
     }
 

--- a/crates/temps-core/src/lib.rs
+++ b/crates/temps-core/src/lib.rs
@@ -79,8 +79,8 @@ pub use app_settings::{
     AgentSandboxSettings, AiConfigSettings, AppSettings, BuildLimitsSettings, ClusterDnsSettings,
     ContainerLogSettings, DiskSpaceAlertSettings, DnsProviderSettings, DockerRegistrySettings,
     LetsEncryptSettings, MetricsStoreKind, MonitoringSettings, MultiNodeSettings,
-    ObservabilityCompressionSettings, PreviewGatewaySettings, ProviderConfig, RateLimitSettings,
-    ScreenshotSettings, SecurityHeadersSettings,
+    ObservabilityCompressionSettings, ObservabilityRetentionSettings, PreviewGatewaySettings,
+    ProviderConfig, RateLimitSettings, ScreenshotSettings, SecurityHeadersSettings,
 };
 pub use async_trait;
 pub use chrono;

--- a/crates/temps-core/src/lib.rs
+++ b/crates/temps-core/src/lib.rs
@@ -79,8 +79,8 @@ pub use app_settings::{
     AgentSandboxSettings, AiConfigSettings, AppSettings, BuildLimitsSettings, ClusterDnsSettings,
     ContainerLogSettings, DiskSpaceAlertSettings, DnsProviderSettings, DockerRegistrySettings,
     LetsEncryptSettings, MetricsStoreKind, MonitoringSettings, MultiNodeSettings,
-    PreviewGatewaySettings, ProviderConfig, RateLimitSettings, ScreenshotSettings,
-    SecurityHeadersSettings,
+    ObservabilityCompressionSettings, PreviewGatewaySettings, ProviderConfig, RateLimitSettings,
+    ScreenshotSettings, SecurityHeadersSettings,
 };
 pub use async_trait;
 pub use chrono;

--- a/crates/temps-migrations/src/migration/m20260716_000001_observability_compression_24h.rs
+++ b/crates/temps-migrations/src/migration/m20260716_000001_observability_compression_24h.rs
@@ -1,0 +1,70 @@
+use sea_orm::DatabaseBackend;
+use sea_orm_migration::prelude::*;
+
+const DEFAULT_COMPRESSION_AFTER_HOURS: u32 = 24;
+const PREVIOUS_COMPRESSION_AFTER_HOURS: u32 = 7 * 24;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+fn replace_policy_sql(table: &str, after_hours: u32) -> String {
+    format!(
+        "SELECT remove_compression_policy('{table}', if_exists => TRUE); \
+         SELECT add_compression_policy(\
+             '{table}', \
+             compress_after => make_interval(hours => {after_hours}), \
+             if_not_exists => TRUE\
+         )"
+    )
+}
+
+async fn replace_policy(
+    manager: &SchemaManager<'_>,
+    table: &str,
+    after_hours: u32,
+) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute_unprepared(&replace_policy_sql(table, after_hours))
+        .await?;
+    Ok(())
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() != DatabaseBackend::Postgres {
+            return Ok(());
+        }
+
+        // Proxy logs and spans are append-only. Keeping seven days of chunks
+        // uncompressed wastes disk and cache without making writes safer; one
+        // day still leaves a full chunk for normal late arrivals.
+        replace_policy(manager, "proxy_logs", DEFAULT_COMPRESSION_AFTER_HOURS).await?;
+        replace_policy(manager, "otel_spans", DEFAULT_COMPRESSION_AFTER_HOURS).await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() != DatabaseBackend::Postgres {
+            return Ok(());
+        }
+
+        replace_policy(manager, "otel_spans", PREVIOUS_COMPRESSION_AFTER_HOURS).await?;
+        replace_policy(manager, "proxy_logs", PREVIOUS_COMPRESSION_AFTER_HOURS).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_sql_uses_24_hour_interval() {
+        let sql = replace_policy_sql("otel_spans", DEFAULT_COMPRESSION_AFTER_HOURS);
+        assert!(sql.contains("remove_compression_policy('otel_spans', if_exists => TRUE)"));
+        assert!(sql.contains("make_interval(hours => 24)"));
+        assert!(sql.contains("if_not_exists => TRUE"));
+    }
+}

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -150,6 +150,7 @@ mod m20260711_000002_add_ip_geolocations_hosting_provider;
 mod m20260711_000003_add_visitor_non_crawler_partial_index;
 mod m20260713_000001_add_mfa_pending_to_sessions;
 mod m20260714_000001_fix_otel_spans_compression_segmentby;
+mod m20260716_000001_observability_compression_24h;
 
 pub struct Migrator;
 
@@ -305,6 +306,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260711_000003_add_visitor_non_crawler_partial_index::Migration),
             Box::new(m20260713_000001_add_mfa_pending_to_sessions::Migration),
             Box::new(m20260714_000001_fix_otel_spans_compression_segmentby::Migration),
+            Box::new(m20260716_000001_observability_compression_24h::Migration),
         ]
     }
 }

--- a/crates/temps-proxy/src/service/proxy_log_service.rs
+++ b/crates/temps-proxy/src/service/proxy_log_service.rs
@@ -623,7 +623,8 @@ impl ProxyLogService {
     /// Get a single proxy log by ID.
     ///
     /// `proxy_logs` is a TimescaleDB hypertable partitioned by `timestamp`
-    /// (1-day chunks, compressed after 7 days), so a bare `WHERE id = $1`
+    /// (1-day chunks, compressed after 24 hours by default), so a bare
+    /// `WHERE id = $1`
     /// cannot exclude any chunk and must decompress every compressed chunk —
     /// observed as multi-second lookups. When the caller knows the row's event
     /// time (the list endpoint returns it), a ±1-day bound reduces the lookup
@@ -649,10 +650,10 @@ impl ProxyLogService {
             return Ok(log);
         }
 
-        // Compression policy compresses chunks older than 7 days; probing the
+        // Compression defaults to chunks older than 24 hours; probing that
         // uncompressed window first keeps the common case (recent log, no
         // timestamp supplied) off the decompression path.
-        let recent_cutoff = Utc::now() - chrono::Duration::days(7);
+        let recent_cutoff = Utc::now() - chrono::Duration::hours(24);
         let log = proxy_logs::Entity::find()
             .filter(proxy_logs::Column::Id.eq(id))
             .filter(proxy_logs::Column::Timestamp.gte(recent_cutoff))

--- a/web/src/api/platformSettings.ts
+++ b/web/src/api/platformSettings.ts
@@ -150,6 +150,8 @@ export interface PlatformSettings extends AppSettingsResponse {
   attack_mode?: boolean
   build_limits: BuildLimitsSettings
   observability_compression: ObservabilityCompressionSettings
+  /** Effective backend for proxy logs and OTel spans. */
+  effective_observability_store: MetricsStoreKind
   /** Set to true by `temps setup` once initial configuration has been applied.
    * The web onboarding wizard checks this and skips itself when true. */
   setup_complete: boolean

--- a/web/src/api/platformSettings.ts
+++ b/web/src/api/platformSettings.ts
@@ -123,6 +123,13 @@ export interface MonitoringSettings {
   clickhouse_url?: string | null
 }
 
+export interface ObservabilityCompressionSettings {
+  /** Compress immutable proxy-log chunks after this many hours. */
+  proxy_logs_after_hours: number
+  /** Compress immutable OpenTelemetry span chunks after this many hours. */
+  otel_spans_after_hours: number
+}
+
 /** Per-managed-domain hostname layout (configured under DNS providers, not here). */
 export type PublicHostnameStrategy = 'standard' | 'flat'
 
@@ -142,6 +149,7 @@ export interface PlatformSettings extends AppSettingsResponse {
   insecure_tls: boolean
   attack_mode?: boolean
   build_limits: BuildLimitsSettings
+  observability_compression: ObservabilityCompressionSettings
   /** Set to true by `temps setup` once initial configuration has been applied.
    * The web onboarding wizard checks this and skips itself when true. */
   setup_complete: boolean
@@ -185,7 +193,6 @@ export async function updatePlatformSettings(
 
   validateSettings(updated)
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const body: any = {
     dns_provider: updated.dns_provider,
     external_url: updated.external_url,
@@ -202,6 +209,7 @@ export async function updatePlatformSettings(
     attack_mode: updated.attack_mode,
     build_limits: updated.build_limits,
     monitoring: updated.monitoring,
+    observability_compression: updated.observability_compression,
   }
   const result = await updateSettings({ body })
   if (result.error) {

--- a/web/src/api/platformSettings.ts
+++ b/web/src/api/platformSettings.ts
@@ -130,6 +130,17 @@ export interface ObservabilityCompressionSettings {
   otel_spans_after_hours: number
 }
 
+export interface ObservabilityRetentionSettings {
+  /** Raw proxy request-log retention in days. */
+  proxy_logs_days: number
+  /** OpenTelemetry span/trace retention in days. */
+  otel_spans_days: number
+  /** OpenTelemetry log-event retention in days. */
+  otel_logs_days: number
+  /** OpenTelemetry metric-point retention in days. */
+  otel_metrics_days: number
+}
+
 /** Per-managed-domain hostname layout (configured under DNS providers, not here). */
 export type PublicHostnameStrategy = 'standard' | 'flat'
 
@@ -150,6 +161,7 @@ export interface PlatformSettings extends AppSettingsResponse {
   attack_mode?: boolean
   build_limits: BuildLimitsSettings
   observability_compression: ObservabilityCompressionSettings
+  observability_retention: ObservabilityRetentionSettings
   /** Effective backend for proxy logs and OTel spans. */
   effective_observability_store: MetricsStoreKind
   /** Set to true by `temps setup` once initial configuration has been applied.
@@ -212,6 +224,7 @@ export async function updatePlatformSettings(
     build_limits: updated.build_limits,
     monitoring: updated.monitoring,
     observability_compression: updated.observability_compression,
+    observability_retention: updated.observability_retention,
   }
   const result = await updateSettings({ body })
   if (result.error) {

--- a/web/src/pages/settings/MonitoringSettingsPage.tsx
+++ b/web/src/pages/settings/MonitoringSettingsPage.tsx
@@ -23,6 +23,7 @@ import type {
   MetricsStoreKind,
   MonitoringSettings,
   ObservabilityCompressionSettings,
+  ObservabilityRetentionSettings,
 } from '@/api/platformSettings'
 import {
   AlertCircle,
@@ -40,6 +41,7 @@ import { toast } from 'sonner'
 interface MonitoringFormData {
   monitoring: MonitoringSettings
   observability_compression: ObservabilityCompressionSettings
+  observability_retention: ObservabilityRetentionSettings
 }
 
 const DEFAULTS: MonitoringSettings = {
@@ -56,6 +58,13 @@ const DEFAULTS: MonitoringSettings = {
 const COMPRESSION_DEFAULTS: ObservabilityCompressionSettings = {
   proxy_logs_after_hours: 24,
   otel_spans_after_hours: 24,
+}
+
+const RETENTION_DEFAULTS: ObservabilityRetentionSettings = {
+  proxy_logs_days: 30,
+  otel_spans_days: 90,
+  otel_logs_days: 90,
+  otel_metrics_days: 90,
 }
 
 // Bytes per raw metric row (approximate: time 8 + source_kind 12 + source_id 4 +
@@ -92,6 +101,7 @@ export function MonitoringSettingsPage() {
     defaultValues: {
       monitoring: DEFAULTS,
       observability_compression: COMPRESSION_DEFAULTS,
+      observability_retention: RETENTION_DEFAULTS,
     },
   })
 
@@ -122,6 +132,8 @@ export function MonitoringSettingsPage() {
         monitoring: settings.monitoring,
         observability_compression:
           settings.observability_compression ?? COMPRESSION_DEFAULTS,
+        observability_retention:
+          settings.observability_retention ?? RETENTION_DEFAULTS,
       })
     }
   }, [settings, reset])
@@ -380,106 +392,264 @@ export function MonitoringSettingsPage() {
         </CardContent>
       </Card>
 
-      {/* Retention tiers */}
+      {/* Retention spans every observability signal, not only resource metrics. */}
       <Card>
         <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <HardDrive className="h-5 w-5" />
-            Retention
-          </CardTitle>
-          <CardDescription>
-            How long data is kept at each resolution tier. TimescaleDB
-            continuous aggregates enforce hourly and daily retention
-            automatically.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-6">
-          <div className="grid gap-6 sm:grid-cols-3">
-            <div className="space-y-2">
-              <Label htmlFor="retention-raw">Raw data (days)</Label>
-              <Input
-                id="retention-raw"
-                type="number"
-                min={1}
-                max={30}
-                {...register('monitoring.retention_raw_days', {
-                  valueAsNumber: true,
-                  required: true,
-                  min: { value: 1, message: 'Min 1 day' },
-                  max: { value: 30, message: 'Max 30 days' },
-                })}
-              />
-              <p className="text-xs text-muted-foreground">
-                30-second resolution. Min 1, max 30. Default 7.
-              </p>
-              {errors.monitoring?.retention_raw_days && (
-                <p className="text-xs text-destructive">
-                  {errors.monitoring.retention_raw_days.message}
-                </p>
-              )}
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-1.5">
+              <CardTitle className="flex items-center gap-2">
+                <HardDrive className="h-5 w-5" />
+                Data Retention
+              </CardTitle>
+              <CardDescription>
+                Control how long resource metrics, proxy request logs, traces,
+                OpenTelemetry logs, and OpenTelemetry metrics remain available.
+              </CardDescription>
             </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="retention-hourly">Hourly rollup (days)</Label>
-              <Input
-                id="retention-hourly"
-                type="number"
-                min={7}
-                max={365}
-                {...register('monitoring.retention_hourly_days', {
-                  valueAsNumber: true,
-                  required: true,
-                  min: { value: 7, message: 'Min 7 days' },
-                  max: { value: 365, message: 'Max 365 days' },
-                })}
-              />
-              <p className="text-xs text-muted-foreground">
-                1-hour resolution. Min 7, max 365. Default 90.
-              </p>
-              {errors.monitoring?.retention_hourly_days && (
-                <p className="text-xs text-destructive">
-                  {errors.monitoring.retention_hourly_days.message}
-                </p>
-              )}
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="retention-daily">Daily rollup (years)</Label>
-              <Input
-                id="retention-daily"
-                type="number"
-                min={1}
-                max={10}
-                {...register('monitoring.retention_daily_years', {
-                  valueAsNumber: true,
-                  required: true,
-                  min: { value: 1, message: 'Min 1 year' },
-                  max: { value: 10, message: 'Max 10 years' },
-                })}
-              />
-              <p className="text-xs text-muted-foreground">
-                1-day resolution. Default 2 years.
-              </p>
-              {errors.monitoring?.retention_daily_years && (
-                <p className="text-xs text-destructive">
-                  {errors.monitoring.retention_daily_years.message}
-                </p>
-              )}
-            </div>
+            <span className="rounded-md bg-background px-2.5 py-1 text-xs font-medium text-foreground ring-1 ring-inset ring-border">
+              All telemetry
+            </span>
           </div>
+        </CardHeader>
+        <CardContent className="space-y-8">
+          <section className="space-y-4">
+            <div>
+              <h3 className="text-sm font-semibold">Resource metrics</h3>
+              <p className="text-xs text-muted-foreground">
+                Samples and rollups used by service and node dashboards.
+              </p>
+            </div>
+            {effectiveStore === 'click_house' ? (
+              <div className="rounded-lg border bg-muted/30 px-4 py-3">
+                <p className="text-sm font-medium">
+                  ClickHouse retention is managed by table TTL
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Resource metric rows are retained for 90 days, with rollups
+                  calculated at query time.
+                </p>
+              </div>
+            ) : (
+              <div className="grid gap-6 sm:grid-cols-3">
+                <div className="space-y-2">
+                  <Label htmlFor="retention-raw">Raw data (days)</Label>
+                  <Input
+                    id="retention-raw"
+                    type="number"
+                    min={1}
+                    max={30}
+                    {...register('monitoring.retention_raw_days', {
+                      valueAsNumber: true,
+                      required: true,
+                      min: { value: 1, message: 'Min 1 day' },
+                      max: { value: 30, message: 'Max 30 days' },
+                    })}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    30-second resolution. Min 1, max 30. Default 7.
+                  </p>
+                  {errors.monitoring?.retention_raw_days && (
+                    <p className="text-xs text-destructive">
+                      {errors.monitoring.retention_raw_days.message}
+                    </p>
+                  )}
+                </div>
 
-          {/* Estimated storage */}
-          <Alert>
-            <HardDrive className="h-4 w-4" />
-            <AlertTitle>Estimated storage</AlertTitle>
-            <AlertDescription>
-              Approximately <strong>{estimatedMbPerDay} MB/day</strong> of raw
-              metric data based on 5 monitored services, {METRICS_PER_SERVICE}{' '}
-              metrics each, scraped every{' '}
-              {monitoring?.scrape_interval_secs ?? 30}s. Hourly/daily rollups
-              add roughly 5% overhead.
-            </AlertDescription>
-          </Alert>
+                <div className="space-y-2">
+                  <Label htmlFor="retention-hourly">Hourly rollup (days)</Label>
+                  <Input
+                    id="retention-hourly"
+                    type="number"
+                    min={7}
+                    max={365}
+                    {...register('monitoring.retention_hourly_days', {
+                      valueAsNumber: true,
+                      required: true,
+                      min: { value: 7, message: 'Min 7 days' },
+                      max: { value: 365, message: 'Max 365 days' },
+                    })}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    1-hour resolution. Min 7, max 365. Default 90.
+                  </p>
+                  {errors.monitoring?.retention_hourly_days && (
+                    <p className="text-xs text-destructive">
+                      {errors.monitoring.retention_hourly_days.message}
+                    </p>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="retention-daily">Daily rollup (years)</Label>
+                  <Input
+                    id="retention-daily"
+                    type="number"
+                    min={1}
+                    max={10}
+                    {...register('monitoring.retention_daily_years', {
+                      valueAsNumber: true,
+                      required: true,
+                      min: { value: 1, message: 'Min 1 year' },
+                      max: { value: 10, message: 'Max 10 years' },
+                    })}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    1-day resolution. Default 2 years.
+                  </p>
+                  {errors.monitoring?.retention_daily_years && (
+                    <p className="text-xs text-destructive">
+                      {errors.monitoring.retention_daily_years.message}
+                    </p>
+                  )}
+                </div>
+              </div>
+            )}
+
+            <Alert>
+              <HardDrive className="h-4 w-4" />
+              <AlertTitle>Estimated metric storage</AlertTitle>
+              <AlertDescription>
+                Approximately <strong>{estimatedMbPerDay} MB/day</strong> of raw
+                metric data based on 5 monitored services, {METRICS_PER_SERVICE}{' '}
+                metrics each, scraped every{' '}
+                {monitoring?.scrape_interval_secs ?? 30}s. Hourly/daily rollups
+                add roughly 5% overhead.
+              </AlertDescription>
+            </Alert>
+          </section>
+
+          <div className="border-t" />
+
+          <section className="space-y-4">
+            <div>
+              <h3 className="text-sm font-semibold">Logs and traces</h3>
+              <p className="text-xs text-muted-foreground">
+                Raw request and OpenTelemetry signals. TimescaleDB policy
+                changes are saved immediately; cleanup runs in the background.
+              </p>
+            </div>
+
+            {effectiveObservabilityStore === 'click_house' && (
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-lg border bg-muted/30 px-4 py-3">
+                  <p className="text-sm font-medium">Proxy request logs</p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    ClickHouse TTL · 30 days per row
+                  </p>
+                </div>
+                <div className="rounded-lg border bg-muted/30 px-4 py-3">
+                  <p className="text-sm font-medium">OTel spans / traces</p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    ClickHouse TTL · 90 days per row
+                  </p>
+                </div>
+              </div>
+            )}
+
+            <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+              {effectiveObservabilityStore !== 'click_house' && (
+                <>
+                  <div className="space-y-2">
+                    <Label htmlFor="retention-proxy-logs">
+                      Proxy logs (days)
+                    </Label>
+                    <Input
+                      id="retention-proxy-logs"
+                      type="number"
+                      min={1}
+                      max={3650}
+                      {...register('observability_retention.proxy_logs_days', {
+                        valueAsNumber: true,
+                        required: true,
+                        min: { value: 1, message: 'Min 1 day' },
+                        max: { value: 3650, message: 'Max 3650 days' },
+                      })}
+                    />
+                    <p className="text-xs text-muted-foreground">Default 30.</p>
+                    {errors.observability_retention?.proxy_logs_days && (
+                      <p className="text-xs text-destructive">
+                        {errors.observability_retention.proxy_logs_days.message}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="retention-otel-spans">
+                      OTel traces (days)
+                    </Label>
+                    <Input
+                      id="retention-otel-spans"
+                      type="number"
+                      min={1}
+                      max={3650}
+                      {...register('observability_retention.otel_spans_days', {
+                        valueAsNumber: true,
+                        required: true,
+                        min: { value: 1, message: 'Min 1 day' },
+                        max: { value: 3650, message: 'Max 3650 days' },
+                      })}
+                    />
+                    <p className="text-xs text-muted-foreground">Default 90.</p>
+                    {errors.observability_retention?.otel_spans_days && (
+                      <p className="text-xs text-destructive">
+                        {errors.observability_retention.otel_spans_days.message}
+                      </p>
+                    )}
+                  </div>
+                </>
+              )}
+
+              <div className="space-y-2">
+                <Label htmlFor="retention-otel-logs">OTel logs (days)</Label>
+                <Input
+                  id="retention-otel-logs"
+                  type="number"
+                  min={1}
+                  max={3650}
+                  {...register('observability_retention.otel_logs_days', {
+                    valueAsNumber: true,
+                    required: true,
+                    min: { value: 1, message: 'Min 1 day' },
+                    max: { value: 3650, message: 'Max 3650 days' },
+                  })}
+                />
+                <p className="text-xs text-muted-foreground">
+                  TimescaleDB · default 90.
+                </p>
+                {errors.observability_retention?.otel_logs_days && (
+                  <p className="text-xs text-destructive">
+                    {errors.observability_retention.otel_logs_days.message}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="retention-otel-metrics">
+                  OTel metrics (days)
+                </Label>
+                <Input
+                  id="retention-otel-metrics"
+                  type="number"
+                  min={1}
+                  max={3650}
+                  {...register('observability_retention.otel_metrics_days', {
+                    valueAsNumber: true,
+                    required: true,
+                    min: { value: 1, message: 'Min 1 day' },
+                    max: { value: 3650, message: 'Max 3650 days' },
+                  })}
+                />
+                <p className="text-xs text-muted-foreground">
+                  TimescaleDB · default 90.
+                </p>
+                {errors.observability_retention?.otel_metrics_days && (
+                  <p className="text-xs text-destructive">
+                    {errors.observability_retention.otel_metrics_days.message}
+                  </p>
+                )}
+              </div>
+            </div>
+          </section>
         </CardContent>
       </Card>
 

--- a/web/src/pages/settings/MonitoringSettingsPage.tsx
+++ b/web/src/pages/settings/MonitoringSettingsPage.tsx
@@ -34,7 +34,7 @@ import {
   Loader2,
   Save,
 } from 'lucide-react'
-import { useEffect } from 'react'
+import { forwardRef, useEffect, type ComponentProps } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import { toast } from 'sonner'
 
@@ -72,6 +72,29 @@ const RETENTION_DEFAULTS: ObservabilityRetentionSettings = {
 const BYTES_PER_ROW = 100
 // Approximate number of metrics tracked per monitored service
 const METRICS_PER_SERVICE = 15
+
+type DurationUnit = 'hours' | 'days' | 'years'
+
+interface DurationInputProps extends ComponentProps<'input'> {
+  unit: DurationUnit
+}
+
+const DurationInput = forwardRef<HTMLInputElement, DurationInputProps>(
+  ({ unit, ...props }, ref) => (
+    <div className="relative text-base md:text-sm">
+      <Input
+        ref={ref}
+        type="number"
+        className="pr-20 tabular-nums"
+        {...props}
+      />
+      <span className="pointer-events-none absolute inset-y-0 right-8 flex items-center text-muted-foreground">
+        {unit}
+      </span>
+    </div>
+  )
+)
+DurationInput.displayName = 'DurationInput'
 
 function estimateStorageMbPerDay(scrapeIntervalSecs: number): number {
   // Placeholder: pull the "monitored services" count from settings if available
@@ -276,27 +299,21 @@ export function MonitoringSettingsPage() {
                   <Label htmlFor="proxy-compression-delay">
                     Proxy logs delay
                   </Label>
-                  <div className="relative">
-                    <Input
-                      id="proxy-compression-delay"
-                      type="number"
-                      min={1}
-                      max={720}
-                      className="pr-16"
-                      {...register(
-                        'observability_compression.proxy_logs_after_hours',
-                        {
-                          valueAsNumber: true,
-                          required: 'Enter a compression delay',
-                          min: { value: 1, message: 'Min 1 hour' },
-                          max: { value: 720, message: 'Max 720 hours' },
-                        }
-                      )}
-                    />
-                    <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-xs text-muted-foreground">
-                      hours
-                    </span>
-                  </div>
+                  <DurationInput
+                    id="proxy-compression-delay"
+                    unit="hours"
+                    min={1}
+                    max={720}
+                    {...register(
+                      'observability_compression.proxy_logs_after_hours',
+                      {
+                        valueAsNumber: true,
+                        required: 'Enter a compression delay',
+                        min: { value: 1, message: 'Min 1 hour' },
+                        max: { value: 720, message: 'Max 720 hours' },
+                      }
+                    )}
+                  />
                   <p className="text-xs text-muted-foreground">
                     Compresses closed proxy-log chunks once their newest row is
                     this old. It does not delete logs. Default 24 hours; maximum
@@ -316,27 +333,21 @@ export function MonitoringSettingsPage() {
                   <Label htmlFor="span-compression-delay">
                     OTel spans delay
                   </Label>
-                  <div className="relative">
-                    <Input
-                      id="span-compression-delay"
-                      type="number"
-                      min={1}
-                      max={2160}
-                      className="pr-16"
-                      {...register(
-                        'observability_compression.otel_spans_after_hours',
-                        {
-                          valueAsNumber: true,
-                          required: 'Enter a compression delay',
-                          min: { value: 1, message: 'Min 1 hour' },
-                          max: { value: 2160, message: 'Max 2160 hours' },
-                        }
-                      )}
-                    />
-                    <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-xs text-muted-foreground">
-                      hours
-                    </span>
-                  </div>
+                  <DurationInput
+                    id="span-compression-delay"
+                    unit="hours"
+                    min={1}
+                    max={2160}
+                    {...register(
+                      'observability_compression.otel_spans_after_hours',
+                      {
+                        valueAsNumber: true,
+                        required: 'Enter a compression delay',
+                        min: { value: 1, message: 'Min 1 hour' },
+                        max: { value: 2160, message: 'Max 2160 hours' },
+                      }
+                    )}
+                  />
                   <p className="text-xs text-muted-foreground">
                     Compresses closed span chunks once their newest row is this
                     old. It does not delete traces. Default 24 hours; maximum 90
@@ -455,13 +466,13 @@ export function MonitoringSettingsPage() {
                 <div className="space-y-3 rounded-lg border p-4">
                   <Label htmlFor="retention-raw">Raw data (days)</Label>
                   <p className="min-h-10 text-xs leading-5 text-muted-foreground">
-                    Stores every original sample at the selected scrape
-                    interval for detailed recent charts and precise incident
+                    Stores every original sample at the selected scrape interval
+                    for detailed recent charts and precise incident
                     investigation.
                   </p>
-                  <Input
+                  <DurationInput
                     id="retention-raw"
-                    type="number"
+                    unit="days"
                     min={1}
                     max={30}
                     {...register('monitoring.retention_raw_days', {
@@ -488,9 +499,9 @@ export function MonitoringSettingsPage() {
                     Creates an hourly aggregate for each metric to preserve
                     medium-term trends after individual raw samples are deleted.
                   </p>
-                  <Input
+                  <DurationInput
                     id="retention-hourly"
-                    type="number"
+                    unit="days"
                     min={7}
                     max={365}
                     {...register('monitoring.retention_hourly_days', {
@@ -517,9 +528,9 @@ export function MonitoringSettingsPage() {
                     Creates a daily aggregate for each metric for capacity
                     planning, seasonality, and long-term historical trends.
                   </p>
-                  <Input
+                  <DurationInput
                     id="retention-daily"
-                    type="number"
+                    unit="years"
                     min={1}
                     max={10}
                     {...register('monitoring.retention_daily_years', {
@@ -618,9 +629,9 @@ export function MonitoringSettingsPage() {
                       by the proxy. Use these entries to investigate traffic,
                       status codes, and slow requests.
                     </p>
-                    <Input
+                    <DurationInput
                       id="retention-proxy-logs"
-                      type="number"
+                      unit="days"
                       min={1}
                       max={3650}
                       {...register('observability_retention.proxy_logs_days', {
@@ -655,9 +666,9 @@ export function MonitoringSettingsPage() {
                       waterfalls, follow requests across services, and inspect
                       timings, errors, events, and attributes.
                     </p>
-                    <Input
+                    <DurationInput
                       id="retention-otel-spans"
-                      type="number"
+                      unit="days"
                       min={1}
                       max={3650}
                       {...register('observability_retention.otel_spans_days', {
@@ -668,9 +679,9 @@ export function MonitoringSettingsPage() {
                       })}
                     />
                     <p className="text-xs text-muted-foreground">
-                      Spans older than this are permanently deleted and disappear
-                      from trace search and detail views. Range 1–3650 days;
-                      default 90.
+                      Spans older than this are permanently deleted and
+                      disappear from trace search and detail views. Range 1–3650
+                      days; default 90.
                     </p>
                     {errors.observability_retention?.otel_spans_days && (
                       <p className="text-xs text-destructive">
@@ -693,9 +704,9 @@ export function MonitoringSettingsPage() {
                   severity, body, attributes, and trace correlation. This does
                   not control Docker container log files.
                 </p>
-                <Input
+                <DurationInput
                   id="retention-otel-logs"
-                  type="number"
+                  unit="days"
                   min={1}
                   max={3650}
                   {...register('observability_retention.otel_logs_days', {
@@ -706,8 +717,8 @@ export function MonitoringSettingsPage() {
                   })}
                 />
                 <p className="text-xs text-muted-foreground">
-                  OTel log records older than this are permanently deleted. Range
-                  1–3650 days; default 90.
+                  OTel log records older than this are permanently deleted.
+                  Range 1–3650 days; default 90.
                 </p>
                 {errors.observability_retention?.otel_logs_days && (
                   <p className="text-xs text-destructive">
@@ -726,13 +737,13 @@ export function MonitoringSettingsPage() {
                   </code>
                 </div>
                 <p className="min-h-10 text-xs leading-5 text-muted-foreground">
-                  Stores application metric points sent by OpenTelemetry SDKs and
-                  collectors. These are separate from the Temps-scraped resource
-                  metrics configured above.
+                  Stores application metric points sent by OpenTelemetry SDKs
+                  and collectors. These are separate from the Temps-scraped
+                  resource metrics configured above.
                 </p>
-                <Input
+                <DurationInput
                   id="retention-otel-metrics"
-                  type="number"
+                  unit="days"
                   min={1}
                   max={3650}
                   {...register('observability_retention.otel_metrics_days', {

--- a/web/src/pages/settings/MonitoringSettingsPage.tsx
+++ b/web/src/pages/settings/MonitoringSettingsPage.tsx
@@ -298,7 +298,9 @@ export function MonitoringSettingsPage() {
                     </span>
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    Default 24 hours. Maximum 30 days.
+                    Compresses closed proxy-log chunks once their newest row is
+                    this old. It does not delete logs. Default 24 hours; maximum
+                    30 days.
                   </p>
                   {errors.observability_compression?.proxy_logs_after_hours && (
                     <p className="text-xs text-destructive">
@@ -336,7 +338,9 @@ export function MonitoringSettingsPage() {
                     </span>
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    Default 24 hours. Maximum 90 days.
+                    Compresses closed span chunks once their newest row is this
+                    old. It does not delete traces. Default 24 hours; maximum 90
+                    days.
                   </p>
                   {errors.observability_compression?.otel_spans_after_hours && (
                     <p className="text-xs text-destructive">
@@ -388,6 +392,11 @@ export function MonitoringSettingsPage() {
                 <SelectItem value="60">60 seconds</SelectItem>
               </SelectContent>
             </Select>
+            <p className="mt-2 text-xs leading-5 text-muted-foreground">
+              Controls how often Temps samples CPU, memory, database, container,
+              and node metrics. Shorter intervals show finer detail but create
+              more raw metric rows.
+            </p>
           </div>
         </CardContent>
       </Card>
@@ -412,6 +421,17 @@ export function MonitoringSettingsPage() {
           </div>
         </CardHeader>
         <CardContent className="space-y-8">
+          <Alert>
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Retention permanently deletes old data</AlertTitle>
+            <AlertDescription>
+              Each value is an independent policy for one table or resolution
+              tier. Shortening a window makes data beyond that age eligible for
+              deletion on the next background policy run. Compression is
+              different: it reduces storage without deleting rows.
+            </AlertDescription>
+          </Alert>
+
           <section className="space-y-4">
             <div>
               <h3 className="text-sm font-semibold">Resource metrics</h3>
@@ -430,9 +450,14 @@ export function MonitoringSettingsPage() {
                 </p>
               </div>
             ) : (
-              <div className="grid gap-6 sm:grid-cols-3">
-                <div className="space-y-2">
+              <div className="grid gap-4 lg:grid-cols-3">
+                <div className="space-y-3 rounded-lg border p-4">
                   <Label htmlFor="retention-raw">Raw data (days)</Label>
+                  <p className="min-h-10 text-xs leading-5 text-muted-foreground">
+                    Keeps every original sample at the selected scrape interval.
+                    Used for detailed recent charts and precise incident
+                    investigation.
+                  </p>
                   <Input
                     id="retention-raw"
                     type="number"
@@ -446,7 +471,8 @@ export function MonitoringSettingsPage() {
                     })}
                   />
                   <p className="text-xs text-muted-foreground">
-                    30-second resolution. Min 1, max 30. Default 7.
+                    After expiry, hourly and daily summaries remain. Range 1–30
+                    days; default 7.
                   </p>
                   {errors.monitoring?.retention_raw_days && (
                     <p className="text-xs text-destructive">
@@ -455,8 +481,12 @@ export function MonitoringSettingsPage() {
                   )}
                 </div>
 
-                <div className="space-y-2">
+                <div className="space-y-3 rounded-lg border p-4">
                   <Label htmlFor="retention-hourly">Hourly rollup (days)</Label>
+                  <p className="min-h-10 text-xs leading-5 text-muted-foreground">
+                    Keeps one aggregated value per metric and hour. It preserves
+                    medium-term trends after the individual raw samples expire.
+                  </p>
                   <Input
                     id="retention-hourly"
                     type="number"
@@ -470,7 +500,8 @@ export function MonitoringSettingsPage() {
                     })}
                   />
                   <p className="text-xs text-muted-foreground">
-                    1-hour resolution. Min 7, max 365. Default 90.
+                    After expiry, daily summaries remain. Range 7–365 days;
+                    default 90.
                   </p>
                   {errors.monitoring?.retention_hourly_days && (
                     <p className="text-xs text-destructive">
@@ -479,8 +510,12 @@ export function MonitoringSettingsPage() {
                   )}
                 </div>
 
-                <div className="space-y-2">
+                <div className="space-y-3 rounded-lg border p-4">
                   <Label htmlFor="retention-daily">Daily rollup (years)</Label>
+                  <p className="min-h-10 text-xs leading-5 text-muted-foreground">
+                    Keeps one aggregated value per metric and day for capacity
+                    planning, seasonality, and long-term historical trends.
+                  </p>
                   <Input
                     id="retention-daily"
                     type="number"
@@ -494,7 +529,8 @@ export function MonitoringSettingsPage() {
                     })}
                   />
                   <p className="text-xs text-muted-foreground">
-                    1-day resolution. Default 2 years.
+                    This is the longest-lived metrics tier. Range 1–10 years;
+                    default 2.
                   </p>
                   {errors.monitoring?.retention_daily_years && (
                     <p className="text-xs text-destructive">
@@ -524,35 +560,62 @@ export function MonitoringSettingsPage() {
             <div>
               <h3 className="text-sm font-semibold">Logs and traces</h3>
               <p className="text-xs text-muted-foreground">
-                Raw request and OpenTelemetry signals. TimescaleDB policy
-                changes are saved immediately; cleanup runs in the background.
+                Each signal has its own table and retention window, so
+                high-volume request logs can expire sooner than traces or
+                application telemetry. TimescaleDB cleanup runs in the
+                background.
               </p>
             </div>
 
             {effectiveObservabilityStore === 'click_house' && (
               <div className="grid gap-3 sm:grid-cols-2">
-                <div className="rounded-lg border bg-muted/30 px-4 py-3">
-                  <p className="text-sm font-medium">Proxy request logs</p>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    ClickHouse TTL · 30 days per row
+                <div className="rounded-lg border bg-muted/30 p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-sm font-medium">Proxy request logs</p>
+                    <code className="rounded bg-background px-2 py-0.5 text-[11px] text-muted-foreground ring-1 ring-inset ring-border">
+                      proxy_logs
+                    </code>
+                  </div>
+                  <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                    One row per proxied HTTP request, including route, status,
+                    duration, and request metadata. ClickHouse expires each row
+                    after 30 days using its native TTL.
                   </p>
                 </div>
-                <div className="rounded-lg border bg-muted/30 px-4 py-3">
-                  <p className="text-sm font-medium">OTel spans / traces</p>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    ClickHouse TTL · 90 days per row
+                <div className="rounded-lg border bg-muted/30 p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-sm font-medium">OTel spans / traces</p>
+                    <code className="rounded bg-background px-2 py-0.5 text-[11px] text-muted-foreground ring-1 ring-inset ring-border">
+                      spans
+                    </code>
+                  </div>
+                  <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                    Individual operations that compose a distributed trace,
+                    including timings, errors, attributes, and service links.
+                    ClickHouse expires each row after 90 days using its native
+                    TTL.
                   </p>
                 </div>
               </div>
             )}
 
-            <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="grid gap-4 md:grid-cols-2">
               {effectiveObservabilityStore !== 'click_house' && (
                 <>
-                  <div className="space-y-2">
-                    <Label htmlFor="retention-proxy-logs">
-                      Proxy logs (days)
-                    </Label>
+                  <div className="space-y-3 rounded-lg border p-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <Label htmlFor="retention-proxy-logs">
+                        Proxy request logs
+                      </Label>
+                      <code className="rounded bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                        proxy_logs
+                      </code>
+                    </div>
+                    <p className="min-h-10 text-xs leading-5 text-muted-foreground">
+                      Keeps one record per proxied HTTP request for traffic
+                      investigation, status-code analysis, latency debugging,
+                      and request forensics.
+                    </p>
                     <Input
                       id="retention-proxy-logs"
                       type="number"
@@ -565,7 +628,10 @@ export function MonitoringSettingsPage() {
                         max: { value: 3650, message: 'Max 3650 days' },
                       })}
                     />
-                    <p className="text-xs text-muted-foreground">Default 30.</p>
+                    <p className="text-xs text-muted-foreground">
+                      Rows older than this are deleted. Range 1–3650 days;
+                      default 30.
+                    </p>
                     {errors.observability_retention?.proxy_logs_days && (
                       <p className="text-xs text-destructive">
                         {errors.observability_retention.proxy_logs_days.message}
@@ -573,10 +639,20 @@ export function MonitoringSettingsPage() {
                     )}
                   </div>
 
-                  <div className="space-y-2">
-                    <Label htmlFor="retention-otel-spans">
-                      OTel traces (days)
-                    </Label>
+                  <div className="space-y-3 rounded-lg border p-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <Label htmlFor="retention-otel-spans">
+                        OTel spans / traces
+                      </Label>
+                      <code className="rounded bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                        otel_spans
+                      </code>
+                    </div>
+                    <p className="min-h-10 text-xs leading-5 text-muted-foreground">
+                      Keeps the spans used to reconstruct trace waterfalls,
+                      follow requests across services, and inspect timings,
+                      errors, events, and attributes.
+                    </p>
                     <Input
                       id="retention-otel-spans"
                       type="number"
@@ -589,7 +665,10 @@ export function MonitoringSettingsPage() {
                         max: { value: 3650, message: 'Max 3650 days' },
                       })}
                     />
-                    <p className="text-xs text-muted-foreground">Default 90.</p>
+                    <p className="text-xs text-muted-foreground">
+                      Expired spans disappear from trace search and detail
+                      views. Range 1–3650 days; default 90.
+                    </p>
                     {errors.observability_retention?.otel_spans_days && (
                       <p className="text-xs text-destructive">
                         {errors.observability_retention.otel_spans_days.message}
@@ -599,8 +678,18 @@ export function MonitoringSettingsPage() {
                 </>
               )}
 
-              <div className="space-y-2">
-                <Label htmlFor="retention-otel-logs">OTel logs (days)</Label>
+              <div className="space-y-3 rounded-lg border p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <Label htmlFor="retention-otel-logs">OTel log records</Label>
+                  <code className="rounded bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                    otel_log_events
+                  </code>
+                </div>
+                <p className="min-h-10 text-xs leading-5 text-muted-foreground">
+                  Keeps structured logs received over OTLP, including severity,
+                  body, attributes, and trace correlation. This does not control
+                  Docker container log files.
+                </p>
                 <Input
                   id="retention-otel-logs"
                   type="number"
@@ -614,7 +703,7 @@ export function MonitoringSettingsPage() {
                   })}
                 />
                 <p className="text-xs text-muted-foreground">
-                  TimescaleDB · default 90.
+                  Stored in TimescaleDB. Range 1–3650 days; default 90.
                 </p>
                 {errors.observability_retention?.otel_logs_days && (
                   <p className="text-xs text-destructive">
@@ -623,10 +712,20 @@ export function MonitoringSettingsPage() {
                 )}
               </div>
 
-              <div className="space-y-2">
-                <Label htmlFor="retention-otel-metrics">
-                  OTel metrics (days)
-                </Label>
+              <div className="space-y-3 rounded-lg border p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <Label htmlFor="retention-otel-metrics">
+                    OTel metric points
+                  </Label>
+                  <code className="rounded bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                    otel_metrics
+                  </code>
+                </div>
+                <p className="min-h-10 text-xs leading-5 text-muted-foreground">
+                  Keeps application metrics sent by OpenTelemetry SDKs and
+                  collectors. These are separate from the Temps-scraped resource
+                  metrics configured above.
+                </p>
                 <Input
                   id="retention-otel-metrics"
                   type="number"
@@ -640,7 +739,7 @@ export function MonitoringSettingsPage() {
                   })}
                 />
                 <p className="text-xs text-muted-foreground">
-                  TimescaleDB · default 90.
+                  Stored in TimescaleDB. Range 1–3650 days; default 90.
                 </p>
                 {errors.observability_retention?.otel_metrics_days && (
                   <p className="text-xs text-destructive">

--- a/web/src/pages/settings/MonitoringSettingsPage.tsx
+++ b/web/src/pages/settings/MonitoringSettingsPage.tsx
@@ -446,7 +446,8 @@ export function MonitoringSettingsPage() {
                 </p>
                 <p className="mt-1 text-xs text-muted-foreground">
                   Resource metric rows are retained for 90 days, with rollups
-                  calculated at query time.
+                  calculated at query time. Rows older than 90 days are
+                  permanently deleted.
                 </p>
               </div>
             ) : (
@@ -454,8 +455,8 @@ export function MonitoringSettingsPage() {
                 <div className="space-y-3 rounded-lg border p-4">
                   <Label htmlFor="retention-raw">Raw data (days)</Label>
                   <p className="min-h-10 text-xs leading-5 text-muted-foreground">
-                    Keeps every original sample at the selected scrape interval.
-                    Used for detailed recent charts and precise incident
+                    Stores every original sample at the selected scrape
+                    interval for detailed recent charts and precise incident
                     investigation.
                   </p>
                   <Input
@@ -471,8 +472,8 @@ export function MonitoringSettingsPage() {
                     })}
                   />
                   <p className="text-xs text-muted-foreground">
-                    After expiry, hourly and daily summaries remain. Range 1–30
-                    days; default 7.
+                    Raw samples older than this are permanently deleted. Hourly
+                    and daily summaries remain. Range 1–30 days; default 7.
                   </p>
                   {errors.monitoring?.retention_raw_days && (
                     <p className="text-xs text-destructive">
@@ -484,8 +485,8 @@ export function MonitoringSettingsPage() {
                 <div className="space-y-3 rounded-lg border p-4">
                   <Label htmlFor="retention-hourly">Hourly rollup (days)</Label>
                   <p className="min-h-10 text-xs leading-5 text-muted-foreground">
-                    Keeps one aggregated value per metric and hour. It preserves
-                    medium-term trends after the individual raw samples expire.
+                    Creates an hourly aggregate for each metric to preserve
+                    medium-term trends after individual raw samples are deleted.
                   </p>
                   <Input
                     id="retention-hourly"
@@ -500,8 +501,8 @@ export function MonitoringSettingsPage() {
                     })}
                   />
                   <p className="text-xs text-muted-foreground">
-                    After expiry, daily summaries remain. Range 7–365 days;
-                    default 90.
+                    Hourly aggregates older than this are permanently deleted.
+                    Daily summaries remain. Range 7–365 days; default 90.
                   </p>
                   {errors.monitoring?.retention_hourly_days && (
                     <p className="text-xs text-destructive">
@@ -513,7 +514,7 @@ export function MonitoringSettingsPage() {
                 <div className="space-y-3 rounded-lg border p-4">
                   <Label htmlFor="retention-daily">Daily rollup (years)</Label>
                   <p className="min-h-10 text-xs leading-5 text-muted-foreground">
-                    Keeps one aggregated value per metric and day for capacity
+                    Creates a daily aggregate for each metric for capacity
                     planning, seasonality, and long-term historical trends.
                   </p>
                   <Input
@@ -529,6 +530,7 @@ export function MonitoringSettingsPage() {
                     })}
                   />
                   <p className="text-xs text-muted-foreground">
+                    Daily aggregates older than this are permanently deleted.
                     This is the longest-lived metrics tier. Range 1–10 years;
                     default 2.
                   </p>
@@ -561,9 +563,9 @@ export function MonitoringSettingsPage() {
               <h3 className="text-sm font-semibold">Logs and traces</h3>
               <p className="text-xs text-muted-foreground">
                 Each signal has its own table and retention window, so
-                high-volume request logs can expire sooner than traces or
-                application telemetry. TimescaleDB cleanup runs in the
-                background.
+                high-volume request logs can be deleted sooner than traces or
+                application telemetry. TimescaleDB permanently deletes expired
+                rows in the background.
               </p>
             </div>
 
@@ -578,8 +580,8 @@ export function MonitoringSettingsPage() {
                   </div>
                   <p className="mt-2 text-xs leading-5 text-muted-foreground">
                     One row per proxied HTTP request, including route, status,
-                    duration, and request metadata. ClickHouse expires each row
-                    after 30 days using its native TTL.
+                    duration, and request metadata. ClickHouse permanently
+                    deletes rows older than 30 days using its native TTL.
                   </p>
                 </div>
                 <div className="rounded-lg border bg-muted/30 p-4">
@@ -592,8 +594,8 @@ export function MonitoringSettingsPage() {
                   <p className="mt-2 text-xs leading-5 text-muted-foreground">
                     Individual operations that compose a distributed trace,
                     including timings, errors, attributes, and service links.
-                    ClickHouse expires each row after 90 days using its native
-                    TTL.
+                    ClickHouse permanently deletes rows older than 90 days using
+                    its native TTL.
                   </p>
                 </div>
               </div>
@@ -612,9 +614,9 @@ export function MonitoringSettingsPage() {
                       </code>
                     </div>
                     <p className="min-h-10 text-xs leading-5 text-muted-foreground">
-                      Keeps one record per proxied HTTP request for traffic
-                      investigation, status-code analysis, latency debugging,
-                      and request forensics.
+                      Stores a separate log entry for every HTTP request handled
+                      by the proxy. Use these entries to investigate traffic,
+                      status codes, and slow requests.
                     </p>
                     <Input
                       id="retention-proxy-logs"
@@ -629,8 +631,8 @@ export function MonitoringSettingsPage() {
                       })}
                     />
                     <p className="text-xs text-muted-foreground">
-                      Rows older than this are deleted. Range 1–3650 days;
-                      default 30.
+                      Proxy log entries older than this are permanently deleted.
+                      Range 1–3650 days; default 30.
                     </p>
                     {errors.observability_retention?.proxy_logs_days && (
                       <p className="text-xs text-destructive">
@@ -649,9 +651,9 @@ export function MonitoringSettingsPage() {
                       </code>
                     </div>
                     <p className="min-h-10 text-xs leading-5 text-muted-foreground">
-                      Keeps the spans used to reconstruct trace waterfalls,
-                      follow requests across services, and inspect timings,
-                      errors, events, and attributes.
+                      Stores every received OTel span used to reconstruct trace
+                      waterfalls, follow requests across services, and inspect
+                      timings, errors, events, and attributes.
                     </p>
                     <Input
                       id="retention-otel-spans"
@@ -666,8 +668,9 @@ export function MonitoringSettingsPage() {
                       })}
                     />
                     <p className="text-xs text-muted-foreground">
-                      Expired spans disappear from trace search and detail
-                      views. Range 1–3650 days; default 90.
+                      Spans older than this are permanently deleted and disappear
+                      from trace search and detail views. Range 1–3650 days;
+                      default 90.
                     </p>
                     {errors.observability_retention?.otel_spans_days && (
                       <p className="text-xs text-destructive">
@@ -686,9 +689,9 @@ export function MonitoringSettingsPage() {
                   </code>
                 </div>
                 <p className="min-h-10 text-xs leading-5 text-muted-foreground">
-                  Keeps structured logs received over OTLP, including severity,
-                  body, attributes, and trace correlation. This does not control
-                  Docker container log files.
+                  Stores every structured log received over OTLP, including
+                  severity, body, attributes, and trace correlation. This does
+                  not control Docker container log files.
                 </p>
                 <Input
                   id="retention-otel-logs"
@@ -703,7 +706,8 @@ export function MonitoringSettingsPage() {
                   })}
                 />
                 <p className="text-xs text-muted-foreground">
-                  Stored in TimescaleDB. Range 1–3650 days; default 90.
+                  OTel log records older than this are permanently deleted. Range
+                  1–3650 days; default 90.
                 </p>
                 {errors.observability_retention?.otel_logs_days && (
                   <p className="text-xs text-destructive">
@@ -722,7 +726,7 @@ export function MonitoringSettingsPage() {
                   </code>
                 </div>
                 <p className="min-h-10 text-xs leading-5 text-muted-foreground">
-                  Keeps application metrics sent by OpenTelemetry SDKs and
+                  Stores application metric points sent by OpenTelemetry SDKs and
                   collectors. These are separate from the Temps-scraped resource
                   metrics configured above.
                 </p>
@@ -739,7 +743,8 @@ export function MonitoringSettingsPage() {
                   })}
                 />
                 <p className="text-xs text-muted-foreground">
-                  Stored in TimescaleDB. Range 1–3650 days; default 90.
+                  OTel metric points older than this are permanently deleted.
+                  Range 1–3650 days; default 90.
                 </p>
                 {errors.observability_retention?.otel_metrics_days && (
                   <p className="text-xs text-destructive">

--- a/web/src/pages/settings/MonitoringSettingsPage.tsx
+++ b/web/src/pages/settings/MonitoringSettingsPage.tsx
@@ -19,9 +19,14 @@ import {
 import { useBreadcrumbs } from '@/contexts/BreadcrumbContext'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useSettings, useUpdateSettings } from '@/hooks/useSettings'
-import type { MonitoringSettings, MetricsStoreKind } from '@/api/platformSettings'
+import type {
+  MetricsStoreKind,
+  MonitoringSettings,
+  ObservabilityCompressionSettings,
+} from '@/api/platformSettings'
 import {
   AlertCircle,
+  Archive,
   BarChart2,
   Database,
   HardDrive,
@@ -34,6 +39,7 @@ import { toast } from 'sonner'
 
 interface MonitoringFormData {
   monitoring: MonitoringSettings
+  observability_compression: ObservabilityCompressionSettings
 }
 
 const DEFAULTS: MonitoringSettings = {
@@ -47,6 +53,11 @@ const DEFAULTS: MonitoringSettings = {
   clickhouse_url: null,
 }
 
+const COMPRESSION_DEFAULTS: ObservabilityCompressionSettings = {
+  proxy_logs_after_hours: 24,
+  otel_spans_after_hours: 24,
+}
+
 // Bytes per raw metric row (approximate: time 8 + source_kind 12 + source_id 4 +
 // name 20 + value 8 + labels 32 = ~84 bytes; round up to 100 for overhead)
 const BYTES_PER_ROW = 100
@@ -57,7 +68,9 @@ function estimateStorageMbPerDay(scrapeIntervalSecs: number): number {
   // Placeholder: pull the "monitored services" count from settings if available
   // For the estimate we use a hard-coded representative value of 5 services.
   const monitoredServices = 5
-  const scrapesPerDay = Math.floor((24 * 3600) / Math.max(scrapeIntervalSecs, 15))
+  const scrapesPerDay = Math.floor(
+    (24 * 3600) / Math.max(scrapeIntervalSecs, 15)
+  )
   const rowsPerDay = monitoredServices * METRICS_PER_SERVICE * scrapesPerDay
   const bytesPerDay = rowsPerDay * BYTES_PER_ROW
   return Math.round(bytesPerDay / (1024 * 1024))
@@ -75,19 +88,24 @@ export function MonitoringSettingsPage() {
     formState: { isDirty, isSubmitting, errors },
     reset,
     setValue,
-    watch,
   } = useForm<MonitoringFormData>({
-    defaultValues: { monitoring: DEFAULTS },
+    defaultValues: {
+      monitoring: DEFAULTS,
+      observability_compression: COMPRESSION_DEFAULTS,
+    },
   })
 
   const monitoring = useWatch({ control, name: 'monitoring' })
-  const storeKind: MetricsStoreKind = watch('monitoring.store')
+  const storeKind: MetricsStoreKind = monitoring?.store ?? DEFAULTS.store
   // The backend the runtime actually writes to, reconciled server-side with
   // the TEMPS_CLICKHOUSE_* env vars. Falls back to the configured store if the
   // server didn't report it (older binaries).
   const effectiveStore: MetricsStoreKind =
     settings?.effective_metrics_store ?? storeKind
-  const storeMismatch = storeKind === 'click_house' && effectiveStore !== 'click_house'
+  const storeMismatch =
+    storeKind === 'click_house' && effectiveStore !== 'click_house'
+  const effectiveObservabilityStore: MetricsStoreKind =
+    settings?.effective_observability_store ?? 'timescale_db'
 
   useEffect(() => {
     setBreadcrumbs([
@@ -100,7 +118,11 @@ export function MonitoringSettingsPage() {
 
   useEffect(() => {
     if (settings?.monitoring) {
-      reset({ monitoring: settings.monitoring })
+      reset({
+        monitoring: settings.monitoring,
+        observability_compression:
+          settings.observability_compression ?? COMPRESSION_DEFAULTS,
+      })
     }
   }, [settings, reset])
 
@@ -111,7 +133,9 @@ export function MonitoringSettingsPage() {
       toast.success('Monitoring settings saved')
     } catch (err: unknown) {
       const detail =
-        err instanceof Error ? err.message : 'Failed to save monitoring settings'
+        err instanceof Error
+          ? err.message
+          : 'Failed to save monitoring settings'
       toast.error(detail)
     }
   }
@@ -181,13 +205,144 @@ export function MonitoringSettingsPage() {
               <AlertTitle>Configured backend is not active</AlertTitle>
               <AlertDescription>
                 The metrics store is set to <strong>ClickHouse</strong>, but the
-                server's <code className="font-mono">TEMPS_CLICKHOUSE_*</code>{' '}
+                server&apos;s{' '}
+                <code className="font-mono">TEMPS_CLICKHOUSE_*</code>{' '}
                 environment variables are not fully configured, so metrics are
                 being written to <strong>TimescaleDB</strong>. Set the
                 ClickHouse env vars on the control plane and restart, or switch
                 the store back to TimescaleDB to clear this warning.
               </AlertDescription>
             </Alert>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Immutable proxy logs and spans share one operational pattern: write
+          once, then compress closed Timescale chunks. ClickHouse compresses
+          parts automatically and therefore has no age-based policy. */}
+      <Card>
+        <CardHeader>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-1.5">
+              <CardTitle className="flex items-center gap-2">
+                <Archive className="h-5 w-5" />
+                Telemetry Compression
+              </CardTitle>
+              <CardDescription>
+                Reduce storage used by immutable proxy request logs and
+                OpenTelemetry spans after their active ingest window closes.
+              </CardDescription>
+            </div>
+            <span className="rounded-md bg-background px-2.5 py-1 text-xs font-medium text-foreground ring-1 ring-inset ring-border">
+              {effectiveObservabilityStore === 'click_house'
+                ? 'ClickHouse · automatic'
+                : 'TimescaleDB · scheduled'}
+            </span>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {effectiveObservabilityStore === 'click_house' ? (
+            <div className="rounded-lg border border-border bg-muted/30 px-4 py-4">
+              <div className="flex items-start gap-3">
+                <Database className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                <div className="space-y-1">
+                  <p className="text-sm font-medium">
+                    Compression is managed automatically
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    ClickHouse compresses data parts as they are written and
+                    merged using column-specific Delta, Gorilla, and ZSTD
+                    codecs. There is no age-based compression delay to tune.
+                  </p>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-5">
+              <div className="grid gap-5 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="proxy-compression-delay">
+                    Proxy logs delay
+                  </Label>
+                  <div className="relative">
+                    <Input
+                      id="proxy-compression-delay"
+                      type="number"
+                      min={1}
+                      max={720}
+                      className="pr-16"
+                      {...register(
+                        'observability_compression.proxy_logs_after_hours',
+                        {
+                          valueAsNumber: true,
+                          required: 'Enter a compression delay',
+                          min: { value: 1, message: 'Min 1 hour' },
+                          max: { value: 720, message: 'Max 720 hours' },
+                        }
+                      )}
+                    />
+                    <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-xs text-muted-foreground">
+                      hours
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Default 24 hours. Maximum 30 days.
+                  </p>
+                  {errors.observability_compression?.proxy_logs_after_hours && (
+                    <p className="text-xs text-destructive">
+                      {
+                        errors.observability_compression.proxy_logs_after_hours
+                          .message
+                      }
+                    </p>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="span-compression-delay">
+                    OTel spans delay
+                  </Label>
+                  <div className="relative">
+                    <Input
+                      id="span-compression-delay"
+                      type="number"
+                      min={1}
+                      max={2160}
+                      className="pr-16"
+                      {...register(
+                        'observability_compression.otel_spans_after_hours',
+                        {
+                          valueAsNumber: true,
+                          required: 'Enter a compression delay',
+                          min: { value: 1, message: 'Min 1 hour' },
+                          max: { value: 2160, message: 'Max 2160 hours' },
+                        }
+                      )}
+                    />
+                    <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-xs text-muted-foreground">
+                      hours
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Default 24 hours. Maximum 90 days.
+                  </p>
+                  {errors.observability_compression?.otel_spans_after_hours && (
+                    <p className="text-xs text-destructive">
+                      {
+                        errors.observability_compression.otel_spans_after_hours
+                          .message
+                      }
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              <p className="border-l-2 border-border pl-3 text-xs leading-5 text-muted-foreground">
+                Set the delay beyond your normal late-arrival window. Lower
+                values reclaim disk sooner; higher values keep more recent
+                chunks in row storage for operational queries.
+              </p>
+            </div>
           )}
         </CardContent>
       </Card>
@@ -233,8 +388,9 @@ export function MonitoringSettingsPage() {
             Retention
           </CardTitle>
           <CardDescription>
-            How long data is kept at each resolution tier. TimescaleDB continuous
-            aggregates enforce hourly and daily retention automatically.
+            How long data is kept at each resolution tier. TimescaleDB
+            continuous aggregates enforce hourly and daily retention
+            automatically.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
@@ -317,12 +473,11 @@ export function MonitoringSettingsPage() {
             <HardDrive className="h-4 w-4" />
             <AlertTitle>Estimated storage</AlertTitle>
             <AlertDescription>
-              Approximately{' '}
-              <strong>{estimatedMbPerDay} MB/day</strong> of raw metric data
-              based on 5 monitored services, {METRICS_PER_SERVICE} metrics
-              each, scraped every{' '}
-              {monitoring?.scrape_interval_secs ?? 30}s. Hourly/daily
-              rollups add roughly 5% overhead.
+              Approximately <strong>{estimatedMbPerDay} MB/day</strong> of raw
+              metric data based on 5 monitored services, {METRICS_PER_SERVICE}{' '}
+              metrics each, scraped every{' '}
+              {monitoring?.scrape_interval_secs ?? 30}s. Hourly/daily rollups
+              add roughly 5% overhead.
             </AlertDescription>
           </Alert>
         </CardContent>


### PR DESCRIPTION
## Summary

- change TimescaleDB compression defaults for proxy logs and OTel spans from 7 days to 24 hours
- expose proxy-log and span compression delays through the settings API and dashboard
- add configurable TimescaleDB retention for proxy logs, OTel traces, OTel logs, and OTel metrics
- apply compression and retention policy changes transactionally with the settings row
- make the UI backend-aware: TimescaleDB shows editable policies; ClickHouse shows automatic codecs and native TTL behavior

## ClickHouse behavior

- proxy logs and spans use ClickHouse compression automatically, so no age-based compression controls are shown
- proxy logs retain the existing 30-day per-row TTL and spans retain the existing 90-day per-row TTL
- resource metrics show the existing 90-day ClickHouse table TTL and query-time rollups
- OTel logs and OTel metrics remain TimescaleDB-backed and retain editable policy controls

## Runtime impact

TimescaleDB continues to run compression and retention asynchronously. Updating a value replaces only the affected background policy inside the same transaction that persists settings. No new work is added to proxy-request or span-ingest hot paths.

## Validation

- cargo check --lib for affected Rust crates
- cargo clippy --lib for temps-config and temps-core with warnings denied
- cargo test --lib for temps-config and temps-core: 271 passed
- full TypeScript typecheck
- ESLint and Prettier on changed frontend files
- Playwright browser QA for TimescaleDB editing/save and ClickHouse automatic compression/TTL states

## Known baseline

The repository-wide frontend lint remains red on upstream main with unrelated existing errors; the changed frontend files pass ESLint and Prettier.
