### PR TITLE
chore(templates): update observability-starter entry for Cadence demo

### DIFF
--- a/crates/temps-core/templates.yaml
+++ b/crates/temps-core/templates.yaml
@@ -8,12 +8,14 @@ version: "1"
 
 templates:
   # Observability Starter — the one-click "try Temps" demo app.
-  # Showcases all four built-in observability pillars (analytics, error
-  # tracking, distributed tracing) plus a Postgres database in a single deploy,
-  # so a new user can activate without building a project of their own first.
+  # "Cadence", a mock revenue-analytics SaaS, showcases all four built-in
+  # observability pillars (analytics, error tracking, distributed tracing) plus a
+  # Postgres database in a single deploy. Its "Simulate a user journey" button
+  # drives a real funnel so a new user sees the data land without building a
+  # project of their own first.
   - slug: observability-starter
     name: Observability Starter
-    description: A Next.js demo app pre-wired with analytics, error tracking, distributed tracing, and a Postgres database — see Temps in action in one deploy
+    description: Cadence — a mock revenue-analytics SaaS pre-wired with analytics, error tracking, distributed tracing, and a Postgres database. Hit Simulate to watch the funnel fill Temps in one deploy.
     git:
       url: https://github.com/gotempsh/temps-examples.git
       ref: main
@@ -32,10 +34,11 @@ templates:
       - analytics
       - getting-started
     features:
+      - One-click "Simulate a user journey" funnel demo
       - Product analytics with @temps-sdk/react-analytics
       - Error tracking via Sentry-compatible DSN
       - Distributed tracing with OpenTelemetry
-      - Postgres-backed guestbook
+      - Postgres-backed signups & subscriptions
       - Session recording on errors
     services:
       - postgres


### PR DESCRIPTION
Follow-up to **gotempsh/temps-examples#11**, which re-themed the `observability-starter` example into **"Cadence"**, a mock revenue-analytics SaaS (landing / pricing / signup / dashboard) with a one-click **"Simulate a user journey"** funnel.

This refreshes the template registry (`crates/temps-core/templates.yaml`) so the picker matches the app:

- **description** now mentions the Cadence SaaS + the Simulate button
- **features**: add the one-click Simulate funnel; replace the stale **"Postgres-backed guestbook"** (removed in the re-theme) with **"Postgres-backed signups & subscriptions"**

`slug`, `image`, `git` path and `services` are unchanged, so the one-click template keeps working.

### Testing
- `templates.yaml` validated (parses; 3 templates; no `guestbook` references remain).
- Metadata-only change — no Rust behavior affected; CI runs fmt/clippy/tests.
