### PR TITLE
perf(observe): stop proxy-log and span listings scanning the whole retention window

### DIFF
--- a/crates/temps-core/src/lib.rs
+++ b/crates/temps-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod retention;
 pub mod retry;
 pub mod secrets_manager;
 pub mod telemetry;
+pub mod time_window;
 pub mod tls;
 pub mod traces;
 pub mod update_status;

--- a/crates/temps-core/src/time_window.rs
+++ b/crates/temps-core/src/time_window.rs
@@ -23,7 +23,7 @@
 //!
 //! 1. **Never unbounded.** A caller that supplies no lower bound gets one.
 //!    Omitting a date must not mean "scan the whole retention window".
-//! 2. **Never unboundedly wide.** A window wider than [`MAX_WINDOW_DAYS`] is
+//! 2. **Never unboundedly wide.** A window wider than the applicable cap is
 //!    rejected with an actionable error rather than served slowly, because at
 //!    these volumes "slow" means tens of seconds and a request that ties up a
 //!    connection that long is a availability problem, not just a UX one.
@@ -31,6 +31,16 @@
 //! Rule 2 caps the window's WIDTH, not its AGE: retention is 30 days and any
 //! point in it stays reachable — a caller just moves a 7-day window back rather
 //! than asking for all 30 days at once.
+//!
+//! **The cap itself depends on scope.** [`MAX_WINDOW_DAYS`] (7d) is for reads
+//! with no project filter — the measurements above, where the query has
+//! nothing but the sort key to prune on and the row count is the whole
+//! deployment's. [`MAX_WINDOW_DAYS_SCOPED`] (30d) is for reads already
+//! filtered to one project — the row count such a query considers is that
+//! project's own volume, not the deployment's, so a wider window is cheap
+//! enough to allow. Picking the wrong one for a given call site either
+//! under-serves a legitimately cheap query or lets an expensive one through —
+//! see the callers for which applies where.
 
 use chrono::{DateTime, Duration, Utc};
 use thiserror::Error;
@@ -43,12 +53,24 @@ use thiserror::Error;
 /// visible choice in the UI's range picker.
 pub const DEFAULT_LOOKBACK_HOURS: i64 = 1;
 
-/// Widest window any of these endpoints will serve.
+/// Widest window an UNSCOPED (no project filter) read will serve.
 ///
-/// Seven days is the widest preset the UI offers and measures ~1.3s on the
-/// 150M-row reference set — slow, but acceptable for an explicit action. Beyond
-/// that the query grows into the tens of seconds.
+/// Seven days is the widest preset the Proxy Logs table and node-metrics
+/// pages offer, and measures ~1.3s on the 150M-row, whole-deployment reference
+/// set — slow, but acceptable for an explicit action. Beyond that the query
+/// grows into the tens of seconds.
 pub const MAX_WINDOW_DAYS: i64 = 7;
+
+/// Widest window a PROJECT-SCOPED read will serve.
+///
+/// A query that already filters to one `project_id` is bounded by that
+/// project's own row count, not the deployment's — the cost profile the 7-day
+/// cap above exists to protect against doesn't apply. Thirty days matches the
+/// widest preset the Observe feed (`ObserveFilterBar.tsx`) and the Project
+/// Analytics AI Agents tab (`useAnalyticsDateRange.ts`) already ship; both
+/// predate this cap and would otherwise regress from "slow" to "rejected"
+/// for an existing menu option.
+pub const MAX_WINDOW_DAYS_SCOPED: i64 = 30;
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum TimeWindowError {
@@ -96,6 +118,20 @@ pub fn resolve(
     resolve_with_max(start, end, lookback, Duration::days(MAX_WINDOW_DAYS))
 }
 
+/// Absorbs clock/network skew for an open-ended window.
+///
+/// A caller that omits `end` computed `start` as "now minus the preset" on
+/// its OWN clock before the request was sent; this function then measures the
+/// width against a SECOND, later `Utc::now()` call once the request arrives.
+/// For a preset sized to land exactly on the cap (the Observe feed's and the
+/// AI Agents tab's "last N days" options are deliberately sized to equal
+/// [`MAX_WINDOW_DAYS_SCOPED`]), that gap — however small — pushes the
+/// measured span a hair past the cap and the request would be rejected for a
+/// reason invisible to the caller. Only applied when `end` is absent; an
+/// explicit `end` is a fixed instant with no such race, and the width check
+/// against it stays exact (see `requested_days_rounds_up`).
+const OPEN_END_SKEW_TOLERANCE: Duration = Duration::minutes(5);
+
 /// [`resolve`] with an explicit cap, for endpoints whose aggregation is cheap
 /// enough to justify a wider ceiling.
 pub fn resolve_with_max(
@@ -127,8 +163,13 @@ pub fn resolve_with_max(
         });
     }
 
+    let tolerance = if end.is_none() {
+        OPEN_END_SKEW_TOLERANCE
+    } else {
+        Duration::zero()
+    };
     let span = effective_end.signed_duration_since(start);
-    if span > max_span {
+    if span > max_span + tolerance {
         return Err(TimeWindowError::TooWide {
             // Round up: a 7-day-and-one-second request should not report "7".
             requested_days: (span.num_seconds() + 86_399) / 86_400,
@@ -237,11 +278,82 @@ mod tests {
         );
     }
 
+    /// A project-scoped caller (e.g. the Observe feed) gets the wider cap —
+    /// the same 30-day span that `a_span_wider_than_the_cap_is_rejected`
+    /// proves is too wide for an unscoped read.
+    #[test]
+    fn scoped_cap_allows_the_span_the_unscoped_cap_rejects() {
+        let start = at("2026-06-01T00:00:00Z");
+        let end = at("2026-07-01T00:00:00Z");
+        let w = resolve_with_max(
+            Some(start),
+            Some(end),
+            Duration::hours(1),
+            Duration::days(MAX_WINDOW_DAYS_SCOPED),
+        )
+        .expect("30 days is within the scoped cap");
+        assert_eq!(w.start, start);
+        assert_eq!(w.end, Some(end));
+    }
+
     #[test]
     fn underflow_saturates_instead_of_panicking() {
         // `end` reaches this straight from a query parameter.
         let w = resolve(None, Some(DateTime::<Utc>::MIN_UTC), Duration::hours(1))
             .expect("saturating start is still a valid window");
         assert_eq!(w.start, DateTime::<Utc>::MIN_UTC);
+    }
+
+    /// The regression this tolerance exists for: a preset sized to exactly
+    /// equal the cap (the Observe feed's "Last 30 days", the Proxy Logs
+    /// table's "Last 7 days") computes `start` on the CLIENT's clock and sends
+    /// no `end`. By the time this function's OWN `Utc::now()` resolves
+    /// `effective_end`, a little time has always passed — network latency,
+    /// clock skew — so the measured span is a hair over the cap even though
+    /// the caller asked for exactly the cap. Without `OPEN_END_SKEW_TOLERANCE`
+    /// this is rejected for a reason the caller has no way to see or avoid.
+    #[test]
+    fn an_open_ended_request_at_exactly_the_cap_tolerates_clock_skew() {
+        // 50ms stands in for "whatever elapsed between the client computing
+        // `start` and this call computing `effective_end`" — comfortably
+        // inside realistic request latency and inside the 5-minute tolerance.
+        let start =
+            Utc::now() - Duration::days(MAX_WINDOW_DAYS_SCOPED) - Duration::milliseconds(50);
+        let w = resolve_with_max(
+            Some(start),
+            None,
+            Duration::hours(1),
+            Duration::days(MAX_WINDOW_DAYS_SCOPED),
+        )
+        .expect("a few milliseconds of skew at the cap boundary must not be rejected");
+        assert_eq!(w.start, start);
+        assert_eq!(w.end, None);
+    }
+
+    /// The tolerance absorbs clock skew, not a wider request: an open-ended
+    /// window that is genuinely, substantially over the cap must still fail.
+    #[test]
+    fn an_open_ended_request_far_past_the_cap_is_still_rejected() {
+        let start = Utc::now() - Duration::days(MAX_WINDOW_DAYS_SCOPED) - Duration::hours(1);
+        let err = resolve_with_max(
+            Some(start),
+            None,
+            Duration::hours(1),
+            Duration::days(MAX_WINDOW_DAYS_SCOPED),
+        )
+        .expect_err("an hour past the cap is well outside the skew tolerance");
+        assert!(matches!(err, TimeWindowError::TooWide { .. }));
+    }
+
+    /// The tolerance only applies when `end` is absent — an explicit `end` one
+    /// second over the cap is a real, controllable request, not clock skew,
+    /// and must still be rejected exactly as `requested_days_rounds_up` checks.
+    #[test]
+    fn an_explicit_end_gets_no_skew_tolerance() {
+        let start = at("2026-07-13T00:00:00Z");
+        let end = at("2026-07-20T00:00:01Z");
+        let err = resolve(Some(start), Some(end), Duration::hours(1))
+            .expect_err("an explicit end one second over the cap has no tolerance to absorb it");
+        assert!(matches!(err, TimeWindowError::TooWide { .. }));
     }
 }

--- a/crates/temps-core/src/time_window.rs
+++ b/crates/temps-core/src/time_window.rs
@@ -1,0 +1,247 @@
+//! Bounded time windows for high-volume time-series read endpoints.
+//!
+//! Proxy logs, OTel spans and the unified Observe feed are all append-only
+//! tables holding one row per HTTP request / per span. On a busy deployment
+//! that is 100M+ rows inside the retention window, and the cost of answering
+//! "the most recent N rows" is **linear in how much time the window spans** —
+//! the sort keys are project-scoped (`(project_id, timestamp, …)`), so an
+//! unscoped `ORDER BY timestamp DESC` cannot be answered from the index and the
+//! engine reads every granule in the range before sorting.
+//!
+//! Measured on 150M proxy-log rows (ClickHouse 24.8), whole endpoint
+//! (count + page), no project filter:
+//!
+//! | window | latency | rows read |
+//! |--------|---------|-----------|
+//! | 1 hour |  7.7 ms |      1.6M |
+//! | 6 hours|   27 ms |      5.3M |
+//! | 24 hours|  123 ms |     23.8M |
+//! | 7 days | 1336 ms |     151.5M |
+//!
+//! Two rules follow, and this module is the single place both are defined so
+//! every endpoint enforces the same contract:
+//!
+//! 1. **Never unbounded.** A caller that supplies no lower bound gets one.
+//!    Omitting a date must not mean "scan the whole retention window".
+//! 2. **Never unboundedly wide.** A window wider than [`MAX_WINDOW_DAYS`] is
+//!    rejected with an actionable error rather than served slowly, because at
+//!    these volumes "slow" means tens of seconds and a request that ties up a
+//!    connection that long is a availability problem, not just a UX one.
+//!
+//! Rule 2 caps the window's WIDTH, not its AGE: retention is 30 days and any
+//! point in it stays reachable — a caller just moves a 7-day window back rather
+//! than asking for all 30 days at once.
+
+use chrono::{DateTime, Duration, Utc};
+use thiserror::Error;
+
+/// Default lower bound when a caller supplies no start.
+///
+/// One hour keeps the default page load an order of magnitude inside a 100ms
+/// budget (7.7ms above) while still covering "what is happening right now",
+/// which is what these pages are opened for. Wider ranges are a deliberate,
+/// visible choice in the UI's range picker.
+pub const DEFAULT_LOOKBACK_HOURS: i64 = 1;
+
+/// Widest window any of these endpoints will serve.
+///
+/// Seven days is the widest preset the UI offers and measures ~1.3s on the
+/// 150M-row reference set — slow, but acceptable for an explicit action. Beyond
+/// that the query grows into the tens of seconds.
+pub const MAX_WINDOW_DAYS: i64 = 7;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum TimeWindowError {
+    /// The requested span exceeds [`MAX_WINDOW_DAYS`].
+    ///
+    /// The message names the cap AND how to work around it, because the caller
+    /// has no other way to discover either.
+    #[error(
+        "Requested time range spans {requested_days} days, which exceeds the \
+         {max_days}-day maximum for this endpoint. Older data is still \
+         available — request it {max_days} days at a time by moving \
+         start_date/end_date back, or narrow the range with filters."
+    )]
+    TooWide { requested_days: i64, max_days: i64 },
+
+    /// `start` is after `end`.
+    #[error("start ({start}) is after end ({end})")]
+    Inverted { start: String, end: String },
+}
+
+/// A resolved, bounded window. `end` is `None` when the caller did not pin an
+/// upper bound — callers that need a concrete instant should treat that as
+/// "now", but leaving it open lets the storage layer omit the predicate
+/// entirely, which is one less comparison per row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TimeWindow {
+    pub start: DateTime<Utc>,
+    pub end: Option<DateTime<Utc>>,
+}
+
+/// Resolve a caller-supplied range into a bounded window.
+///
+/// * absent `start` → `end` (or now) minus `lookback`
+/// * `start` after `end` → [`TimeWindowError::Inverted`]
+/// * span wider than [`MAX_WINDOW_DAYS`] → [`TimeWindowError::TooWide`]
+///
+/// An absent `end` is measured against *now* for the width check, so
+/// `start_date=<60 days ago>` with no end is rejected rather than silently
+/// scanning the whole retention window.
+pub fn resolve(
+    start: Option<DateTime<Utc>>,
+    end: Option<DateTime<Utc>>,
+    lookback: Duration,
+) -> Result<TimeWindow, TimeWindowError> {
+    resolve_with_max(start, end, lookback, Duration::days(MAX_WINDOW_DAYS))
+}
+
+/// [`resolve`] with an explicit cap, for endpoints whose aggregation is cheap
+/// enough to justify a wider ceiling.
+pub fn resolve_with_max(
+    start: Option<DateTime<Utc>>,
+    end: Option<DateTime<Utc>>,
+    lookback: Duration,
+    max_span: Duration,
+) -> Result<TimeWindow, TimeWindowError> {
+    let start = match start {
+        Some(s) => s,
+        None => {
+            let anchor = end.unwrap_or_else(Utc::now);
+            // Checked: `end` arrives straight from a query parameter and a bare
+            // subtraction panics at the representable boundary.
+            anchor
+                .checked_sub_signed(lookback)
+                .unwrap_or(DateTime::<Utc>::MIN_UTC)
+        }
+    };
+
+    // Width is measured against a concrete upper bound even when the caller
+    // left `end` open, otherwise "start=90 days ago" would slip through.
+    let effective_end = end.unwrap_or_else(Utc::now);
+
+    if start > effective_end {
+        return Err(TimeWindowError::Inverted {
+            start: start.to_rfc3339(),
+            end: effective_end.to_rfc3339(),
+        });
+    }
+
+    let span = effective_end.signed_duration_since(start);
+    if span > max_span {
+        return Err(TimeWindowError::TooWide {
+            // Round up: a 7-day-and-one-second request should not report "7".
+            requested_days: (span.num_seconds() + 86_399) / 86_400,
+            max_days: max_span.num_days(),
+        });
+    }
+
+    Ok(TimeWindow { start, end })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s)
+            .expect("valid fixture timestamp")
+            .with_timezone(&Utc)
+    }
+
+    #[test]
+    fn absent_start_defaults_to_lookback_before_now() {
+        let before = Utc::now();
+        let w = resolve(None, None, Duration::hours(1)).expect("bounded");
+        let after = Utc::now();
+
+        assert!(w.start >= before - Duration::hours(1));
+        assert!(w.start <= after - Duration::hours(1));
+        assert_eq!(w.end, None, "an open upper bound stays open");
+    }
+
+    #[test]
+    fn absent_start_anchors_to_end_when_end_given() {
+        let end = at("2026-07-20T12:00:00Z");
+        let w = resolve(None, Some(end), Duration::hours(1)).expect("bounded");
+        // The window ends where the caller asked, not at "now".
+        assert_eq!(w.start, end - Duration::hours(1));
+        assert_eq!(w.end, Some(end));
+    }
+
+    #[test]
+    fn explicit_start_is_preserved_when_within_the_cap() {
+        let start = at("2026-07-18T00:00:00Z");
+        let end = at("2026-07-20T00:00:00Z");
+        let w = resolve(Some(start), Some(end), Duration::hours(1)).expect("bounded");
+        assert_eq!(w.start, start);
+        assert_eq!(w.end, Some(end));
+    }
+
+    #[test]
+    fn a_span_wider_than_the_cap_is_rejected() {
+        let start = at("2026-06-01T00:00:00Z");
+        let end = at("2026-07-01T00:00:00Z");
+        let err = resolve(Some(start), Some(end), Duration::hours(1))
+            .expect_err("30 days must exceed the 7-day cap");
+        assert_eq!(
+            err,
+            TimeWindowError::TooWide {
+                requested_days: 30,
+                max_days: 7
+            }
+        );
+        // The message has to tell the caller how to still get the data.
+        let msg = err.to_string();
+        assert!(msg.contains("7-day maximum"), "{msg}");
+        assert!(msg.contains("still"), "must point at the workaround: {msg}");
+    }
+
+    #[test]
+    fn exactly_the_cap_is_allowed() {
+        let start = at("2026-07-13T00:00:00Z");
+        let end = at("2026-07-20T00:00:00Z");
+        assert!(resolve(Some(start), Some(end), Duration::hours(1)).is_ok());
+    }
+
+    /// An open `end` must not be an escape hatch around the width cap.
+    #[test]
+    fn an_ancient_start_with_no_end_is_still_rejected() {
+        let start = Utc::now() - Duration::days(30);
+        let err = resolve(Some(start), None, Duration::hours(1))
+            .expect_err("width is measured against now when end is open");
+        assert!(matches!(err, TimeWindowError::TooWide { .. }));
+    }
+
+    #[test]
+    fn inverted_range_is_rejected_before_the_width_check() {
+        let start = at("2026-07-20T00:00:00Z");
+        let end = at("2026-07-19T00:00:00Z");
+        let err = resolve(Some(start), Some(end), Duration::hours(1)).expect_err("inverted");
+        assert!(matches!(err, TimeWindowError::Inverted { .. }));
+    }
+
+    /// Rounding up matters: a range one second over the cap must not report the
+    /// cap back to the user as if it were within it.
+    #[test]
+    fn requested_days_rounds_up() {
+        let start = at("2026-07-13T00:00:00Z");
+        let end = at("2026-07-20T00:00:01Z");
+        let err = resolve(Some(start), Some(end), Duration::hours(1)).expect_err("just over");
+        assert_eq!(
+            err,
+            TimeWindowError::TooWide {
+                requested_days: 8,
+                max_days: 7
+            }
+        );
+    }
+
+    #[test]
+    fn underflow_saturates_instead_of_panicking() {
+        // `end` reaches this straight from a query parameter.
+        let w = resolve(None, Some(DateTime::<Utc>::MIN_UTC), Duration::hours(1))
+            .expect("saturating start is still a valid window");
+        assert_eq!(w.start, DateTime::<Utc>::MIN_UTC);
+    }
+}

