### PR TITLE
feat(env-vars): convert an existing variable to a write-only secret

### DIFF
--- a/apps/temps-cli/src/commands/env-sync/index.ts
+++ b/apps/temps-cli/src/commands/env-sync/index.ts
@@ -10,6 +10,7 @@ import {
   getEnvironmentVariables,
   createEnvironmentVariable,
   updateEnvironmentVariable,
+  getEnvironmentVariableValue,
 } from '../../api/sdk.gen.js'
 import { withSpinner } from '../../ui/spinner.js'
 import { promptSelect, promptConfirm, promptCheckbox } from '../../ui/prompts.js'
@@ -55,6 +56,7 @@ async function pull(
     if (envsResult.error) throw new Error(getErrorMessage(envsResult.error))
 
     return {
+      projectId,
       vars: varsResult.data ?? [],
       envs: envsResult.data ?? [],
     }
@@ -99,9 +101,9 @@ async function pull(
     return
   }
 
-  // Secrets carry no value — the API never returns their plaintext — so they
-  // cannot be written to a .env file. Drop them, but say so explicitly rather
-  // than emitting an empty assignment that would silently blank the variable.
+  // Write-only secrets have no readable value at all. Drop them, but say so
+  // explicitly rather than emitting an empty assignment that would blank the
+  // variable wherever this file gets loaded.
   const secretVars = filteredVars.filter(v => v.is_secret)
   const exportableVars = filteredVars.filter(v => !v.is_secret)
 
@@ -112,10 +114,39 @@ async function pull(
     )
   }
 
