### PR TITLE
fix(deps): patch Dependabot advisories in next, setuptools and serde_with

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,7 +2248,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "serde_with 3.20.0",
+ "serde_with 3.21.0",
  "thiserror 2.0.18",
  "url",
  "urlencoding",
@@ -2266,7 +2266,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "serde_with 3.20.0",
+ "serde_with 3.21.0",
  "thiserror 2.0.18",
  "url",
  "urlencoding",
@@ -4220,6 +4220,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.12",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -4735,7 +4739,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -6100,7 +6104,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_bytes",
- "serde_with 3.20.0",
+ "serde_with 3.21.0",
  "sha1 0.11.0",
  "sha2 0.11.0",
  "socket2 0.6.3",
@@ -6827,7 +6831,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_plain",
- "serde_with 3.20.0",
+ "serde_with 3.21.0",
  "sha2 0.10.9",
  "subtle",
  "thiserror 1.0.69",
@@ -7514,7 +7518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6705a26ad89d241a989a5395641931ba37076f5ab5fbd19ee92402414a43af32"
 dependencies = [
  "arrayvec",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.5",
  "parking_lot",
  "rand 0.8.6",
 ]
@@ -9690,9 +9694,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -9704,7 +9708,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde_core",
  "serde_json",
- "serde_with_macros 3.20.0",
+ "serde_with_macros 3.21.0",
  "time",
 ]
 
@@ -9722,9 +9726,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -13142,7 +13146,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
- "serde_with 3.20.0",
+ "serde_with 3.21.0",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -373,7 +373,12 @@ debug = false
 #      pingora emits metrics via TextEncoder (not ProtobufEncoder); its
 #      PrometheusServer is not wired into any temps listener; the OTLP ingest path
 #      uses prost, not protobuf 2.x. The 2.x parse code is compiled in but never
-#      fed attacker input -> not reachable. (verified 2026-06-29)
+#      fed attacker input -> not reachable. (re-verified 2026-07-25: no
+#      ProtobufEncoder/TextEncoder/protobuf::/PrometheusServer reference anywhere
+#      under crates/. Root cause of the pull is structural: pingora-core 0.8.1
+#      declares `prometheus = "0.13"` with default features, and `protobuf` is a
+#      DEFAULT feature of prometheus 0.13 -- features are additive, so it cannot be
+#      turned off from this workspace without vendoring a pingora fork.)
 #
 # 2. RUSTSEC-2023-0018 / GHSA-mc8h-8q98-g5hr: remove_dir_all 0.5.3 (LOW)
 #    - Path: nixpacks 1.41.0 → tempdir 0.3.7 → remove_dir_all 0.5.3
@@ -383,7 +388,9 @@ debug = false
 #    - Reachability: the TOCTOU race lives in nixpacks get_output_dir()'s
 #      TempDir::new()/remove_dir_all(output.root) branch, taken only when out_dir
 #      is None. temps-presets always passes out_dir: Some(...) (nixpacks_preset.rs
-#      ~L507), so that branch never executes -> dead code here. (verified 2026-06-29)
+#      ~L507), so that branch never executes -> dead code here. (re-verified
+#      2026-07-25: nixpacks_preset.rs:508 is still the ONLY out_dir site in the
+#      whole workspace and still passes Some(...); nixpacks is still 1.41.0 latest.)
 #
 # 2b. GHSA-w9wp-h8wv-79jx: opentelemetry_sdk 0.30.0 (MEDIUM, dependabot-only)
 #    - Path: relay-event-schema (git pin getsentry/relay) → opentelemetry-proto 0.30
@@ -395,7 +402,22 @@ debug = false
 #      pulls opentelemetry-proto only for OTLP span TYPE conversion; the propagation
 #      module is compiled in (trace feature) but BaggagePropagator is never
 #      instantiated and .extract() is never called on attacker headers anywhere in
-#      the workspace -> not reachable. (verified 2026-06-29)
+#      the workspace -> not reachable. (re-verified 2026-07-25: no case-insensitive
+#      match for `baggage` anywhere under crates/.)
+#
+# 2c. GHSA-8wf9-4rjw-8j9r: serde_with 2.3.3 (MEDIUM, dependabot-only)
+#    - Path: nixpacks 1.41.0 → serde_with 2.3.3
+#    - The 3.x copy of serde_with (via cloudflare 0.14) WAS affected and IS fixed:
+#      bumped 3.20.0 → 3.21.0 (see "Previously resolved" below). Only the 2.x copy
+#      remains, and it has no fix: nixpacks requires serde_with ^2.1.0, 2.3.3 is the
+#      latest 2.x ever published, and the fix only landed in 3.21.0.
+#    - Reachability: the panic is in KeyValueMap's Serialize impl on an empty
+#      sequence/map entry. KeyValueMap does exist in 2.3.3 (so the version range is
+#      genuinely accurate here), but nixpacks depends on serde_with with
+#      default-features = false, features = ["macros"] and uses it ONLY for
+#      #[serde_with::skip_serializing_none] (4 sites: nix/pkg.rs, plan/phase.rs x2,
+#      plan/mod.rs). No KeyValueMap reference in nixpacks or in this workspace
+#      -> not reachable. (verified 2026-07-25)
 #
 # 3. GHSA-xxx: libcrux-intrinsics 0.0.3 (HIGH severity, dev-dependency only)
 #    - Path: testcontainers → russh → libcrux-ml-kem → libcrux-intrinsics 0.0.3
