### PR TITLE
fix(otel): bound ingest memory under exporter bursts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **email:** Pin validated SMTP probe addresses and remove request-controlled proxy routing ([#305](https://github.com/gotempsh/temps/pull/305))
 ### Fixed
 
+- **OTel ingest memory backpressure:** Bound concurrent OTLP request processing before body buffering, single-flight repeated token authentication, coalesce token usage writes, remove duplicate metrics authentication, and enforce the decompressed-size limit while streaming zstd payloads.
 - **command palette:** Show a left icon for every search result and rank matching projects ahead of common navigation pages.
 - **Cloud metadata egress isolation:** Block IPv4 and IPv6 metadata endpoints for routed app and Compose bridge traffic with an atomic, startup-reconciled nftables policy; reject Compose network drivers that bypass host filtering ([#431](https://github.com/gotempsh/temps/pull/431))
 - **Clone-error credential redaction:** Reject Git URLs with embedded userinfo and redact both usernames and passwords from libgit2 clone errors before deployment failures are persisted to project logs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **email:** Pin validated SMTP probe addresses and remove request-controlled proxy routing ([#305](https://github.com/gotempsh/temps/pull/305))
 ### Fixed
 
-- **OTel ingest memory backpressure:** Bound concurrent OTLP request processing before body buffering, single-flight repeated token authentication, coalesce token usage writes, remove duplicate metrics authentication, and enforce the decompressed-size limit while streaming zstd payloads.
+- **OTel ingest memory backpressure:** Bound concurrent OTLP request processing before body buffering (ceiling configurable via `TEMPS_OTEL_MAX_CONCURRENT_INGEST_REQUESTS`, default 64), single-flight repeated token authentication, coalesce token usage writes, remove duplicate metrics authentication, enforce the decompressed-size limit while streaming zstd payloads, and cap the compressed request body explicitly rather than relying on Axum's implicit default.
 - **command palette:** Show a left icon for every search result and rank matching projects ahead of common navigation pages.
 - **Cloud metadata egress isolation:** Block IPv4 and IPv6 metadata endpoints for routed app and Compose bridge traffic with an atomic, startup-reconciled nftables policy; reject Compose network drivers that bypass host filtering ([#431](https://github.com/gotempsh/temps/pull/431))
 - **Clone-error credential redaction:** Reject Git URLs with embedded userinfo and redact both usernames and passwords from libgit2 clone errors before deployment failures are persisted to project logs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12400,6 +12400,7 @@ dependencies = [
  "http 1.4.2",
  "http-body-util",
  "hyper",
+ "moka",
  "prost 0.14.4",
  "prost-build",
  "sea-orm",

--- a/crates/temps-otel/Cargo.toml
+++ b/crates/temps-otel/Cargo.toml
@@ -72,6 +72,7 @@ clickhouse = { version = "0.15", features = ["uuid", "chrono"] }
 
 # Rate limiting
 tokio-util = { workspace = true }
+moka = { version = "0.12", features = ["future"] }
 
 [build-dependencies]
 prost-build = "0.13"

--- a/crates/temps-otel/src/error.rs
+++ b/crates/temps-otel/src/error.rs
@@ -18,6 +18,9 @@ pub enum OtelError {
     #[error("Rate limit exceeded for service {service_id}: {limit} requests/min")]
     ServiceRateLimitExceeded { service_id: i32, limit: u32 },
 
+    #[error("OTel ingest is saturated: at most {limit} requests may be processed concurrently")]
+    IngestSaturated { limit: usize },
+
     #[error(
         "Storage quota exceeded for project {project_id}: used {used_bytes} of {limit_bytes} bytes"
     )]
@@ -100,6 +103,15 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "Rate limit exceeded for project 7: 500 requests/min"
+        );
+    }
+
+    #[test]
+    fn test_display_ingest_saturated() {
+        let err = OtelError::IngestSaturated { limit: 64 };
+        assert_eq!(
+            err.to_string(),
+            "OTel ingest is saturated: at most 64 requests may be processed concurrently"
         );
     }
 

--- a/crates/temps-otel/src/handlers/ingest_handler.rs
+++ b/crates/temps-otel/src/handlers/ingest_handler.rs
@@ -91,10 +91,13 @@ impl From<OtelError> for Problem {
             | OtelError::Io(_)
             | OtelError::Serialization(_)
             | OtelError::Internal { .. } => {
+                // Log the real error server-side only — the detail string can
+                // contain DB/S3 error text (schema names, paths) that must not
+                // reach the caller.
                 error!(error = %error, "OTel ingest internal error");
                 problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
                     .with_title("Internal Server Error")
-                    .with_detail(error.to_string())
+                    .with_detail("An internal error occurred")
             }
         }
     }

--- a/crates/temps-otel/src/handlers/ingest_handler.rs
+++ b/crates/temps-otel/src/handlers/ingest_handler.rs
@@ -5,16 +5,18 @@
 //! Return correct OTLP response envelopes.
 
 use std::collections::HashMap;
+use std::future::Future;
 
 use axum::body::Bytes;
-use axum::extract::{Path, State};
-use axum::http::{HeaderMap, StatusCode};
+use axum::extract::{FromRequestParts, Path, State};
+use axum::http::{request::Parts, HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use prost::Message;
+use tokio::sync::OwnedSemaphorePermit;
 use tracing::{debug, error, warn};
 
 use crate::error::OtelError;
-use crate::ingest::auth::{IngestAuth, ServiceAuth};
+use crate::ingest::auth::{IngestAuth, ProjectAuth, ServiceAuth};
 use crate::ingest::decode;
 use crate::proto;
 use crate::services::cross_project::{is_valid_trace_id, TraceHintMsg};
@@ -39,6 +41,12 @@ impl From<OtelError> for Problem {
                 warn!(error = %error, "OTel ingest rate limited");
                 problemdetails::new(StatusCode::TOO_MANY_REQUESTS)
                     .with_title("Rate Limit Exceeded")
+                    .with_detail(error.to_string())
+            }
+            OtelError::IngestSaturated { .. } => {
+                warn!(error = %error, "OTel ingest saturated");
+                problemdetails::new(StatusCode::SERVICE_UNAVAILABLE)
+                    .with_title("OTel Ingest Saturated")
                     .with_detail(error.to_string())
             }
             OtelError::QuotaExceeded { .. } => {
@@ -283,6 +291,28 @@ struct IngestContext {
     deployment_id: Option<i32>,
 }
 
+/// Holds a process-wide ingest permit for the full handler lifetime. As a
+/// request-parts extractor it runs before Axum buffers the `Bytes` body.
+pub struct IngestPermit {
+    _permit: OwnedSemaphorePermit,
+}
+
+impl FromRequestParts<OtelAppState> for IngestPermit {
+    type Rejection = Problem;
+
+    fn from_request_parts(
+        _parts: &mut Parts,
+        state: &OtelAppState,
+    ) -> impl Future<Output = Result<Self, Self::Rejection>> + Send {
+        let permit = state
+            .otel_service
+            .try_acquire_ingest_permit()
+            .map(|permit| Self { _permit: permit })
+            .map_err(Problem::from);
+        async move { permit }
+    }
+}
+
 /// Authenticate the request and resolve the ingest context.
 ///
 /// For header-only requests the IDs come from the `ProjectAuth` returned
@@ -306,6 +336,13 @@ async fn resolve_ingest_context(
         .authenticate(token, effective_project_id)
         .await?;
 
+    resolve_authenticated_ingest_context(auth, path_ids)
+}
+
+fn resolve_authenticated_ingest_context(
+    auth: ProjectAuth,
+    path_ids: Option<(i32, i32, i32)>,
+) -> Result<IngestContext, OtelError> {
     match path_ids {
         Some((path_project_id, path_environment_id, path_deployment_id)) => {
             // Validate: if the token already binds to a project (dt_ tokens),
@@ -471,16 +508,14 @@ async fn do_ingest_metrics(
         .authenticate_any(token, header_project_id)
         .await?;
 
-    match auth_result {
+    let project_auth = match auth_result {
         IngestAuth::Service(service_auth) => {
             return do_ingest_service_metrics(state, service_auth, headers, body).await;
         }
-        IngestAuth::Project(_) => {
-            // Fall through to the existing project auth path below.
-        }
-    }
+        IngestAuth::Project(auth) => auth,
+    };
 
-    let ctx = resolve_ingest_context(state, token, path_ids, headers).await?;
+    let ctx = resolve_authenticated_ingest_context(project_auth, path_ids)?;
     state.otel_service.check_rate_limit(ctx.project_id)?;
     state.otel_service.check_quota(ctx.project_id).await?;
 
@@ -716,6 +751,7 @@ async fn do_ingest_logs(
 )]
 pub async fn ingest_metrics(
     State(state): State<OtelAppState>,
+    _permit: IngestPermit,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<impl IntoResponse, Problem> {
@@ -750,6 +786,7 @@ pub async fn ingest_metrics(
 )]
 pub async fn ingest_traces(
     State(state): State<OtelAppState>,
+    _permit: IngestPermit,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<impl IntoResponse, Problem> {
@@ -785,6 +822,7 @@ pub async fn ingest_traces(
 )]
 pub async fn ingest_logs(
     State(state): State<OtelAppState>,
+    _permit: IngestPermit,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<impl IntoResponse, Problem> {
@@ -835,6 +873,7 @@ type IngestPathParams = (i32, i32, i32);
 pub async fn ingest_metrics_by_path(
     State(state): State<OtelAppState>,
     Path(path_ids): Path<IngestPathParams>,
+    _permit: IngestPermit,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<impl IntoResponse, Problem> {
@@ -872,6 +911,7 @@ pub async fn ingest_metrics_by_path(
 pub async fn ingest_traces_by_path(
     State(state): State<OtelAppState>,
     Path(path_ids): Path<IngestPathParams>,
+    _permit: IngestPermit,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<impl IntoResponse, Problem> {
@@ -909,6 +949,7 @@ pub async fn ingest_traces_by_path(
 pub async fn ingest_logs_by_path(
     State(state): State<OtelAppState>,
     Path(path_ids): Path<IngestPathParams>,
+    _permit: IngestPermit,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<impl IntoResponse, Problem> {
@@ -1045,6 +1086,12 @@ mod tests {
     }
 
     #[test]
+    fn test_error_ingest_saturated_maps_to_503() {
+        let problem: Problem = OtelError::IngestSaturated { limit: 64 }.into();
+        assert_eq!(problem.status_code, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
     fn test_error_quota_exceeded_maps_to_413() {
         let err = OtelError::QuotaExceeded {
             project_id: 1,
@@ -1177,6 +1224,39 @@ mod tests {
         assert_eq!(params.0, 1);
         assert_eq!(params.1, 2);
         assert_eq!(params.2, 3);
+    }
+
+    #[test]
+    fn authenticated_context_uses_existing_auth_without_another_lookup() {
+        let auth = ProjectAuth {
+            project_id: 10,
+            environment_id: Some(20),
+            deployment_id: Some(30),
+            token_id: 40,
+            project_name: "project".into(),
+        };
+
+        let context = resolve_authenticated_ingest_context(auth, Some((10, 20, 30))).unwrap();
+
+        assert_eq!(context.project_id, 10);
+        assert_eq!(context.environment_id, Some(20));
+        assert_eq!(context.deployment_id, Some(30));
+    }
+
+    #[test]
+    fn authenticated_context_rejects_mismatched_project() {
+        let auth = ProjectAuth {
+            project_id: 10,
+            environment_id: None,
+            deployment_id: None,
+            token_id: 40,
+            project_name: "project".into(),
+        };
+
+        assert!(matches!(
+            resolve_authenticated_ingest_context(auth, Some((11, 20, 30))),
+            Err(OtelError::AuthFailed { .. })
+        ));
     }
 
     // ── otlp_to_store_point tests ────────────────────────────────────

--- a/crates/temps-otel/src/handlers/ingest_handler.rs
+++ b/crates/temps-otel/src/handlers/ingest_handler.rs
@@ -1149,6 +1149,23 @@ mod tests {
         assert_eq!(problem.status_code, StatusCode::NOT_FOUND);
     }
 
+    /// Extracts the `detail` string from a converted `Problem`, for asserting
+    /// on response content (not just status code).
+    fn problem_detail(problem: &Problem) -> &str {
+        problem
+            .body
+            .get("detail")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+    }
+
+    /// Internal-error variants must never echo their underlying message (DB
+    /// error text, file paths, S3 reasons) into the HTTP response — only the
+    /// generic detail, with the real error logged server-side instead. See
+    /// `From<OtelError> for Problem`'s `Storage | Database | S3 | Io |
+    /// Serialization | Internal` arm.
+    const SANITIZED_INTERNAL_ERROR_DETAIL: &str = "An internal error occurred";
+
     #[test]
     fn test_error_storage_maps_to_500() {
         let err = OtelError::Storage {
@@ -1156,13 +1173,21 @@ mod tests {
         };
         let problem: Problem = err.into();
         assert_eq!(problem.status_code, StatusCode::INTERNAL_SERVER_ERROR);
+        let detail = problem_detail(&problem);
+        assert_eq!(detail, SANITIZED_INTERNAL_ERROR_DETAIL);
+        assert!(!detail.contains("disk full"), "detail leaked: {detail}");
     }
 
     #[test]
     fn test_error_database_maps_to_500() {
-        let err = OtelError::Database(sea_orm::DbErr::Custom("test".into()));
+        let err = OtelError::Database(sea_orm::DbErr::Custom(
+            "column \"key_hash\" not found in table \"api_keys\"".into(),
+        ));
         let problem: Problem = err.into();
         assert_eq!(problem.status_code, StatusCode::INTERNAL_SERVER_ERROR);
+        let detail = problem_detail(&problem);
+        assert_eq!(detail, SANITIZED_INTERNAL_ERROR_DETAIL);
+        assert!(!detail.contains("api_keys"), "detail leaked: {detail}");
     }
 
     #[test]
@@ -1173,6 +1198,9 @@ mod tests {
         };
         let problem: Problem = err.into();
         assert_eq!(problem.status_code, StatusCode::INTERNAL_SERVER_ERROR);
+        let detail = problem_detail(&problem);
+        assert_eq!(detail, SANITIZED_INTERNAL_ERROR_DETAIL);
+        assert!(!detail.contains("timeout"), "detail leaked: {detail}");
     }
 
     #[test]
@@ -1180,6 +1208,9 @@ mod tests {
         let err = OtelError::Io(std::io::Error::other("test"));
         let problem: Problem = err.into();
         assert_eq!(problem.status_code, StatusCode::INTERNAL_SERVER_ERROR);
+        let detail = problem_detail(&problem);
+        assert_eq!(detail, SANITIZED_INTERNAL_ERROR_DETAIL);
+        assert!(!detail.contains("test"), "detail leaked: {detail}");
     }
 
     #[test]
@@ -1189,6 +1220,9 @@ mod tests {
         };
         let problem: Problem = err.into();
         assert_eq!(problem.status_code, StatusCode::INTERNAL_SERVER_ERROR);
+        let detail = problem_detail(&problem);
+        assert_eq!(detail, SANITIZED_INTERNAL_ERROR_DETAIL);
+        assert!(!detail.contains("unexpected"), "detail leaked: {detail}");
     }
 
     #[test]

--- a/crates/temps-otel/src/handlers/mod.rs
+++ b/crates/temps-otel/src/handlers/mod.rs
@@ -21,7 +21,7 @@ use crate::OtelAppState;
 /// uncompressed request (`Content-Encoding` absent) had no size check of its
 /// own — `decode::decompress` returns it unmodified — and previously relied
 /// solely on Axum's implicit 2 MiB default.
-pub(crate) const INGEST_BODY_LIMIT: usize = MAX_DECOMPRESSED_SIZE + 2 * 1024 * 1024;
+pub const INGEST_BODY_LIMIT: usize = MAX_DECOMPRESSED_SIZE + 2 * 1024 * 1024;
 
 /// Configure all OTel routes.
 ///

--- a/crates/temps-otel/src/handlers/mod.rs
+++ b/crates/temps-otel/src/handlers/mod.rs
@@ -6,10 +6,22 @@ pub mod ingest_handler;
 pub mod metric_alert_handler;
 pub mod query_handler;
 
+use axum::extract::DefaultBodyLimit;
 use axum::routing::{get, post};
 use axum::Router;
 
+use crate::ingest::decode::MAX_DECOMPRESSED_SIZE;
 use crate::OtelAppState;
+
+/// Cap on the *compressed* request body for OTLP ingest routes, applied
+/// before Axum buffers anything. `MAX_DECOMPRESSED_SIZE` plus a margin for
+/// payloads that don't compress well (e.g. already-compressed or
+/// high-entropy data sent as `Content-Encoding: zstd`/`gzip`, which can come
+/// out slightly *larger* than the input). This also closes the gap where an
+/// uncompressed request (`Content-Encoding` absent) had no size check of its
+/// own — `decode::decompress` returns it unmodified — and previously relied
+/// solely on Axum's implicit 2 MiB default.
+pub(crate) const INGEST_BODY_LIMIT: usize = MAX_DECOMPRESSED_SIZE + 2 * 1024 * 1024;
 
 /// Configure all OTel routes.
 ///
@@ -34,7 +46,10 @@ use crate::OtelAppState;
 ///   GET /otel/quota
 ///   GET /otel/pipeline-stats
 pub fn configure_routes() -> Router<OtelAppState> {
-    Router::new()
+    // OTLP ingest endpoints are split into their own sub-router so
+    // `DefaultBodyLimit` applies only to them, not to the query/dashboard
+    // routes below.
+    let ingest_routes = Router::new()
         // OTLP ingest endpoints (header-based auth)
         .route("/otel/v1/metrics", post(ingest_handler::ingest_metrics))
         .route("/otel/v1/traces", post(ingest_handler::ingest_traces))
@@ -52,6 +67,9 @@ pub fn configure_routes() -> Router<OtelAppState> {
             "/otel/v1/{project_id}/{environment_id}/{deployment_id}/logs",
             post(ingest_handler::ingest_logs_by_path),
         )
+        .layer(DefaultBodyLimit::max(INGEST_BODY_LIMIT));
+
+    let query_routes = Router::new()
         // Query endpoints
         .route("/otel/metrics", get(query_handler::query_metrics))
         .route(
@@ -130,5 +148,7 @@ pub fn configure_routes() -> Router<OtelAppState> {
             get(metric_alert_handler::get_alert)
                 .patch(metric_alert_handler::update_alert)
                 .delete(metric_alert_handler::delete_alert),
-        )
+        );
+
+    ingest_routes.merge(query_routes)
 }

--- a/crates/temps-otel/src/handlers/query_handler.rs
+++ b/crates/temps-otel/src/handlers/query_handler.rs
@@ -1084,20 +1084,24 @@ pub async fn get_genai_trace(
 /// The match is exhaustive with no catch-all arm per CLAUDE.md rules.
 impl From<CrossProjectTraceError> for Problem {
     fn from(error: CrossProjectTraceError) -> Self {
-        let detail = error.to_string();
         match error {
             CrossProjectTraceError::InvalidTraceId { .. } => {
                 problemdetails::new(StatusCode::BAD_REQUEST)
                     .with_title("Invalid Trace ID")
-                    .with_detail(detail)
+                    .with_detail(error.to_string())
             }
             CrossProjectTraceError::QuerySiblings { .. }
             | CrossProjectTraceError::QueryProjects { .. }
             | CrossProjectTraceError::Database(_)
             | CrossProjectTraceError::Storage(_) => {
+                // Log the real error server-side only — DB/storage error text
+                // can contain schema/table names or paths that must not reach
+                // the caller. Same pattern as `ingest_handler`'s
+                // `From<OtelError> for Problem`.
+                warn!(error = %error, "Cross-project trace query internal error");
                 problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
                     .with_title("Internal Server Error")
-                    .with_detail(detail)
+                    .with_detail("An internal error occurred")
             }
         }
     }
@@ -1334,6 +1338,40 @@ mod tests {
             Some(0),
             "a genuinely-zero total must still be serialized: {json}"
         );
+    }
+
+    #[test]
+    fn cross_project_trace_error_internal_variants_do_not_leak_db_error_text() {
+        let err = CrossProjectTraceError::Database(sea_orm::DbErr::Custom(
+            "column \"trace_id\" not found in table \"cross_project_trace_refs\"".into(),
+        ));
+        let problem: Problem = err.into();
+        assert_eq!(problem.status_code, StatusCode::INTERNAL_SERVER_ERROR);
+        let detail = problem
+            .body
+            .get("detail")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        assert_eq!(detail, "An internal error occurred");
+        assert!(
+            !detail.contains("cross_project_trace_refs"),
+            "detail leaked: {detail}"
+        );
+    }
+
+    #[test]
+    fn cross_project_trace_error_invalid_trace_id_keeps_user_facing_detail() {
+        let err = CrossProjectTraceError::InvalidTraceId {
+            trace_id: "not-hex".into(),
+        };
+        let problem: Problem = err.into();
+        assert_eq!(problem.status_code, StatusCode::BAD_REQUEST);
+        let detail = problem
+            .body
+            .get("detail")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        assert!(detail.contains("not-hex"), "detail: {detail}");
     }
 
     #[test]

--- a/crates/temps-otel/src/ingest/auth.rs
+++ b/crates/temps-otel/src/ingest/auth.rs
@@ -997,8 +997,21 @@ mod tests {
         assert_eq!(second.unwrap().project_id, 23);
     }
 
+    /// NOTE on what this test does and does not prove: `sea_orm::MockDatabase`
+    /// resolves synchronously (it never actually yields the executor), so
+    /// under `tokio::join!` the first `authenticate` future typically runs to
+    /// completion — including the moka cache insert — before the second is
+    /// ever polled. This test therefore exercises "a second call for the same
+    /// key issued immediately after the first reuses the cached result and
+    /// does not re-query", not a genuine mid-flight race between two
+    /// in-flight lookups. The stronger single-flight guarantee (concurrent
+    /// callers for the same key share one in-flight computation rather than
+    /// each starting their own) comes from moka's documented `try_get_with`
+    /// semantics and isn't independently re-verified here. Kept as a
+    /// regression guard: if cache-sharing were accidentally removed, this
+    /// would fail (the mock has only one query result queued).
     #[tokio::test]
-    async fn deployment_auth_cache_single_flights_concurrent_lookups_for_same_token() {
+    async fn deployment_auth_cache_reuses_result_for_joined_calls_to_same_token() {
         use sea_orm::{MockDatabase, MockExecResult};
         use std::collections::BTreeMap;
 
@@ -1011,12 +1024,10 @@ mod tests {
 
         let db = Arc::new(
             MockDatabase::new(DatabaseBackend::Postgres)
-                // Only ONE query result is queued. If two concurrent
-                // `authenticate` calls for the same token each issued their
-                // own DB lookup instead of sharing moka's single-flight
-                // in-flight computation, the second call would find the
-                // mock's result queue exhausted and fail/panic instead of
-                // returning the cached verdict.
+                // Only ONE query result is queued. If the second call above
+                // issued its own DB lookup instead of reusing the cached
+                // verdict, it would find the mock's result queue exhausted
+                // and fail/panic.
                 .append_query_results(vec![vec![row]])
                 .append_exec_results(vec![MockExecResult {
                     last_insert_id: 0,

--- a/crates/temps-otel/src/ingest/auth.rs
+++ b/crates/temps-otel/src/ingest/auth.rs
@@ -224,6 +224,12 @@ impl OtelAuthService {
             .await
             .map_err(|error| OtelError::from(error.as_ref()))?;
 
+        // Unreachable in practice: `AuthCacheKey::ServiceToken` is a distinct
+        // enum discriminant from `ApiKey`/`DeploymentToken`, and this method
+        // only ever inserts `CachedAuth::Service` under that key, so a
+        // `Project` value can never be read back here. Kept as a defensive
+        // fallback (mapped to a generic 500, no cache internals leaked)
+        // rather than `unreachable!()`, in case that invariant ever changes.
         let CachedAuth::Service(auth) = cached else {
             return Err(OtelError::Internal {
                 message: "Project auth found in service-token cache entry".into(),
@@ -348,6 +354,9 @@ impl OtelAuthService {
             .await
             .map_err(|error| OtelError::from(error.as_ref()))?;
 
+        // Unreachable in practice: see the matching comment in
+        // `authenticate_service_token` — `AuthCacheKey::ApiKey` never shares
+        // a cache slot with a `Service`-typed value.
         let CachedAuth::Project(auth) = cached else {
             return Err(OtelError::Internal {
                 message: "Service auth found in API-key cache entry".into(),
@@ -508,6 +517,9 @@ impl OtelAuthService {
             .await
             .map_err(|error| OtelError::from(error.as_ref()))?;
 
+        // Unreachable in practice: see the matching comment in
+        // `authenticate_service_token` — `AuthCacheKey::DeploymentToken`
+        // never shares a cache slot with a `Service`-typed value.
         let CachedAuth::Project(auth) = cached else {
             return Err(OtelError::Internal {
                 message: "Service auth found in deployment-token cache entry".into(),
@@ -944,5 +956,82 @@ mod tests {
             service.authenticate("tk_abcdefghij", Some(24)).await,
             Err(OtelError::AuthFailed { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn deployment_auth_cache_does_not_cache_failed_lookups() {
+        use sea_orm::{MockDatabase, MockExecResult};
+        use std::collections::BTreeMap;
+
+        let mut row: BTreeMap<&str, sea_orm::Value> = BTreeMap::new();
+        row.insert("token_id", 17_i32.into());
+        row.insert("project_id", 23_i32.into());
+        row.insert("environment_id", Option::<i32>::None.into());
+        row.insert("deployment_id", Option::<i32>::None.into());
+        row.insert("project_name", "recovered-project".into());
+
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![
+                    // First lookup: no matching row (revoked/never existed).
+                    Vec::<BTreeMap<&str, sea_orm::Value>>::new(),
+                    // Second lookup, same token: now succeeds. If the first
+                    // failure had been cached (moka's `try_get_with` is
+                    // documented to only persist `Ok` values, never `Err`),
+                    // this second call would incorrectly return the same
+                    // cached failure instead of re-querying.
+                    vec![row],
+                ])
+                .append_exec_results(vec![MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                }])
+                .into_connection(),
+        );
+        let service = OtelAuthService::new(db);
+
+        let first = service.authenticate("dt_abcdefghij", None).await;
+        assert!(matches!(first, Err(OtelError::AuthFailed { .. })));
+
+        let second = service.authenticate("dt_abcdefghij", None).await;
+        assert_eq!(second.unwrap().project_id, 23);
+    }
+
+    #[tokio::test]
+    async fn deployment_auth_cache_single_flights_concurrent_lookups_for_same_token() {
+        use sea_orm::{MockDatabase, MockExecResult};
+        use std::collections::BTreeMap;
+
+        let mut row: BTreeMap<&str, sea_orm::Value> = BTreeMap::new();
+        row.insert("token_id", 17_i32.into());
+        row.insert("project_id", 23_i32.into());
+        row.insert("environment_id", Option::<i32>::None.into());
+        row.insert("deployment_id", Option::<i32>::None.into());
+        row.insert("project_name", "cached-project".into());
+
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                // Only ONE query result is queued. If two concurrent
+                // `authenticate` calls for the same token each issued their
+                // own DB lookup instead of sharing moka's single-flight
+                // in-flight computation, the second call would find the
+                // mock's result queue exhausted and fail/panic instead of
+                // returning the cached verdict.
+                .append_query_results(vec![vec![row]])
+                .append_exec_results(vec![MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                }])
+                .into_connection(),
+        );
+        let service = OtelAuthService::new(db);
+
+        let (first, second) = tokio::join!(
+            service.authenticate("dt_abcdefghij", None),
+            service.authenticate("dt_abcdefghij", None)
+        );
+
+        assert_eq!(first.unwrap().project_id, 23);
+        assert_eq!(second.unwrap().project_id, 23);
     }
 }

--- a/crates/temps-otel/src/ingest/auth.rs
+++ b/crates/temps-otel/src/ingest/auth.rs
@@ -6,9 +6,12 @@
 //! - **Deployment tokens (`dt_`)**: Project-scoped. Project, environment, and
 //!   deployment IDs are inferred from the token record itself.
 
+use moka::future::Cache;
 use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseConnection, Statement};
 use sha2::{Digest, Sha256};
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use tracing::warn;
 
 use crate::error::OtelError;
@@ -40,9 +43,114 @@ pub enum IngestAuth {
     Service(ServiceAuth),
 }
 
+const AUTH_CACHE_TTL: Duration = Duration::from_secs(5);
+const AUTH_CACHE_CAPACITY: u64 = 10_000;
+const LAST_USED_UPDATE_INTERVAL: Duration = Duration::from_secs(60);
+const LAST_USED_TRACKER_CAPACITY: usize = 10_000;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+enum AuthCacheKey {
+    ApiKey { key_hash: String, project_id: i32 },
+    DeploymentToken { token_hash: String },
+    ServiceToken { key_hash: String },
+}
+
+#[derive(Debug, Clone)]
+enum CachedAuth {
+    Project(ProjectAuth),
+    Service(ServiceAuth),
+}
+
+#[derive(Debug, Clone)]
+enum CachedAuthError {
+    InvalidApiKey,
+    AuthFailed(String),
+    Storage(String),
+}
+
+impl From<OtelError> for CachedAuthError {
+    fn from(error: OtelError) -> Self {
+        match error {
+            OtelError::InvalidApiKey => Self::InvalidApiKey,
+            OtelError::AuthFailed { reason } => Self::AuthFailed(reason),
+            OtelError::Storage { message } => Self::Storage(message),
+            other => Self::Storage(other.to_string()),
+        }
+    }
+}
+
+impl From<&CachedAuthError> for OtelError {
+    fn from(error: &CachedAuthError) -> Self {
+        match error {
+            CachedAuthError::InvalidApiKey => Self::InvalidApiKey,
+            CachedAuthError::AuthFailed(reason) => Self::AuthFailed {
+                reason: reason.clone(),
+            },
+            CachedAuthError::Storage(message) => Self::Storage {
+                message: message.clone(),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+enum TokenTable {
+    ApiKeys,
+    DeploymentTokens,
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+struct TokenUsageKey {
+    table: TokenTable,
+    token_id: i32,
+}
+
+#[derive(Default)]
+struct LastUsedTracker {
+    updates: Mutex<HashMap<TokenUsageKey, Instant>>,
+}
+
+impl LastUsedTracker {
+    fn mark_if_due(&self, key: TokenUsageKey, now: Instant) -> bool {
+        let mut updates = match self.updates.lock() {
+            Ok(updates) => updates,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        if updates.len() >= LAST_USED_TRACKER_CAPACITY && !updates.contains_key(&key) {
+            updates.retain(|_, updated_at| {
+                now.duration_since(*updated_at) < LAST_USED_UPDATE_INTERVAL
+            });
+            if updates.len() >= LAST_USED_TRACKER_CAPACITY {
+                return false;
+            }
+        }
+
+        if updates
+            .get(&key)
+            .is_some_and(|updated_at| now.duration_since(*updated_at) < LAST_USED_UPDATE_INTERVAL)
+        {
+            return false;
+        }
+
+        updates.insert(key, now);
+        true
+    }
+
+    fn forget(&self, key: TokenUsageKey) {
+        let mut updates = match self.updates.lock() {
+            Ok(updates) => updates,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        updates.remove(&key);
+    }
+}
+
 /// Service for authenticating OTel ingest requests.
 pub struct OtelAuthService {
     db: Arc<DatabaseConnection>,
+    auth_cache: Cache<AuthCacheKey, CachedAuth>,
+    last_used_tracker: LastUsedTracker,
     /// ADR-028 team-based project access checker, injected after plugin
     /// registration (see `set_project_access_checker`). `tk_` keys carry a
     /// user identity, so ingest must honour the same project-access grants
@@ -57,6 +165,11 @@ impl OtelAuthService {
     pub fn new(db: Arc<DatabaseConnection>) -> Self {
         Self {
             db,
+            auth_cache: Cache::builder()
+                .max_capacity(AUTH_CACHE_CAPACITY)
+                .time_to_live(AUTH_CACHE_TTL)
+                .build(),
+            last_used_tracker: LastUsedTracker::default(),
             project_access_checker: std::sync::OnceLock::new(),
         }
     }
@@ -96,10 +209,35 @@ impl OtelAuthService {
             return Err(OtelError::InvalidApiKey);
         }
 
-        let mut hasher = Sha256::new();
-        hasher.update(token.as_bytes());
-        let key_hash = hex::encode(hasher.finalize());
+        let key_hash = hash_token(token);
+        let cache_key = AuthCacheKey::ServiceToken {
+            key_hash: key_hash.clone(),
+        };
+        let cached = self
+            .auth_cache
+            .try_get_with(cache_key, async {
+                self.lookup_service_token(key_hash)
+                    .await
+                    .map(CachedAuth::Service)
+                    .map_err(CachedAuthError::from)
+            })
+            .await
+            .map_err(|error| OtelError::from(error.as_ref()))?;
 
+        let CachedAuth::Service(auth) = cached else {
+            return Err(OtelError::Internal {
+                message: "Project auth found in service-token cache entry".into(),
+            });
+        };
+        self.touch_last_used(TokenUsageKey {
+            table: TokenTable::ApiKeys,
+            token_id: auth.token_id,
+        })
+        .await;
+        Ok(auth)
+    }
+
+    async fn lookup_service_token(&self, key_hash: String) -> Result<ServiceAuth, OtelError> {
         let sql = r#"
             SELECT ak.id AS key_id, ak.service_id, es.name AS service_name
             FROM api_keys ak
@@ -140,22 +278,6 @@ impl OtelAuthService {
                         .map_err(|_| OtelError::AuthFailed {
                             reason: "Failed to parse service_name".into(),
                         })?;
-
-                // Update last_used_at (fire-and-forget)
-                let db = self.db.clone();
-                tokio::spawn(async move {
-                    let update_sql = "UPDATE api_keys SET last_used_at = NOW() WHERE id = $1";
-                    if let Err(e) = db
-                        .execute(Statement::from_sql_and_values(
-                            DatabaseBackend::Postgres,
-                            update_sql,
-                            vec![key_id.into()],
-                        ))
-                        .await
-                    {
-                        warn!(key_id, error = %e, "Failed to update service token last_used_at");
-                    }
-                });
 
                 Ok(ServiceAuth {
                     service_id,
@@ -210,11 +332,40 @@ impl OtelAuthService {
                     .into(),
         })?;
 
-        // Hash the key (same algorithm as temps-auth)
-        let mut hasher = Sha256::new();
-        hasher.update(api_key.as_bytes());
-        let key_hash = hex::encode(hasher.finalize());
+        let key_hash = hash_token(api_key);
+        let cache_key = AuthCacheKey::ApiKey {
+            key_hash: key_hash.clone(),
+            project_id,
+        };
+        let cached = self
+            .auth_cache
+            .try_get_with(cache_key, async {
+                self.lookup_api_key(key_hash, project_id)
+                    .await
+                    .map(CachedAuth::Project)
+                    .map_err(CachedAuthError::from)
+            })
+            .await
+            .map_err(|error| OtelError::from(error.as_ref()))?;
 
+        let CachedAuth::Project(auth) = cached else {
+            return Err(OtelError::Internal {
+                message: "Service auth found in API-key cache entry".into(),
+            });
+        };
+        self.touch_last_used(TokenUsageKey {
+            table: TokenTable::ApiKeys,
+            token_id: auth.token_id,
+        })
+        .await;
+        Ok(auth)
+    }
+
+    async fn lookup_api_key(
+        &self,
+        key_hash: String,
+        project_id: i32,
+    ) -> Result<ProjectAuth, OtelError> {
         // Look up the key and confirm the target project exists. The JOIN on a
         // bound constant only proves project existence — the user→project
         // access check happens below via the ADR-028 ProjectAccessChecker,
@@ -267,22 +418,6 @@ impl OtelAuthService {
 
                 self.check_project_access(user_id, &role_type, project_id)
                     .await?;
-
-                // Update last_used_at (fire-and-forget)
-                let db = self.db.clone();
-                tokio::spawn(async move {
-                    let update_sql = "UPDATE api_keys SET last_used_at = NOW() WHERE id = $1";
-                    if let Err(e) = db
-                        .execute(Statement::from_sql_and_values(
-                            DatabaseBackend::Postgres,
-                            update_sql,
-                            vec![key_id.into()],
-                        ))
-                        .await
-                    {
-                        warn!(key_id, error = %e, "Failed to update API key last_used_at");
-                    }
-                });
 
                 Ok(ProjectAuth {
                     project_id,
@@ -358,11 +493,35 @@ impl OtelAuthService {
             return Err(OtelError::InvalidApiKey);
         }
 
-        // Hash the token
-        let mut hasher = Sha256::new();
-        hasher.update(token.as_bytes());
-        let token_hash = hex::encode(hasher.finalize());
+        let token_hash = hash_token(token);
+        let cache_key = AuthCacheKey::DeploymentToken {
+            token_hash: token_hash.clone(),
+        };
+        let cached = self
+            .auth_cache
+            .try_get_with(cache_key, async {
+                self.lookup_deployment_token(token_hash)
+                    .await
+                    .map(CachedAuth::Project)
+                    .map_err(CachedAuthError::from)
+            })
+            .await
+            .map_err(|error| OtelError::from(error.as_ref()))?;
 
+        let CachedAuth::Project(auth) = cached else {
+            return Err(OtelError::Internal {
+                message: "Service auth found in deployment-token cache entry".into(),
+            });
+        };
+        self.touch_last_used(TokenUsageKey {
+            table: TokenTable::DeploymentTokens,
+            token_id: auth.token_id,
+        })
+        .await;
+        Ok(auth)
+    }
+
+    async fn lookup_deployment_token(&self, token_hash: String) -> Result<ProjectAuth, OtelError> {
         let sql = r#"
             SELECT dt.id AS token_id,
                    dt.project_id,
@@ -417,23 +576,6 @@ impl OtelAuthService {
                             reason: "Failed to parse project name".into(),
                         })?;
 
-                // Update last_used_at (fire-and-forget)
-                let db = self.db.clone();
-                tokio::spawn(async move {
-                    let update_sql =
-                        "UPDATE deployment_tokens SET last_used_at = NOW() WHERE id = $1";
-                    if let Err(e) = db
-                        .execute(Statement::from_sql_and_values(
-                            DatabaseBackend::Postgres,
-                            update_sql,
-                            vec![token_id.into()],
-                        ))
-                        .await
-                    {
-                        warn!(token_id, error = %e, "Failed to update deployment token last_used_at");
-                    }
-                });
-
                 Ok(ProjectAuth {
                     project_id,
                     environment_id,
@@ -447,6 +589,42 @@ impl OtelAuthService {
             }),
         }
     }
+
+    async fn touch_last_used(&self, key: TokenUsageKey) {
+        if !self.last_used_tracker.mark_if_due(key, Instant::now()) {
+            return;
+        }
+
+        let sql = match key.table {
+            TokenTable::ApiKeys => "UPDATE api_keys SET last_used_at = NOW() WHERE id = $1",
+            TokenTable::DeploymentTokens => {
+                "UPDATE deployment_tokens SET last_used_at = NOW() WHERE id = $1"
+            }
+        };
+        if let Err(error) = self
+            .db
+            .execute(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                sql,
+                vec![key.token_id.into()],
+            ))
+            .await
+        {
+            self.last_used_tracker.forget(key);
+            warn!(
+                token_id = key.token_id,
+                table = ?key.table,
+                error = %error,
+                "Failed to update OTel token last_used_at"
+            );
+        }
+    }
+}
+
+fn hash_token(token: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(token.as_bytes());
+    hex::encode(hasher.finalize())
 }
 
 #[cfg(test)]
@@ -655,5 +833,116 @@ mod tests {
             IngestAuth::Project(pa) => assert_eq!(pa.project_id, 5),
             IngestAuth::Service(_) => panic!("expected Project variant"),
         }
+    }
+
+    #[test]
+    fn last_used_tracker_coalesces_updates_until_interval_elapses() {
+        let tracker = LastUsedTracker::default();
+        let key = TokenUsageKey {
+            table: TokenTable::ApiKeys,
+            token_id: 7,
+        };
+        let now = Instant::now();
+
+        assert!(tracker.mark_if_due(key, now));
+        assert!(!tracker.mark_if_due(key, now + Duration::from_secs(59)));
+        assert!(tracker.mark_if_due(key, now + Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn last_used_tracker_retries_after_failed_update() {
+        let tracker = LastUsedTracker::default();
+        let key = TokenUsageKey {
+            table: TokenTable::DeploymentTokens,
+            token_id: 11,
+        };
+        let now = Instant::now();
+
+        assert!(tracker.mark_if_due(key, now));
+        tracker.forget(key);
+        assert!(tracker.mark_if_due(key, now));
+    }
+
+    #[tokio::test]
+    async fn deployment_auth_cache_avoids_repeated_database_queries_and_updates() {
+        use sea_orm::{MockDatabase, MockExecResult};
+        use std::collections::BTreeMap;
+
+        let mut row: BTreeMap<&str, sea_orm::Value> = BTreeMap::new();
+        row.insert("token_id", 17_i32.into());
+        row.insert("project_id", 23_i32.into());
+        row.insert("environment_id", Option::<i32>::None.into());
+        row.insert("deployment_id", Option::<i32>::None.into());
+        row.insert("project_name", "cached-project".into());
+
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![vec![row]])
+                .append_exec_results(vec![MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                }])
+                .into_connection(),
+        );
+        let service = OtelAuthService::new(db);
+
+        let first = service.authenticate("dt_abcdefghij", None).await;
+        let second = service.authenticate("dt_abcdefghij", None).await;
+
+        assert!(first.is_ok());
+        assert!(second.is_ok());
+        assert_eq!(second.unwrap().project_id, 23);
+    }
+
+    #[tokio::test]
+    async fn api_key_cache_does_not_reuse_access_verdict_across_projects() {
+        use sea_orm::{MockDatabase, MockExecResult};
+        use std::collections::BTreeMap;
+
+        struct ProjectSpecificChecker;
+
+        #[async_trait::async_trait]
+        impl temps_core::ProjectAccessChecker for ProjectSpecificChecker {
+            async fn user_can_access_project(
+                &self,
+                _user_id: i32,
+                project_id: i32,
+            ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(project_id == 23)
+            }
+        }
+
+        fn auth_row(project_name: &'static str) -> BTreeMap<&'static str, sea_orm::Value> {
+            let mut row = BTreeMap::new();
+            row.insert("key_id", 17_i32.into());
+            row.insert("user_id", 19_i32.into());
+            row.insert("role_type", "user".into());
+            row.insert("project_name", project_name.into());
+            row
+        }
+
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![
+                    vec![auth_row("allowed-project")],
+                    vec![auth_row("denied-project")],
+                ])
+                .append_exec_results(vec![MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                }])
+                .into_connection(),
+        );
+        let service = OtelAuthService::new(db);
+        service.set_project_access_checker(Arc::new(ProjectSpecificChecker));
+
+        assert!(service
+            .authenticate("tk_abcdefghij", Some(23))
+            .await
+            .is_ok());
+        assert!(matches!(
+            service.authenticate("tk_abcdefghij", Some(24)).await,
+            Err(OtelError::AuthFailed { .. })
+        ));
     }
 }

--- a/crates/temps-otel/src/ingest/decode.rs
+++ b/crates/temps-otel/src/ingest/decode.rs
@@ -13,8 +13,10 @@ use crate::error::OtelError;
 use crate::proto;
 use crate::types::*;
 
-/// Maximum decompressed size to prevent decompression bombs (10 MB)
-const MAX_DECOMPRESSED_SIZE: usize = 10 * 1024 * 1024;
+/// Maximum decompressed size to prevent decompression bombs (10 MB).
+/// `pub(crate)` so the ingest router can derive its compressed-body cap from
+/// the same number — see `crate::handlers::INGEST_BODY_LIMIT`.
+pub(crate) const MAX_DECOMPRESSED_SIZE: usize = 10 * 1024 * 1024;
 /// Maximum zstd history window (2^24 = 16 MiB). This is large enough for the
 /// accepted 10 MiB payload while preventing attacker-controlled frame headers
 /// from allocating an unbounded decoder window before output is produced.

--- a/crates/temps-otel/src/ingest/decode.rs
+++ b/crates/temps-otel/src/ingest/decode.rs
@@ -15,6 +15,10 @@ use crate::types::*;
 
 /// Maximum decompressed size to prevent decompression bombs (10 MB)
 const MAX_DECOMPRESSED_SIZE: usize = 10 * 1024 * 1024;
+/// Maximum zstd history window (2^24 = 16 MiB). This is large enough for the
+/// accepted 10 MiB payload while preventing attacker-controlled frame headers
+/// from allocating an unbounded decoder window before output is produced.
+const MAX_ZSTD_WINDOW_LOG: u32 = 24;
 
 /// Decompress a request body based on Content-Encoding header.
 ///
@@ -44,11 +48,26 @@ pub fn decompress(body: &Bytes, encoding: Option<&str>) -> Result<Bytes, OtelErr
             Ok(Bytes::from(decompressed))
         }
         Some("zstd") => {
-            let decompressed =
-                zstd::decode_all(&body[..]).map_err(|e| OtelError::DecompressionFailed {
+            let mut decoder = zstd::stream::read::Decoder::new(&body[..]).map_err(|e| {
+                OtelError::DecompressionFailed {
                     encoding: "zstd".into(),
                     reason: e.to_string(),
-                })?;
+                }
+            })?;
+            decoder.window_log_max(MAX_ZSTD_WINDOW_LOG).map_err(|e| {
+                OtelError::DecompressionFailed {
+                    encoding: "zstd".into(),
+                    reason: format!("Failed to enforce zstd window limit: {e}"),
+                }
+            })?;
+            let mut limited_reader = decoder.take(MAX_DECOMPRESSED_SIZE as u64 + 1);
+            let mut decompressed = Vec::new();
+            limited_reader.read_to_end(&mut decompressed).map_err(|e| {
+                OtelError::DecompressionFailed {
+                    encoding: "zstd".into(),
+                    reason: e.to_string(),
+                }
+            })?;
             if decompressed.len() > MAX_DECOMPRESSED_SIZE {
                 return Err(OtelError::DecompressionFailed {
                     encoding: "zstd".into(),
@@ -692,6 +711,34 @@ mod tests {
 
         let result = decompress(&Bytes::from(compressed), Some("zstd")).unwrap();
         assert_eq!(&result[..], original);
+    }
+
+    #[test]
+    fn test_decompress_zstd_rejects_payload_over_limit() {
+        let original = vec![0_u8; MAX_DECOMPRESSED_SIZE + 1];
+        let compressed = zstd::encode_all(&original[..], 3).unwrap();
+
+        let result = decompress(&Bytes::from(compressed), Some("zstd"));
+
+        assert!(matches!(
+            result,
+            Err(OtelError::DecompressionFailed { encoding, reason })
+                if encoding == "zstd" && reason.contains("exceeds maximum allowed size")
+        ));
+    }
+
+    #[test]
+    fn test_decompress_zstd_rejects_oversized_history_window() {
+        use std::io::Write;
+
+        let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), 3).unwrap();
+        encoder.window_log(MAX_ZSTD_WINDOW_LOG + 1).unwrap();
+        encoder.write_all(b"small payload").unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let result = decompress(&Bytes::from(compressed), Some("zstd"));
+
+        assert!(matches!(result, Err(OtelError::DecompressionFailed { .. })));
     }
 
     #[test]

--- a/crates/temps-otel/src/plugin.rs
+++ b/crates/temps-otel/src/plugin.rs
@@ -59,6 +59,10 @@ pub struct OtelConfig {
     // Background tasks
     pub enable_health_compute: bool,
     pub enable_anomaly_detection: bool,
+
+    // Ingest backpressure. Process-wide operational tuning knob (not
+    // per-tenant config) — see `crate::services::otel_service::DEFAULT_MAX_CONCURRENT_INGEST_REQUESTS`.
+    pub max_concurrent_ingest_requests: usize,
 }
 
 impl Default for OtelConfig {
@@ -77,6 +81,8 @@ impl Default for OtelConfig {
             quota_bytes_per_project: None, // quota disabled unless configured
             enable_health_compute: true,
             enable_anomaly_detection: true,
+            max_concurrent_ingest_requests:
+                crate::services::otel_service::DEFAULT_MAX_CONCURRENT_INGEST_REQUESTS,
         }
     }
 }
@@ -137,6 +143,16 @@ impl OtelConfig {
         }
         if let Ok(v) = std::env::var("TEMPS_OTEL_ENABLE_ANOMALY_DETECTION") {
             config.enable_anomaly_detection = v != "0" && v != "false";
+        }
+        if let Ok(v) = std::env::var("TEMPS_OTEL_MAX_CONCURRENT_INGEST_REQUESTS") {
+            match v.parse::<usize>() {
+                Ok(limit) if limit > 0 => config.max_concurrent_ingest_requests = limit,
+                _ => warn!(
+                    value = %v,
+                    "TEMPS_OTEL_MAX_CONCURRENT_INGEST_REQUESTS is set but is not a positive \
+                     integer; keeping the default ingest concurrency ceiling"
+                ),
+            }
         }
 
         config
@@ -450,6 +466,7 @@ impl TempsPlugin for OtelPlugin {
                 storage.clone(),
                 auth_service,
                 rate_limiter,
+                config.max_concurrent_ingest_requests,
             ));
             context.register_service(otel_service.clone());
             // Also expose the same service behind the storage-agnostic read
@@ -822,6 +839,10 @@ mod tests {
         assert!(!config.has_s3_config());
         assert!(config.enable_health_compute);
         assert!(config.enable_anomaly_detection);
+        assert_eq!(
+            config.max_concurrent_ingest_requests,
+            crate::services::otel_service::DEFAULT_MAX_CONCURRENT_INGEST_REQUESTS
+        );
     }
 
     #[test]

--- a/crates/temps-otel/src/plugin.rs
+++ b/crates/temps-otel/src/plugin.rs
@@ -145,12 +145,13 @@ impl OtelConfig {
             config.enable_anomaly_detection = v != "0" && v != "false";
         }
         if let Ok(v) = std::env::var("TEMPS_OTEL_MAX_CONCURRENT_INGEST_REQUESTS") {
-            match v.parse::<usize>() {
-                Ok(limit) if limit > 0 => config.max_concurrent_ingest_requests = limit,
-                _ => warn!(
+            match parse_max_concurrent_ingest_requests(&v) {
+                Some(limit) => config.max_concurrent_ingest_requests = limit,
+                None => warn!(
                     value = %v,
                     "TEMPS_OTEL_MAX_CONCURRENT_INGEST_REQUESTS is set but is not a positive \
-                     integer; keeping the default ingest concurrency ceiling"
+                     integer within the supported range; keeping the default ingest \
+                     concurrency ceiling"
                 ),
             }
         }
@@ -165,6 +166,19 @@ impl OtelConfig {
             && self.s3_secret_key.is_some()
             && self.s3_bucket.is_some()
     }
+}
+
+/// Parses `TEMPS_OTEL_MAX_CONCURRENT_INGEST_REQUESTS`. Returns `None` (caller
+/// keeps the default) for anything that isn't a positive integer within
+/// `Semaphore::MAX_PERMITS` — `Semaphore::new` asserts on that bound and would
+/// otherwise panic the process at startup on a mistyped value.
+///
+/// A free function (rather than inline in `from_env`) so this parsing/bounds
+/// logic is unit-testable without mutating process-global environment
+/// variables, which the other `TEMPS_OTEL_*` fields in this file don't do.
+fn parse_max_concurrent_ingest_requests(v: &str) -> Option<usize> {
+    let limit = v.parse::<usize>().ok()?;
+    (limit > 0 && limit <= tokio::sync::Semaphore::MAX_PERMITS).then_some(limit)
 }
 
 // ── OpenAPI Schema ──────────────────────────────────────────────────
@@ -842,6 +856,37 @@ mod tests {
         assert_eq!(
             config.max_concurrent_ingest_requests,
             crate::services::otel_service::DEFAULT_MAX_CONCURRENT_INGEST_REQUESTS
+        );
+    }
+
+    #[test]
+    fn test_parse_max_concurrent_ingest_requests_accepts_positive_integers() {
+        assert_eq!(parse_max_concurrent_ingest_requests("1"), Some(1));
+        assert_eq!(parse_max_concurrent_ingest_requests("128"), Some(128));
+    }
+
+    #[test]
+    fn test_parse_max_concurrent_ingest_requests_rejects_zero_and_garbage() {
+        assert_eq!(parse_max_concurrent_ingest_requests("0"), None);
+        assert_eq!(parse_max_concurrent_ingest_requests("-1"), None);
+        assert_eq!(parse_max_concurrent_ingest_requests("not-a-number"), None);
+        assert_eq!(parse_max_concurrent_ingest_requests(""), None);
+    }
+
+    #[test]
+    fn test_parse_max_concurrent_ingest_requests_rejects_values_above_semaphore_max() {
+        // A value that parses as `usize` but exceeds `Semaphore::MAX_PERMITS`
+        // must fall back to the default rather than panicking `Semaphore::new`
+        // at startup — the regression this fix targets.
+        let too_large = (tokio::sync::Semaphore::MAX_PERMITS as u128 + 1).to_string();
+        assert_eq!(parse_max_concurrent_ingest_requests(&too_large), None);
+        assert_eq!(
+            parse_max_concurrent_ingest_requests(&usize::MAX.to_string()),
+            None
+        );
+        assert_eq!(
+            parse_max_concurrent_ingest_requests(&tokio::sync::Semaphore::MAX_PERMITS.to_string()),
+            Some(tokio::sync::Semaphore::MAX_PERMITS)
         );
     }
 

--- a/crates/temps-otel/src/services/otel_service.rs
+++ b/crates/temps-otel/src/services/otel_service.rs
@@ -35,14 +35,25 @@ pub struct OtelService {
     /// [`crate::ingest::quota_cache`].
     quota_cache: Arc<QuotaCache>,
     ingest_semaphore: Arc<Semaphore>,
+    /// The configured value backing `ingest_semaphore`'s capacity, kept
+    /// alongside it so `IngestSaturated` errors report the limit that is
+    /// actually in effect (which may differ from
+    /// [`DEFAULT_MAX_CONCURRENT_INGEST_REQUESTS`] when overridden via
+    /// `TEMPS_OTEL_MAX_CONCURRENT_INGEST_REQUESTS`).
+    ingest_permit_limit: usize,
     stats: PipelineStatsAtomic,
 }
 
-/// Process-wide limit for OTLP requests that may authenticate, decompress,
-/// decode, and write concurrently. The permit is acquired before Axum buffers
-/// the request body, bounding both task and payload memory during exporter
-/// retry storms.
-pub const MAX_CONCURRENT_INGEST_REQUESTS: usize = 64;
+/// Default process-wide limit for OTLP requests that may authenticate,
+/// decompress, decode, and write concurrently. The permit is acquired before
+/// Axum buffers the request body, bounding both task and payload memory
+/// during exporter retry storms.
+///
+/// This is a process-wide operational tuning knob, not per-tenant config, so
+/// deployments that need a higher ceiling (larger hardware, many
+/// projects/services sharing one instance) can override it via
+/// `TEMPS_OTEL_MAX_CONCURRENT_INGEST_REQUESTS` — see `OtelConfig::from_env`.
+pub const DEFAULT_MAX_CONCURRENT_INGEST_REQUESTS: usize = 64;
 
 /// Max `si_` ingest requests per service per window. ~10 req/s — far above a
 /// healthy exporter's cadence, low enough to stop a tight-loop flood from
@@ -89,6 +100,7 @@ impl OtelService {
         storage: Arc<dyn OtelStorage>,
         auth_service: Arc<OtelAuthService>,
         rate_limiter: Arc<RateLimiter>,
+        max_concurrent_ingest_requests: usize,
     ) -> Self {
         Self {
             storage,
@@ -99,7 +111,8 @@ impl OtelService {
                 SERVICE_INGEST_WINDOW,
             )),
             quota_cache: Arc::new(QuotaCache::new(QUOTA_CACHE_TTL)),
-            ingest_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_INGEST_REQUESTS)),
+            ingest_semaphore: Arc::new(Semaphore::new(max_concurrent_ingest_requests)),
+            ingest_permit_limit: max_concurrent_ingest_requests,
             stats: PipelineStatsAtomic::default(),
         }
     }
@@ -110,7 +123,7 @@ impl OtelService {
             .clone()
             .try_acquire_owned()
             .map_err(|_| OtelError::IngestSaturated {
-                limit: MAX_CONCURRENT_INGEST_REQUESTS,
+                limit: self.ingest_permit_limit,
             })
     }
 
@@ -476,7 +489,12 @@ mod tests {
         let db = Arc::new(sea_orm::DatabaseConnection::Disconnected);
         let auth = Arc::new(crate::ingest::auth::OtelAuthService::new(db));
         let limiter = Arc::new(RateLimiter::new(1000, Duration::from_secs(60)));
-        let svc = OtelService::new(Arc::new(storage) as Arc<dyn OtelStorage>, auth, limiter);
+        let svc = OtelService::new(
+            Arc::new(storage) as Arc<dyn OtelStorage>,
+            auth,
+            limiter,
+            DEFAULT_MAX_CONCURRENT_INGEST_REQUESTS,
+        );
         (svc, storage_clone)
     }
 
@@ -742,7 +760,12 @@ mod tests {
         let auth = Arc::new(crate::ingest::auth::OtelAuthService::new(db));
         let limiter = Arc::new(RateLimiter::new(2, Duration::from_secs(60))); // only 2 allowed
         let storage = Arc::new(MockOtelStorage::new()) as Arc<dyn OtelStorage>;
-        let svc = OtelService::new(storage, auth, limiter);
+        let svc = OtelService::new(
+            storage,
+            auth,
+            limiter,
+            DEFAULT_MAX_CONCURRENT_INGEST_REQUESTS,
+        );
 
         assert!(svc.check_rate_limit(1).is_ok());
         assert!(svc.check_rate_limit(1).is_ok());
@@ -806,7 +829,12 @@ mod tests {
         let auth = Arc::new(crate::ingest::auth::OtelAuthService::new(db));
         let project_limiter = Arc::new(RateLimiter::new(2, Duration::from_secs(60)));
         let storage = Arc::new(MockOtelStorage::new()) as Arc<dyn OtelStorage>;
-        let svc = OtelService::new(storage, auth, project_limiter);
+        let svc = OtelService::new(
+            storage,
+            auth,
+            project_limiter,
+            DEFAULT_MAX_CONCURRENT_INGEST_REQUESTS,
+        );
 
         // Spend many service-ingest tokens for service 1...
         for _ in 0..10 {
@@ -1154,14 +1182,14 @@ mod tests {
     #[test]
     fn ingest_concurrency_is_bounded_and_permits_are_released() {
         let (service, _storage) = make_service(MockOtelStorage::new());
-        let permits: Vec<_> = (0..MAX_CONCURRENT_INGEST_REQUESTS)
+        let permits: Vec<_> = (0..DEFAULT_MAX_CONCURRENT_INGEST_REQUESTS)
             .map(|_| service.try_acquire_ingest_permit().unwrap())
             .collect();
 
         assert!(matches!(
             service.try_acquire_ingest_permit(),
             Err(OtelError::IngestSaturated {
-                limit: MAX_CONCURRENT_INGEST_REQUESTS
+                limit: DEFAULT_MAX_CONCURRENT_INGEST_REQUESTS
             })
         ));
 

--- a/crates/temps-otel/src/services/otel_service.rs
+++ b/crates/temps-otel/src/services/otel_service.rs
@@ -8,6 +8,7 @@ use std::sync::{
     Arc,
 };
 use std::time::Duration;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tracing::{error, warn};
 
 use crate::error::OtelError;
@@ -33,8 +34,15 @@ pub struct OtelService {
     /// over the OTel hypertables on every ingest request. See
     /// [`crate::ingest::quota_cache`].
     quota_cache: Arc<QuotaCache>,
+    ingest_semaphore: Arc<Semaphore>,
     stats: PipelineStatsAtomic,
 }
+
+/// Process-wide limit for OTLP requests that may authenticate, decompress,
+/// decode, and write concurrently. The permit is acquired before Axum buffers
+/// the request body, bounding both task and payload memory during exporter
+/// retry storms.
+pub const MAX_CONCURRENT_INGEST_REQUESTS: usize = 64;
 
 /// Max `si_` ingest requests per service per window. ~10 req/s — far above a
 /// healthy exporter's cadence, low enough to stop a tight-loop flood from
@@ -91,8 +99,19 @@ impl OtelService {
                 SERVICE_INGEST_WINDOW,
             )),
             quota_cache: Arc::new(QuotaCache::new(QUOTA_CACHE_TTL)),
+            ingest_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_INGEST_REQUESTS)),
             stats: PipelineStatsAtomic::default(),
         }
+    }
+
+    /// Acquire an ingest slot without queueing more work in memory.
+    pub fn try_acquire_ingest_permit(&self) -> Result<OwnedSemaphorePermit, OtelError> {
+        self.ingest_semaphore
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| OtelError::IngestSaturated {
+                limit: MAX_CONCURRENT_INGEST_REQUESTS,
+            })
     }
 
     /// Authenticate a token (API key `tk_` or deployment token `dt_`).
@@ -1130,5 +1149,23 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, OtelError::Validation { .. }));
+    }
+
+    #[test]
+    fn ingest_concurrency_is_bounded_and_permits_are_released() {
+        let (service, _storage) = make_service(MockOtelStorage::new());
+        let permits: Vec<_> = (0..MAX_CONCURRENT_INGEST_REQUESTS)
+            .map(|_| service.try_acquire_ingest_permit().unwrap())
+            .collect();
+
+        assert!(matches!(
+            service.try_acquire_ingest_permit(),
+            Err(OtelError::IngestSaturated {
+                limit: MAX_CONCURRENT_INGEST_REQUESTS
+            })
+        ));
+
+        drop(permits);
+        assert!(service.try_acquire_ingest_permit().is_ok());
     }
 }

--- a/crates/temps-otel/tests/dynamic_alert_integration_test.rs
+++ b/crates/temps-otel/tests/dynamic_alert_integration_test.rs
@@ -186,6 +186,7 @@ async fn setup_evaluator() -> Option<EvaluatorTestCtx> {
         storage.clone(),
         auth_service,
         rate_limiter,
+        temps_otel::services::otel_service::DEFAULT_MAX_CONCURRENT_INGEST_REQUESTS,
     ));
     let alert_service = Arc::new(MetricAlertService::new(db.clone()));
 

--- a/crates/temps-otel/tests/e2e_http_test.rs
+++ b/crates/temps-otel/tests/e2e_http_test.rs
@@ -725,6 +725,38 @@ async fn test_e2e_missing_api_key_returns_401() {
 }
 
 #[tokio::test]
+async fn test_e2e_ingest_body_over_limit_returns_413() {
+    let Some((_db, router, _project_id)) = setup_e2e().await else {
+        return;
+    };
+
+    // One byte over the router's `DefaultBodyLimit` (see `handlers::INGEST_BODY_LIMIT`).
+    // Axum rejects a body whose declared `Content-Length` exceeds the limit
+    // before dispatching to any handler/extractor, so this doesn't need a
+    // valid API key — the limit must fire ahead of auth.
+    let oversized_body = vec![0_u8; temps_otel::handlers::INGEST_BODY_LIMIT + 1];
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/otel/v1/traces")
+                .header("content-type", "application/x-protobuf")
+                .body(Body::from(oversized_body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "Body over the ingest route's DefaultBodyLimit should be rejected with 413, \
+         not reach the handler/auth layer"
+    );
+}
+
+#[tokio::test]
 async fn test_e2e_invalid_api_key_returns_401() {
     let Some((_db, router, project_id)) = setup_e2e().await else {
         return;

--- a/crates/temps-otel/tests/e2e_http_test.rs
+++ b/crates/temps-otel/tests/e2e_http_test.rs
@@ -183,7 +183,12 @@ async fn setup_e2e() -> Option<(
     let storage = Arc::new(TimescaleDbStorage::new(db.clone(), None));
     let auth_service = Arc::new(OtelAuthService::new(db.clone()));
     let rate_limiter = Arc::new(RateLimiter::new(10000, Duration::from_secs(60)));
-    let otel_service = Arc::new(OtelService::new(storage, auth_service, rate_limiter));
+    let otel_service = Arc::new(OtelService::new(
+        storage,
+        auth_service,
+        rate_limiter,
+        temps_otel::services::otel_service::DEFAULT_MAX_CONCURRENT_INGEST_REQUESTS,
+    ));
     let dashboard_service = Arc::new(temps_otel::services::MetricDashboardService::new(
         db.clone(),
     ));


### PR DESCRIPTION
## Description

Bounds console memory growth during OTLP exporter bursts and restart retry storms.

The metrics ingest path previously authenticated project tokens twice, queried the database for every request, and spawned a detached `last_used_at` update after each successful lookup. Under sustained OTLP traffic this could create thousands of database operations and detached tasks per second. Request processing itself also had no process-wide concurrency ceiling, and the compressed request body had no explicit size cap of its own.

This PR (3 commits):

- adds a positive-only, single-flight auth cache with a five-second TTL and hashed cache keys;
- includes `project_id` in API-key cache keys so authorization decisions cannot cross projects;
- coalesces `last_used_at` writes to at most one per token per minute without detached tasks;
- reuses the existing metrics authentication result instead of authenticating twice;
- limits concurrent OTLP processing before Axum buffers request bodies, returning HTTP 503 under saturation — the ceiling defaults to 64 and is now configurable via `TEMPS_OTEL_MAX_CONCURRENT_INGEST_REQUESTS` (capped against `Semaphore::MAX_PERMITS`, so a malformed value falls back to the default with a warning instead of panicking at startup);
- streams zstd decompression with a 10 MiB output limit and a 16 MiB decoder-window limit;
- adds an explicit `DefaultBodyLimit` on the ingest routes (~12 MiB) instead of relying on Axum's implicit 2 MiB default — this also closes a gap where an uncompressed (`Content-Encoding`-absent) body had no size check of its own;
- sanitizes internal-error HTTP responses (ingest path and the pre-existing cross-project trace query path) so DB/S3/IO error text is logged server-side only, never echoed to the caller;
- adds regression tests for all of the above and a changelog entry.

### Tradeoffs

- Revocations and project-access changes may take up to five seconds to propagate.
- `last_used_at` may lag by up to one minute, and one request per interval pays the update latency.
- The concurrency ceiling converts overload into retryable 503 responses. At 1.3k requests/second, average processing must remain below roughly 49 ms to avoid saturation.
- Under the default 64-request ceiling, peak memory from decompression alone is closer to ~1.8 GiB worst-case (64 × 16 MiB zstd window + 64 × 10 MiB output buffer), not the ~1 GiB originally estimated — decoded protobuf/storage objects amplify this further. The request-body cap now bounds this from growing unboundedly, but a slow-body sender holding a permit through the body-read phase (no per-request read timeout yet) is a known remaining gap, not fully closed by this PR.
- The concurrency ceiling is now operator-configurable but still process-wide (shared across every project/service on the instance), not per-tenant.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Evidence

All commands below were re-run against the current head (3rd commit) in a clean worktree.

**Authorization cache isolation:** the same API key cannot reuse an allowed project authorization for a denied project.

```bash
cargo test --lib -p temps-otel ingest::auth::tests::api_key_cache_does_not_reuse_access_verdict_across_projects -- --exact --nocapture
```

```text
test ingest::auth::tests::api_key_cache_does_not_reuse_access_verdict_across_projects ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 440 filtered out; finished in 0.00s
```

**Ingest concurrency ceiling:** all permits can be acquired, the next request is rejected, and dropping permits restores capacity.

```bash
cargo test --lib -p temps-otel services::otel_service::tests::ingest_concurrency_is_bounded_and_permits_are_released -- --exact --nocapture
```

```text
test services::otel_service::tests::ingest_concurrency_is_bounded_and_permits_are_released ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 440 filtered out; finished in 0.00s
```

**zstd memory bound:** a frame requesting a decoder window above 16 MiB is rejected.

```bash
cargo test --lib -p temps-otel ingest::decode::tests::test_decompress_zstd_rejects_oversized_history_window -- --exact --nocapture
```

```text
test ingest::decode::tests::test_decompress_zstd_rejects_oversized_history_window ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 440 filtered out; finished in 0.00s
```

**Auth cache: failed lookups are never cached** (only `Ok` verdicts persist — a revoked/invalid key doesn't get a free pass on retry).

```bash
cargo test --lib -p temps-otel ingest::auth::tests::deployment_auth_cache_does_not_cache_failed_lookups -- --exact --nocapture
```

```text
test ingest::auth::tests::deployment_auth_cache_does_not_cache_failed_lookups ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 440 filtered out; finished in 0.00s
```

**Auth cache: repeated lookups for the same token reuse the cached result** rather than re-querying (see the test's own doc comment for the precise scope of what this proves under `MockDatabase`'s synchronous resolution).

```bash
cargo test --lib -p temps-otel ingest::auth::tests::deployment_auth_cache_reuses_result_for_joined_calls_to_same_token -- --exact --nocapture
```

```text
test ingest::auth::tests::deployment_auth_cache_reuses_result_for_joined_calls_to_same_token ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 440 filtered out; finished in 0.00s
```

**Concurrency-ceiling env var: a value exceeding `Semaphore::MAX_PERMITS` falls back to the default** instead of panicking `Semaphore::new()` at startup.

```bash
cargo test --lib -p temps-otel plugin::tests::test_parse_max_concurrent_ingest_requests_rejects_values_above_semaphore_max -- --exact --nocapture
```

```text
test plugin::tests::test_parse_max_concurrent_ingest_requests_rejects_values_above_semaphore_max ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 440 filtered out; finished in 0.00s
```

**Internal-error sanitization: the ingest path never echoes DB error text into a 500 response.**

```bash
cargo test --lib -p temps-otel handlers::ingest_handler::tests::test_error_database_maps_to_500 -- --exact --nocapture
```

```text
test handlers::ingest_handler::tests::test_error_database_maps_to_500 ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 440 filtered out; finished in 0.00s
```

**Internal-error sanitization: the (pre-existing) cross-project trace query path is now sanitized too.**

```bash
cargo test --lib -p temps-otel handlers::query_handler::tests::cross_project_trace_error_internal_variants_do_not_leak_db_error_text -- --exact --nocapture
```

```text
test handlers::query_handler::tests::cross_project_trace_error_internal_variants_do_not_leak_db_error_text ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 440 filtered out; finished in 0.00s
```

**`DefaultBodyLimit` returns 413 for an oversized ingest body before reaching auth/handler code:** covered by `tests/e2e_http_test.rs::test_e2e_ingest_body_over_limit_returns_413`. This test is Docker-gated (spins up a real TimescaleDB via testcontainers, like its siblings in the same file) and was not run in this local environment — it will run in CI. Not fabricating output for it here; CI's `e2e_http_test` job result is the evidence for this one.

**Relevant crate suite:**

```bash
cargo test --lib -p temps-otel
```

```text
test result: ok. 441 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s
```

**Workspace validation:**

```bash
cargo check --lib -p temps-otel
cargo clippy -p temps-otel --all-targets -- -D warnings
cargo fmt -p temps-otel -- --check
```

```text
cargo check: 0 errors
cargo clippy (all targets, including tests/): 0 errors, 0 warnings
cargo fmt --check: clean
```

The repository-mandated security re-audit signed off after the zstd decoder-window cap and cross-project cache-isolation regression were added (1st commit), and again after this PR's two follow-up commits (concurrency-ceiling env var + cap, explicit body limit, error-message sanitization) — no findings above LOW across either pass. A production-equivalent 1.3k requests/second load test was not performed.

## Checklist

- [x] I have written tests that cover the changes
- [x] All new and existing relevant crate tests pass (`cargo test --lib -p temps-otel` — 441 passed)
- [x] `cargo check --lib` passes (only pre-existing workspace/build warnings remain)
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have updated documentation where necessary

## Related issues

Production OTLP console memory spike investigation.
