### PR TITLE
ci: fix the cache-budget leak that makes Compose Security take 92 minutes

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,6 +13,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -28,6 +28,11 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -88,8 +88,13 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Cache Bun dependencies
-        uses: actions/cache@v6
+      # Restore always, save only from `main` — see the cache-scoping note in
+      # rust-tests.yml. Saving from every ref stored a byte-identical 161MB
+      # node_modules copy in each open PR's scope (5 copies, ~805MB) for a
+      # `bun install` that takes seconds to redo.
+      - name: Restore Bun dependencies
+        id: bun-cache
+        uses: actions/cache/restore@v6
         with:
           path: web/node_modules
           key: ${{ runner.os }}-bun-${{ hashFiles('web/bun.lock') }}
@@ -98,6 +103,13 @@ jobs:
 
       - name: Install web dependencies (Playwright tests)
         run: cd web && bun install
+
+      - name: Save Bun dependencies
+        if: github.ref == 'refs/heads/main' && steps.bun-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: web/node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('web/bun.lock') }}
 
       - name: Generate self-signed localho.st certificate
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,11 +1,21 @@
 name: E2E Tests
 
+# Called by `rust-tests.yml`, not triggered directly.
+#
+# This job used to build its own `--release` binary — a second full compile of
+# the same workspace that `rust-tests.yml` was already building for Compose
+# Security, plus a second web-UI and WASM build in front of it. It now takes
+# the musl `fast` binary from the `build-binary` job as an artifact, which is
+# both faster and a better test: that is the binary that ships in the Docker
+# image, where `--release` glibc never was.
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      binary-artifact:
+        description: "Name of the artifact holding the prebuilt `temps` binary"
+        required: false
+        default: temps-binary-musl-fast
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,7 +25,6 @@ jobs:
   e2e-test:
     name: E2E Deployment Tests
     runs-on: ubuntu-latest
-    needs: []
     timeout-minutes: 60
 
     services:
@@ -46,6 +55,7 @@ jobs:
       # with phantom "tried N deploys, never shipped" instances. (Opt-out values:
       # 0/false/off/no/disabled — see temps-telemetry/src/service.rs.)
       TEMPS_TELEMETRY: "0"
+      TEMPS_BIN: ./ci-prebuilt/temps
 
     steps:
       - name: Free up disk space
@@ -57,23 +67,26 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7.0.1
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      # No Rust toolchain, no wasm-pack, no rsbuild production build — the
+      # binary arrives prebuilt with the web UI already embedded. Bun stays,
+      # but only to install web/node_modules for the Playwright console tests
+      # below; it no longer builds the UI.
+      - name: Download temps binary
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.binary-artifact }}
+          path: ci-prebuilt
+
+      - name: Verify prebuilt binary runs
+        run: |
+          chmod +x "$TEMPS_BIN"
+          file "$TEMPS_BIN"
+          "$TEMPS_BIN" --version
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-
-      - name: Rust cache (release build)
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: e2e-release
-          # Save from every ref, not just main — PRs used to depend entirely
-          # on main's copy surviving GitHub's cache eviction, which it
-          # routinely didn't (repo-wide cache churn from per-PR debug-build
-          # caches kept evicting this one). Now every PR keeps its own copy
-          # warm too.
 
       - name: Cache Bun dependencies
         uses: actions/cache@v6
@@ -83,36 +96,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
-      - name: Cache wasm-pack binary
-        id: wasm-pack-cache
-        uses: actions/cache@v6
-        with:
-          path: ~/.cargo/bin/wasm-pack
-          key: ${{ runner.os }}-wasm-pack-0.13
-
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
-      - name: Install wasm-pack and build WASM
-        run: |
-          if [ ! -f ~/.cargo/bin/wasm-pack ]; then
-            cargo install wasm-pack
-          fi
-          cd crates/temps-captcha-wasm
-          bun install
-          bun run build
-
-      - name: Build Web UI
-        run: |
-          cd web
-          bun install
-          RSBUILD_OUTPUT_PATH=../crates/temps-cli/dist bun run build
-
-      - name: Build release binary
-        run: cargo build --release --bin temps
-        env:
-          FORCE_WEB_BUILD: 1
-          CARGO_INCREMENTAL: 0
+      - name: Install web dependencies (Playwright tests)
+        run: cd web && bun install
 
       - name: Generate self-signed localho.st certificate
         run: |