@@ -427,6 +449,10 @@ debug = false
 #     out-of-order stream reassembly): RESOLVED by cargo update quinn-proto →
 #     0.11.15. (Orphaned lock entry with no active dependents — bumped for hygiene
 #     so `cargo audit` stays clean.)
+# - serde_with 3.20.0 (GHSA-8wf9-4rjw-8j9r KeyValueMap serialize panic on empty
+#     sequence/map entries): RESOLVED by cargo update serde_with@3.20.0 --precise
+#     3.21.0 (pulls serde_with_macros → 3.21.0). Reached via cloudflare 0.14 →
+#     temps-dns. The 2.x copy from nixpacks has no fix and stays — see 2c above.
 # - rustls-webpki 0.101.7 (RUSTSEC-2026-0098, -0099, -0104) on rustls 0.21:
 #     RESOLVED by disabling default features on aws-sdk-s3, aws-sdk-sesv2, and
 #     aws-config so the deprecated `rustls` feature (which activates

--- a/examples/nextjs/basic/bun.lock
+++ b/examples/nextjs/basic/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "basic",
       "dependencies": {
-        "next": "16.2.3",
+        "next": "^16.2.11",
         "react": "19.2.3",
         "react-dom": "19.2.3",
       },
@@ -151,25 +151,25 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
-    "@next/env": ["@next/env@16.2.3", "", {}, "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA=="],
+    "@next/env": ["@next/env@16.2.11", "", {}, "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA=="],
 
     "@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.0.0", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-IB7RzmmtrPOrpAgEBR1PIQPD0yea5lggh5cq54m51jHjjljU80Ia+czfxJYMlSDl1DPvpzb8S9TalCc0VMo9Hw=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.11", "", { "os": "linux", "cpu": "x64" }, "sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.11", "", { "os": "linux", "cpu": "x64" }, "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.3", "", { "os": "win32", "cpu": "x64" }, "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.11", "", { "os": "win32", "cpu": "x64" }, "sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -657,7 +657,7 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "next": ["next@16.2.3", "", { "dependencies": { "@next/env": "16.2.3", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.3", "@next/swc-darwin-x64": "16.2.3", "@next/swc-linux-arm64-gnu": "16.2.3", "@next/swc-linux-arm64-musl": "16.2.3", "@next/swc-linux-x64-gnu": "16.2.3", "@next/swc-linux-x64-musl": "16.2.3", "@next/swc-win32-arm64-msvc": "16.2.3", "@next/swc-win32-x64-msvc": "16.2.3", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA=="],
+    "next": ["next@16.2.11", "", { "dependencies": { "@next/env": "16.2.11", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.11", "@next/swc-darwin-x64": "16.2.11", "@next/swc-linux-arm64-gnu": "16.2.11", "@next/swc-linux-arm64-musl": "16.2.11", "@next/swc-linux-x64-gnu": "16.2.11", "@next/swc-linux-x64-musl": "16.2.11", "@next/swc-win32-arm64-msvc": "16.2.11", "@next/swc-win32-x64-msvc": "16.2.11", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ=="],
 
     "node-releases": ["node-releases@2.0.26", "", {}, "sha512-S2M9YimhSjBSvYnlr5/+umAnPHE++ODwt5e2Ij6FoX45HA/s4vHdkDx1eax2pAPeAOqu4s9b7ppahsyEFdVqQA=="],
 

--- a/examples/nextjs/basic/package.json
+++ b/examples/nextjs/basic/package.json
@@ -9,9 +9,9 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "next": "16.2.11",
     "react": "19.2.3",
-    "react-dom": "19.2.3",
-    "next": "16.2.6"
+    "react-dom": "19.2.3"
   },
   "devDependencies": {
     "babel-plugin-react-compiler": "1.0.0",

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -527,11 +527,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.0"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/f3/748f4d6f65d1756b9ae577f329c951cda23fb900e4de9f70900ced962085/setuptools-82.0.0.tar.gz", hash = "sha256:22e0a2d69474c6ae4feb01951cb69d515ed23728cf96d05513d36e42b62b37cb", size = 1144893, upload-time = "2026-02-08T15:08:40.206Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/c6/76dc613121b793286a3f91621d7b75a2b493e0390ddca50f11993eadf192/setuptools-82.0.0-py3-none-any.whl", hash = "sha256:70b18734b607bd1da571d097d236cfcfacaf01de45717d59e6e04b96877532e0", size = 1003468, upload-time = "2026-02-08T15:08:38.723Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes 11 of the 14 open Dependabot alerts. The remaining 3 are upstream-blocked; I re-verified their reachability against current source rather than inheriting the existing 2026-06-29 note, and refreshed the triage block in `Cargo.toml`.

## Fixed

| Alerts | Package | Change |
|---|---|---|
| #175–#183 (9) | `next` | 16.2.6 → **16.2.11** (`examples/nextjs/basic`) |
| #174 | `setuptools` | 82.0.0 → **83.0.0** (`sdks/python/uv.lock`) |
| #173 | `serde_with` | 3.20.0 → **3.21.0** (+ `serde_with_macros`) |

The 9 Next.js advisories: SSRF in Server Actions on custom servers, SSRF via attacker-controlled rewrite destination hostname, middleware/proxy bypass with Turbopack + single locale, DoS in Server Actions, cache confusion on invalid-UTF-8 bodies, cache confusion on request bodies, unbounded Server Action payload on Edge, Image Optimization SVG DoS, and unauthenticated Server Function endpoint disclosure.

`serde_with` 3.x is reached via `cloudflare 0.14` → `temps-dns`.

## Not fixable upstream — re-verified unreachable

- **`protobuf` 2.28.0 (#4)** — root cause is structural: `pingora-core` 0.8.1 declares `prometheus = "0.13"` with default features, and `protobuf` is a **default** feature of prometheus 0.13. Cargo features are additive, so it cannot be turned off from this workspace without vendoring a pingora fork. Confirmed `pingora-core` 0.8.1 is still crates.io latest and still pins `prometheus ^0.13`. Reachability: no `ProtobufEncoder` / `TextEncoder` / `protobuf::` / `PrometheusServer` reference anywhere under `crates/`, so the 2.x parser is never fed input.
- **`opentelemetry_sdk` 0.30.0 (#151)** — pinned transitively through the `getsentry/relay` git rev. The bug is in the W3C `BaggagePropagator`; no case-insensitive match for `baggage` exists under `crates/`.
- **`remove_dir_all` 0.5.3 (#1)** — `nixpacks` 1.41.0 (still crates.io latest) uses deprecated `tempdir`, which hard-requires `remove_dir_all ^0.5`, so `--precise 0.8.0` is impossible. The TOCTOU branch only runs when `out_dir` is `None`, and `nixpacks_preset.rs:508` is still the *only* `out_dir` site in the workspace, passing `Some(..)`.

One correction worth flagging: `serde_with` **2.3.3** also remains in the lock via nixpacks, and it *is* genuinely in the advisory range — `KeyValueMap` does exist in 2.3.3, contrary to what one might assume from it being a 3.x-era API. There is no fix available (2.3.3 is the last 2.x ever published; the fix landed only in 3.21.0, and nixpacks requires `^2.1.0`). It is unreachable: nixpacks depends on serde_with with `default-features = false, features = ["macros"]` and uses it solely for `#[serde_with::skip_serializing_none]` (4 sites), never `KeyValueMap`. Documented as item 2c.

## Lockfile note for reviewers

`Cargo.lock` contains two re-unifications unrelated to the version bumps. They are latent drift that **any** `cargo update` surfaces (a plain `cargo metadata` on the pristine lock produces no diff, but any re-resolve does), both within their declared ranges and neither a regression:

- `pingora-lru` → `hashbrown` 0.14.5 (its requirement is literally `"0"`, so both 0.12.3 and 0.14.5 match; `ahash`/`allocator-api2` are 0.14.5 defaults, so gaining them is correct).
- `iana-time-zone` → `windows-core` 0.57.0 (requirement is `>=0.56, <=0.62`; this is a `cfg(target_os = "windows")`-only dep, so it cannot affect Linux/macOS builds, and the move collapses a duplicate copy).

## Verification

- `cargo check --lib --workspace` — clean, 0 errors.
- `cargo audit` — vulnerability count unchanged at the 3 known upstream-blocked entries (`protobuf`, `remove_dir_all`, `rsa`); note RustSec does not carry the `serde_with` or `opentelemetry_sdk` advisories, which are Dependabot-only.
- Next.js example on 16.2.11 — `tsc --noEmit` clean, `next build` succeeds (4 static routes generated); build artifact removed.