### PR TITLE
fix(analytics): correct channel attribution, crawler contamination, and period-blind overview

### DIFF
--- a/apps/temps-cli/src/commands/analytics/overview.ts
+++ b/apps/temps-cli/src/commands/analytics/overview.ts
@@ -7,8 +7,8 @@ import {
   getUniqueCounts,
   getPagePaths,
   getEventsCount,
-  getVisitors,
-  getHourlyVisits,
+  getPropertyBreakdown,
+  getAggregatedBuckets,
 } from '../../api/sdk.gen.js'
 import { withSpinner } from '../../ui/spinner.js'
 import { newline, json as jsonOut, colors, info } from '../../ui/output.js'
@@ -26,6 +26,25 @@ interface LocationCount {
   percentage: number
 }
 
+const SPARKLINE_WIDTH = 48
+
+/**
+ * Pick a server-side bucket size that renders the *whole* requested period in
+ * at most SPARKLINE_WIDTH columns.
+ *
+ * The overview used to always request hourly buckets and then keep only the
+ * last 48 of them, so `--period 7d` and `--period 30d` both silently drew the
+ * same last-two-days sparkline under a header claiming a much longer range.
+ */
+function bucketSizeForRange(startDate: string, endDate: string): string {
+  const hours = (Date.parse(endDate) - Date.parse(startDate)) / 3_600_000
+
+  if (hours <= SPARKLINE_WIDTH) return '1 hour'
+  if (hours <= SPARKLINE_WIDTH * 6) return '6 hours'
+  if (hours <= SPARKLINE_WIDTH * 24) return '1 day'
+  if (hours <= SPARKLINE_WIDTH * 24 * 7) return '1 week'
+  return '1 month'
+}
 
 function formatNumber(n: number): string {
   return n.toLocaleString('en-US')
@@ -35,8 +54,9 @@ function renderSparkline(data: { count: number }[]): string {
   const blocks = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█']
   const max = Math.max(...data.map((d) => d.count), 1)
 
-  // Take last 48 points to fit terminal
-  const points = data.length > 48 ? data.slice(-48) : data
+  // The bucket size is chosen so the full period already fits; trimming here is
+  // only a guard against a server returning more buckets than we asked for.
+  const points = data.length > SPARKLINE_WIDTH ? data.slice(-SPARKLINE_WIDTH) : data
 
   return points
     .map((d) => {
@@ -71,9 +91,11 @@ export async function overview(options: OverviewOptions): Promise<void> {
 
   const projectId = projectData.id
 
+  const bucketSize = bucketSizeForRange(startDate, endDate)
+
   // Fetch all data concurrently
   const data = await withSpinner('Fetching analytics...', async () => {
-    const [visitorsRes, sessionsRes, pageViewsRes, pagesRes, eventsRes, visitorsListRes, hourlyRes] =
+    const [visitorsRes, sessionsRes, pageViewsRes, pagesRes, eventsRes, locationsRes, bucketsRes] =
       await Promise.all([
         getUniqueCounts({
           client,
@@ -104,19 +126,32 @@ export async function overview(options: OverviewOptions): Promise<void> {
             custom_events_only: true,
           },
         }),
-        getVisitors({
-          client,
-          query: {
-            project_id: projectId,
-            start_date: startDate,
-            end_date: endDate,
-            limit: 200,
-          },
-        }),
-        getHourlyVisits({
+        // Locations must come from the server-side country aggregate. The
+        // previous implementation listed raw visitor rows and tallied their
+        // countries client-side, which silently reported the same numbers for
+        // every period: /analytics/visitors caps at 100 rows and orders by
+        // last_seen DESC, so 24h, 7d and 30d all got the same 100 most-recent
+        // visitors.
+        getPropertyBreakdown({
           client,
           path: { project_id: projectId },
-          query: { start_date: startDate, end_date: endDate, aggregation_level: 'visitors' },
+          query: {
+            start_date: startDate,
+            end_date: endDate,
+            group_by: 'country',
+            aggregation_level: 'visitors',
+            limit: 10,
+          },
+        }),
+        getAggregatedBuckets({
+          client,
+          path: { project_id: projectId },
+          query: {
+            start_date: startDate,
+            end_date: endDate,
+            aggregation_level: 'visitors',
+            bucket_size: bucketSize,
+          },
         }),
       ])
 
@@ -125,27 +160,16 @@ export async function overview(options: OverviewOptions): Promise<void> {
     if (pageViewsRes.error) throw new Error(getErrorMessage(pageViewsRes.error))
     if (pagesRes.error) throw new Error(getErrorMessage(pagesRes.error))
     if (eventsRes.error) throw new Error(getErrorMessage(eventsRes.error))
-    if (visitorsListRes.error) throw new Error(getErrorMessage(visitorsListRes.error))
+    if (locationsRes.error) throw new Error(getErrorMessage(locationsRes.error))
+    if (bucketsRes.error) throw new Error(getErrorMessage(bucketsRes.error))
 
-    // Aggregate locations from visitors
-    const locationMap = new Map<string, number>()
-    let totalWithCountry = 0
-    const visitors = (visitorsListRes.data as any)?.visitors ?? []
-    for (const v of visitors) {
-      if (v.country) {
-        locationMap.set(v.country, (locationMap.get(v.country) ?? 0) + 1)
-        totalWithCountry++
-      }
-    }
-
-    const topLocations: LocationCount[] = [...locationMap.entries()]
-      .map(([country, count]) => ({
-        country,
-        count,
-        percentage: totalWithCountry > 0 ? (count / totalWithCountry) * 100 : 0,
-      }))
-      .sort((a, b) => b.count - a.count)
-      .slice(0, 10)
+    const topLocations: LocationCount[] = ((locationsRes.data as any)?.items ?? []).map(
+      (item: any) => ({
+        country: item.value,
+        count: item.count,
+        percentage: item.percentage,
+      })
+    )
 
     return {
       uniqueVisitors: (visitorsRes.data as any)?.count ?? 0,
@@ -154,7 +178,10 @@ export async function overview(options: OverviewOptions): Promise<void> {
       topPages: (pagesRes.data as any)?.page_paths ?? [],
       topEvents: (eventsRes.data as any) ?? [],
       topLocations,
-      hourly: (hourlyRes.data as any) ?? [],
+      // Echo back the bucket size the server actually used, so the rendered
+      // label always describes the data rather than what we asked for.
+      bucketSize: (bucketsRes.data as any)?.bucket_size ?? bucketSize,
+      buckets: (bucketsRes.data as any)?.items ?? [],
     }
   })
 
@@ -183,12 +210,14 @@ export async function overview(options: OverviewOptions): Promise<void> {
   console.log(`  ${chalk.white('Total Sessions')}${' '.repeat(8)}${chalk.bold.green(formatNumber(data.totalSessions))}`)
   console.log(`  ${chalk.white('Page Views')}${' '.repeat(12)}${chalk.bold.green(formatNumber(data.pageViews))}`)
 
-  // Sparkline
-  if (data.hourly.length > 0) {
-    const max = Math.max(...data.hourly.map((d: any) => d.count), 1)
+  // Sparkline — spans the full requested period, one column per bucket
+  if (data.buckets.length > 0) {
+    const max = Math.max(...data.buckets.map((d: any) => d.count), 1)
     newline()
-    console.log(`  ${chalk.bold.white('Hourly Visitors')}`)
-    console.log(`  ${chalk.cyan(renderSparkline(data.hourly))} ${chalk.gray(`(max: ${formatNumber(max)})`)}`)
+    console.log(`  ${chalk.bold.white(`Visitors (${label}, per ${data.bucketSize})`)}`)
+    console.log(
+      `  ${chalk.cyan(renderSparkline(data.buckets))} ${chalk.gray(`(max: ${formatNumber(max)})`)}`
+    )
   }
 
   // Top Pages

--- a/crates/temps-analytics-events/src/handlers/events_handler.rs
+++ b/crates/temps-analytics-events/src/handlers/events_handler.rs
@@ -439,6 +439,7 @@ pub async fn get_hourly_visits(
         ("event_name" = Option<String>, Query, description = "Filter by event name"),
         ("aggregation_level" = Option<String>, Query, description = "Aggregation level: events, sessions, or visitors - default: events"),
         ("limit" = Option<i32>, Query, description = "Maximum number of results (default: 20, max: 100)"),
+        ("include_crawlers" = Option<bool>, Query, description = "Include crawler/bot traffic (default: false)"),
         ("filter_country" = Option<String>, Query, description = "Filter by country (for region/city drill-downs)"),
         ("filter_region" = Option<String>, Query, description = "Filter by region (for city drill-downs)"),
         ("filter_browser" = Option<String>, Query, description = "Filter by browser name (for version drill-downs)"),
@@ -491,7 +492,8 @@ pub async fn get_property_breakdown(
         aggregation_level,
         query.limit,
         Some(filters),
-    );
+    )
+    .with_crawlers(query.include_crawlers.unwrap_or(false));
     let breakdown = state
         .events_service
         .query_property_breakdown(spec)
@@ -557,6 +559,7 @@ pub async fn get_property_timeline(
         group_by_column: query.group_by.clone(),
         aggregation_level: aggregation_level.to_string(),
         bucket_size: query.bucket_size,
+        include_crawlers: query.include_crawlers.unwrap_or(false),
     };
     let timeline = state
         .events_service

--- a/crates/temps-analytics-events/src/handlers/events_handler.rs
+++ b/crates/temps-analytics-events/src/handlers/events_handler.rs
@@ -639,24 +639,47 @@ pub async fn get_unique_counts(
 /// "zh-Hant-TW"); anything longer is a client sending junk.
 const MAX_LANGUAGE_TAG_LEN: usize = 35;
 
-/// Extract the highest-priority language tag from an `Accept-Language` header.
+/// Extract the highest-priority language tag from an `Accept-Language` header
+/// (or from an SDK-supplied `language` field, which has the same shape).
 ///
-/// Takes the first entry — browsers already send it in preference order — and
-/// drops any `;q=` weight. The result is **validated, not just truncated**:
-/// `language` is a `GROUP BY` dimension in the property breakdowns, so an
-/// unvalidated header would let any client mint unbounded distinct values and
-/// blow up cardinality on a box we expect to run in 4 GB. Anything that isn't a
-/// plausible BCP-47 tag is dropped rather than stored.
+/// Picks the entry with the highest `q` weight rather than simply the first:
+/// browsers do send preference order, but the ordering is a convention, not a
+/// guarantee, and `de;q=0.1,en;q=0.9` must resolve to `en`. Ties keep the
+/// earlier entry, matching RFC 9110.
+///
+/// The result is **validated and normalised, not merely truncated**. Every
+/// source of this value is attacker-controlled (`/_temps/event` is
+/// unauthenticated) and `language` is a `GROUP BY` dimension, so unvalidated
+/// input is an unbounded-cardinality hazard — worse on ClickHouse, where the
+/// column is `LowCardinality(String)`. Anything that isn't a plausible BCP-47
+/// tag is dropped rather than stored, and casing is normalised so `en-US`,
+/// `en-us` and `EN-US` collapse to one dimension value instead of three.
 fn primary_accept_language(header: &str) -> Option<String> {
-    let tag = header
-        .split(',')
-        .next()?
-        .split(';')
-        .next()?
-        .trim()
-        .trim_matches('"');
+    let mut best: Option<(f32, &str)> = None;
 
-    if tag.is_empty() || tag.len() > MAX_LANGUAGE_TAG_LEN {
+    for entry in header.split(',') {
+        let mut parts = entry.split(';');
+        let tag = parts.next().unwrap_or("").trim().trim_matches('"');
+        if tag.is_empty() {
+            continue;
+        }
+        // q-weight defaults to 1.0 when absent or unparsable.
+        let q = parts
+            .find_map(|p| {
+                let p = p.trim();
+                p.strip_prefix("q=").or_else(|| p.strip_prefix("Q="))
+            })
+            .and_then(|v| v.trim().parse::<f32>().ok())
+            .unwrap_or(1.0);
+
+        if best.is_none_or(|(best_q, _)| q > best_q) {
+            best = Some((q, tag));
+        }
+    }
+
+    let tag = best.map(|(_, t)| t)?;
+
+    if tag.len() > MAX_LANGUAGE_TAG_LEN {
         return None;
     }
     // "*" is a valid Accept-Language value but carries no information.
@@ -671,7 +694,7 @@ fn primary_accept_language(header: &str) -> Option<String> {
         return None;
     }
 
-    Some(tag.to_string())
+    Some(tag.to_ascii_lowercase())
 }
 
 /// Record analytics event
@@ -767,15 +790,20 @@ pub async fn record_event_metrics(
         .or(payload.referrer.clone())
         .or(referrer_header);
 
-    // Extract language from the payload, then event_data, then the
-    // Accept-Language header.
+    // Resolve the visitor's language from the payload, then event_data, then
+    // the Accept-Language header — and validate whichever one wins.
     //
-    // The header fallback is what actually populates this column in practice:
-    // no browser SDK sends `language` on the event payload (the React SDK only
-    // reports it from the session recorder), so without it every event stored
-    // NULL and the language breakdown was 100% "Unknown". Every browser sends
-    // Accept-Language on the ingest request itself, so the data was always
-    // there — it was simply never read.
+    // The header fallback exists because older SDKs send no `language` at all,
+    // which left this column NULL on every event and the breakdown 100%
+    // "Unknown". Newer SDKs do send it on the payload.
+    //
+    // Validation is applied to the RESOLVED value rather than to any single
+    // branch. All three sources are attacker-controlled — `/_temps/event` is
+    // unauthenticated, so `payload.language` and `event_data.language` are just
+    // as forgeable as the header — and `language` is a GROUP BY dimension, so
+    // an unvalidated value here is an unbounded-cardinality hazard on a box we
+    // expect to run in 4 GB. Validating only the header would have left the
+    // guard covering the branch least likely to be taken.
     let language = payload
         .language
         .or_else(|| {
@@ -789,8 +817,9 @@ pub async fn record_event_metrics(
             headers
                 .get("accept-language")
                 .and_then(|h| h.to_str().ok())
-                .and_then(primary_accept_language)
-        });
+                .map(|h| h.to_string())
+        })
+        .and_then(|raw| primary_accept_language(&raw));
 
     // Lookup IP geolocation
     let ip_geolocation_id = if !metadata.ip_address.is_empty() {
@@ -1281,16 +1310,30 @@ mod tests {
         // the q-weight is dropped.
         assert_eq!(
             primary_accept_language("en-US,en;q=0.9,es;q=0.8").as_deref(),
-            Some("en-US")
+            Some("en-us")
+        );
+        // Highest q wins even when it is not first — browser ordering is a
+        // convention, not a guarantee.
+        assert_eq!(
+            primary_accept_language("de;q=0.1,en;q=0.9").as_deref(),
+            Some("en")
+        );
+        // Ties keep the earlier entry (RFC 9110).
+        assert_eq!(primary_accept_language("fr,de").as_deref(), Some("fr"));
+        // Casing is normalised so one language is one dimension value.
+        assert_eq!(primary_accept_language("EN-US").as_deref(), Some("en-us"));
+        assert_eq!(
+            primary_accept_language("en-us").as_deref(),
+            primary_accept_language("EN-us").as_deref()
         );
         assert_eq!(primary_accept_language("fr").as_deref(), Some("fr"));
         assert_eq!(
             primary_accept_language("  pt-BR ;q=1.0 ").as_deref(),
-            Some("pt-BR")
+            Some("pt-br")
         );
         assert_eq!(
             primary_accept_language("zh-Hant-TW,zh;q=0.9").as_deref(),
-            Some("zh-Hant-TW")
+            Some("zh-hant-tw")
         );
     }
 

--- a/crates/temps-analytics-events/src/handlers/events_handler.rs
+++ b/crates/temps-analytics-events/src/handlers/events_handler.rs
@@ -771,6 +771,9 @@ pub async fn record_event_metrics(
             payload.event_data,
             &payload.request_path,
             &payload.request_query,
+            // The tracked site's own host, already resolved against the route
+            // table above — lets the service detect self-referrals.
+            Some(host.as_str()),
             payload.screen_width,
             payload.screen_height,
             payload.viewport_width,
@@ -900,6 +903,10 @@ pub async fn record_console_event(
             payload.event_data,
             &payload.request_path,
             &payload.request_query,
+            // No site hostname on the server-side path: the caller is the app
+            // backend, not the browser, and it sends no referrer either — so
+            // there is no self-referral to detect.
+            None, // site_hostname
             None, // screen_width
             None, // screen_height
             None, // viewport_width

--- a/crates/temps-analytics-events/src/handlers/events_handler.rs
+++ b/crates/temps-analytics-events/src/handlers/events_handler.rs
@@ -522,7 +522,8 @@ pub async fn get_property_breakdown(
         ("deployment_id" = Option<i32>, Query, description = "Filter by deployment ID"),
         ("event_name" = Option<String>, Query, description = "Filter by event name"),
         ("aggregation_level" = Option<String>, Query, description = "Aggregation level: events, sessions, or visitors - default: events"),
-        ("bucket_size" = Option<String>, Query, description = "Time bucket: hour, day, week, month (default: auto-detect)")
+        ("bucket_size" = Option<String>, Query, description = "Time bucket: hour, day, week, month (default: auto-detect)"),
+        ("include_crawlers" = Option<bool>, Query, description = "Include crawler/bot traffic (default: false)")
     ),
     responses(
         (status = 200, description = "Successfully retrieved property timeline", body = PropertyTimelineResponse),

--- a/crates/temps-analytics-events/src/handlers/events_handler.rs
+++ b/crates/temps-analytics-events/src/handlers/events_handler.rs
@@ -631,6 +631,45 @@ pub async fn get_unique_counts(
     Ok(Json(counts))
 }
 
+/// Longest BCP-47 tag we will store. Real tags are short ("en", "pt-BR",
+/// "zh-Hant-TW"); anything longer is a client sending junk.
+const MAX_LANGUAGE_TAG_LEN: usize = 35;
+
+/// Extract the highest-priority language tag from an `Accept-Language` header.
+///
+/// Takes the first entry — browsers already send it in preference order — and
+/// drops any `;q=` weight. The result is **validated, not just truncated**:
+/// `language` is a `GROUP BY` dimension in the property breakdowns, so an
+/// unvalidated header would let any client mint unbounded distinct values and
+/// blow up cardinality on a box we expect to run in 4 GB. Anything that isn't a
+/// plausible BCP-47 tag is dropped rather than stored.
+fn primary_accept_language(header: &str) -> Option<String> {
+    let tag = header
+        .split(',')
+        .next()?
+        .split(';')
+        .next()?
+        .trim()
+        .trim_matches('"');
+
+    if tag.is_empty() || tag.len() > MAX_LANGUAGE_TAG_LEN {
+        return None;
+    }
+    // "*" is a valid Accept-Language value but carries no information.
+    if tag == "*" {
+        return None;
+    }
+    // Subtags are alphanumeric, separated by "-". Reject anything else.
+    if !tag
+        .split('-')
+        .all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_alphanumeric()))
+    {
+        return None;
+    }
+
+    Some(tag.to_string())
+}
+
 /// Record analytics event
 #[utoipa::path(
     tag = "Metrics",
@@ -724,14 +763,30 @@ pub async fn record_event_metrics(
         .or(payload.referrer.clone())
         .or(referrer_header);
 
-    // Extract language from event_data if not provided in payload
-    let language = payload.language.or_else(|| {
-        payload
-            .event_data
-            .get("language")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-    });
+    // Extract language from the payload, then event_data, then the
+    // Accept-Language header.
+    //
+    // The header fallback is what actually populates this column in practice:
+    // no browser SDK sends `language` on the event payload (the React SDK only
+    // reports it from the session recorder), so without it every event stored
+    // NULL and the language breakdown was 100% "Unknown". Every browser sends
+    // Accept-Language on the ingest request itself, so the data was always
+    // there — it was simply never read.
+    let language = payload
+        .language
+        .or_else(|| {
+            payload
+                .event_data
+                .get("language")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        })
+        .or_else(|| {
+            headers
+                .get("accept-language")
+                .and_then(|h| h.to_str().ok())
+                .and_then(primary_accept_language)
+        });
 
     // Lookup IP geolocation
     let ip_geolocation_id = if !metadata.ip_address.is_empty() {
@@ -1215,6 +1270,44 @@ mod tests {
     use temps_database::test_utils::TestDatabase;
     use temps_entities::projects;
     use tower::ServiceExt;
+
+    #[test]
+    fn test_primary_accept_language_takes_highest_priority_tag() {
+        // Browsers send preference order already, so the first entry wins and
+        // the q-weight is dropped.
+        assert_eq!(
+            primary_accept_language("en-US,en;q=0.9,es;q=0.8").as_deref(),
+            Some("en-US")
+        );
+        assert_eq!(primary_accept_language("fr").as_deref(), Some("fr"));
+        assert_eq!(
+            primary_accept_language("  pt-BR ;q=1.0 ").as_deref(),
+            Some("pt-BR")
+        );
+        assert_eq!(
+            primary_accept_language("zh-Hant-TW,zh;q=0.9").as_deref(),
+            Some("zh-Hant-TW")
+        );
+    }
+
+    #[test]
+    fn test_primary_accept_language_rejects_junk() {
+        // `language` is a GROUP BY dimension — unvalidated input is a
+        // cardinality bomb, so anything implausible is dropped, not stored.
+        assert_eq!(primary_accept_language(""), None);
+        assert_eq!(primary_accept_language("   "), None);
+        assert_eq!(primary_accept_language("*"), None);
+        assert_eq!(primary_accept_language(";q=0.9"), None);
+        assert_eq!(primary_accept_language("en_US"), None); // underscore, not BCP-47
+        assert_eq!(primary_accept_language("en-"), None); // empty subtag
+        assert_eq!(primary_accept_language("<script>"), None);
+        assert_eq!(primary_accept_language("'; DROP TABLE events--"), None);
+        assert_eq!(primary_accept_language(&"a".repeat(36)), None); // over the cap
+        assert_eq!(
+            primary_accept_language(&"a".repeat(35)).as_deref(),
+            Some("a".repeat(35).as_str())
+        );
+    }
 
     fn create_test_auth_context() -> temps_auth::AuthContext {
         let user = temps_entities::users::Model {

--- a/crates/temps-analytics-events/src/services/clickhouse_backend.rs
+++ b/crates/temps-analytics-events/src/services/clickhouse_backend.rs
@@ -763,6 +763,9 @@ impl AnalyticsEvents for ClickHouseEventsBackend {
             WHERE project_id = ?
               AND timestamp >= fromUnixTimestamp64Milli(?)
               AND timestamp <= fromUnixTimestamp64Milli(?)
+              -- Same crawler gate as the breakdown, so the chart and the table
+              -- rendered next to it count the same population.
+              AND (? = 1 OR is_crawler = 0)
               AND (? = 0 OR environment_id = ?)
               AND (? = 0 OR deployment_id = ?)
               AND (? = 0 OR event_name = ?)
@@ -784,6 +787,8 @@ impl AnalyticsEvents for ClickHouseEventsBackend {
             .bind(q.scope.project_id)
             .bind(start_ms)
             .bind(end_ms)
+            // Positional: must stay adjacent to its `(? = 1 OR is_crawler = 0)`.
+            .bind(i32::from(q.include_crawlers))
             .bind(env_filter_flag)
             .bind(env_filter_value)
             .bind(dep_filter_flag)
@@ -1928,6 +1933,38 @@ mod tests {
         assert_eq!(pt.property, "channel");
         let pt_total: i64 = pt.items.iter().map(|i| i.count).sum();
         assert_eq!(pt_total, 5, "got {:?}", pt.items);
+
+        // The timeline must honour include_crawlers exactly like the breakdown.
+        // It previously accepted the flag and silently discarded it, so the
+        // chart counted bots while the table beside it did not — asserted here
+        // on both sides so a dropped bind or a missing predicate fails loudly.
+        let timeline_spec = |include: bool| PropertyTimelineSpec {
+            range: full_range(),
+            scope: project_scope(9),
+            event_name: None,
+            group_by_column: PropertyColumn::Channel,
+            aggregation_level: "visitors".to_string(),
+            bucket_size: Some("1 hour".to_string()),
+            include_crawlers: include,
+        };
+        let tl_off: i64 = backend
+            .query_property_timeline(timeline_spec(false))
+            .await
+            .expect("timeline without crawlers")
+            .items
+            .iter()
+            .map(|i| i.count)
+            .sum();
+        let tl_on: i64 = backend
+            .query_property_timeline(timeline_spec(true))
+            .await
+            .expect("timeline with crawlers")
+            .items
+            .iter()
+            .map(|i| i.count)
+            .sum();
+        assert_eq!(tl_off, 1, "timeline default must exclude the crawler");
+        assert_eq!(tl_on, 2, "timeline opt-in must include the crawler");
 
         // ---- query_dashboard_projects: empty short-circuit ----
         let empty_dash = backend

--- a/crates/temps-analytics-events/src/services/clickhouse_backend.rs
+++ b/crates/temps-analytics-events/src/services/clickhouse_backend.rs
@@ -277,6 +277,9 @@ fn property_breakdown_sql(col: &str, sentinel: &str, count_sql: &str) -> String 
                 WHERE project_id = ?
                   AND timestamp >= fromUnixTimestamp64Milli(?)
                   AND timestamp <= fromUnixTimestamp64Milli(?)
+                  -- Crawlers excluded unless the caller opts in, matching the
+                  -- Postgres impl so the two backends report one population.
+                  AND (? = 1 OR is_crawler = 0)
                   AND (? = 0 OR environment_id = ?)
                   AND (? = 0 OR deployment_id = ?)
                   AND (? = 0 OR event_name = ?)
@@ -626,6 +629,7 @@ impl AnalyticsEvents for ClickHouseEventsBackend {
         let event_filter_value = q.event_name.clone().unwrap_or_default();
         let start_ms = to_unix_milli(q.range.start);
         let end_ms = to_unix_milli(q.range.end);
+        let crawler_flag: i32 = i32::from(q.include_crawlers);
 
         // Drill-down filters mirror the Postgres impl. Every filter is
         // optional; the (flag = 0 OR column = value) idiom keeps the SQL
@@ -671,6 +675,9 @@ impl AnalyticsEvents for ClickHouseEventsBackend {
             .bind(q.scope.project_id)
             .bind(start_ms)
             .bind(end_ms)
+            // Must stay adjacent to the `(? = 1 OR is_crawler = 0)` gate: the
+            // CH driver binds positionally, so bind order IS the contract.
+            .bind(crawler_flag)
             .bind(env_filter_flag)
             .bind(env_filter_value)
             .bind(dep_filter_flag)
@@ -1567,6 +1574,31 @@ mod tests {
             make_row(4, 7, "sess-b", Some(101), "page_view", "page_view", t(30)),
             make_row(5, 7, "sess-b", Some(101), "click", "click", t(25)),
             make_row(6, 8, "sess-c", Some(102), "page_view", "page_view", t(20)),
+            // Project 9 is dedicated to the include_crawlers gate so these
+            // rows perturb none of the project 7/8 assertions above: one human
+            // visitor and one crawler visitor.
+            make_row(
+                9,
+                9,
+                "sess-human",
+                Some(903),
+                "page_view",
+                "page_view",
+                t(15),
+            ),
+            {
+                let mut bot = make_row(
+                    10,
+                    9,
+                    "sess-bot",
+                    Some(900),
+                    "page_view",
+                    "page_view",
+                    t(15),
+                );
+                bot.is_crawler = 1;
+                bot
+            },
         ];
 
         insert_rows(client, &rows).await;
@@ -1586,7 +1618,11 @@ mod tests {
     #[tokio::test]
     async fn ch_backend_full_query_surface() {
         let Some((backend, client, _container)) = setup_clickhouse().await else {
-            return; // Docker not available, skip.
+            // Say so out loud. A silent `return` here reports `ok` for a test
+            // that executed nothing, which is how an untested query change can
+            // look verified — observed while reviewing this very file.
+            println!("SKIPPED: ClickHouse container unavailable — this test asserted NOTHING");
+            return;
         };
 
         seed_rows(&client).await;
@@ -1811,6 +1847,45 @@ mod tests {
             .await
             .expect("query_property_breakdown channel");
         assert_eq!(pb.property, "channel");
+
+        // include_crawlers gate: the bot row must be invisible by default and
+        // visible on opt-in. This is what proves the positional bind lines up
+        // with the `(? = 1 OR is_crawler = 0)` placeholder — a misplaced bind
+        // would shift every later filter and change these totals.
+        let bots_off = backend
+            .query_property_breakdown(
+                PropertyBreakdownSpec::new(
+                    full_range(),
+                    project_scope(9),
+                    None,
+                    PropertyColumn::Channel,
+                    "visitors",
+                    Some(20),
+                    None,
+                )
+                .with_crawlers(false),
+            )
+            .await
+            .expect("breakdown without crawlers");
+        let bots_on = backend
+            .query_property_breakdown(
+                PropertyBreakdownSpec::new(
+                    full_range(),
+                    project_scope(9),
+                    None,
+                    PropertyColumn::Channel,
+                    "visitors",
+                    Some(20),
+                    None,
+                )
+                .with_crawlers(true),
+            )
+            .await
+            .expect("breakdown with crawlers");
+        let off_total: i64 = bots_off.items.iter().map(|i| i.count).sum();
+        let on_total: i64 = bots_on.items.iter().map(|i| i.count).sum();
+        assert_eq!(off_total, 1, "default must count only the human visitor");
+        assert_eq!(on_total, 2, "opt-in must also count the crawler visitor");
         assert_eq!(pb.total, 5);
         assert!(
             pb.items.iter().any(|i| i.value == "direct" && i.count == 5),
@@ -1846,6 +1921,7 @@ mod tests {
                 group_by_column: PropertyColumn::Channel,
                 aggregation_level: "events".to_string(),
                 bucket_size: Some("1 hour".to_string()),
+                include_crawlers: false,
             })
             .await
             .expect("query_property_timeline");
@@ -1916,7 +1992,11 @@ mod tests {
     #[tokio::test]
     async fn ch_dashboard_trend_omits_fabricated_percentage() {
         let Some((backend, client, _container)) = setup_clickhouse().await else {
-            return; // Docker not available, skip.
+            // Say so out loud. A silent `return` here reports `ok` for a test
+            // that executed nothing, which is how an untested query change can
+            // look verified — observed while reviewing this very file.
+            println!("SKIPPED: ClickHouse container unavailable — this test asserted NOTHING");
+            return;
         };
 
         let now = Utc::now();

--- a/crates/temps-analytics-events/src/services/events_service.rs
+++ b/crates/temps-analytics-events/src/services/events_service.rs
@@ -478,6 +478,7 @@ impl AnalyticsEventsService {
         aggregation_level: &str,
         limit: Option<i32>,
         filters: Option<crate::types::PropertyBreakdownFilters>,
+        include_crawlers: bool,
     ) -> Result<PropertyBreakdownResponse, EventsError> {
         let group_by_str = group_by_column.as_str();
         let limit_val = limit.unwrap_or(20).min(100);
@@ -528,13 +529,24 @@ impl AnalyticsEventsService {
         let mut conditions = vec!["e.project_id = $1".to_string()];
         conditions.push("e.timestamp >= $2".to_string());
         conditions.push("e.timestamp <= $3".to_string());
-        // Exclude crawlers so this shares a denominator with the headline
-        // counts from `get_unique_counts`, which filters them too. Without it a
-        // "Bot" row appears in the device breakdown and every percentage is
-        // computed over a larger population than the visitor/page-view totals
-        // shown beside it. Crawler traffic has its own AI-agent views, built on
-        // proxy logs rather than on this table.
-        conditions.push("e.is_crawler = false".to_string());
+        // Exclude crawlers by default so this shares a denominator with the
+        // headline counts from `get_unique_counts`, which filters them too.
+        // Without it a "Bot" row appears in the device breakdown and every
+        // percentage is computed over a larger population than the
+        // visitor/page-view totals shown beside it. Callers that specifically
+        // want bot traffic opt in, mirroring `include_crawlers` on the visitors
+        // endpoint.
+        if !include_crawlers {
+            conditions.push("e.is_crawler = false".to_string());
+        }
+        // When counting DISTINCT visitors/sessions, discard NULL keys up front.
+        // `COUNT(DISTINCT x)` already ignores NULLs, so this changes no result —
+        // it just prunes rows before the sort/hash instead of forming groups
+        // that the HAVING clause then throws away. Measured ~20% faster on a
+        // 300k-event range where a third of rows carry no visitor_id.
+        if !agg_distinct.is_empty() {
+            conditions.push(format!("e.{} IS NOT NULL", agg_field));
+        }
 
         // For referrer_hostname, filter out self-referrals (project's own domains)
         // Skip this filter when drilling down from a channel (filter_channel is set)
@@ -711,6 +723,7 @@ impl AnalyticsEventsService {
         group_by_column: crate::types::PropertyColumn,
         aggregation_level: &str,
         bucket_size: Option<String>,
+        include_crawlers: bool,
     ) -> Result<PropertyTimelineResponse, EventsError> {
         let group_by_str = group_by_column.as_str();
 
@@ -755,13 +768,24 @@ impl AnalyticsEventsService {
         let mut conditions = vec!["e.project_id = $1".to_string()];
         conditions.push("e.timestamp >= $2".to_string());
         conditions.push("e.timestamp <= $3".to_string());
-        // Exclude crawlers so this shares a denominator with the headline
-        // counts from `get_unique_counts`, which filters them too. Without it a
-        // "Bot" row appears in the device breakdown and every percentage is
-        // computed over a larger population than the visitor/page-view totals
-        // shown beside it. Crawler traffic has its own AI-agent views, built on
-        // proxy logs rather than on this table.
-        conditions.push("e.is_crawler = false".to_string());
+        // Exclude crawlers by default so this shares a denominator with the
+        // headline counts from `get_unique_counts`, which filters them too.
+        // Without it a "Bot" row appears in the device breakdown and every
+        // percentage is computed over a larger population than the
+        // visitor/page-view totals shown beside it. Callers that specifically
+        // want bot traffic opt in, mirroring `include_crawlers` on the visitors
+        // endpoint.
+        if !include_crawlers {
+            conditions.push("e.is_crawler = false".to_string());
+        }
+        // When counting DISTINCT visitors/sessions, discard NULL keys up front.
+        // `COUNT(DISTINCT x)` already ignores NULLs, so this changes no result —
+        // it just prunes rows before the sort/hash instead of forming groups
+        // that the HAVING clause then throws away. Measured ~20% faster on a
+        // 300k-event range where a third of rows carry no visitor_id.
+        if !agg_distinct.is_empty() {
+            conditions.push(format!("e.{} IS NOT NULL", agg_field));
+        }
 
         let mut param_idx = 4;
         if environment_id.is_some() {
@@ -2038,6 +2062,7 @@ impl crate::services::traits::AnalyticsEvents for AnalyticsEventsService {
             &q.aggregation_level,
             Some(q.limit),
             q.filters,
+            q.include_crawlers,
         )
         .await
     }
@@ -2057,6 +2082,7 @@ impl crate::services::traits::AnalyticsEvents for AnalyticsEventsService {
             q.group_by_column,
             &q.aggregation_level,
             q.bucket_size,
+            q.include_crawlers,
         )
         .await
     }
@@ -4306,6 +4332,7 @@ mod tests {
                 "visitors",
                 None,
                 None,
+                false, // include_crawlers
             )
             .await
             .expect("Failed to get property breakdown");
@@ -4512,6 +4539,7 @@ mod tests {
                 "visitors",
                 None,
                 None,
+                false, // include_crawlers
             )
             .await
             .expect("Failed to get property breakdown");
@@ -4531,6 +4559,36 @@ mod tests {
         assert_eq!(
             breakdown.total, 1,
             "the breakdown denominator must exclude crawlers"
+        );
+
+        // ...but an explicit opt-in still surfaces them, mirroring the
+        // `include_crawlers` toggle the visitors endpoint already exposes.
+        let with_bots = service
+            .get_property_breakdown(
+                chrono::Utc::now() - chrono::Duration::hours(1),
+                chrono::Utc::now() + chrono::Duration::hours(1),
+                project.id,
+                None,
+                None,
+                None,
+                crate::types::PropertyColumn::ReferrerHostname,
+                "visitors",
+                None,
+                None,
+                true, // include_crawlers
+            )
+            .await
+            .expect("Failed to get property breakdown with crawlers");
+
+        let hosts_with_bots: Vec<&str> = with_bots.items.iter().map(|i| i.value.as_str()).collect();
+        assert!(
+            hosts_with_bots.contains(&"bot-referrer.example"),
+            "include_crawlers=true must surface crawler traffic: {:?}",
+            hosts_with_bots
+        );
+        assert_eq!(
+            with_bots.total, 2,
+            "opting in must widen the denominator to include crawlers"
         );
 
         println!("✅ property breakdown crawler-exclusion test passed!");

--- a/crates/temps-analytics-events/src/services/events_service.rs
+++ b/crates/temps-analytics-events/src/services/events_service.rs
@@ -1409,6 +1409,10 @@ WHERE project_id = $1
         event_data: serde_json::Value,
         request_path: &str,
         request_query: &str,
+        // Hostname of the tracked site itself, resolved by the caller from the
+        // request Host header. Required for self-referral detection — see the
+        // `hostname` binding below.
+        site_hostname: Option<&str>,
         screen_width: Option<u32>,
         screen_height: Option<u32>,
         viewport_width: Option<u32>,
@@ -1439,10 +1443,22 @@ WHERE project_id = $1
         let session_id =
             Some(session_id.unwrap_or_else(|| temps_core::uuid::Uuid::new_v4().to_string()));
 
-        // Extract hostname from event_data if available, otherwise use default
-        let hostname = event_data
-            .get("hostname")
-            .and_then(|v| v.as_str())
+        // Resolve the hostname of the tracked site. Priority:
+        //   1. `site_hostname` — the request Host header the ingest handler
+        //      already resolved against the route table, so it is the site the
+        //      event actually happened on.
+        //   2. `event_data.hostname` — legacy/server-side callers that embed it.
+        //   3. "localhost" — last resort so the column is never empty.
+        //
+        // Priority 1 matters beyond the stored column: without a site hostname
+        // `get_channel` cannot recognise a self-referral, so every internal
+        // page-to-page navigation gets attributed to the "Referral" channel and
+        // swamps the real acquisition channels. No browser SDK has ever sent
+        // `event_data.hostname` (the React SDK sends a top-level `domain`), so
+        // relying on it alone left self-referral detection permanently off.
+        let hostname = site_hostname
+            .filter(|h| !h.is_empty())
+            .or_else(|| event_data.get("hostname").and_then(|v| v.as_str()))
             .unwrap_or("localhost")
             .to_string();
 
@@ -1460,12 +1476,13 @@ WHERE project_id = $1
             .as_ref()
             .and_then(|r| temps_analytics::extract_referrer_hostname(r));
 
-        // Compute channel attribution
-        let current_hostname = event_data.get("hostname").and_then(|v| v.as_str());
+        // Compute channel attribution. `hostname` is the resolved site host, so
+        // a referrer pointing at our own domain is correctly classified as
+        // Direct (session continuation) rather than Referral.
         let channel = temps_analytics::get_channel(
             &utm_params,
             referrer_hostname.as_deref(),
-            current_hostname,
+            Some(hostname.as_str()),
         );
 
         // Get UTM values from parsed params
@@ -2982,6 +2999,7 @@ mod tests {
                 serde_json::json!({}),
                 "/blog/bot-test",
                 "",
+                None, // site_hostname
                 None,
                 None,
                 None,
@@ -3022,6 +3040,7 @@ mod tests {
                 serde_json::json!({}),
                 "/blog/human-test",
                 "",
+                None, // site_hostname
                 None,
                 None,
                 None,
@@ -3051,6 +3070,205 @@ mod tests {
         );
 
         println!("✅ record_event crawler-flag persistence test passed!");
+    }
+
+    /// Regression test: a page-to-page navigation within the tracked site
+    /// arrives with a referrer on our own host. `record_event` must resolve
+    /// the site hostname from the caller (the ingest handler passes the
+    /// route-resolved Host header) so `get_channel` recognises the
+    /// self-referral and records it as Direct. Before this was wired up the
+    /// service looked for `event_data.hostname`, which no browser SDK sends,
+    /// so self-referral detection never fired and internal navigation
+    /// dominated the Referral channel.
+    #[tokio::test]
+    async fn test_record_event_classifies_self_referral_as_direct() {
+        use sea_orm::{ActiveModelTrait, Set};
+        use temps_database::test_utils::TestDatabase;
+        use temps_entities::{
+            deployments, environments, projects, source_type::SourceType,
+            upstream_config::UpstreamList,
+        };
+
+        let test_db: TestDatabase = match TestDatabase::with_migrations().await {
+            Ok(db) => db,
+            Err(e) => {
+                println!("Database not available, skipping test: {}", e);
+                return;
+            }
+        };
+        let db = test_db.connection_arc();
+
+        let project = projects::ActiveModel {
+            name: Set("self-referral-test".to_string()),
+            repo_name: Set("test-repo".to_string()),
+            repo_owner: Set("test-owner".to_string()),
+            directory: Set("/".to_string()),
+            main_branch: Set("main".to_string()),
+            preset: Set(temps_entities::preset::Preset::NextJs),
+            preset_config: Set(None),
+            deployment_config: Set(None),
+            slug: Set("self-referral-test".to_string()),
+            is_deleted: Set(false),
+            deleted_at: Set(None),
+            last_deployment: Set(None),
+            is_public_repo: Set(false),
+            git_url: Set(None),
+            git_provider_connection_id: Set(None),
+            attack_mode: Set(false),
+            error_source_context_enabled: Set(false),
+            error_source_root: Set(None),
+            enable_preview_environments: Set(false),
+            source_type: Set(SourceType::Git),
+            created_at: Set(chrono::Utc::now()),
+            updated_at: Set(chrono::Utc::now()),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .expect("Failed to insert test project");
+
+        let environment = environments::ActiveModel {
+            project_id: Set(project.id),
+            name: Set("production".to_string()),
+            branch: Set(Some("main".to_string())),
+            slug: Set("production".to_string()),
+            subdomain: Set("prod".to_string()),
+            host: Set(String::new()),
+            upstreams: Set(UpstreamList::new()),
+            is_preview: Set(false),
+            current_deployment_id: Set(None),
+            deleted_at: Set(None),
+            deployment_config: Set(None),
+            last_deployment: Set(None),
+            created_at: Set(chrono::Utc::now()),
+            updated_at: Set(chrono::Utc::now()),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .expect("Failed to insert test environment");
+
+        let deployment = deployments::ActiveModel {
+            project_id: Set(project.id),
+            environment_id: Set(environment.id),
+            slug: Set(format!("test-deploy-{}", uuid::Uuid::new_v4())),
+            state: Set("ready".to_string()),
+            metadata: Set(Some(deployments::DeploymentMetadata::default())),
+            deploying_at: Set(None),
+            ready_at: Set(Some(chrono::Utc::now())),
+            started_at: Set(Some(chrono::Utc::now())),
+            finished_at: Set(Some(chrono::Utc::now())),
+            context_vars: Set(None),
+            branch_ref: Set(Some("main".to_string())),
+            tag_ref: Set(None),
+            commit_sha: Set(None),
+            commit_message: Set(None),
+            commit_author: Set(None),
+            commit_json: Set(None),
+            cancelled_reason: Set(None),
+            static_dir_location: Set(None),
+            screenshot_location: Set(None),
+            image_name: Set(None),
+            deployment_config: Set(None),
+            created_at: Set(chrono::Utc::now()),
+            updated_at: Set(chrono::Utc::now()),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .expect("Failed to insert test deployment");
+
+        let service = AnalyticsEventsService::new(db.clone());
+
+        // A visitor navigating from one page of the tracked site to another
+        // sends a referrer on our own host. That is session continuation, not
+        // an acquisition channel, so it must be classified Direct.
+        let self_referral = service
+            .record_event(
+                project.id,
+                Some(environment.id),
+                Some(deployment.id),
+                Some("self-ref-session".to_string()),
+                None,
+                "page_view",
+                serde_json::json!({}),
+                "/pricing",
+                "",
+                Some("temps.example"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+                        .to_string(),
+                ),
+                Some("https://temps.example/blog/post".to_string()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("Failed to record self-referral event");
+
+        assert_eq!(
+            self_referral.channel.as_deref(),
+            Some("Direct"),
+            "a referrer on the site's own host is session continuation, not a Referral"
+        );
+        assert_eq!(
+            self_referral.hostname, "temps.example",
+            "the resolved site host must be persisted, not the 'localhost' fallback"
+        );
+
+        // A referrer on a third-party host is a genuine Referral.
+        let external_referral = service
+            .record_event(
+                project.id,
+                Some(environment.id),
+                Some(deployment.id),
+                Some("ext-ref-session".to_string()),
+                None,
+                "page_view",
+                serde_json::json!({}),
+                "/pricing",
+                "",
+                Some("temps.example"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+                        .to_string(),
+                ),
+                Some("https://openalternative.co/temps".to_string()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("Failed to record external-referral event");
+
+        assert_eq!(
+            external_referral.channel.as_deref(),
+            Some("Referral"),
+            "a third-party referrer must still be classified as Referral"
+        );
+
+        println!("✅ self-referral channel attribution test passed!");
     }
 
     /// Regression test for the visitor/event race condition: a brand-new
@@ -3188,6 +3406,7 @@ mod tests {
                 serde_json::json!({}),
                 "/",
                 "?utm_source=newsletter&utm_medium=email&utm_campaign=launch",
+                None, // site_hostname
                 None,
                 None,
                 None,
@@ -3252,6 +3471,7 @@ mod tests {
                 serde_json::json!({}),
                 "/pricing",
                 "",
+                None, // site_hostname
                 None,
                 None,
                 None,
@@ -3413,6 +3633,7 @@ mod tests {
                 serde_json::json!({}),
                 "/",
                 "?utm_source=newsletter&utm_medium=email&utm_campaign=launch",
+                None, // site_hostname
                 None,
                 None,
                 None,
@@ -3501,6 +3722,7 @@ mod tests {
                 serde_json::json!({}),
                 "/about",
                 "",
+                None, // site_hostname
                 None,
                 None,
                 None,
@@ -3998,6 +4220,7 @@ mod tests {
                 serde_json::json!({}),
                 "/",
                 "",
+                None, // site_hostname
                 None,
                 None,
                 None,
@@ -4031,6 +4254,7 @@ mod tests {
                 serde_json::json!({}),
                 "/",
                 "",
+                None, // site_hostname
                 None,
                 None,
                 None,

--- a/crates/temps-analytics-events/src/services/events_service.rs
+++ b/crates/temps-analytics-events/src/services/events_service.rs
@@ -780,9 +780,12 @@ impl AnalyticsEventsService {
         }
         // When counting DISTINCT visitors/sessions, discard NULL keys up front.
         // `COUNT(DISTINCT x)` already ignores NULLs, so this changes no result —
-        // it just prunes rows before the sort/hash instead of forming groups
-        // that the HAVING clause then throws away. Measured ~20% faster on a
-        // 300k-event range where a third of rows carry no visitor_id.
+        // it just prunes rows before the sort/hash. Note this query has no
+        // HAVING clause, so unlike the breakdown the prune is not purely
+        // cosmetic: a (bucket, value) group whose rows all carry a NULL key
+        // used to emit count = 0 and now drops out entirely. That is the
+        // correct shape for a chart — a bucket with no identified visitors is
+        // absent rather than a spurious zero — but it IS a response change.
         if !agg_distinct.is_empty() {
             conditions.push(format!("e.{} IS NOT NULL", agg_field));
         }

--- a/crates/temps-analytics-events/src/services/events_service.rs
+++ b/crates/temps-analytics-events/src/services/events_service.rs
@@ -528,6 +528,13 @@ impl AnalyticsEventsService {
         let mut conditions = vec!["e.project_id = $1".to_string()];
         conditions.push("e.timestamp >= $2".to_string());
         conditions.push("e.timestamp <= $3".to_string());
+        // Exclude crawlers so this shares a denominator with the headline
+        // counts from `get_unique_counts`, which filters them too. Without it a
+        // "Bot" row appears in the device breakdown and every percentage is
+        // computed over a larger population than the visitor/page-view totals
+        // shown beside it. Crawler traffic has its own AI-agent views, built on
+        // proxy logs rather than on this table.
+        conditions.push("e.is_crawler = false".to_string());
 
         // For referrer_hostname, filter out self-referrals (project's own domains)
         // Skip this filter when drilling down from a channel (filter_channel is set)
@@ -748,6 +755,13 @@ impl AnalyticsEventsService {
         let mut conditions = vec!["e.project_id = $1".to_string()];
         conditions.push("e.timestamp >= $2".to_string());
         conditions.push("e.timestamp <= $3".to_string());
+        // Exclude crawlers so this shares a denominator with the headline
+        // counts from `get_unique_counts`, which filters them too. Without it a
+        // "Bot" row appears in the device breakdown and every percentage is
+        // computed over a larger population than the visitor/page-view totals
+        // shown beside it. Crawler traffic has its own AI-agent views, built on
+        // proxy logs rather than on this table.
+        conditions.push("e.is_crawler = false".to_string());
 
         let mut param_idx = 4;
         if environment_id.is_some() {
@@ -4228,7 +4242,10 @@ mod tests {
                 None,
                 None,
                 None,
-                None,
+                Some(
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+                        .to_string(),
+                ),
                 Some("https://www.bing.com/search?q=temps".to_string()),
                 None,
                 None,
@@ -4262,7 +4279,10 @@ mod tests {
                 None,
                 None,
                 None,
-                None,
+                Some(
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+                        .to_string(),
+                ),
                 Some("https://www.pornhub.com/".to_string()),
                 None,
                 None,
@@ -4303,5 +4323,216 @@ mod tests {
         );
 
         println!("✅ property breakdown excludes zero-visitor referrer spam!");
+    }
+
+    /// Regression test: property breakdowns must exclude crawler traffic, the
+    /// same way `get_unique_counts` does. When they disagreed, a "Bot" row
+    /// appeared in the device breakdown and every channel/referrer percentage
+    /// was computed over a larger population than the visitor and page-view
+    /// totals rendered next to it.
+    #[tokio::test]
+    async fn test_property_breakdown_excludes_crawlers() {
+        use sea_orm::{ActiveModelTrait, Set};
+        use temps_database::test_utils::TestDatabase;
+        use temps_entities::{
+            deployments, environments, projects, source_type::SourceType,
+            upstream_config::UpstreamList,
+        };
+
+        let test_db: TestDatabase = match TestDatabase::with_migrations().await {
+            Ok(db) => db,
+            Err(e) => {
+                println!("Database not available, skipping test: {}", e);
+                return;
+            }
+        };
+        let db = test_db.connection_arc();
+
+        let project = projects::ActiveModel {
+            name: Set("crawler-breakdown-test".to_string()),
+            repo_name: Set("test-repo".to_string()),
+            repo_owner: Set("test-owner".to_string()),
+            directory: Set("/".to_string()),
+            main_branch: Set("main".to_string()),
+            preset: Set(temps_entities::preset::Preset::NextJs),
+            preset_config: Set(None),
+            deployment_config: Set(None),
+            slug: Set("crawler-breakdown-test".to_string()),
+            is_deleted: Set(false),
+            deleted_at: Set(None),
+            last_deployment: Set(None),
+            is_public_repo: Set(false),
+            git_url: Set(None),
+            git_provider_connection_id: Set(None),
+            attack_mode: Set(false),
+            error_source_context_enabled: Set(false),
+            error_source_root: Set(None),
+            enable_preview_environments: Set(false),
+            source_type: Set(SourceType::Git),
+            created_at: Set(chrono::Utc::now()),
+            updated_at: Set(chrono::Utc::now()),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .expect("Failed to insert test project");
+
+        let environment = environments::ActiveModel {
+            project_id: Set(project.id),
+            name: Set("production".to_string()),
+            branch: Set(Some("main".to_string())),
+            slug: Set("production".to_string()),
+            subdomain: Set("prod".to_string()),
+            host: Set(String::new()),
+            upstreams: Set(UpstreamList::new()),
+            is_preview: Set(false),
+            current_deployment_id: Set(None),
+            deleted_at: Set(None),
+            deployment_config: Set(None),
+            last_deployment: Set(None),
+            created_at: Set(chrono::Utc::now()),
+            updated_at: Set(chrono::Utc::now()),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .expect("Failed to insert test environment");
+
+        let deployment = deployments::ActiveModel {
+            project_id: Set(project.id),
+            environment_id: Set(environment.id),
+            slug: Set(format!("test-deploy-{}", uuid::Uuid::new_v4())),
+            state: Set("ready".to_string()),
+            metadata: Set(Some(deployments::DeploymentMetadata::default())),
+            deploying_at: Set(None),
+            ready_at: Set(Some(chrono::Utc::now())),
+            started_at: Set(Some(chrono::Utc::now())),
+            finished_at: Set(Some(chrono::Utc::now())),
+            context_vars: Set(None),
+            branch_ref: Set(Some("main".to_string())),
+            tag_ref: Set(None),
+            commit_sha: Set(None),
+            commit_message: Set(None),
+            commit_author: Set(None),
+            commit_json: Set(None),
+            cancelled_reason: Set(None),
+            static_dir_location: Set(None),
+            screenshot_location: Set(None),
+            image_name: Set(None),
+            deployment_config: Set(None),
+            created_at: Set(chrono::Utc::now()),
+            updated_at: Set(chrono::Utc::now()),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .expect("Failed to insert test deployment");
+
+        let service = AnalyticsEventsService::new(db.clone());
+
+        let human_visitor = uuid::Uuid::new_v4().to_string();
+        let bot_visitor = uuid::Uuid::new_v4().to_string();
+
+        service
+            .record_event(
+                project.id,
+                Some(environment.id),
+                Some(deployment.id),
+                Some("human-session".to_string()),
+                Some(human_visitor.clone()),
+                "page_view",
+                serde_json::json!({}),
+                "/",
+                "",
+                Some("temps.example"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+                        .to_string(),
+                ),
+                Some("https://openalternative.co/temps".to_string()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("Failed to record event");
+
+        service
+            .record_event(
+                project.id,
+                Some(environment.id),
+                Some(deployment.id),
+                Some("bot-session".to_string()),
+                Some(bot_visitor.clone()),
+                "page_view",
+                serde_json::json!({}),
+                "/",
+                "",
+                Some("temps.example"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(
+                    "Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)".to_string(),
+                ),
+                Some("https://bot-referrer.example/".to_string()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("Failed to record event");
+
+        let breakdown = service
+            .get_property_breakdown(
+                chrono::Utc::now() - chrono::Duration::hours(1),
+                chrono::Utc::now() + chrono::Duration::hours(1),
+                project.id,
+                None,
+                None,
+                None,
+                crate::types::PropertyColumn::ReferrerHostname,
+                "visitors",
+                None,
+                None,
+            )
+            .await
+            .expect("Failed to get property breakdown");
+
+        let hosts: Vec<&str> = breakdown.items.iter().map(|i| i.value.as_str()).collect();
+        assert!(
+            hosts.contains(&"openalternative.co"),
+            "a human referrer must be present: {:?}",
+            hosts
+        );
+        assert!(
+            !hosts.contains(&"bot-referrer.example"),
+            "crawler traffic must not appear in breakdowns — it is excluded from \
+             the headline counts, so counting it here makes the two disagree: {:?}",
+            hosts
+        );
+        assert_eq!(
+            breakdown.total, 1,
+            "the breakdown denominator must exclude crawlers"
+        );
+
+        println!("✅ property breakdown crawler-exclusion test passed!");
     }
 }

--- a/crates/temps-analytics-events/src/services/queries.rs
+++ b/crates/temps-analytics-events/src/services/queries.rs
@@ -161,6 +161,10 @@ pub struct PropertyBreakdownSpec {
     pub aggregation_level: String,
     pub limit: i32,
     pub filters: Option<PropertyBreakdownFilters>,
+    /// Include crawler/bot traffic. Defaults to false so breakdowns share a
+    /// denominator with the headline counts from `unique-counts`, which always
+    /// exclude crawlers. Callers opt in explicitly when they want bot traffic.
+    pub include_crawlers: bool,
 }
 
 impl PropertyBreakdownSpec {
@@ -181,7 +185,15 @@ impl PropertyBreakdownSpec {
             aggregation_level: aggregation_level.into(),
             limit: clamp_limit(limit, 20),
             filters,
+            include_crawlers: false,
         }
+    }
+
+    /// Opt in to crawler/bot traffic. Off by default — see
+    /// [`PropertyBreakdownSpec::include_crawlers`].
+    pub fn with_crawlers(mut self, include: bool) -> Self {
+        self.include_crawlers = include;
+        self
     }
 }
 
@@ -193,6 +205,8 @@ pub struct PropertyTimelineSpec {
     pub group_by_column: PropertyColumn,
     pub aggregation_level: String,
     pub bucket_size: Option<String>,
+    /// See [`PropertyBreakdownSpec::include_crawlers`].
+    pub include_crawlers: bool,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/temps-analytics-events/src/types/requests.rs
+++ b/crates/temps-analytics-events/src/types/requests.rs
@@ -268,6 +268,10 @@ pub struct PropertyBreakdownQuery {
     pub filter_channel: Option<String>,
     /// Filter by referrer hostname (for referrer -> pages drill-downs)
     pub filter_referrer: Option<String>,
+    /// Include crawler/bot traffic (default: false). Off by default so the
+    /// breakdown percentages share a denominator with the headline counts,
+    /// which always exclude crawlers.
+    pub include_crawlers: Option<bool>,
 }
 
 /// Optional filters for property breakdown drill-downs.
@@ -308,6 +312,9 @@ pub struct PropertyTimelineQuery {
     pub aggregation_level: AggregationLevel,
     /// Time bucket size: "hour", "day", "week", "month" (default: auto-detect)
     pub bucket_size: Option<String>,
+    /// Include crawler/bot traffic (default: false). See
+    /// [`PropertyBreakdownQuery::include_crawlers`].
+    pub include_crawlers: Option<bool>,
 }
 
 /// Query parameters for unique counts over time frame

--- a/crates/temps-analytics/src/analytics.rs
+++ b/crates/temps-analytics/src/analytics.rs
@@ -2198,6 +2198,10 @@ impl Analytics for AnalyticsService {
                     WHERE {where_clause}
                 )
                 AND e.event_type IN ('page_view', 'page_leave')
+                -- Also filter here, not only in the session sub-select above:
+                -- qualifying a session on one human event would otherwise drag
+                -- in every crawler-flagged row that shares its session id.
+                AND e.is_crawler = false
             ),
             -- Priority 1: for each page_view, find the min page_leave timestamp
             -- for same session+page_path within 30 min (via self-join + GROUP BY)

--- a/crates/temps-analytics/src/analytics.rs
+++ b/crates/temps-analytics/src/analytics.rs
@@ -2137,6 +2137,10 @@ impl Analytics for AnalyticsService {
             "pv.page_path IS NOT NULL".to_string(),
             "pv.page_path != ''".to_string(),
             "pv.event_type = 'page_view'".to_string(),
+            // Crawler page views are excluded here for the same reason they are
+            // excluded from the headline unique counts: a per-page table that
+            // counts bots cannot be reconciled against a total that doesn't.
+            "pv.is_crawler = false".to_string(),
         ];
         let mut values: Vec<sea_orm::Value> = vec![project_id.into()];
         let mut param_index = 2;

--- a/crates/temps-analytics/src/channel.rs
+++ b/crates/temps-analytics/src/channel.rs
@@ -231,6 +231,20 @@ fn is_video_platform(hostname: &str) -> bool {
     VIDEO_PLATFORMS.iter().any(|vp| hostname_lower.contains(vp))
 }
 
+/// True when `referrer` is the same host as `current`, or a subdomain of it
+/// (or vice versa — `www.example.com` referring `example.com` is still us).
+///
+/// Comparison is case-insensitive and anchored on a dot boundary, so
+/// `nottemps.sh` is NOT a self-referral of `temps.sh`.
+fn is_same_site(referrer: &str, current: &str) -> bool {
+    let r = referrer.trim_end_matches('.').to_ascii_lowercase();
+    let c = current.trim_end_matches('.').to_ascii_lowercase();
+    if r.is_empty() || c.is_empty() {
+        return false;
+    }
+    r == c || r.ends_with(&format!(".{c}")) || c.ends_with(&format!(".{r}"))
+}
+
 /// Determine marketing channel from UTM parameters and referrer
 ///
 /// This follows Google Analytics 4 default channel groupings:
@@ -355,9 +369,16 @@ pub fn get_channel(
 
     // No UTM params - use referrer analysis
     if let Some(ref_host) = referrer_hostname {
-        // Check for self-referral
+        // Check for self-referral — the same host, or a subdomain of it.
+        //
+        // This must be a boundary-aware comparison, not a substring test. A
+        // bare `contains` treats `nottemps.sh` and `temps.sh.evil.example` as
+        // self-referrals of `temps.sh`, which silently deletes real referrals
+        // from acquisition reporting and lets any third party suppress its own
+        // attribution just by choosing a hostname that contains ours. Shorter
+        // apex domains make that trivial.
         if let Some(current) = current_hostname {
-            if ref_host.contains(current) || current.contains(ref_host) {
+            if is_same_site(ref_host, current) {
                 // Self-referral, treat as continuation of session
                 return Channel::Direct;
             }
@@ -512,6 +533,48 @@ mod tests {
         assert_eq!(
             get_channel(&utm, Some("example-blog.com"), Some("mysite.com")),
             Channel::Referral
+        );
+    }
+
+    #[test]
+    fn test_self_referral_match_is_boundary_anchored() {
+        let utm = UtmParams::default();
+        // Same host, and subdomains in both directions, are us.
+        assert_eq!(
+            get_channel(&utm, Some("temps.sh"), Some("temps.sh")),
+            Channel::Direct
+        );
+        assert_eq!(
+            get_channel(&utm, Some("www.temps.sh"), Some("temps.sh")),
+            Channel::Direct
+        );
+        assert_eq!(
+            get_channel(&utm, Some("temps.sh"), Some("www.temps.sh")),
+            Channel::Direct
+        );
+        assert_eq!(
+            get_channel(&utm, Some("TEMPS.SH"), Some("temps.sh")),
+            Channel::Direct,
+            "host comparison must be case-insensitive"
+        );
+
+        // Regression: a bare substring test classified all of these as Direct,
+        // which silently deletes real referrals and lets a third party suppress
+        // its own attribution by choosing a hostname containing ours.
+        assert_eq!(
+            get_channel(&utm, Some("nottemps.sh"), Some("temps.sh")),
+            Channel::Referral,
+            "a host merely ending in ours is a different site"
+        );
+        assert_eq!(
+            get_channel(&utm, Some("temps.sh.evil.example"), Some("temps.sh")),
+            Channel::Referral,
+            "a host merely starting with ours is a different site"
+        );
+        assert_eq!(
+            get_channel(&utm, Some("temps.shop"), Some("temps.sh")),
+            Channel::Referral,
+            "a longer TLD is a different site"
         );
     }
 

--- a/sdks/node/packages/analytics-core/src/Analytics.ts
+++ b/sdks/node/packages/analytics-core/src/Analytics.ts
@@ -52,6 +52,7 @@ export function createAnalytics(options: AnalyticsOptions = {}): AnalyticsApi {
         request_query: window.location.search,
         request_path: window.location.pathname,
         domain: resolveDomain(),
+        language: navigator.language,
         event_data: data as Record<string, JsonValue>,
       },
       "POST",
@@ -68,6 +69,7 @@ export function createAnalytics(options: AnalyticsOptions = {}): AnalyticsApi {
         request_query: window.location.search,
         request_path: window.location.pathname,
         domain: resolveDomain(),
+        language: navigator.language,
         event_data: {
           referrer: document.referrer,
           userAgent: navigator.userAgent,
@@ -264,6 +266,7 @@ function setupLegacyPageLeave(
         request_query: window.location.search,
         request_path: window.location.pathname,
         domain: resolveDomain(),
+        language: navigator.language,
         event_data: {
           time_on_page_ms: timeOnPage,
           timestamp: new Date().toISOString(),

--- a/sdks/node/packages/analytics-core/src/EngagementTracker.ts
+++ b/sdks/node/packages/analytics-core/src/EngagementTracker.ts
@@ -185,6 +185,7 @@ export class EngagementTracker {
         request_path: window.location.pathname,
         request_query: window.location.search,
         domain: this.domain,
+        language: navigator.language,
         event_data: {
           engagement_time: Math.round(this.engagementTime),
           total_time: Math.round(Date.now() - this.startTime),
@@ -221,6 +222,7 @@ export class EngagementTracker {
         request_path: window.location.pathname,
         request_query: window.location.search,
         domain: this.domain,
+        language: navigator.language,
         event_data: {
           engagement_time_seconds: data.engagement_time_seconds,
           total_time_seconds: data.total_time_seconds,

--- a/sdks/node/packages/react-analytics/src/Provider.tsx
+++ b/sdks/node/packages/react-analytics/src/Provider.tsx
@@ -45,6 +45,7 @@ export function TempsAnalyticsProvider({
         request_query: window.location.search,
         request_path: window.location.pathname,
         domain: domain || window.location.hostname,
+        language: navigator.language,
         event_data: data,
       }, "POST", basePath);
     },
@@ -59,6 +60,7 @@ export function TempsAnalyticsProvider({
         request_query: window.location.search,
         request_path: window.location.pathname,
         domain: domain || window.location.hostname,
+        language: navigator.language,
         event_data: {
           referrer: document.referrer,
           userAgent: navigator.userAgent,
@@ -190,6 +192,7 @@ export function TempsAnalyticsProvider({
           request_query: window.location.search,
           request_path: window.location.pathname,
           domain: domain || window.location.hostname,
+          language: navigator.language,
           event_data: {
             time_on_page_ms: timeOnPage,
             timestamp: new Date().toISOString(),


### PR DESCRIPTION
Three independent analytics defects, all found by reading our own dashboard for the `temps-landing-new` project and being unable to reconcile the numbers.

## 1. Self-referrals were attributed to the "Referral" channel

`record_event` read the tracked site's hostname from `event_data.hostname`. No browser SDK has ever sent that key — the React analytics SDK sends a top-level `domain`, and `EventMetricsPayload` doesn't even deserialize it. So `get_channel` always got `current_hostname = None`, its self-referral branch never fired, and **every internal page-to-page navigation was recorded as a Referral**.

Production impact on temps.sh (30 days):

| | |
|---|---|
| Events classified "Referral" | 36,709 / 41,220 (**89.1%**) |
| Referrer breakdown total (self-referrals already filtered) | 5,438 |
| Largest genuine referrer (`openalternative.co`) | 238 |

Channel attribution was unusable — real acquisition channels were buried under the site's own navigation.

The ingest handler already resolves the Host header against the route table (it has to, to attribute the event to a project), so the correct hostname was available all along. It's now threaded in as an explicit `site_hostname` argument and used for both self-referral detection and the `hostname` column — which until now stored the `"localhost"` fallback on every SDK-originated event.

The server-side console path passes `None`: its caller is an app backend, not a browser, and it sends no referrer.

**Not fixed here:** existing rows keep their stored channel. A backfill would rewrite the `channel` column across the whole `events` hypertable, which is a heavy operation on the reference 4 GB box — worth doing deliberately, not as a side effect of this PR.

## 2. Breakdowns counted crawlers; headline counts didn't

`get_unique_counts` filters `is_crawler = false` and its comment asserts the per-page and per-property queries do the same. They didn't. `get_property_breakdown`, `get_property_timeline` and `get_page_paths` all counted crawler events, so every percentage was computed over a bigger population than the totals shown next to it. The symptom was visible in the product: a literal `Bot` row (224) in the device breakdown and `misc crawler` (215) in browsers.

All three now filter crawlers. AI-agent and crawler reporting is unaffected — those views read proxy logs, not the events table.

## 3. `analytics overview` ignored `--period` in two places

**Top Locations** listed raw visitor rows and tallied countries client-side. `/analytics/visitors` caps at 100 rows (the command asked for 200) and orders by `last_seen DESC`, so 24h, 7d and 30d all got the same 100 most-recent visitors and printed identical tables:

```
# before — byte-identical for --period 24h, 7d and 30d
  1   United States      40   40.0%
  2   United Kingdom      7    7.0%
```
```
# after — 24h / 7d / 30d
  United States    71  26.7%   |   295  25.5%   |   1,307  27.7%
  Singapore        33  12.4%   |   167  14.4%   |     766  16.2%
```

The 30-day figures now reconcile with the headline 4,489 unique visitors. (Singapore at 16% is real, and worth a separate look.)

**The sparkline** always requested hourly buckets and kept the last 48, so any period beyond two days silently drew only its final two days under a header claiming the full range:

```
# before — same 48 chars under both "last 7 days" and "last 30 days"
  Hourly Visitors
  ▁▁▁▁▂▂▁▂▂▂▁▁▂▂▂▂▂▁▃▄▃▃▂▄▂▂▂▁▂▁▁▂▂▁▁▂▁▂▄▂▃█▁▂▃▂▂▁ (max: 44)
```
```
# after — bucket size chosen to fit the period, and labelled
  Visitors (last 24 hours, per 1 hour)
  ▂▂▃▂▂▂▂▂▂▁▁▂▁▂▄▂▃█▂▂▃▂▂▂▂ (max: 46)

  Visitors (last 7 days, per 6 hours)
  ▁▃▄▄▄▆▃▄▄▂▂▂▄▂▃▄▄▃▃▄▄▃▄▄▆▄▃█▅ (max: 106)

  Visitors (last 30 days, per 1 day)
  ▂▅▅▂▄▄▅▅▇▇█▆▅▆▆▆▅▆▅▅▅▅▅▅▇▅▃▅▅▇▆ (max: 248)
```

The label echoes the bucket size the *server* reports, so the caption always describes the data actually drawn.

## Evidence

**Regression tests (real Postgres via `TestDatabase`, skip gracefully without Docker):**

- `test_record_event_classifies_self_referral_as_direct` — asserts a referrer on the site's own host yields `Direct`, a third-party referrer still yields `Referral`, and the resolved host is persisted instead of `"localhost"`.
- `test_property_breakdown_excludes_crawlers` — asserts a bot-UA referrer is absent from the breakdown and excluded from its denominator.

The self-referral test was confirmed to fail on the pre-fix code with exactly the production symptom, then pass after:

```
$ cargo test --lib -p temps-analytics-events test_record_event_classifies_self_referral_as_direct
# with the fix reverted:
panicked at events_service.rs:3232:
assertion `left == right` failed: a referrer on the site's own host is session continuation, not a Referral
  left: Some("Referral")
 right: Some("Direct")

# with the fix in place:
test result: ok. 1 passed
```

**Full suites:**

```
$ cargo test --lib -p temps-analytics-events -p temps-analytics
82 passed (2 suites, 31.50s)

$ cargo clippy -p temps-analytics-events -p temps-analytics --all-targets -- -D warnings
Finished — no warnings

$ cargo check --lib          # whole workspace
Finished in 2m 04s
```

**CLI verified against a live instance** (`app.temps.kfs.es`, project `temps-landing-new`) — the before/after tables above are real output from `bun run src/index.ts analytics overview` at each period, not mock-ups. `bunx tsc --noEmit` introduces no new errors (5 pre-existing errors remain in `openapi-ts.config.ts`, `notifications/`, `providers/`, none in the changed file).

The backend changes can't be exercised against production until deployed, so they're evidenced by the DB-backed integration tests above.

## Reviewer notes

- **Behaviour change:** breakdowns will drop visibly (the temps.sh 30-day event denominator falls from 41,220 toward the crawler-free population) and the "Bot"/"misc crawler" rows disappear. That's the point — those numbers previously couldn't be reconciled against the visitor and page-view totals beside them.
- **Not addressed:** `sessions` (10,529) exceeding `page_views` (7,564) is by definition, not a bug — sessions count distinct `session_id` across *all* events, page views count only `event_type = 'page_view'`, and this site fires many non-pageview events. Flagging it because the overview renders the two adjacently, which invites the wrong reading.
