### PR TITLE
feat(flags): multi-language integration guide, and shiki-highlighted code blocks

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -64,6 +64,7 @@
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
         "rrweb-player": "^2.1.1",
+        "shiki": "^4.4.2",
         "simple-icons": "^16.27.1",
         "slugify": "^1.6.9",
         "sonner": "^2.0.7",
@@ -412,6 +413,22 @@
     "@rspack/core": ["@rspack/core@2.1.7", "", { "dependencies": { "@rspack/binding": "2.1.7" }, "peerDependencies": { "@module-federation/runtime-tools": "^0.24.1 || ^2.0.0", "@swc/helpers": "^0.5.23" }, "optionalPeers": ["@module-federation/runtime-tools", "@swc/helpers"] }, "sha512-d5Ju3zXzGgbqQWvlMlLUtek2eFPIzsFe2QOF4nwTAknxo/4OZ64t+kPT9nM6fr3aZX93VK0R3v02/kZYIRrV9Q=="],
 
     "@rspack/plugin-react-refresh": ["@rspack/plugin-react-refresh@2.0.2", "", { "peerDependencies": { "@rspack/core": "^2.0.0", "react-refresh": ">=0.10.0 <1.0.0" }, "optionalPeers": ["@rspack/core"] }, "sha512-dGNZiCxQxgAUI9sah7gd8u+O7OJZRCmqtEJNDOd8xW5RqcieC86F7p5qcShyw6onH5pKf57evpr2VjGbaFGkZg=="],
