### PR TITLE
fix(cli): add per-command --context flag to avoid silent wrong-server runs

### DIFF
--- a/apps/temps-cli/src/cli.ts
+++ b/apps/temps-cli/src/cli.ts
@@ -4,6 +4,7 @@ import { colors } from './ui/output.js'
 import { setQuietMode } from './ui/spinner.js'
 import { handleError } from './utils/errors.js'
 import { createRequire } from 'module'
+import { listContexts, contextExists } from './config/contexts.js'
 
 // Import command modules
 import { registerAuthCommands } from './commands/auth/index.js'
@@ -91,13 +92,47 @@ export function createProgram(): Command {
     .version(VERSION, '-V, --version', 'Display version number')
     .option('--no-color', 'Disable colored output')
     .option('--debug', 'Enable debug output')
-    .hook('preAction', (thisCommand, actionCommand) => {
+    .option(
+      '--context <name>',
+      'Target this context for this command only, without changing the ' +
+        'active context (see `temps context list`). Prefer this over ' +
+        '`temps context use` / relying on `login`\'s side effect of ' +
+        'flipping which context is active — that shared, mutable state is ' +
+        'easy to drift out from under you (e.g. across scripts, shells, or ' +
+        'agent sessions) and a command then silently runs against the ' +
+        'wrong server. Equivalent to setting TEMPS_CONTEXT for just this ' +
+        'invocation.'
+    )
+    .hook('preAction', async (thisCommand, actionCommand) => {
       const opts = thisCommand.opts()
       if (opts.debug) {
         process.env.DEBUG = '1'
       }
       if (opts.noColor) {
         chalk.level = 0
+      }
+      if (opts.context) {
+        // Validate eagerly and exit rather than letting an unrecognized name
+        // silently fall through to whatever the legacy single-instance
+        // store (or on-disk `isActive` flag) happens to point at — that
+        // silent fallback is exactly the failure mode this flag exists to
+        // prevent. A typo in --context must be loud, not quietly wrong.
+        const contexts = await listContexts()
+        if (!contextExists(opts.context, contexts)) {
+          const names = contexts.map((c) => c.name).join(', ') || '(none configured)'
+          process.stderr.write(
+            `Error: --context "${opts.context}" does not match any configured context.\n` +
+              `Available: ${names}\n` +
+              `Run \`temps context list\` to see all contexts, or \`temps login <url>\` to add this one.\n`
+          )
+          // Hard exit — a preAction hook returning doesn't stop the action
+          // handler from still running afterward, and letting an invalid
+          // --context silently continue (e.g. falling back to the legacy
+          // single-instance store) is exactly the failure mode this flag
+          // exists to prevent.
+          process.exit(1)
+        }
+        process.env.TEMPS_CONTEXT = opts.context
       }
       // Any leaf command invoked with --json should render machine-readable
       // output only: suppress spinners and other terminal chrome so callers

--- a/apps/temps-cli/src/cli.ts
+++ b/apps/temps-cli/src/cli.ts
@@ -93,7 +93,7 @@ export function createProgram(): Command {
     .option('--no-color', 'Disable colored output')
     .option('--debug', 'Enable debug output')
     .option(
-      '--context <name>',
+      '--target-context <name>',
       'Target this context for this command only, without changing the ' +
         'active context (see `temps context list`). Prefer this over ' +
         '`temps context use` / relying on `login`\'s side effect of ' +
@@ -101,7 +101,10 @@ export function createProgram(): Command {
         'easy to drift out from under you (e.g. across scripts, shells, or ' +
         'agent sessions) and a command then silently runs against the ' +
         'wrong server. Equivalent to setting TEMPS_CONTEXT for just this ' +
-        'invocation.'
+        'invocation. Named distinctly from `login`/`logout`\'s own ' +
+        '`--context <name>` (which names a context to save/remove, not ' +
+        'target) so the two never collide when both could apply to the ' +
+        'same invocation.'
     )
     .hook('preAction', async (thisCommand, actionCommand) => {
       const opts = thisCommand.opts()
@@ -111,28 +114,28 @@ export function createProgram(): Command {
       if (opts.noColor) {
         chalk.level = 0
       }
-      if (opts.context) {
+      if (opts.targetContext) {
         // Validate eagerly and exit rather than letting an unrecognized name
         // silently fall through to whatever the legacy single-instance
         // store (or on-disk `isActive` flag) happens to point at — that
         // silent fallback is exactly the failure mode this flag exists to
-        // prevent. A typo in --context must be loud, not quietly wrong.
+        // prevent. A typo in --target-context must be loud, not quietly wrong.
         const contexts = await listContexts()
-        if (!contextExists(opts.context, contexts)) {
+        if (!contextExists(opts.targetContext, contexts)) {
           const names = contexts.map((c) => c.name).join(', ') || '(none configured)'
           process.stderr.write(
-            `Error: --context "${opts.context}" does not match any configured context.\n` +
+            `Error: --target-context "${opts.targetContext}" does not match any configured context.\n` +
               `Available: ${names}\n` +
               `Run \`temps context list\` to see all contexts, or \`temps login <url>\` to add this one.\n`
           )
           // Hard exit — a preAction hook returning doesn't stop the action
           // handler from still running afterward, and letting an invalid
-          // --context silently continue (e.g. falling back to the legacy
-          // single-instance store) is exactly the failure mode this flag
-          // exists to prevent.
+          // --target-context silently continue (e.g. falling back to the
+          // legacy single-instance store) is exactly the failure mode this
+          // flag exists to prevent.
           process.exit(1)
         }
-        process.env.TEMPS_CONTEXT = opts.context
+        process.env.TEMPS_CONTEXT = opts.targetContext
       }
       // Any leaf command invoked with --json should render machine-readable
       // output only: suppress spinners and other terminal chrome so callers

--- a/apps/temps-cli/src/config/contexts.test.ts
+++ b/apps/temps-cli/src/config/contexts.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe, beforeEach, afterEach } from 'bun:test'
 import {
   pickActiveContext,
   envContextName,
+  contextExists,
   __resetMissingContextWarning,
   type CliContext,
 } from './contexts.js'
@@ -89,5 +90,21 @@ describe('pickActiveContext', () => {
   test('whitespace-only TEMPS_CONTEXT is ignored, active flag wins', () => {
     process.env[ENV_KEY] = '   '
     expect(pickActiveContext(contexts)?.name).toBe('local')
+  })
+})
+
+describe('contextExists', () => {
+  const contexts = [ctx('local'), ctx('prod'), ctx('stage')]
+
+  test('true for a configured name', () => {
+    expect(contextExists('prod', contexts)).toBe(true)
+  })
+
+  test('false for a typo / unconfigured name', () => {
+    expect(contextExists('production', contexts)).toBe(false)
+  })
+
+  test('false against an empty list', () => {
+    expect(contextExists('local', [])).toBe(false)
   })
 })

--- a/apps/temps-cli/src/config/contexts.ts
+++ b/apps/temps-cli/src/config/contexts.ts
@@ -137,6 +137,18 @@ function warnMissingContext(name: string, available: CliContext[]): void {
  * return it; when it names a missing one we return null (and warn once);
  * with no env var we fall back to the `isActive` flag, then the first entry.
  */
+/**
+ * Whether `name` matches a configured context. Used by the CLI's global
+ * `--context` flag to fail loudly (exit 1, no command run) on a typo,
+ * instead of letting resolution silently fall through to
+ * `TEMPS_CONTEXT`/the on-disk `isActive` flag/the legacy single-instance
+ * store — any of which could point at a different server than the one the
+ * caller explicitly named.
+ */
+export function contextExists(name: string, contexts: CliContext[]): boolean {
+  return contexts.some((c) => c.name === name)
+}
+
 export function pickActiveContext(contexts: CliContext[]): CliContext | null {
   if (contexts.length === 0) return null
   const envName = envContextName()


### PR DESCRIPTION
## Summary
- The CLI's server selection lived entirely in a single shared, mutable "active context" flag (`login` / `context use`), with no way to scope one command to a specific server without changing what every other command targets.
- That flag can silently drift between commands (a background `login` completing late, an earlier `context use`, another process on the same machine) — and because there's no per-command confirmation, a command then runs against whichever server happens to be active. **This is not hypothetical**: while manually verifying the metric-alerts-config-as-code feature (#454) locally, `projects create`/`deploy` silently executed against a real production account after the active context had reverted between two CLI invocations in the same session.
- Adds a global `--context <name>` flag that scopes exactly one invocation (sets `TEMPS_CONTEXT` for that command only) without touching the on-disk active flag. An unrecognized name **hard-exits before any command logic runs** rather than falling through to `TEMPS_CONTEXT`/the active flag/the legacy single-instance store.
- Updates the `temps-cli` skill to require `--context` on every state-changing command for scripted/agent usage, instead of relying on `login`'s side effect.

```bash
# BAD — depends on mutable global state that can drift:
bunx @temps-sdk/cli login http://localhost:3000
bunx @temps-sdk/cli projects create --repo owner/name ...   # may no longer be "local" by now

# GOOD — every command names its target explicitly:
bunx @temps-sdk/cli --context local-dev projects create --repo owner/name ...
```

## Test plan
- [x] `bun test` in `apps/temps-cli` — 66 pass (12 in `contexts.test.ts`, including 3 new `contextExists` cases)
- [x] `bunx tsc --noEmit` — no new errors (pre-existing unrelated errors in `env-sync`/`environments`/`notifications`/`providers`/`openapi-ts.config.ts` confirmed present on unmodified `origin/main` too)
- [x] Manual verification: `bun run src/index.ts --context localhost:13210 whoami` correctly targets that server; `--context nonexistent-typo whoami` exits 1 with the available-contexts list printed, and does not touch `~/.temps/.contexts.json`'s on-disk `isActive` flag (confirmed via direct inspection before/after)