### PR TITLE
feat(telemetry): aggregated anonymous error_summary event

### DIFF
--- a/crates/temps-cli/src/commands/serve/console.rs
+++ b/crates/temps-cli/src/commands/serve/console.rs
@@ -322,7 +322,9 @@ fn build_error_summary_event(
 /// the fixed label `unmatched` so a 500 storm there is still visible without
 /// capturing raw paths. Runs only on the console listeners — proxied user-app
 /// traffic never passes through this router, so user requests are never
-/// counted. Cost outside the 5xx case is one extension lookup per request.
+/// counted. Cost outside the 5xx case is one extension lookup and two short
+/// string allocations per request (fine for the control plane; this
+/// middleware must never be mounted on the proxy data path).
 async fn track_server_errors(
     req: axum::extract::Request,
     next: axum::middleware::Next,

--- a/crates/temps-cli/src/commands/serve/console.rs
+++ b/crates/temps-cli/src/commands/serve/console.rs
@@ -246,6 +246,103 @@ fn spawn_heartbeat_task(
     });
 }
 
+/// Interval between anonymous `error_summary` flushes. Shorter than the daily
+/// heartbeat so shorter-lived instances still report, but coarse enough that
+/// even a melting-down instance costs at most 4 small POSTs per day.
+const ERROR_SUMMARY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(6 * 60 * 60);
+
+/// Spawn a detached task that drains the process-global error counters (see
+/// `temps_core::error_metrics`) every [`ERROR_SUMMARY_INTERVAL`] and reports
+/// one aggregated `error_summary` event. Emits nothing when no errors were
+/// recorded, so healthy instances stay silent. Best-effort and opt-out aware
+/// like every other telemetry emission.
+fn spawn_error_summary_task(
+    reporter: std::sync::Arc<dyn temps_core::telemetry::TelemetryReporter>,
+) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(ERROR_SUMMARY_INTERVAL);
+        // Skip the immediate first tick: nothing meaningful has accumulated
+        // at boot, and instance_started already covers "alive today".
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            let Some(summary) = temps_core::error_metrics::global().drain() else {
+                continue;
+            };
+            reporter.report(build_error_summary_event(&summary));
+            tracing::debug!("emitted anonymous error_summary telemetry event");
+        }
+    });
+}
+
+/// Build the `error_summary` telemetry event from a drained counter snapshot.
+///
+/// Every value is a count or a compile-time identifier of our own code
+/// (tracing target, route template, crate-relative source location) — see the
+/// privacy contract in `temps_core::error_metrics`. `overflow` is included
+/// only when non-zero so truncation by the key cap is never silent.
+fn build_error_summary_event(
+    summary: &temps_core::error_metrics::ErrorSummary,
+) -> temps_core::telemetry::TelemetryEvent {
+    use temps_core::telemetry::{TelemetryEvent, TelemetryEventKind};
+
+    let mut event = TelemetryEvent::new(TelemetryEventKind::ErrorSummary)
+        .with(
+            "window_hours",
+            (ERROR_SUMMARY_INTERVAL.as_secs() / 3600) as i64,
+        )
+        .with("total", summary.total as i64)
+        .with_opt(
+            "overflow",
+            (summary.overflow > 0).then_some(summary.overflow as i64),
+        );
+    for (category, count) in &summary.category_totals {
+        event = event.with(format!("{category}_total"), *count as i64);
+    }
+    let top: Vec<serde_json::Value> = summary
+        .top
+        .iter()
+        .map(|entry| {
+            serde_json::json!({
+                "category": entry.category,
+                "key": entry.key,
+                "count": entry.count,
+            })
+        })
+        .collect();
+    event.with("top", serde_json::Value::Array(top))
+}
+
+/// Middleware counting console-API 5xx responses for the anonymous
+/// `error_summary` telemetry event.
+///
+/// Records only the method, the route TEMPLATE (axum's `MatchedPath`, e.g.
+/// `/api/projects/{id}` — never the concrete URL, query, or body), and the
+/// status code. Unmatched requests (e.g. the SPA fallback) are recorded under
+/// the fixed label `unmatched` so a 500 storm there is still visible without
+/// capturing raw paths. Runs only on the console listeners — proxied user-app
+/// traffic never passes through this router, so user requests are never
+/// counted. Cost outside the 5xx case is one extension lookup per request.
+async fn track_server_errors(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let route = req
+        .extensions()
+        .get::<axum::extract::MatchedPath>()
+        .map(|matched| matched.as_str().to_owned());
+    let method = req.method().as_str().to_owned();
+    let response = next.run(req).await;
+    if response.status().is_server_error() {
+        temps_core::error_metrics::record_http_5xx(
+            &method,
+            route.as_deref().unwrap_or("unmatched"),
+            response.status().as_u16(),
+        );
+    }
+    response
+}
+
 /// This user is referenced by webhook-created resources (e.g., GitHub App installations)
 /// that don't have an authenticated user context.
 async fn ensure_system_user(db: &sea_orm::DatabaseConnection) -> anyhow::Result<()> {
@@ -1525,6 +1622,20 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
         update_status,
     } = params;
 
