### PR TITLE
fix(web): add icons and prioritize projects in command search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **email:** Pin validated SMTP probe addresses and remove request-controlled proxy routing ([#305](https://github.com/gotempsh/temps/pull/305))
 ### Fixed
 
+- **command palette:** Show a left icon for every search result and rank matching projects ahead of common navigation pages.
 - **Cloud metadata egress isolation:** Block IPv4 and IPv6 metadata endpoints for routed app and Compose bridge traffic with an atomic, startup-reconciled nftables policy; reject Compose network drivers that bypass host filtering ([#431](https://github.com/gotempsh/temps/pull/431))
 - **Clone-error credential redaction:** Reject Git URLs with embedded userinfo and redact both usernames and passwords from libgit2 clone errors before deployment failures are persisted to project logs.
 - **Credential reveal boundaries:** Mask environment variables, container configuration, external-service parameters, notification providers, MCP servers, and legacy agent tool credentials by default; plaintext now requires an explicit, audited, non-cacheable reveal request

--- a/web/e2e/anonymous/command-palette.spec.ts
+++ b/web/e2e/anonymous/command-palette.spec.ts
@@ -1,0 +1,97 @@
+import { expect, expectAppMounted, test } from '../fixtures'
+
+test.describe('command palette', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/user/me', async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        json: {
+          avatar_url: '',
+          email: 'verify@temps.sh',
+          id: 999,
+          mfa_enabled: false,
+          name: 'Verification User',
+          role: 'admin',
+          username: 'verify',
+        },
+      })
+    })
+
+    await page.route('**/api/projects?*', async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        json: {
+          page: 1,
+          per_page: 100,
+          projects: [
+            {
+              id: 999,
+              name: 'Monitoring App',
+              slug: 'monitoring-app',
+            },
+          ],
+          total: 1,
+        },
+      })
+    })
+
+    await page.goto('/settings')
+    await expectAppMounted(page)
+    await page.getByRole('button', { name: /Find/ }).click()
+    await expect(
+      page.getByPlaceholder('Type a command or search...')
+    ).toBeVisible()
+  })
+
+  test('renders a left icon for actions', async ({ page }) => {
+    const initialHeadings = page.locator('[cmdk-group-heading]')
+    await expect(initialHeadings.first()).toHaveText('Navigation')
+
+    const missingLeftIcons = await page
+      .locator('[cmdk-item]')
+      .evaluateAll((items) =>
+        items
+          .filter((item) => {
+            const firstChild = item.firstElementChild
+            if (!firstChild) return true
+            return !(
+              firstChild.tagName.toLowerCase() === 'svg' ||
+              (firstChild.tagName.toLowerCase() === 'span' &&
+                firstChild.classList.contains('size-6'))
+            )
+          })
+          .map((item) => item.textContent?.trim())
+      )
+    expect(missingLeftIcons).toEqual([])
+
+    await page.getByPlaceholder('Type a command or search...').fill('toggle')
+
+    const themeAction = page.locator('[cmdk-item]').filter({
+      hasText: 'Toggle Theme',
+    })
+    await expect(themeAction).toBeVisible()
+    await expect(themeAction.locator(':scope > svg')).toHaveCount(1)
+  })
+
+  test('prioritizes project matches over common pages', async ({ page }) => {
+    await page.getByPlaceholder('Type a command or search...').fill('monitor')
+
+    const headings = page.locator('[cmdk-group-heading]')
+    await expect(headings.first()).toHaveText('Projects')
+    await expect(headings.filter({ hasText: 'Navigation' })).toHaveCount(1)
+
+    const project = page.locator('[cmdk-item]').filter({
+      hasText: 'monitoring-app',
+    })
+    await expect(project).toBeVisible()
+    await expect(project.locator(':scope > span').first()).toBeVisible()
+
+    const navigationGroup = page.locator('[cmdk-group]').filter({
+      has: page.locator('[cmdk-group-heading]', { hasText: 'Navigation' }),
+    })
+    const navigation = navigationGroup.locator('[cmdk-item]').filter({
+      hasText: 'Monitoring',
+    })
+    await expect(navigation.locator(':scope > svg')).toHaveCount(1)
+  })
+})

