### PR TITLE
fix(release): dispatch builds for nightly tags

### DIFF
--- a/.github/scripts/test-nightly-release-workflows.sh
+++ b/.github/scripts/test-nightly-release-workflows.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+nightly_workflow="$repository_root/.github/workflows/nightly-release.yml"
+release_workflow="$repository_root/.github/workflows/release.yml"
+
+fail() {
+  echo "nightly workflow regression: $*" >&2
+  exit 1
+}
+
+grep -Fq 'actions: write' "$nightly_workflow" ||
+  fail "nightly workflow cannot dispatch the release workflow"
+
+# The literal $TAG is the workflow contract under test.
+# shellcheck disable=SC2016
+grep -Fq 'gh workflow run release.yml --ref "$TAG" --field dry_run=false' \
+  "$nightly_workflow" ||
+  fail "nightly tags are not explicitly dispatched to the release workflow"
+
+grep -A5 -F 'dry_run:' "$release_workflow" | grep -Fq 'default: true' ||
+  fail "manual release dispatches must default to a safe dry-run"
+
+tag_aware_dispatch_count="$(
+  # The workflow variable must remain literal here.
+  # shellcheck disable=SC2016
+  grep -Fc 'if [[ "$DRY_RUN" == "true" ]]; then' "$release_workflow"
+)"
+if [[ "$tag_aware_dispatch_count" -ne 5 ]]; then
+  fail "expected release channel and version logic to distinguish dry-runs from tag dispatches"
+fi
+
+echo "nightly release workflow wiring is valid"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -3,8 +3,9 @@ name: Nightly Release
 # Cuts a nightly prerelease build from main once a day, but only when main
 # has moved since the last nightly tag. The tag it mints
 # (v<version>-nightly.<date>.<short-sha>) contains a `-`, so it matches the
-# `release.yml` tag trigger (`v*.*.*-*`) and rides that same pipeline —
-# there is no separate nightly build/publish logic to keep in sync.
+# `release.yml` tag trigger (`v*.*.*-*`). Tags pushed with GITHUB_TOKEN do
+# not trigger other workflows, so this workflow explicitly dispatches the
+# release pipeline at the newly-created tag.
 
 on:
   schedule:
@@ -13,6 +14,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
+  actions: write
   contents: write
 
 jobs:
@@ -74,3 +76,13 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Nightly build $TAG"
           git push origin "$TAG"
+
+      - name: Start release workflow for nightly tag
+        if: steps.check.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh workflow run release.yml --ref "$TAG" --field dry_run=false
+          echo "Dispatched release workflow for $TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
         description: "Dry-run: skip pushes, only build to verify the pipeline works"
         required: false
         type: boolean
-        default: false
+        default: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -384,22 +384,25 @@ jobs:
       - name: Determine release channel
         id: channel
         # Tag pushes: prerelease iff the tag contains a `-` (e.g. `v0.1.0-beta.6`).
-        # Manual dispatches: always treated as prerelease so a dry-run or test
-        # invocation cannot promote to the stable `:<version>` ref by accident.
-        # If you ever need workflow_dispatch to mint a stable build, pass it as
-        # an explicit input (and add it to the dispatch inputs above).
+        # Dry-runs are always treated as prereleases so a test invocation
+        # cannot promote to the stable `:<version>` ref by accident. A
+        # non-dry-run dispatch at a tag (used by nightly-release.yml) follows
+        # the same tag-based channel selection as a tag push.
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "is_prerelease=true" >> $GITHUB_OUTPUT
-            echo "channel_tag=beta" >> $GITHUB_OUTPUT
-            echo "Channel: beta (workflow_dispatch — never promotes to stable)"
-          elif [[ "${{ github.ref_name }}" == *"-"* ]]; then
-            echo "is_prerelease=true" >> $GITHUB_OUTPUT
-            echo "channel_tag=beta" >> $GITHUB_OUTPUT
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "channel_tag=beta" >> "$GITHUB_OUTPUT"
+            echo "Channel: beta (dry-run — never promotes to stable)"
+          elif [[ "$RELEASE_TAG" == *"-"* ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "channel_tag=beta" >> "$GITHUB_OUTPUT"
             echo "Channel: beta (prerelease)"
           else
-            echo "is_prerelease=false" >> $GITHUB_OUTPUT
-            echo "channel_tag=latest" >> $GITHUB_OUTPUT
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "channel_tag=latest" >> "$GITHUB_OUTPUT"
             echo "Channel: latest (stable)"
           fi
 
@@ -433,13 +436,13 @@ jobs:
           chmod +x release/install.sh
 
       - name: Generate Homebrew formula
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          # workflow_dispatch runs against a branch, not a tag, so GITHUB_REF
-          # is refs/heads/<branch> and the prefix-strip below leaves it
-          # untouched -- if the branch name contains a `/` (as most do),
-          # that lands in VERSION and breaks the `sed -e "s/.../.../"` call
-          # below (VERSION's `/` collides with sed's own delimiter).
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          # A dry-run usually runs against a branch, so GITHUB_REF is
+          # refs/heads/<branch> and the prefix-strip below would leave it
+          # untouched. A real workflow_dispatch runs at a release tag.
+          if [[ "$DRY_RUN" == "true" ]]; then
             VERSION="dryrun-${{ github.run_id }}"
           else
             VERSION="${GITHUB_REF#refs/tags/v}"
@@ -571,13 +574,14 @@ jobs:
 
       - name: Create GitHub Release
         env:
+          DRY_RUN: ${{ inputs.dry_run }}
           GH_TOKEN: ${{ github.token }}
         run: |
           # workflow_dispatch dry-runs must not mint a real Release object
           # under the dispatched branch name — everything above this step
           # (artifact download, formula/checksum/notes generation) still
           # runs and is inspectable in the job logs/artifacts.
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.dry_run }}" == "true" ]]; then
+          if [[ "$DRY_RUN" == "true" ]]; then
             echo "Dry-run (workflow_dispatch): skipping actual GitHub Release creation for ${{ github.ref_name }}"
             exit 0
           fi
