### PR TITLE
fix(agents): stop dumping raw CLI JSONL as autofix error messages

### DIFF
--- a/crates/temps-agents/src/ai_cli/claude.rs
+++ b/crates/temps-agents/src/ai_cli/claude.rs
@@ -248,7 +248,7 @@ impl AiCliProvider for ClaudeCliProvider {
             return Err(AgentError::AiCliFailed {
                 provider: self.name().to_string(),
                 exit_code,
-                stderr: error_output,
+                stderr: crate::ai_cli::summarize_cli_failure(self.name(), &error_output),
             });
         }
 
@@ -380,7 +380,7 @@ impl AiCliProvider for ClaudeCliProvider {
             return Err(AgentError::AiCliFailed {
                 provider: self.name().to_string(),
                 exit_code,
-                stderr: error_output,
+                stderr: crate::ai_cli::summarize_cli_failure(self.name(), &error_output),
             });
         }
 

--- a/crates/temps-agents/src/ai_cli/codex.rs
+++ b/crates/temps-agents/src/ai_cli/codex.rs
@@ -121,7 +121,7 @@ impl AiCliProvider for CodexCliProvider {
             return Err(AgentError::AiCliFailed {
                 provider: self.name().to_string(),
                 exit_code,
-                stderr,
+                stderr: crate::ai_cli::summarize_cli_failure(self.name(), &stderr),
             });
         }
 

--- a/crates/temps-agents/src/ai_cli/mod.rs
+++ b/crates/temps-agents/src/ai_cli/mod.rs
@@ -103,6 +103,106 @@ pub fn parse_output(provider: &str, output: &str) -> claude::ParsedClaudeOutput 
     }
 }
 
