### PR TITLE
feat(skills): add temps-best-practices skill

### DIFF
--- a/skills/temps-best-practices/SKILL.md
+++ b/skills/temps-best-practices/SKILL.md
@@ -19,7 +19,7 @@ Temps replaces Sentry + Datadog/Honeycomb + PostHog with one ingestion surface. 
 
 Goal: an app in any language gets error tracking and traces flowing with minimal setup. Both signals use the same shape — one env var pointing at Temps, and the language's own official SDK does the rest.
 
-**If the app is deployed on Temps, most of this is already done.** Every deployment automatically gets these env vars injected — no manual DSN copy-paste or token minting required:
+**If the app is deployed as a project on Temps (i.e. through Temps' own build/deploy pipeline), this is already done — zero configuration, by any user.** Every such deployment automatically gets these env vars injected, at **both** Docker build time (as `--build-arg`, so frontend bundlers can inline them) **and** container runtime (as `-e`, for server-side/SSR code reading `process.env` at request time):
 
 | Env var | What it's for |
 |---|---|
@@ -28,11 +28,13 @@ Goal: an app in any language gets error tracking and traces flowing with minimal
 | `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL` (always `http/protobuf`), `OTEL_EXPORTER_OTLP_HEADERS` (deployment token auth) | Traces, auto-configured |
 | `OTEL_SERVICE_NAME` (project name), `OTEL_SERVICE_VERSION` (commit SHA when available) | Auto-populated span metadata |
 
-Implemented in `temps-deployments` crate: `src/services/workflow_planner.rs` (`gather_environment_variables`). If any of these are missing on a running deployment, that's a platform bug, not something to work around by hand-rolling credentials.
+Implemented in `temps-deployments` crate: `src/services/workflow_planner.rs` (`gather_environment_variables` collects them; the same map is threaded to both the build job as `build_args` — `workflow_planner.rs:1164-1198`/`1264-1306` → `docker.rs:960-988`'s `buildargs` — and the deploy job as runtime `env` — `docker.rs:1778-1784`). There is **no build-time-vs-runtime gap** for apps going through this pipeline: a `NEXT_PUBLIC_SENTRY_DSN`-style var is genuinely present when the client bundle is compiled, not just after the container starts. If a variable from the table is missing on a running deployment, that's a platform bug — investigate the deployment's build/deploy logs, don't work around it by hardcoding a value.
 
-For an app **not** deployed on Temps (running elsewhere, only sending telemetry to a self-hosted Temps instance), get credentials manually:
+**This auto-injection is scoped to apps deployed *through* Temps.** It does not apply to: an app running elsewhere and only sending telemetry to a self-hosted Temps instance, or to Temps' own console/dashboard (which is built by its own CI, not through this deploy pipeline — self-referential, since Temps doesn't deploy itself as a project on itself). For those cases, get the real credential from the dashboard and wire it through whatever env var / build-arg / secrets mechanism that project's *own* build system already uses:
 - Error tracking DSN: **Error Tracking → DSN & Setup** (`https://<public_key>@<temps-host>/<project_id>`)
 - A deployment token (`dt_...`) or API key (`tk_...`) for OTLP: **Project Settings → API Keys**
+
+**Never hardcode a DSN, token, or endpoint value into source code, a Dockerfile, or CI config — and never ask the user to supply one so it can be hardcoded.** The fix for "this needs to be available at build time" is always to pass it as a build arg / build-time env var through the project's existing mechanism (matching the dual-injection pattern above), never to bake a literal secret into a file. If the real value is genuinely unknown, the answer is "go get it from **Error Tracking → DSN & Setup**" or "go get it from **Project Settings → API Keys**" — not "paste it here so I can commit it."
 
 Either way, the app-side steps are the same:
 

--- a/skills/temps-best-practices/SKILL.md
+++ b/skills/temps-best-practices/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: temps-best-practices
+description: |
+  Best-practices reference for building apps on Temps — currently covers observability (error tracking, traces, metrics, logs, analytics), with room to grow into other pillars later. Use to: design how an app should emit telemetry to Temps, debug why errors/traces/metrics/logs/events aren't showing up, choose which pillar a signal belongs in, wire up multiple pillars at once, or check ingestion endpoints/auth tokens (tk_/dt_/si_)/rate limits/quotas for Temps' OTLP/Sentry/analytics APIs. Triggers: "temps best practices", "temps observability", "wire up telemetry", "why isn't this showing up in traces/metrics/logs", "otel best practices for temps", "instrument this app for temps". For single-pillar setup prefer add-error-tracking or add-react-analytics. For anything outside observability (deploy, services/databases, domains, CI automation), use the temps-cli skill instead.
+---
+
+# Temps Best Practices
+
+Best practices for building on Temps. Today this covers the **observability** pillar end to end (error tracking, traces, metrics, logs, analytics) — everything else an app needs from the platform (deploy, provisioning databases/caches, domains, CI/CD automation, notifications) is CLI-driven and covered by the **temps-cli** skill, not duplicated here.
+
+## Observability
+
+Temps replaces Sentry + Datadog/Honeycomb + PostHog with one ingestion surface. This section is the map across all five pillars — use it to decide *which* pillar a signal belongs in, and to find the concrete endpoint/auth/gotcha details for each. It complements, not replaces, the narrower setup skills:
+
+- **add-error-tracking** — step-by-step Sentry SDK init per language/framework
+- **add-react-analytics** — step-by-step `@temps-sdk/react-analytics` hook usage
+
+## The five pillars
+
+| Pillar | What it's for | Reference |
+|---|---|---|
+| Error tracking | Uncaught exceptions, handled errors, stack traces, source maps | [references/error-tracking.md](references/error-tracking.md) |
+| Traces (OTLP) | Distributed request spans, AI/gen_ai call chains, latency breakdowns | [references/opentelemetry-traces.md](references/opentelemetry-traces.md) |
+| Metrics (OTLP) | Counters/gauges/histograms — request rates, queue depth, custom business metrics | [references/metrics.md](references/metrics.md) |
+| Logs (OTLP) | Structured log records correlated to traces | [references/logs.md](references/logs.md) |
+| Analytics | Page views, custom product events, session replay, Web Vitals | [references/analytics.md](references/analytics.md) |
+
+Read the specific reference file(s) for the pillar(s) in play — don't load all five unless doing a full-stack instrumentation pass.
+
+## Deciding which pillar a signal belongs in
+
+- **"This threw/crashed"** → error tracking, not a log line. Logs are for structured record-keeping, not exception capture.
+- **"How long did this request/DB call/LLM call take, and what did it call downstream?"** → traces. If it's a single number you want to alert on or chart over time (not per-request), that's a metric instead.
+- **"I want to count/aggregate something over time"** (requests/sec, cache hit rate, custom business counter) → metrics, not traces. Don't create a span just to record a number.
+- **"A user did X in the product"** → analytics event, not a log or a trace attribute.
+- **"I need to debug what happened at a point in time, correlated to a trace"** → OTEL logs with `trace_id`/`span_id` attributes set, so they join with the trace in the dashboard.
+
+## Shared ingestion facts across pillars
+
+All Temps telemetry ingestion (OTLP traces/metrics/logs) shares one auth and rate-limit model — know this once instead of re-deriving it per pillar:
+
+- **Token prefixes**: `tk_` (API key, needs `X-Temps-Project-Id` header), `dt_` (deployment token, project-scoped already), `si_` (webhook/integration token). Sentry-compatible error ingestion uses the DSN's public key instead, not these tokens.
+- **Auth header**: `Authorization: Bearer <token>` or `X-Temps-Api-Key: <token>`. Some OTLP exporters URL-encode the header as `Bearer%20<token>` — Temps accepts that too.
+- **Rate limit**: 1000 req/60s per token by default (`TEMPS_OTEL_RATE_LIMIT`, `TEMPS_OTEL_RATE_LIMIT_WINDOW_SECS` — server-side config, not something the app sets).
+- **Storage quota**: off by default; a self-hosted instance can opt in via `TEMPS_OTEL_QUOTA_GB`. If ingestion suddenly starts 413'ing, that's the likely cause.
+- **Endpoint shape**: path-based `POST /otel/v1/{project_id}/{environment_id}/{deployment_id}/{traces|metrics|logs}` or header-based `POST /otel/v1/{traces|metrics|logs}` with project/env/deployment resolved from the token. Prefer the standard OTLP exporter env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`) over hand-rolling requests — any OTLP/HTTP protobuf exporter works unmodified against these endpoints.
+
+## Verification checklist for a full instrumentation pass
+
+1. Error tracking: trigger a deliberate error, confirm it appears in **Error Tracking → Error Groups**.
+2. Traces: make a request through the instrumented path, confirm a span appears in **Observe → Traces** with a sane `duration_ms` (see the unit gotcha in [references/opentelemetry-traces.md](references/opentelemetry-traces.md)).
+3. Metrics: confirm a custom metric name passes the `[a-zA-Z0-9_.:- ]` character set (see [references/metrics.md](references/metrics.md)) and shows up in **Observe → Metrics**.
+4. Logs: confirm log records with `trace_id` set join the correct trace in the UI.
+5. Analytics: confirm `/_temps/event` or `/projects/{id}/events/ingest` calls land in **Analytics** within a few seconds.
+
+If a signal never appears, check auth token prefix/header first, then rate limit/quota, before assuming the SDK integration is broken — most "nothing shows up" cases are one of those two.
+
+## Everything else
+
+Deployment, service/database provisioning, environment variables, domains, monitoring config, backups, and CI/CD automation are all reached through the Temps CLI (`bunx @temps-sdk/cli`). Use the **temps-cli** skill for those — this skill only owns the observability pillars above.

--- a/skills/temps-best-practices/SKILL.md
+++ b/skills/temps-best-practices/SKILL.md
@@ -15,6 +15,31 @@ Temps replaces Sentry + Datadog/Honeycomb + PostHog with one ingestion surface. 
 - **add-error-tracking** — step-by-step Sentry SDK init per language/framework
 - **add-react-analytics** — step-by-step `@temps-sdk/react-analytics` hook usage
 
+## Quickstart: wire up any app end to end
+
+Goal: an app in any language gets error tracking and traces flowing with minimal setup. Both signals use the same shape — one env var pointing at Temps, and the language's own official SDK does the rest.
+
+**If the app is deployed on Temps, most of this is already done.** Every deployment automatically gets these env vars injected — no manual DSN copy-paste or token minting required:
+
+| Env var | What it's for |
+|---|---|
+| `SENTRY_DSN` | Server-side/generic error tracking DSN, always present |
+| `NEXT_PUBLIC_SENTRY_DSN` / `NUXT_PUBLIC_SENTRY_DSN` / `VITE_SENTRY_DSN` / `PUBLIC_SENTRY_DSN` / `REACT_APP_SENTRY_DSN` | Framework-specific public DSN, added when the detected build preset needs a public-prefixed var to expose it client-side (Next.js/Nuxt/Vite,React,Vue,SolidStart,Remix/SvelteKit,Astro,Rsbuild/Docusaurus respectively) — not added for Angular or backend/generic presets, which just use `SENTRY_DSN` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL` (always `http/protobuf`), `OTEL_EXPORTER_OTLP_HEADERS` (deployment token auth) | Traces, auto-configured |
+| `OTEL_SERVICE_NAME` (project name), `OTEL_SERVICE_VERSION` (commit SHA when available) | Auto-populated span metadata |
+
+Implemented in `temps-deployments` crate: `src/services/workflow_planner.rs` (`gather_environment_variables`). If any of these are missing on a running deployment, that's a platform bug, not something to work around by hand-rolling credentials.
+
+For an app **not** deployed on Temps (running elsewhere, only sending telemetry to a self-hosted Temps instance), get credentials manually:
+- Error tracking DSN: **Error Tracking → DSN & Setup** (`https://<public_key>@<temps-host>/<project_id>`)
+- A deployment token (`dt_...`) or API key (`tk_...`) for OTLP: **Project Settings → API Keys**
+
+Either way, the app-side steps are the same:
+
+1. **Error tracking**: follow [add-error-tracking](../add-error-tracking/SKILL.md) for the app's language — install the official Sentry SDK, point it at `SENTRY_DSN` (or the framework's public variant). No Temps-specific package exists or is needed.
+2. **Traces**: follow the per-language quickstart in [references/opentelemetry-traces.md](references/opentelemetry-traces.md) — install the official OpenTelemetry SDK/agent for the language; if the three `OTEL_EXPORTER_OTLP_*` env vars are already set, most SDKs pick them up with zero additional config.
+3. **Verify** both landed using the checklist below before considering the app "instrumented."
+
 ## The five pillars
 
 | Pillar | What it's for | Reference |

