### PR TITLE
fix(release): recover failed nightly dispatches

### DIFF
--- a/.github/scripts/nightly-release-decision.sh
+++ b/.github/scripts/nightly-release-decision.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [[ "$#" -ne 5 ]]; then
-  echo "usage: $0 <head-sha> <last-tag> <last-tag-sha> <release-exists> <active-run-count>" >&2
+  echo "usage: $0 <head-sha> <last-tag> <last-tag-sha> <release-exists> <run-state>" >&2
   exit 2
 fi
 
@@ -10,15 +10,15 @@ head_sha="$1"
 last_tag="$2"
 last_tag_sha="$3"
 release_exists="$4"
-active_run_count="$5"
+run_state="$5"
 
 if [[ "$release_exists" != "true" && "$release_exists" != "false" ]]; then
   echo "release-exists must be true or false" >&2
   exit 2
 fi
 
-if [[ ! "$active_run_count" =~ ^[0-9]+$ ]]; then
-  echo "active-run-count must be a non-negative integer" >&2
+if [[ ! "$run_state" =~ ^(missing|active|success|failed)$ ]]; then
+  echo "run-state must be missing, active, success, or failed" >&2
   exit 2
 fi
 
@@ -26,18 +26,18 @@ if [[ -z "$last_tag" || "$last_tag_sha" != "$head_sha" ]]; then
   echo "should_release=true"
   echo "should_create_tag=true"
   echo "existing_tag="
-elif [[ "$release_exists" == "true" ]]; then
+elif [[ "$run_state" == "active" ]]; then
   echo "should_release=false"
   echo "should_create_tag=false"
   echo "existing_tag=$last_tag"
-elif ((active_run_count > 0)); then
+elif [[ "$run_state" == "success" && "$release_exists" == "true" ]]; then
   echo "should_release=false"
   echo "should_create_tag=false"
   echo "existing_tag=$last_tag"
 else
-  # The tag exists at HEAD, but neither a release nor an active release run
-  # does. Re-dispatch the existing tag to recover from a prior dispatch/build
-  # failure instead of skipping this commit forever.
+  # The tag exists at HEAD, but the matching release workflow is missing,
+  # failed, or completed without producing a GitHub Release. Re-dispatch the
+  # existing tag instead of skipping this commit forever.
   echo "should_release=true"
   echo "should_create_tag=false"
   echo "existing_tag=$last_tag"

--- a/.github/scripts/nightly-release-decision.sh
+++ b/.github/scripts/nightly-release-decision.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 5 ]]; then
+  echo "usage: $0 <head-sha> <last-tag> <last-tag-sha> <release-exists> <active-run-count>" >&2
+  exit 2
+fi
+
+head_sha="$1"
+last_tag="$2"
+last_tag_sha="$3"
+release_exists="$4"
+active_run_count="$5"
+
+if [[ "$release_exists" != "true" && "$release_exists" != "false" ]]; then
+  echo "release-exists must be true or false" >&2
+  exit 2
+fi
+
+if [[ ! "$active_run_count" =~ ^[0-9]+$ ]]; then
+  echo "active-run-count must be a non-negative integer" >&2
+  exit 2
+fi
+
+if [[ -z "$last_tag" || "$last_tag_sha" != "$head_sha" ]]; then
+  echo "should_release=true"
+  echo "should_create_tag=true"
+  echo "existing_tag="
+elif [[ "$release_exists" == "true" ]]; then
+  echo "should_release=false"
+  echo "should_create_tag=false"
+  echo "existing_tag=$last_tag"
+elif ((active_run_count > 0)); then
+  echo "should_release=false"
+  echo "should_create_tag=false"
+  echo "existing_tag=$last_tag"
+else
+  # The tag exists at HEAD, but neither a release nor an active release run
+  # does. Re-dispatch the existing tag to recover from a prior dispatch/build
+  # failure instead of skipping this commit forever.
+  echo "should_release=true"
+  echo "should_create_tag=false"
+  echo "existing_tag=$last_tag"
+fi

--- a/.github/scripts/test-nightly-release-workflows.sh
+++ b/.github/scripts/test-nightly-release-workflows.sh
@@ -65,15 +65,19 @@ expect_decision() {
 }
 
 expect_decision $'should_release=true\nshould_create_tag=true\nexisting_tag=' \
-  new-sha "" "" false 0
+  new-sha "" "" false missing
 expect_decision $'should_release=true\nshould_create_tag=true\nexisting_tag=' \