--- a/crates/temps-observability/src/error.rs
+++ b/crates/temps-observability/src/error.rs
@@ -25,6 +25,12 @@ pub enum ObservabilityError {
     #[error("Time range invalid: from={from} is after to={to}; the merge query needs from <= to")]
     InvalidTimeRange { from: String, to: String },
 
+    /// The requested window is wider than the shared cap. Carries the message
+    /// from [`temps_core::time_window`] verbatim, because that message names
+    /// both the limit and how to still reach older data.
+    #[error("{0}")]
+    InvalidTimeWindow(String),
+
     #[error("Database error: {0}")]
     Database(#[from] sea_orm::DbErr),
 

--- a/crates/temps-observability/src/handlers/events.rs
+++ b/crates/temps-observability/src/handlers/events.rs
@@ -161,7 +161,8 @@ impl From<ObservabilityError> for Problem {
                 .with_detail(error.to_string()),
             ObservabilityError::InvalidKindsFilter { .. }
             | ObservabilityError::InvalidCursor { .. }
-            | ObservabilityError::InvalidTimeRange { .. } => {
+            | ObservabilityError::InvalidTimeRange { .. }
+            | ObservabilityError::InvalidTimeWindow(_) => {
                 problemdetails::new(StatusCode::BAD_REQUEST)
                     .with_title("Invalid Request")
                     .with_detail(error.to_string())

--- a/crates/temps-observability/src/service.rs
+++ b/crates/temps-observability/src/service.rs
@@ -149,10 +149,18 @@ impl ObservabilityService {
         // otherwise scan their whole table for a caller that simply omitted a
         // date. The web UI always sends a range; the API must not depend on
         // that. Rules and measurements live in temps_core::time_window.
-        let window = temps_core::time_window::resolve(
+        //
+        // The SCOPED cap applies unconditionally: `EventFilters::project_id`
+        // is a required `i32`, not `Option` — every call into this feed is
+        // already narrowed to one project's rows, so it gets the same 30-day
+        // ceiling `list_page`/the AI-breakdown endpoints grant a project-scoped
+        // caller (see `ProxyLogService::resolve_window`), matching the 30-day
+        // preset the Observe picker (`ObserveFilterBar.tsx`) already ships.
+        let window = temps_core::time_window::resolve_with_max(
             filters.from,
             filters.to,
             chrono::Duration::hours(temps_core::time_window::DEFAULT_LOOKBACK_HOURS),
+            chrono::Duration::days(temps_core::time_window::MAX_WINDOW_DAYS_SCOPED),
         )
         .map_err(|e| ObservabilityError::InvalidTimeWindow(e.to_string()))?;
         let filters = EventFilters {

--- a/crates/temps-observability/src/service.rs
+++ b/crates/temps-observability/src/service.rs
@@ -143,6 +143,24 @@ impl ObservabilityService {
     ) -> Result<Vec<ObservabilityEvent>, ObservabilityError> {
         filters.validate()?;
 
+        // Bound the window BEFORE any fetcher runs, so every kind inherits it.
+        // `from` is an optional query parameter, and the span and request
+        // stores take the range verbatim — `query_spans` and `list_page` would
+        // otherwise scan their whole table for a caller that simply omitted a
+        // date. The web UI always sends a range; the API must not depend on
+        // that. Rules and measurements live in temps_core::time_window.
+        let window = temps_core::time_window::resolve(
+            filters.from,
+            filters.to,
+            chrono::Duration::hours(temps_core::time_window::DEFAULT_LOOKBACK_HOURS),
+        )
+        .map_err(|e| ObservabilityError::InvalidTimeWindow(e.to_string()))?;
+        let filters = EventFilters {
+            from: Some(window.start),
+            to: window.end,
+            ..filters
+        };
+
         // A disabled kind resolves to an empty stream without touching its
         // store, so the join arms stay uniform in type.
         let requests = async {

--- a/crates/temps-observability/src/service.rs
+++ b/crates/temps-observability/src/service.rs
@@ -122,29 +122,62 @@ impl ObservabilityService {
     /// Strategy:
     ///   1. Validate the filter struct.
     ///   2. For each enabled kind in `filters.kinds`, run an independent
-    ///      Sea-ORM query (LIMIT = page size) returning rows already mapped
-    ///      to the `ObservabilityEvent` wire type — no follow-up fetches.
+    ///      query (LIMIT = page size) returning rows already mapped to the
+    ///      `ObservabilityEvent` wire type — no follow-up fetches.
     ///   3. k-way merge the streams by ts DESC and trim to `filters.limit`.
+    ///
+    /// Step 2 runs the enabled fetchers CONCURRENTLY. They are independent —
+    /// different stores entirely (proxy logs and spans go to ClickHouse when
+    /// it is configured; errors and revenue to Postgres) — so awaiting them
+    /// one after another made the endpoint cost the SUM of four round trips
+    /// instead of the slowest one. With spans being by far the slowest kind
+    /// at volume, that serialisation was a large share of the observed
+    /// multi-second latency on busy projects.
+    ///
+    /// `try_join!` short-circuits on the first error, matching the previous
+    /// `?`-per-fetcher behaviour: one failing store still fails the request
+    /// rather than silently returning a partial feed.
     pub async fn query(
         &self,
         filters: EventFilters,
     ) -> Result<Vec<ObservabilityEvent>, ObservabilityError> {
         filters.validate()?;
 
-        let mut streams: Vec<Vec<ObservabilityEvent>> = Vec::new();
+        // A disabled kind resolves to an empty stream without touching its
+        // store, so the join arms stay uniform in type.
+        let requests = async {
+            if filters.kinds.contains(&EventKind::Request) {
+                self.fetch_requests(&filters).await
+            } else {
+                Ok(Vec::new())
+            }
+        };
+        let errors = async {
+            if filters.kinds.contains(&EventKind::Error) {
+                self.fetch_errors(&filters).await
+            } else {
+                Ok(Vec::new())
+            }
+        };
+        let revenue = async {
+            if filters.kinds.contains(&EventKind::Revenue) {
+                self.fetch_revenue(&filters).await
+            } else {
+                Ok(Vec::new())
+            }
+        };
+        let spans = async {
+            if filters.kinds.contains(&EventKind::Span) {
+                self.fetch_spans(&filters).await
+            } else {
+                Ok(Vec::new())
+            }
+        };
 
-        if filters.kinds.contains(&EventKind::Request) {
-            streams.push(self.fetch_requests(&filters).await?);
-        }
-        if filters.kinds.contains(&EventKind::Error) {
-            streams.push(self.fetch_errors(&filters).await?);
-        }
-        if filters.kinds.contains(&EventKind::Revenue) {
-            streams.push(self.fetch_revenue(&filters).await?);
-        }
-        if filters.kinds.contains(&EventKind::Span) {
-            streams.push(self.fetch_spans(&filters).await?);
-        }
+        let (requests, errors, revenue, spans) =
+            tokio::try_join!(requests, errors, revenue, spans)?;
+
+        let streams: Vec<Vec<ObservabilityEvent>> = vec![requests, errors, revenue, spans];
 
         Ok(merge_desc_by_ts(streams, filters.limit as usize))
     }

--- a/crates/temps-observability/tests/clickhouse_observe_test.rs
+++ b/crates/temps-observability/tests/clickhouse_observe_test.rs
@@ -486,4 +486,17 @@ async fn observe_feed_bounds_the_window_and_rejects_an_over_wide_one() {
     };
     assert!(msg.contains("maximum"), "{msg}");
     assert!(msg.contains("still"), "must name the workaround: {msg}");
+
+    // `EventFilters::project_id` is a required `i32` — every call into this
+    // feed is already scoped to one project — so a 30-day window (exactly the
+    // "Last 30 days" preset ObserveFilterBar.tsx ships) must be ALLOWED, not
+    // rejected like the unscoped 60-day request above. This is the regression
+    // this test guards: the feed's own shipped time-range option must not 400.
+    let mut thirty_days = filters(&[EventKind::Request], None, None);
+    thirty_days.from = Some(Utc::now() - Duration::days(30));
+    thirty_days.to = None;
+    env.service
+        .query(thirty_days)
+        .await
+        .expect("a 30-day project-scoped window must not be rejected");
 }

--- a/crates/temps-observability/tests/clickhouse_observe_test.rs
+++ b/crates/temps-observability/tests/clickhouse_observe_test.rs
@@ -446,3 +446,44 @@ async fn observe_feed_merges_correctly_when_only_some_kinds_are_enabled() {
     sorted.sort_by(|a, b| b.cmp(a));
     assert_eq!(timestamps, sorted, "feed must stay newest-first");
 }
+
+/// The feed must be bounded even when the client sends no `from`.
+///
+/// `from` is an optional query parameter and the request/span stores take the
+/// range verbatim, so an omitted date used to mean "scan the whole table". The
+/// web UI always sends a range, but the API cannot depend on that. A window
+/// wider than the shared cap is refused outright rather than served slowly.
+#[tokio::test]
+async fn observe_feed_bounds_the_window_and_rejects_an_over_wide_one() {
+    let Some(env) = setup().await else { return };
+
+    // No `from` at all: still returns the seeded rows (they are recent), and
+    // crucially does not error — the default window is applied silently.
+    let mut open = filters(&[EventKind::Request], None, None);
+    open.from = None;
+    open.to = None;
+    let events = env
+        .service
+        .query(open)
+        .await
+        .expect("an omitted range must be defaulted, not rejected");
+    assert_eq!(events.len(), 3, "recent rows are inside the default window");
+
+    // A range wider than the cap is a client error, not a slow query.
+    let mut too_wide = filters(&[EventKind::Request], None, None);
+    too_wide.from = Some(Utc::now() - Duration::days(60));
+    too_wide.to = None;
+    let err = env
+        .service
+        .query(too_wide)
+        .await
+        .expect_err("60 days must exceed the cap");
+
+    // Must be the variant the handler maps to 400 — a client mistake surfacing
+    // as a 500 would be misleading.
+    let temps_observability::ObservabilityError::InvalidTimeWindow(msg) = err else {
+        panic!("expected InvalidTimeWindow so the handler returns 400, got {err:?}");
+    };
+    assert!(msg.contains("maximum"), "{msg}");
+    assert!(msg.contains("still"), "must name the workaround: {msg}");
+}

--- a/crates/temps-observability/tests/clickhouse_observe_test.rs
+++ b/crates/temps-observability/tests/clickhouse_observe_test.rs
@@ -14,9 +14,10 @@
 //! be `#[ignore]`d — they detect unavailability at runtime and return).
 //!
 //! The inner Postgres connections are sea-orm `MockDatabase`s: the Request and
-//! Span fetchers under test read only ClickHouse, and the query is restricted
-//! to those two kinds so the error/revenue fetchers (always Postgres) never
-//! run.
+//! Span fetchers under test read only ClickHouse. The error and revenue
+//! fetchers are always Postgres-backed, so the service's own mock is primed
+//! with empty result sets — they resolve to empty streams rather than erroring
+//! when a test enables all four kinds.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -163,7 +164,20 @@ async fn setup() -> Option<ChTestEnv> {
         .await
         .expect("store_spans to ClickHouse");
 
-    let service = ObservabilityService::new(mock_pg(), proxy_logs, ch_otel);
+    // The service's own Postgres handle backs the error and revenue fetchers.
+    // Those kinds have nothing seeded here, but a bare MockDatabase errors with
+    // "`query_results` buffer is empty" the moment they run — which would make
+    // any test that enables all four kinds fail on the harness rather than on
+    // the behaviour under test. Queue empty result sets so they resolve to
+    // empty streams instead.
+    let empty_pg_result = || Vec::<BTreeMap<String, sea_orm::Value>>::new();
+    let service_db = Arc::new(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(std::iter::repeat_with(empty_pg_result).take(8))
+            .into_connection(),
+    );
+
+    let service = ObservabilityService::new(service_db, proxy_logs, ch_otel);
     Some(ChTestEnv {
         service,
         _container: Box::new(container),
@@ -359,4 +373,76 @@ async fn observe_feed_reads_requests_and_spans_from_clickhouse() {
         wrong_project.is_err(),
         "request_id lookups must not leak across projects"
     );
+}
+
+/// The per-kind fetchers run concurrently via `try_join!` rather than being
+/// awaited one after another, which changed how a DISABLED kind is represented:
+/// it used to contribute nothing to the merge input, and now contributes an
+/// empty stream. `merge_desc_by_ts` therefore has to tolerate empty cursors
+/// interleaved with populated ones — if it did not, asking for a subset of
+/// kinds would drop rows or reorder them wrongly, and the feed would look
+/// subtly wrong rather than fail outright.
+///
+/// Errors also still short-circuit: `try_join!` propagates the first failure,
+/// matching the previous `?`-per-fetcher behaviour, so one broken store fails
+/// the request instead of silently returning a partial feed.
+#[tokio::test]
+async fn observe_feed_merges_correctly_when_only_some_kinds_are_enabled() {
+    let Some(env) = setup().await else { return };
+
+    // All four kinds: the baseline the subsets are checked against.
+    let all = env
+        .service
+        .query(filters(
+            &[
+                EventKind::Request,
+                EventKind::Error,
+                EventKind::Revenue,
+                EventKind::Span,
+            ],
+            None,
+            None,
+        ))
+        .await
+        .expect("all-kinds query");
+
+    // Requests only — three empty streams (error, revenue, span) join the merge.
+    let requests_only = env
+        .service
+        .query(filters(&[EventKind::Request], None, None))
+        .await
+        .expect("requests-only query");
+    assert!(
+        requests_only.iter().all(|e| e.kind() == EventKind::Request),
+        "a disabled kind must not surface"
+    );
+    assert_eq!(
+        requests_only.len(),
+        3,
+        "empty streams from disabled kinds must not swallow rows"
+    );
+
+    // Spans only — same, with the populated stream in a different slot, so a
+    // positional bug in the merge input can't pass both cases.
+    let spans_only = env
+        .service
+        .query(filters(&[EventKind::Span], None, None))
+        .await
+        .expect("spans-only query");
+    assert!(spans_only.iter().all(|e| e.kind() == EventKind::Span));
+    assert_eq!(spans_only.len(), 1);
+
+    // The subsets must partition the full result, not merely be contained in it.
+    assert_eq!(
+        requests_only.len() + spans_only.len(),
+        all.len(),
+        "enabling every kind must yield exactly the union of the subsets \
+         (errors and revenue live in Postgres and are unseeded here)"
+    );
+
+    // Descending-by-ts ordering has to survive the empty cursors.
+    let timestamps: Vec<_> = requests_only.iter().map(|e| e.ts()).collect();
+    let mut sorted = timestamps.clone();
+    sorted.sort_by(|a, b| b.cmp(a));
+    assert_eq!(timestamps, sorted, "feed must stay newest-first");
 }

--- a/crates/temps-observability/tests/merge_integration.rs
+++ b/crates/temps-observability/tests/merge_integration.rs
@@ -148,8 +148,11 @@ async fn merge_returns_rows_in_descending_ts_across_kinds() {
         .query(EventFilters {
             project_id,
             kinds: EventKind::ALL.iter().copied().collect(),
-            from: None,
-            to: None,
+            // Fixture rows sit at a fixed 2026-05-01 timestamp, not "now" — an
+            // omitted range now defaults to the last hour (see
+            // `temps_core::time_window`), which would silently exclude them.
+            from: Some(t_revenue - Duration::minutes(1)),
+            to: Some(t_request + Duration::minutes(1)),
             deployment_id: None,
             environment_id: None,
             search: None,
@@ -540,7 +543,9 @@ async fn fetch_spans_returns_span_rows_from_otel_table() {
         .query(EventFilters {
             project_id,
             kinds: [EventKind::Span].iter().copied().collect(),
-            from: None,
+            // `t` sits exactly at the default 1h lookback boundary — pin an
+            // explicit `from` so this doesn't flake on execution timing.
+            from: Some(t - Duration::minutes(5)),
             to: None,
             deployment_id: None,
             environment_id: None,
@@ -573,7 +578,7 @@ async fn fetch_spans_returns_span_rows_from_otel_table() {
         .query(EventFilters {
             project_id,
             kinds: [EventKind::Span].iter().copied().collect(),
-            from: None,
+            from: Some(t - Duration::minutes(5)),
             to: None,
             deployment_id: None,
             environment_id: None,
@@ -696,8 +701,11 @@ async fn merge_interleaves_spans_with_other_kinds() {
         .query(EventFilters {
             project_id,
             kinds: EventKind::ALL.iter().copied().collect(),
-            from: None,
-            to: None,
+            // Fixture rows sit at a fixed 2026-05-01 timestamp, not "now" — an
+            // omitted range now defaults to the last hour (see
+            // `temps_core::time_window`), which would silently exclude them.
+            from: Some(t_revenue - Duration::minutes(1)),
+            to: Some(t_request + Duration::minutes(1)),
             deployment_id: None,
             environment_id: None,
             search: None,

--- a/crates/temps-otel/migrations/clickhouse/0007_spans_recent_projection.sql
+++ b/crates/temps-otel/migrations/clickhouse/0007_spans_recent_projection.sql
@@ -1,0 +1,91 @@
+-- Projection giving `spans` a second physical ordering by (project_id, start_time),
+-- so "most recent N spans for this project" stops being a full-table scan.
+--
+-- WHY
+--
+-- The table's ORDER BY is (project_id, trace_id, span_id) — chosen in
+-- 0001_spans.sql to make get_trace() lookups (all spans of one trace_id) a
+-- contiguous read. That is the right key for trace lookups and the wrong key
+-- for every time-ordered query:
+--
+--   * `trace_id` is a random 128-bit hash, so rows within a project are
+--     scattered by ingest time. Every granule therefore spans essentially the
+--     whole retention window.
+--   * `start_time` is not in the sort key, and a minmax skip index on it would
+--     be useless for the same reason (min/max per granule ≈ the full window).
+--   * The partition key is toYYYYMM(start_time), so pruning only happens at
+--     MONTH granularity. A 24h query still reads the entire current month.
+--
+-- The consequence: `SELECT … WHERE project_id = ? AND start_time >= ?
+-- ORDER BY start_time DESC LIMIT 100` — the Observe feed and the Traces span
+-- list — read every span the project has in the month, to return 100 rows.
+--
+-- MEASURED (2026-07-26, ClickHouse 24.8.14, local single-node)
+--   Dataset: 159.8M spans / 23.84 GiB, 150M of them in one busy project,
+--   spread over 7 days. Query: root spans, 24h window, ORDER BY start_time
+--   DESC LIMIT 100 (exactly what ObservabilityService::fetch_spans issues).
+--   Best of 3 warm runs, statistics.elapsed from FORMAT JSON.
+--
+--     current (FINAL, single-stage)            5050 ms   rows_read 151.6M
+--     drop FINAL only                          3842 ms   rows_read 150.0M
+--     drop FINAL + two-stage, no projection     671 ms   rows_read 158.8M
+--     drop FINAL + two-stage + THIS projection  132 ms   rows_read  24.2M
+--
+--   34x faster than the shipped query, and the result set is byte-identical
+--   (verified by hashing the returned (trace_id, span_id, start_time) rows).
+--
+-- WHY A PROJECTION AND NOT A NEW SORT KEY
+--
+-- Changing ORDER BY would require rewriting the table and would trade the
+-- trace-lookup locality that get_trace() depends on. A projection keeps both
+-- access patterns fast at the cost of storing the narrow columns twice.
+--
+-- COST — measured on identical 10M-row loads into two tables differing only by
+-- this projection (same box, same data, ClickHouse 24.8.14):
+--
+--     read (Observe feed, above)      671 ms  →  132 ms    5x faster
+--     disk                           1.49 GiB → 1.78 GiB     +19%
+--     merge (OPTIMIZE FINAL, 10M)      14.2 s →   16.0 s     +13%
+--     ingest (10M rows)                21.6 s →   22.6 s      +5%
+--
+-- Only the five columns below are duplicated — the fat `attributes` / `events`
+-- JSON strings are NOT in the projection, which is the entire point: the query
+-- planner resolves the ordering and the LIMIT against the narrow projection,
+-- then reads the wide columns for just the ~100 surviving rows via the base
+-- table's primary key. That is why the disk cost is +19% and not +100%.
+--
+-- Whether this trade is worth it depends on span volume, and the cost is paid
+-- by every deployment while the benefit only accrues to ones large enough for
+-- the scan to hurt. It is kept because the read cost WITHOUT the projection
+-- grows with total table size, while WITH it the read is proportional to the
+-- queried window and stays roughly flat as the table grows. A deployment that
+-- decides otherwise can drop it — `ALTER TABLE spans DROP PROJECTION
+-- proj_recent` — and query_spans keeps working, just at the 671ms shape.
+--
+-- deduplicate_merge_projection_mode = 'rebuild'
+--   ClickHouse refuses projections on a ReplacingMergeTree unless this is set
+--   (error 344, SUPPORT_IS_DISABLED). 'rebuild' regenerates the projection
+--   when parts merge, which is correct here: the read paths that use this
+--   projection do not use FINAL (see 0001_spans.sql — the feed and list
+--   queries are LIMIT-ed and duplicate-tolerant), so projection rows and base
+--   rows stay consistent with each other.
+ALTER TABLE spans MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild';
+
+ALTER TABLE spans ADD PROJECTION IF NOT EXISTS proj_recent
+(
+    SELECT project_id, start_time, trace_id, span_id, parent_span_id
+    ORDER BY (project_id, start_time)
+);
+
+-- Backfill the projection into existing parts. ClickHouse can only use a
+-- projection when EVERY part being read has it, so without this the projection
+-- would do nothing until the whole table had been rewritten by TTL/merges.
+--
+-- This is a mutation: it re-reads the five projected columns for every existing
+-- part and writes the sorted copy. It took 2m08s for 159.8M rows / 23.84 GiB on
+-- the benchmark box. The migration runner does NOT wait for it (mutations are
+-- asynchronous by default — no mutations_sync setting is issued), so server
+-- startup is not blocked; queries keep using the base-table path and get faster
+-- part-by-part as the mutation progresses. Track it via:
+--   SELECT * FROM system.mutations WHERE table = 'spans' AND NOT is_done;
+ALTER TABLE spans MATERIALIZE PROJECTION proj_recent;

--- a/crates/temps-otel/migrations/clickhouse/0007_spans_recent_projection.sql
+++ b/crates/temps-otel/migrations/clickhouse/0007_spans_recent_projection.sql
@@ -31,8 +31,20 @@
 --     drop FINAL + two-stage, no projection     671 ms   rows_read 158.8M
 --     drop FINAL + two-stage + THIS projection  132 ms   rows_read  24.2M
 --
---   34x faster than the shipped query, and the result set is byte-identical
---   (verified by hashing the returned (trace_id, span_id, start_time) rows).
+--   38x faster than the query this replaces, and the result set is
+--   byte-identical (verified by hashing the returned
+--   (trace_id, span_id, start_time) rows).
+--
+--   Those four rows predate the `LIMIT 1 BY (trace_id, span_id)` dedup that
+--   query_spans applies to restore the row-count guarantee FINAL used to give
+--   (see the two-stage comment in storage/clickhouse/mod.rs). Re-measured on a
+--   10M-span single-project rebuild of the same shape:
+--
+--     FINAL, single-stage                       932 ms   rows_read 10.2M
+--     two-stage + projection, no dedup          112 ms   rows_read  5.3M
+--     two-stage + projection + dedup (SHIPS)    122 ms   rows_read  5.3M
+--
+--   The dedup costs ~8% and the projection's advantage is unaffected.
 --
 -- WHY A PROJECTION AND NOT A NEW SORT KEY
 --

--- a/crates/temps-otel/src/storage/clickhouse/migrations.rs
+++ b/crates/temps-otel/src/storage/clickhouse/migrations.rs
@@ -46,6 +46,10 @@ const MIGRATIONS: &[Migration] = &[
         name: "0006_trace_refs",
         sql: include_str!("../../../migrations/clickhouse/0006_trace_refs.sql"),
     },
+    Migration {
+        name: "0007_spans_recent_projection",
+        sql: include_str!("../../../migrations/clickhouse/0007_spans_recent_projection.sql"),
+    },
 ];
 
 /// SQL for the migration tracking table. Created on first run.

--- a/crates/temps-otel/src/storage/clickhouse/mod.rs
+++ b/crates/temps-otel/src/storage/clickhouse/mod.rs
@@ -1195,28 +1195,47 @@ impl OtelStorage for ClickHouseOtelStorage {
             //
             // Measured on 159.8M spans (150M in one project), root spans, 24h
             // window, LIMIT 100: 5050ms single-stage with FINAL → 132ms here,
-            // with a byte-identical result set.
+            // with a byte-identical result set. The dedup added below costs a
+            // further ~8% (112ms → 122ms on a 10M re-measure).
+            // `LIMIT 1 BY (trace_id, span_id)` in BOTH stages is what keeps the
+            // page honest without FINAL. spans is a ReplacingMergeTree, so a
+            // retried OTLP batch leaves two physical rows for one span identity
+            // until the next merge:
+            //
+            //   * inner — without it, a duplicated pair consumes two of the
+            //     `limit` slots and the page comes back short on distinct spans.
+            //   * outer — without it, the IN-set matches every physical row for
+            //     each pair, so the statement can return MORE rows than the
+            //     caller asked for. The single-stage shape cannot drift this way
+            //     because its LIMIT applies to rows directly.
+            //
+            // This restores the row-count guarantee FINAL used to provide, at
+            // the cost of a dedup over ≤`limit` rows rather than a merge over
+            // every part. Retried rows are byte-identical apart from `_version`,
+            // so which copy survives is not observable (FINAL would keep the
+            // highest `_version`).
             let inner_sql = format!(
                 "SELECT trace_id, span_id FROM spans WHERE {where_sql} \
-                 ORDER BY {order_sql} LIMIT ? OFFSET ?"
+                 ORDER BY {order_sql} LIMIT 1 BY (trace_id, span_id) LIMIT ? OFFSET ?"
             );
             let sql = format!(
                 "SELECT {SPAN_COLUMNS} \
                  FROM spans \
                  WHERE project_id = ?{time_sql} AND (trace_id, span_id) IN ({inner_sql}) \
-                 ORDER BY {order_sql}"
+                 ORDER BY {order_sql} LIMIT 1 BY (trace_id, span_id) LIMIT ?"
             );
 
             // Bind order must match the rendered placeholder order: the outer
             // project_id and time bounds come first (they precede the subquery
-            // in the statement), then the subquery's own binds, then
-            // LIMIT/OFFSET.
-            let mut all_binds: Vec<Bv> = Vec::with_capacity(binds.len() + time_binds.len() + 3);
+            // in the statement), then the subquery's own binds and its
+            // LIMIT/OFFSET, and finally the outer LIMIT.
+            let mut all_binds: Vec<Bv> = Vec::with_capacity(binds.len() + time_binds.len() + 4);
             all_binds.push(Bv::I32(query.project_id));
             all_binds.extend(time_binds);
             all_binds.extend(binds);
             all_binds.push(Bv::I64(limit as i64));
             all_binds.push(Bv::I64(offset as i64));
+            all_binds.push(Bv::I64(limit as i64));
             (sql, all_binds)
         };
 

--- a/crates/temps-otel/src/storage/clickhouse/mod.rs
+++ b/crates/temps-otel/src/storage/clickhouse/mod.rs
@@ -1059,17 +1059,15 @@ impl OtelStorage for ClickHouseOtelStorage {
         // QueryBuilder is not object-safe). Instead we use a small state
         // machine: we render SQL with `?` placeholders in the same order as
         // the values, then call .bind() in the same order.
-        let mut sql = String::from(
-            "SELECT project_id, deployment_id, service_name, service_version, \
-             deployment_environment, trace_id, span_id, parent_span_id, name, kind, \
-             toUnixTimestamp64Milli(start_time) AS start_time_ms, \
-             toUnixTimestamp64Milli(end_time) AS end_time_ms, \
-             duration_ms, status_code, status_message, attributes, events \
-             FROM spans FINAL WHERE project_id = ?",
-        );
+        //
+        // The predicate is accumulated into `where_sql` rather than straight
+        // into the final statement because it is used TWICE — see the
+        // two-stage assembly at the end of this method.
+        let mut where_sql = String::from("project_id = ?");
 
         // We build bind values as a Vec<ChBindValue> — a local enum that lets
         // us defer the actual .bind() calls until we have the full query string.
+        #[derive(Clone)]
         enum Bv {
             I32(i32),
             I64(i64),
@@ -1078,32 +1076,43 @@ impl OtelStorage for ClickHouseOtelStorage {
         }
         let mut binds: Vec<Bv> = vec![Bv::I32(query.project_id)];
 
+        // The time predicates are ALSO tracked separately so the outer stage of
+        // the two-stage query can repeat them. Repeating them is what preserves
+        // monthly partition pruning on the outer read; the `IN` set alone would
+        // leave the outer query unbounded in time.
+        let mut time_sql = String::new();
+        let mut time_binds: Vec<Bv> = Vec::new();
+
         if let Some(ref tid) = query.trace_id {
-            sql.push_str(" AND trace_id = ?");
+            where_sql.push_str(" AND trace_id = ?");
             binds.push(Bv::Str(tid.clone()));
         }
         if let Some(ref svc) = query.service_name {
-            sql.push_str(" AND service_name = ?");
+            where_sql.push_str(" AND service_name = ?");
             binds.push(Bv::Str(svc.clone()));
         }
         if let Some(status) = query.status {
-            sql.push_str(" AND status_code = ?");
+            where_sql.push_str(" AND status_code = ?");
             binds.push(Bv::Str(span_status_to_str(status).to_owned()));
         }
         if let Some(min_dur) = query.min_duration_ms {
-            sql.push_str(" AND duration_ms >= ?");
+            where_sql.push_str(" AND duration_ms >= ?");
             binds.push(Bv::F64(min_dur));
         }
         if let Some(start) = query.start_time {
-            sql.push_str(" AND start_time >= fromUnixTimestamp64Milli(?)");
+            where_sql.push_str(" AND start_time >= fromUnixTimestamp64Milli(?)");
             binds.push(Bv::I64(start.timestamp_millis()));
+            time_sql.push_str(" AND start_time >= fromUnixTimestamp64Milli(?)");
+            time_binds.push(Bv::I64(start.timestamp_millis()));
         }
         if let Some(end) = query.end_time {
-            sql.push_str(" AND start_time <= fromUnixTimestamp64Milli(?)");
+            where_sql.push_str(" AND start_time <= fromUnixTimestamp64Milli(?)");
             binds.push(Bv::I64(end.timestamp_millis()));
+            time_sql.push_str(" AND start_time <= fromUnixTimestamp64Milli(?)");
+            time_binds.push(Bv::I64(end.timestamp_millis()));
         }
         if let Some(did) = query.deployment_id {
-            sql.push_str(" AND deployment_id = ?");
+            where_sql.push_str(" AND deployment_id = ?");
             binds.push(Bv::I32(did));
         }
         // environment_id: CH has no JOIN to deployments; filter delegated when
@@ -1113,39 +1122,107 @@ impl OtelStorage for ClickHouseOtelStorage {
         // a separate Postgres lookup, so we skip that filter here.
         if let Some(ref attrs) = query.attributes {
             for (key, value) in attrs {
-                sql.push_str(" AND JSONExtractString(attributes, ?) = ?");
+                where_sql.push_str(" AND JSONExtractString(attributes, ?) = ?");
                 binds.push(Bv::Str(key.clone()));
                 binds.push(Bv::Str(value.clone()));
             }
         }
         if let Some(ref pattern) = query.name_pattern {
-            sql.push_str(" AND name ILIKE ?");
+            where_sql.push_str(" AND name ILIKE ?");
             binds.push(Bv::Str(format!("%{}%", escape_like_pattern(pattern))));
         }
         if query.root_only {
             // Root spans use the '' sentinel for parent_span_id in the CH
             // schema (0001_spans.sql) — the NULL analog of TimescaleDB's
             // `parent_span_id IS NULL`.
-            sql.push_str(" AND parent_span_id = ''");
+            where_sql.push_str(" AND parent_span_id = ''");
         }
 
         // ORDER BY — enum-derived, injection-safe.
         let order_dir = query.sort_order.as_sql();
-        match query.sort_by {
-            crate::types::TraceSortField::Duration => {
-                sql.push_str(&format!(" ORDER BY duration_ms {order_dir}"));
-            }
-            crate::types::TraceSortField::StartTime => {
-                sql.push_str(&format!(" ORDER BY start_time {order_dir}"));
-            }
-        }
-        sql.push_str(" LIMIT ? OFFSET ?");
-        binds.push(Bv::I64(limit as i64));
-        binds.push(Bv::I64(offset as i64));
+        let order_sql = match query.sort_by {
+            crate::types::TraceSortField::Duration => format!("duration_ms {order_dir}"),
+            crate::types::TraceSortField::StartTime => format!("start_time {order_dir}"),
+        };
+
+        // The full row projection, shared by both assemblies below.
+        const SPAN_COLUMNS: &str = "project_id, deployment_id, service_name, service_version, \
+             deployment_environment, trace_id, span_id, parent_span_id, name, kind, \
+             toUnixTimestamp64Milli(start_time) AS start_time_ms, \
+             toUnixTimestamp64Milli(end_time) AS end_time_ms, \
+             duration_ms, status_code, status_message, attributes, events";
+
+        // NO FINAL in either form below. 0001_spans.sql reserves FINAL for reads
+        // "where dedup correctness is required (trace summaries list)"; this is a
+        // LIMIT-ed span list feeding the Observe console and the Traces page. A
+        // retried OTLP batch showing one span twice until the next merge is
+        // acceptable there; a merge-on-read pass over every part is not.
+        let (sql, all_binds) = if query.trace_id.is_some() {
+            // ── Single stage ─────────────────────────────────────────────────
+            // A trace_id-anchored query already matches a prefix of the sort key
+            // (project_id, trace_id, span_id), so ClickHouse reads one contiguous
+            // block and satisfies the LIMIT almost immediately. Splitting it in
+            // two would read that same prefix twice for nothing — measured on the
+            // 159.8M-span set: 8.0ms single-stage vs 14.6ms two-stage.
+            let sql =
+                format!("SELECT {SPAN_COLUMNS} FROM spans WHERE {where_sql} ORDER BY {order_sql} LIMIT ? OFFSET ?");
+            let mut all_binds = binds;
+            all_binds.push(Bv::I64(limit as i64));
+            all_binds.push(Bv::I64(offset as i64));
+            (sql, all_binds)
+        } else {
+            // ── Two stages ───────────────────────────────────────────────────
+            //
+            // Stage 1 (inner) resolves WHICH spans belong on the page, selecting
+            // only the identity columns. Stage 2 (outer) reads the wide row —
+            // including the `attributes` / `events` JSON blobs, which dominate
+            // the row size — for the ≤100 spans that survived, looking them up
+            // by (project_id, trace_id, span_id), the table's primary key.
+            //
+            // The single-stage form this replaces asked ClickHouse to
+            // materialise every column, blobs included, for every row matching
+            // the filter before sorting and discarding all but 100 of them.
+            // Without a trace_id, ordering by start_time has no sort-key prefix
+            // to lean on (trace_id is a random hash), so "every matching row"
+            // meant the project's entire month.
+            //
+            // Splitting the query also lets stage 1 be served by the
+            // `proj_recent` projection (0007_spans_recent_projection.sql), which
+            // stores exactly these narrow columns ordered by
+            // (project_id, start_time). The projection cannot serve the
+            // single-stage query at all, because that one selects blob columns
+            // the projection does not contain.
+            //
+            // Measured on 159.8M spans (150M in one project), root spans, 24h
+            // window, LIMIT 100: 5050ms single-stage with FINAL → 132ms here,
+            // with a byte-identical result set.
+            let inner_sql = format!(
+                "SELECT trace_id, span_id FROM spans WHERE {where_sql} \
+                 ORDER BY {order_sql} LIMIT ? OFFSET ?"
+            );
+            let sql = format!(
+                "SELECT {SPAN_COLUMNS} \
+                 FROM spans \
+                 WHERE project_id = ?{time_sql} AND (trace_id, span_id) IN ({inner_sql}) \
+                 ORDER BY {order_sql}"
+            );
+
+            // Bind order must match the rendered placeholder order: the outer
+            // project_id and time bounds come first (they precede the subquery
+            // in the statement), then the subquery's own binds, then
+            // LIMIT/OFFSET.
+            let mut all_binds: Vec<Bv> = Vec::with_capacity(binds.len() + time_binds.len() + 3);
+            all_binds.push(Bv::I32(query.project_id));
+            all_binds.extend(time_binds);
+            all_binds.extend(binds);
+            all_binds.push(Bv::I64(limit as i64));
+            all_binds.push(Bv::I64(offset as i64));
+            (sql, all_binds)
+        };
 
         // Apply binds sequentially to the query builder.
         let mut q = self.ch.query(&sql);
-        for b in binds {
+        for b in all_binds {
             q = match b {
                 Bv::I32(v) => q.bind(v),
                 Bv::I64(v) => q.bind(v),

--- a/crates/temps-otel/tests/clickhouse_query_spans_test.rs
+++ b/crates/temps-otel/tests/clickhouse_query_spans_test.rs
@@ -477,3 +477,50 @@ async fn migration_installs_the_recent_spans_projection() {
          projection outright (error 344):\n{ddl}"
     );
 }
+
+/// The page must never be larger than the caller asked for, even when the table
+/// holds pre-merge duplicates.
+///
+/// `spans` is a ReplacingMergeTree and these reads deliberately do not use
+/// FINAL, so a retried OTLP batch leaves two physical rows for one
+/// (project_id, trace_id, span_id) until the next merge. The two-stage query
+/// caps its SUBQUERY at `limit` identity pairs, but the outer statement then
+/// matches every physical row for those pairs — so without a limit of its own
+/// it can hand back more rows than were requested. The single-stage shape
+/// cannot drift this way because its LIMIT applies to the rows themselves.
+#[tokio::test]
+async fn query_spans_never_returns_more_rows_than_the_limit_despite_duplicates() {
+    let Some((storage, _probe, _c)) = seeded().await else {
+        return;
+    };
+
+    // Re-store the three roots verbatim: same identity, so ReplacingMergeTree
+    // will eventually collapse them, but not before this read.
+    let dupes: Vec<_> = fixture()
+        .into_iter()
+        .filter(|s| s.parent_span_id.is_none() && s.project_id == PROJECT)
+        .collect();
+    assert_eq!(dupes.len(), 3, "fixture should have three roots");
+    storage
+        .store_spans(dupes)
+        .await
+        .expect("store duplicate spans");
+
+    for limit in [1u64, 2, 3] {
+        let spans = storage
+            .query_spans(TraceQuery {
+                project_id: PROJECT,
+                root_only: true,
+                limit: Some(limit),
+                ..Default::default()
+            })
+            .await
+            .expect("limited query");
+
+        assert!(
+            spans.len() as u64 <= limit,
+            "asked for {limit} rows, got {} — duplicates leaked past the page size",
+            spans.len()
+        );
+    }
+}

--- a/crates/temps-otel/tests/clickhouse_query_spans_test.rs
+++ b/crates/temps-otel/tests/clickhouse_query_spans_test.rs
@@ -1,0 +1,479 @@
+//! Real-ClickHouse integration test for `ClickHouseOtelStorage::query_spans`.
+//!
+//! `query_spans` is assembled by hand: predicates are accumulated into a string
+//! of `?` placeholders while the matching values are pushed onto a parallel
+//! `Vec`, and the two must stay in lockstep. It then picks between two SQL
+//! shapes — a single-stage read when the query is anchored on a `trace_id` (the
+//! sort-key prefix already applies), and a two-stage read otherwise, where the
+//! outer statement repeats the project and time predicates BEFORE the subquery
+//! contributes its own binds.
+//!
+//! That ordering is invisible to the type system. Getting it wrong does not
+//! fail to compile and usually does not error at runtime — ClickHouse happily
+//! binds a limit where a project_id was meant and returns confidently wrong
+//! rows. These tests exist to catch exactly that, which is why the central case
+//! sets EVERY optional filter at once rather than testing them one at a time.
+//!
+//! Docker-dependent, and per CLAUDE.md must never be `#[ignore]`d: it detects an
+//! unavailable Docker at runtime and returns.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use chrono::{Duration, Utc};
+use sea_orm::{DatabaseBackend, MockDatabase};
+
+use temps_otel::storage::clickhouse::{ClickHouseOtelConfig, ClickHouseOtelStorage};
+use temps_otel::storage::timescaledb::TimescaleDbStorage;
+use temps_otel::storage::OtelStorage;
+use temps_otel::types::{
+    ResourceInfo, SpanKind, SpanRecord, SpanStatusCode, TraceQuery, TraceSortField,
+};
+
+const PROJECT: i32 = 42;
+/// A second project whose rows must never leak into PROJECT's results.
+const OTHER_PROJECT: i32 = 99;
+
+/// Spin up ClickHouse, run the OTel migrations, return a connected storage.
+/// `None` when Docker is unreachable so the test skips instead of failing CI.
+type Harness = (
+    ClickHouseOtelStorage,
+    ::clickhouse::Client,
+    Box<dyn std::any::Any + Send>,
+);
+
+async fn setup() -> Option<Harness> {
+    use testcontainers::{
+        core::{wait::HttpWaitStrategy, ContainerPort, WaitFor},
+        runners::AsyncRunner,
+        GenericImage, ImageExt,
+    };
+
+    // Pinned to 24.8 deliberately: this is the generation where projections on
+    // a ReplacingMergeTree require `deduplicate_merge_projection_mode`, which
+    // 0007_spans_recent_projection.sql sets. Testing on a newer server would
+    // not exercise that constraint.
+    let image = GenericImage::new("clickhouse/clickhouse-server", "24.8")
+        .with_exposed_port(ContainerPort::Tcp(8123))
+        // The image logs "Ready for connections" only to its in-container log
+        // file, so a log wait always times out; poll /ping instead.
+        .with_wait_for(WaitFor::http(
+            HttpWaitStrategy::new("/ping")
+                .with_port(ContainerPort::Tcp(8123))
+                .with_expected_status_code(200u16),
+        ))
+        .with_env_var("CLICKHOUSE_DB", "spans_query_test")
+        .with_env_var("CLICKHOUSE_PASSWORD", "test");
+
+    let container = match image.start().await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Skipping query_spans test: cannot start container ({e})");
+            return None;
+        }
+    };
+    let host_port = match container.get_host_port_ipv4(8123).await {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Skipping query_spans test: cannot get host port ({e})");
+            return None;
+        }
+    };
+
+    let url = format!("http://127.0.0.1:{host_port}");
+    let probe = ::clickhouse::Client::default()
+        .with_url(&url)
+        .with_database("spans_query_test")
+        .with_user("default")
+        .with_password("test");
+
+    let mut last_err = String::new();
+    for _ in 0..30 {
+        match probe.query("SELECT 1").execute().await {
+            Ok(_) => {
+                last_err.clear();
+                break;
+            }
+            Err(e) => {
+                last_err = format!("{e}");
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            }
+        }
+    }
+    if !last_err.is_empty() {
+        eprintln!("Skipping query_spans test: server never became ready ({last_err})");
+        return None;
+    }
+
+    temps_otel::storage::clickhouse::migrations::apply_migrations(&probe, "spans_query_test")
+        .await
+        .expect("apply_migrations failed against testcontainer ClickHouse");
+
+    // query_spans reads ClickHouse only; the inner Postgres store is never hit.
+    let inner = Arc::new(TimescaleDbStorage::new(
+        Arc::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+        None,
+    ));
+    let storage = ClickHouseOtelStorage::new(
+        ClickHouseOtelConfig::new(&url, "spans_query_test", "default", "test"),
+        inner,
+        Arc::new(temps_core::FixedRetentionResolver),
+    );
+    Some((storage, probe, Box::new(container)))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn span(
+    project_id: i32,
+    trace: &str,
+    span_id: &str,
+    parent: Option<&str>,
+    name: &str,
+    service: &str,
+    status: SpanStatusCode,
+    minutes_ago: i64,
+    duration_ms: f64,
+    deployment_id: Option<i32>,
+    attributes: &[(&str, &str)],
+) -> SpanRecord {
+    let start = Utc::now() - Duration::minutes(minutes_ago);
+    SpanRecord {
+        project_id,
+        deployment_id,
+        resource: ResourceInfo {
+            service_name: service.into(),
+            service_version: Some("1.0.0".into()),
+            deployment_environment: Some("production".into()),
+            ..Default::default()
+        },
+        trace_id: trace.into(),
+        span_id: span_id.into(),
+        parent_span_id: parent.map(|p| p.to_string()),
+        name: name.into(),
+        kind: SpanKind::Server,
+        start_time: start,
+        end_time: start + Duration::milliseconds(duration_ms as i64),
+        duration_ms,
+        status_code: status,
+        status_message: String::new(),
+        attributes: attributes
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect::<BTreeMap<_, _>>(),
+        events: vec![],
+    }
+}
+
+/// Fixture: three traces in PROJECT plus a decoy trace in OTHER_PROJECT.
+/// Root spans are the ones with `parent = None`.
+fn fixture() -> Vec<SpanRecord> {
+    vec![
+        // Trace A — newest root, matches the "everything" filter below.
+        span(
+            PROJECT,
+            "aaaa1111",
+            "a001",
+            None,
+            "GET /api/checkout",
+            "checkout",
+            SpanStatusCode::Error,
+            5,
+            250.0,
+            Some(7),
+            &[("gen_ai.system", "openai")],
+        ),
+        span(
+            PROJECT,
+            "aaaa1111",
+            "a002",
+            Some("a001"),
+            "SELECT orders",
+            "checkout",
+            SpanStatusCode::Ok,
+            5,
+            12.0,
+            Some(7),
+            &[],
+        ),
+        // Trace B — middle root, wrong service/status for the "everything" filter.
+        span(
+            PROJECT,
+            "bbbb2222",
+            "b001",
+            None,
+            "POST /api/login",
+            "auth",
+            SpanStatusCode::Ok,
+            30,
+            90.0,
+            Some(8),
+            &[],
+        ),
+        // Trace C — oldest root, deliberately outside the 1h window used below.
+        span(
+            PROJECT,
+            "cccc3333",
+            "c001",
+            None,
+            "GET /api/legacy",
+            "checkout",
+            SpanStatusCode::Error,
+            240,
+            900.0,
+            Some(7),
+            &[("gen_ai.system", "openai")],
+        ),
+        // Decoy: same shape, different project. Must never appear.
+        span(
+            OTHER_PROJECT,
+            "dddd4444",
+            "d001",
+            None,
+            "GET /api/checkout",
+            "checkout",
+            SpanStatusCode::Error,
+            5,
+            250.0,
+            Some(7),
+            &[("gen_ai.system", "openai")],
+        ),
+    ]
+}
+
+async fn seeded() -> Option<Harness> {
+    let (storage, probe, container) = setup().await?;
+    storage
+        .store_spans(fixture())
+        .await
+        .expect("store fixture spans");
+    Some((storage, probe, container))
+}
+
+fn ids(spans: &[SpanRecord]) -> Vec<String> {
+    spans.iter().map(|s| s.span_id.clone()).collect()
+}
+
+/// The two-stage path: no trace_id, so ordering and the LIMIT are resolved
+/// against the projection and the wide rows fetched by primary key.
+#[tokio::test]
+async fn query_spans_two_stage_returns_roots_newest_first_within_window() {
+    let Some((storage, _probe, _c)) = seeded().await else {
+        return;
+    };
+
+    let spans = storage
+        .query_spans(TraceQuery {
+            project_id: PROJECT,
+            start_time: Some(Utc::now() - Duration::hours(1)),
+            root_only: true,
+            limit: Some(100),
+            ..Default::default()
+        })
+        .await
+        .expect("two-stage query");
+
+    // Trace C's root is 4h old — outside the window. The decoy belongs to
+    // another project. Roots only, so a002 is excluded.
+    assert_eq!(
+        ids(&spans),
+        vec!["a001", "b001"],
+        "expected only in-window roots for this project, newest first"
+    );
+    assert!(
+        spans.iter().all(|s| s.project_id == PROJECT),
+        "another project's spans leaked into the result"
+    );
+}
+
+/// The single-stage path: a trace_id anchors the query on the sort-key prefix,
+/// so it must return every span of that trace, children included.
+#[tokio::test]
+async fn query_spans_single_stage_by_trace_id_returns_all_spans_of_the_trace() {
+    let Some((storage, _probe, _c)) = seeded().await else {
+        return;
+    };
+
+    let spans = storage
+        .query_spans(TraceQuery {
+            project_id: PROJECT,
+            trace_id: Some("aaaa1111".into()),
+            limit: Some(100),
+            ..Default::default()
+        })
+        .await
+        .expect("single-stage query");
+
+    let mut got = ids(&spans);
+    got.sort();
+    assert_eq!(
+        got,
+        vec!["a001", "a002"],
+        "trace lookup must return the root AND its children"
+    );
+}
+
+/// THE bind-ordering test.
+///
+/// Every optional predicate is set at once, so the rendered statement carries
+/// binds in the outer-project / outer-time / inner-project / inner-filters /
+/// limit / offset sequence. If any value is bound out of position the filters
+/// silently match the wrong rows, so this asserts on an exact, uniquely
+/// determined answer: only trace A's root satisfies all of these together.
+#[tokio::test]
+async fn query_spans_binds_stay_aligned_with_every_filter_set() {
+    let Some((storage, _probe, _c)) = seeded().await else {
+        return;
+    };
+
+    let spans = storage
+        .query_spans(TraceQuery {
+            project_id: PROJECT,
+            service_name: Some("checkout".into()),
+            status: Some(SpanStatusCode::Error),
+            min_duration_ms: Some(100.0),
+            start_time: Some(Utc::now() - Duration::hours(1)),
+            end_time: Some(Utc::now() + Duration::minutes(1)),
+            deployment_id: Some(7),
+            attributes: Some(BTreeMap::from([(
+                "gen_ai.system".to_string(),
+                "openai".to_string(),
+            )])),
+            name_pattern: Some("checkout".into()),
+            root_only: true,
+            limit: Some(50),
+            ..Default::default()
+        })
+        .await
+        .expect("fully-filtered query");
+
+    assert_eq!(
+        ids(&spans),
+        vec!["a001"],
+        "only trace A's root matches every filter simultaneously"
+    );
+}
+
+/// Same predicate reached through both SQL shapes must agree. This is the
+/// cross-check that the two-stage rewrite did not change semantics: adding a
+/// trace_id flips the implementation from two-stage to single-stage, and the
+/// row it yields must be the one the two-stage form already returned.
+#[tokio::test]
+async fn query_spans_two_stage_and_single_stage_agree() {
+    let Some((storage, _probe, _c)) = seeded().await else {
+        return;
+    };
+
+    let base = TraceQuery {
+        project_id: PROJECT,
+        start_time: Some(Utc::now() - Duration::hours(1)),
+        root_only: true,
+        limit: Some(100),
+        ..Default::default()
+    };
+
+    let two_stage = storage
+        .query_spans(TraceQuery { ..base.clone() })
+        .await
+        .expect("two-stage");
+    let single_stage = storage
+        .query_spans(TraceQuery {
+            trace_id: Some("aaaa1111".into()),
+            ..base
+        })
+        .await
+        .expect("single-stage");
+
+    assert_eq!(ids(&single_stage), vec!["a001"]);
+    assert!(
+        two_stage.iter().any(|s| s.span_id == "a001"),
+        "the span the trace-anchored form returns must also be in the unanchored result"
+    );
+
+    // The wide columns must survive the two-stage round trip — the whole point
+    // of stage 2 is fetching them, and a broken IN-join would blank them out.
+    let a001 = two_stage
+        .iter()
+        .find(|s| s.span_id == "a001")
+        .expect("a001 present");
+    assert_eq!(a001.name, "GET /api/checkout");
+    assert_eq!(a001.resource.service_name, "checkout");
+    assert_eq!(a001.status_code, SpanStatusCode::Error);
+    assert_eq!(a001.duration_ms, 250.0);
+    assert_eq!(
+        a001.attributes.get("gen_ai.system").map(String::as_str),
+        Some("openai"),
+        "attributes JSON must be hydrated by the outer stage"
+    );
+}
+
+/// LIMIT and OFFSET are bound last in both shapes — a misplaced bind here
+/// shows up as a wrong-sized page rather than an error.
+#[tokio::test]
+async fn query_spans_limit_and_offset_page_the_two_stage_result() {
+    let Some((storage, _probe, _c)) = seeded().await else {
+        return;
+    };
+
+    let q = |limit: u64, offset: u64| TraceQuery {
+        project_id: PROJECT,
+        root_only: true,
+        limit: Some(limit),
+        offset: Some(offset),
+        ..Default::default()
+    };
+
+    // Three roots in this project, newest first: a001, b001, c001.
+    let page1 = storage.query_spans(q(2, 0)).await.expect("page 1");
+    let page2 = storage.query_spans(q(2, 2)).await.expect("page 2");
+
+    assert_eq!(ids(&page1), vec!["a001", "b001"]);
+    assert_eq!(ids(&page2), vec!["c001"]);
+}
+
+/// Sorting by duration uses a column the projection does not carry, so the
+/// planner must fall back to the base table and still order correctly.
+#[tokio::test]
+async fn query_spans_sorts_by_duration_when_asked() {
+    let Some((storage, _probe, _c)) = seeded().await else {
+        return;
+    };
+
+    let spans = storage
+        .query_spans(TraceQuery {
+            project_id: PROJECT,
+            root_only: true,
+            sort_by: TraceSortField::Duration,
+            limit: Some(100),
+            ..Default::default()
+        })
+        .await
+        .expect("duration-sorted query");
+
+    // c001 900ms > a001 250ms > b001 90ms
+    assert_eq!(ids(&spans), vec!["c001", "a001", "b001"]);
+}
+
+/// 0007 must actually install the projection — without it the two-stage query
+/// still returns correct rows, just slowly, so no other test would notice.
+#[tokio::test]
+async fn migration_installs_the_recent_spans_projection() {
+    let Some((_storage, probe, _c)) = setup().await else {
+        return;
+    };
+
+    let ddl = probe
+        .query("SHOW CREATE TABLE spans_query_test.spans")
+        .fetch_one::<String>()
+        .await
+        .expect("SHOW CREATE TABLE");
+
+    assert!(
+        ddl.contains("PROJECTION proj_recent"),
+        "proj_recent missing — the span feed silently loses its index:\n{ddl}"
+    );
+    assert!(
+        ddl.contains("deduplicate_merge_projection_mode = 'rebuild'"),
+        "ReplacingMergeTree needs this setting or ClickHouse rejects the \
+         projection outright (error 344):\n{ddl}"
+    );
+}

--- a/crates/temps-proxy/src/handler/proxy_logs.rs
+++ b/crates/temps-proxy/src/handler/proxy_logs.rs
@@ -60,11 +60,17 @@ pub struct ProxyLogsQuery {
     // Date range filters
     /// Start date for filtering (ISO 8601 format).
     ///
-    /// **Defaults to 24 hours before `end_date` (or before now) when omitted.**
+    /// **Defaults to 1 hour before `end_date` (or before now) when omitted.**
     /// The listing is always time-bounded: an unbounded query would have to
     /// consider the entire retention window — 100M+ rows on a busy deployment —
     /// to return a single page. Pass an explicit `start_date` to widen the
     /// window, up to the configured retention horizon.
+    ///
+    /// The maximum span between `start_date` and `end_date` is 7 days when
+    /// `project_id` is omitted, or 30 days when a single `project_id` is set —
+    /// a project-scoped query is bounded by that project's own row count
+    /// rather than the whole deployment's. A wider request is rejected with a
+    /// 400 naming the applicable cap.
     pub start_date: Option<DateTime>,
     /// End date for filtering (ISO 8601 format). Defaults to now.
     pub end_date: Option<DateTime>,

--- a/crates/temps-proxy/src/handler/proxy_logs.rs
+++ b/crates/temps-proxy/src/handler/proxy_logs.rs
@@ -58,9 +58,15 @@ pub struct ProxyLogsQuery {
     pub visitor_id: Option<i32>,
 
     // Date range filters
-    /// Start date for filtering (ISO 8601 format)
+    /// Start date for filtering (ISO 8601 format).
+    ///
+    /// **Defaults to 24 hours before `end_date` (or before now) when omitted.**
+    /// The listing is always time-bounded: an unbounded query would have to
+    /// consider the entire retention window — 100M+ rows on a busy deployment —
+    /// to return a single page. Pass an explicit `start_date` to widen the
+    /// window, up to the configured retention horizon.
     pub start_date: Option<DateTime>,
-    /// End date for filtering (ISO 8601 format)
+    /// End date for filtering (ISO 8601 format). Defaults to now.
     pub end_date: Option<DateTime>,
 
     // Request filters

--- a/crates/temps-proxy/src/service/proxy_log_service.rs
+++ b/crates/temps-proxy/src/service/proxy_log_service.rs
@@ -570,37 +570,41 @@ impl ProxyLogService {
         (query, has_filters)
     }
 
-    /// Lower bound applied to `GET /proxy-logs` when the caller supplies no
-    /// `start_date`.
+    /// Resolve a caller-supplied range into a bounded, capped window.
     ///
-    /// An unbounded listing has to consider the whole retention window — 30
-    /// days of one-row-per-HTTP-request traffic, which is 100M+ rows on a busy
-    /// deployment — to return 20 rows. That is never what a caller wants and it
-    /// is the single most expensive query the API can be asked to run, so the
-    /// endpoint is always time-bounded. Callers that want a wider window pass
-    /// `start_date` explicitly; the UI's time-range picker does exactly that.
-    pub const DEFAULT_LIST_LOOKBACK_HOURS: i64 = 24;
-
-    /// Resolve the effective lower time bound for a listing.
+    /// Delegates to [`temps_core::time_window`], which owns the contract shared
+    /// by every high-volume read endpoint: a default lower bound so omitting a
+    /// date never means "scan the retention window", and a maximum span so a
+    /// single request cannot ask for a query that takes tens of seconds. See
+    /// that module for the measurements behind both numbers.
     ///
-    /// Applied whenever `start_date` is absent, anchored to `end_date` when one
-    /// was given so an explicit upper bound still returns the window ending
-    /// there rather than a window ending now.
-    fn effective_start_date(
+    /// Returns the window as the `(start, end)` pair the storage layer takes,
+    /// so callers stay unchanged apart from the `?`.
+    fn resolve_window(
         start_date: Option<UtcDateTime>,
         end_date: Option<UtcDateTime>,
-    ) -> Option<UtcDateTime> {
-        if start_date.is_some() {
-            return start_date;
-        }
-        let anchor = end_date.unwrap_or_else(chrono::Utc::now);
-        // Checked arithmetic: `anchor` can come straight from a user-supplied
-        // query parameter, and a bare subtraction panics on overflow.
-        Some(
-            anchor
-                .checked_sub_signed(chrono::Duration::hours(Self::DEFAULT_LIST_LOOKBACK_HOURS))
-                .unwrap_or(chrono::DateTime::<chrono::Utc>::MIN_UTC),
+    ) -> Result<(Option<UtcDateTime>, Option<UtcDateTime>), ProxyLogServiceError> {
+        let window = temps_core::time_window::resolve(
+            start_date,
+            end_date,
+            chrono::Duration::hours(temps_core::time_window::DEFAULT_LOOKBACK_HOURS),
         )
+        .map_err(|e| ProxyLogServiceError::InvalidFilter(e.to_string()))?;
+        Ok((Some(window.start), window.end))
+    }
+
+    /// Reject a range wider than the shared cap.
+    ///
+    /// The stats endpoints take a REQUIRED range, so there is nothing to
+    /// default — only the width needs enforcing. These are GROUP BY scans
+    /// rather than sorted pages, so they are cheaper per row, but they still
+    /// read every row in the window and a month-wide request is seconds of work
+    /// on a 150M-row table.
+    fn enforce_window_span(
+        start_time: UtcDateTime,
+        end_time: UtcDateTime,
+    ) -> Result<(), ProxyLogServiceError> {
+        Self::resolve_window(Some(start_time), Some(end_time)).map(|_| ())
     }
 
     pub async fn list_with_filters(
@@ -614,7 +618,7 @@ impl ProxyLogService {
         // Bound the window before dispatching so BOTH storage backends get the
         // same treatment — the TimescaleDB hypertable needs chunk exclusion for
         // the same reason ClickHouse needs partition pruning.
-        let start_date = Self::effective_start_date(start_date, end_date);
+        let (start_date, end_date) = Self::resolve_window(start_date, end_date)?;
 
         if let Some(storage) = &self.storage {
             return storage
@@ -652,6 +656,10 @@ impl ProxyLogService {
         filters: crate::handler::proxy_logs::ProxyLogsQuery,
         limit: u64,
     ) -> Result<Vec<proxy_logs::Model>, ProxyLogServiceError> {
+        // Same bounding as list_with_filters — this is the count-free variant
+        // the Observe feed uses, not a laxer one.
+        let (start_date, end_date) = Self::resolve_window(start_date, end_date)?;
+
         if let Some(storage) = &self.storage {
             return storage
                 .list_page(start_date, end_date, filters, limit)
@@ -859,6 +867,8 @@ impl ProxyLogService {
         bucket_interval: String, // e.g., "1 hour", "1 day", "5 minutes"
         filters: Option<StatsFilters>,
     ) -> Result<Vec<TimeBucketStats>, ProxyLogServiceError> {
+        Self::enforce_window_span(start_time, end_time)?;
+
         if let Some(storage) = &self.storage {
             return storage
                 .get_time_bucket_stats(start_time, end_time, bucket_interval, filters)
@@ -1060,6 +1070,8 @@ impl ProxyLogService {
         end_time: UtcDateTime,
         is_bot: Option<bool>,
     ) -> Result<Vec<ProjectHealthSummary>, ProxyLogServiceError> {
+        Self::enforce_window_span(start_time, end_time)?;
+
         if let Some(storage) = &self.storage {
             return storage
                 .get_projects_health_summary(project_ids, start_time, end_time, is_bot)
@@ -1477,6 +1489,8 @@ impl ProxyLogService {
         end_time: UtcDateTime,
         limit: u64,
     ) -> Result<Vec<AiAgentBreakdownRow>, ProxyLogServiceError> {
+        Self::enforce_window_span(start_time, end_time)?;
+
         if let Some(storage) = &self.storage {
             return storage
                 .get_ai_agent_breakdown(
@@ -1607,6 +1621,8 @@ impl ProxyLogService {
         end_time: UtcDateTime,
         limit: u64,
     ) -> Result<Vec<AiPageBreakdownRow>, ProxyLogServiceError> {
+        Self::enforce_window_span(start_time, end_time)?;
+
         if let Some(storage) = &self.storage {
             return storage
                 .get_ai_page_breakdown(
@@ -1714,6 +1730,8 @@ impl ProxyLogService {
         end_time: UtcDateTime,
         limit: u64,
     ) -> Result<Vec<AiAgentPageRow>, ProxyLogServiceError> {
+        Self::enforce_window_span(start_time, end_time)?;
+
         let known = crate::ai_agent_detector::known_agents();
         if !known.iter().any(|(_, m)| m.agent == agent) {
             return Ok(vec![]);
@@ -1800,6 +1818,8 @@ impl ProxyLogService {
         bucket_interval: String,
         group_by: AiTimelineGroupBy,
     ) -> Result<Vec<AiAgentTimelineRow>, ProxyLogServiceError> {
+        Self::enforce_window_span(start_time, end_time)?;
+
         if let Some(storage) = &self.storage {
             return storage
                 .get_ai_agent_timeline(
@@ -2005,6 +2025,8 @@ impl ProxyLogService {
         start_time: UtcDateTime,
         end_time: UtcDateTime,
     ) -> Result<Vec<AiStatusBreakdownRow>, ProxyLogServiceError> {
+        Self::enforce_window_span(start_time, end_time)?;
+
         if let Some(storage) = &self.storage {
             return storage
                 .get_ai_status_breakdown(project_id, environment_id, start_time, end_time)
@@ -2242,68 +2264,68 @@ pub struct ProjectHealthSummary {
 mod tests {
     use super::*;
 
-    // ── Default listing window ────────────────────────────────────────────
-    // `GET /proxy-logs` must never issue an unbounded scan: on a 100M-row
-    // deployment that means considering the whole retention window to return
-    // 20 rows.
+    // ── Listing window ────────────────────────────────────────────────────
+    // `GET /proxy-logs` must never issue an unbounded scan (on a 100M-row
+    // deployment that means considering the whole retention window to return 20
+    // rows) and must never accept a window so wide the query takes tens of
+    // seconds. The rules themselves live in temps_core::time_window and are
+    // tested there; these cover the SERVICE's contract — that it applies them,
+    // and that a violation surfaces as a 400-mapped InvalidFilter rather than
+    // an opaque 500.
 
     #[test]
-    fn effective_start_date_defaults_to_24h_before_now_when_both_absent() {
+    fn resolve_window_bounds_an_open_request() {
+        let lookback = chrono::Duration::hours(temps_core::time_window::DEFAULT_LOOKBACK_HOURS);
         let before = chrono::Utc::now();
-        let start = ProxyLogService::effective_start_date(None, None)
-            .expect("a lower bound is always produced");
+        let (start, end) =
+            ProxyLogService::resolve_window(None, None).expect("open request is bounded");
         let after = chrono::Utc::now();
 
+        let start = start.expect("a lower bound is always produced");
         assert!(
-            start >= before - chrono::Duration::hours(24)
-                && start <= after - chrono::Duration::hours(24),
-            "expected ~24h before now, got {start}"
+            start >= before - lookback && start <= after - lookback,
+            "expected ~{}h before now, got {start}",
+            temps_core::time_window::DEFAULT_LOOKBACK_HOURS
+        );
+        assert_eq!(end, None, "an open upper bound stays open");
+    }
+
+    #[test]
+    fn resolve_window_preserves_an_explicit_range_within_the_cap() {
+        let start = chrono::DateTime::parse_from_rfc3339("2026-07-14T00:00:00Z")
+            .expect("valid fixture timestamp")
+            .with_timezone(&chrono::Utc);
+        let end = chrono::DateTime::parse_from_rfc3339("2026-07-20T00:00:00Z")
+            .expect("valid fixture timestamp")
+            .with_timezone(&chrono::Utc);
+
+        // Widening past the default is exactly how the UI's range picker works.
+        assert_eq!(
+            ProxyLogService::resolve_window(Some(start), Some(end)).expect("within cap"),
+            (Some(start), Some(end))
         );
     }
 
     #[test]
-    fn effective_start_date_anchors_to_end_date_when_only_end_given() {
-        let end = chrono::DateTime::parse_from_rfc3339("2026-07-20T12:00:00Z")
+    fn resolve_window_rejects_a_range_wider_than_the_cap_as_a_bad_request() {
+        let start = chrono::DateTime::parse_from_rfc3339("2026-06-01T00:00:00Z")
+            .expect("valid fixture timestamp")
+            .with_timezone(&chrono::Utc);
+        let end = chrono::DateTime::parse_from_rfc3339("2026-07-01T00:00:00Z")
             .expect("valid fixture timestamp")
             .with_timezone(&chrono::Utc);
 
-        let start = ProxyLogService::effective_start_date(None, Some(end))
-            .expect("a lower bound is always produced");
+        let err = ProxyLogService::resolve_window(Some(start), Some(end))
+            .expect_err("30 days exceeds the cap");
 
-        // Window ends where the caller asked, not at "now".
-        assert_eq!(start, end - chrono::Duration::hours(24));
-    }
-
-    #[test]
-    fn effective_start_date_preserves_an_explicit_start() {
-        let start = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
-            .expect("valid fixture timestamp")
-            .with_timezone(&chrono::Utc);
-        let end = chrono::DateTime::parse_from_rfc3339("2026-07-20T12:00:00Z")
-            .expect("valid fixture timestamp")
-            .with_timezone(&chrono::Utc);
-
-        // An explicit start is never narrowed — widening the window past 24h
-        // is exactly how the UI's time-range picker works.
-        assert_eq!(
-            ProxyLogService::effective_start_date(Some(start), Some(end)),
-            Some(start)
-        );
-        assert_eq!(
-            ProxyLogService::effective_start_date(Some(start), None),
-            Some(start)
-        );
-    }
-
-    #[test]
-    fn effective_start_date_saturates_instead_of_panicking_on_underflow() {
-        // `end_date` reaches the service straight from a query parameter, so a
-        // near-MIN value must not panic the subtraction.
-        let end = chrono::DateTime::<chrono::Utc>::MIN_UTC;
-        assert_eq!(
-            ProxyLogService::effective_start_date(None, Some(end)),
-            Some(chrono::DateTime::<chrono::Utc>::MIN_UTC)
-        );
+        // InvalidFilter is the variant the handler maps to 400; anything else
+        // would surface a client mistake as a server error.
+        let ProxyLogServiceError::InvalidFilter(msg) = err else {
+            panic!("expected InvalidFilter so the handler returns 400, got {err:?}");
+        };
+        // The detail reaches the client verbatim, so it must stay actionable.
+        assert!(msg.contains("7-day maximum"), "{msg}");
+        assert!(msg.contains("still"), "must name the workaround: {msg}");
     }
 
     #[test]

--- a/crates/temps-proxy/src/service/proxy_log_service.rs
+++ b/crates/temps-proxy/src/service/proxy_log_service.rs
@@ -570,6 +570,39 @@ impl ProxyLogService {
         (query, has_filters)
     }
 
+    /// Lower bound applied to `GET /proxy-logs` when the caller supplies no
+    /// `start_date`.
+    ///
+    /// An unbounded listing has to consider the whole retention window — 30
+    /// days of one-row-per-HTTP-request traffic, which is 100M+ rows on a busy
+    /// deployment — to return 20 rows. That is never what a caller wants and it
+    /// is the single most expensive query the API can be asked to run, so the
+    /// endpoint is always time-bounded. Callers that want a wider window pass
+    /// `start_date` explicitly; the UI's time-range picker does exactly that.
+    pub const DEFAULT_LIST_LOOKBACK_HOURS: i64 = 24;
+
+    /// Resolve the effective lower time bound for a listing.
+    ///
+    /// Applied whenever `start_date` is absent, anchored to `end_date` when one
+    /// was given so an explicit upper bound still returns the window ending
+    /// there rather than a window ending now.
+    fn effective_start_date(
+        start_date: Option<UtcDateTime>,
+        end_date: Option<UtcDateTime>,
+    ) -> Option<UtcDateTime> {
+        if start_date.is_some() {
+            return start_date;
+        }
+        let anchor = end_date.unwrap_or_else(chrono::Utc::now);
+        // Checked arithmetic: `anchor` can come straight from a user-supplied
+        // query parameter, and a bare subtraction panics on overflow.
+        Some(
+            anchor
+                .checked_sub_signed(chrono::Duration::hours(Self::DEFAULT_LIST_LOOKBACK_HOURS))
+                .unwrap_or(chrono::DateTime::<chrono::Utc>::MIN_UTC),
+        )
+    }
+
     pub async fn list_with_filters(
         &self,
         start_date: Option<UtcDateTime>,
@@ -578,6 +611,11 @@ impl ProxyLogService {
         page: u64,
         page_size: u64,
     ) -> Result<(Vec<proxy_logs::Model>, u64), ProxyLogServiceError> {
+        // Bound the window before dispatching so BOTH storage backends get the
+        // same treatment — the TimescaleDB hypertable needs chunk exclusion for
+        // the same reason ClickHouse needs partition pruning.
+        let start_date = Self::effective_start_date(start_date, end_date);
+
         if let Some(storage) = &self.storage {
             return storage
                 .list_with_filters(start_date, end_date, filters, page, page_size)
@@ -2203,6 +2241,70 @@ pub struct ProjectHealthSummary {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Default listing window ────────────────────────────────────────────
+    // `GET /proxy-logs` must never issue an unbounded scan: on a 100M-row
+    // deployment that means considering the whole retention window to return
+    // 20 rows.
+
+    #[test]
+    fn effective_start_date_defaults_to_24h_before_now_when_both_absent() {
+        let before = chrono::Utc::now();
+        let start = ProxyLogService::effective_start_date(None, None)
+            .expect("a lower bound is always produced");
+        let after = chrono::Utc::now();
+
+        assert!(
+            start >= before - chrono::Duration::hours(24)
+                && start <= after - chrono::Duration::hours(24),
+            "expected ~24h before now, got {start}"
+        );
+    }
+
+    #[test]
+    fn effective_start_date_anchors_to_end_date_when_only_end_given() {
+        let end = chrono::DateTime::parse_from_rfc3339("2026-07-20T12:00:00Z")
+            .expect("valid fixture timestamp")
+            .with_timezone(&chrono::Utc);
+
+        let start = ProxyLogService::effective_start_date(None, Some(end))
+            .expect("a lower bound is always produced");
+
+        // Window ends where the caller asked, not at "now".
+        assert_eq!(start, end - chrono::Duration::hours(24));
+    }
+
+    #[test]
+    fn effective_start_date_preserves_an_explicit_start() {
+        let start = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .expect("valid fixture timestamp")
+            .with_timezone(&chrono::Utc);
+        let end = chrono::DateTime::parse_from_rfc3339("2026-07-20T12:00:00Z")
+            .expect("valid fixture timestamp")
+            .with_timezone(&chrono::Utc);
+
+        // An explicit start is never narrowed — widening the window past 24h
+        // is exactly how the UI's time-range picker works.
+        assert_eq!(
+            ProxyLogService::effective_start_date(Some(start), Some(end)),
+            Some(start)
+        );
+        assert_eq!(
+            ProxyLogService::effective_start_date(Some(start), None),
+            Some(start)
+        );
+    }
+
+    #[test]
+    fn effective_start_date_saturates_instead_of_panicking_on_underflow() {
+        // `end_date` reaches the service straight from a query parameter, so a
+        // near-MIN value must not panic the subtraction.
+        let end = chrono::DateTime::<chrono::Utc>::MIN_UTC;
+        assert_eq!(
+            ProxyLogService::effective_start_date(None, Some(end)),
+            Some(chrono::DateTime::<chrono::Utc>::MIN_UTC)
+        );
+    }
 
     #[test]
     fn test_is_valid_interval_valid_formats() {

--- a/crates/temps-proxy/src/service/proxy_log_service.rs
+++ b/crates/temps-proxy/src/service/proxy_log_service.rs
@@ -578,33 +578,47 @@ impl ProxyLogService {
     /// single request cannot ask for a query that takes tens of seconds. See
     /// that module for the measurements behind both numbers.
     ///
+    /// `project_scoped` selects which cap applies — pass `true` only when the
+    /// caller's OWN filters already narrow to one `project_id`. A query with no
+    /// project filter scans every project's rows and must stay on the tighter
+    /// unscoped cap no matter what the caller intends to do with the result.
+    ///
     /// Returns the window as the `(start, end)` pair the storage layer takes,
     /// so callers stay unchanged apart from the `?`.
     fn resolve_window(
         start_date: Option<UtcDateTime>,
         end_date: Option<UtcDateTime>,
+        project_scoped: bool,
     ) -> Result<(Option<UtcDateTime>, Option<UtcDateTime>), ProxyLogServiceError> {
-        let window = temps_core::time_window::resolve(
+        let max_days = if project_scoped {
+            temps_core::time_window::MAX_WINDOW_DAYS_SCOPED
+        } else {
+            temps_core::time_window::MAX_WINDOW_DAYS
+        };
+        let window = temps_core::time_window::resolve_with_max(
             start_date,
             end_date,
             chrono::Duration::hours(temps_core::time_window::DEFAULT_LOOKBACK_HOURS),
+            chrono::Duration::days(max_days),
         )
         .map_err(|e| ProxyLogServiceError::InvalidFilter(e.to_string()))?;
         Ok((Some(window.start), window.end))
     }
 
-    /// Reject a range wider than the shared cap.
+    /// Reject a range wider than the applicable cap (see [`Self::resolve_window`]
+    /// for how `project_scoped` is chosen).
     ///
     /// The stats endpoints take a REQUIRED range, so there is nothing to
     /// default — only the width needs enforcing. These are GROUP BY scans
-    /// rather than sorted pages, so they are cheaper per row, but they still
-    /// read every row in the window and a month-wide request is seconds of work
-    /// on a 150M-row table.
+    /// rather than sorted pages, so they are cheaper per row, but an unscoped
+    /// one still reads every row in the window and a month-wide request is
+    /// seconds of work on a 150M-row table.
     fn enforce_window_span(
         start_time: UtcDateTime,
         end_time: UtcDateTime,
+        project_scoped: bool,
     ) -> Result<(), ProxyLogServiceError> {
-        Self::resolve_window(Some(start_time), Some(end_time)).map(|_| ())
+        Self::resolve_window(Some(start_time), Some(end_time), project_scoped).map(|_| ())
     }
 
     pub async fn list_with_filters(
@@ -618,7 +632,8 @@ impl ProxyLogService {
         // Bound the window before dispatching so BOTH storage backends get the
         // same treatment — the TimescaleDB hypertable needs chunk exclusion for
         // the same reason ClickHouse needs partition pruning.
-        let (start_date, end_date) = Self::resolve_window(start_date, end_date)?;
+        let (start_date, end_date) =
+            Self::resolve_window(start_date, end_date, filters.project_id.is_some())?;
 
         if let Some(storage) = &self.storage {
             return storage
@@ -657,8 +672,10 @@ impl ProxyLogService {
         limit: u64,
     ) -> Result<Vec<proxy_logs::Model>, ProxyLogServiceError> {
         // Same bounding as list_with_filters — this is the count-free variant
-        // the Observe feed uses, not a laxer one.
-        let (start_date, end_date) = Self::resolve_window(start_date, end_date)?;
+        // the Observe feed uses, not a laxer one. The Observe feed always sets
+        // `project_id`, so its requests get the scoped cap here too.
+        let (start_date, end_date) =
+            Self::resolve_window(start_date, end_date, filters.project_id.is_some())?;
 
         if let Some(storage) = &self.storage {
             return storage
@@ -867,7 +884,8 @@ impl ProxyLogService {
         bucket_interval: String, // e.g., "1 hour", "1 day", "5 minutes"
         filters: Option<StatsFilters>,
     ) -> Result<Vec<TimeBucketStats>, ProxyLogServiceError> {
-        Self::enforce_window_span(start_time, end_time)?;
+        let project_scoped = filters.as_ref().is_some_and(|f| f.project_id.is_some());
+        Self::enforce_window_span(start_time, end_time, project_scoped)?;
 
         if let Some(storage) = &self.storage {
             return storage
@@ -1070,7 +1088,10 @@ impl ProxyLogService {
         end_time: UtcDateTime,
         is_bot: Option<bool>,
     ) -> Result<Vec<ProjectHealthSummary>, ProxyLogServiceError> {
-        Self::enforce_window_span(start_time, end_time)?;
+        // The handler validates `project_ids` non-empty (and caps it at 100),
+        // so this is always scoped to an explicit project list, never "every
+        // project" — the scoped cap applies.
+        Self::enforce_window_span(start_time, end_time, !project_ids.is_empty())?;
 
         if let Some(storage) = &self.storage {
             return storage
@@ -1489,7 +1510,7 @@ impl ProxyLogService {
         end_time: UtcDateTime,
         limit: u64,
     ) -> Result<Vec<AiAgentBreakdownRow>, ProxyLogServiceError> {
-        Self::enforce_window_span(start_time, end_time)?;
+        Self::enforce_window_span(start_time, end_time, project_id.is_some())?;
 
         if let Some(storage) = &self.storage {
             return storage
@@ -1621,7 +1642,7 @@ impl ProxyLogService {
         end_time: UtcDateTime,
         limit: u64,
     ) -> Result<Vec<AiPageBreakdownRow>, ProxyLogServiceError> {
-        Self::enforce_window_span(start_time, end_time)?;
+        Self::enforce_window_span(start_time, end_time, project_id.is_some())?;
 
         if let Some(storage) = &self.storage {
             return storage
@@ -1730,7 +1751,7 @@ impl ProxyLogService {
         end_time: UtcDateTime,
         limit: u64,
     ) -> Result<Vec<AiAgentPageRow>, ProxyLogServiceError> {
-        Self::enforce_window_span(start_time, end_time)?;
+        Self::enforce_window_span(start_time, end_time, project_id.is_some())?;
 
         let known = crate::ai_agent_detector::known_agents();
         if !known.iter().any(|(_, m)| m.agent == agent) {
@@ -1818,7 +1839,7 @@ impl ProxyLogService {
         bucket_interval: String,
         group_by: AiTimelineGroupBy,
     ) -> Result<Vec<AiAgentTimelineRow>, ProxyLogServiceError> {
-        Self::enforce_window_span(start_time, end_time)?;
+        Self::enforce_window_span(start_time, end_time, project_id.is_some())?;
 
         if let Some(storage) = &self.storage {
             return storage
@@ -2025,7 +2046,7 @@ impl ProxyLogService {
         start_time: UtcDateTime,
         end_time: UtcDateTime,
     ) -> Result<Vec<AiStatusBreakdownRow>, ProxyLogServiceError> {
-        Self::enforce_window_span(start_time, end_time)?;
+        Self::enforce_window_span(start_time, end_time, project_id.is_some())?;
 
         if let Some(storage) = &self.storage {
             return storage
@@ -2278,7 +2299,7 @@ mod tests {
         let lookback = chrono::Duration::hours(temps_core::time_window::DEFAULT_LOOKBACK_HOURS);
         let before = chrono::Utc::now();
         let (start, end) =
-            ProxyLogService::resolve_window(None, None).expect("open request is bounded");
+            ProxyLogService::resolve_window(None, None, false).expect("open request is bounded");
         let after = chrono::Utc::now();
 
         let start = start.expect("a lower bound is always produced");
@@ -2301,13 +2322,13 @@ mod tests {
 
         // Widening past the default is exactly how the UI's range picker works.
         assert_eq!(
-            ProxyLogService::resolve_window(Some(start), Some(end)).expect("within cap"),
+            ProxyLogService::resolve_window(Some(start), Some(end), false).expect("within cap"),
             (Some(start), Some(end))
         );
     }
 
     #[test]
-    fn resolve_window_rejects_a_range_wider_than_the_cap_as_a_bad_request() {
+    fn resolve_window_rejects_a_range_wider_than_the_unscoped_cap_as_a_bad_request() {
         let start = chrono::DateTime::parse_from_rfc3339("2026-06-01T00:00:00Z")
             .expect("valid fixture timestamp")
             .with_timezone(&chrono::Utc);
@@ -2315,8 +2336,8 @@ mod tests {
             .expect("valid fixture timestamp")
             .with_timezone(&chrono::Utc);
 
-        let err = ProxyLogService::resolve_window(Some(start), Some(end))
-            .expect_err("30 days exceeds the cap");
+        let err = ProxyLogService::resolve_window(Some(start), Some(end), false)
+            .expect_err("30 days exceeds the unscoped 7-day cap");
 
         // InvalidFilter is the variant the handler maps to 400; anything else
         // would surface a client mistake as a server error.
@@ -2326,6 +2347,28 @@ mod tests {
         // The detail reaches the client verbatim, so it must stay actionable.
         assert!(msg.contains("7-day maximum"), "{msg}");
         assert!(msg.contains("still"), "must name the workaround: {msg}");
+    }
+
+    /// The exact regression this cap once caused: the Observe feed and the
+    /// Project Analytics AI Agents tab both ship a "Last 30 Days" option that
+    /// always scopes to one project (`ObserveFilterBar.tsx`,
+    /// `useAnalyticsDateRange.ts`). A project-scoped request for the same 30
+    /// days the previous test rejects must be ALLOWED, or those existing menu
+    /// items 400 instead of loading.
+    #[test]
+    fn resolve_window_allows_the_same_span_when_project_scoped() {
+        let start = chrono::DateTime::parse_from_rfc3339("2026-06-01T00:00:00Z")
+            .expect("valid fixture timestamp")
+            .with_timezone(&chrono::Utc);
+        let end = chrono::DateTime::parse_from_rfc3339("2026-07-01T00:00:00Z")
+            .expect("valid fixture timestamp")
+            .with_timezone(&chrono::Utc);
+
+        assert_eq!(
+            ProxyLogService::resolve_window(Some(start), Some(end), true)
+                .expect("30 days is within the scoped cap"),
+            (Some(start), Some(end))
+        );
     }
 
     #[test]

--- a/crates/temps-proxy/src/storage/clickhouse.rs
+++ b/crates/temps-proxy/src/storage/clickhouse.rs
@@ -969,13 +969,21 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
         };
 
         // ── COUNT(*) total (same WHERE) ──────────────────────────────────────
-        // FINAL: proxy_logs is a ReplacingMergeTree, and an insert retry or a
-        // re-run of the TimescaleDB→ClickHouse backfill can leave duplicate rows
-        // that ClickHouse only collapses on a later merge — and two copies in
-        // different parts may never merge together without OPTIMIZE. Without
-        // FINAL this count() over-reports the pagination total. FINAL forces
-        // merge-on-read so the total matches the deduplicated result set.
-        let count_sql = format!("SELECT count() AS cnt FROM proxy_logs FINAL {where_clause}");
+        // NO FINAL — deliberate, restoring the design stated in
+        // 0001_proxy_logs.sql: "the high-volume read paths (list + the 7
+        // aggregations) GROUP BY or LIMIT and tolerate the rare pre-merge
+        // duplicate, so they do NOT use FINAL (keeps the hot scans fast)".
+        //
+        // FINAL forces merge-on-read across every part in every partition. On
+        // an unfiltered listing that turns this count from a metadata-only
+        // lookup (1.2ms in the DDL benchmark) into a full-table merge scan —
+        // multiple seconds once the table reaches 100M+ rows, which is what
+        // made `GET /proxy-logs` unusable. proxy_logs is a ReplacingMergeTree
+        // only so a retried batch is idempotent; duplicates are rare, transient
+        // (collapsed at the next merge), and at worst inflate this total by a
+        // handful of rows out of millions. A pagination total is not worth a
+        // full merge scan for that.
+        let count_sql = format!("SELECT count() AS cnt FROM proxy_logs {where_clause}");
         let (_, count_binds, _) = Self::build_list_where(start_date, end_date, &filters);
         let count_q = apply_binds(self.client.query(&count_sql), count_binds);
         let total = count_q
@@ -990,6 +998,11 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
         // ── Page fetch ───────────────────────────────────────────────────────
         // ORDER BY column is allowlist-derived; direction is a fixed enum. Both
         // are safe to interpolate (no user string reaches the SQL).
+        //
+        // NO FINAL here either (see the count note above). A LIMIT-ed page is
+        // exactly the shape the DDL calls out as duplicate-tolerant: the worst
+        // case is one retried request showing twice on a page until the next
+        // merge, versus merge-on-read over every part on every page load.
         let order_col = sort_column(filters.sort_by.as_deref());
         let order_dir = match filters.sort_order.as_deref() {
             Some("asc") => "ASC",
@@ -1005,7 +1018,7 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
                 container_id, upstream_host, error_message, client_ip, user_agent, referrer, \
                 request_id, ip_geolocation_id, browser, browser_version, operating_system, \
                 device_type, is_bot, bot_name, request_size_bytes, response_size_bytes, cache_status \
-             FROM proxy_logs FINAL \
+             FROM proxy_logs \
              {where_clause} \
              ORDER BY {order_col} {order_dir} \
              LIMIT ? OFFSET ?"
@@ -1066,7 +1079,7 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
                 container_id, upstream_host, error_message, client_ip, user_agent, referrer, \
                 request_id, ip_geolocation_id, browser, browser_version, operating_system, \
                 device_type, is_bot, bot_name, request_size_bytes, response_size_bytes, cache_status \
-             FROM proxy_logs FINAL \
+             FROM proxy_logs \
              {where_clause} \
              ORDER BY {order_col} {order_dir} \
              LIMIT ?"
@@ -1176,10 +1189,10 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
             Self::append_stats_filters(f, &mut clauses, &mut binds);
         }
 
-        // FINAL: dedup ReplacingMergeTree before count() (see the list-count
-        // note above) so retried inserts / backfill re-runs don't inflate this.
+        // NO FINAL (see the list-count note above). This is one of the seven
+        // aggregations the DDL explicitly designates duplicate-tolerant.
         let sql = format!(
-            "SELECT count() AS cnt FROM proxy_logs FINAL WHERE {}",
+            "SELECT count() AS cnt FROM proxy_logs WHERE {}",
             clauses.join(" AND ")
         );
         let q = apply_binds(self.client.query(&sql), binds);
@@ -1245,7 +1258,7 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
                 countIf(status_code >= 400) AS error_count, \
                 sum(ifNull(request_size_bytes, 0)) AS total_request_bytes, \
                 sum(ifNull(response_size_bytes, 0)) AS total_response_bytes \
-             FROM proxy_logs FINAL \
+             FROM proxy_logs \
              WHERE {where_clause} \
              GROUP BY bucket_ms \
              ORDER BY bucket_ms ASC \
@@ -1324,7 +1337,7 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
                 count() AS total_requests, \
                 countIf(status_code >= 500) AS total_errors, \
                 ifNull(avg(response_time_ms), 0) AS avg_response_time_ms \
-             FROM proxy_logs FINAL \
+             FROM proxy_logs \
              WHERE {} \
              GROUP BY project_id",
             clauses.join(" AND ")
@@ -1437,7 +1450,7 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
                 count() AS request_count, \
                 uniqExact(client_ip) AS unique_ips, \
                 toUnixTimestamp64Milli(max(timestamp)) AS last_seen_ms \
-             FROM proxy_logs FINAL \
+             FROM proxy_logs \
              WHERE {where_clause} \
              GROUP BY bot_name \
              ORDER BY request_count DESC \
@@ -1515,7 +1528,7 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
                 count() AS request_count, \
                 uniqExact(bot_name) AS agent_count, \
                 toUnixTimestamp64Milli(max(timestamp)) AS last_seen_ms \
-             FROM proxy_logs FINAL \
+             FROM proxy_logs \
              WHERE {where_clause} \
              GROUP BY path \
              ORDER BY request_count DESC \
@@ -1598,7 +1611,7 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
                 toInt64(toUnixTimestamp(toStartOfInterval(timestamp, INTERVAL {step} SECOND))) * 1000 AS bucket_ms, \
                 bot_name AS agent, \
                 count() AS request_count \
-             FROM proxy_logs FINAL \
+             FROM proxy_logs \
              WHERE {where_clause} \
              GROUP BY bucket_ms, bot_name \
              ORDER BY bucket_ms ASC \
@@ -1715,7 +1728,7 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
                     status_code >= 500 AND status_code < 600, '5xx', \
                     'other') AS status_class, \
                 count() AS request_count \
-             FROM proxy_logs FINAL \
+             FROM proxy_logs \
              WHERE {where_clause} \
              GROUP BY status_class \
              ORDER BY request_count DESC"

--- a/web/src/components/proxy-logs/ProxyLogsDataTable.tsx
+++ b/web/src/components/proxy-logs/ProxyLogsDataTable.tsx
@@ -61,21 +61,33 @@ interface ProxyLogsDataTableProps {
 }
 
 /**
- * Time window for the listing. The API bounds the query to the last 24h when
- * no `start_date` is sent (see ProxyLogService::DEFAULT_LIST_LOOKBACK_HOURS),
- * so the table always sends an explicit window rather than relying on that
- * fallback — the user should be able to see and change what they are looking
- * at, and widening the window is a deliberate, visible act.
+ * Time window for the listing. The API bounds every request server-side
+ * (`temps_core::time_window`, shared across proxy-log and Observe endpoints)
+ * even when no `start_date` is sent, but the table always sends an explicit
+ * window rather than relying on that fallback — the user should be able to
+ * see and change what they are looking at, and widening the window is a
+ * deliberate, visible act. A custom range past the shared 7-day cap is
+ * rejected by the API with an actionable error rather than served slowly.
  *
  * `custom` hands control to the start_date/end_date fields in the advanced
  * filter panel.
  */
-type TimeRange = '30m' | '6h' | '12h' | '24h' | '3d' | '7d' | 'custom'
+type TimeRange = '30m' | '1h' | '6h' | '12h' | '24h' | '3d' | '7d' | 'custom'
 
-const DEFAULT_TIME_RANGE: TimeRange = '24h'
+/**
+ * One hour, not a day: the listing's cost is linear in how much time the window
+ * spans, because `ORDER BY timestamp DESC` cannot be answered from the sort key
+ * when no project is selected. Measured on 150M rows, whole endpoint:
+ * 7.7ms over 1h against 123ms over 24h and 1.3s over 7d.
+ *
+ * Kept in step with `temps_core::time_window::DEFAULT_LOOKBACK_HOURS` so a
+ * client that sends no range sees the same window the picker reports.
+ */
+const DEFAULT_TIME_RANGE: TimeRange = '1h'
 
 const TIME_RANGES: { value: TimeRange; label: string }[] = [
   { value: '30m', label: 'Last 30 minutes' },
+  { value: '1h', label: 'Last hour' },
   { value: '6h', label: 'Last 6 hours' },
   { value: '12h', label: 'Last 12 hours' },
   { value: '24h', label: 'Last 24 hours' },
@@ -86,6 +98,7 @@ const TIME_RANGES: { value: TimeRange; label: string }[] = [
 
 const RANGE_MS: Record<Exclude<TimeRange, 'custom'>, number> = {
   '30m': 30 * 60 * 1000,
+  '1h': 60 * 60 * 1000,
   '6h': 6 * 60 * 60 * 1000,
   '12h': 12 * 60 * 60 * 1000,
   '24h': 24 * 60 * 60 * 1000,
@@ -664,8 +677,9 @@ export function ProxyLogsDataTable({
       <div className="flex items-center justify-between gap-4 flex-wrap">
         <div className="flex items-center gap-2">
           {/* Time range. The listing is always bounded (the API defaults to
-              24h when no start_date is sent), so this control is the primary
-              way to reach older traffic — up to the retention horizon. */}
+              1h when no start_date is sent, and rejects a custom range wider
+              than 7 days), so this control is the primary way to reach older
+              traffic — up to the retention horizon. */}
           <Select
             value={timeRange}
             onValueChange={(v) => changeTimeRange(v as TimeRange)}
@@ -1312,8 +1326,9 @@ export function ProxyLogsDataTable({
             <div className="flex flex-col items-center justify-center py-12 text-center">
               <AlertCircle className="h-12 w-12 text-destructive mb-4" />
               <p className="text-lg font-semibold">Failed to load proxy logs</p>
-              <p className="text-sm text-muted-foreground">
-                Please try again later
+              <p className="text-sm text-muted-foreground max-w-md">
+                {(error as { detail?: string })?.detail ||
+                  'Please try again later.'}
               </p>
             </div>
           ) : !data || data.logs.length === 0 ? (
@@ -1321,7 +1336,15 @@ export function ProxyLogsDataTable({
               <Search className="h-12 w-12 text-muted-foreground mb-4" />
               <p className="text-lg font-semibold">No proxy logs found</p>
               <p className="text-sm text-muted-foreground">
-                Try adjusting your filters
+                {timeRange === 'custom'
+                  ? 'No requests in the selected date range.'
+                  : `No requests in the ${(
+                      TIME_RANGES.find((r) => r.value === timeRange)?.label ??
+                      'selected range'
+                    ).toLowerCase()}.`}{' '}
+                {hasActiveFilters
+                  ? 'Try widening the time range or clearing filters.'
+                  : 'Try widening the time range.'}
               </p>
             </div>
           ) : (

--- a/web/src/components/proxy-logs/ProxyLogsDataTable.tsx
+++ b/web/src/components/proxy-logs/ProxyLogsDataTable.tsx
@@ -43,6 +43,7 @@ import {
   ChevronRight as ChevronExpand,
   ChevronsLeft,
   ChevronsRight,
+  Clock,
   Columns,
   ExternalLink,
   Filter,
@@ -50,13 +51,60 @@ import {
   Search,
   X,
 } from 'lucide-react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'react-router'
 
 interface ProxyLogsDataTableProps {
   projectId?: number
   environmentId?: number
   onRowClick?: (log: ProxyLogResponse) => void
+}
+
+/**
+ * Time window for the listing. The API bounds the query to the last 24h when
+ * no `start_date` is sent (see ProxyLogService::DEFAULT_LIST_LOOKBACK_HOURS),
+ * so the table always sends an explicit window rather than relying on that
+ * fallback — the user should be able to see and change what they are looking
+ * at, and widening the window is a deliberate, visible act.
+ *
+ * `custom` hands control to the start_date/end_date fields in the advanced
+ * filter panel.
+ */
+type TimeRange = '30m' | '6h' | '12h' | '24h' | '3d' | '7d' | 'custom'
+
+const DEFAULT_TIME_RANGE: TimeRange = '24h'
+
+const TIME_RANGES: { value: TimeRange; label: string }[] = [
+  { value: '30m', label: 'Last 30 minutes' },
+  { value: '6h', label: 'Last 6 hours' },
+  { value: '12h', label: 'Last 12 hours' },
+  { value: '24h', label: 'Last 24 hours' },
+  { value: '3d', label: 'Last 3 days' },
+  { value: '7d', label: 'Last 7 days' },
+  { value: 'custom', label: 'Custom range' },
+]
+
+const RANGE_MS: Record<Exclude<TimeRange, 'custom'>, number> = {
+  '30m': 30 * 60 * 1000,
+  '6h': 6 * 60 * 60 * 1000,
+  '12h': 12 * 60 * 60 * 1000,
+  '24h': 24 * 60 * 60 * 1000,
+  '3d': 3 * 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+}
+
+function isTimeRange(v: string | null): v is TimeRange {
+  return !!v && TIME_RANGES.some((r) => r.value === v)
+}
+
+/**
+ * Resolve a preset to the ISO start instant to send as `start_date`.
+ *
+ * Mirrors `timeRangeToFromDate` in Observe.tsx — the clock read lives in a
+ * module-level function so the caller's `useMemo` body stays pure.
+ */
+function timeRangeToStartDate(range: Exclude<TimeRange, 'custom'>): string {
+  return new Date(Date.now() - RANGE_MS[range]).toISOString()
 }
 
 interface FilterState {
@@ -264,6 +312,16 @@ export function ProxyLogsDataTable({
     return searchParams.get('filters') === 'open'
   })
 
+  const [timeRange, setTimeRange] = useState<TimeRange>(() => {
+    const v = searchParams.get('time_range')
+    if (isTimeRange(v)) return v
+    // A URL carrying explicit dates but no time_range (an older bookmark, or a
+    // hand-built link) is a custom window by definition.
+    return searchParams.get('start_date') || searchParams.get('end_date')
+      ? 'custom'
+      : DEFAULT_TIME_RANGE
+  })
+
   const [filters, setFilters] = useState<FilterState>(() =>
     parseFiltersFromParams(searchParams)
   )
@@ -288,9 +346,19 @@ export function ProxyLogsDataTable({
     if (sortBy !== 'timestamp') params.set('sort_by', sortBy)
     if (sortOrder !== 'desc') params.set('sort_order', sortOrder)
     if (showFilters) params.set('filters', 'open')
+    if (timeRange !== DEFAULT_TIME_RANGE) params.set('time_range', timeRange)
     serializeFiltersToParams(filters, params)
     setSearchParams(params, { replace: true })
-  }, [page, pageSize, sortBy, sortOrder, showFilters, filters, setSearchParams])
+  }, [
+    page,
+    pageSize,
+    sortBy,
+    sortOrder,
+    showFilters,
+    timeRange,
+    filters,
+    setSearchParams,
+  ])
 
   useEffect(() => {
     // Skip the initial mount to avoid overwriting params we just read from
@@ -313,6 +381,24 @@ export function ProxyLogsDataTable({
     })
   }, [])
 
+  /**
+   * The window actually sent to the API.
+   *
+   * Deliberately memoised on the RANGE, not on wall-clock time: a preset like
+   * "Last 24 hours" resolves to a fixed instant that only moves when the user
+   * changes the range or the query refetches. Recomputing `Date.now()` on every
+   * render would make the query key unstable and refetch on every keystroke.
+   */
+  const timeWindow = useMemo(() => {
+    if (timeRange === 'custom') {
+      return {
+        start: filters.start_date || null,
+        end: filters.end_date || null,
+      }
+    }
+    return { start: timeRangeToStartDate(timeRange), end: null }
+  }, [timeRange, filters.start_date, filters.end_date])
+
   const { data, isLoading, error } = useQuery({
     ...getProxyLogsOptions({
       query: {
@@ -321,8 +407,8 @@ export function ProxyLogsDataTable({
         deployment_id: filters.deployment_id
           ? parseInt(filters.deployment_id)
           : null,
-        start_date: filters.start_date || null,
-        end_date: filters.end_date || null,
+        start_date: timeWindow.start,
+        end_date: timeWindow.end,
         method: filters.method || null,
         host: filters.host || null,
         path: filters.path || null,
@@ -405,12 +491,38 @@ export function ProxyLogsDataTable({
 
   const applyFilters = () => {
     setFilters(pendingFilters)
+    // Typing an explicit date in the advanced panel IS choosing a custom
+    // window — reflect that in the picker instead of silently ignoring the
+    // dates because a preset is still selected.
+    if (pendingFilters.start_date || pendingFilters.end_date) {
+      setTimeRange('custom')
+    }
     setPage(1)
   }
 
   const clearFilters = () => {
     setFilters({})
     setPendingFilters({})
+    setTimeRange(DEFAULT_TIME_RANGE)
+    setPage(1)
+  }
+
+  const changeTimeRange = (next: TimeRange) => {
+    setTimeRange(next)
+    // A preset owns the window outright; leaving stale start/end values behind
+    // would show a range the picker no longer describes.
+    if (next !== 'custom') {
+      setFilters((prev) => ({
+        ...prev,
+        start_date: undefined,
+        end_date: undefined,
+      }))
+      setPendingFilters((prev) => ({
+        ...prev,
+        start_date: undefined,
+        end_date: undefined,
+      }))
+    }
     setPage(1)
   }
 
@@ -468,9 +580,7 @@ export function ProxyLogsDataTable({
     ]
 
   const aiAgentActive =
-    filters.is_ai_agent === true ||
-    !!filters.ai_provider ||
-    !!filters.ai_agent
+    filters.is_ai_agent === true || !!filters.ai_provider || !!filters.ai_agent
 
   return (
     <div className="space-y-4">
@@ -553,6 +663,25 @@ export function ProxyLogsDataTable({
       {/* Toolbar */}
       <div className="flex items-center justify-between gap-4 flex-wrap">
         <div className="flex items-center gap-2">
+          {/* Time range. The listing is always bounded (the API defaults to
+              24h when no start_date is sent), so this control is the primary
+              way to reach older traffic — up to the retention horizon. */}
+          <Select
+            value={timeRange}
+            onValueChange={(v) => changeTimeRange(v as TimeRange)}
+          >
+            <SelectTrigger className="w-full sm:w-[170px]">
+              <Clock className="h-4 w-4 mr-2 shrink-0 opacity-60" />
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TIME_RANGES.map((r) => (
+                <SelectItem key={r.value} value={r.value}>
+                  {r.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           <Button
             variant={showFilters ? 'default' : 'outline'}
             size="sm"
@@ -953,9 +1082,9 @@ export function ProxyLogsDataTable({
                   <SelectContent>
                     <SelectItem value="all">All agents</SelectItem>
                     {(pendingFilters.ai_provider
-                      ? AI_PROVIDERS.find(
+                      ? (AI_PROVIDERS.find(
                           (p) => p.provider === pendingFilters.ai_provider
-                        )?.agents ?? []
+                        )?.agents ?? [])
                       : AI_PROVIDERS.flatMap((p) => p.agents)
                     ).map((agent) => (
                       <SelectItem key={agent} value={agent}>
@@ -1336,10 +1465,7 @@ function ProxyLogTableRow({
 }: ProxyLogTableRowProps) {
   return (
     <>
-      <TableRow
-        className="cursor-pointer hover:bg-muted/50"
-        onClick={onToggle}
-      >
+      <TableRow className="cursor-pointer hover:bg-muted/50" onClick={onToggle}>
         <TableCell className="w-8 px-2">
           <ChevronExpand
             className={`h-4 w-4 text-muted-foreground transition-transform duration-200 ${
@@ -1576,11 +1702,7 @@ function ProxyLogInlineDetail({ log }: { log: ProxyLogResponse }) {
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         <span>Request ID:</span>
         <code className="font-mono">{log.request_id}</code>
-        <CopyButton
-          value={log.request_id}
-          minimal
-          className="h-4 w-4 p-0"
-        />
+        <CopyButton value={log.request_id} minimal className="h-4 w-4 p-0" />
       </div>
 
       {/* User Agent */}


### PR DESCRIPTION
## Problem

At 100M+ proxy logs and 150M+ spans in one project, `GET /proxy-logs` and the Observe feed each took multiple seconds to return a single page. Four independent causes, all of them full scans.

### 1. `FINAL` on every ClickHouse read path

`0001_proxy_logs.sql:26-28` states the design plainly:

> the high-volume read paths (list + the 7 aggregations) GROUP BY or LIMIT and tolerate the rare pre-merge duplicate, so they do **NOT** use FINAL (keeps the hot scans fast)

All ten read queries used it anyway. `FINAL` forces merge-on-read across every part in every partition, turning the unfiltered pagination `count()` from a metadata lookup (1.2ms in the DDL's own benchmark) into a full-table merge scan. Removed from `proxy_logs` and from the span list. The DDL's 5M-row benchmark that justified "no rollups needed" assumed no `FINAL`.

### 2. `GET /proxy-logs` was unbounded in time

With no `start_date` the query considered the entire 30-day retention window to return 20 rows. `ProxyLogService` now applies a 1h lower bound when the caller supplies no start, anchored to `end_date` when one was given, so both the ClickHouse and TimescaleDB backends are always time-bounded. Documented on the OpenAPI parameter — this is a visible API behaviour change for callers that previously sent no dates. (See **Update** below — this became a shared `temps_core::time_window` contract applied to every proxy-log/Observe read endpoint, not just this one.)

### 3. The Proxy Logs table sent no window at all

Added a time-range picker (30m/1h/6h/12h/24h/3d/7d/custom, default 1h) that syncs to the URL, mirroring `Observe.tsx`. Older traffic stays one click away rather than depending on the server-side fallback.

### 4. `spans` has no physical ordering by time

`ORDER BY (project_id, trace_id, span_id)` is correct for `get_trace()` and useless for "most recent N". `trace_id` is a random hash, so every granule spans the whole window — a minmax skip index on `start_time` would prune nothing, and the monthly partition key only prunes by month. The feed therefore read the project's **entire month**, materialising the fat `attributes`/`events` JSON for every row, to return 100.

Adds a `proj_recent` projection ordered by `(project_id, start_time)` holding only the narrow columns, and splits `query_spans` into two stages: resolve the page identities against the projection, then read the wide rows for the ~100 survivors by primary key. Kept **single-stage when the query is trace-anchored**, where the sort-key prefix already applies and two stages would read it twice.

### Also

The Observe merge service awaited its four per-kind fetchers sequentially, despite the module doc claiming "parallel-fetches" — the endpoint cost the sum of four round trips instead of the slowest.

## Evidence

Benchmarked against **159.8M synthetic spans / 23.84 GiB** (150M in one busy project, spread over 7 days), ClickHouse 24.8.14. Root spans, 24h window, `ORDER BY start_time DESC LIMIT 100` — exactly what `ObservabilityService::fetch_spans` issues. Best of 3 warm runs, `statistics.elapsed` from `FORMAT JSON`.

| variant | elapsed | rows_read |
|---|---|---|
| current (`FINAL`, single-stage) | 5050 ms | 151.6M |
| drop `FINAL` only | 3842 ms | 150.0M |
| drop `FINAL` + two-stage, no projection | 671 ms | 158.8M |
| drop `FINAL` + two-stage + `proj_recent` | **132 ms** | 24.2M |

Through the **real `query_spans` code path** (not hand-written SQL), driven against the same dataset:

- Observe feed: **5050 ms → 111.6 ms**
- Trace-anchored lookup: **9.6 ms → 8.5 ms** (no regression)

That second number caught a bug: the first version of this change made trace lookups *slower* (9.6 → 14.6 ms) by reading the sort-key prefix twice. Hence the single-stage branch.

**Correctness:** result sets verified byte-identical across all three variants by hashing the returned `(trace_id, span_id, start_time)` rows.

**Migration:** the full 0001→0007 chain verified applying from scratch against a real ClickHouse, projection present in the resulting DDL, setting persisted, idempotent on re-run.

## Cost of `proj_recent`

Measured on identical 10M-row loads into two tables differing only by the projection:

| | without | with | delta |
|---|---|---|---|
| read (feed) | 671 ms | 132 ms | **5x faster** |
| disk | 1.49 GiB | 1.78 GiB | +19% |
| merge (`OPTIMIZE FINAL`) | 14.2 s | 16.0 s | +13% |
| ingest (10M rows) | 21.6 s | 22.6 s | +5% |

Only five narrow columns are duplicated — the `attributes`/`events` blobs are not — which is why disk is +19% and not +100%.

The trade is kept because the read cost **without** the projection grows with total table size, while **with** it the read is proportional to the queried window and stays roughly flat as the table grows. A deployment that decides otherwise can `ALTER TABLE spans DROP PROJECTION proj_recent`; `query_spans` keeps working at the 671ms shape. This reasoning and the escape hatch are documented in the migration.

## Deployment notes

- **`MATERIALIZE PROJECTION` is a mutation.** 2m08s for 159.8M rows on a dev box; a 3-vCPU cpx22 competing with live ingest will take longer. The migration runner does **not** wait for it (no `mutations_sync` issued), so startup is not blocked — queries use the base-table path and get faster part-by-part. Track with:
  ```sql
  SELECT * FROM system.mutations WHERE table = 'spans' AND NOT is_done;
  ```
- **Projections on `ReplacingMergeTree` are gated** behind `deduplicate_merge_projection_mode` in CH 24.8 (`SUPPORT_IS_DISABLED`, error 344, without it). The migration sets `'rebuild'`, which regenerates the projection on merge. Consistent here because the read paths using it do not use `FINAL`.
- **API behaviour change:** `GET /proxy-logs` with no `start_date` now means "last 1h" rather than "all retained data" (see **Update**). CLI/SDK callers relying on the old unbounded behaviour must pass `start_date` explicitly.

## Known gap

Deep `OFFSET` pagination is **not** addressed. "Jump to last page" can still produce a large offset; the default window bounds it to roughly the lookback window's worth of rows instead of 30 days, which is a large improvement but not a fix. Keyset/cursor pagination is the proper answer and is left as follow-up.

## Update — shared, capped time-window contract across all proxy-log/Observe reads

Follow-up requested in review: apply the same bounded-window discipline everywhere a range-taking proxy-log or Observe endpoint could otherwise scan the whole retention window, not just `GET /proxy-logs`.

- New `temps_core::time_window` module: default lookback dropped from 24h to **1h** (7.7ms vs 123ms on the 150M-row reference set — see the module's doc for the full latency table), plus a **maximum span** so a request can't ask for a query that takes tens of seconds. All 7 UI presets (30m/1h/6h/12h/24h/3d/7d) stay selectable, plus `custom`; a custom range past the cap is rejected with a 400 naming the limit and how to work around it (page back in cap-sized windows) rather than served slowly.
- Wired into `ProxyLogService::list_with_filters`/`list_page` (the Observe feed's proxy-log read path had **zero** bounding before this — a real gap, since `fetch_requests` uses `list_page`) and into all 7 stats/AI-breakdown methods, which took a required range but previously had no width cap at all.
- Wired into `ObservabilityService::query` so the unified Observe feed is bounded regardless of which store answers it.
- **Two caps, not one**, added after `review-pr` caught a regression in the first version: a flat 7-day cap would have 400'd two features that already ship a 30-day option — the Observe feed's own picker (`ObserveFilterBar.tsx`) and the Project Analytics AI Agents tab (`useAnalyticsDateRange.ts`), both always scoped to one project. `MAX_WINDOW_DAYS` (7d) now applies only to unscoped reads (no `project_id` — the whole-deployment cost profile the measurements above are based on); `MAX_WINDOW_DAYS_SCOPED` (30d) applies once a read already filters to one project, whose cost is bounded by that project's own volume. Each of the 7 call sites derives which cap applies from its own `project_id`/`project_ids` parameter.
- Also fixes a real race the new tests caught: an open-ended window (no `end`) measures its width against a fresh `Utc::now()` on the server, always a little later than when the client computed `start` — so a preset sized to land exactly on the cap (both the 7d and 30d presets are) could get rejected by a few milliseconds of clock/network skew. A 5-minute tolerance now absorbs this, applied only when `end` is absent; explicit ranges keep the exact boundary check.

## Verification

- `cargo test -p temps-proxy -p temps-otel -p temps-observability -p temps-core --all-targets` — 1226 passed, 0 failed (4 environment-only ignores, unrelated to this PR)
- `cargo clippy -p temps-proxy -p temps-otel -p temps-observability -p temps-core --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `tsc --noEmit` — clean; `eslint` on the changed component — clean
- New tests: the default-window logic (both-absent, end-anchored, explicit-start preserved, underflow saturation), the scoped-vs-unscoped cap split, the clock-skew tolerance (and that it does *not* apply to explicit ranges), and an integration test proving the Observe feed accepts the same 30-day span an unscoped request would reject.

