### PR TITLE
feat(otel): store cross-project trace refs in ClickHouse when enabled

### DIFF
--- a/crates/temps-cli/src/commands/backfill.rs
+++ b/crates/temps-cli/src/commands/backfill.rs
@@ -54,10 +54,11 @@ pub enum BackfillTarget {
 
 /// Which observability domain to copy from TimescaleDB into ClickHouse.
 ///
-/// `events` replicates via the live outbox too, but the other three
-/// (`proxy-logs`, `traces`, `metrics`) are backend-swap domains with no live
-/// replication — enabling ClickHouse routes *new* writes there but leaves the
-/// historical TimescaleDB rows behind. This backfill copies that history over.
+/// `events` replicates via the live outbox too, but the others
+/// (`proxy-logs`, `traces`, `metrics`, `trace-refs`) are backend-swap domains
+/// with no live replication — enabling ClickHouse routes *new* writes there
+/// but leaves the historical TimescaleDB rows behind. This backfill copies
+/// that history over.
 #[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BackfillDomain {
     /// Analytics events (`events` → ClickHouse `events`).
@@ -68,7 +69,12 @@ pub enum BackfillDomain {
     Traces,
     /// Resource metrics (`service_metrics` → ClickHouse `service_metrics`).
     Metrics,
-    /// All four domains, in turn.
+    /// Cross-project trace refs (`cross_project_trace_refs` → ClickHouse
+    /// table of the same name). Optional: the live read path unions both
+    /// backends, so skipping this only means pre-cutover refs resolve from
+    /// Postgres until they age out.
+    TraceRefs,
+    /// All domains, in turn.
     All,
 }
 
@@ -76,8 +82,9 @@ pub enum BackfillDomain {
 pub struct ClickhouseBackfillArgs {
     /// Which domain(s) to copy. Defaults to `events` to preserve the prior
     /// behaviour of this command. Use `all` to copy every observability domain,
-    /// or pick `proxy-logs` / `traces` / `metrics` for a backend-swap domain
-    /// whose history did not migrate when you enabled ClickHouse.
+    /// or pick `proxy-logs` / `traces` / `metrics` / `trace-refs` for a
+    /// backend-swap domain whose history did not migrate when you enabled
+    /// ClickHouse.
     #[arg(long, value_enum, default_value_t = BackfillDomain::Events)]
     pub domain: BackfillDomain,
 
@@ -205,6 +212,7 @@ async fn run_clickhouse_async(args: ClickhouseBackfillArgs) -> anyhow::Result<()
             BackfillDomain::ProxyLogs,
             BackfillDomain::Traces,
             BackfillDomain::Metrics,
+            BackfillDomain::TraceRefs,
         ],
         single => vec![single],
     };
@@ -215,7 +223,10 @@ async fn run_clickhouse_async(args: ClickhouseBackfillArgs) -> anyhow::Result<()
     for domain in domains {
         match domain {
             BackfillDomain::Events => run_events_backfill(db.clone(), &args).await?,
-            BackfillDomain::ProxyLogs | BackfillDomain::Traces | BackfillDomain::Metrics => {
+            BackfillDomain::ProxyLogs
+            | BackfillDomain::Traces
+            | BackfillDomain::Metrics
+            | BackfillDomain::TraceRefs => {
                 crate::commands::ch_backfill_domains::run_domain_backfill(db.clone(), &args, domain)
                     .await?
             }

--- a/crates/temps-cli/src/commands/ch_backfill_domains.rs
+++ b/crates/temps-cli/src/commands/ch_backfill_domains.rs
@@ -1,8 +1,9 @@
 //! TimescaleDB → ClickHouse backfill for the *backend-swap* observability
-//! domains: proxy/request logs, OTel traces, and resource metrics.
+//! domains: proxy/request logs, OTel traces, resource metrics, and
+//! cross-project trace refs.
 //!
 //! Unlike analytics `events` (which replicate live through the outbox + fan-out
-//! worker), these three domains pick their backend at construction: when
+//! worker), these domains pick their backend at construction: when
 //! `TEMPS_CLICKHOUSE_*` is set, new writes go to ClickHouse and the historical
 //! rows already in TimescaleDB are left behind. This module copies that history
 //! across so the UI shows a continuous record after a cutover.
@@ -51,8 +52,9 @@ pub async fn run_domain_backfill(
         BackfillDomain::ProxyLogs => "proxy / request logs",
         BackfillDomain::Traces => "OTel traces (spans)",
         BackfillDomain::Metrics => "resource metrics",
+        BackfillDomain::TraceRefs => "cross-project trace refs",
         BackfillDomain::Events | BackfillDomain::All => {
-            anyhow::bail!("run_domain_backfill is only for proxy-logs/traces/metrics")
+            anyhow::bail!("run_domain_backfill is only for proxy-logs/traces/metrics/trace-refs")
         }
     };
     println!("{}", format!("▸ Domain: {label}").bright_white().bold());
@@ -165,6 +167,9 @@ pub async fn run_domain_backfill(
         BackfillDomain::Metrics => {
             metrics::copy(db.as_ref(), &ch, since, until, batch_size, &pb).await?
         }
+        BackfillDomain::TraceRefs => {
+            trace_refs::copy(db.as_ref(), &ch, since, until, batch_size, &pb).await?
+        }
         _ => unreachable!(),
     };
 
@@ -218,6 +223,12 @@ fn domain_spec(domain: BackfillDomain) -> DomainSpec {
             ch_table: "service_metrics",
             ch_time_column: "time",
         },
+        BackfillDomain::TraceRefs => DomainSpec {
+            source_table: "cross_project_trace_refs",
+            time_column: "first_seen",
+            ch_table: "cross_project_trace_refs",
+            ch_time_column: "first_seen",
+        },
         BackfillDomain::Events | BackfillDomain::All => {
             unreachable!("domain_spec only covers backend-swap domains")
         }
@@ -237,7 +248,7 @@ async fn apply_schema(
                 .await
                 .map_err(|e| anyhow::anyhow!("proxy-log CH migrations failed: {e}"))?;
         }
-        BackfillDomain::Traces => {
+        BackfillDomain::Traces | BackfillDomain::TraceRefs => {
             temps_otel::storage::clickhouse::migrations::apply_migrations(ch, db_name)
                 .await
                 .map_err(|e| anyhow::anyhow!("otel CH migrations failed: {e}"))?;
@@ -888,6 +899,107 @@ mod metrics {
         }
 
         info!(copied, "service_metrics backfill complete");
+        Ok(copied)
+    }
+}
+
+// ── cross_project_trace_refs ─────────────────────────────────────────────────
+
+mod trace_refs {
+    use super::*;
+    use temps_otel::storage::clickhouse::{trace_ref_version, ChTraceRefRow};
+
+    #[derive(FromQueryResult)]
+    struct Row {
+        trace_id: String,
+        project_id: i32,
+        first_seen: DBDateTime,
+    }
+
+    // Keyset over (first_seen, trace_id, project_id) — a total order, since
+    // (trace_id, project_id) is the table's primary key.
+    const SELECT: &str = "SELECT trace_id, project_id, first_seen \
+        FROM cross_project_trace_refs \
+        WHERE first_seen >= $1 AND first_seen <= $2 \
+          AND (first_seen, trace_id, project_id) > ($3, $4, $5) \
+        ORDER BY first_seen ASC, trace_id ASC, project_id ASC \
+        LIMIT $6";
+
+    fn to_ch(r: &Row) -> ChTraceRefRow {
+        let ms = r.first_seen.timestamp_millis();
+        ChTraceRefRow {
+            trace_id: r.trace_id.clone(),
+            project_id: r.project_id,
+            first_seen: ms,
+            retention_days: temps_core::RetentionTable::Spans.default_days(),
+            // Inverted version: the Postgres row predates any live ClickHouse
+            // row for the same pair, so it wins the ReplacingMergeTree dedup
+            // and `first_seen` keeps meaning "earliest observation".
+            _version: trace_ref_version(ms),
+        }
+    }
+
+    pub async fn copy(
+        db: &DatabaseConnection,
+        ch: &::clickhouse::Client,
+        since: DBDateTime,
+        until: DBDateTime,
+        batch_size: u64,
+        pb: &ProgressBar,
+    ) -> anyhow::Result<u64> {
+        let mut last_ts = since - chrono::Duration::milliseconds(1);
+        let mut last_trace_id = String::new();
+        let mut last_project_id: i32 = i32::MIN;
+        let mut copied = 0u64;
+
+        loop {
+            let rows = Row::find_by_statement(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                SELECT,
+                vec![
+                    since.into(),
+                    until.into(),
+                    last_ts.into(),
+                    last_trace_id.clone().into(),
+                    last_project_id.into(),
+                    (batch_size as i64).into(),
+                ],
+            ))
+            .all(db)
+            .await?;
+
+            if rows.is_empty() {
+                break;
+            }
+
+            let mut inserter = ch
+                .insert::<ChTraceRefRow>("cross_project_trace_refs")
+                .await
+                .context("ClickHouse cross_project_trace_refs inserter setup")?;
+            for r in &rows {
+                inserter
+                    .write(&to_ch(r))
+                    .await
+                    .context("ClickHouse cross_project_trace_refs write")?;
+            }
+            inserter
+                .end()
+                .await
+                .context("ClickHouse cross_project_trace_refs end")?;
+
+            let last = rows.last().expect("non-empty");
+            last_ts = last.first_seen;
+            last_trace_id = last.trace_id.clone();
+            last_project_id = last.project_id;
+            copied += rows.len() as u64;
+            pb.set_position(copied);
+
+            if (rows.len() as u64) < batch_size {
+                break;
+            }
+        }
+
+        info!(copied, "cross_project_trace_refs backfill complete");
         Ok(copied)
     }
 }

--- a/crates/temps-otel/migrations/clickhouse/0006_trace_refs.sql
+++ b/crates/temps-otel/migrations/clickhouse/0006_trace_refs.sql
@@ -1,0 +1,48 @@
+-- Cross-project trace ref index (ADR-027 Phase 0) — ClickHouse edition.
+--
+-- Answers "which projects hold spans for this trace_id?" WITHOUT knowing the
+-- project up front. The `spans` table cannot serve this: its primary index is
+-- (project_id, trace_id, span_id), so a trace_id-only lookup is a full scan.
+-- This table flips the key order and stores one tiny row per
+-- (trace_id, project_id) pair, replacing the PostgreSQL
+-- `cross_project_trace_refs` control table when ClickHouse is enabled
+-- (that table reached 125 GB in three weeks; the same tuples compress to a
+-- small fraction of that here).
+--
+--   ORDER BY (trace_id, project_id)
+--     trace_id first: discovery lookups (`WHERE trace_id = ?`) read a
+--     contiguous primary-index range. project_id second: the pair is the
+--     logical primary key, so ReplacingMergeTree dedupes per pair.
+--
+--   ENGINE = ReplacingMergeTree(_version) with an INVERTED version
+--     The PG table used `INSERT … ON CONFLICT DO NOTHING`: the FIRST insert
+--     wins, so `first_seen` means "earliest observation". ReplacingMergeTree
+--     keeps the HIGHEST _version, so writers stamp
+--     `_version = UInt64.MAX - first_seen_ms` — the earliest observation gets
+--     the highest version and survives merges. Readers additionally take
+--     min(first_seen) per project at query time so correctness never depends
+--     on merge state.
+--
+--   TTL toDateTime(first_seen) + toIntervalDay(retention_days)
+--     Per-row TTL driven by retention_days, stamped from the SAME resolver
+--     value as span rows (RetentionTable::Spans). Trace refs MUST expire on
+--     the same horizon as the traces they point to — earlier would dangle the
+--     "also in" banner at live traces; later would point at expired ones.
+--
+--   PARTITION BY toYYYYMM(first_seen)
+--     Whole-partition drops once every row in a month falls outside its TTL,
+--     matching the `spans` table's partitioning scheme.
+CREATE TABLE IF NOT EXISTS cross_project_trace_refs
+(
+    trace_id        String,
+    project_id      Int32,
+    first_seen      DateTime64(3, 'UTC') DEFAULT now64(3),
+    retention_days  UInt16 DEFAULT 90,
+    -- Inverted so the EARLIEST insert has the HIGHEST version (first-wins).
+    _version        UInt64 DEFAULT (18446744073709551615 - toUnixTimestamp64Milli(now64()))
+)
+ENGINE = ReplacingMergeTree(_version)
+PARTITION BY toYYYYMM(first_seen)
+ORDER BY (trace_id, project_id)
+TTL toDateTime(first_seen) + toIntervalDay(retention_days)
+SETTINGS index_granularity = 8192;

--- a/crates/temps-otel/src/handlers/query_handler.rs
+++ b/crates/temps-otel/src/handlers/query_handler.rs
@@ -1041,8 +1041,7 @@ impl From<CrossProjectTraceError> for Problem {
                     .with_title("Invalid Trace ID")
                     .with_detail(detail)
             }
-            CrossProjectTraceError::RecordHint { .. }
-            | CrossProjectTraceError::QuerySiblings { .. }
+            CrossProjectTraceError::QuerySiblings { .. }
             | CrossProjectTraceError::QueryProjects { .. }
             | CrossProjectTraceError::Database(_)
             | CrossProjectTraceError::Storage(_) => {

--- a/crates/temps-otel/src/ingest/auth.rs
+++ b/crates/temps-otel/src/ingest/auth.rs
@@ -43,11 +43,28 @@ pub enum IngestAuth {
 /// Service for authenticating OTel ingest requests.
 pub struct OtelAuthService {
     db: Arc<DatabaseConnection>,
+    /// ADR-028 team-based project access checker, injected after plugin
+    /// registration (see `set_project_access_checker`). `tk_` keys carry a
+    /// user identity, so ingest must honour the same project-access grants
+    /// as the query-side `project_access_guard!` — otherwise any valid key
+    /// could ingest telemetry into any project by ID. Absent (plain OSS
+    /// binary, no checker plugin) → allow, matching the guard's no-op
+    /// semantics.
+    project_access_checker: std::sync::OnceLock<Arc<dyn temps_core::ProjectAccessChecker>>,
 }
 
 impl OtelAuthService {
     pub fn new(db: Arc<DatabaseConnection>) -> Self {
-        Self { db }
+        Self {
+            db,
+            project_access_checker: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// Inject the ADR-028 project access checker once plugins have registered.
+    /// Later calls are no-ops (first registration wins).
+    pub fn set_project_access_checker(&self, checker: Arc<dyn temps_core::ProjectAccessChecker>) {
+        let _ = self.project_access_checker.set(checker);
     }
 
     /// Authenticate any ingest token — project (`tk_`/`dt_`) or service (`si_`).
@@ -198,9 +215,13 @@ impl OtelAuthService {
         hasher.update(api_key.as_bytes());
         let key_hash = hex::encode(hasher.finalize());
 
-        // Look up key + verify user has access to the requested project
+        // Look up the key and confirm the target project exists. The JOIN on a
+        // bound constant only proves project existence — the user→project
+        // access check happens below via the ADR-028 ProjectAccessChecker,
+        // mirroring `project_access_guard!` (admin bypass, fail-closed on
+        // infrastructure errors, allow when no checker is registered).
         let sql = r#"
-            SELECT ak.id AS key_id, p.name AS project_name
+            SELECT ak.id AS key_id, ak.user_id, ak.role_type, p.name AS project_name
             FROM api_keys ak
             JOIN projects p ON p.id = $2
             WHERE ak.key_hash = $1
@@ -228,11 +249,24 @@ impl OtelAuthService {
                     .map_err(|_| OtelError::AuthFailed {
                         reason: "Failed to parse auth result".into(),
                     })?;
+                let user_id: i32 =
+                    row.try_get("", "user_id")
+                        .map_err(|_| OtelError::AuthFailed {
+                            reason: "Failed to parse auth result".into(),
+                        })?;
+                let role_type: String =
+                    row.try_get("", "role_type")
+                        .map_err(|_| OtelError::AuthFailed {
+                            reason: "Failed to parse auth result".into(),
+                        })?;
                 let project_name: String =
                     row.try_get("", "project_name")
                         .map_err(|_| OtelError::AuthFailed {
                             reason: "Failed to parse project name".into(),
                         })?;
+
+                self.check_project_access(user_id, &role_type, project_id)
+                    .await?;
 
                 // Update last_used_at (fire-and-forget)
                 let db = self.db.clone();
@@ -261,6 +295,57 @@ impl OtelAuthService {
             None => Err(OtelError::AuthFailed {
                 reason: "Invalid or expired API key, or project not found".into(),
             }),
+        }
+    }
+
+    /// Enforce ADR-028 team-based project access for a `tk_` key's user,
+    /// mirroring `project_access_guard!` semantics exactly:
+    ///
+    /// - Instance `admin` / `platform_admin` roles bypass the check.
+    /// - No checker registered (plain OSS binary) → allow.
+    /// - `Ok(false)` → deny.
+    /// - `Err` → deny (**fail-closed**): a broken check must never silently
+    ///   grant cross-project ingest.
+    ///
+    /// (`dt_` tokens never reach this path — they are confined to their bound
+    /// project by construction and carry no user identity.)
+    async fn check_project_access(
+        &self,
+        user_id: i32,
+        role_type: &str,
+        project_id: i32,
+    ) -> Result<(), OtelError> {
+        use temps_auth::permissions::Role;
+
+        let is_instance_admin = matches!(
+            Role::from_str(role_type),
+            Some(Role::Admin) | Some(Role::PlatformAdmin)
+        );
+        if is_instance_admin {
+            return Ok(());
+        }
+
+        let Some(checker) = self.project_access_checker.get() else {
+            return Ok(());
+        };
+
+        match checker.user_can_access_project(user_id, project_id).await {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(OtelError::AuthFailed {
+                reason: format!("API key user does not have access to project {project_id}"),
+            }),
+            Err(e) => {
+                warn!(
+                    user_id,
+                    project_id,
+                    error = %e,
+                    "ProjectAccessChecker infrastructure failure during OTel \
+                     ingest auth — denying (fail-closed)"
+                );
+                Err(OtelError::AuthFailed {
+                    reason: "Project access check failed".into(),
+                })
+            }
         }
     }
 
@@ -439,6 +524,93 @@ mod tests {
         assert!(!token.starts_with("si_"));
         assert!(!token.starts_with("tk_"));
         assert!(!token.starts_with("dt_"));
+    }
+
+    // ── check_project_access (ADR-028 enforcement on tk_ ingest) ─────────────
+
+    /// Stub checker: `Some(bool)` answers, `None` simulates infrastructure
+    /// failure. Counts calls so admin-bypass tests can assert it was skipped.
+    struct StubChecker {
+        allow: Option<bool>,
+        calls: std::sync::atomic::AtomicU32,
+    }
+
+    #[async_trait::async_trait]
+    impl temps_core::ProjectAccessChecker for StubChecker {
+        async fn user_can_access_project(
+            &self,
+            _user_id: i32,
+            _project_id: i32,
+        ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            match self.allow {
+                Some(b) => Ok(b),
+                None => Err("checker database unreachable".into()),
+            }
+        }
+    }
+
+    fn service_with_checker(allow: Option<bool>) -> (OtelAuthService, Arc<StubChecker>) {
+        let db = Arc::new(
+            sea_orm::MockDatabase::new(sea_orm::DatabaseBackend::Postgres).into_connection(),
+        );
+        let svc = OtelAuthService::new(db);
+        let checker = Arc::new(StubChecker {
+            allow,
+            calls: std::sync::atomic::AtomicU32::new(0),
+        });
+        svc.set_project_access_checker(checker.clone());
+        (svc, checker)
+    }
+
+    #[tokio::test]
+    async fn access_allowed_without_registered_checker() {
+        // Plain OSS binary: no checker plugin → allow (guard no-op parity).
+        let db = Arc::new(
+            sea_orm::MockDatabase::new(sea_orm::DatabaseBackend::Postgres).into_connection(),
+        );
+        let svc = OtelAuthService::new(db);
+        assert!(svc.check_project_access(1, "user", 42).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn admin_roles_bypass_checker() {
+        let (svc, checker) = service_with_checker(Some(false)); // would deny
+        assert!(svc.check_project_access(1, "admin", 42).await.is_ok());
+        assert!(svc
+            .check_project_access(1, "platform_admin", 42)
+            .await
+            .is_ok());
+        assert_eq!(
+            checker.calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "instance admins must not consult the checker"
+        );
+    }
+
+    #[tokio::test]
+    async fn checker_verdict_is_enforced_for_non_admins() {
+        let (svc, _) = service_with_checker(Some(true));
+        assert!(svc.check_project_access(1, "user", 42).await.is_ok());
+
+        let (svc, _) = service_with_checker(Some(false));
+        assert!(matches!(
+            svc.check_project_access(1, "user", 42).await,
+            Err(OtelError::AuthFailed { .. })
+        ));
+
+        // Unknown/custom role strings get no bypass either.
+        let (svc, _) = service_with_checker(Some(false));
+        assert!(svc.check_project_access(1, "custom", 42).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn checker_infrastructure_failure_is_fail_closed() {
+        let (svc, _) = service_with_checker(None); // simulates Err from checker
+        assert!(matches!(
+            svc.check_project_access(1, "user", 42).await,
+            Err(OtelError::AuthFailed { .. })
+        ));
     }
 
     // ── ServiceAuth struct ───────────────────────────────────────────────────

--- a/crates/temps-otel/src/plugin.rs
+++ b/crates/temps-otel/src/plugin.rs
@@ -433,8 +433,11 @@ impl TempsPlugin for OtelPlugin {
             };
             context.register_service(storage.clone());
 
-            // Create auth service
+            // Create auth service. Also registered in the context so
+            // `configure_routes` can inject the ADR-028 ProjectAccessChecker
+            // (registered by a later plugin) into the `tk_`-key ingest path.
             let auth_service = Arc::new(OtelAuthService::new(db.clone()));
+            context.register_service(auth_service.clone());
 
             // Create rate limiter
             let rate_limiter = Arc::new(RateLimiter::new(
@@ -732,6 +735,14 @@ impl TempsPlugin for OtelPlugin {
         let mut app_state: OtelAppState = app_state_arc.as_ref().clone();
         app_state.project_access_checker =
             context.get_service::<dyn temps_core::ProjectAccessChecker>();
+
+        // Same checker feeds the `tk_`-key ingest auth path, so team-based
+        // project access is enforced on writes exactly as on reads.
+        if let Some(checker) = app_state.project_access_checker.clone() {
+            context
+                .require_service::<OtelAuthService>()
+                .set_project_access_checker(checker);
+        }
 
         let router = handlers::configure_routes().with_state(app_state);
 

--- a/crates/temps-otel/src/plugin.rs
+++ b/crates/temps-otel/src/plugin.rs
@@ -474,11 +474,13 @@ impl TempsPlugin for OtelPlugin {
             // ── ADR-027 Phase 0: Cross-project trace hint pipeline ───────────
             //
             // A bounded mpsc channel (capacity 1,000) decouples span ingest
-            // latency from the Postgres hint write.  When the channel is full,
+            // latency from the hint write.  When the channel is full,
             // `do_ingest_traces` drops the hint (non-blocking try_send) and
             // warns.  The background consumer below drains the channel and
-            // calls `record_hint`, which issues a single multi-row
-            // `INSERT … ON CONFLICT DO NOTHING`.
+            // calls `record_hint`, which routes through the active storage
+            // backend: a multi-row `INSERT … ON CONFLICT DO NOTHING` into the
+            // Postgres control table, or a batched insert into the compressed
+            // ClickHouse `cross_project_trace_refs` table when CH is enabled.
             let (trace_hint_tx, mut trace_hint_rx) =
                 tokio::sync::mpsc::channel::<TraceHintMsg>(1000);
 
@@ -624,8 +626,13 @@ impl TempsPlugin for OtelPlugin {
                 });
             }
 
-            // 1d. ADR-027 Phase 0: daily prune of cross_project_trace_refs rows
-            //     older than 90 days (matching the OTel span TTL on both backends).
+            // 1d. ADR-027 Phase 0: daily prune of POSTGRES cross_project_trace_refs
+            //     rows older than 90 days (matching the OTel span TTL on both
+            //     backends). Runs unconditionally: on the TimescaleDB backend it
+            //     is the retention mechanism; on the ClickHouse backend (where
+            //     new refs expire via native per-row TTL) it drains the legacy
+            //     Postgres rows written before the cutover and becomes a no-op
+            //     after one retention window.
             //
             // Deliberately uses a periodic tokio::spawn loop rather than a
             // Job enum variant to keep the scheduler dependency minimal.

--- a/crates/temps-otel/src/services/cross_project.rs
+++ b/crates/temps-otel/src/services/cross_project.rs
@@ -4,8 +4,13 @@
 //!
 //! 1. **Hint recording** (Phase 0): after a successful span ingest, the ingest
 //!    path fires a `TraceHintMsg` on a bounded mpsc channel.  A background
-//!    consumer calls `record_hint` to insert `(trace_id, project_id)` rows into
-//!    the `cross_project_trace_refs` control table.
+//!    consumer calls `record_hint` to insert `(trace_id, project_id)` rows via
+//!    `OtelStorage::record_trace_refs` — the Postgres
+//!    `cross_project_trace_refs` control table on the TimescaleDB backend, or
+//!    the compressed ClickHouse table of the same name when ClickHouse is
+//!    enabled (the raw tuples reached 125 GB of uncompressed Postgres heap +
+//!    b-tree in three weeks; ClickHouse stores them at a small fraction of
+//!    that).
 //!
 //! 2. **Discovery and unified waterfall** (Phases 1 & 2): `find_sibling_projects`
 //!    powers the Phase 1 "also in" banner; `get_unified_trace` fans out to each
@@ -35,14 +40,6 @@ pub enum CrossProjectTraceError {
     /// trace_id failed the 32-character lowercase hex format check.
     #[error("Invalid trace_id '{trace_id}': expected exactly 32 lowercase hex characters")]
     InvalidTraceId { trace_id: String },
-
-    /// Database error while recording cross-project hints for a project.
-    #[error("Database error recording cross-project hints for project {project_id}: {source}")]
-    RecordHint {
-        project_id: i32,
-        #[source]
-        source: sea_orm::DbErr,
-    },
 
     /// Database error while querying sibling projects for a trace.
     #[error("Database error querying sibling projects for trace {trace_id}: {source}")]
@@ -192,6 +189,13 @@ pub struct CrossProjectTraceService {
     storage: Arc<dyn OtelStorage>,
 }
 
+/// Project metadata joined onto trace refs from the Postgres `projects` table.
+struct ProjectMeta {
+    name: String,
+    slug: String,
+    sharing: bool,
+}
+
 impl CrossProjectTraceService {
     pub fn new(db: Arc<DatabaseConnection>, storage: Arc<dyn OtelStorage>) -> Self {
         Self { db, storage }
@@ -201,9 +205,11 @@ impl CrossProjectTraceService {
 
     /// Record that `project_id` holds spans for each trace_id in the set.
     ///
-    /// Issues a single multi-row `INSERT … ON CONFLICT DO NOTHING` so
-    /// subsequent batches for the same `(trace_id, project_id)` pair are
-    /// cheaply discarded at the primary-key level.  Empty sets are no-ops.
+    /// Delegates to `OtelStorage::record_trace_refs` so the ref lands on the
+    /// active backend (Postgres control table, or the ClickHouse table when
+    /// ClickHouse is enabled). Both backends give the `(trace_id, project_id)`
+    /// pair first-write-wins semantics, so re-recording is cheap and never
+    /// moves `first_seen`.  Empty sets are no-ops.
     pub async fn record_hint(
         &self,
         trace_ids: HashSet<String>,
@@ -212,41 +218,8 @@ impl CrossProjectTraceService {
         if trace_ids.is_empty() {
             return Ok(());
         }
-
-        // Build a parameterized multi-row INSERT to avoid N individual round-trips.
-        // ($1, $2), ($3, $4), …  where odd params are trace_id and even are project_id.
         let ids_vec: Vec<String> = trace_ids.into_iter().collect();
-
-        let mut sql =
-            String::from("INSERT INTO cross_project_trace_refs (trace_id, project_id) VALUES ");
-        let mut param_idx = 1u32;
-        for (i, _) in ids_vec.iter().enumerate() {
-            if i > 0 {
-                sql.push_str(", ");
-            }
-            sql.push_str(&format!("(${param_idx}, ${})", param_idx + 1));
-            param_idx += 2;
-        }
-        sql.push_str(" ON CONFLICT DO NOTHING");
-
-        let mut values: Vec<sea_orm::Value> = Vec::with_capacity(ids_vec.len() * 2);
-        for tid in &ids_vec {
-            values.push(tid.clone().into());
-            values.push(project_id.into());
-        }
-
-        self.db
-            .execute(Statement::from_sql_and_values(
-                DatabaseBackend::Postgres,
-                &sql,
-                values,
-            ))
-            .await
-            .map_err(|e| CrossProjectTraceError::RecordHint {
-                project_id,
-                source: e,
-            })?;
-
+        self.storage.record_trace_refs(&ids_vec, project_id).await?;
         Ok(())
     }
 
@@ -325,39 +298,33 @@ impl CrossProjectTraceService {
         trace_id: &str,
         exclude_project_id: Option<i32>,
     ) -> Result<Vec<SiblingRef>, CrossProjectTraceError> {
-        let rows = self
-            .db
-            .query_all(Statement::from_sql_and_values(
-                DatabaseBackend::Postgres,
-                r#"SELECT r.project_id, p.name AS project_name, p.slug AS project_slug, r.first_seen
-                   FROM cross_project_trace_refs r
-                   JOIN projects p ON p.id = r.project_id
-                   WHERE r.trace_id = $1
-                     AND p.cross_project_trace_sharing = TRUE
-                     AND ($2::integer IS NULL OR r.project_id != $2)
-                   ORDER BY r.first_seen ASC"#,
-                [
-                    trace_id.into(),
-                    match exclude_project_id {
-                        Some(id) => sea_orm::Value::Int(Some(id)),
-                        None => sea_orm::Value::Int(None),
-                    },
-                ],
-            ))
-            .await
-            .map_err(|e| CrossProjectTraceError::QuerySiblings {
+        // Refs come from the active storage backend; project metadata always
+        // lives in Postgres, so it is joined in a second, tiny query.
+        let mut refs = self.storage.get_trace_ref_projects(trace_id).await?;
+        refs.sort_by_key(|r| r.first_seen);
+
+        let ids: Vec<i32> = refs.iter().map(|r| r.project_id).collect();
+        let meta = self.load_project_meta(&ids).await.map_err(|e| {
+            CrossProjectTraceError::QuerySiblings {
                 trace_id: trace_id.to_string(),
                 source: e,
-            })?;
+            }
+        })?;
 
-        let siblings = rows
-            .iter()
-            .filter_map(|row| {
+        // Refs whose project no longer exists are dropped (JOIN semantics).
+        let siblings = refs
+            .into_iter()
+            .filter(|r| exclude_project_id != Some(r.project_id))
+            .filter_map(|r| {
+                let m = meta.get(&r.project_id)?;
+                if !m.sharing {
+                    return None;
+                }
                 Some(SiblingRef {
-                    project_id: row.try_get("", "project_id").ok()?,
-                    project_name: row.try_get("", "project_name").ok()?,
-                    project_slug: row.try_get("", "project_slug").ok()?,
-                    first_seen: row.try_get("", "first_seen").ok()?,
+                    project_id: r.project_id,
+                    project_name: m.name.clone(),
+                    project_slug: m.slug.clone(),
+                    first_seen: r.first_seen,
                 })
             })
             .collect();
@@ -376,38 +343,86 @@ impl CrossProjectTraceService {
         &self,
         trace_id: &str,
     ) -> Result<Vec<TraceProjectRef>, CrossProjectTraceError> {
-        let rows = self
-            .db
-            .query_all(Statement::from_sql_and_values(
-                DatabaseBackend::Postgres,
-                r#"SELECT r.project_id, p.name AS project_name, p.slug AS project_slug, r.first_seen,
-                          p.cross_project_trace_sharing AS sharing
-                   FROM cross_project_trace_refs r
-                   JOIN projects p ON p.id = r.project_id
-                   WHERE r.trace_id = $1
-                   ORDER BY r.first_seen ASC"#,
-                [trace_id.into()],
-            ))
-            .await
-            .map_err(|e| CrossProjectTraceError::QueryProjects {
+        let mut refs = self.storage.get_trace_ref_projects(trace_id).await?;
+        refs.sort_by_key(|r| r.first_seen);
+
+        let ids: Vec<i32> = refs.iter().map(|r| r.project_id).collect();
+        let meta = self.load_project_meta(&ids).await.map_err(|e| {
+            CrossProjectTraceError::QueryProjects {
                 trace_id: trace_id.to_string(),
                 source: e,
-            })?;
+            }
+        })?;
 
-        let refs = rows
-            .iter()
-            .filter_map(|row| {
+        // Refs whose project no longer exists are dropped (JOIN semantics).
+        let refs = refs
+            .into_iter()
+            .filter_map(|r| {
+                let m = meta.get(&r.project_id)?;
                 Some(TraceProjectRef {
-                    project_id: row.try_get("", "project_id").ok()?,
-                    project_name: row.try_get("", "project_name").ok()?,
-                    project_slug: row.try_get("", "project_slug").ok()?,
-                    first_seen: row.try_get("", "first_seen").ok()?,
-                    sharing: row.try_get("", "sharing").ok()?,
+                    project_id: r.project_id,
+                    project_name: m.name.clone(),
+                    project_slug: m.slug.clone(),
+                    first_seen: r.first_seen,
+                    sharing: m.sharing,
                 })
             })
             .collect();
 
         Ok(refs)
+    }
+
+    /// Fetch name / slug / sharing flag for a set of project ids from the
+    /// Postgres `projects` table. Returns a map keyed by project id; ids with
+    /// no matching project are simply absent.
+    async fn load_project_meta(
+        &self,
+        project_ids: &[i32],
+    ) -> Result<std::collections::HashMap<i32, ProjectMeta>, sea_orm::DbErr> {
+        use std::collections::HashMap;
+        if project_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut sql = String::from(
+            "SELECT id, name, slug, cross_project_trace_sharing FROM projects WHERE id IN (",
+        );
+        for i in 0..project_ids.len() {
+            if i > 0 {
+                sql.push_str(", ");
+            }
+            sql.push_str(&format!("${}", i + 1));
+        }
+        sql.push(')');
+
+        let values: Vec<sea_orm::Value> = project_ids.iter().map(|id| (*id).into()).collect();
+        let rows = self
+            .db
+            .query_all(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                &sql,
+                values,
+            ))
+            .await?;
+
+        let mut map = HashMap::with_capacity(rows.len());
+        for row in &rows {
+            let id: i32 = match row.try_get("", "id") {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            map.insert(
+                id,
+                ProjectMeta {
+                    name: row.try_get("", "name").unwrap_or_default(),
+                    slug: row.try_get("", "slug").unwrap_or_default(),
+                    sharing: row
+                        .try_get("", "cross_project_trace_sharing")
+                        .unwrap_or(false),
+                },
+            );
+        }
+        Ok(map)
     }
 
     // ── Phase 2: unified waterfall assembly ─────────────────────────────────
@@ -558,11 +573,16 @@ impl CrossProjectTraceService {
 
 // ── Prune helper ─────────────────────────────────────────────────────────────
 
-/// Delete `cross_project_trace_refs` rows older than 90 days.
+/// Delete Postgres `cross_project_trace_refs` rows older than 90 days.
 ///
 /// Called by the daily background prune task in `plugin.rs`.  Returns the
 /// number of deleted rows (for logging).  Errors are logged by the caller and
 /// do not affect the prune schedule.
+///
+/// This targets the POSTGRES control table only. When the ClickHouse backend
+/// is active, new refs land in ClickHouse (expired natively by per-row TTL)
+/// and this task's remaining job is draining the legacy Postgres rows written
+/// before the cutover — after one retention window it deletes nothing.
 pub async fn prune_stale_hints(db: &DatabaseConnection) -> Result<u64, sea_orm::DbErr> {
     let result = db
         .execute(Statement::from_string(
@@ -694,6 +714,94 @@ mod tests {
         };
         assert_eq!(msg.project_id, 42);
         assert_eq!(msg.trace_ids.len(), 2);
+    }
+
+    // ── Service paths over MockOtelStorage + MockDatabase ────────────────────
+
+    fn meta_row(
+        id: i32,
+        name: &str,
+        slug: &str,
+        sharing: bool,
+    ) -> std::collections::BTreeMap<String, sea_orm::Value> {
+        [
+            ("id".to_string(), sea_orm::Value::from(id)),
+            ("name".to_string(), sea_orm::Value::from(name)),
+            ("slug".to_string(), sea_orm::Value::from(slug)),
+            (
+                "cross_project_trace_sharing".to_string(),
+                sea_orm::Value::from(sharing),
+            ),
+        ]
+        .into_iter()
+        .collect()
+    }
+
+    #[tokio::test]
+    async fn record_hint_dedupes_pairs_first_write_wins() {
+        use crate::test_support::MockOtelStorage;
+        use sea_orm::MockDatabase;
+
+        let storage = Arc::new(MockOtelStorage::new());
+        let db = Arc::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+        let svc = CrossProjectTraceService::new(db, storage.clone());
+
+        let tid = "4bf92f3577b34da6a3ce929d0e0e4736".to_string();
+        let mut ids = HashSet::new();
+        ids.insert(tid.clone());
+
+        svc.record_hint(ids.clone(), 7).await.unwrap();
+        let first_seen = storage.trace_refs.lock().unwrap()[&(tid.clone(), 7)];
+        svc.record_hint(ids, 7).await.unwrap();
+
+        let refs = storage.trace_refs.lock().unwrap();
+        assert_eq!(refs.len(), 1, "re-recording must not duplicate the pair");
+        assert_eq!(refs[&(tid, 7)], first_seen, "first_seen must not move");
+    }
+
+    #[tokio::test]
+    async fn discovery_filters_sharing_exclusion_and_deleted_projects() {
+        use crate::test_support::MockOtelStorage;
+        use sea_orm::MockDatabase;
+
+        let storage = Arc::new(MockOtelStorage::new());
+        let tid = "4bf92f3577b34da6a3ce929d0e0e4736".to_string();
+        for project_id in [1, 2, 3, 4] {
+            storage
+                .record_trace_refs(std::slice::from_ref(&tid), project_id)
+                .await
+                .unwrap();
+        }
+
+        // Project meta: 1 shares, 2 opted out, 3 shares (used as `exclude`),
+        // project 4 is absent (deleted) — one result set per service call.
+        let meta = vec![
+            meta_row(1, "alpha", "alpha", true),
+            meta_row(2, "beta", "beta", false),
+            meta_row(3, "gamma", "gamma", true),
+        ];
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![meta.clone(), meta])
+                .into_connection(),
+        );
+        let svc = CrossProjectTraceService::new(db, storage);
+
+        // Siblings: opted-out (2), excluded (3), and deleted (4) all drop out.
+        let siblings = svc.find_sibling_projects(&tid, Some(3)).await.unwrap();
+        assert_eq!(siblings.len(), 1);
+        assert_eq!(siblings[0].project_id, 1);
+        assert_eq!(siblings[0].project_slug, "alpha");
+
+        // find_trace_projects keeps opted-out projects (with their flag) but
+        // still drops deleted ones.
+        let mut all = svc.find_trace_projects(&tid).await.unwrap();
+        all.sort_by_key(|p| p.project_id);
+        assert_eq!(
+            all.iter().map(|p| p.project_id).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+        assert!(!all[1].sharing);
     }
 
     #[test]

--- a/crates/temps-otel/src/storage/clickhouse/migrations.rs
+++ b/crates/temps-otel/src/storage/clickhouse/migrations.rs
@@ -42,6 +42,10 @@ const MIGRATIONS: &[Migration] = &[
         name: "0005_retention_ttl",
         sql: include_str!("../../../migrations/clickhouse/0005_retention_ttl.sql"),
     },
+    Migration {
+        name: "0006_trace_refs",
+        sql: include_str!("../../../migrations/clickhouse/0006_trace_refs.sql"),
+    },
 ];
 
 /// SQL for the migration tracking table. Created on first run.

--- a/crates/temps-otel/src/storage/clickhouse/mod.rs
+++ b/crates/temps-otel/src/storage/clickhouse/mod.rs
@@ -50,7 +50,10 @@ use temps_metrics::validate_metric_name;
 
 use crate::error::OtelError;
 use crate::storage::timescaledb::TimescaleDbStorage;
-use crate::storage::{BaselinePoint, DeployEvent, MinuteAggregate, OtelStorage, StorageResult};
+use crate::storage::{
+    merge_trace_ref_projects, BaselinePoint, DeployEvent, MinuteAggregate, OtelStorage,
+    StorageResult, TraceRefProject,
+};
 use crate::types::{
     GenAiEvent, GenAiSpanDetail, GenAiTraceSummary, HealthSummary, HistogramSummary, Insight,
     InsightStatus, LogQuery, LogRecord, MetricAggregation, MetricBucket, MetricPoint, MetricQuery,
@@ -901,6 +904,38 @@ pub(crate) fn ch_query_err(operation: &str, err: ::clickhouse::error::Error) -> 
 }
 
 // ── ClickHouseOtelStorage ────────────────────────────────────────────────────
+
+// ── Cross-project trace ref row ─────────────────────────────────────────────
+
+/// ClickHouse row matching the `cross_project_trace_refs` DDL in
+/// `0006_trace_refs.sql`. Field order must match the DDL column order
+/// exactly (positional binary serialization — same rule as [`ChSpanRow`]).
+#[derive(::clickhouse::Row, Serialize, Deserialize, Debug, Clone)]
+pub struct ChTraceRefRow {
+    /// trace_id  String
+    pub trace_id: String,
+    /// project_id  Int32
+    pub project_id: i32,
+    /// first_seen  DateTime64(3, 'UTC') — stored as Unix milliseconds
+    pub first_seen: i64,
+    /// retention_days  UInt16 — stamped from the same resolver value as span
+    /// rows so refs expire on exactly the trace retention horizon.
+    pub retention_days: u16,
+    /// _version  UInt64 — INVERTED first_seen (see [`trace_ref_version`]).
+    pub _version: u64,
+}
+
+/// Dedup version for a trace-ref row: `u64::MAX - first_seen_ms`.
+///
+/// The Postgres table's `ON CONFLICT DO NOTHING` gave `(trace_id, project_id)`
+/// pairs first-write-wins semantics — `first_seen` means "earliest
+/// observation". `ReplacingMergeTree` keeps the HIGHEST version, so the
+/// version is inverted: the earliest observation gets the highest version and
+/// survives merges, preserving those semantics (including against backfilled
+/// historical rows, which are older and therefore always win).
+pub fn trace_ref_version(first_seen_ms: i64) -> u64 {
+    u64::MAX - first_seen_ms.max(0) as u64
+}
 
 /// ClickHouse-backed OTel storage.
 ///
@@ -2492,6 +2527,98 @@ impl OtelStorage for ClickHouseOtelStorage {
         self.inner.query_logs(query).await
     }
 
+    // ── Cross-project trace refs — native ClickHouse (ADR-027) ──────────────
+
+    /// Insert `(trace_id, project_id)` pairs into the ClickHouse
+    /// `cross_project_trace_refs` table. `ReplacingMergeTree` with the
+    /// inverted `_version` dedupes re-recordings while keeping the earliest
+    /// `first_seen` — the CH equivalent of the Postgres table's
+    /// `ON CONFLICT DO NOTHING`.
+    async fn record_trace_refs(&self, trace_ids: &[String], project_id: i32) -> StorageResult<u64> {
+        if trace_ids.is_empty() {
+            return Ok(0);
+        }
+
+        let first_seen_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+        let retention_days = self
+            .resolver
+            .resolve(project_id, temps_core::RetentionTable::Spans);
+
+        let mut inserter = self
+            .ch
+            .insert::<ChTraceRefRow>("cross_project_trace_refs")
+            .await
+            .map_err(|e| OtelError::Storage {
+                message: format!("ClickHouse cross_project_trace_refs inserter setup failed: {e}"),
+            })?;
+        for trace_id in trace_ids {
+            inserter
+                .write(&ChTraceRefRow {
+                    trace_id: trace_id.clone(),
+                    project_id,
+                    first_seen: first_seen_ms,
+                    retention_days,
+                    _version: trace_ref_version(first_seen_ms),
+                })
+                .await
+                .map_err(|e| OtelError::Storage {
+                    message: format!("ClickHouse cross_project_trace_refs write failed: {e}"),
+                })?;
+        }
+        inserter.end().await.map_err(|e| OtelError::Storage {
+            message: format!("ClickHouse cross_project_trace_refs insert failed: {e}"),
+        })?;
+
+        Ok(trace_ids.len() as u64)
+    }
+
+    /// Union of the native ClickHouse rows and any legacy rows still in the
+    /// Postgres `cross_project_trace_refs` table (earliest `first_seen` wins
+    /// per project). The union makes enabling ClickHouse migration-free:
+    /// pre-cutover traces resolve from Postgres until they age out (or are
+    /// copied over via `temps backfill clickhouse --domain trace-refs`).
+    async fn get_trace_ref_projects(&self, trace_id: &str) -> StorageResult<Vec<TraceRefProject>> {
+        #[derive(::clickhouse::Row, Deserialize)]
+        struct RefRow {
+            project_id: i32,
+            first_seen_ms: i64,
+        }
+
+        // min(first_seen) at query time keeps the earliest observation even
+        // before ReplacingMergeTree merges collapse duplicate pairs.
+        let ch_rows = self
+            .ch
+            .query(
+                "SELECT project_id, \
+                        toInt64(toUnixTimestamp64Milli(min(first_seen))) AS first_seen_ms \
+                 FROM cross_project_trace_refs \
+                 WHERE trace_id = ? \
+                 GROUP BY project_id",
+            )
+            .bind(trace_id)
+            .fetch_all::<RefRow>()
+            .await
+            .map_err(|e| OtelError::Storage {
+                message: format!("ClickHouse cross_project_trace_refs query failed: {e}"),
+            })?;
+
+        let ch_refs: Vec<TraceRefProject> = ch_rows
+            .into_iter()
+            .map(|r| TraceRefProject {
+                project_id: r.project_id,
+                first_seen: chrono::DateTime::from_timestamp_millis(r.first_seen_ms)
+                    .unwrap_or_default(),
+            })
+            .collect();
+
+        let pg_refs = self.inner.get_trace_ref_projects(trace_id).await?;
+
+        Ok(merge_trace_ref_projects(ch_refs, pg_refs))
+    }
+
     // ── Control-row methods — always Postgres (insights, health, quota) ──────
 
     async fn upsert_insight(&self, insight: &Insight) -> StorageResult<i64> {
@@ -2714,6 +2841,17 @@ mod tests {
     use crate::types::{ResourceInfo, SpanKind, SpanRecord, SpanStatusCode};
     use chrono::Utc;
     use std::collections::BTreeMap;
+
+    /// The inverted version must give the EARLIEST observation the HIGHEST
+    /// version, so ReplacingMergeTree merges keep first-write-wins semantics.
+    #[test]
+    fn trace_ref_version_is_first_wins() {
+        let earlier = trace_ref_version(1_000);
+        let later = trace_ref_version(2_000);
+        assert!(earlier > later);
+        // Negative (pre-epoch) timestamps clamp to 0 rather than wrapping.
+        assert_eq!(trace_ref_version(-5), u64::MAX);
+    }
 
     fn make_span() -> SpanRecord {
         SpanRecord {

--- a/crates/temps-otel/src/storage/mod.rs
+++ b/crates/temps-otel/src/storage/mod.rs
@@ -109,6 +109,23 @@ pub trait OtelStorage: Send + Sync {
     /// Query log records from the fast-query store.
     async fn query_logs(&self, query: LogQuery) -> StorageResult<Vec<LogRecord>>;
 
+    // ── Cross-project trace refs (ADR-027 Phase 0) ──────────────────
+
+    /// Record that `project_id` holds spans for each `trace_id` — the
+    /// reverse index behind cross-project trace discovery. First write
+    /// per `(trace_id, project_id)` pair wins; re-recording an existing
+    /// pair must not move its `first_seen`.
+    ///
+    /// Returns the number of pairs submitted (duplicates included — both
+    /// backends dedupe internally).
+    async fn record_trace_refs(&self, trace_ids: &[String], project_id: i32) -> StorageResult<u64>;
+
+    /// Return every `(project_id, first_seen)` pair recorded for
+    /// `trace_id`, at most one entry per project (earliest `first_seen`
+    /// wins), in no guaranteed order. Project metadata (name, slug,
+    /// sharing flag) is NOT resolved here — callers join it from Postgres.
+    async fn get_trace_ref_projects(&self, trace_id: &str) -> StorageResult<Vec<TraceRefProject>>;
+
     // ── GenAI queries ────────────────────────────────────────────────
 
     /// Query GenAI trace summaries — traces that contain spans with `gen_ai.*` attributes.
@@ -220,6 +237,39 @@ pub trait OtelStorage: Send + Sync {
     ) -> StorageResult<f64>;
 }
 
+/// A `(project_id, first_seen)` pair from the cross-project trace ref index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceRefProject {
+    pub project_id: i32,
+    pub first_seen: chrono::DateTime<chrono::Utc>,
+}
+
+/// Merge trace-ref lookups from two sources into one entry per project,
+/// keeping the earliest `first_seen` when both sources know a project.
+///
+/// Used by the ClickHouse backend to union its native rows with legacy rows
+/// still sitting in the Postgres `cross_project_trace_refs` table, so
+/// enabling ClickHouse needs no data migration: old traces resolve from
+/// Postgres until they age out, new traces resolve from ClickHouse.
+pub fn merge_trace_ref_projects(
+    a: Vec<TraceRefProject>,
+    b: Vec<TraceRefProject>,
+) -> Vec<TraceRefProject> {
+    let mut by_project: std::collections::HashMap<i32, TraceRefProject> =
+        std::collections::HashMap::new();
+    for r in a.into_iter().chain(b) {
+        by_project
+            .entry(r.project_id)
+            .and_modify(|existing| {
+                if r.first_seen < existing.first_seen {
+                    existing.first_seen = r.first_seen;
+                }
+            })
+            .or_insert(r);
+    }
+    by_project.into_values().collect()
+}
+
 /// A baseline data point for anomaly detection.
 #[derive(Debug, Clone)]
 pub struct BaselinePoint {
@@ -246,4 +296,41 @@ pub struct DeployEvent {
     pub environment_id: Option<i32>,
     pub deployed_at: chrono::DateTime<chrono::Utc>,
     pub service_name: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Utc};
+
+    fn r(project_id: i32, secs: i64) -> TraceRefProject {
+        TraceRefProject {
+            project_id,
+            first_seen: DateTime::<Utc>::from_timestamp(secs, 0).unwrap(),
+        }
+    }
+
+    #[test]
+    fn merge_unions_disjoint_projects() {
+        let merged = merge_trace_ref_projects(vec![r(1, 100)], vec![r(2, 200)]);
+        assert_eq!(merged.len(), 2);
+    }
+
+    #[test]
+    fn merge_keeps_earliest_first_seen_for_shared_project() {
+        // Same project known to both sources — earliest observation wins,
+        // regardless of which side holds it.
+        let merged = merge_trace_ref_projects(vec![r(1, 300)], vec![r(1, 100)]);
+        assert_eq!(merged, vec![r(1, 100)]);
+
+        let merged = merge_trace_ref_projects(vec![r(1, 100)], vec![r(1, 300)]);
+        assert_eq!(merged, vec![r(1, 100)]);
+    }
+
+    #[test]
+    fn merge_handles_empty_sides() {
+        assert!(merge_trace_ref_projects(vec![], vec![]).is_empty());
+        assert_eq!(merge_trace_ref_projects(vec![r(1, 1)], vec![]).len(), 1);
+        assert_eq!(merge_trace_ref_projects(vec![], vec![r(1, 1)]).len(), 1);
+    }
 }

--- a/crates/temps-otel/src/storage/timescaledb.rs
+++ b/crates/temps-otel/src/storage/timescaledb.rs
@@ -2041,6 +2041,73 @@ impl OtelStorage for TimescaleDbStorage {
         Ok(records)
     }
 
+    // ── Cross-project trace refs (ADR-027 Phase 0) ──────────────────────────
+
+    /// Single multi-row `INSERT … ON CONFLICT DO NOTHING` into the
+    /// `cross_project_trace_refs` control table. The `(trace_id, project_id)`
+    /// primary key discards re-recordings cheaply, so `first_seen` (DEFAULT
+    /// NOW()) keeps the earliest observation.
+    async fn record_trace_refs(&self, trace_ids: &[String], project_id: i32) -> StorageResult<u64> {
+        if trace_ids.is_empty() {
+            return Ok(0);
+        }
+
+        // Parameterized multi-row VALUES: ($1, $2), ($3, $4), … where odd
+        // params are trace_id and even are project_id.
+        let mut sql =
+            String::from("INSERT INTO cross_project_trace_refs (trace_id, project_id) VALUES ");
+        let mut param_idx = 1u32;
+        for i in 0..trace_ids.len() {
+            if i > 0 {
+                sql.push_str(", ");
+            }
+            sql.push_str(&format!("(${param_idx}, ${})", param_idx + 1));
+            param_idx += 2;
+        }
+        sql.push_str(" ON CONFLICT DO NOTHING");
+
+        let mut values: Vec<sea_orm::Value> = Vec::with_capacity(trace_ids.len() * 2);
+        for tid in trace_ids {
+            values.push(tid.clone().into());
+            values.push(project_id.into());
+        }
+
+        self.db
+            .execute(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                &sql,
+                values,
+            ))
+            .await?;
+
+        Ok(trace_ids.len() as u64)
+    }
+
+    async fn get_trace_ref_projects(
+        &self,
+        trace_id: &str,
+    ) -> StorageResult<Vec<super::TraceRefProject>> {
+        let rows = self
+            .db
+            .query_all(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                "SELECT project_id, first_seen FROM cross_project_trace_refs \
+                 WHERE trace_id = $1",
+                [trace_id.into()],
+            ))
+            .await?;
+
+        Ok(rows
+            .iter()
+            .filter_map(|row| {
+                Some(super::TraceRefProject {
+                    project_id: row.try_get("", "project_id").ok()?,
+                    first_seen: row.try_get("", "first_seen").ok()?,
+                })
+            })
+            .collect())
+    }
+
     async fn upsert_insight(&self, insight: &Insight) -> StorageResult<i64> {
         let anomaly_ids_json = serde_json::to_value(&insight.anomaly_ids).unwrap_or_default();
 

--- a/crates/temps-otel/src/test_support.rs
+++ b/crates/temps-otel/src/test_support.rs
@@ -11,6 +11,9 @@ use crate::error::OtelError;
 use crate::storage::{BaselinePoint, DeployEvent, MinuteAggregate, OtelStorage, StorageResult};
 use crate::types::*;
 
+/// Cross-project trace refs: `(trace_id, project_id)` → `first_seen`.
+pub type TraceRefMap = HashMap<(String, i32), chrono::DateTime<chrono::Utc>>;
+
 /// In-memory storage backend for tests.
 ///
 /// Stores all data in `Arc<Mutex<...>>` collections so tests can
@@ -23,6 +26,9 @@ pub struct MockOtelStorage {
     pub archived_logs: Arc<Mutex<Vec<LogRecord>>>,
     pub insights: Arc<Mutex<Vec<Insight>>>,
     pub health_summaries: Arc<Mutex<Vec<HealthSummary>>>,
+    /// Cross-project trace refs keyed by `(trace_id, project_id)` — value is
+    /// the `first_seen` of the FIRST recording (later re-recordings are no-ops).
+    pub trace_refs: Arc<Mutex<TraceRefMap>>,
     pub next_insight_id: Arc<Mutex<i64>>,
     /// If set, store_spans will return this error instead.
     pub fail_store_spans: Arc<Mutex<Option<String>>>,
@@ -247,6 +253,34 @@ impl OtelStorage for MockOtelStorage {
             .cloned()
             .collect();
         Ok(filtered)
+    }
+
+    async fn record_trace_refs(&self, trace_ids: &[String], project_id: i32) -> StorageResult<u64> {
+        let mut refs = self.trace_refs.lock().unwrap();
+        for tid in trace_ids {
+            // First write per (trace_id, project_id) wins, matching both
+            // production backends.
+            refs.entry((tid.clone(), project_id))
+                .or_insert_with(chrono::Utc::now);
+        }
+        Ok(trace_ids.len() as u64)
+    }
+
+    async fn get_trace_ref_projects(
+        &self,
+        trace_id: &str,
+    ) -> StorageResult<Vec<crate::storage::TraceRefProject>> {
+        let refs = self.trace_refs.lock().unwrap();
+        Ok(refs
+            .iter()
+            .filter(|((tid, _), _)| tid == trace_id)
+            .map(
+                |((_, project_id), first_seen)| crate::storage::TraceRefProject {
+                    project_id: *project_id,
+                    first_seen: *first_seen,
+                },
+            )
+            .collect())
     }
 
     async fn upsert_insight(&self, insight: &Insight) -> StorageResult<i64> {

--- a/crates/temps-otel/tests/clickhouse_storage_test.rs
+++ b/crates/temps-otel/tests/clickhouse_storage_test.rs
@@ -127,7 +127,14 @@ async fn setup() -> Option<(ClickHouseOtelStorage, Box<dyn std::any::Any + Send>
 
     // The inner Timescale storage is never exercised by the metric methods under
     // test; a MockDatabase satisfies the constructor without a Postgres server.
-    let mock_db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+    // The trace-refs test IS an exception: `get_trace_ref_projects` unions the
+    // ClickHouse rows with the inner Postgres table, so a stack of empty query
+    // results is queued for those lookups (unused results are harmless to the
+    // metric tests, which never touch the mock).
+    let empty_pg_result = || Vec::<std::collections::BTreeMap<String, sea_orm::Value>>::new();
+    let mock_db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(std::iter::repeat_with(empty_pg_result).take(8))
+        .into_connection();
     let inner = Arc::new(TimescaleDbStorage::new(Arc::new(mock_db), None));
 
     let storage =
@@ -683,4 +690,60 @@ async fn query_metrics_cumulative_histogram_uses_latest_not_sum() {
         vec![32, 32, 16],
         "per-series latest buckets summed across series"
     );
+}
+
+/// Round-trip for the ADR-027 cross-project trace ref index on the ClickHouse
+/// backend (`0006_trace_refs.sql`): record refs, re-record the same pair
+/// (must dedupe, not duplicate), and look them up per trace_id. The lookup
+/// unions with the inner Postgres storage — the queued-empty MockDatabase in
+/// `setup()` stands in for a drained legacy table.
+#[tokio::test]
+async fn trace_refs_roundtrip_record_and_lookup() {
+    let Some((storage, _container)) = setup().await else {
+        return; // Docker unavailable — skip gracefully.
+    };
+
+    let t1 = "4bf92f3577b34da6a3ce929d0e0e4736".to_string();
+    let t2 = "abcdef1234567890abcdef1234567890".to_string();
+
+    storage
+        .record_trace_refs(&[t1.clone(), t2.clone()], 1)
+        .await
+        .expect("record refs for project 1");
+    // Re-recording an existing (trace_id, project_id) pair must be a no-op
+    // at read time (GROUP BY + ReplacingMergeTree dedup).
+    storage
+        .record_trace_refs(std::slice::from_ref(&t1), 1)
+        .await
+        .expect("re-record same pair");
+    storage
+        .record_trace_refs(std::slice::from_ref(&t1), 2)
+        .await
+        .expect("record ref for project 2");
+
+    let refs = storage
+        .get_trace_ref_projects(&t1)
+        .await
+        .expect("lookup shared trace");
+    let mut projects: Vec<i32> = refs.iter().map(|r| r.project_id).collect();
+    projects.sort_unstable();
+    assert_eq!(projects, vec![1, 2], "one entry per project, no duplicates");
+    for r in &refs {
+        // Sanity: first_seen decoded from DateTime64(3) into a real timestamp.
+        assert!(r.first_seen.timestamp() > 1_500_000_000);
+    }
+
+    let refs_t2 = storage
+        .get_trace_ref_projects(&t2)
+        .await
+        .expect("lookup single-project trace");
+    assert_eq!(refs_t2.len(), 1);
+    assert_eq!(refs_t2[0].project_id, 1);
+
+    // Unknown trace_id resolves to an empty list, never an error.
+    let none = storage
+        .get_trace_ref_projects("00000000000000000000000000000000")
+        .await
+        .expect("lookup unknown trace");
+    assert!(none.is_empty());
 }

--- a/docs/adr/027-cross-project-trace-linking.md
+++ b/docs/adr/027-cross-project-trace-linking.md
@@ -116,6 +116,15 @@ DELETE FROM cross_project_trace_refs WHERE first_seen < NOW() - INTERVAL '90 day
 
 **Size estimate:** Each row is approximately 50 bytes (32-char hex `trace_id` + `i32` + `timestamptz`). An installation generating one million distinct traces per day across ten projects with a 90-day window accumulates roughly 4.5 million rows — approximately 225 MB on a standard B-tree index. Cross-project propagation requires explicit SDK configuration by developers, so the table will be sparse on most installations. A primary-key lookup on `(trace_id)` plus a single Postgres JOIN is sub-millisecond at this row count; no hash partitioning is required at this scale. If row counts exceed 50 million (approximately 550K distinct cross-project traces per day across a 90-day window), converting to a TimescaleDB hypertable partitioned by `first_seen` is the Phase 3 follow-up.
 
+#### Amendment (2026-07-24) — ClickHouse-backed refs when CH is enabled
+
+The size estimate above did not hold in production: a high-ingest installation accumulated **125 GB** (39 GB heap + 87 GB b-tree) of `cross_project_trace_refs` in three weeks. The tuples themselves are the shape ClickHouse compresses best, so ref storage now routes through the `OtelStorage` trait (`record_trace_refs` / `get_trace_ref_projects`):
+
+- **TimescaleDB backend (default):** unchanged — Postgres control table, daily prune.
+- **ClickHouse backend:** refs are written to a CH `cross_project_trace_refs` table (`0006_trace_refs.sql`), `ORDER BY (trace_id, project_id)` — the key order the `spans` table cannot serve — with `ReplacingMergeTree` over an *inverted* `_version` so first-write-wins/`first_seen` semantics survive merges. Per-row `retention_days` is stamped from the same `RetentionTable::Spans` resolver value as span rows, keeping ref TTL locked to trace TTL by construction (this supersedes the manual coupling note above on the CH backend).
+
+Reads union CH with any legacy Postgres rows, so the cutover needs **no data migration**: pre-cutover refs resolve from Postgres until the daily prune drains them (one retention window), and `temps backfill clickhouse --domain trace-refs` exists for operators who want history copied immediately. The prune job keeps running unconditionally; on the CH backend it only drains legacy rows and then becomes a no-op.
+
 ### 3. Phase 1 — Follow navigation (cross-project banner and discovery endpoint)
 
 **New endpoint — sibling project discovery:**


### PR DESCRIPTION
## Problem

The `cross_project_trace_refs` Postgres control table (ADR-027 Phase 0) reached **125 GB** (39 GB heap + 87 GB b-tree indexes) in three weeks on a high-ingest install. The ADR's size estimate (~225 MB) did not hold, and the `(trace_id, project_id, first_seen)` tuples are exactly the shape ClickHouse compresses best — but the CH `spans` table can't serve trace-id-only discovery because its primary index is `(project_id, trace_id, span_id)`.

## Change

Ref storage now routes through the `OtelStorage` trait (`record_trace_refs` / `get_trace_ref_projects`):

- **TimescaleDB backend (default):** unchanged — Postgres control table + daily prune.
- **ClickHouse backend:** new `cross_project_trace_refs` CH table (`0006_trace_refs.sql`), `ORDER BY (trace_id, project_id)`, `ReplacingMergeTree` over an **inverted `_version`** so the Postgres first-write-wins / earliest-`first_seen` semantics survive merges. Per-row `retention_days` is stamped from the same `RetentionTable::Spans` resolver value as span rows — **ref TTL is locked to trace TTL by construction** (requirement: cross-trace retention must equal trace retention).

## No automatic migration

Reads union ClickHouse with legacy Postgres rows, so enabling CH needs no data migration and startup is unaffected: pre-cutover refs resolve from Postgres until the daily prune drains them (one retention window). Operators who want history copied immediately can use the new opt-in backfill domain:

```
temps backfill clickhouse --domain trace-refs
```

(also included in `--domain all`; keyset walk over `(first_seen, trace_id, project_id)`, idempotent re-runs via the inverted version).

The Postgres prune job keeps running unconditionally — on the CH backend it drains legacy rows and then becomes a no-op. ADR-027 amended accordingly.

## Evidence

- `cargo check --lib` clean; `cargo clippy -p temps-otel -p temps-cli --all-targets -- -D warnings` clean
- `cargo test -p temps-otel --lib`: 417 passed (incl. new merge-semantics, inverted-version, and service filtering tests over MockOtelStorage + MockDatabase)
- Real-ClickHouse testcontainer roundtrip (`trace_refs_roundtrip_record_and_lookup`): migration 0006 applies, record → dedupe on re-record → per-trace lookup → union with (empty) PG all verified against clickhouse-server 26.2.5