-  new-sha old-tag old-sha true 0
+  new-sha old-tag old-sha true success
 expect_decision $'should_release=false\nshould_create_tag=false\nexisting_tag=nightly-tag' \
-  same-sha nightly-tag same-sha true 0
+  same-sha nightly-tag same-sha true success
 expect_decision $'should_release=false\nshould_create_tag=false\nexisting_tag=nightly-tag' \
-  same-sha nightly-tag same-sha false 1
+  same-sha nightly-tag same-sha false active
 expect_decision $'should_release=true\nshould_create_tag=false\nexisting_tag=nightly-tag' \
-  same-sha nightly-tag same-sha false 0
+  same-sha nightly-tag same-sha false missing
+expect_decision $'should_release=true\nshould_create_tag=false\nexisting_tag=nightly-tag' \
+  same-sha nightly-tag same-sha true failed
+expect_decision $'should_release=true\nshould_create_tag=false\nexisting_tag=nightly-tag' \
+  same-sha nightly-tag same-sha false success
 
 "$validation_script" true branch main >/dev/null
 "$validation_script" false tag v0.1.0 >/dev/null

--- a/.github/scripts/test-nightly-release-workflows.sh
+++ b/.github/scripts/test-nightly-release-workflows.sh
@@ -4,20 +4,25 @@ set -euo pipefail
 repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 nightly_workflow="$repository_root/.github/workflows/nightly-release.yml"
 release_workflow="$repository_root/.github/workflows/release.yml"
+decision_script="$repository_root/.github/scripts/nightly-release-decision.sh"
+validation_script="$repository_root/.github/scripts/validate-release-ref.sh"
 
 fail() {
   echo "nightly workflow regression: $*" >&2
   exit 1
 }
 
-grep -Fq 'actions: write' "$nightly_workflow" ||
-  fail "nightly workflow cannot dispatch the release workflow"
-
 # The literal $TAG is the workflow contract under test.
 # shellcheck disable=SC2016
 grep -Fq 'gh workflow run release.yml --ref "$TAG" --field dry_run=false' \
   "$nightly_workflow" ||
   fail "nightly tags are not explicitly dispatched to the release workflow"
+
+# The active-run query must be scoped to the nightly tag, not merely the SHA;
+# an unrelated branch dry-run can share the same commit.
+# shellcheck disable=SC2016
+grep -Fq -- '--branch "$last_nightly_tag"' "$nightly_workflow" ||
+  fail "nightly recovery can mistake an unrelated branch run for the release"
 
 grep -A5 -F 'dry_run:' "$release_workflow" | grep -Fq 'default: true' ||
   fail "manual release dispatches must default to a safe dry-run"
@@ -29,6 +34,58 @@ tag_aware_dispatch_count="$(
 )"
 if [[ "$tag_aware_dispatch_count" -ne 5 ]]; then
   fail "expected release channel and version logic to distinguish dry-runs from tag dispatches"
+fi
+
+ruby - "$nightly_workflow" "$release_workflow" <<'RUBY'
+require "yaml"
+
+nightly = YAML.safe_load(File.read(ARGV[0]), aliases: true)
+release = YAML.safe_load(File.read(ARGV[1]), aliases: true)
+
+check_permissions = nightly.dig("jobs", "check-and-tag", "permissions")
+abort "check-and-tag permissions are not read-actions/write-contents" unless
+  check_permissions == {"actions" => "read", "contents" => "write"}
+
+dispatch_permissions = nightly.dig("jobs", "dispatch-release", "permissions")
+abort "dispatch-release must only have actions: write" unless
+  dispatch_permissions == {"actions" => "write"}
+
+abort "release builds can bypass ref validation" unless
+  release.dig("jobs", "build-web-assets", "needs") == "validate-release-ref"
+RUBY
+
+expect_decision() {
+  local expected="$1"
+  shift
+  local actual
+  actual="$("$decision_script" "$@")"
+  if [[ "$actual" != "$expected" ]]; then
+    fail "unexpected nightly decision for inputs '$*': expected '$expected', got '$actual'"
+  fi
+}
+
+expect_decision $'should_release=true\nshould_create_tag=true\nexisting_tag=' \
+  new-sha "" "" false 0
+expect_decision $'should_release=true\nshould_create_tag=true\nexisting_tag=' \
+  new-sha old-tag old-sha true 0
+expect_decision $'should_release=false\nshould_create_tag=false\nexisting_tag=nightly-tag' \
+  same-sha nightly-tag same-sha true 0
+expect_decision $'should_release=false\nshould_create_tag=false\nexisting_tag=nightly-tag' \
+  same-sha nightly-tag same-sha false 1
+expect_decision $'should_release=true\nshould_create_tag=false\nexisting_tag=nightly-tag' \
+  same-sha nightly-tag same-sha false 0
+
+"$validation_script" true branch main >/dev/null
+"$validation_script" false tag v0.1.0 >/dev/null
+"$validation_script" false tag v0.1.0-beta.55 >/dev/null
+"$validation_script" false tag v0.1.0-nightly.20260729.abc12345 >/dev/null
+
+if "$validation_script" false branch main >/dev/null 2>&1; then
+  fail "a non-dry branch dispatch was accepted for publishing"
+fi
+
+if "$validation_script" false tag latest >/dev/null 2>&1; then
+  fail "a malformed release tag was accepted for publishing"
 fi
 
 echo "nightly release workflow wiring is valid"

