### PR TITLE
chore: bump version to v0.1.0-beta.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.51] - 2026-07-21
+
+### Added
+
+- **deployments:** Preview commits before deployment ([#379](https://github.com/gotempsh/temps/issues/379))
+- **email:** Dedup shared email UI helpers, working event filters, per-domain delivery stats ([#307](https://github.com/gotempsh/temps/issues/307))
+- **deployments:** Preview tag commits before deployment ([#383](https://github.com/gotempsh/temps/issues/383))
+- **email:** Add provider detail page with domains and delivery tracking setup ([#382](https://github.com/gotempsh/temps/issues/382))
+- **telemetry:** Add deploy_cancelled event ([#385](https://github.com/gotempsh/temps/issues/385))
+- **web:** Add metrics storage backend selector to monitoring settings ([#399](https://github.com/gotempsh/temps/issues/399))
+- **sandbox:** Firecracker microVM backend alongside Docker (ADR-029)
+
+### Fixed
+
+- **cli:** Type email command output and sanitize rendered bodies ([#306](https://github.com/gotempsh/temps/issues/306))
+- **email:** Secure SES SNS event processing with one-click tracking setup ([#297](https://github.com/gotempsh/temps/issues/297))
+- **email:** Stop leaking suppressed recipient addresses via logs/error_message ([#380](https://github.com/gotempsh/temps/issues/380))
+- **web:** Make DNS records table horizontally scroll on mobile ([#381](https://github.com/gotempsh/temps/issues/381))
+- **email:** Correct SES IAM action namespace from sesv2: to ses: ([#384](https://github.com/gotempsh/temps/issues/384))
+- **analytics:** Derive bounce/entry/exit from session pageviews at query time ([#398](https://github.com/gotempsh/temps/issues/398))
+- **sandbox:** Address PR #400 review — CI, OpenAPI/SDK, guard, security
+- **sandbox:** Satisfy clippy + vercel-compat guardrail (PR #400 CI)
+- **cli:** Update sandbox_url tests to canonical plural route
+- **proxy:** Resolve request-log detail by request_id across storage backends ([#402](https://github.com/gotempsh/temps/issues/402))
+- **audit:** Keep audit history when a user account is deleted ([#386](https://github.com/gotempsh/temps/issues/386))
+
+### Miscellaneous
+
+- **auth:** Remove magic-link login ([#375](https://github.com/gotempsh/temps/issues/375))
+
 ## [0.1.0-beta.50] - 2026-07-17
 
 ### Added
@@ -27,8 +57,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Email SNS webhook security and durability**: SES notifications now require an exact topic ARN configured on the active SES provider, validate AWS confirmation/certificate endpoints, correlate recipients and provider ownership, commit events and domain-scoped suppressions atomically, and deduplicate retries before acknowledging SNS. Upgrades preserve legacy global suppression safety by copying those entries to every existing sending domain, then enforce tenant-scoped ownership for future changes.
-- **No-op visitor deduplication migration**: `m20260705_000001_add_visitor_unique_index` now skips bulk foreign-key rewrites when no duplicate `(visitor_id, project_id)` pairs exist, preventing TimescaleDB from eagerly decompressing unrelated hypertable chunks and exceeding `timescaledb.max_tuples_decompressed_per_dml_transaction` during upgrades.
 - **core:** Resolve request IP trust-awarely for audit/logging ([#363](https://github.com/gotempsh/temps/issues/363))
 - **skill:** Remove piped shell install and explicit credential paths from docs ([#365](https://github.com/gotempsh/temps/issues/365))
 - **deployments:** Emit deploy_succeeded telemetry on the real success path ([#372](https://github.com/gotempsh/temps/issues/372))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10708,7 +10708,7 @@ dependencies = [
 
 [[package]]
 name = "temps-agent"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -10748,7 +10748,7 @@ dependencies = [
 
 [[package]]
 name = "temps-agents"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10793,7 +10793,7 @@ dependencies = [
 
 [[package]]
 name = "temps-agents-mcp-proxy"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "serde",
  "serde_json",
@@ -10801,7 +10801,7 @@ dependencies = [
 
 [[package]]
 name = "temps-ai"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "futures",
@@ -10815,7 +10815,7 @@ dependencies = [
 
 [[package]]
 name = "temps-ai-api-tools"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -10837,7 +10837,7 @@ dependencies = [
 
 [[package]]
 name = "temps-ai-chat"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10866,7 +10866,7 @@ dependencies = [
 
 [[package]]
 name = "temps-ai-gateway"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10897,7 +10897,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10927,7 +10927,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-backend"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10944,7 +10944,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-events"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10977,7 +10977,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-funnels"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10998,7 +10998,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-performance"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -11022,7 +11022,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-session-replay"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11048,7 +11048,7 @@ dependencies = [
 
 [[package]]
 name = "temps-audit"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -11069,7 +11069,7 @@ dependencies = [
 
 [[package]]
 name = "temps-auth"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "argon2",
@@ -11111,7 +11111,7 @@ dependencies = [
 
 [[package]]
 name = "temps-backup"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -11158,7 +11158,7 @@ dependencies = [
 
 [[package]]
 name = "temps-backup-core"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11178,7 +11178,7 @@ dependencies = [
 
 [[package]]
 name = "temps-blob"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11227,7 +11227,7 @@ dependencies = [
 
 [[package]]
 name = "temps-cli"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "argon2",
@@ -11335,7 +11335,7 @@ dependencies = [
 
 [[package]]
 name = "temps-config"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -11367,7 +11367,7 @@ dependencies = [
 
 [[package]]
 name = "temps-core"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -11406,7 +11406,7 @@ dependencies = [
 
 [[package]]
 name = "temps-database"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "futures",
@@ -11424,7 +11424,7 @@ dependencies = [
 
 [[package]]
 name = "temps-deployer"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11463,7 +11463,7 @@ dependencies = [
 
 [[package]]
 name = "temps-deployments"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11531,7 +11531,7 @@ dependencies = [
 
 [[package]]
 name = "temps-dns"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11573,7 +11573,7 @@ dependencies = [
 
 [[package]]
 name = "temps-dns-resolver"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11594,7 +11594,7 @@ dependencies = [
 
 [[package]]
 name = "temps-domains"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11644,7 +11644,7 @@ dependencies = [
 
 [[package]]
 name = "temps-edge"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -11686,7 +11686,7 @@ dependencies = [
 
 [[package]]
 name = "temps-email"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11727,7 +11727,7 @@ dependencies = [
 
 [[package]]
 name = "temps-email-tracking"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -11764,7 +11764,7 @@ dependencies = [
 
 [[package]]
 name = "temps-embeddings"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11775,7 +11775,7 @@ dependencies = [
 
 [[package]]
 name = "temps-entities"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "chrono",
  "sea-orm",
@@ -11789,7 +11789,7 @@ dependencies = [
 
 [[package]]
 name = "temps-environments"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "argon2",
@@ -11818,7 +11818,7 @@ dependencies = [
 
 [[package]]
 name = "temps-error-tracking"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11890,7 +11890,7 @@ dependencies = [
 
 [[package]]
 name = "temps-external-plugins"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -11916,7 +11916,7 @@ dependencies = [
 
 [[package]]
 name = "temps-file-store"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11932,7 +11932,7 @@ dependencies = [
 
 [[package]]
 name = "temps-geo"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -11955,7 +11955,7 @@ dependencies = [
 
 [[package]]
 name = "temps-git"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12006,7 +12006,7 @@ dependencies = [
 
 [[package]]
 name = "temps-git-credential"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "chrono",
  "nix 0.31.3",
@@ -12047,7 +12047,7 @@ dependencies = [
 
 [[package]]
 name = "temps-import"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -12074,7 +12074,7 @@ dependencies = [
 
 [[package]]
 name = "temps-import-docker"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "bollard",
@@ -12097,7 +12097,7 @@ dependencies = [
 
 [[package]]
 name = "temps-import-types"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "chrono",
@@ -12134,7 +12134,7 @@ dependencies = [
 
 [[package]]
 name = "temps-infra"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -12158,7 +12158,7 @@ dependencies = [
 
 [[package]]
 name = "temps-kv"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12211,7 +12211,7 @@ dependencies = [
 
 [[package]]
 name = "temps-log-aggregator"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -12246,7 +12246,7 @@ dependencies = [
 
 [[package]]
 name = "temps-logs"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-stream",
  "bollard",
@@ -12266,7 +12266,7 @@ dependencies = [
 
 [[package]]
 name = "temps-memory"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "thiserror 2.0.18",
@@ -12275,7 +12275,7 @@ dependencies = [
 
 [[package]]
 name = "temps-metrics"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -12302,7 +12302,7 @@ dependencies = [
 
 [[package]]
 name = "temps-migrations"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "sea-orm",
@@ -12316,7 +12316,7 @@ dependencies = [
 
 [[package]]
 name = "temps-monitoring"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12343,7 +12343,7 @@ dependencies = [
 
 [[package]]
 name = "temps-network"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "bollard",
@@ -12372,7 +12372,7 @@ dependencies = [
 
 [[package]]
 name = "temps-notifications"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12403,7 +12403,7 @@ dependencies = [
 
 [[package]]
 name = "temps-observability"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12430,7 +12430,7 @@ dependencies = [
 
 [[package]]
 name = "temps-otel"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12476,7 +12476,7 @@ dependencies = [
 
 [[package]]
 name = "temps-plugin-sdk"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -12501,7 +12501,7 @@ dependencies = [
 
 [[package]]
 name = "temps-presets"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12520,7 +12520,7 @@ dependencies = [
 
 [[package]]
 name = "temps-preview-gateway"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "tokio",
@@ -12530,7 +12530,7 @@ dependencies = [
 
 [[package]]
 name = "temps-projects"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -12568,7 +12568,7 @@ dependencies = [
 
 [[package]]
 name = "temps-providers"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12626,7 +12626,7 @@ dependencies = [
 
 [[package]]
 name = "temps-proxy"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -12702,7 +12702,7 @@ dependencies = [
 
 [[package]]
 name = "temps-pty-agent"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "bytes",
  "clap",
@@ -12720,7 +12720,7 @@ dependencies = [
 
 [[package]]
 name = "temps-query"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "bytes",
@@ -12754,7 +12754,7 @@ dependencies = [
 
 [[package]]
 name = "temps-query-postgres"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "chrono",
@@ -12811,7 +12811,7 @@ dependencies = [
 
 [[package]]
 name = "temps-queue"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "log",
  "serde",
@@ -12824,7 +12824,7 @@ dependencies = [
 
 [[package]]
 name = "temps-revenue"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12858,7 +12858,7 @@ dependencies = [
 
 [[package]]
 name = "temps-routes"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12883,7 +12883,7 @@ dependencies = [
 
 [[package]]
 name = "temps-sandbox"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "argon2",
  "async-stream",
@@ -12917,7 +12917,7 @@ dependencies = [
 
 [[package]]
 name = "temps-screenshots"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12943,7 +12943,7 @@ dependencies = [
 
 [[package]]
 name = "temps-static-files"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "axum 0.8.9",
  "temps-auth",
@@ -12956,7 +12956,7 @@ dependencies = [
 
 [[package]]
 name = "temps-status-page"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12989,7 +12989,7 @@ dependencies = [
 
 [[package]]
 name = "temps-telemetry"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "chrono",
@@ -13007,7 +13007,7 @@ dependencies = [
 
 [[package]]
 name = "temps-vm-agent"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "hex",
  "libc",
@@ -13017,7 +13017,7 @@ dependencies = [
 
 [[package]]
 name = "temps-vulnerability-scanner"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13049,7 +13049,7 @@ dependencies = [
 
 [[package]]
 name = "temps-webhooks"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13080,7 +13080,7 @@ dependencies = [
 
 [[package]]
 name = "temps-wireguard"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "base64 0.22.1",
  "defguard_wireguard_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Temps Contributors"]


### PR DESCRIPTION
Release version bump to `v0.1.0-beta.51`.

Generated the standard way via the release procedure:
- `[workspace.package] version` → `0.1.0-beta.51` (Cargo.toml)
- `Cargo.lock` regenerated (75 path-crate entries bumped, zero stale)
- `CHANGELOG.md` regenerated with git-cliff from Conventional Commits since `v0.1.0-beta.50`

## What ships in beta.51 (20 commits since the last tag)

Notable: proxy-log request-log detail fix + auth on all proxy-log endpoints (#402), audit history survives user deletion (#386), Firecracker microVM sandbox backend (ADR-029), email provider/delivery-tracking work (#382/#307/#297/#380/#384), deployment commit preview (#379/#383), metrics storage backend selector (#399), magic-link login removed (#375). Full list in CHANGELOG.md.

## Post-merge

The `v0.1.0-beta.51` tag will be pushed against the **merged** commit (not the branch head) so the release workflow builds the right SHA.

## ⚠️ Coordination note (does NOT block this release)

This release includes #386, which made `audit_logs.user_id` nullable (`ON DELETE SET NULL`). Per the follow-up tracked for temps-ee, the EE audit-chain reads `user_id` as non-null and must handle `Option<i32>` **before EE bumps its temps dependency to beta.51** — otherwise deleted-user audit rows produce fetch errors / false tamper findings. OSS is unaffected.