### PR TITLE
feat(deployments): preview tag commits before deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11978,6 +11978,7 @@ dependencies = [
  "rand 0.8.6",
  "regex",
  "reqwest 0.12.28",
+ "rustls",
  "sea-orm",
  "serde",
  "serde_derive",

--- a/crates/temps-deployments/src/jobs/download_repo.rs
+++ b/crates/temps-deployments/src/jobs/download_repo.rs
@@ -172,13 +172,15 @@ impl DownloadRepoJob {
 
     /// Get the branch/ref to checkout based on priority
     fn get_checkout_ref(&self, context: &WorkflowContext) -> String {
-        // Priority: tag_ref > commit_sha > branch_ref > context branch > "main"
-        if let Some(ref tag) = self.tag_ref {
-            return tag.clone();
-        }
-
+        // A tag may move after it is resolved. When both the human-readable
+        // tag and its verified commit are present, checkout must use the
+        // immutable commit while retaining the tag as deployment metadata.
         if let Some(ref commit) = self.commit_sha {
             return commit.clone();
+        }
+
+        if let Some(ref tag) = self.tag_ref {
+            return tag.clone();
         }
 
         if let Some(ref branch) = self.branch_ref {
@@ -225,12 +227,9 @@ impl DownloadRepoJob {
         )
         .await?;
 
-        // Determine clone strategy based on what ref type we have
-        // commit_sha requires full clone + checkout, branches/tags can use shallow clone with --branch
-        let needs_full_clone = self.commit_sha.is_some() && self.tag_ref.is_none();
-
-        if needs_full_clone {
-            let commit_sha = self.commit_sha.as_ref().unwrap();
+        // A verified commit always requires a full clone + immutable checkout,
+        // even when a tag is also retained for display and audit metadata.
+        if let Some(commit_sha) = self.commit_sha.as_ref() {
             self.log(context, format!("Cloning for commit SHA: {}", commit_sha))
                 .await?;
 
@@ -563,7 +562,13 @@ impl WorkflowTask for DownloadRepoJob {
         context.set_artifact(&self.job_id, "source_code", repo_dir.clone());
 
         // Update working directory in context
-        context.work_dir = Some(repo_dir.parent().unwrap().to_path_buf());
+        let work_dir = repo_dir.parent().ok_or_else(|| {
+            WorkflowError::JobExecutionFailed(format!(
+                "Repository path '{}' has no parent directory",
+                repo_dir.display()
+            ))
+        })?;
+        context.work_dir = Some(work_dir.to_path_buf());
 
         Ok(JobResult::success(context))
     }
@@ -903,8 +908,8 @@ mod tests {
 
         let context = crate::test_utils::create_test_context("test".to_string(), 1, 1, 1);
 
-        // Tag should have highest priority
-        assert_eq!(job.get_checkout_ref(&context), "v1.0.0");
+        // The verified commit must win over the mutable tag.
+        assert_eq!(job.get_checkout_ref(&context), "abc123");
 
         // Test without tag
         let job_no_tag = DownloadRepoJob::new(
@@ -917,7 +922,7 @@ mod tests {
         .with_branch_ref("branch".to_string())
         .with_commit_sha("abc123".to_string());
 
-        // Commit should have second priority
+        // Commit should also win over a branch when no tag is present.
         assert_eq!(job_no_tag.get_checkout_ref(&context), "abc123");
     }
 
@@ -973,9 +978,9 @@ mod tests {
         assert_eq!(job.tag_ref, Some("v2.0.0".to_string()));
         assert_eq!(job.commit_sha, Some("def456".to_string()));
 
-        // Verify tag has highest priority
+        // Preserve tag metadata while checking out the immutable commit.
         let context = crate::test_utils::create_test_context("test".to_string(), 1, 1, 1);
-        assert_eq!(job.get_checkout_ref(&context), "v2.0.0");
+        assert_eq!(job.get_checkout_ref(&context), "def456");
     }
 
     #[test]

--- a/crates/temps-git/Cargo.toml
+++ b/crates/temps-git/Cargo.toml
@@ -19,6 +19,7 @@ sha2 = { workspace = true }
 hex = { workspace = true }
 base64 = "0.22"
 futures = { workspace = true }
+rustls = { workspace = true }
 
 [dependencies]
 temps-auth = { path = "../temps-auth" }

--- a/crates/temps-git/src/handlers/repositories.rs
+++ b/crates/temps-git/src/handlers/repositories.rs
@@ -100,7 +100,7 @@ fn normalize_commit_sha(commit_sha: &str) -> Result<String, CommitShaValidationE
     Ok(commit_sha.to_ascii_lowercase())
 }
 
-fn commit_lookup_principal(auth: &AuthContext) -> String {
+fn provider_lookup_principal(auth: &AuthContext) -> String {
     match &auth.source {
         AuthSource::Session { user } | AuthSource::CliToken { user } => {
             format!("user:{}", user.id)
@@ -232,6 +232,7 @@ pub async fn get_repository_branches(
         (status = 200, description = "List of tags", body = TagListResponse),
         (status = 401, description = "Unauthorized"),
         (status = 404, description = "Repository not found"),
+        (status = 429, description = "Fresh tag lookup rate limit exceeded"),
         (status = 500, description = "Internal server error")
     ),
     tag = "Repositories",
@@ -307,6 +308,22 @@ pub async fn get_repository_tags(
                 .collect();
             return Ok(Json(TagListResponse { tags: tag_infos }));
         }
+    }
+
+    if params.fresh {
+        let principal = provider_lookup_principal(&auth);
+        state
+            .cache_manager
+            .tag_refresh_rate_limiter
+            .check(&principal)
+            .await
+            .map_err(|retry_after_seconds| {
+                ErrorBuilder::new(StatusCode::TOO_MANY_REQUESTS)
+                    .title("Tag Refresh Rate Limit Exceeded")
+                    .detail("Too many fresh tag lookups. Please retry later.")
+                    .value("retry_after_seconds", retry_after_seconds)
+                    .build()
+            })?;
     }
 
     // Get tags from the git provider
@@ -473,6 +490,7 @@ pub async fn get_branches_by_repository_id(
         (status = 200, description = "List of tags", body = TagListResponse),
         (status = 401, description = "Unauthorized"),
         (status = 404, description = "Repository not found"),
+        (status = 429, description = "Fresh tag lookup rate limit exceeded"),
         (status = 500, description = "Internal server error")
     ),
     tag = "Repositories",
@@ -551,6 +569,22 @@ pub async fn get_tags_by_repository_id(
                 .collect();
             return Ok(Json(TagListResponse { tags: tag_infos }));
         }
+    }
+
+    if params.fresh {
+        let principal = provider_lookup_principal(&auth);
+        state
+            .cache_manager
+            .tag_refresh_rate_limiter
+            .check(&principal)
+            .await
+            .map_err(|retry_after_seconds| {
+                ErrorBuilder::new(StatusCode::TOO_MANY_REQUESTS)
+                    .title("Tag Refresh Rate Limit Exceeded")
+                    .detail("Too many fresh tag lookups. Please retry later.")
+                    .value("retry_after_seconds", retry_after_seconds)
+                    .build()
+            })?;
     }
 
     // Get tags from the git provider using owner and repo from repository
@@ -671,7 +705,7 @@ pub async fn check_commit_exists(
                 .build()
         })?;
 
-    let principal = commit_lookup_principal(&auth);
+    let principal = provider_lookup_principal(&auth);
     state
         .cache_manager
         .commit_lookup_rate_limiter

--- a/crates/temps-git/src/services/cache.rs
+++ b/crates/temps-git/src/services/cache.rs
@@ -7,7 +7,8 @@ use tokio::sync::{Mutex, RwLock};
 
 const DEFAULT_CACHE_MAX_ENTRIES: usize = 10_000;
 const COMMIT_LOOKUP_REQUESTS_PER_MINUTE: usize = 60;
-const COMMIT_LOOKUP_MAX_PRINCIPALS: usize = 10_000;
+const TAG_REFRESH_REQUESTS_PER_MINUTE: usize = 5;
+const PROVIDER_LOOKUP_MAX_PRINCIPALS: usize = 10_000;
 
 /// Cache entry with expiration time
 #[derive(Clone, Debug)]
@@ -169,20 +170,20 @@ pub struct CommitCacheKey {
 }
 
 #[derive(Debug)]
-struct CommitLookupWindow {
+struct ProviderLookupWindow {
     requests: VecDeque<Instant>,
     last_seen: Instant,
 }
 
-/// Bounded, per-principal sliding-window limiter for provider commit lookups.
-pub struct CommitLookupRateLimiter {
-    windows: Mutex<HashMap<String, CommitLookupWindow>>,
+/// Bounded, per-principal sliding-window limiter for upstream provider lookups.
+pub struct ProviderLookupRateLimiter {
+    windows: Mutex<HashMap<String, ProviderLookupWindow>>,
     max_requests: usize,
     window: Duration,
     max_principals: usize,
 }
 
-impl CommitLookupRateLimiter {
+impl ProviderLookupRateLimiter {
     pub fn new(max_requests: usize, window: Duration, max_principals: usize) -> Self {
         Self {
             windows: Mutex::new(HashMap::new()),
@@ -211,7 +212,7 @@ impl CommitLookupRateLimiter {
 
         let entry = windows
             .entry(principal.to_string())
-            .or_insert_with(|| CommitLookupWindow {
+            .or_insert_with(|| ProviderLookupWindow {
                 requests: VecDeque::new(),
                 last_seen: now,
             });
@@ -311,7 +312,12 @@ pub struct GitProviderCacheManager {
     pub commits: GitProviderCache<CommitCacheKey, Option<crate::services::git_provider::Commit>>,
 
     /// Per-user or API-key limiter for cache-miss provider lookups.
-    pub commit_lookup_rate_limiter: CommitLookupRateLimiter,
+    pub commit_lookup_rate_limiter: ProviderLookupRateLimiter,
+
+    /// Per-user or API-key limiter for cache-bypassing tag refreshes. A single
+    /// refresh can paginate through up to ten provider pages, so this is
+    /// intentionally stricter than the immutable commit lookup limiter.
+    pub tag_refresh_rate_limiter: ProviderLookupRateLimiter,
 
     /// Cache for public repository branches (15 minutes TTL - shorter due to rate limits)
     pub public_branches:
@@ -327,10 +333,15 @@ impl GitProviderCacheManager {
             branches: GitProviderCache::new(60), // 60 minutes for branches
             tags: GitProviderCache::new(60),     // 60 minutes for tags
             commits: GitProviderCache::new(30),  // 30 minutes for commits
-            commit_lookup_rate_limiter: CommitLookupRateLimiter::new(
+            commit_lookup_rate_limiter: ProviderLookupRateLimiter::new(
                 COMMIT_LOOKUP_REQUESTS_PER_MINUTE,
                 Duration::from_secs(60),
-                COMMIT_LOOKUP_MAX_PRINCIPALS,
+                PROVIDER_LOOKUP_MAX_PRINCIPALS,
+            ),
+            tag_refresh_rate_limiter: ProviderLookupRateLimiter::new(
+                TAG_REFRESH_REQUESTS_PER_MINUTE,
+                Duration::from_secs(60),
+                PROVIDER_LOOKUP_MAX_PRINCIPALS,
             ),
             public_branches: GitProviderCache::new(15), // 15 minutes for public branches (rate limit aware)
             public_presets: GitProviderCache::new(30),  // 30 minutes for public presets
@@ -447,7 +458,7 @@ mod tests {
 
     #[tokio::test]
     async fn commit_lookup_rate_limiter_is_scoped_by_principal() {
-        let limiter = CommitLookupRateLimiter::new(1, Duration::from_secs(60), 10);
+        let limiter = ProviderLookupRateLimiter::new(1, Duration::from_secs(60), 10);
 
         assert!(limiter.check("user:1").await.is_ok());
         assert!(limiter.check("user:1").await.is_err());
@@ -456,13 +467,37 @@ mod tests {
 
     #[tokio::test]
     async fn commit_lookup_rate_limiter_bounds_principal_memory() {
-        let limiter = CommitLookupRateLimiter::new(1, Duration::from_secs(60), 2);
+        let limiter = ProviderLookupRateLimiter::new(1, Duration::from_secs(60), 2);
 
         assert!(limiter.check("user:1").await.is_ok());
         assert!(limiter.check("user:2").await.is_ok());
         assert!(limiter.check("user:3").await.is_ok());
 
         assert!(limiter.windows.lock().await.len() <= 2);
+    }
+
+    #[tokio::test]
+    async fn tag_refresh_rate_limiter_uses_the_stricter_provider_budget() {
+        let manager = GitProviderCacheManager::new();
+
+        for _ in 0..TAG_REFRESH_REQUESTS_PER_MINUTE {
+            assert!(manager
+                .tag_refresh_rate_limiter
+                .check("user:1")
+                .await
+                .is_ok());
+        }
+
+        assert!(manager
+            .tag_refresh_rate_limiter
+            .check("user:1")
+            .await
+            .is_err());
+        assert!(manager
+            .tag_refresh_rate_limiter
+            .check("user:2")
+            .await
+            .is_ok());
     }
 
     #[tokio::test]

--- a/crates/temps-git/src/services/github_provider.rs
+++ b/crates/temps-git/src/services/github_provider.rs
@@ -9,9 +9,13 @@ use futures_util::StreamExt;
 use octocrab::{Octocrab, OctocrabBuilder};
 use reqwest;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use tracing::{debug, error, info};
 
 const MAX_GITHUB_TAGS: usize = 1_000;
+const MAX_GITHUB_TAG_PAGES: usize = 10;
+const MAX_GITHUB_BRANCHES: usize = 1_000;
+const MAX_GITHUB_BRANCH_PAGES: usize = 10;
 
 fn append_github_tags(
     tags: &mut Vec<GitProviderTag>,
@@ -27,6 +31,118 @@ fn append_github_tags(
                 commit_sha: tag.commit.sha,
             }),
     );
+}
+
+/// Validate a provider-supplied pagination link before issuing another request.
+///
+/// GitHub Enterprise may use a path prefix such as `/api/v3`. Returning only
+/// the validated path and query keeps Octocrab's authentication and base-URI
+/// middleware in control of the final destination.
+fn github_pagination_route(api_url: &str, next_url: &str) -> Result<String, GitProviderError> {
+    let base_url = url::Url::parse(api_url).map_err(|error| {
+        GitProviderError::ApiError(format!("Invalid configured GitHub API URL: {error}"))
+    })?;
+    let next_url = match url::Url::parse(next_url) {
+        Ok(url) => url,
+        Err(url::ParseError::RelativeUrlWithoutBase) => {
+            base_url.join(next_url).map_err(|error| {
+                GitProviderError::ApiError(format!(
+                    "Invalid relative GitHub pagination URL: {error}"
+                ))
+            })?
+        }
+        Err(error) => {
+            return Err(GitProviderError::ApiError(format!(
+                "Invalid GitHub pagination URL: {error}"
+            )))
+        }
+    };
+
+    let same_origin = next_url.scheme() == base_url.scheme()
+        && next_url.host_str().map(str::to_ascii_lowercase)
+            == base_url.host_str().map(str::to_ascii_lowercase)
+        && next_url.port_or_known_default() == base_url.port_or_known_default();
+    if !same_origin
+        || !next_url.username().is_empty()
+        || next_url.password().is_some()
+        || next_url.fragment().is_some()
+    {
+        return Err(GitProviderError::ApiError(
+            "GitHub pagination URL must use the configured API origin without credentials or fragments"
+                .to_string(),
+        ));
+    }
+
+    let base_path = base_url.path().trim_end_matches('/');
+    if !base_path.is_empty()
+        && next_url.path() != base_path
+        && !next_url
+            .path()
+            .strip_prefix(base_path)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+    {
+        return Err(GitProviderError::ApiError(
+            "GitHub pagination URL escaped the configured API path".to_string(),
+        ));
+    }
+
+    let mut route = next_url.path().to_string();
+    if let Some(query) = next_url.query() {
+        route.push('?');
+        route.push_str(query);
+    }
+    Ok(route)
+}
+
+async fn collect_guarded_github_pages<T: serde::de::DeserializeOwned>(
+    octocrab: &Octocrab,
+    api_url: &str,
+    mut page: octocrab::Page<T>,
+    max_items: usize,
+    max_pages: usize,
+    resource: &str,
+    repository: (&str, &str),
+) -> Result<Vec<T>, GitProviderError> {
+    let (owner, repo) = repository;
+    let mut items = Vec::new();
+    let mut pages_fetched = 1usize;
+    let mut visited_next_routes = HashSet::new();
+
+    loop {
+        let remaining = max_items.saturating_sub(items.len());
+        items.extend(page.take_items().into_iter().take(remaining));
+        if items.len() >= max_items {
+            break;
+        }
+
+        let Some(next_url) = page.next.as_ref() else {
+            break;
+        };
+        if pages_fetched >= max_pages {
+            return Err(GitProviderError::ApiError(format!(
+                "GitHub {resource} pagination for {owner}/{repo} exceeded the {max_pages}-page safety limit"
+            )));
+        }
+        let next_route = github_pagination_route(api_url, &next_url.to_string())?;
+        if !visited_next_routes.insert(next_route.clone()) {
+            return Err(GitProviderError::ApiError(format!(
+                "GitHub {resource} pagination for {owner}/{repo} repeated page URL"
+            )));
+        }
+
+        page = octocrab
+            .get::<octocrab::Page<T>, _, _>(&next_route, None::<&()>)
+            .await
+            .map_err(|error| {
+                GitProviderError::ApiError(format!(
+                    "Failed to paginate {resource} for {owner}/{repo} (page {}): {error}",
+                    pages_fetched + 1
+                ))
+            })?;
+        pages_fetched += 1;
+    }
+
+    Ok(items)
 }
 
 // Response structs for API calls
@@ -172,21 +288,19 @@ impl GitHubProvider {
 
     /// Create an Octocrab client with the given access token
     async fn get_octocrab_client(&self, access_token: &str) -> Result<Octocrab, GitProviderError> {
-        // Note: Octocrab doesn't support custom base URLs through the builder
-        // For GitHub Enterprise support, we'd need to use the underlying reqwest client
-        // For now, we'll only support the default GitHub API with Octocrab
+        let mut builder = OctocrabBuilder::new().personal_token(access_token.to_string());
         if self.api_url != "https://api.github.com" {
-            return Err(GitProviderError::Other(
-                "Custom API URLs are not supported with Octocrab integration yet".to_string(),
-            ));
+            builder = builder.base_uri(self.api_url.clone()).map_err(|error| {
+                GitProviderError::Other(format!(
+                    "Failed to configure GitHub API URL '{}': {}",
+                    self.api_url, error
+                ))
+            })?;
         }
 
-        let octocrab = OctocrabBuilder::new()
-            .personal_token(access_token.to_string())
-            .build()
-            .map_err(|e| {
-                GitProviderError::Other(format!("Failed to build Octocrab client: {}", e))
-            })?;
+        let octocrab = builder.build().map_err(|e| {
+            GitProviderError::Other(format!("Failed to build Octocrab client: {}", e))
+        })?;
 
         Ok(octocrab)
     }
@@ -1112,11 +1226,9 @@ impl GitProviderService for GitHubProvider {
     ) -> Result<Vec<Branch>, GitProviderError> {
         let octocrab = self.get_octocrab_client(access_token).await?;
 
-        // Fetch the first page with the maximum page size, then walk every
-        // remaining page so callers always see the complete branch list.
-        // GitHub paginates branches at 30 items per page by default; without
-        // `all_pages` we'd silently truncate repos like ours where `main`
-        // sorts past page 1.
+        // Fetch the first page with the maximum page size, then walk bounded,
+        // same-origin pages so callers see large branch lists without trusting
+        // provider-controlled Link targets.
         let first_page = octocrab
             .repos(owner, repo)
             .list_branches()
@@ -1125,9 +1237,16 @@ impl GitProviderService for GitHubProvider {
             .await
             .map_err(|e| GitProviderError::ApiError(format!("Failed to list branches: {}", e)))?;
 
-        let all = octocrab.all_pages(first_page).await.map_err(|e| {
-            GitProviderError::ApiError(format!("Failed to paginate branches: {}", e))
-        })?;
+        let all = collect_guarded_github_pages(
+            &octocrab,
+            &self.api_url,
+            first_page,
+            MAX_GITHUB_BRANCHES,
+            MAX_GITHUB_BRANCH_PAGES,
+            "branch",
+            (owner, repo),
+        )
+        .await?;
 
         let branches = all
             .into_iter()
@@ -1149,7 +1268,7 @@ impl GitProviderService for GitHubProvider {
     ) -> Result<Vec<GitProviderTag>, GitProviderError> {
         let octocrab = self.get_octocrab_client(access_token).await?;
 
-        let mut page = octocrab
+        let page = octocrab
             .repos(owner, repo)
             .list_tags()
             .per_page(100u8)
@@ -1165,26 +1284,18 @@ impl GitProviderService for GitHubProvider {
         // GitHub defaults to 30 tags and the previous implementation silently
         // ignored every later page. Follow pagination while retaining the same
         // 1,000-tag memory bound used by the other providers.
-        let mut tags = Vec::new();
-        loop {
-            append_github_tags(&mut tags, page.take_items());
-            if tags.len() >= MAX_GITHUB_TAGS {
-                break;
-            }
-
-            page = match octocrab
-                .get_page::<octocrab::models::repos::Tag>(&page.next)
-                .await
-                .map_err(|error| {
-                    GitProviderError::ApiError(format!(
-                        "Failed to paginate tags for {}/{}: {}",
-                        owner, repo, error
-                    ))
-                })? {
-                Some(next_page) => next_page,
-                None => break,
-            };
-        }
+        let raw_tags = collect_guarded_github_pages(
+            &octocrab,
+            &self.api_url,
+            page,
+            MAX_GITHUB_TAGS,
+            MAX_GITHUB_TAG_PAGES,
+            "tag",
+            (owner, repo),
+        )
+        .await?;
+        let mut tags = Vec::with_capacity(raw_tags.len());
+        append_github_tags(&mut tags, raw_tags);
 
         Ok(tags)
     }
@@ -2677,8 +2788,21 @@ mod archive_redirect_tests {
 mod tag_pagination_tests {
     use super::*;
 
-    fn github_tag(index: usize) -> octocrab::models::repos::Tag {
-        serde_json::from_value(serde_json::json!({
+    fn install_test_crypto_provider() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+
+    fn provider(api_url: String) -> GitHubProvider {
+        GitHubProvider::new(
+            Some(api_url),
+            AuthMethod::PersonalAccessToken {
+                token: "test-token".to_string(),
+            },
+        )
+    }
+
+    fn github_tag_json(index: usize) -> serde_json::Value {
+        serde_json::json!({
             "name": format!("v1.0.{index}"),
             "commit": {
                 "sha": format!("{index:040x}"),
@@ -2687,8 +2811,22 @@ mod tag_pagination_tests {
             "zipball_url": format!("https://api.github.com/repos/temps/example/zipball/v1.0.{index}"),
             "tarball_url": format!("https://api.github.com/repos/temps/example/tarball/v1.0.{index}"),
             "node_id": format!("tag-{index}")
-        }))
-        .unwrap()
+        })
+    }
+
+    fn github_tag(index: usize) -> octocrab::models::repos::Tag {
+        serde_json::from_value(github_tag_json(index)).unwrap()
+    }
+
+    fn github_branch_json(index: usize) -> serde_json::Value {
+        serde_json::json!({
+            "name": format!("branch-{index}"),
+            "commit": {
+                "sha": format!("{index:040x}"),
+                "url": format!("https://api.github.com/repos/temps/example/commits/{index}")
+            },
+            "protected": false
+        })
     }
 
     #[test]
@@ -2702,6 +2840,287 @@ mod tag_pagination_tests {
         assert_eq!(tags[0].name, "v1.0.0");
         assert_eq!(tags[0].commit_sha, format!("{:040x}", 0));
         assert_eq!(tags[MAX_GITHUB_TAGS - 1].name, "v1.0.999");
+    }
+
+    #[test]
+    fn pagination_route_allows_only_the_configured_api_origin_and_path() {
+        let base = "https://ghe.example.com/api/v3";
+
+        assert_eq!(
+            github_pagination_route(
+                base,
+                "https://ghe.example.com/api/v3/repos/temps/example/tags?page=2"
+            )
+            .unwrap(),
+            "/api/v3/repos/temps/example/tags?page=2"
+        );
+        assert_eq!(
+            github_pagination_route(base, "/api/v3/repos/temps/example/tags?page=2").unwrap(),
+            "/api/v3/repos/temps/example/tags?page=2"
+        );
+        assert!(github_pagination_route(
+            base,
+            "https://evil.example/api/v3/repos/temps/example/tags?page=2"
+        )
+        .is_err());
+        assert!(github_pagination_route(
+            base,
+            "https://127.0.0.1/api/v3/repos/temps/example/tags?page=2"
+        )
+        .is_err());
+        assert!(
+            github_pagination_route(base, "https://169.254.169.254/latest/meta-data/iam").is_err()
+        );
+        assert!(github_pagination_route(
+            base,
+            "https://ghe.example.com@evil.example/api/v3/repos/temps/example/tags?page=2"
+        )
+        .is_err());
+        assert!(github_pagination_route(
+            base,
+            "http://ghe.example.com/api/v3/repos/temps/example/tags?page=2"
+        )
+        .is_err());
+        assert!(github_pagination_route(
+            base,
+            "https://ghe.example.com:444/api/v3/repos/temps/example/tags?page=2"
+        )
+        .is_err());
+        assert!(github_pagination_route(
+            base,
+            "https://ghe.example.com/repos/temps/example/tags?page=2"
+        )
+        .is_err());
+    }
+
+    #[tokio::test]
+    async fn list_branches_rejects_cross_origin_and_path_escape_links() {
+        install_test_crypto_provider();
+
+        for path_escape in [false, true] {
+            let mut server = mockito::Server::new_async().await;
+            let next_url = if path_escape {
+                format!("{}/outside/branches?page=2", server.url())
+            } else {
+                "http://169.254.169.254/latest/meta-data/iam".to_string()
+            };
+            let first_page = server
+                .mock("GET", "/api/v3/repos/temps/example/branches")
+                .match_query(mockito::Matcher::Exact("per_page=100".to_string()))
+                .with_status(200)
+                .with_header("content-type", "application/json")
+                .with_header("link", &format!("<{next_url}>; rel=\"next\""))
+                .with_body(serde_json::json!([github_branch_json(1)]).to_string())
+                .create_async()
+                .await;
+
+            let error = provider(format!("{}/api/v3", server.url()))
+                .list_branches("test-token", "temps", "example")
+                .await
+                .expect_err("unsafe branch pagination URL must fail closed");
+
+            assert!(error.to_string().contains("GitHub pagination URL"));
+            first_page.assert_async().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn list_branches_rejects_a_repeated_next_page_url() {
+        install_test_crypto_provider();
+        let mut server = mockito::Server::new_async().await;
+        let next_url = format!(
+            "{}/repos/temps/example/branches?per_page=100&page=2",
+            server.url()
+        );
+        let link = format!("<{next_url}>; rel=\"next\"");
+        let first_page = server
+            .mock("GET", "/repos/temps/example/branches")
+            .match_query(mockito::Matcher::Exact("per_page=100".to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", &link)
+            .with_body(serde_json::json!([github_branch_json(1)]).to_string())
+            .create_async()
+            .await;
+        let repeated_page = server
+            .mock("GET", "/repos/temps/example/branches")
+            .match_query(mockito::Matcher::Exact("per_page=100&page=2".to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", &link)
+            .with_body("[]")
+            .create_async()
+            .await;
+
+        let error = provider(server.url())
+            .list_branches("test-token", "temps", "example")
+            .await
+            .expect_err("repeated branch pagination URL must fail closed");
+
+        assert!(error.to_string().contains("repeated page URL"));
+        first_page.assert_async().await;
+        repeated_page.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn list_branches_enforces_the_page_limit() {
+        install_test_crypto_provider();
+        let mut server = mockito::Server::new_async().await;
+        let first_next_url = format!(
+            "{}/repos/temps/example/branches?per_page=100&page=2",
+            server.url()
+        );
+        let first_page = server
+            .mock("GET", "/repos/temps/example/branches")
+            .match_query(mockito::Matcher::Exact("per_page=100".to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", &format!("<{first_next_url}>; rel=\"next\""))
+            .with_body(serde_json::json!([github_branch_json(1)]).to_string())
+            .create_async()
+            .await;
+        let mut later_pages = Vec::new();
+        for page in 2..=MAX_GITHUB_BRANCH_PAGES {
+            let next_url = format!(
+                "{}/repos/temps/example/branches?per_page=100&page={}",
+                server.url(),
+                page + 1
+            );
+            later_pages.push(
+                server
+                    .mock("GET", "/repos/temps/example/branches")
+                    .match_query(mockito::Matcher::Exact(format!("per_page=100&page={page}")))
+                    .with_status(200)
+                    .with_header("content-type", "application/json")
+                    .with_header("link", &format!("<{next_url}>; rel=\"next\""))
+                    .with_body(serde_json::json!([github_branch_json(page)]).to_string())
+                    .create_async()
+                    .await,
+            );
+        }
+
+        let error = provider(server.url())
+            .list_branches("test-token", "temps", "example")
+            .await
+            .expect_err("branch pagination must stop at its page limit");
+
+        assert!(error.to_string().contains("10-page safety limit"));
+        first_page.assert_async().await;
+        for page in later_pages {
+            page.assert_async().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn list_tags_follows_github_link_pagination() {
+        install_test_crypto_provider();
+        let mut server = mockito::Server::new_async().await;
+        let next_url = format!(
+            "{}/repos/temps/example/tags?per_page=100&page=2",
+            server.url()
+        );
+        let first_page = server
+            .mock("GET", "/repos/temps/example/tags")
+            .match_query(mockito::Matcher::Exact("per_page=100".to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", &format!("<{next_url}>; rel=\"next\""))
+            .with_body(serde_json::json!([github_tag_json(1)]).to_string())
+            .create_async()
+            .await;
+        let second_page = server
+            .mock("GET", "/repos/temps/example/tags")
+            .match_query(mockito::Matcher::Exact("per_page=100&page=2".to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::json!([github_tag_json(2)]).to_string())
+            .create_async()
+            .await;
+
+        let tags = provider(server.url())
+            .list_tags("test-token", "temps", "example")
+            .await
+            .expect("two-page tag listing should succeed");
+
+        assert_eq!(tags.len(), 2);
+        assert_eq!(tags[0].name, "v1.0.1");
+        assert_eq!(tags[1].name, "v1.0.2");
+        first_page.assert_async().await;
+        second_page.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn list_tags_rejects_a_repeated_next_page_url() {
+        install_test_crypto_provider();
+        let mut server = mockito::Server::new_async().await;
+        let next_url = format!(
+            "{}/repos/temps/example/tags?per_page=100&page=2",
+            server.url()
+        );
+        let link = format!("<{next_url}>; rel=\"next\"");
+        let first_page = server
+            .mock("GET", "/repos/temps/example/tags")
+            .match_query(mockito::Matcher::Exact("per_page=100".to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", &link)
+            .with_body(serde_json::json!([github_tag_json(1)]).to_string())
+            .create_async()
+            .await;
+        let repeated_page = server
+            .mock("GET", "/repos/temps/example/tags")
+            .match_query(mockito::Matcher::Exact("per_page=100&page=2".to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", &link)
+            .with_body("[]")
+            .create_async()
+            .await;
+
+        let error = provider(server.url())
+            .list_tags("test-token", "temps", "example")
+            .await
+            .expect_err("repeated pagination URL must fail closed");
+
+        assert!(error.to_string().contains("repeated page URL"));
+        first_page.assert_async().await;
+        repeated_page.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn list_tags_reports_the_failing_later_page() {
+        install_test_crypto_provider();
+        let mut server = mockito::Server::new_async().await;
+        let next_url = format!(
+            "{}/repos/temps/example/tags?per_page=100&page=2",
+            server.url()
+        );
+        let first_page = server
+            .mock("GET", "/repos/temps/example/tags")
+            .match_query(mockito::Matcher::Exact("per_page=100".to_string()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", &format!("<{next_url}>; rel=\"next\""))
+            .with_body(serde_json::json!([github_tag_json(1)]).to_string())
+            .create_async()
+            .await;
+        let failing_page = server
+            .mock("GET", "/repos/temps/example/tags")
+            .match_query(mockito::Matcher::Exact("per_page=100&page=2".to_string()))
+            .with_status(502)
+            .with_body("upstream unavailable")
+            .expect(4)
+            .create_async()
+            .await;
+
+        let error = provider(server.url())
+            .list_tags("test-token", "temps", "example")
+            .await
+            .expect_err("later-page provider failure must be returned");
+
+        assert!(error.to_string().contains("page 2"));
+        first_page.assert_async().await;
+        failing_page.assert_async().await;
     }
 }
 

--- a/crates/temps-git/src/services/github_provider.rs
+++ b/crates/temps-git/src/services/github_provider.rs
@@ -11,6 +11,24 @@ use reqwest;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info};
 
+const MAX_GITHUB_TAGS: usize = 1_000;
+
+fn append_github_tags(
+    tags: &mut Vec<GitProviderTag>,
+    page_items: Vec<octocrab::models::repos::Tag>,
+) {
+    let remaining = MAX_GITHUB_TAGS.saturating_sub(tags.len());
+    tags.extend(
+        page_items
+            .into_iter()
+            .take(remaining)
+            .map(|tag| GitProviderTag {
+                name: tag.name,
+                commit_sha: tag.commit.sha,
+            }),
+    );
+}
+
 // Response structs for API calls
 
 /// Request body for `POST /app/installations/{id}/access_tokens`.
@@ -1131,23 +1149,42 @@ impl GitProviderService for GitHubProvider {
     ) -> Result<Vec<GitProviderTag>, GitProviderError> {
         let octocrab = self.get_octocrab_client(access_token).await?;
 
-        // Get all tags using Octocrab
-        let tags = octocrab
+        let mut page = octocrab
             .repos(owner, repo)
             .list_tags()
+            .per_page(100u8)
             .send()
             .await
-            .map_err(|e| GitProviderError::ApiError(format!("Failed to list tags: {}", e)))?;
+            .map_err(|error| {
+                GitProviderError::ApiError(format!(
+                    "Failed to list tags for {}/{} (page 1): {}",
+                    owner, repo, error
+                ))
+            })?;
 
-        // Convert Octocrab tags to our GitProviderTag type
-        let tags = tags
-            .items
-            .into_iter()
-            .map(|t| GitProviderTag {
-                name: t.name,
-                commit_sha: t.commit.sha,
-            })
-            .collect();
+        // GitHub defaults to 30 tags and the previous implementation silently
+        // ignored every later page. Follow pagination while retaining the same
+        // 1,000-tag memory bound used by the other providers.
+        let mut tags = Vec::new();
+        loop {
+            append_github_tags(&mut tags, page.take_items());
+            if tags.len() >= MAX_GITHUB_TAGS {
+                break;
+            }
+
+            page = match octocrab
+                .get_page::<octocrab::models::repos::Tag>(&page.next)
+                .await
+                .map_err(|error| {
+                    GitProviderError::ApiError(format!(
+                        "Failed to paginate tags for {}/{}: {}",
+                        owner, repo, error
+                    ))
+                })? {
+                Some(next_page) => next_page,
+                None => break,
+            };
+        }
 
         Ok(tags)
     }
@@ -2633,6 +2670,38 @@ mod archive_redirect_tests {
         // `codeload.github.com.` ends with `com.`, not `.github.com` → rejected.
         // Locks in url-crate parsing behavior against dependency bumps.
         assert!(check(None, "https://codeload.github.com./foo").is_err());
+    }
+}
+
+#[cfg(test)]
+mod tag_pagination_tests {
+    use super::*;
+
+    fn github_tag(index: usize) -> octocrab::models::repos::Tag {
+        serde_json::from_value(serde_json::json!({
+            "name": format!("v1.0.{index}"),
+            "commit": {
+                "sha": format!("{index:040x}"),
+                "url": format!("https://api.github.com/repos/temps/example/commits/{index}")
+            },
+            "zipball_url": format!("https://api.github.com/repos/temps/example/zipball/v1.0.{index}"),
+            "tarball_url": format!("https://api.github.com/repos/temps/example/tarball/v1.0.{index}"),
+            "node_id": format!("tag-{index}")
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn appending_github_tag_pages_maps_commit_shas_and_enforces_the_cap() {
+        let mut tags = Vec::new();
+        let page = (0..=MAX_GITHUB_TAGS).map(github_tag).collect();
+
+        append_github_tags(&mut tags, page);
+
+        assert_eq!(tags.len(), MAX_GITHUB_TAGS);
+        assert_eq!(tags[0].name, "v1.0.0");
+        assert_eq!(tags[0].commit_sha, format!("{:040x}", 0));
+        assert_eq!(tags[MAX_GITHUB_TAGS - 1].name, "v1.0.999");
     }
 }
 

--- a/web/src/components/deployments/RedeploymentModal.tsx
+++ b/web/src/components/deployments/RedeploymentModal.tsx
@@ -3,8 +3,13 @@ import {
   getEnvironmentsOptions,
   getProjectBySlugOptions,
   getRepositoryByNameOptions,
+  getTagsByRepositoryIdOptions,
 } from '@/api/client/@tanstack/react-query.gen'
-import { EnvironmentResponse, ProjectResponse } from '@/api/client/types.gen'
+import type {
+  CommitInfo,
+  EnvironmentResponse,
+  ProjectResponse,
+} from '@/api/client/types.gen'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -33,6 +38,7 @@ import {
   GitCommitHorizontal,
   Loader2,
   RefreshCw,
+  Tag as TagIcon,
 } from 'lucide-react'
 import { BranchSelector } from './BranchSelector'
 
@@ -50,6 +56,53 @@ function formatCommitDate(date: string) {
     dateStyle: 'medium',
     timeStyle: 'short',
   }).format(parsedDate)
+}
+
+function CommitDetailsCard({
+  commit,
+  label,
+  reference,
+}: {
+  commit: CommitInfo
+  label: string
+  reference?: string
+}) {
+  return (
+    <div className="overflow-hidden rounded-md border bg-muted/20">
+      <div className="flex items-center justify-between gap-3 border-b bg-muted/40 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
+          <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
+          {label}
+        </div>
+        <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+          {reference && (
+            <span className="flex min-w-0 items-center gap-1 font-medium text-foreground">
+              <TagIcon className="h-3.5 w-3.5 shrink-0" />
+              <span className="max-w-40 truncate" title={reference}>
+                {reference}
+              </span>
+            </span>
+          )}
+          <span className="flex shrink-0 items-center gap-1 font-mono">
+            <GitCommitHorizontal className="h-3.5 w-3.5" />
+            {commit.sha.slice(0, 12)}
+          </span>
+        </div>
+      </div>
+      <div className="space-y-2.5 px-3 py-3">
+        <p className="max-h-24 overflow-y-auto whitespace-pre-wrap text-sm leading-relaxed">
+          {commit.message}
+        </p>
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">{commit.author}</span>
+          <span aria-hidden="true">·</span>
+          <span>{formatCommitDate(commit.date)}</span>
+          <span aria-hidden="true">·</span>
+          <span className="truncate">{commit.author_email}</span>
+        </div>
+      </div>
+    </div>
+  )
 }
 
 interface RedeploymentModalProps {
@@ -136,19 +189,22 @@ export function RedeploymentModal({
   >(defaultType || 'branch')
   const [availableBranches, setAvailableBranches] = useState<string[]>([])
   const [commitToCheck, setCommitToCheck] = useState('')
+  const [tagToCheck, setTagToCheck] = useState('')
 
   // Derive effective values (either user-selected or initial/default)
   const effectiveBranch = selectedBranch !== '' ? selectedBranch : initialBranch
   const effectiveEnvironment = selectedEnvironment ?? initialEnvironment
   const normalizedCommit = selectedCommit.trim()
+  const normalizedTag = selectedTag.trim()
   const commitFormatIsValid = isValidCommitSha(normalizedCommit)
+  const tagHasValue = normalizedTag.length > 0
   const branchNotFound = Boolean(
     effectiveBranch &&
     availableBranches.length > 0 &&
     !availableBranches.includes(effectiveBranch)
   )
   const projectDetails = projectQuery.data ?? project
-  const shouldLookUpCommit = Boolean(
+  const shouldLookUpGitReference = Boolean(
     projectDetails.git_provider_connection_id &&
     projectDetails.repo_owner &&
     projectDetails.repo_name
@@ -167,8 +223,9 @@ export function RedeploymentModal({
     enabled:
       isOpen &&
       mode === 'new' &&
-      deploymentType === 'commit' &&
-      shouldLookUpCommit,
+      (deploymentType === 'commit' ||
+        (deploymentType === 'tag' && tagHasValue)) &&
+      shouldLookUpGitReference,
   })
 
   const commitQuery = useQuery({
@@ -190,6 +247,48 @@ export function RedeploymentModal({
     !!commitToCheck && commitToCheck === normalizedCommit.toLowerCase()
   const commitIsVerified = Boolean(
     checkedCurrentCommit && commitQuery.data?.exists && commitQuery.data.commit
+  )
+
+  const tagsQuery = useQuery({
+    ...getTagsByRepositoryIdOptions({
+      path: { repository_id: repositoryQuery.data?.id || 0 },
+      query: { fresh: true },
+    }),
+    enabled:
+      isOpen &&
+      deploymentType === 'tag' &&
+      !!repositoryQuery.data?.id &&
+      !!tagToCheck,
+    retry: false,
+    staleTime: 60_000,
+  })
+
+  const checkedCurrentTag =
+    !!tagToCheck && tagToCheck === normalizedTag && tagHasValue
+  const matchingTag = checkedCurrentTag
+    ? tagsQuery.data?.tags.find((tag) => tag.name === tagToCheck)
+    : undefined
+
+  const tagCommitQuery = useQuery({
+    ...checkCommitExistsOptions({
+      path: {
+        repository_id: repositoryQuery.data?.id || 0,
+        commit_sha: matchingTag?.commit_sha || '',
+      },
+    }),
+    enabled:
+      isOpen &&
+      deploymentType === 'tag' &&
+      !!repositoryQuery.data?.id &&
+      !!matchingTag?.commit_sha,
+    retry: false,
+  })
+
+  const tagIsVerified = Boolean(
+    checkedCurrentTag &&
+    matchingTag &&
+    tagCommitQuery.data?.exists &&
+    tagCommitQuery.data.commit
   )
 
   // Reset form state when modal opens or default values change
@@ -228,7 +327,7 @@ export function RedeploymentModal({
     const canCheckCommit =
       isOpen &&
       deploymentType === 'commit' &&
-      shouldLookUpCommit &&
+      shouldLookUpGitReference &&
       commitFormatIsValid
     const nextCommit = canCheckCommit ? normalizedCommit.toLowerCase() : ''
 
@@ -245,7 +344,33 @@ export function RedeploymentModal({
     deploymentType,
     isOpen,
     normalizedCommit,
-    shouldLookUpCommit,
+    shouldLookUpGitReference,
+  ])
+
+  // Tag names are matched case-sensitively against the provider's tag list.
+  // Debouncing avoids flashing a not-found state while a tag is being typed.
+  useEffect(() => {
+    const canCheckTag =
+      isOpen &&
+      deploymentType === 'tag' &&
+      shouldLookUpGitReference &&
+      tagHasValue
+    const nextTag = canCheckTag ? normalizedTag : ''
+
+    const timeoutId = window.setTimeout(
+      () => {
+        setTagToCheck(nextTag)
+      },
+      canCheckTag ? 350 : 0
+    )
+
+    return () => window.clearTimeout(timeoutId)
+  }, [
+    deploymentType,
+    isOpen,
+    normalizedTag,
+    shouldLookUpGitReference,
+    tagHasValue,
   ])
 
   const validateCommit = (commit: string) => {
@@ -292,10 +417,22 @@ export function RedeploymentModal({
     }
     if (
       deploymentType === 'commit' &&
-      shouldLookUpCommit &&
+      shouldLookUpGitReference &&
       !commitIsVerified
     ) {
       toast.error('Wait for the commit to be verified before deploying')
+      return
+    }
+    if (deploymentType === 'tag' && !tagHasValue) {
+      toast.error('Enter a tag name')
+      return
+    }
+    if (
+      deploymentType === 'tag' &&
+      shouldLookUpGitReference &&
+      !tagIsVerified
+    ) {
+      toast.error('Wait for the tag to be verified before deploying')
       return
     }
     if (!effectiveEnvironment) {
@@ -316,7 +453,7 @@ export function RedeploymentModal({
         deploymentType === 'commit'
           ? normalizedCommit.toLowerCase()
           : undefined,
-      tag: deploymentType === 'tag' ? selectedTag : undefined,
+      tag: deploymentType === 'tag' ? normalizedTag : undefined,
       environmentId: effectiveEnvironment,
     })
   }
@@ -553,7 +690,7 @@ export function RedeploymentModal({
                     </div>
 
                     <div id="commit-lookup-status" aria-live="polite">
-                      {commitFormatIsValid && shouldLookUpCommit && (
+                      {commitFormatIsValid && shouldLookUpGitReference && (
                         <>
                           {(repositoryQuery.isLoading ||
                             !checkedCurrentCommit ||
@@ -610,49 +747,121 @@ export function RedeploymentModal({
                             )}
 
                           {commitIsVerified && commitQuery.data?.commit && (
-                            <div className="overflow-hidden rounded-md border bg-muted/20">
-                              <div className="flex items-center justify-between gap-3 border-b bg-muted/40 px-3 py-2">
-                                <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
-                                  <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
-                                  Commit found
-                                </div>
-                                <div className="flex items-center gap-1.5 font-mono text-xs text-muted-foreground">
-                                  <GitCommitHorizontal className="h-3.5 w-3.5" />
-                                  {commitQuery.data.commit.sha.slice(0, 12)}
-                                </div>
-                              </div>
-                              <div className="space-y-2.5 px-3 py-3">
-                                <p className="max-h-24 overflow-y-auto whitespace-pre-wrap text-sm leading-relaxed">
-                                  {commitQuery.data.commit.message}
-                                </p>
-                                <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-                                  <span className="font-medium text-foreground">
-                                    {commitQuery.data.commit.author}
-                                  </span>
-                                  <span aria-hidden="true">·</span>
-                                  <span>
-                                    {formatCommitDate(
-                                      commitQuery.data.commit.date
-                                    )}
-                                  </span>
-                                  <span aria-hidden="true">·</span>
-                                  <span className="truncate">
-                                    {commitQuery.data.commit.author_email}
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
+                            <CommitDetailsCard
+                              commit={commitQuery.data.commit}
+                              label="Commit found"
+                            />
                           )}
                         </>
                       )}
                     </div>
                   </TabsContent>
-                  <TabsContent value="tag">
-                    <Input
-                      value={selectedTag}
-                      onChange={(e) => setSelectedTag(e.target.value)}
-                      placeholder="Enter tag name"
-                    />
+                  <TabsContent value="tag" className="space-y-3">
+                    <div className="space-y-1.5">
+                      <Input
+                        value={selectedTag}
+                        onChange={(e) => setSelectedTag(e.target.value)}
+                        placeholder="Enter tag name"
+                        spellCheck={false}
+                        autoComplete="off"
+                        className="font-mono"
+                        aria-invalid={selectedTag.length > 0 && !tagHasValue}
+                        aria-describedby="tag-lookup-status"
+                      />
+                      {selectedTag.length > 0 && !tagHasValue && (
+                        <p className="text-xs text-destructive">
+                          Enter a non-empty tag name.
+                        </p>
+                      )}
+                    </div>
+
+                    <div id="tag-lookup-status" aria-live="polite">
+                      {tagHasValue && shouldLookUpGitReference && (
+                        <>
+                          {(repositoryQuery.isLoading ||
+                            !checkedCurrentTag ||
+                            tagsQuery.isLoading ||
+                            (!!matchingTag && tagCommitQuery.isLoading)) &&
+                            !repositoryQuery.isError &&
+                            !tagsQuery.isError &&
+                            !tagCommitQuery.isError && (
+                              <div className="flex items-center gap-2 rounded-md border bg-muted/30 px-3 py-2.5 text-sm text-muted-foreground">
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                                Checking tag with the Git provider…
+                              </div>
+                            )}
+
+                          {(repositoryQuery.isError ||
+                            tagsQuery.isError ||
+                            tagCommitQuery.isError) && (
+                            <Alert variant="destructive">
+                              <AlertTriangle className="h-4 w-4" />
+                              <AlertDescription className="flex items-center justify-between gap-3">
+                                <span>
+                                  Tag details could not be loaded. Check the Git
+                                  provider connection and try again.
+                                </span>
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  size="sm"
+                                  className="shrink-0"
+                                  onClick={() => {
+                                    if (repositoryQuery.isError) {
+                                      void repositoryQuery.refetch()
+                                    } else if (tagsQuery.isError) {
+                                      void tagsQuery.refetch()
+                                    } else {
+                                      void tagCommitQuery.refetch()
+                                    }
+                                  }}
+                                >
+                                  <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+                                  Retry
+                                </Button>
+                              </AlertDescription>
+                            </Alert>
+                          )}
+
+                          {checkedCurrentTag &&
+                            tagsQuery.data &&
+                            !matchingTag && (
+                              <Alert variant="destructive">
+                                <AlertTriangle className="h-4 w-4" />
+                                <AlertDescription>
+                                  Tag “{normalizedTag}” was not found in{' '}
+                                  <span className="font-medium">
+                                    {projectDetails.repo_owner}/
+                                    {projectDetails.repo_name}
+                                  </span>
+                                  . Tag names are case-sensitive.
+                                </AlertDescription>
+                              </Alert>
+                            )}
+
+                          {checkedCurrentTag &&
+                            matchingTag &&
+                            tagCommitQuery.data &&
+                            !tagCommitQuery.data.exists && (
+                              <Alert variant="destructive">
+                                <AlertTriangle className="h-4 w-4" />
+                                <AlertDescription>
+                                  Tag “{normalizedTag}” exists, but its commit
+                                  could not be found.
+                                </AlertDescription>
+                              </Alert>
+                            )}
+
+                          {tagIsVerified && tagCommitQuery.data?.commit && (
+                            <CommitDetailsCard
+                              commit={tagCommitQuery.data.commit}
+                              label="Tag found"
+                              reference={normalizedTag}
+                            />
+                          )}
+                        </>
+                      )}
+                    </div>
                   </TabsContent>
                 </Tabs>
               </div>
@@ -695,7 +904,10 @@ export function RedeploymentModal({
                   environmentsQuery.isLoading ||
                   (deploymentType === 'commit' &&
                     (!commitFormatIsValid ||
-                      (shouldLookUpCommit && !commitIsVerified)))
+                      (shouldLookUpGitReference && !commitIsVerified))) ||
+                  (deploymentType === 'tag' &&
+                    (!tagHasValue ||
+                      (shouldLookUpGitReference && !tagIsVerified)))
                 }
               >
                 {isLoading ? 'Deploying...' : 'Deploy'}

--- a/web/src/components/deployments/RedeploymentModal.tsx
+++ b/web/src/components/deployments/RedeploymentModal.tsx
@@ -28,7 +28,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { useQuery } from '@tanstack/react-query'
+import { hashKey, useQuery } from '@tanstack/react-query'
 import { useMemo, useState, useEffect } from 'react'
 import { toast } from 'sonner'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -249,18 +249,24 @@ export function RedeploymentModal({
     checkedCurrentCommit && commitQuery.data?.exists && commitQuery.data.commit
   )
 
+  const tagsQueryOptions = getTagsByRepositoryIdOptions({
+    path: { repository_id: repositoryQuery.data?.id || 0 },
+    query: { fresh: true },
+  })
   const tagsQuery = useQuery({
-    ...getTagsByRepositoryIdOptions({
-      path: { repository_id: repositoryQuery.data?.id || 0 },
-      query: { fresh: true },
-    }),
+    ...tagsQueryOptions,
+    // The endpoint returns the repository's full tag list, but verification is
+    // tied to one user-entered tag. Including it in the client query key forces
+    // a new provider-backed check when the tag changes instead of reusing a
+    // previously verified list for a different deployment decision.
+    queryKeyHashFn: (queryKey) => hashKey([...queryKey, tagToCheck]),
     enabled:
       isOpen &&
       deploymentType === 'tag' &&
       !!repositoryQuery.data?.id &&
       !!tagToCheck,
     retry: false,
-    staleTime: 60_000,
+    staleTime: 0,
   })
 
   const checkedCurrentTag =
@@ -286,7 +292,9 @@ export function RedeploymentModal({
 
   const tagIsVerified = Boolean(
     checkedCurrentTag &&
+    !tagsQuery.isFetching &&
     matchingTag &&
+    !tagCommitQuery.isFetching &&
     tagCommitQuery.data?.exists &&
     tagCommitQuery.data.commit
   )
@@ -401,7 +409,10 @@ export function RedeploymentModal({
 
       await onConfirm({
         branch: defaultType === 'branch' ? defaultBranch : undefined,
-        commit: defaultType === 'commit' ? defaultCommit : undefined,
+        commit:
+          defaultType === 'commit' || defaultType === 'tag'
+            ? defaultCommit
+            : undefined,
         tag: defaultType === 'tag' ? defaultTag : undefined,
         environmentId: defaultEnvironment,
       })
@@ -452,7 +463,9 @@ export function RedeploymentModal({
       commit:
         deploymentType === 'commit'
           ? normalizedCommit.toLowerCase()
-          : undefined,
+          : deploymentType === 'tag'
+            ? tagCommitQuery.data?.commit?.sha.toLowerCase()
+            : undefined,
       tag: deploymentType === 'tag' ? normalizedTag : undefined,
       environmentId: effectiveEnvironment,
     })
@@ -780,8 +793,8 @@ export function RedeploymentModal({
                         <>
                           {(repositoryQuery.isLoading ||
                             !checkedCurrentTag ||
-                            tagsQuery.isLoading ||
-                            (!!matchingTag && tagCommitQuery.isLoading)) &&
+                            tagsQuery.isFetching ||
+                            (!!matchingTag && tagCommitQuery.isFetching)) &&
                             !repositoryQuery.isError &&
                             !tagsQuery.isError &&
                             !tagCommitQuery.isError && (


### PR DESCRIPTION
## Summary
- resolve exact, case-sensitive repository tags before deployment
- show the tag's commit author, email, date, message, and SHA in the deploy dialog
- keep Deploy disabled until both the tag and resolved commit are verified
- paginate GitHub tags with a bounded 1,000-tag cap

## Testing
- cargo check --lib
- cargo clippy --lib -p temps-git -- -D warnings
- cargo test --lib -p temps-git tag_pagination_tests
- npx eslint src/components/deployments/RedeploymentModal.tsx
- npx tsc --noEmit
- headless Chromium: case-sensitive not-found, successful commit detail rendering, request paths, and deployment payload

## Security
- tag input is matched client-side against provider-returned data and is never interpolated into a provider URL
- commit lookup uses the provider-resolved SHA through the existing repository-scoped endpoint
- repository lookup retains connection scoping and deployment remains gated on verification