--- a/.github/scripts/validate-release-ref.sh
+++ b/.github/scripts/validate-release-ref.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 3 ]]; then
+  echo "usage: $0 <dry-run> <ref-type> <ref-name>" >&2
+  exit 2
+fi
+
+dry_run="$1"
+ref_type="$2"
+ref_name="$3"
+
+if [[ "$dry_run" == "true" ]]; then
+  echo "Dry-run release validation passed for $ref_type '$ref_name'"
+  exit 0
+fi
+
+if [[ "$ref_type" != "tag" ]]; then
+  echo "::error::Non-dry release dispatches must target a tag, got $ref_type '$ref_name'" >&2
+  exit 1
+fi
+
+release_tag_pattern='^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$'
+if [[ ! "$ref_name" =~ $release_tag_pattern ]]; then
+  echo "::error::Release tag '$ref_name' does not match the required v<major>.<minor>.<patch>[-prerelease] format" >&2
+  exit 1
+fi
+
+echo "Release validation passed for tag '$ref_name'"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -48,7 +48,7 @@ jobs:
           last_nightly_tag="$(git tag -l 'v*-nightly.*' --sort=-creatordate | head -n1 || true)"
           last_nightly_sha=""
           release_exists=false
-          active_run_count=0
+          release_run_state=missing
 
           if [[ -n "$last_nightly_tag" ]]; then
             last_nightly_sha="$(git rev-list -n1 "$last_nightly_tag")"
@@ -57,18 +57,24 @@ jobs:
             if [[ "$last_nightly_sha" == "$head_sha" ]]; then
               if gh release view "$last_nightly_tag" >/dev/null 2>&1; then
                 release_exists=true
-              else
-                active_run_count="$(
-                  gh run list \
-                    --workflow release.yml \
-                    --branch "$last_nightly_tag" \
-                    --commit "$head_sha" \
-                    --event workflow_dispatch \
-                    --limit 100 \
-                    --json status \
-                    --jq '[.[] | select(.status != "completed")] | length'
-                )"
               fi
+
+              release_run_state="$(
+                gh run list \
+                  --workflow release.yml \
+                  --branch "$last_nightly_tag" \
+                  --commit "$head_sha" \
+                  --event workflow_dispatch \
+                  --limit 1 \
+                  --json conclusion,status \
+                  --jq '
+                    if length == 0 then "missing"
+                    elif .[0].status != "completed" then "active"
+                    elif .[0].conclusion == "success" then "success"
+                    else "failed"
+                    end
+                  '
+              )"
             fi
           fi
 
@@ -78,7 +84,7 @@ jobs:
               "$last_nightly_tag" \
               "$last_nightly_sha" \
               "$release_exists" \
-              "$active_run_count"
+              "$release_run_state"
           )"
           printf '%s\n' "$decision" >> "$GITHUB_OUTPUT"
           printf '%s\n' "$decision"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -13,14 +13,20 @@ on:
     - cron: "0 3 * * *"
   workflow_dispatch: {}
 
-permissions:
-  actions: write
-  contents: write
+concurrency:
+  group: nightly-release
+  cancel-in-progress: false
 
 jobs:
   check-and-tag:
     name: Check for new commits and tag
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v7
@@ -30,44 +36,83 @@ jobs:
 
       - name: Determine if a nightly build is needed
         id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
           head_sha="$(git rev-parse HEAD)"
           echo "HEAD is at $head_sha"
 