@@ -139,7 +124,7 @@ jobs:
 
       - name: Run temps setup
         run: |
-          ./target/release/temps setup --non-interactive \
+          "$TEMPS_BIN" setup --non-interactive \
             --database-url "$DATABASE_URL" \
             --data-dir "$TEMPS_DATA_DIR" \
             --admin-email "$ADMIN_EMAIL" \
@@ -161,7 +146,7 @@ jobs:
 
       - name: Start temps serve
         run: |
-          ./target/release/temps serve \
+          "$TEMPS_BIN" serve \
             --database-url "$DATABASE_URL" \
             --data-dir "$TEMPS_DATA_DIR" \
             --address 0.0.0.0:3000 \
@@ -219,7 +204,7 @@ jobs:
       - name: Create API key via CLI
         id: auth
         run: |
-          API_OUTPUT=$(./target/release/temps api-key \
+          API_OUTPUT=$("$TEMPS_BIN" api-key \
             --database-url "$DATABASE_URL" \
             --name "e2e-test" \
             --role admin \

--- a/.github/workflows/network-kernel-tests.yml
+++ b/.github/workflows/network-kernel-tests.yml
@@ -13,6 +13,11 @@ on:
       - "scripts/network-poc/**"
       - ".github/workflows/network-kernel-tests.yml"
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,26 @@
 name: Release
 
+# GHA cache is read-only here (`cache-from` without `cache-to`).
+#
+# GitHub scopes Actions cache *writes* to the ref that produced them, and
+# scopes *reads* to the current ref plus the default branch. This workflow
+# only ever runs on a tag ref — either the `push: tags:` trigger below, or
+# `workflow_dispatch --ref <tag>` from `nightly-release.yml`. A cache written
+# on a tag is therefore readable by exactly one thing: another run on that
+# same tag, which never happens.
+#
+# So every byte `cache-to: type=gha,mode=max` wrote here was unreadable, and
+# it was not free: the repo cache is a single 10GB LRU pool. One nightly run
+# left 206 `buildkit-blob-*` entries totalling 7.4GB behind, evicting the
+# Rust build caches that `rust-tests.yml` and the e2e job depend on. That is
+# what turned the Compose Security job's musl build from ~5 minutes into 81.
+#
+# Reads stay: `sandbox-images-beta.yml` writes the `sandbox-*` and
+# `preview-gateway` scopes from `main`, where they *are* readable from a tag.
+# If cross-nightly layer reuse becomes worth it, use a registry-backed cache
+# (`type=registry,ref=ghcr.io/...:buildcache`) — it does not touch the 10GB
+# Actions cache budget and is readable across refs.
+
 on:
   push:
     tags:
@@ -746,8 +767,10 @@ jobs:
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.title=Temps
             org.opencontainers.image.description=Open-source platform for deploying and managing applications
+          # Read-only on purpose — see the "GHA cache is read-only here" note
+          # at the top of this file. This workflow only ever runs on tag refs,
+          # whose cache scope nothing else can read.
           cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   create-docker-manifest:
     name: Create Docker Manifest
@@ -1006,8 +1029,10 @@ jobs:
             org.opencontainers.image.version=${{ needs.prepare-sandbox-context.outputs.sandbox_image_version }}
             org.opencontainers.image.title=temps-sandbox-${{ matrix.runtime }}
             org.opencontainers.image.description=Temps workspace sandbox image (${{ matrix.runtime }} runtime)
+          # Read-only: `sandbox-images-beta.yml` populates this scope from
+          # `main`, where it is readable by every ref. See the "GHA cache is
+          # read-only here" note at the top of this file.
           cache-from: type=gha,scope=sandbox-${{ matrix.runtime }}
-          cache-to: type=gha,scope=sandbox-${{ matrix.runtime }},mode=max
 
   build-and-push-preview-gateway:
     name: Build preview gateway image
@@ -1073,5 +1098,5 @@ jobs:
             org.opencontainers.image.version=${{ needs.prepare-sandbox-context.outputs.gateway_version }}
             org.opencontainers.image.title=temps-preview-gateway
             org.opencontainers.image.description=Temps preview gateway — routes ws-<sid>-<port> hosts to sandbox containers
+          # Read-only, same reasoning as the sandbox images above.
           cache-from: type=gha,scope=preview-gateway
-          cache-to: type=gha,scope=preview-gateway,mode=max

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -78,7 +78,16 @@ jobs:
           cache-from: |
             type=gha,scope=temps-toolchain
             type=gha,scope=compose-security-toolchain
-          cache-to: type=gha,scope=temps-toolchain,mode=max
+          # Write from `main` only. Cache writes are scoped to the producing
+          # ref, so exporting from PRs stored a private copy of a
+          # byte-identical image in every open PR's scope — four concurrent
+          # PRs held four copies of the same layer set, ~718MB each, ~2.9GB
+          # of a 10GB pool, evicting the cargo caches this job depends on.
+          # Reads see `main`'s copy, which is what every ref can read anyway.
+          # A PR touching the Dockerfile's toolchain stage rebuilds it (~7min)
+          # and can't cache that for its own next push; toolchain changes are
+          # rare enough that this is the cheaper side of the trade.
+          cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,scope=temps-toolchain,mode=max' || '' }}
 
       # Keyed on Cargo.lock + Dockerfile, so any dependency bump misses. The
       # `restore-keys` prefix is what makes that survivable: it falls back to

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -96,8 +96,17 @@ jobs:
       # `release.yml` about the 10GB pool being flooded by dead tag-scoped
       # buildkit blobs, which is what made this miss outright and turned a
       # ~5 minute incremental build into 81 minutes of cold compile.
-      - name: Cache cargo target dir (musl, fast profile)
-        uses: actions/cache@v6
+      #
+      # Restore always, save from `main` only. This is the largest single
+      # cache in the repo (a musl target dir plus cargo registry for 55
+      # crates), so a per-ref copy of it is what pushed the pool over its
+      # 10GB limit fastest — four open PRs each holding their own was several
+      # GB spent guaranteeing that nobody's copy survived. A PR that changes
+      # Cargo.lock now rebuilds the delta on top of main's copy on every
+      # push, instead of everyone cold-building because the pool thrashed.
+      - name: Restore cargo target dir (musl, fast profile)
+        id: musl-cache
+        uses: actions/cache/restore@v6
         with:
           path: ci-build-cache
           key: temps-musl-fast-${{ hashFiles('Cargo.lock', 'Dockerfile') }}
@@ -131,6 +140,13 @@ jobs:
             '
           chmod +x ci-prebuilt/temps
           file ci-prebuilt/temps
+
+      - name: Save cargo target dir (musl, fast profile)
+        if: github.ref == 'refs/heads/main' && steps.musl-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ci-build-cache
+          key: temps-musl-fast-${{ hashFiles('Cargo.lock', 'Dockerfile') }}
 
       - name: Upload temps binary
         uses: actions/upload-artifact@v7
@@ -209,10 +225,18 @@ jobs:
           # Share the same cache slot as build-tests/clippy instead of each
           # getting its own — they compile largely the same dependency graph,
           # and per-job caches were bloating the repo's total cache footprint
-          # enough to evict other workflows' caches (e.g. e2e-tests.yml's
-          # release build) well before their 7-day idle expiry.
+          # enough to evict other workflows' caches well before their 7-day
+          # idle expiry.
+          #
+          # Deduping by key was only half of it: writes are also scoped to the
+          # producing ref, so `save-if: true` stored a separate ~886MB copy in
+          # every open PR's scope. A snapshot with three PRs in flight held
+          # 2.66GB of this one key. Save from `main` — the scope every ref can
+          # read — and let PRs restore from it. A PR that shifts the
+          # dependency graph rebuilds the delta on top of main's copy, which
+          # is what the prefix restore-keys are for.
           shared-key: test-build
-          save-if: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cache wasm-pack binary
         uses: actions/cache@v6
@@ -261,8 +285,11 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Cache Bun dependencies
-        uses: actions/cache@v6
+      # Restore always, save only from `main` — see the cache-scoping note on
+      # the toolchain export above.
+      - name: Restore Bun dependencies
+        id: bun-cache
+        uses: actions/cache/restore@v6
         with:
           path: web/node_modules
           key: ${{ runner.os }}-bun-${{ hashFiles('web/bun.lock') }}
@@ -271,6 +298,13 @@ jobs:
 
       - name: Install dependencies
         run: cd web && bun install
+
+      - name: Save Bun dependencies
+        if: github.ref == 'refs/heads/main' && steps.bun-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: web/node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('web/bun.lock') }}
 
       # react/react-dom drifting apart is invisible to tsc and rsbuild but
       # blanks the console at runtime with React error #527 (issue #504).
