### PR TITLE
fix(ci): unbreak the E2E palette spec and the live-API test in unit-b

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -481,6 +481,17 @@ jobs:
               package(temps-audit) or package(temps-analytics-performance))
               and kind(=lib)
           - group: unit-b
+            # `not (temps-git and *_real_api)`: those six tests call the live
+            # github.com / gitlab.com REST APIs unauthenticated, so they share
+            # a per-IP rate limit with every other job on the runner fleet.
+            # They only tolerate `RateLimitExceeded`, but a throttled provider
+            # answers with a body the parser can't decode, which surfaces as
+            # `ApiError("Failed to parse tree: error decoding response body")`
+            # and panics -- turning third-party availability into a red build
+            # on PRs that never touched temps-git. Same reasoning already
+            # applied to temps-auth::oidc_discovery_live and
+            # temps-git::gitea_e2e in unit-integration below. They still run
+            # (and still assert strictly) with `cargo test -p temps-git`.
             filter: >-
               (package(temps-proxy) or package(temps-error-tracking) or
               package(temps-git) or package(temps-screenshots) or
@@ -491,6 +502,7 @@ jobs:
               package(temps-dns) or package(temps-email) or
               package(temps-analytics) or package(temps-analytics-events) or
               package(temps-otel)) and kind(=lib)
+              and not (package(temps-git) and test(/_real_api$/))
           - group: unit-integration
             # The kind(=test) counterpart to the two groups above: crates
             # whose tests/*.rs files need neither Docker nor a database, and