-          # Last nightly tag, if any (sorted by tag creation date via version sort on the date segment).
+          # Last nightly tag, if any, sorted by tag creation date.
           last_nightly_tag="$(git tag -l 'v*-nightly.*' --sort=-creatordate | head -n1 || true)"
+          last_nightly_sha=""
+          release_exists=false
+          active_run_count=0
 
-          if [ -z "$last_nightly_tag" ]; then
-            echo "No previous nightly tag found -- building."
-            echo "should_release=true" >> "$GITHUB_OUTPUT"
-          else
+          if [[ -n "$last_nightly_tag" ]]; then
             last_nightly_sha="$(git rev-list -n1 "$last_nightly_tag")"
             echo "Last nightly tag: $last_nightly_tag ($last_nightly_sha)"
-            if [ "$last_nightly_sha" = "$head_sha" ]; then
-              echo "No new commits on main since last nightly -- skipping."
-              echo "should_release=false" >> "$GITHUB_OUTPUT"
-            else
-              echo "New commits since last nightly -- building."
-              echo "should_release=true" >> "$GITHUB_OUTPUT"
+
+            if [[ "$last_nightly_sha" == "$head_sha" ]]; then
+              if gh release view "$last_nightly_tag" >/dev/null 2>&1; then
+                release_exists=true
+              else
+                active_run_count="$(
+                  gh run list \
+                    --workflow release.yml \
+                    --branch "$last_nightly_tag" \
+                    --commit "$head_sha" \
+                    --event workflow_dispatch \
+                    --limit 100 \
+                    --json status \
+                    --jq '[.[] | select(.status != "completed")] | length'
+                )"
+              fi
             fi
+          fi
+
+          decision="$(
+            .github/scripts/nightly-release-decision.sh \
+              "$head_sha" \
+              "$last_nightly_tag" \
+              "$last_nightly_sha" \
+              "$release_exists" \
+              "$active_run_count"
+          )"
+          printf '%s\n' "$decision" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$decision"
+
+          if grep -q '^should_release=true$' <<< "$decision"; then
+            if [[ -n "$last_nightly_tag" && "$last_nightly_sha" == "$head_sha" ]]; then
+              echo "Nightly release is missing or failed -- reusing $last_nightly_tag."
+            else
+              echo "New commits since the last nightly -- creating a tag."
+            fi
+          else
+            echo "Nightly release already exists or is currently running -- skipping."
           fi
 
       - name: Compute nightly tag
         id: tag
         if: steps.check.outputs.should_release == 'true'
+        env:
+          EXISTING_TAG: ${{ steps.check.outputs.existing_tag }}
         run: |
           set -euo pipefail