@@ -302,9 +336,10 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          # See the check job above for why this shares build-tests' key.
+          # See the check job above for why this shares build-tests' key
+          # and why it only saves from `main`.
           shared-key: test-build
-          save-if: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cache wasm-pack binary
         uses: actions/cache@v6
@@ -375,7 +410,10 @@ jobs:
           # so there's no cross-scope resolver mismatch to worry about (see
           # the removed per-group cache keys this replaces).
           shared-key: nextest-archive
-          save-if: true
+          # Save from `main` only — this key's archive runs ~1.3GB, and
+          # per-PR copies of it were a top-three consumer of the repo's 10GB
+          # cache pool. See the check job for the full reasoning.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -7,6 +7,15 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Superseded PR pushes used to leave the previous run's jobs going to
+# completion — including an 80-minute cold musl build whose output nobody
+# would ever look at, while the new commit's jobs queued behind it. Cancel
+# them. Never on `main`: those runs are what populate the default-branch
+# cache scope that every PR reads from.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -22,9 +31,27 @@ jobs:
       - name: Verify nightly release wiring
         run: .github/scripts/test-nightly-release-workflows.sh
 
-  compose-security:
-    name: Compose Security
+  # ---------------------------------------------------------------------------
+  # One `temps` binary, two consumers.
+  #
+  # Compose Security needs a musl binary to assemble the production image
+  # around; the e2e job needs a runnable `temps` to drive real deployments.
+  # These used to be two separate compiles of the same workspace — a `fast`
+  # musl build here and a `--release` glibc build in `e2e-tests.yml`, each
+  # with its own web-UI + WASM build in front of it. Now this job compiles
+  # once and both consume the artifact.
+  #
+  # musl-static is the right target for both: it is exactly the binary that
+  # ships in the Docker image, and a static binary runs fine directly on the
+  # runner. E2E therefore now tests the artifact users actually get.
+  # ---------------------------------------------------------------------------
+  build-binary:
+    name: Build temps Binary (musl)
     runs-on: ubuntu-latest