+/// Turn a failed CLI's raw stream output into a short, actionable message.
+/// The full output is preserved in the run's `ai_event` logs — this summary
+/// is what lands in `error_message` and the failure banner, so a self-hosted
+/// user sees "out of credits, retry with another provider" instead of a
+/// multi-kilobyte JSON dump.
+pub fn summarize_cli_failure(provider: &str, output: &str) -> String {
+    // Claude rate-limit frame: {"type":"rate_limit_event","rate_limit_info":
+    // {"status":...,"overageStatus":"rejected","resetsAt":...}}
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('{') {
+            continue;
+        }
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+            continue;
+        };
+        if v.get("type").and_then(|t| t.as_str()) == Some("rate_limit_event") {
+            let info = v.get("rate_limit_info");
+            let rejected = info
+                .and_then(|i| i.get("overageStatus"))
+                .and_then(|s| s.as_str())
+                == Some("rejected");
+            let exhausted =
+                info.and_then(|i| i.get("status")).and_then(|s| s.as_str()) == Some("exceeded");
+            if rejected || exhausted {
+                return format!(
+                    "The {} subscription hit its usage limit (out of credits). \
+                     Wait for the limit to reset, or start a new run with a \
+                     different provider or an API key.",
+                    provider
+                );
+            }
+        }
+        // Claude terminal error frame: {"type":"result","is_error":true,"result":"..."}
+        if v.get("type").and_then(|t| t.as_str()) == Some("result")
+            && v.get("is_error").and_then(|b| b.as_bool()) == Some(true)
+        {
+            if let Some(msg) = v.get("result").and_then(|r| r.as_str()) {
+                if !msg.trim().is_empty() {
+                    return scrub_and_bound(msg);
+                }
+            }
+        }
+    }
+    // Fallback: last non-JSON line (CLIs print human errors to the tail),
+    // else a bounded slice of the output.
+    if let Some(tail) = output
+        .lines()
+        .map(str::trim)
+        .rev()
+        .find(|l| !l.is_empty() && !l.starts_with('{'))
+    {
+        return scrub_and_bound(tail);
+    }
+    let bounded = scrub_and_bound(output.trim());
+    if bounded.is_empty() {
+        format!("{} exited with an error but produced no output", provider)
+    } else {
+        bounded
+    }
+}
+
+/// Bound an error snippet to 500 chars and redact anything that looks like a
+/// credential — CLI errors occasionally echo key fragments, and this string
+/// lands in `error_message`, which is returned to any user with read access.
+pub fn scrub_and_bound(s: &str) -> String {
+    let bounded: String = s.trim().chars().take(500).collect();
+    // Redact common secret prefixes followed by their token body.
+    let mut out = String::with_capacity(bounded.len());
+    let mut rest = bounded.as_str();
+    const PREFIXES: &[&str] = &["sk-ant-", "sk-", "Bearer ", "ghp_", "gho_", "glpat-"];
+    while !rest.is_empty() {
+        // Redact the EARLIEST secret in `rest` across all prefixes, not the
+        // first prefix that matches anywhere — otherwise a token whose prefix
+        // sits later in the list but earlier in the string would be emitted
+        // verbatim before the "matched" one.
+        let earliest = PREFIXES
+            .iter()
+            .filter_map(|p| rest.find(p).map(|idx| (idx, p.len())))
+            .min_by_key(|(idx, _)| *idx);
+        match earliest {
+            Some((idx, plen)) => {
+                out.push_str(&rest[..idx]);
+                out.push_str("[redacted]");
+                // Skip the prefix and the following token body (non-space run).
+                let after = &rest[idx + plen..];
+                let body_end = after
+                    .find(|c: char| c.is_whitespace())
+                    .unwrap_or(after.len());
+                rest = &after[body_end..];
+            }
+            None => {
+                out.push_str(rest);
+                break;
+            }
+        }
+    }
+    out
+}
+
 /// Create an AI CLI provider by name
 pub fn create_provider(name: &str) -> Option<Box<dyn AiCliProvider>> {
     match name {
@@ -119,3 +219,88 @@ pub const PROVIDER_NAMES: &[(&str, &str)] = &[
     ("opencode", "OpenCode"),
     ("codex_cli", "Codex"),
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_summarize_cli_failure_rate_limit_rejected() {
+        let output = r#"{"type":"system","subtype":"init","session_id":"abc"}
+{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1784910000,"rateLimitType":"five_hour","overageStatus":"rejected","overageDisabledReason":"out_of_credits","isUsingOverage":false}}
+{"type":"assistant","message":{}}"#;
+        let msg = summarize_cli_failure("claude_cli", output);
+        assert!(msg.contains("usage limit"), "got: {}", msg);
+        assert!(msg.contains("different provider"), "got: {}", msg);
+    }
+
+    #[test]
+    fn test_summarize_cli_failure_result_error_frame() {
+        let output = r#"{"type":"result","is_error":true,"result":"Invalid API key"}"#;
+        assert_eq!(
+            summarize_cli_failure("claude_cli", output),
+            "Invalid API key"
+        );
+    }
+
+    #[test]
+    fn test_summarize_cli_failure_falls_back_to_tail_line() {
+        let output = "{\"type\":\"noise\"}\nError: not logged in\n";
+        assert_eq!(
+            summarize_cli_failure("codex_cli", output),
+            "Error: not logged in"
+        );
+    }
+
+    #[test]
+    fn test_summarize_cli_failure_empty_output() {
+        let msg = summarize_cli_failure("claude_cli", "");
+        assert!(msg.contains("no output"));
+    }
+
+    #[test]
+    fn test_scrub_and_bound_redacts_secrets() {
+        assert_eq!(
+            scrub_and_bound("auth failed: sk-ant-abc123XYZ is invalid"),
+            "auth failed: [redacted] is invalid"
+        );
+        assert_eq!(
+            scrub_and_bound("header Bearer eyJhbGciOi.foo rejected"),
+            "header [redacted] rejected"
+        );
+        // Non-secret text is left intact.
+        assert_eq!(
+            scrub_and_bound("plain error message"),
+            "plain error message"
+        );
+    }
+
+    #[test]
+    fn test_scrub_and_bound_redacts_earliest_secret_first() {
+        // `Bearer ` appears before `sk-ant-` in the string but later in the
+        // prefix list — the earlier one must still be redacted, not emitted
+        // verbatim before the "matched" one.
+        let out = scrub_and_bound("Bearer abc123 then sk-ant-xyz789 end");
+        assert!(!out.contains("abc123"), "leaked Bearer token: {}", out);
+        assert!(!out.contains("xyz789"), "leaked sk-ant token: {}", out);
+        assert_eq!(out, "[redacted] then [redacted] end");
+    }
+
+    #[test]
+    fn test_scrub_and_bound_caps_length() {
+        let long = "x".repeat(1000);
+        assert_eq!(scrub_and_bound(&long).len(), 500);
+    }
+
+    #[test]
+    fn test_summarize_cli_failure_result_frame_is_scrubbed_and_bounded() {
+        let secret = "sk-ant-topsecretkey";
+        let output = format!(
+            r#"{{"type":"result","is_error":true,"result":"key {} rejected"}}"#,
+            secret
+        );
+        let msg = summarize_cli_failure("claude_cli", &output);
+        assert!(!msg.contains(secret), "secret leaked: {}", msg);
+        assert!(msg.contains("[redacted]"));
+    }
+}

--- a/crates/temps-agents/src/ai_cli/opencode.rs
+++ b/crates/temps-agents/src/ai_cli/opencode.rs
@@ -186,7 +186,7 @@ impl AiCliProvider for OpenCodeCliProvider {
             return Err(AgentError::AiCliFailed {
                 provider: self.name().to_string(),
                 exit_code,
-                stderr: error_output,
+                stderr: crate::ai_cli::summarize_cli_failure(self.name(), &error_output),
             });
         }
 
@@ -297,7 +297,7 @@ impl AiCliProvider for OpenCodeCliProvider {
             return Err(AgentError::AiCliFailed {
                 provider: self.name().to_string(),
                 exit_code,
-                stderr: error_output,
+                stderr: crate::ai_cli::summarize_cli_failure(self.name(), &error_output),
             });
         }
 

--- a/crates/temps-agents/src/services/autofixer.rs
+++ b/crates/temps-agents/src/services/autofixer.rs
@@ -460,7 +460,7 @@ impl AutofixerService {
             return Err(AgentError::AiCliFailed {
                 provider: cfg.provider.clone(),
                 exit_code: exec_result.exit_code,
-                stderr: summarize_cli_failure(&cfg.provider, &exec_result.stdout),
+                stderr: crate::ai_cli::summarize_cli_failure(&cfg.provider, &exec_result.stdout),
             });
         }
 
@@ -693,7 +693,7 @@ impl AutofixerService {
             return Err(AgentError::AiCliFailed {
                 provider: cfg.provider.clone(),
                 exit_code: exec_result.exit_code,
-                stderr: summarize_cli_failure(&cfg.provider, &exec_result.stdout),
+                stderr: crate::ai_cli::summarize_cli_failure(&cfg.provider, &exec_result.stdout),
             });
         }
 
@@ -1233,7 +1233,7 @@ impl AutofixerService {
             return Err(AgentError::AiCliFailed {
                 provider: cfg.provider.clone(),
                 exit_code: exec_result.exit_code,
-                stderr: summarize_cli_failure(&cfg.provider, &exec_result.stdout),
+                stderr: crate::ai_cli::summarize_cli_failure(&cfg.provider, &exec_result.stdout),
             });
         }
 
@@ -1496,106 +1496,6 @@ impl AutofixerService {
     }
 }
 
