### PR TITLE
fix(monitoring): close race that fires false ContainerCrash alerts on deploy

### DIFF
--- a/crates/temps-deployments/src/services/services.rs
+++ b/crates/temps-deployments/src/services/services.rs
@@ -1798,7 +1798,12 @@ impl DeploymentService {
                 let mut active_container: deployment_containers::ActiveModel = container.into();
                 active_container.deleted_at = Set(Some(chrono::Utc::now()));
                 active_container.status = Set(Some("removed".to_string()));
-                let _ = active_container.update(self.db.as_ref()).await;
+                if let Err(e) = active_container.update(self.db.as_ref()).await {
+                    warn!(
+                        "Failed to mark container {} deleted before pre-rollback stop: {}",
+                        container_id, e
+                    );
+                }
 
                 if let Err(e) = self.deployer.stop_container(&container_id).await {
                     warn!(
@@ -5748,5 +5753,112 @@ mod tests {
             DeploymentService::resolve_resource_usage(Some(&empty_env), Some(&cfg(None, None)));
         assert_eq!(still_none.cpu_limit, None);
         assert_eq!(still_none.memory_limit, None);
+    }
+
+    /// `stop_environment_containers` (pre-rollback cleanup) has the same
+    /// deleted-before-stopped ordering requirement as
+    /// `WorkflowExecutionService::teardown_previous_deployment`. Uses
+    /// `block_in_place` to run a real DB check from inside the mock's
+    /// `stop_container` expectation, which requires the multi-thread runtime.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_stop_environment_containers_marks_deleted_before_stopping_container(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+
+        let (_project, environment, old_deployment) = setup_test_data(&db).await?;
+
+        let container = deployment_containers::ActiveModel {
+            deployment_id: Set(old_deployment.id),
+            container_id: Set("old-env-container-1".to_string()),
+            container_name: Set("old-env-container-1".to_string()),
+            container_port: Set(3000),
+            deployed_at: Set(Utc::now()),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await?;
+
+        // Deployment state must be one of the active states
+        // `stop_environment_containers` scans for; a nonexistent id is enough
+        // for the "exclude current deployment" filter.
+        let exclude_deployment_id = old_deployment.id + 1_000_000;
+
+        let log_service = Arc::new(temps_logs::LogService::new(std::env::temp_dir()));
+        let test_db_url = "postgresql://test_user:test_password@localhost:5432/test_db";
+        let server_config = Arc::new(
+            temps_config::ServerConfig::new(
+                "127.0.0.1:8080".to_string(),
+                test_db_url.to_string(),
+                None,
+                None,
+            )
+            .expect("Failed to create test server config"),
+        );
+        let config_service = Arc::new(temps_config::ConfigService::new(server_config, db.clone()));
+
+        let mut queue_service = MockQueueService::new();
+        queue_service.expect_send().returning(|_| Ok(()));
+        queue_service
+            .expect_subscribe()
+            .returning(|| Box::new(MockJobReceiver::new()));
+        let queue_service: Arc<dyn temps_core::JobQueue> = Arc::new(queue_service);
+
+        let docker = Arc::new(bollard::Docker::connect_with_local_defaults().unwrap());
+        let docker_log_service = Arc::new(temps_logs::DockerLogService::new(docker));
+
+        let db_for_check = db.clone();
+        let mut deployer = MockContainerDeployer::new();
+        deployer
+            .expect_stop_container()
+            .returning(move |container_id| {
+                let db_for_check = db_for_check.clone();
+                let container_id = container_id.to_string();
+                let refreshed = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(async {
+                        deployment_containers::Entity::find()
+                            .filter(deployment_containers::Column::ContainerId.eq(container_id))
+                            .one(db_for_check.as_ref())
+                            .await
+                    })
+                })
+                .expect("query deployment_containers row")
+                .expect("deployment_containers row exists");
+                assert!(
+                    refreshed.deleted_at.is_some(),
+                    "container must be marked deleted before stop_container() is called \
+                     during pre-rollback cleanup — otherwise ContainerHealthMonitor's \
+                     concurrent poll can observe it mid-exit with no signal the exit is \
+                     intentional, and fires a false ContainerCrash alarm"
+                );
+                Ok(())
+            });
+        deployer.expect_remove_container().returning(|_| Ok(()));
+        let deployer: Arc<dyn temps_deployer::ContainerDeployer> = Arc::new(deployer);
+
+        let service = DeploymentService {
+            db: db.clone(),
+            log_service,
+            config_service,
+            queue_service,
+            docker_log_service,
+            deployer,
+            encryption_service: create_test_encryption_service(),
+            telemetry: std::sync::OnceLock::new(),
+            env_resolver: std::sync::OnceLock::new(),
+        };
+
+        service
+            .stop_environment_containers(environment.id, exclude_deployment_id)
+            .await;
+
+        let refreshed = deployment_containers::Entity::find_by_id(container.id)
+            .one(db.as_ref())
+            .await?
+            .expect("container row still exists");
+        assert!(refreshed.deleted_at.is_some());
+        assert_eq!(refreshed.status.as_deref(), Some("removed"));
+
+        Ok(())
     }
 }

