### PR TITLE
chore: bump version to v0.1.0-beta.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.53] - 2026-07-23
+
+### Added
+
+- **error-tracking:** Source context for native stack traces (Go/Rust/all languages) ([#419](https://github.com/gotempsh/temps/issues/419))
+- **web:** Add project onboarding tour
+- **web:** Add subtle "Take a tour" relaunch on project overview
+- **error-tracking:** Default source capture to the Docker build context + configurable root ([#423](https://github.com/gotempsh/temps/issues/423))
+
+### Fixed
+
+- **web:** Ignore spurious empty-string onValueChange from Radix Select ([#424](https://github.com/gotempsh/temps/issues/424))
+- **deployments:** Stop infinite reconnect loop on container logs ([#425](https://github.com/gotempsh/temps/issues/425))
+- **observability:** Read Observe feed through ClickHouse-aware storage backends ([#426](https://github.com/gotempsh/temps/issues/426))
+
+### Miscellaneous
+
+- **templates:** Update observability-starter entry for Cadence demo
+
 ## [0.1.0-beta.52] - 2026-07-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10708,7 +10708,7 @@ dependencies = [
 
 [[package]]
 name = "temps-agent"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -10748,7 +10748,7 @@ dependencies = [
 
 [[package]]
 name = "temps-agents"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10793,7 +10793,7 @@ dependencies = [
 
 [[package]]
 name = "temps-agents-mcp-proxy"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "serde",
  "serde_json",
@@ -10801,7 +10801,7 @@ dependencies = [
 
 [[package]]
 name = "temps-ai"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "futures",
@@ -10815,7 +10815,7 @@ dependencies = [
 
 [[package]]
 name = "temps-ai-api-tools"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -10837,7 +10837,7 @@ dependencies = [
 
 [[package]]
 name = "temps-ai-chat"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10866,7 +10866,7 @@ dependencies = [
 
 [[package]]
 name = "temps-ai-gateway"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10897,7 +10897,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10927,7 +10927,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-backend"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10944,7 +10944,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-events"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10977,7 +10977,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-funnels"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10998,7 +10998,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-performance"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -11022,7 +11022,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-session-replay"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11048,7 +11048,7 @@ dependencies = [
 
 [[package]]
 name = "temps-audit"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -11069,7 +11069,7 @@ dependencies = [
 
 [[package]]
 name = "temps-auth"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "argon2",
@@ -11111,7 +11111,7 @@ dependencies = [
 
 [[package]]
 name = "temps-backup"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -11158,7 +11158,7 @@ dependencies = [
 
 [[package]]
 name = "temps-backup-core"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11178,7 +11178,7 @@ dependencies = [
 
 [[package]]
 name = "temps-blob"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11227,7 +11227,7 @@ dependencies = [
 
 [[package]]
 name = "temps-cli"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "argon2",
@@ -11335,7 +11335,7 @@ dependencies = [
 
 [[package]]
 name = "temps-config"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -11367,7 +11367,7 @@ dependencies = [
 
 [[package]]
 name = "temps-core"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -11406,7 +11406,7 @@ dependencies = [
 
 [[package]]
 name = "temps-database"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "futures",
@@ -11424,7 +11424,7 @@ dependencies = [
 
 [[package]]
 name = "temps-deployer"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11463,7 +11463,7 @@ dependencies = [
 
 [[package]]
 name = "temps-deployments"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11531,7 +11531,7 @@ dependencies = [
 
 [[package]]
 name = "temps-dns"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11573,7 +11573,7 @@ dependencies = [
 
 [[package]]
 name = "temps-dns-resolver"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11594,7 +11594,7 @@ dependencies = [
 
 [[package]]
 name = "temps-domains"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11644,7 +11644,7 @@ dependencies = [
 
 [[package]]
 name = "temps-edge"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -11686,7 +11686,7 @@ dependencies = [
 
 [[package]]
 name = "temps-email"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11727,7 +11727,7 @@ dependencies = [
 
 [[package]]
 name = "temps-email-tracking"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -11764,7 +11764,7 @@ dependencies = [
 
 [[package]]
 name = "temps-embeddings"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11775,7 +11775,7 @@ dependencies = [
 
 [[package]]
 name = "temps-entities"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "chrono",
  "sea-orm",
@@ -11789,7 +11789,7 @@ dependencies = [
 
 [[package]]
 name = "temps-environments"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "argon2",
@@ -11818,7 +11818,7 @@ dependencies = [
 
 [[package]]
 name = "temps-error-tracking"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11890,7 +11890,7 @@ dependencies = [
 
 [[package]]
 name = "temps-external-plugins"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "axum 0.8.9",
  "chrono",
@@ -11916,7 +11916,7 @@ dependencies = [
 
 [[package]]
 name = "temps-file-store"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11932,7 +11932,7 @@ dependencies = [
 
 [[package]]
 name = "temps-geo"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -11955,7 +11955,7 @@ dependencies = [
 
 [[package]]
 name = "temps-git"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12006,7 +12006,7 @@ dependencies = [
 
 [[package]]
 name = "temps-git-credential"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "chrono",
  "nix 0.31.3",
@@ -12047,7 +12047,7 @@ dependencies = [
 
 [[package]]
 name = "temps-import"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -12074,7 +12074,7 @@ dependencies = [
 
 [[package]]
 name = "temps-import-docker"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "bollard",
@@ -12097,7 +12097,7 @@ dependencies = [
 
 [[package]]
 name = "temps-import-types"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "chrono",
@@ -12134,7 +12134,7 @@ dependencies = [
 
 [[package]]
 name = "temps-infra"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -12158,7 +12158,7 @@ dependencies = [
 
 [[package]]
 name = "temps-kv"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12211,7 +12211,7 @@ dependencies = [
 
 [[package]]
 name = "temps-log-aggregator"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -12246,7 +12246,7 @@ dependencies = [
 
 [[package]]
 name = "temps-logs"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-stream",
  "bollard",
@@ -12266,7 +12266,7 @@ dependencies = [
 
 [[package]]
 name = "temps-memory"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "thiserror 2.0.18",
@@ -12275,7 +12275,7 @@ dependencies = [
 
 [[package]]
 name = "temps-metrics"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -12305,7 +12305,7 @@ dependencies = [
 
 [[package]]
 name = "temps-migrations"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "sea-orm",
@@ -12319,7 +12319,7 @@ dependencies = [
 
 [[package]]
 name = "temps-monitoring"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12346,7 +12346,7 @@ dependencies = [
 
 [[package]]
 name = "temps-network"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "bollard",
@@ -12375,7 +12375,7 @@ dependencies = [
 
 [[package]]
 name = "temps-notifications"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12406,7 +12406,7 @@ dependencies = [
 
 [[package]]
 name = "temps-observability"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12438,7 +12438,7 @@ dependencies = [
 
 [[package]]
 name = "temps-otel"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12484,7 +12484,7 @@ dependencies = [
 
 [[package]]
 name = "temps-plugin-sdk"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -12509,7 +12509,7 @@ dependencies = [
 
 [[package]]
 name = "temps-presets"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12528,7 +12528,7 @@ dependencies = [
 
 [[package]]
 name = "temps-preview-gateway"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "tokio",
@@ -12538,7 +12538,7 @@ dependencies = [
 
 [[package]]
 name = "temps-projects"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -12576,7 +12576,7 @@ dependencies = [
 
 [[package]]
 name = "temps-providers"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12634,7 +12634,7 @@ dependencies = [
 
 [[package]]
 name = "temps-proxy"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -12710,7 +12710,7 @@ dependencies = [
 
 [[package]]
 name = "temps-pty-agent"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "bytes",
  "clap",
@@ -12728,7 +12728,7 @@ dependencies = [
 
 [[package]]
 name = "temps-query"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "bytes",
@@ -12762,7 +12762,7 @@ dependencies = [
 
 [[package]]
 name = "temps-query-postgres"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "chrono",
@@ -12819,7 +12819,7 @@ dependencies = [
 
 [[package]]
 name = "temps-queue"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "log",
  "serde",
@@ -12832,7 +12832,7 @@ dependencies = [
 
 [[package]]
 name = "temps-revenue"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12866,7 +12866,7 @@ dependencies = [
 
 [[package]]
 name = "temps-routes"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12891,7 +12891,7 @@ dependencies = [
 
 [[package]]
 name = "temps-sandbox"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "argon2",
  "async-stream",
@@ -12925,7 +12925,7 @@ dependencies = [
 
 [[package]]
 name = "temps-screenshots"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12951,7 +12951,7 @@ dependencies = [
 
 [[package]]
 name = "temps-static-files"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "axum 0.8.9",
  "temps-auth",
@@ -12964,7 +12964,7 @@ dependencies = [
 
 [[package]]
 name = "temps-status-page"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12997,7 +12997,7 @@ dependencies = [
 
 [[package]]
 name = "temps-telemetry"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "chrono",
@@ -13015,7 +13015,7 @@ dependencies = [
 
 [[package]]
 name = "temps-vm-agent"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "hex",
  "libc",
@@ -13025,7 +13025,7 @@ dependencies = [
 
 [[package]]
 name = "temps-vulnerability-scanner"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13057,7 +13057,7 @@ dependencies = [
 
 [[package]]
 name = "temps-webhooks"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13088,7 +13088,7 @@ dependencies = [
 
 [[package]]
 name = "temps-wireguard"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "base64 0.22.1",
  "defguard_wireguard_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Temps Contributors"]


### PR DESCRIPTION
Release bump for **v0.1.0-beta.53**: workspace version, regenerated Cargo.lock, regenerated CHANGELOG.md via git-cliff (`--tag v0.1.0-beta.53`).

Ships since beta.52: error-tracking native source context (#419) + build-context source root (#423), project onboarding tour, Radix Select fix (#424), container-log reconnect-loop fix (#425), Observe-page ClickHouse fix (#426).

Gates run locally on this exact commit: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --lib --workspace` (5717 passed, 20 ignored, 78 suites).

After merge: tag `v0.1.0-beta.53` on the main commit to trigger the release workflow.