-/// Turn a failed CLI's raw stream output into a short, actionable message.
-/// The full output is preserved in the run's `ai_event` logs — this summary
-/// is what lands in `error_message` and the failure banner, so a self-hosted
-/// user sees "out of credits, retry with another provider" instead of a
-/// multi-kilobyte JSON dump.
-fn summarize_cli_failure(provider: &str, output: &str) -> String {
-    // Claude rate-limit frame: {"type":"rate_limit_event","rate_limit_info":
-    // {"status":...,"overageStatus":"rejected","resetsAt":...}}
-    for line in output.lines() {
-        let trimmed = line.trim();
-        if !trimmed.starts_with('{') {
-            continue;
-        }
-        let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) else {
-            continue;
-        };
-        if v.get("type").and_then(|t| t.as_str()) == Some("rate_limit_event") {
-            let info = v.get("rate_limit_info");
-            let rejected = info
-                .and_then(|i| i.get("overageStatus"))
-                .and_then(|s| s.as_str())
-                == Some("rejected");
-            let exhausted =
-                info.and_then(|i| i.get("status")).and_then(|s| s.as_str()) == Some("exceeded");
-            if rejected || exhausted {
-                return format!(
-                    "The {} subscription hit its usage limit (out of credits). \
-                     Wait for the limit to reset, or start a new run with a \
-                     different provider or an API key.",
-                    provider
-                );
-            }
-        }
-        // Claude terminal error frame: {"type":"result","is_error":true,"result":"..."}
-        if v.get("type").and_then(|t| t.as_str()) == Some("result")
-            && v.get("is_error").and_then(|b| b.as_bool()) == Some(true)
-        {
-            if let Some(msg) = v.get("result").and_then(|r| r.as_str()) {
-                if !msg.trim().is_empty() {
-                    return scrub_and_bound(msg);
-                }
-            }
-        }
-    }
-    // Fallback: last non-JSON line (CLIs print human errors to the tail),
-    // else a bounded slice of the output.
-    if let Some(tail) = output
-        .lines()
-        .map(str::trim)
-        .rev()
-        .find(|l| !l.is_empty() && !l.starts_with('{'))
-    {
-        return scrub_and_bound(tail);
-    }
-    let bounded = scrub_and_bound(output.trim());
-    if bounded.is_empty() {
-        format!("{} exited with an error but produced no output", provider)
-    } else {
-        bounded
-    }
-}
-
-/// Bound an error snippet to 500 chars and redact anything that looks like a
-/// credential — CLI errors occasionally echo key fragments, and this string
-/// lands in `error_message`, which is returned to any user with read access.
-fn scrub_and_bound(s: &str) -> String {
-    let bounded: String = s.trim().chars().take(500).collect();
-    // Redact common secret prefixes followed by their token body.
-    let mut out = String::with_capacity(bounded.len());
-    let mut rest = bounded.as_str();
-    const PREFIXES: &[&str] = &["sk-ant-", "sk-", "Bearer ", "ghp_", "gho_", "glpat-"];
-    while !rest.is_empty() {
-        // Redact the EARLIEST secret in `rest` across all prefixes, not the
-        // first prefix that matches anywhere — otherwise a token whose prefix
-        // sits later in the list but earlier in the string would be emitted
-        // verbatim before the "matched" one.
-        let earliest = PREFIXES
-            .iter()
-            .filter_map(|p| rest.find(p).map(|idx| (idx, p.len())))
-            .min_by_key(|(idx, _)| *idx);
-        match earliest {
-            Some((idx, plen)) => {
-                out.push_str(&rest[..idx]);
-                out.push_str("[redacted]");
-                // Skip the prefix and the following token body (non-space run).
-                let after = &rest[idx + plen..];
-                let body_end = after
-                    .find(|c: char| c.is_whitespace())
-                    .unwrap_or(after.len());
-                rest = &after[body_end..];
-            }
-            None => {
-                out.push_str(rest);
-                break;
-            }
-        }
-    }
-    out
-}
-
 /// Extract the human-readable analysis text from AI CLI output for any
 /// provider. Claude's stream-json has a dedicated `result` frame; Codex and
 /// OpenCode go through the generic report-text extractor which understands
