### PR TITLE
fix(otel): warn AI chat that only duration_ms is milliseconds

### DIFF
--- a/crates/temps-cli/src/commands/serve/console.rs
+++ b/crates/temps-cli/src/commands/serve/console.rs
@@ -3309,6 +3309,37 @@ mod ai_tool_allowlist_tests {
              resolvable via the read-only AI tool allowlist"
         );
     }
+
+    /// `describe_api` only ever surfaces an operation's `summary`/`description`
+    /// to the model — never response-body field docs — so a span's
+    /// `duration_ms` vs. unlabeled `attributes` units can only be explained via
+    /// the operation description itself. This proves the unit-guidance text
+    /// added to the trace/GenAI-trace handler doc comments actually survives
+    /// into the real compiled `OtelApiDoc` and would reach the model through
+    /// `describe_api`, rather than just existing as a comment nobody reads.
+    #[test]
+    fn trace_tool_descriptions_warn_about_unlabeled_attribute_units() {
+        let openapi = temps_otel::plugin::OtelApiDoc::openapi();
+        let index = ReadOnlyApiIndex::from_openapi(&openapi, &[]);
+
+        for operation_id in [
+            "get_trace",
+            "query_traces",
+            "query_genai_traces",
+            "get_genai_trace",
+        ] {
+            let op = index
+                .get(operation_id)
+                .unwrap_or_else(|| panic!("{operation_id} missing from OtelApiDoc"));
+            let description = op.description.as_deref().unwrap_or_default();
+            assert!(
+                description.contains("duration_ms") && description.contains("milliseconds"),
+                "{operation_id}'s OpenAPI description must warn the model that only \
+                 `duration_ms` is guaranteed to be milliseconds and other numeric \
+                 fields carry unlabeled/different units — got: {description:?}"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/temps-otel/src/handlers/query_handler.rs
+++ b/crates/temps-otel/src/handlers/query_handler.rs
@@ -470,6 +470,15 @@ pub async fn list_metric_label_values(
 }
 
 /// Query trace spans with optional filters.
+///
+/// Each returned span has a `duration_ms` field (float, milliseconds) — this is
+/// the ONLY field guaranteed to be in milliseconds. Spans also carry an
+/// `attributes` map of raw key/value pairs exactly as reported by the
+/// instrumenting library: numeric attribute values may be seconds, milliseconds,
+/// microseconds, or nanoseconds depending on that library's convention, and
+/// nothing in this response labels the unit. Never assume an attribute's
+/// numeric value shares `duration_ms`'s unit, and never state a duration in
+/// milliseconds unless it came from a `duration_ms` field.
 #[utoipa::path(
     tag = "Traces",
     get,
@@ -665,6 +674,16 @@ pub async fn query_trace_summaries(
 }
 
 /// Get all spans for a specific trace.
+///
+/// Each span has a `duration_ms` field (float, milliseconds) — the ONLY field
+/// guaranteed to be in milliseconds — plus an `attributes` map of raw
+/// key/value pairs exactly as the instrumenting library reported them.
+/// Numeric attribute values (e.g. connection-pool wait times, queue delays)
+/// may be in seconds, milliseconds, microseconds, or nanoseconds depending on
+/// that library's own convention; this response never labels the unit. When
+/// explaining what a span spent time on, only quote milliseconds from
+/// `duration_ms` (or from `start_time`/`end_time` deltas) — never assume a raw
+/// attribute number is already in milliseconds.
 #[utoipa::path(
     tag = "Traces",
     get,
@@ -902,6 +921,11 @@ pub async fn get_pipeline_stats(
 // ── GenAI Agent Activity Handlers ──────────────────────────────────
 
 /// Query GenAI trace summaries — traces containing spans with `gen_ai.*` attributes.
+///
+/// `duration_ms` is the only field guaranteed to be milliseconds. `gen_ai.*`
+/// span attributes (e.g. time-to-first-token, token latency) often follow the
+/// OTel GenAI semantic conventions, which use **seconds** (a fractional
+/// double), not milliseconds — do not read them as ms without converting.
 #[utoipa::path(
     tag = "GenAI",
     get,
@@ -978,6 +1002,11 @@ pub async fn query_genai_traces(
 }
 
 /// Get GenAI span details for a specific trace.
+///
+/// `duration_ms` is the only field guaranteed to be milliseconds. `gen_ai.*`
+/// span attributes (e.g. time-to-first-token, token latency) often follow the
+/// OTel GenAI semantic conventions, which use **seconds** (a fractional
+/// double), not milliseconds — do not read them as ms without converting.
 #[utoipa::path(
     tag = "GenAI",
     get,

--- a/crates/temps-otel/src/types.rs
+++ b/crates/temps-otel/src/types.rs
@@ -429,9 +429,15 @@ pub struct SpanRecord {
     pub start_time: DateTime<Utc>,
     #[schema(value_type = String, format = DateTime)]
     pub end_time: DateTime<Utc>,
+    /// Span duration in milliseconds. The only field on this struct guaranteed
+    /// to be in milliseconds.
     pub duration_ms: f64,
     pub status_code: SpanStatusCode,
     pub status_message: String,
+    /// Raw key/value pairs exactly as reported by the instrumenting library.
+    /// Numeric values are NOT guaranteed to share `duration_ms`'s unit — they
+    /// may be seconds, milliseconds, microseconds, or nanoseconds depending on
+    /// the exporter's own convention, and the unit is not labeled here.
     pub attributes: BTreeMap<String, String>,
     pub events: Vec<SpanEvent>,
 }


### PR DESCRIPTION
## Summary
- The AI chat's `describe_api`/`--help` mechanism only ever surfaces an operation's request params to the model — never response-body field docs — so nothing told the model that trace-span `attributes` values are raw, unlabeled passthroughs from the instrumenting library (often ns/µs/s, not ms), sitting right next to a correctly-computed `duration_ms` field.
- Extends the OpenAPI doc comments on `get_trace` / `query_traces` / `query_genai_traces` / `get_genai_trace` (these doc comments are exactly what reaches the model via `describe_api`) plus `SpanRecord` field docs, stating explicitly that `duration_ms` is the only ms-guaranteed field and that `gen_ai.*` attributes commonly use OTel semantic-convention **seconds**.
- Adds a unit test that builds the real compiled `OtelApiDoc` and asserts the guidance text is actually present in the operation descriptions, so it can't silently rot back into an unread doc comment.

## Test plan
- [x] `cargo check --lib` clean across the workspace (0 errors)
- [x] `cargo test --lib -p temps-cli trace_tool_descriptions_warn_about_unlabeled_attribute_units` passes
- [x] Verified in an isolated worktree/instance (random ports, dedicated throwaway DB) that the compiled `OtelApiDoc` carries the new description text end-to-end