+    # Warm this is ~5 minutes. The ceiling is sized for a fully cold cache,
+    # which took 81 minutes the last time the cargo cache was evicted — a
+    # tighter bound would turn a slow run into a failed one.
+    timeout-minutes: 100
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.1
@@ -45,15 +72,28 @@ jobs:
           target: toolchain
           load: true
           tags: temps-toolchain:ci
-          cache-from: type=gha,scope=compose-security-toolchain
-          cache-to: type=gha,scope=compose-security-toolchain,mode=max
+          # Second entry is the pre-rename scope, kept so in-flight PRs don't
+          # all pay for a cold toolchain build until `main` repopulates the
+          # new one. Safe to drop after a `main` build has run.
+          cache-from: |
+            type=gha,scope=temps-toolchain
+            type=gha,scope=compose-security-toolchain
+          cache-to: type=gha,scope=temps-toolchain,mode=max
 
+      # Keyed on Cargo.lock + Dockerfile, so any dependency bump misses. The
+      # `restore-keys` prefix is what makes that survivable: it falls back to
+      # the most recent musl target dir and rebuilds only what changed. That
+      # fallback only works if the entry still exists — see the note in
+      # `release.yml` about the 10GB pool being flooded by dead tag-scoped
+      # buildkit blobs, which is what made this miss outright and turned a
+      # ~5 minute incremental build into 81 minutes of cold compile.
       - name: Cache cargo target dir (musl, fast profile)
         uses: actions/cache@v6
         with:
           path: ci-build-cache
-          key: compose-security-musl-${{ hashFiles('Cargo.lock', 'Dockerfile') }}
+          key: temps-musl-fast-${{ hashFiles('Cargo.lock', 'Dockerfile') }}
           restore-keys: |
+            temps-musl-fast-
             compose-security-musl-
 
       # Mirrors the Dockerfile builder stage (WASM -> web UI -> cargo build)
@@ -81,6 +121,46 @@ jobs:
                 ci-prebuilt crates/temps-cli/dist
             '
           chmod +x ci-prebuilt/temps