--- a/skills/temps-best-practices/SKILL.md
+++ b/skills/temps-best-practices/SKILL.md
@@ -25,6 +25,7 @@ Goal: an app in any language gets error tracking and traces flowing with minimal
 |---|---|
 | `SENTRY_DSN` | Server-side/generic error tracking DSN, always present |
 | `NEXT_PUBLIC_SENTRY_DSN` / `NUXT_PUBLIC_SENTRY_DSN` / `VITE_SENTRY_DSN` / `PUBLIC_SENTRY_DSN` / `REACT_APP_SENTRY_DSN` | Framework-specific public DSN, added when the detected build preset needs a public-prefixed var to expose it client-side (Next.js/Nuxt/Vite,React,Vue,SolidStart,Remix/SvelteKit,Astro,Rsbuild/Docusaurus respectively) — not added for Angular or backend/generic presets, which just use `SENTRY_DSN` |
+| `SENTRY_RELEASE` | Commit SHA — every Sentry SDK reads this automatically when `release` isn't set explicitly; don't hardcode `release` in `Sentry.init()` or you override this and break source-context lookup |
 | `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL` (always `http/protobuf`), `OTEL_EXPORTER_OTLP_HEADERS` (deployment token auth) | Traces, auto-configured |
 | `OTEL_SERVICE_NAME` (project name), `OTEL_SERVICE_VERSION` (commit SHA when available) | Auto-populated span metadata |
 

--- a/skills/temps-best-practices/SKILL.md
+++ b/skills/temps-best-practices/SKILL.md
@@ -68,7 +68,7 @@ All Temps telemetry ingestion (OTLP traces/metrics/logs) shares one auth and rat
 - **Auth header**: `Authorization: Bearer <token>` or `X-Temps-Api-Key: <token>`. Some OTLP exporters URL-encode the header as `Bearer%20<token>` — Temps accepts that too.
 - **Rate limit**: 1000 req/60s per token by default (`TEMPS_OTEL_RATE_LIMIT`, `TEMPS_OTEL_RATE_LIMIT_WINDOW_SECS` — server-side config, not something the app sets).
 - **Storage quota**: off by default; a self-hosted instance can opt in via `TEMPS_OTEL_QUOTA_GB`. If ingestion suddenly starts 413'ing, that's the likely cause.
-- **Endpoint shape**: path-based `POST /otel/v1/{project_id}/{environment_id}/{deployment_id}/{traces|metrics|logs}` or header-based `POST /otel/v1/{traces|metrics|logs}` with project/env/deployment resolved from the token. Prefer the standard OTLP exporter env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`) over hand-rolling requests — any OTLP/HTTP protobuf exporter works unmodified against these endpoints.
+- **Endpoint shape**: every plugin's routes are nested under `/api` by the console server — path-based `POST /api/otel/v1/{project_id}/{environment_id}/{deployment_id}/{traces|metrics|logs}` or header-based `POST /api/otel/v1/{traces|metrics|logs}` with project/env/deployment resolved from the token. Prefer the standard OTLP exporter env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`) over hand-rolling requests — any OTLP/HTTP protobuf exporter works unmodified against these endpoints.
 
 ## Verification checklist for a full instrumentation pass
 
