### PR TITLE
fix(web): make DNS records table horizontally scroll on mobile

### DIFF
--- a/web/src/components/email/EmailDomainsManagement.tsx
+++ b/web/src/components/email/EmailDomainsManagement.tsx
@@ -322,58 +322,60 @@ export function DnsRecordsTable({ records }: { records: DnsRecord[] }) {
   }
 
   return (
-    <div className="rounded-md border">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-[100px]">Type</TableHead>
-            <TableHead>Name</TableHead>
-            <TableHead>Value</TableHead>
-            <TableHead className="w-[80px]">Priority</TableHead>
-            <TableHead className="w-[100px]">Status</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {records.map((record, index) => (
-            <TableRow
-              key={index}
-              className={
-                record.status === 'verified'
-                  ? 'bg-emerald-50/50 dark:bg-emerald-950/20'
-                  : record.status === 'failed'
-                    ? 'bg-red-50/50 dark:bg-red-950/20'
-                    : ''
-              }
-            >
-              <TableCell>
-                <Badge variant="outline">{record.record_type}</Badge>
-              </TableCell>
-              <TableCell>
-                <div className="flex items-center gap-2">
-                  <span className="break-all font-mono text-xs">{record.name}</span>
-                  <CopyButton
-                    value={record.name}
-                    className="h-6 w-6 shrink-0 rounded-md p-0 hover:bg-accent hover:text-accent-foreground"
-                  />
-                </div>
-              </TableCell>
-              <TableCell>
-                <div className="flex items-center gap-2">
-                  <span className="break-all font-mono text-xs">{record.value}</span>
-                  <CopyButton
-                    value={record.value}
-                    className="h-6 w-6 shrink-0 rounded-md p-0 hover:bg-accent hover:text-accent-foreground"
-                  />
-                </div>
-              </TableCell>
-              <TableCell>{record.priority ?? '-'}</TableCell>
-              <TableCell>
-                <DnsRecordStatusBadge status={record.status} />
-              </TableCell>
+    <div className="-mx-6 overflow-x-auto whitespace-nowrap sm:mx-0 sm:rounded-md sm:border">
+      <div className="inline-block min-w-full px-6 align-middle sm:px-0">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[100px] whitespace-nowrap">Type</TableHead>
+              <TableHead className="whitespace-nowrap">Name</TableHead>
+              <TableHead className="whitespace-nowrap">Value</TableHead>
+              <TableHead className="w-[80px] whitespace-nowrap">Priority</TableHead>
+              <TableHead className="w-[100px] whitespace-nowrap">Status</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHeader>
+          <TableBody>
+            {records.map((record, index) => (
+              <TableRow
+                key={index}
+                className={
+                  record.status === 'verified'
+                    ? 'bg-emerald-50/50 dark:bg-emerald-950/20'
+                    : record.status === 'failed'
+                      ? 'bg-red-50/50 dark:bg-red-950/20'
+                      : ''
+                }
+              >
+                <TableCell>
+                  <Badge variant="outline">{record.record_type}</Badge>
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-xs">{record.name}</span>
+                    <CopyButton
+                      value={record.name}
+                      className="h-6 w-6 shrink-0 rounded-md p-0 hover:bg-accent hover:text-accent-foreground"
+                    />
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-xs">{record.value}</span>
+                    <CopyButton
+                      value={record.value}
+                      className="h-6 w-6 shrink-0 rounded-md p-0 hover:bg-accent hover:text-accent-foreground"
+                    />
+                  </div>
+                </TableCell>
+                <TableCell>{record.priority ?? '-'}</TableCell>
+                <TableCell>
+                  <DnsRecordStatusBadge status={record.status} />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- The email domain detail page (`/email/domains/:id`) had a 5-column DNS records table (Type, Name, Value, Priority, Status) with long `font-mono` Name/Value cells and no scroll wrapper, causing overflow on narrow viewports.
- Wraps the table in the project's standard `overflow-x-auto` pattern with matching negative container margins (`-mx-6`/`px-6` to match the parent `CardContent`'s `p-6`) and `whitespace-nowrap` headers, so it scrolls horizontally on mobile instead of overflowing.
- Removed the now-redundant `break-all` on the Name/Value cells since the row itself now scrolls.

## Test plan
- [x] `bunx tsc --noEmit` passes for the changed file
- [x] Manually verify `/email/domains/:id` at mobile/tablet/desktop widths