--- a/web/src/components/command/CommandPalette.tsx
+++ b/web/src/components/command/CommandPalette.tsx
@@ -55,6 +55,7 @@ import {
   Shield,
   Sparkles,
   SquareTerminal,
+  SunMoon,
   Upload,
   Users,
   Wand2,
@@ -70,6 +71,24 @@ interface NavigationItem {
   icon: LucideIcon
   keywords?: string[]
 }
+
+interface CommandAction {
+  id: string
+  title: string
+  icon: LucideIcon
+  keywords: string[]
+  run: () => void
+}
+
+const commandActions: CommandAction[] = [
+  {
+    id: 'toggle-theme',
+    title: 'Toggle Theme',
+    icon: SunMoon,
+    keywords: ['toggle', 'theme', 'dark', 'light', 'mode'],
+    run: () => document.body.classList.toggle('dark'),
+  },
+]
 
 const mainNavItems: NavigationItem[] = [
   {
@@ -285,7 +304,16 @@ const settingsNavItems: NavigationItem[] = [
     title: 'Add Git Provider',
     url: '/git-providers/add',
     icon: GitBranch,
-    keywords: ['new', 'create', 'add', 'connect', 'github', 'gitlab', 'bitbucket', 'gitea'],
+    keywords: [
+      'new',
+      'create',
+      'add',
+      'connect',
+      'github',
+      'gitlab',
+      'bitbucket',
+      'gitea',
+    ],
   },
   {
     title: 'DNS Providers',
@@ -746,14 +774,20 @@ export function CommandPalette() {
     enabled: open,
     staleTime: 60_000,
   })
-  const globalSkills = globalSkillsData?.items ?? []
+  const globalSkills = useMemo(
+    () => globalSkillsData?.items ?? [],
+    [globalSkillsData]
+  )
 
   const { data: globalMcpServersData, refetch: refetchMcp } = useQuery({
     ...listGlobalMcpsOptions(),
     enabled: open,
     staleTime: 60_000,
   })
-  const globalMcpServers = globalMcpServersData?.items ?? []
+  const globalMcpServers = useMemo(
+    () => globalMcpServersData?.items ?? [],
+    [globalMcpServersData]
+  )
 
   // Detect if user is on a project page and extract slug
   const currentProjectSlug = useMemo(() => {
@@ -936,7 +970,7 @@ export function CommandPalette() {
         projects: projects,
         skills: globalSkills,
         mcpServers: globalMcpServers,
-        actions: ['toggle-theme'],
+        actions: commandActions,
       }
     }
 
@@ -1011,13 +1045,12 @@ export function CommandPalette() {
       .sort((a, b) => b.score - a.score)
       .map((entry) => entry.item)
 
-    // Search actions (simple fuzzy match for now)
-    const actions: string[] = []
-    const themeKeywords = ['toggle', 'theme', 'dark', 'light', 'mode']
-    const themeFuse = new Fuse(themeKeywords, { threshold: 0.4 })
-    if (themeFuse.search(search).length > 0) {
-      actions.push('toggle-theme')
-    }
+    const actions = commandActions.filter((action) => {
+      const actionFuse = new Fuse([action.title, ...action.keywords], {
+        threshold: 0.4,
+      })
+      return actionFuse.search(search).length > 0
+    })
 
     return {
       navigation: sortByScore(groupedNavResults.navigation),
@@ -1115,12 +1148,17 @@ export function CommandPalette() {
           icon: <Server className="h-4 w-4" />,
           run: () => navigate(`/mcp-servers/${mcp.slug}`),
         })
-      } else if (key === 'action:toggle-theme') {
+      } else if (key.startsWith('action:')) {
+        const action = commandActions.find(
+          ({ id }) => id === key.slice('action:'.length)
+        )
+        if (!action) continue
+        const Icon = action.icon
         out.push({
           key,
-          title: 'Toggle Theme',
-          icon: <Settings className="h-4 w-4" />,
-          run: () => document.body.classList.toggle('dark'),
+          title: action.title,
+          icon: <Icon className="h-4 w-4" />,
+          run: action.run,
         })
       } else {
         // Treat as nav URL
@@ -1148,6 +1186,31 @@ export function CommandPalette() {
     globalMcpServers,
     navigate,
   ])
+
+  const projectResultsGroup = searchResults.projects.length > 0 && (
+    <>
+      <CommandGroup heading="Projects">
+        {searchResults.projects.map((project) => (
+          <CommandItem
+            key={project.id}
+            onSelect={() =>
+              runWithFrecency(`project:${project.id}`, () =>
+                navigate(`/projects/${project.slug}`)
+              )
+            }
+            className="flex items-center gap-2"
+          >
+            <Avatar className="size-6">
+              <AvatarImage src={`/api/projects/${project.id}/favicon`} />
+              <AvatarFallback>{project.name.charAt(0)}</AvatarFallback>
+            </Avatar>
+            <span>{project.slug}</span>
+          </CommandItem>
+        ))}
+      </CommandGroup>
+      <CommandSeparator />
+    </>
+  )
 
   return (
     <CommandDialog
@@ -1214,6 +1277,9 @@ export function CommandPalette() {
               <CommandSeparator />
             </>
           )}
+
+          {/* Matching projects take priority over common navigation pages. */}
+          {search && projectResultsGroup}
 
           {/* Main Navigation */}
           {searchResults.navigation.length > 0 && (
@@ -1377,46 +1443,24 @@ export function CommandPalette() {
             </>
           )}
 
-          {/* Projects */}
-          {searchResults.projects.length > 0 && (
-            <>
-              <CommandGroup heading="Projects">
-                {searchResults.projects.map((project) => (
-                  <CommandItem
-                    key={project.id}
-                    onSelect={() =>
-                      runWithFrecency(`project:${project.id}`, () =>
-                        navigate(`/projects/${project.slug}`)
-                      )
-                    }
-                    className="flex items-center gap-2"
-                  >
-                    <Avatar className="size-6">
-                      <AvatarImage
-                        src={`/api/projects/${project.id}/favicon`}
-                      />
-                      <AvatarFallback>{project.name.charAt(0)}</AvatarFallback>
-                    </Avatar>
-                    <span>{project.slug}</span>
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-              <CommandSeparator />
-            </>
-          )}
+          {/* Preserve the browse order when the palette opens without a query. */}
+          {!search && projectResultsGroup}
 
           {/* Actions */}
-          {searchResults.actions.includes('toggle-theme') && (
+          {searchResults.actions.length > 0 && (
             <CommandGroup heading="Actions">
-              <CommandItem
-                onSelect={() =>
-                  runWithFrecency('action:toggle-theme', () =>
-                    document.body.classList.toggle('dark')
-                  )
-                }
-              >
-                <span>Toggle Theme</span>
-              </CommandItem>
+              {searchResults.actions.map((action) => (
+                <CommandItem
+                  key={action.id}
+                  onSelect={() =>
+                    runWithFrecency(`action:${action.id}`, action.run)
+                  }
+                  className="flex items-center gap-2"
+                >
+                  <action.icon className="h-4 w-4" />
+                  <span>{action.title}</span>
+                </CommandItem>
+              ))}
             </CommandGroup>
           )}
         </CommandList>


### PR DESCRIPTION
## Summary

- require every command action to define a left-side icon and add a Sun/Moon icon to Toggle Theme
- rank matching projects ahead of common navigation pages while preserving the normal empty-palette browse order
- add browser coverage for icon presence, project priority, and empty-palette ordering
- document the change in the changelog

## Verification

- `bun test src tests` — 97 passed
- `bunx tsc --noEmit`
- `bunx eslint src/components/command/CommandPalette.tsx e2e/anonymous/command-palette.spec.ts`
- `E2E_BASE_URL=http://localhost:3001 bunx playwright test e2e/anonymous/command-palette.spec.ts --project chromium-anonymous` — 2 passed
- `bun run build`
- live browser verification against the local Temps stack
