### PR TITLE
fix(otel): bound span-stats project count and time window

### DIFF
--- a/apps/temps-cli/openapi.json
+++ b/apps/temps-cli/openapi.json
@@ -91557,7 +91557,7 @@
           "Traces"
         ],
         "summary": "Rank operations by latency, volume, or inconsistency.",
-        "description": "Groups spans by `(project, service, span name)` over a bounded window and\nreturns count, error rate, total/min/max/avg/stddev duration, p50/p95/p99,\nand two variability ratios per operation. Sorting is what makes it useful:\n\n- `sort_by=total_time` (default) \u2014 where the wall-clock actually goes.\n- `sort_by=p95` / `p99` \u2014 what users actually feel.\n- `sort_by=variability` or `tail_ratio` \u2014 operations whose *spread* is the\n  problem: the ones that take 40ms most of the time and 4s the rest.\n- `span_name=payments.charge` \u2014 the worst this one operation ever got, in\n  `max_duration_ms`.\n\nPair the variability sorts with `min_count` \u2014 a ratio computed from three\nsamples is noise, and without a floor it outranks every real signal.",
+        "description": "Groups spans by `(project, service, span name)` over a bounded window and\nreturns count, error rate, total/min/max/avg/stddev duration, p50/p95/p99,\nand two variability ratios per operation. Sorting is what makes it useful:\n\n- `sort_by=total_time` (default) \u2014 where the wall-clock actually goes.\n- `sort_by=p95` / `p99` \u2014 what users actually feel.\n- `sort_by=variability` or `tail_ratio` \u2014 operations whose *spread* is the\n  problem: the ones that take 40ms most of the time and 4s the rest.\n- `span_name=payments.charge` \u2014 the worst this one operation ever got, in\n  `max_duration_ms`.\n\nPair the variability sorts with `min_count` \u2014 a ratio computed from three\nsamples is noise, and without a floor it outranks every real signal.\n\nTwo bounds are enforced rather than clamped, so a result never claims to\ncover more than it does: at most 50 projects, and a window no wider than\n31 days. Both return 400. Unlike the trace list this report has no early\nexit \u2014 it aggregates every span in the window before it can rank anything.",
         "operationId": "query_span_stats",
         "parameters": [
           {
@@ -91573,7 +91573,7 @@
           {
             "name": "project_ids",
             "in": "query",
-            "description": "Comma-separated project ids, e.g. `4,5,6`",
+            "description": "Comma-separated project ids, e.g. `4,5,6` (max 50)",
             "required": false,
             "schema": {
               "type": "string"
@@ -91582,7 +91582,7 @@
           {
             "name": "start_time",
             "in": "query",
-            "description": "Window start (RFC 3339); defaults to 24h before end_time",
+            "description": "Window start (RFC 3339); defaults to 24h before end_time. The window may not exceed 31 days",
             "required": false,
             "schema": {
               "type": "string"

--- a/apps/temps-cli/src/api/sdk.gen.ts
+++ b/apps/temps-cli/src/api/sdk.gen.ts
@@ -8017,6 +8017,11 @@ export const getAuditLog = <ThrowOnError extends boolean = false>(options: Optio
  *
  * Pair the variability sorts with `min_count` — a ratio computed from three
  * samples is noise, and without a floor it outranks every real signal.
+ *
+ * Two bounds are enforced rather than clamped, so a result never claims to
+ * cover more than it does: at most 50 projects, and a window no wider than
+ * 31 days. Both return 400. Unlike the trace list this report has no early
+ * exit — it aggregates every span in the window before it can rank anything.
  */
 export const querySpanStats = <ThrowOnError extends boolean = false>(options?: Options<QuerySpanStatsData, ThrowOnError>): RequestResult<QuerySpanStatsResponses, QuerySpanStatsErrors, ThrowOnError> => (options?.client ?? client).get<QuerySpanStatsResponses, QuerySpanStatsErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],

--- a/apps/temps-cli/src/api/types.gen.ts
+++ b/apps/temps-cli/src/api/types.gen.ts
@@ -49821,11 +49821,11 @@ export type QuerySpanStatsData = {
          */
         project_id?: number;
         /**
-         * Comma-separated project ids, e.g. `4,5,6`
+         * Comma-separated project ids, e.g. `4,5,6` (max 50)
          */
         project_ids?: string;
         /**
-         * Window start (RFC 3339); defaults to 24h before end_time
+         * Window start (RFC 3339); defaults to 24h before end_time. The window may not exceed 31 days
          */
         start_time?: string;
         /**

--- a/apps/temps-cli/src/commands/traces/index.ts
+++ b/apps/temps-cli/src/commands/traces/index.ts
@@ -59,6 +59,10 @@ const SORT_FIELDS = [
 const SPAN_KINDS = ['server', 'client', 'internal', 'producer', 'consumer', 'unspecified']
 const SPAN_STATUSES = ['ok', 'error', 'unset']
 
+/** Server-side caps, mirrored so the CLI can explain them before a round trip. */
+const MAX_PROJECTS = 50
+const MAX_WINDOW_DAYS = 31
+
 /**
  * Parse a relative duration like `30m`, `24h`, `7d` into milliseconds.
  * Returns `null` for anything that isn't one of those shapes, so the caller can
@@ -106,8 +110,8 @@ export function registerTracesCommands(program: Command): void {
     .alias('ops')
     .description('Rank operations by time spent, latency percentiles, or inconsistency')
     .option('--project-id <id>', 'Project ID')
-    .option('--project-ids <ids>', 'Comma-separated project IDs to rank across, e.g. 4,5,6')
-    .option('--since <duration>', 'Relative window: 30m, 24h, 7d', '24h')
+    .option('--project-ids <ids>', `Comma-separated project IDs to rank across, e.g. 4,5,6 (max ${MAX_PROJECTS})`)
+    .option('--since <duration>', `Relative window: 30m, 24h, 7d (max ${MAX_WINDOW_DAYS}d)`, '24h')
     .option('--start-time <iso>', 'Window start (ISO 8601); overrides --since')
     .option('--end-time <iso>', 'Window end (ISO 8601); defaults to now')
     .option('--service <name>', 'Only this service')
@@ -159,6 +163,13 @@ async function spanStatsAction(options: SpanStatsOptions): Promise<void> {
     warning('Provide --project-id, or --project-ids with a comma-separated list')
     return
   }
+  if (options.projectIds) {
+    const count = options.projectIds.split(',').filter((s) => s.trim()).length
+    if (count > MAX_PROJECTS) {
+      warning(`--project-ids accepts at most ${MAX_PROJECTS} projects, got ${count}`)
+      return
+    }
+  }
   if (options.sortBy && !SORT_FIELDS.includes(options.sortBy)) {
     warning(`Invalid --sort-by: ${options.sortBy}. Available: ${SORT_FIELDS.join(', ')}`)
     return
@@ -193,6 +204,17 @@ async function spanStatsAction(options: SpanStatsOptions): Promise<void> {
       return
     }
     startTime = new Date(endTime.getTime() - sinceMs)
+  }
+
+  // The server rejects an over-wide window rather than narrowing it, so catch
+  // it here and say which flag to change instead of surfacing a bare 400.
+  const windowDays = (endTime.getTime() - startTime.getTime()) / 86_400_000
+  if (windowDays > MAX_WINDOW_DAYS) {
+    warning(
+      `Window is ${windowDays.toFixed(1)} days; the maximum is ${MAX_WINDOW_DAYS}. ` +
+        `Narrow --since, or --start-time/--end-time.`,
+    )
+    return
   }
 
   const result = await withSpinner('Aggregating operation latency...', async () => {

--- a/crates/temps-otel/src/handlers/query_handler.rs
+++ b/crates/temps-otel/src/handlers/query_handler.rs
@@ -113,7 +113,8 @@ pub struct TraceQueryParams {
 pub struct SpanStatsQueryParams {
     /// Single project to report on. Ignored when `project_ids` is given.
     pub project_id: Option<i32>,
-    /// Comma-separated project ids, e.g. `4,5,6`.
+    /// Comma-separated project ids, e.g. `4,5,6`. At most
+    /// [`SPAN_STATS_MAX_PROJECTS`].
     pub project_ids: Option<String>,
     /// Window start (RFC 3339). Defaults to 24h before `end_time`.
     pub start_time: Option<String>,
@@ -764,14 +765,19 @@ pub async fn query_trace_summaries(
 ///
 /// Pair the variability sorts with `min_count` — a ratio computed from three
 /// samples is noise, and without a floor it outranks every real signal.
+///
+/// Two bounds are enforced rather than clamped, so a result never claims to
+/// cover more than it does: at most 50 projects, and a window no wider than
+/// 31 days. Both return 400. Unlike the trace list this report has no early
+/// exit — it aggregates every span in the window before it can rank anything.
 #[utoipa::path(
     tag = "Traces",
     get,
     path = "/otel/span-stats",
     params(
         ("project_id" = Option<i32>, Query, description = "Single project to report on"),
-        ("project_ids" = Option<String>, Query, description = "Comma-separated project ids, e.g. `4,5,6`"),
-        ("start_time" = Option<String>, Query, description = "Window start (RFC 3339); defaults to 24h before end_time"),
+        ("project_ids" = Option<String>, Query, description = "Comma-separated project ids, e.g. `4,5,6` (max 50)"),
+        ("start_time" = Option<String>, Query, description = "Window start (RFC 3339); defaults to 24h before end_time. The window may not exceed 31 days"),
         ("end_time" = Option<String>, Query, description = "Window end (RFC 3339); defaults to now"),
         ("service_name" = Option<String>, Query, description = "Restrict to one service"),
         ("span_name" = Option<String>, Query, description = "Restrict to one operation by exact span name"),
@@ -899,6 +905,18 @@ fn parse_project_ids(params: &SpanStatsQueryParams) -> Result<Vec<i32>, Problem>
             .with_detail(
                 "Provide project_id, or project_ids as a comma-separated list of project ids",
             ));
+    }
+    // Rejected here, before the per-project access checks run, so an oversized
+    // list costs one string parse rather than one authorization round-trip per
+    // id. The service re-checks the same bound for non-HTTP callers.
+    if ids.len() > SPAN_STATS_MAX_PROJECTS {
+        return Err(problemdetails::new(StatusCode::BAD_REQUEST)
+            .with_title("Too Many Projects")
+            .with_detail(format!(
+                "span-stats accepts at most {} projects per query, got {}",
+                SPAN_STATS_MAX_PROJECTS,
+                ids.len()
+            )));
     }
     Ok(ids)
 }

--- a/crates/temps-otel/src/services/otel_service.rs
+++ b/crates/temps-otel/src/services/otel_service.rs
@@ -417,6 +417,15 @@ impl OtelService {
                 message: "span-stats requires at least one project id".to_string(),
             });
         }
+        if query.project_ids.len() > SPAN_STATS_MAX_PROJECTS {
+            return Err(OtelError::Validation {
+                message: format!(
+                    "span-stats accepts at most {} projects per query, got {}",
+                    SPAN_STATS_MAX_PROJECTS,
+                    query.project_ids.len()
+                ),
+            });
+        }
         if query.end_time <= query.start_time {
             return Err(OtelError::Validation {
                 message: format!(
@@ -424,6 +433,20 @@ impl OtelService {
                      end_time {}",
                     query.start_time.to_rfc3339(),
                     query.end_time.to_rfc3339()
+                ),
+            });
+        }
+        // Reject rather than silently truncate: a caller asking for 90 days and
+        // getting 31 back would read the result as "the last 90 days", and the
+        // whole point of the report is that the numbers mean what they say.
+        let window = query.end_time - query.start_time;
+        if window > chrono::Duration::days(SPAN_STATS_MAX_WINDOW_DAYS) {
+            return Err(OtelError::Validation {
+                message: format!(
+                    "span-stats time window is {} days, which exceeds the {}-day maximum; \
+                     narrow start_time/end_time",
+                    window.num_days(),
+                    SPAN_STATS_MAX_WINDOW_DAYS
                 ),
             });
         }
@@ -1234,5 +1257,79 @@ mod tests {
 
         drop(permits);
         assert!(service.try_acquire_ingest_permit().is_ok());
+    }
+
+    // ── span-stats query validation ─────────────────────────────────
+
+    fn span_stats_query(project_ids: Vec<i32>, window_days: i64) -> SpanStatsQuery {
+        let end = chrono::Utc::now();
+        SpanStatsQuery {
+            project_ids,
+            start_time: end - chrono::Duration::days(window_days),
+            end_time: end,
+            service_name: None,
+            span_name: None,
+            name_pattern: None,
+            kind: None,
+            status: None,
+            environment_id: None,
+            deployment_id: None,
+            attributes: None,
+            min_duration_ms: None,
+            min_count: 1,
+            sort_by: SpanStatsSortField::default(),
+            sort_order: SortOrder::default(),
+            limit: None,
+            offset: None,
+        }
+    }
+
+    #[test]
+    fn span_stats_rejects_more_projects_than_the_cap() {
+        // The handler checks a project's access one round-trip at a time, and
+        // an instance admin skips those checks entirely — so the id list has to
+        // be bounded before it reaches storage, not just before it reaches auth.
+        let too_many: Vec<i32> = (1..=(SPAN_STATS_MAX_PROJECTS as i32 + 1)).collect();
+        let err = OtelService::validate_span_stats_query(&span_stats_query(too_many, 1))
+            .expect_err("over-cap project list must be rejected");
+        assert!(matches!(err, OtelError::Validation { .. }), "got {err:?}");
+        assert!(err.to_string().contains("at most"), "got {err}");
+
+        let at_cap: Vec<i32> = (1..=SPAN_STATS_MAX_PROJECTS as i32).collect();
+        assert!(OtelService::validate_span_stats_query(&span_stats_query(at_cap, 1)).is_ok());
+    }
+
+    #[test]
+    fn span_stats_rejects_a_window_wider_than_the_cap() {
+        // This report aggregates the whole window before it can rank anything,
+        // so an unbounded window is an unbounded query on a small box.
+        let err = OtelService::validate_span_stats_query(&span_stats_query(
+            vec![1],
+            SPAN_STATS_MAX_WINDOW_DAYS + 1,
+        ))
+        .expect_err("over-wide window must be rejected");
+        assert!(matches!(err, OtelError::Validation { .. }), "got {err:?}");
+        assert!(err.to_string().contains("exceeds"), "got {err}");
+
+        // Rejected, never silently narrowed: a caller who asked for 90 days and
+        // got 31 back would read the numbers as covering 90.
+        assert!(OtelService::validate_span_stats_query(&span_stats_query(
+            vec![1],
+            SPAN_STATS_MAX_WINDOW_DAYS
+        ))
+        .is_ok());
+    }
+
+    #[test]
+    fn span_stats_still_rejects_empty_and_inverted_windows() {
+        assert!(OtelService::validate_span_stats_query(&span_stats_query(vec![], 1)).is_err());
+
+        let now = chrono::Utc::now();
+        let inverted = SpanStatsQuery {
+            start_time: now,
+            end_time: now - chrono::Duration::hours(1),
+            ..span_stats_query(vec![1], 1)
+        };
+        assert!(OtelService::validate_span_stats_query(&inverted).is_err());
     }
 }

--- a/crates/temps-otel/src/types.rs
+++ b/crates/temps-otel/src/types.rs
@@ -766,6 +766,26 @@ pub const SPAN_STATS_DEFAULT_LIMIT: u64 = 20;
 /// Hard cap on span-stats rows per page.
 pub const SPAN_STATS_MAX_LIMIT: u64 = 100;
 
+/// Hard cap on how many projects one span-stats query may aggregate.
+///
+/// Bounds two costs that scale with the list. The handler runs a project-access
+/// check per id, and the ClickHouse backend renders one bind placeholder per id
+/// — an instance admin skips the access checks entirely, so without a cap a
+/// single request could hand storage an arbitrarily long id list. Ranking
+/// across more than a few dozen projects is not a real workflow; ranking across
+/// ten thousand is a typo or an attack.
+pub const SPAN_STATS_MAX_PROJECTS: usize = 50;
+
+/// Hard cap on the span-stats time window.
+///
+/// Unlike the trace list, this report has no early exit: it aggregates every
+/// span in the window before it can rank anything, so cost grows with the
+/// window rather than with the page size. A month covers "how did last month
+/// look"; a full 90-day retention scan on a busy project is the query that
+/// takes the instance down, and the reference deployment is a 3 vCPU / 4 GB
+/// box.
+pub const SPAN_STATS_MAX_WINDOW_DAYS: i64 = 31;
+
 /// Filter for the span-stats (per-operation latency) report.
 ///
 /// Unlike [`TraceQuery`], the time window is **not** optional. Every backend

--- a/scripts/seed-data/admin-key.ts
+++ b/scripts/seed-data/admin-key.ts
@@ -1,0 +1,77 @@
+/**
+ * Mint an API key against a local dev instance through the product's own flow.
+ *
+ * `POST /api-keys` is a step-up-guarded sensitive action: it needs a browser
+ * session with MFA enrolled and verified in the last five minutes. Rather than
+ * reach around that guard, this enrols TOTP on the calling account, satisfies
+ * the challenge for real, creates the key, and then unwinds the enrolment.
+ *
+ * Shared by every seeding/replay script so the unwind — the part that is easy
+ * to get wrong and expensive to get wrong — exists in exactly one place.
+ */
+
+import { totp, waitForFreshWindow } from "./totp.ts";
+
+/** The caller's authenticated JSON helper, already carrying a session cookie. */
+export type ApiFn = <T>(path: string, init?: RequestInit) => Promise<T>;
+
+interface MfaSetup {
+  secret_key: string;
+  recovery_codes?: string[];
+}
+
+export async function mintApiKey(api: ApiFn, name: string): Promise<string> {
+  const setup = await api<MfaSetup>("/users/me/mfa/setup", { method: "POST" });
+  const secret = setup.secret_key;
+
+  try {
+    await waitForFreshWindow();
+    await api<void>("/users/me/mfa/verify", {
+      method: "POST",
+      body: JSON.stringify({ code: await totp(secret) }),
+    });
+
+    await api("/auth/step-up", {
+      method: "POST",
+      body: JSON.stringify({ code: await totp(secret) }),
+    });
+
+    const created = await api<{ api_key: string }>("/api-keys", {
+      method: "POST",
+      body: JSON.stringify({ name, role_type: "admin" }),
+    });
+    return created.api_key;
+  } finally {
+    // Always unwind, including when the steps above threw. MFA was turned on
+    // purely to satisfy the step-up challenge; leaving it on with the TOTP
+    // secret discarded would lock the developer out of their own dev instance
+    // on the next login.
+    await disableMfa(api, secret, setup.recovery_codes ?? []);
+  }
+}
+
+/**
+ * Turn MFA back off, and if that fails, print what the developer needs to get
+ * back in rather than exiting with a silently-changed login.
+ */
+async function disableMfa(
+  api: ApiFn,
+  secret: string,
+  recoveryCodes: string[],
+): Promise<void> {
+  try {
+    await waitForFreshWindow();
+    await api<void>("/users/me/mfa", {
+      method: "DELETE",
+      body: JSON.stringify({ code: await totp(secret) }),
+    });
+  } catch (err) {
+    console.error(
+      `\n!! Could not disable MFA (${err instanceof Error ? err.message : err}).\n` +
+        `!! MFA is still ENABLED on this account. Keep these to sign in:\n` +
+        `!!   TOTP secret:    ${secret}\n` +
+        (recoveryCodes.length ? `!!   Recovery codes: ${recoveryCodes.join(", ")}\n` : "") +
+        `!! Add the secret to an authenticator app, or disable MFA in the console.\n`,
+    );
+  }
+}

--- a/scripts/seed-data/ingest-trace-json.ts
+++ b/scripts/seed-data/ingest-trace-json.ts
@@ -20,7 +20,7 @@ import {
   type ResourceSpanGroup,
   type SeedSpan,
 } from "./otlp.ts";
-import { totp, waitForFreshWindow } from "./totp.ts";
+import { mintApiKey } from "./admin-key.ts";
 
 const API = process.env.TEMPS_API || "http://localhost:8080";
 const EMAIL = process.env.TEMPS_EMAIL || "dev@temps.sh";
@@ -98,25 +98,7 @@ sessionCookie = session;
 
 // Same real MFA + step-up flow the seeder uses — `POST /api-keys` is a guarded
 // sensitive action, and a replay script is not a reason to route around it.
-const setup = await api<{ secret_key: string }>("/users/me/mfa/setup", { method: "POST" });
-await waitForFreshWindow();
-await api<void>("/users/me/mfa/verify", {
-  method: "POST",
-  body: JSON.stringify({ code: await totp(setup.secret_key) }),
-});
-await api("/auth/step-up", {
-  method: "POST",
-  body: JSON.stringify({ code: await totp(setup.secret_key) }),
-});
-const { api_key: apiKey } = await api<{ api_key: string }>("/api-keys", {
-  method: "POST",
-  body: JSON.stringify({ name: `trace-replay-${Date.now()}`, role_type: "admin" }),
-});
-await waitForFreshWindow();
-await api<void>("/users/me/mfa", {
-  method: "DELETE",
-  body: JSON.stringify({ code: await totp(setup.secret_key) }),
-});
+const apiKey = await mintApiKey(api, `trace-replay-${Date.now()}`);
 console.log("✓ minted ingest key (MFA enrolled, used, removed)");
 
 // ── replay ──────────────────────────────────────────────────────────

--- a/scripts/seed-data/mint-api-key.ts
+++ b/scripts/seed-data/mint-api-key.ts
@@ -10,7 +10,7 @@
  *   TEMPS_API=http://localhost:8261 TEMPS_PASSWORD=... bun run mint-api-key.ts
  */
 
-import { totp, waitForFreshWindow } from "./totp.ts";
+import { mintApiKey } from "./admin-key.ts";
 
 const API = process.env.TEMPS_API || "http://localhost:8080";
 const EMAIL = process.env.TEMPS_EMAIL || "dev@temps.sh";
@@ -51,27 +51,6 @@ const session = (login.headers.getSetCookie?.() ?? [])
 if (!session) throw new Error("login returned no session cookie");
 sessionCookie = session;
 
-const setup = await api<{ secret_key: string }>("/users/me/mfa/setup", { method: "POST" });
-await waitForFreshWindow();
-await api<void>("/users/me/mfa/verify", {
-  method: "POST",
-  body: JSON.stringify({ code: await totp(setup.secret_key) }),
-});
-await api("/auth/step-up", {
-  method: "POST",
-  body: JSON.stringify({ code: await totp(setup.secret_key) }),
-});
+const apiKey = await mintApiKey(api, `cli-dev-${Date.now()}`);
 
-const created = await api<{ api_key: string }>("/api-keys", {
-  method: "POST",
-  body: JSON.stringify({ name: `cli-dev-${Date.now()}`, role_type: "admin" }),
-});
-
-// Restore the account to how we found it.
-await waitForFreshWindow();
-await api<void>("/users/me/mfa", {
-  method: "DELETE",
-  body: JSON.stringify({ code: await totp(setup.secret_key) }),
-});
-
-console.log(created.api_key);
+console.log(apiKey);

--- a/scripts/seed-data/seed-otel-traces.ts
+++ b/scripts/seed-data/seed-otel-traces.ts
@@ -38,7 +38,7 @@ import {
   type ResourceSpanGroup,
   type SeedSpan,
 } from "./otlp.ts";
-import { totp, waitForFreshWindow } from "./totp.ts";
+import { mintApiKey } from "./admin-key.ts";
 
 const API = process.env.TEMPS_API || "http://localhost:8080";
 const EMAIL = process.env.TEMPS_EMAIL || "dev@temps.sh";
@@ -461,46 +461,11 @@ async function ensureProject(def: ProjectDef): Promise<number> {
   return created.id;
 }
 
-/**
- * Mint an OTLP ingest key through the product's own flow.
- *
- * `POST /api-keys` is a step-up-guarded sensitive action: it requires a browser
- * session with MFA enrolled and verified within the last five minutes. Rather
- * than reach around that guard, this enrols TOTP on the seeding account,
- * satisfies the step-up challenge for real, creates the key, and then disables
- * MFA again so the dev account is left exactly as it was found.
- */
+/** Mint the OTLP ingest key. See `admin-key.ts` for why this is not a direct insert. */
 async function createIngestKey(): Promise<string> {
-  const setup = await api<{ secret_key: string }>("/users/me/mfa/setup", { method: "POST" });
-  const secret = setup.secret_key;
-
-  await waitForFreshWindow();
-  await api<void>("/users/me/mfa/verify", {
-    method: "POST",
-    body: JSON.stringify({ code: await totp(secret) }),
-  });
-
-  await api<{ step_up_expires_at?: string }>("/auth/step-up", {
-    method: "POST",
-    body: JSON.stringify({ code: await totp(secret) }),
-  });
-
-  const created = await api<{ api_key: string }>("/api-keys", {
-    method: "POST",
-    body: JSON.stringify({ name: `otel-trace-seed-${Date.now()}`, role_type: "admin" }),
-  });
-
-  // Leave the account as we found it — MFA was enrolled purely to satisfy the
-  // step-up challenge, and a seeding run should not silently change how the
-  // developer logs in tomorrow.
-  await waitForFreshWindow();
-  await api<void>("/users/me/mfa", {
-    method: "DELETE",
-    body: JSON.stringify({ code: await totp(secret) }),
-  });
-
+  const key = await mintApiKey(api, `otel-trace-seed-${Date.now()}`);
   console.log("✓ created OTLP ingest API key (MFA enrolled, used, and removed)");
-  return created.api_key;
+  return key;
 }
 
 // ── trace generation ────────────────────────────────────────────────

--- a/web/src/api/client/@tanstack/react-query.gen.ts
+++ b/web/src/api/client/@tanstack/react-query.gen.ts
@@ -8331,6 +8331,11 @@ export const querySpanStatsQueryKey = (options?: Options<QuerySpanStatsData>) =>
  *
  * Pair the variability sorts with `min_count` — a ratio computed from three
  * samples is noise, and without a floor it outranks every real signal.
+ *
+ * Two bounds are enforced rather than clamped, so a result never claims to
+ * cover more than it does: at most 50 projects, and a window no wider than
+ * 31 days. Both return 400. Unlike the trace list this report has no early
+ * exit — it aggregates every span in the window before it can rank anything.
  */
 export const querySpanStatsOptions = (options?: Options<QuerySpanStatsData>) => queryOptions<QuerySpanStatsResponse, QuerySpanStatsError, QuerySpanStatsResponse, ReturnType<typeof querySpanStatsQueryKey>>({
     queryFn: async ({ queryKey, signal }) => {
@@ -8363,6 +8368,11 @@ export const querySpanStatsInfiniteQueryKey = (options?: Options<QuerySpanStatsD
  *
  * Pair the variability sorts with `min_count` — a ratio computed from three
  * samples is noise, and without a floor it outranks every real signal.
+ *
+ * Two bounds are enforced rather than clamped, so a result never claims to
+ * cover more than it does: at most 50 projects, and a window no wider than
+ * 31 days. Both return 400. Unlike the trace list this report has no early
+ * exit — it aggregates every span in the window before it can rank anything.
  */
 export const querySpanStatsInfiniteOptions = (options?: Options<QuerySpanStatsData>) => {
     const opts = infiniteQueryOptions<QuerySpanStatsResponse, QuerySpanStatsError, InfiniteData<QuerySpanStatsResponse>, QueryKey<Options<QuerySpanStatsData>>, number | Pick<QueryKey<Options<QuerySpanStatsData>>[0], 'body' | 'headers' | 'path' | 'query'>>(

--- a/web/src/api/client/sdk.gen.ts
+++ b/web/src/api/client/sdk.gen.ts
@@ -4160,6 +4160,11 @@ export const getQuota = <ThrowOnError extends boolean = false>(options: Options<
  *
  * Pair the variability sorts with `min_count` — a ratio computed from three
  * samples is noise, and without a floor it outranks every real signal.
+ *
+ * Two bounds are enforced rather than clamped, so a result never claims to
+ * cover more than it does: at most 50 projects, and a window no wider than
+ * 31 days. Both return 400. Unlike the trace list this report has no early
+ * exit — it aggregates every span in the window before it can rank anything.
  */
 export const querySpanStats = <ThrowOnError extends boolean = false>(options?: Options<QuerySpanStatsData, ThrowOnError>): RequestResult<QuerySpanStatsResponses, QuerySpanStatsErrors, ThrowOnError> => (options?.client ?? client).get<QuerySpanStatsResponses, QuerySpanStatsErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -34401,11 +34401,11 @@ export type QuerySpanStatsData = {
          */
         project_id?: number;
         /**
-         * Comma-separated project ids, e.g. `4,5,6`
+         * Comma-separated project ids, e.g. `4,5,6` (max 50)
          */
         project_ids?: string;
         /**
-         * Window start (RFC 3339); defaults to 24h before end_time
+         * Window start (RFC 3339); defaults to 24h before end_time. The window may not exceed 31 days
          */
         start_time?: string;
         /**


### PR DESCRIPTION
Review follow-up on #566. Two inputs were unbounded in a report whose cost is proportional to them, plus a lockout hazard in the seeding scripts. No behaviour change for normal queries.

## `project_ids` had no cap

The handler runs a project-access check **per id**, and an instance admin skips those checks entirely — so an admin could hand storage an arbitrarily long list, which the ClickHouse backend renders as one bind placeholder per id. For a non-admin the blast radius was self-limiting (the guard 403s at the first inaccessible project), but the admin path had nothing stopping it.

Capped at **50**, rejected in the handler *before* any authorization round-trip, and re-checked in the service so a non-HTTP caller gets the same bound.

## The time window had no maximum

Unlike the trace list, this report has no early exit — it aggregates every span in the window before it can rank anything. A 90-day request on a busy project is an unbounded query on the 3 vCPU / 4 GB reference box.

Capped at **31 days**, which still covers "how did last month look".

## Both reject rather than clamp

Silently narrowing 90 days to 31 would hand back numbers the caller reads as covering 90. The whole value of this report is that the numbers mean what they say, so an over-wide window is a 400 with the reason, not a quiet truncation.

## Evidence

Against a live ClickHouse-backed instance:

```
$ curl '.../otel/span-stats?project_ids=1,2,...,51'
HTTP 400
Too Many Projects — span-stats accepts at most 50 projects per query, got 51

$ curl '.../otel/span-stats?project_id=4&start_time=<32 days ago>'
HTTP 400
Invalid Payload — span-stats time window is 32 days, which exceeds the 31-day
maximum; narrow start_time/end_time

$ curl '.../otel/span-stats?project_id=4&start_time=<30d23h ago>'   # boundary
HTTP 200

$ curl '.../otel/span-stats?project_ids=4,5,6&sort_by=tail_ratio&min_count=100'
HTTP 200 — 29 operations, ranking unchanged
```

CLI mirrors both bounds locally, so the user gets told which flag to change instead of a bare 400:

```
$ temps traces span-stats --project-ids 1,...,51
⚠ --project-ids accepts at most 50 projects, got 51

$ temps traces span-stats --project-id 4 --since 60d
⚠ Window is 60.0 days; the maximum is 31. Narrow --since, or --start-time/--end-time.
```

## Seeding scripts: MFA lockout hazard

All three scripts enrol MFA to satisfy the step-up guard on `POST /api-keys`, then disable it. The disable was **not** in a `finally`, so a failure anywhere in between left the dev account with MFA enabled and the TOTP secret discarded — the developer would be locked out of their own instance on next login.

The flow now lives in one shared `admin-key.ts` with the unwind guaranteed, and if the unwind itself fails it prints the secret and recovery codes rather than exiting with a silently-changed login. Verified by re-running the seeder end-to-end (600 traces, MFA unwound cleanly).

## Tests

3 new service-validation tests: over-cap project list rejected and at-cap accepted; over-wide window rejected and at-boundary accepted; empty/inverted windows still rejected.

449 unit + 13 TimescaleDB + 31 ClickHouse passing. Clippy `-D warnings` clean, `tsc` clean for web and CLI. OpenAPI description states the actual limits; both SDKs regenerated (doc-only diff).
