### PR TITLE
feat(telemetry): add deployment failure taxonomy and template context

### DIFF
--- a/crates/temps-agents/src/services/config_service.rs
+++ b/crates/temps-agents/src/services/config_service.rs
@@ -1240,6 +1240,7 @@ mod tests {
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
             slug: "test".into(),
+            template_slug: None,
             is_deleted: false,
             deleted_at: None,
             last_deployment: None,

--- a/crates/temps-agents/src/services/executor.rs
+++ b/crates/temps-agents/src/services/executor.rs
@@ -4131,6 +4131,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             slug: "test-app".into(),
+            template_slug: None,
             is_deleted: false,
             deleted_at: None,
             last_deployment: None,

--- a/crates/temps-ai-chat/src/handlers.rs
+++ b/crates/temps-ai-chat/src/handlers.rs
@@ -1140,6 +1140,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             slug: "p".to_string(),
+            template_slug: None,
             is_deleted: false,
             deleted_at: None,
             last_deployment: None,

--- a/crates/temps-ai-chat/src/pending_actions.rs
+++ b/crates/temps-ai-chat/src/pending_actions.rs
@@ -551,6 +551,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             slug: "test-project".to_string(),
+            template_slug: None,
             is_deleted: false,
             deleted_at: None,
             last_deployment: None,

--- a/crates/temps-ai-chat/src/providers/project.rs
+++ b/crates/temps-ai-chat/src/providers/project.rs
@@ -90,6 +90,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             slug: "slug".to_string(),
+            template_slug: None,
             is_deleted: false,
             deleted_at: None,
             last_deployment: None,

--- a/crates/temps-ai-chat/src/providers/repo_tools.rs
+++ b/crates/temps-ai-chat/src/providers/repo_tools.rs
@@ -679,6 +679,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             slug: "test".to_string(),
+            template_slug: None,
             is_deleted: false,
             deleted_at: None,
             last_deployment: None,

--- a/crates/temps-ai-chat/src/service.rs
+++ b/crates/temps-ai-chat/src/service.rs
@@ -1832,6 +1832,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             slug: slug.to_string(),
+            template_slug: None,
             is_deleted: false,
             deleted_at: None,
             last_deployment: None,

--- a/crates/temps-core/src/templates.rs
+++ b/crates/temps-core/src/templates.rs
@@ -255,11 +255,37 @@ const BUNDLED_TELEMETRY_TEMPLATE_SLUGS: &[&str] = &[
     "nextjs-docs-template",
 ];
 
+/// Stored provenance marker for projects created from an operator-defined
+/// template. The operator's actual slug stays local to the template catalog.
+pub const CUSTOM_TEMPLATE_PROVENANCE: &str = "custom";
+
 /// Return the slug only when it is a fixed label from the bundled catalog.
 pub fn telemetry_safe_template_slug(slug: &str) -> Option<&str> {
     BUNDLED_TELEMETRY_TEMPLATE_SLUGS
         .contains(&slug)
         .then_some(slug)
+}
+
+/// Return the public bundled slug only when the selected template exactly
+/// matches its embedded catalog definition.
+///
+/// External template files can replace the bundled catalog and may reuse one
+/// of its slugs. Comparing the complete definition prevents such an override
+/// from being attributed to the bundled template merely because its name
+/// matches a public label.
+pub fn bundled_telemetry_template_slug(template: &ProjectTemplate) -> Option<&str> {
+    telemetry_safe_template_slug(&template.slug)?;
+    let bundled = TemplatesConfig::from_yaml(BUNDLED_TEMPLATES).ok()?;
+    bundled
+        .templates
+        .iter()
+        .any(|candidate| candidate == template)
+        .then_some(template.slug.as_str())
+}
+
+/// Produce the bounded value persisted on a template-created project.
+pub fn template_provenance(template: &ProjectTemplate) -> &str {
+    bundled_telemetry_template_slug(template).unwrap_or(CUSTOM_TEMPLATE_PROVENANCE)
 }
 
 /// Template service that manages loading and caching templates
@@ -807,6 +833,25 @@ templates:
             Some("observability-starter")
         );
         assert_eq!(telemetry_safe_template_slug("customer-acme-private"), None);
+    }
+
+    #[test]
+    fn external_override_reusing_bundled_slug_is_custom_provenance() {
+        let mut config = TemplatesConfig::from_yaml(BUNDLED_TEMPLATES)
+            .expect("bundled templates.yaml must parse");
+        let template = config
+            .templates
+            .iter_mut()
+            .find(|template| template.slug == "observability-starter")
+            .expect("observability template must be bundled");
+        template.git.url = "https://example.com/operator/observability.git".to_string();
+
+        assert_eq!(bundled_telemetry_template_slug(template), None);
+        assert_eq!(template_provenance(template), CUSTOM_TEMPLATE_PROVENANCE);
+        assert_eq!(
+            telemetry_safe_template_slug(template_provenance(template)),
+            None
+        );
     }
 
     #[test]

--- a/crates/temps-core/src/templates.rs
+++ b/crates/temps-core/src/templates.rs
@@ -241,6 +241,27 @@ pub enum TemplateConfigError {
 /// Bundled default templates (embedded at compile time)
 const BUNDLED_TEMPLATES: &str = include_str!("../templates.yaml");
 
+/// Maximum template slug length accepted by the catalog and project schema.
+pub const MAX_TEMPLATE_SLUG_CHARS: usize = 255;
+
+/// Fixed, reviewable labels that are safe to include in anonymous telemetry.
+///
+/// Operators can load private templates with arbitrary slugs. Those slugs must
+/// never leave the instance, so telemetry callers must pass them through
+/// [`telemetry_safe_template_slug`] and treat `None` as a custom template.
+const BUNDLED_TELEMETRY_TEMPLATE_SLUGS: &[&str] = &[
+    "observability-starter",
+    "nextjs-saas-starter",
+    "nextjs-docs-template",
+];
+
+/// Return the slug only when it is a fixed label from the bundled catalog.
+pub fn telemetry_safe_template_slug(slug: &str) -> Option<&str> {
+    BUNDLED_TELEMETRY_TEMPLATE_SLUGS
+        .contains(&slug)
+        .then_some(slug)
+}
+
 /// Template service that manages loading and caching templates
 pub struct TemplateService {
     config: Arc<RwLock<TemplatesConfig>>,
@@ -308,6 +329,10 @@ impl TemplateService {
         // Check for empty slug
         if template.slug.is_empty() {
             errors.push("Slug cannot be empty".to_string());
+        } else if template.slug.chars().count() > MAX_TEMPLATE_SLUG_CHARS {
+            errors.push(format!(
+                "Slug cannot exceed {MAX_TEMPLATE_SLUG_CHARS} characters"
+            ));
         }
 
         // Check for empty name
@@ -759,6 +784,39 @@ templates:
             starter.services.iter().any(|s| s == "postgres"),
             "observability-starter must depend on postgres"
         );
+    }
+
+    #[test]
+    fn telemetry_slug_allowlist_exactly_matches_bundled_catalog() {
+        let config = TemplatesConfig::from_yaml(BUNDLED_TEMPLATES)
+            .expect("bundled templates.yaml must parse");
+        let bundled: std::collections::BTreeSet<&str> = config
+            .templates
+            .iter()
+            .map(|template| template.slug.as_str())
+            .collect();
+        let allowlisted: std::collections::BTreeSet<&str> =
+            BUNDLED_TELEMETRY_TEMPLATE_SLUGS.iter().copied().collect();
+
+        assert_eq!(
+            allowlisted, bundled,
+            "every bundled slug must be explicitly reviewed for telemetry, and custom slugs must stay excluded"
+        );
+        assert_eq!(
+            telemetry_safe_template_slug("observability-starter"),
+            Some("observability-starter")
+        );
+        assert_eq!(telemetry_safe_template_slug("customer-acme-private"), None);
+    }
+
+    #[test]
+    fn template_validation_rejects_slug_longer_than_project_column() {
+        let mut config = TemplatesConfig::from_yaml(SAMPLE_CONFIG).expect("sample config parses");
+        config.templates[0].slug = "x".repeat(MAX_TEMPLATE_SLUG_CHARS + 1);
+
+        let errors = TemplateService::validate_config(&config);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].errors.iter().any(|error| error.contains("255")));
     }
 
     #[test]

