### PR TITLE
fix(config,proxy): stop settings writes from wiping the admin gate allowlist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10620,6 +10620,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "sqlx 0.8.6",
  "sysinfo",
  "tar",
  "tempfile",

--- a/crates/temps-cli/Cargo.toml
+++ b/crates/temps-cli/Cargo.toml
@@ -103,6 +103,9 @@ utoipa = { workspace = true }
 utoipa-swagger-ui = { workspace = true }
 async-trait = { workspace = true }
 sea-orm = { workspace = true }
+# Used for Postgres LISTEN/NOTIFY (`settings_change`) so the standalone
+# `temps proxy` picks up admin-gate edits made in another process.
+sqlx = { workspace = true }
 sysinfo = { workspace = true }
 include_dir = "0.7"
 ipnet = "2.10"

--- a/crates/temps-cli/src/commands/proxy.rs
+++ b/crates/temps-cli/src/commands/proxy.rs
@@ -467,11 +467,13 @@ impl ProxyCommand {
         // persist API). `new` fails CLOSED on a DB error, so a broken settings
         // row refuses to boot rather than opening the gate.
         //
-        // NOTE: this is boot-time config only. Live admin-gate edits made
-        // through the console's API swap the console's in-process handle but do
-        // NOT yet propagate to this separate proxy process — operators must
-        // restart `temps proxy` to pick up a changed allowlist. Cross-process
-        // admin-gate refresh is tracked as ADR-017 Phase 3.
+        // Live admin-gate edits made through the console's API swap only the
+        // console's in-process handle, so this separate process subscribes to
+        // the Postgres `settings_change` channel and reloads the allowlist
+        // itself. Without that, this proxy would enforce its boot-time config
+        // forever: a newly saved allowlist would go unenforced here, and a
+        // cleared one would keep 404ing hosts that should now fall through to
+        // the console.
         let admin_gate_handle = match rt.block_on(
             crate::commands::serve::admin_gate_service::AdminGateService::new(
                 db.clone(),
@@ -480,7 +482,16 @@ impl ProxyCommand {
                 config.admin_trust_forwarded_for,
             ),
         ) {
-            Ok((_service, handle)) => Some(handle),
+            Ok((service, handle)) => {
+                // `start_settings_listener` calls `tokio::spawn`, so it must run
+                // inside the runtime context. `rt` lives on this stack for the
+                // duration of the blocking Pingora server below, which is what
+                // keeps the task alive (same pattern as the route listeners).
+                let service = Arc::new(service);
+                let database_url = self.database_url.clone();
+                rt.block_on(async { service.start_settings_listener(database_url) });
+                Some(handle)
+            }
             Err(e) => {
                 return Err(anyhow::anyhow!(
                     "Failed to initialize admin gate: {}. Refusing to start the proxy with \

--- a/crates/temps-cli/src/commands/serve/admin_gate_service.rs
+++ b/crates/temps-cli/src/commands/serve/admin_gate_service.rs
@@ -21,15 +21,39 @@
 use std::net::IpAddr;
 use std::sync::Arc;
 
-use sea_orm::{ActiveModelTrait, ActiveValue::Set, DatabaseConnection, EntityTrait};
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::Set, ConnectionTrait, DatabaseConnection, EntityTrait,
+    QuerySelect, TransactionTrait,
+};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::info;
 
 use super::admin_gate::{AdminGateConfig, AdminGateConfigError, AdminGateHandle, AdminGateSource};
 
+/// Postgres channel the settings row's trigger fires on.
+const SETTINGS_CHANGE_CHANNEL: &str = "settings_change";
+
+/// Reconciliation floor for the gate listener. `PgListener` does not replay
+/// notifications missed while its connection was down, so without a periodic
+/// re-read a single dropped NOTIFY strands the process on a stale allowlist
+/// forever, with nothing to tell the operator.
+const RECONCILE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+
+const RECONNECT_BACKOFF_MIN: std::time::Duration = std::time::Duration::from_secs(1);
+const RECONNECT_BACKOFF_MAX: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// JSON shape stored under `settings.data["admin_gate"]`. Versioned so we
 /// can evolve the schema without a migration.
+///
+/// Deliberately NOT `deny_unknown_fields`: a newer binary in a rolling upgrade
+/// (or before a rollback) may have written a field this build doesn't know,
+/// and rejecting it would propagate out of `AdminGateService::new` and stop
+/// BOTH `temps proxy` and `temps serve` from booting at all — turning a
+/// forward-compatible field into an outage. Unknown keys are instead reported
+/// loudly by [`unknown_admin_gate_keys`], which covers the case that motivated
+/// strictness (a renamed/typo'd key silently deserializing to an empty, i.e.
+/// OPEN, allowlist) without the availability cost.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct AdminGateSettings {
     #[serde(default)]
@@ -212,30 +236,87 @@ impl AdminGateService {
     /// perform the write (the standalone `temps proxy`, whose console lives in
     /// a different process) still converges on the operator's current config.
     ///
-    /// Fails SAFE: on a load error the previous config is retained rather than
-    /// falling back to an open gate — a transient DB blip must never widen the
-    /// management surface. Env-overridden processes are a no-op, matching
-    /// `update()`'s precedence rule.
+    /// Fails SAFE in every direction: a load error, a malformed sub-document,
+    /// or a *missing* sub-document all retain the currently active config
+    /// rather than falling back to an open gate. A transient DB blip, a
+    /// restore from a pre-gate backup, or an out-of-band writer must never
+    /// widen the management surface. Env-overridden processes are a no-op,
+    /// matching `update()`'s precedence rule.
     pub async fn reload_from_db(&self) -> Result<Arc<AdminGateConfig>, AdminGateServiceError> {
         if self.env_overridden {
             return Ok(self.handle.current());
         }
 
-        let config = match load_from_db(self.db.as_ref()).await? {
-            Some(settings) => AdminGateConfig::from_parts(
-                &settings.allowed_ips,
-                &settings.allowed_hosts,
-                settings.trust_forwarded_for,
-                AdminGateSource::Db,
-            )?,
-            None => AdminGateConfig::from_parts(&[], &[], false, AdminGateSource::Default)?,
+        let Some(settings) = load_from_db(self.db.as_ref()).await? else {
+            // The sub-document is GONE, which is NOT the same as "the operator
+            // cleared the gate". `update()` always persists an explicit
+            // `admin_gate` object — empty lists included — so a deliberate
+            // clear comes back through the `Some` branch below and converges
+            // to a noop config normally. Reaching here means the key was
+            // destroyed out of band: a settings writer that dropped it, a
+            // control-plane restore from a snapshot taken before the gate was
+            // configured, or a DELETE on the row. Widening the gate on that
+            // signal would turn any of those into instant, silent privilege
+            // escalation on a LIVE proxy — the boot path already refuses to
+            // start with an open gate for exactly this reason, so the reload
+            // path must not do by NOTIFY what boot refuses to do at all.
+            //
+            // Note the deliberate asymmetry with `new()`, which maps a missing
+            // key to an open Default config: at boot there is no prior state,
+            // so "the key is absent" is indistinguishable from "this operator
+            // has never configured a gate" — and a fresh install must be able
+            // to start. Only here, with a known-good previous config in hand,
+            // can absence be recognized as loss rather than as never-set. The
+            // protection is therefore uptime-scoped: it stops a running proxy
+            // from being opened by a NOTIFY, but a restart after the key is
+            // gone still comes up open. The merge fix in `to_json_merged` is
+            // what stops the key from being destroyed in the first place; this
+            // is the backstop for writers outside this repo.
+            let current = self.handle.current();
+            if !current.is_noop() {
+                tracing::error!(
+                    target: "temps_cli::admin_gate",
+                    "Admin gate: the `admin_gate` sub-document disappeared from the settings \
+                     row. REFUSING to widen the gate — keeping the currently active allowlist. \
+                     Re-save the admin gate under Settings → Security to restore it in the \
+                     database, otherwise the next restart of this process WILL come up with an \
+                     open gate."
+                );
+            }
+            return Ok(current);
         };
 
+        let config = AdminGateConfig::from_parts(
+            &settings.allowed_ips,
+            &settings.allowed_hosts,
+            settings.trust_forwarded_for,
+            AdminGateSource::Db,
+        )?;
+
+        // Any reload that turns a restrictive gate into an open one is worth an
+        // ERROR even when it is legitimate (the operator cleared the lists):
+        // on a self-hosted box this is the only signal that the management
+        // surface just became reachable from everywhere.
+        let widening = !self.handle.current().is_noop() && config.is_noop();
         let prev = self.handle.store(config);
-        info!(
-            previous_source = ?prev.source,
-            "Admin gate: reloaded after settings_change notification"
-        );
+        if widening {
+            tracing::error!(
+                target: "temps_cli::admin_gate",
+                "Admin gate: reload installed an EMPTY allowlist — the management surface is \
+                 now reachable from any IP and any Host header. This is expected only if the \
+                 gate was just cleared in the console."
+            );
+        } else {
+            let now = self.handle.current();
+            info!(
+                previous_source = ?prev.source,
+                allowed_ips = ?now.allowed_nets.iter().map(|n| n.to_string()).collect::<Vec<_>>(),
+                allowed_hosts = ?now.allowed_hosts,
+                trust_forwarded_for = now.trust_forwarded_for,
+                is_noop = now.is_noop(),
+                "Admin gate: reloaded after settings_change notification"
+            );
+        }
         Ok(self.handle.current())
     }
 
@@ -253,9 +334,12 @@ impl AdminGateService {
     /// and a cleared allowlist keeps 404ing hosts that should now fall through
     /// to the console.
     ///
-    /// Startup failure to connect is non-fatal: the gate keeps its boot-time
-    /// config (the pre-existing behavior) and the operator can still restart
-    /// the process to pick up changes.
+    /// The task never gives up: connect, subscribe and recv failures all retry
+    /// with capped backoff rather than returning, because a listener that
+    /// silently exits leaves the process enforcing a stale allowlist with no
+    /// indication anything is wrong. A 60s reconcile tick runs alongside the
+    /// subscription so a NOTIFY dropped during a transparent reconnect
+    /// self-heals instead of stranding the gate.
     pub fn start_settings_listener(self: &Arc<Self>, database_url: String) {
         let service = Arc::clone(self);
 
@@ -266,71 +350,112 @@ impl AdminGateService {
         }
 
         tokio::spawn(async move {
-            use sqlx::postgres::{PgListener, PgPool};
+            use sqlx::postgres::{PgListener, PgPoolOptions};
 
-            let pool = match PgPool::connect(&database_url).await {
-                Ok(pool) => pool,
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        "Admin gate: failed to connect for settings_change LISTEN; \
-                         the gate will keep its boot-time config until this process restarts"
-                    );
-                    return;
-                }
-            };
-
-            let mut listener = match PgListener::connect_with(&pool).await {
-                Ok(listener) => listener,
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        "Admin gate: failed to create PgListener; \
-                         the gate will keep its boot-time config until this process restarts"
-                    );
-                    return;
-                }
-            };
-
-            if let Err(e) = listener.listen("settings_change").await {
-                tracing::warn!(
-                    error = %e,
-                    "Admin gate: failed to subscribe to settings_change; \
-                     the gate will keep its boot-time config until this process restarts"
-                );
-                return;
-            }
-            info!("Admin gate: listening for settings_change to refresh the allowlist");
-
-            loop {
-                match listener.recv().await {
-                    Ok(_) => {
-                        if let Err(e) = service.reload_from_db().await {
-                            // Keep the previous (stricter or equal) config.
-                            tracing::error!(
-                                error = %e,
-                                "Admin gate: reload after settings_change failed; \
-                                 keeping the previously active configuration"
-                            );
-                        }
-                    }
+            // One connection is all a listener needs; the process already has a
+            // Sea-ORM pool for everything else and this runs on a 4 GB box
+            // alongside the proxy.
+            let pool = loop {
+                match PgPoolOptions::new()
+                    .max_connections(1)
+                    .connect(&database_url)
+                    .await
+                {
+                    Ok(pool) => break pool,
                     Err(e) => {
                         tracing::warn!(
                             error = %e,
-                            "Admin gate: settings_change listener error; reconnecting"
+                            "Admin gate: failed to connect for settings_change LISTEN; \
+                             retrying in {}s. Until this succeeds the gate keeps its \
+                             boot-time allowlist and will NOT see console edits.",
+                            RECONNECT_BACKOFF_MAX.as_secs()
                         );
-                        // Reconnect, then reload once to catch anything missed
-                        // during the gap.
-                        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                        if listener.listen("settings_change").await.is_ok() {
-                            let _ = service.reload_from_db().await;
-                        } else {
-                            return;
+                        tokio::time::sleep(RECONNECT_BACKOFF_MAX).await;
+                    }
+                }
+            };
+
+            // Outer loop owns listener construction so every reconnect builds a
+            // FRESH `PgListener`. Re-calling `listen()` on an existing one
+            // appends to its internal channel list and re-issues LISTEN for
+            // every entry on reconnect, which leaks on a flapping connection.
+            let mut backoff = RECONNECT_BACKOFF_MIN;
+            loop {
+                let mut listener = match PgListener::connect_with(&pool).await {
+                    Ok(mut listener) => match listener.listen(SETTINGS_CHANGE_CHANNEL).await {
+                        Ok(()) => {
+                            backoff = RECONNECT_BACKOFF_MIN;
+                            info!(
+                                "Admin gate: listening for settings_change to refresh the allowlist"
+                            );
+                            listener
                         }
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                "Admin gate: failed to subscribe to settings_change; retrying"
+                            );
+                            tokio::time::sleep(backoff).await;
+                            backoff = (backoff * 2).min(RECONNECT_BACKOFF_MAX);
+                            continue;
+                        }
+                    },
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "Admin gate: failed to create PgListener; retrying"
+                        );
+                        tokio::time::sleep(backoff).await;
+                        backoff = (backoff * 2).min(RECONNECT_BACKOFF_MAX);
+                        continue;
+                    }
+                };
+
+                // Reload once on (re)subscribe so anything written while we had
+                // no subscription is picked up immediately.
+                reload_logging_failure(&service).await;
+
+                // `PgListener::recv` reconnects transparently and documents that
+                // notifications received while the connection was down are NOT
+                // replayed — so a Postgres restart or connection reaper silently
+                // eats the NOTIFY without ever returning an error. The interval
+                // is the reconciliation floor that makes that self-healing: one
+                // indexed single-row read per minute, which is nothing next to
+                // being silently stuck on a stale allowlist.
+                let mut reconcile = tokio::time::interval(RECONCILE_INTERVAL);
+                reconcile.tick().await; // first tick completes immediately
+
+                loop {
+                    tokio::select! {
+                        received = listener.recv() => match received {
+                            Ok(_) => reload_logging_failure(&service).await,
+                            Err(e) => {
+                                tracing::warn!(
+                                    error = %e,
+                                    "Admin gate: settings_change listener error; rebuilding"
+                                );
+                                tokio::time::sleep(backoff).await;
+                                backoff = (backoff * 2).min(RECONNECT_BACKOFF_MAX);
+                                break;
+                            }
+                        },
+                        _ = reconcile.tick() => reload_logging_failure(&service).await,
                     }
                 }
             }
         });
+    }
+}
+
+/// Reload the gate, logging (never propagating) a failure. A failed reload
+/// retains the currently active config — see `reload_from_db`.
+async fn reload_logging_failure(service: &AdminGateService) {
+    if let Err(e) = service.reload_from_db().await {
+        tracing::error!(
+            target: "temps_cli::admin_gate",
+            error = %e,
+            "Admin gate: reload failed; keeping the previously active configuration"
+        );
     }
 }
 
@@ -348,6 +473,21 @@ async fn load_from_db(
     };
     match row.data.get("admin_gate").cloned() {
         Some(val) if !val.is_null() => {
+            // Report schema drift before parsing. A renamed or typo'd key
+            // (`allowedHosts`, `allow_ips`) deserializes happily into
+            // all-defaults — an OPEN gate — and this is the only place that
+            // can tell the operator why their allowlist stopped applying.
+            let unknown = unknown_admin_gate_keys(&val);
+            if !unknown.is_empty() {
+                tracing::error!(
+                    target: "temps_cli::admin_gate",
+                    unknown_keys = ?unknown,
+                    "Admin gate: the stored `admin_gate` document contains unrecognized keys. \
+                     They are IGNORED — if one is a misspelling of allowed_ips / allowed_hosts / \
+                     trust_forwarded_for, the gate is running with a narrower (possibly empty) \
+                     allowlist than intended. Re-save it under Settings → Security."
+                );
+            }
             let settings: AdminGateSettings = serde_json::from_value(val)?;
             Ok(Some(settings))
         }
@@ -355,18 +495,51 @@ async fn load_from_db(
     }
 }
 
+/// Keys present in a stored `admin_gate` document that this build does not
+/// recognize. Used for operator-visible drift reporting only — unknown keys are
+/// never fatal, see [`AdminGateSettings`].
+fn unknown_admin_gate_keys(value: &serde_json::Value) -> Vec<String> {
+    const KNOWN: [&str; 3] = ["allowed_ips", "allowed_hosts", "trust_forwarded_for"];
+    value
+        .as_object()
+        .map(|map| {
+            map.keys()
+                .filter(|key| !KNOWN.contains(&key.as_str()))
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Write `admin_gate` into the singleton `settings` row, creating it if
 /// necessary. Uses an upsert via either insert (no row) or update (row
 /// present + merge sub-key).
+///
+/// Runs in a transaction with the row locked FOR UPDATE on Postgres: this is a
+/// read-modify-write of a document shared with `AppSettings`, so without the
+/// lock a concurrent `ConfigService::update_settings` can compute its merge
+/// from a snapshot that predates this write and clobber the allowlist the
+/// operator just saved.
 async fn persist_to_db(
     db: &DatabaseConnection,
     new_settings: &AdminGateSettings,
 ) -> Result<(), AdminGateServiceError> {
     let now = chrono::Utc::now();
-    let row = temps_entities::settings::Entity::find_by_id(1)
-        .one(db)
-        .await?;
     let new_value = serde_json::to_value(new_settings)?;
+    let is_postgres = matches!(
+        db.get_database_backend(),
+        sea_orm::DatabaseBackend::Postgres
+    );
+
+    let txn = db.begin().await?;
+
+    let row_query = temps_entities::settings::Entity::find_by_id(1);
+    let row_query = if is_postgres {
+        row_query.lock_exclusive()
+    } else {
+        row_query
+    };
+    let row = row_query.one(&txn).await?;
 
     match row {
         Some(existing) => {
@@ -385,7 +558,7 @@ async fn persist_to_db(
             let mut am: temps_entities::settings::ActiveModel = existing.into();
             am.data = Set(data);
             am.updated_at = Set(now);
-            am.update(db).await?;
+            am.update(&txn).await?;
         }
         None => {
             let am = temps_entities::settings::ActiveModel {
@@ -394,9 +567,11 @@ async fn persist_to_db(
                 created_at: Set(now),
                 updated_at: Set(now),
             };
-            am.insert(db).await?;
+            am.insert(&txn).await?;
         }
     }
+
+    txn.commit().await?;
     Ok(())
 }
 
@@ -543,6 +718,11 @@ mod tests {
 
     /// A cleared allowlist must also converge — otherwise the proxy keeps
     /// 404ing hosts the operator has since unblocked.
+    ///
+    /// Note the shape: clearing the gate through `update()` persists an
+    /// EXPLICIT `admin_gate` document with empty lists (see `persist_to_db`),
+    /// not a missing key. That distinction is the whole point of the test
+    /// below — an absent key is an anomaly, not a clear.
     #[tokio::test]
     async fn reload_from_db_converges_when_gate_is_cleared() {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
@@ -553,8 +733,14 @@ mod tests {
                     "trust_forwarded_for": false
                 }
             }))]])
-            // Console cleared the key.
-            .append_query_results(vec![vec![settings_row(serde_json::json!({}))]])
+            // Console cleared the lists — the key is still there, now empty.
+            .append_query_results(vec![vec![settings_row(serde_json::json!({
+                "admin_gate": {
+                    "allowed_ips": [],
+                    "allowed_hosts": [],
+                    "trust_forwarded_for": false
+                }
+            }))]])
             .into_connection();
 
         let (svc, handle) = AdminGateService::new(Arc::new(db), &[], &[], false)
@@ -565,7 +751,136 @@ mod tests {
         svc.reload_from_db().await.unwrap();
 
         assert!(handle.current().is_noop());
-        assert_eq!(handle.current().source, AdminGateSource::Default);
+        assert_eq!(handle.current().source, AdminGateSource::Db);
+    }
+
+    /// SECURITY: a *missing* `admin_gate` sub-document must never widen the
+    /// gate. `update()` always writes an explicit document, so absence means
+    /// the key was destroyed out of band (a writer that dropped it, a restore
+    /// from a pre-gate snapshot, a DELETE on the row). Widening on that signal
+    /// would turn any of those into instant privilege escalation on a live
+    /// proxy — the boot path refuses to start with an open gate for the same
+    /// reason.
+    #[tokio::test]
+    async fn reload_from_db_refuses_to_widen_when_subdocument_vanishes() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![settings_row(serde_json::json!({
+                "admin_gate": {
+                    "allowed_ips": ["10.0.0.0/8"],
+                    "allowed_hosts": ["app.temps.kfs.es"],
+                    "trust_forwarded_for": false
+                }
+            }))]])
+            // The key is GONE — not cleared.
+            .append_query_results(vec![vec![settings_row(serde_json::json!({
+                "preview_domain": "temps.kfs.es"
+            }))]])
+            .into_connection();
+
+        let (svc, handle) = AdminGateService::new(Arc::new(db), &[], &[], false)
+            .await
+            .unwrap();
+
+        svc.reload_from_db().await.unwrap();
+
+        let cfg = handle.current();
+        assert!(
+            !cfg.is_noop(),
+            "a vanished admin_gate key must NOT open the gate"
+        );
+        assert_eq!(cfg.allowed_hosts.len(), 1);
+        assert_eq!(cfg.allowed_nets.len(), 1);
+    }
+
+    /// A malformed sub-document must fail closed too — the previous config
+    /// stays installed rather than degrading to an open gate.
+    #[tokio::test]
+    async fn reload_from_db_keeps_previous_config_on_malformed_document() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![settings_row(serde_json::json!({
+                "admin_gate": {
+                    "allowed_ips": [],
+                    "allowed_hosts": ["app.temps.kfs.es"],
+                    "trust_forwarded_for": false
+                }
+            }))]])
+            // `allowed_hosts` is the wrong type.
+            .append_query_results(vec![vec![settings_row(serde_json::json!({
+                "admin_gate": { "allowed_hosts": "not-a-list" }
+            }))]])
+            .into_connection();
+
+        let (svc, handle) = AdminGateService::new(Arc::new(db), &[], &[], false)
+            .await
+            .unwrap();
+
+        assert!(svc.reload_from_db().await.is_err());
+        assert!(
+            !handle.current().is_noop(),
+            "a malformed admin_gate document must not open the gate"
+        );
+    }
+
+    /// A typo'd/renamed key deserializes to all-defaults — an open gate — so
+    /// it must at least be *reported*. It must NOT be fatal: a newer binary's
+    /// forward-compatible field would otherwise stop this one from booting.
+    #[test]
+    fn unknown_keys_are_reported_but_never_fatal() {
+        let doc = serde_json::json!({
+            "allowedHosts": ["app.temps.kfs.es"],
+            "trust_forwarded_for": false
+        });
+
+        assert_eq!(
+            unknown_admin_gate_keys(&doc),
+            vec!["allowedHosts".to_string()]
+        );
+
+        let parsed: Result<AdminGateSettings, _> = serde_json::from_value(doc);
+        assert!(
+            parsed.is_ok(),
+            "an unknown key must not fail the parse — that would turn a newer peer's \
+             field into a boot failure"
+        );
+    }
+
+    #[test]
+    fn known_keys_are_not_reported_as_unknown() {
+        let doc = serde_json::json!({
+            "allowed_ips": ["10.0.0.0/8"],
+            "allowed_hosts": ["app.temps.kfs.es"],
+            "trust_forwarded_for": true
+        });
+        assert!(unknown_admin_gate_keys(&doc).is_empty());
+    }
+
+    /// The documented fail-safe: a DB error during reload must retain the
+    /// currently active config rather than degrading to an open gate.
+    #[tokio::test]
+    async fn reload_from_db_keeps_previous_config_on_db_error() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![settings_row(serde_json::json!({
+                "admin_gate": {
+                    "allowed_ips": ["10.0.0.0/8"],
+                    "allowed_hosts": ["app.temps.kfs.es"],
+                    "trust_forwarded_for": false
+                }
+            }))]])
+            .append_query_errors(vec![sea_orm::DbErr::Custom(
+                "connection reset by peer".to_string(),
+            )])
+            .into_connection();
+
+        let (svc, handle) = AdminGateService::new(Arc::new(db), &[], &[], false)
+            .await
+            .unwrap();
+
+        assert!(svc.reload_from_db().await.is_err());
+
+        let cfg = handle.current();
+        assert!(!cfg.is_noop(), "a DB error must not open the gate");
+        assert_eq!(cfg.allowed_hosts.len(), 1);
+        assert_eq!(cfg.allowed_nets.len(), 1);
     }
 
     /// Env precedence holds on the reload path too: a DB write must not be

