### PR TITLE
fix(providers): enforce project scoping for session/API-key/CLI callers

### DIFF
--- a/crates/temps-providers/src/handlers/handlers.rs
+++ b/crates/temps-providers/src/handlers/handlers.rs
@@ -753,38 +753,15 @@ async fn require_service_parameter_project_access(
         .map(|link| link.project.id)
         .collect::<Vec<_>>();
     if let Some(checker) = app_state.project_access_checker.as_ref() {
-        require_access_to_any_linked_project(auth.user_id(), &project_ids, checker.as_ref()).await
+        super::metrics_handlers::require_access_to_any_linked_project(
+            auth.user_id(),
+            &project_ids,
+            checker.as_ref(),
+        )
+        .await
     } else {
         Ok(())
     }
-}
-
-async fn require_access_to_any_linked_project(
-    user_id: i32,
-    project_ids: &[i32],
-    checker: &dyn temps_core::ProjectAccessChecker,
-) -> Result<(), Problem> {
-    let mut infrastructure_error = None;
-    for project_id in project_ids {
-        match checker.user_can_access_project(user_id, *project_id).await {
-            Ok(true) => return Ok(()),
-            Ok(false) => {}
-            Err(error) => infrastructure_error = Some(error),
-        }
-    }
-
-    if let Some(error) = infrastructure_error {
-        error!(user_id, error = %error, "Project access check failed during credential reveal");
-        return Err(internal_server_error()
-            .title("Project Access Check Failed")
-            .detail("Could not verify project access; please try again")
-            .build());
-    }
-
-    Err(forbidden()
-        .title("Project Access Denied")
-        .detail("Your team membership does not include access to this service")
-        .build())
 }
 
 fn require_reveal_audit(
@@ -2627,6 +2604,7 @@ pub struct ExternalServiceApiDoc;
 
 #[cfg(test)]
 mod tests {
+    use super::super::metrics_handlers::require_access_to_any_linked_project;
     use super::*;
     use axum::response::IntoResponse;
     use sea_orm::MockDatabase;
@@ -2845,7 +2823,14 @@ mod tests {
         };
         let db = Arc::new(
             MockDatabase::new(sea_orm::DatabaseBackend::Postgres)
-                .append_query_results([vec![model.clone()], vec![model]])
+                // 1: assert_service_owned_by_caller's existence check
+                .append_query_results([vec![model.clone()]])
+                // 2: assert_service_owned_by_caller's linked-projects lookup
+                // (empty — irrelevant here since project_access_checker is
+                // None, which fails open regardless of the project list)
+                .append_query_results([Vec::<temps_entities::project_services::Model>::new()])
+                // 3: get_sensitive_parameter_value's own fetch
+                .append_query_results([vec![model]])
                 .into_connection(),
         );
         let docker = Arc::new(

--- a/crates/temps-providers/src/handlers/metrics_handlers.rs
+++ b/crates/temps-providers/src/handlers/metrics_handlers.rs
@@ -42,7 +42,7 @@ use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
 use serde::{Deserialize, Serialize};
 use temps_auth::{permission_guard, RequireAuth};
 use temps_core::{
-    error_builder::{bad_request, internal_server_error, not_found, ErrorBuilder},
+    error_builder::{bad_request, forbidden, internal_server_error, not_found, ErrorBuilder},
     problemdetails::Problem,
 };
 use temps_entities::{external_services, monitoring_alert_rules};
@@ -1251,13 +1251,20 @@ fn validate_severity(sev: &str) -> Result<(), Problem> {
 /// - The service exists but is not linked to the user's project (return 404
 ///   — do not distinguish these cases to avoid leaking service existence).
 ///
-/// For session-based users, the user's project is identified via the
-/// `project_services` table — the user must have a project that owns the
-/// service.  For deployment tokens, the token's `project_id` is used.
+/// For deployment tokens, the token's bound `project_id` is checked directly
+/// against `project_services`. For session/API-key/CLI callers there is no
+/// single bound project, so ownership is expressed through team-based access:
+/// the caller must be able to access at least one of the projects the
+/// service is linked to, via the [`temps_core::ProjectAccessChecker`]
+/// extension point (ADR-028) — a no-op in OSS (no team-access concept
+/// exists), real enforcement in EE when a team-access checker is registered.
+/// This mirrors [`require_service_parameter_project_access`] in
+/// `handlers.rs`, which enforces the same rule for the credential-reveal
+/// endpoint.
 ///
 /// Returns `Ok(())` if the caller may access the service, or `Err(Problem)`
-/// with a 404 response (does not distinguish "not found" from "forbidden"
-/// to avoid leaking the existence of services in other projects).
+/// with a 404 (service not found / not linked to caller's project) or 403
+/// (linked, but caller's team has no grant on any of its projects).
 pub(crate) async fn assert_service_owned_by_caller(
     service_id: i32,
     auth: &temps_auth::AuthContext,
@@ -1287,30 +1294,116 @@ pub(crate) async fn assert_service_owned_by_caller(
         return Ok(());
     }
 
-    // For session users: check that the service exists at all (the user may
-    // have access to all projects on this server).
+    // Session/API-key/CLI caller: verify the service exists (same check as
+    // before this fix), then resolve which projects it's linked to for the
+    // access decision below.
     //
-    // FIXME(metrics-security-6): When multi-tenancy (teams/projects) is fully
-    // enforced, this must check that the user is a member of at least one
-    // project that owns this service.  For the current single-project model,
-    // any session user with the appropriate permission may access any service.
-    // A strict multi-tenant check would be:
-    //   SELECT 1 FROM project_services ps
-    //   JOIN project_members pm ON pm.project_id = ps.project_id
-    //   WHERE ps.service_id = $service_id AND pm.user_id = $user_id
+    // Deliberately a direct `project_services` query, not
+    // `ExternalServiceManager::list_service_projects` — that also fetches
+    // full project metadata with a `projects` table lookup per linked row,
+    // which is unneeded N+1 cost here (only the IDs matter) on a path now
+    // shared by every session/API-key/CLI request across 30+ handlers.
     let service_exists = state
         .external_service_manager
         .get_service(service_id)
         .await
         .is_ok();
-
     if !service_exists {
         return Err(not_found()
             .detail(format!("External service {} not found", service_id))
             .build());
     }
 
-    Ok(())
+    let project_ids: Vec<i32> = project_services::Entity::find()
+        .filter(project_services::Column::ServiceId.eq(service_id))
+        .all(state.db.as_ref())
+        .await
+        .map_err(|e| {
+            error!(service_id, error = %e, "assert_service_owned: failed to resolve linked projects");
+            internal_server_error()
+                .detail("Failed to verify service ownership")
+                .build()
+        })?
+        .into_iter()
+        .map(|link| link.project_id)
+        .collect();
+
+    session_caller_may_access_linked_projects(
+        auth,
+        &project_ids,
+        state.project_access_checker.as_deref(),
+    )
+    .await
+}
+
+/// Pure authorization decision for the session/API-key/CLI branch of
+/// [`assert_service_owned_by_caller`]: given the projects a service is
+/// linked to, may this caller access it?
+///
+/// * Instance-wide Admin/PlatformAdmin bypasses, matching the documented
+///   contract of [`temps_core::ProjectAccessChecker`] (implementations are
+///   not required to duplicate that check themselves).
+/// * No checker registered (plain OSS, or EE before any team-access grant
+///   exists) → allow. This "fail-open-when-unconfigured" behaviour is a
+///   documented property of the extension point, not a bug: it's what keeps
+///   an EE binary with no grants configured yet behaving identically to OSS.
+/// * Checker registered → allow iff the caller can access at least one of
+///   the linked projects.
+///
+/// Extracted as its own function — taking already-resolved data instead of
+/// `AppState` — so the decision is unit-testable without a database round
+/// trip, the same reasoning as [`deployment_visible_to_caller`] below.
+async fn session_caller_may_access_linked_projects(
+    auth: &temps_auth::AuthContext,
+    project_ids: &[i32],
+    checker: Option<&dyn temps_core::ProjectAccessChecker>,
+) -> Result<(), Problem> {
+    if auth.is_admin() || auth.has_role(&temps_auth::Role::PlatformAdmin) {
+        return Ok(());
+    }
+
+    match checker {
+        Some(checker) => {
+            require_access_to_any_linked_project(auth.user_id(), project_ids, checker).await
+        }
+        None => Ok(()),
+    }
+}
+
+/// Allow iff `user_id` can access at least one of `project_ids`, per the
+/// registered [`temps_core::ProjectAccessChecker`]. Fails closed (denies) on
+/// any infrastructure error from the checker — a checker that can't verify
+/// access must never be treated as "access granted".
+///
+/// Shared with the credential-reveal path
+/// (`handlers::require_service_parameter_project_access`), which enforces
+/// the identical rule for a different endpoint.
+pub(crate) async fn require_access_to_any_linked_project(
+    user_id: i32,
+    project_ids: &[i32],
+    checker: &dyn temps_core::ProjectAccessChecker,
+) -> Result<(), Problem> {
+    let mut infrastructure_error = None;
+    for project_id in project_ids {
+        match checker.user_can_access_project(user_id, *project_id).await {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(error) => infrastructure_error = Some(error),
+        }
+    }
+
+    if let Some(error) = infrastructure_error {
+        error!(user_id, error = %error, "Project access check failed");
+        return Err(internal_server_error()
+            .title("Project Access Check Failed")
+            .detail("Could not verify project access; please try again")
+            .build());
+    }
+
+    Err(forbidden()
+        .title("Project Access Denied")
+        .detail("Your team membership does not include access to this service")
+        .build())
 }
 
 /// Pure authorization policy: may a caller see/act on a deployment?
@@ -1560,5 +1653,141 @@ mod tests {
         // single-project model, regardless of the deployment's project.
         assert!(deployment_visible_to_caller(1, None));
         assert!(deployment_visible_to_caller(999, None));
+    }
+
+    // ── session-caller project access (SECURITY metrics-security-6) ────────
+    //
+    // `session_caller_may_access_linked_projects` is the pure policy behind
+    // the session/API-key/CLI branch of `assert_service_owned_by_caller`.
+    // Unlike deployment tokens (checked above via a direct project_services
+    // row match), these callers have no single bound project, so ownership
+    // is expressed through the `ProjectAccessChecker` EE extension point —
+    // a no-op in OSS, real team-based enforcement in EE.
+
+    struct TestProjectAccessChecker {
+        allowed_project_ids: Vec<i32>,
+        fail: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl temps_core::ProjectAccessChecker for TestProjectAccessChecker {
+        async fn user_can_access_project(
+            &self,
+            _user_id: i32,
+            project_id: i32,
+        ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+            if self.fail {
+                return Err("checker infrastructure failure".into());
+            }
+            Ok(self.allowed_project_ids.contains(&project_id))
+        }
+    }
+
+    fn test_session_auth(role: temps_auth::Role) -> temps_auth::AuthContext {
+        let now = chrono::Utc::now();
+        let user = temps_entities::users::Model {
+            id: 1,
+            name: "Test User".to_string(),
+            email: "test@example.com".to_string(),
+            password_hash: None,
+            email_verified: true,
+            email_verification_token: None,
+            email_verification_expires: None,
+            password_reset_token: None,
+            password_reset_expires: None,
+            deleted_at: None,
+            mfa_secret: None,
+            mfa_enabled: false,
+            mfa_recovery_codes: None,
+            oidc_subject: None,
+            oidc_provider_id: None,
+            created_at: now,
+            updated_at: now,
+        };
+        temps_auth::AuthContext::new_session(user, role)
+    }
+
+    #[tokio::test]
+    async fn session_user_allowed_with_no_checker_registered() {
+        // OSS has no team-access concept: an unregistered checker must
+        // fail open, identical to the pre-fix behaviour (existence-only).
+        let result = session_caller_may_access_linked_projects(
+            &test_session_auth(temps_auth::Role::User),
+            &[10, 11],
+            None,
+        )
+        .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn session_admin_bypasses_a_denying_checker() {
+        let checker = TestProjectAccessChecker {
+            allowed_project_ids: vec![],
+            fail: false,
+        };
+        let result = session_caller_may_access_linked_projects(
+            &test_session_auth(temps_auth::Role::Admin),
+            &[10, 11],
+            Some(&checker),
+        )
+        .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn session_user_denied_when_checker_grants_no_linked_project() {
+        // This is the actual EE-enforced fix: a non-admin member whose team
+        // has no grant on any project the service is linked to is denied,
+        // instead of the pre-fix behaviour of "any session user may access
+        // any service that exists".
+        let checker = TestProjectAccessChecker {
+            allowed_project_ids: vec![99],
+            fail: false,
+        };
+        let problem = session_caller_may_access_linked_projects(
+            &test_session_auth(temps_auth::Role::User),
+            &[10, 11],
+            Some(&checker),
+        )
+        .await
+        .expect_err("no linked project is accessible — must deny");
+        assert_eq!(problem.into_response().status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn session_user_allowed_when_checker_grants_one_linked_project() {
+        let checker = TestProjectAccessChecker {
+            allowed_project_ids: vec![11],
+            fail: false,
+        };
+        let result = session_caller_may_access_linked_projects(
+            &test_session_auth(temps_auth::Role::User),
+            &[10, 11],
+            Some(&checker),
+        )
+        .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn session_user_denied_when_checker_infrastructure_fails() {
+        // Fail-closed: a checker that cannot verify access must never be
+        // treated as "access granted".
+        let checker = TestProjectAccessChecker {
+            allowed_project_ids: vec![],
+            fail: true,
+        };
+        let problem = session_caller_may_access_linked_projects(
+            &test_session_auth(temps_auth::Role::User),
+            &[10],
+            Some(&checker),
+        )
+        .await
+        .expect_err("checker infrastructure failure must deny, not allow");
+        assert_eq!(
+            problem.into_response().status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
     }
 }

--- a/crates/temps-providers/src/handlers/pg_stat_statements_handlers.rs
+++ b/crates/temps-providers/src/handlers/pg_stat_statements_handlers.rs
@@ -203,6 +203,7 @@ async fn get_slow_queries(
     Query(params): Query<SlowQueryParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
+    super::metrics_handlers::assert_service_owned_by_caller(service_id, &auth, &state).await?;
 
     let page = params.page.unwrap_or(1).max(1);
     let page_size = params
@@ -334,4 +335,95 @@ pub fn configure_routes() -> Router<Arc<AppState>> {
             "/external-services/{service_id}/pg-stat-statements/enable",
             post(enable_pg_stat_statements),
         )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::MockDatabase;
+
+    struct NoopAuditLogger;
+
+    #[async_trait::async_trait]
+    impl temps_core::AuditLogger for NoopAuditLogger {
+        async fn create_audit_log(
+            &self,
+            _operation: &dyn temps_core::AuditOperation,
+        ) -> Result<(), temps_core::anyhow::Error> {
+            Ok(())
+        }
+    }
+
+    fn test_deployment_token_auth(project_id: i32) -> temps_auth::AuthContext {
+        temps_auth::AuthContext::new_deployment_token(
+            project_id,
+            None,
+            None,
+            1,
+            "test-token".to_string(),
+            vec![temps_entities::deployment_tokens::DeploymentTokenPermission::FullAccess],
+        )
+    }
+
+    /// A deployment token can never satisfy `ExternalServicesRead` — the
+    /// deployment-token permission bridge in `AuthContext::has_permission`
+    /// only maps a small explicit whitelist (analytics/email/AI-gateway),
+    /// deliberately excluding external-services access. `get_slow_queries`
+    /// must reject it at the permission gate (403) regardless of the
+    /// service/project it targets, and never reach
+    /// `assert_service_owned_by_caller`'s DB-touching ownership check —
+    /// this is why `state.db` here is a bare, empty `MockDatabase`: any
+    /// unexpected query beyond the permission check would panic the mock.
+    #[tokio::test]
+    async fn get_slow_queries_rejects_deployment_token_at_permission_gate() {
+        let db = Arc::new(MockDatabase::new(sea_orm::DatabaseBackend::Postgres).into_connection());
+        let encryption_service = Arc::new(temps_core::EncryptionService::new_from_password(
+            "pg-stat-statements-idor-test",
+        ));
+        let docker = Arc::new(
+            bollard::Docker::connect_with_local_defaults()
+                .expect("Docker client configuration should be available"),
+        );
+        let manager = Arc::new(crate::services::ExternalServiceManager::new(
+            db.clone(),
+            encryption_service,
+            docker,
+            Arc::new(temps_dns::DnsRegistry::new(db.clone())),
+        ));
+        let state = Arc::new(AppState {
+            external_service_manager: manager.clone(),
+            audit_service: Arc::new(NoopAuditLogger),
+            query_service: Arc::new(crate::QueryService::new(manager)),
+            health_monitor: None,
+            metrics_store: None,
+            db: db.clone(),
+            api_key_service: Arc::new(temps_auth::ApiKeyService::new(db)),
+            config_service: None,
+            telemetry: Arc::new(temps_core::NoopTelemetryReporter),
+            project_access_checker: None,
+        });
+
+        let result = get_slow_queries(
+            RequireAuth(test_deployment_token_auth(100)),
+            State(state),
+            Path(7),
+            Query(SlowQueryParams {
+                page: None,
+                page_size: None,
+                sort_by: None,
+                sort_order: None,
+            }),
+        )
+        .await;
+
+        let problem = match result {
+            Ok(_) => panic!("deployment tokens must never be granted ExternalServicesRead"),
+            Err(problem) => problem,
+        };
+        assert_eq!(problem.into_response().status(), StatusCode::FORBIDDEN);
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to #480. That review surfaced an IDOR on `get_slow_queries` (missing `assert_service_owned_by_caller`, present on 18+ sibling handlers). Investigating turned up something more fundamental worth being upfront about:

- **My first pass (adding the missing call) was a no-op.** `assert_service_owned_by_caller`'s real per-project ownership check only ever activates for deployment tokens (`auth.project_id() == Some(..)`) — but deployment tokens can **never** hold `ExternalServicesRead` (`AuthContext::has_permission`'s deployment-token bridge is a deliberately small whitelist that excludes it). So the only caller type the check would restrict can't reach this endpoint at all, and every caller who *can* reach it (session/API-key/CLI) hit the *other* branch, which only checked the service exists — not who owns it. That's an explicit, pre-existing `FIXME(metrics-security-6)` shared by ~34 call sites, not specific to this endpoint.
- **This PR fixes the actual gap** at the shared choke point (`assert_service_owned_by_caller`) instead of papering over one endpoint, using the `ProjectAccessChecker` extension point (ADR-028) that PR #459 (credential reveal, merged) already established for exactly this class of problem:
  - **OSS** (no checker registered): behavior is unchanged — fail-open, since OSS has no team/project-membership concept. Verified via unit test.
  - **EE** (checker registered): a session/API-key/CLI caller is now denied (403) unless their team has an access grant on at least one project the service is linked to. Verified via unit test.
- Deliberately queries `project_services` directly for project IDs rather than `ExternalServiceManager::list_service_projects` (which does a `projects` table lookup per linked row — N+1 — unnecessary here and now on the hot path of every session/API-key/CLI request across 30+ handlers). Caught this the hard way: my first attempt used `list_service_projects` and broke an existing credential-reveal test by silently adding an unaccounted-for DB round trip.
- Moved `require_access_to_any_linked_project` from `handlers.rs` into `metrics_handlers.rs` (removing duplication) so both the credential-reveal endpoint and this fix share one implementation.

## Test plan

- [x] `cargo test --lib -p temps-providers` — 384 passed (0 failed), including:
  - New unit tests for `session_caller_may_access_linked_projects`: no-checker-registered → allow (proves OSS behavior is unchanged), admin bypass, checker denies all linked projects → 403, checker allows one → ok, checker infrastructure failure → fails closed (500, not silent allow)
  - Existing `require_access_to_any_linked_project` tests (relocated, unmodified) still pass
  - Fixed an existing credential-reveal test whose `MockDatabase` query count assumed the old, cheaper session-branch check — this failure is what caught my initial `list_service_projects` N+1 mistake
  - New test proving deployment tokens are rejected at the permission gate (403) before ever reaching the ownership check, since they can never hold `ExternalServicesRead`
- [x] `cargo check --lib` (full workspace) — 0 errors
- [x] `cargo clippy -p temps-providers --all-targets --all-features -- -D warnings` (real cargo binary, not rtk) — 0 warnings
- [ ] Live end-to-end verification against a running server was attempted but not completed — the shared local dev Postgres hit `too many clients already` from multiple concurrent `temps serve` instances sharing it, and I stopped rather than kill other potentially-in-use instances without asking. The change is backend-only (no new UI surface) and the exact regression class this fix is sensitive to (query-count/behavior changes in a shared hot-path function) is what the fixed credential-reveal test already caught and proves against, end-to-end, via a real handler call chain — just with a mocked DB rather than a live one.