### PR TITLE
fix(import): deploy docker-source imports for real instead of leaving them pending

### DIFF
--- a/crates/temps-deployments/src/services/services.rs
+++ b/crates/temps-deployments/src/services/services.rs
@@ -1109,6 +1109,52 @@ impl DeploymentService {
         Ok(())
     }
 
+    /// Trigger a real deployment of a pre-built Docker image, with no build
+    /// step. This is the DockerImage-source counterpart to `trigger_pipeline`
+    /// (which is Git-only and requires `repo_owner`/`repo_name`) — used to
+    /// deploy projects that have no git repository at all, e.g. imports from
+    /// Portainer, Kubernetes, or Kamal.
+    ///
+    /// Reuses the `DeployImageRequested` job already driven by the template
+    /// one-click-deploy flow (see `job_processor::process_deploy_image_requested_job`),
+    /// which creates the deployment row itself (with `external_image_ref` in
+    /// its metadata) and plans a pull+run pipeline for the project's
+    /// non-preview environment(s).
+    pub async fn trigger_image_deployment(
+        &self,
+        project_id: i32,
+        image_ref: String,
+        health_check_path: Option<String>,
+    ) -> Result<(), DeploymentError> {
+        if image_ref.is_empty() {
+            return Err(DeploymentError::InvalidInput(
+                "Image reference is missing".to_string(),
+            ));
+        }
+
+        info!(
+            "Triggering image deployment for project_id: {} (image: {})",
+            project_id, image_ref
+        );
+
+        self.queue_service
+            .send(temps_core::Job::DeployImageRequested(
+                temps_core::DeployImageRequestedJob {
+                    project_id,
+                    image_ref,
+                    health_check_path,
+                },
+            ))
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to send DeployImageRequested to queue: {}", e);
+                DeploymentError::QueueError(e.to_string())
+            })?;
+
+        tracing::debug!("DeployImageRequested successfully sent to queue");
+        Ok(())
+    }
+
     /// Redeploy an environment using the context (branch, tag, commit) from its
     /// latest successful deployment.  Used by node drain and failover — these
     /// operations need to reschedule existing workloads, not start a fresh