@@ -1785,86 +1685,6 @@ mod tests {
         assert_eq!(cfg.model, None);
         assert_eq!(cfg.max_turns_analysis, DEFAULT_MAX_TURNS_ANALYSIS);
         assert_eq!(cfg.branch, None);
-    }
-
-    #[test]
-    fn test_summarize_cli_failure_rate_limit_rejected() {
-        let output = r#"{"type":"system","subtype":"init","session_id":"abc"}
-{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1784910000,"rateLimitType":"five_hour","overageStatus":"rejected","overageDisabledReason":"out_of_credits","isUsingOverage":false}}
-{"type":"assistant","message":{}}"#;
-        let msg = summarize_cli_failure("claude_cli", output);
-        assert!(msg.contains("usage limit"), "got: {}", msg);
-        assert!(msg.contains("different provider"), "got: {}", msg);
-    }
-
-    #[test]
-    fn test_summarize_cli_failure_result_error_frame() {
-        let output = r#"{"type":"result","is_error":true,"result":"Invalid API key"}"#;
-        assert_eq!(
-            summarize_cli_failure("claude_cli", output),
-            "Invalid API key"
-        );
-    }
-
-    #[test]
-    fn test_summarize_cli_failure_falls_back_to_tail_line() {
-        let output = "{\"type\":\"noise\"}\nError: not logged in\n";
-        assert_eq!(
-            summarize_cli_failure("codex_cli", output),
-            "Error: not logged in"
-        );
-    }
-
-    #[test]
-    fn test_summarize_cli_failure_empty_output() {
-        let msg = summarize_cli_failure("claude_cli", "");
-        assert!(msg.contains("no output"));
-    }
-
-    #[test]
-    fn test_scrub_and_bound_redacts_secrets() {
-        assert_eq!(
-            scrub_and_bound("auth failed: sk-ant-abc123XYZ is invalid"),
-            "auth failed: [redacted] is invalid"
-        );
-        assert_eq!(
-            scrub_and_bound("header Bearer eyJhbGciOi.foo rejected"),
-            "header [redacted] rejected"
-        );
-        // Non-secret text is left intact.
-        assert_eq!(
-            scrub_and_bound("plain error message"),
-            "plain error message"
-        );
-    }
-
-    #[test]
-    fn test_scrub_and_bound_redacts_earliest_secret_first() {
-        // `Bearer ` appears before `sk-ant-` in the string but later in the
-        // prefix list — the earlier one must still be redacted, not emitted
-        // verbatim before the "matched" one.
-        let out = scrub_and_bound("Bearer abc123 then sk-ant-xyz789 end");
-        assert!(!out.contains("abc123"), "leaked Bearer token: {}", out);
-        assert!(!out.contains("xyz789"), "leaked sk-ant token: {}", out);
-        assert_eq!(out, "[redacted] then [redacted] end");
-    }
-
-    #[test]
-    fn test_scrub_and_bound_caps_length() {
-        let long = "x".repeat(1000);
-        assert_eq!(scrub_and_bound(&long).len(), 500);
-    }
-
-    #[test]
-    fn test_summarize_cli_failure_result_frame_is_scrubbed_and_bounded() {
-        let secret = "sk-ant-topsecretkey";
-        let output = format!(
-            r#"{{"type":"result","is_error":true,"result":"key {} rejected"}}"#,
-            secret
-        );
-        let msg = summarize_cli_failure("claude_cli", &output);
-        assert!(!msg.contains(secret), "secret leaked: {}", msg);
-        assert!(msg.contains("[redacted]"));
     }
 
     #[test]