+
+    "@shikijs/core": ["@shikijs/core@4.4.2", "", { "dependencies": { "@shikijs/primitive": "4.4.2", "@shikijs/types": "4.4.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5", "hast-util-to-html": "^9.0.5" } }, "sha512-StyzbAyxg2/tBGf78gwbBkGyeQ73lf8UiJArFaQhTQIDqQOCKPCQFanvrs4/Yv3Yfyc+ONInJM6K+FMIf+P+kA=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.4.2", "", { "dependencies": { "@shikijs/types": "4.4.2", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-MnIkeqWdVPUWsxlx8gKLVCJFTsqrQJgpTPBPpQwaFeJ56lOnJxj5aN2LUFnfxUEcvOQuNocmbaMnVrCEln6rkw=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.4.2", "", { "dependencies": { "@shikijs/types": "4.4.2", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-GLhowz1+jixjz+wiZ3wMnOn1jTxiFCGl2PkXufivbnwPHKuyw1AYqu5/hbWhZZ2oAb0NP05WUJhYeigY14drnw=="],
+
+    "@shikijs/langs": ["@shikijs/langs@4.4.2", "", { "dependencies": { "@shikijs/types": "4.4.2" } }, "sha512-8DfeusD+Zdv/eYIDdXyJTUnSMHt+aAWjAOCXV20HNGAHRlInXpG8wh421v6B91WOm9TFwRLN+b/LG5F2NAIojg=="],
+
+    "@shikijs/primitive": ["@shikijs/primitive@4.4.2", "", { "dependencies": { "@shikijs/types": "4.4.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5" } }, "sha512-l6fQQKsOMlz72n38fztmSgZ76MO6KSWuw8o+GJ+FhmqrpC9pIOJNQNXGgbb5yX2AwpzlEHwsaLPnk/8o4Fm+rA=="],
+
+    "@shikijs/themes": ["@shikijs/themes@4.4.2", "", { "dependencies": { "@shikijs/types": "4.4.2" } }, "sha512-H0CFoL07ddDC2Dd6EdrPYNkRhUR6YCkJlnuYFceYYUJJA5TIm2b5B33qqiDYryBExgbKMndFJPb2u1gTuqO37g=="],
+
+    "@shikijs/types": ["@shikijs/types@4.4.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5" } }, "sha512-PFYitV4vpDr/iPCIhnHp+Q4ftic5N5VeNJ3KQ1O8gn3h2ar8qgwMAXF7tq4m1CWaMS60fV4VqF6vfnWH4F7vqQ=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -919,6 +936,8 @@
 
     "hast-util-is-element": ["hast-util-is-element@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g=="],
 
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
     "hast-util-to-text": ["hast-util-to-text@4.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "hast-util-is-element": "^3.0.0", "unist-util-find-after": "^5.0.0" } }, "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A=="],
@@ -934,6 +953,8 @@
     "hls.js": ["hls.js@1.6.15", "", {}, "sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
@@ -1227,6 +1248,10 @@
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
+    "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
+
     "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
@@ -1329,6 +1354,12 @@
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
 
     "rehype-highlight": ["rehype-highlight@7.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-text": "^4.0.0", "lowlight": "^3.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA=="],
@@ -1380,6 +1411,8 @@
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "shiki": ["shiki@4.4.2", "", { "dependencies": { "@shikijs/core": "4.4.2", "@shikijs/engine-javascript": "4.4.2", "@shikijs/engine-oniguruma": "4.4.2", "@shikijs/langs": "4.4.2", "@shikijs/themes": "4.4.2", "@shikijs/types": "4.4.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5" } }, "sha512-P8F/dFhRevaw2uSdeIYlq/5SXZNY85DPtmXQ947gD1Zj2JqO5AkNvVVBar0Me9JkFx3uzVud/qOtP5ek9NEQGA=="],
 
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
@@ -1565,6 +1598,12 @@
 
     "@rrweb/packer/fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
+    "@shikijs/core/@types/hast": ["@types/hast@3.0.5", "", { "dependencies": { "@types/unist": "*" } }, "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g=="],
+
+    "@shikijs/primitive/@types/hast": ["@types/hast@3.0.5", "", { "dependencies": { "@types/unist": "*" } }, "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g=="],
+
+    "@shikijs/types/@types/hast": ["@types/hast@3.0.5", "", { "dependencies": { "@types/unist": "*" } }, "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
@@ -1611,6 +1650,8 @@
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "hast-util-to-html/@types/hast": ["@types/hast@3.0.5", "", { "dependencies": { "@types/unist": "*" } }, "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g=="],
+
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
@@ -1618,6 +1659,8 @@
     "postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "shiki/@types/hast": ["@types/hast@3.0.5", "", { "dependencies": { "@types/unist": "*" } }, "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g=="],
 
     "stats-gl/@types/three": ["@types/three@0.182.0", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~0.22.0" } }, "sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -93,6 +93,7 @@
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
     "rrweb-player": "^2.1.1",
+    "shiki": "^4.4.2",
     "simple-icons": "^16.27.1",
     "slugify": "^1.6.9",
     "sonner": "^2.0.7",

--- a/web/src/components/project/flags/FlagsSetupGuide.tsx
+++ b/web/src/components/project/flags/FlagsSetupGuide.tsx
@@ -1,0 +1,734 @@
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { CodeBlock } from '@/components/ui/code-block'
+import { CopyButton } from '@/components/ui/copy-button'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Info } from 'lucide-react'
+
+interface FlagsSetupGuideProps {
+  /** Environment the flags table is currently showing, so the snippets ask for the same one. */
+  environmentId?: number
+  environmentName?: string
+  /** An existing flag key makes the examples copy-paste runnable; falls back to a placeholder. */
+  sampleFlagKey?: string
+}
+
+/**
+ * Integration guide for reading flags from a running application.
+ *
+ * There is no per-language Temps flag SDK, and inventing one for six ecosystems
+ * is not the same job as shipping flags. What every language *does* have is an
+ * HTTP client, so each snippet is a complete, self-contained client against the
+ * two public endpoints:
+ *
+ *   GET  $TEMPS_API_URL/flags/snapshot   -> every flag for the token's environment
+ *   POST $TEMPS_API_URL/flags/exposure   -> which keys the app actually read
+ *
+ * Every snippet implements the same four rules, because getting any of them
+ * wrong is what turns a flag into an outage:
+ *   1. Poll in the background and evaluate from memory — never block a request
+ *      on the control plane.
+ *   2. Send If-None-Match, so the steady state is a 304.
+ *   3. On any failure (network, 5xx, malformed value) serve the caller's own
+ *      fallback rather than throwing.
+ *   4. `enabled: false` is the kill switch — serve `default_value`, ignoring
+ *      any environment override.
+ */
+export function FlagsSetupGuide({
+  environmentId,
+  environmentName,
+  sampleFlagKey,
+}: FlagsSetupGuideProps) {
+  const flagKey = sampleFlagKey ?? 'checkout.v2'
+  // A deployment token is normally pinned to one environment and the query
+  // parameter is ignored. Project-wide tokens must say which environment they
+  // mean, so the snippets carry it — using the one the operator is looking at.
+  const envQuery = environmentId ? `?environment_id=${environmentId}` : ''
+  const envSuffix = environmentName ? ` (${environmentName})` : ''
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">1. Credentials</CardTitle>
+          <CardDescription>
+            Apps deployed on this instance already have these. Set them yourself
+            only when running locally or somewhere else — a deployment token
+            pins the project and environment, so no app can read another
+            project&apos;s flags.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <CodeBlock
+            code={`# Injected automatically into every deployment on Temps
+TEMPS_API_URL=https://your-instance.temps.dev/api
+TEMPS_API_TOKEN=dt_...`}
+            language="bash"
+          />
+          <p className="text-sm text-muted-foreground">
+            Verify the token can see this environment{envSuffix} before wiring
+            up any code:
+          </p>
+          <CodeBlock
+            code={`curl -s -H "Authorization: Bearer $TEMPS_API_TOKEN" \\
+  "$TEMPS_API_URL/flags/snapshot${envQuery}"`}
+            language="bash"
+          />
+          <Alert>
+            <Info className="h-4 w-4" />
+            <AlertDescription>
+              A <strong>400 Deployment Token Required</strong> means you used a
+              session or API key. Those read flags through{' '}
+              <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                /projects/{'{project_id}'}/flags
+              </code>{' '}
+              instead — the snapshot endpoint is only for running apps.
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-start justify-between gap-2">
+            <div className="space-y-1.5">
+              <CardTitle className="text-base">
+                2. Read flags from your app
+              </CardTitle>
+              <CardDescription>
+                Each snippet is a complete client: it polls in the background,
+                caches with an ETag, evaluates in memory, and falls back to your
+                own default whenever Temps is unreachable. No request of yours
+                ever waits on the control plane.
+              </CardDescription>
+            </div>
+            <CopyButton
+              value={aiPrompt(flagKey, envQuery)}
+              className="shrink-0 rounded-md border border-border px-3 py-1.5 text-xs font-medium"
+            >
+              Copy AI Prompt
+            </CopyButton>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Tabs defaultValue="node" className="w-full">
+            <TabsList className="flex h-auto w-full flex-wrap justify-start gap-1">
+              <TabsTrigger value="node">Node.js</TabsTrigger>
+              <TabsTrigger value="python">Python</TabsTrigger>
+              <TabsTrigger value="go">Go</TabsTrigger>
+              <TabsTrigger value="ruby">Ruby</TabsTrigger>
+              <TabsTrigger value="php">PHP</TabsTrigger>
+              <TabsTrigger value="java">Java</TabsTrigger>
+              <TabsTrigger value="curl">Any language</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="node" className="mt-4">
+              <CodeBlock
+                code={nodeSnippet(flagKey, envQuery)}
+                language="typescript"
+              />
+            </TabsContent>
+            <TabsContent value="python" className="mt-4">
+              <CodeBlock
+                code={pythonSnippet(flagKey, envQuery)}
+                language="python"
+              />
+            </TabsContent>
+            <TabsContent value="go" className="mt-4">
+              <CodeBlock code={goSnippet(flagKey, envQuery)} language="go" />
+            </TabsContent>
+            <TabsContent value="ruby" className="mt-4">
+              <CodeBlock
+                code={rubySnippet(flagKey, envQuery)}
+                language="ruby"
+              />
+            </TabsContent>
+            <TabsContent value="php" className="mt-4">
+              <CodeBlock code={phpSnippet(flagKey, envQuery)} language="php" />
+            </TabsContent>
+            <TabsContent value="java" className="mt-4">
+              <CodeBlock
+                code={javaSnippet(flagKey, envQuery)}
+                language="java"
+              />
+            </TabsContent>
+            <TabsContent value="curl" className="mt-4 space-y-3">
+              <p className="text-sm text-muted-foreground">
+                The whole contract is two endpoints and one evaluation rule, so
+                a client in any language is about forty lines.
+              </p>
+              <CodeBlock code={wireContract(envQuery)} language="bash" />
+            </TabsContent>
+          </Tabs>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">
+            3. Report which flags you read
+          </CardTitle>
+          <CardDescription>
+            Optional, and worth it. Evaluation happens inside your process, so
+            without this the control plane cannot tell a flag live code depends
+            on from one nothing has called in a year — which is what makes flags
+            safe to delete. Batch the keys and post them on an interval; the
+            endpoint only stamps a timestamp and can never change what a flag
+            serves.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <CodeBlock
+            code={`curl -s -X POST -H "Authorization: Bearer $TEMPS_API_TOKEN" \\
+  -H "Content-Type: application/json" \\
+  -d '{"keys": ["${flagKey}"]}' \\
+  "$TEMPS_API_URL/flags/exposure"`}
+            language="bash"
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">
+            4. Manage flags from anywhere
+          </CardTitle>
+          <CardDescription>
+            Everything on this page is also a CLI command, so flag flips can
+            live in scripts, CI, and incident runbooks instead of only in a
+            browser tab.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <CodeBlock
+            code={cliSnippet(flagKey, environmentName)}
+            language="bash"
+          />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+// =============================================================================
+// Snippets
+//
+// Kept as plain functions rather than a template map: each ecosystem has a
+// different idiom for background work and HTTP, and flattening them into one
+// parameterised template produces code nobody would actually write.
+// =============================================================================
+
+function nodeSnippet(flagKey: string, envQuery: string): string {
+  return `// flags.ts — no dependencies, works in Node 18+ and Bun.
+const API_URL = process.env.TEMPS_API_URL!
+const TOKEN = process.env.TEMPS_API_TOKEN!
+
+type Flag = {
+  key: string
+  value_type: 'bool' | 'string' | 'number' | 'json'
+  default_value: unknown
+  enabled: boolean
+  environment_value: unknown | null
+}
+
+let cache = new Map<string, Flag>()
+let etag: string | null = null
+
+async function refresh() {
+  const res = await fetch(\`\${API_URL}/flags/snapshot${envQuery}\`, {
+    headers: {
+      Authorization: \`Bearer \${TOKEN}\`,
+      ...(etag ? { 'If-None-Match': etag } : {}),
+    },
+  })
+  if (res.status === 304) return // unchanged — the common case
+  if (!res.ok) throw new Error(\`flag snapshot: \${res.status}\`)
+  etag = res.headers.get('etag')
+  const body = (await res.json()) as { flags: Flag[] }
+  cache = new Map(body.flags.map((f) => [f.key, f]))
+}
+
+/** Never throws, never blocks: an unreachable control plane serves your fallback. */
+export function flag<T>(key: string, fallback: T): T {
+  const f = cache.get(key)
+  if (!f) return fallback
+  // enabled: false is the kill switch — the override is ignored.
+  const value = f.enabled ? (f.environment_value ?? f.default_value) : f.default_value
+  return (value as T) ?? fallback
+}
+
+/** Await once at boot so the first request already has real values. */
+export async function startFlags(intervalMs = 15_000) {
+  await refresh().catch((e) => console.warn('flags: initial fetch failed', e))
+  setInterval(() => refresh().catch(() => {}), intervalMs).unref()
+}
+
+// Usage
+// await startFlags()
+// if (flag('${flagKey}', false)) { /* new path */ }`
+}
+
+function pythonSnippet(flagKey: string, envQuery: string): string {
+  return `# flags.py — requires: pip install requests
+import os, threading, time, requests
+
+API_URL = os.environ["TEMPS_API_URL"]
+TOKEN = os.environ["TEMPS_API_TOKEN"]
+
+_cache: dict[str, dict] = {}
+_etag: str | None = None
+_lock = threading.Lock()
+
+
+def _refresh() -> None:
+    global _etag
+    headers = {"Authorization": f"Bearer {TOKEN}"}
+    if _etag:
+        headers["If-None-Match"] = _etag
+    res = requests.get(f"{API_URL}/flags/snapshot${envQuery}", headers=headers, timeout=5)
+    if res.status_code == 304:  # unchanged — the common case
+        return
+    res.raise_for_status()
+    _etag = res.headers.get("ETag")
+    with _lock:
+        _cache.clear()
+        _cache.update({f["key"]: f for f in res.json()["flags"]})
+
+
+def flag(key: str, fallback):
+    """Never raises, never blocks: an unreachable control plane serves your fallback."""
+    with _lock:
+        f = _cache.get(key)
+    if f is None:
+        return fallback
+    # enabled: False is the kill switch — the override is ignored.
+    value = (f["environment_value"] if f["enabled"] else None)
+    if value is None:
+        value = f["default_value"]
+    return fallback if value is None else value
+
+
+def start_flags(interval: float = 15.0) -> None:
+    """Call once at startup. Blocks only for the first fetch."""
+    try:
+        _refresh()
+    except Exception as e:  # noqa: BLE001 — flags must never break boot
+        print(f"flags: initial fetch failed: {e}")
+
+    def loop() -> None:
+        while True:
+            time.sleep(interval)
+            try:
+                _refresh()
+            except Exception:  # noqa: BLE001
+                pass
+
+    threading.Thread(target=loop, daemon=True).start()
+
+
+# Usage
+# start_flags()
+# if flag("${flagKey}", False):
+#     ...`
+}
+
+function goSnippet(flagKey: string, envQuery: string): string {
+  return `// flags.go — standard library only.
+package flags
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+type Flag struct {
+	Key              string          \`json:"key"\`
+	ValueType        string          \`json:"value_type"\`
+	DefaultValue     json.RawMessage \`json:"default_value"\`
+	Enabled          bool            \`json:"enabled"\`
+	EnvironmentValue json.RawMessage \`json:"environment_value"\`
+}
+
+var (
+	mu    sync.RWMutex
+	cache = map[string]Flag{}
+	etag  string
+	http5 = &http.Client{Timeout: 5 * time.Second}
+)
+
+func refresh() error {
+	req, err := http.NewRequest("GET", os.Getenv("TEMPS_API_URL")+"/flags/snapshot${envQuery}", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+os.Getenv("TEMPS_API_TOKEN"))
+	mu.RLock()
+	if etag != "" {
+		req.Header.Set("If-None-Match", etag)
+	}
+	mu.RUnlock()
+
+	res, err := http5.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode == http.StatusNotModified { // unchanged — the common case
+		return nil
+	}
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("flag snapshot: %s", res.Status)
+	}
+	var body struct {
+		Flags []Flag \`json:"flags"\`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		return err
+	}
+	next := make(map[string]Flag, len(body.Flags))
+	for _, f := range body.Flags {
+		next[f.Key] = f
+	}
+	mu.Lock()
+	cache, etag = next, res.Header.Get("ETag")
+	mu.Unlock()
+	return nil
+}
+
+// Bool never errors and never blocks: an unreachable control plane serves your fallback.
+func Bool(key string, fallback bool) bool {
+	mu.RLock()
+	f, ok := cache[key]
+	mu.RUnlock()
+	if !ok {
+		return fallback
+	}
+	raw := f.DefaultValue
+	// Enabled == false is the kill switch — the override is ignored.
+	if f.Enabled && len(f.EnvironmentValue) > 0 && string(f.EnvironmentValue) != "null" {
+		raw = f.EnvironmentValue
+	}
+	var v bool
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return fallback
+	}
+	return v
+}
+
+// Start once at boot. The first fetch is synchronous so the first request has real values.
+func Start(interval time.Duration) {
+	if err := refresh(); err != nil {
+		fmt.Fprintf(os.Stderr, "flags: initial fetch failed: %v\\n", err)
+	}
+	go func() {
+		for range time.Tick(interval) {
+			_ = refresh()
+		}
+	}()
+}
+
+// Usage
+// flags.Start(15 * time.Second)
+// if flags.Bool("${flagKey}", false) { ... }`
+}
+
+function rubySnippet(flagKey: string, envQuery: string): string {
+  return `# flags.rb — standard library only.
+require 'json'
+require 'net/http'
+
+module Flags
+  API_URL = ENV.fetch('TEMPS_API_URL')
+  TOKEN = ENV.fetch('TEMPS_API_TOKEN')
+
+  @cache = {}
+  @etag = nil
+  @mutex = Mutex.new
+
+  class << self
+    def refresh
+      uri = URI("#{API_URL}/flags/snapshot${envQuery}")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{TOKEN}"
+      req['If-None-Match'] = @etag if @etag
+
+      res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https',
+                            open_timeout: 5, read_timeout: 5) { |h| h.request(req) }
+      return if res.code == '304' # unchanged — the common case
+      raise "flag snapshot: #{res.code}" unless res.code == '200'
+
+      flags = JSON.parse(res.body)['flags'].each_with_object({}) { |f, h| h[f['key']] = f }
+      @mutex.synchronize { @cache = flags; @etag = res['ETag'] }
+    end
+
+    # Never raises, never blocks: an unreachable control plane serves your fallback.
+    def get(key, fallback)
+      f = @mutex.synchronize { @cache[key] }
+      return fallback if f.nil?
+
+      # enabled: false is the kill switch — the override is ignored.
+      value = f['enabled'] ? f['environment_value'] : nil
+      value = f['default_value'] if value.nil?
+      value.nil? ? fallback : value
+    end
+
+    def start(interval = 15)
+      begin
+        refresh
+      rescue StandardError => e
+        warn "flags: initial fetch failed: #{e}"
+      end
+      Thread.new do
+        loop do
+          sleep interval
+          begin
+            refresh
+          rescue StandardError
+            nil
+          end
+        end
+      end
+    end
+  end
+end
+
+# Usage
+# Flags.start
+# if Flags.get('${flagKey}', false)`
+}
+
+function phpSnippet(flagKey: string, envQuery: string): string {
+  return `<?php
+// Flags.php — no dependencies. PHP is request-scoped, so cache the snapshot on
+// disk (or APCu/Redis) instead of in a background thread: one process refreshes
+// it, every request reads it.
+
+final class Flags
+{
+    private const TTL = 15; // seconds
+    private const CACHE = '/tmp/temps-flags.json';
+
+    private static array $flags = [];
+
+    public static function load(): void
+    {
+        $cached = @file_get_contents(self::CACHE);
+        $fresh = $cached !== false && (time() - @filemtime(self::CACHE)) < self::TTL;
+
+        if ($fresh) {
+            self::$flags = json_decode($cached, true)['flags'] ?? [];
+            return;
+        }
+
+        $ch = curl_init(getenv('TEMPS_API_URL') . '/flags/snapshot${envQuery}');
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => 5,
+            CURLOPT_HTTPHEADER => ['Authorization: Bearer ' . getenv('TEMPS_API_TOKEN')],
+        ]);
+        $body = curl_exec($ch);
+        $status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+        curl_close($ch);
+
+        if ($status === 200 && $body !== false) {
+            @file_put_contents(self::CACHE, $body, LOCK_EX);
+            self::$flags = json_decode($body, true)['flags'] ?? [];
+        } elseif ($cached !== false) {
+            // Control plane unreachable: keep serving the last good snapshot
+            // rather than losing every flag at once.
+            self::$flags = json_decode($cached, true)['flags'] ?? [];
+        }
+    }
+
+    /** Never throws: an unreachable control plane serves your fallback. */
+    public static function get(string $key, mixed $fallback): mixed
+    {
+        foreach (self::$flags as $f) {
+            if ($f['key'] !== $key) {
+                continue;
+            }
+            // enabled: false is the kill switch — the override is ignored.
+            $value = $f['enabled'] ? ($f['environment_value'] ?? null) : null;
+            return $value ?? $f['default_value'] ?? $fallback;
+        }
+        return $fallback;
+    }
+}
+
+// Usage (bootstrap)
+// Flags::load();
+// if (Flags::get('${flagKey}', false)) { ... }`
+}
+
+function javaSnippet(flagKey: string, envQuery: string): string {
+  return `// Flags.java — JDK 11+, no dependencies beyond a JSON parser (Jackson here).
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.net.http.*;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.*;
+
+public final class Flags {
+    private static final String API_URL = System.getenv("TEMPS_API_URL");
+    private static final String TOKEN = System.getenv("TEMPS_API_TOKEN");
+    private static final HttpClient HTTP =
+            HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private static volatile Map<String, JsonNode> cache = Map.of();
+    private static volatile String etag = null;
+
+    private static void refresh() throws Exception {
+        var builder = HttpRequest.newBuilder(URI.create(API_URL + "/flags/snapshot${envQuery}"))
+                .header("Authorization", "Bearer " + TOKEN)
+                .timeout(Duration.ofSeconds(5));
+        if (etag != null) builder.header("If-None-Match", etag);
+
+        HttpResponse<String> res = HTTP.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+        if (res.statusCode() == 304) return; // unchanged — the common case
+        if (res.statusCode() != 200) throw new IllegalStateException("flag snapshot: " + res.statusCode());
+
+        Map<String, JsonNode> next = new HashMap<>();
+        for (JsonNode f : JSON.readTree(res.body()).get("flags")) next.put(f.get("key").asText(), f);
+        cache = Map.copyOf(next);
+        etag = res.headers().firstValue("etag").orElse(null);
+    }
+
+    /** Never throws, never blocks: an unreachable control plane serves your fallback. */
+    public static boolean bool(String key, boolean fallback) {
+        JsonNode f = cache.get(key);
+        if (f == null) return fallback;
+        // enabled: false is the kill switch — the override is ignored.
+        JsonNode value = f.get("default_value");
+        JsonNode override = f.get("environment_value");
+        if (f.get("enabled").asBoolean() && override != null && !override.isNull()) value = override;
+        return value != null && value.isBoolean() ? value.asBoolean() : fallback;
+    }
+
+    /** Call once at startup. The first fetch is synchronous. */
+    public static void start(Duration interval) {
+        try {
+            refresh();
+        } catch (Exception e) {
+            System.err.println("flags: initial fetch failed: " + e.getMessage());
+        }
+        Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "temps-flags");
+            t.setDaemon(true);
+            return t;
+        }).scheduleAtFixedRate(() -> {
+            try {
+                refresh();
+            } catch (Exception ignored) {
+            }
+        }, interval.toSeconds(), interval.toSeconds(), TimeUnit.SECONDS);
+    }
+}
+
+// Usage
+// Flags.start(Duration.ofSeconds(15));
+// if (Flags.bool("${flagKey}", false)) { ... }`
+}
+
+function wireContract(envQuery: string): string {
+  return `# 1. Fetch every flag for the token's environment.
+#    Send If-None-Match to make the steady state a cheap 304.
+curl -s -D- -H "Authorization: Bearer $TEMPS_API_TOKEN" \\
+  "$TEMPS_API_URL/flags/snapshot${envQuery}"
+
+# ETag: "9f2c..."
+# {
+#   "environment_id": 3,
+#   "flags": [
+#     {
+#       "key": "checkout.v2",
+#       "value_type": "bool",         # bool | string | number | json
+#       "default_value": false,       # served when nothing more specific applies
+#       "enabled": true,              # false = kill switch for this environment
+#       "environment_value": true     # null = inherit default_value
+#     }
+#   ]
+# }
+
+# 2. Evaluate locally, in this exact order:
+#    a. key missing from the snapshot -> your own fallback
+#    b. enabled == false              -> default_value  (ignore the override)
+#    c. environment_value != null     -> environment_value
+#    d. otherwise                     -> default_value
+#    e. value does not match value_type, or any error -> your own fallback
+#
+# 3. Refresh every ~15s in the background. Never fetch on the request path:
+#    a flag lookup must not add a network hop to your p99, and your app must
+#    keep serving the last good snapshot when the control plane is down.
+
+# 4. Optional: report the keys you read so unused flags become visible.
+curl -s -X POST -H "Authorization: Bearer $TEMPS_API_TOKEN" \\
+  -H "Content-Type: application/json" \\
+  -d '{"keys": ["checkout.v2"]}' \\
+  "$TEMPS_API_URL/flags/exposure"`
+}
+
+function cliSnippet(flagKey: string, environmentName?: string): string {
+  const env = environmentName ?? 'production'
+  return `# Create a flag (type and default are fixed at create time)
+bunx @temps-sdk/cli flags create ${flagKey} --type bool --default false \\
+  --description "New checkout flow"
+
+# Turn it on in one environment
+bunx @temps-sdk/cli flags set ${flagKey} true --environment ${env}
+
+# Kill switch: serve the default again, ignoring the override
+bunx @temps-sdk/cli flags disable ${flagKey} --environment ${env}
+
+# See where it stands everywhere
+bunx @temps-sdk/cli flags get ${flagKey}
+
+# Retire it once the code path is gone
+bunx @temps-sdk/cli flags archive ${flagKey}`
+}
+
+function aiPrompt(flagKey: string, envQuery: string): string {
+  return `Add Temps feature flags to this application.
+
+Temps injects TEMPS_API_URL and TEMPS_API_TOKEN into deployments. Do not add a
+new SDK dependency — implement a small client using the HTTP endpoints below,
+in the language and idiom this codebase already uses.
+
+Endpoints:
+  GET  $TEMPS_API_URL/flags/snapshot${envQuery}
+       Header: Authorization: Bearer $TEMPS_API_TOKEN
+       Header: If-None-Match: <last ETag>   (returns 304 when unchanged)
+       200 body: { "environment_id": 3, "flags": [
+         { "key": "${flagKey}", "value_type": "bool" | "string" | "number" | "json",
+           "default_value": <any>, "enabled": true, "environment_value": <any|null> } ] }
+
+  POST $TEMPS_API_URL/flags/exposure
+       Body: { "keys": ["${flagKey}"] }   (optional; marks flags as still in use)
+
+Requirements:
+1. Fetch the snapshot in a background loop (~15s) and cache it in memory. Never
+   fetch on the request path.
+2. Send If-None-Match and treat 304 as "keep the cached snapshot".
+3. Evaluate locally in this order: key missing -> caller's fallback;
+   enabled == false -> default_value (the override is ignored); otherwise
+   environment_value if non-null, else default_value.
+4. The lookup function must never throw and never block. Any failure — network
+   error, non-200, wrong type for value_type — serves the caller's fallback.
+5. Do the first fetch synchronously at startup so the first request has real
+   values, but a failed first fetch must not prevent the app from booting.
+6. Add one call site as an example, using a caller-supplied fallback that
+   matches today's behaviour.`
+}

--- a/web/src/components/project/flags/ProjectFeatureFlags.tsx
+++ b/web/src/components/project/flags/ProjectFeatureFlags.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/ui/select'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Switch } from '@/components/ui/switch'
+
 import {
   Table,
   TableBody,
@@ -33,11 +34,12 @@ import {
 } from '@/components/ui/table'
 import { cn } from '@/lib/utils'
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { Flag, MoreHorizontal, Plus, RefreshCcw } from 'lucide-react'
+import { Code2, Flag, MoreHorizontal, Plus, RefreshCcw } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { CreateFlagDialog } from './CreateFlagDialog'
 import { FlagDetailSheet } from './FlagDetailSheet'
+import { FlagsSetupGuide } from './FlagsSetupGuide'
 import {
   asFlagValueType,
   environmentOverride,
@@ -56,6 +58,7 @@ export function ProjectFeatureFlags({ project }: ProjectFeatureFlagsProps) {
   const [page, setPage] = useState(1)
   const [createOpen, setCreateOpen] = useState(false)
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
+  const [tab, setTab] = useState<'flags' | 'setup'>('flags')
 
   const environmentsQuery = useQuery({
     ...getEnvironmentsOptions({ path: { project_id: project.id } }),
@@ -119,36 +122,20 @@ export function ProjectFeatureFlags({ project }: ProjectFeatureFlagsProps) {
           </p>
         </div>
 
+        {/* Two actions only. Filtering belongs to the table below, not up
+            here competing with the things that actually create something. */}
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-          {/* Filters first, primary CTA last. */}
+          {/* A flag nobody's app can read is just a row in a table, so the
+              integration guide gets a permanent home in the header rather
+              than living in docs the operator would have to know exist. */}
           <Button
-            variant="ghost"
-            size="sm"
-            className="w-full justify-start sm:w-auto"
-            onClick={() => {
-              setShowArchived((v) => !v)
-              setPage(1)
-            }}
+            variant={tab === 'setup' ? 'secondary' : 'outline'}
+            className="w-full sm:w-auto"
+            onClick={() => setTab(tab === 'setup' ? 'flags' : 'setup')}
           >
-            {showArchived ? 'Hide archived' : 'Show archived'}
+            <Code2 className="mr-1.5 h-4 w-4" />
+            {tab === 'setup' ? 'Back to flags' : 'Setup'}
           </Button>
-
-          <Select
-            value={environmentId ? String(environmentId) : undefined}
-            onValueChange={(next) => setChosenEnvironmentId(Number(next))}
-            disabled={environments.length === 0}
-          >
-            <SelectTrigger className="w-full sm:w-[200px]">
-              <SelectValue placeholder="Environment" />
-            </SelectTrigger>
-            <SelectContent>
-              {environments.map((environment) => (
-                <SelectItem key={environment.id} value={String(environment.id)}>
-                  {environment.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
 
           <Button
             className="w-full sm:w-auto"
@@ -160,101 +147,155 @@ export function ProjectFeatureFlags({ project }: ProjectFeatureFlagsProps) {
         </div>
       </div>
 
-      {isLoading ? (
-        <FlagTableSkeleton />
-      ) : flags.length === 0 ? (
-        <EmptyPlaceholder
-          icon={Flag}
-          title={showArchived ? 'No flags found' : 'No feature flags yet'}
-          description="Create a flag to turn features on and off without shipping a new deployment."
-          action={
-            <Button onClick={() => setCreateOpen(true)}>
-              <Plus className="mr-1.5 h-4 w-4" />
-              New flag
-            </Button>
-          }
+      {tab === 'setup' ? (
+        <FlagsSetupGuide
+          environmentId={environmentId}
+          environmentName={selectedEnvironment?.name}
+          sampleFlagKey={flags[0]?.key}
         />
       ) : (
-        <div className="overflow-x-auto">
-          {/* A min-width plus horizontal scroll, rather than letting the
-              columns compress — the flag key is the one thing that must stay
-              readable, and on a phone it would otherwise crush to "ch…". */}
-          <Table className="min-w-[600px]">
-            <TableHeader>
-              <TableRow>
-                <TableHead className="min-w-[200px] whitespace-nowrap">
-                  Flag
-                </TableHead>
-                {/* Fixed widths keep the value and its source side by side
-                    instead of drifting to opposite edges on wide screens. */}
-                <TableHead className="w-[220px] whitespace-nowrap">
-                  Value in {selectedEnvironment?.name ?? 'environment'}
-                </TableHead>
-                <TableHead className="hidden w-[140px] whitespace-nowrap sm:table-cell">
-                  Source
-                </TableHead>
-                <TableHead className="w-[60px] text-right">
-                  <span className="sr-only">Actions</span>
-                </TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {flags.map((flag) => (
-                <FlagRow
-                  key={flag.key}
-                  flag={flag}
-                  environmentId={environmentId}
-                  environmentName={selectedEnvironment?.name}
-                  pending={setEnvironmentValue.isPending}
-                  onOpen={() => setSelectedKey(flag.key)}
-                  onSet={(body) => {
-                    if (environmentId === undefined) return
-                    setEnvironmentValue.mutate({
-                      path: {
-                        project_id: project.id,
-                        key: flag.key,
-                        environment_id: environmentId,
-                      },
-                      body,
-                    })
-                  }}
-                />
-              ))}
-            </TableBody>
-          </Table>
-        </div>
-      )}
+        <div className="space-y-4">
+          {/* The environment picker sits on the table because it isn't a page
+              filter — it decides what the "Value in …" column means. Archived
+              is next to it for the same reason: both change what the rows
+              below say. */}
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <Select
+              value={environmentId ? String(environmentId) : undefined}
+              onValueChange={(next) => setChosenEnvironmentId(Number(next))}
+              disabled={environments.length === 0}
+            >
+              <SelectTrigger className="w-full sm:w-[200px]">
+                <SelectValue placeholder="Environment" />
+              </SelectTrigger>
+              <SelectContent>
+                {environments.map((environment) => (
+                  <SelectItem
+                    key={environment.id}
+                    value={String(environment.id)}
+                  >
+                    {environment.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
 
-      {/* Hidden entirely when everything fits on one page. */}
-      {total > pageSize && (
-        <div className="flex flex-col gap-2 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
-          <p className="text-xs tabular-nums text-muted-foreground">
-            <span className="hidden sm:inline">
-              Showing {(page - 1) * pageSize + 1}–
-              {Math.min(page * pageSize, total)} of {total}
-            </span>
-            <span className="sm:hidden">
-              Page {page} / {totalPages}
-            </span>
-          </p>
-          <div className="flex items-center gap-2">
             <Button
-              variant="outline"
+              variant="ghost"
               size="sm"
-              disabled={page === 1}
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              className="w-full justify-start text-muted-foreground sm:w-auto"
+              onClick={() => {
+                setShowArchived((v) => !v)
+                setPage(1)
+              }}
             >
-              Previous
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page >= totalPages}
-              onClick={() => setPage((p) => p + 1)}
-            >
-              Next
+              {showArchived ? 'Hide archived' : 'Show archived'}
             </Button>
           </div>
+
+          {isLoading ? (
+            <FlagTableSkeleton />
+          ) : flags.length === 0 ? (
+            <EmptyPlaceholder
+              icon={Flag}
+              title={showArchived ? 'No flags found' : 'No feature flags yet'}
+              description="Create a flag to turn features on and off without shipping a new deployment, then read it from your app in any language."
+              action={
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <Button onClick={() => setCreateOpen(true)}>
+                    <Plus className="mr-1.5 h-4 w-4" />
+                    New flag
+                  </Button>
+                  <Button variant="outline" onClick={() => setTab('setup')}>
+                    <Code2 className="mr-1.5 h-4 w-4" />
+                    Integrate your app
+                  </Button>
+                </div>
+              }
+            />
+          ) : (
+            <div className="overflow-x-auto">
+              {/* A min-width plus horizontal scroll, rather than letting the
+              columns compress — the flag key is the one thing that must stay
+              readable, and on a phone it would otherwise crush to "ch…". */}
+              <Table className="min-w-[600px]">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="min-w-[200px] whitespace-nowrap">
+                      Flag
+                    </TableHead>
+                    {/* Fixed widths keep the value and its source side by side
+                    instead of drifting to opposite edges on wide screens. */}
+                    <TableHead className="w-[220px] whitespace-nowrap">
+                      Value in {selectedEnvironment?.name ?? 'environment'}
+                    </TableHead>
+                    <TableHead className="hidden w-[140px] whitespace-nowrap sm:table-cell">
+                      Source
+                    </TableHead>
+                    <TableHead className="w-[60px] text-right">
+                      <span className="sr-only">Actions</span>
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {flags.map((flag) => (
+                    <FlagRow
+                      key={flag.key}
+                      flag={flag}
+                      environmentId={environmentId}
+                      environmentName={selectedEnvironment?.name}
+                      pending={setEnvironmentValue.isPending}
+                      onOpen={() => setSelectedKey(flag.key)}
+                      onSet={(body) => {
+                        if (environmentId === undefined) return
+                        setEnvironmentValue.mutate({
+                          path: {
+                            project_id: project.id,
+                            key: flag.key,
+                            environment_id: environmentId,
+                          },
+                          body,
+                        })
+                      }}
+                    />
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+
+          {/* Hidden entirely when everything fits on one page. */}
+          {total > pageSize && (
+            <div className="flex flex-col gap-2 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-xs tabular-nums text-muted-foreground">
+                <span className="hidden sm:inline">
+                  Showing {(page - 1) * pageSize + 1}–
+                  {Math.min(page * pageSize, total)} of {total}
+                </span>
+                <span className="sm:hidden">
+                  Page {page} / {totalPages}
+                </span>
+              </p>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page === 1}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                >
+                  Previous
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page >= totalPages}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          )}
         </div>
       )}
 

--- a/web/src/components/ui/code-block.tsx
+++ b/web/src/components/ui/code-block.tsx
@@ -1,26 +1,129 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Check, Copy, Hash, WrapText } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import type { HighlighterCore } from 'shiki/core'
+
+/**
+ * Languages this block can highlight.
+ *
+ * Adding one means adding its grammar to `LANG_LOADERS` below — the list is
+ * explicit rather than shiki's full bundle because that bundle is several
+ * megabytes of grammars for languages the console will never render.
+ */
+export type CodeLanguage =
+  | 'bash'
+  | 'shell'
+  | 'yaml'
+  | 'json'
+  | 'javascript'
+  | 'typescript'
+  | 'tsx'
+  | 'text'
+  | 'python'
+  | 'go'
+  | 'rust'
+  | 'ruby'
+  | 'php'
+  | 'java'
+  | 'sql'
+  | 'dockerfile'
 
 interface CodeBlockProps {
   code: string
-  language?:
-    | 'bash'
-    | 'yaml'
-    | 'json'
-    | 'javascript'
-    | 'typescript'
-    | 'shell'
-    | 'text'
-    | 'python'
-    | 'go'
+  language?: CodeLanguage
   className?: string
   showCopy?: boolean
   title?: string
   defaultWrap?: boolean
   defaultShowLineNumbers?: boolean
   disableWrapToggle?: boolean
+}
+
+// Same themes the docs site compiles its MDX with, so a snippet reads
+// identically whether it's on temps.sh/docs or inside the console.
+const THEMES = { light: 'github-light', dark: 'github-dark' } as const
+
+const LANG_LOADERS: Record<
+  Exclude<CodeLanguage, 'text'>,
+  () => Promise<unknown>
+> = {
+  bash: () => import('shiki/langs/bash.mjs'),
+  shell: () => import('shiki/langs/shellscript.mjs'),
+  yaml: () => import('shiki/langs/yaml.mjs'),
+  json: () => import('shiki/langs/json.mjs'),
+  javascript: () => import('shiki/langs/javascript.mjs'),
+  typescript: () => import('shiki/langs/typescript.mjs'),
+  tsx: () => import('shiki/langs/tsx.mjs'),
+  python: () => import('shiki/langs/python.mjs'),
+  go: () => import('shiki/langs/go.mjs'),
+  rust: () => import('shiki/langs/rust.mjs'),
+  ruby: () => import('shiki/langs/ruby.mjs'),
+  php: () => import('shiki/langs/php.mjs'),
+  java: () => import('shiki/langs/java.mjs'),
+  sql: () => import('shiki/langs/sql.mjs'),
+  dockerfile: () => import('shiki/langs/docker.mjs'),
+}
+
+// One highlighter for the whole app, built lazily on the first code block and
+// grown one grammar at a time. Loading every grammar up front would pull
+// megabytes into the initial bundle for pages that show no code at all.
+let highlighterPromise: Promise<HighlighterCore> | null = null
+const loadedLangs = new Set<string>()
+
+async function getHighlighter(): Promise<HighlighterCore> {
+  if (!highlighterPromise) {
+    highlighterPromise = (async () => {
+      const [{ createHighlighterCore }, { createJavaScriptRegexEngine }] =
+        await Promise.all([
+          import('shiki/core'),
+          import('shiki/engine/javascript'),
+        ])
+      // The JS engine keeps us off the 450 KB oniguruma wasm blob, which
+      // rsbuild would have to serve as a separate asset.
+      return createHighlighterCore({
+        themes: [
+          import('shiki/themes/github-light.mjs'),
+          import('shiki/themes/github-dark.mjs'),
+        ],
+        langs: [],
+        engine: createJavaScriptRegexEngine({ forgiving: true }),
+      })
+    })()
+  }
+  return highlighterPromise
+}
+
+async function highlight(
+  code: string,
+  language: CodeLanguage
+): Promise<string | null> {
+  if (language === 'text') return null
+
+  const highlighter = await getHighlighter()
+  if (!loadedLangs.has(language)) {
+    await highlighter.loadLanguage(
+      (await LANG_LOADERS[language]()) as Parameters<
+        typeof highlighter.loadLanguage
+      >[0]
+    )
+    loadedLangs.add(language)
+  }
+
+  const html = highlighter.codeToHtml(code, {
+    lang: language,
+    themes: THEMES,
+    // Emits --shiki-light / --shiki-dark custom properties instead of baking
+    // one theme's colours in, so the block follows the console's theme
+    // toggle without re-highlighting. globals.css maps the vars to `color`.
+    defaultColor: false,
+  })
+
+  // Shiki hands back a full <pre><code>…</code></pre>; we only want the token
+  // markup, since the surrounding chrome is ours.
+  return (
+    html.match(/<pre[^>]*><code[^>]*>([\s\S]*?)<\/code><\/pre>/)?.[1] ?? null
+  )
 }
 
 export function CodeBlock({
@@ -36,6 +139,21 @@ export function CodeBlock({
   const [copied, setCopied] = useState(false)
   const [wrapLines, setWrapLines] = useState(defaultWrap)
   const [showLineNumbers, setShowLineNumbers] = useState(defaultShowLineNumbers)
+  const [html, setHtml] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    highlight(code, language)
+      .then((result) => {
+        if (!cancelled) setHtml(result)
+      })
+      // A grammar that fails to load must not blank the snippet — the plain
+      // fallback below is already rendered and stays.
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [code, language])
 
   const visibleButtonCount =
     1 + (disableWrapToggle ? 0 : 1) + (showCopy ? 1 : 0)
@@ -46,826 +164,33 @@ export function CodeBlock({
     setTimeout(() => setCopied(false), 2000)
   }
 
-  // Simple syntax highlighting - returns React elements instead of HTML strings
-  const renderHighlightedCode = (code: string, lang: string) => {
-    const lines = code.split('\n')
-
-    if (lang === 'bash' || lang === 'shell') {
-      return lines.map((line, i) => (
-        <span key={i} className="block">
-          {showLineNumbers && (
-            <span className="text-muted-foreground/40 select-none pr-4 text-right min-w-[3ch] inline-block">
-              {i + 1}
-            </span>
-          )}
-          {line.trim().startsWith('#') ? (
-            <span className="text-muted-foreground opacity-70 italic">
-              {line || '\u00A0'}
-            </span>
-          ) : (
-            <>
-              {line.split(' ').map((word, j) => {
-                // Commands
-                if (
-                  j === 0 &&
-                  [
-                    'npm',
-                    'yarn',
-                    'pnpm',
-                    'bun',
-                    'curl',
-                    'brew',
-                    'sudo',
-                    'chmod',
-                    'cloudflared',
-                    'systemctl',
-                    'mkdir',
-                    'cd',
-                    'ls',
-                    'echo',
-                    'export',
-                    'cat',
-                    'mv',
-                    'cp',
-                  ].includes(word)
-                ) {
-                  return (
-                    <span
-                      key={j}
-                      className="text-blue-600 dark:text-blue-400 font-semibold"
-                    >
-                      {word}{' '}
-                    </span>
-                  )
-                }
-                // Flags
-                if (word.startsWith('-')) {
-                  return (
-                    <span
-                      key={j}
-                      className="text-orange-600 dark:text-orange-400"
-                    >
-                      {word}{' '}
-                    </span>
-                  )
-                }
-                // Environment variables
-                if (word.includes('=') && !word.startsWith('-')) {
-                  const [key, value] = word.split('=')
-                  return (
-                    <span key={j}>
-                      <span className="text-purple-600 dark:text-purple-400">
-                        {key}
-                      </span>
-                      <span className="text-muted-foreground">=</span>
-                      <span className="text-green-600 dark:text-green-400">
-                        {value}
-                      </span>
-                      <span> </span>
-                    </span>
-                  )
-                }
-                return <span key={j}>{word} </span>
-              })}
-            </>
-          )}
-        </span>
-      ))
-    }
-
-    if (lang === 'python') {
-      const keywords = [
-        'import',
-        'from',
-        'def',
-        'class',
-        'return',
-        'if',
-        'elif',
-        'else',
-        'for',
-        'while',
-        'try',
-        'except',
-        'finally',
-        'with',
-        'as',
-        'pass',
-        'break',
-        'continue',
-        'global',
-        'nonlocal',
-        'lambda',
-        'yield',
-        'raise',
-        'del',
-        'assert',
-        'and',
-        'or',
-        'not',
-        'in',
-        'is',
-      ]
-      const builtins = [
-        'True',
-        'False',
-        'None',
-        'print',
-        'len',
-        'range',
-        'str',
-        'int',
-        'float',
-        'list',
-        'dict',
-        'tuple',
-        'set',
-        'open',
-        'file',
-        'input',
-        'type',
-        'super',
-        'self',
-      ]
-
-      return lines.map((line, lineIdx) => {
-        // Comments
-        if (line.trim().startsWith('#')) {
-          return (
-            <span key={lineIdx} className="block">
-              {showLineNumbers && (
-                <span className="text-muted-foreground/40 select-none pr-4 text-right min-w-[3ch] inline-block">
-                  {lineIdx + 1}
-                </span>
-              )}
-              <span className="text-muted-foreground opacity-70 italic">
-                {line || '\u00A0'}
-              </span>
-            </span>
-          )
-        }
-
-        // Process each line with a simple tokenizer
-        const tokens: React.ReactNode[] = []
-        let current = ''
-        let inString = false
-        let stringChar = ''
-
-        for (let i = 0; i < line.length; i++) {
-          const char = line[i]
-
-          // Handle strings
-          if ((char === '"' || char === "'") && !inString) {
-            if (current) {
-              tokens.push(renderPythonToken(current, keywords, builtins))
-            }
-            inString = true
-            stringChar = char
-            current = char
-          } else if (char === stringChar && inString) {
-            current += char
-            tokens.push(
-              <span className="text-green-600 dark:text-green-400">
-                {current}
-              </span>
-            )
-            current = ''
-            inString = false
-            stringChar = ''
-          } else if (inString) {
-            current += char
-          } else if (
-            char === ' ' ||
-            char === '(' ||
-            char === ')' ||
-            char === '[' ||
-            char === ']' ||
-            char === ':' ||
-            char === ',' ||
-            char === '.' ||
-            char === '=' ||
-            char === '+' ||
-            char === '-' ||
-            char === '*' ||
-            char === '/'
-          ) {
-            if (current) {
-              tokens.push(renderPythonToken(current, keywords, builtins))
-              current = ''
-            }
-            tokens.push(char)
-          } else {
-            current += char
-          }
-        }
-
-        if (current) {
-          if (inString) {
-            tokens.push(
-              <span className="text-green-600 dark:text-green-400">
-                {current}
-              </span>
-            )
-          } else {
-            tokens.push(renderPythonToken(current, keywords, builtins))
-          }
-        }
-
-        return (
-          <span key={lineIdx} className="block">
-            {showLineNumbers && (
-              <span className="text-muted-foreground/40 select-none pr-4 text-right min-w-[3ch] inline-block">
-                {lineIdx + 1}
-              </span>
-            )}
-            {tokens.length === 0 ? '\u00A0' : tokens}
-          </span>
-        )
-      })
-    }
-
-    if (lang === 'json') {
-      return lines.map((line, lineIdx) => {
-        // HTML-escape first: the highlighter below injects <span> markup and
-        // renders via dangerouslySetInnerHTML, and JSON string values/keys can
-        // be attacker-controlled (e.g. custom event props). Escaping &, <, >
-        // neutralises tag injection; the token regexes below match on ", :,
-        // digits and keywords, which escaping leaves intact, and user content
-        // only ever lands in text position (never inside an attribute).
-        let processedLine = line
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-
-        // Keys (property names with quotes followed by colon)
-        processedLine = processedLine.replace(
-          /"([^"]+)"(\s*):/g,
-          '<span class="text-purple-600 dark:text-purple-400">"$1"</span>$2:'
-        )
-
-        // String values (quotes not followed by colon)
-        processedLine = processedLine.replace(
-          /:(\s*)"([^"]*)"/g,
-          ':<span class="text-green-600 dark:text-green-400">$1"$2"</span>'
-        )
-
-        // Booleans
-        processedLine = processedLine.replace(
-          /\b(true|false)\b/g,
-          '<span class="text-orange-600 dark:text-orange-400">$1</span>'
-        )
-
-        // Null
-        processedLine = processedLine.replace(
-          /\bnull\b/g,
-          '<span class="text-red-600 dark:text-red-400">null</span>'
-        )
-
-        // Numbers
-        processedLine = processedLine.replace(
-          /:\s*(-?\d+(\.\d+)?)/g,
-          ': <span class="text-cyan-600 dark:text-cyan-400">$1</span>'
-        )
-
-        return (
-          <span key={lineIdx} className="block">
-            {showLineNumbers && (
-              <span className="text-muted-foreground/40 select-none pr-4 text-right min-w-[3ch] inline-block">
-                {lineIdx + 1}
-              </span>
-            )}
-            <span
-              dangerouslySetInnerHTML={{ __html: processedLine || '&nbsp;' }}
-            />
-          </span>
-        )
-      })
-    }
-
-    if (lang === 'typescript' || lang === 'javascript') {
-      const keywords = [
-        'import',
-        'from',
-        'export',
-        'const',
-        'let',
-        'var',
-        'function',
-        'return',
-        'if',
-        'else',
-        'for',
-        'while',
-        'class',
-        'extends',
-        'implements',
-        'interface',
-        'type',
-        'enum',
-        'async',
-        'await',
-        'new',
-        'this',
-        'super',
-        'static',
-        'public',
-        'private',
-        'protected',
-        'readonly',
-        'default',
-      ]
-      const types = [
-        'string',
-        'number',
-        'boolean',
-        'void',
-        'null',
-        'undefined',
-        'any',
-        'unknown',
-        'never',
-        'React',
-        'ReactNode',
-        'AppProps',
-        'Metadata',
-        'NextApiRequest',
-        'NextApiResponse',
-        'Readonly',
-      ]
-
-      return lines.map((line, lineIdx) => {
-        // Comments
-        if (line.trim().startsWith('//')) {
-          return (
-            <span key={lineIdx} className="block">
-              {showLineNumbers && (
-                <span className="text-muted-foreground/40 select-none pr-4 text-right min-w-[3ch] inline-block">
-                  {lineIdx + 1}
-                </span>
-              )}
-              <span className="text-muted-foreground opacity-70 italic">
-                {line || '\u00A0'}
-              </span>
-            </span>
-          )
-        }
-
-        // Process each line with a simple tokenizer
-        const tokens: React.ReactNode[] = []
-        let current = ''
-        let inString = false
-        let stringChar = ''
-
-        for (let i = 0; i < line.length; i++) {
-          const char = line[i]
-
-          // Handle strings
-          if ((char === '"' || char === "'" || char === '`') && !inString) {
-            if (current) {
-              tokens.push(renderToken(current, keywords, types))
-            }
-            inString = true
-            stringChar = char
-            current = char
-          } else if (char === stringChar && inString) {
-            current += char
-            tokens.push(
-              <span className="text-green-600 dark:text-green-400">
-                {current}
-              </span>
-            )
-            current = ''
-            inString = false
-            stringChar = ''
-          } else if (inString) {
-            current += char
-          } else if (
-            char === ' ' ||
-            char === '(' ||
-            char === ')' ||
-            char === '{' ||
-            char === '}' ||
-            char === '[' ||
-            char === ']' ||
-            char === ':' ||
-            char === ';' ||
-            char === ',' ||
-            char === '.' ||
-            char === '<' ||
-            char === '>' ||
-            char === '=' ||
-            char === '!'
-          ) {
-            if (current) {
-              tokens.push(renderToken(current, keywords, types))
-              current = ''
-            }
-            tokens.push(char)
-          } else {
-            current += char
-          }
-        }
-
-        if (current) {
-          if (inString) {
-            tokens.push(
-              <span className="text-green-600 dark:text-green-400">
-                {current}
-              </span>
-            )
-          } else {
-            tokens.push(renderToken(current, keywords, types))
-          }
-        }
-
-        return (
-          <span key={lineIdx} className="block">
-            {showLineNumbers && (
-              <span className="text-muted-foreground/40 select-none pr-4 text-right min-w-[3ch] inline-block">
-                {lineIdx + 1}
-              </span>
-            )}
-            {tokens.length === 0 ? '\u00A0' : tokens}
-          </span>
-        )
-      })
-    }
-
-    if (lang === 'go') {
-      const keywords = [
-        'package',
-        'import',
-        'func',
-        'return',
-        'if',
-        'else',
-        'for',
-        'range',
-        'switch',
-        'case',
-        'default',
-        'break',
-        'continue',
-        'goto',
-        'fallthrough',
-        'defer',
-        'go',
-        'chan',
-        'select',
-        'type',
-        'struct',
-        'interface',
-        'map',
-        'var',
-        'const',
-        'nil',
-        'true',
-        'false',
-      ]
-      const types = [
-        'string',
-        'int',
-        'int8',
-        'int16',
-        'int32',
-        'int64',
-        'uint',
-        'uint8',
-        'uint16',
-        'uint32',
-        'uint64',
-        'float32',
-        'float64',
-        'bool',
-        'byte',
-        'rune',
-        'error',
-        'any',
-      ]
-
-      return lines.map((line, lineIdx) => {
-        // Comments
-        if (line.trim().startsWith('//')) {
-          return (
-            <span key={lineIdx} className="block">
-              {showLineNumbers && (
-                <span className="text-muted-foreground/40 select-none pr-4 text-right min-w-[3ch] inline-block">
-                  {lineIdx + 1}
-                </span>
-              )}
-              <span className="text-muted-foreground opacity-70 italic">
-                {line || '\u00A0'}
-              </span>
-            </span>
-          )
-        }
-
-        // Process each line with a simple tokenizer
-        const tokens: React.ReactNode[] = []
-        let current = ''
-        let inString = false
-        let stringChar = ''
-
-        for (let i = 0; i < line.length; i++) {
-          const char = line[i]
-
-          // Handle strings
-          if ((char === '"' || char === "'" || char === '`') && !inString) {
-            if (current) {
-              tokens.push(renderGoToken(current, keywords, types))
-            }
-            inString = true
-            stringChar = char
-            current = char
-          } else if (char === stringChar && inString) {
-            current += char
-            tokens.push(
-              <span className="text-green-600 dark:text-green-400">
-                {current}
-              </span>
-            )
-            current = ''
-            inString = false
-            stringChar = ''
-          } else if (inString) {
-            current += char
-          } else if (
-            char === ' ' ||
-            char === '(' ||
-            char === ')' ||
-            char === '{' ||
-            char === '}' ||
-            char === '[' ||
-            char === ']' ||
-            char === ':' ||
-            char === ';' ||
-            char === ',' ||
-            char === '.' ||
-            char === '<' ||
-            char === '>' ||
-            char === '=' ||
-            char === '!' ||
-            char === '&' ||
-            char === '*'
-          ) {
-            if (current) {
-              tokens.push(renderGoToken(current, keywords, types))
-              current = ''
-            }
-            tokens.push(char)
-          } else {
-            current += char
-          }
-        }
-
-        if (current) {
-          if (inString) {
-            tokens.push(
-              <span className="text-green-600 dark:text-green-400">
-                {current}
-              </span>
-            )
-          } else {
-            tokens.push(renderGoToken(current, keywords, types))
-          }
-        }
-
-        return (
-          <span key={lineIdx} className="block">
-            {showLineNumbers && (
-              <span className="text-muted-foreground/40 select-none pr-4 text-right min-w-[3ch] inline-block">
-                {lineIdx + 1}
-              </span>
-            )}
-            {tokens.length === 0 ? '\u00A0' : tokens}
-          </span>
-        )
-      })
-    }
-
-    if (lang === 'yaml') {
-      return lines.map((line, lineIdx) => {
-        // Comments
-        if (line.trim().startsWith('#')) {
-          return (
-            <span key={lineIdx} className="block">
-              {showLineNumbers && (
-                <span className="text-muted-foreground/40 select-none pr-4 text-right min-w-[3ch] inline-block">
-                  {lineIdx + 1}
-                </span>
-              )}
-              <span className="text-muted-foreground opacity-70 italic">
-                {line || '\u00A0'}
-              </span>
-            </span>
-          )
-        }
-
-        // Preserve leading whitespace for indentation
-        const leadingWs = line.match(/^(\s*)/)?.[1] ?? ''
-        const rest = line.slice(leadingWs.length)
-
-        // List items: leading "- "
-        let listDash: string | null = null
-        let afterList = rest
-        if (rest.startsWith('- ')) {
-          listDash = '- '
-          afterList = rest.slice(2)
-        } else if (rest === '-') {
-          listDash = '-'
-          afterList = ''
-        }
-
-        // Match `key:` optionally followed by a value
-        const keyMatch = afterList.match(/^([^:#\s][^:]*?):(\s*)(.*)$/)
-
-        const renderValue = (value: string) => {
-          const trimmed = value.trim()
-          if (trimmed === '') return value
-          // Block scalar markers
-          if (
-            trimmed === '|' ||
-            trimmed === '>' ||
-            trimmed === '|-' ||
-            trimmed === '>-'
-          ) {
-            return (
-              <span className="text-orange-600 dark:text-orange-400">
-                {value}
-              </span>
-            )
-          }
-          // Quoted strings
-          if (
-            (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
-            (trimmed.startsWith("'") && trimmed.endsWith("'"))
-          ) {
-            return (
-              <span className="text-green-600 dark:text-green-400">
-                {value}
-              </span>
-            )
-          }
-          // Booleans / null
-          if (['true', 'false', 'null', '~', 'yes', 'no'].includes(trimmed)) {
-            return (
-              <span className="text-orange-600 dark:text-orange-400">
-                {value}
-              </span>
-            )
-          }
-          // Numbers
-          if (/^-?\d+(\.\d+)?$/.test(trimmed)) {
-            return (
-              <span className="text-cyan-600 dark:text-cyan-400">{value}</span>
-            )
-          }
-          // Plain string value
-          return (
-            <span className="text-green-600 dark:text-green-400">{value}</span>
-          )
-        }
-
-        return (
-          <span key={lineIdx} className="block">
-            {showLineNumbers && (
-              <span className="text-muted-foreground/40 select-none pr-4 text-right min-w-[3ch] inline-block">
-                {lineIdx + 1}
-              </span>
-            )}
-            {leadingWs && <span>{leadingWs}</span>}
-            {listDash && (
-              <span className="text-muted-foreground">{listDash}</span>
-            )}
-            {keyMatch ? (
-              <>
-                <span className="text-purple-600 dark:text-purple-400">
-                  {keyMatch[1]}
-                </span>
-                <span className="text-muted-foreground">:</span>
-                {keyMatch[2]}
-                {keyMatch[3] && renderValue(keyMatch[3])}
-              </>
-            ) : (
-              afterList && renderValue(afterList)
-            )}
-            {!leadingWs && !listDash && !keyMatch && !afterList && '\u00A0'}
-          </span>
-        )
-      })
-    }
-
-    // Default - no highlighting
-    return lines.map((line, i) => (
-      <span key={i} className="block">
-        {showLineNumbers && (
-          <span className="text-muted-foreground/40 select-none pr-4 text-right min-w-[3ch] inline-block">
-            {i + 1}
-          </span>
-        )}
-        {line || '\u00A0'}
-      </span>
-    ))
-  }
-
-  const renderGoToken = (
-    token: string,
-    keywords: string[],
-    types: string[]
-  ) => {
-    if (keywords.includes(token)) {
-      return (
-        <span className="text-purple-600 dark:text-purple-400 font-semibold">
-          {token}
-        </span>
-      )
-    }
-    if (types.includes(token)) {
-      return <span className="text-cyan-600 dark:text-cyan-400">{token}</span>
-    }
-    if (/^\d+$/.test(token)) {
-      return (
-        <span className="text-orange-600 dark:text-orange-400">{token}</span>
-      )
-    }
-    // Check if it might be a type (starts with uppercase)
-    if (/^[A-Z]/.test(token)) {
-      return <span className="text-blue-600 dark:text-blue-400">{token}</span>
-    }
-    return token
-  }
-
-  const renderPythonToken = (
-    token: string,
-    keywords: string[],
-    builtins: string[]
-  ) => {
-    if (keywords.includes(token)) {
-      return (
-        <span className="text-purple-600 dark:text-purple-400 font-semibold">
-          {token}
-        </span>
-      )
-    }
-    if (builtins.includes(token)) {
-      return <span className="text-cyan-600 dark:text-cyan-400">{token}</span>
-    }
-    if (/^\d+(\.\d+)?$/.test(token)) {
-      return (
-        <span className="text-orange-600 dark:text-orange-400">{token}</span>
-      )
-    }
-    return token
-  }
-
-  const renderToken = (token: string, keywords: string[], types: string[]) => {
-    if (keywords.includes(token)) {
-      return (
-        <span className="text-purple-600 dark:text-purple-400 font-semibold">
-          {token}
-        </span>
-      )
-    }
-    if (types.includes(token)) {
-      return <span className="text-cyan-600 dark:text-cyan-400">{token}</span>
-    }
-    if (/^\d+$/.test(token)) {
-      return (
-        <span className="text-orange-600 dark:text-orange-400">{token}</span>
-      )
-    }
-    if (token.startsWith('@')) {
-      return <span className="text-pink-600 dark:text-pink-400">{token}</span>
-    }
-    // Check if it might be a component (starts with uppercase)
-    if (/^[A-Z]/.test(token)) {
-      return <span className="text-blue-600 dark:text-blue-400">{token}</span>
-    }
-    return token
-  }
-
   return (
-    <div className={cn('relative group', className)}>
+    // Container, header and type scale are lifted verbatim from the docs site's
+    // `CodeGroup` (temps-landing `src/components/Code.tsx`): a rounded-2xl
+    // panel on zinc-900 in dark with a hairline ring, rather than a bordered
+    // zinc-950 box. Same snippet, same surface, whether you're reading
+    // temps.sh/docs or the console.
+    <div
+      className={cn(
+        'group overflow-hidden rounded-2xl bg-white shadow-md ring-1 ring-zinc-900/[0.075]',
+        'dark:bg-zinc-900 dark:ring-white/10',
+        className
+      )}
+    >
       {title && (
-        <div className="px-4 py-2 bg-zinc-200/70 dark:bg-zinc-900/50 border-b border-border text-xs text-muted-foreground font-mono rounded-t-lg">
+        <div className="flex h-9 items-center gap-2 border-b border-zinc-900/[0.075] bg-zinc-900/[0.025] px-4 font-mono text-xs text-muted-foreground dark:border-b-white/5 dark:bg-white/[0.01]">
           {title}
         </div>
       )}
-      <div
-        className={cn(
-          'relative rounded-lg min-w-0',
-          'bg-zinc-100 dark:bg-zinc-950/50',
-          'border border-border',
-          'transition-colors duration-200',
-          'hover:bg-zinc-100/80 dark:group-hover:bg-zinc-950/70',
-          title && 'rounded-t-none border-t-0'
-        )}
-      >
+      {/* The white/2.5 wash over zinc-900 is what gives the dark panel its
+          slightly-lifted tone in the docs; without it the block reads as a
+          flat hole in the page. */}
+      <div className="relative min-w-0 dark:bg-white/[0.025]">
         <div
           className={cn(
             // w-0 min-w-full max-w-full is the trick: forces this element to
             // parent width while letting its children overflow horizontally.
-            'w-0 min-w-full max-w-full rounded-lg py-3.5 pl-4',
+            'w-0 min-w-full max-w-full py-4 pl-4',
             visibleButtonCount === 3 && 'pr-28',
             visibleButtonCount === 2 && 'pr-20',
             visibleButtonCount === 1 && 'pr-12',
@@ -875,18 +200,37 @@ export function CodeBlock({
         >
           <pre
             className={cn(
-              'text-sm font-mono leading-6 m-0',
+              'm-0 font-mono text-[13px] leading-6 sm:text-xs',
               wrapLines ? 'whitespace-pre-wrap break-all' : 'whitespace-pre'
             )}
           >
-            <code
-              className={cn(
-                `language-${language}`,
-                'text-foreground dark:text-zinc-100'
-              )}
-            >
-              {renderHighlightedCode(code, language)}
-            </code>
+            {/* Shiki's output is HTML-escaped token markup — the only thing it
+                emits around user text is <span style="--shiki-*">. */}
+            {html ? (
+              <code
+                className={cn(
+                  'shiki-code',
+                  showLineNumbers && 'shiki-line-numbers'
+                )}
+                dangerouslySetInnerHTML={{ __html: html }}
+              />
+            ) : (
+              <code
+                className={cn(
+                  'shiki-code text-foreground dark:text-zinc-100',
+                  showLineNumbers && 'shiki-line-numbers'
+                )}
+              >
+                {/* Pre-highlight (and for `text`) the same lines render
+                    unstyled, so nothing shifts when colours arrive. */}
+                {code.split('\n').map((line, i, all) => (
+                  <span key={i} className="line">
+                    {line}
+                    {i < all.length - 1 ? '\n' : ''}
+                  </span>
+                ))}
+              </code>
+            )}
           </pre>
         </div>
         <div className="absolute top-2 right-2 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-200">

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -478,3 +478,40 @@ body {
     animation: none;
   }
 }
+
+/* Shiki syntax highlighting.
+   The docs site (temps-landing) compiles its MDX with the same github-light /
+   github-dark pair and `defaultColor: false`, which makes shiki emit both
+   colours as custom properties on every token instead of baking one theme in.
+   Mapping them here is what lets a snippet follow the console's theme toggle
+   with no re-highlight — and keeps console snippets visually identical to the
+   ones in the documentation. */
+[style*='--shiki-light'] {
+  color: var(--shiki-light);
+}
+
+.dark [style*='--shiki-dark'] {
+  color: var(--shiki-dark);
+}
+
+/* Shiki emits one <span class="line"> per source line, separated by real
+   newlines. The wrapping <pre> already preserves those, so the line spans
+   stay inline — making them blocks would render every break twice and
+   double-space the whole snippet. */
+
+/* Line numbers via a counter rather than injected text, so copying the block
+   never picks the numbers up. */
+.shiki-code.shiki-line-numbers {
+  counter-reset: shiki-line;
+}
+
+.shiki-code.shiki-line-numbers .line::before {
+  counter-increment: shiki-line;
+  content: counter(shiki-line);
+  display: inline-block;
+  min-width: 3ch;
+  padding-right: 1rem;
+  text-align: right;
+  color: color-mix(in oklch, var(--muted-foreground) 40%, transparent);
+  user-select: none;
+}


### PR DESCRIPTION
## Why

Feature flags shipped in #526 with a page that creates and flips flags — but nothing that tells a running service how to *read* one. There is no per-language flag SDK to point at, so the step between "flag created" and "flag working" was undocumented, and self-hosted users have no one to ask.

While writing those snippets it became obvious the console's code blocks and the docs site disagree about what the same snippet looks like: the console coloured code with a hand-rolled tokenizer (~800 lines of keyword lists) covering six languages, badly; the docs site uses shiki.

## What

**1. Setup view on the feature flags page** (`FlagsSetupGuide.tsx`)

- **Credentials** — the `TEMPS_API_URL` / `TEMPS_API_TOKEN` pair deployments already receive, a verify-first `curl` carrying the environment currently selected, and the "400 Deployment Token Required" case called out (sessions and API keys read flags through `/projects/{project_id}/flags` instead).
- **A complete client** for Node.js, Python, Go, Ruby, PHP and Java, plus the raw wire contract for anything else. All six implement the same four rules, because getting any of them wrong turns a flag into an outage:
  1. poll in the background, evaluate from memory — never on the request path;
  2. send `If-None-Match`, so the steady state is a 304;
  3. serve the caller's own fallback on any failure (network, non-200, wrong type);
  4. `enabled: false` is the kill switch — serve `default_value`, ignore the override.
  PHP caches to disk instead of a background thread, since it has no process to keep one in.
- **Copy AI Prompt** — emits the same contract for an agent to implement in whatever idiom the target repo uses.
- **Exposure reporting** (`POST /flags/exposure`) with the reason it matters: evaluation happens inside the caller, so without it the control plane can't tell a flag live code depends on from one nothing has called in a year.
- **The CLI equivalents**, so flag flips can live in scripts, CI and runbooks.

**2. Header cleanup** — the header keeps only the two actions that create something (`Setup`, `New flag`). The environment picker and archived toggle move onto the table: neither is a page filter, both change what the rows below say.

**3. `CodeBlock` on shiki** — same configuration as the docs site (`github-light`/`github-dark`, `defaultColor: false`) and the same `CodeGroup` chrome (rounded-2xl on white/zinc-900, hairline ring, white/2.5 wash, 13px/xs type). Props are unchanged, so every existing call site — error tracking, KV, blob, deploy docs — inherits real grammars with no edit. Loading is lazy and fine-grained (`createHighlighterCore` + JS regex engine, no oniguruma wasm asset, one grammar fetched on demand); pages with no code blocks pull in nothing, and un-highlighted code renders as a plain fallback so there's no flash, no layout shift, and a failed grammar degrades to plain text.

## Evidence

Run against a local control plane (slot 12: api `:8200`, web `:3012`, db `temps_dev_s12`), with three flags created through the API and walked through in the browser:

- **Header + table** — `Setup` / `New flag` only; environment picker and archived toggle moved down onto the table.

- **Setup view, step 1** — environment id interpolated into the verify curl (`?environment_id=3`), button flipped to `Back to flags`.

- **Language tabs, Go** — real grammar, not the old keyword list.

- **Steps 3 and 4** — exposure + CLI, using the project's real flag key.

Shiki verified in the running console rather than by eye alone:

```
# dark mode active
keyword `package` style  --shiki-light:#D73A49;--shiki-dark:#F97583
computed colour (dark)   rgb(249, 117, 131)   = #F97583  (github-dark)
computed colour (light)  rgb(215, 58, 73)     = #D73A49  (github-light)

# panel chrome, dark
background  lab(8.31 0.62 -2.17)  = zinc-900 #18181b
overlay     white / 0.025
ring        1px white / 0.1
radius      16px          code font  12px
```

Checks: `tsc --noEmit` clean, `eslint` clean on the touched files, both re-run on top of `origin/main` in a fresh worktree.

## Notes for review

- No backend changes — this consumes `GET /flags/snapshot` and `POST /flags/exposure` as they shipped in #526, so no CLI parity work is implied.
- `shiki` is a new `web/` dependency. It is imported dynamically and never enters the initial bundle.
- The screenshots are PDF exports rendered to PNG (light theme): `agent-browser screenshot` wedges its CDP session on my machine for anything that needs scrolling into view. Dark-theme values were verified through computed styles as above.

