### PR TITLE
fix(web): stop env var edit modal showing blank value after save

### DIFF
--- a/web/src/components/project/settings/EnvironmentVariablesSettings.tsx
+++ b/web/src/components/project/settings/EnvironmentVariablesSettings.tsx
@@ -111,7 +111,13 @@ function EnvironmentVariableRow({
 
   const revealValue = async (): Promise<string | undefined> => {
     if (isSecret) return undefined
-    const request = revealGuard.current.begin('value')
+    // Capture the guard instance once: revealGuard.current gets swapped to a
+    // fresh guard (new, empty request map) whenever revealScope changes, which
+    // happens as soon as this row's own edit is saved and the list refetches.
+    // Re-reading revealGuard.current after the await would compare against
+    // that new, unrelated guard and always report the request as stale.
+    const guard = revealGuard.current
+    const request = guard.begin('value')
     setIsRevealing(true)
     try {
       const value = await getEnvVarValue(
@@ -119,16 +125,16 @@ function EnvironmentVariableRow({
         variable.key,
         variable.id
       )
-      if (!revealGuard.current.isCurrent('value', request)) return undefined
+      if (!guard.isCurrent('value', request)) return undefined
       setRevealedValue({ value, scope: revealScope })
       return value
     } catch {
-      if (revealGuard.current.isCurrent('value', request)) {
+      if (guard.isCurrent('value', request)) {
         toast.error(`Failed to reveal ${variable.key}`)
       }
       return undefined
     } finally {
-      if (revealGuard.current.finish('value', request)) {
+      if (guard.finish('value', request)) {
         setIsRevealing(false)
       }
     }


### PR DESCRIPTION
## Summary
- Reopening the "Edit Environment Variable" modal right after saving showed a blank Value field instead of the current value.
- Root cause: `revealValue()` in `EnvironmentVariablesSettings.tsx` re-read `revealGuard.current` after an `await`, instead of capturing it once. Saving a non-secret env var bumps `variable.updated_at`, which changes `revealScope` and swaps in a brand-new guard instance (fresh, empty request map) via the row's mount effect. If that swap happened while the reveal request was still in flight, the post-await `isCurrent`/`finish` checks ran against the new, unrelated guard and always reported the request as stale — silently discarding the fetched value.
- Fix: capture `const guard = revealGuard.current` once at the top of `revealValue()` and use that single instance throughout (`begin`/`isCurrent`/`finish`), so a legitimate in-flight request is judged against the guard it was registered on, not whatever guard happens to be current after the await.

## Test plan
- [x] `tsc --noEmit` clean for the changed file
- [x] `eslint` clean around the changed lines (pre-existing unrelated warnings elsewhere in the file untouched)
- [x] Manual verification via browser automation (agent-browser) against a live local server:
  1. Created a non-secret env var `MY_TEST_VAR=hello-world-123`.
  2. Opened Edit → value correctly pre-filled.
  3. Edited value to `race-condition-value-999`, clicked Save Changes, then immediately (0ms gap) clicked Edit again — the exact reported repro (save → reopen).
  4. Value field showed `race-condition-value-999` (empty for one render tick while the reveal request was in flight, per the async fetch, then correctly populated) — confirming the fix holds even under the tightest timing.
- [x] security-auditor review of the diff: no findings; confirmed the fix does not weaken the guard's actual purpose (stale/cross-identity reveals are still correctly rejected via `invalidate()` on the *same* captured guard instance).

## Note for follow-up (not in this PR's scope)
The same "re-read `revealGuard.current` across an `await`" pattern exists in a few other places that reuse `createCredentialRevealGuard`: `IntegrationEnvVarRow` in this same file, plus `McpCredentialRevealControls.tsx`, `ContainerConfiguration.tsx`, `ProviderForm.tsx`, and `ServiceDetail.tsx`. All are the same reliability bug direction (values dropped, not stale values leaked), not a security issue, but worth a follow-up pass to apply the same one-line capture fix.