--- a/crates/temps-agents/src/services/executor.rs
+++ b/crates/temps-agents/src/services/executor.rs
@@ -2280,7 +2280,10 @@ impl AgentExecutor {
                 return Err(AgentError::AiCliFailed {
                     provider: config.ai_provider.clone(),
                     exit_code: exec_result.exit_code,
-                    stderr: exec_result.stdout,
+                    stderr: crate::ai_cli::summarize_cli_failure(
+                        &config.ai_provider,
+                        &exec_result.stdout,
+                    ),
                 });
             }
 

--- a/web/src/components/agents/AutopilotRunDetail.tsx
+++ b/web/src/components/agents/AutopilotRunDetail.tsx
@@ -1499,9 +1499,30 @@ export function AutopilotRunDetail({ project }: AutopilotRunDetailProps) {
       {run.error_message && (
         <Alert variant="destructive">
           <AlertTriangle className="h-4 w-4" />
-          <AlertTitle>Error</AlertTitle>
-          <AlertDescription className="whitespace-pre-wrap font-mono text-xs">
-            {run.error_message}
+          <AlertTitle className="flex items-center justify-between gap-2">
+            Error
+            {run.error_message.length > 1200 && (
+              <Dialog>
+                <DialogTrigger asChild>
+                  <Button variant="outline" size="sm">
+                    View full
+                  </Button>
+                </DialogTrigger>
+                <DialogContent className="max-w-3xl">
+                  <DialogHeader>
+                    <DialogTitle>Full error message</DialogTitle>
+                  </DialogHeader>
+                  <pre className="text-xs bg-muted/40 border border-border rounded p-3 overflow-auto max-h-[70vh] whitespace-pre-wrap break-words">
+                    {run.error_message}
+                  </pre>
+                </DialogContent>
+              </Dialog>
+            )}
+          </AlertTitle>
+          <AlertDescription className="whitespace-pre-wrap font-mono text-xs max-h-48 overflow-y-auto break-words">
+            {run.error_message.length > 1200
+              ? run.error_message.slice(0, 1200) + '\n\n… (truncated)'
+              : run.error_message}
           </AlertDescription>
         </Alert>
       )}

--- a/web/src/components/autofixer/AutofixButton.tsx
+++ b/web/src/components/autofixer/AutofixButton.tsx
@@ -37,6 +37,9 @@ export function AutofixButton({ projectId, projectSlug, errorGroupId }: AutofixB
   })
 
   const latestRun = runWithLogs?.run