@@ -5933,6 +5979,55 @@ mod tests {
         assert!(refreshed.deleted_at.is_some());
         assert_eq!(refreshed.status.as_deref(), Some("removed"));
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_trigger_image_deployment_rejects_empty_image_ref(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+        let deployment_service = create_deployment_service_for_test(db);
+
+        let result = deployment_service
+            .trigger_image_deployment(1, String::new(), None)
+            .await;
+
+        assert!(matches!(result, Err(DeploymentError::InvalidInput(_))));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_trigger_image_deployment_sends_deploy_image_requested_job(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+
+        let deployment_service = create_deployment_service_for_test(db.clone());
+        let mut receiver = deployment_service.queue_service.subscribe();
+
+        deployment_service
+            .trigger_image_deployment(
+                42,
+                "ghcr.io/org/app:latest".to_string(),
+                Some("/healthz".to_string()),
+            )
+            .await?;
+
+        // The auto-responder spawned in create_deployment_service_for_test also
+        // listens on this queue (to keep RouteTableUpdated flowing) — drain past
+        // whatever else it produces until our own job shows up.
+        let job = loop {
+            match receiver.recv().await {
+                Ok(temps_core::Job::DeployImageRequested(job)) => break job,
+                Ok(_) => continue,
+                Err(e) => panic!("queue closed before DeployImageRequested arrived: {}", e),
+            }
+        };
+
+        assert_eq!(job.project_id, 42);
+        assert_eq!(job.image_ref, "ghcr.io/org/app:latest");
+        assert_eq!(job.health_check_path.as_deref(), Some("/healthz"));
         Ok(())
     }
 }

--- a/crates/temps-import-kamal/src/importer.rs
+++ b/crates/temps-import-kamal/src/importer.rs
@@ -1125,7 +1125,11 @@ async fn execute_plan(
         git_url: None,
         git_provider_connection_id: context.git_provider_connection_id,
         exposed_port: None,
-        source_type: temps_entities::source_type::SourceType::Git,
+        // Kamal deploys a pre-built image from deploy.yml, no git repo —
+        // DockerImage is the correct source_type (was incorrectly Git, which
+        // both misrepresents the project and made determine_deployment_source_type
+        // try to plan a git deploy on any future redeploy with no metadata override).
+        source_type: temps_entities::source_type::SourceType::DockerImage,
     };
 
     let project = project_service

--- a/crates/temps-import-kubernetes/src/importer.rs
+++ b/crates/temps-import-kubernetes/src/importer.rs
@@ -1925,7 +1925,11 @@ async fn execute_plan(
         git_url: None,
         git_provider_connection_id: context.git_provider_connection_id,
         exposed_port: None,
-        source_type: temps_entities::source_type::SourceType::Git,
+        // Kubernetes workloads are pure containers with no git repo —
+        // DockerImage is the correct source_type (was incorrectly Git, which
+        // both misrepresents the project and made determine_deployment_source_type
+        // try to plan a git deploy on any future redeploy with no metadata override).
+        source_type: temps_entities::source_type::SourceType::DockerImage,
     };
 
     let project = project_service

--- a/crates/temps-import-portainer/src/importer.rs
+++ b/crates/temps-import-portainer/src/importer.rs
@@ -1091,7 +1091,11 @@ async fn execute_plan(
         git_url: None,
         git_provider_connection_id: context.git_provider_connection_id,
         exposed_port: None,
-        source_type: temps_entities::source_type::SourceType::Git,
+        // Portainer workloads are pure containers/stacks with no git repo —
+        // DockerImage is the correct source_type (was incorrectly Git, which
+        // both misrepresents the project and made determine_deployment_source_type
+        // try to plan a git deploy on any future redeploy with no metadata override).
+        source_type: temps_entities::source_type::SourceType::DockerImage,
     };
 
     let project = project_service

--- a/crates/temps-import/src/services/deployment_verifier.rs
+++ b/crates/temps-import/src/services/deployment_verifier.rs
@@ -22,7 +22,7 @@
 use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use temps_entities::deployments;
+use temps_entities::{deployments, projects};
 use temps_import_types::StepResult;
 use tracing::{info, warn};
 
@@ -46,6 +46,23 @@ fn is_terminal(state: &str) -> bool {
 
 fn is_success(state: &str) -> bool {
     state == "completed"
+}
+
+/// Decide how to (re)trigger a real deployment when nothing started on its
+/// own: git-backed projects use the normal git-push pipeline (returns
+/// `None`, meaning "not an image deploy"); projects with no git repo but a
+/// known image (docker-source imports: Portainer, Kubernetes, Kamal) deploy
+/// that image directly instead, since `trigger_pipeline` always fails for
+/// them (it requires non-empty `repo_owner`/`repo_name`).
+fn resolve_image_deploy_target(
+    repo_owner: &str,
+    repo_name: &str,
+    placeholder_image_name: Option<String>,
+) -> Option<String> {
+    if !repo_owner.is_empty() && !repo_name.is_empty() {
+        return None;
+    }
+    placeholder_image_name
 }
 
 /// Result of the deploy-and-verify phase
@@ -114,11 +131,30 @@ impl DeploymentVerifier {
             .await;
 
         if initial.is_none() {
-            if let Err(e) = self
-                .deployment_service
-                .trigger_pipeline(project_id, environment_id, branch.clone(), None, None)
-                .await
-            {
+            // Git-backed imports (Coolify/Dokploy/CapRover) go through the
+            // normal git-push pipeline. Image-based imports (Portainer,
+            // Kubernetes, Kamal) have no repository at all — trigger_pipeline
+            // would always fail for them (it requires repo_owner/repo_name) —
+            // so deploy the pre-built image directly instead, using the
+            // importer's own placeholder deployment row to find the image.
+            let image_ref = self
+                .placeholder_image_ref(project_id, placeholder_deployment_id)
+                .await;
+
+            let trigger_result = match image_ref {
+                Some(image_ref) => {
+                    self.deployment_service
+                        .trigger_image_deployment(project_id, image_ref, None)
+                        .await
+                }
+                None => {
+                    self.deployment_service
+                        .trigger_pipeline(project_id, environment_id, branch.clone(), None, None)
+                        .await
+                }
+            };
+
+            if let Err(e) = trigger_result {
                 let message = format!(
                     "Could not start a deployment: {} — the project and its services were created, but nothing is running yet. Deploy it from the project page once the cause is resolved (most often: no repository linked, or the image is not reachable).",
                     e
@@ -262,6 +298,38 @@ impl DeploymentVerifier {
         }
     }
 
+    /// Resolve the image reference to deploy directly, for projects with no
+    /// git repository. Returns `None` when the project has a git repo linked
+    /// (the normal git-push pipeline should run instead) or when the
+    /// importer's placeholder deployment carries no image.
+    async fn placeholder_image_ref(
+        &self,
+        project_id: i32,
+        placeholder_deployment_id: Option<i32>,
+    ) -> Option<String> {
+        let project = projects::Entity::find_by_id(project_id)
+            .one(self.db.as_ref())
+            .await
+            .ok()
+            .flatten()?;
+
+        let deployment_image_name = match placeholder_deployment_id {
+            Some(deployment_id) => deployments::Entity::find_by_id(deployment_id)
+                .one(self.db.as_ref())
+                .await
+                .ok()
+                .flatten()
+                .and_then(|d| d.image_name),
+            None => None,
+        };
+
+        resolve_image_deploy_target(
+            &project.repo_owner,
+            &project.repo_name,
+            deployment_image_name,
+        )
+    }
+
     async fn latest_deployment_id(&self, project_id: i32, environment_id: i32) -> Option<i32> {
         deployments::Entity::find()
             .filter(deployments::Column::ProjectId.eq(project_id))
@@ -363,5 +431,46 @@ mod tests {
         ] {
             assert!(!is_success(state), "{state} must not count as success");
         }
+    }
+
+    #[test]
+    fn git_backed_projects_never_use_image_deploy() {
+        // Even when the placeholder happens to carry an image_name (unusual
+        // but not impossible), a project with a real repo must go through
+        // the normal git-push pipeline, not a direct image deploy.
+        assert_eq!(
+            resolve_image_deploy_target("acme", "web", Some("nginx:latest".to_string())),
+            None
+        );
+    }
+
+    #[test]
+    fn repo_less_projects_with_no_image_still_use_the_git_pipeline() {
+        // Nothing to deploy directly — fall through to trigger_pipeline,
+        // which will report its own (accurate) error for this case.
+        assert_eq!(resolve_image_deploy_target("", "", None), None);
+    }
+
+    #[test]
+    fn repo_less_projects_with_an_image_deploy_it_directly() {
+        assert_eq!(
+            resolve_image_deploy_target("", "", Some("ghcr.io/org/app:v1".to_string())),
+            Some("ghcr.io/org/app:v1".to_string())
+        );
+    }
+
+    #[test]
+    fn partial_repo_info_is_treated_as_repo_less() {
+        // repo_owner and repo_name must both be present — a half-populated
+        // project (e.g. owner set but name empty) cannot go through the git
+        // pipeline either.
+        assert_eq!(
+            resolve_image_deploy_target("acme", "", Some("nginx:latest".to_string())),
+            Some("nginx:latest".to_string())
+        );
+        assert_eq!(
+            resolve_image_deploy_target("", "web", Some("nginx:latest".to_string())),
+            Some("nginx:latest".to_string())
+        );
     }
 }


### PR DESCRIPTION
## Summary

Portainer, Kubernetes, and Kamal imports (from #441) create the project and a deployment row successfully — execute returns 202 — but the deployment sat in `pending` forever and the app never actually went live. Root-caused via live verification against real lab instances of all three platforms (not staged/mocked).

**Root cause:** `DeploymentVerifier::deploy_and_verify` (the shared deploy-and-verify phase every importer runs through after `execute`) unconditionally falls back to `DeploymentService::trigger_pipeline` when nothing deploys on its own. `trigger_pipeline` is git-only — it requires non-empty `repo_owner`/`repo_name` and sends a `GitPushEvent` — so it always failed for these three platforms' repo-less projects, and the placeholder deployment row the importer created was simply never picked up by anything else.

**Fix:**
- Added `DeploymentService::trigger_image_deployment`, a sibling to `trigger_pipeline` for pre-built images. It sends the existing `DeployImageRequested` job (already used and tested by the template one-click-deploy flow), which creates its own deployment row with `external_image_ref`/`deployment_source_type` in its metadata, plans a pull+run pipeline (no build step), and executes it.
- `deploy_and_verify` now resolves which trigger to use via `resolve_image_deploy_target` (a pure, unit-tested function): git repo present → the normal git-push pipeline (unchanged for Coolify/Dokploy/CapRover); no repo but the importer's placeholder deployment carries an image → deploy that image directly.
- Also fixed a real, separate data-correctness bug found along the way: all three importers (Portainer/Kubernetes/Kamal) set the new project's `source_type` to `Git` even though these workloads have no git repository at all. Fixed to `DockerImage`.

## Test plan
- [x] `cargo test --lib -p temps-deployments -p temps-import -p temps-import-portainer -p temps-import-kubernetes -p temps-import-kamal` — 569 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` on touched crates — clean
- [x] New unit tests: `trigger_image_deployment` (empty-image validation + real job sent to queue, asserted via a live receiver), `resolve_image_deploy_target` (git-repo / repo-less+image / repo-less+no-image / partial-repo-info cases)
- [x] **Live-verified against real Portainer, Kubernetes, and Kamal lab instances** — full discover → plan → execute flow for each:
  - Kubernetes: `storefront-k8s-fixed` — deploy step "Deployment finished (completed)"; confirmed live via direct `curl` returning real `traefik/whoami` response body, matching the actual running container ID
  - Portainer: `lab-portainer-fixed` — `"status":"completed"`, verify step "responded with HTTP 200"
  - Kamal: `lab-shop-kamal-fixed` — `"status":"completed"`, verify step "responded with HTTP 200"