### PR TITLE
fix(web): advance traces time window on refresh and skip it for trace-id search

### DIFF
--- a/web/src/lib/traces-time-window.test.ts
+++ b/web/src/lib/traces-time-window.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  computeTracesTimeWindow,
+  tracesListTimeBounds,
+  type TracesTimeRange,
+} from './traces-time-window'
+
+const FIXED_NOW = new Date('2026-08-04T12:00:00.000Z')
+
+describe('computeTracesTimeWindow', () => {
+  const cases: Array<[TracesTimeRange, string]> = [
+    ['1h', '2026-08-04T11:00:00.000Z'],
+    ['6h', '2026-08-04T06:00:00.000Z'],
+    ['24h', '2026-08-03T12:00:00.000Z'],
+    ['7d', '2026-07-28T12:00:00.000Z'],
+    ['30d', '2026-07-05T12:00:00.000Z'],
+  ]
+
+  for (const [range, expectedStart] of cases) {
+    test(`${range} anchors start relative to now`, () => {
+      const window = computeTracesTimeWindow(range, FIXED_NOW)
+      expect(window.endTime).toBe(FIXED_NOW.toISOString())
+      expect(window.startTime).toBe(expectedStart)
+    })
+  }
+
+  test('a later now advances end_time (refresh contract)', () => {
+    const first = computeTracesTimeWindow('24h', FIXED_NOW)
+    const later = new Date('2026-08-04T12:05:00.000Z')
+    const second = computeTracesTimeWindow('24h', later)
+
+    expect(second.endTime).toBe(later.toISOString())
+    expect(second.endTime > first.endTime).toBe(true)
+    // Span ingested at 12:02 would miss first.end (12:00) but land in second.
+    const ingestedAt = '2026-08-04T12:02:00.000Z'
+    expect(ingestedAt > first.endTime).toBe(true)
+    expect(ingestedAt <= second.endTime).toBe(true)
+  })
+})
+
+describe('tracesListTimeBounds', () => {
+  const window = computeTracesTimeWindow('24h', FIXED_NOW)
+
+  test('applies the window when not searching by trace id', () => {
+    expect(tracesListTimeBounds(undefined, window)).toEqual({
+      start_time: window.startTime,
+      end_time: window.endTime,
+    })
+    expect(tracesListTimeBounds('', window)).toEqual({
+      start_time: window.startTime,
+      end_time: window.endTime,
+    })
+  })
+
+  test('omits the window when searching by trace id', () => {
+    expect(tracesListTimeBounds('abc123def456', window)).toEqual({
+      start_time: undefined,
+      end_time: undefined,
+    })
+  })
+})

--- a/web/src/lib/traces-time-window.ts
+++ b/web/src/lib/traces-time-window.ts
@@ -1,0 +1,54 @@
+export type TracesTimeRange = '1h' | '6h' | '24h' | '7d' | '30d'
+
+export type TracesTimeWindow = {
+  startTime: string
+  endTime: string
+}
+
+/**
+ * Relative time window for the Traces list.
+ *
+ * Callers that keep a page open must recompute against a fresh `now` (e.g. on
+ * Refresh) — freezing the window at mount filters out newly ingested spans.
+ */
+export function computeTracesTimeWindow(
+  timeRange: TracesTimeRange,
+  now: Date = new Date(),
+): TracesTimeWindow {
+  const start = new Date(now.getTime())
+  switch (timeRange) {
+    case '1h':
+      start.setHours(start.getHours() - 1)
+      break
+    case '6h':
+      start.setHours(start.getHours() - 6)
+      break
+    case '24h':
+      start.setDate(start.getDate() - 1)
+      break
+    case '7d':
+      start.setDate(start.getDate() - 7)
+      break
+    case '30d':
+      start.setDate(start.getDate() - 30)
+      break
+  }
+  return { startTime: start.toISOString(), endTime: now.toISOString() }
+}
+
+/**
+ * Query time bounds for the Traces list.
+ *
+ * When pinned to a trace ID, omit the window — same contract as LogsList. An
+ * exact ID is already specific, and a freshly ingested span can land after a
+ * frozen end_time on a long-lived page.
+ */
+export function tracesListTimeBounds(
+  traceIdSearch: string | undefined,
+  window: TracesTimeWindow,
+): { start_time?: string; end_time?: string } {
+  if (traceIdSearch) {
+    return { start_time: undefined, end_time: undefined }
+  }
+  return { start_time: window.startTime, end_time: window.endTime }
+}

