### PR TITLE
fix(release): install protoc for sandbox helpers

### DIFF
--- a/.github/scripts/test-nightly-release-workflows.sh
+++ b/.github/scripts/test-nightly-release-workflows.sh
@@ -61,6 +61,11 @@ abort "release builds can bypass ref validation" unless
 
 abort "release dependency fetches can fall back to Cargo's embedded Git client" unless
   release.dig("env", "CARGO_NET_GIT_FETCH_WITH_CLI") == "true"
+
+sandbox_steps = release.dig("jobs", "prepare-sandbox-context", "steps")
+sandbox_dependencies = sandbox_steps.find { |step| step["name"] == "Install build dependencies" }
+abort "sandbox helper builds do not install protoc" unless
+  sandbox_dependencies&.fetch("run", "")&.include?("protobuf-compiler")
 RUBY
 
 expect_decision() {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -827,6 +827,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
       - name: Cache cargo deps
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary
- install `protobuf-compiler` before compiling sandbox context helpers
- add a workflow contract assertion that the dependency remains installed

## Why
Post-merge nightly Release run 30501878232 built and published all native artifacts, but `Prepare sandbox build context` failed because the `temps-otel` build script could not find `protoc`. This skipped sandbox and preview image publishing.

## Verification
- `.github/scripts/test-nightly-release-workflows.sh`
- `shellcheck .github/scripts/test-nightly-release-workflows.sh .github/scripts/nightly-release-decision.sh .github/scripts/validate-release-ref.sh`
- `actionlint -ignore 'SC(2086|2129)' .github/workflows/nightly-release.yml .github/workflows/release.yml`
- `git diff --check`