--- a/crates/temps-deployments/src/services/workflow_execution_service.rs
+++ b/crates/temps-deployments/src/services/workflow_execution_service.rs
@@ -25,41 +25,453 @@ use crate::jobs::{
 use crate::services::DeploymentJobTracker;
 use temps_screenshots::ScreenshotService;
 
-/// Map a deployment's free-form failure reason to a coarse, NON-identifying
-/// category for telemetry. The raw reason can contain build logs, file paths,
-/// or repo names, so it is never sent verbatim — only one of these stable
-/// labels (or `unknown`). Matching is on lowercased substrings.
-fn categorize_failure_reason(reason: Option<&str>) -> &'static str {
+/// Version of the allowlisted failure taxonomy emitted in deployment telemetry.
+/// Increment this when matching semantics or wire labels change.
+const FAILURE_CLASSIFIER_VERSION: u8 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeploymentFailureStage {
+    Source,
+    Configuration,
+    DependencyInstall,
+    Build,
+    Image,
+    Deploy,
+    Runtime,
+    HealthCheck,
+    Resource,
+    Platform,
+    Unknown,
+}
+
+impl DeploymentFailureStage {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Source => "source",
+            Self::Configuration => "configuration",
+            Self::DependencyInstall => "dependency_install",
+            Self::Build => "build",
+            Self::Image => "image",
+            Self::Deploy => "deploy",
+            Self::Runtime => "runtime",
+            Self::HealthCheck => "health_check",
+            Self::Resource => "resource",
+            Self::Platform => "platform",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeploymentFailureCode {
+    OutOfMemory,
+    DiskExhausted,
+    Timeout,
+    HealthCheckFailed,
+    RepositoryAuthentication,
+    RepositoryNotFound,
+    RepositoryClone,
+    DnsResolution,
+    NetworkConnection,
+    DependencyLockfileOutOfSync,
+    DependencyResolution,
+    DependencyDownload,
+    RuntimeVersionUnsupported,
+    MissingBuildScript,
+    CompileError,
+    DockerfileInvalid,
+    BaseImagePull,
+    ImageMissing,
+    StaticOutputMissing,
+    PortUnavailable,
+    PermissionDenied,
+    InvalidConfiguration,
+    ContainerStart,
+    BuildError,
+    PlatformInternal,
+    Cancelled,
+    Unknown,
+}
+
+impl DeploymentFailureCode {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::OutOfMemory => "out_of_memory",
+            Self::DiskExhausted => "disk_exhausted",
+            Self::Timeout => "timeout",
+            Self::HealthCheckFailed => "health_check_failed",
+            Self::RepositoryAuthentication => "repository_authentication",
+            Self::RepositoryNotFound => "repository_not_found",
+            Self::RepositoryClone => "repository_clone",
+            Self::DnsResolution => "dns_resolution",
+            Self::NetworkConnection => "network_connection",
+            Self::DependencyLockfileOutOfSync => "dependency_lockfile_out_of_sync",
+            Self::DependencyResolution => "dependency_resolution",
+            Self::DependencyDownload => "dependency_download",
+            Self::RuntimeVersionUnsupported => "runtime_version_unsupported",
+            Self::MissingBuildScript => "missing_build_script",
+            Self::CompileError => "compile_error",
+            Self::DockerfileInvalid => "dockerfile_invalid",
+            Self::BaseImagePull => "base_image_pull",
+            Self::ImageMissing => "image_missing",
+            Self::StaticOutputMissing => "static_output_missing",
+            Self::PortUnavailable => "port_unavailable",
+            Self::PermissionDenied => "permission_denied",
+            Self::InvalidConfiguration => "invalid_configuration",
+            Self::ContainerStart => "container_start",
+            Self::BuildError => "build_error",
+            Self::PlatformInternal => "platform_internal",
+            Self::Cancelled => "cancelled",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DeploymentFailureClassification {
+    stage: DeploymentFailureStage,
+    code: DeploymentFailureCode,
+    /// Coarse pre-taxonomy value retained for telemetry consumers that already
+    /// group by `reason`.
+    legacy_reason: &'static str,
+}
+
+impl DeploymentFailureClassification {
+    const fn new(
+        stage: DeploymentFailureStage,
+        code: DeploymentFailureCode,
+        legacy_reason: &'static str,
+    ) -> Self {
+        Self {
+            stage,
+            code,
+            legacy_reason,
+        }
+    }
+}
+
+fn contains_any(reason: &str, signals: &[&str]) -> bool {
+    signals.iter().any(|signal| reason.contains(signal))
+}
+
+/// Classify a deployment's free-form failure reason locally into fixed,
+/// NON-identifying labels. The raw reason can contain secrets, source code,
+/// paths, repository names, and dependency names, so it must never leave the
+/// instance. Matching order is deliberately most-specific-first.
+fn classify_failure_reason(reason: Option<&str>) -> DeploymentFailureClassification {
     let Some(reason) = reason else {
-        return "unknown";
+        return DeploymentFailureClassification::new(
+            DeploymentFailureStage::Unknown,
+            DeploymentFailureCode::Unknown,
+            "unknown",
+        );
     };
     let r = reason.to_lowercase();
 
-    // Order matters: check the most specific signals first.
-    if r.contains("out of memory") || r.contains("oom") || r.contains("exit code 137") {
-        "oom"
-    } else if r.contains("timeout") || r.contains("timed out") || r.contains("deadline") {
-        "timeout"
-    } else if r.contains("health check") || r.contains("healthcheck") || r.contains("unhealthy") {
-        "health_check"
-    } else if r.contains("build") || r.contains("compile") || r.contains("nixpacks") {
-        "build_error"
-    } else if r.contains("clone")
-        || r.contains("network")
-        || r.contains("connection")
-        || r.contains("download")
-        || r.contains("dns")
+    if contains_any(&r, &["out of memory", "oomkilled", "exit code 137"]) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Resource,
+            DeploymentFailureCode::OutOfMemory,
+            "oom",
+        )
+    } else if contains_any(
+        &r,
+        &["no space left on device", "disk quota exceeded", "enospc"],
+    ) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Resource,
+            DeploymentFailureCode::DiskExhausted,
+            "unknown",
+        )
+    } else if contains_any(&r, &["health check", "healthcheck", "unhealthy"]) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::HealthCheck,
+            DeploymentFailureCode::HealthCheckFailed,
+            "health_check",
+        )
+    } else if contains_any(&r, &["timeout", "timed out", "deadline exceeded"]) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Platform,
+            DeploymentFailureCode::Timeout,
+            "timeout",
+        )
+    } else if contains_any(
+        &r,
+        &[
+            "authentication failed",
+            "could not read username",
+            "permission denied (publickey)",
+            "invalid credentials",
+        ],
+    ) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Source,
+            DeploymentFailureCode::RepositoryAuthentication,
+            "network",
+        )
+    } else if contains_any(&r, &["repository not found", "remote ref does not exist"]) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Source,
+            DeploymentFailureCode::RepositoryNotFound,
+            "network",
+        )
+    } else if contains_any(&r, &["failed to clone", "git clone", "clone task failed"]) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Source,
+            DeploymentFailureCode::RepositoryClone,
+            "network",
+        )
+    } else if contains_any(
+        &r,
+        &[
+            "could not resolve host",
+            "name or service not known",
+            "dns lookup failed",
+            "dns resolution",
+        ],
+    ) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Source,
+            DeploymentFailureCode::DnsResolution,
+            "network",
+        )
+    } else if contains_any(
+        &r,
+        &[
+            "err_pnpm_outdated_lockfile",
+            "frozen lockfile",
+            "lockfile is out of date",
+            "package-lock.json is not in sync",
+            "yarn.lock needs to be updated",
+        ],
+    ) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::DependencyInstall,
+            DeploymentFailureCode::DependencyLockfileOutOfSync,
+            "build_error",
+        )
+    } else if contains_any(
+        &r,
+        &[
+            "eresolve",
+            "could not resolve dependency",
+            "unable to resolve dependency tree",
+            "version solving failed",
+        ],
+    ) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::DependencyInstall,
+            DeploymentFailureCode::DependencyResolution,
+            "build_error",
+        )
+    } else if contains_any(
+        &r,
+        &[
+            "failed to download",
+            "error fetching packages",
+            "package download failed",
+            "registry request failed",
+        ],
+    ) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::DependencyInstall,
+            DeploymentFailureCode::DependencyDownload,
+            "network",
+        )
+    } else if contains_any(
+        &r,
+        &[
+            "ebadengine",
+            "unsupported engine",
+            "unsupported runtime",
+            "runtime version not found",
+            "no matching version found",
+        ],
+    ) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Configuration,
+            DeploymentFailureCode::RuntimeVersionUnsupported,
+            "build_error",
+        )
+    } else if contains_any(
+        &r,
+        &[
+            "missing script: build",
+            "command \"build\" not found",
+            "couldn't find a script named \"build\"",
+        ],
+    ) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Build,
+            DeploymentFailureCode::MissingBuildScript,
+            "build_error",
+        )
+    } else if contains_any(
+        &r,
+        &[
+            "compilation failed",
+            "failed to compile",
+            "syntax error",
+            "type error",
+            "typescript error",
+        ],
+    ) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Build,
+            DeploymentFailureCode::CompileError,
+            "build_error",
+        )
+    } else if r.contains("dockerfile")
+        && contains_any(
+            &r,
+            &["parse error", "invalid", "failed to read", "not found"],
+        )
     {
-        "network"
-    } else if r.contains("image")
-        && (r.contains("not found") || r.contains("missing") || r.contains("no such"))
-    {
-        "image_missing"
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Configuration,
+            DeploymentFailureCode::DockerfileInvalid,
+            "build_error",
+        )
+    } else if contains_any(
+        &r,
+        &[
+            "failed to pull image",
+            "pull access denied",
+            "manifest unknown",
+            "failed to resolve source metadata",
+        ],
+    ) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Image,
+            DeploymentFailureCode::BaseImagePull,
+            "network",
+        )
+    } else if r.contains("image") && contains_any(&r, &["not found", "missing", "no such image"]) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Image,
+            DeploymentFailureCode::ImageMissing,
+            "image_missing",
+        )
+    } else if contains_any(
+        &r,
+        &[
+            "static output directory not found",
+            "index.html not found",
+            "build output not found",
+        ],
+    ) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Build,
+            DeploymentFailureCode::StaticOutputMissing,
+            "build_error",
+        )
+    } else if contains_any(
+        &r,
+        &[
+            "address already in use",
+            "failed to find available port",
+            "no available port",
+        ],
+    ) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Deploy,
+            DeploymentFailureCode::PortUnavailable,
+            "unknown",
+        )
+    } else if contains_any(&r, &["permission denied", "operation not permitted"]) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Platform,
+            DeploymentFailureCode::PermissionDenied,
+            "unknown",
+        )
+    } else if contains_any(
+        &r,
+        &[
+            "failed to parse .temps.yaml",
+            "invalid configuration",
+            "configuration validation failed",
+        ],
+    ) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Configuration,
+            DeploymentFailureCode::InvalidConfiguration,
+            "unknown",
+        )
+    } else if contains_any(
+        &r,
+        &[
+            "failed to start container",
+            "container failed to start",
+            "container exited before",
+        ],
+    ) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Runtime,
+            DeploymentFailureCode::ContainerStart,
+            "unknown",
+        )
+    } else if contains_any(
+        &r,
+        &["connection refused", "connection reset", "network error"],
+    ) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Platform,
+            DeploymentFailureCode::NetworkConnection,
+            "network",
+        )
+    } else if contains_any(&r, &["build failed", "build error", "compile", "nixpacks"]) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Build,
+            DeploymentFailureCode::BuildError,
+            "build_error",
+        )
     } else if r.contains("cancel") {
-        "cancelled"
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Platform,
+            DeploymentFailureCode::Cancelled,
+            "cancelled",
+        )
+    } else if contains_any(
+        &r,
+        &[
+            "workflow execution failed",
+            "internal error",
+            "job validation failed",
+        ],
+    ) {
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Platform,
+            DeploymentFailureCode::PlatformInternal,
+            "unknown",
+        )
     } else {
-        "unknown"
+        DeploymentFailureClassification::new(
+            DeploymentFailureStage::Unknown,
+            DeploymentFailureCode::Unknown,
+            "unknown",
+        )
     }
+}
+
+fn deploy_failed_telemetry_event(
+    reason: Option<&str>,
+    source_type: Option<String>,
+    preset: Option<String>,
+    template_slug: Option<String>,
+) -> temps_core::telemetry::TelemetryEvent {
+    let failure = classify_failure_reason(reason);
+    let is_template = template_slug.is_some();
+    temps_core::telemetry::TelemetryEvent::new(
+        temps_core::telemetry::TelemetryEventKind::DeployFailed,
+    )
+    .with("reason", failure.legacy_reason)
+    .with("failure_stage", failure.stage.as_str())
+    .with("failure_code", failure.code.as_str())
+    .with("classifier_version", FAILURE_CLASSIFIER_VERSION)
+    .with_opt("source_type", source_type)
+    .with_opt("preset", preset)
+    .with("is_template", is_template)
+    .with_opt("template_slug", template_slug)
 }
 
 /// Service for executing deployment workflows
@@ -192,7 +604,9 @@ impl WorkflowExecutionService {
                 "preset",
                 temps_presets::runtime_slug(project.preset, project.preset_config.as_ref()),
             )
-            .with("is_preview", environment.is_preview),
+            .with("is_preview", environment.is_preview)
+            .with("is_template", project.template_slug.is_some())
+            .with_opt("template_slug", project.template_slug.clone()),
         );
 
         // Load all jobs for this deployment
@@ -322,7 +736,9 @@ impl WorkflowExecutionService {
                         "preset",
                         temps_presets::runtime_slug(project.preset, project.preset_config.as_ref()),
                     )
-                    .with("is_preview", environment.is_preview),
+                    .with("is_preview", environment.is_preview)
+                    .with("is_template", project.template_slug.is_some())
+                    .with_opt("template_slug", project.template_slug.clone()),
                 );
                 // Once-per-instance: "this instance shipped its first deploy".
                 telemetry.report_once(
@@ -334,7 +750,9 @@ impl WorkflowExecutionService {
                     .with(
                         "preset",
                         temps_presets::runtime_slug(project.preset, project.preset_config.as_ref()),
-                    ),
+                    )
+                    .with("is_template", project.template_slug.is_some())
+                    .with_opt("template_slug", project.template_slug.clone()),
                 );
 
                 // NOW teardown previous deployment for zero-downtime deployment
