### PR TITLE
fix(web): bump rrweb-player to 2.1.1 (broken 2.1.0 dist → blank session replays)

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -63,7 +63,7 @@
         "recharts": "3.9.2",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
-        "rrweb-player": "^2.1.0",
+        "rrweb-player": "^2.1.1",
         "slugify": "^1.6.9",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
@@ -365,13 +365,13 @@
 
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.12.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw=="],
 
-    "@rrweb/packer": ["@rrweb/packer@2.1.0", "", { "dependencies": { "@rrweb/types": "^2.1.0", "fflate": "^0.4.4" } }, "sha512-M3Di2TuUN2xqgwK6OiLgikB0ebU1Wxx6iXMoSiDVhDZRgyc6euL5JQs3GclJOuYstDx+8jjbZ12hTcQe+Ai8WQ=="],
+    "@rrweb/packer": ["@rrweb/packer@2.1.1", "", { "dependencies": { "@rrweb/types": "^2.1.1", "fflate": "^0.4.4" } }, "sha512-xPGT7/Cfn1yHD2MOwQhX/8yTvNculurUxPT6ZKXVW8Wh/LI7Jn19L+e8PYKFhj/M89uwNeoTr6hiUQxgb8SMzQ=="],
 
-    "@rrweb/replay": ["@rrweb/replay@2.1.0", "", { "dependencies": { "@rrweb/types": "^2.1.0", "rrweb": "^2.1.0" } }, "sha512-a6s3Lzf4iIEL22o6+DHZrbjH/q6OIM9CFh/KzU6pDZ2mOYFP3u3Yd3IL57Oc9usnqFt/kNCvOjUf5JbBrQ9o7A=="],
+    "@rrweb/replay": ["@rrweb/replay@2.1.1", "", { "dependencies": { "@rrweb/types": "^2.1.1", "rrweb": "^2.1.1" } }, "sha512-jq64eyJvrh/ioBS1MpDrs/Lj+7QY2TW4xGxp4g4LJKdltSkqMjMbUmhTDcpzaEDZt66S0gasGcgqCulsksSXnw=="],
 
-    "@rrweb/types": ["@rrweb/types@2.1.0", "", {}, "sha512-svOHkcuukP6rIjz2umwVsS7uYct+2h0N97+bg+8IJYKIUj5+YjwIvqx5y9NILFKPIu3yk+Mb+KDFfJ8RV+4JlA=="],
+    "@rrweb/types": ["@rrweb/types@2.1.1", "", {}, "sha512-g0I3nCNL1S7slDXwhunxOuOoswkY8WVZJQrPFiwixOc6xoD514d1JLTuyAzCKIox8g/PaLKtV5g31Uk42inQSQ=="],
 
-    "@rrweb/utils": ["@rrweb/utils@2.1.0", "", {}, "sha512-hU7MT3TSdD+Do7FmMoHrBfPevFCheN5vo2mn97Y4vbXuwemopAmo8dqo5KJeMaA6oQQt7FinHJ0Xqb7k68Ci6Q=="],
+    "@rrweb/utils": ["@rrweb/utils@2.1.1", "", {}, "sha512-x2SgJAD3YJ9eVcLZ5l6OqWMtczdA3VfS5XqPeqpZdQgV9oh6Id5GK2cDN4bimnkqryOcIJdz8cTvV0yNvqQ+nA=="],
 
     "@rsbuild/core": ["@rsbuild/core@2.1.5", "", { "dependencies": { "@rspack/core": "~2.1.3", "@swc/helpers": "^0.5.23" }, "peerDependencies": { "core-js": ">= 3.0.0" }, "optionalPeers": ["core-js"], "bin": { "rsbuild": "./bin/rsbuild.js" } }, "sha512-7TW4U1SH7VxQZzSTIOzvwj5lo9uNTmGpsmTXFr4axQAE4giLDKP3kVUA1ZW4P3/Mz4QQJJyvZP29mVcb8kZCfg=="],
 
@@ -1335,13 +1335,13 @@
 
     "robust-predicates": ["robust-predicates@3.0.2", "", {}, "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="],
 
-    "rrdom": ["rrdom@2.1.0", "", { "dependencies": { "rrweb-snapshot": "^2.1.0" } }, "sha512-d7oaIHzwffxI74UJMZDGq/f97/Yfm3QX4CcTIlQelt2HsLavItLjp8x8nQ0g9Pet5+5wG1RGr9yvsxb1gJlo8A=="],
+    "rrdom": ["rrdom@2.1.1", "", { "dependencies": { "rrweb-snapshot": "^2.1.1" } }, "sha512-VBkTF3bGNqcZjqnbo/gKi9GVQPIxiG0dofw7CQdAZQFQ2juJdt2YKIf3oS9QudL8HTpGh9bz5TUN+3amBn1Geg=="],
 
