### PR TITLE
fix(observability): prevent ClickHouse Array(Nothing) decode failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12281,10 +12281,12 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
+ "aws-smithy-http-client",
  "chrono",
  "clickhouse",
  "libc",
  "mongodb",
+ "pem",
  "redis",
  "reqwest 0.12.28",
  "sea-orm",
@@ -12298,6 +12300,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tracing",
+ "webpki-root-certs",
 ]
 
 [[package]]

--- a/crates/temps-analytics-events/src/services/events_service.rs
+++ b/crates/temps-analytics-events/src/services/events_service.rs
@@ -2298,54 +2298,18 @@ mod tests {
     #[tokio::test]
     async fn test_ip_geolocation_integration() {
         use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+        use temps_database::test_utils::TestDatabase;
         use temps_entities::ip_geolocations;
         use temps_geo::{GeoIpService, IpAddressService};
 
-        // Setup PostgreSQL test container
-        use testcontainers::{
-            core::{ContainerPort, WaitFor},
-            runners::AsyncRunner,
-            GenericImage, ImageExt,
+        let test_db = match TestDatabase::with_migrations().await {
+            Ok(db) => db,
+            Err(error) => {
+                eprintln!("Skipping IP geolocation integration test: {error}");
+                return;
+            }
         };
-
-        // Use TimescaleDB with pgvector support
-        let postgres_image = GenericImage::new("timescale/timescaledb-ha", "pg18")
-            .with_exposed_port(ContainerPort::Tcp(5432))
-            .with_wait_for(WaitFor::message_on_stderr(
-                "database system is ready to accept connections",
-            ))
-            .with_env_var("POSTGRES_PASSWORD", "postgres")
-            .with_env_var("POSTGRES_USER", "postgres")
-            .with_env_var("POSTGRES_DB", "postgres");
-
-        let node = postgres_image
-            .start()
-            .await
-            .expect("Failed to start PostgreSQL container");
-        let port = node
-            .get_host_port_ipv4(5432)
-            .await
-            .expect("Failed to get port");
-
-        let database_url = format!(
-            "postgresql://postgres:postgres@localhost:{}/postgres?sslmode=disable",
-            port
-        );
-
-        // Wait a bit for PostgreSQL to be fully ready
-        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-
-        // Create database connection
-        let db = sea_orm::Database::connect(&database_url)
-            .await
-            .expect("Failed to connect to database");
-        let db = Arc::new(db);
-
-        // Run migrations to create tables
-        use temps_migrations::{Migrator, MigratorTrait};
-        Migrator::up(&*db, None)
-            .await
-            .expect("Failed to run migrations");
+        let db = test_db.connection_arc();
 
         // Create mock GeoIP service
         let geoip_service = Arc::new(GeoIpService::Mock(temps_geo::MockGeoIpService::new()));
@@ -2691,49 +2655,17 @@ mod tests {
     #[tokio::test]
     async fn test_hourly_visits_gap_filling() {
         use sea_orm::{ActiveModelTrait, ActiveValue::Set};
+        use temps_database::test_utils::TestDatabase;
         use temps_entities::{deployments, environments, events, projects, visitor};
-        use testcontainers::{
-            core::{ContainerPort, WaitFor},
-            runners::AsyncRunner,
-            GenericImage, ImageExt,
+
+        let test_db = match TestDatabase::with_migrations().await {
+            Ok(db) => db,
+            Err(error) => {
+                eprintln!("Skipping hourly visits gap-filling test: {error}");
+                return;
+            }
         };
-
-        // Setup PostgreSQL test container with TimescaleDB
-        let postgres_image = GenericImage::new("timescale/timescaledb-ha", "pg18")
-            .with_exposed_port(ContainerPort::Tcp(5432))
-            .with_wait_for(WaitFor::message_on_stderr(
-                "database system is ready to accept connections",
-            ))
-            .with_env_var("POSTGRES_PASSWORD", "postgres")
-            .with_env_var("POSTGRES_USER", "postgres")
-            .with_env_var("POSTGRES_DB", "postgres");
-
-        let node = postgres_image
-            .start()
-            .await
-            .expect("Failed to start PostgreSQL container");
-        let port = node
-            .get_host_port_ipv4(5432)
-            .await
-            .expect("Failed to get port");
-
-        let database_url = format!(
-            "postgresql://postgres:postgres@localhost:{}/postgres?sslmode=disable",
-            port
-        );
-
-        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-
-        let db = sea_orm::Database::connect(&database_url)
-            .await
-            .expect("Failed to connect to database");
-        let db = Arc::new(db);
-
-        // Run migrations
-        use temps_migrations::{Migrator, MigratorTrait};
-        Migrator::up(&*db, None)
-            .await
-            .expect("Failed to run migrations");
+        let db = test_db.connection_arc();
 
         // Create test project, environment, and deployment
         let base_time = Utc.with_ymd_and_hms(2025, 10, 6, 10, 0, 0).unwrap();

--- a/crates/temps-metrics/Cargo.toml
+++ b/crates/temps-metrics/Cargo.toml
@@ -41,6 +41,9 @@ redis = { workspace = true }
 aws-sdk-s3 = { workspace = true }
 aws-config = { workspace = true }
 aws-credential-types = "1.2"
+aws-smithy-http-client = { version = "1.1", default-features = false, features = ["rustls-aws-lc"] }
+webpki-root-certs = "1.0"
+pem = "3"
 reqwest = { workspace = true }
 
 # Node collector (Linux /proc + statvfs)

--- a/crates/temps-metrics/src/collector/s3.rs
+++ b/crates/temps-metrics/src/collector/s3.rs
@@ -41,10 +41,14 @@
 
 use async_trait::async_trait;
 use aws_credential_types::Credentials;
-use aws_sdk_s3::config::{Region, SharedCredentialsProvider};
+use aws_sdk_s3::config::{Region, SharedCredentialsProvider, SharedHttpClient};
 use aws_sdk_s3::Client;
+use aws_smithy_http_client::tls::{
+    rustls_provider::CryptoMode, Provider as TlsProvider, TlsContext, TrustStore,
+};
 use chrono::Utc;
 use std::collections::HashMap;
+use std::sync::OnceLock;
 use std::time::Duration;
 use tracing::{debug, warn};
 
@@ -94,6 +98,37 @@ fn parse_connection_string(s: &str) -> Option<S3ConnParams<'_>> {
         secret_key,
         endpoint,
     })
+}
+
+/// Shared HTTPS client backed by Mozilla's bundled CA roots.
+///
+/// The AWS default client loads roots from the host OS. Minimal production
+/// images and sandboxed macOS test processes can return zero valid roots,
+/// which makes `aws-smithy-http-client` panic in debug builds and leaves HTTPS
+/// unusable in release builds. A compiled-in trust store keeps collection
+/// independent of ambient host certificate configuration.
+fn bundled_roots_http_client() -> Result<SharedHttpClient, String> {
+    static CLIENT: OnceLock<Result<SharedHttpClient, String>> = OnceLock::new();
+
+    CLIENT
+        .get_or_init(|| {
+            let mut trust_store = TrustStore::empty().with_native_roots(false);
+            for der in webpki_root_certs::TLS_SERVER_ROOT_CERTS {
+                let pem = pem::Pem::new("CERTIFICATE", der.to_vec());
+                trust_store = trust_store.with_pem_certificate(pem::encode(&pem).into_bytes());
+            }
+
+            let tls_context = TlsContext::builder()
+                .with_trust_store(trust_store)
+                .build()
+                .map_err(|error| format!("failed to build bundled S3 TLS context: {error}"))?;
+
+            Ok(aws_smithy_http_client::Builder::new()
+                .tls_provider(TlsProvider::Rustls(CryptoMode::AwsLc))
+                .tls_context(tls_context)
+                .build_https())
+        })
+        .clone()
 }
 
 #[async_trait]
@@ -151,10 +186,17 @@ async fn run_list_buckets(config: &CollectorConfig) -> Result<Vec<MetricPoint>, 
         "temps-metrics",
     );
     let creds_provider = SharedCredentialsProvider::new(credentials);
+    let http_client = bundled_roots_http_client().map_err(|reason| {
+        format!(
+            "Failed to configure S3 HTTPS client for source {}: {reason}",
+            config.source_id
+        )
+    })?;
 
     let mut aws_cfg_builder = aws_config::defaults(aws_config::BehaviorVersion::latest())
         .region(Region::new(params.region.to_string()))
-        .credentials_provider(creds_provider);
+        .credentials_provider(creds_provider)
+        .http_client(http_client);
 
     if let Some(ep) = params.endpoint {
         aws_cfg_builder = aws_cfg_builder.endpoint_url(ep);

--- a/crates/temps-otel/src/storage/clickhouse/mod.rs
+++ b/crates/temps-otel/src/storage/clickhouse/mod.rs
@@ -603,6 +603,14 @@ struct ChMetricBucketRow {
     series_values: Vec<String>,
 }
 
+/// Typed empty array used when a metrics query has no `group_by` labels.
+///
+/// A bare ClickHouse `[]` literal can be exposed as `Array(Nothing)` in the
+/// response header. The Rust ClickHouse client cannot decode that element type
+/// into `Vec<String>`, so empty arrays projected into typed rows must carry a
+/// concrete element type explicitly.
+const EMPTY_STRING_ARRAY_SQL: &str = "CAST([], 'Array(String)')";
+
 /// Row of the temporality-aware histogram sub-aggregation (one per
 /// bucket × grouped-series). Matched back to [`ChMetricBucketRow`] by
 /// `(bucket_ms, series_values)`.
@@ -2151,7 +2159,7 @@ impl OtelStorage for ClickHouseOtelStorage {
         // Grouped label values as an Array(String), in group_by order. CH binds
         // the key via the `?` map-index parameter, never string interpolation.
         let group_select = if query.group_by.is_empty() {
-            "[] AS series_values".to_string()
+            format!("{EMPTY_STRING_ARRAY_SQL} AS series_values")
         } else {
             let parts: Vec<String> = query
                 .group_by
@@ -2168,7 +2176,7 @@ impl OtelStorage for ClickHouseOtelStorage {
         // The grouped-label array WITHOUT the `AS series_values` alias, for reuse
         // inside the histogram sub-aggregation's projection.
         let group_array = if query.group_by.is_empty() {
-            "[]".to_string()
+            EMPTY_STRING_ARRAY_SQL.to_string()
         } else {
             let parts: Vec<String> = query
                 .group_by
@@ -2951,6 +2959,12 @@ mod tests {
         let err = ::clickhouse::error::Error::BadResponse("timeout".into());
         let otel_err = ch_query_err("query_trace_summaries", err);
         assert!(otel_err.to_string().contains("query_trace_summaries"));
+    }
+
+    #[test]
+    fn empty_metric_series_array_has_explicit_clickhouse_type() {
+        assert_eq!(EMPTY_STRING_ARRAY_SQL, "CAST([], 'Array(String)')");
+        assert_ne!(EMPTY_STRING_ARRAY_SQL, "[]");
     }
 
     // ── Metric row tests ────────────────────────────────────────────────────

--- a/crates/temps-otel/tests/clickhouse_storage_test.rs
+++ b/crates/temps-otel/tests/clickhouse_storage_test.rs
@@ -29,6 +29,11 @@ use temps_otel::types::{
     AggregationTemporality, MetricAggregation, MetricPoint, MetricQuery, MetricType, ResourceInfo,
 };
 
+#[derive(::clickhouse::Row, serde::Deserialize)]
+struct ChTypeNameRow {
+    type_name: String,
+}
+
 /// Container handle + a connected `ClickHouseOtelStorage`. Returns `None` when
 /// Docker is unavailable so the test can skip without failing CI.
 async fn setup() -> Option<(ClickHouseOtelStorage, Box<dyn std::any::Any + Send>)> {
@@ -38,7 +43,11 @@ async fn setup() -> Option<(ClickHouseOtelStorage, Box<dyn std::any::Any + Send>
         GenericImage, ImageExt,
     };
 
-    let image = GenericImage::new("clickhouse/clickhouse-server", "24.8")
+    // This storage suite exercises the production-generation ClickHouse used
+    // by the schema benchmarks. decode_to_store_test remains pinned to 24.8,
+    // so together they cover both ends of the supported server range. Newer
+    // ClickHouse versions expose bare empty arrays as Array(Nothing).
+    let image = GenericImage::new("clickhouse/clickhouse-server", "26.2.5")
         .with_exposed_port(ContainerPort::Tcp(8123))
         // The clickhouse-server image writes "Ready for connections" only to its
         // in-container log file — never to stdout/stderr — so a log-message wait
@@ -52,7 +61,7 @@ async fn setup() -> Option<(ClickHouseOtelStorage, Box<dyn std::any::Any + Send>
         .with_env_var("CLICKHOUSE_DB", "temps_otel_test")
         // Do NOT set CLICKHOUSE_USER=default (the image's user-init then rejects
         // the pre-existing default user) and do NOT use an empty password (an
-        // empty CLICKHOUSE_PASSWORD leaves `default` unauthenticatable in 24.8).
+        // empty CLICKHOUSE_PASSWORD leaves `default` unauthenticatable).
         .with_env_var("CLICKHOUSE_PASSWORD", "test");
 
     let container = match image.start().await {
@@ -99,6 +108,16 @@ async fn setup() -> Option<(ClickHouseOtelStorage, Box<dyn std::any::Any + Send>
         eprintln!("Skipping ClickHouse OTel metrics test: server never became ready ({last_err})");
         return None;
     }
+
+    // Prove this test server exposes the production failure mode. A regression
+    // to a bare [] projection will therefore fail when the clickhouse client
+    // parses the Array(Nothing) response header into a typed Vec<T> field.
+    let empty_array_type = probe
+        .query("SELECT toTypeName([]) AS type_name")
+        .fetch_one::<ChTypeNameRow>()
+        .await
+        .expect("query empty-array ClickHouse type");
+    assert_eq!(empty_array_type.type_name, "Array(Nothing)");
 
     // Apply OTel CH migrations (spans + metrics). This MUST succeed — it is the
     // entire reason for the test. Assert loudly on failure.

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -99,10 +99,12 @@
     },
   },
   "overrides": {
+    "brace-expansion": "^2.1.2",
     "d3-color": "^3.1.0",
     "defu": "^6.1.5",
     "flatted": "^3.4.2",
     "handlebars": "^4.7.9",
+    "js-yaml": "^4.3.0",
     "lodash": "^4.17.24",
     "minimatch": "^9.0.7",
     "picomatch": "^2.3.2",
@@ -613,7 +615,7 @@
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
-    "brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
+    "brace-expansion": ["brace-expansion@2.1.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA=="],
 
     "browserslist": ["browserslist@4.26.3", "", { "dependencies": { "baseline-browser-mapping": "^2.8.9", "caniuse-lite": "^1.0.30001746", "electron-to-chromium": "^1.5.227", "node-releases": "^2.0.21", "update-browserslist-db": "^1.1.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w=="],
 
@@ -1017,7 +1019,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
+    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -120,9 +120,11 @@
     "typescript-eslint": "^8.63.0"
   },
   "overrides": {
+    "brace-expansion": "^2.1.2",
     "d3-color": "^3.1.0",
     "flatted": "^3.4.2",
     "handlebars": "^4.7.9",
+    "js-yaml": "^4.3.0",
     "picomatch": "^2.3.2",
     "minimatch": "^9.0.7",
     "tar": "^7.5.7",


### PR DESCRIPTION
## Description

Fixes production metric queries failing when ClickHouse reports an untyped empty array as Array(Nothing). Ungrouped scalar and histogram queries now project an explicit Array(String), matching the Rust Vec<String> response type.

Also hardens adjacent backend coverage discovered during regression testing:

- runs the OTel ClickHouse storage suite against 26.2.5 while retaining 24.8 decode coverage
- asserts that the modern test server exposes Array(Nothing), proving the regression environment
- configures the S3 metrics collector with bundled Mozilla roots so missing host roots cannot panic the AWS client
- moves two analytics integration tests to TestDatabase so Docker unavailability skips cleanly and real TimescaleDB behavior remains covered

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Validation

- 411 temps-otel unit tests passed
- 7 ClickHouse 26.2.5 storage integration tests passed
- 2 ClickHouse 24.8 decode/storage integration tests passed
- 103 temps-metrics unit tests passed
- 55 temps-analytics-events unit tests passed
- both repaired analytics tests passed against real TimescaleDB containers
- 21 proxy ClickHouse tests passed
- cargo check --lib passed across 163 crates with zero compile errors
- cargo clippy --lib -- -D warnings passed with zero errors
- security review approved the bundled-root TLS change with no blockers

## Checklist

- [x] I have written tests that cover the changes
- [x] All new and existing affected tests pass
- [x] cargo check --lib passes
- [x] My commits follow Conventional Commits format
- [x] No documentation update is necessary

## Security

Bundled Mozilla roots preserve certificate and hostname verification and use rustls with AWS-LC. The cached HTTP client contains no credentials. Private or self-signed CA endpoints fail closed pending an explicit custom-CA feature.