### PR TITLE
fix(web): Appearance submenu not appearing when clicked in account dropdown

### DIFF
--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -42,14 +42,16 @@ const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
 >(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]',
-      className
-    )}
-    {...props}
-  />
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.SubContent
+      ref={ref}
+      className={cn(
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]',
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
 ))
 DropdownMenuSubContent.displayName =
   DropdownMenuPrimitive.SubContent.displayName


### PR DESCRIPTION
## Summary
- The account dropdown's Appearance > Light/Dark/System submenu never appeared on click, even though it looked interactive (hover highlight, chevron).
- Root cause: `DropdownMenuContent` has `overflow-y-auto overflow-x-hidden` (added to support scrolling long menus) and Radix positions it via a CSS `transform`, which makes it the containing block for `position: fixed` descendants. `DropdownMenuSubContent` wasn't portaled, so it rendered nested inside that clipped, transformed box. On click, `aria-expanded` flipped to `true` and the DOM nodes existed with `opacity: 1`/`visible` computed styles, but the part of the submenu extending past the parent's own edges was clipped out of paint and hit-testing — confirmed via `document.elementFromPoint()` returning nothing where the submenu geometrically claimed to be.
- Fix: wrap `DropdownMenuSubContent` in `DropdownMenuPrimitive.Portal`, same as the top-level `DropdownMenuContent` already does, so it renders as a sibling under `document.body` instead of nested inside the clipped ancestor.

## Test plan
- [x] Reproduced locally: `elementFromPoint()` at the submenu's own coordinates hit nothing (just `<html>`) before the fix.
- [x] After the fix, `elementFromPoint()` hits the actual "Dark" menu item, and clicking it correctly applies dark mode (`document.documentElement.className` → `dark`).
- [x] Verified the parent Account dropdown (Account link / Log out) still opens and behaves normally — no regression from the Portal wrap.
- [x] `bunx tsc --noEmit` clean on the changed file.