### PR TITLE
fix(web): stop analytics/errors setup-redirect from breaking project tour

### DIFF
--- a/web/src/components/project/ProjectAnalytics.tsx
+++ b/web/src/components/project/ProjectAnalytics.tsx
@@ -33,6 +33,7 @@ import { SessionReplays } from '@/components/analytics/SessionReplays'
 import { FunnelDetail } from '@/components/funnel/FunnelDetail'
 import { FunnelManagement } from '@/components/funnel/FunnelManagement'
 import { LiveVisitors } from '@/pages/LiveVisitors'
+import { useProjectTourActive } from '@/components/project/ProjectTour'
 import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
 import {
@@ -1582,7 +1583,9 @@ function ProjectAnalyticsOverview({ project }: ProjectAnalyticsOverviewProps) {
     number | undefined
   >(undefined)
   const [isRefreshing, setIsRefreshing] = React.useState(false)
-  const [showSetupOverride] = React.useState(false)
+  // While the guided tour is showing off this page, don't yank the user to
+  // /setup — the empty-state banner below already covers "no data yet".
+  const showSetupOverride = useProjectTourActive()
   const [insightsOpen, setInsightsOpen] = useInsightsOpen()
   const queryClient = useQueryClient()
   const { startDate, endDate } = getDateRangeFromFilter(dateFilter)

--- a/web/src/components/project/ProjectTour.tsx
+++ b/web/src/components/project/ProjectTour.tsx
@@ -1,7 +1,13 @@
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { Sparkles, X } from 'lucide-react'
-import { type CSSProperties, useCallback, useEffect, useState } from 'react'
+import {
+  type CSSProperties,
+  useCallback,
+  useEffect,
+  useState,
+  useSyncExternalStore,
+} from 'react'
 import { createPortal } from 'react-dom'
 import { useNavigate, useParams } from 'react-router-dom'
 
@@ -16,6 +22,29 @@ import { useNavigate, useParams } from 'react-router-dom'
 
 const SEEN_KEY = 'temps.project-tour.v1'
 export const PROJECT_TOUR_EVENT = 'temps:project-tour'
+
+// Shared active-state so pages the tour visits (analytics, errors) can skip
+// their own "no data yet, redirect to setup" logic while the tour is
+// showing them off — otherwise the tour lands on a page that immediately
+// navigates itself away to a /setup route the tour never asked for.
+let tourActive = false
+const tourActiveListeners = new Set<() => void>()
+function setTourActive(value: boolean) {
+  tourActive = value
+  for (const listener of tourActiveListeners) listener()
+}
+export function isProjectTourActive() {
+  return tourActive
+}
+export function useProjectTourActive() {
+  return useSyncExternalStore(
+    (listener) => {
+      tourActiveListeners.add(listener)
+      return () => tourActiveListeners.delete(listener)
+    },
+    () => tourActive
+  )
+}
 
 interface TourStep {
   route: string
@@ -76,10 +105,12 @@ export function ProjectTour() {
   const start = useCallback(() => {
     setIdx(0)
     setActive(true)
+    setTourActive(true)
   }, [])
 
   const finish = useCallback(() => {
     setActive(false)
+    setTourActive(false)
     try {
       window.localStorage.setItem(SEEN_KEY, '1')
     } catch {

--- a/web/src/components/projects/ErrorTracking.tsx
+++ b/web/src/components/projects/ErrorTracking.tsx
@@ -8,6 +8,7 @@ import {
   listDsnsOptions,
 } from '@/api/client/@tanstack/react-query.gen'
 import { ErrorTimeSeriesChart } from '@/components/error-tracking/ErrorTimeSeriesChart'
+import { useProjectTourActive } from '@/components/project/ProjectTour'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -209,14 +210,18 @@ export function ErrorTracking({ project }: ErrorTrackingProps) {
   })
 
   // When the project has never received any errors, route to the onboarding
-  // wizard (mirrors analytics empty-state behavior).
+  // wizard (mirrors analytics empty-state behavior). Skip while the guided
+  // tour is showing off this page — it should render its own empty state
+  // rather than get bounced to /setup out from under the tour.
+  const isTourActive = useProjectTourActive()
   useEffect(() => {
-    if (isCheckingErrors) return
+    if (isCheckingErrors || isTourActive) return
     if (!hasErrorGroupsData?.has_error_groups) {
       navigate(`/projects/${project.slug}/errors/setup`, { replace: true })
     }
   }, [
     isCheckingErrors,
+    isTourActive,
     hasErrorGroupsData?.has_error_groups,
     navigate,
     project.slug,


### PR DESCRIPTION
## Summary
- The guided project tour navigates to `/analytics` and `/errors` to show them off, but both pages auto-redirect to their `/setup` wizard whenever the project has no data yet — which is always true for a brand-new project, i.e. exactly when the tour runs. This desyncs the tour's step tracking from the actual URL, which reads as an infinite loop.
- Added a small shared "is the tour active" store/hook in `ProjectTour.tsx` and wired it into `ProjectAnalytics.tsx`'s previously-dead `showSetupOverride` and `ErrorTracking.tsx`'s setup-redirect effect, so both skip the auto-redirect while the tour is active. Both pages already render an inline empty-state banner for the no-data case, so nothing is left blank.
- Verified the other tour stops (Traces, Metrics, Runtime logs) have no similar auto-redirect logic — only Analytics and Errors had this pattern.

## Test plan
- [x] `bunx tsc --noEmit` clean on touched files
- [x] `bunx eslint` clean on touched files (pre-existing unrelated warnings only)
- [ ] Manually run the tour on a fresh project and confirm it lands on `/analytics` and `/errors` without bouncing to `/setup`