@@ -1909,7 +2327,7 @@ impl WorkflowExecutionService {
         // type the deploy used. That's what lets us see *which* presets fail
         // most, not just the overall failure rate. (Success telemetry is
         // emitted in execute_deployment_workflow, not here.)
-        let (telemetry_source_type, telemetry_preset) =
+        let (telemetry_source_type, telemetry_preset, telemetry_template_slug) =
             match projects::Entity::find_by_id(updated_deployment.project_id)
                 .one(self.db.as_ref())
                 .await
@@ -1920,8 +2338,9 @@ impl WorkflowExecutionService {
                         p.preset,
                         p.preset_config.as_ref(),
                     )),
+                    p.template_slug,
                 ),
-                _ => (None, None),
+                _ => (None, None, None),
             };
 
         match status {
@@ -2001,20 +2420,15 @@ impl WorkflowExecutionService {
 
                 // Anonymous telemetry: terminal failure point. The raw
                 // `cancelled_reason` may contain build logs / paths / repo
-                // names, so it is NEVER sent — only a coarse category label.
-                // preset/source_type are included so we can see which build
-                // types fail most (e.g. "nixpacks deploys OOM 3x more often").
-                self.telemetry().report(
-                    temps_core::telemetry::TelemetryEvent::new(
-                        temps_core::telemetry::TelemetryEventKind::DeployFailed,
-                    )
-                    .with(
-                        "reason",
-                        categorize_failure_reason(cancelled_reason.as_deref()),
-                    )
-                    .with_opt("source_type", telemetry_source_type.clone())
-                    .with_opt("preset", telemetry_preset.clone()),
-                );
+                // names, so it is NEVER sent — only fixed allowlisted stage,
+                // code, and legacy category labels. preset/source_type are
+                // included so we can compare failure rates by build type.
+                self.telemetry().report(deploy_failed_telemetry_event(
+                    cancelled_reason.as_deref(),
+                    telemetry_source_type.clone(),
+                    telemetry_preset.clone(),
+                    telemetry_template_slug.clone(),
+                ));
             }
             temps_entities::types::PipelineStatus::Cancelled => {
                 let event = Job::DeploymentCancelled(temps_core::DeploymentCancelledJob {
@@ -2416,6 +2830,194 @@ mod tests {
     use temps_database::test_utils::TestDatabase;
     use temps_entities::{preset::Preset, types::JobStatus, upstream_config::UpstreamList};
 
+    #[test]
+    fn failure_classifier_maps_specific_errors_to_allowlisted_stage_and_code() {
+        let cases = [
+            (
+                "process was OOMKilled (exit code 137)",
+                DeploymentFailureStage::Resource,
+                DeploymentFailureCode::OutOfMemory,
+            ),
+            (
+                "write failed: no space left on device",
+                DeploymentFailureStage::Resource,
+                DeploymentFailureCode::DiskExhausted,
+            ),
+            (
+                "workflow deadline exceeded",
+                DeploymentFailureStage::Platform,
+                DeploymentFailureCode::Timeout,
+            ),
+            (
+                "application health check timed out",
+                DeploymentFailureStage::HealthCheck,
+                DeploymentFailureCode::HealthCheckFailed,
+            ),
+            (
+                "authentication failed while fetching repository",
+                DeploymentFailureStage::Source,
+                DeploymentFailureCode::RepositoryAuthentication,
+            ),
+            (
+                "repository not found",
+                DeploymentFailureStage::Source,
+                DeploymentFailureCode::RepositoryNotFound,
+            ),
+            (
+                "Git clone task failed",
+                DeploymentFailureStage::Source,
+                DeploymentFailureCode::RepositoryClone,
+            ),
+            (
+                "could not resolve host: example.invalid",
+                DeploymentFailureStage::Source,
+                DeploymentFailureCode::DnsResolution,
+            ),
+            (
+                "connection refused by build service",
+                DeploymentFailureStage::Platform,
+                DeploymentFailureCode::NetworkConnection,
+            ),
+            (
+                "ERR_PNPM_OUTDATED_LOCKFILE Cannot install with frozen lockfile",
+                DeploymentFailureStage::DependencyInstall,
+                DeploymentFailureCode::DependencyLockfileOutOfSync,
+            ),
+            (
+                "npm ERR! ERESOLVE unable to resolve dependency tree",
+                DeploymentFailureStage::DependencyInstall,
+                DeploymentFailureCode::DependencyResolution,
+            ),
+            (
+                "registry request failed while fetching packages",
+                DeploymentFailureStage::DependencyInstall,
+                DeploymentFailureCode::DependencyDownload,
+            ),
+            (
+                "npm ERR! code EBADENGINE Unsupported engine",
+                DeploymentFailureStage::Configuration,
+                DeploymentFailureCode::RuntimeVersionUnsupported,
+            ),
+            (
+                "npm error Missing script: build",
+                DeploymentFailureStage::Build,
+                DeploymentFailureCode::MissingBuildScript,
+            ),
+            (
+                "TypeScript error: failed to compile",
+                DeploymentFailureStage::Build,
+                DeploymentFailureCode::CompileError,
+            ),
+            (
+                "Dockerfile parse error on line 4",
+                DeploymentFailureStage::Configuration,
+                DeploymentFailureCode::DockerfileInvalid,
+            ),
+            (
+                "pull access denied for private/base-image",
+                DeploymentFailureStage::Image,
+                DeploymentFailureCode::BaseImagePull,
+            ),
+            (
+                "built image not found",
+                DeploymentFailureStage::Image,
+                DeploymentFailureCode::ImageMissing,
+            ),
+            (
+                "static output directory not found",
+                DeploymentFailureStage::Build,
+                DeploymentFailureCode::StaticOutputMissing,
+            ),
+            (
+                "failed to find available port",
+                DeploymentFailureStage::Deploy,
+                DeploymentFailureCode::PortUnavailable,
+            ),
+            (
+                "operation not permitted while creating build directory",
+                DeploymentFailureStage::Platform,
+                DeploymentFailureCode::PermissionDenied,
+            ),
+            (
+                "failed to parse .temps.yaml: invalid field",
+                DeploymentFailureStage::Configuration,
+                DeploymentFailureCode::InvalidConfiguration,
+            ),
+            (
+                "failed to start container",
+                DeploymentFailureStage::Runtime,
+                DeploymentFailureCode::ContainerStart,
+            ),
+            (
+                "Nixpacks build failed",
+                DeploymentFailureStage::Build,
+                DeploymentFailureCode::BuildError,
+            ),
+            (
+                "workflow execution failed before scheduling",
+                DeploymentFailureStage::Platform,
+                DeploymentFailureCode::PlatformInternal,
+            ),
+            (
+                "deployment cancelled by workflow",
+                DeploymentFailureStage::Platform,
+                DeploymentFailureCode::Cancelled,
+            ),
+        ];
+
+        for (message, expected_stage, expected_code) in cases {
+            let classification = classify_failure_reason(Some(message));
+            assert_eq!(classification.stage, expected_stage, "message: {message}");
+            assert_eq!(classification.code, expected_code, "message: {message}");
+        }
+    }
+
+    #[test]
+    fn deploy_failed_telemetry_never_copies_sensitive_failure_input() {
+        let sensitive = "Build failed in /srv/repos/acme-secret with token ghp_private123";
+        let event = deploy_failed_telemetry_event(
+            Some(sensitive),
+            Some("git".to_string()),
+            Some("nextjs".to_string()),
+            Some("observability-starter".to_string()),
+        );
+        let serialized = serde_json::to_string(&event).expect("telemetry event serializes");
+
+        assert_eq!(event.event_type, "deploy_failed");
+        assert_eq!(event.properties["failure_stage"], "build");
+        assert_eq!(event.properties["failure_code"], "build_error");
+        assert_eq!(event.properties["classifier_version"], 1);
+        assert_eq!(event.properties["is_template"], true);
+        assert_eq!(event.properties["template_slug"], "observability-starter");
+        assert!(!serialized.contains("acme-secret"));
+        assert!(!serialized.contains("ghp_private123"));
+        assert!(!serialized.contains("/srv/repos"));
+
+        let regular_project_event = deploy_failed_telemetry_event(
+            Some("build failed"),
+            Some("git".to_string()),
+            Some("nextjs".to_string()),
+            None,
+        );
+        assert_eq!(regular_project_event.properties["is_template"], false);
+        assert!(!regular_project_event
+            .properties
+            .contains_key("template_slug"));
+    }
+
+    #[test]
+    fn failure_classifier_handles_missing_and_unrecognized_reasons() {
+        for reason in [
+            None,
+            Some("an entirely novel failure containing customer-data"),
+        ] {
+            let classification = classify_failure_reason(reason);
+            assert_eq!(classification.stage, DeploymentFailureStage::Unknown);
+            assert_eq!(classification.code, DeploymentFailureCode::Unknown);
+            assert_eq!(classification.legacy_reason, "unknown");
+        }
+    }
+
     // Mock services for testing
     struct MockGitProvider;
 
@@ -2777,6 +3379,7 @@ mod tests {
             repo_name: Set("test-repo".to_string()),
             git_provider_connection_id: Set(Some(1)),
             preset: Set(Preset::NextJs),
+            template_slug: Set(Some("observability-starter".to_string())),
             directory: Set("/".to_string()),
             main_branch: Set("main".to_string()),
             created_at: Set(Utc::now()),
@@ -3035,6 +3638,14 @@ mod tests {
             telemetry.has_event("deploy_attempted"),
             "deploy_attempted telemetry must fire for every workflow execution"
         );
+        let attempted = telemetry
+            .event("deploy_attempted")
+            .expect("deploy_attempted event must be captured");
+        assert_eq!(attempted.properties["is_template"], true);
+        assert_eq!(
+            attempted.properties["template_slug"],
+            "observability-starter"
+        );
 
         // Note: This might fail due to the mock implementations not being complete enough
         // But the structure should be correct
@@ -3090,6 +3701,15 @@ mod tests {
                 .expect("telemetry capture lock poisoned")
                 .iter()
                 .any(|e| e.event_type == event_type)
+        }
+
+        fn event(&self, event_type: &str) -> Option<temps_core::telemetry::TelemetryEvent> {
+            self.events
+                .lock()
+                .expect("telemetry capture lock poisoned")
+                .iter()
+                .find(|event| event.event_type == event_type)
+                .cloned()
         }
     }
 

--- a/crates/temps-deployments/src/services/workflow_execution_service.rs
+++ b/crates/temps-deployments/src/services/workflow_execution_service.rs
@@ -2910,6 +2910,13 @@ mod tests {
     use temps_database::test_utils::TestDatabase;
     use temps_entities::{preset::Preset, types::JobStatus, upstream_config::UpstreamList};
 
+    async fn docker_available() -> bool {
+        match bollard::Docker::connect_with_local_defaults() {
+            Ok(docker) => docker.ping().await.is_ok(),
+            Err(_) => false,
+        }
+    }
+
     #[test]
     fn failure_classifier_maps_specific_errors_to_allowlisted_stage_and_code() {
         let cases = [
@@ -3663,6 +3670,10 @@ mod tests {
     #[tokio::test]
     async fn test_execute_deployment_workflow_with_jobs() -> Result<(), Box<dyn std::error::Error>>
     {
+        if !docker_available().await {
+            println!("Docker not available, skipping");
+            return Ok(());
+        }
         let test_db = TestDatabase::with_migrations().await?;
         let db = test_db.connection_arc();
 
@@ -3763,6 +3774,10 @@ mod tests {
     #[tokio::test]
     async fn failed_status_path_sanitizes_operator_template_and_raw_reason(
     ) -> Result<(), Box<dyn std::error::Error>> {
+        if !docker_available().await {
+            println!("Docker not available, skipping");
+            return Ok(());
+        }
         let test_db = TestDatabase::with_migrations().await?;
         let db = test_db.connection_arc();
         let (project, _environment, deployment) = create_test_data(&db).await?;

--- a/crates/temps-deployments/src/services/workflow_execution_service.rs
+++ b/crates/temps-deployments/src/services/workflow_execution_service.rs
@@ -154,6 +154,72 @@ fn contains_any(reason: &str, signals: &[&str]) -> bool {
     signals.iter().any(|signal| reason.contains(signal))
 }
 
+/// Add bounded template context without allowing operator-defined template
+/// slugs to become identifying or high-cardinality outbound telemetry.
+fn with_template_telemetry(
+    event: temps_core::telemetry::TelemetryEvent,
+    template_slug: Option<&str>,
+) -> temps_core::telemetry::TelemetryEvent {
+    let safe_slug = template_slug.and_then(temps_core::templates::telemetry_safe_template_slug);
+    let template_source = match (template_slug, safe_slug) {
+        (None, _) => "none",
+        (Some(_), Some(_)) => "bundled",
+        (Some(_), None) => "custom",
+    };
+
+    event
+        .with("is_template", template_slug.is_some())
+        .with("template_source", template_source)
+        .with_opt("template_slug", safe_slug.map(str::to_string))
+}
+
+/// Preserve the pre-taxonomy `reason` wire value exactly for existing
+/// telemetry consumers. New stage/code matching may be more specific, but it
+/// must not silently change this compatibility dimension.
+fn legacy_failure_reason(reason: Option<&str>) -> &'static str {
+    let Some(reason) = reason else {
+        return "unknown";
+    };
+    let reason = reason.to_lowercase();
+
+    if reason.contains("out of memory")
+        || reason.contains("oom")
+        || reason.contains("exit code 137")
+    {
+        "oom"
+    } else if reason.contains("timeout")
+        || reason.contains("timed out")
+        || reason.contains("deadline")
+    {
+        "timeout"
+    } else if reason.contains("health check")
+        || reason.contains("healthcheck")
+        || reason.contains("unhealthy")
+    {
+        "health_check"
+    } else if reason.contains("build") || reason.contains("compile") || reason.contains("nixpacks")
+    {
+        "build_error"
+    } else if reason.contains("clone")
+        || reason.contains("network")
+        || reason.contains("connection")
+        || reason.contains("download")
+        || reason.contains("dns")
+    {
+        "network"
+    } else if reason.contains("image")
+        && (reason.contains("not found")
+            || reason.contains("missing")
+            || reason.contains("no such"))
+    {
+        "image_missing"
+    } else if reason.contains("cancel") {
+        "cancelled"
+    } else {
+        "unknown"
+    }
+}
+
 /// Classify a deployment's free-form failure reason locally into fixed,
 /// NON-identifying labels. The raw reason can contain secrets, source code,
 /// paths, repository names, and dependency names, so it must never leave the
@@ -168,288 +234,302 @@ fn classify_failure_reason(reason: Option<&str>) -> DeploymentFailureClassificat
     };
     let r = reason.to_lowercase();
 
-    if contains_any(&r, &["out of memory", "oomkilled", "exit code 137"]) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Resource,
-            DeploymentFailureCode::OutOfMemory,
-            "oom",
-        )
-    } else if contains_any(
-        &r,
-        &["no space left on device", "disk quota exceeded", "enospc"],
-    ) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Resource,
-            DeploymentFailureCode::DiskExhausted,
-            "unknown",
-        )
-    } else if contains_any(&r, &["health check", "healthcheck", "unhealthy"]) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::HealthCheck,
-            DeploymentFailureCode::HealthCheckFailed,
-            "health_check",
-        )
-    } else if contains_any(&r, &["timeout", "timed out", "deadline exceeded"]) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Platform,
-            DeploymentFailureCode::Timeout,
-            "timeout",
-        )
-    } else if contains_any(
-        &r,
-        &[
-            "authentication failed",
-            "could not read username",
-            "permission denied (publickey)",
-            "invalid credentials",
-        ],
-    ) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Source,
-            DeploymentFailureCode::RepositoryAuthentication,
-            "network",
-        )
-    } else if contains_any(&r, &["repository not found", "remote ref does not exist"]) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Source,
-            DeploymentFailureCode::RepositoryNotFound,
-            "network",
-        )
-    } else if contains_any(&r, &["failed to clone", "git clone", "clone task failed"]) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Source,
-            DeploymentFailureCode::RepositoryClone,
-            "network",
-        )
-    } else if contains_any(
-        &r,
-        &[
-            "could not resolve host",
-            "name or service not known",
-            "dns lookup failed",
-            "dns resolution",
-        ],
-    ) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Source,
-            DeploymentFailureCode::DnsResolution,
-            "network",
-        )
-    } else if contains_any(
-        &r,
-        &[
-            "err_pnpm_outdated_lockfile",
-            "frozen lockfile",
-            "lockfile is out of date",
-            "package-lock.json is not in sync",
-            "yarn.lock needs to be updated",
-        ],
-    ) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::DependencyInstall,
-            DeploymentFailureCode::DependencyLockfileOutOfSync,
-            "build_error",
-        )
-    } else if contains_any(
-        &r,
-        &[
-            "eresolve",
-            "could not resolve dependency",
-            "unable to resolve dependency tree",
-            "version solving failed",
-        ],
-    ) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::DependencyInstall,
-            DeploymentFailureCode::DependencyResolution,
-            "build_error",
-        )
-    } else if contains_any(
-        &r,
-        &[
-            "failed to download",
-            "error fetching packages",
-            "package download failed",
-            "registry request failed",
-        ],
-    ) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::DependencyInstall,
-            DeploymentFailureCode::DependencyDownload,
-            "network",
-        )
-    } else if contains_any(
-        &r,
-        &[
-            "ebadengine",
-            "unsupported engine",
-            "unsupported runtime",
-            "runtime version not found",
-            "no matching version found",
-        ],
-    ) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Configuration,
-            DeploymentFailureCode::RuntimeVersionUnsupported,
-            "build_error",
-        )
-    } else if contains_any(
-        &r,
-        &[
-            "missing script: build",
-            "command \"build\" not found",
-            "couldn't find a script named \"build\"",
-        ],
-    ) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Build,
-            DeploymentFailureCode::MissingBuildScript,
-            "build_error",
-        )
-    } else if contains_any(
-        &r,
-        &[
-            "compilation failed",
-            "failed to compile",
-            "syntax error",
-            "type error",
-            "typescript error",
-        ],
-    ) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Build,
-            DeploymentFailureCode::CompileError,
-            "build_error",
-        )
-    } else if r.contains("dockerfile")
-        && contains_any(
+    let classification =
+        if contains_any(&r, &["out of memory", "oom", "oomkilled", "exit code 137"]) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Resource,
+                DeploymentFailureCode::OutOfMemory,
+                "oom",
+            )
+        } else if contains_any(
             &r,
-            &["parse error", "invalid", "failed to read", "not found"],
-        )
-    {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Configuration,
-            DeploymentFailureCode::DockerfileInvalid,
-            "build_error",
-        )
-    } else if contains_any(
-        &r,
-        &[
-            "failed to pull image",
-            "pull access denied",
-            "manifest unknown",
-            "failed to resolve source metadata",
-        ],
-    ) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Image,
-            DeploymentFailureCode::BaseImagePull,
-            "network",
-        )
-    } else if r.contains("image") && contains_any(&r, &["not found", "missing", "no such image"]) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Image,
-            DeploymentFailureCode::ImageMissing,
-            "image_missing",
-        )
-    } else if contains_any(
-        &r,
-        &[
-            "static output directory not found",
-            "index.html not found",
-            "build output not found",
-        ],
-    ) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Build,
-            DeploymentFailureCode::StaticOutputMissing,
-            "build_error",
-        )
-    } else if contains_any(
-        &r,
-        &[
-            "address already in use",
-            "failed to find available port",
-            "no available port",
-        ],
-    ) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Deploy,
-            DeploymentFailureCode::PortUnavailable,
-            "unknown",
-        )
-    } else if contains_any(&r, &["permission denied", "operation not permitted"]) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Platform,
-            DeploymentFailureCode::PermissionDenied,
-            "unknown",
-        )
-    } else if contains_any(
-        &r,
-        &[
-            "failed to parse .temps.yaml",
-            "invalid configuration",
-            "configuration validation failed",
-        ],
-    ) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Configuration,
-            DeploymentFailureCode::InvalidConfiguration,
-            "unknown",
-        )
-    } else if contains_any(
-        &r,
-        &[
-            "failed to start container",
-            "container failed to start",
-            "container exited before",
-        ],
-    ) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Runtime,
-            DeploymentFailureCode::ContainerStart,
-            "unknown",
-        )
-    } else if contains_any(
-        &r,
-        &["connection refused", "connection reset", "network error"],
-    ) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Platform,
-            DeploymentFailureCode::NetworkConnection,
-            "network",
-        )
-    } else if contains_any(&r, &["build failed", "build error", "compile", "nixpacks"]) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Build,
-            DeploymentFailureCode::BuildError,
-            "build_error",
-        )
-    } else if r.contains("cancel") {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Platform,
-            DeploymentFailureCode::Cancelled,
-            "cancelled",
-        )
-    } else if contains_any(
-        &r,
-        &[
-            "workflow execution failed",
-            "internal error",
-            "job validation failed",
-        ],
-    ) {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Platform,
-            DeploymentFailureCode::PlatformInternal,
-            "unknown",
-        )
-    } else {
-        DeploymentFailureClassification::new(
-            DeploymentFailureStage::Unknown,
-            DeploymentFailureCode::Unknown,
-            "unknown",
-        )
+            &["no space left on device", "disk quota exceeded", "enospc"],
+        ) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Resource,
+                DeploymentFailureCode::DiskExhausted,
+                "unknown",
+            )
+        } else if contains_any(&r, &["health check", "healthcheck", "unhealthy"]) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::HealthCheck,
+                DeploymentFailureCode::HealthCheckFailed,
+                "health_check",
+            )
+        } else if contains_any(&r, &["timeout", "timed out", "deadline"]) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Platform,
+                DeploymentFailureCode::Timeout,
+                "timeout",
+            )
+        } else if contains_any(
+            &r,
+            &[
+                "authentication failed",
+                "could not read username",
+                "permission denied (publickey)",
+                "invalid credentials",
+            ],
+        ) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Source,
+                DeploymentFailureCode::RepositoryAuthentication,
+                "network",
+            )
+        } else if contains_any(&r, &["repository not found", "remote ref does not exist"]) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Source,
+                DeploymentFailureCode::RepositoryNotFound,
+                "network",
+            )
+        } else if contains_any(&r, &["failed to clone", "git clone", "clone task failed"]) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Source,
+                DeploymentFailureCode::RepositoryClone,
+                "network",
+            )
+        } else if contains_any(
+            &r,
+            &[
+                "could not resolve host",
+                "name or service not known",
+                "dns lookup failed",
+                "dns resolution",
+            ],
+        ) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Source,
+                DeploymentFailureCode::DnsResolution,
+                "network",
+            )
+        } else if contains_any(
+            &r,
+            &[
+                "err_pnpm_outdated_lockfile",
+                "frozen lockfile",
+                "lockfile is out of date",
+                "package-lock.json is not in sync",
+                "yarn.lock needs to be updated",
+            ],
+        ) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::DependencyInstall,
+                DeploymentFailureCode::DependencyLockfileOutOfSync,
+                "build_error",
+            )
+        } else if contains_any(
+            &r,
+            &[
+                "eresolve",
+                "could not resolve dependency",
+                "unable to resolve dependency tree",
+                "version solving failed",
+            ],
+        ) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::DependencyInstall,
+                DeploymentFailureCode::DependencyResolution,
+                "build_error",
+            )
+        } else if contains_any(
+            &r,
+            &[
+                "failed to download",
+                "error fetching packages",
+                "package download failed",
+                "registry request failed",
+            ],
+        ) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::DependencyInstall,
+                DeploymentFailureCode::DependencyDownload,
+                "network",
+            )
+        } else if contains_any(
+            &r,
+            &[
+                "ebadengine",
+                "unsupported engine",
+                "unsupported runtime",
+                "runtime version not found",
+                "no matching version found",
+            ],
+        ) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Configuration,
+                DeploymentFailureCode::RuntimeVersionUnsupported,
+                "build_error",
+            )
+        } else if contains_any(
+            &r,
+            &[
+                "missing script: build",
+                "command \"build\" not found",
+                "couldn't find a script named \"build\"",
+            ],
+        ) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Build,
+                DeploymentFailureCode::MissingBuildScript,
+                "build_error",
+            )
+        } else if contains_any(
+            &r,
+            &[
+                "compilation failed",
+                "failed to compile",
+                "syntax error",
+                "type error",
+                "typescript error",
+            ],
+        ) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Build,
+                DeploymentFailureCode::CompileError,
+                "build_error",
+            )
+        } else if r.contains("dockerfile")
+            && contains_any(
+                &r,
+                &["parse error", "invalid", "failed to read", "not found"],
+            )
+        {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Configuration,
+                DeploymentFailureCode::DockerfileInvalid,
+                "build_error",
+            )
+        } else if contains_any(
+            &r,
+            &[
+                "failed to pull image",
+                "pull access denied",
+                "manifest unknown",
+                "failed to resolve source metadata",
+            ],
+        ) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Image,
+                DeploymentFailureCode::BaseImagePull,
+                "network",
+            )
+        } else if r.contains("image")
+            && contains_any(&r, &["not found", "missing", "no such image"])
+        {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Image,
+                DeploymentFailureCode::ImageMissing,
+                "image_missing",
+            )
+        } else if contains_any(
+            &r,
+            &[
+                "static output directory not found",
+                "index.html not found",
+                "build output not found",
+            ],
+        ) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Build,
+                DeploymentFailureCode::StaticOutputMissing,
+                "build_error",
+            )
+        } else if contains_any(
+            &r,
+            &[
+                "address already in use",
+                "failed to find available port",
+                "no available port",
+            ],
+        ) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Deploy,
+                DeploymentFailureCode::PortUnavailable,
+                "unknown",
+            )
+        } else if contains_any(&r, &["permission denied", "operation not permitted"]) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Platform,
+                DeploymentFailureCode::PermissionDenied,
+                "unknown",
+            )
+        } else if contains_any(
+            &r,
+            &[
+                "failed to parse .temps.yaml",
+                "invalid configuration",
+                "configuration validation failed",
+            ],
+        ) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Configuration,
+                DeploymentFailureCode::InvalidConfiguration,
+                "unknown",
+            )
+        } else if contains_any(
+            &r,
+            &[
+                "failed to start container",
+                "container failed to start",
+                "container exited before",
+            ],
+        ) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Runtime,
+                DeploymentFailureCode::ContainerStart,
+                "unknown",
+            )
+        } else if contains_any(
+            &r,
+            &["connection refused", "connection reset", "network error"],
+        ) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Platform,
+                DeploymentFailureCode::NetworkConnection,
+                "network",
+            )
+        } else if contains_any(&r, &["build", "compile", "nixpacks"]) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Build,
+                DeploymentFailureCode::BuildError,
+                "build_error",
+            )
+        } else if contains_any(&r, &["clone", "network", "connection", "download", "dns"]) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Platform,
+                DeploymentFailureCode::NetworkConnection,
+                "network",
+            )
+        } else if r.contains("cancel") {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Platform,
+                DeploymentFailureCode::Cancelled,
+                "cancelled",
+            )
+        } else if contains_any(
+            &r,
+            &[
+                "workflow execution failed",
+                "internal error",
+                "job validation failed",
+            ],
+        ) {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Platform,
+                DeploymentFailureCode::PlatformInternal,
+                "unknown",
+            )
+        } else {
+            DeploymentFailureClassification::new(
+                DeploymentFailureStage::Unknown,
+                DeploymentFailureCode::Unknown,
+                "unknown",
+            )
+        };
+
+    DeploymentFailureClassification {
+        legacy_reason: legacy_failure_reason(Some(reason)),
+        ..classification
     }
 }
 
