### PR TITLE
feat(telemetry-api): accept error_summary event

### DIFF
--- a/telemetry-api/src/routes/events.ts
+++ b/telemetry-api/src/routes/events.ts
@@ -62,6 +62,11 @@ export const KNOWN_EVENT_TYPES = new Set([
 
   // Status page
   "status_page_published",
+
+  // Instance health — periodic aggregated error counts (ERROR logs by
+  // target, console-API 5xx by route template, panics by source location).
+  // Counts keyed by compile-time identifiers only; never error messages.
+  "error_summary",
 ]);
 
 interface IngestBody {


### PR DESCRIPTION
Companion to #373: adds `error_summary` to `KNOWN_EVENT_TYPES` so the ingest accepts the new aggregated error event instead of rejecting it. Kept in lockstep with `TelemetryEventKind::as_str()` per the comment contract (now 37 events).

Deploying the ingest from this branch to the `telemetry-api` project alongside this PR.