### PR TITLE
fix(web): blank Storage backend select after refresh when ClickHouse is configured

### DIFF
--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -4,7 +4,25 @@ import { Check, ChevronDown, ChevronUp } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 
-const Select = SelectPrimitive.Root
+// Radix renders a hidden native <select> when the Select sits inside a <form>.
+// That input echoes programmatic value changes (e.g. react-hook-form reset()
+// after settings load) back through a synthetic change event; when the new
+// value's <option> isn't committed yet, the native select coerces to "" and
+// Radix emits onValueChange(""), clobbering controlled form state and leaving
+// the trigger blank. Item values are documented non-empty, so "" can never be
+// a real selection — drop it. (Reproduced with @radix-ui/react-select 2.3.5.)
+const Select = ({
+  onValueChange,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) => (
+  <SelectPrimitive.Root
+    {...props}
+    onValueChange={(value) => {
+      if (value === '') return
+      onValueChange?.(value)
+    }}
+  />
+)
 
 const SelectGroup = SelectPrimitive.Group
 


### PR DESCRIPTION
## Problem

On **Settings → Metrics Monitoring**, with the metrics store set to ClickHouse, refreshing the page showed the Storage backend select **blank** (while the `Active: ClickHouse` badge rendered correctly).

## Root cause

Radix Select renders a hidden native `<select>` (bubble input) whenever it sits inside a `<form>`. That input echoes programmatic value changes back through a synthetic `change` event. On this page the form mounts with the default value (`timescale_db`) and is then `reset()` to `click_house` once the settings query resolves. At that moment the native select can't hold the new value yet, coerces to `""`, and Radix emits `onValueChange("")` — which the page dutifully writes into the form via `setValue`, permanently blanking the select.

Reproduced in a 30-line standalone against `@radix-ui/react-select` **2.3.3** (ours) and **2.3.5** (latest, published 2026-07-22) — upstream bug, no fixed release available. Without the `<form>` wrapper the bug does not occur, which is why only form pages are affected.

## Fix

Guard the shared shadcn `Select` wrapper (`web/src/components/ui/select.tsx`): drop `onValueChange("")`. Radix documents that `SelectItem` values must be non-empty strings, so `""` can never be a legitimate user selection — the only producer is the bubble-input echo. Fixing it centrally covers every other form page using the same mount-then-reset pattern.

## Verification

- Reproduced the blank select against the real page (web dev server + mocked `/api/settings` returning `store: click_house`): trigger empty, hidden native select value `""`, form state `store: ""` while the API response held `click_house`, and `onValueChange("")` captured with a stack through Radix's bubble-input `onChange`.
- After the fix: trigger shows **ClickHouse**, form not dirty on load, selecting another option still updates the value and shows the unsaved-changes banner.
- `tsc --noEmit` clean; `eslint` clean on the changed file.