### PR TITLE
fix(cli): repo lookup by search, nested group paths, and --secret for env vars

### DIFF
--- a/apps/temps-cli/src/commands/environments/index.ts
+++ b/apps/temps-cli/src/commands/environments/index.ts
@@ -91,6 +91,7 @@ export function registerEnvironmentsCommands(program: Command): void {
     .option('-e, --environments <names>', 'Comma-separated environment names (interactive if not provided)')
     .option('--no-preview', 'Exclude from preview environments')
     .option('--update', 'Update existing variable instead of creating new')
+    .option('--secret', 'Store as a secret: the value is masked in the UI and never returned by the API. One-way — a secret cannot later be made non-secret')
     .action(async (key, value, options, cmd) => {
       const projectSlug = cmd.parent!.opts().project
       return setEnvVar(projectSlug, key, value, options)
@@ -513,7 +514,7 @@ async function setEnvVar(
   projectFlag: string | undefined,
   key: string,
   value: string | undefined,
-  options: { environments?: string; preview?: boolean; update?: boolean }
+  options: { environments?: string; preview?: boolean; update?: boolean; secret?: boolean }
 ): Promise<void> {
   await requireAuth()
   await setupClient()
@@ -608,11 +609,15 @@ async function setEnvVar(
           value: actualValue,
           environment_ids: environmentIds,
           include_in_preview: options.preview !== false,
+          // Only sent when --secret is passed. Omitting it leaves the existing
+          // flag untouched; sending false against an already-secret variable is
+          // rejected by the API, since promotion is deliberately one-way.
+          ...(options.secret ? { is_secret: true } : {}),
         },
       })
       if (error) throw new Error(getErrorMessage(error))
     })
-    success(`Updated ${key}`)
+    success(`Updated ${key}${options.secret ? ' (secret)' : ''}`)
   } else {
     // Create new variable
     await withSpinner(`Setting ${key}...`, async () => {
@@ -624,11 +629,12 @@ async function setEnvVar(
           value: actualValue,
           environment_ids: environmentIds,
           include_in_preview: options.preview !== false,
+          ...(options.secret ? { is_secret: true } : {}),
         },
       })
       if (error) throw new Error(getErrorMessage(error))
     })
-    success(`Set ${key}`)
+    success(`Set ${key}${options.secret ? ' (secret)' : ''}`)
   }
 
   info(`Environments: ${envs.filter(e => environmentIds.includes(e.id)).map(e => e.name).join(', ')}`)

--- a/apps/temps-cli/src/commands/projects/create.ts
+++ b/apps/temps-cli/src/commands/projects/create.ts
@@ -73,6 +73,22 @@ const MANUAL_SOURCE_TYPES: {
   },
 ]
 