--- a/crates/temps-cli/src/commands/serve/admin_gate_service.rs
+++ b/crates/temps-cli/src/commands/serve/admin_gate_service.rs
@@ -205,6 +205,133 @@ impl AdminGateService {
         );
         Ok(self.handle.current())
     }
+
+    /// Re-read the gate config from the DB and swap the live handle.
+    ///
+    /// Used by the `settings_change` listener so a process that did NOT
+    /// perform the write (the standalone `temps proxy`, whose console lives in
+    /// a different process) still converges on the operator's current config.
+    ///
+    /// Fails SAFE: on a load error the previous config is retained rather than
+    /// falling back to an open gate — a transient DB blip must never widen the
+    /// management surface. Env-overridden processes are a no-op, matching
+    /// `update()`'s precedence rule.
+    pub async fn reload_from_db(&self) -> Result<Arc<AdminGateConfig>, AdminGateServiceError> {
+        if self.env_overridden {
+            return Ok(self.handle.current());
+        }
+
+        let config = match load_from_db(self.db.as_ref()).await? {
+            Some(settings) => AdminGateConfig::from_parts(
+                &settings.allowed_ips,
+                &settings.allowed_hosts,
+                settings.trust_forwarded_for,
+                AdminGateSource::Db,
+            )?,
+            None => AdminGateConfig::from_parts(&[], &[], false, AdminGateSource::Default)?,
+        };
+
+        let prev = self.handle.store(config);
+        info!(
+            previous_source = ?prev.source,
+            "Admin gate: reloaded after settings_change notification"
+        );
+        Ok(self.handle.current())
+    }
+
+    /// Spawn the background task that LISTENs on the Postgres `settings_change`
+    /// channel and reloads the gate whenever ANY process writes the settings
+    /// row.
+    ///
+    /// In the single-binary `temps serve` the console and the Pingora proxy
+    /// share one `AdminGateHandle`, so a UI save is visible to both instantly.
+    /// In the ADR-017 split topology they are separate processes with separate
+    /// handles: without this listener the standalone `temps proxy` enforces
+    /// whatever allowlist existed when it booted, forever. That divergence is
+    /// visible in both directions — a newly saved allowlist isn't enforced at
+    /// the proxy (management surface stays reachable from disallowed hosts),
+    /// and a cleared allowlist keeps 404ing hosts that should now fall through
+    /// to the console.
+    ///
+    /// Startup failure to connect is non-fatal: the gate keeps its boot-time
+    /// config (the pre-existing behavior) and the operator can still restart
+    /// the process to pick up changes.
+    pub fn start_settings_listener(self: &Arc<Self>, database_url: String) {
+        let service = Arc::clone(self);
+
+        // Env precedence: the DB is not the source of truth here, so there is
+        // nothing to converge on.
+        if service.env_overridden {
+            return;
+        }
+
+        tokio::spawn(async move {
+            use sqlx::postgres::{PgListener, PgPool};
+
+            let pool = match PgPool::connect(&database_url).await {
+                Ok(pool) => pool,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "Admin gate: failed to connect for settings_change LISTEN; \
+                         the gate will keep its boot-time config until this process restarts"
+                    );
+                    return;
+                }
+            };
+
+            let mut listener = match PgListener::connect_with(&pool).await {
+                Ok(listener) => listener,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "Admin gate: failed to create PgListener; \
+                         the gate will keep its boot-time config until this process restarts"
+                    );
+                    return;
+                }
+            };
+
+            if let Err(e) = listener.listen("settings_change").await {
+                tracing::warn!(
+                    error = %e,
+                    "Admin gate: failed to subscribe to settings_change; \
+                     the gate will keep its boot-time config until this process restarts"
+                );
+                return;
+            }
+            info!("Admin gate: listening for settings_change to refresh the allowlist");
+
+            loop {
+                match listener.recv().await {
+                    Ok(_) => {
+                        if let Err(e) = service.reload_from_db().await {
+                            // Keep the previous (stricter or equal) config.
+                            tracing::error!(
+                                error = %e,
+                                "Admin gate: reload after settings_change failed; \
+                                 keeping the previously active configuration"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "Admin gate: settings_change listener error; reconnecting"
+                        );
+                        // Reconnect, then reload once to catch anything missed
+                        // during the gap.
+                        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                        if listener.listen("settings_change").await.is_ok() {
+                            let _ = service.reload_from_db().await;
+                        } else {
+                            return;
+                        }
+                    }
+                }
+            }
+        });
+    }
 }
 
 /// Read the `admin_gate` key off the singleton `settings` row. Returns
