### PR TITLE
fix(deps): bump brace-expansion override to ^5.0.9 (GHSA-rgw5-rvv9-x895)

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -102,7 +102,7 @@
     },
   },
   "overrides": {
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "d3-color": "^3.1.0",
     "defu": "^6.1.5",
     "flatted": "^3.4.2",
@@ -625,7 +625,7 @@
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "browserslist": ["browserslist@4.26.3", "", { "dependencies": { "baseline-browser-mapping": "^2.8.9", "caniuse-lite": "^1.0.30001746", "electron-to-chromium": "^1.5.227", "node-releases": "^2.0.21", "update-browserslist-db": "^1.1.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -129,7 +129,7 @@
     "typescript-eslint": "^8.65.0"
   },
   "overrides": {
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "d3-color": "^3.1.0",
     "defu": "^6.1.5",
     "flatted": "^3.4.2",


### PR DESCRIPTION
## Problem

The **Web Dependency Audit (bun audit)** job fails on `main` and every PR branch (e.g. run for PR #486):

```
brace-expansion  >=4.0.0 <5.0.9
  eslint › @eslint/config-array › minimatch › brace-expansion
  eslint-plugin-react › minimatch › brace-expansion
  @typescript-eslint/parser › @typescript-eslint/typescript-estree › minimatch › brace-expansion
  ...
  high: brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation
        https://github.com/advisories/GHSA-rgw5-rvv9-x895
1 vulnerabilities (1 high)
Error: Process completed with exit code 1.
```

## Root cause

`web/package.json` already carried a `brace-expansion` override, but pinned at `^5.0.8`. `5.0.8` is the *last vulnerable* release — the advisory's fixed version is `5.0.9`. The lockfile resolved to exactly `5.0.8`, so the override was in place but one patch short.

The package is only reachable transitively via `minimatch` from the eslint / typescript-eslint dev dependencies.

## Fix

- `web/package.json`: `brace-expansion` override `^5.0.8` → `^5.0.9`
- `web/bun.lock`: refreshed (`brace-expansion@5.0.8` → `5.0.9`, single entry)

Consistent with the existing approach documented in `.github/workflows/dependency-scan.yml` — transitive advisories are fixed via `overrides`, not ignored (`bun audit --ignore` is non-functional in bun 1.3.14).

## Evidence

Before (on `origin/main`), the CI command exits 1 with the high finding above. After, in this branch:

```
$ cd web && bun install
725 packages installed [3.23s]

$ bun audit --audit-level=high
bun audit v1.3.14 (0d9b296a)
EXIT=0
```

Full audit (no level filter) shows only pre-existing low/moderate findings, which do not gate the job:

```
$ bun audit
@babel/core  <=7.29.0        (low)
dompurify    <=3.4.11        (1 moderate, 2 low)
4 vulnerabilities (1 moderate, 3 low)
```

## Scope check

Other lockfiles in the repo were checked and are unaffected — `sdks/node`, `examples/nextjs/basic`, `examples/nestjs/basic` and `examples/vite/react-basic` all resolve `brace-expansion` 1.1.12 / 2.0.2, outside the `>=4.0.0 <5.0.9` affected range. Only `web/` is audited by CI.

Diff is 2 files, 3 lines.