### PR TITLE
fix(deployments): persist terminal status for jobs that never run

### DIFF
--- a/crates/temps-core/src/workflow_executor.rs
+++ b/crates/temps-core/src/workflow_executor.rs
@@ -443,6 +443,54 @@ impl WorkflowExecutor {
         Ok(order)
     }
 
+    /// Record a terminal status for a job that never entered execution.
+    ///
+    /// Jobs that are skipped or fail prerequisite validation never reach the
+    /// batch-result handling in [`execute_workflow`](Self::execute_workflow), so
+    /// without this their tracker row keeps whatever status the planner created it
+    /// with (`Pending`) indefinitely. Tracker failures are logged and swallowed —
+    /// they must not take down the surrounding workflow.
+    async fn persist_terminal_status(
+        &self,
+        context: &WorkflowContext,
+        job_id: &str,
+        status: JobStatus,
+        message: Option<String>,
+    ) {
+        let Some(ref tracker) = self.job_tracker else {
+            return;
+        };
+
+        let execution_id = match tracker
+            .create_job_execution(&context.workflow_run_id, job_id, status.clone())
+            .await
+        {
+            Ok(id) => id,
+            Err(e) => {
+                error!(
+                    "Failed to record terminal status {:?} for job '{}': {}",
+                    status, job_id, e
+                );
+                return;
+            }
+        };
+
+        if let Err(e) = tracker
+            .update_job_status(execution_id, status.clone(), message)
+            .await
+        {
+            error!(
+                "Failed to update job '{}' (execution {}) to {:?}: {}",
+                job_id, execution_id, status, e
+            );
+        } else {
+            debug!(
+                "✅ Recorded terminal status {:?} for job '{}'",
+                status, job_id
+            );
+        }
+    }
+
     /// Execute a batch of jobs in parallel
     async fn execute_job_batch(
         &self,
@@ -463,6 +511,16 @@ impl WorkflowExecutor {
                 if job_state.job_config.job.should_skip(context).await? {
                     info!("⏭️ Skipping job: {}", job_id);
                     job_state.status = JobStatus::Skipped;
+                    // A job that never enters the batch results below must still reach a
+                    // terminal state in the tracker, or its pre-created row stays Pending
+                    // forever and the UI shows the step as still running.
+                    self.persist_terminal_status(
+                        context,
+                        &job_id,
+                        JobStatus::Skipped,
+                        Some("Job skipped: preconditions for running it were not met".to_string()),
+                    )
+                    .await;
                     continue;
                 }
 
@@ -476,11 +534,33 @@ impl WorkflowExecutor {
                     let error_msg = format!("Prerequisites not met for job '{}': {}", job_id, e);
                     error!("{}", error_msg);
 
+                    // Failed prerequisites are a real failure, not a silent skip — record
+                    // them as Failure with the reason so the operator can act on it. This
+                    // applies to optional jobs too: they are optional for *deployment
+                    // completion*, not exempt from reporting why they didn't run.
+                    job_state.status = JobStatus::Failure;
+                    self.persist_terminal_status(
+                        context,
+                        &job_id,
+                        JobStatus::Failure,
+                        Some(error_msg.clone()),
+                    )
+                    .await;
+
+                    if let Err(log_err) = context.log(&error_msg).await {
+                        error!(
+                            "Failed to log prerequisite failure for '{}': {}",
+                            job_id, log_err
+                        );
+                    }
+
                     if job_state.job_config.required && !continue_on_failure {
                         return Err(e);
                     } else {
-                        warn!("Skipping job '{}' due to failed prerequisites", job_id);
-                        job_state.status = JobStatus::Skipped;
+                        warn!(
+                            "Not running job '{}' due to failed prerequisites: {}",
+                            job_id, e
+                        );
                         continue;
                     }
                 }
@@ -844,5 +924,265 @@ mod tests {
         } else {
             panic!("Expected DependencyCycleDetected error");
         }
+    }
+
+    /// A job that never runs: either its prerequisites fail or it opts out via
+    /// `should_skip`. Mirrors `TakeScreenshotJob` when Chrome is missing.
+    #[derive(Debug)]
+    struct NonRunningJob {
+        id: String,
+        skip: bool,
+        prerequisite_error: Option<String>,
+        executed: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl WorkflowTask for NonRunningJob {
+        fn job_id(&self) -> &str {
+            &self.id
+        }
+
+        fn name(&self) -> &str {
+            "Non-running job"
+        }
+
+        fn description(&self) -> &str {
+            "A job that is skipped or fails prerequisite validation"
+        }
+
+        async fn execute(&self, context: WorkflowContext) -> Result<JobResult, WorkflowError> {
+            self.executed.fetch_add(1, Ordering::SeqCst);
+            Ok(JobResult::success(context))
+        }
+
+        async fn should_skip(&self, _context: &WorkflowContext) -> Result<bool, WorkflowError> {
+            Ok(self.skip)
+        }
+
+        async fn validate_prerequisites(
+            &self,
+            _context: &WorkflowContext,
+        ) -> Result<(), WorkflowError> {
+            match &self.prerequisite_error {
+                Some(msg) => Err(WorkflowError::JobValidationFailed(msg.clone())),
+                None => Ok(()),
+            }
+        }
+
+        fn depends_on(&self) -> Vec<String> {
+            Vec::new()
+        }
+    }
+
+    /// Records every status the executor persists, keyed by job id.
+    #[derive(Default)]
+    struct RecordingJobTracker {
+        statuses: std::sync::Mutex<Vec<(String, JobStatus, Option<String>)>>,
+        ids: std::sync::Mutex<HashMap<i32, String>>,
+    }
+
+    impl RecordingJobTracker {
+        fn statuses_for(&self, job_id: &str) -> Vec<(JobStatus, Option<String>)> {
+            self.statuses
+                .lock()
+                .expect("statuses lock poisoned")
+                .iter()
+                .filter(|(id, _, _)| id == job_id)
+                .map(|(_, status, msg)| (status.clone(), msg.clone()))
+                .collect()
+        }
+
+        /// The status the deployment_jobs row would be left with.
+        fn final_status(&self, job_id: &str) -> Option<(JobStatus, Option<String>)> {
+            self.statuses_for(job_id).last().cloned()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl JobTracker for RecordingJobTracker {
+        async fn create_job_execution(
+            &self,
+            _workflow_run_id: &str,
+            job_id: &str,
+            status: JobStatus,
+        ) -> Result<i32, WorkflowError> {
+            let mut ids = self.ids.lock().expect("ids lock poisoned");
+            let execution_id = ids.len() as i32 + 1;
+            ids.insert(execution_id, job_id.to_string());
+            self.statuses.lock().expect("statuses lock poisoned").push((
+                job_id.to_string(),
+                status,
+                None,
+            ));
+            Ok(execution_id)
+        }
+
+        async fn update_job_status(
+            &self,
+            job_execution_id: i32,
+            status: JobStatus,
+            message: Option<String>,
+        ) -> Result<(), WorkflowError> {
+            let job_id = self
+                .ids
+                .lock()
+                .expect("ids lock poisoned")
+                .get(&job_execution_id)
+                .cloned()
+                .ok_or_else(|| {
+                    WorkflowError::Other(format!("Unknown execution id {}", job_execution_id))
+                })?;
+            self.statuses
+                .lock()
+                .expect("statuses lock poisoned")
+                .push((job_id, status, message));
+            Ok(())
+        }
+
+        async fn add_job_logs(&self, _id: i32, _logs: Vec<String>) -> Result<(), WorkflowError> {
+            Ok(())
+        }
+
+        async fn mark_job_started(&self, _id: i32) -> Result<(), WorkflowError> {
+            Ok(())
+        }
+
+        async fn mark_job_finished(&self, _id: i32) -> Result<(), WorkflowError> {
+            Ok(())
+        }
+
+        async fn save_job_outputs(
+            &self,
+            _id: i32,
+            _outputs: serde_json::Value,
+        ) -> Result<(), WorkflowError> {
+            Ok(())
+        }
+
+        async fn cancel_pending_jobs(
+            &self,
+            _workflow_run_id: &str,
+            _reason: String,
+        ) -> Result<(), WorkflowError> {
+            Ok(())
+        }
+    }
+
+    async fn run_with_tracker(
+        job: Arc<dyn WorkflowTask>,
+        required: bool,
+        continue_on_failure: bool,
+    ) -> (
+        Arc<RecordingJobTracker>,
+        Result<WorkflowContext, WorkflowError>,
+    ) {
+        let tracker = Arc::new(RecordingJobTracker::default());
+        let config = WorkflowBuilder::new()
+            .with_workflow_run_id("test-workflow".to_string())
+            .with_deployment_context(1, 1, 1)
+            .with_log_writer(Arc::new(MockLogWriter))
+            .with_job_config(job, vec![], required)
+            .continue_on_failure(continue_on_failure)
+            .build()
+            .expect("workflow config should build");
+
+        let executor = WorkflowExecutor::new(Some(tracker.clone()));
+        let result = executor
+            .execute_workflow(
+                config,
+                Arc::new(TestCancellationProvider { cancelled: false }),
+            )
+            .await;
+
+        (tracker, result)
+    }
+
+    /// Regression test for #477: an optional job whose prerequisites fail (e.g.
+    /// `take_screenshot` on a server with no working Chrome) must be persisted as
+    /// Failure with the reason — previously only an in-memory status was set, so
+    /// the deployment_jobs row stayed Pending forever and the UI showed the step
+    /// as perpetually "generating".
+    #[tokio::test]
+    async fn test_optional_job_failing_prerequisites_is_persisted_as_failure() {
+        let executed = Arc::new(AtomicUsize::new(0));
+        let job = Arc::new(NonRunningJob {
+            id: "take_screenshot".to_string(),
+            skip: false,
+            prerequisite_error: Some(
+                "Screenshot provider 'local-headless-chrome' is not available: \
+                 Chrome browser error: Failed to launch Chrome browser"
+                    .to_string(),
+            ),
+            executed: executed.clone(),
+        });
+
+        let (tracker, result) = run_with_tracker(job, false, true).await;
+
+        // The optional job must not fail the workflow...
+        assert!(
+            result.is_ok(),
+            "optional job should not fail the workflow: {:?}",
+            result.err()
+        );
+        assert_eq!(executed.load(Ordering::SeqCst), 0, "job must not execute");
+
+        // ...but it must reach a terminal, non-Pending state in the tracker.
+        let (status, message) = tracker
+            .final_status("take_screenshot")
+            .expect("prerequisite failure must be persisted, not left Pending");
+        assert_eq!(status, JobStatus::Failure);
+
+        let message = message.expect("failure must carry a reason");
+        assert!(
+            message.contains("Failed to launch Chrome browser"),
+            "reason must reach the user, got: {}",
+            message
+        );
+    }
+
+    /// A required job that fails prerequisites still fails the workflow, but must
+    /// also leave a Failure row behind rather than a Pending one.
+    #[tokio::test]
+    async fn test_required_job_failing_prerequisites_is_persisted_before_erroring() {
+        let job = Arc::new(NonRunningJob {
+            id: "deploy".to_string(),
+            skip: false,
+            prerequisite_error: Some("docker daemon unreachable".to_string()),
+            executed: Arc::new(AtomicUsize::new(0)),
+        });
+
+        let (tracker, result) = run_with_tracker(job, true, false).await;
+
+        assert!(matches!(result, Err(WorkflowError::JobValidationFailed(_))));
+
+        let (status, message) = tracker
+            .final_status("deploy")
+            .expect("prerequisite failure must be persisted, not left Pending");
+        assert_eq!(status, JobStatus::Failure);
+        assert!(message
+            .unwrap_or_default()
+            .contains("docker daemon unreachable"));
+    }
+
+    /// A job that opts out via `should_skip` must be persisted as Skipped.
+    #[tokio::test]
+    async fn test_skipped_job_is_persisted_as_skipped() {
+        let executed = Arc::new(AtomicUsize::new(0));
+        let job = Arc::new(NonRunningJob {
+            id: "configure_crons".to_string(),
+            skip: true,
+            prerequisite_error: None,
+            executed: executed.clone(),
+        });
+
+        let (tracker, result) = run_with_tracker(job, false, true).await;
+
+        assert!(result.is_ok());
+        assert_eq!(executed.load(Ordering::SeqCst), 0, "job must not execute");
+
+        let (status, _) = tracker
+            .final_status("configure_crons")
+            .expect("skipped job must be persisted, not left Pending");
+        assert_eq!(status, JobStatus::Skipped);
     }
 }

--- a/crates/temps-core/src/workflow_executor.rs
+++ b/crates/temps-core/src/workflow_executor.rs
@@ -130,28 +130,17 @@ impl WorkflowExecutor {
             {
                 warn!("🚫 Workflow {} was cancelled", config.workflow_run_id);
 
-                // Cancel all pending jobs via job tracker
-                if let Some(ref tracker) = self.job_tracker {
-                    warn!(
-                        "🧹 Cancelling all pending jobs in workflow {}",
-                        config.workflow_run_id
-                    );
-                    if let Err(e) = tracker
-                        .cancel_pending_jobs(
-                            &config.workflow_run_id,
-                            "Workflow cancelled by user".to_string(),
-                        )
-                        .await
-                    {
-                        error!("Failed to cancel pending jobs: {}", e);
-                    }
-                }
+                self.cancel_remaining_pending(
+                    &config.workflow_run_id,
+                    "Workflow cancelled by user".to_string(),
+                )
+                .await;
 
                 return Err(WorkflowError::WorkflowCancelled);
             }
 
             // Execute all jobs in this batch in parallel
-            let batch_results = self
+            let batch_results = match self
                 .execute_job_batch(
                     batch,
                     &mut job_states,
@@ -160,7 +149,22 @@ impl WorkflowExecutor {
                     cancellation_provider.clone(),
                     config.continue_on_failure,
                 )
-                .await?;
+                .await
+            {
+                Ok(results) => results,
+                Err(e) => {
+                    // Aborting mid-batch skips the per-result handling below, which is
+                    // what would normally cancel the rest of the workflow. Without this,
+                    // every job that never got to run keeps the planner's `Pending`
+                    // status forever and the UI polls it as still in progress.
+                    self.cancel_remaining_pending(
+                        &config.workflow_run_id,
+                        format!("Workflow aborted: {}", e),
+                    )
+                    .await;
+                    return Err(e);
+                }
+            };
 
             // Check if any required jobs failed
             for (job_id, result) in batch_results {
@@ -443,6 +447,27 @@ impl WorkflowExecutor {
         Ok(order)
     }
 
+    /// Move every still-`Pending` job in this workflow to `Cancelled`.
+    ///
+    /// Any path that leaves `execute_workflow` early must call this: jobs that
+    /// never ran keep the status the planner created them with, and a row left at
+    /// `Pending` reads as "still running" forever in the UI. Tracker failures are
+    /// logged and swallowed — cancellation bookkeeping must not mask the original
+    /// error that caused the abort.
+    async fn cancel_remaining_pending(&self, workflow_run_id: &str, reason: String) {
+        let Some(ref tracker) = self.job_tracker else {
+            return;
+        };
+
+        warn!(
+            "🧹 Cancelling all pending jobs in workflow {}",
+            workflow_run_id
+        );
+        if let Err(e) = tracker.cancel_pending_jobs(workflow_run_id, reason).await {
+            error!("Failed to cancel pending jobs: {}", e);
+        }
+    }
+
     /// Record a terminal status for a job that never entered execution.
     ///
     /// Jobs that are skipped or fail prerequisite validation never reach the
@@ -514,13 +539,13 @@ impl WorkflowExecutor {
                     // A job that never enters the batch results below must still reach a
                     // terminal state in the tracker, or its pre-created row stays Pending
                     // forever and the UI shows the step as still running.
-                    self.persist_terminal_status(
-                        context,
-                        &job_id,
-                        JobStatus::Skipped,
-                        Some("Job skipped: preconditions for running it were not met".to_string()),
-                    )
-                    .await;
+                    //
+                    // No message: `should_skip` is a deliberate opt-out (feature disabled,
+                    // nothing to do), not a failure, and the executor doesn't know the
+                    // job-specific reason — inventing one would put a fabricated string in
+                    // the `error_message` column for a job that never errored.
+                    self.persist_terminal_status(context, &job_id, JobStatus::Skipped, None)
+                        .await;
                     continue;
                 }
 
@@ -979,9 +1004,19 @@ mod tests {
     struct RecordingJobTracker {
         statuses: std::sync::Mutex<Vec<(String, JobStatus, Option<String>)>>,
         ids: std::sync::Mutex<HashMap<i32, String>>,
+        cancellations: std::sync::Mutex<Vec<String>>,
     }
 
     impl RecordingJobTracker {
+        /// Reasons passed to `cancel_pending_jobs` — i.e. the sweeps that would
+        /// move leftover Pending rows to Cancelled.
+        fn cancellations(&self) -> Vec<String> {
+            self.cancellations
+                .lock()
+                .expect("cancellations lock poisoned")
+                .clone()
+        }
+
         fn statuses_for(&self, job_id: &str) -> Vec<(JobStatus, Option<String>)> {
             self.statuses
                 .lock()
@@ -1062,8 +1097,12 @@ mod tests {
         async fn cancel_pending_jobs(
             &self,
             _workflow_run_id: &str,
-            _reason: String,
+            reason: String,
         ) -> Result<(), WorkflowError> {
+            self.cancellations
+                .lock()
+                .expect("cancellations lock poisoned")
+                .push(reason);
             Ok(())
         }
     }
@@ -1164,6 +1203,78 @@ mod tests {
             .contains("docker daemon unreachable"));
     }
 
+    /// Aborting out of a batch must sweep the jobs that never got to run.
+    ///
+    /// The early `return Err` on a required job's failed prerequisites bypasses the
+    /// per-result handling that normally cancels the rest of the workflow, so every
+    /// downstream job kept the planner's `Pending` status forever — the same stuck
+    /// state as #477, one branch over.
+    #[tokio::test]
+    async fn test_aborting_batch_cancels_jobs_that_never_ran() {
+        let downstream_executed = Arc::new(AtomicUsize::new(0));
+
+        let failing = Arc::new(NonRunningJob {
+            id: "deploy".to_string(),
+            skip: false,
+            prerequisite_error: Some("docker daemon unreachable".to_string()),
+            executed: Arc::new(AtomicUsize::new(0)),
+        });
+        let downstream = Arc::new(NonRunningJob {
+            id: "take_screenshot".to_string(),
+            skip: false,
+            prerequisite_error: None,
+            executed: downstream_executed.clone(),
+        });
+
+        let tracker = Arc::new(RecordingJobTracker::default());
+        let config = WorkflowBuilder::new()
+            .with_workflow_run_id("test-workflow".to_string())
+            .with_deployment_context(1, 1, 1)
+            .with_log_writer(Arc::new(MockLogWriter))
+            .with_job_config(failing, vec![], true)
+            .with_job_config(downstream, vec!["deploy".to_string()], false)
+            .continue_on_failure(false)
+            .build()
+            .expect("workflow config should build");
+
+        let executor = WorkflowExecutor::new(Some(tracker.clone()));
+        let result = executor
+            .execute_workflow(
+                config,
+                Arc::new(TestCancellationProvider { cancelled: false }),
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "required job failure must abort the workflow"
+        );
+        assert_eq!(
+            downstream_executed.load(Ordering::SeqCst),
+            0,
+            "downstream job must not run"
+        );
+
+        // take_screenshot never reached the executor, so only the sweep can move it
+        // off Pending.
+        assert!(
+            tracker.final_status("take_screenshot").is_none(),
+            "sanity: the downstream job should have no status of its own"
+        );
+        let cancellations = tracker.cancellations();
+        assert_eq!(
+            cancellations.len(),
+            1,
+            "aborting the workflow must cancel jobs left Pending, got: {:?}",
+            cancellations
+        );
+        assert!(
+            cancellations[0].contains("docker daemon unreachable"),
+            "cancellation reason should explain the abort, got: {}",
+            cancellations[0]
+        );
+    }
+
     /// A job that opts out via `should_skip` must be persisted as Skipped.
     #[tokio::test]
     async fn test_skipped_job_is_persisted_as_skipped() {
@@ -1180,9 +1291,15 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(executed.load(Ordering::SeqCst), 0, "job must not execute");
 
-        let (status, _) = tracker
+        let (status, message) = tracker
             .final_status("configure_crons")
             .expect("skipped job must be persisted, not left Pending");
         assert_eq!(status, JobStatus::Skipped);
+        assert!(
+            message.is_none(),
+            "an intentional skip is not an error and the executor doesn't know the \
+             job's reason — it must not fabricate one, got: {:?}",
+            message
+        );
     }
 }

--- a/crates/temps-deployments/src/jobs/take_screenshot.rs
+++ b/crates/temps-deployments/src/jobs/take_screenshot.rs
@@ -260,11 +260,14 @@ impl WorkflowTask for TakeScreenshotJob {
             ));
         }
 
-        // Check if screenshot service is available
-        if !self.screenshot_service.is_provider_available().await {
-            return Err(WorkflowError::JobValidationFailed(
-                "Screenshot provider is not available".to_string(),
-            ));
+        // Check if screenshot service is available, surfacing *why* it is not so the
+        // operator gets an actionable message instead of a silent skip.
+        if let Err(e) = self.screenshot_service.check_provider_availability().await {
+            return Err(WorkflowError::JobValidationFailed(format!(
+                "Screenshot provider '{}' is not available: {}",
+                self.screenshot_service.provider_name(),
+                e
+            )));
         }
 
         Ok(())
@@ -375,5 +378,130 @@ impl TakeScreenshotJobBuilder {
 impl Default for TakeScreenshotJobBuilder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::{DatabaseBackend, MockDatabase};
+    use std::path::PathBuf;
+    use temps_screenshots::{ScreenshotError, ScreenshotResult};
+
+    /// Screenshot service whose provider is unavailable, mirroring a server where
+    /// Chrome is installed but its shared libraries are missing.
+    struct UnavailableScreenshotService;
+
+    #[async_trait]
+    impl ScreenshotServiceTrait for UnavailableScreenshotService {
+        async fn capture_and_save(&self, _url: &str, _filename: &str) -> ScreenshotResult<PathBuf> {
+            Err(ScreenshotError::ProviderNotConfigured)
+        }
+
+        async fn capture(&self, _url: &str) -> ScreenshotResult<Vec<u8>> {
+            Err(ScreenshotError::ProviderNotConfigured)
+        }
+
+        async fn is_enabled(&self) -> bool {
+            true
+        }
+
+        fn provider_name(&self) -> &'static str {
+            "local-headless-chrome"
+        }
+
+        async fn is_provider_available(&self) -> bool {
+            false
+        }
+
+        async fn check_provider_availability(&self) -> ScreenshotResult<()> {
+            Err(ScreenshotError::ChromeError(
+                "Failed to launch Chrome browser: libnss3.so: cannot open shared object file"
+                    .to_string(),
+            ))
+        }
+    }
+
+    fn test_config_service(db: Arc<DbConnection>) -> Arc<ConfigService> {
+        let server_config = Arc::new(temps_config::ServerConfig {
+            address: "127.0.0.1:3000".to_string(),
+            database_url: "postgres://test".to_string(),
+            tls_address: None,
+            console_address: "127.0.0.1:0".to_string(),
+            console_admin_address: None,
+            admin_allowed_ips: Vec::new(),
+            admin_allowed_hosts: Vec::new(),
+            admin_trust_forwarded_for: false,
+            data_dir: std::path::PathBuf::from("/tmp/temps-test"),
+            auth_secret: "test-secret".to_string(),
+            encryption_key: "test-key".to_string(),
+            api_base_url: "/api".to_string(),
+            postgres_max_connections: None,
+            postgres_min_connections: None,
+            postgres_connect_timeout_secs: None,
+            postgres_acquire_timeout_secs: None,
+            postgres_idle_timeout_secs: None,
+            postgres_max_lifetime_secs: None,
+            clickhouse_url: None,
+            clickhouse_database: None,
+            clickhouse_user: None,
+            clickhouse_password: None,
+        });
+        Arc::new(ConfigService::new(server_config, db))
+    }
+
+    struct NoopLogWriter;
+
+    #[async_trait]
+    impl temps_core::LogWriter for NoopLogWriter {
+        async fn write_log(&self, _message: String) -> Result<(), WorkflowError> {
+            Ok(())
+        }
+
+        fn stage_id(&self) -> i32 {
+            1
+        }
+    }
+
+    fn test_context() -> WorkflowContext {
+        WorkflowContext::new(
+            "test-workflow".to_string(),
+            1,
+            1,
+            1,
+            Arc::new(NoopLogWriter),
+        )
+    }
+
+    /// Regression test for #477: the prerequisite failure must name the provider
+    /// and carry the underlying reason, so the deployment job's error message tells
+    /// the operator what to actually fix.
+    #[tokio::test]
+    async fn test_validate_prerequisites_surfaces_provider_failure_reason() {
+        let db = Arc::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+        let job = TakeScreenshotJob::new(
+            "take_screenshot".to_string(),
+            1,
+            Arc::new(UnavailableScreenshotService),
+            test_config_service(db.clone()),
+            db,
+        );
+
+        let err = job
+            .validate_prerequisites(&test_context())
+            .await
+            .expect_err("unavailable provider must fail prerequisites");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("local-headless-chrome"),
+            "error should name the provider, got: {}",
+            message
+        );
+        assert!(
+            message.contains("libnss3.so"),
+            "error should carry the underlying reason, got: {}",
+            message
+        );
     }
 }

--- a/crates/temps-deployments/src/services/job_tracker.rs
+++ b/crates/temps-deployments/src/services/job_tracker.rs
@@ -93,7 +93,10 @@ impl JobTracker for DeploymentJobTracker {
                 active_job.started_at = Set(Some(now));
                 debug!("Job {} started at {}", job_execution_id, now);
             }
-            CoreJobStatus::Success | CoreJobStatus::Failure | CoreJobStatus::Cancelled => {
+            CoreJobStatus::Success
+            | CoreJobStatus::Failure
+            | CoreJobStatus::Cancelled
+            | CoreJobStatus::Skipped => {
                 let now = chrono::Utc::now();
                 active_job.finished_at = Set(Some(now));
                 debug!("Job {} finished at {}", job_execution_id, now);
@@ -569,6 +572,98 @@ mod tests {
             .all(db.as_ref())
             .await?;
         assert_eq!(pending_jobs.len(), 2); // crons and screenshot still pending
+
+        Ok(())
+    }
+
+    /// Regression test for #477: an optional job that never ran (failed
+    /// prerequisites) must leave a terminal row behind — not stay Pending — with the
+    /// reason and a finish time, so the UI stops showing it as in-progress.
+    #[tokio::test]
+    async fn test_prerequisite_failure_leaves_job_failed_not_pending(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+
+        let (deployment_id, _environment_id) = create_test_deployment(&db).await?;
+        let screenshot_job_id = create_test_job(
+            &db,
+            deployment_id,
+            "take_screenshot",
+            false,
+            EntityJobStatus::Pending,
+        )
+        .await?;
+
+        let tracker = DeploymentJobTracker::new(db.clone(), deployment_id);
+
+        // This is what WorkflowExecutor::persist_terminal_status does when
+        // validate_prerequisites fails.
+        let execution_id = tracker
+            .create_job_execution(
+                "deployment-workflow",
+                "take_screenshot",
+                CoreJobStatus::Failure,
+            )
+            .await?;
+        assert_eq!(execution_id, screenshot_job_id);
+
+        tracker
+            .update_job_status(
+                execution_id,
+                CoreJobStatus::Failure,
+                Some(
+                    "Screenshot provider 'local-headless-chrome' is not available: \
+                      Chrome browser error: libnss3.so: cannot open shared object file"
+                        .to_string(),
+                ),
+            )
+            .await?;
+
+        let job = DeploymentJobs::find_by_id(screenshot_job_id)
+            .one(db.as_ref())
+            .await?
+            .ok_or("screenshot job should exist")?;
+
+        assert_eq!(job.status, EntityJobStatus::Failure);
+        assert!(
+            job.finished_at.is_some(),
+            "a job that reached a terminal state must have finished_at set"
+        );
+        assert!(job.error_message.unwrap_or_default().contains("libnss3.so"));
+
+        Ok(())
+    }
+
+    /// A skipped job must also be terminal, including `finished_at`.
+    #[tokio::test]
+    async fn test_skipped_job_records_finished_at() -> Result<(), Box<dyn std::error::Error>> {
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+
+        let (deployment_id, _environment_id) = create_test_deployment(&db).await?;
+        let job_id =
+            create_test_job(&db, deployment_id, "crons", false, EntityJobStatus::Pending).await?;
+
+        let tracker = DeploymentJobTracker::new(db.clone(), deployment_id);
+        tracker
+            .update_job_status(
+                job_id,
+                CoreJobStatus::Skipped,
+                Some("Not configured".to_string()),
+            )
+            .await?;
+
+        let job = DeploymentJobs::find_by_id(job_id)
+            .one(db.as_ref())
+            .await?
+            .ok_or("job should exist")?;
+
+        assert_eq!(job.status, EntityJobStatus::Skipped);
+        assert!(
+            job.finished_at.is_some(),
+            "skipped jobs are terminal and must record finished_at"
+        );
 
         Ok(())
     }

--- a/crates/temps-screenshots/src/lib.rs
+++ b/crates/temps-screenshots/src/lib.rs
@@ -38,6 +38,13 @@ pub trait ScreenshotServiceTrait: Send + Sync {
 
     /// Check if the provider is available
     async fn is_provider_available(&self) -> bool;
+
+    /// Check whether the provider is available, returning the reason if it is not
+    ///
+    /// Callers that surface failures to the user (e.g. deployment jobs) must use
+    /// this instead of [`is_provider_available`](Self::is_provider_available) so
+    /// the operator sees *why* screenshots are unavailable.
+    async fn check_provider_availability(&self) -> ScreenshotResult<()>;
 }
 
 /// Implement the trait for the concrete ScreenshotService
@@ -61,6 +68,10 @@ impl ScreenshotServiceTrait for ScreenshotService {
 
     async fn is_provider_available(&self) -> bool {
         self.is_provider_available().await
+    }
+
+    async fn check_provider_availability(&self) -> ScreenshotResult<()> {
+        self.check_provider_availability().await
     }
 }
 

--- a/crates/temps-screenshots/src/local_provider.rs
+++ b/crates/temps-screenshots/src/local_provider.rs
@@ -175,7 +175,7 @@ impl ScreenshotProvider for LocalScreenshotProvider {
         "local-headless-chrome"
     }
 
-    async fn is_available(&self) -> bool {
+    async fn check_availability(&self) -> ScreenshotResult<()> {
         // Try to launch browser to check if Chrome is available
         // Use a 10-second timeout to prevent hanging on VPS/servers without Chrome
         let check_result = tokio::time::timeout(
@@ -189,7 +189,7 @@ impl ScreenshotProvider for LocalScreenshotProvider {
 
                 match options {
                     Ok(opts) => match Browser::new(opts) {
-                        Ok(_) => Ok(true),
+                        Ok(_) => Ok(()),
                         Err(e) => Err(format!("Failed to launch Chrome browser: {}", e)),
                     },
                     Err(e) => Err(format!("Failed to build launch options: {}", e)),
@@ -198,42 +198,31 @@ impl ScreenshotProvider for LocalScreenshotProvider {
         )
         .await;
 
-        match check_result {
-            Ok(Ok(Ok(true))) => {
+        let reason = match check_result {
+            Ok(Ok(Ok(()))) => {
                 debug!("Chrome browser is available");
-                true
+                return Ok(());
             }
-            Ok(Ok(Ok(false))) => {
-                // This shouldn't happen with our current logic, but handle it gracefully
-                debug!("Chrome browser check returned false");
-                false
-            }
-            Ok(Ok(Err(e))) => {
-                error!(
-                    "Chrome browser is NOT available: {}. \
-                    Screenshot features will be disabled. \
-                    To fix: install chromium (apt-get install chromium) or set up a remote screenshot provider.",
-                    e
-                );
-                false
-            }
-            Ok(Err(e)) => {
-                error!(
-                    "Chrome availability check task failed: {}. Screenshot features will be disabled.",
-                    e
-                );
-                false
-            }
+            Ok(Ok(Err(e))) => e,
+            Ok(Err(e)) => format!("Chrome availability check task failed: {}", e),
             Err(_) => {
-                error!(
-                    "Chrome availability check timed out after 10 seconds. \
-                    This usually means Chrome is not installed or has missing dependencies. \
-                    Screenshot features will be disabled. \
-                    To fix: install chromium (apt-get install chromium) or set up a remote screenshot provider."
-                );
-                false
+                "Chrome availability check timed out after 10 seconds; Chrome is most likely \
+                 installed but missing shared libraries (check `ldd <chrome-binary> | grep \
+                 'not found'`)"
+                    .to_string()
             }
-        }
+        };
+
+        let message = format!(
+            "{}. To fix: install Chrome's runtime dependencies (on Debian/Ubuntu: \
+             `apt-get install -y chromium` or `apt-get install -y libnss3 libnspr4 libatk1.0-0 \
+             libatk-bridge2.0-0 libcups2 libatspi2.0-0 libxcomposite1 libxdamage1 libxfixes3 \
+             libxrandr2 libgbm1 libxkbcommon0 libpango-1.0-0 libcairo2 libasound2t64`), or switch \
+             to a remote screenshot provider in Settings.",
+            reason
+        );
+        error!("Chrome browser is NOT available: {}", message);
+        Err(ScreenshotError::ChromeError(message))
     }
 }
 

--- a/crates/temps-screenshots/src/noop_provider.rs
+++ b/crates/temps-screenshots/src/noop_provider.rs
@@ -48,10 +48,10 @@ impl ScreenshotProvider for NoopScreenshotProvider {
         "noop"
     }
 
-    async fn is_available(&self) -> bool {
+    async fn check_availability(&self) -> ScreenshotResult<()> {
         // Always available since it doesn't do anything
-        debug!("NoopScreenshotProvider: is_available() returning true (noop mode)");
-        true
+        debug!("NoopScreenshotProvider: check_availability() returning Ok (noop mode)");
+        Ok(())
     }
 }
 

--- a/crates/temps-screenshots/src/provider.rs
+++ b/crates/temps-screenshots/src/provider.rs
@@ -14,6 +14,17 @@ pub trait ScreenshotProvider: Send + Sync {
     /// Get the name of this provider (for logging/debugging)
     fn provider_name(&self) -> &'static str;
 
-    /// Check if the provider is available/configured
-    async fn is_available(&self) -> bool;
+    /// Check if the provider is available/configured, returning *why* it is not.
+    ///
+    /// Implementations must surface an actionable reason (missing binary, missing
+    /// shared libraries, unreachable remote service) rather than a bare boolean —
+    /// self-hosted operators have no support channel and the reason is what ends
+    /// up in the deployment job's error message.
+    async fn check_availability(&self) -> ScreenshotResult<()>;
+
+    /// Convenience wrapper over [`check_availability`](Self::check_availability)
+    /// for call sites that only need a yes/no answer.
+    async fn is_available(&self) -> bool {
+        self.check_availability().await.is_ok()
+    }
 }

--- a/crates/temps-screenshots/src/remote_provider.rs
+++ b/crates/temps-screenshots/src/remote_provider.rs
@@ -11,6 +11,33 @@ use tracing::{debug, error, info};
 use crate::error::{ScreenshotError, ScreenshotResult};
 use crate::provider::ScreenshotProvider;
 
+/// Strip credentials and query parameters from a URL before it appears in an
+/// error message.
+///
+/// The remote screenshot service URL is operator-supplied free text and is the
+/// only place credentials for that service can be configured (`api_key` is not
+/// wired through from settings), so it routinely contains userinfo
+/// (`https://user:pass@host`) or a key in the query string. Availability errors
+/// are persisted to `deployment_jobs.error_message` and rendered to every
+/// project member, so only scheme, host, port and path may survive.
+///
+/// An unparsable URL yields a placeholder rather than the raw string — falling
+/// back to the original would defeat the whole point.
+fn redact_url(raw: &str) -> String {
+    let Ok(mut parsed) = url::Url::parse(raw) else {
+        return "<invalid screenshot service URL>".to_string();
+    };
+
+    // Errors here only occur for URLs that cannot have credentials (e.g. `data:`),
+    // in which case there is nothing to strip.
+    let _ = parsed.set_username("");
+    let _ = parsed.set_password(None);
+    parsed.set_query(None);
+    parsed.set_fragment(None);
+
+    parsed.to_string()
+}
+
 /// Remote screenshot provider that calls an external API
 pub struct RemoteScreenshotProvider {
     /// Base URL of the screenshot service
@@ -150,6 +177,11 @@ impl ScreenshotProvider for RemoteScreenshotProvider {
     async fn check_availability(&self) -> ScreenshotResult<()> {
         // Try a simple health check to the service URL
         let health_url = format!("{}/health", self.service_url.trim_end_matches('/'));
+        // This error reaches the deployment job's error_message, which is visible to
+        // every project member — never let the configured URL through verbatim, it
+        // is the only place an operator can put credentials for the remote service.
+        let safe_url = redact_url(&health_url);
+
         let response = self
             .client
             .get(&health_url)
@@ -157,10 +189,13 @@ impl ScreenshotProvider for RemoteScreenshotProvider {
             .send()
             .await
             .map_err(|e| {
+                // `without_url()` strips the request URL from reqwest's own Display
+                // output, which would otherwise re-introduce the unredacted URL.
                 ScreenshotError::ProviderError(format!(
                     "Remote screenshot service health check failed for {}: {}. \
                      Verify the service URL is correct and reachable from this server.",
-                    health_url, e
+                    safe_url,
+                    e.without_url()
                 ))
             })?;
 
@@ -168,7 +203,7 @@ impl ScreenshotProvider for RemoteScreenshotProvider {
             return Err(ScreenshotError::ProviderError(format!(
                 "Remote screenshot service health check for {} returned HTTP {}. \
                  Verify the service is healthy and the API key is valid.",
-                health_url,
+                safe_url,
                 response.status()
             )));
         }
@@ -180,6 +215,41 @@ impl ScreenshotProvider for RemoteScreenshotProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Availability errors are stored in `deployment_jobs.error_message` and shown
+    /// to every project member, so credentials configured in the service URL must
+    /// never survive into them.
+    #[test]
+    fn test_redact_url_strips_credentials_and_query() {
+        assert_eq!(
+            redact_url("https://admin:hunter2@shots.internal:8443/health"),
+            "https://shots.internal:8443/health"
+        );
+        assert_eq!(
+            redact_url("https://shots.example.com/health?api_key=sk_live_secret"),
+            "https://shots.example.com/health"
+        );
+        assert_eq!(
+            redact_url("https://token@shots.example.com/health"),
+            "https://shots.example.com/health"
+        );
+        // Host, port and path are preserved — the operator still needs to know
+        // which endpoint failed.
+        assert_eq!(
+            redact_url("http://127.0.0.1:9000/api/v1/health"),
+            "http://127.0.0.1:9000/api/v1/health"
+        );
+    }
+
+    #[test]
+    fn test_redact_url_does_not_echo_unparsable_input() {
+        let redacted = redact_url("not a url with pass:word@ in it");
+        assert!(
+            !redacted.contains("pass:word"),
+            "unparsable input must not be echoed back, got: {}",
+            redacted
+        );
+    }
 
     #[tokio::test]
     async fn test_remote_provider_creation() {

--- a/crates/temps-screenshots/src/remote_provider.rs
+++ b/crates/temps-screenshots/src/remote_provider.rs
@@ -147,16 +147,33 @@ impl ScreenshotProvider for RemoteScreenshotProvider {
         "remote-api"
     }
 
-    async fn is_available(&self) -> bool {
+    async fn check_availability(&self) -> ScreenshotResult<()> {
         // Try a simple health check to the service URL
         let health_url = format!("{}/health", self.service_url.trim_end_matches('/'));
-        self.client
+        let response = self
+            .client
             .get(&health_url)
             .timeout(Duration::from_secs(5))
             .send()
             .await
-            .map(|r| r.status().is_success())
-            .unwrap_or(false)
+            .map_err(|e| {
+                ScreenshotError::ProviderError(format!(
+                    "Remote screenshot service health check failed for {}: {}. \
+                     Verify the service URL is correct and reachable from this server.",
+                    health_url, e
+                ))
+            })?;
+
+        if !response.status().is_success() {
+            return Err(ScreenshotError::ProviderError(format!(
+                "Remote screenshot service health check for {} returned HTTP {}. \
+                 Verify the service is healthy and the API key is valid.",
+                health_url,
+                response.status()
+            )));
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/temps-screenshots/src/service.rs
+++ b/crates/temps-screenshots/src/service.rs
@@ -85,10 +85,11 @@ impl ScreenshotService {
         };
 
         // Check if provider is available
-        if !provider.is_available().await {
+        if let Err(e) = provider.check_availability().await {
             warn!(
-                "Screenshot provider '{}' may not be available",
-                provider.provider_name()
+                "Screenshot provider '{}' may not be available: {}",
+                provider.provider_name(),
+                e
             );
         }
 
@@ -202,5 +203,10 @@ impl ScreenshotService {
     /// Check if the provider is available
     pub async fn is_provider_available(&self) -> bool {
         self.provider.is_available().await
+    }
+
+    /// Check whether the provider is available, returning the reason if it is not
+    pub async fn check_provider_availability(&self) -> ScreenshotResult<()> {
+        self.provider.check_availability().await
     }
 }

--- a/crates/temps-screenshots/src/tests.rs
+++ b/crates/temps-screenshots/src/tests.rs
@@ -41,8 +41,13 @@ impl ScreenshotProvider for TestProvider {
         "test-provider"
     }
 
-    async fn is_available(&self) -> bool {
-        !self.should_fail
+    async fn check_availability(&self) -> ScreenshotResult<()> {
+        if self.should_fail {
+            return Err(ScreenshotError::ProviderError(
+                "Test provider unavailable".to_string(),
+            ));
+        }
+        Ok(())
     }
 }
 

--- a/crates/temps-screenshots/tests/service_test.rs
+++ b/crates/temps-screenshots/tests/service_test.rs
@@ -40,8 +40,13 @@ impl ScreenshotProvider for MockScreenshotProvider {
         "mock-provider"
     }
 
-    async fn is_available(&self) -> bool {
-        !self.should_fail
+    async fn check_availability(&self) -> Result<(), ScreenshotError> {
+        if self.should_fail {
+            return Err(ScreenshotError::ProviderError(
+                "Mock provider unavailable".to_string(),
+            ));
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Fixes #477.

## Root cause

Not the screenshot code — the workflow executor.

`WorkflowExecutor::execute_job_batch` (`crates/temps-core/src/workflow_executor.rs`) has two paths that bail out before a job runs:

- `should_skip()` returns true
- `validate_prerequisites()` fails and the job is optional (or `continue_on_failure` is set)

Both only set the **in-memory** `job_state.status` and then `continue` — before `create_job_execution` is reached. Because a job that bails never appears in `batch_results` either, the post-batch tracker-update block in `execute_workflow` never runs for it.

The `deployment_jobs` row is pre-created as `Pending` by the workflow planner (`DeploymentJobTracker::create_job_execution` *updates* an existing row, it does not insert). So nothing ever moved that row off `Pending` — it stayed there forever while the rest of the deployment finished, and the UI kept showing "Take Screenshot" as still generating.

`TakeScreenshotJob::validate_prerequisites` → `is_provider_available()` → `LocalScreenshotProvider::is_available()` is what fails on a fresh server whose Chrome is missing shared libraries (`libnss3.so` et al, as in the report) — but that was only the trigger. Any optional job with failing prerequisites hit the same permanent-Pending bug.

Secondary defect: `is_available() -> bool` discarded the Chrome error, and the job then reported a generic `"Screenshot provider is not available"`, so even once persisted the operator had nothing actionable.

## Fix

1. **`workflow_executor.rs`** — new `persist_terminal_status()` helper, called on both bail-out paths, so the tracker row always reaches a terminal state:
   - `should_skip` → `Skipped`
   - failed prerequisites → `Failure` with the reason, also written to the job log
   Optional jobs get `Failure` too: optional means optional for *deployment completion*, not exempt from reporting why the step didn't run. Tracker errors are logged and swallowed — they must not take down the workflow.
2. **`ScreenshotProvider`** — `check_availability() -> ScreenshotResult<()>` replaces the bare bool as the primary method (`is_available()` stays as a defaulted wrapper). Implemented for local/noop/remote. The local provider's message now calls out the missing-shared-library case and lists the packages to install; the remote provider reports the failing health-check URL and status.
3. **`take_screenshot.rs`** — prerequisite failure now names the provider and includes the underlying reason.
4. **`DeploymentJobTracker`** — `Skipped` is terminal, so it records `finished_at` like the other terminal states.

## Evidence

**The regression tests fail against pre-fix behavior.** With `persist_terminal_status` neutralized to an early return:

```
thread '...test_optional_job_failing_prerequisites_is_persisted_as_failure' panicked:
  prerequisite failure must be persisted, not left Pending
thread '...test_required_job_failing_prerequisites_is_persisted_before_erroring' panicked:
  prerequisite failure must be persisted, not left Pending
thread '...test_skipped_job_is_persisted_as_skipped' panicked:
  skipped job must be persisted, not left Pending

test result: FAILED. 3 passed; 3 failed
```

And with the `Skipped` arm reverted in the tracker:

```
thread '...test_skipped_job_records_finished_at' panicked:
  skipped jobs are terminal and must record finished_at
test result: FAILED. 0 passed; 1 failed
```

**With the fix in place:**

```
$ cargo test --lib -p temps-core workflow_executor
test result: ok. 6 passed; 0 failed

$ TEMPS_TEST_DATABASE_URL=... cargo test --lib -p temps-deployments job_tracker
test result: ok. 7 passed; 0 failed          # 5 pre-existing + 2 new, real Postgres

$ cargo test --lib -p temps-deployments take_screenshot
test result: ok. 1 passed; 0 failed

$ cargo test -p temps-screenshots
39 passed (4 suites)

$ cargo clippy -p temps-core -p temps-screenshots -p temps-deployments --all-targets -- -D warnings
Finished — no warnings
```

New tests:
- `test_optional_job_failing_prerequisites_is_persisted_as_failure` — the #477 case: optional job, failing prereqs, must not fail the workflow but must land as `Failure` carrying the Chrome reason
- `test_required_job_failing_prerequisites_is_persisted_before_erroring` — required job still aborts the workflow, but leaves a `Failure` row, not `Pending`
- `test_skipped_job_is_persisted_as_skipped`
- `test_prerequisite_failure_leaves_job_failed_not_pending` — DB-level, asserts status/`finished_at`/`error_message` on the real row
- `test_skipped_job_records_finished_at`
- `test_validate_prerequisites_surfaces_provider_failure_reason` — asserts the message names the provider and contains `libnss3.so`

**Not verified end-to-end on a fresh Ubuntu box without Chrome libs** — I reproduced the failure mode at the unit level (a provider that reports unavailable with a Chrome library error) rather than provisioning a bare Hetzner server. The persistence bug is fully covered by the executor tests, which are exercised against the real code path.

Pre-existing, unrelated: `cargo test --doc -p temps-core` has 4 failing doctests (`types.rs`, `plugin.rs`, `openapi.rs`) — confirmed identical on stock `origin/main` via `git stash`.