@@ -382,6 +509,80 @@ mod tests {
             result.unwrap_err(),
             AdminGateServiceError::WouldLockOut { .. }
         ));
+    }
+
+    /// The split-topology convergence path: a write performed by the *console*
+    /// process must become effective in the *proxy* process, which only sees
+    /// the `settings_change` NOTIFY.
+    #[tokio::test]
+    async fn reload_from_db_picks_up_another_process_write() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // Boot: gate empty.
+            .append_query_results(vec![vec![settings_row(serde_json::json!({}))]])
+            // After the console saved an allowlist.
+            .append_query_results(vec![vec![settings_row(serde_json::json!({
+                "admin_gate": {
+                    "allowed_ips": [],
+                    "allowed_hosts": ["app.temps.kfs.es"],
+                    "trust_forwarded_for": false
+                }
+            }))]])
+            .into_connection();
+
+        let (svc, handle) = AdminGateService::new(Arc::new(db), &[], &[], false)
+            .await
+            .unwrap();
+        assert!(handle.current().is_noop(), "boots with an empty gate");
+
+        svc.reload_from_db().await.unwrap();
+
+        let cfg = handle.current();
+        assert_eq!(cfg.source, AdminGateSource::Db);
+        assert_eq!(cfg.allowed_hosts.len(), 1);
+    }
+
+    /// A cleared allowlist must also converge — otherwise the proxy keeps
+    /// 404ing hosts the operator has since unblocked.
+    #[tokio::test]
+    async fn reload_from_db_converges_when_gate_is_cleared() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![settings_row(serde_json::json!({
+                "admin_gate": {
+                    "allowed_ips": [],
+                    "allowed_hosts": ["app.temps.kfs.es"],
+                    "trust_forwarded_for": false
+                }
+            }))]])
+            // Console cleared the key.
+            .append_query_results(vec![vec![settings_row(serde_json::json!({}))]])
+            .into_connection();
+
+        let (svc, handle) = AdminGateService::new(Arc::new(db), &[], &[], false)
+            .await
+            .unwrap();
+        assert!(!handle.current().is_noop());
+
+        svc.reload_from_db().await.unwrap();
+
+        assert!(handle.current().is_noop());
+        assert_eq!(handle.current().source, AdminGateSource::Default);
+    }
+
+    /// Env precedence holds on the reload path too: a DB write must not be
+    /// able to override an env-pinned gate.
+    #[tokio::test]
+    async fn reload_from_db_is_noop_when_env_overridden() {
+        // Zero queued results — touching the DB would panic.
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+        let (svc, handle) =
+            AdminGateService::new(Arc::new(db), &["10.0.0.0/8".to_string()], &[], false)
+                .await
+                .unwrap();
+
+        svc.reload_from_db().await.unwrap();
+
+        assert_eq!(handle.current().source, AdminGateSource::Env);
+        assert_eq!(handle.current().allowed_nets.len(), 1);
     }
 
     #[tokio::test]

