### PR TITLE
fix(cli): environments resources always fails with "Project not found"

### DIFF
--- a/apps/temps-cli/src/commands/environments/index.ts
+++ b/apps/temps-cli/src/commands/environments/index.ts
@@ -952,6 +952,7 @@ async function exportEnvVars(
 // ============ Resources Command ============
 
 interface ResourcesOptions {
+  project?: string
   cpu?: string
   memory?: string
   cpuRequest?: string
@@ -959,15 +960,12 @@ interface ResourcesOptions {
   json?: boolean
 }
 
-async function resourcesCmd(
-  project: string,
-  environment: string,
-  options: ResourcesOptions
-): Promise<void> {
+async function resourcesCmd(environment: string, options: ResourcesOptions): Promise<void> {
   await requireAuth()
   await setupClient()
 
-  const projectId = await getProjectId(project)
+  const resolved = await requireProjectSlug(options.project)
+  const projectId = await getProjectId(resolved.slug)
 
   // Find environment by slug
   const envs = await withSpinner('Fetching environments...', async () => {
@@ -1072,7 +1070,7 @@ async function resourcesCmd(
     }
 
     newline()
-    success(`Resources updated for ${project}/${environment}`)
+    success(`Resources updated for ${resolved.slug}/${environment}`)
     newline()
     displayResources(updatedEnv)
   } else {
@@ -1090,7 +1088,7 @@ async function resourcesCmd(
     }
 
     newline()
-    header(`${icons.folder} Resources for ${project}/${environment}`)
+    header(`${icons.folder} Resources for ${resolved.slug}/${environment}`)
     newline()
     displayResources(targetEnv)
   }


### PR DESCRIPTION
## Summary
- `temps environments resources <environment> -p <project>` always errored with `Project "<environment>" not found`, regardless of how `-p`/`--project` was passed.
- Root cause: `resourcesCmd`'s parameter order (`project, environment, options`) didn't match how commander actually invokes it for a `resources <environment>` command with `-p` declared as an *option*, not a second positional — commander calls the handler with `(environment, options)`. The environment string landed in the `project` parameter, and `options` (containing the real `-p` value) was never read as `options`.
- Fixed the signature to `(environment, options)` and resolve the project via `requireProjectSlug(options.project)`, matching the pattern every other command in this file already uses.

## Test plan
- [x] `bunx tsc --noEmit` — no new errors introduced (pre-existing unrelated errors in this file untouched)
- [x] `bun run build` succeeds
- [x] Verified against production: `node dist/index.js environments resources production -p temps-landing-agent --json` now returns real resource data instead of erroring
- [x] Verified the write path too: `--memory 1024` successfully updated the environment's `memory_limit`/`memory_request`, confirmed via a follow-up read