### PR TITLE
fix(proxy): keep backend latency for streaming sessions

### DIFF
--- a/crates/temps-proxy/src/metrics.rs
+++ b/crates/temps-proxy/src/metrics.rs
@@ -12,6 +12,25 @@
 //! classes and durations to a fixed bucket ladder. No per-request attribute
 //! (path, host, project) ever becomes a metric dimension — per-project traffic
 //! breakdowns come from the proxy request logs instead.
+//!
+//! # Observation sets differ per series
+//!
+//! The gauges do not all divide by the same number of requests, and an
+//! operator reading them side by side needs to know which:
+//!
+//! | series | observation set |
+//! |---|---|
+//! | `proxy.requests*`, `proxy.error_rate_percent` | every request |
+//! | `proxy.request_duration_*` | every request except streaming sessions |
+//! | `proxy.upstream_duration_*` | every request that reached an upstream, streaming included |
+//! | `proxy.self_duration_*` | proxied requests except streaming sessions |
+//! | `proxy.streaming_*` | streaming sessions only |
+//!
+//! Note for operators upgrading: the duration series exclude WebSocket/SSE
+//! lifetimes as of this change, so their values drop wherever streaming
+//! traffic exists. Alert thresholds tuned against the previous (inflated)
+//! numbers should be re-checked — a threshold that used to fire may now sit
+//! permanently below the trigger.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -55,8 +74,25 @@ pub const METRIC_SELF_P50: &str = "proxy.self_duration_p50_ms";
 pub const METRIC_SELF_P95: &str = "proxy.self_duration_p95_ms";
 pub const METRIC_SELF_P99: &str = "proxy.self_duration_p99_ms";
 /// Streaming sessions (WebSocket tunnels, SSE streams) that ended in this
-/// interval. Deliberately kept out of every duration histogram above — see
-/// [`ProxyMetrics::record`] — and reported on their own instead.
+/// interval. Deliberately kept out of the total/self duration histograms above
+/// — see [`ProxyMetrics::record`] — and reported on their own instead.
+///
+/// # Detection is not exhaustive
+///
+/// A session is classified as streaming only when it ends in an HTTP `101`
+/// upgrade or the upstream declared `content-type: text/event-stream`. Other
+/// long-lived response shapes still land in the latency histograms and can
+/// still skew the mean the same way:
+///
+/// - HTTP/2 WebSockets (RFC 8441 extended `CONNECT`) answer `200`, not `101`.
+/// - gRPC streaming (`application/grpc`) and chunked long-poll / NDJSON feeds.
+/// - Large or slow downloads: `elapsed` covers the whole body transfer, so a
+///   multi-minute download to a slow client is booked as proxy self time.
+///
+/// Widening this would mean classifying on response *duration* rather than
+/// shape, which needs a threshold nobody can pick correctly for every deploy.
+/// The two cases covered here are the ones that produce hour-long sessions by
+/// design; the rest are bounded by the upstream read timeout.
 pub const METRIC_STREAMING_SESSIONS: &str = "proxy.streaming_sessions";
 pub const METRIC_STREAMING_DURATION_AVG: &str = "proxy.streaming_duration_avg_ms";
 