@@ -76,7 +76,7 @@ All Temps telemetry ingestion (OTLP traces/metrics/logs) shares one auth and rat
 2. Traces: make a request through the instrumented path, confirm a span appears in **Observe → Traces** with a sane `duration_ms` (see the unit gotcha in [references/opentelemetry-traces.md](references/opentelemetry-traces.md)).
 3. Metrics: confirm a custom metric name passes the `[a-zA-Z0-9_.:- ]` character set (see [references/metrics.md](references/metrics.md)) and shows up in **Observe → Metrics**.
 4. Logs: confirm log records with `trace_id` set join the correct trace in the UI.
-5. Analytics: confirm `/_temps/event` or `/projects/{id}/events/ingest` calls land in **Analytics** within a few seconds.
+5. Analytics: confirm `/api/_temps/event` or `/api/projects/{id}/events/ingest` calls land in **Analytics** within a few seconds — see [references/analytics.md](references/analytics.md) for a language-agnostic quickstart, since analytics has no per-language SDK beyond React.
 
 If a signal never appears, check auth token prefix/header first, then rate limit/quota, before assuming the SDK integration is broken — most "nothing shows up" cases are one of those two.
 

--- a/skills/temps-best-practices/references/analytics.md
+++ b/skills/temps-best-practices/references/analytics.md
@@ -1,0 +1,29 @@
+# Analytics
+
+For React apps, use the **add-react-analytics** skill for step-by-step provider/hook setup (`@temps-sdk/react-analytics`, `TempsAnalyticsProvider`, `useTrackEvent`, `useAnalytics`, session recording). This file covers the underlying ingestion API and cross-framework facts.
+
+## Ingestion endpoints
+
+- `POST /_temps/event` — public, unauthenticated, CORS-enabled browser-side event ingestion. This is what the React SDK (and any hand-rolled browser tracker) posts to. Request body: `EventMetricsPayload` JSON (`event_name`, optional `properties`, optional `timestamp`); browser context (IP, User-Agent, session cookie) is extracted server-side from request headers, not sent by the client.
+- `POST /projects/{project_id}/events/ingest` — authenticated (session or API key), for server-side/console event submission. Request body: `ConsoleEventPayload` JSON.
+
+Both endpoints funnel through the same write path (`AnalyticsEventsService::record_event`) into an outbox table in Postgres; a background worker (`ChFanoutWorker`) fans events out to ClickHouse if it's configured for the instance.
+
+Implemented in `temps-analytics-events` crate: `src/handlers/events_handler.rs`.
+
+## Auth
+
+- `/_temps/event` is intentionally public/unauthenticated — it's the browser-facing beacon endpoint, protected by project-scoped event validation rather than a bearer token. Don't try to add auth headers to it; that's not how it's gated.
+- `/projects/{project_id}/events/ingest` requires a session cookie or API key bearer token — use this for server-side event submission (e.g., a backend job recording a business event), not for browser code.
+
+## What belongs here vs. other pillars
+
+- Page views, custom product events ("signed up", "clicked upgrade"), scroll/engagement/Web Vitals — all analytics.
+- Session replay is bundled under analytics (`SessionRecordingProvider` in the React SDK), separate from error-tracking's replay-on-error integration — the two are independent capture paths even though both are called "replay."
+- Don't route business events through OTEL logs or traces — analytics has its own dashboard, retention, and ClickHouse fan-out tuned for high-volume event data; OTEL logs/traces are not.
+
+## Gotchas
+
+- **Events not appearing**: check the Network tab for calls to `/_temps/event` first — if the request never fires, it's a client wiring issue (provider not mounted, `basePath` misconfigured), not a server-side ingestion problem.
+- **Server-side events silently rejected**: `/projects/{project_id}/events/ingest` requires real auth — a missing/expired session or API key returns an auth error, unlike the public `/_temps/event` beacon.
+- **ClickHouse-backed views lagging**: events land in the Postgres outbox immediately but ClickHouse fan-out is asynchronous via a background worker — a just-fired event may take a few seconds to appear in ClickHouse-backed dashboard views even though it's already durably recorded.

--- a/skills/temps-best-practices/references/analytics.md
+++ b/skills/temps-best-practices/references/analytics.md
@@ -1,20 +1,86 @@
 # Analytics
 
-For React apps, use the **add-react-analytics** skill for step-by-step provider/hook setup (`@temps-sdk/react-analytics`, `TempsAnalyticsProvider`, `useTrackEvent`, `useAnalytics`, session recording). This file covers the underlying ingestion API and cross-framework facts.
+For React apps, use the **add-react-analytics** skill for step-by-step provider/hook setup (`@temps-sdk/react-analytics`, `TempsAnalyticsProvider`, `useTrackEvent`, `useAnalytics`, session recording). That's currently the only official SDK — there is no Temps analytics SDK for other languages/frameworks. This file covers the underlying ingestion API so any language can send events directly over HTTP, the same way [error tracking](error-tracking.md) and [traces](opentelemetry-traces.md) are protocol-level rather than SDK-locked.
 
 ## Ingestion endpoints
 
-- `POST /_temps/event` — public, unauthenticated, CORS-enabled browser-side event ingestion. This is what the React SDK (and any hand-rolled browser tracker) posts to. Request body: `EventMetricsPayload` JSON (`event_name`, optional `properties`, optional `timestamp`); browser context (IP, User-Agent, session cookie) is extracted server-side from request headers, not sent by the client.
-- `POST /projects/{project_id}/events/ingest` — authenticated (session or API key), for server-side/console event submission. Request body: `ConsoleEventPayload` JSON.
+Routes are registered as `/_temps/event` and `/projects/{project_id}/events/ingest` inside the crate, but the console server nests every plugin's routes under `/api` (`temps-cli/src/commands/serve/console.rs`), so the real externally-reachable paths are:
 
-Both endpoints funnel through the same write path (`AnalyticsEventsService::record_event`) into an outbox table in Postgres; a background worker (`ChFanoutWorker`) fans events out to ClickHouse if it's configured for the instance.
+- `POST /api/_temps/event` — public, unauthenticated, reachable from any HTTP client (not just browsers). Body: `EventMetricsPayload` JSON.
+- `POST /api/projects/{project_id}/events/ingest` — authenticated, for server-side/backend event submission. Body: `ConsoleEventPayload` JSON.
 
