### PR TITLE
fix(web): show a back button in the collapsed sidebar's sub-navigation

### DIFF
--- a/web/src/components/dashboard/Sidebar.tsx
+++ b/web/src/components/dashboard/Sidebar.tsx
@@ -874,7 +874,7 @@ function SettingsNav({ onBack }: { onBack: () => void }) {
   )
   return (
     <>
-      <SwapHeader title="Settings" onBack={onBack} />
+      <SwapHeader title="Settings" onBack={onBack} backLabel="Back to menu" />
       {settingsGroups.map((group) => {
         const ownUrls = new Set(group.items.map((i) => i.url))
         const siblings = allSettingsUrls.filter((u) => !ownUrls.has(u))
@@ -1068,7 +1068,7 @@ function ProjectNav({ slug, onBack }: { slug: string; onBack: () => void }) {
   if (!project) {
     return (
       <>
-        <SwapHeader title="Loading…" onBack={onBack} />
+        <SwapHeader title="Loading…" onBack={onBack} backLabel="Back to menu" />
       </>
     )
   }
@@ -1090,7 +1090,11 @@ function ProjectNav({ slug, onBack }: { slug: string; onBack: () => void }) {
     if (parent?.subItems?.length) {
       return (
         <>
-          <SwapHeader title={parent.title} onBack={() => setDrilledTo(null)} />
+          <SwapHeader
+            title={parent.title}
+            onBack={() => setDrilledTo(null)}
+            backLabel={`Back to ${project.name}`}
+          />
           <SidebarGroup className="pt-0">
             <SidebarMenu>
               {parent.subItems.map((sub) => {
@@ -1123,7 +1127,11 @@ function ProjectNav({ slug, onBack }: { slug: string; onBack: () => void }) {
 
   return (
     <>
-      <SwapHeader title={project.name} onBack={onBack} />
+      <SwapHeader
+        title={project.name}
+        onBack={onBack}
+        backLabel="Back to menu"
+      />
       <SidebarGroup className="pt-0">
         <SidebarMenu>
           {items.map((item) => {
@@ -1251,10 +1259,43 @@ function CurrentProjectPin({
 
 // Shared back-arrow header used by Settings, Project, and drill-down
 // sub-views. `onBack` is a state callback — it never navigates.
-function SwapHeader({ title, onBack }: { title: string; onBack: () => void }) {
+//
+// `backLabel` names the destination, and is only surfaced when the sidebar is
+// collapsed: expanded, the row reads "← Analytics" (where you *are*, which the
+// surrounding items already imply), but collapsed there is nothing but an arrow,
+// so the tooltip has to say where it goes.
+function SwapHeader({
+  title,
+  onBack,
+  backLabel = 'Back',
+}: {
+  title: string
+  onBack: () => void
+  backLabel?: string
+}) {
   const { isMinimal, isMobile } = useSidebar()
   const compact = isMinimal && !isMobile
-  if (compact) return null
+  // Collapsed, this used to render nothing at all — leaving a second-level nav
+  // (e.g. a project's Analytics sub-items) with no way back out except
+  // re-expanding the sidebar or using the breadcrumb.
+  if (compact) {
+    return (
+      <SidebarGroup className="pb-0">
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              tooltip={backLabel}
+              aria-label={backLabel}
+              onClick={onBack}
+              className="justify-center text-muted-foreground hover:text-foreground"
+            >
+              <ArrowLeft />
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarGroup>
+    )
+  }
   return (
     <SidebarGroup className="pb-0">
       <button


### PR DESCRIPTION
## Problem

Collapse the sidebar, then enter a second-level navigation inside a project (e.g. a project's **Analytics** sub-items). The icon rail shows the children — and nothing else. There is no way back up: you have to re-expand the sidebar, or fall back to the breadcrumb.

Expanded, that same nav has a `← Analytics` row at the top. Collapsed, it is simply absent.

## Root cause

`SwapHeader` — the shared back-arrow row used by Settings, the project nav and drill-down sub-views — bailed out entirely when the sidebar is collapsed:

```tsx
const compact = isMinimal && !isMobile
if (compact) return null
```

## Fix

Render an icon-only back button in that state, using the same shape `CurrentProjectPin` already uses for its own collapsed variant (`SidebarMenuButton` + `tooltip` + `justify-center`), so it sits in the rail like every other icon.

Collapsed, a bare arrow says nothing about *where* it goes, so `SwapHeader` takes an optional `backLabel` used for the tooltip and `aria-label` — "Back to beta-site-nextjs", "Back to menu". The expanded row is deliberately unchanged: there the label is the section you are *in*, which the items below it already imply.

## Verification

Live against a local instance, project drilled into Analytics with `sidebar:minimal` set:

```
collapsed back button aria-label: Back to beta-site-nextjs
visible: true
tooltip count: 1
tooltip text: Back to beta-site-nextjs
after click, back label: Back to menu
project nav restored (Deployments link present): true
```

So the button appears, the tooltip names the destination, and clicking it swaps back to the project nav exactly as the expanded arrow does — `onBack` is untouched, it is still the same pure state callback and still never navigates.

Screenshots of both states (collapsed rail with the new arrow above the Analytics icons, and the unchanged expanded rail) were captured locally during verification.

`eslint` on `Sidebar.tsx` reports the same 2 pre-existing errors before and after this change (both in `ProjectNav`'s drill-sync effect, untouched here) and no new ones; `tsc --noEmit` reports nothing for the file.

## Not covered

No e2e regression test. The suite's `navigation.spec.ts` deliberately excludes `/projects/*` routes because they need a project to exist, and spec ordering against the shared instance makes depending on `project-create.spec.ts` fragile. Worth revisiting when there is a reusable project fixture.
