### PR TITLE
docs(skills): add runtime and telemetry guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **skills:** Scan changed agent skills in pull requests and all skills nightly, on demand, after relevant pushes to `main`, or when scanner controls change, using the hash-locked Cisco AI Defense Skill Scanner with behavioral analysis, a high-severity merge gate, and fail-closed symlink validation.
+- **temps-best-practices skill:** Add an application runtime contract covering `.temps.yaml` readiness paths, OpenTelemetry health-request suppression, port binding, graceful shutdown, replica-safe state, migrations, telemetry privacy, and browser credential boundaries so generated deployment guidance is safe and production-ready.
 
 ### Fixed
 

--- a/skills/temps-best-practices/SKILL.md
+++ b/skills/temps-best-practices/SKILL.md
@@ -1,12 +1,33 @@
 ---
 name: temps-best-practices
 description: |
-  Best-practices reference for building apps on Temps — currently covers observability (error tracking, traces, metrics, logs, analytics), with room to grow into other pillars later. Use to: design how an app should emit telemetry to Temps, debug why errors/traces/metrics/logs/events aren't showing up, choose which pillar a signal belongs in, wire up multiple pillars at once, or check ingestion endpoints/auth tokens (tk_/dt_/si_)/rate limits/quotas for Temps' OTLP/Sentry/analytics APIs. Triggers: "temps best practices", "temps observability", "wire up telemetry", "why isn't this showing up in traces/metrics/logs", "otel best practices for temps", "instrument this app for temps". For single-pillar setup prefer add-error-tracking or add-react-analytics. For anything outside observability (deploy, services/databases, domains, CI automation), use the temps-cli skill instead.
+  Best-practices reference for preparing and instrumenting applications on Temps. Covers the app runtime contract (`.temps.yaml` health, HOST/PORT, readiness, SIGTERM, replicas, migrations) and production observability (errors, traces, metrics, logs, analytics, privacy, sampling, cardinality, credential boundaries). Use whenever building or reviewing an app for Temps, configuring health checks, adding telemetry, diagnosing missing/noisy signals, or checking OTLP/Sentry/analytics ingestion. Triggers include "temps best practices", "prepare this app for Temps", ".temps.yaml health", "temps health check", "ignore health checks in otel", "temps observability", "wire up telemetry", and "instrument this app for temps". Prefer focused setup skills for a single SDK. Use temps-cli for executing deploy and resource-management commands.
 ---
 
 # Temps Best Practices
 
-Best practices for building on Temps. Today this covers the **observability** pillar end to end (error tracking, traces, metrics, logs, analytics) — everything else an app needs from the platform (deploy, provisioning databases/caches, domains, CI/CD automation, notifications) is CLI-driven and covered by the **temps-cli** skill, not duplicated here.
+Best practices for application code that runs on Temps. This skill owns the **runtime contract** and **production observability**; use `temps-cli` for platform operations.
+
+## Required workflow
+
+1. For any deployable application, read [references/runtime-contract.md](references/runtime-contract.md).
+2. When any telemetry or replay is enabled, read [references/telemetry-hygiene.md](references/telemetry-hygiene.md).
+3. Read only the reference for each observability pillar in scope.
+4. Inspect the existing application and `.temps.yaml` before editing. Merge configuration; do not overwrite unrelated keys.
+5. Run the runtime and telemetry verification checklists before considering the work complete.
+
+## Runtime contract summary
+
+Every web application should expose a dedicated readiness endpoint and configure it in `.temps.yaml` under the project's effective Temps Root Directory / Docker build context:
+
+```yaml
+health:
+  path: /healthz
+```
+
+Use `health.path`; do not rely on the currently parsed-but-unapplied `status`, `interval`, `timeout`, or `retries` fields. If OpenTelemetry server tracing is enabled, exclude the exact health path from incoming spans and routine access-log/request-metric noise. Keep the route, `.temps.yaml`, and filters synchronized.
+
+Also require the app to read `PORT`, bind to `HOST`/`0.0.0.0`, align a custom image's `EXPOSE`, handle `SIGTERM`, flush telemetry, and exit inside Temps' 10-second shutdown window. See the runtime reference for readiness semantics, scale-to-zero caveats, replicas, migrations, stdout/stderr, and cron authentication.
 
 ## Observability
 
@@ -14,34 +35,38 @@ Temps replaces Sentry + Datadog/Honeycomb + PostHog with one ingestion surface. 
 
 - **add-error-tracking** — step-by-step Sentry SDK init per language/framework
 - **add-react-analytics** — step-by-step `@temps-sdk/react-analytics` hook usage
+- **add-session-recording** — privacy-aware session replay setup and verification
 
 ## Quickstart: wire up any app end to end
 
-Goal: an app in any language gets error tracking and traces flowing with minimal setup. Both signals use the same shape — one env var pointing at Temps, and the language's own official SDK does the rest.
+Goal: an app in any language gets runtime health, error tracking, and traces working safely.
 
-**If the app is deployed as a project on Temps (i.e. through Temps' own build/deploy pipeline), this is already done — zero configuration, by any user.** Every such deployment automatically gets these env vars injected, at **both** Docker build time (as `--build-arg`, so frontend bundlers can inline them) **and** container runtime (as `-e`, for server-side/SSR code reading `process.env` at request time):
+**Temps auto-injects exporter destinations and credentials; it does not install or initialize an SDK.** Apps deployed through Temps receive these variables at Docker build time and container runtime, but application instrumentation still has to be installed, initialized, filtered, and verified:
 
-| Env var | What it's for |
-|---|---|
-| `SENTRY_DSN` | Server-side/generic error tracking DSN, always present |
-| `NEXT_PUBLIC_SENTRY_DSN` / `NUXT_PUBLIC_SENTRY_DSN` / `VITE_SENTRY_DSN` / `PUBLIC_SENTRY_DSN` / `REACT_APP_SENTRY_DSN` | Framework-specific public DSN, added when the detected build preset needs a public-prefixed var to expose it client-side (Next.js/Nuxt/Vite,React,Vue,SolidStart,Remix/SvelteKit,Astro,Rsbuild/Docusaurus respectively) — not added for Angular or backend/generic presets, which just use `SENTRY_DSN` |
-| `SENTRY_RELEASE` | Commit SHA — every Sentry SDK reads this automatically when `release` isn't set explicitly; don't hardcode `release` in `Sentry.init()` or you override this and break source-context lookup |
-| `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL` (always `http/protobuf`), `OTEL_EXPORTER_OTLP_HEADERS` (deployment token auth) | Traces, auto-configured |
-| `OTEL_SERVICE_NAME` (project name), `OTEL_SERVICE_VERSION` (commit SHA when available) | Auto-populated span metadata |
+| Env var | What it's for | Client-safe? |
+|---|---|---:|
+| `SENTRY_DSN` | Server-side/generic error-tracking DSN | Server by default |
+| `NEXT_PUBLIC_SENTRY_DSN` / `NUXT_PUBLIC_SENTRY_DSN` / `VITE_SENTRY_DSN` / `PUBLIC_SENTRY_DSN` / `REACT_APP_SENTRY_DSN` | Framework-specific public Sentry write key | Yes |
+| `SENTRY_RELEASE` | Commit SHA; leave `release` unset in `Sentry.init()` so the SDK reads it | Server/build metadata |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL` | OTLP destination and `http/protobuf` protocol | Endpoint is non-secret |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Deployment-token authorization for OTLP | **No — server only** |
+| `OTEL_SERVICE_NAME`, `OTEL_SERVICE_VERSION` | Stable service and release metadata | Non-secret |
 
-Implemented in `temps-deployments` crate: `src/services/workflow_planner.rs` (`gather_environment_variables` collects them; the same map is threaded to both the build job as `build_args` — `workflow_planner.rs:1164-1198`/`1264-1306` → `docker.rs:960-988`'s `buildargs` — and the deploy job as runtime `env` — `docker.rs:1778-1784`). There is **no build-time-vs-runtime gap** for apps going through this pipeline: a `NEXT_PUBLIC_SENTRY_DSN`-style var is genuinely present when the client bundle is compiled, not just after the container starts. If a variable from the table is missing on a running deployment, that's a platform bug — investigate the deployment's build/deploy logs, don't work around it by hardcoding a value.
+Build-time availability does not make a server credential browser-safe. Never expose `OTEL_EXPORTER_OTLP_HEADERS`, `TEMPS_API_TOKEN`, `dt_`, or `tk_` through a public-prefixed variable or client bundle. Browser/mobile OTLP must use an authenticated backend or collector; see [references/telemetry-hygiene.md](references/telemetry-hygiene.md).
 
 **This auto-injection is scoped to apps deployed *through* Temps.** It does not apply to: an app running elsewhere and only sending telemetry to a self-hosted Temps instance, or to Temps' own console/dashboard (which is built by its own CI, not through this deploy pipeline — self-referential, since Temps doesn't deploy itself as a project on itself). For those cases, get the real credential from the dashboard and wire it through whatever env var / build-arg / secrets mechanism that project's *own* build system already uses:
 - Error tracking DSN: **Error Tracking → DSN & Setup** (`https://<public_key>@<temps-host>/<project_id>`)
-- A deployment token (`dt_...`) or API key (`tk_...`) for OTLP: **Project Settings → API Keys**
+- A server-side deployment token (`dt_...`) or API key (`tk_...`) for OTLP: **Project Settings → API Keys**
 
-**Never hardcode a DSN, token, or endpoint value into source code, a Dockerfile, or CI config — and never ask the user to supply one so it can be hardcoded.** The fix for "this needs to be available at build time" is always to pass it as a build arg / build-time env var through the project's existing mechanism (matching the dual-injection pattern above), never to bake a literal secret into a file. If the real value is genuinely unknown, the answer is "go get it from **Error Tracking → DSN & Setup**" or "go get it from **Project Settings → API Keys**" — not "paste it here so I can commit it."
+Never hardcode a token or endpoint into source, a Dockerfile, or CI config. Do not ask the user for a token so it can be committed. A Sentry DSN public key is designed for client writes, but should still come from the platform's supported configuration path.
 
 Either way, the app-side steps are the same:
 
-1. **Error tracking**: follow [add-error-tracking](../add-error-tracking/SKILL.md) for the app's language — install the official Sentry SDK, point it at `SENTRY_DSN` (or the framework's public variant). No Temps-specific package exists or is needed.
-2. **Traces**: follow the per-language quickstart in [references/opentelemetry-traces.md](references/opentelemetry-traces.md) — install the official OpenTelemetry SDK/agent for the language; if the three `OTEL_EXPORTER_OTLP_*` env vars are already set, most SDKs pick them up with zero additional config.
-3. **Verify** both landed using the checklist below before considering the app "instrumented."
+1. **Runtime**: apply [references/runtime-contract.md](references/runtime-contract.md).
+2. **Hygiene**: establish credential boundaries, redaction, cardinality, batching, sampling, and shutdown using [references/telemetry-hygiene.md](references/telemetry-hygiene.md).
+3. **Error tracking**: follow [add-error-tracking](../add-error-tracking/SKILL.md), leaving release metadata environment-driven.
+4. **Traces**: install and initialize the official OpenTelemetry SDK/agent using [references/opentelemetry-traces.md](references/opentelemetry-traces.md). Auto-injected env vars only configure export.
+5. **Verify** runtime and telemetry behavior before considering the app production-ready.
 
 ## The five pillars
 