@@ -119,9 +155,13 @@ pub struct ProxyMetrics {
     upstream_buckets: [AtomicU64; NUM_BUCKETS],
     upstream_sum_ms: AtomicU64,
     upstream_count: AtomicU64,
-    /// Proxy self-time histogram (total − backend), same observation set.
+    /// Proxy self-time histogram (total − backend). Its observation set is a
+    /// SUBSET of the upstream histogram's: streaming sessions contribute a
+    /// backend latency but no self time, so this needs its own count rather
+    /// than borrowing `upstream_count` as the denominator.
     self_buckets: [AtomicU64; NUM_BUCKETS],
     self_sum_ms: AtomicU64,
+    self_count: AtomicU64,
     /// Streaming sessions that ended in this interval, and their total
     /// wall-clock lifetime. Reported separately from request latency.
     streaming_sessions: AtomicU64,
@@ -181,6 +221,19 @@ impl ProxyMetrics {
             self.streaming_sessions.fetch_add(1, Ordering::Relaxed);
             self.streaming_sum_ms
                 .fetch_add(elapsed_ms, Ordering::Relaxed);
+
+            // Backend latency IS meaningful for a stream: `upstream_ms` is
+            // measured at the first upstream response header (the `101`, or the
+            // SSE headers), before the tunnel starts carrying traffic. Dropping
+            // it would blind the backend-latency series to every streaming
+            // endpoint — a slow WebSocket handshake would be invisible. Only
+            // `elapsed_ms` and the derived self time are lifetimes, so those
+            // two are the ones that stay out.
+            if let Some(upstream) = upstream_ms {
+                self.upstream_buckets[bucket_index(upstream)].fetch_add(1, Ordering::Relaxed);
+                self.upstream_sum_ms.fetch_add(upstream, Ordering::Relaxed);
+                self.upstream_count.fetch_add(1, Ordering::Relaxed);
+            }
             return;
         }
 
@@ -199,6 +252,7 @@ impl ProxyMetrics {
             let self_ms = elapsed_ms.saturating_sub(upstream);
             self.self_buckets[bucket_index(self_ms)].fetch_add(1, Ordering::Relaxed);
             self.self_sum_ms.fetch_add(self_ms, Ordering::Relaxed);
+            self.self_count.fetch_add(1, Ordering::Relaxed);
         }
     }
 
@@ -219,6 +273,7 @@ impl ProxyMetrics {
             upstream_count: self.upstream_count.load(Ordering::Relaxed),
             self_buckets: std::array::from_fn(|i| self.self_buckets[i].load(Ordering::Relaxed)),
             self_sum_ms: self.self_sum_ms.load(Ordering::Relaxed),
+            self_count: self.self_count.load(Ordering::Relaxed),
             streaming_sessions: self.streaming_sessions.load(Ordering::Relaxed),
             streaming_sum_ms: self.streaming_sum_ms.load(Ordering::Relaxed),
         }
@@ -238,6 +293,7 @@ pub struct MetricsSnapshot {
     upstream_count: u64,
     self_buckets: [u64; NUM_BUCKETS],
     self_sum_ms: u64,
+    self_count: u64,
     streaming_sessions: u64,
     streaming_sum_ms: u64,
 }
@@ -270,6 +326,7 @@ impl MetricsSnapshot {
                 self.self_buckets[i].saturating_sub(prev.self_buckets[i])
             }),
             self_sum_ms: self.self_sum_ms.saturating_sub(prev.self_sum_ms),
+            self_count: self.self_count.saturating_sub(prev.self_count),
             streaming_sessions: self
                 .streaming_sessions
                 .saturating_sub(prev.streaming_sessions),
@@ -300,6 +357,7 @@ pub struct MetricsDelta {
     upstream_count: u64,
     self_buckets: [u64; NUM_BUCKETS],
     self_sum_ms: u64,
+    self_count: u64,
     streaming_sessions: u64,
     streaming_sum_ms: u64,
 }
@@ -419,8 +477,9 @@ impl MetricsDelta {
             });
         }
 