--- a/crates/temps-git/src/services/public_repo.rs
+++ b/crates/temps-git/src/services/public_repo.rs
@@ -827,6 +827,18 @@ mod tests {
 
     // =============================================================================
     // Integration Tests - GitHub API
+    //
+    // The `*_real_api` tests below call github.com / gitlab.com for real, with
+    // no credentials, so they are subject to a per-IP rate limit shared with
+    // everything else running on the CI fleet. They are EXCLUDED from the
+    // unit-b job in .github/workflows/rust-tests.yml for that reason: a
+    // throttled provider returns a body these parsers can't decode, which
+    // arrives as `ApiError`, not `RateLimitExceeded`, and fails the build on
+    // PRs that never touched this crate.
+    //
+    // They are not dead: `cargo test -p temps-git` runs them, and they still
+    // assert strictly there. Keep them that way -- if you add one, expect it
+    // to run locally and on demand, not on every PR.
     // =============================================================================
 
     #[tokio::test]

--- a/web/e2e/anonymous/command-palette.spec.ts
+++ b/web/e2e/anonymous/command-palette.spec.ts
@@ -73,25 +73,51 @@ test.describe('command palette', () => {
     await expect(themeAction.locator(':scope > svg')).toHaveCount(1)
   })
 
+  // Typing collapses the palette into ONE relevance-ranked list headed
+  // "Results" (the fixed per-section groups only render on an empty input) --
+  // so ordering, not grouping, is what carries the priority guarantee now.
+  // The section a hit came from rides along as a right-aligned label.
   test('prioritizes project matches over common pages', async ({ page }) => {
     await page.getByPlaceholder('Type a command or search...').fill('monitor')
 
     const headings = page.locator('[cmdk-group-heading]')
-    await expect(headings.first()).toHaveText('Projects')
-    await expect(headings.filter({ hasText: 'Navigation' })).toHaveCount(1)
+    await expect(headings.first()).toHaveText('Results')
 
-    const project = page.locator('[cmdk-item]').filter({
-      hasText: 'monitoring-app',
+    const items = page.locator('[cmdk-item]')
+    const project = items.filter({ hasText: 'monitoring-app' })
+    // `hasText` is a case-insensitive substring match, so 'Monitoring' alone
+    // would also select the monitoring-app row. Match the title span exactly.
+    const navigation = items.filter({
+      has: page.getByText('Monitoring', { exact: true }),
     })
+
     await expect(project).toBeVisible()
-    await expect(project.locator(':scope > span').first()).toBeVisible()
+    await expect(navigation).toBeVisible()
 
-    const navigationGroup = page.locator('[cmdk-group]').filter({
-      has: page.locator('[cmdk-group-heading]', { hasText: 'Navigation' }),
-    })
-    const navigation = navigationGroup.locator('[cmdk-item]').filter({
-      hasText: 'Monitoring',
-    })
+    // The actual guarantee: the project outranks the similarly-named common
+    // page. Both earn an identical title boost ("monitor" prefixes both
+    // "monitoring-app" and "Monitoring"), so the ordering rests on the Fuse
+    // score alone -- 0.5990 vs 0.5958 at the time of writing. That margin is
+    // thin by design of the scoring, which is exactly why it is pinned here:
+    // a scoring or keyword change that flips it should fail this test.
+    const texts = await items.allTextContents()
+    const projectIndex = texts.findIndex((t) => t.includes('monitoring-app'))
+    const navigationIndex = texts.findIndex(
+      (t) => t.includes('Monitoring') && t.includes('Navigation')
+    )
+    expect(projectIndex).toBeGreaterThanOrEqual(0)
+    expect(navigationIndex).toBeGreaterThanOrEqual(0)
+    expect(projectIndex).toBeLessThan(navigationIndex)
+
+    // Each hit still says which section it came from, since the grouping no
+    // longer does.
+    await expect(project.locator(':scope > span').last()).toHaveText('Project')
+    await expect(navigation.locator(':scope > span').last()).toHaveText(
+      'Navigation'
+    )
+
+    // Icons survive the flattening: projects render an avatar, pages an svg.
+    await expect(project.locator(':scope > span').first()).toBeVisible()
     await expect(navigation.locator(':scope > svg')).toHaveCount(1)
   })
 })


### PR DESCRIPTION
Two checks have been red on **every** open PR regardless of its contents. Neither
is caused by the PRs they appear on. This fixes both, and identifies a third red
that needs no fix at all.

## 1. `E2E / E2E Deployment Tests` — a stale assertion, failing since 11:25 today

`97e5f8bb` ("rank palette results by relevance") replaced the palette's fixed
per-section groups with a single relevance-ranked list headed **"Results"** when
the user types, and did not update `command-palette.spec.ts`. The spec still
asserted the old grouping:

```
Locator:  locator('[cmdk-group-heading]').first()
Expected: "Projects"
Received: "Results"
```

Deterministic, not flaky — it failed the first attempt and the retry, with the
locator resolving 34×.

**The test's premise still holds**, so this rewrites it rather than deleting it.
I reproduced the ranking with the real `fuse.js` and the spec's own fixture: for
the query `monitor`, the project still outranks the similarly-named page.

| entry | fuse score | final score |
|---|---|---|
| `PROJ monitoring-app` | 0.0039 | **0.5990** |
| `NAV  Monitoring` | 0.0167 | 0.5958 |

Both earn the same `0.35` prefix title boost, so the Fuse score alone decides.
That is worth pinning, so the rewritten test asserts **ordering** — which is
where the priority guarantee moved once grouping stopped carrying it — plus the
category labels and icons that replaced the group headings.

It also fixes a latent bug in the old locator: Playwright's `hasText` is a
case-insensitive substring match, so `hasText: 'Monitoring'` selected the
`monitoring-app` row too. The nav row is now matched on its exact title.

## 2. `Unit Tests (unit-b)` — a live third-party API call in a unit shard

```
temps-git services::public_repo::tests::test_gitlab_get_file_tree_real_api
panicked: ApiError("Failed to parse tree: error decoding response body")
```

`test_gitlab_get_file_tree_real_api` calls **gitlab.com for real**, without
credentials, sharing a per-IP rate limit with every other job on the runner
fleet. It tolerates `RateLimitExceeded` — but a throttled provider answers with
a body the parser cannot decode, which surfaces as `ApiError` and hits the
`panic!` arm. Because nextest cancels on first failure, this also stopped
**1088 of the shard's 2259 tests** from running at all.

The six `*_real_api` tests are excluded from the unit-b filter. That is the
treatment this workflow already documents for live-network tests
(`temps-auth::oidc_discovery_live`, `temps-git::gitea_e2e`). They are **not**
disabled — `cargo test -p temps-git` still runs them, still strictly.

## 3. Not fixed, because it is not broken: main's `Cargo Check`

```
Failed to resolve action download info. Error: Service Unavailable
Retrying in 15.176 seconds
##[error]Failed to resolve action download info.
```

A GitHub Actions incident on `51a84476`, not a code failure — it needs a re-run,
which I have triggered. The `unit-b` jobs that showed as `cancelled` during that
same window (16:04–16:22 UTC) were collateral from the same incident. I had
initially guessed a fail-fast cascade from the E2E job; that was wrong — both
test matrices set `fail-fast: false` and nothing `needs: e2e`, so a failing E2E
job cannot cancel a sibling shard.

## Evidence

**Palette spec passes against a dev server built from this branch:**
```
Running 2 tests using 1 worker
  ✓  1 …command-palette.spec.ts:46:7 › renders a left icon for actions (1.4s)
  ✓  2 …command-palette.spec.ts:80:7 › prioritizes project matches over common pages (1.3s)
  2 passed (4.4s)
```

**Negative control — the ordering assertion actually bites.** Inverting it to
`toBeGreaterThan` fails, showing the project really is ranked first:
```
Expected: > 1
Received:   0
> 110 |     expect(projectIndex).toBeGreaterThan(navigationIndex) // NEGATIVE CONTROL
```

**The filter drops exactly the six live tests and nothing else:**
```
DROPPED: services::public_repo::tests::test_github_get_file_tree_real_api
DROPPED: services::public_repo::tests::test_github_get_repository_real_api
DROPPED: services::public_repo::tests::test_github_list_branches_real_api
DROPPED: services::public_repo::tests::test_gitlab_get_file_tree_real_api
DROPPED: services::public_repo::tests::test_gitlab_get_repository_real_api
DROPPED: services::public_repo::tests::test_gitlab_list_branches_real_api
total dropped: 6
```

**temps-git under the new filter — green, no network dependency:**
```
Summary [7.357s] 293 tests run: 293 passed, 6 skipped
```

**Static checks:** `tsc --noEmit` clean, `eslint` clean on the spec, workflow YAML
parses and the unit-b filter expression is accepted by `cargo nextest`.
