### PR TITLE
feat(email): add provider detail page with domains and delivery tracking setup

### DIFF
--- a/crates/temps-email/src/handlers/domains.rs
+++ b/crates/temps-email/src/handlers/domains.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     response::IntoResponse,
     routing::{get, post},
@@ -21,7 +21,8 @@ use tracing::{error, info, warn};
 use super::audit::{EmailDomainCreatedAudit, EmailDomainDeletedAudit, EmailDomainVerifiedAudit};
 use super::types::{
     AppState, CreateEmailDomainRequest, DnsRecordResponse, DnsRecordSetupResult,
-    EmailDomainResponse, EmailDomainWithDnsResponse, SetupDnsRequest, SetupDnsResponse,
+    EmailDomainResponse, EmailDomainWithDnsResponse, ListDomainsQuery, SetupDnsRequest,
+    SetupDnsResponse,
 };
 use crate::errors::EmailError;
 use crate::services::CreateDomainRequest;
@@ -176,6 +177,7 @@ pub async fn create_email_domain(
     tag = "Email Domains",
     get,
     path = "/email-domains",
+    params(ListDomainsQuery),
     responses(
         (status = 200, description = "List of email domains", body = Vec<EmailDomainResponse>),
         (status = 401, description = "Unauthorized"),
@@ -187,10 +189,15 @@ pub async fn create_email_domain(
 pub async fn list_email_domains(
     RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
+    Query(query): Query<ListDomainsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EmailDomainsRead);
 
-    let domains = state.domain_service.list().await.map_err(|e| {
+    let domains = match query.provider_id {
+        Some(provider_id) => state.domain_service.list_by_provider(provider_id).await,
+        None => state.domain_service.list().await,
+    }
+    .map_err(|e| {
         error!("Failed to list email domains: {}", e);
         internal_server_error()
             .detail("Failed to list domains")

--- a/crates/temps-email/src/handlers/types.rs
+++ b/crates/temps-email/src/handlers/types.rs
@@ -360,6 +360,12 @@ pub struct EmailDomainWithDnsResponse {
     pub dns_records: Vec<DnsRecordResponse>,
 }
 
+#[derive(Debug, Deserialize, ToSchema, IntoParams)]
+pub struct ListDomainsQuery {
+    /// Only return domains belonging to this provider
+    pub provider_id: Option<i32>,
+}
+
 /// Request to setup DNS records using a configured DNS provider
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct SetupDnsRequest {

--- a/docs/features/email/page.mdx
+++ b/docs/features/email/page.mdx
@@ -41,6 +41,8 @@ Configure providers under **Email → Providers**. Each provider stores its regi
 
 Use **Test provider** after saving — it sends a test email to your own account address through the provider so failures surface immediately instead of on your first real send.
 
+Click a provider to open its detail page: the domains assigned to it, its configuration, and — for SES — the delivery event tracking setup below.
+
 ## Domains & DNS {{ id: 'domains' }}
 
 Add a sending domain under **Email → Domains** and Temps shows the DNS records the provider requires. If the domain's DNS zone is managed by a DNS provider configured in Temps, **Setup DNS** creates the records for you; otherwise create them manually and hit **Verify**.
@@ -62,7 +64,7 @@ When enabled per email, Temps injects a tracking pixel and rewrites links throug
 
 Bounces, complaints, and delivery confirmations come from the provider, not from the recipient — for SES they arrive through an SNS topic subscribed to your instance's webhook. This requires one-time AWS-side setup; see [Set up email event tracking](/docs/set-up-email-event-tracking) for the one-click flow and the manual steps.
 
-Once configured, the provider dialog shows the subscription state ("confirmed" vs "pending") and the time of the last event received, so a broken pipeline is visible instead of silently delivering nothing.
+Once configured, the provider's detail page shows the subscription state ("confirmed" vs "pending") and the time of the last event received, so a broken pipeline is visible instead of silently delivering nothing.
 
 ## Suppression List {{ id: 'suppression-list' }}
 

--- a/docs/howto/set-up-email-event-tracking/page.mdx
+++ b/docs/howto/set-up-email-event-tracking/page.mdx
@@ -24,7 +24,7 @@ Wire AWS SES to your Temps instance so bounces, complaints, and delivery confirm
 
 - `delivered`, `bounced`, and `complained` events on the per-email Activity timeline and in Email Analytics.
 - Automatic per-domain suppression of hard-bounced and complaining recipients.
-- Pipeline health in the provider dialog: subscription confirmed/pending, and the time of the last event received.
+- Pipeline health on the provider's detail page: subscription confirmed/pending, and the time of the last event received.
 
 Events flow SES → SNS topic → HTTPS webhook on your instance (`/api/t/webhook/ses`). Temps verifies each message's SNS signature and only accepts topics bound to an active SES provider.
 
@@ -35,7 +35,7 @@ Events flow SES → SNS topic → HTTPS webhook on your instance (`/api/t/webhoo
 
 ## Automatic setup {{ id: 'automatic-setup' }}
 
-Open the SES provider in **Email → Providers → Edit** and press **Set up automatically** in the *Delivery event tracking* section. Using the provider's stored credentials, Temps:
+Open the SES provider's detail page (**Email → Providers → click the provider**) and press **Set up automatically** in the *Delivery event tracking* section. Using the provider's stored credentials, Temps:
 
 1. Creates (or reuses) an SNS topic named `temps-email-events-{provider-id}` in the provider's region.
 2. Saves the topic ARN on the provider — this authorizes the topic *before* anything subscribes to it.
@@ -79,11 +79,11 @@ If you prefer creating resources yourself, **the order matters**:
 1. Create an SNS topic in the **same region** as the provider.
 2. Paste the topic ARN into the provider's **SNS Topic ARN** field in Temps and **save**. Temps only auto-confirms subscription requests for topics it already knows about — subscribing first leaves the subscription stuck in "pending" forever, with no error shown anywhere.
 3. In the SES console, add an event destination to the `temps-tracking` configuration set for **bounce, complaint, and delivery** events, publishing to your topic.
-4. Subscribe your webhook URL — shown in the provider dialog, of the form `https://your-instance.example.com/api/t/webhook/ses` — to the topic with protocol HTTPS. Temps confirms the subscription automatically.
+4. Subscribe your webhook URL — shown on the provider's detail page, of the form `https://your-instance.example.com/api/t/webhook/ses` — to the topic with protocol HTTPS. Temps confirms the subscription automatically.
 
 ## Verify it works {{ id: 'verify' }}
 
-1. The provider dialog should show **Subscription confirmed** within seconds of setup.
+1. The provider's detail page should show **Subscription confirmed** within seconds of setup.
 2. Send a test to SES's bounce simulator: `bounce@simulator.amazonses.com`. A `bounced` event should appear on the email's timeline shortly after, and the recipient lands on the domain's suppression list.
 3. `success@simulator.amazonses.com` produces a `delivered` event; `complaint@simulator.amazonses.com` a `complained` event.
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -189,6 +189,11 @@ const EmailDomainDetail = lazy(() =>
     default: m.EmailDomainDetail,
   }))
 )
+const EmailProviderDetail = lazy(() =>
+  import('./pages/EmailProviderDetail').then((m) => ({
+    default: m.EmailProviderDetail,
+  }))
+)
 const AuditLogs = lazy(() =>
   import('./pages/AuditLogs').then((m) => ({ default: m.AuditLogs }))
 )
@@ -524,6 +529,7 @@ const FullAppRoutes = () => {
                 <Route path="/storage/:id/members/add" element={<AddClusterMember />} />
                 <Route path="/email" element={<Email />} />
                 <Route path="/email/domains/:id" element={<EmailDomainDetail />} />
+                <Route path="/email/providers/:id" element={<EmailProviderDetail />} />
                 <Route path="/email/:id" element={<EmailDetail />} />
                 <Route path="/ai-gateway" element={<AiGateway />} />
                 <Route path="/agent-sandbox" element={<AgentSandboxLayout />}>

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -24234,7 +24234,12 @@ export type CheckDomainStatusResponse = CheckDomainStatusResponses[keyof CheckDo
 export type ListEmailDomainsData = {
     body?: never;
     path?: never;
-    query?: never;
+    query?: {
+        /**
+         * Only return domains belonging to this provider
+         */
+        provider_id?: number | null;
+    };
     url: '/email-domains';
 };
 

--- a/web/src/components/email/EmailProvidersManagement.tsx
+++ b/web/src/components/email/EmailProvidersManagement.tsx
@@ -2,7 +2,6 @@
 
 import {
   createEmailProvider as createProvider2,
-  deleteEmailProvider as deleteProvider2,
   listEmailProviders as listProviders2,
   testProvider,
   updateEmailProvider as updateProvider2,
@@ -60,14 +59,18 @@ import {
   Send,
   Server,
 } from 'lucide-react'
-import { EmailTrackingSetup } from './EmailTrackingSetup'
 import { AWSIcon } from '@/components/icons/AWSIcon'
 import { ScalewayIcon } from '@/components/icons/ScalewayIcon'
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import { z } from 'zod'
-import { problemMessage } from './sharedUtils'
+import {
+  deleteEmailProvider,
+  problemMessage,
+  readMaskedCreds,
+} from './sharedUtils'
 
 // Types for email providers — alias over SDK response
 type EmailProvider = EmailProviderResponse
@@ -203,15 +206,6 @@ async function createEmailProvider(
   return response.data
 }
 
-async function deleteEmailProvider(id: number): Promise<void> {
-  const response = await deleteProvider2({ path: { id } })
-  if (response.error) {
-    throw new Error(
-      problemMessage(response.error, 'Failed to delete email provider')
-    )
-  }
-}
-
 async function updateEmailProviderApi(
   id: number,
   body: UpdateEmailProviderRequest
@@ -223,32 +217,6 @@ async function updateEmailProviderApi(
     )
   }
   return response.data
-}
-
-/**
- * The backend returns credentials as a freeform JSON value masked for display
- * (e.g. `{"host":"...", "port":587, "encryption":"starttls", "username":"AKIA...XYZ"}`).
- * This pulls out only the non-secret fields we need to prefill the edit form.
- */
-function readMaskedCreds(credentials: unknown): {
-  host?: string
-  port?: number
-  encryption?: 'starttls' | 'tls' | 'none'
-  accept_invalid_certs?: boolean
-} {
-  if (!credentials || typeof credentials !== 'object') return {}
-  const c = credentials as Record<string, unknown>
-  const enc = typeof c.encryption === 'string' ? c.encryption : undefined
-  return {
-    host: typeof c.host === 'string' ? c.host : undefined,
-    port: typeof c.port === 'number' ? c.port : undefined,
-    encryption:
-      enc === 'starttls' || enc === 'tls' || enc === 'none' ? enc : undefined,
-    accept_invalid_certs:
-      typeof c.accept_invalid_certs === 'boolean'
-        ? c.accept_invalid_certs
-        : undefined,
-  }
 }
 
 async function testEmailProvider(
@@ -315,7 +283,7 @@ function providerTypeLabel(type: 'ses' | 'scaleway' | 'smtp'): string {
   }
 }
 
-function TestEmailDialog({
+export function TestEmailDialog({
   open,
   onOpenChange,
   providerId,
@@ -444,6 +412,7 @@ function ProviderCard({
   onEditClick: (provider: EmailProvider) => void
 }) {
   const [isDeleting, setIsDeleting] = useState(false)
+  const navigate = useNavigate()
 
   const handleDelete = () => {
     setIsDeleting(true)
@@ -455,7 +424,10 @@ function ProviderCard({
   }
 
   return (
-    <Card>
+    <Card
+      onClick={() => navigate(`/email/providers/${provider.id}`)}
+      className="cursor-pointer transition-colors hover:bg-muted/40"
+    >
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <div className="flex items-center gap-3">
           <ProviderIcon type={provider.provider_type} />
@@ -468,7 +440,10 @@ function ProviderCard({
             </p>
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div
+          className="flex items-center gap-2"
+          onClick={(e) => e.stopPropagation()}
+        >
           <Badge variant={provider.is_active ? 'default' : 'secondary'}>
             {provider.is_active ? 'Active' : 'Inactive'}
           </Badge>
@@ -610,7 +585,7 @@ interface EditProviderDialogProps {
   onSuccess: () => void
 }
 
-function EditProviderDialog({
+export function EditProviderDialog({
   provider,
   open,
   onOpenChange,
@@ -860,13 +835,14 @@ function EditProviderDialog({
                         </FormControl>
                         <FormDescription>
                           Exact SNS topic authorized to send SES delivery,
-                          bounce, and complaint events for this provider.
+                          bounce, and complaint events for this provider. To set
+                          this up automatically, close this dialog and open the
+                          provider&apos;s detail page.
                         </FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}
                   />
-                  {provider && <EmailTrackingSetup providerId={provider.id} />}
                   <FormField
                     control={form.control}
                     name="access_key_id"

--- a/web/src/components/email/sharedUtils.ts
+++ b/web/src/components/email/sharedUtils.ts
@@ -3,6 +3,8 @@
 // EmailDomainDetail / EmailProvidersManagement / EmailEventTimeline /
 // EmailAnalytics to avoid copy-pasted logic drifting out of sync.
 
+import { deleteEmailProvider as deleteEmailProviderApi } from '@/api/client'
+
 export function problemMessage(error: unknown, fallback: string): string {
   if (error && typeof error === 'object' && 'detail' in error) {
     const detail = (error as { detail?: unknown }).detail
@@ -15,9 +17,11 @@ export function problemMessage(error: unknown, fallback: string): string {
 
 export function parseUserAgent(ua: string): string {
   // Email image proxies (check first — they masquerade as browsers)
-  if (ua.includes('GoogleImageProxy') || ua.includes('ggpht.com')) return 'Gmail (Google Proxy)'
+  if (ua.includes('GoogleImageProxy') || ua.includes('ggpht.com'))
+    return 'Gmail (Google Proxy)'
   if (ua.includes('YahooMailProxy')) return 'Yahoo Mail (Proxy)'
-  if (ua.includes('Outlook-iOS') || ua.includes('Outlook-Android')) return 'Outlook Mobile'
+  if (ua.includes('Outlook-iOS') || ua.includes('Outlook-Android'))
+    return 'Outlook Mobile'
   // Email clients
   if (ua.includes('Gmail')) return 'Gmail'
   if (ua.includes('Yahoo')) return 'Yahoo Mail'
@@ -31,4 +35,39 @@ export function parseUserAgent(ua: string): string {
   if (ua.includes('AppleWebKit')) return 'WebKit'
   if (ua.length > 50) return ua.substring(0, 50) + '...'
   return ua
+}
+
+export async function deleteEmailProvider(id: number): Promise<void> {
+  const response = await deleteEmailProviderApi({ path: { id } })
+  if (response.error) {
+    throw new Error(
+      problemMessage(response.error, 'Failed to delete email provider')
+    )
+  }
+}
+
+/**
+ * The backend returns credentials as a freeform JSON value masked for display
+ * (e.g. `{"host":"...", "port":587, "encryption":"starttls", "username":"AKIA...XYZ"}`).
+ * This pulls out only the non-secret fields we need to prefill the edit form.
+ */
+export function readMaskedCreds(credentials: unknown): {
+  host?: string
+  port?: number
+  encryption?: 'starttls' | 'tls' | 'none'
+  accept_invalid_certs?: boolean
+} {
+  if (!credentials || typeof credentials !== 'object') return {}
+  const c = credentials as Record<string, unknown>
+  const enc = typeof c.encryption === 'string' ? c.encryption : undefined
+  return {
+    host: typeof c.host === 'string' ? c.host : undefined,
+    port: typeof c.port === 'number' ? c.port : undefined,
+    encryption:
+      enc === 'starttls' || enc === 'tls' || enc === 'none' ? enc : undefined,
+    accept_invalid_certs:
+      typeof c.accept_invalid_certs === 'boolean'
+        ? c.accept_invalid_certs
+        : undefined,
+  }
 }

--- a/web/src/pages/EmailProviderDetail.tsx
+++ b/web/src/pages/EmailProviderDetail.tsx
@@ -1,0 +1,447 @@
+'use client'
+
+import {
+  getEmailProvider,
+  listEmailDomains,
+  type EmailDomainResponse,
+  type EmailProviderResponse,
+} from '@/api/client'
+import {
+  EditProviderDialog,
+  TestEmailDialog,
+} from '@/components/email/EmailProvidersManagement'
+import { StatusPill } from '@/components/email/EmailDomainsManagement'
+import { EmailTrackingSetup } from '@/components/email/EmailTrackingSetup'
+import {
+  deleteEmailProvider,
+  problemMessage,
+} from '@/components/email/sharedUtils'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  EmailProviderLogo,
+  getEmailProviderLabel,
+  type EmailProviderType,
+} from '@/components/ui/email-provider-logo'
+import { EmptyState } from '@/components/ui/empty-state'
+import { Skeleton } from '@/components/ui/skeleton'
+import { TimeAgo } from '@/components/utils/TimeAgo'
+import { useBreadcrumbs } from '@/contexts/BreadcrumbContext'
+import { usePageTitle } from '@/hooks/usePageTitle'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { AlertCircle, ArrowLeft, Globe, Plus, Send, Trash2 } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { toast } from 'sonner'
+
+async function fetchProvider(id: number): Promise<EmailProviderResponse> {
+  const response = await getEmailProvider({ path: { id } })
+  if (response.error || !response.data) {
+    throw new Error(
+      problemMessage(response.error, 'Failed to fetch email provider')
+    )
+  }
+  return response.data
+}
+
+async function fetchDomainsForProvider(
+  providerId: number
+): Promise<EmailDomainResponse[]> {
+  const response = await listEmailDomains({
+    query: { provider_id: providerId },
+  })
+  if (response.error) {
+    throw new Error(problemMessage(response.error, 'Failed to fetch domains'))
+  }
+  return response.data ?? []
+}
+
+function Row({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="grid grid-cols-3 gap-3 py-2.5 text-sm first:pt-0 last:pb-0">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="col-span-2 min-w-0">{children}</dd>
+    </div>
+  )
+}
+
+export function EmailProviderDetail() {
+  const { id: idParam } = useParams<{ id: string }>()
+  const id = idParam ? parseInt(idParam, 10) : undefined
+  const { setBreadcrumbs } = useBreadcrumbs()
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
+  const [isTestDialogOpen, setIsTestDialogOpen] = useState(false)
+
+  const {
+    data: provider,
+    isLoading,
+    error: fetchError,
+  } = useQuery({
+    queryKey: ['email-provider', id],
+    queryFn: () => fetchProvider(id!),
+    enabled: !!id,
+  })
+
+  const {
+    data: domains,
+    isLoading: isLoadingDomains,
+    error: domainsError,
+  } = useQuery({
+    queryKey: ['email-domains', { provider_id: id }],
+    queryFn: () => fetchDomainsForProvider(id!),
+    enabled: !!id,
+  })
+
+  useEffect(() => {
+    setBreadcrumbs([
+      { label: 'Email', href: '/email' },
+      { label: 'Providers', href: '/email?tab=providers' },
+      { label: provider?.name ?? 'Provider' },
+    ])
+  }, [setBreadcrumbs, provider?.name])
+
+  usePageTitle(provider?.name ?? 'Email Provider')
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteEmailProvider(id!),
+    onSuccess: () => {
+      toast.success('Email provider deleted')
+      queryClient.invalidateQueries({ queryKey: ['email-providers'] })
+      navigate('/email?tab=providers')
+    },
+    onError: (err: Error) => {
+      toast.error('Failed to delete provider', { description: err.message })
+    },
+  })
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 overflow-auto">
+        <div className="space-y-6 sm:p-4 md:p-6">
+          <Skeleton className="h-8 w-32" />
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex min-w-0 items-start gap-3">
+              <Skeleton className="size-11 shrink-0 rounded-md" />
+              <div className="space-y-2">
+                <Skeleton className="h-7 w-56" />
+                <Skeleton className="h-4 w-72" />
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <Skeleton className="h-10 w-28" />
+              <Skeleton className="h-10 w-24" />
+            </div>
+          </div>
+          <div className="grid gap-6 lg:grid-cols-3">
+            <div className="space-y-6 lg:col-span-2">
+              <Card>
+                <CardHeader>
+                  <Skeleton className="h-5 w-32" />
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <Skeleton className="h-14 w-full rounded-lg" />
+                  <Skeleton className="h-14 w-full rounded-lg" />
+                </CardContent>
+              </Card>
+            </div>
+            <div className="space-y-6">
+              <Card>
+                <CardHeader>
+                  <Skeleton className="h-5 w-24" />
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-3">
+                    {[1, 2, 3, 4].map((i) => (
+                      <div key={i} className="grid grid-cols-3 gap-3">
+                        <Skeleton className="h-4 w-20" />
+                        <Skeleton className="col-span-2 h-4 w-full" />
+                      </div>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (fetchError || !provider) {
+    return (
+      <div className="flex-1 overflow-auto">
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <h2 className="text-lg font-semibold">Provider not found</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            The requested email provider could not be found.
+          </p>
+          <Button asChild className="mt-4">
+            <Link to="/email?tab=providers">
+              <ArrowLeft className="mr-2 size-4" />
+              Back to providers
+            </Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="space-y-6 sm:p-4 md:p-6">
+        {/* Back link */}
+        <Button variant="ghost" size="sm" asChild className="-ml-2 w-fit">
+          <Link to="/email?tab=providers">
+            <ArrowLeft className="mr-2 size-4" />
+            Back to providers
+          </Link>
+        </Button>
+
+        {/* Header */}
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex min-w-0 items-start gap-3">
+            <div className="flex size-11 shrink-0 items-center justify-center rounded-md border bg-background">
+              <EmailProviderLogo
+                provider={provider.provider_type as EmailProviderType}
+                size={22}
+              />
+            </div>
+            <div className="min-w-0 space-y-1.5">
+              <h1 className="truncate text-xl font-semibold sm:text-2xl">
+                {provider.name}
+              </h1>
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+                <Badge variant={provider.is_active ? 'default' : 'secondary'}>
+                  {provider.is_active ? 'Active' : 'Inactive'}
+                </Badge>
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="text-foreground">
+                    {getEmailProviderLabel(
+                      provider.provider_type as EmailProviderType
+                    )}
+                  </span>
+                  <Badge
+                    variant="outline"
+                    className="font-mono text-[10px] uppercase"
+                  >
+                    {provider.region}
+                  </Badge>
+                </span>
+                <span className="hidden sm:inline" aria-hidden>
+                  ·
+                </span>
+                <span>
+                  Added <TimeAgo date={provider.created_at} />
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button variant="outline" onClick={() => setIsTestDialogOpen(true)}>
+              <Send className="mr-2 size-4" />
+              Send Test Email
+            </Button>
+            <Button variant="outline" onClick={() => setIsEditDialogOpen(true)}>
+              Edit
+            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="outline"
+                  className="text-destructive hover:text-destructive"
+                >
+                  <Trash2 className="mr-2 size-4" />
+                  Delete
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete {provider.name}?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will permanently delete the provider and its stored
+                    credentials from Temps. Domains still assigned to this
+                    provider will be unable to send email until reassigned.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => deleteMutation.mutate()}
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  >
+                    Delete provider
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        </div>
+
+        {/* Two-column layout: domains + tracking setup on left, overview on right */}
+        <div className="grid gap-6 lg:grid-cols-3">
+          <div className="space-y-6 lg:col-span-2">
+            {/* Domains using this provider */}
+            <Card>
+              <CardHeader>
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <CardTitle>Domains</CardTitle>
+                  <Button variant="outline" size="sm" asChild>
+                    <Link to="/email?tab=domains">
+                      <Plus className="mr-2 size-4" />
+                      Add domain
+                    </Link>
+                  </Button>
+                </div>
+              </CardHeader>
+              <CardContent>
+                {isLoadingDomains ? (
+                  <div className="space-y-2">
+                    <Skeleton className="h-12 w-full" />
+                    <Skeleton className="h-12 w-full" />
+                  </div>
+                ) : domainsError ? (
+                  <Alert variant="destructive">
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertTitle>Failed to load domains</AlertTitle>
+                    <AlertDescription>
+                      {domainsError instanceof Error
+                        ? domainsError.message
+                        : 'Could not fetch domains for this provider.'}
+                    </AlertDescription>
+                  </Alert>
+                ) : !domains || domains.length === 0 ? (
+                  <EmptyState
+                    icon={Globe}
+                    title="No domains yet"
+                    description="Add a sending domain and assign it to this provider to start sending email."
+                    action={
+                      <Button asChild size="sm">
+                        <Link to="/email?tab=domains">
+                          <Plus className="mr-2 size-4" />
+                          Add domain
+                        </Link>
+                      </Button>
+                    }
+                  />
+                ) : (
+                  <ul role="list" className="divide-y rounded-lg border">
+                    {domains.map((domain) => (
+                      <li key={domain.id}>
+                        <Link
+                          to={`/email/domains/${domain.id}`}
+                          className="flex items-center justify-between gap-4 px-4 py-3 transition-colors hover:bg-muted/40"
+                        >
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-medium">
+                              {domain.domain}
+                            </p>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              Added <TimeAgo date={domain.created_at} />
+                            </p>
+                          </div>
+                          <StatusPill status={domain.status} />
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </CardContent>
+            </Card>
+
+            {/* Delivery event tracking — self-gates to SES providers only */}
+            <EmailTrackingSetup providerId={provider.id} />
+          </div>
+
+          {/* Right column — overview */}
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Overview</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <dl className="divide-y">
+                  <Row label="Type">
+                    {getEmailProviderLabel(
+                      provider.provider_type as EmailProviderType
+                    )}
+                  </Row>
+                  <Row label="Region">
+                    <span className="font-mono">{provider.region}</span>
+                  </Row>
+                  <Row label="Status">
+                    <Badge
+                      variant={provider.is_active ? 'default' : 'secondary'}
+                    >
+                      {provider.is_active ? 'Active' : 'Inactive'}
+                    </Badge>
+                  </Row>
+                  {provider.provider_type === 'ses' && (
+                    <Row label="SNS Topic ARN">
+                      {provider.sns_topic_arn ? (
+                        <span className="break-all font-mono text-xs">
+                          {provider.sns_topic_arn}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">
+                          Not configured
+                        </span>
+                      )}
+                    </Row>
+                  )}
+                  <Row label="Domains">
+                    <span className="tabular-nums">{domains?.length ?? 0}</span>
+                  </Row>
+                  <Row label="Created">
+                    <TimeAgo date={provider.created_at} />
+                  </Row>
+                  <Row label="Updated">
+                    <TimeAgo date={provider.updated_at} />
+                  </Row>
+                </dl>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </div>
+
+      <EditProviderDialog
+        provider={provider}
+        open={isEditDialogOpen}
+        onOpenChange={setIsEditDialogOpen}
+        onSuccess={() => {
+          queryClient.invalidateQueries({ queryKey: ['email-provider', id] })
+          queryClient.invalidateQueries({ queryKey: ['email-providers'] })
+        }}
+      />
+      <TestEmailDialog
+        open={isTestDialogOpen}
+        onOpenChange={setIsTestDialogOpen}
+        providerId={provider.id}
+        onSuccess={() => {}}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Follow-up from the SES event-tracking work (#297, #380): providers only had a list view, and clicking one opened a cramped edit modal that also happened to host the delivery-tracking setup section — easy to miss, and hard to tell apart from credential editing. This was flagged as a UX gap while debugging why bounce/complaint tracking "wasn't working" on a real instance: there was no obvious place to go configure it.

- New page `web/src/pages/EmailProviderDetail.tsx` at `/email/providers/:id`, mirroring the existing `EmailDomainDetail` page: header (logo, active/inactive, region, test/edit/delete actions), a **Domains** card listing every domain assigned to the provider (linking to each domain's own detail page), the **delivery event tracking** setup prominently on the page body (not in a dialog), and an Overview sidebar (type, region, status, SNS topic ARN, domain count, timestamps).
- Provider cards in **Email → Providers** now navigate to this page on click (dropdown menu still handles Test/Edit/Delete inline, via `stopPropagation`).
- The Edit dialog goes back to being just about credentials — removed the `EmailTrackingSetup` embed that was bolted onto it in #297, with a one-line pointer to the detail page instead.
- Backend: `GET /email-domains` gains an optional `provider_id` query filter (the `DomainService::list_by_provider` method already existed, it just wasn't exposed via the handler), so the new page's domains list is server-scoped instead of fetching everything and filtering client-side.
- Extracted `deleteEmailProvider` and `readMaskedCreds` out of `EmailProvidersManagement.tsx` into `sharedUtils.ts` so the new page can reuse them without importing non-component exports from a component file (this also fixes two new `react-refresh/only-export-components` warnings that reuse would've caused).
- Updated the email feature doc and the event-tracking howto to point at the provider's detail page instead of the old "Providers → Edit" dialog location.

## Test plan

- [x] `cargo check --lib -p temps-email` — clean
- [x] `cargo check --lib` (full workspace) — clean
- [x] `cargo fmt --check` / clippy — clean (pre-commit hooks passed)
- [x] `tsc --noEmit` — clean
- [x] `eslint` on all touched files — 0 errors, 0 new warnings
- [x] SDK regenerated against a scratch server + throwaway DB/API key (both torn down after); diff is the minimal expected `provider_id` query param addition
- [ ] Manual click-through in a running dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)