### PR TITLE
feat(auth): let deployment tokens call the AI gateway (ai_gateway:execute)

### DIFF
--- a/crates/temps-ai-gateway/src/handlers/gateway.rs
+++ b/crates/temps-ai-gateway/src/handlers/gateway.rs
@@ -112,7 +112,7 @@ fn wrap_stream_with_usage_tracking(
         Box<dyn tokio_stream::Stream<Item = Result<Bytes, AiGatewayError>> + Send>,
     >,
     usage_service: Arc<UsageService>,
-    user_id: i32,
+    user_id: Option<i32>,
     provider: String,
     model: String,
     start: Instant,
@@ -165,7 +165,7 @@ fn wrap_stream_with_usage_tracking(
                 tokio::spawn(async move {
                     if let Err(e) = usage_service
                         .log_usage_with_context(
-                            Some(user_id),
+                            user_id,
                             &provider,
                             &model,
                             input,
@@ -404,7 +404,9 @@ async fn chat_completions(
     let start = Instant::now();
     let model = request.model.clone();
     let is_streaming = request.stream;
-    let user_id = auth.user_id();
+    // None for deployment tokens (machine callers) so usage rows store NULL
+    // instead of falsely attributing all deployed-app traffic to user id 0.
+    let user_id = auth.user_id_opt();
 
     if is_streaming {
         match app_state
@@ -418,7 +420,7 @@ async fn chat_completions(
 
                 info!(
                     model = model,
-                    user_id = user_id,
+                    user_id = ?user_id,
                     streaming = true,
                     credential_type = credential_type_str(cred_type),
                     "AI gateway streaming request started"
@@ -495,7 +497,7 @@ async fn chat_completions(
                     tokio::spawn(async move {
                         if let Err(e) = usage_service
                             .log_usage_with_context(
-                                Some(user_id),
+                                user_id,
                                 &provider_clone,
                                 &model_clone,
                                 input,
@@ -516,7 +518,7 @@ async fn chat_completions(
 
                 info!(
                     model = model,
-                    user_id = user_id,
+                    user_id = ?user_id,
                     latency_ms = latency.as_millis() as u64,
                     credential_type = credential_type_str(cred_type),
                     "AI gateway request completed"
@@ -627,10 +629,86 @@ async fn embeddings(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, AiGatewayExecute);
 
+    if request.model.is_empty() {
+        return Ok(error_to_response(AiGatewayError::Validation {
+            message: "model field is required".to_string(),
+        })
+        .into_response());
+    }
+
+    match &request.input {
+        EmbeddingInput::Single(s) if s.is_empty() => {
+            return Ok(error_to_response(AiGatewayError::Validation {
+                message: "input cannot be empty".to_string(),
+            })
+            .into_response());
+        }
+        EmbeddingInput::Multiple(items) if items.is_empty() => {
+            return Ok(error_to_response(AiGatewayError::Validation {
+                message: "input array cannot be empty".to_string(),
+            })
+            .into_response());
+        }
+        EmbeddingInput::Multiple(items) if items.len() > 2048 => {
+            return Ok(error_to_response(AiGatewayError::Validation {
+                message: format!("input array has {} items, maximum is 2048", items.len()),
+            })
+            .into_response());
+        }
+        _ => {}
+    }
+
     let byok = extract_byok(&headers);
+    let ai_context = extract_ai_context(&headers);
+    let start = Instant::now();
+    let user_id = auth.user_id_opt();
 
     match app_state.gateway_service.embeddings(&request, &byok).await {
         Ok((response, cred_type)) => {
+            let latency = start.elapsed();
+            let provider_id =
+                crate::providers::route_model_to_provider(&request.model).unwrap_or("unknown");
+
+            // Log usage asynchronously (don't block the response). Embeddings
+            // only consume prompt tokens; there is no completion output.
+            {
+                let usage_service = app_state.usage_service.clone();
+                let model = request.model.clone();
+                let provider = provider_id.to_string();
+                let input_tokens = response.usage.prompt_tokens;
+                let latency_ms = latency.as_millis() as i32;
+                let is_byok = cred_type == CredentialType::Byok;
+                let ctx = ai_context.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = usage_service
+                        .log_usage_with_context(
+                            user_id,
+                            &provider,
+                            &model,
+                            input_tokens,
+                            0,
+                            latency_ms,
+                            0,
+                            200,
+                            false,
+                            is_byok,
+                            &ctx,
+                        )
+                        .await
+                    {
+                        error!(error = %e, "Failed to log AI embedding usage");
+                    }
+                });
+            }
+
+            info!(
+                model = request.model,
+                user_id = ?user_id,
+                latency_ms = latency.as_millis() as u64,
+                credential_type = credential_type_str(cred_type),
+                "AI gateway embedding request completed"
+            );
+
             let resp = axum::response::Response::builder()
                 .status(StatusCode::OK)
                 .header("content-type", "application/json")

--- a/crates/temps-auth/src/context.rs
+++ b/crates/temps-auth/src/context.rs
@@ -186,6 +186,10 @@ impl AuthContext {
                 // is documented, project-scoped machine access, so map it to the
                 // matching deployment-token permission.
                 Permission::EmailsSend => DeploymentTokenPermission::EmailsSend,
+                // Deployed apps also use TEMPS_API_TOKEN to call the AI gateway
+                // (POST /ai/v1/chat/completions, guarded by AiGatewayExecute).
+                // Same documented machine-access pattern as EmailsSend.
+                Permission::AiGatewayExecute => DeploymentTokenPermission::AiGatewayExecute,
                 // No implicit bridge from deployment-token permissions to
                 // general control-plane permissions.
                 _ => return false,
@@ -402,6 +406,35 @@ mod tests {
     fn deployment_token_without_emails_send_is_denied_emails_send() {
         let ctx = deployment_token_ctx(7, vec![DeploymentTokenPermission::AnalyticsRead]);
         assert!(!ctx.has_permission(&Permission::EmailsSend));
+    }
+
+    #[test]
+    fn deployment_token_full_access_grants_ai_gateway_execute() {
+        // Deployed apps use their injected deployment token to call the AI
+        // gateway; the default auto-minted token carries FullAccess, so it
+        // must satisfy AiGatewayExecute — same contract as EmailsSend.
+        let ctx = deployment_token_ctx(7, vec![DeploymentTokenPermission::FullAccess]);
+        assert!(ctx.has_permission(&Permission::AiGatewayExecute));
+    }
+
+    #[test]
+    fn deployment_token_ai_gateway_permission_grants_only_ai_gateway() {
+        let ctx = deployment_token_ctx(7, vec![DeploymentTokenPermission::AiGatewayExecute]);
+        assert!(ctx.has_permission(&Permission::AiGatewayExecute));
+        // ...but a narrow ai_gateway:execute token must not gain other access.
+        assert!(!ctx.has_permission(&Permission::EmailsSend));
+        assert!(!ctx.has_permission(&Permission::AnalyticsRead));
+    }
+
+    #[test]
+    fn deployment_token_without_ai_gateway_is_denied_ai_gateway_execute() {
+        let ctx = deployment_token_ctx(7, vec![DeploymentTokenPermission::AnalyticsRead]);
+        assert!(!ctx.has_permission(&Permission::AiGatewayExecute));
+        // AI gateway read/write management APIs stay control-plane only,
+        // even for FullAccess tokens.
+        let full = deployment_token_ctx(7, vec![DeploymentTokenPermission::FullAccess]);
+        assert!(!full.has_permission(&Permission::AiGatewayRead));
+        assert!(!full.has_permission(&Permission::AiGatewayWrite));
     }
 
     #[test]

--- a/crates/temps-deployments/src/services/deployment_token_service.rs
+++ b/crates/temps-deployments/src/services/deployment_token_service.rs
@@ -1566,6 +1566,7 @@ mod tests {
             "analytics:read",
             "events:write",
             "errors:read",
+            "ai_gateway:execute",
             "*",
         ];
 

--- a/crates/temps-deployments/src/services/deployment_token_service.rs
+++ b/crates/temps-deployments/src/services/deployment_token_service.rs
@@ -1333,12 +1333,13 @@ mod tests {
     #[test]
     fn test_permission_all() {
         let all = DeploymentTokenPermission::all();
-        assert_eq!(all.len(), 6);
+        assert_eq!(all.len(), 7);
         assert!(all.contains(&DeploymentTokenPermission::VisitorsEnrich));
         assert!(all.contains(&DeploymentTokenPermission::EmailsSend));
         assert!(all.contains(&DeploymentTokenPermission::AnalyticsRead));
         assert!(all.contains(&DeploymentTokenPermission::EventsWrite));
         assert!(all.contains(&DeploymentTokenPermission::ErrorsRead));
+        assert!(all.contains(&DeploymentTokenPermission::AiGatewayExecute));
         assert!(all.contains(&DeploymentTokenPermission::FullAccess));
     }
 

--- a/crates/temps-entities/src/deployment_tokens.rs
+++ b/crates/temps-entities/src/deployment_tokens.rs
@@ -134,6 +134,8 @@ pub enum DeploymentTokenPermission {
     EventsWrite,
     /// Read error tracking data
     ErrorsRead,
+    /// Execute AI gateway requests (chat completions, embeddings)
+    AiGatewayExecute,
     /// Full access (all permissions)
     FullAccess,
 }
@@ -147,6 +149,7 @@ impl DeploymentTokenPermission {
             DeploymentTokenPermission::AnalyticsRead => "analytics:read",
             DeploymentTokenPermission::EventsWrite => "events:write",
             DeploymentTokenPermission::ErrorsRead => "errors:read",
+            DeploymentTokenPermission::AiGatewayExecute => "ai_gateway:execute",
             DeploymentTokenPermission::FullAccess => "*",
         }
     }
@@ -160,6 +163,7 @@ impl DeploymentTokenPermission {
             "analytics:read" => Some(DeploymentTokenPermission::AnalyticsRead),
             "events:write" => Some(DeploymentTokenPermission::EventsWrite),
             "errors:read" => Some(DeploymentTokenPermission::ErrorsRead),
+            "ai_gateway:execute" => Some(DeploymentTokenPermission::AiGatewayExecute),
             "*" | "full_access" => Some(DeploymentTokenPermission::FullAccess),
             _ => None,
         }
@@ -173,6 +177,7 @@ impl DeploymentTokenPermission {
             DeploymentTokenPermission::AnalyticsRead,
             DeploymentTokenPermission::EventsWrite,
             DeploymentTokenPermission::ErrorsRead,
+            DeploymentTokenPermission::AiGatewayExecute,
             DeploymentTokenPermission::FullAccess,
         ]
     }


### PR DESCRIPTION
## Problem

PR #165 constrained deployment tokens to an explicit permission allowlist. That correctly killed the `FullAccess`-grants-everything wildcard, but it also broke deployed apps calling the AI gateway with their injected `TEMPS_API_TOKEN`:

```json
{"title":"Insufficient Permissions","required_permission":"ai_gateway:execute","user_role":"custom"}
```

AI gateway access must work by default for deployed apps, same as `emails:send` (the precedent fixed in 83fe6ed5).

## Change

- New `DeploymentTokenPermission::AiGatewayExecute` (`"ai_gateway:execute"`) in `temps-entities`.
- Bridge `Permission::AiGatewayExecute` → `DeploymentTokenPermission::AiGatewayExecute` in `AuthContext::has_permission`, mirroring the EmailsSend mapping. The auto-minted `["*"]` token satisfies it via `grants()`, so **existing deployed apps work immediately — no re-mint or redeploy**. A narrow token can opt in with just `ai_gateway:execute`.
- Management APIs (`ai_gateway:read`/`ai_gateway:write` — provider keys, usage analytics, model listing) remain control-plane only, verified by tests.

## Security audit (security-auditor: APPROVE-WITH-CONDITIONS, conditions resolved here)

- **Fixed**: embeddings handler logged no usage at all — now logs prompt tokens to `ai_usage_logs` like the chat path, and validates model/input (empty model, empty input, max 2048 array items).
- **Fixed**: usage rows attributed machine calls to `user_id = 0` — chat + embeddings now use `auth.user_id_opt()` so deployment-token traffic stores `NULL`.
- **Tracked, accepted launch risk**: no per-project rate limit / spend cap on the gateway (matches EmailsSend precedent) → #376.

## Tests

- `temps-auth`: FullAccess grants execute; narrow `ai_gateway:execute` token gets nothing else; read/write denied even for FullAccess (36 pass).
- `temps-entities` (45 pass), `temps-ai-gateway` (164 pass), `temps-deployments` permission-string coverage.

Expected load: unchanged hot-path behavior — the permission check is an in-memory match; usage logging is spawned async off the request path.