+          file ci-prebuilt/temps
+
+      - name: Upload temps binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: temps-binary-musl-fast
+          path: ci-prebuilt/temps
+          retention-days: 1
+          # Already a stripped binary; re-compressing costs more than it saves.
+          compression-level: 0
+
+  # Lives in its own file for readability; called from here so it can reuse
+  # the binary `build-binary` already compiled. Artifacts are per-run, and a
+  # called workflow is part of the same run, so the download just works.
+  e2e:
+    name: E2E
+    needs: build-binary
+    uses: ./.github/workflows/e2e-tests.yml
+    with:
+      binary-artifact: temps-binary-musl-fast
+
+  compose-security:
+    name: Compose Security
+    runs-on: ubuntu-latest
+    needs: build-binary
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Download temps binary
+        uses: actions/download-artifact@v8
+        with:
+          name: temps-binary-musl-fast
+          path: ci-prebuilt
+
+      - name: Restore executable bit
+        run: chmod +x ci-prebuilt/temps
 
       # Assemble the production runtime stage around the prebuilt binary —
       # the builder stage is skipped entirely, so this takes ~1 minute.

--- a/.github/workflows/skill-security.yml
+++ b/.github/workflows/skill-security.yml
@@ -14,6 +14,11 @@ on:
     - cron: "23 3 * * *"
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## The problem

Compose Security isn't slow. It's cache-starved, and `release.yml` is doing the starving.

