### PR TITLE
feat(containers): show metrics history in container detail

### DIFF
--- a/web/src/components/containers/ContainerHeaderBar.tsx
+++ b/web/src/components/containers/ContainerHeaderBar.tsx
@@ -13,10 +13,8 @@ import {
   ArrowUp,
   Check,
   ChevronsUpDown,
-  Cpu,
   ExternalLink,
   FileText,
-  HardDrive,
   Loader2,
   Play,
   RotateCw,
@@ -26,7 +24,7 @@ import {
 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { useContainerMetricsStream } from './useContainerMetricsStream'
-import { formatCpuUsage } from '@/lib/cpu-format'
+import { ContainerMetricHistory } from './ContainerMetricHistory'
 
 type ContainerStatus = string
 type ContainerTab = 'logs' | 'configuration'
@@ -132,30 +130,24 @@ export function ContainerHeaderBar({
               )}
               {isRunning && metrics && (
                 <>
-                  <div className="inline-flex items-center gap-1.5 tabular-nums">
-                    <Cpu className="size-3.5" aria-hidden="true" />
-                    <span>
-                      CPU{' '}
-                      {formatCpuUsage(
-                        metrics.cpu_percent,
-                        metrics.cpu_limit_cores,
-                      )}
-                    </span>
-                  </div>
-                  <div className="inline-flex items-center gap-1.5 tabular-nums">
-                    <HardDrive className="size-3.5" aria-hidden="true" />
-                    <span>
-                      Mem {formatBytes(metrics.memory_bytes)}
-                      {hasRealMemoryLimit(metrics.memory_limit_bytes) ? (
-                        <>
-                          {' / '}
-                          {formatBytes(metrics.memory_limit_bytes!)}
-                          {metrics.memory_percent != null &&
-                            ` (${metrics.memory_percent.toFixed(0)}%)`}
-                        </>
-                      ) : null}
-                    </span>
-                  </div>
+                  <ContainerMetricHistory
+                    projectId={parseInt(projectId)}
+                    environmentId={parseInt(environmentId)}
+                    containerId={selectedContainer.container_id}
+                    metric="container.cpu_percent"
+                    label="CPU"
+                    currentValue={metrics.cpu_percent}
+                    format={(value) => `${value.toFixed(1)}%`}
+                  />
+                  <ContainerMetricHistory
+                    projectId={parseInt(projectId)}
+                    environmentId={parseInt(environmentId)}
+                    containerId={selectedContainer.container_id}
+                    metric="container.memory_used_bytes"
+                    label="Mem"
+                    currentValue={metrics.memory_bytes}
+                    format={formatBytes}
+                  />
                   <div className="inline-flex items-center gap-1.5 tabular-nums">
                     <ArrowDown className="size-3.5" aria-hidden="true" />
                     <span>{formatBytes(metrics.network_rx_rate)}/s</span>
@@ -470,15 +462,6 @@ function RestartCountChip({ count }: { count: number }) {
       Restarted {count}×
     </span>
   )
-}
-
-/** Docker reports the host's total memory as the "limit" when no explicit
- * limit was set on the container. Treat anything above 100 GiB as no-limit
- * to avoid showing nonsense numbers like "Mem 126 MB / 128 GB". */
-function hasRealMemoryLimit(bytes: number | null | undefined): boolean {
-  if (bytes == null || bytes <= 0) return false
-  const HUNDRED_GIB = 100 * 1024 * 1024 * 1024
-  return bytes < HUNDRED_GIB
 }
 
 function formatBytes(bytes: number): string {

--- a/web/src/components/containers/ContainerHeaderBar.tsx
+++ b/web/src/components/containers/ContainerHeaderBar.tsx
@@ -128,26 +128,28 @@ export function ContainerHeaderBar({
               {(metrics?.restart_count ?? 0) > 0 && (
                 <RestartCountChip count={metrics?.restart_count ?? 0} />
               )}
+              <ContainerMetricHistory
+                projectId={parseInt(projectId)}
+                environmentId={parseInt(environmentId)}
+                containerId={selectedContainer?.container_id ?? ''}
+                metric="container.cpu_percent"
+                label="CPU"
+                currentValue={metrics?.cpu_percent}
+                format={(value) => `${value.toFixed(1)}%`}
+                enabled={Boolean(isRunning && selectedContainer)}
+              />
+              <ContainerMetricHistory
+                projectId={parseInt(projectId)}
+                environmentId={parseInt(environmentId)}
+                containerId={selectedContainer?.container_id ?? ''}
+                metric="container.memory_used_bytes"
+                label="Mem"
+                currentValue={metrics?.memory_bytes}
+                format={formatBytes}
+                enabled={Boolean(isRunning && selectedContainer)}
+              />
               {isRunning && metrics && (
                 <>
-                  <ContainerMetricHistory
-                    projectId={parseInt(projectId)}
-                    environmentId={parseInt(environmentId)}
-                    containerId={selectedContainer.container_id}
-                    metric="container.cpu_percent"
-                    label="CPU"
-                    currentValue={metrics.cpu_percent}
-                    format={(value) => `${value.toFixed(1)}%`}
-                  />
-                  <ContainerMetricHistory
-                    projectId={parseInt(projectId)}
-                    environmentId={parseInt(environmentId)}
-                    containerId={selectedContainer.container_id}
-                    metric="container.memory_used_bytes"
-                    label="Mem"
-                    currentValue={metrics.memory_bytes}
-                    format={formatBytes}
-                  />
                   <div className="inline-flex items-center gap-1.5 tabular-nums">
                     <ArrowDown className="size-3.5" aria-hidden="true" />
                     <span>{formatBytes(metrics.network_rx_rate)}/s</span>

--- a/web/src/components/containers/ContainerList.tsx
+++ b/web/src/components/containers/ContainerList.tsx
@@ -204,30 +204,28 @@ function ContainerRow({
         </div>
       </div>
 
-      {running && (
-        <>
-          <ContainerMetricHistory
-            projectId={project.id}
-            environmentId={parseInt(environmentId)}
-            containerId={container.container_id}
-            metric="container.cpu_percent"
-            label="CPU"
-            format={(v) => `${v.toFixed(1)}%`}
-            hideWithoutHistory
-            className="hidden lg:flex"
-          />
-          <ContainerMetricHistory
-            projectId={project.id}
-            environmentId={parseInt(environmentId)}
-            containerId={container.container_id}
-            metric="container.memory_used_bytes"
-            label="Mem"
-            format={formatBytes}
-            hideWithoutHistory
-            className="hidden lg:flex"
-          />
-        </>
-      )}
+      <ContainerMetricHistory
+        projectId={project.id}
+        environmentId={parseInt(environmentId)}
+        containerId={container.container_id}
+        metric="container.cpu_percent"
+        label="CPU"
+        format={(v) => `${v.toFixed(1)}%`}
+        hideWithoutHistory
+        enabled={running}
+        className="hidden lg:flex"
+      />
+      <ContainerMetricHistory
+        projectId={project.id}
+        environmentId={parseInt(environmentId)}
+        containerId={container.container_id}
+        metric="container.memory_used_bytes"
+        label="Mem"
+        format={formatBytes}
+        hideWithoutHistory
+        enabled={running}
+        className="hidden lg:flex"
+      />
 
       <div
         className="flex items-center gap-1 shrink-0"

--- a/web/src/components/containers/ContainerList.tsx
+++ b/web/src/components/containers/ContainerList.tsx
@@ -1,10 +1,8 @@
 import { ContainerInfoResponse, ProjectResponse } from '@/api/client'
 import {
-  containerMetricsGetHistoryOptions,
   getContainerMetricsOptions,
   listContainersOptions,
 } from '@/api/client/@tanstack/react-query.gen'
-import { MetricSparkline } from '@/components/charts/metric-sparkline'
 import { formatCpuUsage } from '@/lib/cpu-format'
 import {
   DropdownMenu,
@@ -28,6 +26,7 @@ import {
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { ContainerMetricHistory } from './ContainerMetricHistory'
 
 interface ContainerListProps {
   project: ProjectResponse
@@ -207,21 +206,25 @@ function ContainerRow({
 
       {running && (
         <>
-          <HistorySparkline
-            project={project}
-            environmentId={environmentId}
+          <ContainerMetricHistory
+            projectId={project.id}
+            environmentId={parseInt(environmentId)}
             containerId={container.container_id}
             metric="container.cpu_percent"
             label="CPU"
             format={(v) => `${v.toFixed(1)}%`}
+            hideWithoutHistory
+            className="hidden lg:flex"
           />
-          <HistorySparkline
-            project={project}
-            environmentId={environmentId}
+          <ContainerMetricHistory
+            projectId={project.id}
+            environmentId={parseInt(environmentId)}
             containerId={container.container_id}
             metric="container.memory_used_bytes"
             label="Mem"
             format={formatBytes}
+            hideWithoutHistory
+            className="hidden lg:flex"
           />
         </>
       )}
@@ -280,57 +283,6 @@ function ContainerRow({
           aria-hidden="true"
         />
       </div>
-    </div>
-  )
-}
-
-/**
- * Compact 1h sparkline + current value for one container resource metric
- * (history recorded every ~30s by the container health monitor). Renders
- * nothing when there's no history yet (metrics store disabled, container
- * just started) so rows stay clean.
- */
-function HistorySparkline({
-  project,
-  environmentId,
-  containerId,
-  metric,
-  label,
-  format,
-}: {
-  project: ProjectResponse
-  environmentId: string
-  containerId: string
-  metric: string
-  label: string
-  format: (value: number) => string
-}) {
-  const { data } = useQuery({
-    ...containerMetricsGetHistoryOptions({
-      path: {
-        project_id: project.id,
-        environment_id: parseInt(environmentId),
-        container_id: containerId,
-      },
-      query: { metric, range: '1h' },
-    }),
-    staleTime: 30_000,
-    refetchInterval: 30_000,
-    // Metrics store disabled → the endpoint 503s; don't retry-spam.
-    retry: false,
-  })
-
-  if (!data?.length) return null
-
-  const values = data.map((p) => p.value)
-  const last = values[values.length - 1]
-
-  return (
-    <div className="hidden w-24 shrink-0 flex-col items-stretch gap-0.5 lg:flex">
-      <MetricSparkline data={values} height={16} />
-      <span className="text-right text-[10px] tabular-nums text-neutral-500 dark:text-neutral-400">
-        {label} {format(last)}
-      </span>
     </div>
   )
 }

--- a/web/src/components/containers/ContainerMetricHistory.tsx
+++ b/web/src/components/containers/ContainerMetricHistory.tsx
@@ -13,6 +13,7 @@ interface ContainerMetricHistoryProps {
   format: (value: number) => string
   currentValue?: number | null
   hideWithoutHistory?: boolean
+  enabled?: boolean
   className?: string
 }
 
@@ -26,6 +27,7 @@ export function ContainerMetricHistory({
   format,
   currentValue,
   hideWithoutHistory = false,
+  enabled = true,
   className,
 }: ContainerMetricHistoryProps) {
   const { data } = useQuery({
@@ -39,10 +41,12 @@ export function ContainerMetricHistory({
     }),
     staleTime: 30_000,
     refetchInterval: 30_000,
+    enabled,
     // Metrics store disabled -> the endpoint returns 503; avoid retry spam.
     retry: false,
   })
 
+  if (!enabled) return null
   if (hideWithoutHistory && !data?.length) return null
 
   const values = buildMetricHistorySeries(data, currentValue)
@@ -54,6 +58,7 @@ export function ContainerMetricHistory({
         'flex w-24 shrink-0 flex-col items-stretch gap-0.5',
         className
       )}
+      role="img"
       aria-label={`${label} usage over the last hour`}
     >
       <MetricSparkline data={values} height={16} />

--- a/web/src/components/containers/ContainerMetricHistory.tsx
+++ b/web/src/components/containers/ContainerMetricHistory.tsx
@@ -1,0 +1,65 @@
+import { containerMetricsGetHistoryOptions } from '@/api/client/@tanstack/react-query.gen'
+import { MetricSparkline } from '@/components/charts/metric-sparkline'
+import { cn } from '@/lib/utils'
+import { useQuery } from '@tanstack/react-query'
+import { buildMetricHistorySeries } from './container-metric-history'
+
+interface ContainerMetricHistoryProps {
+  projectId: number
+  environmentId: number
+  containerId: string
+  metric: string
+  label: string
+  format: (value: number) => string
+  currentValue?: number | null
+  hideWithoutHistory?: boolean
+  className?: string
+}
+
+/** Compact one-hour resource sparkline with its latest value. */
+export function ContainerMetricHistory({
+  projectId,
+  environmentId,
+  containerId,
+  metric,
+  label,
+  format,
+  currentValue,
+  hideWithoutHistory = false,
+  className,
+}: ContainerMetricHistoryProps) {
+  const { data } = useQuery({
+    ...containerMetricsGetHistoryOptions({
+      path: {
+        project_id: projectId,
+        environment_id: environmentId,
+        container_id: containerId,
+      },
+      query: { metric, range: '1h' },
+    }),
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+    // Metrics store disabled -> the endpoint returns 503; avoid retry spam.
+    retry: false,
+  })
+
+  if (hideWithoutHistory && !data?.length) return null
+
+  const values = buildMetricHistorySeries(data, currentValue)
+  const latest = values[values.length - 1]
+
+  return (
+    <div
+      className={cn(
+        'flex w-24 shrink-0 flex-col items-stretch gap-0.5',
+        className
+      )}
+      aria-label={`${label} usage over the last hour`}
+    >
+      <MetricSparkline data={values} height={16} />
+      <span className="text-right text-[10px] tabular-nums text-neutral-500 dark:text-neutral-400">
+        {label} {latest == null ? 'No data' : format(latest)}
+      </span>
+    </div>
+  )
+}

--- a/web/src/components/containers/container-metric-history.ts
+++ b/web/src/components/containers/container-metric-history.ts
@@ -1,0 +1,23 @@
+interface MetricHistoryPoint {
+  value: number
+}
+
+/**
+ * Build a sparkline series from stored history and the latest live sample.
+ * The live sample keeps the right edge current between 30-second history
+ * refreshes and still gives the UI a baseline when history is unavailable.
+ */
+export function buildMetricHistorySeries(
+  history: MetricHistoryPoint[] | undefined,
+  currentValue?: number | null
+): number[] {
+  const values = (history ?? [])
+    .map((point) => point.value)
+    .filter(Number.isFinite)
+
+  if (currentValue != null && Number.isFinite(currentValue)) {
+    values.push(currentValue)
+  }
+
+  return values
+}

--- a/web/tests/container-metric-history.test.ts
+++ b/web/tests/container-metric-history.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test'
+import { buildMetricHistorySeries } from '../src/components/containers/container-metric-history'
+
+describe('buildMetricHistorySeries', () => {
+  test('appends the live sample to stored history', () => {
+    expect(buildMetricHistorySeries([{ value: 1 }, { value: 2 }], 3)).toEqual([
+      1, 2, 3,
+    ])
+  })
+
+  test('uses the live sample when stored history is unavailable', () => {
+    expect(buildMetricHistorySeries(undefined, 12)).toEqual([12])
+  })
+
+  test('filters non-finite samples so the chart remains renderable', () => {
+    expect(
+      buildMetricHistorySeries(
+        [
+          { value: 1 },
+          { value: Number.NaN },
+          { value: Number.POSITIVE_INFINITY },
+        ],
+        Number.NEGATIVE_INFINITY
+      )
+    ).toEqual([1])
+  })
+})


### PR DESCRIPTION
## Summary

- show one-hour CPU and memory sparklines in the environment container-detail header
- keep the graph's right edge current by appending the latest streamed metrics sample
- reuse the same history component in the container list and detail view
- preserve the list's existing hide-when-history-is-unavailable behavior while the detail view can render stored history without a live stream

## Evidence

**Container detail UI**: rendered the authenticated project route against the local feature-worktree dev server with deterministic API fixtures and a deliberately failed SSE stream.

```text
url=http://localhost:3000/projects/checkout-api/environments/containers/9a7c4f18d2e1?env=10&tab=configuration
title=checkout-api - Temps
verified=CPU 0.1%, Mem 12 MB
```

The rendered header displayed both one-hour sparklines next to the container image, node, and uptime metadata using stored history despite the unavailable live stream. Screenshot captured locally at `artifacts/container-detail-metrics.png` and inspected at 1440x900.

**Focused behavior tests**:

```bash
cd web && bun test tests/container-metric-history.test.ts
```

```text
3 pass
0 fail
3 expect() calls
```

**Frontend verification**:

```bash
cd web
bunx prettier --check src/components/containers/ContainerHeaderBar.tsx src/components/containers/ContainerList.tsx src/components/containers/ContainerMetricHistory.tsx src/components/containers/container-metric-history.ts tests/container-metric-history.test.ts
bunx eslint src/components/containers/ContainerHeaderBar.tsx src/components/containers/ContainerList.tsx src/components/containers/ContainerMetricHistory.tsx src/components/containers/container-metric-history.ts tests/container-metric-history.test.ts
bunx tsc --noEmit -p tsconfig.json
```

```text
All matched files use Prettier code style.
ESLint: passed
TypeScript: passed
```

**Workspace verification**:

```bash
cargo check --lib
```

```text
cargo build: 0 errors, 5 warnings (0 crates)
```

The warnings are existing workspace/profile and future-compatibility notices; no new warnings were introduced by this web-only change.

## Test plan

- [x] Stored history is rendered in order
- [x] Latest live sample is appended to the series
- [x] Missing history falls back to the live sample
- [x] Stored history remains visible when the live metrics stream fails
- [x] Non-finite samples are filtered before chart rendering
- [x] CPU label matches the existing container-list percentage format
- [x] CPU and memory graphs visually verified in the container-detail header
