### PR TITLE
refactor(web): move project setup into project sidebar

### DIFF
--- a/web/src/components/dashboard/Sidebar.tsx
+++ b/web/src/components/dashboard/Sidebar.tsx
@@ -73,7 +73,15 @@ import {
   Zap,
 } from 'lucide-react'
 
-import { getProjectBySlugOptions } from '@/api/client/@tanstack/react-query.gen'
+import { ProjectResponse } from '@/api/client'
+import {
+  getProjectBySlugOptions,
+  hasAnalyticsEventsOptions,
+  hasErrorGroupsOptions,
+  listCustomDomainsForProjectOptions,
+  listMonitorsOptions,
+  listProjectServicesOptions,
+} from '@/api/client/@tanstack/react-query.gen'
 import { useAuth } from '@/contexts/AuthContext'
 import { useGettingStarted } from '@/hooks/useGettingStarted'
 import { useCanViewAuditLogs } from '@/hooks/useAuditAccess'
@@ -351,13 +359,10 @@ export default function AppSidebar() {
       : null
 
   // Override: user pressed Back from a route-driven swap; show DefaultNav
-  // even though we're still on /settings or /projects/:slug. Cleared on
-  // any pathname change (so re-clicking Settings or any sub-link
-  // re-triggers the swap).
-  const [forceDefault, setForceDefault] = useState(false)
-  useEffect(() => {
-    setForceDefault(false)
-  }, [location.pathname])
+  // only for that exact pathname. Navigating anywhere else clears the override
+  // by derivation, without a setState-in-effect render cycle.
+  const [forceDefaultPath, setForceDefaultPath] = useState<string | null>(null)
+  const forceDefault = forceDefaultPath === location.pathname
 
   const compact = isMinimal && !isMobile
 
@@ -409,12 +414,15 @@ export default function AppSidebar() {
           <DefaultNav
             pluginItems={pluginItems}
             pinnedProjectSlug={forceDefault && projectSlug ? projectSlug : null}
-            onReturnToProject={() => setForceDefault(false)}
+            onReturnToProject={() => setForceDefaultPath(null)}
           />
         ) : settingsMode ? (
-          <SettingsNav onBack={() => setForceDefault(true)} />
+          <SettingsNav onBack={() => setForceDefaultPath(location.pathname)} />
         ) : projectSlug ? (
-          <ProjectNav slug={projectSlug} onBack={() => setForceDefault(true)} />
+          <ProjectNav
+            slug={projectSlug}
+            onBack={() => setForceDefaultPath(location.pathname)}
+          />
         ) : null}
       </SidebarContent>
       <SidebarFooter>
@@ -977,6 +985,162 @@ const projectBaseNav: ProjectNavItem[] = [
   },
 ]
 
