### PR TITLE
fix(clickhouse): align query result integer types

### DIFF
--- a/crates/temps-metrics/Cargo.toml
+++ b/crates/temps-metrics/Cargo.toml
@@ -50,4 +50,4 @@ reqwest = { workspace = true }
 libc = "0.2"
 
 [dev-dependencies]
-testcontainers = { workspace = true }
+testcontainers = { workspace = true, features = ["http_wait_plain"] }

--- a/crates/temps-metrics/src/store/clickhouse.rs
+++ b/crates/temps-metrics/src/store/clickhouse.rs
@@ -732,7 +732,7 @@ impl ClickhouseMetricsStore {
         // metric's full history before the LIMIT.
         let sql = format!(
             "SELECT min(k) AS min_keys FROM ( \
-               SELECT length(JSONExtractKeys(labels)) AS k \
+               SELECT toInt64(length(JSONExtractKeys(labels))) AS k \
                FROM service_metrics \
                WHERE source_kind = ? AND source_id = ? AND name = '{nm}' \
                  AND time > (SELECT max(time) FROM service_metrics \
@@ -756,7 +756,17 @@ impl ClickhouseMetricsStore {
             // No rows => min over empty set is 0 in CH; that still yields a
             // harmless `= 0` filter. We only treat a query error as `None`.
             Ok(r) => Some(r.min_keys),
-            Err(_) => None,
+            Err(error) => {
+                warn!(
+                    operation = "min_label_key_count",
+                    source_kind,
+                    source_id,
+                    metric_name = name,
+                    reason = %error,
+                    "ClickHouse label-count query failed; range query will use all label series"
+                );
+                None
+            }
         }
     }
 }
