### PR TITLE
feat(web): add project onboarding tour

### DIFF
--- a/web/src/components/dashboard/Sidebar.tsx
+++ b/web/src/components/dashboard/Sidebar.tsx
@@ -1024,7 +1024,10 @@ function ProjectNav({
             const hasSub = !!item.subItems?.length
             const splitRow = hasSub && item.navigateOnClick
             return (
-              <SidebarMenuItem key={item.title}>
+              <SidebarMenuItem
+                key={item.title}
+                data-tour={item.url.split('?')[0]}
+              >
                 {splitRow ? (
                   <SidebarMenuButton
                     asChild

--- a/web/src/components/project/ProjectTour.tsx
+++ b/web/src/components/project/ProjectTour.tsx
@@ -1,0 +1,227 @@
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { Sparkles, X } from 'lucide-react'
+import { type CSSProperties, useCallback, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useNavigate, useParams } from 'react-router-dom'
+
+/**
+ * A lightweight, dependency-free guided tour for new projects. It walks the user
+ * through the "sites of interest" by navigating to each page — Overview,
+ * Analytics, Traces, Error tracking, Logs, Metrics — while a coachmark card,
+ * anchored next to the relevant sidebar item (top-left, where the eye is), and a
+ * highlight ring point at where each one lives. Auto-runs once per browser on the
+ * first project visit; re-launch by dispatching a `temps:project-tour` event.
+ */
+
+const SEEN_KEY = 'temps.project-tour.v1'
+export const PROJECT_TOUR_EVENT = 'temps:project-tour'
+
+interface TourStep {
+  route: string
+  anchor: string // data-tour of the sidebar item to anchor/point at
+  title: string
+  body: string
+}
+
+const STEPS: TourStep[] = [
+  {
+    route: 'project',
+    anchor: 'project',
+    title: 'Overview',
+    body: 'Your project home — deployments, status and setup all live here.',
+  },
+  {
+    route: 'analytics',
+    anchor: 'analytics',
+    title: 'Analytics',
+    body: 'Pageviews, visitors, funnels and session replays from your app.',
+  },
+  {
+    route: 'traces',
+    anchor: 'observe',
+    title: 'Traces',
+    body: 'Distributed OpenTelemetry traces — every request, span by span.',
+  },
+  {
+    route: 'errors',
+    anchor: 'observe',
+    title: 'Error tracking',
+    body: 'Exceptions with stack traces, grouped and alertable.',
+  },
+  {
+    route: 'metrics',
+    anchor: 'observe',
+    title: 'Metrics',
+    body: 'Counters, histograms and gauges — with anomaly alerts.',
+  },
+  {
+    route: 'runtime',
+    anchor: 'runtime',
+    title: 'Runtime logs',
+    body: 'Live logs streamed straight from your running containers.',
+  },
+]
+
+const CARD_WIDTH = 320 // matches w-80
+const CARD_EST_HEIGHT = 180
+
+export function ProjectTour() {
+  const navigate = useNavigate()
+  const { slug } = useParams<{ slug: string }>()
+  const [active, setActive] = useState(false)
+  const [idx, setIdx] = useState(0)
+  const [rect, setRect] = useState<DOMRect | null>(null)
+
+  const start = useCallback(() => {
+    setIdx(0)
+    setActive(true)
+  }, [])
+
+  const finish = useCallback(() => {
+    setActive(false)
+    try {
+      window.localStorage.setItem(SEEN_KEY, '1')
+    } catch {
+      // storage disabled — the tour simply runs again next time
+    }
+  }, [])
+
+  // Auto-start once per browser, plus a manual re-launch via window event.
+  useEffect(() => {
+    const onStart = () => start()
+    window.addEventListener(PROJECT_TOUR_EVENT, onStart)
+
+    const seen = (() => {
+      try {
+        return !!window.localStorage.getItem(SEEN_KEY)
+      } catch {
+        return true
+      }
+    })()
+    const timer = seen ? undefined : window.setTimeout(start, 800)
+
+    return () => {
+      window.removeEventListener(PROJECT_TOUR_EVENT, onStart)
+      if (timer) window.clearTimeout(timer)
+    }
+  }, [start])
+
+  // Navigate to each step's page as the tour advances, so the user sees it.
+  useEffect(() => {
+    if (active && slug) navigate(`/projects/${slug}/${STEPS[idx].route}`)
+  }, [active, idx, slug, navigate])
+
+  // Measure the anchor sidebar item to place the card + ring (deferred a frame,
+  // and kept aligned on scroll/resize).
+  useEffect(() => {
+    if (!active) return
+    const measure = () => {
+      const el = document.querySelector<HTMLElement>(
+        `[data-tour="${STEPS[idx].anchor}"]`
+      )
+      setRect(el ? el.getBoundingClientRect() : null)
+    }
+    const raf = requestAnimationFrame(measure)
+    window.addEventListener('resize', measure)
+    window.addEventListener('scroll', measure, true)
+    return () => {
+      cancelAnimationFrame(raf)
+      window.removeEventListener('resize', measure)
+      window.removeEventListener('scroll', measure, true)
+    }
+  }, [active, idx])
+
+  useEffect(() => {
+    if (!active) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') finish()
+      if (e.key === 'Enter') setIdx((i) => (i >= STEPS.length - 1 ? i : i + 1))
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [active, finish])
+
+  if (!active) return null
+
+  const step = STEPS[idx]
+  const isLast = idx === STEPS.length - 1
+
+  const cardStyle: CSSProperties = rect
+    ? {
+        top: Math.min(
+          Math.max(12, rect.top),
+          window.innerHeight - CARD_EST_HEIGHT - 12
+        ),
+        left: Math.min(rect.right + 12, window.innerWidth - CARD_WIDTH - 12),
+      }
+    : { top: 88, left: 24 }
+
+  return createPortal(
+    <>
+      {rect && (
+        <div
+          className="pointer-events-none fixed z-[95] rounded-md ring-2 ring-primary ring-offset-2 ring-offset-background transition-all"
+          style={{
+            top: rect.top - 2,
+            left: rect.left - 2,
+            width: rect.width + 4,
+            height: rect.height + 4,
+          }}
+        />
+      )}
+      <div
+        className="fixed z-[100] w-80 rounded-xl border bg-popover p-4 text-popover-foreground shadow-2xl"
+        style={cardStyle}
+      >
+        <div className="flex items-center justify-between">
+          <span className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+            <Sparkles className="size-3.5 text-primary" />
+            Quick tour · {idx + 1}/{STEPS.length}
+          </span>
+          <button
+            type="button"
+            onClick={finish}
+            aria-label="Close tour"
+            className="text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+        <p className="mt-2 text-sm font-semibold">{step.title}</p>
+        <p className="mt-1 text-sm text-muted-foreground">{step.body}</p>
+        <div className="mt-4 flex items-center justify-between">
+          <div className="flex gap-1">
+            {STEPS.map((_, i) => (
+              <span
+                key={i}
+                className={cn(
+                  'size-1.5 rounded-full',
+                  i === idx ? 'bg-primary' : 'bg-muted'
+                )}
+              />
+            ))}
+          </div>
+          <div className="flex gap-2">
+            {idx > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setIdx((i) => Math.max(0, i - 1))}
+              >
+                Back
+              </Button>
+            )}
+            <Button
+              size="sm"
+              onClick={() => (isLast ? finish() : setIdx((i) => i + 1))}
+            >
+              {isLast ? 'Done' : 'Next'}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>,
+    document.body
+  )
+}

--- a/web/src/pages/ProjectDetail.tsx
+++ b/web/src/pages/ProjectDetail.tsx
@@ -45,6 +45,7 @@ import ProjectAiCrawlers from './ProjectAiCrawlers'
 import Traces from './Traces'
 import LogsList from './LogsList'
 import Metrics from './Metrics'
+import { ProjectTour } from '@/components/project/ProjectTour'
 import { ProjectAgentActivity } from './AiGateway'
 import { AutofixerPage } from '@/components/autofixer/AutofixerPage'
 import { AutofixRedirect } from '@/components/autofixer/AutofixRedirect'
@@ -326,6 +327,7 @@ export function ProjectDetail() {
                 </AlertDescription>
               </Alert>
             )}
+            <ProjectTour />
             <Routes>
               <Route
                 index


### PR DESCRIPTION
Replaces the earlier Journey-page approach with a lightweight **onboarding tour**.

When a user opens a project for the first time, a guided tour auto-starts and walks them through the "sites of interest" — **Overview → Analytics → Traces → Error tracking → Metrics → Runtime logs** — navigating to each page while a coachmark card (anchored next to the relevant sidebar item, with a highlight ring) explains what lives there.

- No page / route / tab — a portal overlay mounted in `ProjectDetail`.
- Runs once per browser (`localStorage` `temps.project-tour.v1`); re-launchable via `window.dispatchEvent(new Event('temps:project-tour'))`.
- Dependency-free (no tour library); anchors to sidebar items via a `data-tour` attribute.

### Files
- `web/src/components/project/ProjectTour.tsx` (new)
- `web/src/pages/ProjectDetail.tsx` (mount)
- `web/src/components/dashboard/Sidebar.tsx` (data-tour anchors)

### Verification
- Whole-project `tsc --noEmit`, `eslint` and `prettier` clean.
- Verified live against a running console (dev server proxying to :8080).