@@ -460,18 +540,18 @@ fn deploy_failed_telemetry_event(
     template_slug: Option<String>,
 ) -> temps_core::telemetry::TelemetryEvent {
     let failure = classify_failure_reason(reason);
-    let is_template = template_slug.is_some();
-    temps_core::telemetry::TelemetryEvent::new(
-        temps_core::telemetry::TelemetryEventKind::DeployFailed,
+    with_template_telemetry(
+        temps_core::telemetry::TelemetryEvent::new(
+            temps_core::telemetry::TelemetryEventKind::DeployFailed,
+        )
+        .with("reason", failure.legacy_reason)
+        .with("failure_stage", failure.stage.as_str())
+        .with("failure_code", failure.code.as_str())
+        .with("classifier_version", FAILURE_CLASSIFIER_VERSION)
+        .with_opt("source_type", source_type)
+        .with_opt("preset", preset),
+        template_slug.as_deref(),
     )
-    .with("reason", failure.legacy_reason)
-    .with("failure_stage", failure.stage.as_str())
-    .with("failure_code", failure.code.as_str())
-    .with("classifier_version", FAILURE_CLASSIFIER_VERSION)
-    .with_opt("source_type", source_type)
-    .with_opt("preset", preset)
-    .with("is_template", is_template)
-    .with_opt("template_slug", template_slug)
 }
 
 /// Service for executing deployment workflows
@@ -595,7 +675,7 @@ impl WorkflowExecutionService {
         // Anonymous telemetry: a deploy is now being attempted. This runs once
         // per deployment workflow. Properties are non-identifying enum labels
         // (source type, build preset) plus whether this is a preview env.
-        self.telemetry().report(
+        self.telemetry().report(with_template_telemetry(
             temps_core::telemetry::TelemetryEvent::new(
                 temps_core::telemetry::TelemetryEventKind::DeployAttempted,
             )
@@ -604,10 +684,9 @@ impl WorkflowExecutionService {
                 "preset",
                 temps_presets::runtime_slug(project.preset, project.preset_config.as_ref()),
             )
-            .with("is_preview", environment.is_preview)
-            .with("is_template", project.template_slug.is_some())
-            .with_opt("template_slug", project.template_slug.clone()),
-        );
+            .with("is_preview", environment.is_preview),
+            project.template_slug.as_deref(),
+        ));
 
         // Load all jobs for this deployment
         let db_jobs = self.get_deployment_jobs(deployment_id).await?;
@@ -727,7 +806,7 @@ impl WorkflowExecutionService {
                 // path (finalization bypasses it), so success must be emitted
                 // here to pair with the deploy_attempted event above.
                 let telemetry = self.telemetry();
-                telemetry.report(
+                telemetry.report(with_template_telemetry(
                     temps_core::telemetry::TelemetryEvent::new(
                         temps_core::telemetry::TelemetryEventKind::DeploySucceeded,
                     )
@@ -736,23 +815,26 @@ impl WorkflowExecutionService {
                         "preset",
                         temps_presets::runtime_slug(project.preset, project.preset_config.as_ref()),
                     )
-                    .with("is_preview", environment.is_preview)
-                    .with("is_template", project.template_slug.is_some())
-                    .with_opt("template_slug", project.template_slug.clone()),
-                );
+                    .with("is_preview", environment.is_preview),
+                    project.template_slug.as_deref(),
+                ));
                 // Once-per-instance: "this instance shipped its first deploy".
                 telemetry.report_once(
                     "first_deploy_succeeded",
-                    temps_core::telemetry::TelemetryEvent::new(
-                        temps_core::telemetry::TelemetryEventKind::FirstDeploySucceeded,
-                    )
-                    .with("source_type", project.source_type.to_string())
-                    .with(
-                        "preset",
-                        temps_presets::runtime_slug(project.preset, project.preset_config.as_ref()),
-                    )
-                    .with("is_template", project.template_slug.is_some())
-                    .with_opt("template_slug", project.template_slug.clone()),
+                    with_template_telemetry(
+                        temps_core::telemetry::TelemetryEvent::new(
+                            temps_core::telemetry::TelemetryEventKind::FirstDeploySucceeded,
+                        )
+                        .with("source_type", project.source_type.to_string())
+                        .with(
+                            "preset",
+                            temps_presets::runtime_slug(
+                                project.preset,
+                                project.preset_config.as_ref(),
+                            ),
+                        ),
+                        project.template_slug.as_deref(),
+                    ),
                 );
 
                 // NOW teardown previous deployment for zero-downtime deployment
@@ -2322,27 +2404,6 @@ impl WorkflowExecutionService {
                 ))
             })?;
 
