### PR TITLE
ci: run temps-otel and four other crates' integration tests

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -359,6 +359,29 @@ jobs:
               package(temps-dns) or package(temps-email) or
               package(temps-analytics) or package(temps-analytics-events) or
               package(temps-otel)) and kind(=lib)
+          - group: unit-integration
+            # The kind(=test) counterpart to the two groups above: crates
+            # whose tests/*.rs files need neither Docker nor a database, and
+            # which therefore no CI job has ever run (the groups above are
+            # all kind(=lib)).
+            #
+            # This list is deliberately short. Every candidate was run
+            # locally first, and two were dropped because they FAIL today —
+            # they are not in scope here and each needs its own fix:
+            #   temps-dns-resolver  both end_to_end tests time out
+            #                       ("first sync converged: Elapsed(())")
+            #   temps-agents        sandbox_credential_smoke_test builds a
+            #                       Docker image; `cargo build --release
+            #                       --bin temps-pty-agent` exits 101
+            # Also excluded, needing infrastructure CI does not have:
+            # temps-network (it_kernel/it_allocator — covered by
+            # network-kernel-tests.yml), temps-agents::firecracker_e2e (KVM),
+            # temps-auth::oidc_discovery_live and temps-git::gitea_e2e (live
+            # network / a Gitea server).
+            filter: >-
+              (package(temps-ai-gateway) or package(temps-git-credential) or
+              package(temps-memory) or package(temps-pty-agent))
+              and kind(=test)
 
     steps:
       - name: Free up disk space
@@ -521,6 +544,49 @@ jobs:
             archive: default
             filter: package(temps-migrations)
             test_threads: "1"
+          # ---------------------------------------------------------------
+          # temps-otel integration tests. Previously NO CI job ran these: the
+          # unit-tests groups are pinned to kind(=lib), which excludes
+          # tests/*.rs entirely. An audit of the whole workspace found 37 of
+          # 47 integration-test binaries, across 18 crates, in that state.
+          # These two groups close the temps-otel share of it.
+          #
+          # Split by what each binary needs, not by size:
+          #
+          #   otel        — TestDatabase-backed. These MUST keep the shared
+          #                 TimescaleDB (i.e. must NOT be added to the
+          #                 TEMPS_TEST_DATABASE_URL exclusion below). Without
+          #                 it, TestDatabase falls back to a process-local
+          #                 OnceCell container, and because nextest runs every
+          #                 test in its own process that means cold-booting a
+          #                 fresh container PER TEST — the exact pathology the
+          #                 unit-tests job documents. Measured: 41 tests take
+          #                 195s against the shared DB and roughly 90 MINUTES
+          #                 without it. --test-threads=1 for the same
+          #                 shared-DB deadlock reason as docker-deployments.
+          #
+          #   otel-clickhouse — provisions its own ClickHouse per test via
+          #                 testcontainers and uses a MockDatabase for the
+          #                 inner store, so the shared DB is irrelevant here
+          #                 and the container cost is unavoidable (~60s/test,
+          #                 23 tests). Isolated containers mean no shared
+          #                 state, so --test-threads=2 is safe.
+          - group: otel
+            archive: default
+            filter: >-
+              package(temps-otel) and kind(=test) and
+              (binary(timescaledb_storage_test) or binary(e2e_http_test) or
+               binary(dynamic_alert_integration_test) or
+               binary(decode_to_store_test))
+            test_threads: "1"
+          - group: otel-clickhouse
+            archive: default
+            filter: >-
+              package(temps-otel) and kind(=test) and
+              (binary(clickhouse_storage_test) or
+               binary(clickhouse_query_spans_test) or
+               binary(clickhouse_trace_summaries_test))
+            test_threads: "2"
 
     steps:
       - name: Free up disk space


### PR DESCRIPTION
## Problem

**No CI job has ever run temps-otel's integration tests** — or most other crates'.

The `unit-tests` groups are pinned to `kind(=lib)`, which excludes `tests/*.rs` entirely, and only 2 of the 7 filtered test groups include non-lib targets. Auditing the whole workspace with `cargo nextest list`:

**37 of 47 integration-test binaries, across 18 crates, never execute in CI.**

Only `temps-deployments`, `temps-backup`, `temps-logs`, `temps-migrations` and `temps-vulnerability-scanner` have theirs running today. This was noticed while reviewing #493, whose new ClickHouse tests would have passed CI without ever being executed.

This PR adds **108 of those tests**.

## The finding that shaped the design

My first attempt excluded the otel groups from `TEMPS_TEST_DATABASE_URL`, copying the `migrations` group. That was **wrong**, and measurably so.

Without that variable, `TestDatabase` falls back to a process-local `OnceCell` container. nextest runs every test in its own process, so the `OnceCell` resets each time and every test cold-boots a fresh TimescaleDB — the exact pathology the `unit-tests` job already documents in a comment.

| | 41 DB-backed otel tests |
|---|---|
| without `TEMPS_TEST_DATABASE_URL` | **~90 minutes** |
| with the shared DB (what this PR does) | **195 seconds** |

Same tests, same machine. I initially reported temps-otel as "too slow to enable" on the strength of the first number; it was my own misconfiguration, not a property of the suite.

## Groups added

| group | tests | why it is shaped this way |
|---|---|---|
| `integration-tests/otel` | 41 | TestDatabase-backed. Keeps the shared TimescaleDB (see above). `--test-threads=1` for the same shared-DB deadlock reason as `docker-deployments`. |
| `integration-tests/otel-clickhouse` | 23 | Provisions its own ClickHouse per test, MockDatabase for the inner store — shared DB irrelevant, container cost unavoidable (~60s/test). Isolated containers ⇒ no shared state ⇒ `--test-threads=2` is safe. |
| `unit-tests/unit-integration` | 44 | Needs neither Docker nor a database. Runs in 10.8s. |

## Validation

Every group was run locally before being enabled — this is not a "flip it on and see" change.

```
otel              41 tests run: 41 passed, 0 failed   [194.7s]
unit-integration  44 tests run: 44 passed, 0 skipped  [ 10.8s]
temps-otel (full) 64 tests run: 64 passed, 0 failed
```

`otel-clickhouse`'s 23 tests are part of that 64/64. A later re-run of just that group hit 8 `NOT_ENOUGH_SPACE` failures once my local Docker disk filled to 100% — an environment artifact, not a test failure; CI runners start clean.

## Deliberately NOT enabled

Because I ran them and **they fail today**:

- `temps-dns-resolver` — both `end_to_end` tests time out (`first sync converged: Elapsed(())`)
- `temps-agents::sandbox_credential_smoke_test` — builds a Docker image; `cargo build --release --bin temps-pty-agent` exits 101

Because CI lacks the infrastructure:

- `temps-network` (`it_kernel`/`it_allocator`) — already covered by `network-kernel-tests.yml`
- `temps-agents::firecracker_e2e` — needs KVM
- `temps-auth::oidc_discovery_live`, `temps-git::gitea_e2e` — live network / a Gitea server

Still uncovered and untouched here, each needing the same run-it-first treatment: `temps-core`, `temps-dns`, `temps-metrics`, `temps-observability`, `temps-providers`, `temps-revenue`, `temps-sandbox`, `temps-screenshots`.

## Follow-up

`clickhouse_trace_summaries_test.rs` (merged in #493) documents sharing one container across the file via a `static OnceCell`. That holds under `cargo test` (~5s) but **not** under nextest (~424s), which is what CI runs. The comment should be corrected, and making these ClickHouse suites genuinely share a container is the obvious win if `otel-clickhouse`'s runtime becomes a problem.