--- a/web/src/pages/TracesList.tsx
+++ b/web/src/pages/TracesList.tsx
@@ -23,6 +23,11 @@ import { EmptyState } from '@/components/ui/empty-state'
 import { Input } from '@/components/ui/input'
 import { useDebounce } from '@/hooks/useDebounce'
 import {
+  computeTracesTimeWindow,
+  tracesListTimeBounds,
+  type TracesTimeRange,
+} from '@/lib/traces-time-window'
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -73,8 +78,6 @@ import { useNavigate, useSearchParams } from 'react-router'
 interface TracesListProps {
   project: ProjectResponse
 }
-
-type TimeRange = '1h' | '6h' | '24h' | '7d' | '30d'
 
 function statusBadge(status: SpanStatusCode) {
   switch (status) {
@@ -615,8 +618,8 @@ export default function TracesList({ project }: TracesListProps) {
   usePageTitle(`Traces - ${project.name}`)
 
   // State from URL params
-  const [timeRange, setTimeRange] = useState<TimeRange>(
-    () => (searchParams.get('range') as TimeRange) || '24h'
+  const [timeRange, setTimeRange] = useState<TracesTimeRange>(
+    () => (searchParams.get('range') as TracesTimeRange) || '24h'
   )
   const [serviceName, setServiceName] = useState(
     () => searchParams.get('service') || ''
@@ -659,29 +662,11 @@ export default function TracesList({ project }: TracesListProps) {
   // page reload — including exact trace-id searches that still AND the window.
   const [refreshKey, setRefreshKey] = useState(0)
 
-  // Compute time window
-  const { startTime, endTime } = useMemo(() => {
-    const now = new Date()
-    const start = new Date()
-    switch (timeRange) {
-      case '1h':
-        start.setHours(start.getHours() - 1)
-        break
-      case '6h':
-        start.setHours(start.getHours() - 6)
-        break
-      case '24h':
-        start.setDate(start.getDate() - 1)
-        break
-      case '7d':
-        start.setDate(start.getDate() - 7)
-        break
-      case '30d':
-        start.setDate(start.getDate() - 30)
-        break
-    }
-    return { startTime: start.toISOString(), endTime: now.toISOString() }
-  }, [timeRange, refreshKey])
+  // Compute time window (refreshKey forces a fresh "now" on Refresh)
+  const { startTime, endTime } = useMemo(
+    () => computeTracesTimeWindow(timeRange),
+    [timeRange, refreshKey],
+  )
 
   // Fetch environments for the filter dropdown
   const { data: environments } = useQuery({
@@ -753,16 +738,18 @@ export default function TracesList({ project }: TracesListProps) {
     ])
   }, [project.name, project.slug, setBreadcrumbs])
 
+  const timeBounds = tracesListTimeBounds(debouncedSearch || undefined, {
+    startTime,
+    endTime,
+  })
+
   // Fetch trace summaries (one row per trace, server-side aggregation)
   const { data, isLoading, isFetching, refetch } = useQuery({
     ...queryTraceSummariesOptions({
       query: {
         project_id: project.id,
-        // When pinned to a trace ID, ignore the time window — same contract as
-        // LogsList. An exact ID is already specific, and a freshly ingested
-        // span can land after the frozen end_time of a long-lived page.
-        start_time: debouncedSearch ? undefined : startTime,
-        end_time: debouncedSearch ? undefined : endTime,
+        start_time: timeBounds.start_time,
+        end_time: timeBounds.end_time,
         service_name: serviceName || undefined,
         status: status !== 'all' ? status : undefined,
         trace_id: debouncedSearch || undefined,
@@ -847,7 +834,7 @@ export default function TracesList({ project }: TracesListProps) {
 
   const handleTimeRangeChange = useCallback(
     (v: string) => {
-      setTimeRange(v as TimeRange)
+      setTimeRange(v as TracesTimeRange)
       setPage(1)
     },
     []

--- a/web/src/pages/TracesList.tsx
+++ b/web/src/pages/TracesList.tsx
@@ -653,6 +653,11 @@ export default function TracesList({ project }: TracesListProps) {
     searchParams.get('dir') === 'asc' ? 'asc' : 'desc',
   )
   const [showSetup, setShowSetup] = useState(false)
+  // Bumped by Refresh so relative ranges recompute against "now". Without
+  // this, start/end freeze at mount (or last range change) and newly ingested
+  // traces that land after that frozen end_time stay invisible until a full
+  // page reload — including exact trace-id searches that still AND the window.
+  const [refreshKey, setRefreshKey] = useState(0)
 
   // Compute time window
   const { startTime, endTime } = useMemo(() => {
@@ -676,7 +681,7 @@ export default function TracesList({ project }: TracesListProps) {
         break
     }
     return { startTime: start.toISOString(), endTime: now.toISOString() }
-  }, [timeRange])
+  }, [timeRange, refreshKey])
 
   // Fetch environments for the filter dropdown
   const { data: environments } = useQuery({
@@ -753,8 +758,11 @@ export default function TracesList({ project }: TracesListProps) {
     ...queryTraceSummariesOptions({
       query: {
         project_id: project.id,
-        start_time: startTime,
-        end_time: endTime,
+        // When pinned to a trace ID, ignore the time window — same contract as
+        // LogsList. An exact ID is already specific, and a freshly ingested
+        // span can land after the frozen end_time of a long-lived page.
+        start_time: debouncedSearch ? undefined : startTime,
+        end_time: debouncedSearch ? undefined : endTime,
         service_name: serviceName || undefined,
         status: status !== 'all' ? status : undefined,
         trace_id: debouncedSearch || undefined,
@@ -793,7 +801,11 @@ export default function TracesList({ project }: TracesListProps) {
   // expensive query on this page (measured at ~10s on an 860M-span project).
   // Asking for one row and checking whether we got it answers the same question
   // without computing a count nobody reads.
-  const { data: anyTraceData, isLoading: isProbeLoading } = useQuery({
+  const {
+    data: anyTraceData,
+    isLoading: isProbeLoading,
+    refetch: refetchProbe,
+  } = useQuery({
     ...queryTraceSummariesOptions({
       query: { project_id: project.id, limit: 1, include_total: false },
     }),
@@ -884,7 +896,15 @@ export default function TracesList({ project }: TracesListProps) {
           <Button
             variant="ghost"
             size="icon"
-            onClick={() => refetch()}
+            onClick={() => {
+              // Advance the relative window so list queries recompute against
+              // "now". Trace-id searches omit the window, so their query key
+              // does not change — refetch those explicitly. Also re-check the
+              // unwindowed "ever received a trace" probe.
+              setRefreshKey((k) => k + 1)
+              if (debouncedSearch) void refetch()
+              void refetchProbe()
+            }}
             disabled={isFetching}
           >
             <RefreshCw className={`h-4 w-4 ${isFetching ? 'animate-spin' : ''}`} />


### PR DESCRIPTION
## Description

Relative `start_time`/`end_time` on the Traces page froze at mount (or last range change). Newly ingested traces — including exact trace-id searches that still AND the time window — stayed invisible until a full page reload.

Fix:
- omit the time window when searching by trace ID (same contract as LogsList)
- advance the relative window (and re-check the unwindowed "ever received a trace" probe) on Refresh

Window/bound logic lives in `web/src/lib/traces-time-window.ts` with unit tests covering range anchors, refresh advancing `end_time`, and trace-id search omitting bounds (`bun test src/lib/traces-time-window.test.ts` — 8/8 pass). No Rust or OpenAPI changes.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have written tests that cover the changes
- [x] All new and existing tests pass (`cargo test --lib`)
- [x] `cargo check --lib` passes with no warnings
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have updated documentation where necessary

## Related issues

<!-- No linked issue. -->