### PR TITLE
feat(sandbox): track agent-run sandboxes as first-class sandbox items

### DIFF
--- a/crates/temps-agents/src/handlers/autofixer.rs
+++ b/crates/temps-agents/src/handlers/autofixer.rs
@@ -365,6 +365,7 @@ pub async fn start_analysis(
             request.user_context,
             requested_provider,
             run_config,
+            Some(auth.user_id()),
         )
         .await
         .map_err(Problem::from)?;
@@ -947,6 +948,7 @@ mod tests {
             prompt_text: None,
             workspace_volume: None,
             run_config: None,
+            triggered_by_user_id: None,
         }
     }
 

--- a/crates/temps-agents/src/handlers/trigger.rs
+++ b/crates/temps-agents/src/handlers/trigger.rs
@@ -783,6 +783,7 @@ pub async fn smoke_test_agent(
         let image = format!("temps-sandbox-{}:latest", global_sandbox.runtime);
         let sandbox_config = crate::sandbox::SandboxCreateConfig {
             run_id: test_run_id,
+            owner_user_id: Some(auth.user_id()),
             container_name_override: None,
             host_work_dir: work_dir.clone(),
             workspace_volume: None,

--- a/crates/temps-agents/src/plugin.rs
+++ b/crates/temps-agents/src/plugin.rs
@@ -545,6 +545,10 @@ impl TempsPlugin for AgentsPlugin {
             context.register_service(sandbox_provider.clone());
 
             let sandbox_registry = Arc::new(SandboxRegistry::new(sandbox_provider));
+            // Registered so the temps-sandbox plugin can inject its managed
+            // run-sandbox service (agent runs then get first-class
+            // `sandboxes` rows in the standalone sandbox API).
+            context.register_service(sandbox_registry.clone());
 
             let config_service = Arc::new(AgentConfigService::new(
                 db.clone(),

--- a/crates/temps-agents/src/sandbox/docker.rs
+++ b/crates/temps-agents/src/sandbox/docker.rs
@@ -2758,6 +2758,7 @@ mod tests {
 
         // 1. Create sandbox
         let create_config = SandboxCreateConfig {
+            owner_user_id: None,
             run_id,
             container_name_override: None,
             host_work_dir: work_dir.clone(),
@@ -3104,6 +3105,7 @@ mod tests {
         let _ = std::fs::create_dir_all(&work_dir);
 
         let create_config = SandboxCreateConfig {
+            owner_user_id: None,
             run_id,
             container_name_override: None,
             host_work_dir: work_dir.clone(),
@@ -3325,6 +3327,7 @@ mod tests {
         let _ = std::fs::create_dir_all(&work_dir);
 
         let create_config = SandboxCreateConfig {
+            owner_user_id: None,
             run_id,
             container_name_override: Some(label.to_string()),
             host_work_dir: work_dir.clone(),

--- a/crates/temps-agents/src/sandbox/firecracker.rs
+++ b/crates/temps-agents/src/sandbox/firecracker.rs
@@ -1322,6 +1322,7 @@ mod tests {
     fn resolve_name_prefers_override() {
         let p = provider();
         let mut config = SandboxCreateConfig {
+            owner_user_id: None,
             run_id: 7,
             container_name_override: Some("abc123".to_string()),
             host_work_dir: PathBuf::from("/tmp"),

--- a/crates/temps-agents/src/sandbox/local.rs
+++ b/crates/temps-agents/src/sandbox/local.rs
@@ -296,6 +296,7 @@ mod tests {
 
     fn test_config(run_id: i32, work_dir: PathBuf) -> SandboxCreateConfig {
         SandboxCreateConfig {
+            owner_user_id: None,
             run_id,
             container_name_override: None,
             host_work_dir: work_dir,

--- a/crates/temps-agents/src/sandbox/managed.rs
+++ b/crates/temps-agents/src/sandbox/managed.rs
@@ -1,0 +1,39 @@
+//! Seam that lets agent runs create their sandboxes through the standalone
+//! sandbox service (`temps-sandbox`) instead of the raw [`SandboxProvider`].
+//!
+//! `temps-sandbox` depends on this crate for the provider trait, so agent
+//! code cannot call `SandboxService` at compile time. Instead, the sandbox
+//! plugin implements [`RunSandboxService`] and injects it into the
+//! [`SandboxRegistry`](crate::services::sandbox_registry::SandboxRegistry)
+//! during plugin initialization. When present, every agent-run sandbox gets
+//! a first-class `sandboxes` row (visible in the sandbox API, with lifecycle
+//! events); when absent (e.g. the sandbox plugin is disabled), the registry
+//! falls back to the raw provider exactly as before.
+
+use async_trait::async_trait;
+
+use super::{SandboxCreateConfig, SandboxHandle};
+use crate::error::AgentError;
+
+/// Managed creation/teardown of agent-run sandboxes, implemented by the
+/// standalone sandbox service. All container work still goes through the
+/// shared `SandboxProvider`; this trait only adds the DB row + event
+/// bookkeeping around it.
+#[async_trait]
+pub trait RunSandboxService: Send + Sync {
+    /// Create a sandbox for an agent run: insert a `sandboxes` row linked
+    /// via `agent_run_id`, then create the container through the provider.
+    async fn create_for_run(
+        &self,
+        config: SandboxCreateConfig,
+    ) -> Result<SandboxHandle, AgentError>;
+
+    /// Destroy the container for a run's sandbox and mark its row destroyed.
+    /// `handle` is the registry's cached handle when it has one; when `None`
+    /// the implementation recovers the container by run id.
+    async fn release_for_run(
+        &self,
+        run_id: i32,
+        handle: Option<&SandboxHandle>,
+    ) -> Result<(), AgentError>;
+}

--- a/crates/temps-agents/src/sandbox/mod.rs
+++ b/crates/temps-agents/src/sandbox/mod.rs
@@ -2,6 +2,7 @@ pub mod docker;
 pub mod firecracker;
 pub mod git_credential_bundle;
 pub mod local;
+pub mod managed;
 pub mod pty_agent_bundle;
 pub mod routing;
 pub mod user;
@@ -170,6 +171,11 @@ pub struct SandboxCreateConfig {
     /// default. Only meaningful when the registered provider is the
     /// routing provider; single-backend hosts ignore it.
     pub backend: Option<SandboxBackend>,
+    /// User to attribute the sandbox to in the standalone sandbox API
+    /// (`sandboxes.user_id`). Only read by the managed run-sandbox path
+    /// ([`managed::RunSandboxService`]); providers ignore it. `None` for
+    /// webhook-triggered runs with no acting user.
+    pub owner_user_id: Option<i32>,
 }
 
 /// A cached rootfs image (Firecracker backend). Digest-keyed build artifact

--- a/crates/temps-agents/src/services/autofixer.rs
+++ b/crates/temps-agents/src/services/autofixer.rs
@@ -1578,6 +1578,7 @@ mod tests {
             prompt_text: None,
             workspace_volume: None,
             run_config: None,
+            triggered_by_user_id: None,
         }
     }
 

--- a/crates/temps-agents/src/services/executor.rs
+++ b/crates/temps-agents/src/services/executor.rs
@@ -562,8 +562,18 @@ impl AgentExecutor {
             tracing::warn!("Run {}: failed to persist workspace_volume: {}", run_id, e);
         }
 
+        // Attribute the sandbox to the user who triggered the run (if any)
+        // so it shows under their sandboxes in the standalone sandbox API.
+        let owner_user_id = self
+            .run_service
+            .get_run(run_id)
+            .await
+            .ok()
+            .and_then(|r| r.triggered_by_user_id);
+
         let sandbox_config = SandboxCreateConfig {
             run_id,
+            owner_user_id,
             container_name_override: None,
             host_work_dir: host_work_dir.clone(),
             workspace_volume: Some(workspace_volume),
@@ -4058,6 +4068,7 @@ mod tests {
             prompt_text: None,
             workspace_volume: None,
             run_config: None,
+            triggered_by_user_id: None,
         }
     }
 

--- a/crates/temps-agents/src/services/run_service.rs
+++ b/crates/temps-agents/src/services/run_service.rs
@@ -109,11 +109,13 @@ impl AgentRunService {
         user_context: Option<String>,
         ai_provider: Option<String>,
         run_config: Option<serde_json::Value>,
+        triggered_by_user_id: Option<i32>,
     ) -> Result<agent_runs::Model, AgentError> {
         let active = agent_runs::ActiveModel {
             project_id: Set(project_id),
             config_id: Set(None),
             agent_id: Set(None),
+            triggered_by_user_id: Set(triggered_by_user_id),
             trigger_type: Set("autofixer".to_string()),
             trigger_source_type: Set(Some("error_group".to_string())),
             trigger_source_id: Set(Some(error_group_id)),
@@ -640,6 +642,7 @@ mod tests {
             prompt_text: None,
             workspace_volume: None,
             run_config: None,
+            triggered_by_user_id: None,
         }
     }
 

--- a/crates/temps-agents/src/services/run_service.rs
+++ b/crates/temps-agents/src/services/run_service.rs
@@ -9,6 +9,24 @@ use temps_entities::{agent_run_logs, agent_runs};
 
 use crate::error::AgentError;
 
+/// Non-terminal run statuses: a run in one of these states is in-flight.
+/// Used for concurrency counting and restart recovery.
+pub const ACTIVE_RUN_STATUSES: &[&str] = &[
+    "pending",
+    "cloning",
+    "analyzing",
+    "fixing",
+    "pushing",
+    "creating_pr",
+    "deploying",
+];
+
+/// Terminal run statuses: once a run reaches one of these it never
+/// transitions again. Consumers outside this crate (e.g. the sandbox
+/// plugin's orphaned agent-run sandbox cleanup) rely on this to decide
+/// when resources attributed to a run can safely be released.
+pub const TERMINAL_RUN_STATUSES: &[&str] = &["completed", "failed", "no_fix", "cancelled"];
+
 /// Fields that can be updated when changing a run's status.
 #[derive(Default)]
 pub struct UpdateRunFields {
@@ -497,19 +515,17 @@ impl AgentRunService {
 
     /// Recover stuck runs after server restart.
     /// Marks all runs in active (non-terminal) states as failed.
+    ///
+    /// Note on sandboxes: this runs during the plugin *register* phase,
+    /// before the temps-sandbox plugin has injected its managed
+    /// `RunSandboxService` seam, so the runs' `sandboxes` rows (and their
+    /// containers) cannot be released from here. The sandbox plugin's
+    /// `initialize_plugin_services` calls
+    /// `SandboxService::release_orphaned_agent_run_sandboxes` afterwards,
+    /// which releases every sandbox attributed to a now-terminal run.
     pub async fn recover_stuck_runs(&self) -> Result<u64, AgentError> {
-        let active_statuses = vec![
-            "pending",
-            "cloning",
-            "analyzing",
-            "fixing",
-            "pushing",
-            "creating_pr",
-            "deploying",
-        ];
-
         let stuck_runs = agent_runs::Entity::find()
-            .filter(agent_runs::Column::Status.is_in(active_statuses))
+            .filter(agent_runs::Column::Status.is_in(ACTIVE_RUN_STATUSES.iter().copied()))
             .all(self.db.as_ref())
             .await
             .map_err(AgentError::Database)?;
@@ -535,8 +551,7 @@ impl AgentRunService {
     pub async fn cancel_run(&self, run_id: i32) -> Result<agent_runs::Model, AgentError> {
         let run = self.get_run(run_id).await?;
 
-        let terminal = ["completed", "failed", "no_fix", "cancelled"];
-        if terminal.contains(&run.status.as_str()) {
+        if TERMINAL_RUN_STATUSES.contains(&run.status.as_str()) {
             return Err(AgentError::Validation {
                 message: format!(
                     "Run {} is already in terminal state '{}'",
@@ -558,19 +573,9 @@ impl AgentRunService {
 
     /// Count runs in active (non-terminal) states for a project.
     pub async fn count_active_runs(&self, project_id: i32) -> Result<u64, AgentError> {
-        let active_statuses = vec![
-            "pending",
-            "cloning",
-            "analyzing",
-            "fixing",
-            "pushing",
-            "creating_pr",
-            "deploying",
-        ];
-
         let count = agent_runs::Entity::find()
             .filter(agent_runs::Column::ProjectId.eq(project_id))
-            .filter(agent_runs::Column::Status.is_in(active_statuses))
+            .filter(agent_runs::Column::Status.is_in(ACTIVE_RUN_STATUSES.iter().copied()))
             .count(self.db.as_ref())
             .await
             .map_err(AgentError::Database)?;
@@ -851,6 +856,25 @@ mod tests {
             );
         }
         assert_eq!(expected.len(), 7, "Expected exactly 7 active statuses");
+    }
+
+    #[test]
+    fn active_and_terminal_status_sets_are_disjoint_and_complete() {
+        // Every status a run can hold is either active or terminal —
+        // consumers (recover_stuck_runs, count_active_runs, and the
+        // sandbox plugin's orphan cleanup) rely on these two sets
+        // partitioning the lifecycle with no overlap.
+        for s in ACTIVE_RUN_STATUSES {
+            assert!(
+                !TERMINAL_RUN_STATUSES.contains(s),
+                "status '{}' cannot be both active and terminal",
+                s
+            );
+        }
+        assert_eq!(ACTIVE_RUN_STATUSES.len(), 7);
+        assert_eq!(TERMINAL_RUN_STATUSES.len(), 4);
+        assert!(TERMINAL_RUN_STATUSES.contains(&"failed"));
+        assert!(TERMINAL_RUN_STATUSES.contains(&"cancelled"));
     }
 
     #[tokio::test]

--- a/crates/temps-agents/src/services/sandbox_registry.rs
+++ b/crates/temps-agents/src/services/sandbox_registry.rs
@@ -4,6 +4,7 @@ use tokio::sync::RwLock;
 
 use crate::ai_cli::OnEventCallback;
 use crate::error::AgentError;
+use crate::sandbox::managed::RunSandboxService;
 use crate::sandbox::{SandboxCreateConfig, SandboxExecResult, SandboxHandle, SandboxProvider};
 
 /// Registry that maps run IDs to active sandbox handles. This is critical for
@@ -12,6 +13,11 @@ use crate::sandbox::{SandboxCreateConfig, SandboxExecResult, SandboxHandle, Sand
 pub struct SandboxRegistry {
     provider: Arc<dyn SandboxProvider>,
     sandboxes: RwLock<HashMap<i32, SandboxHandle>>,
+    /// When the standalone sandbox plugin is active it injects itself here
+    /// (see `sandbox::managed`) so every agent-run sandbox is created as a
+    /// first-class `sandboxes` row instead of a bare container. Set once
+    /// during plugin initialization; `None` = raw-provider fallback.
+    managed: std::sync::OnceLock<Arc<dyn RunSandboxService>>,
 }
 
 impl SandboxRegistry {
@@ -19,6 +25,15 @@ impl SandboxRegistry {
         Self {
             provider,
             sandboxes: RwLock::new(HashMap::new()),
+            managed: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// Inject the managed run-sandbox service (called by the temps-sandbox
+    /// plugin at initialization). Subsequent calls are ignored.
+    pub fn set_managed(&self, managed: Arc<dyn RunSandboxService>) {
+        if self.managed.set(managed).is_err() {
+            tracing::warn!("SandboxRegistry: managed run-sandbox service already set — ignoring");
         }
     }
 
@@ -70,8 +85,13 @@ impl SandboxRegistry {
             return Ok(recovered);
         }
 
-        // Create a new sandbox
-        let handle = self.provider.create(config).await?;
+        // Create a new sandbox — through the standalone sandbox service
+        // when it's registered (gives the run a first-class `sandboxes`
+        // row in the API), otherwise straight through the provider.
+        let handle = match self.managed.get() {
+            Some(managed) => managed.create_for_run(config).await?,
+            None => self.provider.create(config).await?,
+        };
         let mut sandboxes = self.sandboxes.write().await;
         sandboxes.insert(run_id, handle.clone());
 
@@ -145,7 +165,17 @@ impl SandboxRegistry {
             sandboxes.remove(&run_id)
         };
 
-        if let Some(handle) = handle {
+        if let Some(managed) = self.managed.get() {
+            // Managed path: destroys the container AND marks the run's
+            // `sandboxes` row destroyed (with a lifecycle event).
+            if let Err(e) = managed.release_for_run(run_id, handle.as_ref()).await {
+                tracing::warn!(
+                    "Failed to release managed sandbox for run {}: {}",
+                    run_id,
+                    e
+                );
+            }
+        } else if let Some(handle) = handle {
             // Agent runs are ephemeral — purge the home volume too.
             if let Err(e) = self.provider.destroy(&handle, true).await {
                 tracing::warn!(
@@ -210,6 +240,7 @@ mod tests {
     fn test_config(run_id: i32) -> SandboxCreateConfig {
         let work_dir = std::env::temp_dir().join(format!("test-registry-{}", run_id));
         SandboxCreateConfig {
+            owner_user_id: None,
             run_id,
             container_name_override: None,
             host_work_dir: work_dir,

--- a/crates/temps-agents/tests/firecracker_e2e.rs
+++ b/crates/temps-agents/tests/firecracker_e2e.rs
@@ -32,6 +32,7 @@ fn gated() -> Option<PathBuf> {
 
 fn create_config(run_id: i32) -> SandboxCreateConfig {
     SandboxCreateConfig {
+        owner_user_id: None,
         run_id,
         container_name_override: Some(format!("e2e{}", run_id)),
         host_work_dir: PathBuf::from("/tmp"),

--- a/crates/temps-cli/src/lib.rs
+++ b/crates/temps-cli/src/lib.rs
@@ -174,6 +174,7 @@ pub fn install_tracing_extra(log_level: &str, log_format: &str, extra: &str) {
              temps_ai_chat={level},\
              temps_ai_api_tools={level},\
              temps_agents={level},\
+             temps_sandbox={level},\
              pingora=warn,\
              sqlx=warn,\
              sea_orm=warn,\

--- a/crates/temps-entities/src/agent_runs.rs
+++ b/crates/temps-entities/src/agent_runs.rs
@@ -72,6 +72,11 @@ pub struct Model {
     /// Null for historical rows and generic agent runs.
     #[sea_orm(column_type = "JsonBinary", nullable)]
     pub run_config: Option<Json>,
+    /// Authenticated user who started this run (e.g. clicked "Analyze" in
+    /// the autofixer UI). Used to attribute the run's sandbox row so it
+    /// appears in that user's sandbox list. NULL for webhook-triggered
+    /// runs and historical rows.
+    pub triggered_by_user_id: Option<i32>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/temps-entities/src/sandboxes.rs
+++ b/crates/temps-entities/src/sandboxes.rs
@@ -22,7 +22,15 @@ pub struct Model {
 
     /// Owner of the sandbox. All sandbox operations require the
     /// authenticated user to match this column (or have admin override).
-    pub user_id: i32,
+    /// `None` for agent-run sandboxes with no attributable user (e.g. a
+    /// workflow run triggered by a git webhook).
+    pub user_id: Option<i32>,
+
+    /// When set, this sandbox executes the linked `agent_runs` row
+    /// (autofixer / workflow agent). Its lifecycle is owned by the agent
+    /// run — the expiration sweeper skips these rows. NULL for standalone
+    /// API sandboxes.
+    pub agent_run_id: Option<i32>,
 
     /// Container name used by the sandbox provider.
     pub name: String,

--- a/crates/temps-migrations/src/migration/m20260725_000001_sandboxes_agent_run_link.rs
+++ b/crates/temps-migrations/src/migration/m20260725_000001_sandboxes_agent_run_link.rs
@@ -1,0 +1,60 @@
+//! Make agent-run sandboxes first-class `sandboxes` rows.
+//!
+//! Agent runs (autofixer, workflow agents) historically created their
+//! containers through the raw `SandboxProvider` without a `sandboxes` row,
+//! so they were invisible to the standalone sandbox API. This migration:
+//!
+//! - `sandboxes.user_id` becomes nullable: agent-run sandboxes triggered
+//!   by webhooks have no owning user.
+//! - `sandboxes.agent_run_id` (nullable, indexed): links a sandbox row to
+//!   the `agent_runs` row it executes. NULL for standalone API sandboxes.
+//! - `agent_runs.triggered_by_user_id` (nullable): the authenticated user
+//!   who started the run (e.g. clicked "Analyze" in the autofixer UI), so
+//!   the resulting sandbox can be attributed to them in the sandbox list.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        conn.execute_unprepared("ALTER TABLE sandboxes ALTER COLUMN user_id DROP NOT NULL")
+            .await?;
+        conn.execute_unprepared(
+            "ALTER TABLE sandboxes ADD COLUMN IF NOT EXISTS agent_run_id INTEGER",
+        )
+        .await?;
+        conn.execute_unprepared(
+            "CREATE INDEX IF NOT EXISTS idx_sandboxes_agent_run_id ON sandboxes (agent_run_id) WHERE agent_run_id IS NOT NULL",
+        )
+        .await?;
+        conn.execute_unprepared(
+            "ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS triggered_by_user_id INTEGER",
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        conn.execute_unprepared(
+            "ALTER TABLE agent_runs DROP COLUMN IF EXISTS triggered_by_user_id",
+        )
+        .await?;
+        conn.execute_unprepared("DROP INDEX IF EXISTS idx_sandboxes_agent_run_id")
+            .await?;
+        conn.execute_unprepared("ALTER TABLE sandboxes DROP COLUMN IF EXISTS agent_run_id")
+            .await?;
+        // Backfill NULL owners before restoring NOT NULL is impossible in a
+        // generic down; delete orphaned agent rows instead (they only exist
+        // when the up migration's feature was in use).
+        conn.execute_unprepared("DELETE FROM sandboxes WHERE user_id IS NULL")
+            .await?;
+        conn.execute_unprepared("ALTER TABLE sandboxes ALTER COLUMN user_id SET NOT NULL")
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -162,6 +162,7 @@ mod m20260722_000001_create_source_files;
 mod m20260722_000002_add_source_context_enabled_to_projects;
 mod m20260723_000001_add_error_source_root_to_projects;
 mod m20260724_000001_add_run_config_to_agent_runs;
+mod m20260725_000001_sandboxes_agent_run_link;
 
 pub struct Migrator;
 
@@ -329,6 +330,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260722_000002_add_source_context_enabled_to_projects::Migration),
             Box::new(m20260723_000001_add_error_source_root_to_projects::Migration),
             Box::new(m20260724_000001_add_run_config_to_agent_runs::Migration),
+            Box::new(m20260725_000001_sandboxes_agent_run_link::Migration),
         ]
     }
 }

--- a/crates/temps-proxy/src/preview_auth.rs
+++ b/crates/temps-proxy/src/preview_auth.rs
@@ -970,7 +970,8 @@ mod tests {
         sandboxes::Model {
             id: 1,
             public_id: public_id.to_string(),
-            user_id: 1,
+            user_id: Some(1),
+            agent_run_id: None,
             name: "test-sandbox".to_string(),
             status: status.to_string(),
             image: Some("ubuntu:22.04".to_string()),

--- a/crates/temps-sandbox/src/error.rs
+++ b/crates/temps-sandbox/src/error.rs
@@ -56,6 +56,18 @@ pub enum SandboxError {
         operation: String,
     },
 
+    /// The sandbox row is attributed to an agent run (`agent_run_id` is
+    /// set). Its container is named `temps-sandbox-<run_id>` — not by the
+    /// row's public id — and the run owns the lifecycle, so standalone
+    /// lifecycle ops (pause/resume/restart/resize, and destroy while the
+    /// run is active) must not act on it: the registry would miss the real
+    /// container and the DB row would drift from reality. Mapped to
+    /// HTTP 409 telling the user to stop/cancel the run instead.
+    #[error(
+        "Sandbox {sandbox_id} belongs to agent run {run_id} and its lifecycle is managed by that run — stop or cancel agent run {run_id} instead"
+    )]
+    ManagedByAgentRun { sandbox_id: String, run_id: i32 },
+
     /// An operation exceeded the per-sandbox timeout.
     #[error("Operation timed out in sandbox {sandbox_id} after {timeout_secs}s")]
     Timeout {
@@ -151,6 +163,19 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("stopped"));
         assert!(msg.contains("exec"));
+    }
+
+    #[test]
+    fn managed_by_agent_run_names_sandbox_and_run() {
+        let err = SandboxError::ManagedByAgentRun {
+            sandbox_id: "sbx_abc".into(),
+            run_id: 42,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("sbx_abc"), "msg: {}", msg);
+        assert!(msg.contains("42"), "msg: {}", msg);
+        // The whole point of this variant: tell the user what to do instead.
+        assert!(msg.contains("stop or cancel"), "msg: {}", msg);
     }
 
     #[test]

--- a/crates/temps-sandbox/src/handlers/sandboxes.rs
+++ b/crates/temps-sandbox/src/handlers/sandboxes.rs
@@ -511,6 +511,10 @@ pub struct SandboxInner {
     pub preview_url_template: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preview_password_hint: Option<String>,
+    /// Agent run this sandbox executes (autofixer / workflow agent).
+    /// `None` for sandboxes created via this API.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_run_id: Option<i32>,
 }
 
 /// `@vercel/sandbox` wraps every single-sandbox response as
@@ -568,6 +572,7 @@ impl SandboxResponse {
                 disk_size_mb: s.disk_size_mb,
                 preview_url_template: template,
                 preview_password_hint: s.preview_password_hint,
+                agent_run_id: s.agent_run_id,
             },
             routes,
         }
@@ -2478,6 +2483,7 @@ mod tests {
             ports: vec![],
             backend: None,
             disk_size_mb: None,
+            agent_run_id: None,
         };
         let r = SandboxResponse::from(summary);
         assert_eq!(r.sandbox.id, "sbx_abc");
@@ -2504,6 +2510,7 @@ mod tests {
             ports: vec![3000, 5173],
             backend: None,
             disk_size_mb: None,
+            agent_run_id: None,
         };
         let parts = PreviewUrlParts {
             protocol: "https".into(),

--- a/crates/temps-sandbox/src/handlers/sandboxes.rs
+++ b/crates/temps-sandbox/src/handlers/sandboxes.rs
@@ -120,6 +120,9 @@ impl From<SandboxError> for Problem {
             SandboxError::InvalidState { .. } => problemdetails::new(StatusCode::CONFLICT)
                 .with_title("Invalid Sandbox State")
                 .with_detail(error.to_string()),
+            SandboxError::ManagedByAgentRun { .. } => problemdetails::new(StatusCode::CONFLICT)
+                .with_title("Sandbox Managed By Agent Run")
+                .with_detail(error.to_string()),
             SandboxError::Timeout { .. } => problemdetails::new(StatusCode::GATEWAY_TIMEOUT)
                 .with_title("Sandbox Operation Timed Out")
                 .with_detail(error.to_string()),
@@ -1075,7 +1078,8 @@ pub async fn get_sandbox(
     path = "/v1/sandboxes/{id}/stop",
     responses(
         (status = 204, description = "Sandbox stopped and destroyed"),
-        (status = 404, description = "Not found")
+        (status = 404, description = "Not found"),
+        (status = 409, description = "Sandbox belongs to an active agent run — stop the run instead")
     ),
     security(("bearer_auth" = []))
 )]
@@ -1098,7 +1102,8 @@ pub async fn stop_sandbox(
     path = "/v1/sandboxes/{id}/destroy",
     responses(
         (status = 204, description = "Sandbox destroyed (alias for `/stop` with an explicit verb)"),
-        (status = 404, description = "Not found")
+        (status = 404, description = "Not found"),
+        (status = 409, description = "Sandbox belongs to an active agent run — stop the run instead")
     ),
     security(("bearer_auth" = []))
 )]

--- a/crates/temps-sandbox/src/plugin.rs
+++ b/crates/temps-sandbox/src/plugin.rs
@@ -143,6 +143,27 @@ impl TempsPlugin for SandboxPlugin {
             };
             let db = context.require_service::<sea_orm::DatabaseConnection>();
 
+            // Inject this plugin's service into the agents' sandbox registry
+            // so agent runs (autofixer, workflow agents) create first-class
+            // `sandboxes` rows instead of untracked containers.
+            match (
+                context.get_service::<temps_agents::services::sandbox_registry::SandboxRegistry>(),
+                context.get_service::<SandboxService>(),
+            ) {
+                (Some(agent_registry), Some(service)) => {
+                    agent_registry.set_managed(Arc::new(
+                        crate::services::agent_run_bridge::AgentRunSandboxBridge::new(service),
+                    ));
+                    info!("Sandbox plugin: agent-run sandboxes now tracked in the sandbox API");
+                }
+                _ => {
+                    debug!(
+                        "Sandbox plugin: agents registry or sandbox service absent — \
+                         agent runs keep using the raw provider"
+                    );
+                }
+            }
+
             match sandboxes::Entity::find()
                 .filter(sandboxes::Column::Status.eq("running"))
                 .all(db.as_ref())
@@ -151,6 +172,10 @@ impl TempsPlugin for SandboxPlugin {
                 Ok(rows) => {
                     let entries: Vec<(i32, String)> = rows
                         .iter()
+                        // Agent-run sandboxes use `temps-sandbox-<run_id>`
+                        // container names and are recovered by the agents'
+                        // own registry — skip them here.
+                        .filter(|r| r.agent_run_id.is_none())
                         .map(|r| {
                             let label = r
                                 .public_id

--- a/crates/temps-sandbox/src/plugin.rs
+++ b/crates/temps-sandbox/src/plugin.rs
@@ -143,12 +143,14 @@ impl TempsPlugin for SandboxPlugin {
             };
             let db = context.require_service::<sea_orm::DatabaseConnection>();
 
+            let sandbox_service = context.get_service::<SandboxService>();
+
             // Inject this plugin's service into the agents' sandbox registry
             // so agent runs (autofixer, workflow agents) create first-class
             // `sandboxes` rows instead of untracked containers.
             match (
                 context.get_service::<temps_agents::services::sandbox_registry::SandboxRegistry>(),
-                context.get_service::<SandboxService>(),
+                sandbox_service.clone(),
             ) {
                 (Some(agent_registry), Some(service)) => {
                     agent_registry.set_managed(Arc::new(
@@ -196,6 +198,33 @@ impl TempsPlugin for SandboxPlugin {
                 }
                 Err(e) => {
                     warn!("Sandbox plugin: failed to list running sandboxes: {}", e);
+                }
+            }
+
+            // Agent-run counterpart of the recovery above: runs that were
+            // in flight when the server died were just marked failed by
+            // `AgentRunService::recover_stuck_runs` (register phase), but
+            // their `sandboxes` rows still say "running" — and both the
+            // scan above and the expiration sweeper skip agent-run rows by
+            // design. Release them (container destroy by run id + row flip)
+            // so a restart can't leave zombie rows or leaked containers.
+            match &sandbox_service {
+                Some(service) => match service.release_orphaned_agent_run_sandboxes().await {
+                    Ok(0) => {}
+                    Ok(n) => info!(
+                        "Sandbox plugin: released {} orphaned agent-run sandbox(es) on startup",
+                        n
+                    ),
+                    Err(e) => warn!(
+                        "Sandbox plugin: failed to release orphaned agent-run sandboxes: {}",
+                        e
+                    ),
+                },
+                None => {
+                    warn!(
+                        "Sandbox plugin: sandbox service absent — skipping orphaned \
+                         agent-run sandbox cleanup"
+                    );
                 }
             }
 

--- a/crates/temps-sandbox/src/services/agent_run_bridge.rs
+++ b/crates/temps-sandbox/src/services/agent_run_bridge.rs
@@ -1,0 +1,63 @@
+//! Bridge that plugs [`SandboxService`] into the agents' sandbox registry.
+//!
+//! `temps-sandbox` depends on `temps-agents`, so agent code can't call this
+//! crate directly. Instead this adapter implements the
+//! [`RunSandboxService`](temps_agents::sandbox::managed::RunSandboxService)
+//! seam and is injected into the agents' `SandboxRegistry` during plugin
+//! initialization — from then on every agent-run sandbox is created as a
+//! first-class `sandboxes` row visible in the standalone sandbox API.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use temps_agents::error::AgentError;
+use temps_agents::sandbox::managed::RunSandboxService;
+use temps_agents::sandbox::{SandboxCreateConfig, SandboxHandle};
+
+use crate::error::SandboxError;
+use crate::services::sandbox_service::SandboxService;
+
+pub struct AgentRunSandboxBridge {
+    service: Arc<SandboxService>,
+}
+
+impl AgentRunSandboxBridge {
+    pub fn new(service: Arc<SandboxService>) -> Self {
+        Self { service }
+    }
+}
+
+/// Map the sandbox-service error back onto the agents' error type at the
+/// seam. Creation failures keep their full context in the reason string.
+fn to_agent_error(run_id: i32, e: SandboxError) -> AgentError {
+    AgentError::SandboxCreationFailed {
+        run_id,
+        provider: "standalone-sandbox-service".to_string(),
+        reason: e.to_string(),
+    }
+}
+
+#[async_trait]
+impl RunSandboxService for AgentRunSandboxBridge {
+    async fn create_for_run(
+        &self,
+        config: SandboxCreateConfig,
+    ) -> Result<SandboxHandle, AgentError> {
+        let run_id = config.run_id;
+        self.service
+            .create_for_agent_run(config)
+            .await
+            .map_err(|e| to_agent_error(run_id, e))
+    }
+
+    async fn release_for_run(
+        &self,
+        run_id: i32,
+        handle: Option<&SandboxHandle>,
+    ) -> Result<(), AgentError> {
+        self.service
+            .release_for_agent_run(run_id, handle)
+            .await
+            .map_err(|e| to_agent_error(run_id, e))
+    }
+}

--- a/crates/temps-sandbox/src/services/expiration_sweeper.rs
+++ b/crates/temps-sandbox/src/services/expiration_sweeper.rs
@@ -70,6 +70,10 @@ impl SandboxExpirationSweeper {
         let expired = sandboxes::Entity::find()
             .filter(sandboxes::Column::Status.eq("running"))
             .filter(sandboxes::Column::ExpiresAt.lt(now))
+            // Agent-run sandboxes are lifecycle-owned by the run itself
+            // (analysis → fix → PR can legitimately outlive any timeout
+            // while the user reviews between phases) — never sweep them.
+            .filter(sandboxes::Column::AgentRunId.is_null())
             .all(self.db.as_ref())
             .await?;
 
@@ -146,7 +150,8 @@ mod tests {
         sandboxes::Model {
             id,
             public_id: format!("sbx_test{:06x}", id),
-            user_id: 1,
+            user_id: Some(1),
+            agent_run_id: None,
             name: format!("sbx-{}", id),
             status: status.to_string(),
             image: None,

--- a/crates/temps-sandbox/src/services/mod.rs
+++ b/crates/temps-sandbox/src/services/mod.rs
@@ -1,6 +1,7 @@
 //! Service layer for the standalone sandbox API. All business logic lives
 //! here; HTTP handlers are thin wrappers that call into these services.
 
+pub mod agent_run_bridge;
 pub mod exec;
 pub mod expiration_sweeper;
 pub mod fs;

--- a/crates/temps-sandbox/src/services/sandbox_service.rs
+++ b/crates/temps-sandbox/src/services/sandbox_service.rs
@@ -22,8 +22,9 @@ use sea_orm::{
 };
 
 use temps_agents::sandbox::SandboxCreateConfig;
+use temps_agents::services::run_service::TERMINAL_RUN_STATUSES;
 use temps_config::ConfigService;
-use temps_entities::{sandbox_events, sandboxes};
+use temps_entities::{agent_runs, sandbox_events, sandboxes};
 use temps_git::GitProviderManager;
 
 use crate::error::{from_agent_error, SandboxError};
@@ -179,6 +180,32 @@ fn ports_from_metadata(metadata: Option<&serde_json::Value>) -> Vec<u16> {
         .unwrap_or_default()
 }
 
+/// Reject standalone lifecycle ops (`pause`/`resume`/`restart`/`resize`)
+/// on rows attributed to an agent run. Those containers are named
+/// `temps-sandbox-<run_id>` — not by the row's public id — so the
+/// standalone registry's name-based recovery would miss them and the DB
+/// row would drift from the real container state. The run owns the
+/// lifecycle; the user must act on the run instead.
+fn ensure_not_agent_run(row: &sandboxes::Model) -> Result<(), SandboxError> {
+    if let Some(run_id) = row.agent_run_id {
+        return Err(SandboxError::ManagedByAgentRun {
+            sandbox_id: row.public_id.clone(),
+            run_id,
+        });
+    }
+    Ok(())
+}
+
+/// Is the owning agent run finished (or gone)? `None` means the run row
+/// no longer exists — nothing owns the sandbox anymore, so treat it as
+/// terminal and let cleanup proceed. Shared by `destroy_sandbox`'s
+/// agent-run branch and `release_orphaned_agent_run_sandboxes`.
+fn run_status_is_terminal(status: Option<&str>) -> bool {
+    status
+        .map(|s| TERMINAL_RUN_STATUSES.contains(&s))
+        .unwrap_or(true)
+}
+
 /// Bounds on `timeout_secs` at the service layer. The upper bound
 /// protects against "sandbox leaks" where a caller creates sandboxes
 /// with absurd timeouts and relies on the server never cleaning up.
@@ -291,6 +318,72 @@ impl SandboxService {
     }
 
     // ── Agent-run sandboxes ──────────────────────────────────────────────
+
+    /// Release every non-destroyed sandbox row attributed to an agent run
+    /// that is already terminal (or whose run row no longer exists).
+    ///
+    /// Called by the plugin on startup, *after* the agents plugin's
+    /// `AgentRunService::recover_stuck_runs` (register phase) has failed
+    /// every run that was in flight when the server died. Without this,
+    /// those runs' `sandboxes` rows stay "running" forever: the standalone
+    /// recovery scan and the expiration sweeper both skip agent-run rows
+    /// by design, and the run itself will never call `release` again —
+    /// zombie row, possibly a leaked container.
+    ///
+    /// Per-run failures are logged and skipped so one bad row can't block
+    /// cleanup of the rest. Returns the number of runs whose sandboxes
+    /// were released.
+    pub async fn release_orphaned_agent_run_sandboxes(&self) -> Result<usize, SandboxError> {
+        let rows = sandboxes::Entity::find()
+            .filter(sandboxes::Column::AgentRunId.is_not_null())
+            .filter(sandboxes::Column::Status.ne("destroyed"))
+            .all(self.db.as_ref())
+            .await?;
+        if rows.is_empty() {
+            return Ok(0);
+        }
+
+        // One lookup for all runs (no per-row query), deduped: a run can
+        // in principle have several stale rows, and `release_for_agent_run`
+        // already sweeps every row for its run.
+        let mut run_ids: Vec<i32> = rows.iter().filter_map(|r| r.agent_run_id).collect();
+        run_ids.sort_unstable();
+        run_ids.dedup();
+        let runs = agent_runs::Entity::find()
+            .filter(agent_runs::Column::Id.is_in(run_ids.iter().copied()))
+            .all(self.db.as_ref())
+            .await?;
+        let status_by_run: HashMap<i32, String> =
+            runs.into_iter().map(|r| (r.id, r.status)).collect();
+
+        let mut released = 0usize;
+        for run_id in run_ids {
+            let terminal = run_status_is_terminal(status_by_run.get(&run_id).map(|s| s.as_str()));
+            if !terminal {
+                // Legitimately active run (e.g. re-triggered right after
+                // restart) — its sandbox is alive and owned; leave it.
+                continue;
+            }
+            match self.release_for_agent_run(run_id, None).await {
+                Ok(()) => released += 1,
+                Err(e) => {
+                    tracing::warn!(
+                        "orphaned agent-run sandbox cleanup: failed to release sandbox(es) \
+                         for terminal agent run {}: {}",
+                        run_id,
+                        e
+                    );
+                }
+            }
+        }
+        if released > 0 {
+            tracing::info!(
+                "Released sandboxes for {} terminal agent run(s) on startup",
+                released
+            );
+        }
+        Ok(released)
+    }
 
     /// Create a sandbox for an agent run (autofixer / workflow agent) as a
     /// first-class `sandboxes` row, then create the container through the
@@ -926,12 +1019,37 @@ TEMPS_ASKPASS_EOF\n\
     /// Stop + destroy a sandbox. Aborts any background jobs, asks the
     /// provider to tear down the container + volumes, and marks the
     /// DB row "destroyed".
+    ///
+    /// Agent-run sandboxes (`agent_run_id` set) are special-cased: their
+    /// container is named `temps-sandbox-<run_id>`, so the standalone
+    /// registry (which recovers by `public_id`) would miss it, flip the
+    /// row to "destroyed", and leave the real container running. While
+    /// the run is active we refuse with [`SandboxError::ManagedByAgentRun`]
+    /// (destroying the sandbox under a live run would break it); once the
+    /// run is terminal we route through `release_for_agent_run`, which
+    /// targets the container by run id.
     pub async fn destroy_sandbox(
         &self,
         public_id_value: &str,
         user_id: i32,
     ) -> Result<(), SandboxError> {
         let row = self.find_by_public_id(public_id_value, user_id).await?;
+
+        if let Some(run_id) = row.agent_run_id {
+            let run = agent_runs::Entity::find_by_id(run_id)
+                .one(self.db.as_ref())
+                .await?;
+            let terminal = run_status_is_terminal(run.as_ref().map(|r| r.status.as_str()));
+            if !terminal {
+                return Err(SandboxError::ManagedByAgentRun {
+                    sandbox_id: public_id_value.to_string(),
+                    run_id,
+                });
+            }
+            self.jobs.abort_all(row.id).await;
+            return self.release_for_agent_run(run_id, None).await;
+        }
+
         self.jobs.abort_all(row.id).await;
         if let Err(e) = self.registry.destroy(row.id, public_id_value).await {
             // Even if the container destroy failed, mark the row
@@ -958,6 +1076,7 @@ TEMPS_ASKPASS_EOF\n\
         user_id: i32,
     ) -> Result<sandboxes::Model, SandboxError> {
         let row = self.find_by_public_id(public_id_value, user_id).await?;
+        ensure_not_agent_run(&row)?;
         if row.status == "stopped" {
             return Ok(row);
         }
@@ -992,6 +1111,7 @@ TEMPS_ASKPASS_EOF\n\
         user_id: i32,
     ) -> Result<sandboxes::Model, SandboxError> {
         let row = self.find_by_public_id(public_id_value, user_id).await?;
+        ensure_not_agent_run(&row)?;
         if row.status == "running" {
             return Ok(row);
         }
@@ -1026,6 +1146,7 @@ TEMPS_ASKPASS_EOF\n\
         user_id: i32,
     ) -> Result<sandboxes::Model, SandboxError> {
         let row = self.find_by_public_id(public_id_value, user_id).await?;
+        ensure_not_agent_run(&row)?;
         if row.status != "running" {
             return Err(SandboxError::InvalidState {
                 sandbox_id: public_id_value.to_string(),
@@ -1068,6 +1189,7 @@ TEMPS_ASKPASS_EOF\n\
             });
         }
         let row = self.find_by_public_id(public_id_value, user_id).await?;
+        ensure_not_agent_run(&row)?;
         if row.backend.as_deref() != Some("firecracker") {
             return Err(SandboxError::Validation {
                 message: "disk resize is only supported on Firecracker sandboxes".into(),
@@ -1471,6 +1593,78 @@ mod tests {
         const _: () = assert!(MIN_TIMEOUT_SECS < DEFAULT_TIMEOUT_SECS);
         const _: () = assert!(DEFAULT_TIMEOUT_SECS < MAX_TIMEOUT_SECS);
         assert_eq!(MAX_TIMEOUT_SECS, 86400);
+    }
+
+    fn agent_run_row(run_id: Option<i32>) -> sandboxes::Model {
+        let now = Utc::now();
+        sandboxes::Model {
+            id: 7,
+            public_id: "sbx_deadbeef01234567".into(),
+            user_id: Some(1),
+            agent_run_id: run_id,
+            name: match run_id {
+                Some(id) => format!("temps-sandbox-{}", id),
+                None => "sbx-7".into(),
+            },
+            status: "running".into(),
+            image: None,
+            work_dir: "/workspace".into(),
+            timeout_secs: 3600,
+            metadata: None,
+            backend: None,
+            created_at: now,
+            last_activity_at: now,
+            expires_at: now,
+            preview_password_hash: None,
+            preview_password_hint: None,
+        }
+    }
+
+    /// Lifecycle ops on agent-run rows must be rejected with a typed
+    /// error naming both the sandbox and the run — pre-fix, pause/resume/
+    /// restart went through the standalone registry, missed the run's
+    /// `temps-sandbox-<run_id>` container, and let the DB row drift from
+    /// the real container state.
+    #[test]
+    fn ensure_not_agent_run_rejects_attributed_rows() {
+        let row = agent_run_row(Some(42));
+        let err = ensure_not_agent_run(&row).expect_err("agent-run row must be rejected");
+        match err {
+            SandboxError::ManagedByAgentRun { sandbox_id, run_id } => {
+                assert_eq!(sandbox_id, "sbx_deadbeef01234567");
+                assert_eq!(run_id, 42);
+            }
+            other => panic!("expected ManagedByAgentRun, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn ensure_not_agent_run_allows_standalone_rows() {
+        let row = agent_run_row(None);
+        assert!(ensure_not_agent_run(&row).is_ok());
+    }
+
+    /// Terminal decision shared by `destroy_sandbox` (agent-run branch)
+    /// and `release_orphaned_agent_run_sandboxes`: every terminal status
+    /// allows cleanup, every active status keeps the run's ownership, and
+    /// a missing run row (deleted run) counts as terminal so the sandbox
+    /// isn't orphaned forever.
+    #[test]
+    fn run_status_is_terminal_matches_run_lifecycle() {
+        for s in TERMINAL_RUN_STATUSES {
+            assert!(run_status_is_terminal(Some(s)), "{} must be terminal", s);
+        }
+        for s in temps_agents::services::run_service::ACTIVE_RUN_STATUSES {
+            assert!(
+                !run_status_is_terminal(Some(s)),
+                "{} must NOT be terminal",
+                s
+            );
+        }
+        assert!(
+            run_status_is_terminal(None),
+            "missing run row must count as terminal so cleanup can proceed"
+        );
     }
 
     #[test]

--- a/crates/temps-sandbox/src/services/sandbox_service.rs
+++ b/crates/temps-sandbox/src/services/sandbox_service.rs
@@ -127,6 +127,9 @@ pub struct SandboxSummary {
     pub backend: Option<String>,
     /// Configured root disk size in MB (from metadata). `None` = default.
     pub disk_size_mb: Option<u64>,
+    /// Set when this sandbox executes an agent run (autofixer / workflow
+    /// agent). `None` for sandboxes created via the standalone API.
+    pub agent_run_id: Option<i32>,
 }
 
 impl From<&sandboxes::Model> for SandboxSummary {
@@ -147,6 +150,7 @@ impl From<&sandboxes::Model> for SandboxSummary {
                 .as_ref()
                 .and_then(|v| v.get("disk_size_mb"))
                 .and_then(|v| v.as_u64()),
+            agent_run_id: m.agent_run_id,
         }
     }
 }
@@ -252,7 +256,7 @@ impl SandboxService {
             .ok_or_else(|| SandboxError::NotFound {
                 sandbox_id: public_id_value.to_string(),
             })?;
-        if row.user_id != user_id {
+        if row.user_id != Some(user_id) {
             // Don't leak existence to non-owners.
             return Err(SandboxError::NotFound {
                 sandbox_id: public_id_value.to_string(),
@@ -284,6 +288,165 @@ impl SandboxService {
         let rows = paginator.fetch_page(page - 1).await?;
         let items = rows.iter().map(SandboxSummary::from).collect();
         Ok((items, total))
+    }
+
+    // ── Agent-run sandboxes ──────────────────────────────────────────────
+
+    /// Create a sandbox for an agent run (autofixer / workflow agent) as a
+    /// first-class `sandboxes` row, then create the container through the
+    /// shared provider. Called by the agents' `SandboxRegistry` via the
+    /// `RunSandboxService` seam (see `temps_agents::sandbox::managed`).
+    ///
+    /// Unlike standalone sandboxes, the container keeps the historical
+    /// `temps-sandbox-<run_id>` naming (no `container_name_override`) so
+    /// run recovery after a server restart keeps working, and the handle is
+    /// keyed by `run_id` in the agents' registry — NOT by this row's `id`.
+    /// The row is bookkeeping + API visibility; the agent run owns the
+    /// lifecycle (the expiration sweeper skips rows with `agent_run_id`).
+    pub async fn create_for_agent_run(
+        &self,
+        config: SandboxCreateConfig,
+    ) -> Result<temps_agents::sandbox::SandboxHandle, SandboxError> {
+        let run_id = config.run_id;
+
+        // A run can recreate its sandbox after a dead container — retire
+        // any previous non-destroyed row for the same run first so the API
+        // never shows two "running" sandboxes for one run.
+        let stale = sandboxes::Entity::find()
+            .filter(sandboxes::Column::AgentRunId.eq(run_id))
+            .filter(sandboxes::Column::Status.ne("destroyed"))
+            .all(self.db.as_ref())
+            .await?;
+        for row in stale {
+            self.mark_destroyed(row.id).await.ok();
+            self.record_event(
+                row.id,
+                "destroyed",
+                Some(serde_json::json!({ "reason": "superseded by new container for agent run" })),
+            )
+            .await;
+        }
+
+        let public_id_value = public_id::generate();
+        let now = Utc::now();
+        let timeout = config
+            .idle_timeout
+            .as_secs()
+            .clamp(MIN_TIMEOUT_SECS, MAX_TIMEOUT_SECS);
+        let active = sandboxes::ActiveModel {
+            public_id: Set(public_id_value.clone()),
+            user_id: Set(config.owner_user_id),
+            agent_run_id: Set(Some(run_id)),
+            name: Set(format!("temps-sandbox-{}", run_id)),
+            status: Set("running".to_string()),
+            image: Set(config.image.clone()),
+            work_dir: Set(temps_agents::sandbox::SANDBOX_WORK_DIR.to_string()),
+            timeout_secs: Set(timeout as i32),
+            metadata: Set(Some(serde_json::json!({ "source": "agent_run" }))),
+            created_at: Set(now),
+            last_activity_at: Set(now),
+            expires_at: Set(now + chrono::Duration::seconds(timeout as i64)),
+            ..Default::default()
+        };
+        let row = active.insert(self.db.as_ref()).await?;
+
+        let handle = match self.registry.provider_arc().create(config).await {
+            Ok(h) => h,
+            Err(e) => {
+                // Roll the row over to destroyed so the API doesn't show a
+                // zombie "running" sandbox for a container that never started.
+                self.mark_destroyed(row.id).await.ok();
+                return Err(SandboxError::CreateFailed {
+                    user_id: 0,
+                    reason: format!("agent run {}: {}", run_id, e),
+                });
+            }
+        };
+
+        if let Err(e) = self
+            .record_backend(
+                row.id,
+                handle.backend,
+                (!handle.image.is_empty()).then(|| handle.image.clone()),
+            )
+            .await
+        {
+            tracing::warn!(
+                "failed to record backend/image for agent-run sandbox {} (run {}): {}",
+                public_id_value,
+                run_id,
+                e
+            );
+        }
+
+        self.record_event(
+            row.id,
+            "created",
+            Some(serde_json::json!({
+                "agent_run_id": run_id,
+                "backend": handle.backend.to_string(),
+                "image": handle.image,
+            })),
+        )
+        .await;
+
+        tracing::info!(
+            "Created agent-run sandbox {} (internal {}) for run {}",
+            public_id_value,
+            row.id,
+            run_id
+        );
+
+        Ok(handle)
+    }
+
+    /// Destroy the container backing an agent run's sandbox and mark its
+    /// row(s) destroyed. `handle` is the agents' registry cached handle
+    /// when available; otherwise the container is recovered by run id.
+    pub async fn release_for_agent_run(
+        &self,
+        run_id: i32,
+        handle: Option<&temps_agents::sandbox::SandboxHandle>,
+    ) -> Result<(), SandboxError> {
+        let provider = self.registry.provider_arc();
+        let resolved = match handle {
+            Some(h) => Some(h.clone()),
+            None => provider.recover(run_id).await.unwrap_or_else(|e| {
+                tracing::warn!(
+                    "release_for_agent_run: recover for run {} failed: {}",
+                    run_id,
+                    e
+                );
+                None
+            }),
+        };
+        if let Some(h) = resolved {
+            // Agent runs are ephemeral — purge the home volume too.
+            if let Err(e) = provider.destroy(&h, true).await {
+                tracing::warn!(
+                    "Failed to destroy agent-run sandbox {} for run {}: {}",
+                    h.sandbox_name,
+                    run_id,
+                    e
+                );
+            }
+        }
+
+        let rows = sandboxes::Entity::find()
+            .filter(sandboxes::Column::AgentRunId.eq(run_id))
+            .filter(sandboxes::Column::Status.ne("destroyed"))
+            .all(self.db.as_ref())
+            .await?;
+        for row in rows {
+            self.mark_destroyed(row.id).await?;
+            self.record_event(
+                row.id,
+                "destroyed",
+                Some(serde_json::json!({ "agent_run_id": run_id })),
+            )
+            .await;
+        }
+        Ok(())
     }
 
     // ── Lifecycle ────────────────────────────────────────────────────────
@@ -368,7 +531,7 @@ impl SandboxService {
         };
         let active = sandboxes::ActiveModel {
             public_id: Set(public_id_value.clone()),
-            user_id: Set(user_id),
+            user_id: Set(Some(user_id)),
             name: Set(name.clone()),
             status: Set("running".to_string()),
             image: Set(req.image.clone()),
@@ -405,6 +568,7 @@ impl SandboxService {
             .to_string();
 
         let config = SandboxCreateConfig {
+            owner_user_id: None,
             run_id: row.id,
             container_name_override: Some(container_label.clone()),
             host_work_dir,
@@ -1315,7 +1479,8 @@ mod tests {
         let m = sandboxes::Model {
             id: 1_000_042,
             public_id: "sbx_abc1234567890def".into(),
-            user_id: 7,
+            user_id: Some(7),
+            agent_run_id: Some(42),
             name: "my-sbx".into(),
             status: "running".into(),
             image: Some("node:20".into()),
@@ -1333,5 +1498,6 @@ mod tests {
         assert_eq!(s.public_id, "sbx_abc1234567890def");
         assert_eq!(s.status, "running");
         assert_eq!(s.image.as_deref(), Some("node:20"));
+        assert_eq!(s.agent_run_id, Some(42));
     }
 }

--- a/crates/temps-sandbox/tests/vercel_compat.rs
+++ b/crates/temps-sandbox/tests/vercel_compat.rs
@@ -375,6 +375,7 @@ fn sandbox_response_matches_sdk_envelope() {
             disk_size_mb: None,
             preview_url_template: String::new(),
             preview_password_hint: None,
+            agent_run_id: None,
         },
         routes: Vec::new(),
     };
@@ -449,6 +450,7 @@ fn sandbox_status_uses_sdk_enum_values() {
                 disk_size_mb: None,
                 preview_url_template: String::new(),
                 preview_password_hint: None,
+                agent_run_id: None,
             },
             routes: Vec::new(),
         };

--- a/web/src/components/agents/AutopilotRunDetail.tsx
+++ b/web/src/components/agents/AutopilotRunDetail.tsx
@@ -13,9 +13,17 @@ import {
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useEffect, useRef, useState } from 'react'
+import {
+  isValidElement,
+  useEffect,
+  useRef,
+  useState,
+  type ComponentProps,
+  type ReactNode,
+} from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { CodeBlock } from '@/components/ui/code-block'
 import {
   AlertTriangle,
   ArrowLeft,
@@ -54,7 +62,7 @@ import {
 } from 'lucide-react'
 
 const proseClasses =
-  'prose prose-sm dark:prose-invert max-w-none prose-pre:bg-black/30 prose-pre:text-muted-foreground prose-pre:text-xs prose-pre:border-0 prose-code:before:content-none prose-code:after:content-none prose-p:my-1.5 prose-headings:my-2 prose-ul:my-1.5 prose-ul:list-disc prose-ul:pl-5 prose-ol:my-1.5 prose-ol:list-decimal prose-ol:pl-5 prose-li:my-0.5 prose-li:marker:text-foreground/60 prose-hr:my-3 prose-hr:border-border prose-table:text-xs prose-th:px-2 prose-th:py-1 prose-td:px-2 prose-td:py-1'
+  'prose prose-sm dark:prose-invert max-w-none prose-code:before:content-none prose-code:after:content-none prose-p:my-1.5 prose-headings:my-2 prose-ul:my-1.5 prose-ul:list-disc prose-ul:pl-5 prose-ol:my-1.5 prose-ol:list-decimal prose-ol:pl-5 prose-li:my-0.5 prose-li:marker:text-foreground/60 prose-hr:my-3 prose-hr:border-border prose-table:text-xs prose-th:px-2 prose-th:py-1 prose-td:px-2 prose-td:py-1'
 
 interface AutopilotRunDetailProps {
   project: ProjectResponse
@@ -114,11 +122,85 @@ function logLevelColor(level: string): string {
   }
 }
 
-/** Render markdown content using prose styles */
+type CodeBlockLanguage = NonNullable<
+  ComponentProps<typeof CodeBlock>['language']
+>
+
+/** Map common markdown fence hints onto the languages the shared CodeBlock
+ *  highlights. Unknown/absent hints fall back to 'text' (no highlighting). */
+const fenceLanguageMap: Record<string, CodeBlockLanguage> = {
+  bash: 'bash',
+  sh: 'shell',
+  shell: 'shell',
+  zsh: 'shell',
+  console: 'shell',
+  yaml: 'yaml',
+  yml: 'yaml',
+  json: 'json',
+  jsonc: 'json',
+  javascript: 'javascript',
+  js: 'javascript',
+  jsx: 'javascript',
+  typescript: 'typescript',
+  ts: 'typescript',
+  tsx: 'typescript',
+  python: 'python',
+  py: 'python',
+  go: 'go',
+  golang: 'go',
+  text: 'text',
+  txt: 'text',
+  plaintext: 'text',
+}
+
+function fenceLanguage(className: string | undefined): CodeBlockLanguage {
+  const match = /language-([\w-]+)/.exec(className ?? '')
+  return (match && fenceLanguageMap[match[1].toLowerCase()]) || 'text'
+}
+
+/** Flatten a react-markdown code element's children to the raw code string. */
+function extractText(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(extractText).join('')
+  if (isValidElement(node)) {
+    return extractText((node.props as { children?: ReactNode }).children)
+  }
+  return ''
+}
+
+/** Fenced code blocks render through the shared CodeBlock (same component as
+ *  the AI Gateway page): syntax colors, line numbers, copy button, and a wrap
+ *  toggle. Long lines scroll horizontally instead of stretching the layout. */
+function MarkdownPre({ children }: { children?: ReactNode }) {
+  if (isValidElement(children)) {
+    const codeProps = children.props as {
+      className?: string
+      children?: ReactNode
+    }
+    return (
+      <CodeBlock
+        code={extractText(codeProps.children).replace(/\n$/, '')}
+        language={fenceLanguage(codeProps.className)}
+        className="not-prose my-3 text-left"
+        defaultShowLineNumbers
+      />
+    )
+  }
+  return <pre>{children}</pre>
+}
+
+/** Render markdown content using prose styles. Fenced code blocks are routed
+ *  to the shared CodeBlock via the `pre` component override; inline code keeps
+ *  the prose styling (react-markdown only wraps fences in `<pre>`). */
 function Markdown({ children }: { children: string }) {
   return (
     <div className={proseClasses}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{children}</ReactMarkdown>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{ pre: MarkdownPre }}
+      >
+        {children}
+      </ReactMarkdown>
     </div>
   )
 }


### PR DESCRIPTION
## Why

AI autofix (and workflow agent runs) launched containers through the raw `SandboxProvider` with no `sandboxes` row — invisible to the standalone sandbox API, no lifecycle events, no user attribution. The autofixer couldn't consume `SandboxService` directly because `temps-sandbox` depends on `temps-agents` (compile-time cycle).

## What

Dependency inversion via the plugin system:
- New `RunSandboxService` seam in `temps-agents::sandbox::managed`; the agents' `SandboxRegistry` uses it for create/release when present, raw provider otherwise (minimal installs without the sandbox plugin keep working).
- `temps-sandbox` implements it (`AgentRunSandboxBridge` over `SandboxService::create_for_agent_run`/`release_for_agent_run`) and injects it at plugin initialize. Rows get `agent_run_id`, lifecycle events (`created`/`destroyed`), and appear in the sandbox API.
- Migration: `sandboxes.user_id` nullable (webhook-triggered runs have no user), `sandboxes.agent_run_id` (indexed, partial), `agent_runs.triggered_by_user_id` — UI-triggered autofix runs attribute the sandbox to the clicking user so it shows in their sandbox list.
- Expiration sweeper + startup recovery skip agent-run rows (the run owns its lifecycle; autofix analysis→fix→PR legitimately outlives idle timeouts while the user reviews).
- `agent_run_id` surfaced in `SandboxSummary` / `SandboxInner` API responses.

## Verification
- `cargo check --workspace --all-targets`: clean
- `cargo test --lib -p temps-agents -p temps-sandbox`: 323 passed
- `sandbox_credential_smoke_test` fails identically on clean origin/main (pre-existing Docker-image perms assertion, unrelated)

## Follow-ups
- SDK regen for the new `agent_run_id` response field + optional UI badge for agent-run sandboxes
- e2e: trigger an autofix run and confirm the sandbox appears/disappears in the API