### PR TITLE
fix(auth): select jsonwebtoken crypto provider

### DIFF
--- a/crates/temps-git/Cargo.toml
+++ b/crates/temps-git/Cargo.toml
@@ -49,7 +49,7 @@ sha2 = { workspace = true }
 url = { workspace = true }
 serde_json = { workspace = true }
 serde_derive = { workspace = true }
-jsonwebtoken = "10.3.0"
+jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 uuid = { workspace = true }
 http-body-util = { workspace = true }
 git2 = { version = "0.21.0", features = ["https", "ssh"] }

--- a/examples/google-indexing-plugin/Cargo.toml
+++ b/examples/google-indexing-plugin/Cargo.toml
@@ -25,7 +25,7 @@ url = "2.5"
 thiserror = { workspace = true }
 include_dir = "0.7"
 mime_guess = "2.0"
-jsonwebtoken = "10.3.0"
+jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 base64 = "0.22"
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- explicitly select jsonwebtoken's rust_crypto provider for Temps Git and the Google indexing plugin
- prevent jsonwebtoken 10.4 JWT creation from panicking after the dependency update

## Evidence
- cargo test -p temps-google-indexing-plugin: 19 passed
- cargo test --lib -p temps-git: 297 passed
- cargo check --lib: 0 errors
- security audit: APPROVE, provider selection is unambiguous and preserves PEM/RS256 support