+    // Count panics for the anonymous `error_summary` telemetry event. Only
+    // the sanitized source location (crate-relative file:line) is recorded —
+    // never the panic message, which can embed user data. Chains to the
+    // previous hook so normal backtrace printing is unaffected. Task panics
+    // don't kill the process, so they are flushed by the summary task below;
+    // a fatal main-thread panic may be lost, which is acceptable for v1.
+    {
+        let previous_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |panic_info| {
+            temps_core::error_metrics::record_panic(panic_info.location());
+            previous_hook(panic_info);
+        }));
+    }
+
     // Readiness flag for the `/readyz` probe. Starts `false` (not ready) and is
     // flipped to `true` at the same point the legacy `ready_signal` fires —
     // after the full plugin system has initialized and immediately before the
@@ -1978,6 +2089,11 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
             // instance still checks in even when it isn't deploying. No-op when
             // telemetry is disabled (guarded above + report() no-ops anyway).
             spawn_heartbeat_task(reporter.clone(), db.clone());
+            // Periodic aggregated error_summary flush (ERROR logs / console
+            // 5xx / panics — counts only, never messages). Only spawned when
+            // telemetry is enabled; the counters themselves are just bounded
+            // in-process memory either way.
+            spawn_error_summary_task(reporter.clone());
         }
     }
     if let Some(user_service) = service_context.get_service::<temps_auth::UserService>() {
@@ -2701,7 +2817,8 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
     // regardless of `console_admin_address`.
     let public_app = Router::new()
         .merge(health_router(ready_flag.clone()))
-        .nest("/api", public_router);
+        .nest("/api", public_router)
+        .layer(axum::middleware::from_fn(track_server_errors));
 
     // Platform-console listener: when an embedding binary overrode the root
     // bundle AND configured an address, serve the ORIGINAL console (same
@@ -2715,7 +2832,8 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
 
     let admin_app = Router::new()
         .nest("/api", admin_router)
-        .fallback(serve_static_file);
+        .fallback(serve_static_file)
+        .layer(axum::middleware::from_fn(track_server_errors));
 
     // Defense-in-depth: the Pingora proxy is now the primary enforcer (it
     // 404s gated requests before they ever reach this listener). The axum
@@ -2733,6 +2851,7 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
         let platform_app = Router::new()
             .nest("/api", router)
             .fallback(serve_original_console)
+            .layer(axum::middleware::from_fn(track_server_errors))
             .layer(axum::middleware::from_fn_with_state(
                 admin_gate_handle.clone(),
                 super::admin_gate::admin_gate,
@@ -3182,5 +3301,173 @@ mod ai_tool_allowlist_tests {
             "DeploymentMetricsToggle is a write (PATCH) operation and must never be \
              resolvable via the read-only AI tool allowlist"
         );
+    }
+}
+
+#[cfg(test)]
+mod error_telemetry_tests {
+    use super::*;
+    use axum::response::IntoResponse;
+    use axum::routing::get;
+    use temps_core::error_metrics::{self, CATEGORY_HTTP_5XX};
+    use tower::ServiceExt;
+
+    async fn failing_handler() -> axum::response::Response {
+        (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            "it broke, with details that must never reach telemetry",
+        )
+            .into_response()
+    }
+
+    async fn ok_handler() -> &'static str {
+        "ok"
+    }
+
+    fn get_request(uri: &str) -> axum::http::Request<axum::body::Body> {
+        axum::http::Request::builder()
+            .uri(uri)
+            .body(axum::body::Body::empty())
+            .expect("valid test request")
+    }
+
+    /// The middleware must count 5xx responses under the route TEMPLATE (the
+    /// compile-time string from our route table), never the concrete request
+    /// path, and must not count non-5xx responses at all. Route names are
+    /// unique to this test so parallel tests can't interfere via the global
+    /// counter store.
+    #[tokio::test]
+    async fn track_server_errors_counts_5xx_by_route_template_only() {
+        let app = Router::new()
+            .route("/error-telemetry-test/{id}", get(failing_handler))
+            .route("/error-telemetry-test-ok", get(ok_handler))
+            .layer(axum::middleware::from_fn(track_server_errors));
+
+        let response = app
+            .clone()
+            .oneshot(get_request("/error-telemetry-test/12345"))
+            .await
+            .expect("request succeeds");
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR
+        );
+
+        let response = app
+            .oneshot(get_request("/error-telemetry-test-ok"))
+            .await
+            .expect("request succeeds");
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let counters = error_metrics::global();
+        assert_eq!(
+            counters.count_for(CATEGORY_HTTP_5XX, "GET /error-telemetry-test/{id} 500"),
+            1,
+            "5xx must be recorded under the route template"
+        );
+        assert_eq!(
+            counters.count_for(CATEGORY_HTTP_5XX, "GET /error-telemetry-test/12345 500"),
+            0,
+            "the concrete request path must never be recorded"
+        );
+        assert_eq!(
+            counters.count_for(CATEGORY_HTTP_5XX, "GET /error-telemetry-test-ok 200"),
+            0,
+            "non-5xx responses must not be recorded"
+        );
+    }
+
+    /// Requests that don't match any route (SPA fallback and friends) are
+    /// recorded under the fixed `unmatched` label — visible, but without
+    /// capturing the raw path.
+    #[tokio::test]
+    async fn track_server_errors_uses_unmatched_label_for_fallback() {
+        async fn failing_fallback() -> axum::response::Response {
+            (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "boom").into_response()
+        }
+
+        let app = Router::new()
+            .fallback(failing_fallback)
+            .layer(axum::middleware::from_fn(track_server_errors));
+
+        let before = error_metrics::global().count_for(CATEGORY_HTTP_5XX, "GET unmatched 500");
+        let response = app
+            .oneshot(get_request("/error-telemetry-secret-user-path"))
+            .await
+            .expect("request succeeds");
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR
+        );
+
+        let counters = error_metrics::global();
+        assert_eq!(
+            counters.count_for(CATEGORY_HTTP_5XX, "GET unmatched 500"),
+            before + 1
+        );
+        assert_eq!(
+            counters.count_for(
+                CATEGORY_HTTP_5XX,
+                "GET /error-telemetry-secret-user-path 500"
+            ),
+            0,
+            "unmatched raw paths must never be recorded"
+        );
+    }
+
+    /// The error_summary event must carry only counts and identifier keys —
+    /// with per-category totals, a capped top list, and overflow present only
+    /// when keys were actually dropped.
+    #[test]
+    fn build_error_summary_event_shape() {
+        use temps_core::error_metrics::{ErrorCount, ErrorSummary};
+
+        let summary = ErrorSummary {
+            total: 7,
+            overflow: 0,
+            category_totals: vec![("http_5xx", 2), ("log_error", 5)],
+            top: vec![
+                ErrorCount {
+                    category: "log_error",
+                    key: "temps_backup::service".to_string(),
+                    count: 5,
+                },
+                ErrorCount {
+                    category: "http_5xx",
+                    key: "GET /api/projects/{id} 500".to_string(),
+                    count: 2,
+                },
+            ],
+        };
+
+        let event = build_error_summary_event(&summary);
+        assert_eq!(event.event_type, "error_summary");
+        assert_eq!(event.properties["total"], serde_json::json!(7));
+        assert_eq!(event.properties["log_error_total"], serde_json::json!(5));
+        assert_eq!(event.properties["http_5xx_total"], serde_json::json!(2));
+        assert!(
+            !event.properties.contains_key("overflow"),
+            "overflow must be omitted when zero"
+        );
+
+        let top = event.properties["top"].as_array().expect("top is an array");
+        assert_eq!(top.len(), 2);
+        assert_eq!(top[0]["key"], serde_json::json!("temps_backup::service"));
+        assert_eq!(top[0]["count"], serde_json::json!(5));
+    }
+
+    #[test]
+    fn build_error_summary_event_reports_overflow_when_capped() {
+        use temps_core::error_metrics::ErrorSummary;
+
+        let summary = ErrorSummary {
+            total: 10,
+            overflow: 3,
+            category_totals: vec![("log_error", 7)],
+            top: vec![],
+        };
+
+        let event = build_error_summary_event(&summary);
+        assert_eq!(event.properties["overflow"], serde_json::json!(3));
     }
 }