@@ -55,6 +80,8 @@ Either way, the app-side steps are the same:
 
 Read the specific reference file(s) for the pillar(s) in play — don't load all five unless doing a full-stack instrumentation pass.
 
+Cross-pillar production rules live in [references/telemetry-hygiene.md](references/telemetry-hygiene.md), not duplicated in every pillar.
+
 ## Deciding which pillar a signal belongs in
 
 - **"This threw/crashed"** → error tracking, not a log line. Logs are for structured record-keeping, not exception capture.
@@ -65,24 +92,31 @@ Read the specific reference file(s) for the pillar(s) in play — don't load all
 
 ## Shared ingestion facts across pillars
 
-All Temps telemetry ingestion (OTLP traces/metrics/logs) shares one auth and rate-limit model — know this once instead of re-deriving it per pillar:
+Temps OTLP ingestion shares a rate-limit/quota model, but token support differs by signal:
 
-- **Token prefixes**: `tk_` (API key, needs `X-Temps-Project-Id` header), `dt_` (deployment token, project-scoped already), `si_` (webhook/integration token). Sentry-compatible error ingestion uses the DSN's public key instead, not these tokens.
+- **`tk_` API key**: server-side; needs `X-Temps-Project-Id`.
+- **`dt_` deployment token**: server-side and project/environment scoped. Prefer the header-based endpoint so Temps resolves attribution from the token. Do not expose it to a browser.
+- **`si_` integration token**: supported for infrastructure metrics ingestion, not general traces/logs.
+- **Sentry-compatible ingestion**: uses the DSN public key rather than these machine tokens.
 - **Auth header**: `Authorization: Bearer <token>` or `X-Temps-Api-Key: <token>`. Some OTLP exporters URL-encode the header as `Bearer%20<token>` — Temps accepts that too.
 - **Rate limit**: 1000 req/60s per token by default (`TEMPS_OTEL_RATE_LIMIT`, `TEMPS_OTEL_RATE_LIMIT_WINDOW_SECS` — server-side config, not something the app sets).
 - **Storage quota**: off by default; a self-hosted instance can opt in via `TEMPS_OTEL_QUOTA_GB`. If ingestion suddenly starts 413'ing, that's the likely cause.
-- **Endpoint shape**: every plugin's routes are nested under `/api` by the console server — path-based `POST /api/otel/v1/{project_id}/{environment_id}/{deployment_id}/{traces|metrics|logs}` or header-based `POST /api/otel/v1/{traces|metrics|logs}` with project/env/deployment resolved from the token. Prefer the standard OTLP exporter env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`) over hand-rolling requests — any OTLP/HTTP protobuf exporter works unmodified against these endpoints.
+- **Endpoint shape**: prefer header-based `POST /api/otel/v1/{traces|metrics|logs}` with attribution resolved from the token. Path-based endpoints exist, but should not be used to override a deployment token's intended deployment attribution.
 
-## Verification checklist for a full instrumentation pass
+## Definition of done
 
-1. Error tracking: trigger a deliberate error, confirm it appears in **Error Tracking → Error Groups**.
-2. Traces: make a request through the instrumented path, confirm a span appears in **Observe → Traces** with a sane `duration_ms` (see the unit gotcha in [references/opentelemetry-traces.md](references/opentelemetry-traces.md)).
-3. Metrics: confirm a custom metric name passes the `[a-zA-Z0-9_.:- ]` character set (see [references/metrics.md](references/metrics.md)) and shows up in **Observe → Metrics**.
-4. Logs: confirm log records with `trace_id` set join the correct trace in the UI.
-5. Analytics: confirm `/api/_temps/event` or `/api/projects/{id}/events/ingest` calls land in **Analytics** within a few seconds — see [references/analytics.md](references/analytics.md) for a language-agnostic quickstart, since analytics has no per-language SDK beyond React.
+1. Runtime: app listens on the injected port/interface; readiness is configured in the effective app root; `SIGTERM` drains and exits within 10 seconds.
+2. Health noise: repeated health requests succeed without routine server spans, access logs, or request metrics; a normal route remains observable.
+3. Error tracking: a deliberate test error appears in **Error Tracking → Error Groups** with the expected release and no sensitive data.
+4. Traces: a normal request appears in **Observe → Traces**, uses a route-template name, propagates context downstream, and has a sane `duration_ms`.
+5. Metrics: names and bounded labels pass validation; no user/session/request identifiers create cardinality explosions.
+6. Logs: a structured log inside an active span joins the correct trace and contains no secrets.
+7. Analytics: browser events are treated as untrusted; an authoritative test conversion comes from authenticated server code.
+8. Replay: recording is consent-gated, masked, path-restricted, and inspected with synthetic sensitive values.
+9. Client bundle: built assets contain no `dt_`, `tk_`, `TEMPS_API_TOKEN`, or OTLP authorization header.
 
-If a signal never appears, check auth token prefix/header first, then rate limit/quota, before assuming the SDK integration is broken — most "nothing shows up" cases are one of those two.
+If a signal never appears, check whether the SDK was actually initialized, then endpoint/protocol, token type/header, rate limit, and quota.
 
 ## Everything else
 
-Deployment, service/database provisioning, environment variables, domains, monitoring config, backups, and CI/CD automation are all reached through the Temps CLI (`bunx @temps-sdk/cli`). Use the **temps-cli** skill for those — this skill only owns the observability pillars above.
+Beyond the runtime health contract and observability guidance above, deployment, service/database provisioning, environment variables, domains, monitoring config, backups, and CI/CD automation are all reached through the Temps CLI (`bunx @temps-sdk/cli`). Use the **temps-cli** skill for those operations.

--- a/skills/temps-best-practices/SKILL.md
+++ b/skills/temps-best-practices/SKILL.md
@@ -13,12 +13,12 @@ Best practices for application code that runs on Temps. This skill owns the **ru
 1. For any deployable application, read [references/runtime-contract.md](references/runtime-contract.md).
 2. When any telemetry or replay is enabled, read [references/telemetry-hygiene.md](references/telemetry-hygiene.md).
 3. Read only the reference for each observability pillar in scope.
-4. Inspect the existing application and `.temps.yaml` before editing. Merge configuration; do not overwrite unrelated keys.
+4. Determine the deployment source. For repository builds, inspect and merge `.temps.yaml`; for image/static deployments, inspect the deployment health-path override because no repository config is available.
 5. Run the runtime and telemetry verification checklists before considering the work complete.
 
 ## Runtime contract summary
 
-Every web application should expose a dedicated readiness endpoint and configure it in `.temps.yaml` under the project's effective Temps Root Directory / Docker build context:
+Every web application should expose a dedicated health endpoint. Repository builds configure it in `.temps.yaml` under the project's effective Temps Root Directory / Docker build context:
 
 ```yaml
 health:
@@ -26,6 +26,8 @@ health:
 ```
 
 Use `health.path`; do not rely on the currently parsed-but-unapplied `status`, `interval`, `timeout`, or `retries` fields. If OpenTelemetry server tracing is enabled, exclude the exact health path from incoming spans and routine access-log/request-metric noise. Keep the route, `.temps.yaml`, and filters synchronized.
+
+Image and static deployments cannot read `.temps.yaml`; set the same route through their deployment `health_check_path` / CLI `--health-check-path` override instead.
 
 Also require the app to read `PORT`, bind to `HOST`/`0.0.0.0`, align a custom image's `EXPOSE`, handle `SIGTERM`, flush telemetry, and exit inside Temps' 10-second shutdown window. See the runtime reference for readiness semantics, scale-to-zero caveats, replicas, migrations, stdout/stderr, and cron authentication.
 
