### PR TITLE
fix(domains): reserve the console hostname from project domains

### DIFF
--- a/crates/temps-core/src/app_settings.rs
+++ b/crates/temps-core/src/app_settings.rs
@@ -1021,11 +1021,112 @@ impl AppSettings {
             .unwrap_or_else(|| format!("http://host.docker.internal:{console_port}"));
         raw.trim_end_matches('/').to_string()
     }
+
+    /// Hostname the Temps console is served on, derived from `external_url`.
+    ///
+    /// Returns `None` when `external_url` is unset or unparsable (installs
+    /// reached by raw IP), in which case there is no console hostname to
+    /// protect.
+    pub fn console_hostname(&self) -> Option<String> {
+        let raw = self.external_url.as_ref()?.trim();
+        if raw.is_empty() {
+            return None;
+        }
+        // Tolerate a bare host ("console.example.com") as well as a full URL.
+        let candidate = if raw.contains("://") {
+            raw.to_string()
+        } else {
+            format!("https://{raw}")
+        };
+        url::Url::parse(&candidate)
+            .ok()?
+            .host_str()
+            .map(|h| h.trim_end_matches('.').to_ascii_lowercase())
+    }
+
+    /// True when `host` is owned by the platform itself and must never be
+    /// claimed by a project domain.
+    ///
+    /// Reserved hosts are the console hostname (`external_url`) and the
+    /// preview domain apex — routing either of them at a project makes the
+    /// console or every generated preview URL unreachable, and recovering
+    /// requires shell/IP access to the box (issue #478).
+    pub fn is_reserved_hostname(&self, host: &str) -> bool {
+        let host = host.trim().trim_end_matches('.').to_ascii_lowercase();
+        if host.is_empty() {
+            return false;
+        }
+        if self.console_hostname().as_deref() == Some(host.as_str()) {
+            return true;
+        }
+        let preview = self
+            .preview_domain
+            .trim()
+            .trim_end_matches('.')
+            .to_ascii_lowercase();
+        !preview.is_empty() && preview == host
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Issue #478: a project domain must never be allowed to claim the
+    // console hostname — doing so locks the operator out of the console and
+    // recovery requires the raw public IP.
+    #[test]
+    fn console_hostname_parses_url_and_bare_host() {
+        let with_external_url = |raw: Option<&str>| AppSettings {
+            external_url: raw.map(str::to_string),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            with_external_url(Some("https://Console.Example.com:8443/"))
+                .console_hostname()
+                .as_deref(),
+            Some("console.example.com")
+        );
+        assert_eq!(
+            with_external_url(Some("console.example.com"))
+                .console_hostname()
+                .as_deref(),
+            Some("console.example.com")
+        );
+        assert_eq!(with_external_url(Some("   ")).console_hostname(), None);
+        assert_eq!(with_external_url(None).console_hostname(), None);
+    }
+
+    #[test]
+    fn reserved_hostname_covers_console_and_preview_apex() {
+        let s = AppSettings {
+            external_url: Some("https://console.example.com".to_string()),
+            preview_domain: "apps.example.com".to_string(),
+            ..Default::default()
+        };
+
+        assert!(s.is_reserved_hostname("console.example.com"));
+        // Case and trailing-dot variants are the same host.
+        assert!(s.is_reserved_hostname("CONSOLE.example.com."));
+        assert!(s.is_reserved_hostname("apps.example.com"));
+
+        // Ordinary project domains, including subdomains of the preview
+        // domain, stay assignable.
+        assert!(!s.is_reserved_hostname("shop.example.com"));
+        assert!(!s.is_reserved_hostname("my-app.apps.example.com"));
+        assert!(!s.is_reserved_hostname(""));
+    }
+
+    #[test]
+    fn reserved_hostname_is_inert_without_external_url() {
+        let s = AppSettings {
+            external_url: None,
+            preview_domain: String::new(),
+            ..Default::default()
+        };
+        assert!(!s.is_reserved_hostname("anything.example.com"));
+    }
 
     // ADR-024: cluster-DNS injection is experimental/beta and defaults OFF
     // to avoid the DNS-timeout-cascade failure mode (22-27 s TCP delays when

--- a/crates/temps-projects/src/services/custom_domains.rs
+++ b/crates/temps-projects/src/services/custom_domains.rs
@@ -1,7 +1,8 @@
 use sea_orm::{ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set};
 use std::sync::Arc;
 use temps_core::url_validation;
-use temps_entities::project_custom_domains;
+use temps_core::AppSettings;
+use temps_entities::{project_custom_domains, settings};
 use thiserror::Error;
 use tracing::{debug, info};
 use url::Url;
@@ -31,6 +32,29 @@ pub struct CustomDomainService {
 impl CustomDomainService {
     pub fn new(db: Arc<DatabaseConnection>) -> Self {
         Self { db }
+    }
+
+    /// Rejects domains that the platform itself serves (issue #478).
+    ///
+    /// Pointing a project at the console hostname (`external_url`) or the
+    /// preview-domain apex hijacks the proxy route for the control plane, and
+    /// the only way back in is the server's public IP — so the assignment is
+    /// refused up front instead of being made and then undone.
+    async fn ensure_domain_not_reserved(&self, domain: &str) -> Result<(), CustomDomainError> {
+        let settings = settings::Entity::find()
+            .one(self.db.as_ref())
+            .await?
+            .map(|s| AppSettings::from_json(s.data))
+            .unwrap_or_default();
+
+        if settings.is_reserved_hostname(domain) {
+            return Err(CustomDomainError::InvalidDomain(format!(
+                "'{}' is reserved by Temps itself (console or preview domain) and cannot be assigned to a project",
+                domain
+            )));
+        }
+
+        Ok(())
     }
 
     /// Normalizes a redirect URL by adding https:// scheme if missing
@@ -204,6 +228,9 @@ impl CustomDomainService {
             domain, project_id
         );
 
+        // Refuse hostnames the platform serves itself (console, preview apex)
+        self.ensure_domain_not_reserved(&domain).await?;
+
         // Check if domain already exists
         if let Some(_existing) = project_custom_domains::Entity::find()
             .filter(project_custom_domains::Column::Domain.eq(&domain))
@@ -328,6 +355,9 @@ impl CustomDomainService {
 
         // Determine the final domain name for validation
         let final_domain = if let Some(ref new_domain) = domain {
+            // Refuse hostnames the platform serves itself (console, preview apex)
+            self.ensure_domain_not_reserved(new_domain).await?;
+
             // Check if new domain already exists (for a different record)
             if let Some(existing) = project_custom_domains::Entity::find()
                 .filter(project_custom_domains::Column::Domain.eq(new_domain))
@@ -538,6 +568,96 @@ mod tests {
         assert_eq!(domain.project_id, project_id);
         assert_eq!(domain.environment_id, env_id);
         assert_eq!(domain.status, "pending");
+    }
+
+    /// Issue #478: assigning the console hostname to a project made the
+    /// console unreachable — only the raw public IP could get the operator
+    /// back in. Create and update must both refuse it.
+    #[tokio::test]
+    async fn test_console_domain_is_rejected() {
+        let test_db = temps_database::test_utils::TestDatabase::with_migrations()
+            .await
+            .unwrap();
+        let service = CustomDomainService::new(test_db.db.clone());
+        let (project_id, env_id) = setup_test_data(&test_db.db).await;
+
+        let app_settings = AppSettings {
+            external_url: Some("https://console.example.com".to_string()),
+            preview_domain: "apps.example.com".to_string(),
+            ..Default::default()
+        };
+        settings::Entity::insert(settings::ActiveModel {
+            id: Set(1),
+            data: Set(app_settings.to_json()),
+            ..sea_orm::ActiveModelBehavior::new()
+        })
+        .on_conflict(
+            sea_orm::sea_query::OnConflict::column(settings::Column::Id)
+                .update_column(settings::Column::Data)
+                .to_owned(),
+        )
+        .exec(test_db.db.as_ref())
+        .await
+        .unwrap();
+
+        for reserved in [
+            "console.example.com",
+            "CONSOLE.example.com",
+            "apps.example.com",
+        ] {
+            let result = service
+                .create_custom_domain(
+                    project_id,
+                    env_id,
+                    reserved.to_string(),
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .await;
+
+            match result {
+                Err(CustomDomainError::InvalidDomain(msg)) => assert!(
+                    msg.contains("reserved"),
+                    "expected a reserved-domain message, got: {msg}"
+                ),
+                other => panic!("expected InvalidDomain for '{reserved}', got: {other:?}"),
+            }
+        }
+
+        // A normal domain still works, and cannot be renamed onto the console.
+        let created = service
+            .create_custom_domain(
+                project_id,
+                env_id,
+                "shop.example.com".to_string(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let result = service
+            .update_custom_domain(
+                created.id,
+                Some("console.example.com".to_string()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+        assert!(
+            matches!(result, Err(CustomDomainError::InvalidDomain(_))),
+            "renaming a domain onto the console hostname must be refused"
+        );
     }
 
     #[tokio::test]

--- a/crates/temps-routes/src/route_table.rs
+++ b/crates/temps-routes/src/route_table.rs
@@ -1513,6 +1513,24 @@ impl CachedPeerTable {
         debug!("Loaded all active deployments. Final cache: {} projects, {} environments, {} deployments",
             projects_cache.len(), environments_cache.len(), deployments_cache.len());
 
+        // The console hostname is owned by the control plane, never by a
+        // project. A route pointing it at a deployment locks the operator out
+        // of the console entirely (issue #478) — the create/update API now
+        // refuses such domains, but installs that already stored one would
+        // otherwise stay bricked until the row is deleted over the public IP.
+        // Dropping it here makes the next reload self-heal.
+        if let Some(console_host) = app_settings.console_hostname() {
+            let removed = routes.remove(&console_host).is_some()
+                | http_routes_map.remove(&console_host).is_some()
+                | tls_routes_map.remove(&console_host).is_some();
+            if removed {
+                warn!(
+                    "Ignoring project route for reserved console hostname '{}' — the Temps console keeps it (issue #478)",
+                    console_host
+                );
+            }
+        }
+
         // Atomically replace all route tables
         let route_count = routes.len();
         let http_routes_count = http_routes_map.len();

--- a/crates/temps-routes/src/route_table_test.rs
+++ b/crates/temps-routes/src/route_table_test.rs
@@ -158,6 +158,76 @@ mod route_table_tests {
         Ok(())
     }
 
+    /// Issue #478: a project custom domain that matches the console hostname
+    /// (`external_url`) must never win the route, otherwise the operator is
+    /// locked out of the console and can only recover over the public IP.
+    /// Installs that stored such a row before the API-level guard existed
+    /// self-heal on the next route reload.
+    #[tokio::test]
+    async fn test_route_table_skips_console_hostname() -> Result<(), Box<dyn std::error::Error>> {
+        use sea_orm::{ActiveModelBehavior, EntityTrait};
+        use temps_core::AppSettings;
+        use temps_entities::settings;
+
+        let test_db_mock = TestDatabase::with_migrations().await?;
+        let test_db = TestDBMockOperations::new(test_db_mock.db.clone()).await?;
+
+        // Configure the console to live on console.example.com
+        let app_settings = AppSettings {
+            external_url: Some("https://console.example.com".to_string()),
+            ..Default::default()
+        };
+        settings::Entity::insert(settings::ActiveModel {
+            id: Set(1),
+            data: Set(app_settings.to_json()),
+            ..settings::ActiveModel::new()
+        })
+        .on_conflict(
+            sea_orm::sea_query::OnConflict::column(settings::Column::Id)
+                .update_column(settings::Column::Data)
+                .to_owned(),
+        )
+        .exec(test_db.db.as_ref())
+        .await?;
+
+        let (project, environment, deployment) = test_db
+            .create_test_project_with_domain("test.example.com")
+            .await?;
+        test_db
+            .create_deployment_container(deployment.id, 9010, None)
+            .await?;
+
+        // A pre-existing row claiming the console hostname, plus a normal one
+        for domain in ["console.example.com", "app.example.com"] {
+            project_custom_domains::ActiveModel {
+                domain: Set(domain.to_string()),
+                project_id: Set(project.id),
+                environment_id: Set(environment.id),
+                status: Set("active".to_string()),
+                redirect_to: Set(None),
+                status_code: Set(None),
+                ..Default::default()
+            }
+            .insert(test_db.db.as_ref())
+            .await?;
+        }
+
+        let route_table = Arc::new(CachedPeerTable::new(test_db.db.clone()));
+        route_table.load_routes().await?;
+
+        assert!(
+            route_table.get_route("console.example.com").is_none(),
+            "console hostname must not be routed to a project (issue #478)"
+        );
+        assert!(
+            route_table.get_route("app.example.com").is_some(),
+            "ordinary custom domains must still route"
+        );
+
+        test_db.cleanup().await?;
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_route_table_with_redirect() -> Result<(), Box<dyn std::error::Error>> {
         let test_db_mock = TestDatabase::with_migrations().await?;

--- a/web/src/components/domains/DomainSelector.tsx
+++ b/web/src/components/domains/DomainSelector.tsx
@@ -14,7 +14,9 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover'
 import { cn } from '@/lib/utils'
+import { reservedHostnameReason } from '@/lib/reservedHostnames'
 import { useDebounce } from '@/hooks/useDebounce'
+import { useSettings } from '@/hooks/useSettings'
 import { useQuery } from '@tanstack/react-query'
 import { Check, ChevronsUpDown, Globe } from 'lucide-react'
 import { useState } from 'react'
@@ -60,6 +62,7 @@ export function DomainSelector({
   })
 
   const domains = data?.domains ?? []
+  const { data: platformSettings } = useSettings()
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -98,27 +101,49 @@ export function DomainSelector({
             </CommandEmpty>
             {domains.length > 0 && (
               <CommandGroup>
-                {domains.map((domain) => (
-                  <CommandItem
-                    key={domain.id}
-                    value={domain.domain}
-                    onSelect={() => {
-                      onValueChange(domain.domain)
-                      setOpen(false)
-                      setSearch('')
-                    }}
-                  >
-                    <Check
-                      className={cn(
-                        'mr-2 h-4 w-4 shrink-0',
-                        value === domain.domain ? 'opacity-100' : 'opacity-0'
+                {domains.map((domain) => {
+                  // Reserved hostnames (console, preview apex) belong to the
+                  // platform — selecting one takes the console offline, so it
+                  // is shown but not selectable (issue #478).
+                  const reserved = !!reservedHostnameReason(
+                    domain.domain,
+                    platformSettings
+                  )
+                  return (
+                    <CommandItem
+                      key={domain.id}
+                      value={domain.domain}
+                      disabled={reserved}
+                      title={
+                        reserved
+                          ? 'Reserved by Temps — this is the console or preview domain'
+                          : undefined
+                      }
+                      onSelect={() => {
+                        if (reserved) return
+                        onValueChange(domain.domain)
+                        setOpen(false)
+                        setSearch('')
+                      }}
+                    >
+                      <Check
+                        className={cn(
+                          'mr-2 h-4 w-4 shrink-0',
+                          value === domain.domain ? 'opacity-100' : 'opacity-0'
+                        )}
+                      />
+                      <Globe className="mr-2 h-4 w-4 shrink-0 text-muted-foreground" />
+                      <span className="truncate flex-1">{domain.domain}</span>
+                      {reserved ? (
+                        <span className="ml-2 shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                          Reserved
+                        </span>
+                      ) : (
+                        <DomainStatusBadge status={domain.status} />
                       )}
-                    />
-                    <Globe className="mr-2 h-4 w-4 shrink-0 text-muted-foreground" />
-                    <span className="truncate flex-1">{domain.domain}</span>
-                    <DomainStatusBadge status={domain.status} />
-                  </CommandItem>
-                ))}
+                    </CommandItem>
+                  )
+                })}
               </CommandGroup>
             )}
             {data && data.total > domains.length && (

--- a/web/src/components/project/settings/DomainForm.tsx
+++ b/web/src/components/project/settings/DomainForm.tsx
@@ -25,6 +25,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { useSettings } from '@/hooks/useSettings'
+import { reservedHostnameReason } from '@/lib/reservedHostnames'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { X } from 'lucide-react'
@@ -212,6 +214,15 @@ export function DomainForm({
     control: form.control,
     name: 'redirectTo',
   })
+
+  // Reserved hostnames (console, preview apex) would take the control plane
+  // offline if routed at a project — block them before submit (issue #478).
+  const { data: platformSettings } = useSettings()
+  const watchedDomain = useWatch({ control: form.control, name: 'domain' })
+  const reservedDomainReason = useMemo(
+    () => reservedHostnameReason(watchedDomain ?? '', platformSettings),
+    [watchedDomain, platformSettings]
+  )
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
@@ -257,6 +268,12 @@ export function DomainForm({
                       .{selectedDomain.split('*.')?.[1]}
                     </span>
                   </div>
+                )}
+
+                {reservedDomainReason && (
+                  <p className="text-sm text-destructive">
+                    {reservedDomainReason}
+                  </p>
                 )}
               </div>
             </FormItem>
@@ -424,7 +441,11 @@ export function DomainForm({
           </Button>
           <Button
             type="submit"
-            disabled={createDomain.isPending || updateDomain.isPending}
+            disabled={
+              createDomain.isPending ||
+              updateDomain.isPending ||
+              !!reservedDomainReason
+            }
           >
             {createDomain.isPending || updateDomain.isPending
               ? initialData

--- a/web/src/lib/reservedHostnames.test.ts
+++ b/web/src/lib/reservedHostnames.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test'
+import { consoleHostname, reservedHostnameReason } from './reservedHostnames'
+
+const settings = {
+  external_url: 'https://console.example.com:8443/',
+  preview_domain: 'apps.example.com',
+}
+
+describe('consoleHostname', () => {
+  test('extracts the host from a full URL', () => {
+    expect(consoleHostname(settings)).toBe('console.example.com')
+  })
+
+  test('accepts a bare host and normalizes case', () => {
+    expect(consoleHostname({ external_url: 'Console.Example.com' })).toBe(
+      'console.example.com'
+    )
+  })
+
+  test('returns null when unset', () => {
+    expect(consoleHostname({ external_url: '' })).toBeNull()
+    expect(consoleHostname(undefined)).toBeNull()
+  })
+})
+
+describe('reservedHostnameReason', () => {
+  // Issue #478: assigning the console domain to a project made the console
+  // unreachable until the operator went back in over the public IP.
+  test('flags the console hostname', () => {
+    expect(reservedHostnameReason('console.example.com', settings)).toContain(
+      'console'
+    )
+    expect(
+      reservedHostnameReason('CONSOLE.example.com.', settings)
+    ).not.toBeNull()
+  })
+
+  test('flags the preview domain apex', () => {
+    expect(reservedHostnameReason('apps.example.com', settings)).toContain(
+      'preview domain'
+    )
+  })
+
+  test('allows ordinary project domains and preview subdomains', () => {
+    expect(reservedHostnameReason('shop.example.com', settings)).toBeNull()
+    expect(
+      reservedHostnameReason('my-app.apps.example.com', settings)
+    ).toBeNull()
+  })
+
+  test('ignores wildcards and empty input', () => {
+    expect(reservedHostnameReason('*.example.com', settings)).toBeNull()
+    expect(reservedHostnameReason('', settings)).toBeNull()
+  })
+
+  test('is inert when the platform is unconfigured', () => {
+    expect(reservedHostnameReason('anything.example.com', undefined)).toBeNull()
+  })
+})

--- a/web/src/lib/reservedHostnames.ts
+++ b/web/src/lib/reservedHostnames.ts
@@ -1,0 +1,57 @@
+/**
+ * Hostnames the platform serves itself and that must never be routed at a
+ * project (issue #478).
+ *
+ * Assigning the console hostname to a project hijacks the proxy route for the
+ * control plane, and the only way back in is the server's public IP. The API
+ * rejects these too — this mirrors the rule client-side so the user sees it
+ * before submitting.
+ */
+
+function normalizeHost(value: string | null | undefined): string | null {
+  if (!value) return null
+  const raw = value.trim()
+  if (!raw) return null
+  try {
+    const url = new URL(raw.includes('://') ? raw : `https://${raw}`)
+    return url.hostname.replace(/\.$/, '').toLowerCase()
+  } catch {
+    return null
+  }
+}
+
+/** Hostname the Temps console is served on, derived from `external_url`. */
+export function consoleHostname(
+  settings: { external_url?: string | null } | undefined | null
+): string | null {
+  return normalizeHost(settings?.external_url)
+}
+
+/**
+ * Returns the reason `domain` is reserved, or `null` when it is assignable.
+ * Mirrors `AppSettings::is_reserved_hostname` on the server.
+ */
+export function reservedHostnameReason(
+  domain: string,
+  settings:
+    | { external_url?: string | null; preview_domain?: string | null }
+    | undefined
+    | null
+): string | null {
+  const host = domain.trim().replace(/\.$/, '').toLowerCase()
+  if (!host || host.includes('*')) return null
+
+  if (consoleHostname(settings) === host) {
+    return 'This is the Temps console domain. Routing it to a project would make the console unreachable.'
+  }
+
+  const preview = settings?.preview_domain
+    ?.trim()
+    .replace(/\.$/, '')
+    .toLowerCase()
+  if (preview && preview === host) {
+    return 'This is the preview domain Temps generates deployment URLs from and cannot be assigned to a project.'
+  }
+
+  return null
+}


### PR DESCRIPTION
Closes #478

## Problem

A project custom domain could be set to the Temps console hostname. The proxy then routed the console host at the project's deployment, so the console became unreachable and the only way back in was the server's public IP.

## Fix

Three layers, because the API guard alone leaves already-broken installs broken:

1. **`AppSettings::is_reserved_hostname`** (`temps-core`) — the console hostname (derived from `external_url`, accepting a full URL or a bare host) and the preview-domain apex are platform-owned. Case- and trailing-dot-insensitive. Inert when `external_url` is unset (IP-only installs).
2. **`CustomDomainService`** — `create_custom_domain` and `update_custom_domain` (rename path) reject reserved hostnames with `InvalidDomain`, which already maps to a 400 Problem Details response. This also covers the importers, which go through the same service.
3. **Route table** — any route resolving to the console hostname is dropped just before the atomic swap, with a `warn!`. Installs that already stored such a row self-heal on the next reload instead of requiring public-IP access to delete it.
4. **Web UI** — `DomainSelector` renders reserved entries with a "Reserved" badge and `disabled`; `DomainForm` blocks submit and explains why, which also covers the wildcard-plus-subdomain path where the reserved host is typed rather than picked.

Subdomains of the preview domain are deliberately still assignable — only the apex is reserved.

No new API endpoint, so no `@temps-sdk/cli` change is needed; the CLI surfaces the 400 from the existing endpoint.

## Evidence

New tests, all run locally:

```
$ cargo test -p temps-core --lib app_settings
cargo test: 19 passed, 253 filtered out

$ DOCKER_HOST=unix://.../colima/default/docker.sock cargo test -p temps-projects --lib custom_domain
cargo test: 26 passed, 36 filtered out
   (incl. test_console_domain_is_rejected: create rejects console/CONSOLE/preview apex,
    a normal domain still creates, and renaming onto the console host is refused)

$ DOCKER_HOST=unix://.../colima/default/docker.sock cargo test -p temps-routes --lib test_route_table
cargo test: 15 passed, 43 filtered out
   (incl. test_route_table_skips_console_hostname: a pre-existing project_custom_domains row
    for console.example.com produces no route, while app.example.com still routes)

$ cd web && bun test src/lib/reservedHostnames.test.ts
8 pass, 0 fail
```

Lint/type gates:

```
$ cargo clippy -p temps-core -p temps-projects -p temps-routes --all-targets -- -D warnings   # clean
$ cd web && bunx tsc --noEmit                                                                  # clean
```

`eslint` on `DomainForm.tsx` reports 2 `react-hooks/preserve-manual-memoization` errors — both pre-existing on `origin/main` (verified by stashing), untouched by this change.