### PR TITLE
fix(email): stop leaking suppressed recipient addresses via logs/error_message

### DIFF
--- a/crates/temps-email/src/services/email_service.rs
+++ b/crates/temps-email/src/services/email_service.rs
@@ -210,8 +210,17 @@ impl EmailService {
         };
 
         if !suppressed.is_empty() {
+            // Addresses go to `debug!` only — `info!` (and any field
+            // persisted where a caller with send+read access could read it
+            // back, like `error_message` below) must not let one recipient
+            // enumerate another recipient's bounce/complaint history.
             info!(
-                "Dropping suppressed recipient(s) from email {}: {:?}",
+                "Dropping {} suppressed recipient(s) from email {}",
+                suppressed.len(),
+                email_id
+            );
+            debug!(
+                "Suppressed recipient(s) dropped from email {}: {:?}",
                 email_id, suppressed
             );
         }
@@ -223,16 +232,20 @@ impl EmailService {
         // sending an email with no primary recipient.
         if to.is_empty() {
             info!(
-                "Refusing to send email {} — all recipient(s) suppressed: {:?}",
+                "Refusing to send email {} — {} recipient(s) suppressed",
+                email_id,
+                suppressed.len()
+            );
+            debug!(
+                "Email {} refused — suppressed recipient(s): {:?}",
                 email_id, suppressed
             );
 
             let mut active_model: emails::ActiveModel = email_model.into();
             active_model.status = Set("captured".to_string());
-            active_model.error_message = Set(Some(format!(
-                "Recipient(s) suppressed (previous hard bounce or complaint): {}",
-                suppressed.join(", ")
-            )));
+            active_model.error_message = Set(Some(
+                "Recipient(s) suppressed (previous hard bounce or complaint)".to_string(),
+            ));
             active_model.sent_at = Set(Some(Utc::now()));
 
             active_model.update(self.db.as_ref()).await?;


### PR DESCRIPTION
## Summary

Follow-up from reviewing #296/#297: the suppression-list feature that shipped as part of #297's merge logs the actual suppressed email addresses and, when every recipient on a send is suppressed, writes them verbatim into `emails.error_message`.

- Any caller with send + email-read permission could send to a target address, observe `status=captured`, then read `error_message` (or the application logs) back and learn whether that address previously hard-bounced or complained — an enumeration oracle for other users'/recipients' delivery history, without any access to the suppression table itself.
- Fix: address lists are logged at `debug!` only; `info!` now logs a count, not the addresses. `error_message` uses a generic "Recipient(s) suppressed (previous hard bounce or complaint)" string instead of naming them.

No behavior change to sending, suppression, or capture logic — only what's exposed in logs/response data.

## Test plan

- [x] `cargo check --lib -p temps-email` — clean
- [x] `cargo test --lib -p temps-email` — 183 passed
- [x] `cargo fmt -p temps-email -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)