--- a/crates/temps-cli/src/lib.rs
+++ b/crates/temps-cli/src/lib.rs
@@ -200,9 +200,35 @@ pub fn install_tracing_extra(log_level: &str, log_format: &str, extra: &str) {
             .boxed(),
     };
 
-    let subscriber = tracing_subscriber::registry().with(filter).with(fmt_layer);
+    let subscriber = tracing_subscriber::registry()
+        .with(filter)
+        .with(fmt_layer)
+        .with(ErrorMetricsLayer);
     tracing::subscriber::set_global_default(subscriber)
         .expect("Failed to set global default subscriber");
+}
+
+/// Tracing layer that counts ERROR-level events for the anonymous
+/// `error_summary` telemetry event (see `temps_core::error_metrics`).
+///
+/// Records ONLY the event's target — the module path, a compile-time
+/// identifier of our own code. The message and all fields are ignored, so no
+/// user data (IDs, paths, resource names embedded in error messages) can
+/// reach telemetry. Counting is in-memory and bounded; nothing leaves the
+/// process unless the serve command's telemetry flusher is running and the
+/// operator hasn't opted out.
+struct ErrorMetricsLayer;
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for ErrorMetricsLayer {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        if *event.metadata().level() == tracing::Level::ERROR {
+            temps_core::error_metrics::record_log_error(event.metadata().target());
+        }
+    }
 }
 
 // Re-exported so embedding binaries build their UI bundle with the exact
@@ -403,4 +429,42 @@ pub fn run(extra_plugins: Vec<Box<dyn temps_core::plugin::TempsPlugin>>) -> anyh
     scrub_sensitive_argv();
     install_tracing(&cli.log_level, &cli.log_format);
     dispatch(cli, extra_plugins)
+}
+
+#[cfg(test)]
+mod error_metrics_layer_tests {
+    use super::*;
+    use temps_core::error_metrics::{self, CATEGORY_LOG_ERROR};
+
+    /// The layer must count ERROR events by target and ignore every other
+    /// level. Targets are unique to this test so parallel tests can't
+    /// interfere via the global counter store.
+    #[test]
+    fn counts_only_error_level_events_by_target() {
+        let subscriber = tracing_subscriber::registry().with(ErrorMetricsLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::error!(
+                target: "layer_test_error_target",
+                "message with user data {} that must never be recorded",
+                "/home/alice/secret"
+            );
+            tracing::error!(target: "layer_test_error_target", "second error");
+            tracing::warn!(target: "layer_test_warn_target", "not counted");
+            tracing::info!(target: "layer_test_info_target", "not counted");
+        });
+
+        let counters = error_metrics::global();
+        assert_eq!(
+            counters.count_for(CATEGORY_LOG_ERROR, "layer_test_error_target"),
+            2
+        );
+        assert_eq!(
+            counters.count_for(CATEGORY_LOG_ERROR, "layer_test_warn_target"),
+            0
+        );
+        assert_eq!(
+            counters.count_for(CATEGORY_LOG_ERROR, "layer_test_info_target"),
+            0
+        );
+    }
 }

