### PR TITLE
fix(release): identify repository for nightly dispatch

### DIFF
--- a/.github/scripts/test-nightly-release-workflows.sh
+++ b/.github/scripts/test-nightly-release-workflows.sh
@@ -21,6 +21,9 @@ grep -Fq -- '--repo "$REPOSITORY"' "$nightly_workflow" ||
 grep -Fq -- '--ref "$TAG"' "$nightly_workflow" ||
   fail "nightly tags are not explicitly dispatched to the release workflow"
 
+grep -Fq -- '--field dry_run=false' "$nightly_workflow" ||
+  fail "nightly release dispatches would use the safe dry-run default"
+
 # The active-run query must be scoped to the nightly tag, not merely the SHA;
 # an unrelated branch dry-run can share the same commit.
 # shellcheck disable=SC2016

--- a/.github/scripts/test-nightly-release-workflows.sh
+++ b/.github/scripts/test-nightly-release-workflows.sh
@@ -12,10 +12,13 @@ fail() {
   exit 1
 }
 
-# The literal $TAG is the workflow contract under test.
+# The no-checkout dispatch job must identify both repository and tag explicitly.
 # shellcheck disable=SC2016
-grep -Fq 'gh workflow run release.yml --ref "$TAG" --field dry_run=false' \
-  "$nightly_workflow" ||
+grep -Fq -- '--repo "$REPOSITORY"' "$nightly_workflow" ||
+  fail "the no-checkout dispatch job cannot identify its repository"
+
+# shellcheck disable=SC2016
+grep -Fq -- '--ref "$TAG"' "$nightly_workflow" ||
   fail "nightly tags are not explicitly dispatched to the release workflow"
 
 # The active-run query must be scoped to the nightly tag, not merely the SHA;

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -139,8 +139,12 @@ jobs:
       - name: Start release workflow for nightly tag
         env:
           GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
           TAG: ${{ needs.check-and-tag.outputs.tag }}
         run: |
           set -euo pipefail
-          gh workflow run release.yml --ref "$TAG" --field dry_run=false
+          gh workflow run release.yml \
+            --repo "$REPOSITORY" \
+            --ref "$TAG" \
+            --field dry_run=false
           echo "Dispatched release workflow for $TAG"


### PR DESCRIPTION
## Summary

- pass `github.repository` explicitly to `gh workflow run`
- keep the dispatch job checkout-free and limited to `actions: write`
- extend the release workflow contract test to require an explicit repository

## Root cause

The production E2E run created
`v0.1.0-nightly.20260729.bd382d68`, then failed in the dispatch-only job:

```text
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The job intentionally has no checkout to keep `actions: write` isolated from
repository contents. Without a checkout, `gh workflow run` cannot infer the
repository from Git metadata. Passing `--repo "$REPOSITORY"` preserves that
security boundary and lets the command run from an empty workspace.

## Evidence

**Production reproduction**

```text
Nightly Release run: 30491027217
Tag creation: success
Dispatch release workflow: failure
TAG: v0.1.0-nightly.20260729.bd382d68
Error: fatal: not a git repository
```

**Regression contract**

```bash
.github/scripts/test-nightly-release-workflows.sh
```

```text
nightly release workflow wiring is valid
```

**Workflow validation**

```bash
shellcheck .github/scripts/test-nightly-release-workflows.sh
/tmp/temps-nightly-actionlint-bin/actionlint \
  -ignore 'SC(2086|2129)' \
  .github/workflows/nightly-release.yml \
  .github/workflows/release.yml \
  .github/workflows/rust-tests.yml
git diff --check origin/main...HEAD
```

All commands passed.

After merge, rerunning `Nightly Release` will exercise #471's recovery path:
it must reuse the existing tag rather than create another one, then dispatch
the full Release workflow.
