### PR TITLE
feat(config): expose sandbox backend selection in settings API and UI

### DIFF
--- a/crates/temps-agents/src/handlers/trigger.rs
+++ b/crates/temps-agents/src/handlers/trigger.rs
@@ -434,6 +434,7 @@ pub struct SandboxStatusResponse {
     pub image_ready: bool,
     pub image_name: String,
     pub error: Option<String>,
+    pub firecracker_available: bool,
 }
 
 #[utoipa::path(
@@ -483,6 +484,7 @@ pub async fn get_sandbox_status(
         image_ready,
         image_name,
         error,
+        firecracker_available: false,
     }))
 }
 
@@ -519,11 +521,21 @@ pub async fn get_global_sandbox_status(
         )
     };
 
+    let data_dir = std::env::var("TEMPS_DATA_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
+                .join(".temps")
+        });
+    let firecracker_available =
+        crate::sandbox::firecracker::is_firecracker_available(&data_dir).await;
+
     Ok(Json(SandboxStatusResponse {
         docker_available,
         image_ready,
         image_name,
         error,
+        firecracker_available,
     }))
 }
 

--- a/crates/temps-agents/src/sandbox/firecracker.rs
+++ b/crates/temps-agents/src/sandbox/firecracker.rs
@@ -1281,6 +1281,31 @@ fn dir_size(root: &Path) -> u64 {
     total
 }
 
+/// Check whether the Firecracker backend is ready on this host given the
+/// Temps data directory. Mirrors the logic in `FirecrackerSandboxProvider::is_available`
+/// without requiring a fully-constructed provider — used by the settings
+/// health endpoint so the UI can report backend availability without
+/// instantiating the full agent executor.
+pub async fn is_firecracker_available(data_dir: &Path) -> bool {
+    let config = FirecrackerSandboxConfig::from_data_dir(data_dir.to_path_buf());
+    let state_ok = std::fs::read(config.fc_root().join("state.json"))
+        .ok()
+        .and_then(|data| serde_json::from_slice::<serde_json::Value>(&data).ok())
+        .is_some_and(|s| s["smoke_ok"].as_bool().unwrap_or(false));
+    state_ok
+        && config.firecracker_bin().exists()
+        && config.agent_bin().exists()
+        && std::fs::read_dir(config.kernel_glob_dir())
+            .ok()
+            .and_then(|mut d| d.next())
+            .is_some()
+        && std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/kvm")
+            .is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/temps-config/src/handler.rs
+++ b/crates/temps-config/src/handler.rs
@@ -226,6 +226,7 @@ pub struct AgentSandboxSettingsMasked {
     pub cpu_limit: f64,
     pub memory_limit_mb: u64,
     pub network_mode: String,
+    pub sandbox_backend: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -342,6 +343,10 @@ impl From<AppSettings> for AppSettingsResponse {
                 cpu_limit: settings.agent_sandbox.cpu_limit,
                 memory_limit_mb: settings.agent_sandbox.memory_limit_mb,
                 network_mode: settings.agent_sandbox.network_mode,
+                sandbox_backend: settings
+                    .agent_sandbox
+                    .sandbox_backend
+                    .unwrap_or_else(|| "docker".to_string()),
             },
             ai_config: settings.ai_config,
             preview_gateway: PreviewGatewaySettingsMasked {
@@ -1218,6 +1223,19 @@ async fn update_settings(
                      the save was aborted to avoid wiping them. Retry the save; if \
                      this persists, check database connectivity: {}",
                     e
+                ))
+                .build());
+        }
+    }
+
+    if let Some(ref backend) = settings.agent_sandbox.sandbox_backend {
+        let backend = backend.trim();
+        if backend != "docker" && backend != "firecracker" {
+            return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
+                .title("Invalid Sandbox Backend")
+                .detail(format!(
+                    "sandbox_backend must be \"docker\" or \"firecracker\", got \"{}\"",
+                    backend
                 ))
                 .build());
         }

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -506,6 +506,7 @@ export type AgentSandboxSettingsMasked = {
         [key: string]: ProviderConfigMasked;
     };
     runtime: string;
