### PR TITLE
feat(web): add subtle "Take a tour" relaunch on project overview

### DIFF
--- a/web/src/components/project/ProjectOverview.tsx
+++ b/web/src/components/project/ProjectOverview.tsx
@@ -22,6 +22,7 @@ import {
   Circle,
   DollarSign,
   Minus,
+  Sparkles,
   TrendingDown,
   TrendingUp,
   Users,
@@ -30,6 +31,7 @@ import { ReactNode, useEffect, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { MetricCard } from '../dashboard/MetricCard'
 import { DeploymentActivityGraph } from './DeploymentActivityGraph'
+import { PROJECT_TOUR_EVENT } from './ProjectTour'
 
 interface ProjectOverviewProps {
   project: ProjectResponse
@@ -316,7 +318,6 @@ export function ProjectOverview({
 
         <RevenueMetric project={project} />
 
-
         <Link to={`/projects/${project.slug}/errors`} className="h-full w-full">
           <MetricCard
             change={''}
@@ -338,6 +339,17 @@ export function ProjectOverview({
 
       <div className="mt-4 sm:mt-6">
         <DeploymentActivityGraph projectId={project.id} />
+      </div>
+
+      <div className="mt-4 flex justify-center sm:mt-6">
+        <button
+          type="button"
+          onClick={() => window.dispatchEvent(new Event(PROJECT_TOUR_EVENT))}
+          className="inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <Sparkles className="size-3.5" />
+          Take a tour of your project
+        </button>
       </div>
     </>
   )


### PR DESCRIPTION
Follow-up to #421. Adds a discreet **"Take a tour of your project"** button at the bottom of the project Overview (muted text + a small Sparkles icon, brightens on hover) that re-launches the onboarding tour by dispatching the existing `temps:project-tour` window event.

- No new state or storage — just fires the event the `ProjectTour` component already listens for.
- Lets users replay the tour without clearing `localStorage`.

### Files
- `web/src/components/project/ProjectOverview.tsx`

### Verification
- `tsc --noEmit`, `eslint`, `prettier` clean; verified live on the dev console.
