### PR TITLE
feat(deployments): preview commits before deployment

### DIFF
--- a/crates/temps-git/src/handlers/base.rs
+++ b/crates/temps-git/src/handlers/base.rs
@@ -155,6 +155,16 @@ impl From<GitProviderError> for Problem {
                 .with_type("https://docs.temps.sh/errors/api_error")
                 .with_title("API Error")
                 .with_detail(msg),
+            GitProviderError::CommitNotFound {
+                repository,
+                commit_sha,
+            } => problem_new(StatusCode::NOT_FOUND)
+                .with_type("https://docs.temps.sh/errors/commit_not_found")
+                .with_title("Commit Not Found")
+                .with_detail(format!(
+                    "Commit '{}' was not found in repository '{}'",
+                    commit_sha, repository
+                )),
             GitProviderError::RepositoryAlreadyExists { ref name } => {
                 problem_new(StatusCode::CONFLICT)
                     .with_type("https://docs.temps.sh/errors/repository_already_exists")

--- a/crates/temps-git/src/handlers/repositories.rs
+++ b/crates/temps-git/src/handlers/repositories.rs
@@ -6,9 +6,15 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use temps_auth::{permission_check, Permission, RequireAuth};
+use temps_auth::{permission_check, AuthContext, AuthSource, Permission, RequireAuth};
 use temps_core::{error_builder::ErrorBuilder, problemdetails::Problem};
+use tracing::warn;
 use utoipa::{IntoParams, OpenApi, ToSchema};
+
+use crate::services::{
+    cache::CommitCacheKey,
+    git_provider::{Commit, GitProviderError},
+};
 
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct ConnectionQueryParams {
@@ -66,12 +72,42 @@ impl CommitExistsResponse {
         }
     }
 
-    fn found(commit: crate::services::git_provider::Commit) -> Self {
+    fn found(commit: Commit) -> Self {
         let commit_sha = commit.sha.clone();
         Self {
             exists: true,
             commit_sha: Some(commit_sha),
             commit: Some(commit.into()),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+enum CommitShaValidationError {
+    #[error("commit SHA must contain between 7 and 40 hexadecimal characters")]
+    InvalidLength,
+    #[error("commit SHA must contain only hexadecimal characters")]
+    NonHexadecimal,
+}
+
+fn normalize_commit_sha(commit_sha: &str) -> Result<String, CommitShaValidationError> {
+    if !(7..=40).contains(&commit_sha.len()) {
+        return Err(CommitShaValidationError::InvalidLength);
+    }
+    if !commit_sha.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(CommitShaValidationError::NonHexadecimal);
+    }
+    Ok(commit_sha.to_ascii_lowercase())
+}
+
+fn commit_lookup_principal(auth: &AuthContext) -> String {
+    match &auth.source {
+        AuthSource::Session { user } | AuthSource::CliToken { user } => {
+            format!("user:{}", user.id)
+        }
+        AuthSource::ApiKey { key_id, .. } => format!("api-key:{}", key_id),
+        AuthSource::DeploymentToken { token_id, .. } => {
+            format!("deployment-token:{}", token_id)
         }
     }
 }
@@ -552,8 +588,10 @@ pub async fn get_tags_by_repository_id(
     ),
     responses(
         (status = 200, description = "Commit existence check result", body = CommitExistsResponse),
+        (status = 400, description = "Invalid commit SHA"),
         (status = 401, description = "Unauthorized"),
         (status = 404, description = "Repository not found"),
+        (status = 429, description = "Commit lookup rate limit exceeded"),
         (status = 500, description = "Internal server error"),
         (status = 502, description = "Git provider request failed")
     ),
@@ -570,6 +608,13 @@ pub async fn check_commit_exists(
     // Check permission
     permission_check!(auth, Permission::GitRepositoriesRead);
 
+    let commit_sha = normalize_commit_sha(&commit_sha).map_err(|error| {
+        ErrorBuilder::new(StatusCode::BAD_REQUEST)
+            .title("Invalid Commit SHA")
+            .detail(error.to_string())
+            .build()
+    })?;
+
     // Find the repository by ID
     let repository = state
         .git_provider_manager
@@ -578,6 +623,19 @@ pub async fn check_commit_exists(
 
     // Check if repository has a git provider connection
     let connection_id = repository.git_provider_connection_id;
+
+    let cache_key = CommitCacheKey::new(
+        connection_id,
+        repository.owner.clone(),
+        repository.name.clone(),
+        commit_sha.clone(),
+    );
+    if let Some(cached_commit) = state.cache_manager.commits.get(&cache_key).await {
+        return Ok(Json(match cached_commit {
+            Some(commit) => CommitExistsResponse::found(commit),
+            None => CommitExistsResponse::missing(),
+        }));
+    }
 
     // Get the connection and provider
     let connection = state
@@ -613,49 +671,59 @@ pub async fn check_commit_exists(
                 .build()
         })?;
 
-    // Check existence first because provider-specific get-commit errors do not
-    // consistently distinguish a missing SHA from an upstream failure.
-    let exists = provider_service
-        .check_commit_exists(
-            &access_token,
-            &repository.owner,
-            &repository.name,
-            &commit_sha,
-        )
+    let principal = commit_lookup_principal(&auth);
+    state
+        .cache_manager
+        .commit_lookup_rate_limiter
+        .check(&principal)
         .await
-        .map_err(|error| {
-            ErrorBuilder::new(StatusCode::BAD_GATEWAY)
-                .title("Failed to verify commit")
-                .detail(format!(
-                    "Failed to verify commit '{}' in repository '{}/{}': {}",
-                    commit_sha, repository.owner, repository.name, error
-                ))
+        .map_err(|retry_after_seconds| {
+            ErrorBuilder::new(StatusCode::TOO_MANY_REQUESTS)
+                .title("Commit Lookup Rate Limit Exceeded")
+                .detail("Too many uncached commit lookups. Please retry later.")
+                .value("retry_after_seconds", retry_after_seconds)
                 .build()
         })?;
 
-    if !exists {
-        return Ok(Json(CommitExistsResponse::missing()));
-    }
-
-    let commit = provider_service
+    let commit_result = provider_service
         .get_commit(
             &access_token,
             &repository.owner,
             &repository.name,
             &commit_sha,
         )
-        .await
-        .map_err(|error| {
-            ErrorBuilder::new(StatusCode::BAD_GATEWAY)
-                .title("Failed to fetch commit details")
-                .detail(format!(
-                    "Commit '{}' exists in repository '{}/{}', but its details could not be fetched: {}",
-                    commit_sha, repository.owner, repository.name, error
-                ))
-                .build()
-        })?;
+        .await;
 
-    Ok(Json(CommitExistsResponse::found(commit)))
+    match commit_result {
+        Ok(commit) => {
+            state
+                .cache_manager
+                .commits
+                .set(cache_key, Some(commit.clone()))
+                .await;
+            Ok(Json(CommitExistsResponse::found(commit)))
+        }
+        Err(GitProviderError::CommitNotFound { .. }) => {
+            state.cache_manager.commits.set(cache_key, None).await;
+            Ok(Json(CommitExistsResponse::missing()))
+        }
+        Err(error @ GitProviderError::RateLimitExceeded) => Err(error.into()),
+        Err(error) => {
+            warn!(
+                repository_id,
+                connection_id,
+                owner = %repository.owner,
+                repository = %repository.name,
+                commit_sha = %commit_sha,
+                error = %error,
+                "Git provider commit lookup failed"
+            );
+            Err(ErrorBuilder::new(StatusCode::BAD_GATEWAY)
+                .title("Failed to fetch commit details")
+                .detail("The git provider could not complete the commit lookup.")
+                .build())
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, IntoParams)]
@@ -832,7 +900,7 @@ pub struct RepositoriesApiDoc;
 
 #[cfg(test)]
 mod tests {
-    use super::CommitExistsResponse;
+    use super::{normalize_commit_sha, CommitExistsResponse, CommitShaValidationError};
     use crate::services::git_provider::Commit;
 
     #[test]
@@ -872,6 +940,34 @@ mod tests {
         assert_eq!(
             commit.map(|value| value.date),
             Some(chrono::DateTime::UNIX_EPOCH)
+        );
+    }
+
+    #[test]
+    fn commit_sha_validation_normalizes_hex_case() {
+        assert_eq!(
+            normalize_commit_sha("ABCDEF1234567"),
+            Ok("abcdef1234567".to_string())
+        );
+    }
+
+    #[test]
+    fn commit_sha_validation_rejects_short_long_and_non_hex_values() {
+        assert_eq!(
+            normalize_commit_sha("abcdef"),
+            Err(CommitShaValidationError::InvalidLength)
+        );
+        assert_eq!(
+            normalize_commit_sha("01234567890123456789012345678901234567890"),
+            Err(CommitShaValidationError::InvalidLength)
+        );
+        assert_eq!(
+            normalize_commit_sha("abcdefg"),
+            Err(CommitShaValidationError::NonHexadecimal)
+        );
+        assert_eq!(
+            normalize_commit_sha("abcdef/123456"),
+            Err(CommitShaValidationError::NonHexadecimal)
         );
     }
 }

--- a/crates/temps-git/src/handlers/repositories.rs
+++ b/crates/temps-git/src/handlers/repositories.rs
@@ -53,6 +53,27 @@ pub struct TagListResponse {
 pub struct CommitExistsResponse {
     pub exists: bool,
     pub commit_sha: Option<String>,
+    /// Commit metadata when the requested SHA exists.
+    pub commit: Option<CommitInfo>,
+}
+
+impl CommitExistsResponse {
+    fn missing() -> Self {
+        Self {
+            exists: false,
+            commit_sha: None,
+            commit: None,
+        }
+    }
+
+    fn found(commit: crate::services::git_provider::Commit) -> Self {
+        let commit_sha = commit.sha.clone();
+        Self {
+            exists: true,
+            commit_sha: Some(commit_sha),
+            commit: Some(commit.into()),
+        }
+    }
 }
 
 /// Get repository branches
@@ -533,7 +554,8 @@ pub async fn get_tags_by_repository_id(
         (status = 200, description = "Commit existence check result", body = CommitExistsResponse),
         (status = 401, description = "Unauthorized"),
         (status = 404, description = "Repository not found"),
-        (status = 500, description = "Internal server error")
+        (status = 500, description = "Internal server error"),
+        (status = 502, description = "Git provider request failed")
     ),
     tag = "Repositories",
     security(
@@ -591,7 +613,8 @@ pub async fn check_commit_exists(
                 .build()
         })?;
 
-    // Check if commit exists using the git provider
+    // Check existence first because provider-specific get-commit errors do not
+    // consistently distinguish a missing SHA from an upstream failure.
     let exists = provider_service
         .check_commit_exists(
             &access_token,
@@ -600,12 +623,39 @@ pub async fn check_commit_exists(
             &commit_sha,
         )
         .await
-        .unwrap_or(false); // If there's an error checking, assume it doesn't exist
+        .map_err(|error| {
+            ErrorBuilder::new(StatusCode::BAD_GATEWAY)
+                .title("Failed to verify commit")
+                .detail(format!(
+                    "Failed to verify commit '{}' in repository '{}/{}': {}",
+                    commit_sha, repository.owner, repository.name, error
+                ))
+                .build()
+        })?;
 
-    Ok(Json(CommitExistsResponse {
-        exists,
-        commit_sha: if exists { Some(commit_sha) } else { None },
-    }))
+    if !exists {
+        return Ok(Json(CommitExistsResponse::missing()));
+    }
+
+    let commit = provider_service
+        .get_commit(
+            &access_token,
+            &repository.owner,
+            &repository.name,
+            &commit_sha,
+        )
+        .await
+        .map_err(|error| {
+            ErrorBuilder::new(StatusCode::BAD_GATEWAY)
+                .title("Failed to fetch commit details")
+                .detail(format!(
+                    "Commit '{}' exists in repository '{}/{}', but its details could not be fetched: {}",
+                    commit_sha, repository.owner, repository.name, error
+                ))
+                .build()
+        })?;
+
+    Ok(Json(CommitExistsResponse::found(commit)))
 }
 
 #[derive(Debug, Deserialize, IntoParams)]
@@ -629,6 +679,18 @@ pub struct CommitInfo {
     /// Commit date in ISO 8601 format
     #[schema(value_type = String, format = DateTime, example = "2025-10-12T12:15:47.609192Z")]
     pub date: chrono::DateTime<chrono::Utc>,
+}
+
+impl From<crate::services::git_provider::Commit> for CommitInfo {
+    fn from(commit: crate::services::git_provider::Commit) -> Self {
+        Self {
+            sha: commit.sha,
+            message: commit.message,
+            author: commit.author,
+            author_email: commit.author_email,
+            date: commit.date,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -767,3 +829,49 @@ pub async fn list_commits_by_repository_id(
     )
 )]
 pub struct RepositoriesApiDoc;
+
+#[cfg(test)]
+mod tests {
+    use super::CommitExistsResponse;
+    use crate::services::git_provider::Commit;
+
+    #[test]
+    fn missing_commit_response_has_no_commit_metadata() {
+        let response = CommitExistsResponse::missing();
+
+        assert!(!response.exists);
+        assert!(response.commit_sha.is_none());
+        assert!(response.commit.is_none());
+    }
+
+    #[test]
+    fn found_commit_response_includes_provider_metadata() {
+        let response = CommitExistsResponse::found(Commit {
+            sha: "0123456789abcdef".to_string(),
+            message: "Show commit details".to_string(),
+            author: "Temps Contributor".to_string(),
+            author_email: "contributor@example.com".to_string(),
+            date: chrono::DateTime::UNIX_EPOCH,
+        });
+
+        assert!(response.exists);
+        assert_eq!(response.commit_sha.as_deref(), Some("0123456789abcdef"));
+        let commit = response.commit.as_ref();
+        assert_eq!(
+            commit.map(|value| value.sha.as_str()),
+            Some("0123456789abcdef")
+        );
+        assert_eq!(
+            commit.map(|value| value.message.as_str()),
+            Some("Show commit details")
+        );
+        assert_eq!(
+            commit.map(|value| value.author.as_str()),
+            Some("Temps Contributor")
+        );
+        assert_eq!(
+            commit.map(|value| value.date),
+            Some(chrono::DateTime::UNIX_EPOCH)
+        );
+    }
+}

--- a/crates/temps-git/src/services/bitbucket_provider.rs
+++ b/crates/temps-git/src/services/bitbucket_provider.rs
@@ -947,6 +947,13 @@ impl GitProviderService for BitbucketProvider {
             .send_with_retry(|| self.apply_auth(client.get(&url)))
             .await?;
 
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(GitProviderError::CommitNotFound {
+                repository: format!("{}/{}", owner, repo),
+                commit_sha: reference.to_string(),
+            });
+        }
+
         if !response.status().is_success() {
             return Err(GitProviderError::ApiError(format!(
                 "Failed to get commit {} for {}/{}: {}",

--- a/crates/temps-git/src/services/cache.rs
+++ b/crates/temps-git/src/services/cache.rs
@@ -1,8 +1,13 @@
-use chrono::{DateTime, Duration, Utc};
-use std::collections::HashMap;
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use std::collections::{HashMap, VecDeque};
 use std::hash::Hash;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use std::time::{Duration, Instant};
+use tokio::sync::{Mutex, RwLock};
+
+const DEFAULT_CACHE_MAX_ENTRIES: usize = 10_000;
+const COMMIT_LOOKUP_REQUESTS_PER_MINUTE: usize = 60;
+const COMMIT_LOOKUP_MAX_PRINCIPALS: usize = 10_000;
 
 /// Cache entry with expiration time
 #[derive(Clone, Debug)]
@@ -15,7 +20,7 @@ impl<T> CacheEntry<T> {
     fn new(value: T, ttl_minutes: i64) -> Self {
         Self {
             value,
-            expires_at: Utc::now() + Duration::minutes(ttl_minutes),
+            expires_at: Utc::now() + ChronoDuration::minutes(ttl_minutes),
         }
     }
 
@@ -32,6 +37,7 @@ where
 {
     cache: Arc<RwLock<HashMap<K, CacheEntry<V>>>>,
     default_ttl_minutes: i64,
+    max_entries: usize,
 }
 
 impl<K, V> GitProviderCache<K, V>
@@ -41,9 +47,15 @@ where
 {
     /// Create a new cache with the given default TTL in minutes
     pub fn new(default_ttl_minutes: i64) -> Self {
+        Self::new_with_capacity(default_ttl_minutes, DEFAULT_CACHE_MAX_ENTRIES)
+    }
+
+    /// Create a cache with an explicit entry bound.
+    pub fn new_with_capacity(default_ttl_minutes: i64, max_entries: usize) -> Self {
         Self {
             cache: Arc::new(RwLock::new(HashMap::new())),
             default_ttl_minutes,
+            max_entries: max_entries.max(1),
         }
     }
 
@@ -69,6 +81,14 @@ where
     /// Set a value in the cache with a custom TTL
     pub async fn set_with_ttl(&self, key: K, value: V, ttl_minutes: i64) {
         let mut cache = self.cache.write().await;
+        if cache.len() >= self.max_entries && !cache.contains_key(&key) {
+            cache.retain(|_, entry| !entry.is_expired());
+        }
+        if cache.len() >= self.max_entries && !cache.contains_key(&key) {
+            if let Some(eviction_key) = cache.keys().next().cloned() {
+                cache.remove(&eviction_key);
+            }
+        }
         cache.insert(key, CacheEntry::new(value, ttl_minutes));
     }
 
@@ -139,13 +159,83 @@ impl TagCacheKey {
     }
 }
 
-/// Cache key for commit existence checks
+/// Cache key for immutable commit metadata lookups
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CommitCacheKey {
     pub connection_id: i32,
     pub owner: String,
     pub repo: String,
     pub commit_ref: String,
+}
+
+#[derive(Debug)]
+struct CommitLookupWindow {
+    requests: VecDeque<Instant>,
+    last_seen: Instant,
+}
+
+/// Bounded, per-principal sliding-window limiter for provider commit lookups.
+pub struct CommitLookupRateLimiter {
+    windows: Mutex<HashMap<String, CommitLookupWindow>>,
+    max_requests: usize,
+    window: Duration,
+    max_principals: usize,
+}
+
+impl CommitLookupRateLimiter {
+    pub fn new(max_requests: usize, window: Duration, max_principals: usize) -> Self {
+        Self {
+            windows: Mutex::new(HashMap::new()),
+            max_requests: max_requests.max(1),
+            window,
+            max_principals: max_principals.max(1),
+        }
+    }
+
+    /// Record an upstream lookup, returning the retry delay when the limit is reached.
+    pub async fn check(&self, principal: &str) -> Result<(), u64> {
+        let now = Instant::now();
+        let cutoff = now.checked_sub(self.window).unwrap_or(now);
+        let mut windows = self.windows.lock().await;
+
+        windows.retain(|_, entry| entry.last_seen >= cutoff);
+        if windows.len() >= self.max_principals && !windows.contains_key(principal) {
+            if let Some(oldest) = windows
+                .iter()
+                .min_by_key(|(_, entry)| entry.last_seen)
+                .map(|(key, _)| key.clone())
+            {
+                windows.remove(&oldest);
+            }
+        }
+
+        let entry = windows
+            .entry(principal.to_string())
+            .or_insert_with(|| CommitLookupWindow {
+                requests: VecDeque::new(),
+                last_seen: now,
+            });
+        entry.last_seen = now;
+        while entry
+            .requests
+            .front()
+            .is_some_and(|request| *request < cutoff)
+        {
+            entry.requests.pop_front();
+        }
+
+        if entry.requests.len() >= self.max_requests {
+            let retry_after = entry
+                .requests
+                .front()
+                .map(|request| self.window.saturating_sub(now.duration_since(*request)))
+                .unwrap_or(self.window);
+            return Err(retry_after.as_secs().max(1));
+        }
+
+        entry.requests.push_back(now);
+        Ok(())
+    }
 }
 
 impl CommitCacheKey {
@@ -217,8 +307,11 @@ pub struct GitProviderCacheManager {
     /// Cache for repository tags (60 minutes TTL)
     pub tags: GitProviderCache<TagCacheKey, Vec<crate::services::git_provider::GitProviderTag>>,
 
-    /// Cache for commit existence checks (30 minutes TTL)
-    pub commits: GitProviderCache<CommitCacheKey, bool>,
+    /// Cache for immutable commit metadata and negative lookups (30 minutes TTL)
+    pub commits: GitProviderCache<CommitCacheKey, Option<crate::services::git_provider::Commit>>,
+
+    /// Per-user or API-key limiter for cache-miss provider lookups.
+    pub commit_lookup_rate_limiter: CommitLookupRateLimiter,
 
     /// Cache for public repository branches (15 minutes TTL - shorter due to rate limits)
     pub public_branches:
@@ -234,6 +327,11 @@ impl GitProviderCacheManager {
             branches: GitProviderCache::new(60), // 60 minutes for branches
             tags: GitProviderCache::new(60),     // 60 minutes for tags
             commits: GitProviderCache::new(30),  // 30 minutes for commits
+            commit_lookup_rate_limiter: CommitLookupRateLimiter::new(
+                COMMIT_LOOKUP_REQUESTS_PER_MINUTE,
+                Duration::from_secs(60),
+                COMMIT_LOOKUP_MAX_PRINCIPALS,
+            ),
             public_branches: GitProviderCache::new(15), // 15 minutes for public branches (rate limit aware)
             public_presets: GitProviderCache::new(30),  // 30 minutes for public presets
         }
@@ -319,6 +417,52 @@ mod tests {
             cache.get(&"valid".to_string()).await,
             Some("value".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn cache_never_exceeds_its_entry_bound() {
+        let cache: GitProviderCache<String, String> = GitProviderCache::new_with_capacity(1, 2);
+
+        cache.set("one".to_string(), "1".to_string()).await;
+        cache.set("two".to_string(), "2".to_string()).await;
+        cache.set("three".to_string(), "3".to_string()).await;
+
+        assert_eq!(cache.len().await, 2);
+        assert_eq!(cache.get(&"three".to_string()).await.as_deref(), Some("3"));
+    }
+
+    #[tokio::test]
+    async fn commit_cache_distinguishes_negative_result_from_cache_miss() {
+        let cache: GitProviderCache<String, Option<crate::services::git_provider::Commit>> =
+            GitProviderCache::new(1);
+
+        cache.set("missing".to_string(), None).await;
+
+        assert!(cache.get(&"unknown".to_string()).await.is_none());
+        assert!(matches!(
+            cache.get(&"missing".to_string()).await,
+            Some(None)
+        ));
+    }
+
+    #[tokio::test]
+    async fn commit_lookup_rate_limiter_is_scoped_by_principal() {
+        let limiter = CommitLookupRateLimiter::new(1, Duration::from_secs(60), 10);
+
+        assert!(limiter.check("user:1").await.is_ok());
+        assert!(limiter.check("user:1").await.is_err());
+        assert!(limiter.check("api-key:1").await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn commit_lookup_rate_limiter_bounds_principal_memory() {
+        let limiter = CommitLookupRateLimiter::new(1, Duration::from_secs(60), 2);
+
+        assert!(limiter.check("user:1").await.is_ok());
+        assert!(limiter.check("user:2").await.is_ok());
+        assert!(limiter.check("user:3").await.is_ok());
+
+        assert!(limiter.windows.lock().await.len() <= 2);
     }
 
     #[tokio::test]

--- a/crates/temps-git/src/services/git_provider.rs
+++ b/crates/temps-git/src/services/git_provider.rs
@@ -23,6 +23,12 @@ pub enum GitProviderError {
     #[error("API error: {0}")]
     ApiError(String),
 
+    #[error("Commit '{commit_sha}' not found in repository '{repository}'")]
+    CommitNotFound {
+        repository: String,
+        commit_sha: String,
+    },
+
     #[error("A repository named '{name}' already exists on this account")]
     RepositoryAlreadyExists { name: String },
 

--- a/crates/temps-git/src/services/gitea_provider.rs
+++ b/crates/temps-git/src/services/gitea_provider.rs
@@ -945,6 +945,13 @@ impl GitProviderService for GiteaProvider {
             .send_with_retry(|| client.get(&url).headers(headers.clone()))
             .await?;
 
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(GitProviderError::CommitNotFound {
+                repository: format!("{}/{}", owner, repo),
+                commit_sha: reference.to_string(),
+            });
+        }
+
         if !response.status().is_success() {
             return Err(GitProviderError::ApiError(format!(
                 "Failed to get commit {} for {}/{}: {}",

--- a/crates/temps-git/src/services/github_provider.rs
+++ b/crates/temps-git/src/services/github_provider.rs
@@ -1573,7 +1573,10 @@ impl GitProviderService for GitHubProvider {
         // GitHub API endpoint for getting a commit
         let url = format!(
             "{}/repos/{}/{}/commits/{}",
-            self.api_url, owner, repo, reference
+            self.api_url,
+            owner,
+            repo,
+            urlencoding::encode(reference)
         );
 
         let response = self
@@ -1582,6 +1585,12 @@ impl GitProviderService for GitHubProvider {
 
         if !response.status().is_success() {
             let status = response.status();
+            if status == reqwest::StatusCode::NOT_FOUND {
+                return Err(GitProviderError::CommitNotFound {
+                    repository: format!("{}/{}", owner, repo),
+                    commit_sha: reference.to_string(),
+                });
+            }
             let error_text = response
                 .text()
                 .await

--- a/crates/temps-git/src/services/gitlab_provider.rs
+++ b/crates/temps-git/src/services/gitlab_provider.rs
@@ -1280,6 +1280,12 @@ impl GitProviderService for GitLabProvider {
 
         if !response.status().is_success() {
             let status = response.status();
+            if status == reqwest::StatusCode::NOT_FOUND {
+                return Err(GitProviderError::CommitNotFound {
+                    repository: format!("{}/{}", owner, repo),
+                    commit_sha: reference.to_string(),
+                });
+            }
             let error_text = response
                 .text()
                 .await

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -2202,6 +2202,10 @@ export type CmdResponse = {
 };
 
 export type CommitExistsResponse = {
+    /**
+     * Commit metadata when the requested SHA exists.
+     */
+    commit?: CommitInfo | null;
     commit_sha?: string | null;
     exists: boolean;
 };
@@ -43172,6 +43176,10 @@ export type CheckCommitExistsErrors = {
      * Internal server error
      */
     500: unknown;
+    /**
+     * Git provider request failed
+     */
+    502: unknown;
 };
 
 export type CheckCommitExistsResponses = {

--- a/web/src/components/deployments/RedeploymentModal.tsx
+++ b/web/src/components/deployments/RedeploymentModal.tsx
@@ -1,6 +1,8 @@
 import {
+  checkCommitExistsOptions,
   getEnvironmentsOptions,
   getProjectBySlugOptions,
+  getRepositoryByNameOptions,
 } from '@/api/client/@tanstack/react-query.gen'
 import { EnvironmentResponse, ProjectResponse } from '@/api/client/types.gen'
 import { Button } from '@/components/ui/button'
@@ -25,8 +27,30 @@ import { useQuery } from '@tanstack/react-query'
 import { useMemo, useState, useEffect } from 'react'
 import { toast } from 'sonner'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { AlertTriangle } from 'lucide-react'
+import {
+  AlertTriangle,
+  CheckCircle2,
+  GitCommitHorizontal,
+  Loader2,
+  RefreshCw,
+} from 'lucide-react'
 import { BranchSelector } from './BranchSelector'
+
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{7,40}$/i
+
+function isValidCommitSha(commit: string) {
+  return COMMIT_SHA_PATTERN.test(commit.trim())
+}
+
+function formatCommitDate(date: string) {
+  const parsedDate = new Date(date)
+  if (Number.isNaN(parsedDate.getTime())) return date
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(parsedDate)
+}
 
 interface RedeploymentModalProps {
   project: ProjectResponse
@@ -111,66 +135,118 @@ export function RedeploymentModal({
     'branch' | 'commit' | 'tag'
   >(defaultType || 'branch')
   const [availableBranches, setAvailableBranches] = useState<string[]>([])
-  const [branchNotFound, setBranchNotFound] = useState(false)
+  const [commitToCheck, setCommitToCheck] = useState('')
 
   // Derive effective values (either user-selected or initial/default)
   const effectiveBranch = selectedBranch !== '' ? selectedBranch : initialBranch
   const effectiveEnvironment = selectedEnvironment ?? initialEnvironment
+  const normalizedCommit = selectedCommit.trim()
+  const commitFormatIsValid = isValidCommitSha(normalizedCommit)
+  const branchNotFound = Boolean(
+    effectiveBranch &&
+    availableBranches.length > 0 &&
+    !availableBranches.includes(effectiveBranch)
+  )
+  const projectDetails = projectQuery.data ?? project
+  const shouldLookUpCommit = Boolean(
+    projectDetails.git_provider_connection_id &&
+    projectDetails.repo_owner &&
+    projectDetails.repo_name
+  )
+
+  const repositoryQuery = useQuery({
+    ...getRepositoryByNameOptions({
+      path: {
+        owner: projectDetails.repo_owner || '',
+        name: projectDetails.repo_name || '',
+      },
+    }),
+    enabled:
+      isOpen &&
+      mode === 'new' &&
+      deploymentType === 'commit' &&
+      shouldLookUpCommit,
+  })
+
+  const commitQuery = useQuery({
+    ...checkCommitExistsOptions({
+      path: {
+        repository_id: repositoryQuery.data?.id || 0,
+        commit_sha: commitToCheck,
+      },
+    }),
+    enabled:
+      isOpen &&
+      deploymentType === 'commit' &&
+      !!repositoryQuery.data?.id &&
+      !!commitToCheck,
+    retry: false,
+  })
+
+  const checkedCurrentCommit =
+    !!commitToCheck && commitToCheck === normalizedCommit.toLowerCase()
+  const commitIsVerified = Boolean(
+    checkedCurrentCommit && commitQuery.data?.exists && commitQuery.data.commit
+  )
 
   // Reset form state when modal opens or default values change
   useEffect(() => {
     if (isOpen) {
+      // The dialog is controlled by its parent, so opening it is the boundary
+      // where draft selections must be reset to the latest defaults.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setSelectedBranch('')
       setSelectedEnvironment(null)
       setSelectedCommit(defaultCommit || '')
       setSelectedTag(defaultTag || '')
       setDeploymentType(defaultType || 'branch')
-      setBranchNotFound(false)
     }
   }, [isOpen, defaultCommit, defaultTag, defaultType])
 
-  // Auto-select the repo's default branch once it resolves, so the modal opens
-  // with the default branch pre-selected instead of an empty "Select a branch"
-  // state. Only fills an empty selection — never overrides a user's pick or an
-  // environment-derived branch.
-  useEffect(() => {
-    if (!isOpen || mode !== 'new' || deploymentType !== 'branch') return
-    if (selectedBranch || !initialBranch) return
-    setSelectedBranch(initialBranch)
-  }, [isOpen, mode, deploymentType, selectedBranch, initialBranch])
+  const handleEnvironmentChange = (value: string) => {
+    const environmentId = value ? parseInt(value) : null
+    setSelectedEnvironment(environmentId)
 
-  // When environment selection changes, automatically select its branch
-  useEffect(() => {
-    if (!selectedEnvironment || !environmentsQuery.data) return
+    if (!environmentId || !environmentsQuery.data || isImageDeploy) return
 
     const selectedEnv = environmentsQuery.data.find(
-      (env: EnvironmentResponse) => env.id === selectedEnvironment
+      (env: EnvironmentResponse) => env.id === environmentId
+    )
+    if (selectedEnv?.branch) {
+      setDeploymentType('branch')
+      setSelectedBranch(selectedEnv.branch)
+    }
+  }
+
+  // Avoid issuing a provider API request for every character after the
+  // minimum SHA length. Pasting or pausing on a syntactically valid SHA
+  // resolves the commit details after a short debounce.
+  useEffect(() => {
+    const canCheckCommit =
+      isOpen &&
+      deploymentType === 'commit' &&
+      shouldLookUpCommit &&
+      commitFormatIsValid
+    const nextCommit = canCheckCommit ? normalizedCommit.toLowerCase() : ''
+
+    const timeoutId = window.setTimeout(
+      () => {
+        setCommitToCheck(nextCommit)
+      },
+      canCheckCommit ? 350 : 0
     )
 
-    if (!selectedEnv?.branch) return
-
-    // Set branch type and switch to branch deployment mode
-    setDeploymentType('branch')
-    setSelectedBranch(selectedEnv.branch)
-    setBranchNotFound(false)
-  }, [selectedEnvironment, environmentsQuery.data])
-
-  // Check if the selected branch exists in available branches (after branches load)
-  useEffect(() => {
-    if (!selectedBranch || availableBranches.length === 0) {
-      setBranchNotFound(false)
-      return
-    }
-    setBranchNotFound(!availableBranches.includes(selectedBranch))
-  }, [selectedBranch, availableBranches])
+    return () => window.clearTimeout(timeoutId)
+  }, [
+    commitFormatIsValid,
+    deploymentType,
+    isOpen,
+    normalizedCommit,
+    shouldLookUpCommit,
+  ])
 
   const validateCommit = (commit: string) => {
-    const commitRegex = /^[0-9a-f]{7,40}$/
-    if (!commit.trim()) return true // Optional
-    if (!commitRegex.test(commit)) {
-      return false
-    }
-    return true
+    return isValidCommitSha(commit)
   }
 
   const handleConfirm = async () => {
@@ -178,7 +254,8 @@ export function RedeploymentModal({
     // the prebuilt image. In redeploy mode the environment is fixed; in new
     // mode the user picks it.
     if (isImageDeploy) {
-      const envId = mode === 'redeploy' ? defaultEnvironment : effectiveEnvironment
+      const envId =
+        mode === 'redeploy' ? defaultEnvironment : effectiveEnvironment
       if (!envId) {
         toast.error('No environment specified for deployment')
         return
@@ -205,7 +282,17 @@ export function RedeploymentModal({
 
     // In new mode, validate and use selected/effective values
     if (deploymentType === 'commit' && !validateCommit(selectedCommit)) {
-      toast.error('Invalid commit hash')
+      toast.error(
+        'Enter a commit hash containing 7 to 40 hexadecimal characters'
+      )
+      return
+    }
+    if (
+      deploymentType === 'commit' &&
+      shouldLookUpCommit &&
+      !commitIsVerified
+    ) {
+      toast.error('Wait for the commit to be verified before deploying')
       return
     }
     if (!effectiveEnvironment) {
@@ -222,22 +309,27 @@ export function RedeploymentModal({
 
     await onConfirm({
       branch: deploymentType === 'branch' ? effectiveBranch : undefined,
-      commit: deploymentType === 'commit' ? selectedCommit : undefined,
+      commit:
+        deploymentType === 'commit'
+          ? normalizedCommit.toLowerCase()
+          : undefined,
       tag: deploymentType === 'tag' ? selectedTag : undefined,
       environmentId: effectiveEnvironment,
     })
   }
 
   // Get environment name for redeploy mode
-  const environmentName = environmentsQuery.data?.find(
-    (env: EnvironmentResponse) => env.id === defaultEnvironment
-  )?.name || environmentsQuery.data?.find(
-    (env: EnvironmentResponse) => env.id === defaultEnvironment
-  )?.slug
+  const environmentName =
+    environmentsQuery.data?.find(
+      (env: EnvironmentResponse) => env.id === defaultEnvironment
+    )?.name ||
+    environmentsQuery.data?.find(
+      (env: EnvironmentResponse) => env.id === defaultEnvironment
+    )?.slug
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent>
+      <DialogContent className="sm:max-w-[640px]">
         <DialogHeader>
           <DialogTitle>
             {mode === 'redeploy' ? 'Redeploy' : 'Deploy Project'}
@@ -256,13 +348,18 @@ export function RedeploymentModal({
             <div className="space-y-3 rounded-md border bg-muted/50 p-4">
               <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-2">
                 <div className="text-sm font-medium">Image:</div>
-                <div className="truncate text-sm font-mono" title={imageRef || ''}>
+                <div
+                  className="truncate text-sm font-mono"
+                  title={imageRef || ''}
+                >
                   {imageRef || 'N/A'}
                 </div>
                 {mode === 'redeploy' ? (
                   <>
                     <div className="text-sm font-medium">Environment:</div>
-                    <div className="text-sm">{environmentName || 'Loading...'}</div>
+                    <div className="text-sm">
+                      {environmentName || 'Loading...'}
+                    </div>
                   </>
                 ) : null}
               </div>
@@ -272,9 +369,7 @@ export function RedeploymentModal({
                 <Label htmlFor="image-environment">Environment</Label>
                 <Select
                   value={effectiveEnvironment?.toString() || ''}
-                  onValueChange={(value) =>
-                    setSelectedEnvironment(value ? parseInt(value) : null)
-                  }
+                  onValueChange={handleEnvironmentChange}
                   disabled={environmentsQuery.isLoading}
                 >
                   <SelectTrigger>
@@ -305,7 +400,9 @@ export function RedeploymentModal({
                 disabled={
                   isLoading ||
                   !imageRef ||
-                  (mode === 'redeploy' ? !defaultEnvironment : !effectiveEnvironment)
+                  (mode === 'redeploy'
+                    ? !defaultEnvironment
+                    : !effectiveEnvironment)
                 }
               >
                 {isLoading
@@ -359,7 +456,10 @@ export function RedeploymentModal({
               <Button variant="outline" onClick={onClose} disabled={isLoading}>
                 Cancel
               </Button>
-              <Button onClick={handleConfirm} disabled={isLoading || !defaultEnvironment}>
+              <Button
+                onClick={handleConfirm}
+                disabled={isLoading || !defaultEnvironment}
+              >
                 {isLoading ? 'Redeploying...' : 'Redeploy'}
               </Button>
             </DialogFooter>
@@ -386,15 +486,20 @@ export function RedeploymentModal({
                       <Alert className="border-amber-200 bg-amber-50">
                         <AlertTriangle className="h-4 w-4 text-amber-600" />
                         <AlertDescription className="text-amber-800">
-                          The branch "{selectedBranch}" for this environment was not found in the repository.
-                          You can continue with the current branch name, or switch to deploy by commit hash.
+                          The branch “{effectiveBranch}” for this environment
+                          was not found in the repository. You can continue with
+                          the current branch name, or switch to deploy by commit
+                          hash.
                         </AlertDescription>
                       </Alert>
                     )}
-                    {deploymentType === 'branch' && selectedEnvironment && !availableBranches.includes(selectedBranch) && availableBranches.length > 0 ? (
+                    {deploymentType === 'branch' &&
+                    selectedEnvironment &&
+                    !availableBranches.includes(selectedBranch) &&
+                    availableBranches.length > 0 ? (
                       <div className="space-y-2">
                         <Input
-                          value={selectedBranch}
+                          value={effectiveBranch}
                           onChange={(e) => setSelectedBranch(e.target.value)}
                           placeholder="Enter branch name manually"
                           disabled={isLoading}
@@ -405,26 +510,139 @@ export function RedeploymentModal({
                         repoOwner={projectQuery.data?.repo_owner || ''}
                         repoName={projectQuery.data?.repo_name || ''}
                         connectionId={
-                          projectQuery.data?.git_provider_connection_id || undefined
+                          projectQuery.data?.git_provider_connection_id ||
+                          undefined
                         }
                         gitUrl={(projectQuery.data as any)?.git_url}
-                        defaultBranch={initialBranch || projectQuery.data?.main_branch}
-                        value={selectedBranch}
+                        defaultBranch={
+                          initialBranch || projectQuery.data?.main_branch
+                        }
+                        value={effectiveBranch}
                         onChange={(branch) => {
                           setSelectedBranch(branch)
-                          setBranchNotFound(false)
                         }}
-                        onBranchesLoaded={(branches) => setAvailableBranches(branches)}
+                        onBranchesLoaded={(branches) =>
+                          setAvailableBranches(branches)
+                        }
                         disabled={isLoading}
                       />
                     )}
                   </TabsContent>
-                  <TabsContent value="commit">
-                    <Input
-                      value={selectedCommit}
-                      onChange={(e) => setSelectedCommit(e.target.value)}
-                      placeholder="Enter commit hash"
-                    />
+                  <TabsContent value="commit" className="space-y-3">
+                    <div className="space-y-1.5">
+                      <Input
+                        value={selectedCommit}
+                        onChange={(e) => setSelectedCommit(e.target.value)}
+                        placeholder="Enter commit hash"
+                        spellCheck={false}
+                        autoComplete="off"
+                        className="font-mono"
+                        aria-invalid={
+                          normalizedCommit.length > 0 && !commitFormatIsValid
+                        }
+                        aria-describedby="commit-lookup-status"
+                      />
+                      {normalizedCommit.length > 0 && !commitFormatIsValid && (
+                        <p className="text-xs text-destructive">
+                          Use 7 to 40 hexadecimal characters.
+                        </p>
+                      )}
+                    </div>
+
+                    <div id="commit-lookup-status" aria-live="polite">
+                      {commitFormatIsValid && shouldLookUpCommit && (
+                        <>
+                          {(repositoryQuery.isLoading ||
+                            !checkedCurrentCommit ||
+                            commitQuery.isLoading) &&
+                            !repositoryQuery.isError && (
+                              <div className="flex items-center gap-2 rounded-md border bg-muted/30 px-3 py-2.5 text-sm text-muted-foreground">
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                                Checking commit with the Git provider…
+                              </div>
+                            )}
+
+                          {(repositoryQuery.isError || commitQuery.isError) && (
+                            <Alert variant="destructive">
+                              <AlertTriangle className="h-4 w-4" />
+                              <AlertDescription className="flex items-center justify-between gap-3">
+                                <span>
+                                  Commit details could not be loaded. Check the
+                                  Git provider connection and try again.
+                                </span>
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  size="sm"
+                                  className="shrink-0"
+                                  onClick={() => {
+                                    if (repositoryQuery.isError) {
+                                      void repositoryQuery.refetch()
+                                    } else {
+                                      void commitQuery.refetch()
+                                    }
+                                  }}
+                                >
+                                  <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+                                  Retry
+                                </Button>
+                              </AlertDescription>
+                            </Alert>
+                          )}
+
+                          {checkedCurrentCommit &&
+                            commitQuery.data &&
+                            !commitQuery.data.exists && (
+                              <Alert variant="destructive">
+                                <AlertTriangle className="h-4 w-4" />
+                                <AlertDescription>
+                                  This commit was not found in{' '}
+                                  <span className="font-medium">
+                                    {projectDetails.repo_owner}/
+                                    {projectDetails.repo_name}
+                                  </span>
+                                  .
+                                </AlertDescription>
+                              </Alert>
+                            )}
+
+                          {commitIsVerified && commitQuery.data?.commit && (
+                            <div className="overflow-hidden rounded-md border bg-muted/20">
+                              <div className="flex items-center justify-between gap-3 border-b bg-muted/40 px-3 py-2">
+                                <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
+                                  <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
+                                  Commit found
+                                </div>
+                                <div className="flex items-center gap-1.5 font-mono text-xs text-muted-foreground">
+                                  <GitCommitHorizontal className="h-3.5 w-3.5" />
+                                  {commitQuery.data.commit.sha.slice(0, 12)}
+                                </div>
+                              </div>
+                              <div className="space-y-2.5 px-3 py-3">
+                                <p className="max-h-24 overflow-y-auto whitespace-pre-wrap text-sm leading-relaxed">
+                                  {commitQuery.data.commit.message}
+                                </p>
+                                <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+                                  <span className="font-medium text-foreground">
+                                    {commitQuery.data.commit.author}
+                                  </span>
+                                  <span aria-hidden="true">·</span>
+                                  <span>
+                                    {formatCommitDate(
+                                      commitQuery.data.commit.date
+                                    )}
+                                  </span>
+                                  <span aria-hidden="true">·</span>
+                                  <span className="truncate">
+                                    {commitQuery.data.commit.author_email}
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          )}
+                        </>
+                      )}
+                    </div>
                   </TabsContent>
                   <TabsContent value="tag">
                     <Input
@@ -440,9 +658,7 @@ export function RedeploymentModal({
                 <Label htmlFor="environment">Environment</Label>
                 <Select
                   value={effectiveEnvironment?.toString() || ''}
-                  onValueChange={(value) =>
-                    setSelectedEnvironment(value ? parseInt(value) : null)
-                  }
+                  onValueChange={handleEnvironmentChange}
                   disabled={environmentsQuery.isLoading}
                 >
                   <SelectTrigger>
@@ -471,7 +687,12 @@ export function RedeploymentModal({
               <Button
                 onClick={handleConfirm}
                 disabled={
-                  isLoading || !effectiveEnvironment || environmentsQuery.isLoading
+                  isLoading ||
+                  !effectiveEnvironment ||
+                  environmentsQuery.isLoading ||
+                  (deploymentType === 'commit' &&
+                    (!commitFormatIsValid ||
+                      (shouldLookUpCommit && !commitIsVerified)))
                 }
               >
                 {isLoading ? 'Deploying...' : 'Deploy'}

--- a/web/src/components/deployments/RedeploymentModal.tsx
+++ b/web/src/components/deployments/RedeploymentModal.tsx
@@ -160,6 +160,9 @@ export function RedeploymentModal({
         owner: projectDetails.repo_owner || '',
         name: projectDetails.repo_name || '',
       },
+      query: {
+        connection_id: projectDetails.git_provider_connection_id || 0,
+      },
     }),
     enabled:
       isOpen &&


### PR DESCRIPTION
## Summary

- extend the repository commit lookup API with typed commit metadata
- show commit message, author, email, date, and SHA in the deploy dialog
- debounce commit lookups and surface loading, missing-commit, provider-error, and retry states
- prevent deployment until connected-repository commits are verified

## Testing

- `cargo test --lib -p temps-git` (277 passed)
- `cargo check --lib`
- `cargo clippy --lib -p temps-git -- -D warnings`
- targeted ESLint for `RedeploymentModal.tsx`
- `tsc --noEmit`
- Prettier and `git diff --check`
- runtime: feature backend `/healthz` returned 200 and web dev root returned 200

## Notes

- repository-wide `bun run lint` remains blocked by pre-existing ESLint failures outside the changed component; the changed component passes targeted ESLint and the full TypeScript check passes.