### PR TITLE
fix(web): make the AI chat page fill the content area exactly

### DIFF
--- a/web/e2e/authenticated/ai-chat-layout.spec.ts
+++ b/web/e2e/authenticated/ai-chat-layout.spec.ts
@@ -1,0 +1,57 @@
+import { expect, expectAppMounted, test } from '../fixtures'
+
+/**
+ * The full-screen AI chat (`/chat`) has to fit the shell's content slot exactly:
+ * its composer is bottom-anchored, so any overflow pushes the textarea below the
+ * fold and the user has to scroll the whole page down to type.
+ *
+ * That is a real regression this guards against -- the page used to size itself
+ * with viewport math (`calc(100dvh - 3.5rem)`), which ignored the shell's own
+ * padding, the true 4rem header, and the app-wide banners (disk space, update
+ * available). With a banner up it overflowed by ~90px and the composer was cut
+ * in half.
+ *
+ * The assertion is on the scroll container rather than on a screenshot because
+ * this is a layout invariant, not an appearance one: the page must never make
+ * the shell's content area scroll, at any viewport, with or without banners.
+ */
+test.describe('AI chat layout', () => {
+  test('fits the content area without making the shell scroll', async ({
+    page,
+    consoleErrors,
+  }) => {
+    await page.goto('/chat')
+    await expectAppMounted(page)
+
+    // The chat list renders after the conversations request settles; measuring
+    // before that can catch an intermediate layout and pass by accident.
+    await expect(
+      page.getByRole('heading', { name: 'Chats', exact: true })
+    ).toBeVisible()
+
+    const overflow = await page.evaluate(() => {
+      // The shell's page-content slot: the only scroller between <main> and the
+      // routed page. If it can scroll, the page overflowed it.
+      const scroller = Array.from(document.querySelectorAll('main > div')).find(
+        (element) => getComputedStyle(element).overflowY === 'auto'
+      ) as HTMLElement | undefined
+
+      if (!scroller) return null
+      return {
+        scrollHeight: scroller.scrollHeight,
+        clientHeight: scroller.clientHeight,
+      }
+    })
+
+    expect(
+      overflow,
+      'the shell content scroller should be findable'
+    ).not.toBeNull()
+    expect(
+      overflow!.scrollHeight,
+      'the AI chat page must not overflow the shell content area -- when it does, the bottom-anchored composer falls below the fold'
+    ).toBeLessThanOrEqual(overflow!.clientHeight)
+
+    expect(consoleErrors).toEqual([])
+  })
+})

--- a/web/src/pages/AiChat.tsx
+++ b/web/src/pages/AiChat.tsx
@@ -30,8 +30,13 @@ export function AiChat() {
     close()
   }, [close])
 
+  // Fill the content area exactly. The shell already bounds this page (a
+  // `dvh`-tall column whose content slot is whatever is left under the header
+  // and any banners), so `h-full` tracks that remaining height. Guessing it with
+  // viewport math instead overflowed by the banner and container-padding heights
+  // and pushed the composer below the fold.
   return (
-    <div className="flex-1 min-h-0 h-[calc(100dvh-var(--header-height,3.5rem))]">
+    <div className="h-full min-h-0">
       {/* `initialContext` is set when the user expands a dock conversation to
           full screen, so this lands on that same thread; it is undefined on a
           direct visit, which opens on the chat list. */}


### PR DESCRIPTION
## Problem

On `/chat` (full-screen AI chat) the composer is cut off at the bottom — the user has to scroll the whole page down to reach the textarea.

## Root cause

`AiChat.tsx` sized the page with viewport math:

```tsx
<div className="flex-1 min-h-0 h-[calc(100dvh-var(--header-height,3.5rem))]">
```

Three things are wrong with that:

1. **`--header-height` is never defined anywhere in the codebase** — `grep -rn "header-height" web/src` returns exactly this one line. It always falls back to `3.5rem`, while the real header is `h-16` (4rem). 8px short.
2. It ignores the shell's own content padding — `<div className="h-full overflow-y-auto py-2 px-0 sm:p-4">` in `App.tsx`. Another 32px.
3. It ignores the app-wide banners that sit *above* the header inside `SidebarInset` (`DiskSpaceAlert`, `UpdateAvailableBanner`), which are dynamic and can't be expressed in a static `calc()` at all.

So the page was always taller than the slot it lives in, and since the composer is bottom-anchored, the overflow lands directly on the textarea.

## Fix

The shell already bounds this page: `SidebarInset` is `flex h-dvh flex-col overflow-hidden`, and the routed page's slot is whatever is left after the banners and header. `h-full` tracks that exactly, at any viewport, banners or not.

```tsx
<div className="h-full min-h-0">
```

## Evidence

Measured live against a local instance (`temps serve` on :8080, console dev server on :3020), on `/chat` with a project chat open.

**Before** — shell content scroller overflows, composer below the fold:

```
{"viewportH":577,"textareaTop":505,"textareaBottom":585,"composerFullyVisible":false,
 "cutOffBy":8,
 "overflowingScroller":{"cls":"h-full overflow-y-auto py-2 px-0 sm:p-4","scrollH":553,"clientH":513}}
```

The 40px scroller overflow decomposes exactly as predicted: 32px shell padding + 8px header underestimate.

**After** — no overflow, composer fully visible:

```
{"viewportH":577,"textareaBottom":545,"composerFullyVisible":true,"overflowingScroller":null}
```

**With a banner present** (48px non-shrinking element injected above the header, simulating `DiskSpaceAlert`): content slot correctly shrinks 513 → 465, composer still fully visible, still no overflow — the case the old `calc()` could never handle.

```
{"bannerH":48,"viewportH":577,"textareaBottom":545,"composerFullyVisible":true,"overflowing":null}
```

## Regression test

`web/e2e/authenticated/ai-chat-layout.spec.ts` asserts the page never makes the shell's content scroller scrollable. It needs no fixtures — the overflow reproduces on the empty chat-list state too.

Verified it actually catches the bug (reverted the one line, re-ran against the same server):

```
✘  [chromium] › ai-chat-layout.spec.ts › fits the content area without making the shell scroll
   Error: the AI chat page must not overflow the shell content area
   Expected: <= 656
   Received:    696
```

and passes on the fix:

```
✓  1 [setup] › e2e/auth.setup.ts:13:6 › authenticate (1.6s)
✓  2 [chromium] › ai-chat-layout.spec.ts:19:7 › AI chat layout › fits the content area without making the shell scroll (1.2s)
2 passed (3.7s)
```

`eslint` clean on both changed files; `tsc --noEmit` reports nothing for either.

## Scope

Frontend only, two files. `DockBody` itself is untouched — the docked (`layout="dock"`) assistant already sized correctly and is unaffected.
