### PR TITLE
fix(ci): pin privileged workflow actions

### DIFF
--- a/.github/scripts/test-nightly-release-workflows.sh
+++ b/.github/scripts/test-nightly-release-workflows.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 nightly_workflow="$repository_root/.github/workflows/nightly-release.yml"
 release_workflow="$repository_root/.github/workflows/release.yml"
+sandbox_workflow="$repository_root/.github/workflows/sandbox-images-beta.yml"
 decision_script="$repository_root/.github/scripts/nightly-release-decision.sh"
 validation_script="$repository_root/.github/scripts/validate-release-ref.sh"
 
@@ -42,11 +43,12 @@ if [[ "$tag_aware_dispatch_count" -ne 5 ]]; then
   fail "expected release channel and version logic to distinguish dry-runs from tag dispatches"
 fi
 
-ruby - "$nightly_workflow" "$release_workflow" <<'RUBY'
+ruby - "$nightly_workflow" "$release_workflow" "$sandbox_workflow" <<'RUBY'
 require "yaml"
 
 nightly = YAML.safe_load(File.read(ARGV[0]), aliases: true)
 release = YAML.safe_load(File.read(ARGV[1]), aliases: true)
+sandbox = YAML.safe_load(File.read(ARGV[2]), aliases: true)
 
 check_permissions = nightly.dig("jobs", "check-and-tag", "permissions")
 abort "check-and-tag permissions are not read-actions/write-contents" unless
@@ -61,6 +63,52 @@ abort "release builds can bypass ref validation" unless
 
 abort "release dependency fetches can fall back to Cargo's embedded Git client" unless
   release.dig("env", "CARGO_NET_GIT_FETCH_WITH_CLI") == "true"