-        // Non-identifying deploy labels for the failure telemetry below —
-        // best-effort lookup so deploy_failed can report which preset / source
-        // type the deploy used. That's what lets us see *which* presets fail
-        // most, not just the overall failure rate. (Success telemetry is
-        // emitted in execute_deployment_workflow, not here.)
-        let (telemetry_source_type, telemetry_preset, telemetry_template_slug) =
-            match projects::Entity::find_by_id(updated_deployment.project_id)
-                .one(self.db.as_ref())
-                .await
-            {
-                Ok(Some(p)) => (
-                    Some(p.source_type.to_string()),
-                    Some(temps_presets::runtime_slug(
-                        p.preset,
-                        p.preset_config.as_ref(),
-                    )),
-                    p.template_slug,
-                ),
-                _ => (None, None, None),
-            };
-
         match status {
             temps_entities::types::PipelineStatus::Completed => {
                 // Get deployment URL from environment: prefer custom host, fall back to preview domain
@@ -2402,6 +2463,25 @@ impl WorkflowExecutionService {
                 // gains a caller.
             }
             temps_entities::types::PipelineStatus::Failed => {
+                // Best-effort labels used only for failure telemetry. Keep the
+                // lookup inside this arm so other status transitions do not pay
+                // for an unrelated project query.
+                let (telemetry_source_type, telemetry_preset, telemetry_template_slug) =
+                    match projects::Entity::find_by_id(updated_deployment.project_id)
+                        .one(self.db.as_ref())
+                        .await
+                    {
+                        Ok(Some(project)) => (
+                            Some(project.source_type.to_string()),
+                            Some(temps_presets::runtime_slug(
+                                project.preset,
+                                project.preset_config.as_ref(),
+                            )),
+                            project.template_slug,
+                        ),
+                        _ => (None, None, None),
+                    };
+
                 let event = Job::DeploymentFailed(temps_core::DeploymentFailedJob {
                     deployment_id: updated_deployment.id,
                     project_id: updated_deployment.project_id,
@@ -2988,6 +3068,7 @@ mod tests {
         assert_eq!(event.properties["failure_code"], "build_error");
         assert_eq!(event.properties["classifier_version"], 1);
         assert_eq!(event.properties["is_template"], true);
+        assert_eq!(event.properties["template_source"], "bundled");
         assert_eq!(event.properties["template_slug"], "observability-starter");
         assert!(!serialized.contains("acme-secret"));
         assert!(!serialized.contains("ghp_private123"));
@@ -3000,9 +3081,53 @@ mod tests {
             None,
         );
         assert_eq!(regular_project_event.properties["is_template"], false);
+        assert_eq!(regular_project_event.properties["template_source"], "none");
         assert!(!regular_project_event
             .properties
             .contains_key("template_slug"));
+
+        let private_slug = "customer-acme-private-ghp_secret456";
+        let custom_template_event = deploy_failed_telemetry_event(
+            Some("build failed"),
+            Some("git".to_string()),
+            Some("nextjs".to_string()),
+            Some(private_slug.to_string()),
+        );
+        let serialized =
+            serde_json::to_string(&custom_template_event).expect("telemetry event serializes");
+        assert_eq!(custom_template_event.properties["is_template"], true);
+        assert_eq!(
+            custom_template_event.properties["template_source"],
+            "custom"
+        );
+        assert!(!custom_template_event
+            .properties
+            .contains_key("template_slug"));
+        assert!(!serialized.contains(private_slug));
+    }
+
+    #[test]
+    fn failure_classifier_preserves_legacy_reason_wire_values() {
+        let cases = [
+            ("OOM", "oom"),
+            ("deadline reached", "timeout"),
+            ("health check timed out", "timeout"),
+            ("healthcheck failed", "health_check"),
+            ("build command exited", "build_error"),
+            ("DNS error", "network"),
+            ("image not found", "image_missing"),
+            ("deployment cancelled", "cancelled"),
+            ("novel error", "unknown"),
+        ];
+
+        for (message, expected) in cases {
+            assert_eq!(legacy_failure_reason(Some(message)), expected);
+            assert_eq!(
+                classify_failure_reason(Some(message)).legacy_reason,
+                expected,
+                "message: {message}"
+            );
+        }
     }
 
     #[test]
@@ -3035,9 +3160,15 @@ mod tests {
             _connection_id: i32,
             _repo_owner: &str,
             _repo_name: &str,
-            _target_dir: &std::path::Path,
+            target_dir: &std::path::Path,
             _branch_or_ref: Option<&str>,
         ) -> Result<(), temps_git::GitProviderManagerError> {
+            tokio::fs::create_dir_all(target_dir)
+                .await
+                .map_err(|error| temps_git::GitProviderManagerError::Other(error.to_string()))?;
+            tokio::fs::write(target_dir.join("package.json"), b"{}")
+                .await
+                .map_err(|error| temps_git::GitProviderManagerError::Other(error.to_string()))?;
             Ok(())
         }
 
@@ -3557,41 +3688,6 @@ mod tests {
         };
         download_job.insert(db.as_ref()).await?;
 
-        let build_job = deployment_jobs::ActiveModel {
-            deployment_id: Set(deployment.id),
-            job_id: Set("build_image".to_string()),
-            job_type: Set("BuildImageJob".to_string()),
-            name: Set("Build Image".to_string()),
-            description: Set(Some("Build Docker image".to_string())),
-            status: Set(JobStatus::Pending),
-            log_id: Set(format!("deployment-{}-job-build_image", deployment.id)),
-            job_config: Set(Some(serde_json::json!({
-                "dockerfile_path": "Dockerfile"
-            }))),
-            dependencies: Set(Some(serde_json::json!(["download_repo"]))),
-            execution_order: Set(Some(1)),
-            ..Default::default()
-        };
-        build_job.insert(db.as_ref()).await?;
-
-        let deploy_job = deployment_jobs::ActiveModel {
-            deployment_id: Set(deployment.id),
-            job_id: Set("deploy_container".to_string()),
-            job_type: Set("DeployContainerJob".to_string()),
-            name: Set("Deploy Container".to_string()),
-            description: Set(Some("Deploy container".to_string())),
-            status: Set(JobStatus::Pending),
-            log_id: Set(format!("deployment-{}-job-deploy_container", deployment.id)),
-            job_config: Set(Some(serde_json::json!({
-                "port": 3000,
-                "replicas": 1
-            }))),
-            dependencies: Set(Some(serde_json::json!(["build_image"]))),
-            execution_order: Set(Some(2)),
-            ..Default::default()
-        };
-        deploy_job.insert(db.as_ref()).await?;
-
         let (queue, _receiver) = temps_queue::BroadcastQueueService::create_broadcast_channel(100);
         let queue = Arc::new(queue) as Arc<dyn temps_core::JobQueue>;
         let git_provider = Arc::new(MockGitProvider);
@@ -3630,8 +3726,12 @@ mod tests {
         let telemetry = Arc::new(CapturingTelemetryReporter::default());
         service.set_telemetry(telemetry.clone());
 
-        // Execute workflow - this will use mock services so should succeed
-        let result = service.execute_deployment_workflow(deployment.id).await;
+        // Execute workflow. This test is the terminal-success proof, so an
+        // unexpected mock failure must fail the test rather than being accepted.
+        service
+            .execute_deployment_workflow(deployment.id)
+            .await
+            .expect("mock deployment workflow must complete successfully");
 
         // deploy_attempted fires unconditionally once jobs are loaded.
         assert!(
@@ -3642,47 +3742,91 @@ mod tests {
             .event("deploy_attempted")
             .expect("deploy_attempted event must be captured");
         assert_eq!(attempted.properties["is_template"], true);
+        assert_eq!(attempted.properties["template_source"], "bundled");
         assert_eq!(
             attempted.properties["template_slug"],
             "observability-starter"
         );
 
-        // Note: This might fail due to the mock implementations not being complete enough
-        // But the structure should be correct
-        match result {
-            Ok(_) => {
-                // Success - verify deployment was updated
-                let updated_deployment = deployments::Entity::find_by_id(deployment.id)
-                    .one(db.as_ref())
-                    .await?
-                    .unwrap();
-
-                assert_eq!(updated_deployment.state, "deployed");
-                // Note: container_id field removed after workflow refactoring
-
-                // The success funnel events must fire on the Ok path — this is
-                // the only place they are emitted (MarkDeploymentCompleteJob
-                // bypasses update_deployment_status_with_reason on success).
-                assert!(
-                    telemetry.has_event("deploy_succeeded"),
-                    "deploy_succeeded telemetry must fire when the workflow completes"
-                );
-                assert!(
-                    telemetry.has_event("first_deploy_succeeded"),
-                    "first_deploy_succeeded telemetry must fire on the first successful deploy"
-                );
-            }
-            Err(e) => {
-                // Log error for debugging
-                eprintln!("Workflow execution error (expected in unit test): {}", e);
-                // In unit tests with mocks, some failures are expected — but a
-                // failed workflow must never report success.
-                assert!(
-                    !telemetry.has_event("deploy_succeeded"),
-                    "deploy_succeeded telemetry must not fire when the workflow fails"
-                );
-            }
+        for event_type in ["deploy_succeeded", "first_deploy_succeeded"] {
+            let event = telemetry
+                .event(event_type)
+                .unwrap_or_else(|| panic!("{event_type} event must be captured"));
+            assert_eq!(event.properties["is_template"], true);
+            assert_eq!(event.properties["template_source"], "bundled");
+            assert_eq!(event.properties["template_slug"], "observability-starter");
         }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn failed_status_path_sanitizes_operator_template_and_raw_reason(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+        let (project, _environment, deployment) = create_test_data(&db).await?;
+
+        let private_slug = "customer-acme-private-ghp_secret789";
+        let mut active_project: projects::ActiveModel = project.into();
+        active_project.template_slug = Set(Some(private_slug.to_string()));
+        active_project.update(db.as_ref()).await?;
+
+        let (queue, _receiver) = temps_queue::BroadcastQueueService::create_broadcast_channel(100);
+        let queue = Arc::new(queue) as Arc<dyn temps_core::JobQueue>;
+        let config_service = create_mock_config_service(db.clone());
+        let screenshot_service = Arc::new(ScreenshotService::new(config_service.clone()).await?);
+        let service = WorkflowExecutionService::new(
+            db.clone(),
+            queue,
+            Arc::new(MockGitProvider),
+            Arc::new(MockImageBuilder { should_fail: false }),
+            Arc::new(MockContainerDeployer { should_fail: false }),
+            Arc::new(MockStaticDeployer),
+            Arc::new(LogService::new(std::env::temp_dir())),
+            Arc::new(crate::jobs::NoOpCronConfigService) as Arc<dyn crate::jobs::CronConfigService>,
+            Arc::new(crate::jobs::NoOpMetricAlertConfigService)
+                as Arc<dyn crate::jobs::MetricAlertConfigService>,
+            Arc::new(crate::jobs::NoOpAgentSyncService) as Arc<dyn crate::jobs::AgentSyncService>,
+            config_service,
+            screenshot_service,
+            Arc::new(bollard::Docker::connect_with_local_defaults()?),
+        );
+        let telemetry = Arc::new(CapturingTelemetryReporter::default());
+        service.set_telemetry(telemetry.clone());
+
+        let sensitive_reason =
+            "Build failed in /srv/repos/acme-secret with token ghp_private_failure123";
+        service
+            .update_deployment_status_with_reason(
+                deployment.id,
+                temps_entities::types::PipelineStatus::Failed,
+                Some(sensitive_reason.to_string()),
+            )
+            .await?;
+
+        let event = telemetry
+            .event("deploy_failed")
+            .expect("real failed status path must report deploy_failed");
+        let serialized = serde_json::to_string(&event)?;
+        assert_eq!(event.properties["failure_stage"], "build");
+        assert_eq!(event.properties["failure_code"], "build_error");
+        assert_eq!(event.properties["is_template"], true);
+        assert_eq!(event.properties["template_source"], "custom");
+        assert!(!event.properties.contains_key("template_slug"));
+        for sensitive in [
+            private_slug,
+            "/srv/repos/acme-secret",
+            "ghp_private_failure123",
+        ] {
+            assert!(!serialized.contains(sensitive));
+        }
+
+        let failed_deployment = deployments::Entity::find_by_id(deployment.id)
+            .one(db.as_ref())
+            .await?
+            .expect("deployment row must exist");
+        assert_eq!(failed_deployment.state, "failed");
 
         Ok(())
     }

--- a/crates/temps-entities/src/projects.rs
+++ b/crates/temps-entities/src/projects.rs
@@ -83,6 +83,10 @@ pub struct Model {
     /// Defaults to 'git' for backward compatibility
     #[sea_orm(default_value = "git")]
     pub source_type: SourceType,
+    /// Public slug of the curated template this project was created from.
+    /// NULL means the project was not created through the template catalog.
+    #[serde(skip_serializing)]
+    pub template_slug: Option<String>,
     /// GitLab webhook ID returned by POST /projects/:id/hooks when we auto-install
     /// the webhook on repo connect. NULL when not connected to a GitLab repository.
     pub gitlab_webhook_id: Option<i32>,

--- a/crates/temps-entities/src/projects.rs
+++ b/crates/temps-entities/src/projects.rs
@@ -83,8 +83,9 @@ pub struct Model {
     /// Defaults to 'git' for backward compatibility
     #[sea_orm(default_value = "git")]
     pub source_type: SourceType,
-    /// Public slug of the curated template this project was created from.
-    /// NULL means the project was not created through the template catalog.
+    /// Bounded template provenance: a reviewed bundled slug or `custom`.
+    /// NULL means the project was not created through the template catalog;
+    /// operator-defined slugs are never stored in this field.
     #[serde(skip_serializing)]
     pub template_slug: Option<String>,
     /// GitLab webhook ID returned by POST /projects/:id/hooks when we auto-install

--- a/crates/temps-git/src/handlers/bitbucket.rs
+++ b/crates/temps-git/src/handlers/bitbucket.rs
@@ -410,6 +410,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             slug: format!("project-{id}"),
+            template_slug: None,
             is_deleted: false,
             deleted_at: None,
             last_deployment: None,

--- a/crates/temps-git/src/handlers/generic.rs
+++ b/crates/temps-git/src/handlers/generic.rs
@@ -365,6 +365,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             slug: format!("project-{id}"),
+            template_slug: None,
             is_deleted: false,
             deleted_at: None,
             last_deployment: None,

--- a/crates/temps-import-caprover/src/importer.rs
+++ b/crates/temps-import-caprover/src/importer.rs
@@ -1213,6 +1213,7 @@ async fn execute_plan(
         git_provider_connection_id: context.git_provider_connection_id,
         exposed_port: None,
         source_type: temps_entities::source_type::SourceType::Git,
+        template_slug: None,
     };
 
     let project = project_service

--- a/crates/temps-import-coolify/src/importer.rs
+++ b/crates/temps-import-coolify/src/importer.rs
@@ -1245,6 +1245,7 @@ async fn execute_plan(
         git_provider_connection_id: context.git_provider_connection_id,
         exposed_port: None,
         source_type: temps_entities::source_type::SourceType::Git,
+        template_slug: None,
     };
 
     let project = project_service

--- a/crates/temps-import-docker/src/importer.rs
+++ b/crates/temps-import-docker/src/importer.rs
@@ -668,6 +668,7 @@ impl WorkloadImporter for DockerImporter {
             git_provider_connection_id: context.git_provider_connection_id,
             exposed_port: None,
             source_type: temps_entities::source_type::SourceType::Git,
+            template_slug: None,
         };
 
         let project = project_service

--- a/crates/temps-import-dokploy/src/importer.rs
+++ b/crates/temps-import-dokploy/src/importer.rs
@@ -1224,6 +1224,7 @@ async fn execute_plan(
         git_provider_connection_id: context.git_provider_connection_id,
         exposed_port: None,
         source_type: temps_entities::source_type::SourceType::Git,
+        template_slug: None,
     };
 
     let project = project_service

--- a/crates/temps-import-kamal/src/importer.rs
+++ b/crates/temps-import-kamal/src/importer.rs
@@ -1130,6 +1130,7 @@ async fn execute_plan(
         // both misrepresents the project and made determine_deployment_source_type
         // try to plan a git deploy on any future redeploy with no metadata override).
         source_type: temps_entities::source_type::SourceType::DockerImage,
+        template_slug: None,
     };
 
     let project = project_service

--- a/crates/temps-import-kubernetes/src/importer.rs
+++ b/crates/temps-import-kubernetes/src/importer.rs
@@ -1930,6 +1930,7 @@ async fn execute_plan(
         // both misrepresents the project and made determine_deployment_source_type
         // try to plan a git deploy on any future redeploy with no metadata override).
         source_type: temps_entities::source_type::SourceType::DockerImage,
+        template_slug: None,
     };
 
     let project = project_service

--- a/crates/temps-import-portainer/src/importer.rs
+++ b/crates/temps-import-portainer/src/importer.rs
@@ -1096,6 +1096,7 @@ async fn execute_plan(
         // both misrepresents the project and made determine_deployment_source_type
         // try to plan a git deploy on any future redeploy with no metadata override).
         source_type: temps_entities::source_type::SourceType::DockerImage,
+        template_slug: None,
     };
 
     let project = project_service

--- a/crates/temps-migrations/src/migration/m20260803_000001_add_template_slug_to_projects.rs
+++ b/crates/temps-migrations/src/migration/m20260803_000001_add_template_slug_to_projects.rs
@@ -1,8 +1,9 @@
 //! Persist curated-template provenance on projects.
 //!
-//! The value is the public slug from the bundled template catalog. It lets
-//! deployment telemetry distinguish template activation from user projects
-//! without sending repository names, URLs, or other user-controlled text.
+//! The value is either a reviewed public slug from the bundled catalog or the
+//! fixed `custom` marker. It lets deployment telemetry distinguish bundled,
+//! custom-template, and ordinary projects without persisting or sending an
+//! operator-defined slug, repository name, URL, or other user-controlled text.
 
 use sea_orm_migration::prelude::*;
 

--- a/crates/temps-migrations/src/migration/m20260803_000001_add_template_slug_to_projects.rs
+++ b/crates/temps-migrations/src/migration/m20260803_000001_add_template_slug_to_projects.rs
@@ -1,0 +1,47 @@
+//! Persist curated-template provenance on projects.
+//!
+//! The value is the public slug from the bundled template catalog. It lets
+//! deployment telemetry distinguish template activation from user projects
+//! without sending repository names, URLs, or other user-controlled text.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Projects::Table)
+                    .add_column(
+                        ColumnDef::new(Projects::TemplateSlug)
+                            .string_len(255)
+                            .null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Projects::Table)
+                    .drop_column(Projects::TemplateSlug)
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Projects {
+    Table,
+    TemplateSlug,
+}

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -166,6 +166,7 @@ mod m20260725_000001_sandboxes_agent_run_link;
 mod m20260728_000001_add_environment_id_to_metric_alert_rules;
 mod m20260730_000001_add_architecture_to_nodes;
 mod m20260802_000001_add_environment_force_https;
+mod m20260803_000001_add_template_slug_to_projects;
 
 pub struct Migrator;
 
@@ -339,6 +340,7 @@ impl MigratorTrait for Migrator {
             ),
             Box::new(m20260730_000001_add_architecture_to_nodes::Migration),
             Box::new(m20260802_000001_add_environment_force_https::Migration),
+            Box::new(m20260803_000001_add_template_slug_to_projects::Migration),
         ]
     }
 }

--- a/crates/temps-notifications/src/vulnerability_notifications.rs
+++ b/crates/temps-notifications/src/vulnerability_notifications.rs
@@ -406,6 +406,7 @@ mod tests {
             id: 1,
             name: "My Project".to_string(),
             slug: "my-project".to_string(),
+            template_slug: None,
             repo_name: "my-repo".to_string(),
             repo_owner: "owner".to_string(),
             directory: "/".to_string(),

--- a/crates/temps-projects/src/handlers/handlers.rs
+++ b/crates/temps-projects/src/handlers/handlers.rs
@@ -1455,6 +1455,28 @@ fn parse_owner_repo_from_git_url(git_url: &str) -> (String, String) {
     }
 }
 
+fn project_created_from_template_telemetry_event(
+    template_slug: &str,
+    deploy_mode: &'static str,
+    service_count: usize,
+) -> temps_core::telemetry::TelemetryEvent {
+    let safe_slug = temps_core::templates::telemetry_safe_template_slug(template_slug);
+    temps_core::telemetry::TelemetryEvent::new(
+        temps_core::telemetry::TelemetryEventKind::ProjectCreatedFromTemplate,
+    )
+    .with(
+        "template_source",
+        if safe_slug.is_some() {
+            "bundled"
+        } else {
+            "custom"
+        },
+    )
+    .with_opt("template_slug", safe_slug.map(str::to_string))
+    .with("deploy_mode", deploy_mode)
+    .with("service_count", service_count as i64)
+}
+
 /// Create a new project from a template
 ///
 /// Creates a new repository from a template and sets up the project with the
@@ -1737,14 +1759,13 @@ pub async fn create_project_from_template(
         .with("source_type", project.source_type.to_string())
         .with_opt("preset", project.preset.clone()),
     );
-    state.telemetry.report(
-        temps_core::telemetry::TelemetryEvent::new(
-            temps_core::telemetry::TelemetryEventKind::ProjectCreatedFromTemplate,
-        )
-        .with("template_slug", request.template_slug.clone())
-        .with("deploy_mode", deploy_mode)
-        .with("service_count", request.storage_service_ids.len() as i64),
-    );
+    state
+        .telemetry
+        .report(project_created_from_template_telemetry_event(
+            &request.template_slug,
+            deploy_mode,
+            request.storage_service_ids.len(),
+        ));
 
     // 7. Return the response with the source/repository URL.
     let deploy_note = match deploy_mode {
@@ -1769,7 +1790,29 @@ pub async fn create_project_from_template(
 
 #[cfg(test)]
 mod tests {
-    use super::parse_owner_repo_from_git_url;
+    use super::{parse_owner_repo_from_git_url, project_created_from_template_telemetry_event};
+
+    #[test]
+    fn template_creation_telemetry_omits_operator_defined_slug() {
+        let private_slug = "customer-acme-private-ghp_secret123";
+        let event = project_created_from_template_telemetry_event(private_slug, "image", 2);
+        let serialized = serde_json::to_string(&event).expect("telemetry event serializes");
+
+        assert_eq!(event.properties["template_source"], "custom");
+        assert!(!event.properties.contains_key("template_slug"));
+        assert!(!serialized.contains(private_slug));
+        assert_eq!(event.properties["deploy_mode"], "image");
+        assert_eq!(event.properties["service_count"], 2);
+    }
+
+    #[test]
+    fn template_creation_telemetry_keeps_bundled_observability_slug() {
+        let event =
+            project_created_from_template_telemetry_event("observability-starter", "image", 1);
+
+        assert_eq!(event.properties["template_source"], "bundled");
+        assert_eq!(event.properties["template_slug"], "observability-starter");
+    }
 
     /// Regression test for ADR-028 finding #2: `get_project_by_slug` guard bypass.
     ///

--- a/crates/temps-projects/src/handlers/handlers.rs
+++ b/crates/temps-projects/src/handlers/handlers.rs
@@ -1392,7 +1392,6 @@ pub async fn get_project_template(
                 .with_title("Template Not Found")
                 .with_detail(e.to_string())
         })?;
-
     Ok(Json(super::templates::TemplateResponse::from(template)))
 }
 
@@ -1515,6 +1514,7 @@ pub async fn create_project_from_template(
                 .with_title("Template Not Found")
                 .with_detail(e.to_string())
         })?;
+    let template_provenance = temps_core::templates::template_provenance(&template).to_string();
 
     // 2. Build the environment variables from the request (shared by both modes).
     let env_vars: Option<Vec<(String, String)>> = if request.environment_variables.is_empty() {
@@ -1570,7 +1570,7 @@ pub async fn create_project_from_template(
             // docker_image source skips the build pipeline entirely; the deploy
             // is triggered explicitly below via Job::DeployImageRequested.
             source_type: SourceType::DockerImage,
-            template_slug: Some(request.template_slug.clone()),
+            template_slug: Some(template_provenance.clone()),
         };
         // Surface the template's source repo as the response URL (the image ref
         // isn't a browsable URL); the message clarifies it deployed from an image.
@@ -1639,7 +1639,7 @@ pub async fn create_project_from_template(
                     git_provider_connection_id: Some(connection_id),
                     exposed_port: None,
                     source_type: SourceType::Git,
-                    template_slug: Some(request.template_slug.clone()),
+                    template_slug: Some(template_provenance.clone()),
                 };
                 (req, new_repo.clone_url, "fork")
             }
@@ -1685,7 +1685,7 @@ pub async fn create_project_from_template(
                     git_provider_connection_id: None,
                     exposed_port: None,
                     source_type: SourceType::Git,
-                    template_slug: Some(request.template_slug.clone()),
+                    template_slug: Some(template_provenance.clone()),
                 };
                 (req, template.git.url.clone(), "public_repo")
             }
@@ -1762,7 +1762,7 @@ pub async fn create_project_from_template(
     state
         .telemetry
         .report(project_created_from_template_telemetry_event(
-            &request.template_slug,
+            &template_provenance,
             deploy_mode,
             request.storage_service_ids.len(),
         ));

--- a/crates/temps-projects/src/handlers/handlers.rs
+++ b/crates/temps-projects/src/handlers/handlers.rs
@@ -203,6 +203,7 @@ pub async fn create_project(
         git_provider_connection_id: project.git_provider_connection_id,
         exposed_port: project.exposed_port,
         source_type: project.source_type,
+        template_slug: None,
     };
 
     let new_project = state
@@ -407,6 +408,7 @@ pub async fn update_project(
         git_provider_connection_id: None,   // Keep existing setting
         exposed_port: project.exposed_port, // Keep existing or update if provided
         source_type: project.source_type,   // Preserve source type
+        template_slug: None,                // Template provenance is immutable
     };
     let updated_project = state
         .project_service
@@ -1546,6 +1548,7 @@ pub async fn create_project_from_template(
             // docker_image source skips the build pipeline entirely; the deploy
             // is triggered explicitly below via Job::DeployImageRequested.
             source_type: SourceType::DockerImage,
+            template_slug: Some(request.template_slug.clone()),
         };
         // Surface the template's source repo as the response URL (the image ref
         // isn't a browsable URL); the message clarifies it deployed from an image.
@@ -1614,6 +1617,7 @@ pub async fn create_project_from_template(
                     git_provider_connection_id: Some(connection_id),
                     exposed_port: None,
                     source_type: SourceType::Git,
+                    template_slug: Some(request.template_slug.clone()),
                 };
                 (req, new_repo.clone_url, "fork")
             }
@@ -1659,6 +1663,7 @@ pub async fn create_project_from_template(
                     git_provider_connection_id: None,
                     exposed_port: None,
                     source_type: SourceType::Git,
+                    template_slug: Some(request.template_slug.clone()),
                 };
                 (req, template.git.url.clone(), "public_repo")
             }

--- a/crates/temps-projects/src/services/project.rs
+++ b/crates/temps-projects/src/services/project.rs
@@ -270,6 +270,15 @@ impl ProjectService {
         &self,
         request: CreateProjectRequest,
     ) -> Result<Project, ProjectError> {
+        if request.template_slug.as_deref().is_some_and(|slug| {
+            slug.chars().count() > temps_core::templates::MAX_TEMPLATE_SLUG_CHARS
+        }) {
+            return Err(ProjectError::InvalidInput(format!(
+                "Template slug cannot exceed {} characters",
+                temps_core::templates::MAX_TEMPLATE_SLUG_CHARS
+            )));
+        }
+
         // Verify storage service IDs exist if provided
         if !request.storage_service_ids.is_empty() {
             use temps_entities::external_services;
@@ -3571,6 +3580,30 @@ mod tests {
             persisted.template_slug.as_deref(),
             Some("observability-starter")
         );
+    }
+
+    #[tokio::test]
+    async fn test_create_project_rejects_template_slug_longer_than_schema_limit() {
+        if !docker_available().await {
+            println!("Docker not available, skipping");
+            return;
+        }
+        let test_db = TestDatabase::with_migrations().await.unwrap();
+        let db = test_db.db.clone();
+        let mock_queue = Arc::new(MockJobQueue::new());
+        let project_service = create_test_services(db, mock_queue).await;
+        let mut request = create_request("Custom Template");
+        request.template_slug =
+            Some("x".repeat(temps_core::templates::MAX_TEMPLATE_SLUG_CHARS + 1));
+
+        let error = match project_service.create_project(request).await {
+            Ok(_) => panic!("oversized template slug must be rejected before insertion"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            ProjectError::InvalidInput(message) if message.contains("255")
+        ));
     }
 
     #[tokio::test]

--- a/crates/temps-projects/src/services/project.rs
+++ b/crates/temps-projects/src/services/project.rs
@@ -354,6 +354,7 @@ impl ProjectService {
             deleted_at: Set(None),
             last_deployment: Set(None),
             source_type: Set(request.source_type),
+            template_slug: Set(request.template_slug),
             ..Default::default()
         };
 
@@ -3303,6 +3304,7 @@ mod tests {
             is_public_repo: None,
             storage_service_ids: vec![],
             source_type: temps_entities::source_type::SourceType::Git,
+            template_slug: None,
         };
 
         let result = project_service
@@ -3437,6 +3439,7 @@ mod tests {
             git_provider_connection_id: None,
             exposed_port: None,
             source_type: temps_entities::source_type::SourceType::Git,
+            template_slug: None,
         };
 
         project_service
@@ -3487,6 +3490,7 @@ mod tests {
             is_public_repo: None,
             storage_service_ids: vec![],
             source_type: temps_entities::source_type::SourceType::Git,
+            template_slug: None,
         }
     }
 
@@ -3538,6 +3542,35 @@ mod tests {
             .deployment_config
             .expect("default environment should seed deployment_config");
         assert_eq!(env_config.memory_limit, Some(DEFAULT_MEMORY_LIMIT));
+    }
+
+    #[tokio::test]
+    async fn test_create_project_persists_curated_template_provenance() {
+        if !docker_available().await {
+            println!("Docker not available, skipping");
+            return;
+        }
+        let test_db = TestDatabase::with_migrations().await.unwrap();
+        let db = test_db.db.clone();
+        let mock_queue = Arc::new(MockJobQueue::new());
+        let project_service = create_test_services(db.clone(), mock_queue).await;
+        let mut request = create_request("Observability Starter");
+        request.template_slug = Some("observability-starter".to_string());
+
+        let created = project_service
+            .create_project(request)
+            .await
+            .expect("template project creation should succeed");
+        let persisted = projects::Entity::find_by_id(created.id)
+            .one(db.as_ref())
+            .await
+            .expect("template project query should succeed")
+            .expect("template project should exist");
+
+        assert_eq!(
+            persisted.template_slug.as_deref(),
+            Some("observability-starter")
+        );
     }
 
     #[tokio::test]

--- a/crates/temps-projects/src/services/types.rs
+++ b/crates/temps-projects/src/services/types.rs
@@ -108,8 +108,9 @@ pub struct CreateProjectRequest {
     /// Source type for deployments (git, docker_image, or static_files)
     #[serde(default)]
     pub source_type: SourceType,
-    /// Resolved public slug from the curated template catalog. Internal
-    /// provenance only; normal project-creation paths must leave this unset.
+    /// Bounded template provenance: a reviewed bundled slug or the fixed
+    /// `custom` marker. Internal only; normal project-creation paths leave it
+    /// unset and operator-defined slugs are never persisted here.
     #[serde(default)]
     pub template_slug: Option<String>,
 }

--- a/crates/temps-projects/src/services/types.rs
+++ b/crates/temps-projects/src/services/types.rs
@@ -108,6 +108,10 @@ pub struct CreateProjectRequest {
     /// Source type for deployments (git, docker_image, or static_files)
     #[serde(default)]
     pub source_type: SourceType,
+    /// Resolved public slug from the curated template catalog. Internal
+    /// provenance only; normal project-creation paths must leave this unset.
+    #[serde(default)]
+    pub template_slug: Option<String>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Description

Adds actionable, bounded deployment telemetry while keeping user-controlled build details and custom template identifiers local to the instance.

- Adds fixed `failure_stage` and `failure_code` dimensions; raw logs, paths, repository data, tokens, and free-form error text are never included.
- Preserves the existing coarse `reason` values exactly for compatibility and adds `classifier_version` for future taxonomy changes.
- Adds template context to deployment attempted, succeeded, failed, and first-success events.
- Emits the exact slug only when the selected template matches its fixed, reviewed bundled definition; external overrides and operator-defined templates are represented only as `template_source: "custom"`.
- Identifies the bundled observability template as `template_slug: "observability-starter"`.
- Leaves ordinary projects as `template_source: "none"` with no slug.
- Validates template slug length before persistence so it matches the existing `varchar(255)` project column.

Template provenance remains immutable through ordinary project updates and is not added to serialized project API responses.

## Type of change

- [x] Bug fix (privacy and compatibility hardening)
- [x] New feature (bounded telemetry dimensions)
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests cover success, failure, privacy, compatibility, and validation paths
- [x] Relevant new and existing crate tests pass
- [x] `cargo check --lib` and strict clippy complete without compiler/lint errors
- [x] Commits follow Conventional Commits
- [x] Migration/entity behavior is documented; no user-facing docs are required

## Evidence

**Real deployment success path**: the workflow must complete successfully and the captured attempted, succeeded, and first-success events all contain the bounded observability-template context.

```bash
cargo test --lib -p temps-deployments test_execute_deployment_workflow_with_jobs -- --nocapture
```

```text
test services::workflow_execution_service::tests::test_execute_deployment_workflow_with_jobs ... ok
test result: ok. 1 passed; 0 failed
```

**Real failure status path and privacy**: a failed deployment backed by PostgreSQL classifies a sensitive free-form build error while excluding the raw reason, path, token, and operator-defined template slug from serialized telemetry.

```bash
cargo test --lib -p temps-deployments failed_status_path_sanitizes_operator_template_and_raw_reason -- --nocapture
```

```text
test services::workflow_execution_service::tests::failed_status_path_sanitizes_operator_template_and_raw_reason ... ok
test result: ok. 1 passed; 0 failed
```

**Compatibility and template allowlist**: legacy `reason` values remain stable, the bundled catalog exactly matches the reviewed telemetry allowlist, and custom slugs are omitted.

```bash
cargo test --lib -p temps-deployments failure_classifier_preserves_legacy_reason_wire_values
cargo test --lib -p temps-core telemetry_slug_allowlist_exactly_matches_bundled_catalog
cargo test --lib -p temps-core external_override_reusing_bundled_slug_is_custom_provenance
cargo test --lib -p temps-projects template_creation_telemetry_omits_operator_defined_slug
```

```text
failure_classifier_preserves_legacy_reason_wire_values ... ok
telemetry_slug_allowlist_exactly_matches_bundled_catalog ... ok
external_override_reusing_bundled_slug_is_custom_provenance ... ok
template_creation_telemetry_omits_operator_defined_slug ... ok
```

**Full affected-crate suites**:

```bash
cargo test --lib -p temps-core
cargo test --lib -p temps-projects
cargo test --lib -p temps-deployments
```

```text
temps-core:        279 passed; 0 failed
temps-projects:     77 passed; 0 failed
temps-deployments: 523 passed; 0 failed; 3 ignored
```

**Migration apply and rollback**: the migration was applied by a live Temps instance against isolated database `temps_dev_s15`; PostgreSQL reported the nullable column, and the full migration chain reversed successfully in a disposable TimescaleDB container.

```bash
psql "$TEMPS_DATABASE_URL" -Atc "SELECT column_name || ':' || data_type || ':' || is_nullable FROM information_schema.columns WHERE table_schema='public' AND table_name='projects' AND column_name='template_slug';"
cargo test -p temps-migrations --test migration_tests test_migration_down -- --exact --nocapture
```

```text
template_slug:character varying:YES
cargo test: 1 passed, 12 filtered out (1 suite, 30.14s)
```

**Workspace checks**:

```bash
cargo check --lib
cargo clippy --all-targets --all-features -- -D warnings
git diff --check
```

```text
cargo check: 0 compiler errors
cargo clippy: 0 lint errors
git diff --check: clean
```

### Verification boundary

The telemetry path is integration-tested through real database persistence, actual workflow success/failure branches, event construction, serialization, and reporter capture. It was not sent to the production telemetry ingestion endpoint, avoiding contamination of production analytics.

Security review is required before merge because this changes the telemetry surface.

## Related issues

No linked issue.
