### PR TITLE
docs(contributing): specify temps binary for running server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ docker run -d \
 ### Run the Server
 
 ```bash
-cargo run -- serve --database-url "postgresql://temps:temps@localhost:5432/temps"
+cargo run --bin temps -- serve --database-url "postgresql://temps:temps@localhost:5432/temps"
 ```
 
 ### Pre-commit Hooks


### PR DESCRIPTION
## Description

<!-- A clear description of what this PR does and why. -->

Just a minor update to CONTRIBUTING.md, simply specifying the `temps` the binary to run for the server.

Before:

```
bruny@BensMacBookPro temps % cargo run 
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   xxxxxxxx/temps/crates/temps-captcha-wasm/Cargo.toml
workspace: xxxxxxxx/temps/Cargo.toml
error: `cargo run` could not determine which binary to run. Use the `--bin` option to specify a binary, or the `default-run` manifest key.
available binaries: temps, temps-example-plugin, temps-git-credential-daemon, temps-git-credential-helper, temps-google-indexing-plugin, temps-indexnow-plugin, temps-lighthouse-plugin, temps-preview-gateway, temps-pty-agent, temps-vm-agent
```

After:

```
bruny@BensMacBookPro temps % cargo run --bin temps -- serve --database-url "postgresql://temps:temps@localhost:5432/temps"
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   xxxxxxxx/temps/crates/temps-captcha-wasm/Cargo.toml
workspace: xxxxxxxx/temps/Cargo.toml
   Compiling temps-core v0.1.0-beta.55 (xxxxxxxx/temps/crates/temps-core)
warning: temps-cli@0.1.0-beta.55: Skipping web build in debug mode (use FORCE_WEB_BUILD=1 to build)
    Building [====================>  ] 1302/1370: temps-core
```

Opted for the self-documenting explicit binary definition over the `default-run` manifest key.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [ ] I have written tests that cover the changes
- [ ] All new and existing tests pass (`cargo test --lib`)
- [ ] `cargo check --lib` passes with no warnings
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have updated documentation where necessary

## Related issues

<!-- Link related issues below. Use "Closes #123" to auto-close an issue when this PR is merged. -->

N/A
