### PR TITLE
fix(git): stop invisible connections from blocking provider deletion

### DIFF
--- a/crates/temps-git/src/handlers/base.rs
+++ b/crates/temps-git/src/handlers/base.rs
@@ -2480,9 +2480,12 @@ pub async fn get_provider_connections(
 ) -> Result<impl IntoResponse, Problem> {
     permission_check!(auth, Permission::GitConnectionsRead);
 
+    // Every connection under this provider, not just the caller's active ones:
+    // this list is what tells the user why a provider cannot be deleted, so a
+    // connection it hides is a dead end.
     let connections = state
         .git_provider_manager
-        .get_provider_connections(provider_id)
+        .get_all_provider_connections(provider_id)
         .await?;
 
     let response: Vec<ConnectionResponse> = connections

--- a/crates/temps-git/src/services/git_provider_manager.rs
+++ b/crates/temps-git/src/services/git_provider_manager.rs
@@ -3886,7 +3886,27 @@ impl GitProviderManager {
         )))
     }
 
-    /// Get all connections for a specific provider
+    /// Get every connection for a provider, regardless of owner or active state.
+    ///
+    /// Deletion checks must use this rather than [`Self::get_provider_connections`]:
+    /// a deactivated connection (or one owned by another user) still holds rows
+    /// that block or get cascaded by a provider delete, and counting only the
+    /// active ones produced errors referencing connections the caller could not
+    /// see anywhere in the UI.
+    pub async fn get_all_provider_connections(
+        &self,
+        provider_id: i32,
+    ) -> Result<Vec<git_provider_connections::Model>, GitProviderManagerError> {
+        let connections = git_provider_connections::Entity::find()
+            .filter(git_provider_connections::Column::ProviderId.eq(provider_id))
+            .order_by_desc(git_provider_connections::Column::CreatedAt)
+            .all(self.db.as_ref())
+            .await?;
+
+        Ok(connections)
+    }
+
+    /// Get the active connections for a specific provider
     pub async fn get_provider_connections(
         &self,
         provider_id: i32,
@@ -4136,30 +4156,16 @@ impl GitProviderManager {
         Ok(())
     }
 
-    /// Permanently delete a git provider (hard delete)
+    /// Permanently delete a git provider (hard delete).
+    ///
+    /// A provider is only blocked by *projects* that still depend on one of its
+    /// connections — never by the mere existence of a connection row. Connections
+    /// are listed per-user in the UI, so refusing on connection count made
+    /// providers permanently undeletable whenever the connection belonged to
+    /// another user, had no owner, or was deactivated: the error named a
+    /// connection the caller had no way to find or remove.
     pub async fn delete_provider(&self, provider_id: i32) -> Result<(), GitProviderManagerError> {
-        // Check if provider exists
-        let provider = self.get_provider(provider_id).await?;
-
-        // Check if any connections exist for this provider
-        let connections = self.get_provider_connections(provider_id).await?;
-        if !connections.is_empty() {
-            return Err(GitProviderManagerError::InvalidConfiguration(format!(
-                "Cannot delete provider {} because it has {} connection(s)",
-                provider.name,
-                connections.len()
-            )));
-        }
-
-        // Delete the provider
-        git_providers::Entity::delete_by_id(provider_id)
-            .exec(self.db.as_ref())
-            .await?;
-
-        // Remove from cache
-        self.providers_cache.write().await.remove(&provider_id);
-
-        Ok(())
+        self.delete_provider_safely(provider_id).await
     }
 
     /// Check if a provider can be safely deleted and return detailed usage information
@@ -4171,7 +4177,7 @@ impl GitProviderManager {
         let provider = self.get_provider(provider_id).await?;
 
         // Get all connections for this provider
-        let connections = self.get_provider_connections(provider_id).await?;
+        let connections = self.get_all_provider_connections(provider_id).await?;
 
         if connections.is_empty() {
             return Ok(ProviderDeletionCheck {
@@ -4251,7 +4257,7 @@ impl GitProviderManager {
         let provider = self.get_provider(provider_id).await?;
 
         // Get all connections to delete them along with the provider
-        let connections = self.get_provider_connections(provider_id).await?;
+        let connections = self.get_all_provider_connections(provider_id).await?;
 
         // Delete all repositories associated with these connections
         for connection in &connections {
@@ -4293,18 +4299,28 @@ impl GitProviderManager {
         // Check if connection exists
         self.get_connection(connection_id).await?;
 
-        // Check if connection is in use by any projects
-        let project_count = temps_entities::projects::Entity::find()
-            .filter(
-                temps_entities::projects::Column::GitProviderConnectionId.eq(Some(connection_id)),
-            )
-            .count(self.db.as_ref())
-            .await?;
+        // Check if connection is in use by any projects. Name them — "used by 2
+        // project(s)" leaves the user hunting through every project to work out
+        // which ones to disconnect first.
+        let projects: Vec<temps_entities::projects::Model> =
+            temps_entities::projects::Entity::find()
+                .filter(
+                    temps_entities::projects::Column::GitProviderConnectionId
+                        .eq(Some(connection_id)),
+                )
+                .all(self.db.as_ref())
+                .await?;
 
-        if project_count > 0 {
+        if !projects.is_empty() {
+            let project_names: Vec<String> = projects
+                .iter()
+                .map(|p| format!("'{}' (ID: {})", p.name, p.id))
+                .collect();
             return Err(GitProviderManagerError::InvalidConfiguration(format!(
-                "Cannot delete connection {} because it is used by {} project(s)",
-                connection_id, project_count
+                "Cannot delete connection {} because it is used by {} project(s): {}. Change the git source of those projects (or delete them) first.",
+                connection_id,
+                projects.len(),
+                project_names.join(", ")
             )));
         }
 
@@ -5675,6 +5691,99 @@ mod tests {
 
         // Verify connection and provider were deactivated
         // (actual verification would require querying the database)
+    }
+
+    /// Regression: a provider whose only connection belongs to another user (or
+    /// to nobody, or is deactivated) used to be permanently undeletable — the
+    /// UI lists connections per-user, so the "it has 1 connection(s)" error
+    /// pointed at a row the caller could not see or remove anywhere. Only
+    /// projects actually deploying from the provider may block the delete.
+    #[tokio::test]
+    async fn delete_provider_removes_connections_the_caller_cannot_see() {
+        use chrono::Utc;
+
+        let test_db = TestDatabase::with_migrations().await.unwrap();
+        let db = test_db.connection_arc();
+
+        let provider = git_providers::ActiveModel {
+            name: Set("GitLab".to_string()),
+            provider_type: Set("gitlab".to_string()),
+            base_url: Set(None),
+            api_url: Set(None),
+            auth_method: Set("pat".to_string()),
+            auth_config: Set(serde_json::json!({})),
+            webhook_secret: Set(None),
+            is_active: Set(true),
+            is_default: Set(false),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .unwrap();
+
+        // Two rows the caller can never see: an active but ownerless one
+        // (user_id = NULL — invisible to the per-user list yet counted by the
+        // old guard) and a deactivated one (invisible to the active-only list
+        // but still cascaded on delete).
+        let now = Utc::now();
+        for (account, active) in [("orphan-account", true), ("stale-account", false)] {
+            git_provider_connections::ActiveModel {
+                provider_id: Set(provider.id),
+                user_id: Set(None),
+                account_name: Set(account.to_string()),
+                account_type: Set("User".to_string()),
+                access_token: Set(None),
+                refresh_token: Set(None),
+                token_expires_at: Set(None),
+                refresh_token_expires_at: Set(None),
+                installation_id: Set(None),
+                metadata: Set(None),
+                is_active: Set(active),
+                is_expired: Set(false),
+                syncing: Set(false),
+                last_synced_at: Set(None),
+                created_at: Set(now),
+                updated_at: Set(now),
+                ..Default::default()
+            }
+            .insert(db.as_ref())
+            .await
+            .unwrap();
+        }
+
+        let manager = GitProviderManager::new(
+            db.clone(),
+            Arc::new(
+                temps_core::EncryptionService::new(
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                )
+                .unwrap(),
+            ),
+            Arc::new(MockJobQueue) as Arc<dyn JobQueue>,
+            create_test_config_service(db.clone()),
+        );
+
+        manager
+            .delete_provider(provider.id)
+            .await
+            .expect("provider with no project usage should delete");
+
+        assert!(
+            git_providers::Entity::find_by_id(provider.id)
+                .one(db.as_ref())
+                .await
+                .unwrap()
+                .is_none(),
+            "provider row should be gone"
+        );
+        assert!(
+            manager
+                .get_all_provider_connections(provider.id)
+                .await
+                .unwrap()
+                .is_empty(),
+            "the hidden connection should have been cascaded away"
+        );
     }
 
     #[tokio::test]

--- a/crates/temps-git/src/services/git_provider_manager.rs
+++ b/crates/temps-git/src/services/git_provider_manager.rs
@@ -4194,21 +4194,29 @@ impl GitProviderManager {
 
         // Check each connection for project usage
         for connection in &connections {
-            let projects: Vec<temps_entities::projects::Model> =
-                temps_entities::projects::Entity::find()
-                    .filter(
-                        temps_entities::projects::Column::GitProviderConnectionId
-                            .eq(Some(connection.id)),
-                    )
-                    .order_by_desc(temps_entities::projects::Column::CreatedAt)
-                    .all(self.db.as_ref())
-                    .await?;
+            // id/name/slug only — see delete_connection: deserializing full
+            // project models turns "used by project X" into an opaque
+            // "Database Error: unexpected value for Preset enum" the moment one
+            // blocking project has a column value this build can't decode.
+            let projects: Vec<(i32, String, String)> = temps_entities::projects::Entity::find()
+                .select_only()
+                .column(temps_entities::projects::Column::Id)
+                .column(temps_entities::projects::Column::Name)
+                .column(temps_entities::projects::Column::Slug)
+                .filter(
+                    temps_entities::projects::Column::GitProviderConnectionId
+                        .eq(Some(connection.id)),
+                )
+                .order_by_desc(temps_entities::projects::Column::CreatedAt)
+                .into_tuple()
+                .all(self.db.as_ref())
+                .await?;
 
-            for project in projects {
+            for (id, name, slug) in projects {
                 projects_in_use.push(ProjectUsageInfo {
-                    id: project.id,
-                    name: project.name,
-                    slug: project.slug,
+                    id,
+                    name,
+                    slug,
                     connection_id: connection.id,
                     connection_name: connection.account_name.clone(),
                 });
@@ -4302,19 +4310,26 @@ impl GitProviderManager {
         // Check if connection is in use by any projects. Name them — "used by 2
         // project(s)" leaves the user hunting through every project to work out
         // which ones to disconnect first.
-        let projects: Vec<temps_entities::projects::Model> =
-            temps_entities::projects::Entity::find()
-                .filter(
-                    temps_entities::projects::Column::GitProviderConnectionId
-                        .eq(Some(connection_id)),
-                )
-                .all(self.db.as_ref())
-                .await?;
+        // Select id + name only. Loading whole project models makes the check
+        // fail with an opaque "Database Error: unexpected value for Preset
+        // enum" if any blocking project carries a column value this build's
+        // enums don't know — and the user loses the real reason they can't
+        // delete, which is the whole point of this branch.
+        let projects: Vec<(i32, String)> = temps_entities::projects::Entity::find()
+            .select_only()
+            .column(temps_entities::projects::Column::Id)
+            .column(temps_entities::projects::Column::Name)
+            .filter(
+                temps_entities::projects::Column::GitProviderConnectionId.eq(Some(connection_id)),
+            )
+            .into_tuple()
+            .all(self.db.as_ref())
+            .await?;
 
         if !projects.is_empty() {
             let project_names: Vec<String> = projects
                 .iter()
-                .map(|p| format!("'{}' (ID: {})", p.name, p.id))
+                .map(|(id, name)| format!("'{}' (ID: {})", name, id))
                 .collect();
             return Err(GitProviderManagerError::InvalidConfiguration(format!(
                 "Cannot delete connection {} because it is used by {} project(s): {}. Change the git source of those projects (or delete them) first.",

--- a/web/src/components/git/ConnectionsCompactList.tsx
+++ b/web/src/components/git/ConnectionsCompactList.tsx
@@ -88,7 +88,13 @@ export function ConnectionsCompactList({
       setDeleteDialog({ open: false, connectionId: 0, connectionName: '' })
       onConnectionDeleted?.()
     },
-    onError: () => toast.error('Failed to delete connection'),
+    // The server refuses when projects still deploy from this connection and
+    // says which ones in the Problem Details `detail`. Swallowing that left the
+    // user with a bare "Failed to delete connection" and nothing to act on.
+    onError: (error: any) =>
+      toast.error('Failed to delete connection', {
+        description: error?.detail || error?.title || error?.message,
+      }),
   })
 
   const [healthCheckInFlight, setHealthCheckInFlight] = useState<number | null>(

--- a/web/src/components/git/ConnectionsCompactList.tsx
+++ b/web/src/components/git/ConnectionsCompactList.tsx
@@ -4,7 +4,6 @@ import {
   deleteConnectionMutation,
   runConnectionHealthCheckMutation,
 } from '@/api/client/@tanstack/react-query.gen'
-import { isGitHubApp } from '@/lib/provider'
 import { UpdateTokenDialog } from '@/components/git/UpdateTokenDialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -182,25 +181,26 @@ export function ConnectionsCompactList({
             Update token
           </DropdownMenuItem>
         )}
-        {provider && isGitHubApp(provider) && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              className="text-destructive"
-              onSelect={(e) => {
-                e.preventDefault()
-                setDeleteDialog({
-                  open: true,
-                  connectionId: c.id,
-                  connectionName: c.account_name,
-                })
-              }}
-            >
-              <Trash2 className="mr-2 h-4 w-4" />
-              Delete connection
-            </DropdownMenuItem>
-          </>
-        )}
+        {/* Every provider type, not just GitHub Apps: DELETE /git-connections/
+            {id} is generic, and hiding it left PAT/OAuth connections with no
+            way to be removed — including the ones that block deleting their
+            provider. The server still refuses when a project depends on the
+            connection, and now says which. */}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="text-destructive"
+          onSelect={(e) => {
+            e.preventDefault()
+            setDeleteDialog({
+              open: true,
+              connectionId: c.id,
+              connectionName: c.account_name,
+            })
+          }}
+        >
+          <Trash2 className="mr-2 h-4 w-4" />
+          Delete connection
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/web/src/pages/GitProviderDetail.tsx
+++ b/web/src/pages/GitProviderDetail.tsx
@@ -1,7 +1,8 @@
 import {
   deleteGitProviderMutation,
   getGitProviderOptions,
-  listConnectionsOptions,
+  getProviderConnectionsOptions,
+  getProviderConnectionsQueryKey,
   listConnectionsQueryKey,
   syncRepositoriesMutation,
 } from '@/api/client/@tanstack/react-query.gen'
@@ -89,25 +90,37 @@ export default function GitProviderDetail() {
     isLoading: connectionsLoading,
     refetch: refetchConnections,
   } = useQuery({
-    ...listConnectionsOptions({}),
+    // Provider-scoped endpoint, not the caller's own connection list: the
+    // per-user list hides connections owned by someone else (or by nobody),
+    // and those are exactly the ones that block deleting the provider. Showing
+    // "No connections found" next to "cannot delete, it has 1 connection" left
+    // the user with nothing to act on.
+    ...getProviderConnectionsOptions({ path: { provider_id: providerId } }),
     retry: false,
     enabled: !!provider,
-    select: (data) =>
-      data?.connections?.filter(
-        (connection) => connection.provider_id === providerId
-      ) || [],
+    select: (data) => data || [],
     // Poll every 2s while any connection under this provider is syncing so
     // the running repo count + "Syncing" badge advance live. Polling stops
     // automatically once no connection reports `syncing=true`, keeping idle
     // tabs quiet.
     refetchInterval: (query) => {
-      const anySyncing = query.state.data?.connections?.some(
-        (c) => c.provider_id === providerId && c.syncing,
-      )
+      const anySyncing = query.state.data?.some((c) => c.syncing)
       return anySyncing ? 2000 : false
     },
     refetchIntervalInBackground: false,
   })
+
+  // Connection state shows up in two places: this provider-scoped list and the
+  // per-user list the dashboard renders. Refresh both together so neither goes
+  // stale after a sync or a delete.
+  const invalidateConnectionQueries = () => {
+    queryClient.invalidateQueries({
+      queryKey: getProviderConnectionsQueryKey({
+        path: { provider_id: providerId },
+      }),
+    })
+    queryClient.invalidateQueries({ queryKey: listConnectionsQueryKey({}) })
+  }
 
   const syncMutation = useMutation({
     ...syncRepositoriesMutation(),
@@ -119,7 +132,7 @@ export default function GitProviderDetail() {
     // already in its syncing state. Without this the user saw nothing change
     // until the full sync finished (potentially minutes on 20k-repo orgs).
     onMutate: () => {
-      queryClient.invalidateQueries({ queryKey: listConnectionsQueryKey({}) })
+      invalidateConnectionQueries()
     },
     onSuccess: () => {
       // 202 = sync started, not finished. The background task updates
@@ -127,12 +140,12 @@ export default function GitProviderDetail() {
       // progresses; the periodic refetch on this page surfaces that.
       showSuccess('Repository sync started')
       refetchConnections()
-      queryClient.invalidateQueries({ queryKey: listConnectionsQueryKey({}) })
+      invalidateConnectionQueries()
     },
     onError: (error: any) => {
       // The backend's drop-guard resets `syncing=false` on failure too, so
       // refresh the list to clear any stale "syncing" spinner.
-      queryClient.invalidateQueries({ queryKey: listConnectionsQueryKey({}) })
+      invalidateConnectionQueries()
 
       // Surface the failure. RFC 7807 Problem Details puts the human
       // message in `detail`; fall back to `title` then `message`.
@@ -147,7 +160,7 @@ export default function GitProviderDetail() {
     // Failures surface via the global mutation error handler in App.tsx,
     // which renders Problem Details as a toast: errorTitle becomes the
     // toast title and the API's `detail` becomes the description (e.g.
-    // "Cannot delete provider X because it has N connection(s)").
+    // "Cannot delete provider X because it is used by N project(s): ...").
     meta: { errorTitle: 'Failed to delete provider' },
     onSuccess: () => {
       toast.success('Git provider deleted successfully')
@@ -566,8 +579,10 @@ export default function GitProviderDetail() {
             <DialogTitle>Delete Git Provider</DialogTitle>
             <DialogDescription>
               Are you sure you want to delete &quot;{provider.name}&quot;? This
-              action cannot be undone. Providers with existing connections
-              cannot be deleted — remove connections first.
+              action cannot be undone. Its {connections?.length ?? 0}{' '}
+              connection(s) and their synced repositories are deleted with it.
+              Projects still deployed from this provider block the delete — the
+              error names them.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>


### PR DESCRIPTION
## Problem

Deleting a git provider failed with **\"Cannot delete provider GitLab because it has 1 connection(s)\"** while the same page rendered **\"No connections found\"** — a dead end with nothing to act on.

Root cause is a mismatch between two queries:

- The provider detail page listed connections from the **per-user** endpoint (`get_user_connections_paginated`, `user_id = caller` + `is_active = true`) and filtered client-side by provider.
- `delete_provider` counted **every active connection of the provider**, regardless of owner.

So any connection owned by another user — or with `user_id = NULL` — made the provider permanently undeletable and permanently un-findable. Connection deletes hit the same wall: the blocking row was invisible, and the UI's `onError` threw away the server's explanation.

## Fix

- `delete_provider` now blocks only on **projects that actually deploy from the provider** (naming them), and cascades the provider's connections + repositories — the same semantics as the existing `/safe-delete` route.
- Deletion checks use a new `get_all_provider_connections` (no owner/active filter), so a deactivated connection used by a project is no longer skipped by the safety check while still being cascaded away.
- `GET /git-providers/{id}/connections` returns all of the provider's connections, and the detail page uses it instead of the per-user list — the list can no longer contradict the delete error. Inactive rows already render an "Inactive" badge.
- `delete_connection` names the blocking projects; the UI now shows the Problem Details `detail` instead of a bare "Failed to delete connection".
- Delete dialog states what will be cascaded instead of the now-wrong "remove connections first".

## Evidence

New regression test `delete_provider_removes_connections_the_caller_cannot_see` seeds a provider with an ownerless active connection + a deactivated one and deletes it.

Against the **old** guard it reproduces the reported error verbatim:

\`\`\`
provider with no project usage should delete: InvalidConfiguration("Cannot delete provider GitLab because it has 1 connection(s)")
test result: FAILED. 0 passed; 1 failed
\`\`\`

With the fix:

\`\`\`
$ cargo test -p temps-git --lib
test result: ok. 299 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
\`\`\`

\`\`\`
$ cargo clippy -p temps-git --all-targets -- -D warnings
Finished `dev` profile ... (no warnings)

$ bunx tsc --noEmit -p tsconfig.json   # web/
(clean)
\`\`\`

Note: one earlier full-suite run failed at `TestDatabase::with_migrations()` (testcontainer startup), green on rerun — unrelated to this change.

No API shape change, so no SDK regen or CLI parity work is required.