Step timings from run [`30728219120`](https://github.com/gotempsh/temps/actions/runs/30728219120) (92 min) against [`30725621341`](https://github.com/gotempsh/temps/actions/runs/30725621341) (9 min):

| Step | Slow run | Fast run |
|---|---|---|
| Build toolchain image (GHA layer cache) | 7 min | 0 min |
| Cache cargo target dir | **0 min** — restored nothing | 1 min |
| Build temps binary in container | **81 min** | 4 min |

`0 min` on the restore is the tell. It wasn't a primary-key miss falling back to `restore-keys`; there was no entry at all. Both the cargo target dir and the toolchain layer cache were gone, so the job cold-compiled 55 crates.

## Why they were gone

```
$ gh api repos/gotempsh/temps/actions/cache/usage
active_caches: 215   size: 11GB      # repo limit: 10GB, LRU eviction
```

**206 of those 215 caches are `buildkit-blob-*`, totalling 7.4GB — all on one ref:** `refs/heads/refs/tags/v0.1.0-nightly.20260802.ba96c0f7`.

That's `release.yml` writing `cache-to: type=gha,mode=max` at three sites (`:750` main image, `:1010` sandbox matrix, `:1077` preview-gateway). Two things make it pure loss:

1. **Unreadable.** GitHub scopes cache *writes* to the producing ref and *reads* to the current ref plus the default branch. `release.yml` only ever runs on a tag — the `push: tags:` trigger, or `workflow_dispatch --ref <tag>` from `nightly-release.yml`. A cache written on a tag is readable by exactly one thing: another run on that same tag. Which never happens.
2. **Destructive.** It's a single 10GB LRU pool. `compose-security-musl-*` and `compose-security-toolchain` no longer appear in the cache list at all. Neither survived.

Same mechanism explains Build Test Binaries swinging 15→38 min and E2E 22→42 min. The comment already at `e2e-tests.yml:71-76` describes people fighting this symptom without finding the cause.

## The changes

**1. `ci(release): stop writing tag-scoped buildkit caches that nothing can read`**

Drop `cache-to` at all three sites. Keep `cache-from` — `sandbox-images-beta.yml` populates the `sandbox-*` and `preview-gateway` scopes from `main`, where a tag run *can* read them. That's the direction the sharing was always supposed to go. Recovers 7.4GB.

**2. `ci: compile the temps binary once and share it with e2e and compose security`**

Compose Security and e2e both need a runnable `temps`, and each compiled the whole workspace to get one — a `fast` musl build here, a `--release` glibc build there, each with its own WASM + web-UI build in front. New `build-binary` job compiles once and uploads an artifact; both consume it. `e2e-tests.yml` becomes `workflow_call`, invoked from `rust-tests.yml` so it can `needs:` that job.

musl-static suits both: it's exactly what ships in the Docker image, and a static binary runs directly on the runner — so **e2e now exercises the artifact users actually get** instead of a glibc `--release` build that never ships. e2e keeps Bun only to install `web/node_modules` for the Playwright console tests; it no longer builds the UI, which is already embedded.

**3. `ci: cancel superseded pull-request runs`**

No workflow declared `concurrency`. Pushing to a PR left the prior commit's jobs running to completion — up to an 80-minute cold build nobody would read — while the new commit queued behind it. Added to all six PR-triggered workflows, cancelling on `pull_request` only. `main` runs are deliberately left alone: they populate the default-branch cache scope every PR reads from.

**4. `ci: export the toolchain layer cache from main only`**

The nightly flood was the acute problem; this is the chronic one. Cache *writes* are ref-scoped, so exporting the toolchain image from every PR stored a private copy of a byte-identical layer set per PR. Observed with four PRs in flight — the same digests repeated four times:

| Digest | Size | Copies |
|---|---|---|
| `2a47509c…` | 254MB | PRs 512, 516, 517, 518 |
| `008dcc75…` | 71MB | PRs 512, 516, 517, 518 |
| `6a0ac161…` | 3MB | PRs 512, 516, 517, 518 |

~718MB per PR, ~2.9GB of a 10GB pool, for four copies of one image.

**5. `ci: write every shared build cache from main only`**

Same principle applied to the rest of the pool:

| Cache | Per-ref cost observed |
|---|---|
| `v0-rust-test-build` | 886MB × 3 refs = 2.66GB |
| `v0-rust-nextest-archive` | 1.3GB |
| `Linux-bun` (node_modules) | 161MB × 5 refs = 805MB |
| `temps-musl-fast` | largest single entry, per-ref |

Restore from every ref; save only from `main`, the one scope every ref can already read. Deduping by `shared-key` — which the `check` job already did — only addressed the per-job axis; this addresses the per-ref one.

`actions/cache` has no save condition, so the two `node_modules` caches and the musl target dir became explicit `cache/restore` + conditional `cache/save` pairs. `Swatinem/rust-cache` takes `save-if` directly.

Trade-off, stated plainly: a PR that shifts the dependency graph now rebuilds that delta on every push instead of caching it for itself. That is strictly better than the previous equilibrium, where per-PR copies guaranteed `main`'s copy did not survive and *every* job cold-built. Cancelling superseded runs (change 3) already made per-PR saves unreliable, since the run is killed before the save step.

## Expected effect

Compose Security settles at ~7 min (5 build + 2 validate) instead of oscillating 9–92. One full workspace compile and one web/WASM build removed from every PR. The `v0-rust-e2e-release-*` entry (1.42GB) loses its consumer entirely.

Reclaimed pool, adding it up: 7.4GB nightly blobs + ~2.2GB duplicate toolchain copies + ~1.8GB duplicate `test-build` copies + ~0.65GB duplicate bun copies + 1.42GB dead e2e-release ≈ **13GB of churn out of a 10GB pool.** That is the whole reason nothing ever stayed cached.

## Verification

- All 10 workflow files parse (`yaml.safe_load`).
- `.github/scripts/test-nightly-release-workflows.sh` passes: `privileged workflow action pinning valid: 77 uses across 6 workflows` / `release permission allowlists and tool pins are valid` / `nightly release workflow wiring and publishing workflow security are valid`.
- Branch protection on `main` declares no required status checks (`required_status_checks` absent, the one ruleset is `enforcement: disabled`), so renaming the E2E check to `E2E / E2E Deployment Tests` breaks no merge gate.
- **The real evidence is this PR's own CI run** — `build-binary` must go green and e2e must pass against the musl binary. Cache keys were renamed, so this run starts cold; the fallback `restore-keys` point at the old names, and `timeout-minutes: 100` is sized for the 81-minute cold case rather than the ~5-minute warm one.

## Follow-ups not in this PR

- The 7.4GB of dead nightly-tag blobs still occupy the pool until they age out. Purging them via `gh cache delete` would make the fix take effect immediately rather than after LRU turnover.
- If cross-nightly layer reuse is worth having, move `release.yml` to a registry-backed cache (`type=registry,ref=ghcr.io/...:buildcache`) — doesn't touch the 10GB budget and is readable across refs.
- `Cargo Check` and `Clippy` both build debug `--all-targets` on the same `shared-key: test-build`, both with `save-if: true`, so they race to write the same cache. Clippy is `continue-on-error: true`, so it currently gates nothing.