@@ -661,12 +665,12 @@ jobs:
 
       - name: Extract version
         id: version
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           # See the matching comment in create-release's "Generate Homebrew
-          # formula" step: workflow_dispatch runs against a branch ref, so
-          # this would otherwise leave a `/`-containing string in VERSION,
-          # which is invalid in a Docker tag component.
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          # formula" step: a branch-based dry-run needs a synthetic version.
+          if [[ "$DRY_RUN" == "true" ]]; then
             VERSION="dryrun-${{ github.run_id }}"
           else
             VERSION="${GITHUB_REF#refs/tags/v}"
@@ -730,12 +734,12 @@ jobs:
 
       - name: Extract version
         id: version
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           # See the matching comment in create-release's "Generate Homebrew
-          # formula" step: workflow_dispatch runs against a branch ref, so
-          # this would otherwise leave a `/`-containing string in VERSION,
-          # which is invalid in a Docker tag component.
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          # formula" step: a branch-based dry-run needs a synthetic version.
+          if [[ "$DRY_RUN" == "true" ]]; then
             VERSION="dryrun-${{ github.run_id }}"
           else
             VERSION="${GITHUB_REF#refs/tags/v}"

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -12,6 +12,16 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  workflow-contracts:
+    name: Release Workflow Contracts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Verify nightly release wiring
+        run: .github/scripts/test-nightly-release-workflows.sh
+
   compose-security:
     name: Compose Security
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- explicitly dispatch `release.yml` at each newly-created nightly tag
- grant the nightly workflow the minimal Actions write permission needed to dispatch it
- make manual release dispatches dry-run by default while allowing nightly tag dispatches to publish
- add a CI-enforced regression check for the cross-workflow contract

## Root cause

`nightly-release.yml` pushed its tag with the repository `GITHUB_TOKEN` and expected that push to trigger `release.yml`. GitHub suppresses workflow runs caused by `GITHUB_TOKEN` events, except explicit `workflow_dispatch` and `repository_dispatch` events. The nightly workflow therefore completed successfully and created a tag, but no release build started.

## Evidence

**Production symptom reproduced from GitHub Actions history**

```bash
gh run list --repo gotempsh/temps --workflow nightly-release.yml --limit 10 \
  --json databaseId,status,conclusion,event,headSha,createdAt,url,displayTitle
gh run list --repo gotempsh/temps --workflow release.yml --limit 15 \
  --json databaseId,status,conclusion,event,headSha,createdAt,url,displayTitle
```

The successful nightly runs `30425817060` (`419505e0`) and `30332173190`
(`32b7f235`) created nightly tags, while the Release workflow history contains
no runs for either SHA. Normal beta tag pushes do appear in Release history.

**Regression contract**

```bash
.github/scripts/test-nightly-release-workflows.sh
```

```text
nightly release workflow wiring is valid
```

**Workflow and shell validation**

```bash
shellcheck .github/scripts/test-nightly-release-workflows.sh
/tmp/temps-nightly-actionlint-bin/actionlint \
  -ignore 'SC(2086|2129)' \
  .github/workflows/nightly-release.yml \
  .github/workflows/release.yml \
  .github/workflows/rust-tests.yml
ruby -e 'require "yaml"; ARGV.each { |f| YAML.parse_file(f); puts "valid YAML: #{f}" }' \
  .github/workflows/nightly-release.yml \
  .github/workflows/release.yml \
  .github/workflows/rust-tests.yml
git diff --check origin/main...HEAD
```

```text
valid YAML: .github/workflows/nightly-release.yml
valid YAML: .github/workflows/release.yml
valid YAML: .github/workflows/rust-tests.yml
```

The actual release build can only be exercised after this workflow change is
present on the default branch. The regression contract runs in PR CI and the
next new commit on `main` will cause the scheduled nightly job to dispatch the
release pipeline at its generated tag.