--- a/crates/temps-deployments/src/services/services.rs
+++ b/crates/temps-deployments/src/services/services.rs
@@ -1787,6 +1787,19 @@ impl DeploymentService {
 
             for container in containers {
                 let container_id = container.container_id.clone();
+
+                // Mark the row deleted *before* stopping the container in Docker
+                // (see the identical race explained in
+                // WorkflowExecutionService::teardown_previous_deployment):
+                // ContainerHealthMonitor polls on its own schedule and would
+                // otherwise observe this container mid-exit with no signal that
+                // the exit is an intentional pre-rollback cleanup, firing a
+                // false ContainerCrash alarm.
+                let mut active_container: deployment_containers::ActiveModel = container.into();
+                active_container.deleted_at = Set(Some(chrono::Utc::now()));
+                active_container.status = Set(Some("removed".to_string()));
+                let _ = active_container.update(self.db.as_ref()).await;
+
                 if let Err(e) = self.deployer.stop_container(&container_id).await {
                     warn!(
                         "Failed to stop container {} during pre-rollback cleanup: {}",
@@ -1799,12 +1812,6 @@ impl DeploymentService {
                         container_id, e
                     );
                 }
-
-                // Mark container as deleted
-                let mut active_container: deployment_containers::ActiveModel = container.into();
-                active_container.deleted_at = Set(Some(chrono::Utc::now()));
-                active_container.status = Set(Some("removed".to_string()));
-                let _ = active_container.update(self.db.as_ref()).await;
 
                 info!(
                     "Pre-rollback: stopped and removed container {}",

--- a/crates/temps-deployments/src/services/workflow_execution_service.rs
+++ b/crates/temps-deployments/src/services/workflow_execution_service.rs
@@ -2094,6 +2094,22 @@ impl WorkflowExecutionService {
             for container in containers {
                 let container_id = container.container_id.clone();
 
+                // Mark the row deleted *before* stopping the container in Docker.
+                // ContainerHealthMonitor (temps-monitoring) polls
+                // `deployment_containers` filtered on `DeletedAt.is_null()` on its
+                // own independent schedule. If that poll lands between
+                // `stop_container()` below (which puts Docker's container state
+                // into `Exited`) and this row being marked deleted, it has no way
+                // to tell the exit was an intentional teardown and fires a false
+                // ContainerCrash alarm. Writing `deleted_at` first closes that
+                // window: once this update commits, the health monitor's next
+                // query no longer returns this row at all.
+                use sea_orm::{ActiveModelTrait, Set};
+                let mut active_container: deployment_containers::ActiveModel = container.into();
+                active_container.deleted_at = Set(Some(chrono::Utc::now()));
+                active_container.status = Set(Some("deleted".to_string()));
+                active_container.update(self.db.as_ref()).await?;
+
                 // Stop and remove the container
                 match self.container_deployer.stop_container(&container_id).await {
                     Ok(_) => {
@@ -2116,13 +2132,6 @@ impl WorkflowExecutionService {
                         warn!("Failed to remove container {}: {}", container_id, e);
                     }
                 }
-
-                // Mark container as deleted
-                use sea_orm::{ActiveModelTrait, Set};
-                let mut active_container: deployment_containers::ActiveModel = container.into();
-                active_container.deleted_at = Set(Some(chrono::Utc::now()));
-                active_container.status = Set(Some("deleted".to_string()));
-                active_container.update(self.db.as_ref()).await?;
 
                 if first_stopped_container_id.is_none() {
                     first_stopped_container_id = Some(container_id);
@@ -2951,5 +2960,195 @@ mod tests {
         fn is_enabled(&self) -> bool {
             true
         }
+    }
+
+    /// Deployer used only by
+    /// `test_teardown_previous_deployment_marks_deleted_before_stopping_container`.
+    /// Asserts that by the time Docker is asked to stop a container, its
+    /// `deployment_containers` row is already marked deleted in the database —
+    /// the invariant that closes the race with `ContainerHealthMonitor`'s
+    /// independent poll loop (see the comment in `teardown_previous_deployment`).
+    struct AssertDeletedBeforeStopDeployer {
+        db: Arc<DbConnection>,
+    }
+
+    #[async_trait]
+    impl ContainerDeployer for AssertDeletedBeforeStopDeployer {
+        async fn deploy_container(
+            &self,
+            _request: temps_deployer::DeployRequest,
+        ) -> Result<temps_deployer::DeployResult, temps_deployer::DeployerError> {
+            unimplemented!("not exercised by this test")
+        }
+
+        async fn start_container(
+            &self,
+            _container_id: &str,
+        ) -> Result<(), temps_deployer::DeployerError> {
+            unimplemented!("not exercised by this test")
+        }
+
+        async fn stop_container(
+            &self,
+            container_id: &str,
+        ) -> Result<(), temps_deployer::DeployerError> {
+            let container = temps_entities::deployment_containers::Entity::find()
+                .filter(temps_entities::deployment_containers::Column::ContainerId.eq(container_id))
+                .one(self.db.as_ref())
+                .await
+                .expect("query deployment_containers row")
+                .expect("deployment_containers row exists");
+            assert!(
+                container.deleted_at.is_some(),
+                "container {container_id} must be marked deleted before stop_container() \
+                 is called — otherwise ContainerHealthMonitor's concurrent poll can \
+                 observe an Exited container with no signal that the exit is an \
+                 intentional teardown, and fires a false ContainerCrash alarm"
+            );
+            Ok(())
+        }
+
+        async fn pause_container(
+            &self,
+            _container_id: &str,
+        ) -> Result<(), temps_deployer::DeployerError> {
+            unimplemented!("not exercised by this test")
+        }
+
+        async fn resume_container(
+            &self,
+            _container_id: &str,
+        ) -> Result<(), temps_deployer::DeployerError> {
+            unimplemented!("not exercised by this test")
+        }
+
+        async fn remove_container(
+            &self,
+            _container_id: &str,
+        ) -> Result<(), temps_deployer::DeployerError> {
+            Ok(())
+        }
+
+        async fn get_container_info(
+            &self,
+            _container_id: &str,
+        ) -> Result<temps_deployer::ContainerInfo, temps_deployer::DeployerError> {
+            unimplemented!("not exercised by this test")
+        }
+
+        async fn get_container_stats(
+            &self,
+            _container_id: &str,
+        ) -> Result<temps_deployer::ContainerStats, temps_deployer::DeployerError> {
+            unimplemented!("not exercised by this test")
+        }
+
+        async fn list_containers(
+            &self,
+        ) -> Result<Vec<temps_deployer::ContainerInfo>, temps_deployer::DeployerError> {
+            unimplemented!("not exercised by this test")
+        }
+
+        async fn get_container_logs(
+            &self,
+            _container_id: &str,
+        ) -> Result<String, temps_deployer::DeployerError> {
+            unimplemented!("not exercised by this test")
+        }
+
+        async fn stream_container_logs(
+            &self,
+            _container_id: &str,
+        ) -> Result<
+            Box<dyn futures::Stream<Item = String> + Unpin + Send>,
+            temps_deployer::DeployerError,
+        > {
+            unimplemented!("not exercised by this test")
+        }
+    }
+
+    #[tokio::test]
+    async fn test_teardown_previous_deployment_marks_deleted_before_stopping_container(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use temps_entities::deployment_containers;
+
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+
+        let (project, environment, current_deployment) = create_test_data(&db).await?;
+
+        // A previous deployment in the same environment, still active, whose
+        // container should be torn down now that `current_deployment` is live.
+        let previous_deployment = deployments::ActiveModel {
+            project_id: Set(project.id),
+            environment_id: Set(environment.id),
+            slug: Set("previous-deployment".to_string()),
+            state: Set("completed".to_string()),
+            metadata: Set(Some(
+                temps_entities::deployments::DeploymentMetadata::default(),
+            )),
+            created_at: Set(Utc::now() - chrono::Duration::minutes(5)),
+            updated_at: Set(Utc::now()),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await?;
+
+        let container = deployment_containers::ActiveModel {
+            deployment_id: Set(previous_deployment.id),
+            container_id: Set("old-container-1".to_string()),
+            container_name: Set("old-container-1".to_string()),
+            container_port: Set(3000),
+            deployed_at: Set(Utc::now()),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await?;
+
+        let (queue, _receiver) = temps_queue::BroadcastQueueService::create_broadcast_channel(100);
+        let queue = Arc::new(queue) as Arc<dyn temps_core::JobQueue>;
+        let git_provider = Arc::new(MockGitProvider);
+        let image_builder = Arc::new(MockImageBuilder { should_fail: false });
+        let container_deployer = Arc::new(AssertDeletedBeforeStopDeployer { db: db.clone() });
+        let static_deployer = Arc::new(MockStaticDeployer);
+        let log_service = Arc::new(LogService::new(std::env::temp_dir()));
+        let cron_service =
+            Arc::new(crate::jobs::NoOpCronConfigService) as Arc<dyn crate::jobs::CronConfigService>;
+        let config_service = create_mock_config_service(db.clone());
+        let screenshot_service = Arc::new(ScreenshotService::new(config_service.clone()).await?);
+        let docker = Arc::new(
+            bollard::Docker::connect_with_local_defaults()
+                .unwrap_or_else(|_| panic!("Failed to connect to Docker")),
+        );
+
+        let service = WorkflowExecutionService::new(
+            db.clone(),
+            queue,
+            git_provider,
+            image_builder,
+            container_deployer,
+            static_deployer,
+            log_service,
+            cron_service,
+            Arc::new(crate::jobs::NoOpAgentSyncService) as Arc<dyn crate::jobs::AgentSyncService>,
+            config_service,
+            screenshot_service,
+            docker,
+        );
+
+        let stopped_container_id = service
+            .teardown_previous_deployment(project.id, environment.id, current_deployment.id)
+            .await?;
+
+        assert_eq!(stopped_container_id, Some("old-container-1".to_string()));
+
+        let refreshed = deployment_containers::Entity::find_by_id(container.id)
+            .one(db.as_ref())
+            .await?
+            .expect("container row still exists");
+        assert!(refreshed.deleted_at.is_some());
+        assert_eq!(refreshed.status.as_deref(), Some("deleted"));
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- Fixes false-positive "Container 'X' is exited" Slack alerts that sometimes fire during normal deployments (screenshot: `exit_code: 0`, `oom_killed: false`, `error_message: null` — a clean, intentional exit, not a crash).
- Root cause: teardown code stopped the old container in Docker *then* marked its `deployment_containers` row `deleted_at`. `ContainerHealthMonitor` (temps-monitoring) polls that table on its own independent schedule, filtered on `deleted_at IS NULL`. If a poll landed in the gap between the Docker stop and the DB write, it saw an `Exited` container with no signal the exit was intentional, and fired a `ContainerCrash` alarm.
- Fix: reorder both teardown paths so the row is marked deleted **before** the container is stopped in Docker — closing the race window entirely, since the health monitor's next query then excludes the row outright. Applied to:
  - `WorkflowExecutionService::teardown_previous_deployment` (runs after every successful deploy — the reported path)
  - `DeploymentsService::stop_environment_containers` (pre-rollback cleanup, same pattern)
- No change to `check_container_status`'s alarm logic itself — a container that exits unexpectedly outside a known teardown/sleep window still alerts, which is intentional (a clean exit_code 0 on an otherwise-untouched service is still worth surfacing).
- Follow-up from self-review: `stop_environment_containers`'s deleted_at update was silently discarding its error (`let _ =`) — now logs a warning consistent with the rest of that function, since this write is now load-bearing for the race fix.

## Test plan

- [x] `cargo check --lib` (workspace) — clean
- [x] `test_teardown_previous_deployment_marks_deleted_before_stopping_container` (workflow_execution_service.rs) and `test_stop_environment_containers_marks_deleted_before_stopping_container` (services.rs) — both use a `ContainerDeployer` stub whose `stop_container()` queries the DB and asserts `deleted_at` is already set at call time.
  - Verified both tests **fail** against the old (reverted) stop-then-delete ordering with the exact assertion message, then **pass** against the fix — proving they're real regression tests, not tautologies.
- [x] Full `temps-deployments` crate test suite: 421-423 passed each run; the only failures seen were transient Postgres deadlocks (`40P01`) in *unrelated* tests (a different one each run: `test_cron_secret_differs_per_environment`, `test_update_deployment_token`, `test_start_container_success`), all confirmed to pass cleanly when re-run in isolation — an artifact of this sandbox sharing one non-isolated standalone Postgres across the whole suite, not a regression from this change.

**Note on test infra**: this sandbox's Docker (via colima) isn't reachable through `testcontainers-rs`/bollard directly (`Error in the hyper legacy client: client error (Connect)`) — confirmed pre-existing by an untouched baseline test failing identically. Verified the fix instead via `TEMPS_TEST_DATABASE_URL` against a manually-started standalone Postgres container.