### PR TITLE
ci(release): add nightly build workflow

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,76 @@
+name: Nightly Release
+
+# Cuts a nightly prerelease build from main once a day, but only when main
+# has moved since the last nightly tag. The tag it mints
+# (v<version>-nightly.<date>.<short-sha>) contains a `-`, so it matches the
+# `release.yml` tag trigger (`v*.*.*-*`) and rides that same pipeline —
+# there is no separate nightly build/publish logic to keep in sync.
+
+on:
+  schedule:
+    # 03:00 UTC daily
+    - cron: "0 3 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  check-and-tag:
+    name: Check for new commits and tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Determine if a nightly build is needed
+        id: check
+        run: |
+          set -euo pipefail
+
+          head_sha="$(git rev-parse HEAD)"
+          echo "HEAD is at $head_sha"
+
+          # Last nightly tag, if any (sorted by tag creation date via version sort on the date segment).
+          last_nightly_tag="$(git tag -l 'v*-nightly.*' --sort=-creatordate | head -n1 || true)"
+
+          if [ -z "$last_nightly_tag" ]; then
+            echo "No previous nightly tag found -- building."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          else
+            last_nightly_sha="$(git rev-list -n1 "$last_nightly_tag")"
+            echo "Last nightly tag: $last_nightly_tag ($last_nightly_sha)"
+            if [ "$last_nightly_sha" = "$head_sha" ]; then
+              echo "No new commits on main since last nightly -- skipping."
+              echo "should_release=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "New commits since last nightly -- building."
+              echo "should_release=true" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Compute nightly tag
+        id: tag
+        if: steps.check.outputs.should_release == 'true'
+        run: |
+          set -euo pipefail
+          base_version="$(grep -m1 '^version' Cargo.toml | sed -E 's/version = "([^"]+)"/\1/' | sed -E 's/-.*//')"
+          date_stamp="$(date -u +%Y%m%d)"
+          short_sha="$(git rev-parse --short HEAD)"
+          tag="v${base_version}-nightly.${date_stamp}.${short_sha}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Nightly tag: $tag"
+
+      - name: Create and push nightly tag
+        if: steps.check.outputs.should_release == 'true'
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Nightly build $TAG"
+          git push origin "$TAG"

--- a/crates/temps-cli/src/commands/upgrade.rs
+++ b/crates/temps-cli/src/commands/upgrade.rs
@@ -28,23 +28,39 @@ pub enum UpgradeTier {
 /// available GitHub releases through this channel before selecting the
 /// newest, so a host on `Stable` never auto-upgrades onto a beta tag.
 /// Pre-release tags carry a `-` (`v1.2.0-beta.4`, `v1.2.0-rc.1`); stable
-/// tags don't (`v1.2.0`).
+/// tags don't (`v1.2.0`). Nightly tags are a distinct kind of prerelease,
+/// identified by a `-nightly.` segment (`v1.2.0-nightly.20260727.abc1234`),
+/// minted automatically by CI — see `is_nightly_tag`.
 ///
 /// Channel selection is **CLI-only** — there is no env-var fallback. The
 /// default is `Stable` and the user must explicitly pass `--channel beta`
-/// to opt into prereleases. This is by design: an env var on a long-lived
-/// shell or CI runner could silently switch a host onto beta without an
-/// audit trail, which we want to prevent. Pinning a specific `--version`
-/// ignores the channel entirely.
+/// or `--channel nightly` to opt into prereleases. This is by design: an
+/// env var on a long-lived shell or CI runner could silently switch a host
+/// onto beta/nightly without an audit trail, which we want to prevent.
+/// Pinning a specific `--version` ignores the channel entirely.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
 pub enum UpgradeChannel {
     /// Track stable releases only (default). Tag must NOT contain `-`.
     Stable,
-    /// Track beta releases. Includes any prerelease tag (anything with `-`).
+    /// Track beta releases: any prerelease tag EXCEPT nightly builds.
     /// `Beta` selects the newest of stable + beta, so a beta host receives
     /// stable releases too — they're considered an upgrade from the latest
-    /// beta on the same line.
+    /// beta on the same line. Nightly builds are excluded so an operator who
+    /// opts into a deliberate `-beta.N` cut never silently lands on an
+    /// automated nightly instead.
     Beta,
+    /// Track nightly builds only: tags containing `-nightly.`, cut
+    /// automatically once a day from `main` when it has new commits. The
+    /// least stable channel — intended for testing unreleased work, not
+    /// production hosts.
+    Nightly,
+}
+
+/// Is this tag a nightly build (minted by the `Nightly Release` CI workflow)?
+/// Nightly tags look like `v0.1.0-nightly.20260727.abc1234` — the
+/// `-nightly.` marker distinguishes them from a deliberate `-beta.N` cut.
+fn is_nightly_tag(tag: &str) -> bool {
+    tag.contains("-nightly.")
 }
 
 impl UpgradeChannel {
@@ -52,31 +68,37 @@ impl UpgradeChannel {
         match self {
             Self::Stable => "stable",
             Self::Beta => "beta",
+            Self::Nightly => "nightly",
         }
     }
 
     /// Does this release belong to this channel?
     /// - Stable: only non-prerelease tags. `v1.2.0` matches; `v1.2.0-beta.4` does not.
-    /// - Beta: any non-draft tag. Both stable AND beta releases qualify, so
-    ///   a beta host always sees the freshest available version regardless of
-    ///   whether it was promoted to stable or not.
+    /// - Beta: any non-draft prerelease-or-stable tag EXCEPT nightly builds.
+    /// - Nightly: only tags with a `-nightly.` marker.
     fn includes(self, release: &GitHubRelease) -> bool {
         if release.draft {
             return false;
         }
+        let nightly = is_nightly_tag(&release.tag_name);
         match self {
             Self::Stable => !release.prerelease,
-            Self::Beta => true,
+            Self::Beta => !nightly,
+            Self::Nightly => nightly,
         }
     }
 
     /// Infer the channel an *installed* binary is on from its version tag.
-    /// A prerelease tag (`v1.2.0-beta.4` — anything with a `-` after the
-    /// core version) means the host opted into beta at install/upgrade
-    /// time; a plain tag (`v1.2.0`) means stable. Used by the startup
-    /// update notifier, which has no `--channel` flag to consult.
+    /// A `-nightly.` tag means the host opted into nightly; any other
+    /// prerelease tag (`v1.2.0-beta.4` — anything with a `-` after the core
+    /// version) means the host opted into beta at install/upgrade time; a
+    /// plain tag (`v1.2.0`) means stable. Used by the startup update
+    /// notifier, which has no `--channel` flag to consult.
     pub fn for_installed_version(tag: &str) -> Self {
-        if tag.trim().trim_start_matches('v').contains('-') {
+        let core = tag.trim().trim_start_matches('v');
+        if is_nightly_tag(tag) {
+            Self::Nightly
+        } else if core.contains('-') {
             Self::Beta
         } else {
             Self::Stable
@@ -88,7 +110,9 @@ impl UpgradeChannel {
 #[derive(Args)]
 pub struct UpgradeCommand {
     /// Release channel to track. Default: `stable`. Pass `--channel beta`
-    /// to opt into prereleases. Pinning a `--version` ignores the channel.
+    /// to opt into prereleases, or `--channel nightly` to track automated
+    /// nightly builds cut from `main`. Pinning a `--version` ignores the
+    /// channel.
     #[arg(long, value_enum)]
     pub channel: Option<UpgradeChannel>,
 
@@ -880,6 +904,11 @@ pub async fn fetch_latest_release_in_channel(
             "No stable releases found. Try `--channel beta` to include prereleases."
         ),
         UpgradeChannel::Beta => anyhow::anyhow!("No releases found."),
+        UpgradeChannel::Nightly => anyhow::anyhow!(
+            "No nightly releases found. The nightly build only cuts a new tag when \
+             `main` has commits since the last one — check the 'Nightly Release' \
+             workflow run history, or try `--channel beta`."
+        ),
     })
 }
 
@@ -1584,6 +1613,14 @@ mod tests {
     }
 
     #[test]
+    fn test_installed_channel_nightly_for_nightly_tag() {
+        assert_eq!(
+            UpgradeChannel::for_installed_version("v1.2.0-nightly.20260727.abc1234"),
+            UpgradeChannel::Nightly
+        );
+    }
+
+    #[test]
     fn test_is_newer_version_core_ordering() {
         assert!(is_newer_version("v0.2.0", "v0.1.9"));
         assert!(is_newer_version("v1.0.0", "v0.9.9"));
@@ -1688,6 +1725,29 @@ mod tests {
         assert!(UpgradeChannel::Beta.includes(&stable));
         assert!(UpgradeChannel::Beta.includes(&beta));
         assert!(!UpgradeChannel::Beta.includes(&draft));
+    }
+
+    #[test]
+    fn channel_beta_excludes_nightly_builds() {
+        // Beta must never silently resolve to an automated nightly — an
+        // operator who deliberately opts into beta expects a `-beta.N` cut,
+        // not whatever CI cut overnight. Nightly is a separate, opt-in
+        // channel.
+        let nightly = release("v1.3.0-nightly.20260727.abc1234", true, false);
+        assert!(!UpgradeChannel::Beta.includes(&nightly));
+    }
+
+    #[test]
+    fn channel_nightly_includes_only_nightly_tags() {
+        let stable = release("v1.2.0", false, false);
+        let beta = release("v1.3.0-beta.1", true, false);
+        let nightly = release("v1.3.0-nightly.20260727.abc1234", true, false);
+        let draft_nightly = release("v1.4.0-nightly.20260728.def5678", true, true);
+
+        assert!(!UpgradeChannel::Nightly.includes(&stable));
+        assert!(!UpgradeChannel::Nightly.includes(&beta));
+        assert!(UpgradeChannel::Nightly.includes(&nightly));
+        assert!(!UpgradeChannel::Nightly.includes(&draft_nightly));
     }
 
     #[test]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -113,11 +113,14 @@ command -v curl >/dev/null ||
 
 # Channel selection. Mirrors `temps upgrade --channel`:
 #   stable (default) — track non-prerelease tags only
-#   beta             — track the newest tag, prerelease or not
+#   beta             — track the newest tag, prerelease or not, EXCLUDING
+#                       nightly builds (a `-nightly.` tag never satisfies beta)
+#   nightly          — track only automated nightly builds (`-nightly.` tags),
+#                       cut once a day from `main` when it has new commits
 #
 # CLI-only by design: there is no env-var fallback. A user must pass
-# `--channel beta` explicitly to opt into prereleases. `bash install.sh`
-# always lands on stable — same contract as `temps upgrade`.
+# `--channel beta` or `--channel nightly` explicitly to opt into prereleases.
+# `bash install.sh` always lands on stable — same contract as `temps upgrade`.
 channel="stable"
 positional=()
 while [[ $# -gt 0 ]]; do
@@ -140,9 +143,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$channel" in
-    stable|beta) ;;
+    stable|beta|nightly) ;;
     *)
-        error "Unknown channel '$channel'. Supported: stable, beta"
+        error "Unknown channel '$channel'. Supported: stable, beta, nightly"
         ;;
 esac
 
@@ -181,7 +184,12 @@ if [[ ${#positional[@]} -eq 0 ]]; then
     #   404 means there are zero stable releases yet; fall through to a
     #   helpful error.
     # - beta: /releases/latest skips betas, so we walk the first page of
-    #   /releases (newest-first) and take the very first `tag_name`.
+    #   /releases (newest-first) and take the first `tag_name` that is NOT a
+    #   nightly build (mirrors `temps upgrade`'s `UpgradeChannel::Beta`,
+    #   which excludes `-nightly.` tags so a deliberate beta opt-in never
+    #   silently resolves to an automated nightly).
+    # - nightly: same page, but take the first `tag_name` that IS a nightly
+    #   build (contains `-nightly.`), minted by the "Nightly Release" workflow.
     #
     # Why "first tag_name" (no draft check):
     #   We don't ship draft releases publicly — anything visible on the
@@ -197,11 +205,19 @@ if [[ ${#positional[@]} -eq 0 ]]; then
                     grep '"tag_name":' |
                     head -n 1 |
                     sed -E 's/.*"([^"]+)".*/\1/' 2>/dev/null)
+    elif [[ "$channel" = "nightly" ]]; then
+        # GitHub orders releases newest-first; take the first tag_name that
+        # contains the `-nightly.` marker.
+        temps_tag=$(curl --silent "https://api.github.com/repos/gotempsh/temps/releases?per_page=20" |
+                    grep -oE '"tag_name": *"[^"]*-nightly\.[^"]*"' |
+                    head -n 1 |
+                    sed -E 's/.*"([^"]+)"$/\1/' 2>/dev/null)
     else
-        # GitHub orders releases newest-first, so the first `tag_name`
-        # in the page is the newest release of any kind.
+        # beta: GitHub orders releases newest-first; take the first
+        # tag_name that is NOT a nightly build.
         temps_tag=$(curl --silent "https://api.github.com/repos/gotempsh/temps/releases?per_page=20" |
                     grep '"tag_name":' |
+                    grep -v -- '-nightly\.' |
                     head -n 1 |
                     sed -E 's/.*"([^"]+)".*/\1/' 2>/dev/null)
     fi


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/nightly-release.yml`: runs daily at 03:00 UTC (and via `workflow_dispatch`)
- Compares `main` HEAD against the last `v*-nightly.*` tag; skips silently if there are no new commits
- When there are new commits, tags HEAD as `v<base-version>-nightly.<date>.<short-sha>` and pushes it
- Because the tag contains a `-`, it matches the existing `release.yml` trigger (`v*.*.*-*`) and is already treated as a prerelease (`beta` channel) by that workflow's channel-detection step — so nightly builds ride the same build/publish pipeline with zero duplicated release logic

## Test plan
- [x] `nightly-release.yml` parses as valid YAML (verified locally)
- [x] Manually trigger via `workflow_dispatch` on this branch/main to confirm the "no new commits" skip path and the tag-and-push path both work
- [x] Confirm a pushed nightly tag correctly kicks off `release.yml` and produces a prerelease GitHub Release