+interface ProjectSetupStep {
+  id: string
+  title: string
+  href: string
+  done: boolean
+  icon: LucideIcon
+}
+
+function ProjectSetupNavItem({ project }: { project: ProjectResponse }) {
+  const { isMinimal, isMobile } = useSidebar()
+  const compact = isMinimal && !isMobile
+
+  const analyticsQuery = useQuery({
+    ...hasAnalyticsEventsOptions({ path: { project_id: project.id } }),
+  })
+  const errorsQuery = useQuery({
+    ...hasErrorGroupsOptions({ path: { project_id: project.id } }),
+  })
+  const domainsQuery = useQuery({
+    ...listCustomDomainsForProjectOptions({
+      path: { project_id: project.id },
+    }),
+  })
+  const monitorsQuery = useQuery({
+    ...listMonitorsOptions({ path: { project_id: project.id } }),
+  })
+  const servicesQuery = useQuery({
+    ...listProjectServicesOptions({ path: { project_id: project.id } }),
+  })
+
+  const isLoading =
+    analyticsQuery.isLoading ||
+    errorsQuery.isLoading ||
+    domainsQuery.isLoading ||
+    monitorsQuery.isLoading ||
+    servicesQuery.isLoading
+
+  const steps: ProjectSetupStep[] = [
+    {
+      id: 'analytics',
+      title: 'Install analytics SDK',
+      href: `/projects/${project.slug}/analytics/setup`,
+      done: !!analyticsQuery.data?.has_events,
+      icon: BarChart3,
+    },
+    {
+      id: 'errors',
+      title: 'Install error tracking SDK',
+      href: `/projects/${project.slug}/errors/setup`,
+      done: !!errorsQuery.data?.has_error_groups,
+      icon: ShieldAlert,
+    },
+    {
+      id: 'domain',
+      title: 'Connect a custom domain',
+      href: `/projects/${project.slug}/domains`,
+      done: (domainsQuery.data?.domains?.length ?? 0) > 0,
+      icon: Globe,
+    },
+    {
+      id: 'monitoring',
+      title: 'Add an uptime monitor',
+      href: `/projects/${project.slug}/monitors`,
+      done: (monitorsQuery.data?.length ?? 0) > 0,
+      icon: Activity,
+    },
+    {
+      id: 'storage',
+      title: 'Link database or storage',
+      href: `/projects/${project.slug}/storage`,
+      done: (servicesQuery.data?.length ?? 0) > 0,
+      icon: Database,
+    },
+  ]
+
+  const remainingSteps = steps.filter((step) => !step.done)
+  const completedCount = steps.length - remainingSteps.length
+  const percent = Math.round((completedCount / steps.length) * 100)
+
+  if (isLoading || remainingSteps.length === 0) return null
+
+  if (compact) {
+    const nextStep = remainingSteps[0]
+    return (
+      <SidebarGroup className="py-0 pb-2">
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              asChild
+              tooltip={`Project setup — ${completedCount}/${steps.length}`}
+              className="justify-center"
+            >
+              <Link to={nextStep.href}>
+                <BadgeCheck />
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarGroup>
+    )
+  }
+
+  const visibleSteps = remainingSteps.slice(0, 2)
+  const hiddenCount = remainingSteps.length - visibleSteps.length
+
+  return (
+    <SidebarGroup className="py-0 pb-2">
+      <div className="overflow-hidden rounded-lg border border-sidebar-border bg-sidebar-accent/30">
+        <div className="px-3 py-2.5">
+          <div className="flex items-center gap-2">
+            <BadgeCheck className="size-4 shrink-0 text-primary" />
+            <span className="flex-1 text-sm font-medium">Project setup</span>
+            <span className="text-xs tabular-nums text-muted-foreground">
+              {completedCount}/{steps.length}
+            </span>
+          </div>
+          <div
+            className="mt-2 h-1 w-full overflow-hidden rounded-full bg-sidebar-border"
+            role="progressbar"
+            aria-label={`${project.name} setup progress`}
+            aria-valuemin={0}
+            aria-valuemax={steps.length}
+            aria-valuenow={completedCount}
+          >
+            <div
+              className="h-full rounded-full bg-primary transition-all duration-500"
+              style={{ width: `${percent}%` }}
+            />
+          </div>
+        </div>
+        <ul role="list" className="border-t border-sidebar-border p-1.5">
+          {visibleSteps.map((step) => (
+            <li key={step.id}>
+              <Link
+                to={step.href}
+                className="group flex items-center gap-2 rounded-md px-1.5 py-2 text-xs transition-colors hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+              >
+                <step.icon className="size-3.5 shrink-0 text-muted-foreground group-hover:text-foreground" />
+                <span className="min-w-0 flex-1 leading-tight">
+                  {step.title}
+                </span>
+                <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+              </Link>
+            </li>
+          ))}
+          {hiddenCount > 0 && (
+            <li className="px-1.5 pb-1 pt-0.5 text-[11px] text-muted-foreground">
+              +{hiddenCount} more {hiddenCount === 1 ? 'step' : 'steps'}
+            </li>
+          )}
+        </ul>
+      </div>
+    </SidebarGroup>
+  )
+}
+
 function ProjectNav({ slug, onBack }: { slug: string; onBack: () => void }) {
   const { data: project } = useQuery({
     ...getProjectBySlugOptions({ path: { slug } }),
@@ -1040,6 +1204,8 @@ function ProjectNav({ slug, onBack }: { slug: string; onBack: () => void }) {
     if (didSyncDrillRef.current || !activeRoute) return
     didSyncDrillRef.current = true
     const parent = findDrillParent(activeRoute)
+    // Reconcile the async project lookup with the route-derived initial view.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (parent) setDrilledTo(parent)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeRoute])
@@ -1132,6 +1298,7 @@ function ProjectNav({ slug, onBack }: { slug: string; onBack: () => void }) {
         onBack={onBack}
         backLabel="Back to menu"
       />
+      <ProjectSetupNavItem project={project} />
       <SidebarGroup className="pt-0">
         <SidebarMenu>
           {items.map((item) => {

--- a/web/src/components/project/ProjectOverview.tsx
+++ b/web/src/components/project/ProjectOverview.tsx
@@ -3,11 +3,6 @@ import {
   getErrorDashboardStatsOptions,
   getLastDeploymentOptions,
   getUniqueCountsOptions,
-  hasAnalyticsEventsOptions,
-  hasErrorGroupsOptions,
-  listCustomDomainsForProjectOptions,
-  listMonitorsOptions,
-  listProjectServicesOptions,
   revenueListIntegrationsOptions,
   revenueMetricsSummaryOptions,
 } from '@/api/client/@tanstack/react-query.gen'
@@ -18,20 +13,15 @@ import { cn } from '@/lib/utils'
 import { useQuery } from '@tanstack/react-query'
 import { subDays } from 'date-fns'
 import {
-  Activity,
-  BarChart3,
   Bug,
-  ChevronRight,
-  Database,
   DollarSign,
-  Globe,
   Minus,
   Sparkles,
   TrendingDown,
   TrendingUp,
   Users,
 } from 'lucide-react'
-import { ReactNode, useEffect, useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { Link } from 'react-router'
 import { MetricCard } from '../dashboard/MetricCard'
 import { DeploymentActivityGraph } from './DeploymentActivityGraph'
@@ -69,19 +59,6 @@ function getChangeDisplay(change: number | undefined, inverse = false) {
     ),
     isPositive,
   }
-}
-
-type OnboardingStepId =
-  'analytics' | 'errors' | 'domain' | 'monitoring' | 'storage'
-
-interface OnboardingStep {
-  id: OnboardingStepId
-  title: string
-  description: string
-  href: string
-  done: boolean
-  icon: ReactNode
-  estimate: string
 }
 
 export function ProjectOverview({
@@ -124,41 +101,6 @@ export function ProjectOverview({
     enabled: !!project.id,
   })
 
-  const { data: hasAnalyticsData, isLoading: isCheckingAnalytics } = useQuery({
-    ...hasAnalyticsEventsOptions({
-      path: { project_id: project.id },
-    }),
-    enabled: !!project.id,
-  })
-
-  const { data: hasErrorsData, isLoading: isCheckingErrors } = useQuery({
-    ...hasErrorGroupsOptions({
-      path: { project_id: project.id },
-    }),
-    enabled: !!project.id,
-  })
-
-  const { data: customDomainsData, isLoading: isCheckingDomain } = useQuery({
-    ...listCustomDomainsForProjectOptions({
-      path: { project_id: project.id },
-    }),
-    enabled: !!project.id,
-  })
-
-  const { data: monitorsData, isLoading: isCheckingMonitoring } = useQuery({
-    ...listMonitorsOptions({
-      path: { project_id: project.id },
-    }),
-    enabled: !!project.id,
-  })
-
-  const { data: servicesLinkedData, isLoading: isCheckingStorage } = useQuery({
-    ...listProjectServicesOptions({
-      path: { project_id: project.id },
-    }),
-    enabled: !!project.id,
-  })
-
   const { data: freshLastDeployment, refetch: refetchDeployment } = useQuery({
     ...getLastDeploymentOptions({
       path: {
@@ -192,221 +134,77 @@ export function ProjectOverview({
     }
   }, [project?.id, refetchDeployment])
 
-  const isLoadingOnboarding =
-    isCheckingAnalytics ||
-    isCheckingErrors ||
-    isCheckingDomain ||
-    isCheckingMonitoring ||
-    isCheckingStorage
-  const hasAnalytics = !!hasAnalyticsData?.has_events
-  const hasErrors = !!hasErrorsData?.has_error_groups
-  const hasDomain = (customDomainsData?.domains?.length ?? 0) > 0
-  const hasMonitoring = (monitorsData?.length ?? 0) > 0
-  const hasStorage = (servicesLinkedData?.length ?? 0) > 0
-
-  const steps: OnboardingStep[] = [
-    {
-      id: 'analytics',
-      title: 'Install analytics SDK',
-      description:
-        'Send your first pageview to unlock visitors, pages, and funnels.',
-      href: `/projects/${project.slug}/analytics/setup`,
-      done: hasAnalytics,
-      icon: <BarChart3 className="size-4" />,
-      estimate: '3 min',
-    },
-    {
-      id: 'errors',
-      title: 'Install error tracking SDK',
-      description:
-        'Capture your first exception to unlock stack traces, alerts, and autofix.',
-      href: `/projects/${project.slug}/errors/setup`,
-      done: hasErrors,
-      icon: <Bug className="size-4" />,
-      estimate: '3 min',
-    },
-    {
-      id: 'domain',
-      title: 'Connect a custom domain',
-      description: 'Point your own domain at this project with auto TLS.',
-      href: `/projects/${project.slug}/domains`,
-      done: hasDomain,
-      icon: <Globe className="size-4" />,
-      estimate: '2 min',
-    },
-    {
-      id: 'monitoring',
-      title: 'Add an uptime monitor',
-      description: 'Get alerted the moment your app stops responding.',
-      href: `/projects/${project.slug}/monitors`,
-      done: hasMonitoring,
-      icon: <Activity className="size-4" />,
-      estimate: '1 min',
-    },
-    {
-      id: 'storage',
-      title: 'Link a database or storage service',
-      description:
-        'Attach a managed Postgres, Redis, or S3-compatible service.',
-      href: `/projects/${project.slug}/storage`,
-      done: hasStorage,
-      icon: <Database className="size-4" />,
-      estimate: '2 min',
-    },
-  ]
-
-  const doneCount = steps.filter((s) => s.done).length
-  const totalCount = steps.length
-  const percent = Math.round((doneCount / totalCount) * 100)
-  const allDone = doneCount === totalCount
-  const remainingSteps = steps.filter((step) => !step.done)
-
   return (
-    <div
-      className={cn(
-        !isLoadingOnboarding &&
-          !allDone &&
-          'grid gap-4 sm:gap-6 xl:grid-cols-[17rem_minmax(0,1fr)]'
-      )}
-    >
-      {!isLoadingOnboarding && !allDone && (
-        <aside aria-labelledby="project-setup-heading">
-          <section className="overflow-hidden rounded-xl border bg-card">
-            <div className="p-4">
-              <div className="flex items-center justify-between gap-3">
-                <h2
-                  id="project-setup-heading"
-                  className="text-sm font-semibold tracking-tight"
-                >
-                  Finish setup
-                </h2>
-                <span className="text-xs tabular-nums text-muted-foreground">
-                  {doneCount} of {totalCount}
-                </span>
-              </div>
-              <div
-                className="mt-3 h-1 overflow-hidden rounded-full bg-muted"
-                role="progressbar"
-                aria-label="Project setup progress"
-                aria-valuemin={0}
-                aria-valuemax={totalCount}
-                aria-valuenow={doneCount}
-              >
-                <div
-                  className="h-full rounded-full bg-primary transition-all [transition-duration:400ms]"
-                  style={{ width: `${percent}%` }}
-                />
-              </div>
-            </div>
-
-            <ul role="list" className="border-t p-2">
-              {remainingSteps.map((step) => (
-                <li key={step.id}>
-                  <Link
-                    to={step.href}
-                    className="group flex items-center gap-3 rounded-lg px-2 py-2.5 transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  >
-                    <span className="flex size-8 shrink-0 items-center justify-center rounded-lg border bg-background text-muted-foreground transition-colors group-hover:text-foreground">
-                      {step.icon}
-                    </span>
-                    <span className="min-w-0 flex-1">
-                      <span className="block text-sm font-medium leading-tight">
-                        {step.title}
-                      </span>
-                      <span className="mt-0.5 block text-xs tabular-nums text-muted-foreground">
-                        {step.estimate}
-                      </span>
-                      <span className="sr-only">{step.description}</span>
-                    </span>
-                    <ChevronRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
-                  </Link>
-                </li>
-              ))}
-            </ul>
-
-            {doneCount > 0 && (
-              <p className="border-t px-4 py-3 text-xs text-muted-foreground">
-                {doneCount} {doneCount === 1 ? 'step' : 'steps'} completed
-              </p>
-            )}
-          </section>
-        </aside>
-      )}
-
-      <div className="min-w-0">
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3 lg:gap-6">
-          {isLoadingVisitors ? (
-            <Skeleton className="h-24" />
-          ) : visitorError ? (
-            <Link
-              to={`/projects/${project.slug}/analytics`}
-              className="h-full w-full"
-            >
-              <MetricCard
-                title="Visitors last 24 hours (Unique)"
-                icon={<Users />}
-                value="Error"
-                change=""
-                error={true}
-              />
-            </Link>
-          ) : (
-            <Link
-              to={`/projects/${project.slug}/analytics`}
-              className="h-full w-full"
-            >
-              <MetricCard
-                change=""
-                changeDisplay={getChangeDisplay(
-                  Number((visitorStats?.count || 0).toFixed(1))
-                )}
-                value={visitorStats?.count || '0'}
-                title="Visitors last 24 hours"
-                icon={<Users />}
-              />
-            </Link>
-          )}
-
-          <RevenueMetric project={project} />
-
+    <>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3 lg:gap-6">
+        {isLoadingVisitors ? (
+          <Skeleton className="h-24" />
+        ) : visitorError ? (
           <Link
-            to={`/projects/${project.slug}/errors`}
+            to={`/projects/${project.slug}/analytics`}
             className="h-full w-full"
           >
             <MetricCard
-              change={''}
-              value={errorStats?.error_groups?.toFixed(2) || '0'}
-              title="Errors"
-              icon={<Bug />}
+              title="Visitors last 24 hours (Unique)"
+              icon={<Users />}
+              value="Error"
+              change=""
+              error={true}
             />
           </Link>
-        </div>
-
-        <div className="mt-4 sm:mt-6">
-          {currentDeployment && (
-            <LastDeployment
-              deployment={currentDeployment}
-              projectName={project.slug}
-            />
-          )}
-        </div>
-
-        <div className="mt-4 sm:mt-6">
-          <DeploymentActivityGraph projectId={project.id} />
-        </div>
-
-        <div className="mt-4 flex justify-center sm:mt-6">
-          <button
-            type="button"
-            onClick={() => window.dispatchEvent(new Event(PROJECT_TOUR_EVENT))}
-            className="inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        ) : (
+          <Link
+            to={`/projects/${project.slug}/analytics`}
+            className="h-full w-full"
           >
-            <Sparkles className="size-3.5" />
-            Take a tour of your project
-          </button>
-        </div>
+            <MetricCard
+              change=""
+              changeDisplay={getChangeDisplay(
+                Number((visitorStats?.count || 0).toFixed(1))
+              )}
+              value={visitorStats?.count || '0'}
+              title="Visitors last 24 hours"
+              icon={<Users />}
+            />
+          </Link>
+        )}
+
+        <RevenueMetric project={project} />
+
+        <Link to={`/projects/${project.slug}/errors`} className="h-full w-full">
+          <MetricCard
+            change={''}
+            value={errorStats?.error_groups?.toFixed(2) || '0'}
+            title="Errors"
+            icon={<Bug />}
+          />
+        </Link>
       </div>
-    </div>
+
+      <div className="mt-4 sm:mt-6">
+        {currentDeployment && (
+          <LastDeployment
+            deployment={currentDeployment}
+            projectName={project.slug}
+          />
+        )}
+      </div>
+
+      <div className="mt-4 sm:mt-6">
+        <DeploymentActivityGraph projectId={project.id} />
+      </div>
+
+      <div className="mt-4 flex justify-center sm:mt-6">
+        <button
+          type="button"
+          onClick={() => window.dispatchEvent(new Event(PROJECT_TOUR_EVENT))}
+          className="inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <Sparkles className="size-3.5" />
+          Take a tour of your project
+        </button>
+      </div>
+    </>
   )
 }
 

--- a/web/src/components/project/ProjectOverview.tsx
+++ b/web/src/components/project/ProjectOverview.tsx
@@ -21,9 +21,7 @@ import {
   Activity,
   BarChart3,
   Bug,
-  Check,
   ChevronRight,
-  Circle,
   Database,
   DollarSign,
   Globe,
@@ -74,11 +72,7 @@ function getChangeDisplay(change: number | undefined, inverse = false) {
 }
 
 type OnboardingStepId =
-  | 'analytics'
-  | 'errors'
-  | 'domain'
-  | 'monitoring'
-  | 'storage'
+  'analytics' | 'errors' | 'domain' | 'monitoring' | 'storage'
 
 interface OnboardingStep {
   id: OnboardingStepId
@@ -265,161 +259,154 @@ export function ProjectOverview({
   const totalCount = steps.length
   const percent = Math.round((doneCount / totalCount) * 100)
   const allDone = doneCount === totalCount
+  const remainingSteps = steps.filter((step) => !step.done)
 
   return (
-    <>
+    <div
+      className={cn(
+        !isLoadingOnboarding &&
+          !allDone &&
+          'grid gap-4 sm:gap-6 xl:grid-cols-[17rem_minmax(0,1fr)]'
+      )}
+    >
       {!isLoadingOnboarding && !allDone && (
-        <section className="mb-4 overflow-hidden rounded-xl border bg-card sm:mb-6">
-          <div className="flex flex-col gap-3 border-b p-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4 sm:p-5">
-            <div className="min-w-0 flex-1">
-              <div className="flex flex-wrap items-center gap-2">
-                <h2 className="text-base font-semibold tracking-tight">
-                  Finish setting up {project.slug}
+        <aside aria-labelledby="project-setup-heading">
+          <section className="overflow-hidden rounded-xl border bg-card">
+            <div className="p-4">
+              <div className="flex items-center justify-between gap-3">
+                <h2
+                  id="project-setup-heading"
+                  className="text-sm font-semibold tracking-tight"
+                >
+                  Finish setup
                 </h2>
-                <Badge variant="secondary" className="tabular-nums">
-                  {doneCount} / {totalCount}
-                </Badge>
+                <span className="text-xs tabular-nums text-muted-foreground">
+                  {doneCount} of {totalCount}
+                </span>
               </div>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Wire up observability and infrastructure so Temps can start
-                capturing data and serving your app.
-              </p>
-            </div>
-            <div className="flex items-center gap-3 sm:w-64 sm:shrink-0">
-              <div className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+              <div
+                className="mt-3 h-1 overflow-hidden rounded-full bg-muted"
+                role="progressbar"
+                aria-label="Project setup progress"
+                aria-valuemin={0}
+                aria-valuemax={totalCount}
+                aria-valuenow={doneCount}
+              >
                 <div
-                  className="h-full bg-primary [transition-duration:400ms] transition-all"
+                  className="h-full rounded-full bg-primary transition-all [transition-duration:400ms]"
                   style={{ width: `${percent}%` }}
                 />
               </div>
-              <span className="text-sm font-medium tabular-nums text-muted-foreground">
-                {percent}%
-              </span>
             </div>
-          </div>
-          <ul role="list" className="divide-y">
-            {steps.map((step) => (
-              <li key={step.id}>
-                <Link
-                  to={step.href}
-                  className={cn(
-                    'group flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/50 sm:gap-4 sm:px-5 sm:py-4',
-                    step.done && 'opacity-60'
-                  )}
-                >
-                  <span
-                    className={cn(
-                      'flex size-7 shrink-0 items-center justify-center rounded-full border',
-                      step.done
-                        ? 'border-emerald-500 bg-emerald-500 text-white'
-                        : 'border-muted-foreground/30 text-muted-foreground'
-                    )}
+
+            <ul role="list" className="border-t p-2">
+              {remainingSteps.map((step) => (
+                <li key={step.id}>
+                  <Link
+                    to={step.href}
+                    className="group flex items-center gap-3 rounded-lg px-2 py-2.5 transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   >
-                    {step.done ? (
-                      <Check className="size-4" strokeWidth={3} />
-                    ) : (
-                      <Circle className="size-4" />
-                    )}
-                  </span>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
-                      <p
-                        className={cn(
-                          'text-sm font-medium',
-                          step.done && 'line-through'
-                        )}
-                      >
+                    <span className="flex size-8 shrink-0 items-center justify-center rounded-lg border bg-background text-muted-foreground transition-colors group-hover:text-foreground">
+                      {step.icon}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-sm font-medium leading-tight">
                         {step.title}
-                      </p>
-                      {!step.done && (
-                        <span className="text-xs text-muted-foreground tabular-nums">
-                          · {step.estimate}
-                        </span>
-                      )}
-                    </div>
-                    <p className="mt-0.5 text-sm text-muted-foreground">
-                      {step.description}
-                    </p>
-                  </div>
-                  {!step.done && (
+                      </span>
+                      <span className="mt-0.5 block text-xs tabular-nums text-muted-foreground">
+                        {step.estimate}
+                      </span>
+                      <span className="sr-only">{step.description}</span>
+                    </span>
                     <ChevronRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
-                  )}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </section>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+
+            {doneCount > 0 && (
+              <p className="border-t px-4 py-3 text-xs text-muted-foreground">
+                {doneCount} {doneCount === 1 ? 'step' : 'steps'} completed
+              </p>
+            )}
+          </section>
+        </aside>
       )}
 
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3 lg:gap-6">
-        {isLoadingVisitors ? (
-          <Skeleton className="h-24" />
-        ) : visitorError ? (
+      <div className="min-w-0">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3 lg:gap-6">
+          {isLoadingVisitors ? (
+            <Skeleton className="h-24" />
+          ) : visitorError ? (
+            <Link
+              to={`/projects/${project.slug}/analytics`}
+              className="h-full w-full"
+            >
+              <MetricCard
+                title="Visitors last 24 hours (Unique)"
+                icon={<Users />}
+                value="Error"
+                change=""
+                error={true}
+              />
+            </Link>
+          ) : (
+            <Link
+              to={`/projects/${project.slug}/analytics`}
+              className="h-full w-full"
+            >
+              <MetricCard
+                change=""
+                changeDisplay={getChangeDisplay(
+                  Number((visitorStats?.count || 0).toFixed(1))
+                )}
+                value={visitorStats?.count || '0'}
+                title="Visitors last 24 hours"
+                icon={<Users />}
+              />
+            </Link>
+          )}
+
+          <RevenueMetric project={project} />
+
           <Link
-            to={`/projects/${project.slug}/analytics`}
+            to={`/projects/${project.slug}/errors`}
             className="h-full w-full"
           >
             <MetricCard
-              title="Visitors last 24 hours (Unique)"
-              icon={<Users />}
-              value="Error"
-              change=""
-              error={true}
+              change={''}
+              value={errorStats?.error_groups?.toFixed(2) || '0'}
+              title="Errors"
+              icon={<Bug />}
             />
           </Link>
-        ) : (
-          <Link
-            to={`/projects/${project.slug}/analytics`}
-            className="h-full w-full"
+        </div>
+
+        <div className="mt-4 sm:mt-6">
+          {currentDeployment && (
+            <LastDeployment
+              deployment={currentDeployment}
+              projectName={project.slug}
+            />
+          )}
+        </div>
+
+        <div className="mt-4 sm:mt-6">
+          <DeploymentActivityGraph projectId={project.id} />
+        </div>
+
+        <div className="mt-4 flex justify-center sm:mt-6">
+          <button
+            type="button"
+            onClick={() => window.dispatchEvent(new Event(PROJECT_TOUR_EVENT))}
+            className="inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
           >
-            <MetricCard
-              change=""
-              changeDisplay={getChangeDisplay(
-                Number((visitorStats?.count || 0).toFixed(1))
-              )}
-              value={visitorStats?.count || '0'}
-              title="Visitors last 24 hours"
-              icon={<Users />}
-            />
-          </Link>
-        )}
-
-        <RevenueMetric project={project} />
-
-        <Link to={`/projects/${project.slug}/errors`} className="h-full w-full">
-          <MetricCard
-            change={''}
-            value={errorStats?.error_groups?.toFixed(2) || '0'}
-            title="Errors"
-            icon={<Bug />}
-          />
-        </Link>
+            <Sparkles className="size-3.5" />
+            Take a tour of your project
+          </button>
+        </div>
       </div>
-
-      <div className="mt-4 sm:mt-6">
-        {currentDeployment && (
-          <LastDeployment
-            deployment={currentDeployment}
-            projectName={project.slug}
-          />
-        )}
-      </div>
-
-      <div className="mt-4 sm:mt-6">
-        <DeploymentActivityGraph projectId={project.id} />
-      </div>
-
-      <div className="mt-4 flex justify-center sm:mt-6">
-        <button
-          type="button"
-          onClick={() => window.dispatchEvent(new Event(PROJECT_TOUR_EVENT))}
-          className="inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <Sparkles className="size-3.5" />
-          Take a tour of your project
-        </button>
-      </div>
-    </>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary

- move the project onboarding checklist directly into the project sidebar below the project slug
- show progress and at most two unfinished actions before the regular project navigation
- collapse to a single setup action when the sidebar is minimized and disappear when setup is complete
- restore the project overview metrics and deployment content to full width
- preserve accessible progress semantics and keyboard focus states

## Testing

- `bunx prettier --check src/components/project/ProjectOverview.tsx src/components/dashboard/Sidebar.tsx`
- `bunx eslint src/components/project/ProjectOverview.tsx src/components/dashboard/Sidebar.tsx`
- `bunx tsc --noEmit`
- `git diff --check`

## Evidence

**Frontend / UI**: rendered the PR branch from the isolated local web server at `http://localhost:3001/projects/temps-fleet-telemetry-admin/project`. API responses were mocked inside the browser to exercise the 3-of-5 onboarding state without changing server data or credentials.

`node /private/tmp/capture-project-overview.mjs`

`Screenshot saved: /Users/davidviejo/projects/temps/project-overview-setup-rail.png`

`Rendered URL: http://localhost:3001/projects/temps-fleet-telemetry-admin/project`

`Project setup sidebar card: true`

The capture confirms the project setup card sits immediately below the project slug and above Overview, while the overview content uses the full available width.