@@ -35,7 +37,6 @@ Temps replaces Sentry + Datadog/Honeycomb + PostHog with one ingestion surface. 
 
 - **add-error-tracking** — step-by-step Sentry SDK init per language/framework
 - **add-react-analytics** — step-by-step `@temps-sdk/react-analytics` hook usage
-- **add-session-recording** — privacy-aware session replay setup and verification
 
 ## Quickstart: wire up any app end to end
 
@@ -105,7 +106,7 @@ Temps OTLP ingestion shares a rate-limit/quota model, but token support differs 
 
 ## Definition of done
 
-1. Runtime: app listens on the injected port/interface; readiness is configured in the effective app root; `SIGTERM` drains and exits within 10 seconds.
+1. Runtime: app listens on the injected port/interface; the health route is configured through `.temps.yaml` for repository builds or the deployment override for image/static deploys; `SIGTERM` drains and exits within 10 seconds.
 2. Health noise: repeated health requests succeed without routine server spans, access logs, or request metrics; a normal route remains observable.
 3. Error tracking: a deliberate test error appears in **Error Tracking → Error Groups** with the expected release and no sensitive data.
 4. Traces: a normal request appears in **Observe → Traces**, uses a route-template name, propagates context downstream, and has a sane `duration_ms`.

--- a/skills/temps-best-practices/evals/evals.json
+++ b/skills/temps-best-practices/evals/evals.json
@@ -1,0 +1,45 @@
+{
+  "skill_name": "temps-best-practices",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I have an Express app that currently calls app.listen(3000). It is deployed on Temps with a custom Dockerfile, and OpenTelemetry Node auto-instrumentation is enabled. Prepare it for production on Temps. Show the concrete configuration/code changes and a verification checklist.",
+      "expected_output": "A production-ready plan/code sketch that covers the complete Temps runtime and telemetry contract without exposing credentials.",
+      "files": [],
+      "expectations": [
+        "Creates or merges .temps.yaml in the effective app root with only health.path for the dedicated readiness route.",
+        "Explains that the exact incoming health path must be ignored by OpenTelemetry server instrumentation while a normal route remains traced.",
+        "Requires the app to read PORT, bind to HOST or 0.0.0.0, and align the custom Docker image EXPOSE value.",
+        "Handles SIGTERM by stopping new work, draining, flushing or shutting down telemetry, and exiting within Temps' 10-second window.",
+        "Addresses readiness semantics, bounded telemetry attributes, sensitive-data filtering, and concrete runtime verification."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Our monorepo has a Next.js app under apps/web, and Temps Root Directory is apps/web. apps/web/.temps.yaml already contains build and cron keys. We use @vercel/otel and want to add session replay. What exactly should we change, and what privacy/security checks should block release?",
+      "expected_output": "A merge-safe Next.js plan that places health configuration correctly, distinguishes incoming health suppression from outbound fetch filtering, and gives enforceable replay/privacy release criteria.",
+      "files": [],
+      "expectations": [
+        "Preserves existing build and cron keys and places health.path in apps/web/.temps.yaml, not blindly at repository root.",
+        "States that @vercel/otel outbound fetch ignore configuration does not prove incoming health requests are excluded from server spans.",
+        "Requires a dedicated readiness route and keeps its path synchronized with .temps.yaml and the incoming-request filter.",
+        "Keeps deployment or API tokens and OTEL_EXPORTER_OTLP_HEADERS out of NEXT_PUBLIC variables and browser bundles.",
+        "Requires replay to be default-off until consent, masks sensitive inputs/content, excludes sensitive paths, and verifies the recorder's actual state with synthetic sensitive data.",
+        "Requires CRON_SECRET bearer validation for cron routes and preserves unrelated cron configuration."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "I want to export OTLP traces directly from our React browser app using the Temps deployment token, and use browser analytics purchase events as the source of truth for billing. Give me the recommended implementation.",
+      "expected_output": "A secure correction that rejects both unsafe premises and replaces them with server-authoritative designs.",
+      "files": [],
+      "expectations": [
+        "Explicitly refuses to embed dt_, tk_, TEMPS_API_TOKEN, or OTEL authorization headers in browser code or public-prefixed environment variables.",
+        "Routes browser telemetry through an authenticated backend or controlled collector with validation, rate limiting, and server-side Temps credentials.",
+        "Treats public browser analytics as untrusted attribution data rather than proof of a purchase or billing authority.",
+        "Records authoritative purchase state in authenticated server code and optionally emits analytics only after the transaction succeeds.",
+        "Includes practical verification that production client bundles contain no machine credentials and that spoofed analytics events cannot affect billing."
+      ]
+    }
+  ]
+}

--- a/skills/temps-best-practices/references/analytics.md
+++ b/skills/temps-best-practices/references/analytics.md
@@ -64,7 +64,7 @@ Treat public browser analytics as untrusted input:
 
 - Never drive billing, authorization, entitlements, inventory, or authoritative revenue from `/api/_temps/event`.
 - Send conversion-critical events from authenticated server code after the business transaction commits.
-- Add a stable business-event identifier when retries can create duplicates.
+- Deduplicate in application business storage or an outbox before calling Temps when retries can create duplicates. Temps does not enforce idempotency from an identifier placed in `event_data`.
 - Validate event names and allowlist bounded properties server-side for authoritative events.
 
 ## Quickstart: send analytics from any language
@@ -103,13 +103,15 @@ Do not place secrets, emails, raw identifiers, payment data, or sensitive URL qu
 
 ## Session replay acceptance criteria
 
-Use the dedicated **add-session-recording** skill, but do not enable replay until all of these hold:
+Do not enable replay until all of these hold:
 
 - Recording is off until the required consent exists.
 - `maskAllInputs` is enabled.
 - Authentication, payment, medical, account, admin, and secrets-management routes/elements are blocked or masked.
 - The recorder that is actually mounted responds to consent changes; a separate control-hook state is not sufficient evidence.
 - A replay containing synthetic sensitive values has been inspected in Temps and the values are absent.
+
+Do not treat the current standalone `useSessionRecordingControl` hook as the consent boundary: it owns state independently from the mounted recorder. Consent must mount/start and stop/unmount the actual recording provider until the SDK exposes one shared control path.
 
 ## Gotchas
 

--- a/skills/temps-best-practices/references/analytics.md
+++ b/skills/temps-best-practices/references/analytics.md
@@ -55,8 +55,17 @@ There is no `project_id` field — the project is resolved server-side from the 
 
 ## Auth
 
-- `/api/_temps/event` is intentionally public/unauthenticated — gated by Host-header project resolution, not a token. Don't add auth headers to it; there's nothing to check.
+- `/api/_temps/event` is intentionally public/unauthenticated. Host-header project resolution attributes an event to a project; it does not prove the event came from a genuine browser/user.
 - `/api/projects/{project_id}/events/ingest` requires a bearer token (session cookie, `tk_` API key, or `dt_` deployment token — all three work) with `AnalyticsWrite` permission scoped to that project. A token bound to a different project is rejected.
+
+### Trust boundary
+
+Treat public browser analytics as untrusted input:
+
+- Never drive billing, authorization, entitlements, inventory, or authoritative revenue from `/api/_temps/event`.
+- Send conversion-critical events from authenticated server code after the business transaction commits.
+- Add a stable business-event identifier when retries can create duplicates.
+- Validate event names and allowlist bounded properties server-side for authoritative events.
 
 ## Quickstart: send analytics from any language
 
