### PR TITLE
fix(observability): read active Timescale policies

### DIFF
--- a/crates/temps-config/src/handler.rs
+++ b/crates/temps-config/src/handler.rs
@@ -16,7 +16,7 @@ use temps_core::error_builder::ErrorBuilder;
 use temps_core::{
     problemdetails::Problem, AiConfigSettings, AppSettings, AuditContext, AuditLogger,
     AuditOperation, BuildLimitsSettings, ClusterDnsSettings, ContainerLogSettings,
-    DiskSpaceAlertSettings, LetsEncryptSettings, MetricsStoreKind,
+    DiskSpaceAlertSettings, LetsEncryptSettings, MetricsStoreKind, MonitoringSettings,
     ObservabilityCompressionSettings, ObservabilityRetentionSettings, PublicHostnameStrategy,
     RateLimitSettings, RequestMetadata, ScreenshotSettings, SecurityHeadersSettings,
 };
@@ -130,7 +130,7 @@ pub struct AppSettingsResponse {
 
     /// Number of enabled, running services the MetricsScraper currently
     /// includes. Used for the lightweight storage estimate in the UI.
-    pub monitored_services_count: u64,
+    pub monitored_services_count: Option<u64>,
 
     /// TimescaleDB compression delays for immutable proxy logs and OTel spans.
     pub observability_compression: ObservabilityCompressionSettings,
@@ -147,10 +147,10 @@ pub struct AppSettingsResponse {
     /// effective backend and warns when it diverges from the configured store.
     pub effective_metrics_store: MetricsStoreKind,
 
-    /// Storage backend actually used for proxy logs and OTel spans. Unlike
-    /// metrics, these domains switch to ClickHouse whenever the server-level
-    /// ClickHouse connection is configured; they do not use the monitoring
-    /// store toggle.
+    /// Storage backend actually used for proxy logs, OTel spans, and OTel
+    /// metrics. OTel logs remain TimescaleDB-backed. Unlike resource metrics,
+    /// these domains switch to ClickHouse whenever the server-level ClickHouse
+    /// connection is configured; they do not use the monitoring store toggle.
     pub effective_observability_store: MetricsStoreKind,
 
     // Outbound TLS verification toggle
@@ -370,7 +370,7 @@ impl From<AppSettings> for AppSettingsResponse {
             effective_metrics_store: settings.monitoring.store.clone(),
             effective_observability_store: MetricsStoreKind::TimescaleDb,
             monitoring: MonitoringSettingsMasked::from(settings.monitoring),
-            monitored_services_count: 0,
+            monitored_services_count: None,
             observability_compression: settings.observability_compression,
             observability_retention: settings.observability_retention,
             insecure_tls: settings.insecure_tls,
@@ -407,7 +407,7 @@ impl AppSettingsResponse {
     fn with_effective_timescale_state(
         mut self,
         policies: EffectiveTelemetryPolicies,
-        monitored_services_count: u64,
+        monitored_services_count: Option<u64>,
     ) -> Self {
         self.monitored_services_count = monitored_services_count;
 
@@ -441,8 +441,10 @@ impl AppSettingsResponse {
         if let Some(days) = policies.otel_logs_retention_days {
             self.observability_retention.otel_logs_days = days;
         }
-        if let Some(days) = policies.otel_metrics_retention_days {
-            self.observability_retention.otel_metrics_days = days;
+        if self.effective_observability_store == MetricsStoreKind::TimescaleDb {
+            if let Some(days) = policies.otel_metrics_retention_days {
+                self.observability_retention.otel_metrics_days = days;
+            }
         }
 
         self
@@ -851,13 +853,14 @@ async fn get_settings(
                 );
                 EffectiveTelemetryPolicies::default()
             });
-            let monitored_services_count = monitored_services_result.unwrap_or_else(|error| {
-                tracing::warn!(
-                    %error,
-                    "Failed to count monitored services; storage estimate will use zero services"
-                );
-                0
-            });
+            let monitored_services_count = monitored_services_result
+                .inspect_err(|error| {
+                    tracing::warn!(
+                        %error,
+                        "Failed to count monitored services; storage estimate is unavailable"
+                    );
+                })
+                .ok();
             let response = AppSettingsResponse::from(settings)
                 .with_effective_store(app_state.config_service.is_clickhouse_enabled())
                 .with_effective_timescale_state(policies, monitored_services_count);
@@ -981,6 +984,45 @@ fn validate_observability_compression(
         return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
             .detail("observability_compression.otel_spans_after_hours must be between 1 and 2160")
             .build());
+    }
+    Ok(())
+}
+
+fn validate_monitoring_settings(monitoring: &MonitoringSettings) -> Result<(), Problem> {
+    if monitoring.scrape_interval_secs < 15 {
+        return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
+            .detail("monitoring.scrape_interval_secs must be >= 15")
+            .build());
+    }
+    if !(1..=30).contains(&monitoring.retention_raw_days) {
+        return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
+            .detail("monitoring.retention_raw_days must be between 1 and 30")
+            .build());
+    }
+    if !(7..=365).contains(&monitoring.retention_hourly_days) {
+        return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
+            .detail("monitoring.retention_hourly_days must be between 7 and 365")
+            .build());
+    }
+    if !(1..=10).contains(&monitoring.retention_daily_years) {
+        return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
+            .detail("monitoring.retention_daily_years must be between 1 and 10")
+            .build());
+    }
+    if monitoring.store == MetricsStoreKind::ClickHouse {
+        match &monitoring.clickhouse_url {
+            None => {
+                return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
+                    .detail("monitoring.clickhouse_url is required when store is ClickHouse")
+                    .build());
+            }
+            Some(url) if url::Url::parse(url).is_err() => {
+                return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
+                    .detail("monitoring.clickhouse_url is not a valid URL")
+                    .build());
+            }
+            _ => {}
+        }
     }
     Ok(())
 }
@@ -1161,40 +1203,7 @@ async fn update_settings(
         }
     }
 
-    // Validate monitoring settings fields.
-    {
-        let m = &settings.monitoring;
-        if m.scrape_interval_secs < 15 {
-            return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
-                .detail("monitoring.scrape_interval_secs must be >= 15")
-                .build());
-        }
-        if m.retention_raw_days < 1 || m.retention_raw_days > 30 {
-            return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
-                .detail("monitoring.retention_raw_days must be between 1 and 30")
-                .build());
-        }
-        if m.retention_hourly_days < 7 || m.retention_hourly_days > 365 {
-            return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
-                .detail("monitoring.retention_hourly_days must be between 7 and 365")
-                .build());
-        }
-        if m.store == MetricsStoreKind::ClickHouse {
-            match &m.clickhouse_url {
-                None => {
-                    return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
-                        .detail("monitoring.clickhouse_url is required when store is ClickHouse")
-                        .build());
-                }
-                Some(url) if url::Url::parse(url).is_err() => {
-                    return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
-                        .detail("monitoring.clickhouse_url is not a valid URL")
-                        .build());
-                }
-                _ => {}
-            }
-        }
-    }
+    validate_monitoring_settings(&settings.monitoring)?;
 
     validate_observability_compression(&settings.observability_compression)?;
     validate_observability_retention(&settings.observability_retention)?;