--- a/crates/temps-cli/src/commands/serve/mod.rs
+++ b/crates/temps-cli/src/commands/serve/mod.rs
@@ -483,6 +483,19 @@ impl ServeCommand {
             );
         }
 
+        // Converge on out-of-process gate edits here too. A single-binary
+        // `temps serve` swaps this handle in-process on save, so the listener
+        // is redundant for the common case — but in an HA deployment with
+        // several consoles against one database, replica B would otherwise keep
+        // enforcing its boot-time allowlist after an operator tightened the
+        // gate on replica A. `AdminGateService` is `Clone` and the handle is an
+        // `Arc<ArcSwap<_>>`, so this clone writes to the same live handle.
+        {
+            let listener_service = Arc::new(admin_gate_service.clone());
+            let database_url = self.database_url.clone();
+            rt.block_on(async { listener_service.start_settings_listener(database_url) });
+        }
+
         // Shared retention-resolver slot: constructed ONCE here (before either
         // the console or the proxy bootstraps begin) so both see the same
         // object. The console's ProxyPlugin looks this up via the service

--- a/crates/temps-cli/src/commands/setup.rs
+++ b/crates/temps-cli/src/commands/setup.rs
@@ -1242,10 +1242,15 @@ async fn update_app_settings(
     app_settings.setup_complete = true;
 
     let now = Utc::now();
-    let settings_json = app_settings.to_json();
+    let settings_json = existing
+        .as_ref()
+        .map(|r| app_settings.to_json_merged(&r.data))
+        .unwrap_or_else(|| app_settings.to_json());
 
     if let Some(existing_model) = existing {
-        // Update existing settings
+        // Update existing settings. Merge, don't replace — re-running `temps
+        // setup` on a configured install must not drop sub-documents owned by
+        // other subsystems (`admin_gate`). See `AppSettings::to_json_merged`.
         let mut active_model: settings::ActiveModel = existing_model.into();
         active_model.data = Set(settings_json);
         active_model.updated_at = Set(now);

--- a/crates/temps-config/src/service.rs
+++ b/crates/temps-config/src/service.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseBackend, EntityTrait, FromQueryResult,
-    PaginatorTrait, QueryFilter, Set, Statement, TransactionTrait,
+    PaginatorTrait, QueryFilter, QuerySelect, Set, Statement, TransactionTrait,
 };
 use std::fs;
 use std::path::PathBuf;
@@ -891,8 +891,24 @@ WHERE proc_name IN ('policy_compression', 'policy_retention')
         // a delay that the database did not actually apply (or vice versa).
         let txn = self.db.begin().await?;
 
-        // Check if record exists
-        let existing = settings::Entity::find_by_id(1).one(&txn).await?;
+        // Check if record exists.
+        //
+        // Locked FOR UPDATE on Postgres: this is a read-modify-write of a
+        // shared JSON document, and the window between the read and the write
+        // below spans the TimescaleDB policy comparison — seconds, not
+        // microseconds. Without the lock two concurrent writers both merge
+        // onto the same pre-race snapshot and the loser's sub-document (e.g.
+        // the admin gate's allowlist, saved from the console at the same
+        // moment as a startup `console_version` write) is silently dropped
+        // despite `to_json_merged`. SQLite serializes write transactions
+        // already and has no `FOR UPDATE`, so the lock is Postgres-only.
+        let existing_query = settings::Entity::find_by_id(1);
+        let existing_query = if self.is_postgres() {
+            existing_query.lock_exclusive()
+        } else {
+            existing_query
+        };
+        let existing = existing_query.one(&txn).await?;
 
         let previous_compression = existing
             .as_ref()

--- a/crates/temps-config/src/service.rs
+++ b/crates/temps-config/src/service.rs
@@ -1010,9 +1010,13 @@ WHERE proc_name IN ('policy_compression', 'policy_retention')
         }
 
         if let Some(existing_model) = existing {
-            // Update existing settings
+            // Update existing settings. Merge into the stored document rather
+            // than replacing it: the `settings` row carries sub-documents owned
+            // by other subsystems (`admin_gate`) that `AppSettings` cannot
+            // round-trip. See `AppSettings::to_json_merged`.
+            let merged = settings.to_json_merged(&existing_model.data);
             let mut active_model: settings::ActiveModel = existing_model.into();
-            active_model.data = Set(settings.to_json());
+            active_model.data = Set(merged);
             active_model.updated_at = Set(now);
             active_model.update(&txn).await?;
         } else {

--- a/crates/temps-core/src/app_settings.rs
+++ b/crates/temps-core/src/app_settings.rs
@@ -1086,17 +1086,19 @@ impl AppSettings {
     /// to its default value.
     pub fn to_json_merged(&self, existing: &serde_json::Value) -> serde_json::Value {
         let incoming = self.to_json();
-        let (Some(existing_map), Some(incoming_map)) = (existing.as_object(), incoming.as_object())
+        let (Some(existing_map), serde_json::Value::Object(incoming_map)) =
+            (existing.as_object(), incoming)
         else {
-            // Existing blob isn't an object (fresh row, or corrupt): nothing to
-            // preserve, so the serialized settings are the whole document.
-            return incoming;
+            // Existing blob isn't an object (fresh row, or corrupt), or we
+            // somehow didn't serialize to one: nothing to preserve, so the
+            // serialized settings are the whole document.
+            return self.to_json();
         };
 
+        // `incoming_map` is owned, so move the values in rather than cloning
+        // every key and every serialized sub-document.
         let mut merged = existing_map.clone();
-        for (key, value) in incoming_map {
-            merged.insert(key.clone(), value.clone());
-        }
+        merged.extend(incoming_map);
         serde_json::Value::Object(merged)
     }
 

--- a/crates/temps-core/src/app_settings.rs
+++ b/crates/temps-core/src/app_settings.rs
@@ -1065,6 +1065,41 @@ impl AppSettings {
         serde_json::to_value(self).unwrap_or_else(|_| serde_json::json!({}))
     }
 
+    /// Serialize into an EXISTING `settings.data` document, preserving
+    /// top-level keys this struct does not own.
+    ///
+    /// The singleton `settings` row is a shared JSON document. `AppSettings`
+    /// owns most of it, but other subsystems store their own sub-documents on
+    /// the same row under their own key — today `admin_gate` (written by
+    /// `AdminGateService`), and anything added later. Those keys are invisible
+    /// to serde here: `from_json` drops them and `to_json` never re-emits them,
+    /// so writing `to_json()` straight over `data` DELETES them.
+    ///
+    /// That is not theoretical — the console records `console_version` through
+    /// `update_setting_field` on every startup, which wiped the operator's
+    /// admin-gate allowlist (IPs + Host headers) before the gate had even been
+    /// loaded, silently reverting the management surface to "open to any host"
+    /// on each restart. Every settings write must go through this method so a
+    /// subsystem's sub-document survives an unrelated save.
+    ///
+    /// Keys this struct owns always win, so a field can still be updated back
+    /// to its default value.
+    pub fn to_json_merged(&self, existing: &serde_json::Value) -> serde_json::Value {
+        let incoming = self.to_json();
+        let (Some(existing_map), Some(incoming_map)) = (existing.as_object(), incoming.as_object())
+        else {
+            // Existing blob isn't an object (fresh row, or corrupt): nothing to
+            // preserve, so the serialized settings are the whole document.
+            return incoming;
+        };
+
+        let mut merged = existing_map.clone();
+        for (key, value) in incoming_map {
+            merged.insert(key.clone(), value.clone());
+        }
+        serde_json::Value::Object(merged)
+    }
+
     /// Resolve the URL that service containers use to reach the Temps API from
     /// inside the Docker network. Resolution order:
     ///   1. `internal_url` settings field (admin-editable, runtime)
@@ -1390,5 +1425,78 @@ mod tests {
         let parsed = AppSettings::from_json(settings.to_json());
         assert_eq!(parsed.observability_compression.proxy_logs_after_hours, 12);
         assert_eq!(parsed.observability_compression.otel_spans_after_hours, 48);
+    }
+
+    /// Regression: a settings save must not delete the `admin_gate`
+    /// sub-document. The console writes `console_version` through
+    /// `update_setting_field` on every startup; with a plain `to_json()`
+    /// overwrite that wiped the operator's admin allowlist and reopened the
+    /// management surface to every host on each restart.
+    #[test]
+    fn merge_preserves_foreign_admin_gate_subdocument() {
+        let existing = serde_json::json!({
+            "preview_domain": "temps.kfs.es",
+            "admin_gate": {
+                "allowed_ips": ["10.0.0.0/8"],
+                "allowed_hosts": ["app.temps.kfs.es"],
+                "trust_forwarded_for": false
+            }
+        });
+
+        let mut settings = AppSettings::from_json(existing.clone());
+        settings.console_version = Some("v0.1.0".to_string());
+
+        let merged = settings.to_json_merged(&existing);
+
+        assert_eq!(
+            merged.get("admin_gate"),
+            existing.get("admin_gate"),
+            "an unrelated settings write must not drop the admin_gate sub-document"
+        );
+        assert_eq!(
+            merged.get("console_version").and_then(|v| v.as_str()),
+            Some("v0.1.0"),
+        );
+        assert_eq!(
+            merged.get("preview_domain").and_then(|v| v.as_str()),
+            Some("temps.kfs.es"),
+        );
+    }
+
+    /// Keys `AppSettings` owns must still be updatable — including back to
+    /// their default value — so the merge cannot simply prefer the stored blob.
+    #[test]
+    fn merge_lets_owned_fields_win_over_stored_values() {
+        let existing = serde_json::json!({
+            "preview_domain": "old.example.com",
+            "insecure_tls": true,
+            "admin_gate": { "allowed_hosts": ["app.example.com"] }
+        });
+
+        let mut settings = AppSettings::from_json(existing.clone());
+        settings.preview_domain = "new.example.com".to_string();
+        settings.insecure_tls = false;
+
+        let merged = settings.to_json_merged(&existing);
+
+        assert_eq!(
+            merged.get("preview_domain").and_then(|v| v.as_str()),
+            Some("new.example.com"),
+        );
+        assert_eq!(
+            merged.get("insecure_tls").and_then(|v| v.as_bool()),
+            Some(false),
+            "a field must be settable back to its default value"
+        );
+        assert!(merged.get("admin_gate").is_some());
+    }
+
+    /// A fresh/corrupt row has nothing to preserve — the serialized settings
+    /// become the whole document.
+    #[test]
+    fn merge_falls_back_to_plain_serialization_for_non_object_blob() {
+        let settings = AppSettings::default();
+        let merged = settings.to_json_merged(&serde_json::Value::Null);
+        assert_eq!(merged, settings.to_json());
     }
 }


### PR DESCRIPTION
## The bug

The singleton `settings` row is a shared JSON document. `AppSettings` owns most
of it, but the admin gate stores its own sub-document under `admin_gate`
(written by `AdminGateService`). `AppSettings` has no serde catch-all, so
`from_json` drops that key and `to_json` never re-emits it — and both writers of
the row assigned `data = settings.to_json()`, **deleting it**.

The console records `console_version` via `update_setting_field` on every
startup (`serve/mod.rs:207`), and that runs *before* the gate is loaded
(`mod.rs:467`). So every restart wiped the operator's admin-gate allowlist and
then came up with an open gate — the management surface silently reverted to
reachable from any IP and any Host. Saving any other setting on the same
Settings → Security page, or re-running `temps setup`, did it too.

A second, related defect: in the ADR-017 split topology the console and the
standalone `temps proxy` are separate processes with separate `AdminGateHandle`s,
and the proxy only read the gate at boot. A saved allowlist went unenforced at
the proxy; a cleared one kept 404ing hosts that should now fall through to the
console. That is the user-visible symptom that started this: *"when the proxy is
spun up separately it returns 404 instead of the index.html"*.

## The fix

- **`AppSettings::to_json_merged`** merges into the stored document, preserving
  top-level keys it doesn't own. Keys it *does* own still win, so any field
  remains settable back to its default. Wired into `ConfigService::update_settings`
  and `setup.rs::update_app_settings` — the only two full-replace writers (every
  other writer of `settings.data` already read-modify-writes the raw blob).
- **`AdminGateService::{reload_from_db, start_settings_listener}`** subscribe to
  the existing `settings_change` Postgres channel so a process that did not
  perform the write still converges. Wired into `temps proxy` and `temps serve`
  (the latter for HA consoles).

### Security review changes

A `security-auditor` pass found a fail-open in the first cut of the reload, and
it is fixed here:

- A **missing** `admin_gate` sub-document no longer widens the gate. Clearing the
  gate goes through `update()`, which always persists an explicit document with
  empty lists, so absence only means the key was destroyed out of band. The
  reload keeps the active allowlist and logs an actionable ERROR. Boot still maps
  a missing key to an open default (a fresh install must be able to start); that
  asymmetry is documented in place.
- The listener no longer exits permanently on a failed reconnect, and a **60s
  reconcile tick** covers NOTIFYs that `PgListener` drops during a transparent
  reconnect without surfacing an error.
- Each reconnect builds a **fresh** `PgListener` (re-`listen()` on the same one
  appends to its channel list every time).
- The settings read is **locked `FOR UPDATE`** on Postgres in `update_settings`
  and `persist_to_db`, so a concurrent save can't merge onto a stale snapshot and
  clobber a sub-document. SQLite has no `FOR UPDATE` and serializes writes, so
  the lock is Postgres-only.
- Unknown keys in a stored document are **reported at ERROR, not rejected**.
  `deny_unknown_fields` was tried and reverted: it propagates out of
  `AdminGateService::new` and stops *both* binaries from booting on a field a
  newer peer wrote, turning forward compatibility into an outage.

## Evidence

Real split-mode run (`temps serve --role=console` + standalone `temps proxy`)
against a throwaway TimescaleDB, using the real HTTP API for every gate change.

**1. Baseline — no gate configured, everything falls through to the console:**
```
Host: app.temps.kfs.es  -> 200
Host: evil.example.com  -> 200
has_admin_gate=f | console_version=v0.1.0-nightly.20260806.c64e8f98
```

**2. Save an allowlist via `PATCH /api/admin/gate-settings` — the separately
running proxy converges with no restart (same PID before and after):**
```
proxy pid BEFORE save: 43484
PATCH -> 200
INFO temps_cli::commands::serve::admin_gate_service: Admin gate: reloaded after
  settings_change notification previous_source=Default
  allowed_ips=["127.0.0.1/32"] allowed_hosts=["app.temps.kfs.es", "127.0.0.1"]
  trust_forwarded_for=false is_noop=false
proxy pid AFTER save:  43484

Host: app.temps.kfs.es (allowed) -> 200
Host: evil.example.com (denied)  -> 404
```

**3. It is the NOTIFY path, not the 60s reconcile floor** — a second save at
`12:48:30` was applied at `12:48:30.637`, sub-second:
```
save issued at   12:48:30
INFO ... Admin gate: reloaded after settings_change notification ...
  [timestamp 2026-08-06T12:48:30.637010Z]
```

**4. The allowlist survives a console restart, and the startup write really did
fire** (`updated_at` advances across the restart):
```
updated_at BEFORE: 2026-08-06 12:49:05.243077+00
updated_at AFTER:  2026-08-06 12:49:46.308135+00
admin_gate still there: t
Host: app.temps.kfs.es -> 200
Host: evil.example.com -> 404
```
On `main` the same restart leaves `admin_gate` absent and the gate open.

**5. Fail-safe — destroying the key while the proxy is live (exactly what the
old write did to it) must not open the gate:**
```
UPDATE settings SET data = (data::jsonb - 'admin_gate')::json ...
key gone from DB: f

ERROR temps_cli::admin_gate: Admin gate: the `admin_gate` sub-document
  disappeared from the settings row. REFUSING to widen the gate — keeping the
  currently active allowlist. Re-save the admin gate under Settings → Security
  to restore it in the database, otherwise the next restart of this process
  WILL come up with an open gate.

Host: app.temps.kfs.es (allowed) -> 200
Host: evil.example.com (denied)  -> 404
```

**Tests** (all on this branch):
```
cargo test --lib -p temps-cli admin_gate   -> 15 passed
cargo test --lib -p temps-core app_settings -> 22 passed
cargo test --lib -p temps-config            -> 61 passed
cargo clippy -p temps-cli -p temps-core -p temps-config --all-targets -- -D warnings -> clean
```
New coverage: merge preserves foreign sub-documents / owned keys still win /
non-object blob; reload converges on set and on clear, refuses to widen on a
vanished key, keeps the previous config on a malformed document and on a DB
error, is a no-op under env override; unknown keys are reported but never fatal.

## Follow-up (not in this PR)

`AppSettings::from_json` is `from_value(...).unwrap_or_default()` — one bad field
type in the stored blob silently yields all-defaults, and the next save persists
them (resetting `require_mfa_for_admins`, `security_headers`, `insecure_tls`,
`letsencrypt.email`). Same class of bug, pre-existing, worth its own change.