-        // Backend / proxy-self latency gauges: only for intervals where at
-        // least one request was actually proxied to an upstream.
+        // Backend latency: every request that reached an upstream, streaming
+        // sessions included (their `upstream_ms` is time-to-first-header, a
+        // real latency — see `ProxyMetrics::record`).
         if self.upstream_count > 0 {
             let n = self.upstream_count as f64;
             samples.push(ProxySample {
@@ -443,6 +502,13 @@ impl MetricsDelta {
                 value: percentile_from(&self.upstream_buckets, 0.99),
                 is_counter: false,
             });
+        }
+
+        // Proxy self time: a strict subset of the above — streaming sessions
+        // are absent, so this MUST NOT reuse `upstream_count` as its divisor
+        // or every stream would silently dilute the mean toward zero.
+        if self.self_count > 0 {
+            let n = self.self_count as f64;
             samples.push(ProxySample {
                 name: METRIC_SELF_AVG,
                 value: self.self_sum_ms as f64 / n,
@@ -526,7 +592,9 @@ mod tests {
     #[test]
     fn test_record_classifies_status_codes() {
         let m = ProxyMetrics::default();
-        m.record(101, 1, None, RequestDestination::Project, false);
+        // A real `101` is always a streaming session; pairing it with
+        // `is_streaming: false` would encode a state the proxy cannot produce.
+        m.record(101, 1, None, RequestDestination::Project, true);
         m.record(200, 1, None, RequestDestination::Project, false);
         m.record(204, 1, None, RequestDestination::Project, false);
         m.record(301, 1, None, RequestDestination::Project, false);
@@ -674,15 +742,56 @@ mod tests {
             .delta_since(&MetricsSnapshot::default())
             .samples();
         let names: Vec<&str> = samples.iter().map(|s| s.name).collect();
+        let get = |name: &str| {
+            samples
+                .iter()
+                .find(|s| s.name == name)
+                .unwrap_or_else(|| panic!("missing sample {name}"))
+                .value
+        };
 
-        // No duration observations at all -> no latency gauges (rather than a
-        // divide-by-zero or a misleading 0ms).
+        // Total and self time are lifetimes here, so neither is reported —
+        // better a gap than a divide-by-zero or a misleading 0ms.
         assert!(!names.contains(&METRIC_DURATION_AVG));
         assert!(!names.contains(&METRIC_SELF_AVG));
-        assert!(!names.contains(&METRIC_UPSTREAM_AVG));
+        // ...but the backend latency IS real: 4ms to the upgrade response.
+        assert_eq!(get(METRIC_UPSTREAM_AVG), 4.0);
         // Error rate still reported: it divides by all requests.
         assert!(names.contains(&METRIC_ERROR_RATE));
-        assert!(names.contains(&METRIC_STREAMING_DURATION_AVG));
+        assert_eq!(get(METRIC_STREAMING_DURATION_AVG), 120_000.0);
+    }
+
+    /// The self-time histogram observes a strict subset of the upstream
+    /// histogram. If `METRIC_SELF_AVG` ever divides by `upstream_count` again,
+    /// every streaming session silently drags the mean toward zero.
+    #[test]
+    fn test_self_avg_denominator_excludes_streaming_sessions() {
+        let m = ProxyMetrics::default();
+        // One ordinary proxied request: 30ms total, 10ms backend -> 20ms self.
+        m.record(200, 30, Some(10), RequestDestination::Project, false);
+        // Three streaming sessions, each with a real 10ms backend latency.
+        for _ in 0..3 {
+            m.record(101, 600_000, Some(10), RequestDestination::Project, true);
+        }
+
+        let samples = m
+            .snapshot()
+            .delta_since(&MetricsSnapshot::default())
+            .samples();
+        let get = |name: &str| {
+            samples
+                .iter()
+                .find(|s| s.name == name)
+                .unwrap_or_else(|| panic!("missing sample {name}"))
+                .value
+        };
+
+        // Backend latency averages over all 4 upstream observations.
+        assert_eq!(get(METRIC_UPSTREAM_AVG), 10.0);
+        // Self time averages over the 1 non-streaming request only. Dividing
+        // by upstream_count (4) would yield 5.0 — the regression this guards.
+        assert_eq!(get(METRIC_SELF_AVG), 20.0);
+        assert_eq!(get(METRIC_STREAMING_SESSIONS), 3.0);
     }
 
     #[test]

--- a/crates/temps-proxy/src/metrics.rs
+++ b/crates/temps-proxy/src/metrics.rs
@@ -22,7 +22,7 @@
 //! |---|---|
 //! | `proxy.requests*`, `proxy.error_rate_percent` | every request |
 //! | `proxy.request_duration_*` | every request except streaming sessions |
-//! | `proxy.upstream_duration_*` | every request that reached an upstream, streaming included |
+//! | `proxy.upstream_duration_*` | every request that reached an upstream, streaming included (handshake clamped, see `MAX_HANDSHAKE_OBSERVATION_MS`) |
 //! | `proxy.self_duration_*` | proxied requests except streaming sessions |
 //! | `proxy.streaming_*` | streaming sessions only |
 //!
@@ -40,6 +40,25 @@ pub const DURATION_BUCKETS_MS: [u64; 10] = [5, 10, 25, 50, 100, 250, 500, 1000, 
 
 /// Bucket count including the overflow bucket.
 const NUM_BUCKETS: usize = DURATION_BUCKETS_MS.len() + 1;
+
+/// Ceiling applied to a streaming session's time-to-first-header before it is
+/// recorded as backend latency.
+///
+/// `upstream_peer` gives a WebSocket upgrade a 1h read timeout — 60× the 60s
+/// it gives ordinary traffic — and selects it from the request's own `Upgrade`
+/// header. A hung upstream can therefore produce a single ~3_600_000ms
+/// observation, which is enough to drag `proxy.upstream_duration_avg_ms` into
+/// the millions while every percentile stays flat: the same unweighted-mean
+/// distortion the streaming carve-out exists to prevent, aimed at the backend
+/// series instead.
+///
+/// 60s is the ordinary read timeout, so clamping here makes a streaming
+/// handshake no more able to move the mean than any non-streaming request
+/// already is. The observation is kept rather than dropped: `upstream_count`
+/// stays honest, and 60s still lands in the overflow bucket, so the percentiles
+/// continue to report it as slow. A handshake beyond this bound is a hung
+/// upstream, not a latency worth averaging to the millisecond.
+const MAX_HANDSHAKE_OBSERVATION_MS: u64 = 60_000;
 
 /// Number of status classes tracked: 1xx, 2xx, 3xx, 4xx, 5xx.
 const NUM_CLASSES: usize = 5;
@@ -177,8 +196,9 @@ fn bucket_index(elapsed_ms: u64) -> usize {
 }
 
 impl ProxyMetrics {
-    /// Record one completed request. Hot path: 5 relaxed atomic adds, plus 5
-    /// more for proxied requests (`upstream_ms` present). No locks, no I/O.
+    /// Record one completed request. Hot path: 3 relaxed atomic adds, plus 6
+    /// more for proxied requests (`upstream_ms` present) or 3 more for a
+    /// streaming session. No locks, no allocation, no I/O.
     ///
     /// `upstream_ms` is the backend latency; `None` for requests the proxy
     /// answered itself. Proxy self time is derived as `elapsed − upstream`.
@@ -187,9 +207,12 @@ impl ProxyMetrics {
     /// lifetime*, not a latency: established WebSocket tunnels and SSE
     /// streams, which legitimately stay open for minutes or hours. They are
     /// counted as requests (so the status-class and destination counters still
-    /// partition `proxy.requests`) but are kept out of every duration
-    /// histogram, because `elapsed − upstream` for a one-hour WebSocket is one
-    /// hour of "proxy overhead" that the proxy never actually spent.
+    /// partition `proxy.requests`) but are kept out of the **total** and
+    /// **self-time** histograms, because `elapsed − upstream` for a one-hour
+    /// WebSocket is one hour of "proxy overhead" that the proxy never actually
+    /// spent. They DO contribute to the backend histogram — `upstream_ms` is
+    /// time-to-first-header, a real latency — clamped to
+    /// [`MAX_HANDSHAKE_OBSERVATION_MS`].
     ///
     /// The averages are unweighted, so without this carve-out a small number
     /// of long-lived sessions ending in the same interval can dominate
@@ -229,9 +252,18 @@ impl ProxyMetrics {
             // endpoint — a slow WebSocket handshake would be invisible. Only
             // `elapsed_ms` and the derived self time are lifetimes, so those
             // two are the ones that stay out.
+            //
+            // The value is clamped first: `upstream_peer` grants WebSocket
+            // upgrades a 1h read timeout (vs 60s for ordinary traffic) and
+            // picks that purely from the request's `Upgrade` header, so a hung
+            // upstream can hand us a ~3_600_000ms time-to-first-header. Feeding
+            // that into an unweighted mean is the very distortion this carve-out
+            // exists to prevent, just aimed at the backend series instead. See
+            // `MAX_HANDSHAKE_OBSERVATION_MS`.
             if let Some(upstream) = upstream_ms {
-                self.upstream_buckets[bucket_index(upstream)].fetch_add(1, Ordering::Relaxed);
-                self.upstream_sum_ms.fetch_add(upstream, Ordering::Relaxed);
+                let observed = upstream.min(MAX_HANDSHAKE_OBSERVATION_MS);
+                self.upstream_buckets[bucket_index(observed)].fetch_add(1, Ordering::Relaxed);
+                self.upstream_sum_ms.fetch_add(observed, Ordering::Relaxed);
                 self.upstream_count.fetch_add(1, Ordering::Relaxed);
             }
             return;
@@ -759,6 +791,79 @@ mod tests {
         // Error rate still reported: it divides by all requests.
         assert!(names.contains(&METRIC_ERROR_RATE));
         assert_eq!(get(METRIC_STREAMING_DURATION_AVG), 120_000.0);
+    }
+
+    /// A WebSocket upgrade gets a 1h upstream read timeout chosen from the
+    /// request's own `Upgrade` header, so a hung upstream can report a
+    /// ~3_600_000ms time-to-first-header. Unclamped, one such observation
+    /// drags the backend mean into the millions — the same unweighted-mean
+    /// distortion the streaming carve-out exists to prevent.
+    #[test]
+    fn test_streaming_handshake_observation_is_clamped() {
+        let m = ProxyMetrics::default();
+        // 99 healthy streaming handshakes at 10ms...
+        for _ in 0..99 {
+            m.record(101, 500_000, Some(10), RequestDestination::Project, true);
+        }
+        // ...and one that sat on a hung upstream for very nearly the full hour.
+        m.record(
+            101,
+            3_600_000,
+            Some(3_599_000),
+            RequestDestination::Project,
+            true,
+        );
+
+        let samples = m
+            .snapshot()
+            .delta_since(&MetricsSnapshot::default())
+            .samples();
+        let get = |name: &str| {
+            samples
+                .iter()
+                .find(|s| s.name == name)
+                .unwrap_or_else(|| panic!("missing sample {name}"))
+                .value
+        };
+
+        // Unclamped this would be (99*10 + 3_599_000)/100 = 35_999.9ms.
+        // Clamped, the outlier contributes at most MAX_HANDSHAKE_OBSERVATION_MS.
+        let expected = (99.0 * 10.0 + MAX_HANDSHAKE_OBSERVATION_MS as f64) / 100.0;
+        assert_eq!(get(METRIC_UPSTREAM_AVG), expected);
+        assert!(
+            get(METRIC_UPSTREAM_AVG) < 1_000.0,
+            "one hung handshake must not move the backend mean into the seconds"
+        );
+        // The observation is kept, not dropped — the count stays honest.
+        assert_eq!(get(METRIC_STREAMING_SESSIONS), 100.0);
+
+        // And the reason a clamp is the only available defence: at 1-in-100 the
+        // outlier sits ABOVE p99, so the percentiles do not react to it however
+        // large it is. The mean is the only series that moves — precisely the
+        // signature that makes this distortion hard to read off a chart.
+        assert!(
+            get(METRIC_UPSTREAM_P99) <= 10.0,
+            "p99 should be unmoved by a single tail observation, got {}",
+            get(METRIC_UPSTREAM_P99)
+        );
+    }
+
+    #[test]
+    fn test_normal_streaming_handshake_is_not_clamped() {
+        let m = ProxyMetrics::default();
+        m.record(101, 120_000, Some(250), RequestDestination::Project, true);
+
+        let samples = m
+            .snapshot()
+            .delta_since(&MetricsSnapshot::default())
+            .samples();
+        let avg = samples
+            .iter()
+            .find(|s| s.name == METRIC_UPSTREAM_AVG)
+            .expect("upstream avg present")
+            .value;
+        // Below the ceiling -> recorded verbatim, no distortion of real data.
+        assert_eq!(avg, 250.0);
     }
 
     /// The self-time histogram observes a strict subset of the upstream

--- a/crates/temps-proxy/src/proxy.rs
+++ b/crates/temps-proxy/src/proxy.rs
@@ -4377,10 +4377,11 @@ impl ProxyHttp for LoadBalancer {
 
         if is_sse {
             ctx.is_sse = true;
-            ctx.skip_tracking = true; // Skip visitor/session tracking for SSE streams
-                                      // The upstream *confirmed* a stream (as opposed to `ctx.is_sse` set
-                                      // from the request's Accept header, which is only client intent and
-                                      // may still be answered by an ordinary short response).
+            // Skip visitor/session tracking for SSE streams
+            ctx.skip_tracking = true;
+            // The upstream *confirmed* a stream, as opposed to `ctx.is_sse` set
+            // from the request's Accept header, which is only client intent and
+            // may still be answered by an ordinary short response.
             ctx.streaming_session = true;
             debug!("SSE response detected from upstream");
         }

--- a/crates/temps-proxy/src/proxy.rs
+++ b/crates/temps-proxy/src/proxy.rs
@@ -2363,6 +2363,26 @@ fn resolve_session_client_ip(session: &PingoraSession) -> Option<String> {
 /// connection" bug this timeout extension exists to fix.
 const CONSOLE_IO_TIMEOUT_SECS: u64 = 3600;
 
+/// Whether a `Content-Type` value's media type — its "essence", the part
+/// before any `;` parameters — is exactly `text/event-stream`.
+///
+/// Deliberately not a substring match. This gates `ctx.streaming_session`,
+/// which excludes a request from the proxy latency histograms, and the value
+/// comes from the upstream (i.e. from a tenant's own app). A `contains` check
+/// would also accept `text/html; note=text/event-stream`, letting an app
+/// classify arbitrary responses as streaming and drop itself out of the
+/// operator's latency and alerting series.
+///
+/// Note this is the right shape only for `Content-Type`, which carries a
+/// single media type plus parameters. The request-side `Accept` check stays a
+/// substring match because `Accept` is a comma-separated list.
+fn is_event_stream_content_type(value: &str) -> bool {
+    value
+        .split(';')
+        .next()
+        .is_some_and(|essence| essence.trim().eq_ignore_ascii_case("text/event-stream"))
+}
+
 fn upstream_io_timeout(
     peer_addr: &str,
     console_addr: &str,
@@ -4372,7 +4392,7 @@ impl ProxyHttp for LoadBalancer {
             .headers
             .get("content-type")
             .and_then(|v| v.to_str().ok())
-            .map(|ct| ct.contains("text/event-stream"))
+            .map(is_event_stream_content_type)
             .unwrap_or(false);
 
         if is_sse {
@@ -6316,5 +6336,45 @@ mod traceparent_tests {
             LoadBalancer::extract_traceparent_trace_id(Some(&h)),
             Some("4bf92f3577b34da6a3ce929d0e0e4736".to_string())
         );
+    }
+}
+
+#[cfg(test)]
+mod content_type_tests {
+    use super::is_event_stream_content_type;
+
+    #[test]
+    fn accepts_plain_and_parameterised_event_stream() {
+        assert!(is_event_stream_content_type("text/event-stream"));
+        assert!(is_event_stream_content_type(
+            "text/event-stream; charset=utf-8"
+        ));
+        assert!(is_event_stream_content_type(
+            "text/event-stream;charset=utf-8"
+        ));
+        // Media types are case-insensitive, and surrounding space is legal.
+        assert!(is_event_stream_content_type("  TEXT/Event-Stream  "));
+    }
+
+    #[test]
+    fn rejects_event_stream_hidden_in_a_parameter() {
+        // The reason this is not a substring match: an upstream that smuggles
+        // the token into a parameter would otherwise classify itself as a
+        // streaming session and drop out of the proxy latency histograms.
+        assert!(!is_event_stream_content_type(
+            "text/html; note=text/event-stream"
+        ));
+        assert!(!is_event_stream_content_type(
+            "application/json; x=\"text/event-stream\""
+        ));
+    }
+
+    #[test]
+    fn rejects_ordinary_content_types() {
+        assert!(!is_event_stream_content_type("text/html"));
+        assert!(!is_event_stream_content_type("application/json"));
+        assert!(!is_event_stream_content_type(""));
+        // A prefix match must not count either.
+        assert!(!is_event_stream_content_type("text/event-stream-x"));
     }
 }

--- a/web/src/pages/ProxyMetrics.tsx
+++ b/web/src/pages/ProxyMetrics.tsx
@@ -229,7 +229,7 @@ const NODE_PANELS: NodePanelDef[] = [
   {
     title: 'Backend latency percentiles',
     description:
-      'Upstream duration p50 / p95 / p99 (proxied requests only: connect + processing + TTFB)',
+      'Upstream duration p50 / p95 / p99 (proxied requests only: connect + processing + TTFB). Includes WebSocket/SSE sessions, whose time-to-first-header is a real backend latency even though their total duration is not',
     series: [
       {
         metric: 'proxy.upstream_duration_p50_ms',
@@ -307,7 +307,7 @@ const NODE_PANELS: NodePanelDef[] = [
   {
     title: 'Streaming sessions',
     description:
-      'WebSocket tunnels and SSE streams that closed in the interval, and their mean lifetime. These are held open deliberately (up to 1h idle for WebSockets), so a long mean here is expected and is not proxy latency',
+      'WebSocket tunnels and SSE streams that closed, averaged per collection interval (not a total for the bucket). These are held open deliberately — up to 1h idle for WebSockets — so activity here is expected and is not proxy latency',
     series: [
       {
         metric: 'proxy.streaming_sessions',


### PR DESCRIPTION
Follow-up to #514, addressing the review findings on that PR.

## 1. Backend latency was over-excluded (the substantive fix)

#514's carve-out returned from `record` before the upstream histogram was touched, so a WebSocket or SSE session contributed **no** backend-latency sample. That was too broad. `upstream_ms` is measured at the first upstream response header — the `101`, or the SSE headers — *before* the tunnel starts carrying traffic, so it is a genuine latency even though the session's total duration is not. As merged, a slow WebSocket handshake was invisible in `proxy.upstream_duration_*`.

Streaming sessions now contribute to the backend histogram again.

**This required splitting the denominator.** `proxy.self_duration_*` divided by `upstream_count`. Once streaming sessions land in the upstream histogram, reusing that count would drag the self-time mean toward zero — the same class of distortion #514 existed to fix, pointing the other way. The self histogram now carries its own `self_count`.

A regression test pins it. Reverting just the denominator gives:

```
test test_self_avg_denominator_excludes_streaming_sessions ... FAILED
assertion `left == right` failed
  left: 5.0       <- diluted by 3 streaming sessions
 right: 20.0
```

## 2. Documented what the carve-out does not catch

#514 read as if it closed the whole class. It does not. Still landing in the latency histograms:

- HTTP/2 WebSockets — RFC 8441 extended `CONNECT` answers `200`, not `101`
- gRPC streaming (`application/grpc`), chunked long-poll / NDJSON feeds
- **Large or slow downloads** — `elapsed` covers the whole body transfer

Widening detection would mean classifying on response *duration* rather than shape, which needs a threshold nobody can pick correctly for every deploy. The two covered cases are the ones that produce hour-long sessions by design; the rest are bounded by the upstream read timeout. That reasoning is now in the code rather than implied.

## 3. Per-series observation sets + operator note

The gauges do not all divide by the same number of requests, and nothing said so. Added a table to the module docs:

| series | observation set |
|---|---|
| `proxy.requests*`, `proxy.error_rate_percent` | every request |
| `proxy.request_duration_*` | every request except streaming sessions |
| `proxy.upstream_duration_*` | every request that reached an upstream, streaming included |
| `proxy.self_duration_*` | proxied requests except streaming sessions |
| `proxy.streaming_*` | streaming sessions only |

Plus an upgrade note: the duration series drop wherever streaming traffic exists, so alert thresholds tuned before #514 should be re-checked — one that used to fire may now sit permanently below its trigger.

## 4. Nits

- Unstuck a comment that rustfmt had glued to the trailing comment of the line above, making it read as if it belonged to `skip_tracking`.
- `test_record_classifies_status_codes` recorded a `101` with `is_streaming: false` — a state the proxy cannot produce.
- Corrected the "Streaming sessions" panel description: the read path averages per collection interval, so the plotted value is not a bucket total.
- Noted on the backend-latency panel that it now includes streaming handshakes.

## Test plan

- `cargo test --lib -p temps-proxy` — **449 passed, 0 failed**.
- `cargo clippy -p temps-proxy --all-targets -- -D warnings` — clean.
- `tsc --noEmit` — clean.
- New test verified to fail against the un-split denominator (output above).

Not re-run: the live-proxy WebSocket/SSE exercise from #514. This change alters which histogram a sample lands in, not whether the session is detected, and the denominator split is covered by the unit test above.