@@ -1657,6 +1666,33 @@ mod tests {
         );
     }
 
+    #[test]
+    fn monitoring_validation_accepts_daily_retention_boundaries() {
+        for years in [1, 10] {
+            let monitoring = MonitoringSettings {
+                retention_daily_years: years,
+                ..Default::default()
+            };
+            assert!(validate_monitoring_settings(&monitoring).is_ok());
+        }
+    }
+
+    #[test]
+    fn monitoring_validation_rejects_daily_retention_outside_supported_range() {
+        for years in [0, 11] {
+            let monitoring = MonitoringSettings {
+                retention_daily_years: years,
+                ..Default::default()
+            };
+            let error = validate_monitoring_settings(&monitoring)
+                .expect_err("daily retention outside 1–10 years must be rejected");
+            assert_eq!(
+                error.body.get("detail").and_then(|value| value.as_str()),
+                Some("monitoring.retention_daily_years must be between 1 and 10")
+            );
+        }
+    }
+
     // Regression: the GET /api/settings response must surface agent_sandbox,
     // ai_config, preview_gateway, multi_node, and insecure_tls so the UI can
     // render (and round-trip) resource/runtime/network settings. An earlier
@@ -1816,9 +1852,9 @@ mod tests {
 
         let response = AppSettingsResponse::from(AppSettings::default())
             .with_effective_store(false)
-            .with_effective_timescale_state(policies, 7);
+            .with_effective_timescale_state(policies, Some(7));
 
-        assert_eq!(response.monitored_services_count, 7);
+        assert_eq!(response.monitored_services_count, Some(7));
         assert_eq!(response.monitoring.retention_raw_days, 14);
         assert_eq!(response.monitoring.retention_hourly_days, 120);
         assert_eq!(response.monitoring.retention_daily_years, 3);
@@ -1844,6 +1880,7 @@ mod tests {
         let configured_compression = settings.observability_compression.clone();
         let configured_proxy_retention = settings.observability_retention.proxy_logs_days;
         let configured_span_retention = settings.observability_retention.otel_spans_days;
+        let configured_metric_retention = settings.observability_retention.otel_metrics_days;
 
         let response = AppSettingsResponse::from(settings)
             .with_effective_store(true)
@@ -1858,7 +1895,7 @@ mod tests {
                     otel_metrics_retention_days: Some(60),
                     ..Default::default()
                 },
-                3,
+                Some(3),
             );
 
         assert_eq!(
@@ -1883,8 +1920,11 @@ mod tests {
             configured_span_retention
         );
         assert_eq!(response.observability_retention.otel_logs_days, 45);
-        assert_eq!(response.observability_retention.otel_metrics_days, 60);
-        assert_eq!(response.monitored_services_count, 3);
+        assert_eq!(
+            response.observability_retention.otel_metrics_days,
+            configured_metric_retention
+        );
+        assert_eq!(response.monitored_services_count, Some(3));
     }
 
     // The effective metrics store reconciles the `store` toggle with the

--- a/crates/temps-config/src/handler.rs
+++ b/crates/temps-config/src/handler.rs
@@ -1,5 +1,5 @@
 use crate::disk_status::DiskSpaceCheckResult;
-use crate::ConfigService;
+use crate::{ConfigService, EffectiveTelemetryPolicies};
 use axum::{
     extract::{Extension, State},
     http::StatusCode,
@@ -127,6 +127,10 @@ pub struct AppSettingsResponse {
 
     // Metrics monitoring settings (clickhouse_url masked)
     pub monitoring: MonitoringSettingsMasked,
+
+    /// Number of enabled, running services the MetricsScraper currently
+    /// includes. Used for the lightweight storage estimate in the UI.
+    pub monitored_services_count: u64,
 
     /// TimescaleDB compression delays for immutable proxy logs and OTel spans.
     pub observability_compression: ObservabilityCompressionSettings,
@@ -366,6 +370,7 @@ impl From<AppSettings> for AppSettingsResponse {
             effective_metrics_store: settings.monitoring.store.clone(),
             effective_observability_store: MetricsStoreKind::TimescaleDb,
             monitoring: MonitoringSettingsMasked::from(settings.monitoring),
+            monitored_services_count: 0,
             observability_compression: settings.observability_compression,
             observability_retention: settings.observability_retention,
             insecure_tls: settings.insecure_tls,
@@ -396,6 +401,50 @@ impl AppSettingsResponse {
         } else {
             MetricsStoreKind::TimescaleDb
         };
+        self
+    }
+
+    fn with_effective_timescale_state(
+        mut self,
+        policies: EffectiveTelemetryPolicies,
+        monitored_services_count: u64,
+    ) -> Self {
+        self.monitored_services_count = monitored_services_count;
+
+        if self.effective_metrics_store == MetricsStoreKind::TimescaleDb {
+            if let Some(days) = policies.metrics_raw_days {
+                self.monitoring.retention_raw_days = days;
+            }
+            if let Some(days) = policies.metrics_hourly_days {
+                self.monitoring.retention_hourly_days = days;
+            }
+            if let Some(years) = policies.metrics_daily_years {
+                self.monitoring.retention_daily_years = years;
+            }
+        }
+
+        if self.effective_observability_store == MetricsStoreKind::TimescaleDb {
+            if let Some(hours) = policies.proxy_logs_compression_hours {
+                self.observability_compression.proxy_logs_after_hours = hours;
+            }
+            if let Some(hours) = policies.otel_spans_compression_hours {
+                self.observability_compression.otel_spans_after_hours = hours;
+            }
+            if let Some(days) = policies.proxy_logs_retention_days {
+                self.observability_retention.proxy_logs_days = days;
+            }
+            if let Some(days) = policies.otel_spans_retention_days {
+                self.observability_retention.otel_spans_days = days;
+            }
+        }
+
+        if let Some(days) = policies.otel_logs_retention_days {
+            self.observability_retention.otel_logs_days = days;
+        }
+        if let Some(days) = policies.otel_metrics_retention_days {
+            self.observability_retention.otel_metrics_days = days;
+        }
+
         self
     }
 }
@@ -783,14 +832,35 @@ async fn get_settings(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, SettingsRead);
 
-    match app_state.config_service.get_settings().await {
+    let (settings_result, policies_result, monitored_services_result) = tokio::join!(
+        app_state.config_service.get_settings(),
+        app_state.config_service.get_effective_telemetry_policies(),
+        app_state.config_service.count_monitored_services(),
+    );
+
+    match settings_result {
         Ok(settings) => {
             // Convert to response type that masks sensitive fields, then
             // reconcile the effective metrics store with the server's
             // ClickHouse env-var configuration so the UI shows the backend the
             // runtime actually uses (not just the DB toggle).
+            let policies = policies_result.unwrap_or_else(|error| {
+                tracing::warn!(
+                    %error,
+                    "Failed to read effective TimescaleDB policies; using configured values"
+                );
+                EffectiveTelemetryPolicies::default()
+            });
+            let monitored_services_count = monitored_services_result.unwrap_or_else(|error| {
+                tracing::warn!(
+                    %error,
+                    "Failed to count monitored services; storage estimate will use zero services"
+                );
+                0
+            });
             let response = AppSettingsResponse::from(settings)
-                .with_effective_store(app_state.config_service.is_clickhouse_enabled());
+                .with_effective_store(app_state.config_service.is_clickhouse_enabled())
+                .with_effective_timescale_state(policies, monitored_services_count);
             Ok(Json(response))
         }
         Err(e) => {
@@ -1728,6 +1798,93 @@ mod tests {
         assert_eq!(response.observability_retention.otel_spans_days, 60);
         assert_eq!(response.observability_retention.otel_logs_days, 90);
         assert_eq!(response.observability_retention.otel_metrics_days, 90);
+    }
+
+    #[test]
+    fn response_uses_active_timescale_policies_and_service_count() {
+        let policies = EffectiveTelemetryPolicies {
+            metrics_raw_days: Some(14),
+            metrics_hourly_days: Some(120),
+            metrics_daily_years: Some(3),
+            proxy_logs_compression_hours: Some(12),
+            otel_spans_compression_hours: Some(18),
+            proxy_logs_retention_days: Some(21),
+            otel_spans_retention_days: Some(75),
+            otel_logs_retention_days: Some(45),
+            otel_metrics_retention_days: Some(60),
+        };
+
+        let response = AppSettingsResponse::from(AppSettings::default())
+            .with_effective_store(false)
+            .with_effective_timescale_state(policies, 7);
+
+        assert_eq!(response.monitored_services_count, 7);
+        assert_eq!(response.monitoring.retention_raw_days, 14);
+        assert_eq!(response.monitoring.retention_hourly_days, 120);
+        assert_eq!(response.monitoring.retention_daily_years, 3);
+        assert_eq!(
+            response.observability_compression.proxy_logs_after_hours,
+            12
+        );
+        assert_eq!(
+            response.observability_compression.otel_spans_after_hours,
+            18
+        );
+        assert_eq!(response.observability_retention.proxy_logs_days, 21);
+        assert_eq!(response.observability_retention.otel_spans_days, 75);
+        assert_eq!(response.observability_retention.otel_logs_days, 45);
+        assert_eq!(response.observability_retention.otel_metrics_days, 60);
+    }
+
+    #[test]
+    fn response_does_not_overlay_clickhouse_backed_values() {
+        let mut settings = AppSettings::default();
+        settings.monitoring.store = MetricsStoreKind::ClickHouse;
+        let configured_monitoring = settings.monitoring.clone();
+        let configured_compression = settings.observability_compression.clone();
+        let configured_proxy_retention = settings.observability_retention.proxy_logs_days;
+        let configured_span_retention = settings.observability_retention.otel_spans_days;
+
+        let response = AppSettingsResponse::from(settings)
+            .with_effective_store(true)
+            .with_effective_timescale_state(
+                EffectiveTelemetryPolicies {
+                    metrics_raw_days: Some(1),
+                    proxy_logs_compression_hours: Some(1),
+                    otel_spans_compression_hours: Some(1),
+                    proxy_logs_retention_days: Some(1),
+                    otel_spans_retention_days: Some(1),
+                    otel_logs_retention_days: Some(45),
+                    otel_metrics_retention_days: Some(60),
+                    ..Default::default()
+                },
+                3,
+            );
+
+        assert_eq!(
+            response.monitoring.retention_raw_days,
+            configured_monitoring.retention_raw_days
+        );
+        assert_eq!(
+            response.monitoring.retention_hourly_days,
+            configured_monitoring.retention_hourly_days
+        );
+        assert_eq!(
+            response.monitoring.retention_daily_years,
+            configured_monitoring.retention_daily_years
+        );
+        assert_eq!(response.observability_compression, configured_compression);
+        assert_eq!(
+            response.observability_retention.proxy_logs_days,
+            configured_proxy_retention
+        );
+        assert_eq!(
+            response.observability_retention.otel_spans_days,
+            configured_span_retention
+        );
+        assert_eq!(response.observability_retention.otel_logs_days, 45);
+        assert_eq!(response.observability_retention.otel_metrics_days, 60);
+        assert_eq!(response.monitored_services_count, 3);
     }
 
     // The effective metrics store reconciles the `store` toggle with the

--- a/crates/temps-config/src/lib.rs
+++ b/crates/temps-config/src/lib.rs
@@ -11,4 +11,4 @@ pub use disk_status::{
 pub use enrollment_tokens::{EnrollmentError, EnrollmentTokenService, MintParams};
 pub use handler::{configure_routes, SettingsApiDoc, SettingsState};
 pub use plugin::ConfigPlugin;
-pub use service::{ConfigService, ConfigServiceError, ServerConfig};
+pub use service::{ConfigService, ConfigServiceError, EffectiveTelemetryPolicies, ServerConfig};

--- a/crates/temps-config/src/service.rs
+++ b/crates/temps-config/src/service.rs
@@ -1,12 +1,13 @@
 use chrono::Utc;
 use sea_orm::{
-    ActiveModelTrait, ConnectionTrait, DatabaseBackend, EntityTrait, Set, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseBackend, EntityTrait, FromQueryResult,
+    PaginatorTrait, QueryFilter, Set, Statement, TransactionTrait,
 };
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 use temps_database::DbConnection;
-use temps_entities::settings;
+use temps_entities::{external_services, settings};
 use thiserror::Error;
 use tokio::{
     fs as tokio_fs,
@@ -60,6 +61,78 @@ pub enum ConfigServiceError {
         #[source]
         source: sea_orm::DbErr,
     },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EffectiveTelemetryPolicies {
+    pub metrics_raw_days: Option<u32>,
+    pub metrics_hourly_days: Option<u32>,
+    pub metrics_daily_years: Option<u32>,
+    pub proxy_logs_compression_hours: Option<u32>,
+    pub otel_spans_compression_hours: Option<u32>,
+    pub proxy_logs_retention_days: Option<u32>,
+    pub otel_spans_retention_days: Option<u32>,
+    pub otel_logs_retention_days: Option<u32>,
+    pub otel_metrics_retention_days: Option<u32>,
+}
+
+#[derive(Debug, FromQueryResult)]
+struct TimescalePolicyRow {
+    hypertable_name: String,
+    proc_name: String,
+    interval_seconds: i64,
+}
+
+const SECONDS_PER_HOUR: i64 = 60 * 60;
+const SECONDS_PER_DAY: i64 = 24 * SECONDS_PER_HOUR;
+
+fn rounded_u32(value: i64, divisor: i64) -> Option<u32> {
+    if value <= 0 {
+        return None;
+    }
+    u32::try_from((value + divisor / 2) / divisor).ok()
+}
+
+fn policies_from_rows(rows: Vec<TimescalePolicyRow>) -> EffectiveTelemetryPolicies {
+    let mut policies = EffectiveTelemetryPolicies::default();
+
+    for row in rows {
+        let value = match row.proc_name.as_str() {
+            "policy_compression" => rounded_u32(row.interval_seconds, SECONDS_PER_HOUR),
+            "policy_retention" => rounded_u32(row.interval_seconds, SECONDS_PER_DAY),
+            _ => None,
+        };
+        let Some(value) = value else {
+            continue;
+        };
+
+        match (row.hypertable_name.as_str(), row.proc_name.as_str()) {
+            ("service_metrics", "policy_retention") => policies.metrics_raw_days = Some(value),
+            ("service_metrics_hourly", "policy_retention") => {
+                policies.metrics_hourly_days = Some(value)
+            }
+            ("service_metrics_daily", "policy_retention") => {
+                policies.metrics_daily_years = rounded_u32(value.into(), 365)
+            }
+            ("proxy_logs", "policy_compression") => {
+                policies.proxy_logs_compression_hours = Some(value)
+            }
+            ("otel_spans", "policy_compression") => {
+                policies.otel_spans_compression_hours = Some(value)
+            }
+            ("proxy_logs", "policy_retention") => policies.proxy_logs_retention_days = Some(value),
+            ("otel_spans", "policy_retention") => policies.otel_spans_retention_days = Some(value),
+            ("otel_log_events", "policy_retention") => {
+                policies.otel_logs_retention_days = Some(value)
+            }
+            ("otel_metrics", "policy_retention") => {
+                policies.otel_metrics_retention_days = Some(value)
+            }
+            _ => {}
+        }
+    }
+
+    policies
 }
 
 fn compression_policy_sql(table: &'static str, after_hours: u32) -> String {
@@ -541,6 +614,62 @@ impl ConfigService {
         matches!(self.get_database_backend(), DatabaseBackend::Postgres)
     }
 
+    /// Read the active TimescaleDB retention/compression durations in one
+    /// metadata query. This view contains one row per background policy, so
+    /// the query does not scan telemetry data or hypertable chunks.
+    pub async fn get_effective_telemetry_policies(
+        &self,
+    ) -> Result<EffectiveTelemetryPolicies, ConfigServiceError> {
+        if !self.is_postgres() {
+            return Ok(EffectiveTelemetryPolicies::default());
+        }
+
+        let rows = TimescalePolicyRow::find_by_statement(Statement::from_string(
+            DatabaseBackend::Postgres,
+            r#"
+SELECT
+    hypertable_name,
+    proc_name,
+    EXTRACT(
+        EPOCH FROM (
+            CASE proc_name
+                WHEN 'policy_compression' THEN config ->> 'compress_after'
+                WHEN 'policy_retention' THEN config ->> 'drop_after'
+            END
+        )::interval
+    )::BIGINT AS interval_seconds
+FROM timescaledb_information.jobs
+WHERE proc_name IN ('policy_compression', 'policy_retention')
+  AND hypertable_name IN (
+      'service_metrics',
+      'service_metrics_hourly',
+      'service_metrics_daily',
+      'proxy_logs',
+      'otel_spans',
+      'otel_log_events',
+      'otel_metrics'
+  )
+"#
+            .to_owned(),
+        ))
+        .all(self.db.as_ref())
+        .await?;
+
+        Ok(policies_from_rows(rows))
+    }
+
+    /// Count exactly the services the MetricsScraper will include in its next
+    /// cycle. This is a COUNT over the control-plane service table, not a scan
+    /// of metric samples.
+    pub async fn count_monitored_services(&self) -> Result<u64, ConfigServiceError> {
+        external_services::Entity::find()
+            .filter(external_services::Column::MetricsEnabled.eq(true))
+            .filter(external_services::Column::Status.eq("running"))
+            .count(self.db.as_ref())
+            .await
+            .map_err(ConfigServiceError::from)
+    }
+
     /// Check if using MySQL/MariaDB database
     pub fn is_mysql(&self) -> bool {
         matches!(self.get_database_backend(), DatabaseBackend::MySql)
@@ -693,6 +822,23 @@ impl ConfigService {
     pub async fn update_settings(&self, settings: AppSettings) -> Result<(), ConfigServiceError> {
         let now = Utc::now();
 
+        // The settings row can drift from the actual TimescaleDB jobs (for
+        // example after a manual policy change). Prefer the live, tiny policy
+        // snapshot when deciding what must be replaced. If metadata is
+        // temporarily unavailable, retain the previous settings comparison so
+        // unrelated settings can still be saved.
+        let effective_policies = if self.is_postgres() {
+            match self.get_effective_telemetry_policies().await {
+                Ok(policies) => Some(policies),
+                Err(error) => {
+                    warn!(%error, "Failed to read active TimescaleDB policies before settings update");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         // Persist the settings and replace changed TimescaleDB policies in one
         // transaction. A policy error therefore cannot leave the API reporting
         // a delay that the database did not actually apply (or vice versa).
@@ -709,14 +855,67 @@ impl ConfigService {
             .as_ref()
             .map(|model| AppSettings::from_json(model.data.clone()).observability_retention)
             .unwrap_or_default();
+        let previous_monitoring = existing
+            .as_ref()
+            .map(|model| AppSettings::from_json(model.data.clone()).monitoring)
+            .unwrap_or_default();
 
         if self.db.get_database_backend() == DatabaseBackend::Postgres {
+            let monitoring = &settings.monitoring;
+            let metric_policies = [
+                (
+                    "service_metrics",
+                    monitoring.retention_raw_days,
+                    effective_policies
+                        .as_ref()
+                        .map(|policies| policies.metrics_raw_days)
+                        .unwrap_or(Some(previous_monitoring.retention_raw_days)),
+                ),
+                (
+                    "service_metrics_hourly",
+                    monitoring.retention_hourly_days,
+                    effective_policies
+                        .as_ref()
+                        .map(|policies| policies.metrics_hourly_days)
+                        .unwrap_or(Some(previous_monitoring.retention_hourly_days)),
+                ),
+                (
+                    "service_metrics_daily",
+                    monitoring.retention_daily_years.saturating_mul(365),
+                    effective_policies
+                        .as_ref()
+                        .map(|policies| {
+                            policies
+                                .metrics_daily_years
+                                .map(|years| years.saturating_mul(365))
+                        })
+                        .unwrap_or(Some(
+                            previous_monitoring
+                                .retention_daily_years
+                                .saturating_mul(365),
+                        )),
+                ),
+            ];
+            for (table, after_days, previous_days) in metric_policies {
+                if Some(after_days) != previous_days {
+                    replace_retention_policy(&txn, table, after_days).await?;
+                }
+            }
+
             let compression = &settings.observability_compression;
-            if compression.proxy_logs_after_hours != previous_compression.proxy_logs_after_hours {
+            let proxy_logs_compression_hours = effective_policies
+                .as_ref()
+                .map(|policies| policies.proxy_logs_compression_hours)
+                .unwrap_or(Some(previous_compression.proxy_logs_after_hours));
+            if Some(compression.proxy_logs_after_hours) != proxy_logs_compression_hours {
                 replace_compression_policy(&txn, "proxy_logs", compression.proxy_logs_after_hours)
                     .await?;
             }
-            if compression.otel_spans_after_hours != previous_compression.otel_spans_after_hours {
+            let otel_spans_compression_hours = effective_policies
+                .as_ref()
+                .map(|policies| policies.otel_spans_compression_hours)
+                .unwrap_or(Some(previous_compression.otel_spans_after_hours));
+            if Some(compression.otel_spans_after_hours) != otel_spans_compression_hours {
                 replace_compression_policy(&txn, "otel_spans", compression.otel_spans_after_hours)
                     .await?;
             }
@@ -726,26 +925,38 @@ impl ConfigService {
                 (
                     "proxy_logs",
                     retention.proxy_logs_days,
-                    previous_retention.proxy_logs_days,
+                    effective_policies
+                        .as_ref()
+                        .map(|policies| policies.proxy_logs_retention_days)
+                        .unwrap_or(Some(previous_retention.proxy_logs_days)),
                 ),
                 (
                     "otel_spans",
                     retention.otel_spans_days,
-                    previous_retention.otel_spans_days,
+                    effective_policies
+                        .as_ref()
+                        .map(|policies| policies.otel_spans_retention_days)
+                        .unwrap_or(Some(previous_retention.otel_spans_days)),
                 ),
                 (
                     "otel_log_events",
                     retention.otel_logs_days,
-                    previous_retention.otel_logs_days,
+                    effective_policies
+                        .as_ref()
+                        .map(|policies| policies.otel_logs_retention_days)
+                        .unwrap_or(Some(previous_retention.otel_logs_days)),
                 ),
                 (
                     "otel_metrics",
                     retention.otel_metrics_days,
-                    previous_retention.otel_metrics_days,
+                    effective_policies
+                        .as_ref()
+                        .map(|policies| policies.otel_metrics_retention_days)
+                        .unwrap_or(Some(previous_retention.otel_metrics_days)),
                 ),
             ];
             for (table, after_days, previous_days) in policies {
-                if after_days != previous_days {
+                if Some(after_days) != previous_days {
                     replace_retention_policy(&txn, table, after_days).await?;
                 }
             }
@@ -1124,6 +1335,93 @@ mod tests {
         assert!(sql.contains("if_not_exists => TRUE"));
     }
 
+    #[test]
+    fn timescale_policy_rows_map_to_ui_units() {
+        let rows = vec![
+            TimescalePolicyRow {
+                hypertable_name: "service_metrics".into(),
+                proc_name: "policy_retention".into(),
+                interval_seconds: 14 * SECONDS_PER_DAY,
+            },
+            TimescalePolicyRow {
+                hypertable_name: "service_metrics_hourly".into(),
+                proc_name: "policy_retention".into(),
+                interval_seconds: 90 * SECONDS_PER_DAY,
+            },
+            TimescalePolicyRow {
+                hypertable_name: "service_metrics_daily".into(),
+                proc_name: "policy_retention".into(),
+                interval_seconds: 730 * SECONDS_PER_DAY,
+            },
+            TimescalePolicyRow {
+                hypertable_name: "proxy_logs".into(),
+                proc_name: "policy_compression".into(),
+                interval_seconds: 24 * SECONDS_PER_HOUR,
+            },
+            TimescalePolicyRow {
+                hypertable_name: "otel_spans".into(),
+                proc_name: "policy_compression".into(),
+                interval_seconds: 12 * SECONDS_PER_HOUR,
+            },
+            TimescalePolicyRow {
+                hypertable_name: "proxy_logs".into(),
+                proc_name: "policy_retention".into(),
+                interval_seconds: 30 * SECONDS_PER_DAY,
+            },
+            TimescalePolicyRow {
+                hypertable_name: "otel_spans".into(),
+                proc_name: "policy_retention".into(),
+                interval_seconds: 60 * SECONDS_PER_DAY,
+            },
+            TimescalePolicyRow {
+                hypertable_name: "otel_log_events".into(),
+                proc_name: "policy_retention".into(),
+                interval_seconds: 45 * SECONDS_PER_DAY,
+            },
+            TimescalePolicyRow {
+                hypertable_name: "otel_metrics".into(),
+                proc_name: "policy_retention".into(),
+                interval_seconds: 90 * SECONDS_PER_DAY,
+            },
+        ];
+
+        assert_eq!(
+            policies_from_rows(rows),
+            EffectiveTelemetryPolicies {
+                metrics_raw_days: Some(14),
+                metrics_hourly_days: Some(90),
+                metrics_daily_years: Some(2),
+                proxy_logs_compression_hours: Some(24),
+                otel_spans_compression_hours: Some(12),
+                proxy_logs_retention_days: Some(30),
+                otel_spans_retention_days: Some(60),
+                otel_logs_retention_days: Some(45),
+                otel_metrics_retention_days: Some(90),
+            }
+        );
+    }
+
+    #[test]
+    fn timescale_policy_rows_ignore_unknown_or_non_positive_intervals() {
+        let rows = vec![
+            TimescalePolicyRow {
+                hypertable_name: "proxy_logs".into(),
+                proc_name: "policy_compression".into(),
+                interval_seconds: 0,
+            },
+            TimescalePolicyRow {
+                hypertable_name: "unknown_table".into(),
+                proc_name: "policy_retention".into(),
+                interval_seconds: 30 * SECONDS_PER_DAY,
+            },
+        ];
+
+        assert_eq!(
+            policies_from_rows(rows),
+            EffectiveTelemetryPolicies::default()
+        );
+    }
+
     // The proxy reads settings on the per-request hot path, so get_settings()
     // must serve from the in-memory cache and NOT hit the DB every call.
     #[tokio::test]
@@ -1157,6 +1455,7 @@ mod tests {
         // get_settings, then update_settings' existence check, plus slack.
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results(vec![
+                vec![settings_row("old.example.com")],
                 vec![settings_row("old.example.com")],
                 vec![settings_row("old.example.com")],
                 vec![settings_row("old.example.com")],

--- a/crates/temps-config/src/service.rs
+++ b/crates/temps-config/src/service.rs
@@ -112,7 +112,13 @@ fn policies_from_rows(rows: Vec<TimescalePolicyRow>) -> EffectiveTelemetryPolici
                 policies.metrics_hourly_days = Some(value)
             }
             ("service_metrics_daily", "policy_retention") => {
-                policies.metrics_daily_years = rounded_u32(value.into(), 365)
+                // The API represents this tier in whole years. Do not claim an
+                // arbitrary manually configured day count (for example 500
+                // days) is an exact year value. Leaving it unset falls back to
+                // the configured value, and the next save reconciles the drift.
+                if value % 365 == 0 {
+                    policies.metrics_daily_years = Some(value / 365);
+                }
             }
             ("proxy_logs", "policy_compression") => {
                 policies.proxy_logs_compression_hours = Some(value)
@@ -640,6 +646,7 @@ SELECT
     )::BIGINT AS interval_seconds
 FROM timescaledb_information.jobs
 WHERE proc_name IN ('policy_compression', 'policy_retention')
+  AND hypertable_schema = current_schema()
   AND hypertable_name IN (
       'service_metrics',
       'service_metrics_hourly',
@@ -1292,7 +1299,8 @@ impl Drop for ConfigService {
 mod tests {
     use super::*;
     use chrono::Utc;
-    use sea_orm::{DatabaseBackend, MockDatabase};
+    use sea_orm::{DatabaseBackend, MockDatabase, Value};
+    use std::collections::BTreeMap;
 
     fn test_config() -> Arc<ServerConfig> {
         Arc::new(
@@ -1317,6 +1325,31 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }
+    }
+
+    fn timescale_policy_row(
+        hypertable_name: &str,
+        proc_name: &str,
+        interval_seconds: i64,
+    ) -> BTreeMap<String, Value> {
+        BTreeMap::from([
+            (
+                "hypertable_name".to_string(),
+                Value::String(Some(Box::new(hypertable_name.to_string()))),
+            ),
+            (
+                "proc_name".to_string(),
+                Value::String(Some(Box::new(proc_name.to_string()))),
+            ),
+            (
+                "interval_seconds".to_string(),
+                Value::BigInt(Some(interval_seconds)),
+            ),
+        ])
+    }
+
+    fn count_row(count: i64) -> BTreeMap<String, Value> {
+        BTreeMap::from([("num_items".to_string(), Value::BigInt(Some(count)))])
     }
 
     #[test]
@@ -1420,6 +1453,67 @@ mod tests {
             policies_from_rows(rows),
             EffectiveTelemetryPolicies::default()
         );
+    }
+
+    #[test]
+    fn timescale_policy_rows_do_not_round_partial_years() {
+        let policies = policies_from_rows(vec![TimescalePolicyRow {
+            hypertable_name: "service_metrics_daily".into(),
+            proc_name: "policy_retention".into(),
+            interval_seconds: 500 * SECONDS_PER_DAY,
+        }]);
+
+        assert_eq!(policies.metrics_daily_years, None);
+    }
+
+    #[tokio::test]
+    async fn effective_policy_query_reads_timescale_metadata_without_telemetry_scan() {
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([[
+                    timescale_policy_row("proxy_logs", "policy_compression", 24 * SECONDS_PER_HOUR),
+                    timescale_policy_row("otel_metrics", "policy_retention", 90 * SECONDS_PER_DAY),
+                ]])
+                .into_connection(),
+        );
+        let svc = ConfigService::new(test_config(), db.clone());
+
+        let policies = svc
+            .get_effective_telemetry_policies()
+            .await
+            .expect("Timescale metadata query should map active jobs");
+
+        assert_eq!(policies.proxy_logs_compression_hours, Some(24));
+        assert_eq!(policies.otel_metrics_retention_days, Some(90));
+        drop(svc);
+        let statements = Arc::try_unwrap(db)
+            .expect("test should release database connection")
+            .into_transaction_log();
+        let sql = statements[0].statements()[0].to_string();
+        assert!(sql.contains("timescaledb_information.jobs"));
+        assert!(sql.contains("hypertable_schema = current_schema()"));
+        assert!(!sql.contains("FROM proxy_logs"));
+        assert!(!sql.contains("FROM otel_metrics"));
+    }
+
+    #[tokio::test]
+    async fn monitored_service_count_matches_scraper_predicates() {
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([[count_row(4)]])
+                .into_connection(),
+        );
+        let svc = ConfigService::new(test_config(), db.clone());
+
+        assert_eq!(svc.count_monitored_services().await.unwrap(), 4);
+        drop(svc);
+        let statements = Arc::try_unwrap(db)
+            .expect("test should release database connection")
+            .into_transaction_log();
+        let sql = statements[0].statements()[0].to_string();
+        assert!(sql.contains("metrics_enabled"));
+        assert!(sql.contains("status"));
+        assert!(sql.contains("running"));
     }
 
     // The proxy reads settings on the per-request hot path, so get_settings()
@@ -1534,6 +1628,90 @@ mod tests {
             cached.observability_compression,
             updated.observability_compression
         );
+    }
+
+    #[tokio::test]
+    async fn update_settings_recreates_a_missing_live_policy_even_when_json_matches() {
+        let current = AppSettings::default();
+        let live_rows = vec![
+            timescale_policy_row(
+                "service_metrics",
+                "policy_retention",
+                i64::from(current.monitoring.retention_raw_days) * SECONDS_PER_DAY,
+            ),
+            timescale_policy_row(
+                "service_metrics_hourly",
+                "policy_retention",
+                i64::from(current.monitoring.retention_hourly_days) * SECONDS_PER_DAY,
+            ),
+            timescale_policy_row(
+                "service_metrics_daily",
+                "policy_retention",
+                i64::from(current.monitoring.retention_daily_years) * 365 * SECONDS_PER_DAY,
+            ),
+            // proxy_logs compression is intentionally missing.
+            timescale_policy_row(
+                "otel_spans",
+                "policy_compression",
+                i64::from(current.observability_compression.otel_spans_after_hours)
+                    * SECONDS_PER_HOUR,
+            ),
+            timescale_policy_row(
+                "proxy_logs",
+                "policy_retention",
+                i64::from(current.observability_retention.proxy_logs_days) * SECONDS_PER_DAY,
+            ),
+            timescale_policy_row(
+                "otel_spans",
+                "policy_retention",
+                i64::from(current.observability_retention.otel_spans_days) * SECONDS_PER_DAY,
+            ),
+            timescale_policy_row(
+                "otel_log_events",
+                "policy_retention",
+                i64::from(current.observability_retention.otel_logs_days) * SECONDS_PER_DAY,
+            ),
+            timescale_policy_row(
+                "otel_metrics",
+                "policy_retention",
+                i64::from(current.observability_retention.otel_metrics_days) * SECONDS_PER_DAY,
+            ),
+        ];
+        let row = settings_row("localhost");
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([live_rows])
+                .append_query_results([[row.clone()], [row]])
+                .append_exec_results([
+                    sea_orm::MockExecResult {
+                        last_insert_id: 0,
+                        rows_affected: 1,
+                    },
+                    sea_orm::MockExecResult {
+                        last_insert_id: 1,
+                        rows_affected: 1,
+                    },
+                ])
+                .into_connection(),
+        );
+        let svc = ConfigService::new(test_config(), db.clone());
+
+        svc.update_settings(current)
+            .await
+            .expect("missing live policy should be recreated");
+
+        drop(svc);
+        let statements = Arc::try_unwrap(db)
+            .expect("test should release database connection")
+            .into_transaction_log();
+        let sql = statements
+            .iter()
+            .flat_map(|transaction| transaction.statements())
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(sql.contains("add_compression_policy"));
+        assert!(sql.contains("proxy_logs"));
     }
 
     #[tokio::test]

--- a/crates/temps-core/src/app_settings.rs
+++ b/crates/temps-core/src/app_settings.rs
@@ -700,7 +700,7 @@ pub struct MonitoringSettings {
     pub retention_hourly_days: u32,
 
     /// How many years of daily-aggregate data to keep (converted to days internally).
-    #[schema(minimum = 1, example = 2)]
+    #[schema(minimum = 1, maximum = 10, example = 2)]
     pub retention_daily_years: u32,
 
     /// ClickHouse DSN, required only when `store = "click_house"`.

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -1090,12 +1090,24 @@ export type AppSettingsResponse = {
      * effective backend and warns when it diverges from the configured store.
      */
     effective_metrics_store: MetricsStoreKind;
+    /**
+     * Storage backend actually used for proxy logs, OTel spans, and OTel
+     * metrics. OTel logs remain TimescaleDB-backed.
+     */
+    effective_observability_store: MetricsStoreKind;
     external_url?: string | null;
     insecure_tls: boolean;
     internal_url?: string | null;
     letsencrypt: LetsEncryptSettings;
     monitoring: MonitoringSettingsMasked;
+    /**
+     * Number of enabled, running services included in the metrics scrape
+     * cycle. Null when the count could not be loaded.
+     */
+    monitored_services_count: number | null;
     multi_node: MultiNodeSettingsMasked;
+    observability_compression: ObservabilityCompressionSettings;
+    observability_retention: ObservabilityRetentionSettings;
     preview_domain: string;
     preview_gateway: PreviewGatewaySettingsMasked;
     rate_limiting: RateLimitSettings;
@@ -9462,6 +9474,24 @@ export type MonitoringSettingsMasked = {
     retention_raw_days: number;
     scrape_interval_secs: number;
     store: MetricsStoreKind;
+};
+
+export type ObservabilityCompressionSettings = {
+    /** Compress OpenTelemetry span chunks after this many hours. */
+    otel_spans_after_hours: number;
+    /** Compress proxy-log chunks after this many hours. */
+    proxy_logs_after_hours: number;
+};
+
+export type ObservabilityRetentionSettings = {
+    /** OpenTelemetry log-event retention in days. */
+    otel_logs_days: number;
+    /** OpenTelemetry metric-point retention in days. */
+    otel_metrics_days: number;
+    /** OpenTelemetry span/trace retention in days. */
+    otel_spans_days: number;
+    /** Raw proxy request-log retention in days. */
+    proxy_logs_days: number;
 };
 
 export type MrrBucketResponse = {

--- a/web/src/api/platformSettings.ts
+++ b/web/src/api/platformSettings.ts
@@ -161,7 +161,7 @@ export interface PlatformSettings extends AppSettingsResponse {
   attack_mode?: boolean
   build_limits: BuildLimitsSettings
   /** Enabled, running services included in the metrics scrape cycle. */
-  monitored_services_count: number
+  monitored_services_count: number | null
   observability_compression: ObservabilityCompressionSettings
   observability_retention: ObservabilityRetentionSettings
   /** Effective backend for proxy logs and OTel spans. */
@@ -191,8 +191,8 @@ export async function getPlatformSettings(): Promise<PlatformSettings> {
     throw new Error('Settings endpoint returned no data')
   }
 
-  // Cast to include extended fields not yet present in generated OpenAPI types.
-  // The server contract guarantees these are populated.
+  // OpenAPI represents Rust `Option<T>` response fields as optional, while the
+  // settings handler serializes this complete response object on every read.
   return response.data as PlatformSettings
 }
 

--- a/web/src/api/platformSettings.ts
+++ b/web/src/api/platformSettings.ts
@@ -160,6 +160,8 @@ export interface PlatformSettings extends AppSettingsResponse {
   insecure_tls: boolean
   attack_mode?: boolean
   build_limits: BuildLimitsSettings
+  /** Enabled, running services included in the metrics scrape cycle. */
+  monitored_services_count: number
   observability_compression: ObservabilityCompressionSettings
   observability_retention: ObservabilityRetentionSettings
   /** Effective backend for proxy logs and OTel spans. */

--- a/web/src/pages/settings/MonitoringSettingsPage.tsx
+++ b/web/src/pages/settings/MonitoringSettingsPage.tsx
@@ -96,10 +96,10 @@ const DurationInput = forwardRef<HTMLInputElement, DurationInputProps>(
 )
 DurationInput.displayName = 'DurationInput'
 
-function estimateStorageMbPerDay(scrapeIntervalSecs: number): number {
-  // Placeholder: pull the "monitored services" count from settings if available
-  // For the estimate we use a hard-coded representative value of 5 services.
-  const monitoredServices = 5
+function estimateStorageMbPerDay(
+  scrapeIntervalSecs: number,
+  monitoredServices: number
+): number {
   const scrapesPerDay = Math.floor(
     (24 * 3600) / Math.max(scrapeIntervalSecs, 15)
   )
@@ -194,8 +194,10 @@ export function MonitoringSettingsPage() {
   }
 
   const estimatedMbPerDay = estimateStorageMbPerDay(
-    monitoring?.scrape_interval_secs ?? DEFAULTS.scrape_interval_secs
+    monitoring?.scrape_interval_secs ?? DEFAULTS.scrape_interval_secs,
+    settings?.monitored_services_count ?? 0
   )
+  const monitoredServicesCount = settings?.monitored_services_count ?? 0
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
@@ -559,8 +561,9 @@ export function MonitoringSettingsPage() {
               <AlertTitle>Estimated metric storage</AlertTitle>
               <AlertDescription>
                 Approximately <strong>{estimatedMbPerDay} MB/day</strong> of raw
-                metric data based on 5 monitored services, {METRICS_PER_SERVICE}{' '}
-                metrics each, scraped every{' '}
+                metric data based on {monitoredServicesCount} monitored{' '}
+                {monitoredServicesCount === 1 ? 'service' : 'services'},{' '}
+                {METRICS_PER_SERVICE} metrics each, scraped every{' '}
                 {monitoring?.scrape_interval_secs ?? 30}s. Hourly/daily rollups
                 add roughly 5% overhead.
               </AlertDescription>

--- a/web/src/pages/settings/MonitoringSettingsPage.tsx
+++ b/web/src/pages/settings/MonitoringSettingsPage.tsx
@@ -193,11 +193,14 @@ export function MonitoringSettingsPage() {
     )
   }
 
-  const estimatedMbPerDay = estimateStorageMbPerDay(
-    monitoring?.scrape_interval_secs ?? DEFAULTS.scrape_interval_secs,
-    settings?.monitored_services_count ?? 0
-  )
-  const monitoredServicesCount = settings?.monitored_services_count ?? 0
+  const monitoredServicesCount = settings?.monitored_services_count
+  const estimatedMbPerDay =
+    monitoredServicesCount == null
+      ? null
+      : estimateStorageMbPerDay(
+          monitoring?.scrape_interval_secs ?? DEFAULTS.scrape_interval_secs,
+          monitoredServicesCount
+        )
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
@@ -558,14 +561,26 @@ export function MonitoringSettingsPage() {
 
             <Alert>
               <HardDrive className="h-4 w-4" />
-              <AlertTitle>Estimated metric storage</AlertTitle>
+              <AlertTitle>
+                {effectiveStore === 'click_house'
+                  ? 'Estimated metric ingest'
+                  : 'Estimated metric storage'}
+              </AlertTitle>
               <AlertDescription>
-                Approximately <strong>{estimatedMbPerDay} MB/day</strong> of raw
-                metric data based on {monitoredServicesCount} monitored{' '}
-                {monitoredServicesCount === 1 ? 'service' : 'services'},{' '}
-                {METRICS_PER_SERVICE} metrics each, scraped every{' '}
-                {monitoring?.scrape_interval_secs ?? 30}s. Hourly/daily rollups
-                add roughly 5% overhead.
+                {estimatedMbPerDay == null ? (
+                  'The estimate is unavailable because the monitored service count could not be loaded.'
+                ) : (
+                  <>
+                    Approximately <strong>{estimatedMbPerDay} MB/day</strong> of
+                    raw metric data based on {monitoredServicesCount} monitored{' '}
+                    {monitoredServicesCount === 1 ? 'service' : 'services'},{' '}
+                    {METRICS_PER_SERVICE} metrics each, scraped every{' '}
+                    {monitoring?.scrape_interval_secs ?? 30}s.{' '}
+                    {effectiveStore === 'click_house'
+                      ? 'This is ingest volume before ClickHouse compression; actual disk usage depends on codecs and data cardinality.'
+                      : 'Hourly/daily rollups add roughly 5% overhead.'}
+                  </>
+                )}
               </AlertDescription>
             </Alert>
           </section>
@@ -578,13 +593,13 @@ export function MonitoringSettingsPage() {
               <p className="text-xs text-muted-foreground">
                 Each signal has its own table and retention window, so
                 high-volume request logs can be deleted sooner than traces or
-                application telemetry. TimescaleDB permanently deletes expired
-                rows in the background.
+                application telemetry. The active storage backend permanently
+                deletes expired rows in the background.
               </p>
             </div>
 
             {effectiveObservabilityStore === 'click_house' && (
-              <div className="grid gap-3 sm:grid-cols-2">
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
                 <div className="rounded-lg border bg-muted/30 p-4">
                   <div className="flex items-center justify-between gap-3">
                     <p className="text-sm font-medium">Proxy request logs</p>
@@ -596,6 +611,19 @@ export function MonitoringSettingsPage() {
                     One row per proxied HTTP request, including route, status,
                     duration, and request metadata. ClickHouse permanently
                     deletes rows older than 30 days using its native TTL.
+                  </p>
+                </div>
+                <div className="rounded-lg border bg-muted/30 p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-sm font-medium">OTel metric points</p>
+                    <code className="rounded bg-background px-2 py-0.5 text-[11px] text-muted-foreground ring-1 ring-inset ring-border">
+                      metrics
+                    </code>
+                  </div>
+                  <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                    Application metrics received over OTLP. ClickHouse
+                    permanently deletes rows older than 90 days using its native
+                    TTL.
                   </p>
                 </div>
                 <div className="rounded-lg border bg-muted/30 p-4">
@@ -730,42 +758,44 @@ export function MonitoringSettingsPage() {
                 )}
               </div>
 
-              <div className="space-y-3 rounded-lg border p-4">
-                <div className="flex items-center justify-between gap-3">
-                  <Label htmlFor="retention-otel-metrics">
-                    OTel metric points
-                  </Label>
-                  <code className="rounded bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
-                    otel_metrics
-                  </code>
-                </div>
-                <p className="min-h-10 text-xs leading-5 text-muted-foreground">
-                  Stores application metric points sent by OpenTelemetry SDKs
-                  and collectors. These are separate from the Temps-scraped
-                  resource metrics configured above.
-                </p>
-                <DurationInput
-                  id="retention-otel-metrics"
-                  unit="days"
-                  min={1}
-                  max={3650}
-                  {...register('observability_retention.otel_metrics_days', {
-                    valueAsNumber: true,
-                    required: true,
-                    min: { value: 1, message: 'Min 1 day' },
-                    max: { value: 3650, message: 'Max 3650 days' },
-                  })}
-                />
-                <p className="text-xs text-muted-foreground">
-                  OTel metric points older than this are permanently deleted.
-                  Range 1–3650 days; default 90.
-                </p>
-                {errors.observability_retention?.otel_metrics_days && (
-                  <p className="text-xs text-destructive">
-                    {errors.observability_retention.otel_metrics_days.message}
+              {effectiveObservabilityStore !== 'click_house' && (
+                <div className="space-y-3 rounded-lg border p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <Label htmlFor="retention-otel-metrics">
+                      OTel metric points
+                    </Label>
+                    <code className="rounded bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                      otel_metrics
+                    </code>
+                  </div>
+                  <p className="min-h-10 text-xs leading-5 text-muted-foreground">
+                    Stores application metric points sent by OpenTelemetry SDKs
+                    and collectors. These are separate from the Temps-scraped
+                    resource metrics configured above.
                   </p>
-                )}
-              </div>
+                  <DurationInput
+                    id="retention-otel-metrics"
+                    unit="days"
+                    min={1}
+                    max={3650}
+                    {...register('observability_retention.otel_metrics_days', {
+                      valueAsNumber: true,
+                      required: true,
+                      min: { value: 1, message: 'Min 1 day' },
+                      max: { value: 3650, message: 'Max 3650 days' },
+                    })}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    OTel metric points older than this are permanently deleted.
+                    Range 1–3650 days; default 90.
+                  </p>
+                  {errors.observability_retention?.otel_metrics_days && (
+                    <p className="text-xs text-destructive">
+                      {errors.observability_retention.otel_metrics_days.message}
+                    </p>
+                  )}
+                </div>
+              )}
             </div>
           </section>
         </CardContent>


### PR DESCRIPTION
## Summary
- read active retention and compression durations from TimescaleDB job metadata
- reconcile saves against live policies so manual drift and missing jobs are corrected
- estimate metric storage from enabled, running services instead of a hardcoded count
- preserve ClickHouse-backed values when ClickHouse is active

## Efficiency
- one small query over timescaledb_information.jobs; no telemetry or chunk scan
- one COUNT(*) over the control-plane external_services table
- settings, policy metadata, and service count are fetched concurrently

## Verification
- cargo check --lib -p temps-config
- cargo clippy --lib -p temps-config -- -D warnings
- cargo test --lib -p temps-config (49 passed)
- npx tsc --noEmit
- targeted ESLint and Prettier checks for touched web files
- npm run build

Note: repository-wide web lint remains blocked by pre-existing errors outside these changes.