-          base_version="$(grep -m1 '^version' Cargo.toml | sed -E 's/version = "([^"]+)"/\1/' | sed -E 's/-.*//')"
-          date_stamp="$(date -u +%Y%m%d)"
-          short_sha="$(git rev-parse --short HEAD)"
-          tag="v${base_version}-nightly.${date_stamp}.${short_sha}"
+          if [[ -n "$EXISTING_TAG" ]]; then
+            tag="$EXISTING_TAG"
+          else
+            base_version="$(grep -m1 '^version' Cargo.toml | sed -E 's/version = "([^"]+)"/\1/' | sed -E 's/-.*//')"
+            date_stamp="$(date -u +%Y%m%d)"
+            short_sha="$(git rev-parse --short HEAD)"
+            tag="v${base_version}-nightly.${date_stamp}.${short_sha}"
+          fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "Nightly tag: $tag"
 
       - name: Create and push nightly tag
-        if: steps.check.outputs.should_release == 'true'
+        if: steps.check.outputs.should_create_tag == 'true'
         env:
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
@@ -77,11 +122,18 @@ jobs:
           git tag -a "$TAG" -m "Nightly build $TAG"
           git push origin "$TAG"
 
+  dispatch-release:
+    name: Dispatch release workflow
+    needs: check-and-tag
+    if: needs.check-and-tag.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
       - name: Start release workflow for nightly tag
-        if: steps.check.outputs.should_release == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ steps.tag.outputs.tag }}
+          TAG: ${{ needs.check-and-tag.outputs.tag }}
         run: |
           set -euo pipefail
           gh workflow run release.yml --ref "$TAG" --field dry_run=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,22 @@ permissions:
   packages: write
 
 jobs:
+  validate-release-ref:
+    name: Validate Release Ref
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout release validation script
+        uses: actions/checkout@v7
+
+      - name: Reject unsafe publishing refs
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: .github/scripts/validate-release-ref.sh "$DRY_RUN" "$REF_TYPE" "$REF_NAME"
+
   build-web-assets:
     name: Build web assets (WASM + dist)
     # The web console + captcha WASM are pure static output with no
@@ -36,6 +52,7 @@ jobs:
     # most expensive repeat was the macOS Intel job's wasm-pack step alone
     # (7m26s on the last release), on top of a redundant rsbuild build in
     # each of the other 3 jobs.
+    needs: validate-release-ref
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -576,17 +593,18 @@ jobs:
         env:
           DRY_RUN: ${{ inputs.dry_run }}
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           # workflow_dispatch dry-runs must not mint a real Release object
           # under the dispatched branch name — everything above this step
           # (artifact download, formula/checksum/notes generation) still
           # runs and is inspectable in the job logs/artifacts.
           if [[ "$DRY_RUN" == "true" ]]; then
-            echo "Dry-run (workflow_dispatch): skipping actual GitHub Release creation for ${{ github.ref_name }}"
+            echo "Dry-run (workflow_dispatch): skipping actual GitHub Release creation for $RELEASE_TAG"
             exit 0
           fi
 
-          echo "Creating release ${{ github.ref_name }}..."
+          echo "Creating release $RELEASE_TAG..."
 
           if [[ "${{ steps.channel.outputs.is_prerelease }}" == "true" ]]; then
             PRERELEASE_FLAG="--prerelease"
@@ -596,8 +614,8 @@ jobs:
             echo "This is a stable release"
           fi
 
-          gh release create ${{ github.ref_name }} \
-            --title "${{ github.ref_name }}" \
+          gh release create "$RELEASE_TAG" \
+            --title "$RELEASE_TAG" \
             --notes-file release/release-notes.md \
             $PRERELEASE_FLAG \
             release/temps-linux-amd64.tar.gz \
@@ -613,9 +631,9 @@ jobs:
             release/temps.rb
 
           echo ""
-          echo "✓ Release ${{ github.ref_name }} created successfully!"
+          echo "✓ Release $RELEASE_TAG created successfully!"
           echo ""
-          echo "View release at: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}"
+          echo "View release at: https://github.com/${{ github.repository }}/releases/tag/$RELEASE_TAG"
 
   build-and-push-docker:
     name: Build and Push Docker Image (${{ matrix.platform }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -614,24 +614,37 @@ jobs:
             echo "This is a stable release"
           fi
 
-          gh release create "$RELEASE_TAG" \
-            --title "$RELEASE_TAG" \
-            --notes-file release/release-notes.md \
-            $PRERELEASE_FLAG \
-            release/temps-linux-amd64.tar.gz \
-            release/temps-linux-amd64.tar.gz.sha256 \
-            release/temps-linux-arm64.tar.gz \
-            release/temps-linux-arm64.tar.gz.sha256 \
-            release/temps-darwin-amd64.tar.gz \
-            release/temps-darwin-amd64.tar.gz.sha256 \
-            release/temps-darwin-arm64.tar.gz \
-            release/temps-darwin-arm64.tar.gz.sha256 \
-            release/checksums.txt \
-            release/install.sh \
+          release_assets=(
+            release/temps-linux-amd64.tar.gz
+            release/temps-linux-amd64.tar.gz.sha256
+            release/temps-linux-arm64.tar.gz
+            release/temps-linux-arm64.tar.gz.sha256
+            release/temps-darwin-amd64.tar.gz
+            release/temps-darwin-amd64.tar.gz.sha256
+            release/temps-darwin-arm64.tar.gz
+            release/temps-darwin-arm64.tar.gz.sha256
+            release/checksums.txt
+            release/install.sh
             release/temps.rb
+          )
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists; refreshing metadata and assets."
+            gh release edit "$RELEASE_TAG" \
+              --title "$RELEASE_TAG" \
+              --notes-file release/release-notes.md \
+              $PRERELEASE_FLAG
+            gh release upload "$RELEASE_TAG" --clobber "${release_assets[@]}"
+          else
+            gh release create "$RELEASE_TAG" \
+              --title "$RELEASE_TAG" \
+              --notes-file release/release-notes.md \
+              $PRERELEASE_FLAG \
+              "${release_assets[@]}"
+          fi
 
           echo ""
-          echo "✓ Release $RELEASE_TAG created successfully!"
+          echo "✓ Release $RELEASE_TAG published successfully!"
           echo ""
           echo "View release at: https://github.com/${{ github.repository }}/releases/tag/$RELEASE_TAG"
 


### PR DESCRIPTION
## Summary

- retry an existing nightly tag when its release dispatch/build failed
- avoid duplicate dispatches while a release workflow for that tag is active
- retry completed failed workflows even when they created a partial GitHub Release
- refresh existing release metadata/assets safely on retry
- reject non-dry releases from branches or malformed tags before any build/publish job starts
- isolate `actions: write` in a checkout-free dispatch job
- replace the text-only regression check with behavioral decision/ref-validation cases and semantic YAML assertions

## Why

Follow-up review of #470 found two failure modes:

1. The tag was pushed before dispatch. If dispatch failed, every retry saw the
   tag at `HEAD` and skipped forever. A later pipeline failure could also leave
   a Release object behind and be incorrectly treated as fully successful.
2. An authorized manual dispatch could set `dry_run=false` on a branch, causing
   the release workflow to classify and publish that branch as stable/latest.

## Evidence

**Failed dispatch recovery reuses the existing tag**

```bash
.github/scripts/nightly-release-decision.sh \
  same-sha \
  v0.1.0-nightly.20260729.abc12345 \
  same-sha \
  false \
  missing
```

```text
should_release=true
should_create_tag=false
existing_tag=v0.1.0-nightly.20260729.abc12345
```

The same retry decision is asserted for an existing Release object whose
matching workflow conclusion is `failed`; only `active`, or `success` plus an
existing Release, skips.

**Non-dry branch publishing is rejected**

```bash
.github/scripts/validate-release-ref.sh false branch main
printf 'exit=%s\n' "$?"
```

```text
::error::Non-dry release dispatches must target a tag, got branch 'main'
exit=1
```

**Behavioral contract suite**

```bash
.github/scripts/test-nightly-release-workflows.sh
```

```text
nightly release workflow wiring is valid
```

The suite covers no prior tag, new commit, completed release, active release,
failed/missing/partial release recovery, success-without-release recovery, safe
dry-runs, stable/beta/nightly tags, non-dry branch rejection, malformed-tag
rejection, permission isolation, and the validation job dependency.

**Recovery queries against the latest orphaned nightly tag**

```bash
latest_tag=$(git tag -l 'v*-nightly.*' --sort=-creatordate | head -n1)
latest_sha=$(git rev-list -n1 "$latest_tag")
printf 'tag=%s sha=%s\n' "$latest_tag" "$latest_sha"
gh release view "$latest_tag" --repo gotempsh/temps --json tagName,isPrerelease,url
printf 'release_exit=%s\n' "$?"
gh run list --repo gotempsh/temps \
  --workflow release.yml \
  --branch "$latest_tag" \
  --commit "$latest_sha" \
  --event workflow_dispatch \
  --limit 1 \
  --json conclusion,status,url
```

```text
tag=v0.1.0-nightly.20260729.419505e0 sha=419505e0ba4e60b6b1c1187305775bd36cf26ba7
release not found
release_exit=1
[]
```

This is the exact production state the recovery decision maps to re-dispatching
the existing tag without attempting to create it again.

**Workflow and shell validation**

```bash
shellcheck \
  .github/scripts/nightly-release-decision.sh \
  .github/scripts/validate-release-ref.sh \
  .github/scripts/test-nightly-release-workflows.sh
/tmp/temps-nightly-actionlint-bin/actionlint \
  -ignore 'SC(2086|2129)' \
  .github/workflows/nightly-release.yml \
  .github/workflows/release.yml \
  .github/workflows/rust-tests.yml
ruby -e 'require "yaml"; ARGV.each { |f| YAML.parse_file(f); puts "valid YAML: #{f}" }' \
  .github/workflows/nightly-release.yml \
  .github/workflows/release.yml \
  .github/workflows/rust-tests.yml
git diff --check origin/main...HEAD
```

```text
valid YAML: .github/workflows/nightly-release.yml
valid YAML: .github/workflows/release.yml
valid YAML: .github/workflows/rust-tests.yml
```