+  const errorMessage = latestRun?.error_message || 'Something went wrong'
+  const errorSummary =
+    errorMessage.length > 160 ? errorMessage.slice(0, 160) + '…' : errorMessage
   const goToAutofix = () => navigate(`/projects/${projectSlug}/errors/${errorGroupId}/autofix`)
 
   const phase = latestRun?.phase || latestRun?.status
@@ -75,7 +78,7 @@ export function AutofixButton({ projectId, projectSlug, errorGroupId }: AutofixB
               {latestRun && latestRun.status === 'failed' && 'Autofix failed'}
               {latestRun && latestRun.status === 'cancelled' && 'Autofix cancelled'}
             </p>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-xs text-muted-foreground line-clamp-2 break-words">
               {!latestRun && 'Let AI analyze and fix this error automatically'}
               {latestRun && phase === 'analyzing' && 'Claude is reading your codebase and tracing the error'}
               {latestRun && phase === 'analyzed' && 'Root cause identified — click to review the analysis'}
@@ -83,7 +86,11 @@ export function AutofixButton({ projectId, projectSlug, errorGroupId }: AutofixB
               {latestRun && phase === 'fix_ready' && 'Code changes are ready for review'}
               {latestRun && phase === 'completed' && latestRun.pr_url && `PR #${latestRun.pr_number} created`}
               {latestRun && phase === 'completed' && !latestRun.pr_url && 'Completed'}
-              {latestRun && latestRun.status === 'failed' && (latestRun.error_message || 'Something went wrong')}
+              {latestRun && latestRun.status === 'failed' && (
+                <span title={errorMessage.length > 160 ? errorMessage : undefined}>
+                  {errorSummary}
+                </span>
+              )}
               {latestRun && latestRun.status === 'cancelled' && 'Cancelled by user'}
             </p>
           </div>


### PR DESCRIPTION
## Summary

`autofixer.rs`'s analysis/fix phases already have a `summarize_cli_failure`/`scrub_and_bound` helper that turns a failed AI CLI run into a short, human-readable message instead of a multi-KB stream-json dump. Four other call sites that construct the same `AgentError::AiCliFailed` still stored the raw dump verbatim:

- `ClaudeCliProvider::run` / `continue_conversation` (`ai_cli/claude.rs`)
- `OpenCodeCliProvider::run` / `continue_conversation` (`ai_cli/opencode.rs`)
- `CodexCliProvider::run` (`ai_cli/codex.rs`)
- `AgentExecutor`'s generic workflow-run path (`services/executor.rs`)

These are reachable from the general-purpose AI agents/workflow executor, not just the error-tracking autofix button.

- Extracted `summarize_cli_failure`/`scrub_and_bound` out of `autofixer.rs` into `ai_cli`, moving their tests along with them.
- Repointed all four remaining raw-dump sites to the shared helper.
- Frontend defense-in-depth: `AutofixButton`'s subtitle now clamps to 2 lines/160 chars; `AutopilotRunDetail`'s error Alert caps at 1200 chars with a "View full" dialog.

## Test plan
- [x] `cargo check --lib -p temps-agents` and full workspace `cargo check --lib` clean, no warnings
- [x] `cargo test --lib -p temps-agents` 236 passed
- [x] `tsc --noEmit` and `eslint --quiet` on both changed frontend files, no new errors
- [x] Pre-commit hooks passed