+  // The list endpoint masks every value as `***`; plaintext only comes from the
+  // audited per-key reveal endpoint. Without this the pull would overwrite the
+  // developer's .env with a file full of `***`.
+  const resolvedValues = new Map<string, string>()
+  const unreadable: string[] = []
+  await withSpinner('Resolving values...', async () => {
+    for (const v of exportableVars) {
+      const valueResult = await getEnvironmentVariableValue({
+        client,
+        path: { project_id: result.projectId, key: v.key },
+        query: { var_id: v.id },
+      })
+      if (valueResult.error || !valueResult.data) {
+        unreadable.push(v.key)
+        continue
+      }
+      resolvedValues.set(v.key, valueResult.data.value)
+    }
+  })
+
+  if (unreadable.length > 0) {
+    errorOutput(
+      `Could not read ${unreadable.length} value(s): ${unreadable.join(', ')}. ` +
+        'Reading plaintext needs the secrets:read permission. Nothing was written — ' +
+        `overwriting ${outputFile} with partial values would blank these variables.`
+    )
+    return
+  }
+
   // Generate .env content
   const envContent = exportableVars
     .map(v => {
-      const value = v.value ?? ''
+      const value = resolvedValues.get(v.key) ?? ''
       const escapedValue = value.includes('\n') || value.includes('"')
         ? `"${value.replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`
         : value.includes(' ') || value.includes('#')

--- a/apps/temps-cli/src/commands/env-sync/index.ts
+++ b/apps/temps-cli/src/commands/env-sync/index.ts
@@ -99,14 +99,28 @@ async function pull(
     return
   }
 
+  // Secrets carry no value — the API never returns their plaintext — so they
+  // cannot be written to a .env file. Drop them, but say so explicitly rather
+  // than emitting an empty assignment that would silently blank the variable.
+  const secretVars = filteredVars.filter(v => v.is_secret)
+  const exportableVars = filteredVars.filter(v => !v.is_secret)
+
+  if (secretVars.length > 0) {
+    warning(
+      `Skipping ${secretVars.length} write-only secret(s): ${secretVars.map(v => v.key).join(', ')}. ` +
+        'Their values are never returned by the API — set them by hand where you need them.'
+    )
+  }
+
   // Generate .env content
-  const envContent = filteredVars
+  const envContent = exportableVars
     .map(v => {
-      const escapedValue = v.value.includes('\n') || v.value.includes('"')
-        ? `"${v.value.replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`
-        : v.value.includes(' ') || v.value.includes('#')
-          ? `"${v.value}"`
-          : v.value
+      const value = v.value ?? ''
+      const escapedValue = value.includes('\n') || value.includes('"')
+        ? `"${value.replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`
+        : value.includes(' ') || value.includes('#')
+          ? `"${value}"`
+          : value
       return `${v.key}=${escapedValue}`
     })
     .join('\n')

--- a/apps/temps-cli/src/commands/env-sync/index.ts
+++ b/apps/temps-cli/src/commands/env-sync/index.ts
@@ -117,7 +117,8 @@ async function pull(
   // The list endpoint masks every value as `***`; plaintext only comes from the
   // audited per-key reveal endpoint. Without this the pull would overwrite the
   // developer's .env with a file full of `***`.
-  const resolvedValues = new Map<string, string>()
+  // Keyed by row id: the same name can exist in several environments.
+  const resolvedValues = new Map<number, string>()
   const unreadable: string[] = []
   await withSpinner('Resolving values...', async () => {
     for (const v of exportableVars) {
@@ -130,7 +131,7 @@ async function pull(
         unreadable.push(v.key)
         continue
       }
-      resolvedValues.set(v.key, valueResult.data.value)
+      resolvedValues.set(v.id, valueResult.data.value)
     }
   })
 
@@ -140,13 +141,14 @@ async function pull(
         'Reading plaintext needs the secrets:read permission. Nothing was written — ' +
         `overwriting ${outputFile} with partial values would blank these variables.`
     )
+    process.exitCode = 1
     return
   }
 
   // Generate .env content
   const envContent = exportableVars
     .map(v => {
-      const value = resolvedValues.get(v.key) ?? ''
+      const value = resolvedValues.get(v.id) ?? ''
       const escapedValue = value.includes('\n') || value.includes('"')
         ? `"${value.replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`
         : value.includes(' ') || value.includes('#')
@@ -173,7 +175,7 @@ async function pull(
   }
 
   fs.writeFileSync(outputPath, envContent + '\n')
-  success(`Pulled ${filteredVars.length} variables to ${outputFile}`)
+  success(`Pulled ${exportableVars.length} variables to ${outputFile}`)
 }
 
 async function push(

--- a/apps/temps-cli/src/commands/environments/index.ts
+++ b/apps/temps-cli/src/commands/environments/index.ts
@@ -91,7 +91,7 @@ export function registerEnvironmentsCommands(program: Command): void {
     .option('-e, --environments <names>', 'Comma-separated environment names (interactive if not provided)')
     .option('--no-preview', 'Exclude from preview environments')
     .option('--update', 'Update existing variable instead of creating new')
-    .option('--secret', 'Store as a secret: the value is masked in the UI and never returned by the API. One-way — a secret cannot later be made non-secret')
+    .option('--secret', 'Store as a secret: the value is masked in the UI and never returned by the API. One-way — to make a secret readable again you must delete the variable and create it anew')
     .action(async (key, value, options, cmd) => {
       const projectSlug = cmd.parent!.opts().project
       return setEnvVar(projectSlug, key, value, options)
@@ -414,8 +414,16 @@ async function listEnvVars(
     { header: 'Key', key: 'key', color: (v) => colors.bold(v) },
     {
       header: 'Value',
-      accessor: (v) => options.showValues ? v.value : '••••••••',
-      color: (v) => options.showValues ? colors.primary(v) : colors.muted(v),
+      // Secrets come back with no value at all — the API never returns their
+      // plaintext — so --show-values must say so rather than print an empty cell.
+      accessor: (v) =>
+        v.is_secret ? '(secret)' : options.showValues ? (v.value ?? '') : '••••••••',
+      color: (v) =>
+        v === '(secret)'
+          ? colors.warning(v)
+          : options.showValues
+            ? colors.primary(v)
+            : colors.muted(v),
     },
     {
       header: 'Environments',
@@ -436,6 +444,16 @@ async function listEnvVars(
     info(`Use ${colors.bold('--show-values')} to reveal actual values`)
   }
   newline()
+}
+
+/**
+ * Render an env var's value for display. Secrets carry no value at all — the
+ * API never returns their plaintext — so they must read as deliberately
+ * withheld rather than as an empty variable.
+ */
+function formatEnvVarValue(v: EnvironmentVariableResponse): string {
+  if (v.is_secret) return colors.warning('(secret - write-only, never returned by the API)')
+  return v.value ?? ''
 }
 
 async function getEnvVar(
@@ -501,7 +519,7 @@ async function getEnvVar(
 
     newline()
     keyValue('Key', envVar.key)
-    keyValue('Value', envVar.value)
+    keyValue('Value', formatEnvVarValue(envVar))
     keyValue('Environment', targetEnv.name)
     keyValue('Include in Preview', envVar.include_in_preview ? 'Yes' : 'No')
     newline()
@@ -514,7 +532,7 @@ async function getEnvVar(
 
   for (const v of matchingVars) {
     keyValue('ID', String(v.id))
-    keyValue('Value', v.value)
+    keyValue('Value', formatEnvVarValue(v))
     keyValue('Environments', v.environments.map(e => e.name).join(', ') || 'None')
     keyValue('Include in Preview', v.include_in_preview ? 'Yes' : 'No')
     newline()
@@ -942,14 +960,28 @@ async function exportEnvVars(
     return
   }
 
+  // Secrets carry no value — the API never returns their plaintext — so they
+  // cannot be written to a .env file. Drop them, but say so explicitly rather
+  // than emitting an empty assignment that would silently blank the variable.
+  const secretVars = filteredVars.filter(v => v.is_secret)
+  const exportableVars = filteredVars.filter(v => !v.is_secret)
+
+  if (secretVars.length > 0) {
+    warning(
+      `Skipping ${secretVars.length} write-only secret(s): ${secretVars.map(v => v.key).join(', ')}. ` +
+        'Their values are never returned by the API — set them by hand where you need them.'
+    )
+  }
+
   // Generate .env content
-  const envContent = filteredVars
+  const envContent = exportableVars
     .map(v => {
-      const escapedValue = v.value.includes('\n') || v.value.includes('"')
-        ? `"${v.value.replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`
-        : v.value.includes(' ') || v.value.includes('#')
-          ? `"${v.value}"`
-          : v.value
+      const value = v.value ?? ''
+      const escapedValue = value.includes('\n') || value.includes('"')
+        ? `"${value.replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`
+        : value.includes(' ') || value.includes('#')
+          ? `"${value}"`
+          : value
       return `${v.key}=${escapedValue}`
     })
     .join('\n')

--- a/apps/temps-cli/src/commands/environments/index.ts
+++ b/apps/temps-cli/src/commands/environments/index.ts
@@ -927,8 +927,11 @@ async function resolveEnvVarValues(
   projectId: number,
   vars: EnvironmentVariableResponse[],
   environmentId?: number
-): Promise<{ resolved: Map<string, string>; failed: string[] }> {
-  const resolved = new Map<string, string>()
+): Promise<{ resolved: Map<number, string>; failed: string[] }> {
+  // Keyed by row id, not key: the same name can exist as separate rows in
+  // separate environments, and keying by name would print one row's value
+  // under the other's line.
+  const resolved = new Map<number, string>()
   const failed: string[] = []
 
   for (const v of vars) {
@@ -941,7 +944,7 @@ async function resolveEnvVarValues(
       failed.push(v.key)
       continue
     }
-    resolved.set(v.key, result.data.value)
+    resolved.set(v.id, result.data.value)
   }
 
   return { resolved, failed }
@@ -1027,13 +1030,16 @@ async function exportEnvVars(
         'Reading plaintext needs the secrets:read permission. Nothing was written — ' +
         'a partial export would silently blank these variables.'
     )
+    // Non-zero exit so `export -o .env && deploy` cannot march on with a stale
+    // or missing file believing the export succeeded.
+    process.exitCode = 1
     return
   }
 
   // Generate .env content
   const envContent = exportableVars
     .map(v => {
-      const value = resolved.get(v.key) ?? ''
+      const value = resolved.get(v.id) ?? ''
       const escapedValue = value.includes('\n') || value.includes('"')
         ? `"${value.replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`
         : value.includes(' ') || value.includes('#')

--- a/apps/temps-cli/src/commands/environments/index.ts
+++ b/apps/temps-cli/src/commands/environments/index.ts
@@ -15,6 +15,7 @@ import {
   deleteEnvironmentVariable,
   updateEnvironmentVariable,
   updateEnvironmentSettings,
+  getEnvironmentVariableValue,
   getProjectBySlug,
   getEnvironmentCrons,
   getCronById,
@@ -911,6 +912,41 @@ async function importEnvVars(
   }
 }
 
+/**
+ * Resolve real plaintext values for a set of variables.
+ *
+ * The list endpoint deliberately masks every value as `***` so a bulk read can
+ * never become a credential dump — plaintext is only available one key at a
+ * time through the audited reveal endpoint. Anything that writes a .env file
+ * has to go through here, or it writes `KEY=***` over the user's real config.
+ *
+ * Secrets are skipped by the caller (they have no readable value at all).
+ * A failed reveal is reported, never silently substituted.
+ */
+async function resolveEnvVarValues(
+  projectId: number,
+  vars: EnvironmentVariableResponse[],
+  environmentId?: number
+): Promise<{ resolved: Map<string, string>; failed: string[] }> {
+  const resolved = new Map<string, string>()
+  const failed: string[] = []
+
+  for (const v of vars) {
+    const result = await getEnvironmentVariableValue({
+      client,
+      path: { project_id: projectId, key: v.key },
+      query: { environment_id: environmentId, var_id: v.id },
+    })
+    if (result.error || !result.data) {
+      failed.push(v.key)
+      continue
+    }
+    resolved.set(v.key, result.data.value)
+  }
+
+  return { resolved, failed }
+}
+
 async function exportEnvVars(
   project: string,
   options: { environment?: string; output?: string }
@@ -918,7 +954,7 @@ async function exportEnvVars(
   await requireAuth()
   await setupClient()
 
-  const [vars, environments] = await withSpinner('Fetching environment variables...', async () => {
+  const [projectId, vars, environments] = await withSpinner('Fetching environment variables...', async () => {
     const projectId = await getProjectId(project)
 
     const [varsResult, envsResult] = await Promise.all([
@@ -935,7 +971,7 @@ async function exportEnvVars(
     if (varsResult.error) throw new Error(getErrorMessage(varsResult.error))
     if (envsResult.error) throw new Error(getErrorMessage(envsResult.error))
 
-    return [varsResult.data ?? [], envsResult.data ?? []] as const
+    return [projectId, varsResult.data ?? [], envsResult.data ?? []] as const
   })
 
   let filteredVars = vars
@@ -960,9 +996,9 @@ async function exportEnvVars(
     return
   }
 
-  // Secrets carry no value — the API never returns their plaintext — so they
-  // cannot be written to a .env file. Drop them, but say so explicitly rather
-  // than emitting an empty assignment that would silently blank the variable.
+  // Write-only secrets have no readable value at all. Drop them, but say so
+  // explicitly rather than emitting an empty assignment that would blank the
+  // variable wherever this file gets loaded.
   const secretVars = filteredVars.filter(v => v.is_secret)
   const exportableVars = filteredVars.filter(v => !v.is_secret)
 
@@ -973,10 +1009,31 @@ async function exportEnvVars(
     )
   }
 
+  const targetEnvId = options.environment
+    ? environments.find(
+        e => e.name.toLowerCase() === options.environment!.toLowerCase() ||
+             e.slug === options.environment!.toLowerCase()
+      )?.id
+    : undefined
+
+  const { resolved, failed } = await withSpinner(
+    'Resolving values...',
+    () => resolveEnvVarValues(projectId, exportableVars, targetEnvId)
+  )
+
+  if (failed.length > 0) {
+    errorOutput(
+      `Could not read ${failed.length} value(s): ${failed.join(', ')}. ` +
+        'Reading plaintext needs the secrets:read permission. Nothing was written — ' +
+        'a partial export would silently blank these variables.'
+    )
+    return
+  }
+
   // Generate .env content
   const envContent = exportableVars
     .map(v => {
-      const value = v.value ?? ''
+      const value = resolved.get(v.key) ?? ''
       const escapedValue = value.includes('\n') || value.includes('"')
         ? `"${value.replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`
         : value.includes(' ') || value.includes('#')
@@ -991,7 +1048,7 @@ async function exportEnvVars(
       ? options.output
       : path.resolve(process.cwd(), options.output)
     fs.writeFileSync(outputPath, envContent + '\n')
-    success(`Exported ${filteredVars.length} variables to ${options.output}`)
+    success(`Exported ${exportableVars.length} variables to ${options.output}`)
   } else {
     // Output to stdout
     console.log(envContent)

--- a/crates/temps-environments/src/handlers/audit.rs
+++ b/crates/temps-environments/src/handlers/audit.rs
@@ -194,3 +194,40 @@ impl AuditOperation for EnvironmentDeletedAudit {
             .map_err(|e| anyhow::anyhow!("Failed to serialize audit operation {}", e))
     }
 }
+
+/// Emitted when an existing environment variable is converted into a
+/// write-only secret. The transition is one-way and permanently removes the
+/// value from every read path, so it gets its own audit event rather than
+/// being folded into a generic "variable updated" record.
+#[derive(Debug, Clone, Serialize)]
+pub struct EnvironmentVariablePromotedToSecretAudit {
+    pub context: AuditContext,
+    pub project_id: i32,
+    pub var_id: i32,
+    pub key: String,
+    /// Environments the variable applies to after the update.
+    pub environment_ids: Vec<i32>,
+}
+
+impl AuditOperation for EnvironmentVariablePromotedToSecretAudit {
+    fn operation_type(&self) -> String {
+        "ENVIRONMENT_VARIABLE_PROMOTED_TO_SECRET".to_string()
+    }
+
+    fn user_id(&self) -> Option<i32> {
+        Some(self.context.user_id)
+    }
+
+    fn ip_address(&self) -> Option<String> {
+        self.context.ip_address.clone()
+    }
+
+    fn user_agent(&self) -> &str {
+        &self.context.user_agent
+    }
+
+    fn serialize(&self) -> Result<String> {
+        serde_json::to_string(self)
+            .map_err(|e| anyhow::anyhow!("Failed to serialize audit operation {}", e))
+    }
+}

--- a/crates/temps-environments/src/handlers/handler.rs
+++ b/crates/temps-environments/src/handlers/handler.rs
@@ -1,7 +1,7 @@
 use super::audit::{
     EnvironmentDeletedAudit, EnvironmentSettingsUpdatedAudit, EnvironmentSettingsUpdatedFields,
     EnvironmentSleepStateChangedAudit, EnvironmentSubdomainUpdatedAudit,
-    EnvironmentVariableValueRevealedAudit,
+    EnvironmentVariablePromotedToSecretAudit, EnvironmentVariableValueRevealedAudit,
 };
 use super::types::AppState;
 use axum::Router;
@@ -64,6 +64,7 @@ impl From<crate::services::env_var_service::EnvVarError> for Problem {
                     .build()
             }
             EnvVarError::CannotDemoteSecret { .. } => temps_core::error_builder::bad_request()
+                .title("Secret cannot be converted back to a regular variable")
                 .detail(err.to_string())
                 .build(),
             EnvVarError::SecretValueRequired { .. } => temps_core::error_builder::bad_request()
@@ -893,6 +894,7 @@ pub async fn update_environment_variable(
     State(state): State<Arc<AppState>>,
     Path((project_id, var_id)): Path<(i32, i32)>,
     RequireAuth(auth): RequireAuth,
+    Extension(metadata): Extension<RequestMetadata>,
     Json(request): Json<UpdateEnvironmentVariableRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     project_permission_guard!(
@@ -903,7 +905,7 @@ pub async fn update_environment_variable(
     );
     project_scope_guard!(auth, project_id);
 
-    let var = state
+    let outcome = state
         .env_var_service
         .update_environment_variable(
             project_id,
@@ -915,6 +917,34 @@ pub async fn update_environment_variable(
             request.is_secret,
         )
         .await?;
+    let var = outcome.var;
+
+    // Converting a variable to a secret is irreversible and removes the value
+    // from every read path — audit it explicitly.
+    if outcome.promoted_to_secret {
+        info!(
+            user_id = auth.user_id(),
+            project_id,
+            var_id,
+            environment_variable_key = %var.key,
+            "Environment variable promoted to write-only secret"
+        );
+
+        let audit = EnvironmentVariablePromotedToSecretAudit {
+            context: AuditContext {
+                user_id: auth.user_id(),
+                ip_address: Some(metadata.ip_address.clone()),
+                user_agent: metadata.user_agent.clone(),
+            },
+            project_id,
+            var_id,
+            key: var.key.clone(),
+            environment_ids: var.environments.iter().map(|env| env.id).collect(),
+        };
+        if let Err(e) = state.audit_service.create_audit_log(&audit).await {
+            error!("Failed to create audit log: {}", e);
+        }
+    }
 
     let response = EnvironmentVariableResponse {
         id: var.id,

--- a/crates/temps-environments/src/services/env_var_service.rs
+++ b/crates/temps-environments/src/services/env_var_service.rs
@@ -1,5 +1,6 @@
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect, Set,
+    TransactionTrait,
 };
 use std::sync::Arc;
 use temps_core::EncryptionService;
@@ -374,8 +375,17 @@ impl EnvVarService {
                     let encryption_service = encryption_service.clone();
 
                     Box::pin(async move {
+                        // SELECT ... FOR UPDATE. Every decision below is derived
+                        // from this row — whether the flag may change, and
+                        // whether an empty value is about to be sealed — so the
+                        // read has to be serialized with concurrent updates.
+                        // Without the lock, a promotion committing between this
+                        // read and our own write lets a deliberate blank land on
+                        // a row that has since become secret, which is the
+                        // unrecoverable state both guards exist to prevent.
                         let env_var = env_vars::Entity::find_by_id(var_id)
                             .filter(env_vars::Column::ProjectId.eq(project_id))
+                            .lock_exclusive()
                             .one(txn)
                             .await?
                             .ok_or(EnvVarError::Other(
@@ -1167,15 +1177,29 @@ mod tests {
     async fn test_promoting_legacy_plaintext_row_encrypts_the_stored_value() {
         // Rows written before encryption was enabled hold plaintext. Promoting
         // one without supplying a new value must encrypt what is already there:
-        // a secret that is merely hidden from the API but readable in the
-        // database is not a secret. This is the branch the other tests miss,
-        // since they all start from is_encrypted = true.
+        // a secret that is merely hidden from the API but still readable in the
+        // database is not a secret. This is the only coverage of that branch —
+        // the other tests all start from is_encrypted = true.
+        //
+        // Asserted against the statement the transaction actually emitted, not
+        // against the mock's canned return row: the returned model is whatever
+        // the fixture says, so checking it would pass even if the encryption
+        // branch were deleted.
         let encryption_service = make_encryption_service();
         let before =
             make_env_var_model_full(8, 10, "LEGACY_KEY", "plain_secret_value", false, false);
-        let after = make_env_var_model_full(8, 10, "LEGACY_KEY", "plain_secret_value", true, true);
+        let after = make_env_var_model_full(8, 10, "LEGACY_KEY", "ciphertext", true, true);
 
-        let service = EnvVarService::new(mock_update_db(before, after), encryption_service.clone());
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![before]])
+            .append_query_results(vec![vec![after]])
+            .append_exec_results(vec![MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 0,
+            }])
+            .into_connection();
+        let db = Arc::new(db);
+        let service = EnvVarService::new(db.clone(), encryption_service.clone());
 
         let outcome = service
             .update_environment_variable(
@@ -1189,17 +1213,33 @@ mod tests {
             )
             .await
             .expect("promoting a legacy plaintext row should succeed");
-
         assert!(outcome.promoted_to_secret);
-        assert!(outcome.var.is_secret);
-        assert_eq!(outcome.var.value, None);
 
-        // The ciphertext the transaction wrote must decrypt back to the
-        // original plaintext — proving it was encrypted exactly once and the
-        // value survived the promotion intact.
-        let written = service
-            .encrypt_value("LEGACY_KEY", "plain_secret_value")
-            .unwrap();
+        // DatabaseConnection is not Clone under the `mock` feature, and
+        // into_transaction_log consumes it — drop the service so this Arc is
+        // the sole owner.
+        drop(service);
+        let db = Arc::try_unwrap(db).expect("service dropped, so this is the only handle");
+
+        // Inspect the statements the transaction actually emitted. `Transaction`
+        // keeps its statements private, so match on the Debug rendering: every
+        // bound String shows up quoted, and exactly one of them is the
+        // ciphertext (it is the only candidate our key can decrypt).
+        let log = db.into_transaction_log();
+        let dump = format!("{:?}", log);
+        assert!(
+            dump.to_uppercase().contains("UPDATE"),
+            "the transaction must emit an UPDATE"
+        );
+        let written = dump
+            .split('"')
+            .skip(1)
+            .step_by(2)
+            .find(|candidate| encryption_service.decrypt_string(candidate).is_ok())
+            .map(|candidate| candidate.to_string())
+            .expect("the UPDATE must write a ciphertext this key can decrypt");
+
+        // The plaintext was encrypted exactly once, and survived intact.
         assert_ne!(written, "plain_secret_value");
         assert_eq!(
             encryption_service.decrypt_string(&written).unwrap(),

--- a/crates/temps-environments/src/services/env_var_service.rs
+++ b/crates/temps-environments/src/services/env_var_service.rs
@@ -6,7 +6,7 @@ use temps_core::EncryptionService;
 use temps_entities::{env_var_environments, env_vars, environments};
 use thiserror::Error;
 
-use super::types::{EnvVarEnvironment, EnvVarWithEnvironments};
+use super::types::{EnvVarEnvironment, EnvVarWithEnvironments, UpdateEnvVarOutcome};
 
 #[derive(Error, Debug)]
 pub enum EnvVarError {
@@ -34,8 +34,12 @@ pub enum EnvVarError {
 
     /// `is_secret` is one-way: a row already marked secret cannot be flipped
     /// back to a normal env var. Toggling it off would let a caller leak the
-    /// value by reading the next `list` response.
-    #[error("Cannot demote secret env var '{key}' (id={var_id}) back to non-secret")]
+    /// value by reading the next `list` response. The only way back is to
+    /// delete the variable and create it again as a regular one, which forces
+    /// the operator to supply the value rather than recover it from storage.
+    #[error(
+        "Environment variable '{key}' (id={var_id}) is a secret and cannot be converted back to a regular variable. Delete it and create it again as a non-secret variable, supplying the value yourself."
+    )]
     CannotDemoteSecret { var_id: i32, key: String },
 
     /// Secret env vars require a value on create. On update the value is
@@ -326,6 +330,12 @@ impl EnvVarService {
     /// - `is_secret: Some(true)` promotes a regular env var to a secret.
     ///   `Some(false)` is rejected if the row is already a secret — the flag
     ///   is one-way. `None` leaves the flag unchanged.
+    ///
+    /// Promotion also guarantees the value is encrypted at rest: a legacy row
+    /// still stored as plaintext (`is_encrypted = false`) is re-encrypted as
+    /// part of the same transaction, even when the caller supplies no new
+    /// value. Without that, "secret" would only hide the value from the API
+    /// while leaving it readable in the database.
     // 8 args after adding `is_secret`. Refactoring to an UpdateEnvVarRequest
     // struct would ripple through every caller (handlers + tests) for no
     // semantic gain; the args are the genuine inputs to the operation.
@@ -339,100 +349,124 @@ impl EnvVarService {
         environment_ids: Vec<i32>,
         include_in_preview: bool,
         is_secret: Option<bool>,
-    ) -> Result<EnvVarWithEnvironments, EnvVarError> {
+    ) -> Result<UpdateEnvVarOutcome, EnvVarError> {
         let encrypted_value_opt = match &value {
             Some(v) => Some(self.encrypt_value(&key, v)?),
             None => None,
         };
+        let encryption_service = self.encryption_service.clone();
 
-        let result = self
-            .db
-            .transaction::<_, EnvVarWithEnvironments, EnvVarError>(|txn| {
-                let encrypted_value_opt = encrypted_value_opt.clone();
-                let key = key.clone();
-                let environment_ids = environment_ids.clone();
+        let result =
+            self.db
+                .transaction::<_, UpdateEnvVarOutcome, EnvVarError>(|txn| {
+                    let encrypted_value_opt = encrypted_value_opt.clone();
+                    let key = key.clone();
+                    let environment_ids = environment_ids.clone();
+                    let encryption_service = encryption_service.clone();
 
-                Box::pin(async move {
-                    let env_var = env_vars::Entity::find_by_id(var_id)
-                        .filter(env_vars::Column::ProjectId.eq(project_id))
-                        .one(txn)
-                        .await?
-                        .ok_or(EnvVarError::Other(
-                            "Environment variable not found".to_string(),
-                        ))?;
-
-                    // One-way secret flag: reject demotion.
-                    let final_is_secret = match (env_var.is_secret, is_secret) {
-                        (true, Some(false)) => {
-                            return Err(EnvVarError::CannotDemoteSecret {
-                                var_id: env_var.id,
-                                key: env_var.key.clone(),
-                            });
-                        }
-                        (current, Some(new)) => current || new,
-                        (current, None) => current,
-                    };
-
-                    let mut active_var: env_vars::ActiveModel = env_var.into();
-                    active_var.key = Set(key.clone());
-                    if let Some(encrypted_value) = encrypted_value_opt {
-                        active_var.value = Set(encrypted_value);
-                        active_var.is_encrypted = Set(true);
-                    }
-                    active_var.is_secret = Set(final_is_secret);
-                    active_var.include_in_preview = Set(include_in_preview);
-                    active_var.updated_at = Set(chrono::Utc::now());
-                    let var = active_var.update(txn).await?;
-
-                    env_var_environments::Entity::delete_many()
-                        .filter(env_var_environments::Column::EnvVarId.eq(var_id))
-                        .exec(txn)
-                        .await?;
-
-                    let mut environments = Vec::new();
-                    for env_id in &environment_ids {
-                        let new_env_rel = env_var_environments::ActiveModel {
-                            env_var_id: Set(var.id),
-                            environment_id: Set(*env_id),
-                            created_at: Set(chrono::Utc::now()),
-                            ..Default::default()
-                        };
-
-                        new_env_rel.insert(txn).await?;
-
-                        let env = environments::Entity::find_by_id(*env_id)
+                    Box::pin(async move {
+                        let env_var = env_vars::Entity::find_by_id(var_id)
+                            .filter(env_vars::Column::ProjectId.eq(project_id))
                             .one(txn)
                             .await?
-                            .ok_or(EnvVarError::Other("Environment not found".to_string()))?;
+                            .ok_or(EnvVarError::Other(
+                                "Environment variable not found".to_string(),
+                            ))?;
 
-                        environments.push(EnvVarEnvironment {
-                            id: env.id,
-                            name: env.name,
-                            main_url: env.subdomain,
-                            current_deployment_id: env.current_deployment_id,
-                        });
-                    }
+                        // One-way secret flag: reject demotion.
+                        let final_is_secret = match (env_var.is_secret, is_secret) {
+                            (true, Some(false)) => {
+                                return Err(EnvVarError::CannotDemoteSecret {
+                                    var_id: env_var.id,
+                                    key: env_var.key.clone(),
+                                });
+                            }
+                            (current, Some(new)) => current || new,
+                            (current, None) => current,
+                        };
 
-                    // Secret rows never return plaintext, even from update.
-                    // Non-secret rows return the supplied plaintext or
-                    // None when value wasn't changed (caller already has
-                    // the current value via list).
-                    let value = if var.is_secret { None } else { value };
+                        // A promotion is the transition non-secret -> secret. It is
+                        // reported back to the handler so the write can be audited
+                        // as the one-way, security-relevant change that it is.
+                        let promoted_to_secret = !env_var.is_secret && final_is_secret;
+                        let was_encrypted = env_var.is_encrypted;
+                        let stored_value = env_var.value.clone();
 
-                    Ok(EnvVarWithEnvironments {
-                        id: var.id,
-                        project_id: var.project_id,
-                        key: var.key,
-                        value,
-                        created_at: var.created_at,
-                        updated_at: var.updated_at,
-                        environments,
-                        include_in_preview: var.include_in_preview,
-                        is_secret: var.is_secret,
+                        let mut active_var: env_vars::ActiveModel = env_var.into();
+                        active_var.key = Set(key.clone());
+                        if let Some(encrypted_value) = encrypted_value_opt {
+                            active_var.value = Set(encrypted_value);
+                            active_var.is_encrypted = Set(true);
+                        } else if promoted_to_secret && !was_encrypted {
+                            // Legacy plaintext row being promoted without a new
+                            // value: encrypt what is already there so the secret is
+                            // unreadable at rest, not merely hidden from the API.
+                            let ciphertext = encryption_service
+                                .encrypt_string(&stored_value)
+                                .map_err(|e| EnvVarError::EncryptionFailed {
+                                    key: key.clone(),
+                                    reason: e.to_string(),
+                                })?;
+                            active_var.value = Set(ciphertext);
+                            active_var.is_encrypted = Set(true);
+                        }
+                        active_var.is_secret = Set(final_is_secret);
+                        active_var.include_in_preview = Set(include_in_preview);
+                        active_var.updated_at = Set(chrono::Utc::now());
+                        let var = active_var.update(txn).await?;
+
+                        env_var_environments::Entity::delete_many()
+                            .filter(env_var_environments::Column::EnvVarId.eq(var_id))
+                            .exec(txn)
+                            .await?;
+
+                        let mut environments = Vec::new();
+                        for env_id in &environment_ids {
+                            let new_env_rel = env_var_environments::ActiveModel {
+                                env_var_id: Set(var.id),
+                                environment_id: Set(*env_id),
+                                created_at: Set(chrono::Utc::now()),
+                                ..Default::default()
+                            };
+
+                            new_env_rel.insert(txn).await?;
+
+                            let env = environments::Entity::find_by_id(*env_id)
+                                .one(txn)
+                                .await?
+                                .ok_or(EnvVarError::Other("Environment not found".to_string()))?;
+
+                            environments.push(EnvVarEnvironment {
+                                id: env.id,
+                                name: env.name,
+                                main_url: env.subdomain,
+                                current_deployment_id: env.current_deployment_id,
+                            });
+                        }
+
+                        // Secret rows never return plaintext, even from update.
+                        // Non-secret rows return the supplied plaintext or
+                        // None when value wasn't changed (caller already has
+                        // the current value via list).
+                        let value = if var.is_secret { None } else { value };
+
+                        Ok(UpdateEnvVarOutcome {
+                            var: EnvVarWithEnvironments {
+                                id: var.id,
+                                project_id: var.project_id,
+                                key: var.key,
+                                value,
+                                created_at: var.created_at,
+                                updated_at: var.updated_at,
+                                environments,
+                                include_in_preview: var.include_in_preview,
+                                is_secret: var.is_secret,
+                            },
+                            promoted_to_secret,
+                        })
                     })
                 })
-            })
-            .await?;
+                .await?;
 
         Ok(result)
     }
@@ -521,7 +555,7 @@ impl EnvVarService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sea_orm::{DatabaseBackend, MockDatabase};
+    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
 
     fn make_encryption_service() -> Arc<EncryptionService> {
         Arc::new(
@@ -917,6 +951,110 @@ mod tests {
                 var_id: 4,
                 ref key,
             } if key == "WRITE_ONLY_TOKEN"
+        ));
+    }
+
+    /// Building a mock that walks the update transaction: SELECT the row,
+    /// UPDATE ... RETURNING the new row, then DELETE the environment links.
+    /// `environment_ids` is empty in these tests so no link inserts follow.
+    fn mock_update_db(
+        before: env_vars::Model,
+        after: env_vars::Model,
+    ) -> Arc<sea_orm::DatabaseConnection> {
+        Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![vec![before]])
+                .append_query_results(vec![vec![after]])
+                .append_exec_results(vec![MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 0,
+                }])
+                .into_connection(),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_update_promoting_to_secret_reports_promotion_and_withholds_value() {
+        // Converting an existing variable to a secret is the whole point of the
+        // is_secret transition: the caller must learn it happened (so it can be
+        // audited) and the response must stop carrying the plaintext.
+        let encryption_service = make_encryption_service();
+        let encrypted = encryption_service.encrypt_string("old_value").unwrap();
+        let before = make_env_var_model_full(3, 10, "API_KEY", &encrypted, true, false);
+        let after = make_env_var_model_full(3, 10, "API_KEY", &encrypted, true, true);
+
+        let service = EnvVarService::new(mock_update_db(before, after), encryption_service);
+
+        let outcome = service
+            .update_environment_variable(
+                10,
+                3,
+                "API_KEY".to_string(),
+                None,
+                vec![],
+                false,
+                Some(true),
+            )
+            .await
+            .expect("promotion should succeed");
+
+        assert!(outcome.promoted_to_secret);
+        assert!(outcome.var.is_secret);
+        assert_eq!(outcome.var.value, None);
+    }
+
+    #[tokio::test]
+    async fn test_update_of_already_secret_var_is_not_reported_as_promotion() {
+        // Editing a variable that is already secret (e.g. changing which
+        // environments it applies to) must not emit a second promotion audit.
+        let encryption_service = make_encryption_service();
+        let encrypted = encryption_service.encrypt_string("still_secret").unwrap();
+        let before = make_env_var_model_full(4, 10, "TOKEN", &encrypted, true, true);
+        let after = make_env_var_model_full(4, 10, "TOKEN", &encrypted, true, true);
+
+        let service = EnvVarService::new(mock_update_db(before, after), encryption_service);
+
+        let outcome = service
+            .update_environment_variable(10, 4, "TOKEN".to_string(), None, vec![], false, None)
+            .await
+            .expect("no-op update should succeed");
+
+        assert!(!outcome.promoted_to_secret);
+        assert!(outcome.var.is_secret);
+        assert_eq!(outcome.var.value, None);
+    }
+
+    #[tokio::test]
+    async fn test_update_cannot_demote_a_secret_back_to_plain_var() {
+        // The flag is one-way. Allowing is_secret: false would let a caller
+        // unmask the value simply by toggling it off and re-reading the list.
+        let encryption_service = make_encryption_service();
+        let encrypted = encryption_service.encrypt_string("stays_hidden").unwrap();
+        let before = make_env_var_model_full(5, 10, "PRIVATE_KEY", &encrypted, true, true);
+
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![vec![before]])
+                .into_connection(),
+        );
+        let service = EnvVarService::new(db, encryption_service);
+
+        let error = service
+            .update_environment_variable(
+                10,
+                5,
+                "PRIVATE_KEY".to_string(),
+                None,
+                vec![],
+                false,
+                Some(false),
+            )
+            .await
+            .expect_err("demotion must be rejected");
+
+        assert!(matches!(
+            error,
+            EnvVarError::CannotDemoteSecret { var_id: 5, ref key } if key == "PRIVATE_KEY"
         ));
     }
 }

--- a/crates/temps-environments/src/services/env_var_service.rs
+++ b/crates/temps-environments/src/services/env_var_service.rs
@@ -42,10 +42,13 @@ pub enum EnvVarError {
     )]
     CannotDemoteSecret { var_id: i32, key: String },
 
-    /// Secret env vars require a value on create. On update the value is
-    /// optional (omit to keep the existing ciphertext), but explicitly passing
-    /// an empty string is a logic error in the caller.
-    #[error("Secret env var '{key}' requires a non-empty value on create")]
+    /// Secret env vars require a non-empty value. On update the value is
+    /// optional — omitting it keeps the existing ciphertext — but explicitly
+    /// passing an empty string is a logic error in the caller, and a
+    /// destructive one: the write cannot be read back or undone.
+    #[error(
+        "Secret env var '{key}' requires a non-empty value. Omit the value entirely to keep the one already stored."
+    )]
     SecretValueRequired { key: String },
 
     #[error("Secret env var '{key}' (id={var_id}) is write-only and cannot be revealed")]
@@ -354,6 +357,12 @@ impl EnvVarService {
             Some(v) => Some(self.encrypt_value(&key, v)?),
             None => None,
         };
+        // An explicitly-supplied empty value is only ever a caller bug when the
+        // row ends up secret: the write is unreadable afterwards and the flag
+        // cannot be undone, so there is no way to notice the mistake or recover
+        // the old value. Omitting `value` entirely is the supported way to keep
+        // the existing ciphertext.
+        let value_is_explicitly_empty = value.as_ref().is_some_and(|v| v.is_empty());
         let encryption_service = self.encryption_service.clone();
 
         let result =
@@ -385,10 +394,22 @@ impl EnvVarService {
                             (current, None) => current,
                         };
 
+                        // Refuse to seal an empty value over a real one. Without
+                        // this a client that failed to load the current value
+                        // (a denied or transient reveal) silently overwrites the
+                        // credential with "" and marks it write-only, which is
+                        // unrecoverable: it cannot be read back to notice the
+                        // loss, and cannot be demoted to inspect it. Mirrors the
+                        // create-time `SecretValueRequired` guard.
+                        if final_is_secret && value_is_explicitly_empty {
+                            return Err(EnvVarError::SecretValueRequired { key: key.clone() });
+                        }
+
                         // A promotion is the transition non-secret -> secret. It is
                         // reported back to the handler so the write can be audited
                         // as the one-way, security-relevant change that it is.
-                        let promoted_to_secret = !env_var.is_secret && final_is_secret;
+                        let was_secret = env_var.is_secret;
+                        let promoted_to_secret = !was_secret && final_is_secret;
                         let was_encrypted = env_var.is_encrypted;
                         let stored_value = env_var.value.clone();
 
@@ -410,7 +431,18 @@ impl EnvVarService {
                             active_var.value = Set(ciphertext);
                             active_var.is_encrypted = Set(true);
                         }
-                        active_var.is_secret = Set(final_is_secret);
+                        // Only touch the column on an actual promotion. Writing
+                        // it unconditionally re-asserts a value derived from an
+                        // unlocked read, so two concurrent updates that both saw
+                        // `is_secret = false` would let the second (an ordinary
+                        // edit that never asked to change the flag) clear the
+                        // promotion the first one just committed — silently
+                        // unmasking the secret, since the ciphertext survives.
+                        // Leaving the column out of the UPDATE makes an
+                        // unrequested demote impossible regardless of ordering.
+                        if promoted_to_secret {
+                            active_var.is_secret = Set(true);
+                        }
                         active_var.include_in_preview = Set(include_in_preview);
                         active_var.updated_at = Set(chrono::Utc::now());
                         let var = active_var.update(txn).await?;
@@ -1056,5 +1088,122 @@ mod tests {
             error,
             EnvVarError::CannotDemoteSecret { var_id: 5, ref key } if key == "PRIVATE_KEY"
         ));
+    }
+
+    #[tokio::test]
+    async fn test_update_rejects_empty_value_when_row_ends_up_secret() {
+        // The destructive case: a client that could not load the current value
+        // (denied or failed reveal) submits an empty string together with the
+        // promotion. Sealing "" over a real credential is unrecoverable — it
+        // can never be read back to notice, nor demoted to inspect — so the
+        // write must be refused rather than reported as a success.
+        let encryption_service = make_encryption_service();
+        let encrypted = encryption_service
+            .encrypt_string("real_credential")
+            .unwrap();
+        let before = make_env_var_model_full(6, 10, "API_KEY", &encrypted, true, false);
+
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![vec![before]])
+                .into_connection(),
+        );
+        let service = EnvVarService::new(db, encryption_service);
+
+        let error = service
+            .update_environment_variable(
+                10,
+                6,
+                "API_KEY".to_string(),
+                Some(String::new()),
+                vec![],
+                false,
+                Some(true),
+            )
+            .await
+            .expect_err("promoting with an empty value must be refused");
+
+        assert!(matches!(
+            error,
+            EnvVarError::SecretValueRequired { ref key } if key == "API_KEY"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_update_rejects_empty_value_for_an_existing_secret() {
+        // Same hazard without a promotion: blanking a secret that is already
+        // write-only is equally unrecoverable.
+        let encryption_service = make_encryption_service();
+        let encrypted = encryption_service.encrypt_string("still_needed").unwrap();
+        let before = make_env_var_model_full(7, 10, "TOKEN", &encrypted, true, true);
+
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![vec![before]])
+                .into_connection(),
+        );
+        let service = EnvVarService::new(db, encryption_service);
+
+        let error = service
+            .update_environment_variable(
+                10,
+                7,
+                "TOKEN".to_string(),
+                Some(String::new()),
+                vec![],
+                false,
+                None,
+            )
+            .await
+            .expect_err("blanking an existing secret must be refused");
+
+        assert!(matches!(
+            error,
+            EnvVarError::SecretValueRequired { ref key } if key == "TOKEN"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_promoting_legacy_plaintext_row_encrypts_the_stored_value() {
+        // Rows written before encryption was enabled hold plaintext. Promoting
+        // one without supplying a new value must encrypt what is already there:
+        // a secret that is merely hidden from the API but readable in the
+        // database is not a secret. This is the branch the other tests miss,
+        // since they all start from is_encrypted = true.
+        let encryption_service = make_encryption_service();
+        let before =
+            make_env_var_model_full(8, 10, "LEGACY_KEY", "plain_secret_value", false, false);
+        let after = make_env_var_model_full(8, 10, "LEGACY_KEY", "plain_secret_value", true, true);
+
+        let service = EnvVarService::new(mock_update_db(before, after), encryption_service.clone());
+
+        let outcome = service
+            .update_environment_variable(
+                10,
+                8,
+                "LEGACY_KEY".to_string(),
+                None,
+                vec![],
+                false,
+                Some(true),
+            )
+            .await
+            .expect("promoting a legacy plaintext row should succeed");
+
+        assert!(outcome.promoted_to_secret);
+        assert!(outcome.var.is_secret);
+        assert_eq!(outcome.var.value, None);
+
+        // The ciphertext the transaction wrote must decrypt back to the
+        // original plaintext — proving it was encrypted exactly once and the
+        // value survived the promotion intact.
+        let written = service
+            .encrypt_value("LEGACY_KEY", "plain_secret_value")
+            .unwrap();
+        assert_ne!(written, "plain_secret_value");
+        assert_eq!(
+            encryption_service.decrypt_string(&written).unwrap(),
+            "plain_secret_value"
+        );
     }
 }

--- a/crates/temps-environments/src/services/mod.rs
+++ b/crates/temps-environments/src/services/mod.rs
@@ -7,4 +7,5 @@ pub use secret_service::*;
 mod types;
 pub use types::{
     EnvVarEnvironment, EnvVarWithEnvironments, SecretEnvironmentRef, SecretWithEnvironments,
+    UpdateEnvVarOutcome,
 };

--- a/crates/temps-environments/src/services/types.rs
+++ b/crates/temps-environments/src/services/types.rs
@@ -27,6 +27,17 @@ pub struct EnvVarWithEnvironments {
     pub is_secret: bool,
 }
 
+/// Result of an env-var update. Carries the updated row plus whether this
+/// particular write flipped the variable from regular to secret, so the handler
+/// can audit that one-way transition without re-reading the row.
+#[derive(Debug, Serialize)]
+pub struct UpdateEnvVarOutcome {
+    pub var: EnvVarWithEnvironments,
+    /// True only when the row was non-secret before this update and is secret
+    /// after it. A no-op update of an already-secret row reports `false`.
+    pub promoted_to_secret: bool,
+}
+
 // Secret types. Deliberately NO `value` field — secret plaintext never leaves
 // the service boundary except via SecretService::get_for_deploy.
 #[derive(Debug, Clone, Serialize)]

--- a/crates/temps-projects/src/services/env_vars.rs
+++ b/crates/temps-projects/src/services/env_vars.rs
@@ -8,6 +8,9 @@ use thiserror::Error;
 
 use super::types::{EnvVarEnvironment, EnvVarWithEnvironments};
 
+/// Placeholder returned in place of a write-only secret's plaintext.
+const SECRET_VALUE_MASK: &str = "***";
+
 #[derive(Error, Debug)]
 pub enum EnvVarError {
     #[error("Database connection error: {0}")]
@@ -31,6 +34,9 @@ pub enum EnvVarError {
         key: String,
         reason: String,
     },
+
+    #[error("Secret env var '{key}' (id={var_id}) is write-only and cannot be revealed")]
+    SecretValueCannotBeRevealed { var_id: i32, key: String },
 
     #[error("Other error: {0}")]
     Other(String),
@@ -140,8 +146,14 @@ impl EnvVarService {
         let mut result = Vec::new();
         for var in vars {
             let environments = env_map.get(&var.id).cloned().unwrap_or_default();
-            let decrypted_value =
-                self.decrypt_value(var.id, &var.key, &var.value, var.is_encrypted)?;
+            // Write-only secrets never yield plaintext through a listing path.
+            // Masking (rather than skipping the row) keeps the variable visible
+            // so callers can still see that the key exists.
+            let decrypted_value = if var.is_secret {
+                SECRET_VALUE_MASK.to_string()
+            } else {
+                self.decrypt_value(var.id, &var.key, &var.value, var.is_encrypted)?
+            };
             result.push(EnvVarWithEnvironments {
                 id: var.id,
                 project_id: var.project_id,
@@ -191,70 +203,74 @@ impl EnvVarService {
         let encrypted_value = self.encrypt_value(&key, &value)?;
         let encryption_service = self.encryption_service.clone();
 
-        let result =
-            self.db
-                .transaction::<_, EnvVarWithEnvironments, EnvVarError>(|txn| {
-                    let encrypted_value = encrypted_value.clone();
-                    let key = key.clone();
-                    let environment_ids = environment_ids.clone();
+        let result = self
+            .db
+            .transaction::<_, EnvVarWithEnvironments, EnvVarError>(|txn| {
+                let encrypted_value = encrypted_value.clone();
+                let key = key.clone();
+                let environment_ids = environment_ids.clone();
 
-                    Box::pin(async move {
-                        let new_var = env_vars::ActiveModel {
-                            project_id: Set(project_id),
-                            key: Set(key.clone()),
-                            value: Set(encrypted_value),
-                            is_encrypted: Set(true),
-                            is_secret: Set(false),
+                Box::pin(async move {
+                    let new_var = env_vars::ActiveModel {
+                        project_id: Set(project_id),
+                        key: Set(key.clone()),
+                        value: Set(encrypted_value),
+                        is_encrypted: Set(true),
+                        is_secret: Set(false),
+                        created_at: Set(chrono::Utc::now()),
+                        updated_at: Set(chrono::Utc::now()),
+                        environment_id: Set(None),
+                        ..Default::default()
+                    };
+
+                    let var = new_var.insert(txn).await?;
+
+                    let mut environments = Vec::new();
+                    for env_id in &environment_ids {
+                        let new_env_rel = env_var_environments::ActiveModel {
+                            env_var_id: Set(var.id),
+                            environment_id: Set(*env_id),
                             created_at: Set(chrono::Utc::now()),
-                            updated_at: Set(chrono::Utc::now()),
-                            environment_id: Set(None),
                             ..Default::default()
                         };
 
-                        let var = new_var.insert(txn).await?;
+                        new_env_rel.insert(txn).await?;
 
-                        let mut environments = Vec::new();
-                        for env_id in &environment_ids {
-                            let new_env_rel = env_var_environments::ActiveModel {
-                                env_var_id: Set(var.id),
-                                environment_id: Set(*env_id),
-                                created_at: Set(chrono::Utc::now()),
-                                ..Default::default()
-                            };
+                        let env = environments::Entity::find_by_id(*env_id)
+                            .one(txn)
+                            .await?
+                            .ok_or(EnvVarError::Other("Environment not found".to_string()))?;
 
-                            new_env_rel.insert(txn).await?;
+                        environments.push(EnvVarEnvironment {
+                            id: env.id,
+                            name: env.name,
+                        });
+                    }
 
-                            let env = environments::Entity::find_by_id(*env_id)
-                                .one(txn)
-                                .await?
-                                .ok_or(EnvVarError::Other("Environment not found".to_string()))?;
-
-                            environments.push(EnvVarEnvironment {
-                                id: env.id,
-                                name: env.name,
-                            });
-                        }
-
-                        let decrypted_value = encryption_service
-                            .decrypt_string(&var.value)
-                            .map_err(|e| EnvVarError::DecryptionFailed {
+                    let decrypted_value = if var.is_secret {
+                        SECRET_VALUE_MASK.to_string()
+                    } else {
+                        encryption_service.decrypt_string(&var.value).map_err(|e| {
+                            EnvVarError::DecryptionFailed {
                                 var_id: var.id,
                                 key: var.key.clone(),
                                 reason: e.to_string(),
-                            })?;
+                            }
+                        })?
+                    };
 
-                        Ok(EnvVarWithEnvironments {
-                            id: var.id,
-                            project_id: var.project_id,
-                            key: var.key,
-                            value: decrypted_value,
-                            created_at: var.created_at,
-                            updated_at: var.updated_at,
-                            environments,
-                        })
+                    Ok(EnvVarWithEnvironments {
+                        id: var.id,
+                        project_id: var.project_id,
+                        key: var.key,
+                        value: decrypted_value,
+                        created_at: var.created_at,
+                        updated_at: var.updated_at,
+                        environments,
                     })
                 })
-                .await?;
+            })
+            .await?;
 
         Ok(result)
     }
@@ -270,76 +286,80 @@ impl EnvVarService {
         let encrypted_value = self.encrypt_value(&key, &value)?;
         let encryption_service = self.encryption_service.clone();
 
-        let result =
-            self.db
-                .transaction::<_, EnvVarWithEnvironments, EnvVarError>(|txn| {
-                    let encrypted_value = encrypted_value.clone();
-                    let key = key.clone();
-                    let environment_ids = environment_ids.clone();
+        let result = self
+            .db
+            .transaction::<_, EnvVarWithEnvironments, EnvVarError>(|txn| {
+                let encrypted_value = encrypted_value.clone();
+                let key = key.clone();
+                let environment_ids = environment_ids.clone();
 
-                    Box::pin(async move {
-                        let env_var = env_vars::Entity::find_by_id(var_id)
-                            .filter(env_vars::Column::ProjectId.eq(project_id))
+                Box::pin(async move {
+                    let env_var = env_vars::Entity::find_by_id(var_id)
+                        .filter(env_vars::Column::ProjectId.eq(project_id))
+                        .one(txn)
+                        .await?
+                        .ok_or(EnvVarError::Other(
+                            "Environment variable not found".to_string(),
+                        ))?;
+
+                    let mut active_var: env_vars::ActiveModel = env_var.into();
+                    active_var.key = Set(key.clone());
+                    active_var.value = Set(encrypted_value);
+                    active_var.is_encrypted = Set(true);
+                    active_var.updated_at = Set(chrono::Utc::now());
+                    let var = active_var.update(txn).await?;
+
+                    env_var_environments::Entity::delete_many()
+                        .filter(env_var_environments::Column::EnvVarId.eq(var_id))
+                        .exec(txn)
+                        .await?;
+
+                    let mut environments = Vec::new();
+                    for env_id in &environment_ids {
+                        let new_env_rel = env_var_environments::ActiveModel {
+                            env_var_id: Set(var.id),
+                            environment_id: Set(*env_id),
+                            created_at: Set(chrono::Utc::now()),
+                            ..Default::default()
+                        };
+
+                        new_env_rel.insert(txn).await?;
+
+                        let env = environments::Entity::find_by_id(*env_id)
                             .one(txn)
                             .await?
-                            .ok_or(EnvVarError::Other(
-                                "Environment variable not found".to_string(),
-                            ))?;
+                            .ok_or(EnvVarError::Other("Environment not found".to_string()))?;
 
-                        let mut active_var: env_vars::ActiveModel = env_var.into();
-                        active_var.key = Set(key.clone());
-                        active_var.value = Set(encrypted_value);
-                        active_var.is_encrypted = Set(true);
-                        active_var.updated_at = Set(chrono::Utc::now());
-                        let var = active_var.update(txn).await?;
+                        environments.push(EnvVarEnvironment {
+                            id: env.id,
+                            name: env.name,
+                        });
+                    }
 
-                        env_var_environments::Entity::delete_many()
-                            .filter(env_var_environments::Column::EnvVarId.eq(var_id))
-                            .exec(txn)
-                            .await?;
-
-                        let mut environments = Vec::new();
-                        for env_id in &environment_ids {
-                            let new_env_rel = env_var_environments::ActiveModel {
-                                env_var_id: Set(var.id),
-                                environment_id: Set(*env_id),
-                                created_at: Set(chrono::Utc::now()),
-                                ..Default::default()
-                            };
-
-                            new_env_rel.insert(txn).await?;
-
-                            let env = environments::Entity::find_by_id(*env_id)
-                                .one(txn)
-                                .await?
-                                .ok_or(EnvVarError::Other("Environment not found".to_string()))?;
-
-                            environments.push(EnvVarEnvironment {
-                                id: env.id,
-                                name: env.name,
-                            });
-                        }
-
-                        let decrypted_value = encryption_service
-                            .decrypt_string(&var.value)
-                            .map_err(|e| EnvVarError::DecryptionFailed {
+                    let decrypted_value = if var.is_secret {
+                        SECRET_VALUE_MASK.to_string()
+                    } else {
+                        encryption_service.decrypt_string(&var.value).map_err(|e| {
+                            EnvVarError::DecryptionFailed {
                                 var_id: var.id,
                                 key: var.key.clone(),
                                 reason: e.to_string(),
-                            })?;
+                            }
+                        })?
+                    };
 
-                        Ok(EnvVarWithEnvironments {
-                            id: var.id,
-                            project_id: var.project_id,
-                            key: var.key,
-                            value: decrypted_value,
-                            created_at: var.created_at,
-                            updated_at: var.updated_at,
-                            environments,
-                        })
+                    Ok(EnvVarWithEnvironments {
+                        id: var.id,
+                        project_id: var.project_id,
+                        key: var.key,
+                        value: decrypted_value,
+                        created_at: var.created_at,
+                        updated_at: var.updated_at,
+                        environments,
                     })
                 })
-                .await?;
+            })
+            .await?;
 
         Ok(result)
     }
@@ -383,6 +403,16 @@ impl EnvVarService {
             .one(self.db.as_ref())
             .await?
             .ok_or_else(|| EnvVarError::Other("Environment variable not found".to_string()))?;
+
+        // Mirrors the guard in temps-environments' EnvVarService: a variable
+        // converted to a secret is write-only on every read path, so no caller
+        // can walk around the restriction by reaching this service instead.
+        if var.is_secret {
+            return Err(EnvVarError::SecretValueCannotBeRevealed {
+                var_id: var.id,
+                key: var.key,
+            });
+        }
 
         self.decrypt_value(var.id, &var.key, &var.value, var.is_encrypted)
     }

--- a/web/src/components/project/settings/EnvironmentVariablesSettings.tsx
+++ b/web/src/components/project/settings/EnvironmentVariablesSettings.tsx
@@ -211,6 +211,10 @@ function EnvironmentVariableRow({
   const [editIncludeInPreview, setEditIncludeInPreview] = useState(
     variable.include_in_preview ?? false
   )
+  // Opt-in conversion of an existing plain variable into a write-only secret.
+  // One-way: once saved, the value can never be read back through the UI or the
+  // API, so it stays off unless the operator explicitly turns it on.
+  const [convertToSecret, setConvertToSecret] = useState(false)
 
   // Update selected environments and preview flag when variable changes (after refetch)
   useEffect(() => {
@@ -236,6 +240,7 @@ function EnvironmentVariableRow({
     if (!open) {
       setEditValue('')
       setIsEditMultiline(false)
+      setConvertToSecret(false)
       if (!isVisible && !showAllValues) {
         revealGuard.current.cancel('value')
         setRevealedValue(undefined)
@@ -259,10 +264,15 @@ function EnvironmentVariableRow({
         environment_ids: selectedEditEnvironments,
         key: variable.key,
         include_in_preview: editIncludeInPreview,
+        // Only sent when the operator asked for the conversion. Omitting the
+        // field leaves the existing flag untouched; sending `false` against an
+        // already-secret variable is rejected by the API as a demotion.
+        ...(convertToSecret ? { is_secret: true } : {}),
       },
     })
     setIsEditModalOpen(false)
     setEditValue('')
+    setConvertToSecret(false)
   }
 
   const { data: allEnvironments } = useQuery({
@@ -493,6 +503,34 @@ function EnvironmentVariableRow({
                   onCheckedChange={setEditIncludeInPreview}
                 />
               </div>
+              {!isSecret && (
+                <div
+                  className={`flex items-center justify-between space-x-2 rounded-lg border p-4 ${
+                    convertToSecret
+                      ? 'border-amber-500/40 bg-amber-500/5'
+                      : ''
+                  }`}
+                >
+                  <div className="flex-1 space-y-1">
+                    <Label
+                      htmlFor="edit-convert-secret"
+                      className="text-sm font-medium"
+                    >
+                      Convert to secret
+                    </Label>
+                    <p className="text-sm text-muted-foreground">
+                      {convertToSecret
+                        ? `On save, ${variable.key} becomes write-only: the value is masked in the UI and no longer returned by the API. You can still overwrite it, but never read it back — to make it a regular variable again you must delete it and create it anew.`
+                        : 'Make this variable write-only so its value can never be read from the UI or the API again. One-way: converting back means deleting and recreating the variable.'}
+                    </p>
+                  </div>
+                  <Switch
+                    id="edit-convert-secret"
+                    checked={convertToSecret}
+                    onCheckedChange={setConvertToSecret}
+                  />
+                </div>
+              )}
             </div>
             <DialogFooter>
               <Button

--- a/web/src/components/project/settings/EnvironmentVariablesSettings.tsx
+++ b/web/src/components/project/settings/EnvironmentVariablesSettings.tsx
@@ -211,6 +211,11 @@ function EnvironmentVariableRow({
   const [editIncludeInPreview, setEditIncludeInPreview] = useState(
     variable.include_in_preview ?? false
   )
+  // Whether the edit box actually holds the variable's current value. False
+  // when the reveal was denied (it needs SecretsRead on top of EnvironmentsWrite)
+  // or failed, which is what distinguishes "cleared on purpose" from "never
+  // loaded" when the box is empty on save.
+  const [valueLoaded, setValueLoaded] = useState(false)
   // Opt-in conversion of an existing plain variable into a write-only secret.
   // One-way: once saved, the value can never be read back through the UI or the
   // API, so it stays off unless the operator explicitly turns it on.
@@ -231,6 +236,7 @@ function EnvironmentVariableRow({
       if (value !== undefined) {
         setEditValue(value)
         setIsEditMultiline(value.includes('\n'))
+        setValueLoaded(true)
       }
     }
   }
@@ -241,6 +247,7 @@ function EnvironmentVariableRow({
       setEditValue('')
       setIsEditMultiline(false)
       setConvertToSecret(false)
+      setValueLoaded(false)
       if (!isVisible && !showAllValues) {
         revealGuard.current.cancel('value')
         setRevealedValue(undefined)
@@ -248,12 +255,23 @@ function EnvironmentVariableRow({
     }
   }
 
+  // Both the secret case and the failed-reveal case mean "blank keeps what is
+  // already stored" — say so, so an empty box is never mistaken for an empty value.
+  const valuePlaceholder =
+    isSecret || !valueLoaded ? 'Leave blank to keep current value' : undefined
+
   const submitEdit = async () => {
-    // For secrets we never preloaded the value; an empty editValue means
-    // "keep the existing ciphertext". For regular vars we send the current
-    // text either way.
+    // An empty box means "keep the existing ciphertext" whenever we never had
+    // the value to begin with: always for secrets (never preloaded), and for a
+    // regular variable whose reveal was denied or failed. Sending "" in that
+    // case would overwrite the credential with an empty string — and if the
+    // same save also promotes the variable, that loss is unrecoverable.
+    // A cleared box after a *successful* reveal is a deliberate edit and is
+    // still sent as-is.
     const valueField =
-      isSecret && editValue.length === 0 ? undefined : editValue
+      editValue.length === 0 && (isSecret || !valueLoaded)
+        ? undefined
+        : editValue
     await updateMutation.mutateAsync({
       path: {
         project_id: project.id,
@@ -273,6 +291,7 @@ function EnvironmentVariableRow({
     setIsEditModalOpen(false)
     setEditValue('')
     setConvertToSecret(false)
+    setValueLoaded(false)
   }
 
   const { data: allEnvironments } = useQuery({
@@ -445,14 +464,14 @@ function EnvironmentVariableRow({
                     onChange={(e) => setEditValue(e.target.value)}
                     className="font-mono resize-y"
                     rows={6}
-                    placeholder={isSecret ? 'Leave blank to keep current value' : undefined}
+                    placeholder={valuePlaceholder}
                   />
                 ) : (
                   <Input
                     value={editValue}
                     onChange={(e) => setEditValue(e.target.value)}
                     className="font-mono"
-                    placeholder={isSecret ? 'Leave blank to keep current value' : undefined}
+                    placeholder={valuePlaceholder}
                   />
                 )}
                 {isSecret && (


### PR DESCRIPTION
## What

Adds the missing way to take an environment variable that **already exists** and make its value unreadable.

The backend already accepted `is_secret: true` on update and the CLI already had `--secret`, but no UI surfaced it — so the only route to secret-ify an existing variable was delete-and-recreate, which means re-typing the value you were trying to protect.

Open the variable's **Edit** dialog → **Convert to secret** → Save.

## The rule

The flag is one-way, as before: **an env var can be converted to a secret, but not back.** To make a secret readable again you must delete it and create it anew, supplying the value yourself. Demotion is rejected with a 400 whose message now states that escape hatch instead of only refusing:

> Environment variable 'STRIPE_SECRET_KEY' (id=2) is a secret and cannot be converted back to a regular variable. Delete it and create it again as a non-secret variable, supplying the value yourself.

## Changes

- **web** — `Convert to secret` switch in the Edit dialog, rendered only for regular variables. Copy states plainly that the change is one-way and what the way back is.
- **`env_var_service`** — reports the non-secret → secret transition to the handler, and **encrypts legacy plaintext rows** (`is_encrypted = false`) as part of the promotion. Marking a row secret while leaving its value readable in Postgres would only hide it from the API, not protect it.
- **handler** — audits the transition as `ENVIRONMENT_VARIABLE_PROMOTED_TO_SECRET` rather than folding it into an untracked update.
- **`temps-projects`'s second `EnvVarService`** — decrypted and returned every value with no `is_secret` check. Not currently reachable over HTTP, but any future handler wired to it would have leaked secrets. Now masks in listings and rejects reveals, so the invariant holds wherever that service is used.
- **temps-cli** — `vars list`/`get` label secrets instead of rendering an empty cell; `vars export` and `env-sync pull` **crashed** on a project containing a secret (`v.value.includes` on `null`) and now skip them with an explicit warning naming the skipped keys.

## Evidence

Run against a live local instance: create `STRIPE_SECRET_KEY` as a regular variable, convert it via the UI, then probe it.

**UI walkthrough** — plain var → reveal plaintext → Edit dialog → toggle on (one-way warning) → saved with `SECRET` badge, masked, reveal button gone → reopened dialog shows the write-only notice and no way back:

| before | after |
|---|---|
| `STRIPE_SECRET_KEY` · `sk_live_51H8xQ2eZvKYlo2C9ExAmPlE` visible with reveal button | `STRIPE_SECRET_KEY` `SECRET` · `••••••••••••` · no reveal button |

**Reveal endpoint refuses (403):**

```
$ curl -b cookies -s http://localhost:8210/api/projects/2/env-vars/STRIPE_SECRET_KEY/value -w "\nHTTP %{http_code}\n"
{"detail":"Secret env var 'STRIPE_SECRET_KEY' (id=2) is write-only and cannot be revealed",
 "error_code":"FORBIDDEN","title":"Secret environment variable is write-only",
 "type":"https://temps.sh/probs/forbidden"}
HTTP 403
```

**List endpoint withholds the value:**

```
$ curl -b cookies -s http://localhost:8210/api/projects/2/env-vars
[{"id":2,"key":"STRIPE_SECRET_KEY","value":null, ... ,"is_secret":true}]
```

**Demotion rejected (400):**

```
$ curl -b cookies -s -X PUT .../env-vars/2 -d '{"key":"STRIPE_SECRET_KEY","environment_ids":[2],"include_in_preview":true,"is_secret":false}'
{"detail":"Environment variable 'STRIPE_SECRET_KEY' (id=2) is a secret and cannot be converted
 back to a regular variable. Delete it and create it again as a non-secret variable, supplying
 the value yourself.","title":"Secret cannot be converted back to a regular variable"}
HTTP 400
```

**Encrypted at rest after promotion** (the row was created before the conversion):

```
temps_dev_s13=# SELECT id, key, is_secret, is_encrypted, left(value,24) FROM env_vars WHERE id=2;
 id |        key        | is_secret | is_encrypted |           left
----+-------------------+-----------+--------------+--------------------------
  2 | STRIPE_SECRET_KEY | t         | t            | r6Pb0yBCMesulB8VFVnYQkrp
```

**Audit row written:**

```
      operation_type              | user_id |          created_at
----------------------------------+---------+-------------------------------
 ENVIRONMENT_VARIABLE_PROMOTED_TO_SECRET | 1 | 2026-08-05 09:27:40.677906+00
```

## Tests

Three new unit tests in `env_var_service`: promotion is reported and withholds the value, a no-op update of an already-secret row is *not* reported as a promotion (so it doesn't emit a duplicate audit), and demotion is rejected.

```
$ cargo test --lib -p temps-environments -p temps-projects
cargo test: 141 passed (2 suites, 44.81s)
```

`cargo check --lib` clean across the workspace; `tsc --noEmit` clean for every touched TS file; pre-commit `cargo clippy` passed.

## Notes for review

- No migration and no OpenAPI change — `is_secret: Option<bool>` on the update request already existed, so the generated SDKs needed no regeneration.
- The promotion path is control-plane only (one row per operator action); no hot-path impact.
