### PR TITLE
fix(telemetry): report git-describe version, not static Cargo.toml version

### DIFF
--- a/crates/temps-cli/src/commands/serve/console.rs
+++ b/crates/temps-cli/src/commands/serve/console.rs
@@ -1898,10 +1898,11 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
     // (depends only on ServerConfig for the data dir). Registered early so
     // every later plugin can require the Arc<dyn TelemetryReporter>.
     debug!("Registering TelemetryPlugin");
-    let telemetry_plugin = Box::new(TelemetryPlugin::new(
-        config.clone(),
-        env!("CARGO_PKG_VERSION"),
-    ));
+    // TEMPS_VERSION (git-describe, set by build.rs) is used instead of
+    // CARGO_PKG_VERSION so nightly/beta builds report a version telemetry
+    // can actually distinguish from a tagged release -- CARGO_PKG_VERSION
+    // is the static Cargo.toml version and is identical across all of them.
+    let telemetry_plugin = Box::new(TelemetryPlugin::new(config.clone(), env!("TEMPS_VERSION")));
     plugin_manager.register_plugin(telemetry_plugin);
 
     // 2. QueuePlugin - registers the pre-created job queue into the service context

--- a/crates/temps-telemetry/src/plugin.rs
+++ b/crates/temps-telemetry/src/plugin.rs
@@ -19,7 +19,8 @@ use crate::TelemetryService;
 pub struct TelemetryPlugin {
     server_config: Arc<ServerConfig>,
     /// Version string stamped onto every event (typically the server's
-    /// `CARGO_PKG_VERSION`).
+    /// git-describe `TEMPS_VERSION`, not the static `CARGO_PKG_VERSION` --
+    /// the latter is identical across nightly/beta/release builds).
     temps_version: String,
 }
 

--- a/crates/temps-telemetry/src/service.rs
+++ b/crates/temps-telemetry/src/service.rs
@@ -75,7 +75,9 @@ impl TelemetryService {
     /// Build a reporter rooted at `data_dir`.
     ///
     /// `temps_version` is stamped onto every event (pass the server's
-    /// `CARGO_PKG_VERSION`). Telemetry is enabled unless the operator opted out
+    /// git-describe `TEMPS_VERSION`, not `CARGO_PKG_VERSION` -- the latter is
+    /// a static Cargo.toml value shared by nightly, beta, and release
+    /// builds alike). Telemetry is enabled unless the operator opted out
     /// via `TEMPS_TELEMETRY` set to `0`/`false`/`off`/`no`. The anonymous id is
     /// always loaded/generated (even when disabled) so flipping telemetry back
     /// on doesn't churn the instance identity.

--- a/telemetry-api/src/routes/events.test.ts
+++ b/telemetry-api/src/routes/events.test.ts
@@ -3,10 +3,10 @@ import { createEventsRoutes, KNOWN_EVENT_TYPES } from "./events.js";
 import type { Pool } from "pg";
 
 describe("KNOWN_EVENT_TYPES", () => {
-  it("stays in lockstep with the Rust binary (34 events)", () => {
+  it("stays in lockstep with the Rust binary (38 events)", () => {
     // Mirror of temps-core TelemetryEventKind::all().len(). If this changes,
     // update both this set and the Rust enum together.
-    expect(KNOWN_EVENT_TYPES.size).toBe(34);
+    expect(KNOWN_EVENT_TYPES.size).toBe(38);
   });
 
   it("uses only snake_case names", () => {

--- a/telemetry-api/src/routes/events.ts
+++ b/telemetry-api/src/routes/events.ts
@@ -17,11 +17,13 @@ export const KNOWN_EVENT_TYPES = new Set([
   "deploy_attempted",
   "deploy_succeeded",
   "deploy_failed",
+  "deploy_cancelled",
   "rollback_triggered",
   "first_deploy_succeeded",
 
   // Project & environment
   "project_created",
+  "project_created_from_template",
   "environment_created",
   "scale_to_zero_configured",
   "auto_deploy_enabled",


### PR DESCRIPTION
## Summary
- `TelemetryPlugin::new()` stamped every telemetry event with `env!("CARGO_PKG_VERSION")`, a fixed Cargo.toml value that's identical across nightly, beta, and release builds. As a result, self-hosted nightly instances could never show up as "nightly" in the telemetry admin dashboard's version breakdown — the string never left the binary.
- Switch to `env!("TEMPS_VERSION")`, the git-describe value `build.rs` already computes and that `temps --version` reports to users, so nightly/beta/tagged builds are now distinguishable in telemetry.
- Re-sync `telemetry-api`'s `KNOWN_EVENT_TYPES` allowlist with the current `TelemetryEventKind` Rust enum — it was missing `deploy_cancelled` and `project_created_from_template`, which would 422 on ingest for any client emitting them.
- Fix the allowlist's lockstep test, which had a stale hardcoded count (`34`) that was already wrong before this PR (actual was 36); now `38`, matching `TelemetryEventKind::all().len()`.

## Test plan
- [x] `cargo check --lib` (workspace) — 0 errors
- [x] `cargo clippy --lib -p temps-telemetry -p temps-cli -- -D warnings` — clean
- [x] `cargo test --lib -p temps-telemetry -p temps-core telemetry` — 6 passed
- [x] `bun test` in `telemetry-api/` — 10 passed (including corrected lockstep-count assertion)
- [x] Pre-commit hooks (fmt, clippy, conventional commit, typos) — all passed