### PR TITLE
fix(email): correct SES IAM action namespace from sesv2: to ses:

### DIFF
--- a/docs/howto/set-up-email-event-tracking/page.mdx
+++ b/docs/howto/set-up-email-event-tracking/page.mdx
@@ -57,9 +57,9 @@ Sending email needs no new permissions. The **setup step only** additionally req
       "Action": [
         "sns:CreateTopic",
         "sns:Subscribe",
-        "sesv2:CreateConfigurationSet",
-        "sesv2:CreateConfigurationSetEventDestination",
-        "sesv2:UpdateConfigurationSetEventDestination"
+        "ses:CreateConfigurationSet",
+        "ses:CreateConfigurationSetEventDestination",
+        "ses:UpdateConfigurationSetEventDestination"
       ],
       "Resource": [
         "arn:aws:sns:*:*:temps-email-events-*",

--- a/web/src/components/email/EmailTrackingSetup.tsx
+++ b/web/src/components/email/EmailTrackingSetup.tsx
@@ -80,9 +80,9 @@ const SETUP_IAM_POLICY = `{
       "Action": [
         "sns:CreateTopic",
         "sns:Subscribe",
-        "sesv2:CreateConfigurationSet",
-        "sesv2:CreateConfigurationSetEventDestination",
-        "sesv2:UpdateConfigurationSetEventDestination"
+        "ses:CreateConfigurationSet",
+        "ses:CreateConfigurationSetEventDestination",
+        "ses:UpdateConfigurationSetEventDestination"
       ],
       "Resource": [
         "arn:aws:sns:*:*:temps-email-events-*",


### PR DESCRIPTION
## Summary

The one-click SES tracking-setup IAM policy (shown both in the provider detail page UI and the event-tracking howto doc) listed actions under a `sesv2:` prefix — `sesv2:CreateConfigurationSet`, `sesv2:CreateConfigurationSetEventDestination`, `sesv2:UpdateConfigurationSetEventDestination`. AWS IAM has no `sesv2` service namespace; both the classic SES API and the SESv2 API share the same `ses:` action prefix. The `sesv2:` prefix mirrored the Rust `aws-sdk-sesv2` crate name, not the actual IAM namespace.

Anyone following the docs/UI to paste this policy into the AWS IAM console got "Invalid Service In Action" validation errors and couldn't create the policy at all — reported by a user testing the just-merged provider detail page (#382).

- `web/src/components/email/EmailTrackingSetup.tsx`: `SETUP_IAM_POLICY` constant
- `docs/howto/set-up-email-event-tracking/page.mdx`: the same policy JSON block

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `eslint` — clean
- [x] Verified against AWS's IAM Action Reference: SESv2 API operations (including `CreateConfigurationSet`, `CreateConfigurationSetEventDestination`, `UpdateConfigurationSetEventDestination`) are all listed under the `ses:` prefix, not `sesv2:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)