-    "rrweb": ["rrweb@2.1.0", "", { "dependencies": { "@rrweb/types": "^2.1.0", "@rrweb/utils": "^2.1.0", "@types/css-font-loading-module": "0.0.7", "@xstate/fsm": "^1.4.0", "base64-arraybuffer": "^1.0.1", "mitt": "^3.0.0", "rrdom": "^2.1.0", "rrweb-snapshot": "^2.1.0" } }, "sha512-gGGvd1eXWnOuJpQumH7+gPmBwTXzNrjmQyedWVePcEx0S5fe3VkQW4vw5f5ItY+vuigaaktte9cZKOg0OEvv+w=="],
+    "rrweb": ["rrweb@2.1.1", "", { "dependencies": { "@rrweb/types": "^2.1.1", "@rrweb/utils": "^2.1.1", "@types/css-font-loading-module": "0.0.7", "@xstate/fsm": "^1.4.0", "base64-arraybuffer": "^1.0.1", "mitt": "^3.0.0", "rrdom": "^2.1.1", "rrweb-snapshot": "^2.1.1" } }, "sha512-ToxhJg3SsrAhw+/DPhI/2iiwZQIrGK5BGkZ0kHn4qUExcvQYRaolkciD1FWX2+r6vf1IxFyhsoRY18h3D+XoCg=="],
 
-    "rrweb-player": ["rrweb-player@2.1.0", "", { "dependencies": { "@rrweb/packer": "^2.1.0", "@rrweb/replay": "^2.1.0", "@tsconfig/svelte": "^1.0.0" } }, "sha512-EU0dCgrN66o2E8GAT67wDBRMgcJ1QJuu2lGa8PKO3xSosSS2eCaHlJWmX9fFCMvKkLsahWe15GnuqUjprCGMoA=="],
+    "rrweb-player": ["rrweb-player@2.1.1", "", { "dependencies": { "@rrweb/packer": "^2.1.1", "@rrweb/replay": "^2.1.1", "@tsconfig/svelte": "^1.0.0" } }, "sha512-oiAWx/m9Pz0DD5jlJdrF8QlotOZZBK0jINNSYAixxhGa2dI1TrzVVmF4eWFSd6AR8f2zjazKXI/PXCqj3PttXQ=="],
 
-    "rrweb-snapshot": ["rrweb-snapshot@2.1.0", "", { "dependencies": { "postcss": "^8.4.38" } }, "sha512-CFjUKWlO+Dl72gk8qwcDcNE/Pj9yr6IvGRAiRAx12pmJaSWaOKFoFgpQQ1j/mW0WKwEZXbHnMJL8M92gIsdwUQ=="],
+    "rrweb-snapshot": ["rrweb-snapshot@2.1.1", "", { "dependencies": { "postcss": "^8.4.38" } }, "sha512-al4Kx7Am7YlIn/5Yb2EMr7cdmjGiK+cLhdilJEXqkFXgpnys8t/yMJumXy2Ormgirpg3MBnFha0GTgny+iIL2w=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -86,7 +86,7 @@
     "recharts": "3.9.2",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
-    "rrweb-player": "^2.1.0",
+    "rrweb-player": "^2.1.1",
     "slugify": "^1.6.9",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",


### PR DESCRIPTION
## Problem

Session replays render as a **blank frame with no error** in the analytics console.

The root cause is the pinned player version. `web` depends on **rrweb-player 2.1.0**, whose *published* dist is a broken build: the compiled `onMount` never constructs the `Replayer`. In the shipped `rrweb-player.umd.cjs` there is no `new Replayer(...)` at all, and the controller's `play`/`pause` compile to empty functions. The component mounts an empty `.rr-player__frame` and stops — silently, with nothing logged. rrweb fixed this in **rrweb-player 2.1.1** (published 2026-07-21).

## Evidence

- **The recorded data is fine.** Feeding a real session's stored events to `rrweb.Replayer` — or to rrweb-player **2.1.1** — renders the page correctly.
- **The bundled 2.1.0 player is the failure point.** The same events, passed to a fresh `new rrwebPlayer({ ... })` with the exact props from `web/src/components/session-replay/SessionReplayPlayer.tsx`, produce the blank frame.
- **Broken-build signature:** the strings `new Replayer` and `insertStyleRules` are absent from `rrweb-player@2.1.0`'s `dist/rrweb-player.umd.cjs`; both are present in `2.1.1`.

## Change

- `web/package.json`: `rrweb-player` `^2.1.0` → `^2.1.1`.
- `web/bun.lock`: bumped the rrweb-family subtree that this pulls in — `rrweb-player`, `@rrweb/replay`, `@rrweb/packer`, `@rrweb/types`, `@rrweb/utils`, `rrweb`, `rrdom`, `rrweb-snapshot` — from `2.1.0` to `2.1.1`. The whole family releases in lockstep, so the dependency-tree shape is unchanged (only internal `^2.1.0` ranges move to `^2.1.1`); the integrities are the published npm hashes. Diff is exactly 9 lines.

No console/app code changes are needed — `SessionReplayPlayer.tsx` works unchanged once the player is fixed, and existing recorded sessions replay retroactively.

> Note on the lockfile: it was updated directly to the published 2.1.1 metadata rather than via `bun install` (no bun in my environment). If you'd prefer a tool-regenerated `bun.lock`, a quick `bun install` on this branch will produce an identical result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