@@ -76,11 +85,15 @@ curl -X POST "$TEMPS_API_URL/projects/$TEMPS_PROJECT_ID/events/ingest" \
   }'
 ```
 
+`TEMPS_API_TOKEN` is currently a non-expiring deployment token with broad permissions, not an analytics-only key. Keep it server-side, never log or forward it, and never reuse it in browser code. Prefer a separately managed, purpose-scoped credential when the endpoint and deployment workflow support one; otherwise limit this call site and rotate the deployment credential after suspected exposure.
+
 The equivalent in any language is just an authenticated JSON POST — Python (`requests.post(...)`), Go (`net/http` + `encoding/json`), Ruby (`Net::HTTP` or `httparty`), PHP (`curl_init`/Guzzle), Java (`HttpClient`), .NET (`HttpClient`), Rust (`reqwest`): no client library is needed because this is a plain REST call, not a protocol requiring a purpose-built SDK.
 
 `environment_id`/`deployment_id`/`project_id` are **not** currently among the auto-injected env vars (unlike `TEMPS_API_URL`/`TEMPS_API_TOKEN`) — read them from the Temps dashboard (**Project Settings**) or from whatever IDs your deployment automation already has on hand, and set them yourself (e.g. as regular env vars) if a backend needs to call this endpoint repeatedly.
 
 For browser-side tracking in a non-React frontend (vanilla JS, Vue, Svelte, a mobile app's WebView), POST directly to `/api/_temps/event` with `fetch`/`XMLHttpRequest`/equivalent using the `EventMetricsPayload` shape above — no auth needed, but it only resolves a project when the request's `Host` matches a routed deployment domain, so this only works called from code actually running on/against the deployed app's own origin.
+
+Do not place secrets, emails, raw identifiers, payment data, or sensitive URL query values in `event_data`, `request_query`, URLs, or referrers. The endpoint stores application-provided event data; see [telemetry-hygiene.md](telemetry-hygiene.md).
 
 ## What belongs here vs. other pillars
 
@@ -88,8 +101,20 @@ For browser-side tracking in a non-React frontend (vanilla JS, Vue, Svelte, a mo
 - Session replay is bundled under analytics (`SessionRecordingProvider` in the React SDK), separate from error-tracking's replay-on-error integration — the two are independent capture paths even though both are called "replay."
 - Don't route business events through OTEL logs or traces — analytics has its own dashboard, retention, and ClickHouse fan-out tuned for high-volume event data; OTEL logs/traces are not.
 
+## Session replay acceptance criteria
+
+Use the dedicated **add-session-recording** skill, but do not enable replay until all of these hold:
+
+- Recording is off until the required consent exists.
+- `maskAllInputs` is enabled.
+- Authentication, payment, medical, account, admin, and secrets-management routes/elements are blocked or masked.
+- The recorder that is actually mounted responds to consent changes; a separate control-hook state is not sufficient evidence.
+- A replay containing synthetic sensitive values has been inspected in Temps and the values are absent.
+
 ## Gotchas
 
 - **Browser events not appearing**: check the Network tab for calls to `/api/_temps/event` first — if the request never fires, it's a client wiring issue (provider not mounted, `basePath` misconfigured), not a server-side ingestion problem. If it fires but 404s, the request's Host header doesn't match a routed deployment.
 - **Server-side events silently rejected**: `/api/projects/{project_id}/events/ingest` requires real auth with `AnalyticsWrite` permission — a missing/expired token, or a token scoped to a different project, returns an auth error, unlike the public beacon endpoint.
 - **ClickHouse-backed views lagging**: events land in the Postgres outbox immediately but ClickHouse fan-out is asynchronous via a background worker — a just-fired event may take a few seconds to appear in ClickHouse-backed dashboard views even though it's already durably recorded.
+- **Public event totals disagree with revenue/orders**: expected if the browser endpoint was blocked, retried, or forged. Use authenticated backend events as the authoritative source.
+- **Consent UI says replay is off but events still arrive**: verify the mounted recorder and the consent control share the same state; do not rely on UI state alone.

--- a/skills/temps-best-practices/references/error-tracking.md
+++ b/skills/temps-best-practices/references/error-tracking.md
@@ -16,6 +16,8 @@ https://<public_key>@<temps-host>/<project_id>
 
 The `public_key` is per-project and derived from the DB; the `secret_key` (if any) is never exposed in API responses.
 
+The DSN public key is intentionally safe for browser write-only ingestion. It is not equivalent to a `dt_` deployment token or `tk_` API key, which are server-only machine credentials.
+
 ## Release auto-injection
 
 Temps also auto-injects `SENTRY_RELEASE` (the deployment's commit SHA) alongside `SENTRY_DSN` for apps deployed through Temps (`workflow_planner.rs:1066-1070,1895-1920`) — every official Sentry SDK reads `SENTRY_RELEASE` from the environment when `release` isn't explicitly set in `Sentry.init()`, tagging events with the correct release automatically. **Don't hardcode a `release` value in `Sentry.init()`** — doing so overrides the injected value and breaks the dashboard's ability to join a stack frame back to its source (**Error Tracking → Source Context**). Leave `release` unset and let the SDK pick up `SENTRY_RELEASE` on its own.
@@ -45,6 +47,18 @@ Any of these are accepted, in priority order:
 - Request body: 2 MiB compressed, 10 MiB decompressed (`SENTRY_INGEST_BODY_LIMIT`) — guards against decompression bombs.
 - gzip `Content-Encoding` is supported and decoded with a size guard.
 
+## Sensitive data
+
+Temps stores the event the SDK sends, so scrub it before export:
+
+- Keep legacy `sendDefaultPii` false/undefined, or use the SDK's current granular `dataCollection` allow/deny configuration.
+- Do not collect authorization/cookie headers, HTTP bodies, sensitive query parameters, database parameter values, passwords, tokens, payment data, or raw GenAI inputs/outputs by default.
+- Use `beforeSend` (or the language SDK's equivalent event processor) to remove unsafe request, user, breadcrumb, context, and extra fields after integrations have populated the event.
+- Prefer allowlisting required fields. Returning `null` from `beforeSend` should drop an event that cannot be made safe.
+- Test with synthetic canary secrets and inspect the stored event in Temps.
+
+See [telemetry-hygiene.md](telemetry-hygiene.md) for the cross-pillar policy.
+
 ## Response shape
 
 - Store/Envelope: `{"id": "<event_uuid>"}`, HTTP 200
@@ -56,3 +70,4 @@ Any of these are accepted, in priority order:
 - **Browser apps not reporting**: the DSN env var needs the bundler's public prefix (`NEXT_PUBLIC_`, `VITE_`, `PUBLIC_`) to reach the client bundle; a plain `SENTRY_DSN` won't be inlined into browser code.
 - **Minified stack traces**: upload source maps via `sentry-cli sourcemaps upload` in CI, or through **Error Tracking → Source Maps** in the dashboard — the release version passed to the SDK must match the release the source maps were uploaded under.
 - **Production events missing but local ones work**: the deployment's env vars are separate from local `.env` files — confirm the DSN is actually set in the deployed environment, not just locally.
+- **Unexpected PII**: inspect the SDK's resolved data-collection settings and the post-integration `beforeSend` event; initializing the SDK with defaults does not prove application-added extras/breadcrumbs are safe.

--- a/skills/temps-best-practices/references/logs.md
+++ b/skills/temps-best-practices/references/logs.md
@@ -19,6 +19,17 @@ Standard `ExportLogsServiceRequest` protobuf: `SeverityNumber`, `Body`, `Attribu
 
 **Always set `trace_id`/`span_id` on log records emitted from within a traced request** — this is what lets the Temps dashboard join a log line to the trace it happened during. Without it, the log is stored but orphaned from any trace context.
 
+Application stdout/stderr is captured as container logs. Use OTLP logs when structured severity, attributes, and trace correlation are required; do not write production logs only to container-local files.
+
+## Sensitive data and cardinality
+
+Temps stores log bodies and attributes supplied by the exporter. Apply [telemetry-hygiene.md](telemetry-hygiene.md):
+
+- Never log authorization/cookie headers, passwords, tokens, private keys, connection strings, payment data, raw bodies, or unredacted GenAI prompts/completions.
+- Prefer structured allowlisted fields over serializing entire request/user objects.
+- Keep attribute keys stable and values bounded. Do not turn user/session/request IDs, UUIDs, emails, raw queries, or stack traces into indexed dimensions.
+- Redact in the logger/OTel processor before export, then verify with synthetic canary secrets.
+
 ## Storage and retention
 
 - WARN/ERROR/FATAL-severity logs are stored in the primary time-series store (TimescaleDB/ClickHouse depending on backend config) for querying in the dashboard.
@@ -29,3 +40,4 @@ Standard `ExportLogsServiceRequest` protobuf: `SeverityNumber`, `Body`, `Attribu
 - **Low-severity logs not visible in dashboard queries**: only WARN+ severity is guaranteed to be in the queryable store by default; INFO/DEBUG logs may only exist in S3 archive if configured, otherwise they may not be retained at all. Don't rely on DEBUG-level logs being queryable in the dashboard unless S3 archival is set up.
 - **Logs not correlating with traces**: verify `trace_id`/`span_id` are actually populated on the log record — most OTel logging bridges only auto-populate these when the log call happens inside an active span context (e.g., inside a request handler wrapped by the tracing middleware), not from a background job with no active span.
 - **Use logs for structured record-keeping, not exception capture** — an uncaught exception belongs in error tracking (see [error-tracking.md](error-tracking.md)), not as an ERROR-level log line; you lose stack-trace grouping, source maps, and error-group deduplication if you only log it.
+- **Shutdown loses the last logs**: batch log processors buffer records. Flush/shut down the provider during `SIGTERM` within Temps' runtime deadline.

--- a/skills/temps-best-practices/references/metrics.md
+++ b/skills/temps-best-practices/references/metrics.md
@@ -9,7 +9,7 @@ Routes are registered as `/otel/v1/metrics` inside the crate, but the console se
 - Header-based: `POST /api/otel/v1/metrics`
 - Path-based: `POST /api/otel/v1/{project_id}/{environment_id}/{deployment_id}/metrics`
 
-Same auth (`Authorization: Bearer <tk_|dt_|si_ token>` or `X-Temps-Api-Key`), same rate limit (1000 req/60s/token) and opt-in quota as traces/logs — see the shared-facts section in the top-level SKILL.md.
+Metrics use the same header forms (`Authorization: Bearer <token>` or `X-Temps-Api-Key`), rate limit (1000 req/60s/token), and opt-in quota as traces/logs. Token scope differs: `tk_` and `dt_` are server credentials used across application OTLP signals, while `si_` is accepted only for infrastructure metrics and must not be used for traces or logs. See the shared-facts section in the top-level SKILL.md.
 
 Implemented in `temps-otel` crate: `src/handlers/ingest_handler.rs`; validation in `temps-metrics` crate: `src/store/timescale.rs`.
 
@@ -24,6 +24,8 @@ This is **not** a curated allowlist like Prometheus recording rules — any name
 - Max 64 labels per data point (`MAX_LABELS_PER_POINT`).
 - Max 1024 bytes per label key or value.
 - Any label whose key starts with `temps.` is silently stripped before storage — this namespace is reserved for Temps' own internal routing attributes, so don't rely on setting `temps.*` labels from app code; they will not persist.
+- Use a small allowlist of bounded dimensions. Never use user IDs, session IDs, request IDs, UUIDs, emails, raw URLs/queries, or error messages as labels.
+- For HTTP metrics, use route templates such as `/users/:id`, not raw request paths.
 
 ## Storage split
 
@@ -35,3 +37,5 @@ This is **not** a curated allowlist like Prometheus recording rules — any name
 - **Metric silently missing, no error**: check the name against the character-set regex first — invalid names fail closed with only a server-side warning log, no error surfaced to the exporter.
 - **Custom label not showing up**: confirm it doesn't start with `temps.` — those are dropped by design, not a bug.
 - **High-cardinality metric spiking storage**: cardinality isn't capped by a distinct-value allowlist, only by per-point label count/size — a metric with a label like `user_id` can still blow up cardinality. Prefer bucketing or dropping high-cardinality labels client-side before export rather than relying on server-side protection.
+
+See [telemetry-hygiene.md](telemetry-hygiene.md) for cross-pillar naming, sampling, and sensitive-data rules.

--- a/skills/temps-best-practices/references/opentelemetry-traces.md
+++ b/skills/temps-best-practices/references/opentelemetry-traces.md
@@ -1,8 +1,21 @@
 # OpenTelemetry Traces
 
-Temps ingests standard OTLP/HTTP (protobuf) trace exports — any language's OpenTelemetry SDK works unmodified, there is no Temps-specific tracing SDK. Point the standard OTLP exporter env vars at Temps instead of hand-writing requests.
+Temps ingests standard OTLP/HTTP (protobuf) trace exports. There is no Temps-specific tracing SDK: install and initialize the official OpenTelemetry SDK for the application's language, then point its standard exporter variables at Temps.
 
-**Apps deployed on Temps get this for free, no configuration needed by the user**: every deployment automatically has `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_SERVICE_NAME`, and `OTEL_SERVICE_VERSION` injected — at both Docker build time (`--build-arg`) and container runtime (`-e`), so this is available however the app's OTEL SDK reads it. Never hardcode these values or ask the user for a token/endpoint to hardcode; if they're missing on a running deployment, that's a platform bug, not something to work around manually. See the top-level [SKILL.md](../SKILL.md) quickstart for the exact injection mechanism and its scope (apps deployed *through* Temps only — not Temps' own console, and not apps hosted elsewhere). The manual config below is for apps sending telemetry to a self-hosted Temps instance from outside the platform.
+Apps deployed on Temps receive `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_SERVICE_NAME`, and `OTEL_SERVICE_VERSION`. This configures export only—it does not install instrumentation, choose production sampling, filter health traffic, propagate context, or flush on shutdown. `OTEL_EXPORTER_OTLP_HEADERS` contains a live deployment token and is server-only.
+
+## Contents
+
+- [Endpoints](#endpoints)
+- [Standard OTLP exporter config](#standard-otlp-exporter-config)
+- [Required: exclude the health-check path](#required-exclude-the-health-check-path)
+- [Production baseline](#production-baseline)
+- [Quickstart: instrument any language](#quickstart-instrument-any-language)
+- [Auth](#auth)
+- [Rate limits and quota](#rate-limits-and-quota)
+- [Storage](#storage)
+- [Critical gotcha: trace duration units](#critical-gotcha-trace-duration-units)
+- [Gotchas](#gotchas)
 
 ## Endpoints
 
@@ -23,7 +36,7 @@ OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer%20<dt_or_tk_token>
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 ```
 