-Implemented in `temps-analytics-events` crate: `src/handlers/events_handler.rs`.
+Both funnel through the same write path (`AnalyticsEventsService`) into an outbox table in Postgres; a background worker fans events out to ClickHouse if it's configured for the instance — a just-recorded event can take a few seconds to reach ClickHouse-backed dashboard views even though it's already durably written.
+
+Implemented in `temps-analytics-events` crate: `src/handlers/events_handler.rs` (`record_event_metrics` for the public endpoint at line 646, `record_console_event` for the authenticated one at line 843, route table at line 1085), `src/types/requests.rs` (payload structs, lines 175–229).
+
+### `EventMetricsPayload` (public endpoint)
+
+```json
+{
+  "event_name": "page_view",       // required
+  "event_data": {},                 // required, arbitrary JSON
+  "request_path": "/products",      // required
+  "request_query": "?sort=asc",     // required (empty string if none)
+  "screen_width": 1920,             // optional
+  "screen_height": 1080,            // optional
+  "viewport_width": 1920,           // optional
+  "viewport_height": 1080,          // optional
+  "language": "en-US",              // optional
+  "page_title": "Products",         // optional
+  "referrer": "https://google.com", // optional, falls back to the Referer header
+  "ttfb": 100.5,                    // optional, Web Vitals (ms)
+  "lcp": 2500.0, "fid": 50.0, "fcp": 800.0, "inp": 150.0,  // optional, Web Vitals (ms)
+  "cls": 0.1                        // optional, Web Vitals (score, unitless)
+}
+```
+
+There is no `project_id` field — the project is resolved server-side from the request's `Host` header via the deployment route table. This means calling `/api/_temps/event` **only works if the request's Host header matches a domain Temps already routes to a deployment** (the deployed app's own domain, or a Temps-assigned preview domain). A backend script running outside that domain can't just POST to the Temps console host and expect this to resolve — use the authenticated endpoint instead for out-of-band server-side event submission.
+
+### `ConsoleEventPayload` (authenticated endpoint)
+
+```json
+{
+  "event_name": "purchase",         // required
+  "event_data": { "amount": 49.99 }, // optional, defaults to {}
+  "environment_id": 42,              // required
+  "deployment_id": 100,              // required
+  "visitor_id": null,                // optional, encrypted _temps_visitor_id cookie value (pass through if your backend read it from the user's request)
+  "session_id": null,                // optional, encrypted _temps_sid cookie value
+  "request_path": "/checkout",       // optional, defaults to "/"
+  "request_query": ""                // optional, defaults to ""
+}
+```
+
+`project_id` goes in the URL path, `environment_id`/`deployment_id` go in the body — all three are required to attribute the event correctly.
 
 ## Auth
 
-- `/_temps/event` is intentionally public/unauthenticated — it's the browser-facing beacon endpoint, protected by project-scoped event validation rather than a bearer token. Don't try to add auth headers to it; that's not how it's gated.
-- `/projects/{project_id}/events/ingest` requires a session cookie or API key bearer token — use this for server-side event submission (e.g., a backend job recording a business event), not for browser code.
+- `/api/_temps/event` is intentionally public/unauthenticated — gated by Host-header project resolution, not a token. Don't add auth headers to it; there's nothing to check.
+- `/api/projects/{project_id}/events/ingest` requires a bearer token (session cookie, `tk_` API key, or `dt_` deployment token — all three work) with `AnalyticsWrite` permission scoped to that project. A token bound to a different project is rejected.
+
+## Quickstart: send analytics from any language
+
+Since there's no per-language SDK, the pattern is a plain HTTP POST — the same shape regardless of language:
+
+**From a backend already deployed on Temps** (has `TEMPS_API_URL` and `TEMPS_API_TOKEN` auto-injected — see the top-level [SKILL.md](../SKILL.md) quickstart), record a custom server-side event with any HTTP client:
+
+```bash
+curl -X POST "$TEMPS_API_URL/projects/$TEMPS_PROJECT_ID/events/ingest" \
+  -H "Authorization: Bearer $TEMPS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "event_name": "purchase",
+    "event_data": {"amount": 49.99, "currency": "USD"},
+    "environment_id": '"$TEMPS_ENVIRONMENT_ID"',
+    "deployment_id": '"$TEMPS_DEPLOYMENT_ID"'
+  }'
+```
+
+The equivalent in any language is just an authenticated JSON POST — Python (`requests.post(...)`), Go (`net/http` + `encoding/json`), Ruby (`Net::HTTP` or `httparty`), PHP (`curl_init`/Guzzle), Java (`HttpClient`), .NET (`HttpClient`), Rust (`reqwest`): no client library is needed because this is a plain REST call, not a protocol requiring a purpose-built SDK.
+
+`environment_id`/`deployment_id`/`project_id` are **not** currently among the auto-injected env vars (unlike `TEMPS_API_URL`/`TEMPS_API_TOKEN`) — read them from the Temps dashboard (**Project Settings**) or from whatever IDs your deployment automation already has on hand, and set them yourself (e.g. as regular env vars) if a backend needs to call this endpoint repeatedly.
+
+For browser-side tracking in a non-React frontend (vanilla JS, Vue, Svelte, a mobile app's WebView), POST directly to `/api/_temps/event` with `fetch`/`XMLHttpRequest`/equivalent using the `EventMetricsPayload` shape above — no auth needed, but it only resolves a project when the request's `Host` matches a routed deployment domain, so this only works called from code actually running on/against the deployed app's own origin.
 
 ## What belongs here vs. other pillars
 
@@ -24,6 +90,6 @@ Implemented in `temps-analytics-events` crate: `src/handlers/events_handler.rs`.
 
 ## Gotchas
 
-- **Events not appearing**: check the Network tab for calls to `/_temps/event` first — if the request never fires, it's a client wiring issue (provider not mounted, `basePath` misconfigured), not a server-side ingestion problem.
-- **Server-side events silently rejected**: `/projects/{project_id}/events/ingest` requires real auth — a missing/expired session or API key returns an auth error, unlike the public `/_temps/event` beacon.
+- **Browser events not appearing**: check the Network tab for calls to `/api/_temps/event` first — if the request never fires, it's a client wiring issue (provider not mounted, `basePath` misconfigured), not a server-side ingestion problem. If it fires but 404s, the request's Host header doesn't match a routed deployment.
+- **Server-side events silently rejected**: `/api/projects/{project_id}/events/ingest` requires real auth with `AnalyticsWrite` permission — a missing/expired token, or a token scoped to a different project, returns an auth error, unlike the public beacon endpoint.
 - **ClickHouse-backed views lagging**: events land in the Postgres outbox immediately but ClickHouse fan-out is asynchronous via a background worker — a just-fired event may take a few seconds to appear in ClickHouse-backed dashboard views even though it's already durably recorded.

--- a/skills/temps-best-practices/references/error-tracking.md
+++ b/skills/temps-best-practices/references/error-tracking.md
@@ -2,7 +2,7 @@
 
 For step-by-step SDK init per language/framework, use the **add-error-tracking** skill — it covers Next.js, React, Vue, Svelte, Angular, Node, React Native, Python, Go, Rust, Ruby, Java, PHP, .NET, Flutter with copy-paste snippets. This file covers the ingestion internals worth knowing when debugging or reviewing that setup.
 
-**Apps deployed on Temps get the DSN for free**: every deployment automatically has `SENTRY_DSN` injected (plus a framework-specific public-prefixed variant when the build preset needs one — see the top-level [SKILL.md](../SKILL.md) quickstart for the exact mapping). No dashboard copy-paste needed for those apps.
+**Apps deployed on Temps get the DSN for free, with no build-time-vs-runtime gap**: every deployment automatically has `SENTRY_DSN` injected — and, when the build preset needs one, the framework-specific public-prefixed variant (`NEXT_PUBLIC_SENTRY_DSN`, `VITE_SENTRY_DSN`, etc.) too. Temps injects both as a Docker `--build-arg` *and* as a container runtime env var (`temps-deployments::workflow_planner::gather_environment_variables`, threaded to `docker.rs`'s `buildargs` and `env` respectively), so client bundlers that inline public env vars at build time see the real value — there's no scenario where the DSN "isn't available yet" during the build. No dashboard copy-paste needed, and never hardcode a DSN or ask the user for one to hardcode — see the top-level [SKILL.md](../SKILL.md) quickstart for the exact framework mapping and the scope of this auto-injection (it doesn't cover apps built outside Temps' own deploy pipeline, including Temps' own console).
 
 ## How it works
 

--- a/skills/temps-best-practices/references/error-tracking.md
+++ b/skills/temps-best-practices/references/error-tracking.md
@@ -2,6 +2,8 @@
 
 For step-by-step SDK init per language/framework, use the **add-error-tracking** skill — it covers Next.js, React, Vue, Svelte, Angular, Node, React Native, Python, Go, Rust, Ruby, Java, PHP, .NET, Flutter with copy-paste snippets. This file covers the ingestion internals worth knowing when debugging or reviewing that setup.
 
+**Apps deployed on Temps get the DSN for free**: every deployment automatically has `SENTRY_DSN` injected (plus a framework-specific public-prefixed variant when the build preset needs one — see the top-level [SKILL.md](../SKILL.md) quickstart for the exact mapping). No dashboard copy-paste needed for those apps.
+
 ## How it works
 
 Temps is Sentry wire-compatible: it implements Sentry's ingestion protocol server-side, so the official Sentry SDK for any platform works unmodified against a Temps DSN. There is no Temps-specific error-tracking SDK.

--- a/skills/temps-best-practices/references/error-tracking.md
+++ b/skills/temps-best-practices/references/error-tracking.md
@@ -1,0 +1,48 @@
+# Error Tracking
+
+For step-by-step SDK init per language/framework, use the **add-error-tracking** skill — it covers Next.js, React, Vue, Svelte, Angular, Node, React Native, Python, Go, Rust, Ruby, Java, PHP, .NET, Flutter with copy-paste snippets. This file covers the ingestion internals worth knowing when debugging or reviewing that setup.
+
+## How it works
+
+Temps is Sentry wire-compatible: it implements Sentry's ingestion protocol server-side, so the official Sentry SDK for any platform works unmodified against a Temps DSN. There is no Temps-specific error-tracking SDK.
+
+DSN format:
+
+```
+https://<public_key>@<temps-host>/<project_id>
+```
+
+The `public_key` is per-project and derived from the DB; the `secret_key` (if any) is never exposed in API responses.
+
+## Ingestion endpoints
+
+- `POST /{project_id}/store/` — JSON event ingestion (legacy Sentry envelope-less format)
+- `POST /{project_id}/envelope/` — binary/newline-delimited envelope ingestion (what modern Sentry SDKs use by default)
+- `POST /0/projects/{org_slug}/{project_slug}/releases/{version}/files/` — source map upload, `sentry-cli`-compatible (multipart form: `file`, `name`, `dist`, `header`)
+
+Implemented in `temps-error-tracking` crate: `src/sentry/handlers.rs`, `src/sentry/service.rs`, `src/sentry/envelope.rs`.
+
+## Auth
+
+Any of these are accepted, in priority order:
+- `X-Sentry-Auth: Sentry sentry_key=<public_key>,sentry_version=7` header (what Sentry SDKs send by default)
+- `Authorization: Bearer <public_key>` or `Authorization: DSN <token>`
+- `sentry_key` query parameter (fallback, used by some old SDKs)
+- Deployment tokens (`dt_*`) are also accepted and hash-validated against the DB
+
+## Limits
+
+- Request body: 2 MiB compressed, 10 MiB decompressed (`SENTRY_INGEST_BODY_LIMIT`) — guards against decompression bombs.
+- gzip `Content-Encoding` is supported and decoded with a size guard.
+
+## Response shape
+
+- Store/Envelope: `{"id": "<event_uuid>"}`, HTTP 200
+- Source maps: `{"id": ..., "name": ..., "dist": ..., "headers": {...}, "size": ..., "sha1": ..., "date_created": ...}`
+
+## Gotchas
+
+- **Nothing shows up**: the SDK must be initialized before any code that could throw — for Node, `Sentry.init` must be the first import in the entrypoint, not somewhere mid-file.
+- **Browser apps not reporting**: the DSN env var needs the bundler's public prefix (`NEXT_PUBLIC_`, `VITE_`, `PUBLIC_`) to reach the client bundle; a plain `SENTRY_DSN` won't be inlined into browser code.
+- **Minified stack traces**: upload source maps via `sentry-cli sourcemaps upload` in CI, or through **Error Tracking → Source Maps** in the dashboard — the release version passed to the SDK must match the release the source maps were uploaded under.
+- **Production events missing but local ones work**: the deployment's env vars are separate from local `.env` files — confirm the DSN is actually set in the deployed environment, not just locally.

--- a/skills/temps-best-practices/references/error-tracking.md
+++ b/skills/temps-best-practices/references/error-tracking.md
@@ -18,9 +18,13 @@ The `public_key` is per-project and derived from the DB; the `secret_key` (if an
 
 ## Ingestion endpoints
 
-- `POST /{project_id}/store/` — JSON event ingestion (legacy Sentry envelope-less format)
-- `POST /{project_id}/envelope/` — binary/newline-delimited envelope ingestion (what modern Sentry SDKs use by default)
-- `POST /0/projects/{org_slug}/{project_slug}/releases/{version}/files/` — source map upload, `sentry-cli`-compatible (multipart form: `file`, `name`, `dist`, `header`)
+Routes are registered as `/{project_id}/store/` etc. inside the crate, but the console server nests every plugin's routes under `/api` (`temps-cli/src/commands/serve/console.rs`), so the real externally-reachable paths are:
+
+- `POST /api/{project_id}/store/` — JSON event ingestion (legacy Sentry envelope-less format)
+- `POST /api/{project_id}/envelope/` — binary/newline-delimited envelope ingestion (what modern Sentry SDKs use by default)
+- `POST /api/0/projects/{org_slug}/{project_slug}/releases/{version}/files/` — source map upload, `sentry-cli`-compatible (multipart form: `file`, `name`, `dist`, `header`)
+
+This matches standard Sentry SDK behavior unmodified: every conforming Sentry SDK inserts `api/` itself when building the request URL from a DSN, so a DSN of the form `https://<public_key>@<temps-host>/<project_id>` (no `/api` in the DSN) already produces exactly these URLs — nothing Temps-specific to configure. The `/api` prefix only matters if hand-rolling a raw HTTP request (e.g. `curl`) to test ingestion without going through a real SDK.
 
 Implemented in `temps-error-tracking` crate: `src/sentry/handlers.rs`, `src/sentry/service.rs`, `src/sentry/envelope.rs`.
 

--- a/skills/temps-best-practices/references/error-tracking.md
+++ b/skills/temps-best-practices/references/error-tracking.md
@@ -16,6 +16,10 @@ https://<public_key>@<temps-host>/<project_id>
 
 The `public_key` is per-project and derived from the DB; the `secret_key` (if any) is never exposed in API responses.
 
+## Release auto-injection
+
+Temps also auto-injects `SENTRY_RELEASE` (the deployment's commit SHA) alongside `SENTRY_DSN` for apps deployed through Temps (`workflow_planner.rs:1066-1070,1895-1920`) — every official Sentry SDK reads `SENTRY_RELEASE` from the environment when `release` isn't explicitly set in `Sentry.init()`, tagging events with the correct release automatically. **Don't hardcode a `release` value in `Sentry.init()`** — doing so overrides the injected value and breaks the dashboard's ability to join a stack frame back to its source (**Error Tracking → Source Context**). Leave `release` unset and let the SDK pick up `SENTRY_RELEASE` on its own.
+
 ## Ingestion endpoints
 
 Routes are registered as `/{project_id}/store/` etc. inside the crate, but the console server nests every plugin's routes under `/api` (`temps-cli/src/commands/serve/console.rs`), so the real externally-reachable paths are:

--- a/skills/temps-best-practices/references/logs.md
+++ b/skills/temps-best-practices/references/logs.md
@@ -1,0 +1,29 @@
+# OTEL Logs
+
+Temps ingests standard OTLP/HTTP (protobuf) log exports. Use a standard OpenTelemetry logs SDK/exporter (or a logging bridge that emits OTLP logs); there is no Temps-specific logging SDK.
+
+## Endpoints
+
+- Header-based: `POST /otel/v1/logs`
+- Path-based: `POST /otel/v1/{project_id}/{environment_id}/{deployment_id}/logs`
+
+Same auth, rate limit, and opt-in quota model as traces/metrics — see the shared-facts section in the top-level SKILL.md.
+
+Implemented in `temps-otel` crate: `src/handlers/ingest_handler.rs` (log export handling).
+
+## Payload
+
+Standard `ExportLogsServiceRequest` protobuf: `SeverityNumber`, `Body`, `Attributes`, `Timestamp`, and optionally `TraceId`/`SpanId`.
+
+**Always set `trace_id`/`span_id` on log records emitted from within a traced request** — this is what lets the Temps dashboard join a log line to the trace it happened during. Without it, the log is stored but orphaned from any trace context.
+
+## Storage and retention
+
+- WARN/ERROR/FATAL-severity logs are stored in the primary time-series store (TimescaleDB/ClickHouse depending on backend config) for querying in the dashboard.
+- All logs (including INFO/DEBUG) are optionally archived to S3 if `TEMPS_OTEL_S3_BUCKET` and credentials are configured — this is opt-in, not default.
+
+## Gotchas
+
+- **Low-severity logs not visible in dashboard queries**: only WARN+ severity is guaranteed to be in the queryable store by default; INFO/DEBUG logs may only exist in S3 archive if configured, otherwise they may not be retained at all. Don't rely on DEBUG-level logs being queryable in the dashboard unless S3 archival is set up.
+- **Logs not correlating with traces**: verify `trace_id`/`span_id` are actually populated on the log record — most OTel logging bridges only auto-populate these when the log call happens inside an active span context (e.g., inside a request handler wrapped by the tracing middleware), not from a background job with no active span.
+- **Use logs for structured record-keeping, not exception capture** — an uncaught exception belongs in error tracking (see [error-tracking.md](error-tracking.md)), not as an ERROR-level log line; you lose stack-trace grouping, source maps, and error-group deduplication if you only log it.

--- a/skills/temps-best-practices/references/logs.md
+++ b/skills/temps-best-practices/references/logs.md
@@ -4,8 +4,10 @@ Temps ingests standard OTLP/HTTP (protobuf) log exports. Use a standard OpenTele
 
 ## Endpoints
 
-- Header-based: `POST /otel/v1/logs`
-- Path-based: `POST /otel/v1/{project_id}/{environment_id}/{deployment_id}/logs`
+Routes are registered as `/otel/v1/logs` inside the crate, but the console server nests every plugin's routes under `/api`, so the real externally-reachable paths are:
+
+- Header-based: `POST /api/otel/v1/logs`
+- Path-based: `POST /api/otel/v1/{project_id}/{environment_id}/{deployment_id}/logs`
 
 Same auth, rate limit, and opt-in quota model as traces/metrics — see the shared-facts section in the top-level SKILL.md.
 

--- a/skills/temps-best-practices/references/metrics.md
+++ b/skills/temps-best-practices/references/metrics.md
@@ -4,8 +4,10 @@ Temps ingests standard OTLP/HTTP (protobuf) metrics exports — counters, gauges
 
 ## Endpoints
 
-- Header-based: `POST /otel/v1/metrics`
-- Path-based: `POST /otel/v1/{project_id}/{environment_id}/{deployment_id}/metrics`
+Routes are registered as `/otel/v1/metrics` inside the crate, but the console server nests every plugin's routes under `/api`, so the real externally-reachable paths are:
+
+- Header-based: `POST /api/otel/v1/metrics`
+- Path-based: `POST /api/otel/v1/{project_id}/{environment_id}/{deployment_id}/metrics`
 
 Same auth (`Authorization: Bearer <tk_|dt_|si_ token>` or `X-Temps-Api-Key`), same rate limit (1000 req/60s/token) and opt-in quota as traces/logs — see the shared-facts section in the top-level SKILL.md.
 

--- a/skills/temps-best-practices/references/metrics.md
+++ b/skills/temps-best-practices/references/metrics.md
@@ -1,0 +1,35 @@
+# Metrics
+
+Temps ingests standard OTLP/HTTP (protobuf) metrics exports — counters, gauges, histograms, summaries — through the same ingestion pipeline as traces and logs. Use a standard OpenTelemetry metrics SDK/exporter; there is no Temps-specific metrics SDK.
+
+## Endpoints
+
+- Header-based: `POST /otel/v1/metrics`
+- Path-based: `POST /otel/v1/{project_id}/{environment_id}/{deployment_id}/metrics`
+
+Same auth (`Authorization: Bearer <tk_|dt_|si_ token>` or `X-Temps-Api-Key`), same rate limit (1000 req/60s/token) and opt-in quota as traces/logs — see the shared-facts section in the top-level SKILL.md.
+
+Implemented in `temps-otel` crate: `src/handlers/ingest_handler.rs`; validation in `temps-metrics` crate: `src/store/timescale.rs`.
+
+## Metric name validation
+
+Metric names must match `[a-zA-Z0-9_.:- ]` — alphanumeric plus underscore, dot, colon, hyphen (spaces are in the character class but not meaningfully supported). Names that fail this check are logged with a warning and silently dropped at ingest, not stored anywhere.
+
+This is **not** a curated allowlist like Prometheus recording rules — any name matching the pattern is accepted and stored. The "allowlist" language sometimes used for this internally refers to the validation gate, not a fixed list of permitted metric names.
+
+## Label handling
+
+- Max 64 labels per data point (`MAX_LABELS_PER_POINT`).
+- Max 1024 bytes per label key or value.
+- Any label whose key starts with `temps.` is silently stripped before storage — this namespace is reserved for Temps' own internal routing attributes, so don't rely on setting `temps.*` labels from app code; they will not persist.
+
+## Storage split
+
+- Scalar points (counters, gauges) go into a `service_metrics` table.
+- Histogram/summary points (multi-valued aggregations) are excluded from `service_metrics` but retained in `otel_metrics` — if a custom histogram metric doesn't appear in a scalar-only view, check the histogram-specific store/dashboard instead.
+
+## Gotchas
+
+- **Metric silently missing, no error**: check the name against the character-set regex first — invalid names fail closed with only a server-side warning log, no error surfaced to the exporter.
+- **Custom label not showing up**: confirm it doesn't start with `temps.` — those are dropped by design, not a bug.
+- **High-cardinality metric spiking storage**: cardinality isn't capped by a distinct-value allowlist, only by per-point label count/size — a metric with a label like `user_id` can still blow up cardinality. Prefer bucketing or dropping high-cardinality labels client-side before export rather than relying on server-side protection.

--- a/skills/temps-best-practices/references/opentelemetry-traces.md
+++ b/skills/temps-best-practices/references/opentelemetry-traces.md
@@ -67,6 +67,19 @@ export function register() {
 
 `@vercel/otel` reads the same `OTEL_EXPORTER_OTLP_*` env vars — no Temps-specific config needed.
 
+**Critical gotcha if the app also uses `@sentry/nextjs`**: Sentry's Next.js SDK registers its own global `TracerProvider`/`ContextManager` by default. If `Sentry.init()` runs before `registerOTel()` — which it normally does, since Sentry's config files load ahead of `instrumentation.ts`'s `register()` — every span becomes non-recording and **traces silently stop reaching Temps with no error anywhere**. Fix by passing `skipOpenTelemetrySetup: true` to `Sentry.init()` in `sentry.server.config.ts` (and `sentry.edge.config.ts` if used) so `@vercel/otel` remains the sole tracer provider:
+
+```ts
+// sentry.server.config.ts
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  skipOpenTelemetrySetup: true, // let @vercel/otel own tracing — see gotcha above
+  tracesSampleRate: 1.0,
+});
+```
+
+This is a real, previously-hit bug, not a hypothetical: a Temps example app went through several iterations before landing on this fix (`observability-starter` in `temps-examples`, commits fixing "let @vercel/otel own tracing so traces reach Temps"). If error tracking and traces are both being wired up on the same Next.js app, apply this from the start.
+
 ### Python
 
 Zero-code via `opentelemetry-instrument`:

--- a/skills/temps-best-practices/references/opentelemetry-traces.md
+++ b/skills/temps-best-practices/references/opentelemetry-traces.md
@@ -6,20 +6,24 @@ Temps ingests standard OTLP/HTTP (protobuf) trace exports — any language's Ope
 
 ## Endpoints
 
-- Header-based: `POST /otel/v1/traces` — project/environment/deployment resolved from the auth token
-- Path-based: `POST /otel/v1/{project_id}/{environment_id}/{deployment_id}/traces` — explicit scoping in the URL
+Every plugin's routes (public and authenticated alike) are nested under `/api` by the console server (`temps-cli/src/commands/serve/console.rs`), so the real externally-reachable paths are:
+
+- Header-based: `POST /api/otel/v1/traces` — project/environment/deployment resolved from the auth token
+- Path-based: `POST /api/otel/v1/{project_id}/{environment_id}/{deployment_id}/traces` — explicit scoping in the URL
 
 Both accept `application/x-protobuf` bodies (`ExportTraceServiceRequest`), with optional gzip or zstd `Content-Encoding`.
 
-Implemented in `temps-otel` crate: `src/handlers/ingest_handler.rs`.
+Implemented in `temps-otel` crate: `src/handlers/mod.rs` (route table, doc comment lists the full path set), `src/handlers/ingest_handler.rs` (handler logic).
 
 ## Standard OTLP exporter config
 
 ```bash
-OTEL_EXPORTER_OTLP_ENDPOINT=https://<temps-host>/otel/v1
+OTEL_EXPORTER_OTLP_ENDPOINT=https://<temps-host>/api/otel
 OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer%20<dt_or_tk_token>
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 ```
+
+Most OTLP SDKs auto-append `/v1/traces` (or `/v1/metrics`, `/v1/logs`) to `OTEL_EXPORTER_OTLP_ENDPOINT`, landing on the path above. This is exactly the value Temps auto-injects into every deployment (`{TEMPS_API_URL}/otel`, i.e. `{base_url}/api/otel` — see `temps-deployments::workflow_planner::gather_environment_variables`, `crates/temps-deployments/src/services/workflow_planner.rs:448-452`).
 
 For `tk_` tokens (not project-scoped by default), also set:
 
@@ -213,7 +217,7 @@ const provider = new WebTracerProvider({
   spanProcessors: [
     new BatchSpanProcessor(
       new OTLPTraceExporter({
-        url: 'https://<temps-host>/otel/v1/traces',
+        url: 'https://<temps-host>/api/otel/v1/traces',
         headers: { Authorization: 'Bearer <dt_or_tk_token>' },
       })
     ),

--- a/skills/temps-best-practices/references/opentelemetry-traces.md
+++ b/skills/temps-best-practices/references/opentelemetry-traces.md
@@ -2,6 +2,8 @@
 
 Temps ingests standard OTLP/HTTP (protobuf) trace exports — any language's OpenTelemetry SDK works unmodified, there is no Temps-specific tracing SDK. Point the standard OTLP exporter env vars at Temps instead of hand-writing requests.
 
+**Apps deployed on Temps get this for free**: every deployment automatically has `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_SERVICE_NAME`, and `OTEL_SERVICE_VERSION` injected — see the top-level [SKILL.md](../SKILL.md) quickstart. The manual config below is for apps sending telemetry to a self-hosted Temps instance from outside the platform.
+
 ## Endpoints
 
 - Header-based: `POST /otel/v1/traces` — project/environment/deployment resolved from the auth token
@@ -16,6 +18,7 @@ Implemented in `temps-otel` crate: `src/handlers/ingest_handler.rs`.
 ```bash
 OTEL_EXPORTER_OTLP_ENDPOINT=https://<temps-host>/otel/v1
 OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer%20<dt_or_tk_token>
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 ```
 
 For `tk_` tokens (not project-scoped by default), also set:
@@ -25,6 +28,206 @@ OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer%20<tk_token>,X-Temps-Project-Id=
 ```
 
 `dt_` (deployment token) and `si_` tokens are already project/environment/deployment-scoped and don't need the project-id header.
+
+**Always set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` explicitly.** Several official SDKs (Node, Python, Java, .NET) default their generic OTLP exporter to gRPC — Temps only accepts OTLP/HTTP with a protobuf body, so a gRPC export will silently fail to connect rather than fall back.
+
+## Quickstart: instrument any language
+
+Every OpenTelemetry SDK reads the three env vars above and needs no Temps-specific code — set them, run the app, and spans land in **Observe → Traces**. These are the same setup patterns from the [add-error-tracking](../../add-error-tracking/SKILL.md) skill's platform list, applied to traces instead of Sentry.
+
+### Node.js (and Next.js server/API routes)
+
+Zero-code, via the OpenTelemetry auto-instrumentation agent — no source changes:
+
+```bash
+npm install --save-dev @opentelemetry/auto-instrumentations-node
+node --require @opentelemetry/auto-instrumentations-node/register app.js
+```
+
+Or set `NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/register"` in the deployment env so it applies without changing the start command.
+
+For Next.js specifically, use the built-in `instrumentation.ts` hook instead:
+
+```bash
+npm install @vercel/otel
+```
+
+```ts
+// instrumentation.ts (project root)
+import { registerOTel } from '@vercel/otel';
+
+export function register() {
+  registerOTel({ serviceName: 'your-app' });
+}
+```
+
+`@vercel/otel` reads the same `OTEL_EXPORTER_OTLP_*` env vars — no Temps-specific config needed.
+
+### Python
+
+Zero-code via `opentelemetry-instrument`:
+
+```bash
+pip install opentelemetry-distro opentelemetry-exporter-otlp
+opentelemetry-bootstrap -a install
+opentelemetry-instrument --service_name your-app python app.py
+```
+
+### Go
+
+Go has no stable zero-code agent — initialize the SDK manually and read the standard env vars via `autoexport`:
+
+```bash
+go get go.opentelemetry.io/otel go.opentelemetry.io/contrib/exporters/autoexport go.opentelemetry.io/otel/sdk
+```
+
+```go
+package main
+
+import (
+	"context"
+
+	"go.opentelemetry.io/contrib/exporters/autoexport"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+func main() {
+	ctx := context.Background()
+	exporter, err := autoexport.NewSpanExporter(ctx) // reads OTEL_EXPORTER_OTLP_* env vars
+	if err != nil {
+		panic(err)
+	}
+	tp := sdktrace.NewTracerProvider(sdktrace.WithBatcher(exporter))
+	otel.SetTracerProvider(tp)
+	defer tp.Shutdown(ctx)
+
+	// your app
+}
+```
+
+### Rust
+
+```bash
+cargo add opentelemetry opentelemetry-otlp opentelemetry_sdk --features opentelemetry-otlp/http-proto,opentelemetry-otlp/reqwest-client
+```
+
+```rust
+use opentelemetry_otlp::WithExportConfig;
+
+fn main() {
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http() // reads OTEL_EXPORTER_OTLP_* env vars
+        .build()
+        .expect("failed to build OTLP exporter");
+
+    let provider = opentelemetry_sdk::trace::TracerProvider::builder()
+        .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio)
+        .build();
+
+    opentelemetry::global::set_tracer_provider(provider);
+
+    // your app
+}
+```
+
+### Ruby
+
+Zero-code via the instrumentation-all gem:
+
+```bash
+bundle add opentelemetry-sdk opentelemetry-exporter-otlp opentelemetry-instrumentation-all
+```
+
+```ruby
+# config/initializers/otel.rb (or app entrypoint)
+require 'opentelemetry/sdk'
+require 'opentelemetry/exporter/otlp'
+require 'opentelemetry/instrumentation/all'
+
+OpenTelemetry::SDK.configure do |c|
+  c.service_name = 'your-app'
+  c.use_all # reads OTEL_EXPORTER_OTLP_* env vars
+end
+```
+
+### Java
+
+Zero-code via the OpenTelemetry Java agent — no source changes:
+
+```bash
+curl -L -o opentelemetry-javaagent.jar \
+  https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar
+java -javaagent:opentelemetry-javaagent.jar -Dotel.service.name=your-app -jar app.jar
+```
+
+The agent reads the same `OTEL_EXPORTER_OTLP_*` env vars.
+
+### PHP
+
+```bash
+composer require open-telemetry/opentelemetry open-telemetry/exporter-otlp open-telemetry/transport-grpc
+```
+
+```php
+<?php
+// bootstrap.php — include before your app's entrypoint
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\SDK\Trace\TracerProviderFactory;
+
+$tracerProvider = (new TracerProviderFactory())->create(); // reads OTEL_EXPORTER_OTLP_* env vars
+```
+
+### .NET
+
+```bash
+dotnet add package OpenTelemetry.Extensions.Hosting
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+```
+
+```csharp
+// Program.cs
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddAspNetCoreInstrumentation()
+        .AddOtlpExporter()); // reads OTEL_EXPORTER_OTLP_* env vars
+```
+
+### Browser (React, Vue, Svelte, Angular)
+
+Traces from browser code use the OpenTelemetry Web SDK — the same packages work regardless of frontend framework, since instrumentation is framework-agnostic:
+
+```bash
+npm install @opentelemetry/sdk-trace-web @opentelemetry/exporter-trace-otlp-http @opentelemetry/instrumentation-fetch
+```
+
+```ts
+// src/otel.ts — import this first in your app entrypoint
+import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+
+const provider = new WebTracerProvider({
+  spanProcessors: [
+    new BatchSpanProcessor(
+      new OTLPTraceExporter({
+        url: 'https://<temps-host>/otel/v1/traces',
+        headers: { Authorization: 'Bearer <dt_or_tk_token>' },
+      })
+    ),
+  ],
+});
+provider.register();
+registerInstrumentations({ instrumentations: [new FetchInstrumentation()] });
+```
+
+Browser exporters can't read process env vars, so the endpoint/headers must be passed explicitly in code (via a build-time env var like other bundler-injected config, not hardcoded) rather than through `OTEL_EXPORTER_OTLP_*`.
+
+### React Native / Flutter
+
+Mobile OpenTelemetry SDKs are less mature than the backend/browser ecosystem and package availability changes — check the [OpenTelemetry registry](https://opentelemetry.io/ecosystem/registry/) for the current state before committing to one. For most apps it's more reliable to send mobile telemetry through your own backend (which is already instrumented per above) rather than exporting OTLP directly from the device. Error tracking is the more mature signal for mobile — see [add-error-tracking](../../add-error-tracking/SKILL.md), which has dedicated React Native and Flutter setup.
 
 ## Auth
 

--- a/skills/temps-best-practices/references/opentelemetry-traces.md
+++ b/skills/temps-best-practices/references/opentelemetry-traces.md
@@ -1,0 +1,59 @@
+# OpenTelemetry Traces
+
+Temps ingests standard OTLP/HTTP (protobuf) trace exports — any language's OpenTelemetry SDK works unmodified, there is no Temps-specific tracing SDK. Point the standard OTLP exporter env vars at Temps instead of hand-writing requests.
+
+## Endpoints
+
+- Header-based: `POST /otel/v1/traces` — project/environment/deployment resolved from the auth token
+- Path-based: `POST /otel/v1/{project_id}/{environment_id}/{deployment_id}/traces` — explicit scoping in the URL
+
+Both accept `application/x-protobuf` bodies (`ExportTraceServiceRequest`), with optional gzip or zstd `Content-Encoding`.
+
+Implemented in `temps-otel` crate: `src/handlers/ingest_handler.rs`.
+
+## Standard OTLP exporter config
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=https://<temps-host>/otel/v1
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer%20<dt_or_tk_token>
+```
+
+For `tk_` tokens (not project-scoped by default), also set:
+
+```bash
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer%20<tk_token>,X-Temps-Project-Id=<project_id>
+```
+
+`dt_` (deployment token) and `si_` tokens are already project/environment/deployment-scoped and don't need the project-id header.
+
+## Auth
+
+- `Authorization: Bearer <token>` (percent-encoded `Bearer%20<token>` is also accepted — some OTLP exporters encode headers that way)
+- `X-Temps-Api-Key: <token>` as an alternative to the `Authorization` header
+- `X-Temps-Project-Id: <id>` — required alongside `tk_` tokens, optional/ignored for `dt_`/`si_`
+
+## Rate limits and quota
+
+- 1000 requests / 60s per token by default (`TEMPS_OTEL_RATE_LIMIT`, `TEMPS_OTEL_RATE_LIMIT_WINDOW_SECS`), enforced before protobuf parsing — 429 on exceed.
+- Storage quota is opt-in and off by default (`TEMPS_OTEL_QUOTA_GB`); when enabled, over-quota ingestion returns 413.
+- Decompression bomb protection caps decompressed payload size; oversized payloads return 400.
+
+## Storage
+
+- Spans land in a hypertable (TimescaleDB) segmented by `trace_id`; ClickHouse is used for some analytics reads (see project history: `otel_spans compression fix PR #348`).
+- Always query traces with a time bound — the hypertable lookups are unbounded by default if you don't pass one, which is expensive at scale.
+
+## Critical gotcha: trace duration units
+
+`duration_ms` on a `SpanRecord` is the **only** field guaranteed to be milliseconds. Everything else in a span's `attributes` map carries whatever unit the instrumenting library reported:
+
+- `gen_ai.*` semantic-convention attributes (LLM call attributes) are commonly in **seconds**, not ms.
+- Other attributes may be nanoseconds or microseconds depending on the source library.
+
+This bit the AI trace-summarization feature (see `crates/temps-otel/src/handlers/query_handler.rs`, `crates/temps-otel/src/types.rs`) — it treated raw `gen_ai.*` attribute values as milliseconds and produced wildly inflated duration claims. When computing or displaying a duration from a span, always use `duration_ms` directly rather than reading a raw attribute unless you've confirmed that attribute's unit from the emitting SDK's semantic conventions.
+
+## Gotchas
+
+- **401s**: check token prefix matches what the endpoint expects and the header is well-formed (`Bearer <token>`, not just the raw token).
+- **429s under load testing**: expected past 1000 req/60s per token — use multiple tokens or reduce export frequency (batch spans) rather than treating it as a bug.
+- **Spans not appearing**: confirm `Content-Type: application/x-protobuf` — Temps does not accept OTLP/JSON on these endpoints.

--- a/skills/temps-best-practices/references/opentelemetry-traces.md
+++ b/skills/temps-best-practices/references/opentelemetry-traces.md
@@ -2,7 +2,7 @@
 
 Temps ingests standard OTLP/HTTP (protobuf) trace exports — any language's OpenTelemetry SDK works unmodified, there is no Temps-specific tracing SDK. Point the standard OTLP exporter env vars at Temps instead of hand-writing requests.
 
-**Apps deployed on Temps get this for free**: every deployment automatically has `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_SERVICE_NAME`, and `OTEL_SERVICE_VERSION` injected — see the top-level [SKILL.md](../SKILL.md) quickstart. The manual config below is for apps sending telemetry to a self-hosted Temps instance from outside the platform.
+**Apps deployed on Temps get this for free, no configuration needed by the user**: every deployment automatically has `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_SERVICE_NAME`, and `OTEL_SERVICE_VERSION` injected — at both Docker build time (`--build-arg`) and container runtime (`-e`), so this is available however the app's OTEL SDK reads it. Never hardcode these values or ask the user for a token/endpoint to hardcode; if they're missing on a running deployment, that's a platform bug, not something to work around manually. See the top-level [SKILL.md](../SKILL.md) quickstart for the exact injection mechanism and its scope (apps deployed *through* Temps only — not Temps' own console, and not apps hosted elsewhere). The manual config below is for apps sending telemetry to a self-hosted Temps instance from outside the platform.
 
 ## Endpoints
 


### PR DESCRIPTION
## Summary
- Adds a new `temps-best-practices` skill under `skills/` — a cross-pillar observability reference (error tracking, OpenTelemetry traces, metrics, logs, analytics) for AI coding agents building on Temps.
- Grounded in the real ingestion surface: endpoints, auth token prefixes (`tk_`/`dt_`/`si_`), rate limits, and known gotchas (e.g. the `duration_ms` vs `gen_ai.*` seconds unit mismatch) pulled directly from `temps-error-tracking`, `temps-otel`, `temps-metrics`, and `temps-analytics-events`.
- Defers to the existing `add-error-tracking` / `add-react-analytics` skills for step-by-step SDK setup, and to `temps-cli` for everything outside observability (deploy, services, domains, CI) — no duplication of those skills' content.

## Test plan
- [x] `scripts/package_skill.py`-equivalent validation passed (frontmatter, description length, structure)
- [x] Pre-commit hooks passed (Conventional Commit format, trailing whitespace, typos)
- [x] Manual: install via `npx skills add gotempsh/temps --skill temps-best-practices` and confirm an agent picks it up for an observability-instrumentation task