+
+publishing_workflows = ARGV.drop(1)
+mutable_action_refs = publishing_workflows.flat_map do |path|
+  File.readlines(path).map do |line|
+    action_ref = line[/^\s*uses:\s*([^\s#]+)/, 1]
+    next if action_ref.nil? || action_ref.start_with?("./")
+    "#{path}: #{action_ref}" unless action_ref.match?(/@[0-9a-f]{40}\z/)
+  end.compact
+end
+abort "publishing workflows contain mutable action refs:\n#{mutable_action_refs.join("\n")}" unless
+  mutable_action_refs.empty?
+
+abort "release workflow must deny token permissions by default" unless
+  release["permissions"] == {}
+release["jobs"].each do |name, job|
+  abort "release job #{name} lacks explicit token permissions" unless job.key?("permissions")
+end
+%w[
+  build-linux-amd64
+  build-linux-arm64
+  build-darwin-amd64
+  build-darwin-arm64
+].each do |name|
+  abort "#{name} has broader token permissions than contents: read" unless
+    release.dig("jobs", name, "permissions") == {"contents" => "read"}
+end
+abort "create-release lost its required contents: write permission" unless
+  release.dig("jobs", "create-release", "permissions") == {"contents" => "write"}
+
+build_web_steps = release.dig("jobs", "build-web-assets", "steps")
+bun_step = build_web_steps.find { |step| step["name"] == "Install Bun" }
+abort "release workflow uses an unpinned Bun version" unless
+  bun_step&.dig("with", "bun-version") == "1.3.14"
+wasm_pack_step = build_web_steps.find { |step| step["name"] == "Install wasm-pack and Build WASM" }
+abort "release workflow uses an unpinned wasm-pack version" unless
+  wasm_pack_step&.fetch("run", "")&.include?("cargo install wasm-pack --version 0.13.1 --locked")
+
+abort "beta workflow grants package writes globally" unless
+  sandbox["permissions"] == {"contents" => "read"}
+abort "beta context preparation has broader token permissions than contents: read" unless
+  sandbox.dig("jobs", "prepare-context", "permissions") == {"contents" => "read"}
+%w[build-and-push-sandbox-images build-and-push-preview-gateway].each do |name|
+  abort "#{name} lacks job-scoped package publishing permission" unless
+    sandbox.dig("jobs", name, "permissions") ==
+      {"contents" => "read", "packages" => "write"}
+end
 
 sandbox_steps = release.dig("jobs", "prepare-sandbox-context", "steps")
 sandbox_dependencies = sandbox_steps.find { |step| step["name"] == "Install build dependencies" }
@@ -106,4 +154,4 @@ if "$validation_script" false tag latest >/dev/null 2>&1; then
   fail "a malformed release tag was accepted for publishing"
 fi
 
-echo "nightly release workflow wiring is valid"
+echo "nightly release workflow wiring and publishing workflow security are valid"

--- a/.github/scripts/test-nightly-release-workflows.sh
+++ b/.github/scripts/test-nightly-release-workflows.sh
@@ -90,6 +90,14 @@ mutable_action_refs = privileged_action_refs.select do |_location, action_ref|
 end
 abort "privileged workflows contain mutable action refs:\n#{mutable_action_refs.map { |location, ref| "#{location}: #{ref}" }.join("\n")}" unless
   mutable_action_refs.empty?
+inconsistent_action_pins = privileged_action_refs
+  .reject { |_location, action_ref| action_ref.start_with?("./") }
+  .group_by { |_location, action_ref| action_ref.split("@", 2).first }
+  .select { |_action, refs| refs.map(&:last).uniq.length > 1 }
+unless inconsistent_action_pins.empty?
+  abort "privileged workflows pin the same action to different commits:\n" \
+    "#{inconsistent_action_pins.inspect}"
+end
 
 abort "release workflow must deny token permissions by default" unless
   release["permissions"] == {}

--- a/.github/scripts/test-nightly-release-workflows.sh
+++ b/.github/scripts/test-nightly-release-workflows.sh
@@ -43,12 +43,13 @@ if [[ "$tag_aware_dispatch_count" -ne 5 ]]; then
   fail "expected release channel and version logic to distinguish dry-runs from tag dispatches"
 fi
 
-ruby - "$nightly_workflow" "$release_workflow" "$sandbox_workflow" <<'RUBY'
+ruby - "$repository_root" "$nightly_workflow" "$release_workflow" "$sandbox_workflow" <<'RUBY'
 require "yaml"
 
-nightly = YAML.safe_load(File.read(ARGV[0]), aliases: true)
-release = YAML.safe_load(File.read(ARGV[1]), aliases: true)
-sandbox = YAML.safe_load(File.read(ARGV[2]), aliases: true)
+repository_root = ARGV[0]
+nightly = YAML.safe_load(File.read(ARGV[1]), aliases: true)
+release = YAML.safe_load(File.read(ARGV[2]), aliases: true)
+sandbox = YAML.safe_load(File.read(ARGV[3]), aliases: true)
 
 check_permissions = nightly.dig("jobs", "check-and-tag", "permissions")
 abort "check-and-tag permissions are not read-actions/write-contents" unless
@@ -64,56 +65,89 @@ abort "release builds can bypass ref validation" unless
 abort "release dependency fetches can fall back to Cargo's embedded Git client" unless
   release.dig("env", "CARGO_NET_GIT_FETCH_WITH_CLI") == "true"
 
-publishing_workflows = ARGV.drop(1)
-mutable_action_refs = publishing_workflows.flat_map do |path|
-  File.readlines(path).map do |line|
-    action_ref = line[/^\s*uses:\s*([^\s#]+)/, 1]
-    next if action_ref.nil? || action_ref.start_with?("./")
-    "#{path}: #{action_ref}" unless action_ref.match?(/@[0-9a-f]{40}\z/)
-  end.compact
+workflow_documents = Dir[File.join(repository_root, ".github/workflows/*.{yml,yaml}")].sort.map do |path|
+  [path, YAML.safe_load(File.read(path), aliases: true)]
 end
-abort "publishing workflows contain mutable action refs:\n#{mutable_action_refs.join("\n")}" unless
+privileged_workflows = workflow_documents.select do |_path, workflow|
+  workflow_permissions = workflow.fetch("permissions", {}).values
+  job_permissions = workflow.fetch("jobs", {}).values.flat_map do |job|
+    job.fetch("permissions", {}).values
+  end
+  (workflow_permissions + job_permissions).include?("write")
+end
+privileged_action_refs = privileged_workflows.flat_map do |path, workflow|
+  workflow.fetch("jobs", {}).flat_map do |job_name, job|
+    refs = []
+    refs << ["#{path}: job #{job_name}", job["uses"]] if job["uses"]
+    job.fetch("steps", []).each_with_index do |step, index|
+      refs << ["#{path}: job #{job_name} step #{index + 1}", step["uses"]] if step["uses"]
+    end
+    refs
+  end
+end
+mutable_action_refs = privileged_action_refs.select do |_location, action_ref|
+  !action_ref.start_with?("./") && !action_ref.match?(/@[0-9a-f]{40}\z/)
+end
+abort "privileged workflows contain mutable action refs:\n#{mutable_action_refs.map { |location, ref| "#{location}: #{ref}" }.join("\n")}" unless
   mutable_action_refs.empty?
 
 abort "release workflow must deny token permissions by default" unless
   release["permissions"] == {}
-release["jobs"].each do |name, job|
-  abort "release job #{name} lacks explicit token permissions" unless job.key?("permissions")
+read_contents = {"contents" => "read"}
+publish_packages = {"contents" => "read", "packages" => "write"}
+expected_release_permissions = {
+  "validate-release-ref" => read_contents,
+  "build-web-assets" => read_contents,
+  "build-linux-amd64" => read_contents,
+  "build-linux-arm64" => read_contents,
+  "build-darwin-amd64" => read_contents,
+  "build-darwin-arm64" => read_contents,
+  "create-release" => {"contents" => "write"},
+  "build-and-push-docker" => publish_packages,
+  "create-docker-manifest" => publish_packages,
+  "prepare-sandbox-context" => read_contents,
+  "build-and-push-sandbox-images" => publish_packages,
+  "build-and-push-preview-gateway" => publish_packages,
+}
+actual_release_permissions = release.fetch("jobs").map do |name, job|
+  [name, job["permissions"]]
+end.to_h
+unless actual_release_permissions == expected_release_permissions
+  abort "release job permissions differ from the least-privilege allowlist:\n" \
+    "expected #{expected_release_permissions.inspect}\nactual #{actual_release_permissions.inspect}"
 end
-%w[
-  build-linux-amd64
-  build-linux-arm64
-  build-darwin-amd64
-  build-darwin-arm64
-].each do |name|
-  abort "#{name} has broader token permissions than contents: read" unless
-    release.dig("jobs", name, "permissions") == {"contents" => "read"}
-end
-abort "create-release lost its required contents: write permission" unless
-  release.dig("jobs", "create-release", "permissions") == {"contents" => "write"}
 
-build_web_steps = release.dig("jobs", "build-web-assets", "steps")
-bun_step = build_web_steps.find { |step| step["name"] == "Install Bun" }
+release_steps = release.fetch("jobs").values.flat_map { |job| job.fetch("steps", []) }
+bun_versions = release_steps.map { |step| step.dig("with", "bun-version") }.compact
 abort "release workflow uses an unpinned Bun version" unless
-  bun_step&.dig("with", "bun-version") == "1.3.14"
-wasm_pack_step = build_web_steps.find { |step| step["name"] == "Install wasm-pack and Build WASM" }
+  bun_versions == ["1.3.14"]
+wasm_pack_installs = release_steps.flat_map do |step|
+  step.fetch("run", "").lines.map(&:strip).select { |line| line.include?("cargo install wasm-pack") }
+end
 abort "release workflow uses an unpinned wasm-pack version" unless
-  wasm_pack_step&.fetch("run", "")&.include?("cargo install wasm-pack --version 0.13.1 --locked")
+  wasm_pack_installs == ["cargo install wasm-pack --version 0.13.1 --locked"]
 
-abort "beta workflow grants package writes globally" unless
-  sandbox["permissions"] == {"contents" => "read"}
-abort "beta context preparation has broader token permissions than contents: read" unless
-  sandbox.dig("jobs", "prepare-context", "permissions") == {"contents" => "read"}
-%w[build-and-push-sandbox-images build-and-push-preview-gateway].each do |name|
-  abort "#{name} lacks job-scoped package publishing permission" unless
-    sandbox.dig("jobs", name, "permissions") ==
-      {"contents" => "read", "packages" => "write"}
+expected_sandbox_permissions = {
+  "prepare-context" => read_contents,
+  "build-and-push-sandbox-images" => publish_packages,
+  "build-and-push-preview-gateway" => publish_packages,
+}
+actual_sandbox_permissions = sandbox.fetch("jobs").map do |name, job|
+  [name, job["permissions"]]
+end.to_h
+unless sandbox["permissions"] == read_contents &&
+    actual_sandbox_permissions == expected_sandbox_permissions
+  abort "beta workflow permissions differ from the least-privilege allowlist"
 end
 
 sandbox_steps = release.dig("jobs", "prepare-sandbox-context", "steps")
 sandbox_dependencies = sandbox_steps.find { |step| step["name"] == "Install build dependencies" }
 abort "sandbox helper builds do not install protoc" unless
   sandbox_dependencies&.fetch("run", "")&.include?("protobuf-compiler")
+
+puts "privileged workflow action pinning valid: #{privileged_action_refs.length} uses " \
+  "across #{privileged_workflows.length} workflows"
+puts "release permission allowlists and tool pins are valid"
 RUBY
 
 expect_decision() {

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -67,7 +67,7 @@ jobs:
 
       - name: Generate changelog preview
         id: cliff
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
         with:
           config: cliff.toml
           args: --strip all ${{ steps.range.outputs.range }}
@@ -81,7 +81,7 @@ jobs:
       # above still runs and gates every PR; only the preview comment is skipped.
       - name: Post preview comment
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -42,13 +42,15 @@ jobs:
       checks: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: dependency-scan-cargo-audit
 
@@ -92,7 +94,7 @@ jobs:
       #   yet -- tracked for a ring/aws-lc-rs-backed signing migration.
       # Remove an entry once its upstream is fixed/replaced.
       - name: Run cargo-audit
-        uses: rustsec/audit-check@v2.0.0
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ignore: RUSTSEC-2024-0370,RUSTSEC-2025-0134,RUSTSEC-2018-0017,RUSTSEC-2024-0437,RUSTSEC-2023-0018,RUSTSEC-2023-0071
@@ -104,15 +106,15 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4e66a329aec7e433d2d1c52a9 # v6
         with:
           path: web/node_modules
           key: ${{ runner.os }}-bun-${{ hashFiles('web/bun.lock') }}
@@ -150,10 +152,10 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Run Trivy vulnerability scanner on published image
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           # Matches the tag naming release.yml publishes for stable releases
           # (ghcr.io/${{ github.repository_owner }}/temps:<channel_tag>) --
@@ -175,6 +177,6 @@ jobs:
       - name: Upload Trivy results to GitHub code scanning
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@adfda868f108ac4222129de456ea554034a27db7 # v4
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -114,7 +114,7 @@ jobs:
           bun-version: 1.3.14
 
       - name: Cache Bun dependencies
-        uses: actions/cache@55cc8345863c7cc4e66a329aec7e433d2d1c52a9 # v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: web/node_modules
           key: ${{ runner.os }}-bun-${{ hashFiles('web/bun.lock') }}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -29,7 +29,7 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout main
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,18 +41,20 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
 
       - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: web/node_modules
           key: ${{ runner.os }}-bun-${{ hashFiles('web/bun.lock') }}
@@ -79,7 +81,7 @@ jobs:
           TEMPS_VERSION: ${{ github.ref_name }}
 
       - name: Upload web dist artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: web-dist
           path: crates/temps-cli/dist
@@ -93,7 +95,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install build dependencies
         run: |
@@ -101,17 +103,18 @@ jobs:
           sudo apt-get install -y cmake pkg-config libssl-dev protobuf-compiler
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
+          toolchain: stable
           targets: x86_64-unknown-linux-gnu
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: linux-amd64-release
 
       - name: Download web dist artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: web-dist
           path: crates/temps-cli/dist
@@ -145,7 +148,7 @@ jobs:
           ./temps --version || echo "Note: Binary may require runtime dependencies"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: temps-linux-amd64
           path: |
@@ -160,7 +163,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install build dependencies
         run: |
@@ -168,17 +171,18 @@ jobs:
           sudo apt-get install -y cmake pkg-config libssl-dev protobuf-compiler
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
+          toolchain: stable
           targets: aarch64-unknown-linux-gnu
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: linux-arm64-release
 
       - name: Download web dist artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: web-dist
           path: crates/temps-cli/dist
@@ -215,7 +219,7 @@ jobs:
           ./temps --version || echo "Note: Binary may require runtime dependencies"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: temps-linux-arm64
           path: |
@@ -239,15 +243,16 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
+          toolchain: stable
           targets: x86_64-apple-darwin
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: darwin-amd64-release
 
@@ -255,7 +260,7 @@ jobs:
         run: brew install protobuf
 
       - name: Download web dist artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: web-dist
           path: crates/temps-cli/dist
@@ -289,7 +294,7 @@ jobs:
           ./temps --version || echo "Note: Binary may require runtime dependencies"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: temps-darwin-amd64
           path: |
@@ -304,24 +309,25 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
+          toolchain: stable
           targets: aarch64-apple-darwin
 
       - name: Install system dependencies
         run: brew install protobuf
 
       - name: Download web dist artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: web-dist
           path: crates/temps-cli/dist
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: darwin-arm64-release
 
@@ -354,7 +360,7 @@ jobs:
           ./temps --version || echo "Note: Binary may require runtime dependencies"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: temps-darwin-arm64
           path: |
@@ -379,7 +385,7 @@ jobs:
       channel_tag: ${{ steps.channel.outputs.channel_tag }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Determine release channel
         id: channel
@@ -407,7 +413,7 @@ jobs:
           fi
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
 
@@ -637,10 +643,10 @@ jobs:
             tarball: temps-linux-arm64.tar.gz
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download binary artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ matrix.artifact }}
           path: artifacts
@@ -654,10 +660,10 @@ jobs:
           file temps
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -686,7 +692,7 @@ jobs:
           echo "Platform tag: $PLATFORM_TAG"
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ./Dockerfile.release
@@ -726,7 +732,7 @@ jobs:
       packages: write
     steps:
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -790,13 +796,15 @@ jobs:
       gateway_version: ${{ steps.version.outputs.gateway_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
 
       - name: Cache cargo deps
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: sandbox-image-builder
 
@@ -853,7 +861,7 @@ jobs:
           find sandbox-context/bundle -type f | sort
 
       - name: Upload sandbox build context
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sandbox-context
           path: sandbox-context/
@@ -877,7 +885,7 @@ jobs:
       IS_PRERELEASE: ${{ needs.create-release.outputs.is_prerelease }}
     steps:
       - name: Download prepared context
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: sandbox-context
           path: sandbox-context
@@ -894,13 +902,13 @@ jobs:
           find build-context -maxdepth 2 | sort
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -948,7 +956,7 @@ jobs:
           fi
 
       - name: Build and push sandbox image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./build-context
           platforms: linux/amd64,linux/arm64
@@ -977,16 +985,16 @@ jobs:
       IS_PRERELEASE: ${{ needs.create-release.outputs.is_prerelease }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -1018,7 +1026,7 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: Build and push preview gateway image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./crates/temps-preview-gateway
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/sandbox-images-beta.yml
+++ b/.github/workflows/sandbox-images-beta.yml
@@ -81,13 +81,15 @@ jobs:
       gateway_version: ${{ steps.version.outputs.gateway_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
 
       - name: Cache cargo deps
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: sandbox-image-builder
 
@@ -159,7 +161,7 @@ jobs:
           find sandbox-context/bundle -type f | sort
 
       - name: Upload sandbox build context
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sandbox-context
           path: sandbox-context/
@@ -182,7 +184,7 @@ jobs:
         runtime: [node, bun, python, rust, go, full]
     steps:
       - name: Download prepared context
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: sandbox-context
           path: sandbox-context
@@ -202,13 +204,13 @@ jobs:
           find build-context -maxdepth 2 | sort
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -235,7 +237,7 @@ jobs:
           echo "  $REPO:$SHA"
 
       - name: Build and push sandbox image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./build-context
           platforms: linux/amd64,linux/arm64
@@ -265,16 +267,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -295,7 +297,7 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: Build and push preview gateway image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./crates/temps-preview-gateway
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Create dummy artifacts
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,44 +5,26 @@ Codex, aider, etc.). The detailed engineering rules live in
 [`CLAUDE.md`](./CLAUDE.md); this file is the short list of process
 conventions that go *around* the code. Read both.
 
-## Always update `CHANGELOG.md`
+## Do not hand-edit `CHANGELOG.md`
 
-Every user-visible change in this repo lands with a `CHANGELOG.md`
-entry under `## [Unreleased]`, in the same commit as the code change.
-"User-visible" means anything an operator could notice: behaviour
-change, new flag, new endpoint, removed flag, UI change, performance
-characteristic, error-message format, dependency bump that changes
-the operator surface. Internal refactors with no observable impact
-don't need an entry, but when in doubt, write one.
+`CHANGELOG.md` is generated from Conventional Commits by
+[git-cliff](https://git-cliff.org) at release time. PRs must not edit it
+directly, because concurrent `[Unreleased]` edits caused constant merge
+conflicts.
 
-The file follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/):
-- Sections: `### Added`, `### Changed`, `### Removed`, `### Fixed`,
-  `### Tests` (last is project-specific).
-- Each bullet starts with a **bolded short headline**, then a colon,
-  then a self-contained explanation. Include *why* — not just *what*.
-- Reference migration filenames, endpoint paths, env vars, and crate
-  names by their exact identifiers so the entry is greppable later.
-- Test-only changes go under `### Tests`.
+The `Changelog` workflow validates every non-merge commit in a PR and
+posts a preview of the generated entry. A non-conventional commit is
+dropped from the changelog, so use a precise `type(scope): description`
+subject and make the user or operator impact clear there.
 
-If you're touching code without writing a CHANGELOG entry, you're
-either doing the wrong thing or you forgot. Stop and add the entry
-before staging the commit.
+Preview the generated entry locally with:
 
-**This is CI-enforced on every PR to `main`.** The `changelog-check`
-workflow fails the PR unless the diff touches `CHANGELOG.md` (with a
-valid `## [Unreleased]` category) **or** the PR carries the
-`skip-changelog` label. So for every PR you open, do one of:
+```bash
+scripts/changelog.sh --unreleased
+```
 
-- **Add a `CHANGELOG.md` entry** (the default — see above). This is
-  also required for changes to the `@temps-sdk/cli` npm package, even
-  though it versions separately; tag those bullets with `(\`@temps-sdk/cli\`, #PR)`.
-- **Apply the `skip-changelog` label** (`gh pr edit <n> --add-label
-  skip-changelog`) only when the change is genuinely changelog-exempt:
-  docs/typos, CI/build config, dependency bumps with no operator
-  impact, pure refactors, or test-only changes.
-
-Don't open a PR and leave the changelog check red — resolve it the
-same way you'd resolve a failing test.
+The release process regenerates `CHANGELOG.md`; the commit history is
+the source of truth.
 
 ## Use the generated OpenAPI SDK in `web/`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,13 +16,13 @@ Thank you for your interest in contributing to Temps. Whether you are reporting 
 - **Rust** 1.70 or later (`rustup` recommended)
 - **Docker** (for container runtime, integration tests, and database)
 - **PostgreSQL** with TimescaleDB extension
-- **Bun** (for frontend development)
+- **Bun** 1.3.14 (for frontend development)
 - **Node.js** 18+
 - **C/C++ build toolchain**, **CMake**, and **pkg-config** -- required by native Rust dependencies
 - **OpenSSL development headers** -- required by Pingora/OpenSSL and Git dependencies
 - **protobuf compiler** (`protoc`) -- required by the `temps-otel` crate to compile OpenTelemetry `.proto` files
 - **rustfmt** -- required by generated-code build scripts
-- **wasm-pack** -- required to build the `temps-captcha-wasm` crate
+- **wasm-pack** 0.13.1 -- required to build the `temps-captcha-wasm` crate
 - **wasm32-unknown-unknown Rust target** -- required by the `temps-captcha-wasm` crate
 
 #### Amazon Linux 2023 build prerequisites
@@ -34,7 +34,7 @@ sudo dnf install -y \
   cmake pkgconf-pkg-config openssl-devel protobuf-compiler \
   perl-FindBin perl-IPC-Cmd perl-File-Compare perl-File-Copy perl-Time-Piece
 
-cargo install wasm-pack
+cargo install wasm-pack --version 0.13.1 --locked
 ```
 
 If `cargo install` places `wasm-pack` in `~/.cargo/bin`, make sure that directory is on your `PATH`.
@@ -48,7 +48,7 @@ sudo apt-get install -y \
 
 rustup component add rustfmt
 rustup target add wasm32-unknown-unknown
-cargo install wasm-pack
+cargo install wasm-pack --version 0.13.1 --locked
 ```
 
 #### macOS build prerequisites
@@ -58,7 +58,7 @@ brew install cmake openssl pkg-config protobuf
 
 rustup component add rustfmt
 rustup target add wasm32-unknown-unknown
-cargo install wasm-pack
+cargo install wasm-pack --version 0.13.1 --locked
 ```
 
 ### Clone and Build


### PR DESCRIPTION
## Summary

- pin all external actions used by the six GitHub workflows with write-capable tokens
- deny release permissions by default and allowlist exact per-job scopes
- pin Bun 1.3.14 and wasm-pack 0.13.1 with Cargo's locked dependency graph
- add a YAML-based regression contract covering job and step action refs, consistent SHAs, exact permissions, and tool-install commands
- align contributor guidance with the pinned toolchain and generated changelog workflow

## Security impact

This closes mutable-tag supply-chain paths in release, sandbox publishing, changelog, dependency scanning, nightly release, and test release workflows. Package, release, checks, security-event, action-dispatch, and pull-request write tokens remain limited to the jobs that require them.

## Evidence

```text
$ .github/scripts/test-nightly-release-workflows.sh
privileged workflow action pinning valid: 77 uses across 6 workflows
release permission allowlists and tool pins are valid
nightly release workflow wiring and publishing workflow security are valid
```

```text
$ prek run check-yaml --files <six privileged workflow files>
check yaml...............................................................Passed
$ prek run trailing-whitespace --files <changed files>
trim trailing whitespace.................................................Passed
$ prek run end-of-file-fixer --files <changed files>
fix end of files.........................................................Passed
$ prek run typos --files <changed files>
typos....................................................................Passed
```

Official ref resolution:

```text
$ git ls-remote https://github.com/actions/checkout.git refs/tags/v7
3d3c42e5aac5ba805825da76410c181273ba90b1  refs/tags/v7
$ git ls-remote https://github.com/dtolnay/rust-toolchain.git refs/heads/stable
4cda84d5c5c54efe2404f9d843567869ab1699d4  refs/heads/stable
$ git ls-remote https://github.com/oven-sh/setup-bun.git refs/tags/v2
0c5077e51419868618aeaa5fe8019c62421857d6  refs/tags/v2
$ git ls-remote https://github.com/actions/cache.git refs/tags/v6
55cc8345863c7cc4c66a329aec7e433d2d1c52a9  refs/tags/v6
$ git ls-remote https://github.com/actions/upload-artifact.git refs/tags/v7
043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  refs/tags/v7
$ git ls-remote https://github.com/actions/download-artifact.git refs/tags/v8
3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  refs/tags/v8
$ git ls-remote https://github.com/docker/setup-buildx-action.git refs/tags/v4
bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  refs/tags/v4
$ git ls-remote https://github.com/docker/login-action.git refs/tags/v4
dbcb813823bdd20940b903addbd779551569679f  refs/tags/v4
$ git ls-remote https://github.com/docker/build-push-action.git refs/tags/v7
53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  refs/tags/v7
$ git ls-remote https://github.com/docker/setup-qemu-action.git refs/tags/v4
96fe6ef7f33517b61c61be40b68a1882f3264fb8  refs/tags/v4
$ git ls-remote https://github.com/orhun/git-cliff-action.git refs/tags/v4
f50e11560dce63f7c33227798f90b924471a88b5  refs/tags/v4
$ git ls-remote https://github.com/actions/github-script.git refs/tags/v9
373c709c69115d41ff229c7e5df9f8788daa9553  refs/tags/v9
$ git ls-remote https://github.com/rustsec/audit-check.git refs/tags/v2.0.0
69366f33c96575abad1ee0dba8212993eecbe998  refs/tags/v2.0.0
$ git ls-remote https://github.com/aquasecurity/trivy-action.git refs/tags/v0.36.0
a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  refs/tags/v0.36.0
$ git ls-remote https://github.com/github/codeql-action.git refs/tags/v4
adfda868f108ac4222129de456ea554034a27db7  refs/tags/v4
$ gh api repos/Swatinem/rust-cache/commits/e18b497796c12c097a38f9edb9d0641fb99eee32 --jq .sha
e18b497796c12c097a38f9edb9d0641fb99eee32
```

Safe end-to-end validation on the final head: [release dry-run 30521162507](https://github.com/gotempsh/temps/actions/runs/30521162507).

Live publishing was not run because it would create or overwrite releases and container tags. The dry-run executes the build graph with release creation, image pushes, and manifest publication disabled.