@@ -769,6 +779,71 @@ mod tests {
     use super::*;
     use crate::store::{MetricKind, SourceKind};
     use std::collections::HashMap;
+
+    async fn setup_clickhouse_store(
+    ) -> Option<(ClickhouseMetricsStore, Box<dyn std::any::Any + Send>)> {
+        use testcontainers::{
+            core::{wait::HttpWaitStrategy, ContainerPort, WaitFor},
+            runners::AsyncRunner,
+            GenericImage, ImageExt,
+        };
+
+        let image = GenericImage::new("clickhouse/clickhouse-server", "26.2.5")
+            .with_exposed_port(ContainerPort::Tcp(8123))
+            .with_wait_for(WaitFor::http(
+                HttpWaitStrategy::new("/ping")
+                    .with_port(ContainerPort::Tcp(8123))
+                    .with_expected_status_code(200u16),
+            ))
+            .with_env_var("CLICKHOUSE_DB", "temps_metrics_test")
+            .with_env_var("CLICKHOUSE_PASSWORD", "test");
+
+        let container = match image.start().await {
+            Ok(container) => container,
+            Err(error) => {
+                eprintln!("Skipping ClickHouse metrics test: cannot start container ({error})");
+                return None;
+            }
+        };
+        let host_port = match container.get_host_port_ipv4(8123).await {
+            Ok(port) => port,
+            Err(error) => {
+                eprintln!("Skipping ClickHouse metrics test: cannot get host port ({error})");
+                return None;
+            }
+        };
+
+        let store = ClickhouseMetricsStore::new(ClickHouseMetricsConfig::new(
+            format!("http://127.0.0.1:{host_port}"),
+            "temps_metrics_test",
+            "default",
+            "test",
+        ));
+
+        let mut last_error = String::new();
+        for _ in 0..30 {
+            match store.client().query("SELECT 1").execute().await {
+                Ok(()) => {
+                    last_error.clear();
+                    break;
+                }
+                Err(error) => {
+                    last_error = error.to_string();
+                    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                }
+            }
+        }
+        if !last_error.is_empty() {
+            eprintln!("Skipping ClickHouse metrics test: server never became ready ({last_error})");
+            return None;
+        }
+
+        crate::store::clickhouse_migrations::apply_migrations(store.client(), "temps_metrics_test")
+            .await
+            .expect("apply metrics ClickHouse migrations");
+
+        Some((store, Box::new(container)))
+    }
 
     fn point(name: &str, value: f64, kind: MetricKind) -> MetricPoint {
         let mut labels = HashMap::new();
@@ -785,6 +860,54 @@ mod tests {
             node_id: Some(3),
             labels,
         }
+    }
+
+    #[tokio::test]
+    async fn clickhouse_range_uses_the_fewest_label_key_series() {
+        let Some((store, _container)) = setup_clickhouse_store().await else {
+            return;
+        };
+
+        let timestamp = Utc::now();
+        let mut aggregate = point("pg.connections_active", 10.0, MetricKind::Gauge);
+        aggregate.time = timestamp;
+        aggregate.labels.clear();
+
+        let mut per_database = point("pg.connections_active", 100.0, MetricKind::Gauge);
+        per_database.time = timestamp;
+        per_database.labels.clear();
+        per_database.labels.insert("datname".into(), "app".into());
+
+        store
+            .write_batch(vec![aggregate, per_database])
+            .await
+            .expect("insert aggregate and labelled metric fixtures");
+
+        assert_eq!(
+            store
+                .min_label_key_count("database", 7, "pg.connections_active")
+                .await,
+            Some(0),
+            "ClickHouse UInt64 label counts must decode into the signed query filter"
+        );
+
+        let values = store
+            .query_range(RangeQuery {
+                source_kind: SourceKind::Database,
+                source_id: 7,
+                name: "pg.connections_active".to_string(),
+                from: timestamp - chrono::Duration::minutes(1),
+                to: timestamp + chrono::Duration::minutes(1),
+                step: chrono::Duration::minutes(1),
+                monotonic: false,
+            })
+            .await
+            .expect("query aggregate metric series");
+        assert_eq!(values.len(), 1);
+        assert_eq!(
+            values[0].1, 10.0,
+            "labelled rows must not blend into aggregate series"
+        );
     }
 
     #[test]

--- a/crates/temps-proxy/Cargo.toml
+++ b/crates/temps-proxy/Cargo.toml
@@ -75,7 +75,7 @@ integration = []
 
 [dev-dependencies]
 tokio-test = "0.4"
-testcontainers = { workspace = true }
+testcontainers = { workspace = true, features = ["http_wait_plain"] }
 temp-dir = "0.2"
 hyper = { version = "1.0", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }

--- a/crates/temps-proxy/src/storage/clickhouse.rs
+++ b/crates/temps-proxy/src/storage/clickhouse.rs
@@ -1169,10 +1169,13 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
         // server-derived integer (validated interval → seconds), safe to
         // interpolate; the FILL bounds are bound params. The bucket expression
         // lives in the SELECT so GROUP BY / ORDER BY / WITH FILL reference the
-        // `bucket_ms` alias.
+        // `bucket_ms` alias. ClickHouse's toUnixTimestamp returns UInt32 and
+        // multiplying by 1000 promotes it to UInt64, so cast before arithmetic
+        // to match the i64 field in ChTimeBucketRow. The FILL bounds must use
+        // the same signed type as the ORDER BY expression.
         let sql = format!(
             "SELECT \
-                toUnixTimestamp(toStartOfInterval(timestamp, INTERVAL {step} SECOND)) * 1000 AS bucket_ms, \
+                toInt64(toUnixTimestamp(toStartOfInterval(timestamp, INTERVAL {step} SECOND))) * 1000 AS bucket_ms, \
                 count() AS request_count, \
                 ifNull(avg(response_time_ms), 0) AS avg_response_time_ms, \
                 countIf(status_code >= 400) AS error_count, \
@@ -1183,8 +1186,8 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
              GROUP BY bucket_ms \
              ORDER BY bucket_ms ASC \
              WITH FILL \
-                FROM toUnixTimestamp(toStartOfInterval(fromUnixTimestamp64Milli(?), INTERVAL {step} SECOND)) * 1000 \
-                TO toUnixTimestamp(toStartOfInterval(fromUnixTimestamp64Milli(?), INTERVAL {step} SECOND)) * 1000 \
+                FROM toInt64(toUnixTimestamp(toStartOfInterval(fromUnixTimestamp64Milli(?), INTERVAL {step} SECOND))) * 1000 \
+                TO toInt64(toUnixTimestamp(toStartOfInterval(fromUnixTimestamp64Milli(?), INTERVAL {step} SECOND))) * 1000 \
                 STEP {step_ms}",
             where_clause = clauses.join(" AND "),
             step = step_secs,
@@ -1523,10 +1526,12 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
         // the Postgres path builds — the frontend relies on a continuous
         // x-axis). The empty FILL buckets come back with agent='' and count 0;
         // the Rust roll-up below treats agent='' as an x-axis-only marker,
-        // exactly like the Postgres NULL-agent spine rows.
+        // exactly like the Postgres NULL-agent spine rows. Keep the bucket and
+        // FILL bounds explicitly Int64: toUnixTimestamp otherwise produces an
+        // unsigned value that cannot decode into ChAiTimelineRow::bucket_ms.
         let sql = format!(
             "SELECT \
-                toUnixTimestamp(toStartOfInterval(timestamp, INTERVAL {step} SECOND)) * 1000 AS bucket_ms, \
+                toInt64(toUnixTimestamp(toStartOfInterval(timestamp, INTERVAL {step} SECOND))) * 1000 AS bucket_ms, \
                 bot_name AS agent, \
                 count() AS request_count \
              FROM proxy_logs FINAL \
@@ -1534,8 +1539,8 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
              GROUP BY bucket_ms, bot_name \
              ORDER BY bucket_ms ASC \
              WITH FILL \
-                FROM toUnixTimestamp(toStartOfInterval(fromUnixTimestamp64Milli(?), INTERVAL {step} SECOND)) * 1000 \
-                TO toUnixTimestamp(toStartOfInterval(fromUnixTimestamp64Milli(?), INTERVAL {step} SECOND)) * 1000 \
+                FROM toInt64(toUnixTimestamp(toStartOfInterval(fromUnixTimestamp64Milli(?), INTERVAL {step} SECOND))) * 1000 \
+                TO toInt64(toUnixTimestamp(toStartOfInterval(fromUnixTimestamp64Milli(?), INTERVAL {step} SECOND))) * 1000 \
                 STEP {step_ms}",
             step = step_secs,
             step_ms = step_secs * 1000,
@@ -1759,6 +1764,81 @@ fn status_class_range(class: &str) -> Option<(i16, i16)> {
 mod tests {
     use super::*;
 
+    /// Start a real ClickHouse matching the production major version. Docker
+    /// is optional for local/unit-test environments, so startup failures skip
+    /// gracefully; once the server starts, migration/query failures are real
+    /// test failures.
+    async fn setup_clickhouse_store(
+    ) -> Option<(ClickHouseProxyLogStore, Box<dyn std::any::Any + Send>)> {
+        use testcontainers::{
+            core::{wait::HttpWaitStrategy, ContainerPort, WaitFor},
+            runners::AsyncRunner,
+            GenericImage, ImageExt,
+        };
+
+        let image = GenericImage::new("clickhouse/clickhouse-server", "26.2.5")
+            .with_exposed_port(ContainerPort::Tcp(8123))
+            .with_wait_for(WaitFor::http(
+                HttpWaitStrategy::new("/ping")
+                    .with_port(ContainerPort::Tcp(8123))
+                    .with_expected_status_code(200u16),
+            ))
+            .with_env_var("CLICKHOUSE_DB", "temps_proxy_test")
+            .with_env_var("CLICKHOUSE_PASSWORD", "test");
+
+        let container = match image.start().await {
+            Ok(container) => container,
+            Err(error) => {
+                eprintln!("Skipping ClickHouse proxy-log test: cannot start container ({error})");
+                return None;
+            }
+        };
+
+        let host_port = match container.get_host_port_ipv4(8123).await {
+            Ok(port) => port,
+            Err(error) => {
+                eprintln!("Skipping ClickHouse proxy-log test: cannot get host port ({error})");
+                return None;
+            }
+        };
+
+        let store = ClickHouseProxyLogStore::new(
+            ClickHouseProxyLogConfig::new(
+                format!("http://127.0.0.1:{host_port}"),
+                "temps_proxy_test",
+                "default",
+                "test",
+            ),
+            Arc::new(temps_core::FixedRetentionResolver),
+        );
+
+        let mut last_error = String::new();
+        for _ in 0..30 {
+            match store.client().query("SELECT 1").execute().await {
+                Ok(()) => {
+                    last_error.clear();
+                    break;
+                }
+                Err(error) => {
+                    last_error = error.to_string();
+                    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                }
+            }
+        }
+        if !last_error.is_empty() {
+            eprintln!(
+                "Skipping ClickHouse proxy-log test: server never became ready ({last_error})"
+            );
+            return None;
+        }
+
+        crate::storage::clickhouse_migrations::apply_migrations(store.client(), "temps_proxy_test")
+            .await
+            .expect("apply proxy-log ClickHouse migrations");
+
+        Some((store, Box::new(container)))
+    }
+
     fn make_entry(request_id: &str) -> CreateProxyLogRequest {
         CreateProxyLogRequest {
             method: "GET".to_string(),
@@ -1799,6 +1879,50 @@ mod tests {
             visitor_uuid: None,
             session_uuid: None,
         }
+    }
+
+    #[tokio::test]
+    async fn clickhouse_bucket_queries_decode_signed_millisecond_timestamps() {
+        let Some((store, _container)) = setup_clickhouse_store().await else {
+            return;
+        };
+
+        let mut entry = make_entry("bucket-type-regression");
+        entry.is_bot = Some(true);
+        entry.bot_name = Some("GPTBot".to_string());
+        store
+            .write_batch(vec![entry])
+            .await
+            .expect("insert proxy-log fixture");
+
+        let start = Utc::now() - chrono::Duration::minutes(2);
+        let end = Utc::now() + chrono::Duration::minutes(2);
+        let stats = store
+            .get_time_bucket_stats(start, end, "1 minute".to_string(), None)
+            .await
+            .expect("decode time-bucket stats with signed bucket_ms");
+        assert!(
+            stats.iter().any(|bucket| bucket.request_count == 1),
+            "inserted request must appear in time-bucket stats"
+        );
+
+        let timeline = store
+            .get_ai_agent_timeline(
+                None,
+                None,
+                start,
+                end,
+                "1 minute".to_string(),
+                AiTimelineGroupBy::Agent,
+            )
+            .await
+            .expect("decode AI timeline with signed bucket_ms");
+        assert!(
+            timeline
+                .iter()
+                .any(|bucket| bucket.key == "GPTBot" && bucket.request_count == 1),
+            "inserted AI request must appear in the agent timeline"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- cast proxy-log time-bucket expressions and their `WITH FILL` bounds to `Int64` so ClickHouse rows decode into the existing `i64` fields
- fix the same mismatch in the AI-agent timeline query
- cast metrics label-key counts to `Int64`, preserving the aggregate-series filter instead of silently blending labeled rows
- add real ClickHouse 26.2.5 regression tests for both storage backends

## Root cause and audit

`toUnixTimestamp(...)` returns `UInt32`; multiplying it by `1000` promoted `bucket_ms` to `UInt64`, while the ClickHouse row structs expected `i64`. The same pattern existed in two proxy queries. A repository-wide ClickHouse row/query audit also found `length(JSONExtractKeys(labels))` returning `UInt64` for a metrics row decoded as `i64`; that error was swallowed and disabled label-series filtering.

The audit confirmed existing `toInt64(toUnixTimestamp(...))` expressions in metrics/OTel are safe, `toUnixTimestamp64Milli(...)` maps to `i64`, and `count`/`countIf`/`uniq` fields correctly use `u64`.

## Evidence

**Production symptom reproduced against ClickHouse 26.2.5 before the fix**:

```bash
cargo test -p temps-proxy clickhouse_bucket_queries_decode_signed_millisecond_timestamps -- --nocapture
```

```text
FAILED
decode time-bucket stats with signed bucket_ms: ClickHouse {
  operation: "get_time_bucket_stats",
  reason: "schema mismatch: While processing column ChTimeBucketRow.bucket_ms: attempting to (de)serialize ClickHouse type UInt64 as i64 which is not compatible"
}
```

**Proxy bucket and AI-timeline queries after the fix**:

```bash
cargo test -p temps-proxy clickhouse_bucket_queries_decode_signed_millisecond_timestamps -- --nocapture
```

```text
cargo test: 1 passed, 424 filtered out (1 suite, 4.72s)
```

**Additional audited metrics mismatch reproduced before the fix**:

```bash
cargo test -p temps-metrics clickhouse_range_uses_the_fewest_label_key_series -- --nocapture
```

```text
FAILED
assertion failed: ClickHouse UInt64 label counts must decode into the signed query filter
left: None
right: Some(0)
```

**Metrics label filtering after the fix**:

```bash
cargo test -p temps-metrics clickhouse_range_uses_the_fewest_label_key_series -- --nocapture
```

```text
cargo test: 1 passed, 105 filtered out (2 suites, 4.61s)
```

**Affected crate suites**:

```bash
cargo test --lib -p temps-proxy -p temps-metrics
```

```text
cargo test: 525 passed, 4 ignored (2 suites, 43.57s)
```

**Static verification**:

```bash
cargo fmt --all -- --check
cargo check --lib
cargo clippy -p temps-proxy -p temps-metrics --all-targets --all-features -- -D warnings
```

```text
Formatting: passed
cargo build: 0 errors, 5 existing workspace warnings
cargo clippy: 0 errors
```

## Test plan

- [x] Reproduce the reported `UInt64` to `i64` proxy decode failure on real ClickHouse
- [x] Verify time-bucket stats decode and contain the inserted request
- [x] Verify the AI-agent timeline decodes and contains the inserted agent request
- [x] Reproduce the metrics label-count mismatch on real ClickHouse
- [x] Verify the fewest-label-key aggregate series is selected without blending labeled rows
- [x] Run all library tests for both affected crates
- [x] Run formatting, workspace library check, and targeted Clippy
