### PR TITLE
fix(release): use git CLI for dependencies

### DIFF
--- a/.github/scripts/test-nightly-release-workflows.sh
+++ b/.github/scripts/test-nightly-release-workflows.sh
@@ -58,6 +58,9 @@ abort "dispatch-release must only have actions: write" unless
 
 abort "release builds can bypass ref validation" unless
   release.dig("jobs", "build-web-assets", "needs") == "validate-release-ref"
+
+abort "release dependency fetches can fall back to Cargo's embedded Git client" unless
+  release.dig("env", "CARGO_NET_GIT_FETCH_WITH_CLI") == "true"
 RUBY
 
 expect_decision() {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
   RUST_BACKTRACE: 1
 
 permissions:


### PR DESCRIPTION
## Summary
- force Cargo release jobs to fetch Git dependencies with the system Git CLI
- avoid repeated libgit2/SecureTransport failures cloning Relay nested submodules on macOS runners
- add a workflow contract assertion for the setting

## Evidence
- `.github/scripts/test-nightly-release-workflows.sh`
- `shellcheck .github/scripts/test-nightly-release-workflows.sh`
- `actionlint -ignore 'SC(2086|2129)' .github/workflows/nightly-release.yml .github/workflows/release.yml`\n- `git diff --check`\n\n## E2E failure reproduced\nRelease run 30491925662 failed twice on macOS while fetching Chromium zlib through Cargo’s embedded Git client. Cargo recommended `net.git-fetch-with-cli`; Linux builds succeeded.