-Most OTLP SDKs auto-append `/v1/traces` (or `/v1/metrics`, `/v1/logs`) to `OTEL_EXPORTER_OTLP_ENDPOINT`, landing on the path above. This is exactly the value Temps auto-injects into every deployment (`{TEMPS_API_URL}/otel`, i.e. `{base_url}/api/otel` — see `temps-deployments::workflow_planner::gather_environment_variables`, `crates/temps-deployments/src/services/workflow_planner.rs:448-452`).
+Most OTLP SDKs auto-append `/v1/traces` (or `/v1/metrics`, `/v1/logs`) to `OTEL_EXPORTER_OTLP_ENDPOINT`, landing on the path above.
 
 For `tk_` tokens (not project-scoped by default), also set:
 
@@ -31,9 +44,92 @@ For `tk_` tokens (not project-scoped by default), also set:
 OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer%20<tk_token>,X-Temps-Project-Id=<project_id>
 ```
 
-`dt_` (deployment token) and `si_` tokens are already project/environment/deployment-scoped and don't need the project-id header.
+`dt_` deployment tokens don't need the project-id header. `si_` integration tokens are for infrastructure metrics ingestion; do not use them for application traces or logs.
 
 **Always set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` explicitly.** Several official SDKs (Node, Python, Java, .NET) default their generic OTLP exporter to gRPC — Temps only accepts OTLP/HTTP with a protobuf body, so a gRPC export will silently fail to connect rather than fall back.
+
+## Required: exclude the health-check path
+
+OpenTelemetry server tracing is not complete until the path configured in the effective app root's `.temps.yaml` is excluded from incoming-request instrumentation:
+
+```yaml
+health:
+  path: /healthz
+```
+
+Filter the exact URL pathname before its server span is created or exported. Do not assume the generic `OTEL_EXPORTER_OTLP_*` variables do this: they configure export, not request filtering, and OTel does not define one cross-language health-path exclusion variable. Use the current request-ignore mechanism provided by the app's language/framework instrumentation.
+
+For Node.js auto-instrumentation, use the HTTP instrumentation's `ignoreIncomingRequestHook`. The zero-code `@opentelemetry/auto-instrumentations-node/register` preload cannot accept programmatic instrumentation options, so use a small preload file when health filtering is required:
+
+```bash
+npm install @opentelemetry/sdk-node \
+  @opentelemetry/exporter-trace-otlp-proto \
+  @opentelemetry/auto-instrumentations-node
+```
+
+```js
+// tracing.cjs — load before the application
+const { NodeSDK } = require('@opentelemetry/sdk-node');
+const {
+  OTLPTraceExporter,
+} = require('@opentelemetry/exporter-trace-otlp-proto');
+const {
+  getNodeAutoInstrumentations,
+} = require('@opentelemetry/auto-instrumentations-node');
+
+const HEALTH_PATH = '/healthz'; // must match .temps.yaml health.path
+
+const sdk = new NodeSDK({
+  traceExporter: new OTLPTraceExporter(), // reads OTEL_EXPORTER_OTLP_* env vars
+  instrumentations: [
+    getNodeAutoInstrumentations({
+      '@opentelemetry/instrumentation-http': {
+        ignoreIncomingRequestHook(request) {
+          const pathname = new URL(
+            request.url || '/',
+            'http://localhost',
+          ).pathname;
+          return pathname === HEALTH_PATH;
+        },
+      },
+    }),
+  ],
+});
+
+sdk.start();
+
+process.once('SIGTERM', async () => {
+  await sdk.shutdown(); // compose with the app's request/DB shutdown path
+});
+```
+
+Start with `NODE_OPTIONS="--require ./tracing.cjs"` or `node --require ./tracing.cjs app.js`.
+
+Framework wrappers may expose different filters. Confirm that the option applies to **incoming server requests**; an outbound `fetch` ignore list does not suppress the server span created when Temps calls the app. If the wrapper cannot filter incoming requests, use its supported sampler/span-processor approach or a configurable SDK bootstrap, and verify the result rather than assuming the route is ignored.
+
+Verification is behavioral: call the health route several times and confirm no corresponding server spans appear in **Observe → Traces**, then call a normal route and confirm that its span still appears. If either side fails, the exclusion is too narrow or too broad.
+
+The scale-to-zero wake probe currently calls `/` independently of `.temps.yaml`. Do not exclude `/` to hide those spans because that would also hide legitimate root-route traffic. See [runtime-contract.md](runtime-contract.md).
+
+## Production baseline
+
+Apply [telemetry-hygiene.md](telemetry-hygiene.md) before enabling production export:
+
+- Use a batch span processor with a bounded queue and export timeout.
+- Choose an environment-appropriate parent-based trace-id-ratio sampler rather than assuming 100% collection is affordable:
+
+  ```bash
+  OTEL_TRACES_SAMPLER=parentbased_traceidratio
+  OTEL_TRACES_SAMPLER_ARG=0.05
+  ```
+
+  `0.05` is an example. Base the real ratio on traffic volume and debugging needs.
+- Exclude health checks, static assets, and low-value middleware/socket spans at the source.
+- Use route-template span names and drop high-cardinality attributes.
+- Extract inbound and inject outbound W3C `traceparent`/`tracestate`. Temps configures export; application instrumentation remains responsible for propagation.
+- Preserve parent sampling decisions across services.
+- Flush/shut down the provider during `SIGTERM` inside Temps' 10-second container stop window.
+- Never put raw tokens, authorization/cookie headers, request bodies, sensitive query values, or unredacted GenAI prompts/completions in spans.
 
 ## Quickstart: instrument any language
 
@@ -41,7 +137,7 @@ Every OpenTelemetry SDK reads the three env vars above and needs no Temps-specif
 
 ### Node.js (and Next.js server/API routes)
 
-Zero-code, via the OpenTelemetry auto-instrumentation agent — no source changes:
+For a quick local smoke test, the zero-code OpenTelemetry auto-instrumentation agent needs no source changes:
 
 ```bash
 npm install --save-dev @opentelemetry/auto-instrumentations-node
@@ -49,6 +145,8 @@ node --require @opentelemetry/auto-instrumentations-node/register app.js
 ```
 
 Or set `NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/register"` in the deployment env so it applies without changing the start command.
+
+For a Temps deployment, replace this zero-code preload with the configurable `tracing.cjs` bootstrap above so the `.temps.yaml` health path is excluded.
 
 For Next.js specifically, use the built-in `instrumentation.ts` hook instead:
 
