### PR TITLE
feat(telemetry): add deploy_cancelled event

### DIFF
--- a/crates/temps-core/src/telemetry.rs
+++ b/crates/temps-core/src/telemetry.rs
@@ -40,6 +40,7 @@ pub enum TelemetryEventKind {
     DeployAttempted,
     DeploySucceeded,
     DeployFailed,
+    DeployCancelled,
     RollbackTriggered,
     FirstDeploySucceeded,
 
@@ -111,6 +112,7 @@ impl TelemetryEventKind {
             Self::DeployAttempted => "deploy_attempted",
             Self::DeploySucceeded => "deploy_succeeded",
             Self::DeployFailed => "deploy_failed",
+            Self::DeployCancelled => "deploy_cancelled",
             Self::RollbackTriggered => "rollback_triggered",
             Self::FirstDeploySucceeded => "first_deploy_succeeded",
 
@@ -165,6 +167,7 @@ impl TelemetryEventKind {
             Self::DeployAttempted,
             Self::DeploySucceeded,
             Self::DeployFailed,
+            Self::DeployCancelled,
             Self::RollbackTriggered,
             Self::FirstDeploySucceeded,
             Self::ProjectCreated,
@@ -316,9 +319,9 @@ mod tests {
     fn all_covers_every_variant() {
         // If a variant is added but not added to all(), as_str() on it will be
         // missing from the list and this length check is a cheap tripwire.
-        // 37 events (34 initial + instance_heartbeat + project_created_from_template
-        // + error_summary).
-        assert_eq!(TelemetryEventKind::all().len(), 37);
+        // 38 events (34 initial + instance_heartbeat + project_created_from_template
+        // + error_summary + deploy_cancelled).
+        assert_eq!(TelemetryEventKind::all().len(), 38);
     }
 
     #[test]

--- a/crates/temps-deployments/src/services/services.rs
+++ b/crates/temps-deployments/src/services/services.rs
@@ -3216,6 +3216,22 @@ impl DeploymentService {
             );
         }
 
+        // Anonymous telemetry: this is the explicit "user clicked Cancel"
+        // path (the other emission site, in WorkflowExecutionService, only
+        // fires as a fallback when the executor detects a "cancelled" error
+        // without this method having already set the state — see that
+        // file's comment). Deliberately NOT emitted from the supersede
+        // (cancel_in_flight_deployments) or bulk-shutdown
+        // (cancel_running_deployments) paths, since those fire automatically
+        // on every push / restart and would swamp the funnel signal with
+        // non-user-initiated noise.
+        self.telemetry().report(
+            temps_core::telemetry::TelemetryEvent::new(
+                temps_core::telemetry::TelemetryEventKind::DeployCancelled,
+            )
+            .with("trigger", "user"),
+        );
+
         info!(
             "Successfully cancelled deployment {} for project {} - workflow will stop at next checkpoint",
             deployment_id, project_id

--- a/crates/temps-deployments/src/services/workflow_execution_service.rs
+++ b/crates/temps-deployments/src/services/workflow_execution_service.rs
@@ -1810,6 +1810,23 @@ impl WorkflowExecutionService {
                         deployment_id
                     );
                 }
+
+                // Anonymous telemetry: this arm only runs when the workflow
+                // executor itself detected a "cancelled" error and the
+                // deployment wasn't already marked cancelled (see the
+                // `deployment.state != "cancelled"` guard in
+                // execute_deployment_workflow's Err arm above) — i.e. a
+                // cancellation whose origin wasn't the explicit user-cancel
+                // path in DeploymentService::cancel_deployment (which emits
+                // its own `deploy_cancelled` with trigger="user"). Tagging
+                // this one "workflow" keeps the two mutually exclusive so
+                // the funnel is never double-counted.
+                self.telemetry().report(
+                    temps_core::telemetry::TelemetryEvent::new(
+                        temps_core::telemetry::TelemetryEventKind::DeployCancelled,
+                    )
+                    .with("trigger", "workflow"),
+                );
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary
- Adds `DeployCancelled` (`deploy_cancelled`) to the anonymous product-telemetry event set alongside the existing deploy-funnel events (`deploy_attempted`/`deploy_succeeded`/`deploy_failed`).
- Emits it at the two canonical cancellation points:
  - `DeploymentService::cancel_deployment` — explicit user-initiated cancel from the UI/API, tagged `trigger="user"`.
  - `WorkflowExecutionService`'s `Cancelled` status arm — fallback path where the executor itself detects a cancellation the explicit path didn't already record, tagged `trigger="workflow"`.
- These two sites are mutually exclusive (the workflow arm only fires when the deployment wasn't already marked cancelled), so the funnel is never double-counted.
- Deliberately **not** emitted from `cancel_in_flight_deployments` (auto-cancel on supersede-by-new-push) or `cancel_running_deployments` (bulk cancel on shutdown/startup) — both fire automatically at high frequency and would swamp the signal with non-user-initiated noise rather than reflecting real cancellation intent.

## Test plan
- [x] `cargo check --lib -p temps-core -p temps-deployments` — 0 errors
- [x] `cargo test --lib -p temps-core telemetry` — 4/4 passed (updated the `all().len()` tripwire test to 38)
- [x] `cargo fmt` / `cargo clippy` / Conventional Commit — all pre-commit hooks passed