+/**
+ * Splits a repository path into owner and name.
+ *
+ * Splitting on the LAST slash rather than requiring exactly two segments is
+ * what makes nested GitLab groups work: `gala-games/chain/platform/my-repo`
+ * is owner `gala-games/chain/platform`, name `my-repo`. That matches how the
+ * API stores it (repo_owner / repo_name) and how the provider lists it.
+ * Requiring exactly two segments rejected every repo in a subgroup, even
+ * though the backend supported them.
+ */
+function parseRepoPath(repo: string): { owner: string; name: string } | null {
+  const lastSlash = repo.lastIndexOf('/')
+  if (lastSlash <= 0 || lastSlash === repo.length - 1) return null
+  return { owner: repo.slice(0, lastSlash), name: repo.slice(lastSlash + 1) }
+}
+
 export async function create(options: CreateOptions): Promise<void> {
   await requireAuth()
   await setupClient()
@@ -149,14 +165,14 @@ export async function create(options: CreateOptions): Promise<void> {
       info(`Using git connection: ${connection.account_name}`)
     } else if (options.repo && skipPrompts) {
       // Auto-find the connection that has this repo
-      const parts = options.repo.split('/')
-      if (parts.length !== 2 || !parts[0] || !parts[1]) {
-        error('Repository must be in owner/name format (e.g., myorg/myrepo)')
+      const parsed = parseRepoPath(options.repo)
+      if (!parsed) {
+        error('Repository must be in owner/name format (e.g., myorg/myrepo or mygroup/subgroup/myrepo)')
         return
       }
       const connections = await fetchGitConnections()
       for (const conn of connections) {
-        const repo = await findRepositoryByName(conn.id, parts[0], parts[1])
+        const repo = await findRepositoryByName(conn.id, parsed.owner, parsed.name)
         if (repo) {
           connection = conn
           info(`Auto-selected git connection: ${conn.account_name}`)
@@ -178,13 +194,13 @@ export async function create(options: CreateOptions): Promise<void> {
     // Step 2: Select Repository
     let repository
     if (options.repo) {
-      // Parse owner/name format
-      const parts = options.repo.split('/')
-      if (parts.length !== 2 || !parts[0] || !parts[1]) {
-        error('Repository must be in owner/name format (e.g., myorg/myrepo)')
+      // Parse owner/name, tolerating nested groups (mygroup/subgroup/myrepo)
+      const parsed = parseRepoPath(options.repo)
+      if (!parsed) {
+        error('Repository must be in owner/name format (e.g., myorg/myrepo or mygroup/subgroup/myrepo)')
         return
       }
-      repository = await findRepositoryByName(connection.id, parts[0], parts[1])
+      repository = await findRepositoryByName(connection.id, parsed.owner, parsed.name)
       if (!repository) {
         error(`Repository "${options.repo}" not found in connection "${connection.account_name}".`)
         return

--- a/apps/temps-cli/src/commands/projects/index.ts
+++ b/apps/temps-cli/src/commands/projects/index.ts
@@ -30,7 +30,7 @@ export function registerProjectsCommands(program: Command): void {
     .description('Create a new project (git-based or manual deployment)')
     .option('-n, --name <name>', 'Project name')
     .option('-d, --description <description>', 'Project description')
-    .option('--repo <repository>', 'Repository in owner/name format')
+    .option('--repo <repository>', 'Repository in owner/name format (nested groups supported: group/subgroup/name)')
     .option('--branch <branch>', 'Git branch')
     .option('--directory <directory>', 'Root directory (relative to repo)')
     .option('--preset <preset>', 'Build preset (e.g., nextjs, nodejs, static, docker)')

--- a/apps/temps-cli/src/lib/git-connection.ts
+++ b/apps/temps-cli/src/lib/git-connection.ts
@@ -149,21 +149,35 @@ export async function findRepositoryByName(
   owner: string,
   repoName: string
 ): Promise<RepositoryResponse | null> {
+  // Search server-side rather than paging through everything. Without this the
+  // call fetched an arbitrary first 100 repositories and matched client-side,
+  // so on any organisation with more than 100 repos a perfectly valid --repo
+  // was reported as "not found in connection" purely because it happened to
+  // sort past the first page.
   const { data, error: apiError } = await listRepositoriesByConnection({
     client,
     path: { connection_id: connectionId },
-    query: { per_page: 100 },
+    query: { per_page: 100, search: repoName },
   })
 
   if (apiError || !data?.repositories) {
     return null
   }
 
-  return (
-    data.repositories.find(
-      (r) => r.owner.toLowerCase() === owner.toLowerCase() && r.name.toLowerCase() === repoName.toLowerCase()
-    ) || null
-  )
+  const match = (r: RepositoryResponse) =>
+    r.owner.toLowerCase() === owner.toLowerCase() && r.name.toLowerCase() === repoName.toLowerCase()
+
+  const found = data.repositories.find(match)
+  if (found) return found
+
+  // Fall back to an unfiltered page for providers that ignore `search`, so this
+  // is never worse than the previous behaviour.
+  const { data: unfiltered } = await listRepositoriesByConnection({
+    client,
+    path: { connection_id: connectionId },
+    query: { per_page: 100 },
+  })
+  return unfiltered?.repositories?.find(match) ?? null
 }
 
 /**


### PR DESCRIPTION
Three CLI fixes found while provisioning a project on a self-hosted instance whose
GitLab org has >100 repositories. Each is small; the third is the one that made
`--connection` unusable in practice.

## 1. `--secret` on `environments vars set`

The API has supported per-variable secrecy on both create and update
(`CreateEnvironmentVariableRequest.is_secret`, `UpdateEnvironmentVariableRequest.is_secret`)
and the console exposes it, but the CLI had no way to set it. Provisioning from the
CLI meant creating secrets as plain variables and fixing them in the UI afterwards —
easy to forget, and the value is readable in the meantime.

```bash
temps environments vars set OIDC_CLIENT_SECRET <value> -e production --secret
```

`is_secret` is sent **only** when `--secret` is passed, so omitting it leaves an
existing variable's flag untouched rather than implicitly clearing it. Sending
`false` against an already-secret variable is rejected server-side anyway —
promotion is deliberately one-way (`EnvVarError::CannotDemoteSecret`) — and the help
text says so, so it's discoverable before a failed call rather than after.

Because promotion *is* allowed, `--secret` on an existing plain variable upgrades it
in place, which is the natural way to fix one created without the flag.

## 2. `projects create --repo` rejected nested group paths

```ts
const parts = options.repo.split('/')
if (parts.length !== 2 || ...) error('Repository must be in owner/name format')
```

This rejected every GitLab repository inside a subgroup, e.g.
`gala-games/chain/platform/my-repo`. The backend has no such restriction — it stores
`repo_owner` and `repo_name` separately, and existing projects hold owner
`gala-games/chain/platform` — and the provider lists those repos with their full
path. Only this client-side check stood in the way.

Splitting on the **last** slash matches how the API stores it and how the provider
reports it, and leaves flat `owner/name` behaving exactly as before.

## 3. Repository lookup used an arbitrary first page instead of searching

This is the significant one.

```ts
query: { per_page: 100 }
...
data.repositories.find((r) => r.owner === owner && r.name === repoName)
```

`findRepositoryByName` fetched one unfiltered page of 100 and matched client-side, so
on any organisation with more than 100 repositories a perfectly valid `--repo` was
reported as **"not found in connection"** purely because it sorted past page 1.

Observed directly:

```
repos returned for the connection with no filter:  100
of which match the target repo:                      0
```

…while the same repository came back immediately from
`providers git repos --search`, and the console's picker found it too — both search
server-side; this did not.

The endpoint already accepts `search`, so pass the repository name and let the
provider filter. An unfiltered page is still tried afterwards, so behaviour is never
worse than before for providers that ignore the parameter.

**Why it mattered beyond a confusing error:** `projects git` resolves the repository
*before* sending `git_provider_connection_id`, so a failed lookup meant the
connection could never be attached from the CLI. The documented workaround —
`--manual` then `projects git` — sets the repository but leaves the connection null.
A project in that state renders in the console with a default GitHub icon and a
"Public" badge on a private GitLab repo, and cannot clone.

## Verification

- End to end against a real server: `projects git -p <slug> --owner <group/subgroup> --repo <name> --connection 2` moves `git_provider_connection_id` from `null` to `2`. Before the fix, the same command failed at the lookup.
- `--secret` appears in `environments vars set --help` on the built CLI.
- `bun run typecheck` reports the **same 15 pre-existing errors** as the unmodified baseline (`v.value` nullability in the export path, plus unrelated notifications/providers issues). These changes add none.

## Noticed but not fixed here

`providers connections sync` always prints **"Synced 0 repositories"** regardless of
outcome: the endpoint returns `RepositorySyncStartedResponse` (sync is asynchronous)
and the CLI reads a `total_count` that type doesn't have — it's one of the 15
pre-existing typecheck errors. It's purely cosmetic but actively misleading; it sent
me chasing a sync that was never broken. Happy to fix in a follow-up if you'd like it
in scope.