@@ -66,6 +164,8 @@ export function register() {
 ```
 
 `@vercel/otel` reads the same `OTEL_EXPORTER_OTLP_*` env vars — no Temps-specific config needed.
+
+`instrumentationConfig.fetch.ignoreUrls` controls outbound fetch instrumentation; it does not prove the incoming Next.js health request is suppressed. Use the wrapper/version's supported incoming-span filter or a custom processor/bootstrap and verify behavior in Temps. Do not mark the integration complete merely because `/healthz` appears in an outbound ignore list.
 
 **Critical gotcha if the app also uses `@sentry/nextjs`**: Sentry's Next.js SDK registers its own global `TracerProvider`/`ContextManager` by default. If `Sentry.init()` runs before `registerOTel()` — which it normally does, since Sentry's config files load ahead of `instrumentation.ts`'s `register()` — every span becomes non-recording and **traces silently stop reaching Temps with no error anywhere**. Fix by passing `skipOpenTelemetrySetup: true` to `Sentry.init()` in `sentry.server.config.ts` (and `sentry.edge.config.ts` if used) so `@vercel/otel` remains the sole tracer provider:
 
@@ -212,45 +312,29 @@ builder.Services.AddOpenTelemetry()
 
 ### Browser (React, Vue, Svelte, Angular)
 
-Traces from browser code use the OpenTelemetry Web SDK — the same packages work regardless of frontend framework, since instrumentation is framework-agnostic:
+Do not export browser traces directly to Temps with a `dt_`/`tk_` bearer token. Those are live server credentials, and putting one in JavaScript or a public build-time variable exposes it to every visitor. Temps' OTLP routes are not a public browser-ingest surface.
 
-```bash
-npm install @opentelemetry/sdk-trace-web @opentelemetry/exporter-trace-otlp-http @opentelemetry/instrumentation-fetch
-```
+If browser tracing is required:
 
-```ts
-// src/otel.ts — import this first in your app entrypoint
-import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
-import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
-import { registerInstrumentations } from '@opentelemetry/instrumentation';
+1. Collect with the OpenTelemetry Web SDK.
+2. Send to a same-origin application backend or trusted collector.
+3. Validate and rate-limit the public request there.
+4. Add the Temps OTLP credential only on the server-side hop.
 
-const provider = new WebTracerProvider({
-  spanProcessors: [
-    new BatchSpanProcessor(
-      new OTLPTraceExporter({
-        url: 'https://<temps-host>/api/otel/v1/traces',
-        headers: { Authorization: 'Bearer <dt_or_tk_token>' },
-      })
-    ),
-  ],
-});
-provider.register();
-registerInstrumentations({ instrumentations: [new FetchInstrumentation()] });
-```
-
-Browser exporters can't read process env vars, so the endpoint/headers must be passed explicitly in code (via a build-time env var like other bundler-injected config, not hardcoded) rather than through `OTEL_EXPORTER_OTLP_*`.
+For most browser applications, use Temps analytics/Web Vitals plus Sentry-compatible error tracking and keep full OTLP export on the server. See [telemetry-hygiene.md](telemetry-hygiene.md).
 
 ### React Native / Flutter
 
-Mobile OpenTelemetry SDKs are less mature than the backend/browser ecosystem and package availability changes — check the [OpenTelemetry registry](https://opentelemetry.io/ecosystem/registry/) for the current state before committing to one. For most apps it's more reliable to send mobile telemetry through your own backend (which is already instrumented per above) rather than exporting OTLP directly from the device. Error tracking is the more mature signal for mobile — see [add-error-tracking](../../add-error-tracking/SKILL.md), which has dedicated React Native and Flutter setup.
+Never embed a Temps `dt_`/`tk_` token in a mobile binary. Send mobile telemetry through an authenticated application backend/collector. Error tracking is the more mature direct-device signal — see [add-error-tracking](../../add-error-tracking/SKILL.md).
 
 ## Auth
 
-- `Authorization: Bearer <token>` (percent-encoded `Bearer%20<token>` is also accepted — some OTLP exporters encode headers that way)
-- `X-Temps-Api-Key: <token>` as an alternative to the `Authorization` header
-- `X-Temps-Project-Id: <id>` — required alongside `tk_` tokens, optional/ignored for `dt_`/`si_`
+- `Authorization: Bearer <token>` (Temps also accepts literal `Bearer%20<token>` produced by some exporters)
+- `X-Temps-Api-Key: <token>` as an alternative
+- `X-Temps-Project-Id: <id>` — required with `tk_`; unnecessary with `dt_`
+- `si_` — infrastructure metrics only, not application traces/logs
+
+Prefer the header-based endpoint with a `dt_` so Temps resolves project/environment/deployment attribution from authentication. Do not expose machine tokens to untrusted clients.
 
 ## Rate limits and quota
 

--- a/skills/temps-best-practices/references/opentelemetry-traces.md
+++ b/skills/temps-best-practices/references/opentelemetry-traces.md
@@ -59,10 +59,10 @@ health:
 
 Filter the exact URL pathname before its server span is created or exported. Do not assume the generic `OTEL_EXPORTER_OTLP_*` variables do this: they configure export, not request filtering, and OTel does not define one cross-language health-path exclusion variable. Use the current request-ignore mechanism provided by the app's language/framework instrumentation.
 
-For Node.js auto-instrumentation, use the HTTP instrumentation's `ignoreIncomingRequestHook`. The zero-code `@opentelemetry/auto-instrumentations-node/register` preload cannot accept programmatic instrumentation options, so use a small preload file when health filtering is required:
+For Node.js auto-instrumentation, use the HTTP instrumentation's `ignoreIncomingRequestHook`. The zero-code `@opentelemetry/auto-instrumentations-node/register` preload cannot accept programmatic instrumentation options, so use a small preload file when health filtering is required. Add dependencies through the application's reviewed dependency workflow, commit the lockfile, and use exact versions; disable lifecycle scripts where compatible:
 
 ```bash
-npm install @opentelemetry/sdk-node \
+npm install --ignore-scripts --save-exact @opentelemetry/sdk-node \
   @opentelemetry/exporter-trace-otlp-proto \
   @opentelemetry/auto-instrumentations-node
 ```

--- a/skills/temps-best-practices/references/runtime-contract.md
+++ b/skills/temps-best-practices/references/runtime-contract.md
@@ -2,9 +2,9 @@
 
 Read this file whenever preparing or reviewing an application that will run on Temps. It owns application behavior; use `temps-cli` for the commands that create projects, deploy images, or manage resources.
 
-## Effective application root
+## Deployment source and effective application root
 
-Place `.temps.yaml` in the application's effective Temps **Root Directory / Docker build context**. That is the repository root for a single-app repository, but it is usually an app subdirectory in a monorepo:
+For a repository build, place `.temps.yaml` in the application's effective Temps **Root Directory / Docker build context**. That is the repository root for a single-app repository, but it is usually an app subdirectory in a monorepo:
 
 ```text
 repository/
@@ -20,7 +20,9 @@ If the Temps project Root Directory is `apps/api`, the health configuration belo
 
 Merge known keys instead of replacing the file. Preserve existing `build`, `cron`, `env`, `agents`, `workflows`, `sourceContext`, and health settings.
 
-## Health is readiness
+Image and static deployments do not have repository contents from which Temps can read `.temps.yaml`. Configure their health route through the deployment request's `health_check_path` or the CLI `--health-check-path` option.
+
+## Deployment health
 
 Create a dedicated unauthenticated `GET` endpoint such as `/healthz` and configure it:
 
@@ -33,19 +35,19 @@ Current implementation facts:
 
 - `health.path` is the only `.temps.yaml` health field that reliably changes deployment and monitor behavior today.
 - Do not add or rely on `health.status`, `health.interval`, `health.timeout`, or `health.retries` until their runtime consumers are implemented.
-- A deploy-time `--health-check-path` override wins over `.temps.yaml`; avoid passing it unless the divergence is intentional.
+- A deploy-time `--health-check-path` override wins over `.temps.yaml`. Avoid an accidental override for repository builds; supply it deliberately for image/static deployments.
 - Temps configuration parsing does not reject every unknown key, and an unreadable/invalid file can be treated as absent. Verify the deployment log names the intended health path and confirm the environment's uptime monitor uses it.
 
-The endpoint gates traffic, so it is a readiness check:
+Temps uses the endpoint for deployment health and monitoring. It is not a continuous live-traffic gate, so returning `503` does not by itself remove a running container from routing:
 
 - Return `200` only when the process can serve normal requests.
-- Return `503` while starting, draining, or missing a dependency required by most requests.
+- Return `503` while starting or missing a dependency required by most requests. It may also describe a draining process while the endpoint remains reachable, but do not rely on that response to stop new traffic.
 - Check only essential dependencies, use short timeouts, and never mutate state.
 - Return a constant minimal body such as `{"status":"ok"}`. Do not expose hostnames, versions, commit SHAs, dependency errors, configuration, or secrets.
 
 Temps is permissive about some non-5xx responses during probing, so an explicit `200` is important: it prevents a typo that returns `404` from looking intentionally healthy.
 
-For OpenTelemetry-enabled applications, exclude the exact `health.path` from incoming server spans. Suppress routine health requests from access logs and request metrics where the framework supports it. Keep the application route, `.temps.yaml`, and filters synchronized.
+For OpenTelemetry-enabled applications, exclude the exact configured health path from incoming server spans. Suppress routine health requests from access logs and request metrics where the framework supports it. Keep the application route, repository `.temps.yaml` or deployment override, and filters synchronized.
 
 ### Scale-to-zero caveat
 
@@ -65,12 +67,11 @@ Temps injects `HOST=0.0.0.0` and `PORT`. The application must:
 
 Temps stops containers with the normal termination signal and a 10-second grace period. On `SIGTERM`:
 
-1. Mark readiness unavailable so new work stops arriving.
-2. Stop accepting new requests and jobs.
-3. Let in-flight requests finish within a bounded deadline.
-4. Close database, queue, and cache clients.
-5. flush and shut down OpenTelemetry processors/exporters.
-6. Exit successfully before the 10-second deadline.
+1. Stop accepting new requests and jobs; do not assume a health-response change removes the container from routing.
+2. Let in-flight requests finish within a bounded deadline.
+3. Close database, queue, and cache clients.
+4. Flush and shut down OpenTelemetry processors/exporters.
+5. Exit successfully before the 10-second deadline.
 
 Use an exec-form container command, or `exec` from an entrypoint script, so the application receives signals directly.
 
@@ -98,7 +99,7 @@ Do not depend on in-memory sessions, local uploads, or a single process receivin
 
 Write application logs to stdout/stderr so Temps can capture them. Use OTLP logs when structured trace correlation is required; do not depend on container-local log files.
 
-If `.temps.yaml` defines `cron` routes, validate `Authorization: Bearer <CRON_SECRET>` in every handler and fail closed when either the environment value or header is missing or malformed. Keep handlers idempotent and return a non-success response when authentication or work fails.
+If `.temps.yaml` defines `cron` routes, validate `Authorization: Bearer <CRON_SECRET>` in every handler and fail closed when either the environment value or header is missing or malformed. Use a vetted constant-time comparison helper that safely handles unequal lengths. Keep handlers idempotent and return a non-success response when authentication or work fails.
 
 Treat `CRON_SECRET` as a high-impact server credential: Temps currently supplies the deployment token, which is non-expiring and broadly scoped. Compare the presented value without echoing it, never record the authorization header in logs/traces/errors, and rotate the deployment credential after suspected exposure.
 
@@ -107,8 +108,8 @@ Treat `CRON_SECRET` as a high-impact server credential: Temps currently supplies
 Before considering the app deployable:
 
 1. Confirm the server listens on the injected `PORT` on `0.0.0.0`.
-2. Confirm `.temps.yaml` is in the effective application root and the deploy log uses its `health.path`.
-3. Confirm readiness returns `200`, returns no sensitive details, and produces no routine trace/log/metric noise.
+2. Confirm a repository build reads `.temps.yaml` from the effective application root, or an image/static deployment receives the intended health-path override; verify the deploy log uses that path.
+3. Confirm the health route returns `200`, returns no sensitive details, and produces no routine trace/log/metric noise.
 4. Send `SIGTERM`; confirm the process drains, flushes telemetry, and exits within 10 seconds.
 5. Exercise two replicas or reason explicitly about every mutable in-memory/local-file dependency.
 6. Confirm migrations cannot race and a rollback remains schema-compatible.

--- a/skills/temps-best-practices/references/runtime-contract.md
+++ b/skills/temps-best-practices/references/runtime-contract.md
@@ -1,0 +1,114 @@
+# Application Runtime Contract
+
+Read this file whenever preparing or reviewing an application that will run on Temps. It owns application behavior; use `temps-cli` for the commands that create projects, deploy images, or manage resources.
+
+## Effective application root
+
+Place `.temps.yaml` in the application's effective Temps **Root Directory / Docker build context**. That is the repository root for a single-app repository, but it is usually an app subdirectory in a monorepo:
+
+```text
+repository/
+├── apps/
+│   └── api/
+│       ├── .temps.yaml
+│       ├── package.json
+│       └── src/
+└── packages/
+```
+
+If the Temps project Root Directory is `apps/api`, the health configuration belongs in `apps/api/.temps.yaml`.
+
+Merge known keys instead of replacing the file. Preserve existing `build`, `cron`, `env`, `agents`, `workflows`, `sourceContext`, and health settings.
+
+## Health is readiness
+
+Create a dedicated unauthenticated `GET` endpoint such as `/healthz` and configure it:
+
+```yaml
+health:
+  path: /healthz
+```
+
+Current implementation facts:
+
+- `health.path` is the only `.temps.yaml` health field that reliably changes deployment and monitor behavior today.
+- Do not add or rely on `health.status`, `health.interval`, `health.timeout`, or `health.retries` until their runtime consumers are implemented.
+- A deploy-time `--health-check-path` override wins over `.temps.yaml`; avoid passing it unless the divergence is intentional.
+- Temps configuration parsing does not reject every unknown key, and an unreadable/invalid file can be treated as absent. Verify the deployment log names the intended health path and confirm the environment's uptime monitor uses it.
+
+The endpoint gates traffic, so it is a readiness check:
+
+- Return `200` only when the process can serve normal requests.
+- Return `503` while starting, draining, or missing a dependency required by most requests.
+- Check only essential dependencies, use short timeouts, and never mutate state.
+- Return a constant minimal body such as `{"status":"ok"}`. Do not expose hostnames, versions, commit SHAs, dependency errors, configuration, or secrets.
+
+Temps is permissive about some non-5xx responses during probing, so an explicit `200` is important: it prevents a typo that returns `404` from looking intentionally healthy.
+
+For OpenTelemetry-enabled applications, exclude the exact `health.path` from incoming server spans. Suppress routine health requests from access logs and request metrics where the framework supports it. Keep the application route, `.temps.yaml`, and filters synchronized.
+
+### Scale-to-zero caveat
+
+The scale-to-zero wake readiness probe currently checks `/` independently of `.temps.yaml`. Excluding `/` would hide legitimate homepage traffic, so do not broaden the filter to `/`. Treat remaining wake-probe spans as a platform limitation until Temps uses the configured health path for wake readiness.
+
+## Network binding and port alignment
+
+Temps injects `HOST=0.0.0.0` and `PORT`. The application must:
+
+- Read `PORT` instead of hardcoding a framework default.
+- Bind to `HOST` or `0.0.0.0`, never only `127.0.0.1`/`localhost`.
+- Keep the server's listening port, project port, and Docker `EXPOSE` aligned. For custom images, a conflicting exposed port can make the proxy route to a different port than the process reads from `PORT`.
+
+`EXPOSE` is metadata, not a substitute for listening on the injected port.
+
+## Graceful shutdown
+
+Temps stops containers with the normal termination signal and a 10-second grace period. On `SIGTERM`:
+
+1. Mark readiness unavailable so new work stops arriving.
+2. Stop accepting new requests and jobs.
+3. Let in-flight requests finish within a bounded deadline.
+4. Close database, queue, and cache clients.
+5. flush and shut down OpenTelemetry processors/exporters.
+6. Exit successfully before the 10-second deadline.
+
+Use an exec-form container command, or `exec` from an entrypoint script, so the application receives signals directly.
+
+## Replica-safe state
+
+Each replica has private memory and a private writable filesystem. Store shared state in the appropriate service:
+
+- Sessions, locks, rate-limit state, and cross-replica coordination: database or Redis.
+- User uploads and durable artifacts: blob/S3 storage.
+- Cross-replica realtime broadcasts: shared pub/sub.
+
+Do not depend on in-memory sessions, local uploads, or a single process receiving every request.
+
+## Database migrations
+
+`.temps.yaml` has no general pre-deploy/release hook. Keep operational commands in `temps-cli`, but apply these application rules:
+
+- Make migrations idempotent and concurrency-safe; multiple replicas can start concurrently.
+- Prefer a one-off release/CI step when the workflow supports it.
+- If startup runs migrations, use a database lock and fail startup when migration fails.
+- Use backward-compatible expand/contract changes because rolling back application code does not roll back the database automatically.
+- Never run migrations from the health endpoint.
+
+## Logs and cron endpoints
+
+Write application logs to stdout/stderr so Temps can capture them. Use OTLP logs when structured trace correlation is required; do not depend on container-local log files.
+
+If `.temps.yaml` defines `cron` routes, validate `Authorization: Bearer <CRON_SECRET>` in every handler and fail closed when either the environment value or header is missing or malformed. Keep handlers idempotent and return a non-success response when authentication or work fails.
+
+Treat `CRON_SECRET` as a high-impact server credential: Temps currently supplies the deployment token, which is non-expiring and broadly scoped. Compare the presented value without echoing it, never record the authorization header in logs/traces/errors, and rotate the deployment credential after suspected exposure.
+
+## Runtime verification
+
+Before considering the app deployable:
+
+1. Confirm the server listens on the injected `PORT` on `0.0.0.0`.
+2. Confirm `.temps.yaml` is in the effective application root and the deploy log uses its `health.path`.
+3. Confirm readiness returns `200`, returns no sensitive details, and produces no routine trace/log/metric noise.
+4. Send `SIGTERM`; confirm the process drains, flushes telemetry, and exits within 10 seconds.
+5. Exercise two replicas or reason explicitly about every mutable in-memory/local-file dependency.
+6. Confirm migrations cannot race and a rollback remains schema-compatible.

--- a/skills/temps-best-practices/references/telemetry-hygiene.md
+++ b/skills/temps-best-practices/references/telemetry-hygiene.md
@@ -52,7 +52,7 @@ Session replay is the highest-risk signal because the backend stores captured rr
 - Verify the active recorder actually responds to the consent state; do not claim compliance from a disconnected control hook.
 - Inspect a replay made with synthetic sensitive values before production rollout.
 
-Use the dedicated `add-session-recording` skill for implementation, but retain these acceptance criteria.
+Do not use the current standalone `useSessionRecordingControl` hook as proof that recording stopped: its state is independent from the mounted recorder. Consent must control the actual provider lifecycle until the SDK exposes one shared control path.
 
 ## Cardinality and naming
 
@@ -98,7 +98,7 @@ The public analytics endpoint is intentionally unauthenticated. Treat browser ev
 
 - Do not use them as the source of truth for billing, authorization, entitlements, inventory, or authoritative revenue.
 - Send conversion-critical events from the authenticated backend endpoint after the server has committed the business action.
-- Deduplicate backend events with a stable business-event identifier where retries are possible.
+- Deduplicate in application business storage or an outbox before posting where retries are possible. Temps analytics ingest does not enforce idempotency from a business-event identifier in `event_data`.
 
 ## Hygiene verification
 

--- a/skills/temps-best-practices/references/telemetry-hygiene.md
+++ b/skills/temps-best-practices/references/telemetry-hygiene.md
@@ -1,0 +1,112 @@
+# Telemetry Hygiene and Production Guardrails
+
+Read this file whenever adding or reviewing error tracking, traces, metrics, OTLP logs, analytics, or session replay. Temps stores what applications send; filtering sensitive or unbounded data is primarily the application's responsibility.
+
+## Credential and trust boundaries
+
+Classify telemetry credentials before wiring an exporter:
+
+| Value | Browser-safe? | Rule |
+|---|---:|---|
+| Sentry-compatible DSN public key | Yes | A client-write identifier, not a control-plane credential; still configure it through the platform instead of hardcoding it |
+| Public `/api/_temps/event` analytics endpoint | Yes, but untrusted | Host-based attribution is not proof that an event came from a genuine user |
+| `dt_` deployment token | No | Permanent machine credential; server-side only |
+| `tk_` API key | No | Server-side only |
+| `OTEL_EXPORTER_OTLP_HEADERS` / `TEMPS_API_TOKEN` | No | Contains a live bearer token; never expose to client code |
+
+Build-time availability does not make a server credential browser-safe. Never:
+
+- Give `dt_`, `tk_`, `TEMPS_API_TOKEN`, or `OTEL_EXPORTER_OTLP_HEADERS` a `NEXT_PUBLIC_`, `VITE_`, `PUBLIC_`, or similar prefix.
+- Read those values from a client component or bundle.
+- Put them in browser/mobile OTLP exporter configuration.
+
+Browser or mobile OTLP must go through an application backend or collector that adds authentication server-side. Until Temps offers a restricted public OTLP write key and browser CORS support, direct client OTLP is unsupported.
+
+## Sensitive-data policy
+
+Redact before export. Temps does not provide a universal server-side scrubber for arbitrary telemetry payloads.
+
+Do not send:
+
+- Authorization, cookie, API-key, or session headers.
+- Passwords, access/refresh tokens, private keys, or connection strings.
+- Raw request/response bodies or database parameter values by default.
+- Payment, medical, authentication, or other regulated data.
+- Email addresses, full IP addresses, or stable user identifiers unless the product has an explicit lawful need and retention policy.
+- Raw GenAI prompts/completions unless users knowingly opted in and a redaction policy is enforced.
+- Sensitive URL query parameters or fragments.
+
+Prefer allowlisting safe attributes over maintaining an ever-growing denylist. Use SDK processors/hooks such as Sentry `beforeSend`, OTel span/log processors, and analytics payload builders. Keep legacy Sentry `sendDefaultPii` false/undefined or use the current granular `dataCollection` allow/deny settings.
+
+Test redaction with synthetic canary values that look like tokens, emails, and card numbers, then inspect the actual stored event/span/log/replay.
+
+## Session replay
+
+Session replay is the highest-risk signal because the backend stores captured rrweb events. Treat it as a separate privacy feature:
+
+- Keep recording disabled by default.
+- Obtain the required consent before mounting or starting the recorder.
+- Use `maskAllInputs: true`.
+- Block or mask authentication, payment, medical, account, admin, and secrets-management UI.
+- Exclude sensitive paths explicitly.
+- Verify the active recorder actually responds to the consent state; do not claim compliance from a disconnected control hook.
+- Inspect a replay made with synthetic sensitive values before production rollout.
+
+Use the dedicated `add-session-recording` skill for implementation, but retain these acceptance criteria.
+
+## Cardinality and naming
+
+Unbounded dimensions make telemetry expensive and hard to query across every pillar:
+
+- Name server spans with route templates (`GET /users/:id`), not raw paths (`GET /users/123`) or full URLs.
+- Never use user IDs, session IDs, request IDs, UUIDs, emails, raw SQL, raw queries, or error messages as metric labels.
+- Keep metric label sets small and bounded.
+- Keep analytics event names stable (`purchase_completed`); put only bounded dimensions in properties.
+- Allowlist span and log attributes, and drop high-cardinality auto-instrumentation fields before export.
+- Keep `service.name` stable per service. Put version and environment in their dedicated resource attributes.
+
+## Production volume controls
+
+Use batching in production. Configure sampling deliberately rather than inheriting an SDK's development defaults:
+
+```bash
+OTEL_TRACES_SAMPLER=parentbased_traceidratio
+OTEL_TRACES_SAMPLER_ARG=0.05
+```
+
+Choose the ratio from traffic volume and debugging needs; `0.05` is an example, not a universal default. Preserve parent sampling decisions across services.
+
+Also:
+
+- Exclude health checks, static assets, and other known low-value traffic at the source.
+- Disable noisy middleware/socket instrumentations when they do not answer a real operational question.
+- Prefer batch span/log processors with bounded queues and export timeouts.
+- Call the SDK's shutdown/flush path during `SIGTERM`; otherwise the last buffered telemetry is lost.
+- Treat exporter failure as observable but non-fatal to normal request handling.
+
+## Trace propagation and baggage
+
+Distributed traces require the application SDK to extract inbound and inject outbound W3C `traceparent`/`tracestate` headers. Temps configures export destinations; it does not add propagation to application HTTP clients.
+
+Verify propagation across project/service boundaries. Logs emitted inside a request should carry the active `trace_id` and `span_id`. Background jobs should start or continue an explicit span rather than assuming request-local context survives queue boundaries.
+
+Baggage crosses process boundaries and must not carry secrets or PII. Clear or allowlist baggage before calling an untrusted service.
+
+## Analytics is not an authority
+
+The public analytics endpoint is intentionally unauthenticated. Treat browser events as user-controlled input:
+
+- Do not use them as the source of truth for billing, authorization, entitlements, inventory, or authoritative revenue.
+- Send conversion-critical events from the authenticated backend endpoint after the server has committed the business action.
+- Deduplicate backend events with a stable business-event identifier where retries are possible.
+
+## Hygiene verification
+
+Before considering telemetry production-ready:
+
+1. Search built client assets for `dt_`, `tk_`, `TEMPS_API_TOKEN`, and OTLP authorization headers.
+2. Exercise a normal request and verify route-template span naming and trace propagation.
+3. Send synthetic sensitive values through error, log, trace, analytics, and replay paths; verify they are absent or masked.
+4. Load-test representative traffic and inspect span/metric/event cardinality.
+5. Send `SIGTERM` with telemetry buffered and confirm shutdown flushes it within the runtime deadline.
+6. Confirm authoritative business events originate from authenticated server code.


### PR DESCRIPTION
## Summary

- define the Temps application runtime contract: effective-root `.temps.yaml`, dedicated readiness, `HOST`/`PORT`, custom-image port alignment, graceful shutdown, replica-safe state, migrations, logs, and cron authentication
- require OpenTelemetry server instrumentation to suppress the configured health path without hiding normal routes
- add production telemetry guardrails for machine credentials, browser/mobile OTLP, sensitive data, session replay, cardinality, sampling, propagation, and server-authoritative analytics
- correct `tk_`, `dt_`, and `si_` scope guidance and add three regression evals covering Express, Next.js/replay, and browser trust boundaries

## Evidence

**Skill package validation**: the updated skill and eval manifest parse successfully.

```bash
python3 /Users/davidviejo/projects/temps/.agents/skills/skill-creator/scripts/quick_validate.py skills/temps-best-practices
jq empty skills/temps-best-practices/evals/evals.json
```

```text
Skill is valid!
```

**Static skill security gate**: the repository-pinned Cisco scanner reports no high, medium, or low findings. GitHub CI will additionally run the behavioral scanner.

```bash
python -m pip install \
  --require-hashes \
  --only-binary=:all: \
  --requirement .github/skill-scanner-requirements.txt
skill-scanner scan skills/temps-best-practices \
  --policy balanced \
  --format table \
  --fail-on-severity high
```

```text
Status         [OK] SAFE
Max Severity   INFO
Critical       0
High           0
Medium         0
Low            0
Info           1 (license metadata)
```

**Regression evals**: paired runs used the three prompts and 16 assertions now included in `skills/temps-best-practices/evals/evals.json`.

```text
Updated skill: 16/16 passed (100%)
Pre-expansion snapshot: 9/16 passed (56.25%)
```

The snapshot already contained the initial health-path draft. Its remaining misses included an unsafe public `VITE_` deployment-token fallback, incomplete port/shutdown/readiness guidance, and incomplete replay/cron controls.

**Repository baseline**:

```bash
cargo check --lib
```

```text
cargo build: 0 errors, 5 warnings (1022 crates)
```

The warnings are existing workspace/build-script and future-incompatibility warnings; this PR changes no Rust code.

**Security review**: focused review signed off after verifying cron fail-closed handling, full-access token warnings, metrics token scopes, browser credential boundaries, public-analytics trust, replay consent/masking, and health-response disclosure controls.