--- a/crates/temps-core/src/error_metrics.rs
+++ b/crates/temps-core/src/error_metrics.rs
@@ -26,8 +26,9 @@
 //! occurrences are still counted (in `overflow`) but not keyed, so a
 //! pathological instance can't grow memory or event size. Recording takes a
 //! short-lived `Mutex` — acceptable because errors are not a hot path (the
-//! 5xx recorder only runs on server-error responses, never per-request), and
-//! the proxy data path never calls into this module.
+//! 5xx middleware runs per console-API request but only acquires the lock on
+//! server-error responses), and the proxy data path never calls into this
+//! module.
 
 use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
@@ -214,8 +215,14 @@ pub fn record_panic(location: Option<&std::panic::Location<'_>>) {
 /// components otherwise.
 fn sanitize_source_path(file: &str, line: u32) -> String {
     let normalized = file.replace('\\', "/");
-    let trimmed = if let Some(idx) = normalized.find("crates/") {
-        &normalized[idx..]
+    // Anchor on a path COMPONENT named `crates` (leading slash or path start),
+    // not a bare substring — `my-crates/…` must not match. rfind so the
+    // workspace-level `crates/` wins if a parent directory is also named
+    // `crates` (e.g. a checkout under ~/crates/temps).
+    let trimmed = if normalized.starts_with("crates/") {
+        normalized.as_str()
+    } else if let Some(idx) = normalized.rfind("/crates/") {
+        &normalized[idx + 1..]
     } else {
         let mut components: Vec<&str> = normalized.rsplit('/').take(3).collect();
         components.reverse();
@@ -311,6 +318,22 @@ mod tests {
         assert_eq!(
             sanitize_source_path(r"C:\build\temps\crates\temps-core\src\lib.rs", 3),
             "crates/temps-core/src/lib.rs:3"
+        );
+        // A directory merely CONTAINING "crates" must not anchor the trim.
+        assert_eq!(
+            sanitize_source_path("/home/alice/my-crates/temps/src/lib.rs", 9),
+            "temps/src/lib.rs:9"
+        );
+        // Checkout under ~/crates: the rightmost `crates/` component wins, so
+        // the home directory is still stripped.
+        assert_eq!(
+            sanitize_source_path("/home/alice/crates/temps/crates/temps-core/src/lib.rs", 5),
+            "crates/temps-core/src/lib.rs:5"
+        );
+        // Relative build paths (CI) that already start at crates/ pass through.
+        assert_eq!(
+            sanitize_source_path("crates/temps-core/src/lib.rs", 1),
+            "crates/temps-core/src/lib.rs:1"
         );
     }
 

--- a/crates/temps-core/src/error_metrics.rs
+++ b/crates/temps-core/src/error_metrics.rs
@@ -1,0 +1,331 @@
+//! In-process aggregation of "something went wrong" signals for anonymous
+//! telemetry.
+//!
+//! Self-hosted instances fail where the maintainers can't see them. This
+//! module counts three classes of internal errors so a periodic, aggregated
+//! `error_summary` telemetry event (see [`crate::telemetry`]) can surface
+//! *that* and *where* instances break — without ever collecting the error
+//! itself:
+//!
+//! - `log_error`: ERROR-level tracing events, keyed by target (module path)
+//! - `http_5xx`: console-API 5xx responses, keyed by method + route template
+//! - `panic`: panics, keyed by sanitized source location (`file:line`)
+//!
+//! # Privacy contract
+//!
+//! Every key is a **compile-time identifier of our own code**: a tracing
+//! target, an axum route template (`/api/projects/{id}` — never the resolved
+//! URL), or a crate-relative source path. Error *messages* are never recorded
+//! — in this codebase they deliberately embed IDs, resource names, and paths
+//! (see CLAUDE.md's error rules), which makes them radioactive for telemetry.
+//! Panic *payloads* are likewise never recorded.
+//!
+//! # Bounds
+//!
+//! The counter map is capped at [`MAX_TRACKED_KEYS`] distinct keys; overflow
+//! occurrences are still counted (in `overflow`) but not keyed, so a
+//! pathological instance can't grow memory or event size. Recording takes a
+//! short-lived `Mutex` — acceptable because errors are not a hot path (the
+//! 5xx recorder only runs on server-error responses, never per-request), and
+//! the proxy data path never calls into this module.
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
+/// Maximum number of distinct (category, key) counters kept in memory.
+/// Occurrences past the cap are aggregated into [`ErrorSummary::overflow`].
+pub const MAX_TRACKED_KEYS: usize = 128;
+
+/// Maximum number of per-key entries included in a drained summary. Keys are
+/// sorted by count descending, so these are the most frequent offenders.
+pub const MAX_REPORTED_KEYS: usize = 20;
+
+/// Category for ERROR-level tracing events (key = tracing target).
+pub const CATEGORY_LOG_ERROR: &str = "log_error";
+/// Category for console-API 5xx responses (key = "METHOD /route/{template} STATUS").
+pub const CATEGORY_HTTP_5XX: &str = "http_5xx";
+/// Category for panics (key = sanitized "file:line").
+pub const CATEGORY_PANIC: &str = "panic";
+
+/// Bounded counter store. Prefer the free functions ([`record_log_error`],
+/// [`record_http_5xx`], [`record_panic`]) which write to the process-global
+/// instance; construct your own only in tests.
+#[derive(Default)]
+pub struct ErrorCounters {
+    inner: Mutex<CountersState>,
+}
+
+#[derive(Default)]
+struct CountersState {
+    counts: HashMap<(&'static str, String), u64>,
+    /// Occurrences that arrived after the key cap was reached and whose key
+    /// was not already tracked. Counted so truncation is visible, per the
+    /// no-silent-caps rule.
+    overflow: u64,
+}
+
+/// One aggregated counter, as reported in [`ErrorSummary::top`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ErrorCount {
+    pub category: &'static str,
+    pub key: String,
+    pub count: u64,
+}
+
+/// Snapshot produced by [`ErrorCounters::drain`]. Counters reset to empty.
+#[derive(Debug, Clone)]
+pub struct ErrorSummary {
+    /// Total recorded occurrences, including overflow.
+    pub total: u64,
+    /// Occurrences dropped from per-key tracking by [`MAX_TRACKED_KEYS`].
+    pub overflow: u64,
+    /// Per-category totals, sorted by category name for stable output.
+    pub category_totals: Vec<(&'static str, u64)>,
+    /// The most frequent keys, sorted by count descending, capped at
+    /// [`MAX_REPORTED_KEYS`].
+    pub top: Vec<ErrorCount>,
+}
+
+impl ErrorCounters {
+    /// Count one occurrence of `key` in `category`. Never blocks beyond the
+    /// short map insert; never fails.
+    pub fn record(&self, category: &'static str, key: impl Into<String>) {
+        let mut state = match self.inner.lock() {
+            Ok(state) => state,
+            // A poisoned lock means a panic mid-insert; losing counters is
+            // preferable to propagating the panic out of error accounting.
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let entry_key = (category, key.into());
+        if let Some(count) = state.counts.get_mut(&entry_key) {
+            *count += 1;
+        } else if state.counts.len() < MAX_TRACKED_KEYS {
+            state.counts.insert(entry_key, 1);
+        } else {
+            state.overflow += 1;
+        }
+    }
+
+    /// Current count for one (category, key) pair without resetting anything.
+    /// Lets callers (primarily tests observing the process-global instance)
+    /// assert on specific keys without draining counters that concurrent code
+    /// may also be using.
+    pub fn count_for(&self, category: &'static str, key: &str) -> u64 {
+        let state = match self.inner.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        state
+            .counts
+            .get(&(category, key.to_string()))
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// Take the current counters, resetting them to empty. Returns `None`
+    /// when nothing was recorded, so idle instances emit nothing.
+    pub fn drain(&self) -> Option<ErrorSummary> {
+        let state = {
+            let mut state = match self.inner.lock() {
+                Ok(state) => state,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            std::mem::take(&mut *state)
+        };
+
+        if state.counts.is_empty() && state.overflow == 0 {
+            return None;
+        }
+
+        let mut category_totals: HashMap<&'static str, u64> = HashMap::new();
+        let mut total = state.overflow;
+        for ((category, _), count) in &state.counts {
+            *category_totals.entry(category).or_insert(0) += count;
+            total += count;
+        }
+        let mut category_totals: Vec<_> = category_totals.into_iter().collect();
+        category_totals.sort_by_key(|(category, _)| *category);
+
+        let mut top: Vec<ErrorCount> = state
+            .counts
+            .into_iter()
+            .map(|((category, key), count)| ErrorCount {
+                category,
+                key,
+                count,
+            })
+            .collect();
+        // Secondary sort on (category, key) keeps equal counts deterministic.
+        top.sort_by(|a, b| {
+            b.count
+                .cmp(&a.count)
+                .then_with(|| a.category.cmp(b.category))
+                .then_with(|| a.key.cmp(&b.key))
+        });
+        top.truncate(MAX_REPORTED_KEYS);
+
+        Some(ErrorSummary {
+            total,
+            overflow: state.overflow,
+            category_totals,
+            top,
+        })
+    }
+}
+
+static GLOBAL: LazyLock<ErrorCounters> = LazyLock::new(ErrorCounters::default);
+
+/// The process-global counter store, shared by the tracing layer, the console
+/// 5xx middleware, and the panic hook, and drained by the telemetry flusher.
+pub fn global() -> &'static ErrorCounters {
+    &GLOBAL
+}
+
+/// Count an ERROR-level tracing event by its target (module path — a
+/// compile-time identifier, never the message).
+pub fn record_log_error(target: &str) {
+    global().record(CATEGORY_LOG_ERROR, target);
+}
+
+/// Count a console-API 5xx response by method + route template + status.
+/// `route` must be a route TEMPLATE (e.g. from axum's `MatchedPath`), never a
+/// concrete request path.
+pub fn record_http_5xx(method: &str, route: &str, status: u16) {
+    global().record(CATEGORY_HTTP_5XX, format!("{method} {route} {status}"));
+}
+
+/// Count a panic by its sanitized source location. The panic payload/message
+/// is deliberately ignored.
+pub fn record_panic(location: Option<&std::panic::Location<'_>>) {
+    let key = match location {
+        Some(location) => sanitize_source_path(location.file(), location.line()),
+        None => "unknown".to_string(),
+    };
+    global().record(CATEGORY_PANIC, key);
+}
+
+/// Reduce a compile-time source path to a build-machine-independent form.
+///
+/// Local builds embed absolute paths (`/Users/alice/src/temps/crates/...`)
+/// and dependency panics embed registry paths
+/// (`~/.cargo/registry/src/index.crates.io-.../tokio-1.40.0/src/...`). Both
+/// leak the build user's directory layout, so keep only the meaningful
+/// suffix: from `crates/` for workspace code, or the last three path
+/// components otherwise.
+fn sanitize_source_path(file: &str, line: u32) -> String {
+    let normalized = file.replace('\\', "/");
+    let trimmed = if let Some(idx) = normalized.find("crates/") {
+        &normalized[idx..]
+    } else {
+        let mut components: Vec<&str> = normalized.rsplit('/').take(3).collect();
+        components.reverse();
+        return format!("{}:{line}", components.join("/"));
+    };
+    format!("{trimmed}:{line}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_and_drain_counts_by_category_and_key() {
+        let counters = ErrorCounters::default();
+        counters.record(CATEGORY_LOG_ERROR, "temps_backup::service");
+        counters.record(CATEGORY_LOG_ERROR, "temps_backup::service");
+        counters.record(CATEGORY_HTTP_5XX, "GET /api/projects/{id} 500");
+
+        let summary = counters.drain().expect("summary present");
+        assert_eq!(summary.total, 3);
+        assert_eq!(summary.overflow, 0);
+        assert_eq!(
+            summary.category_totals,
+            vec![(CATEGORY_HTTP_5XX, 1), (CATEGORY_LOG_ERROR, 2)]
+        );
+        assert_eq!(summary.top[0].key, "temps_backup::service");
+        assert_eq!(summary.top[0].count, 2);
+
+        // Drain resets: a second drain is empty.
+        assert!(counters.drain().is_none());
+    }
+
+    #[test]
+    fn drain_on_empty_returns_none() {
+        let counters = ErrorCounters::default();
+        assert!(counters.drain().is_none());
+    }
+
+    #[test]
+    fn key_cap_overflows_into_counter_but_existing_keys_still_count() {
+        let counters = ErrorCounters::default();
+        for i in 0..MAX_TRACKED_KEYS {
+            counters.record(CATEGORY_LOG_ERROR, format!("target_{i}"));
+        }
+        // New key past the cap: dropped into overflow.
+        counters.record(CATEGORY_LOG_ERROR, "one_too_many");
+        // Existing key past the cap: still counted normally.
+        counters.record(CATEGORY_LOG_ERROR, "target_0");
+
+        let summary = counters.drain().expect("summary present");
+        assert_eq!(summary.overflow, 1);
+        assert_eq!(summary.total, MAX_TRACKED_KEYS as u64 + 2);
+        assert_eq!(summary.top.len(), MAX_REPORTED_KEYS);
+        assert_eq!(summary.top[0].key, "target_0");
+        assert_eq!(summary.top[0].count, 2);
+    }
+
+    #[test]
+    fn top_is_sorted_desc_and_deterministic_on_ties() {
+        let counters = ErrorCounters::default();
+        counters.record(CATEGORY_LOG_ERROR, "b_target");
+        counters.record(CATEGORY_LOG_ERROR, "a_target");
+        counters.record(CATEGORY_PANIC, "crates/x/src/lib.rs:1");
+        counters.record(CATEGORY_PANIC, "crates/x/src/lib.rs:1");
+
+        let summary = counters.drain().expect("summary present");
+        assert_eq!(summary.top[0].category, CATEGORY_PANIC);
+        assert_eq!(summary.top[0].count, 2);
+        // Tied counts fall back to category, then key ordering.
+        assert_eq!(summary.top[1].key, "a_target");
+        assert_eq!(summary.top[2].key, "b_target");
+    }
+
+    #[test]
+    fn sanitize_source_path_strips_build_machine_prefixes() {
+        assert_eq!(
+            sanitize_source_path(
+                "/Users/alice/projects/temps/crates/temps-backup/src/service.rs",
+                42
+            ),
+            "crates/temps-backup/src/service.rs:42"
+        );
+        // Dependency path: no crates/ segment — keep the last 3 components.
+        assert_eq!(
+            sanitize_source_path(
+                "/home/alice/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task.rs",
+                7
+            ),
+            "src/runtime/task.rs:7"
+        );
+        // Windows separators are normalized.
+        assert_eq!(
+            sanitize_source_path(r"C:\build\temps\crates\temps-core\src\lib.rs", 3),
+            "crates/temps-core/src/lib.rs:3"
+        );
+    }
+
+    #[test]
+    fn poisoned_lock_does_not_panic() {
+        let counters = std::sync::Arc::new(ErrorCounters::default());
+        let poisoner = counters.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = poisoner.inner.lock().unwrap();
+            panic!("poison the counters lock");
+        })
+        .join();
+
+        counters.record(CATEGORY_LOG_ERROR, "after_poison");
+        let summary = counters.drain().expect("summary present");
+        assert_eq!(summary.total, 1);
+    }
+}

--- a/crates/temps-core/src/lib.rs
+++ b/crates/temps-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod deployment;
 pub mod env_vars_provider;
 pub mod error;
 pub mod error_builder;
+pub mod error_metrics;
 pub mod external_plugin;
 pub mod jobs;
 pub mod node_pki;

--- a/crates/temps-core/src/telemetry.rs
+++ b/crates/temps-core/src/telemetry.rs
@@ -89,6 +89,13 @@ pub enum TelemetryEventKind {
 
     // ---- Status page ----
     StatusPagePublished,
+
+    // ---- Instance health ----
+    /// Periodic aggregated summary of internal errors on the instance (ERROR
+    /// logs by target, console-API 5xx by route template, panics by source
+    /// location). Carries only counts keyed by compile-time identifiers of our
+    /// own code — never error messages. See [`crate::error_metrics`].
+    ErrorSummary,
 }
 
 impl TelemetryEventKind {
@@ -141,6 +148,8 @@ impl TelemetryEventKind {
             Self::EmailProviderConfigured => "email_provider_configured",
 
             Self::StatusPagePublished => "status_page_published",
+
+            Self::ErrorSummary => "error_summary",
         }
     }
 
@@ -184,6 +193,7 @@ impl TelemetryEventKind {
             Self::VulnerabilityScanTriggered,
             Self::EmailProviderConfigured,
             Self::StatusPagePublished,
+            Self::ErrorSummary,
         ]
     }
 }
@@ -306,8 +316,9 @@ mod tests {
     fn all_covers_every_variant() {
         // If a variant is added but not added to all(), as_str() on it will be
         // missing from the list and this length check is a cheap tripwire.
-        // 36 events (34 initial + instance_heartbeat + project_created_from_template).
-        assert_eq!(TelemetryEventKind::all().len(), 36);
+        // 37 events (34 initial + instance_heartbeat + project_created_from_template
+        // + error_summary).
+        assert_eq!(TelemetryEventKind::all().len(), 37);
     }
 
     #[test]

--- a/docs/explanation/data-ownership-and-privacy/page.mdx
+++ b/docs/explanation/data-ownership-and-privacy/page.mdx
@@ -18,7 +18,7 @@ export const sections = [
 
 # Data Ownership & Privacy
 
-When you self-host Temps, every byte of your data — analytics events, error reports, session recordings, database backups, application logs — stays on your infrastructure. None of it is sent to Temps (the company), third-party analytics services, or any external server. The only thing the binary reports is [anonymous product telemetry](#anonymous-telemetry) — event names and counts under a random instance ID, fully disabled with `TEMPS_TELEMETRY=0`. {{ className: 'lead' }}
+When you self-host Temps, every byte of your data — analytics events, error reports, session recordings, database backups, application logs — stays on your infrastructure. None of it is sent to Temps (the company), third-party analytics services, or any external server. The only thing the binary reports is [anonymous product telemetry](#anonymous-telemetry) — event names, counts, and coarse internal labels (Temps module names, route templates) under a random instance ID. Set `TEMPS_TELEMETRY=0` and nothing is sent. {{ className: 'lead' }}
 
 ---
 
@@ -59,7 +59,7 @@ All data lives in one PostgreSQL database:
 - No data is sent to Google, Facebook, or any advertising network
 - No data is shared with analytics aggregators
 - The `temps upgrade` command checks GitHub for new releases (a public API call with no user data)
-- The binary sends anonymous product telemetry to `telemetry.temps.sh` — event names, counts, and coarse labels only, detailed in the next section. Set `TEMPS_TELEMETRY=0` to disable it entirely.
+- The binary sends anonymous product telemetry to `telemetry.temps.sh` — event names, counts, and coarse labels only, detailed in the next section. Set `TEMPS_TELEMETRY=0` and nothing is sent.
 
 ---
 
@@ -85,7 +85,7 @@ Every key is a compile-time identifier of Temps's own code. The error messages t
 
 ### Opting out
 
-Set `TEMPS_TELEMETRY=0` (also accepts `false`, `off`, `no`, `disabled`) in the server's environment and restart. This disables all telemetry, including error summaries. The instance ID file is still created so re-enabling later doesn't churn identity, but nothing is sent while opted out.
+Set `TEMPS_TELEMETRY=0` (also accepts `false`, `off`, `no`, `disabled`) in the server's environment and restart. Nothing is sent while opted out — no events, no error summaries. Two things still happen locally: the instance ID file is created (so re-enabling later doesn't churn identity), and error counts are tallied in a small fixed-size in-process buffer that is never read or transmitted while opted out.
 
 ---
 

--- a/docs/explanation/data-ownership-and-privacy/page.mdx
+++ b/docs/explanation/data-ownership-and-privacy/page.mdx
@@ -18,13 +18,13 @@ export const sections = [
 
 # Data Ownership & Privacy
 
-When you self-host Temps, every byte of data — analytics events, error reports, session recordings, database backups, application logs — stays on your infrastructure. Nothing is sent to Temps (the company), third-party analytics services, or any external server. {{ className: 'lead' }}
+When you self-host Temps, every byte of your data — analytics events, error reports, session recordings, database backups, application logs — stays on your infrastructure. None of it is sent to Temps (the company), third-party analytics services, or any external server. The only thing the binary reports is [anonymous product telemetry](#anonymous-telemetry) — event names and counts under a random instance ID, fully disabled with `TEMPS_TELEMETRY=0`. {{ className: 'lead' }}
 
 ---
 
 ## Your server, your data {{ anchor: true, id: 'your-server-your-data' }}
 
-Temps is a binary you run on your own server. It stores data in a PostgreSQL database (with TimescaleDB extension) running on that same server. There is no cloud backend, no telemetry endpoint, and no "call home" mechanism.
+Temps is a binary you run on your own server. It stores data in a PostgreSQL database (with TimescaleDB extension) running on that same server. There is no cloud backend, and none of your data — analytics, recordings, errors, logs, backups, credentials — ever leaves your infrastructure. The binary does send [anonymous product telemetry](#anonymous-telemetry) (event names and counts under a random instance ID, disable with `TEMPS_TELEMETRY=0`), described in full below.
 
 This means:
 
@@ -55,11 +55,37 @@ All data lives in one PostgreSQL database:
 
 ### Where data does NOT go
 
-- No data is sent to `temps.sh` or any Temps-operated server
+- None of **your** data (analytics events, recordings, error reports, logs, backups, user accounts, credentials) is ever sent to `temps.sh` or any Temps-operated server
 - No data is sent to Google, Facebook, or any advertising network
 - No data is shared with analytics aggregators
-- The Temps binary does not contain tracking code or telemetry
-- The `temps upgrade` command checks GitHub for new releases (a public API call) — this is the only external request, and it contains no user data
+- The `temps upgrade` command checks GitHub for new releases (a public API call with no user data)
+- The binary sends anonymous product telemetry to `telemetry.temps.sh` — event names, counts, and coarse labels only, detailed in the next section. Set `TEMPS_TELEMETRY=0` to disable it entirely.
+
+---
+
+## Anonymous product telemetry {{ anchor: true, id: 'anonymous-telemetry' }}
+
+Temps reports anonymous usage events so the maintainers can tell whether the product actually works for self-hosters (e.g. "how many instances attempted a deploy vs. succeeded"). Every event carries only:
+
+- A **random instance ID** generated on your server (`~/.temps/anonymous_id`) — not derived from your hardware, domain, or account
+- The **event name** (e.g. `deploy_succeeded`, `instance_heartbeat`) and the Temps version
+- A small bag of **non-identifying properties**: counts, enum labels (build preset, source type), and coarse buckets (RAM tier — never exact specs)
+
+What is **never** sent: emails, IPs, repo names, domains, URLs, environment variables, error messages, stack traces, file paths from your projects, or any free-form user text.
+
+### Error summary
+
+To find and fix bugs that only appear on self-hosted instances, Temps periodically (every 6 hours, only if something went wrong) sends one aggregated `error_summary` event containing **counts** of:
+
+- ERROR-level log events, keyed by the Temps source module that logged them
+- Console-API 5xx responses, keyed by route *template* (`/api/projects/{id}` — never the actual URL you requested)
+- Panics, keyed by source file and line in the Temps codebase
+
+Every key is a compile-time identifier of Temps's own code. The error messages themselves — which can contain your project names, paths, and IDs — are never transmitted.
+
+### Opting out
+
+Set `TEMPS_TELEMETRY=0` (also accepts `false`, `off`, `no`, `disabled`) in the server's environment and restart. This disables all telemetry, including error summaries. The instance ID file is still created so re-enabling later doesn't churn identity, but nothing is sent while opted out.
 
 ---
 


### PR DESCRIPTION
## Why

Self-hosted instances fail where we can't see them. The only failure signal in the 36-event telemetry set was `deploy_failed` — a migration failure, cert renewal loop, panicking background job, or 500-ing endpoint is invisible today. This adds the error-tracking foundation discussed for the telemetry revisit.

## What

One new event, `error_summary`, flushed every 6h **only when something went wrong**, aggregating counts from three capture choke points (no per-callsite instrumentation):

| Capture point | Where | Key |
|---|---|---|
| ERROR-level tracing events | `ErrorMetricsLayer` on the global subscriber (`temps-cli/src/lib.rs`) | tracing target (module path) |
| Console-API 5xx responses | middleware on `public_app`/`admin_app`/platform listeners (`console.rs`) | `METHOD /route/{template} STATUS` |
| Panics | chained panic hook (`console.rs`) | sanitized crate-relative `file:line` |

Aggregation lives in `temps_core::error_metrics`: bounded store (128 keys), overflow counted explicitly (no silent truncation), top-20 reported, drained by a task spawned only when telemetry is enabled.

## Privacy

- Every recorded key is a **compile-time identifier of our own code**. Error messages / panic payloads / concrete URLs are never recorded — this codebase's error messages deliberately embed IDs, names, and paths, so only static identifiers are safe.
- The 5xx middleware is on the **console listeners only** — proxied user-app traffic never touches it. Unmatched routes record the fixed label `unmatched`, not the raw path.
- Panic locations are sanitized to strip build-machine home directories (kept from `crates/`, or last 3 components for dependency paths).
- Existing `TEMPS_TELEMETRY` opt-out covers everything.
- The data-ownership docs page falsely claimed "the binary does not contain tracking code or telemetry" (stale since telemetry shipped). This PR makes it honest: full description of what's sent, including `error_summary`, and the opt-out.

## Load & memory bound (per CLAUDE.md hot-path rules)

Counting only happens on errors/5xx (not per-request); bounded map ⇒ constant memory; a melting-down instance costs at most 4 small POSTs/day — same as a healthy one.

## Testing

15 tests pass across the seams: `error_metrics` store (cap/overflow/drain/sort/sanitize/poison), tracing layer (counts ERROR only, ignores message), 5xx middleware (records template, never concrete path; `unmatched` fallback), event builder (shape, overflow omitted when zero). `cargo clippy -p temps-core -p temps-cli --all-targets -- -D warnings` clean.

## Deploy coordination

- `telemetry-dashboard`'s `KNOWN_EVENT_TYPES` needs `error_summary` added and redeployed **before** this ships, or events will be rejected (I've made the local edit; the dir isn't a git repo).
- Security-auditor sign-off still pending before merge (audit run was cancelled mid-session).