+    sandbox_backend: string;
 };
 
 export type AggregatedBucketItem = {
@@ -13246,6 +13247,7 @@ export type SandboxRoute = {
 export type SandboxStatusResponse = {
     docker_available: boolean;
     error?: string | null;
+    firecracker_available: boolean;
     image_name: string;
     image_ready: boolean;
 };

--- a/web/src/api/platformSettings.ts
+++ b/web/src/api/platformSettings.ts
@@ -78,6 +78,7 @@ export interface AgentSandboxSettings {
   cpu_limit: number
   memory_limit_mb: number
   network_mode: string
+  sandbox_backend?: string
 }
 
 export interface PreviewGatewaySettings {

--- a/web/src/pages/agent-sandbox/AgentSandboxSandboxPage.tsx
+++ b/web/src/pages/agent-sandbox/AgentSandboxSandboxPage.tsx
@@ -30,6 +30,7 @@ interface SandboxStatus {
   image_ready: boolean
   image_name: string
   error: string | null
+  firecracker_available: boolean
 }
 
 const RUNTIME_PRESETS = [
@@ -67,6 +68,7 @@ export function AgentSandboxSandboxPage() {
   const [globalConfigRepo, setGlobalConfigRepo] = useState('')
   const [globalConfigRepoBranch, setGlobalConfigRepoBranch] = useState('main')
   const [defaultProvider, setDefaultProvider] = useState('claude_cli')
+  const [sandboxBackend, setSandboxBackend] = useState('docker')
   const [isDirty, setIsDirty] = useState(false)
 
   const [sandboxStatus, setSandboxStatus] = useState<SandboxStatus | null>(null)
@@ -97,6 +99,7 @@ export function AgentSandboxSandboxPage() {
       setCpuLimit(s.cpu_limit)
       setMemoryLimitMb(s.memory_limit_mb)
       setResourcePreset(getResourcePresetLabel(s.cpu_limit, s.memory_limit_mb))
+      setSandboxBackend(s.sandbox_backend || 'docker')
     }
     if (settings?.ai_config) {
       setGlobalConfigRepo(settings.ai_config.config_repo || '')
@@ -188,6 +191,7 @@ export function AgentSandboxSandboxPage() {
           api_key_saved: settings?.agent_sandbox?.api_key_saved ?? false,
           auth_type: settings?.agent_sandbox?.auth_type ?? '',
           providers: settings?.agent_sandbox?.providers ?? {},
+          sandbox_backend: sandboxBackend,
         },
         ai_config: {
           ...(settings?.ai_config ?? {}),
@@ -315,6 +319,66 @@ export function AgentSandboxSandboxPage() {
                 to start.
               </AlertDescription>
             </Alert>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Isolation Backend</CardTitle>
+            <CardDescription>
+              Default sandbox isolation technology for new workflow runs.
+              Firecracker provides stronger isolation via KVM microVMs; Docker is the
+              standard default.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              <button
+                onClick={() => {
+                  setSandboxBackend('docker')
+                  setIsDirty(true)
+                }}
+                className={`rounded-lg border p-3 text-left transition-colors ${
+                  sandboxBackend === 'docker'
+                    ? 'border-primary bg-primary/5'
+                    : 'border-border hover:border-primary/50'
+                }`}
+              >
+                <p className="text-sm font-medium">Docker</p>
+                <p className="text-xs text-muted-foreground">
+                  Container-based isolation — available on all hosts with Docker.
+                </p>
+              </button>
+              <div
+                title={
+                  sandboxStatus && !sandboxStatus.firecracker_available
+                    ? 'Firecracker is not yet available — run `temps firecracker setup` to provision this host'
+                    : undefined
+                }
+              >
+                <button
+                  onClick={() => {
+                    if (!sandboxStatus || sandboxStatus.firecracker_available) {
+                      setSandboxBackend('firecracker')
+                      setIsDirty(true)
+                    }
+                  }}
+                  disabled={sandboxStatus != null && !sandboxStatus.firecracker_available}
+                  className={`w-full rounded-lg border p-3 text-left transition-colors ${
+                    sandboxBackend === 'firecracker'
+                      ? 'border-primary bg-primary/5'
+                      : 'border-border hover:border-primary/50'
+                  } disabled:opacity-50 disabled:cursor-not-allowed`}
+                >
+                  <p className="text-sm font-medium">Firecracker</p>
+                  <p className="text-xs text-muted-foreground">
+                    {sandboxStatus && !sandboxStatus.firecracker_available
+                      ? 'Not available — run `temps firecracker setup`'
+                      : 'KVM microVM isolation — stronger security boundary.'}
+                  </p>
+                </button>
+              </div>
+            </div>
           </CardContent>
         </Card>
 


### PR DESCRIPTION
## Summary
- Expose `sandbox_backend` in the GET /settings response (`AgentSandboxSettingsMasked`), defaulting to `docker`.
- Validate and persist `sandbox_backend` (`docker` | `firecracker`) on settings update.
- Add `is_firecracker_available()` check and surface it via `firecracker_available` on the global sandbox status endpoint.
- Frontend: add an "Isolation Backend" selector to Settings → Sandbox, disabling the Firecracker option with a tooltip when it isn't provisioned yet.

## Why
`sandbox_backend` existed in `AppSettings` but was masked out of the settings API response, so the frontend had no way to read or set a default backend — despite CLI docs telling users to "Select it in Settings → Sandbox". This closes that gap without changing the existing per-sandbox `backend: firecracker` YAML override or the runtime availability gating in `FirecrackerSandboxProvider`.

## Test plan
- [x] `cargo check --lib -p temps-config -p temps-agents` passes
- [ ] Manually verify Settings → Sandbox shows Docker selected by default, Firecracker disabled with tooltip until `temps-vm-agent` + Firecracker are provisioned
- [ ] Manually verify saving a new default backend persists across reload