### PR TITLE
fix(providers): keep stored service config in step with the running container

### DIFF
--- a/crates/temps-blob/src/handlers/handler.rs
+++ b/crates/temps-blob/src/handlers/handler.rs
@@ -571,25 +571,20 @@ pub async fn blob_enable(
             existing.status
         );
 
-        // Get the service config from the database and initialize the plugin's RustfsService
-        let service_config = state
-            .external_service_manager
-            .get_service_config(existing.id)
-            .await
-            .map_err(|e| {
-                error!("Failed to get Blob service config: {}", e);
-                temps_core::problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
-                    .with_title("Failed to Enable Blob Service")
-                    .with_detail(format!("Could not get Blob service config: {}", e))
-            })?;
-
         info!(
-            "Retrieved Blob service config (service_id: {}), initializing RustfsService...",
+            "Initializing RustfsService from stored config (service_id: {})...",
             existing.id
         );
 
-        // Initialize the plugin's RustfsService with the config from database
-        if let Err(e) = state.rustfs_service.init(service_config).await {
+        // Initialize the plugin's RustfsService from the stored config, and
+        // write the engine's inferred parameters back to the row. Calling
+        // `init()` directly here dropped them, letting the stored port drift
+        // from the container's real one — which `health_probe` then reads.
+        if let Err(e) = state
+            .external_service_manager
+            .initialize_plugin_service(existing.id, state.rustfs_service.as_ref())
+            .await
+        {
             error!("Failed to initialize RustfsService: {}", e);
             return Err(
                 temps_core::problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
@@ -674,21 +669,10 @@ pub async fn blob_enable(
         // upload, list and head goes through — is still unconfigured. Without
         // this the branch above returns "enabled successfully" and then every
         // blob request fails until the server is restarted and the plugin
-        // initializes itself on boot. Load the config it just persisted.
-        let service_config = state
-            .external_service_manager
-            .get_service_config(created.id)
-            .await
-            .map_err(|e| {
-                error!("Failed to get config for newly created Blob service: {}", e);
-                temps_core::problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
-                    .with_title("Failed to Enable Blob Service")
-                    .with_detail(format!("Could not read back Blob service config: {}", e))
-            })?;
-
+        // initializes itself on boot.
         state
-            .rustfs_service
-            .init(service_config)
+            .external_service_manager
+            .initialize_plugin_service(created.id, state.rustfs_service.as_ref())
             .await
             .map_err(|e| {
                 error!("Failed to initialize RustfsService after create: {}", e);

--- a/crates/temps-blob/src/plugin.rs
+++ b/crates/temps-blob/src/plugin.rs
@@ -173,35 +173,33 @@ impl TempsPlugin for BlobPlugin {
                             BLOB_RUSTFS_SERVICE_NAME, service_model.id, service_model.status
                         );
 
+                        // Goes through the manager rather than calling
+                        // `init()` directly so the parameters the engine
+                        // infers — notably the port it adopts from the
+                        // running container — are written back to the row.
+                        // `health_probe` reads that stored port, so dropping
+                        // it here makes the health monitor probe a port the
+                        // service no longer uses.
                         match external_service_manager
-                            .get_service_config(service_model.id)
+                            .initialize_plugin_service(service_model.id, rustfs_service.as_ref())
                             .await
                         {
-                            Ok(service_config) => match rustfs_service.init(service_config).await {
-                                Ok(_) => {
-                                    info!(
-                                        "Blob RustFS service '{}' initialized successfully from database config",
-                                        BLOB_RUSTFS_SERVICE_NAME
-                                    );
-                                    if let Err(e) = rustfs_service.start().await {
-                                        warn!(
-                                            "Failed to start Blob RustFS container (may already be running): {}",
-                                            e
-                                        );
-                                    }
-                                }
-                                Err(e) => {
+                            Ok(()) => {
+                                info!(
+                                    "Blob RustFS service '{}' initialized successfully from database config",
+                                    BLOB_RUSTFS_SERVICE_NAME
+                                );
+                                if let Err(e) = rustfs_service.start().await {
                                     warn!(
-                                        "Failed to initialize Blob RustFS service from database config: {}. \
-                                         The service will need to be created via the API.",
+                                        "Failed to start Blob RustFS container (may already be running): {}",
                                         e
                                     );
                                 }
-                            },
+                            }
                             Err(e) => {
                                 warn!(
-                                    "Failed to get Blob service config from database: {}. \
-                                     The service may need to be recreated.",
+                                    "Failed to initialize Blob RustFS service from database config: {}. \
+                                     The service will need to be created via the API.",
                                     e
                                 );
                             }

--- a/crates/temps-kv/src/handlers/handler.rs
+++ b/crates/temps-kv/src/handlers/handler.rs
@@ -459,26 +459,21 @@ pub async fn kv_enable(
             existing.status
         );
 
-        // Get the service config from the database and initialize the plugin's RedisService
-        // This is necessary because the plugin may have skipped initialization if the service was stopped
-        let service_config = state
-            .external_service_manager
-            .get_service_config(existing.id)
-            .await
-            .map_err(|e| {
-                error!("Failed to get KV service config: {}", e);
-                temps_core::problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
-                    .with_title("Failed to Enable KV Service")
-                    .with_detail(format!("Could not get KV service config: {}", e))
-            })?;
-
+        // Initialize the plugin's RedisService from the stored config, and
+        // write the engine's inferred parameters back to the row. This is
+        // necessary because the plugin skips initialization when the service
+        // was stopped; going through the manager also keeps the stored port
+        // — which `health_probe` reads — matching the live container.
         info!(
-            "Retrieved KV service config (service_id: {}), initializing RedisService...",
+            "Initializing RedisService from stored config (service_id: {})...",
             existing.id
         );
 
-        // Initialize the plugin's RedisService with the config from database
-        if let Err(e) = state.redis_service.init(service_config).await {
+        if let Err(e) = state
+            .external_service_manager
+            .initialize_plugin_service(existing.id, state.redis_service.as_ref())
+            .await
+        {
             error!("Failed to initialize RedisService: {}", e);
             return Err(
                 temps_core::problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
@@ -563,21 +558,10 @@ pub async fn kv_enable(
         // set goes through — is still unconfigured. Without this the branch
         // above returns "enabled successfully" and then every KV request
         // fails until the server is restarted and the plugin initializes
-        // itself on boot. Load the config it just persisted.
-        let service_config = state
-            .external_service_manager
-            .get_service_config(created.id)
-            .await
-            .map_err(|e| {
-                error!("Failed to get config for newly created KV service: {}", e);
-                temps_core::problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
-                    .with_title("Failed to Enable KV Service")
-                    .with_detail(format!("Could not read back KV service config: {}", e))
-            })?;
-
+        // itself on boot.
         state
-            .redis_service
-            .init(service_config)
+            .external_service_manager
+            .initialize_plugin_service(created.id, state.redis_service.as_ref())
             .await
             .map_err(|e| {
                 error!("Failed to initialize RedisService after create: {}", e);

--- a/crates/temps-kv/src/plugin.rs
+++ b/crates/temps-kv/src/plugin.rs
@@ -122,35 +122,31 @@ impl TempsPlugin for KvPlugin {
                             KV_REDIS_SERVICE_NAME, service_model.id, service_model.status
                         );
 
+                        // Same contract as the blob plugin: go through the
+                        // manager so inferred parameters land back on the
+                        // row instead of being dropped, keeping the stored
+                        // config (which `health_probe` reads) in step with
+                        // the running container.
                         match external_service_manager
-                            .get_service_config(service_model.id)
+                            .initialize_plugin_service(service_model.id, redis_service.as_ref())
                             .await
                         {
-                            Ok(service_config) => match redis_service.init(service_config).await {
-                                Ok(_) => {
-                                    info!(
-                                        "KV Redis service '{}' initialized successfully from database config",
-                                        KV_REDIS_SERVICE_NAME
-                                    );
-                                    if let Err(e) = redis_service.start().await {
-                                        warn!(
-                                            "Failed to start KV Redis container (may already be running): {}",
-                                            e
-                                        );
-                                    }
-                                }
-                                Err(e) => {
+                            Ok(()) => {
+                                info!(
+                                    "KV Redis service '{}' initialized successfully from database config",
+                                    KV_REDIS_SERVICE_NAME
+                                );
+                                if let Err(e) = redis_service.start().await {
                                     warn!(
-                                        "Failed to initialize KV Redis service from database config: {}. \
-                                         The service will need to be created via the API.",
+                                        "Failed to start KV Redis container (may already be running): {}",
                                         e
                                     );
                                 }
-                            },
+                            }
                             Err(e) => {
                                 warn!(
-                                    "Failed to get KV service config from database: {}. \
-                                     The service may need to be recreated.",
+                                    "Failed to initialize KV Redis service from database config: {}. \
+                                     The service will need to be created via the API.",
                                     e
                                 );
                             }

--- a/crates/temps-providers/src/externalsvc/mariadb.rs
+++ b/crates/temps-providers/src/externalsvc/mariadb.rs
@@ -1,5 +1,6 @@
 use crate::utils::ensure_network_exists;
 
+use super::port_util::{find_available_port, find_available_port_async};
 use super::{
     ExternalService, HealthProbeResult, LogicalResource, NewServiceRestoreResult, RecoveryTarget,
     RuntimeEnvVar, ServiceConfig, ServiceResourceLimits, ServiceType,
@@ -13,7 +14,6 @@ use futures::{StreamExt, TryStreamExt};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::net::TcpListener;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -407,14 +407,6 @@ fn example_root_password() -> &'static str {
 
 fn example_docker_image() -> &'static str {
     DEFAULT_MARIADB_IMAGE
-}
-
-fn is_port_available(port: u16) -> bool {
-    TcpListener::bind(("0.0.0.0", port)).is_ok()
-}
-
-fn find_available_port(start_port: u16) -> Option<u16> {
-    (start_port..start_port + 100).find(|&port| is_port_available(port))
 }
 
 fn generate_password() -> String {
@@ -2516,9 +2508,12 @@ impl MariaDbService {
         let mut config = self.get_mariadb_config(source_config.clone())?;
 
         // Fresh port (the source's is taken). A restored new service is its own
-        // container, not an imported one.
+        // container, not an imported one. Docker-aware here because we have a
+        // client: it also skips ports published by other containers, not just
+        // ones the OS reports as bound.
         config.container_name = None;
-        let new_port = find_available_port(3306)
+        let new_port = find_available_port_async(&self.docker, 3306)
+            .await
             .ok_or_else(|| anyhow::anyhow!("No available ports for new MariaDB service"))?
             .to_string();
         config.port = new_port;

--- a/crates/temps-providers/src/externalsvc/port_util.rs
+++ b/crates/temps-providers/src/externalsvc/port_util.rs
@@ -32,8 +32,26 @@ static NEXT_OFFSET: AtomicU16 = AtomicU16::new(0);
 
 /// Returns `true` if the OS will let us bind the port right now. This does not
 /// reserve the port — see the module docs for why that matters.
+///
+/// Both the wildcard address and loopback are probed, because these containers
+/// publish to `127.0.0.1` (see `utils::local_port_binding`) and a successful
+/// `0.0.0.0` bind is not evidence that `127.0.0.1` is free. `TcpListener::bind`
+/// sets `SO_REUSEADDR` on Unix, so binding the wildcard address can succeed
+/// while another process already holds the same port on loopback — an SSH
+/// tunnel forwarding it, for example. Checking only `0.0.0.0` therefore hands
+/// back a port Docker then fails to bind when the container starts:
+/// `ports are not available: exposing port TCP 127.0.0.1:<port>`.
 pub fn is_port_available(port: u16) -> bool {
-    TcpListener::bind(("0.0.0.0", port)).is_ok()
+    // Probe one address at a time and release each listener before the next:
+    // holding the wildcard binding open while testing loopback would collide
+    // with ourselves and report every port as taken.
+    for addr in ["0.0.0.0", "127.0.0.1"] {
+        match TcpListener::bind((addr, port)) {
+            Ok(listener) => drop(listener),
+            Err(_) => return false,
+        }
+    }
+    true
 }
 
 /// Find an OS-bindable host port at or after `start_port`.
@@ -117,6 +135,39 @@ mod tests {
         let port = find_available_port(28000).expect("a port should be free");
         assert!(port >= 28000, "port {} must be >= base 28000", port);
         assert!(is_port_available(port), "returned port must be bindable");
+    }
+
+    /// A port held on loopback only — an SSH tunnel forwarding it, say — must
+    /// read as unavailable. Probing just `0.0.0.0` misses this, because
+    /// `TcpListener::bind` sets `SO_REUSEADDR` on Unix and the wildcard bind
+    /// succeeds anyway; the finder then returns a port Docker cannot publish
+    /// to `127.0.0.1`, and container creation dies at start with
+    /// `ports are not available`.
+    #[test]
+    fn loopback_only_listener_makes_a_port_unavailable() {
+        let held = TcpListener::bind(("127.0.0.1", 0)).expect("bind an ephemeral loopback port");
+        let port = held.local_addr().expect("local addr").port();
+
+        assert!(
+            !is_port_available(port),
+            "port {port} is held on 127.0.0.1, which is exactly where containers publish"
+        );
+    }
+
+    /// The loopback probe must not reject ports that are genuinely free —
+    /// otherwise the fix above would starve every allocation.
+    #[test]
+    fn a_free_port_is_still_reported_available() {
+        let port = {
+            let probe = TcpListener::bind(("127.0.0.1", 0)).expect("bind ephemeral");
+            probe.local_addr().expect("local addr").port()
+            // listener dropped here, so the port is free again
+        };
+
+        assert!(
+            is_port_available(port),
+            "port {port} was released and should be usable"
+        );
     }
 
     #[test]

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -2220,10 +2220,20 @@ impl ExternalServiceManager {
         Ok(())
     }
 
+    /// Whether the most recent probe found this service operational.
+    ///
+    /// Reads the verdict `ExternalServiceHealthMonitor` persists on the row
+    /// rather than probing inline, so polling this can't stall on a service
+    /// that is unreachable. `degraded` reports `false` here; callers that
+    /// need the distinction should read the health snapshot instead.
+    ///
+    /// This used to return a hardcoded `false` while still doing the lookup,
+    /// so `GET /external-services/{id}/health` reported every service as
+    /// unhealthy — including ones the monitor had just marked operational.
     pub async fn check_service_health(&self, service_id: i32) -> Result<bool> {
-        let _service = self.get_service(service_id).await?;
+        let service = self.get_service(service_id).await?;
 
-        Ok(false)
+        Ok(service.health_status.as_deref() == Some(HealthProbeStatus::Operational.as_str()))
     }
 
     /// Return the current health status for many services in one query.
@@ -11257,6 +11267,32 @@ mod tests {
             ),
             Arc::new(temps_dns::DnsRegistry::new(db)),
         )
+    }
+
+    /// `check_service_health` backed `GET /external-services/{id}/health` with
+    /// a hardcoded `false`, so the endpoint called every service unhealthy no
+    /// matter what the health monitor had just written to the row.
+    #[tokio::test]
+    async fn health_check_reports_the_monitors_verdict() {
+        for (persisted, expected) in [
+            (Some("operational"), true),
+            (Some("degraded"), false),
+            (Some("down"), false),
+            (None, false),
+        ] {
+            let mut model = encrypted_service_model(1, serde_json::json!({}));
+            model.health_status = persisted.map(String::from);
+            let manager = mock_service_manager(vec![vec![model]]);
+
+            assert_eq!(
+                manager
+                    .check_service_health(1)
+                    .await
+                    .expect("health lookup should succeed"),
+                expected,
+                "persisted health_status {persisted:?} should report {expected}"
+            );
+        }
     }
 
     fn encrypted_service_model(id: i32, parameters: serde_json::Value) -> external_services::Model {

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -7026,6 +7026,61 @@ echo "[restore] Pre-seed complete"
         }
     }
 
+    /// Initialize a plugin-owned service instance from its stored config and
+    /// persist whatever the engine inferred back onto the row.
+    ///
+    /// The blob and kv plugins construct their own `RustfsService` /
+    /// `RedisService` and used to call `init()` directly, dropping the
+    /// inferred parameters. That let `external_services.config` drift from
+    /// the container it describes — most consequentially the port, which
+    /// `ExternalService::health_probe` reads straight out of the stored
+    /// config rather than from the live instance.
+    ///
+    /// On an install upgraded across the #495 naming fix, the stored port is
+    /// the one the pre-fix manager container took. Uploads are fine (they go
+    /// through the instance, which adopts the running container's real
+    /// port), but the health monitor probes the stale port — so the console
+    /// reports Blob as down the moment the leftover container is removed,
+    /// while the service is actually healthy. Writing back on this path
+    /// keeps the row describing the container that exists.
+    ///
+    /// Only genuinely inferred keys are merged (see
+    /// `is_inferred_parameter`), so operator-set configuration such as
+    /// `docker_image` or `access_key` is never overwritten.
+    pub async fn initialize_plugin_service(
+        &self,
+        service_id: i32,
+        service_instance: &dyn ExternalService,
+    ) -> Result<(), ExternalServiceError> {
+        let config = self.get_service_config(service_id).await?;
+
+        let inferred_params = service_instance.init(config).await.map_err(|e| {
+            ExternalServiceError::InitializationFailed {
+                id: service_id,
+                reason: e.to_string(),
+            }
+        })?;
+
+        // Persisting is best-effort. By this point the instance is
+        // initialized and the service is usable, so failing the caller would
+        // turn a working enable into a 500 over bookkeeping. A stale row
+        // only degrades health reporting, and the next successful start or
+        // enable rewrites it.
+        if let Err(e) = self
+            .store_inferred_parameters(service_id, service_instance, inferred_params)
+            .await
+        {
+            warn!(
+                service_id,
+                error = %e,
+                "Service initialized, but its inferred parameters could not be persisted — \
+                 health checks may report a stale port until the next start"
+            );
+        }
+
+        Ok(())
+    }
+
     async fn store_inferred_parameters(
         &self,
         service_id: i32,
@@ -11122,6 +11177,33 @@ mod tests {
              `redis-temps-kv`",
             instance.get_name()
         );
+    }
+
+    /// `initialize_plugin_service` runs on every boot, so the write-back it
+    /// performs must be able to correct the port without touching anything
+    /// the operator configured. `store_inferred_parameters` merges only keys
+    /// this predicate accepts — if `docker_image` or the credentials ever
+    /// leaked into it, a restart would silently overwrite operator config.
+    #[test]
+    fn write_back_corrects_the_port_and_leaves_operator_config_alone() {
+        assert!(
+            ExternalServiceManager::is_inferred_parameter("port"),
+            "the port must be written back, or health_probe keeps reading a stale one"
+        );
+
+        for operator_set in [
+            "docker_image",
+            "access_key",
+            "secret_key",
+            "host",
+            "region",
+            "console_port",
+        ] {
+            assert!(
+                !ExternalServiceManager::is_inferred_parameter(operator_set),
+                "'{operator_set}' is operator-facing and must survive a plugin re-init"
+            );
+        }
     }
 
     /// The sweep at the end of `delete_service` reaches pre-fix containers by


### PR DESCRIPTION
Follow-up to #503 (issue #495). Closes the migration gap that fix left open.

## Problem

The blob and kv plugins construct their own `RustfsService` / `RedisService` and called `init()` directly, discarding the parameters the engine infers. So `external_services.config` was free to drift from the container it describes — and the port matters, because `ExternalService::health_probe` reads it out of the **stored config**, not the live instance:

```rust
let cfg = self.get_rustfs_config(service_config)?;
let endpoint = format!("http://{}:{}", cfg.host, cfg.port);
```

On an install upgraded across #495 the stored port is the one the **pre-fix manager container** took (typically 9000), while the live container the plugin created is on another (typically 9001). Uploads are fine — they go through the instance, which adopts the running container's real port. But the health monitor probes the stale port. Before the leftover container is removed it answers, so Blob reports healthy for the wrong reason; once the operator removes it — which is exactly what #503's boot warning instructs — nothing is on that port and **the console reports Blob as down while uploads keep working.**

Self-hosted operators debug alone. Shipping a warning that tells them to do something that makes their dashboard lie is not acceptable.

## Change

`ExternalServiceManager::initialize_plugin_service(service_id, instance)` — load stored config, initialize the instance, write inferred parameters back. Both plugin boot paths and both branches of `blob_enable` / `kv_enable` now call it instead of each hand-rolling load-then-init.

Two deliberate choices:

- **Persisting is best-effort.** By that point the instance is initialized and the service is usable, so failing the caller would turn a working enable into a 500 over bookkeeping. A failed write logs a warning; the next successful start or enable rewrites the row. This follows the same rule as audit-log failures not failing the operation.
- **Only inferred keys are merged.** `store_inferred_parameters` accepts `port`, `connection_string`, `local_address`, `password`, `root_password` — operator-set config (`docker_image`, `access_key`, `host`, `region`, `console_port`) is untouched. Since this now runs on **every boot**, that predicate staying narrow is load-bearing, so there's a test pinning it. If `docker_image` ever leaked into it, a restart would silently overwrite operator configuration.

## Evidence

Local instance on its own slot, own Postgres and data dir. Reproduced the drift an upgraded install experiences: enable Blob, stop the server, remove the container, squat its port so it cannot come back on the same one, restart.

**Baseline after enable — row and container agree:**

```
stored port : 9000
live port   : 127.0.0.1:9000
```

**Drift forced** (container removed, nginx squatting 9000, row still says 9000), then restart:

```
WARN temps_providers::externalsvc::rustfs: Provided port 9000 is not available, finding a new one

### after drift + restart (write-back active)
live port   : 127.0.0.1:9001
stored port : 9001        <- row corrected; without this commit it stays 9000
```

The counterfactual is arithmetic from those recorded values: the row said 9000, the container came back on 9001, and nothing but this write-back rewrites the row.

**The symptom itself — the health monitor's persisted verdict**, after a full probe cycle against the corrected row:

```
 id |    name    | health_status | last_health_error | consecutive_health_failures
  1 | temps-blob | operational   |                   |                           0
```

**Data path still good** across the same restart:

```
### blob status
{"enabled":true,"healthy":true,"version":"1.0.0-alpha.98",...} [200]
### upload / read roundtrip
{"url":"/api/blob/1/wb.txt","size":12,...} [201]
writeback-ok [200]
```

Note: `GET /api/external-services/{id}/health` is a stub — `check_service_health` returns `Ok(false)` unconditionally regardless of state — so it is not a usable signal here. The meaningful one is `external_services.health_status`, written by `ExternalServiceHealthMonitor`, shown above. Worth fixing separately.

## Tests

```
cargo test -p temps-providers -p temps-blob -p temps-kv
  396 passed; 0 failed   (temps-providers lib, incl. the new predicate test)
   24 passed; 0 failed   (temps-blob)
   13 passed; 0 failed   (temps-kv)
    9 passed; 0 failed   (integration suites)

cargo clippy -p temps-providers -p temps-blob -p temps-kv --all-targets -- -D warnings
  clean
```

No API surface change, so no CLI parity needed.

## Also in this PR

Two defects found while verifying the above. Both are independent of the write-back; folded in here because they were discovered by the same run and are small.

### Host-port selection ignored loopback

`is_port_available` probed only `0.0.0.0`, but these containers publish to `127.0.0.1` (`utils::local_port_binding`). `TcpListener::bind` sets `SO_REUSEADDR` on Unix, so the wildcard bind succeeds even when another process already holds the port on loopback — an SSH tunnel forwarding it, for instance. Docker's published-port list doesn't cover that either, since the holder isn't a container. `find_available_port_async` therefore returned a port Docker couldn't bind, and container creation died at start:

```
ports are not available: exposing port TCP 127.0.0.1:9004 -> 127.0.0.1:0:
listen tcp4 127.0.0.1:9004: bind: address already in use
```

This is not hypothetical — it blocked verification of this very PR for an hour on a machine with tunnels on 9004 and 9010.

Both addresses are now probed, sequentially, so the wildcard listener isn't still open when loopback is tested (binding both at once would report every port as taken).

Confirmed the old check really was blind to it, with a standalone program against the pre-fix logic:

```
loopback held on 49585
OLD check (0.0.0.0 only) says available = true
  -> the old code hands Docker a port it cannot bind
```

**Live proof.** Squatted 9000–9003 with containers so the scan reaches 9004, which the SSH tunnel holds on loopback:

```
sq-9000  127.0.0.1:9000->80/tcp     (…9001, 9002, 9003 likewise)
9004: ssh pid=63809 127.0.0.1:9004  (loopback only — invisible to Docker)

### enable Blob under those conditions
{"success":true,...} [200]

### container landed on:
9000/tcp -> 127.0.0.1:9005
9001/tcp -> 127.0.0.1:9008
```

9004 skipped, provisioning succeeds. Pre-fix this is the exact configuration that failed.

MariaDB carried its **own** `is_port_available` / `find_available_port`, so the fix above did not reach it — MariaDB provisioning could still pick a loopback-held port and fail at container start. Those copies also predated the shared helper's other guards: no offset divergence between concurrent allocations, no awareness of ports published by other containers, and a 100-port scan window instead of 1000. Both are deleted; the restore path uses the Docker-aware variant since a client is in scope there. A sweep confirmed `port_util` is now the only definition in the crate.

Not changed: `temps-deployments`'s `find_available_port` deliberately binds `0.0.0.0`, with a comment saying it matches Docker's address for app containers. That subsystem publishes differently from providers, so changing its binding semantics belongs in its own change.

### `GET /external-services/{id}/health` always said false

`check_service_health` looked the service up and then returned a hardcoded `false`, so the endpoint reported every service as unhealthy no matter what the monitor had written:

```rust
let _service = self.get_service(service_id).await?;
Ok(false)
```

It now returns the monitor's persisted verdict rather than probing inline, so polling can't stall on an unreachable service. `degraded` reports `false`; callers needing that distinction should read the health snapshot.

```
### persisted verdict
operational
### GET /external-services/1/health   (was hardcoded false)
true [200]
```

Table-driven test covers `operational` / `degraded` / `down` / `NULL`.

## Tests

```
cargo test -p temps-providers -p temps-blob -p temps-kv
  399 passed; 0 failed   (temps-providers lib)
   24 passed; 0 failed   (temps-blob)
   13 passed; 0 failed   (temps-kv)
    9 passed; 0 failed   (integration suites)

cargo clippy -p temps-providers -p temps-blob -p temps-kv --all-targets -- -D warnings
  clean
```

New regression tests, all failing on `main`:

```
externalsvc::port_util::tests::loopback_only_listener_makes_a_port_unavailable
externalsvc::port_util::tests::a_free_port_is_still_reported_available
services::tests::health_check_reports_the_monitors_verdict
services::tests::write_back_corrects_the_port_and_leaves_operator_config_alone
```

No API surface change, so no CLI parity needed.

