### PR TITLE
ci(sandbox): install protoc in the beta image prepare job

### DIFF
--- a/.github/workflows/sandbox-images-beta.yml
+++ b/.github/workflows/sandbox-images-beta.yml
@@ -89,6 +89,18 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Install build dependencies
+        # `temps-agents` -> `temps-deployments` -> `temps-otel`, whose
+        # build script runs `prost-build` and shells out to `protoc`.
+        # The dependency is transitive and invisible from this workflow's
+        # `paths` filter, so a PR that never touches a sandbox path can
+        # still break this job. `release.yml`'s identical
+        # `prepare-sandbox-context` job installs the same package — keep
+        # the two in lock-step.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
       - name: Cache cargo deps
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:


### PR DESCRIPTION
## Problem

[`Sandbox Images (beta)`](https://github.com/gotempsh/temps/actions/workflows/sandbox-images-beta.yml) has failed on **every `main` push since 2026-07-30**. The beta channel (`:<ver>-beta`, `:beta`, `:<sha>`) has not published a sandbox image or preview gateway in a week — hosts on beta are pinned to images from 2026-07-26.

`Prepare sandbox build context` dies in `Build helpers (print_dockerfile + print_bundle)`:

```
error: failed to run custom build command for `temps-otel v0.1.0-beta.55`

Caused by:
  process didn't exit successfully: .../build-script-build (exit status: 1)
  --- stderr
  Error: Custom { kind: NotFound, error: "Could not find `protoc`. ..." }
```

## Root cause

`temps-agents` → `temps-deployments` → `temps-otel`. `temps-deployments` gained the `temps-otel` dependency in #454 (*metric alerts as config-as-code*, 2026-07-28), and `temps-otel`'s build script runs `prost-build`, which shells out to `protoc`. This job never installed a protobuf compiler.

Timeline lines up exactly:

| run | date | result |
|---|---|---|
| `feat(sandbox): track agent-run sandboxes…` | 2026-07-26 | ✅ success |
| #454 merged — `temps-deployments` gains `temps-otel` | 2026-07-28 | — |
| `fix(ci): pin privileged workflow actions (#473)` | 2026-07-30 | ❌ protoc |
| `fix(sandbox): free volumes and work dirs…` | 2026-08-05 | ❌ protoc |
| `Merge pull request #571…` | 2026-08-07 | ❌ protoc |

## Why PR checks were green

Two independent reasons, both worth knowing:

1. **This workflow has no `pull_request` trigger.** It is `on: push: branches: [main]` only — it has never run on a PR, so no PR could have caught it.
2. **`rust-tests.yml`, which does run on PRs, installs `protobuf-compiler`** (3×). The workspace compiles fine there. The missing dependency existed only in this one workflow.

Note that adding a `pull_request` trigger with the current `paths:` filter would *not* have caught this either — #454 touched `crates/temps-deployments/`, `crates/temps-monitoring/` etc., none of which are in the filter. The breakage arrived through a transitive dependency the path filter is blind to. That gap is called out in a comment on the new step rather than papered over with a trigger change; closing it properly means either running the helper build on every PR (~4 min of Rust) or accepting post-merge detection.

## Fix

Port the `Install build dependencies` step from `release.yml`'s `prepare-sandbox-context` — the byte-identical job, which is exactly why the **stable** channel kept publishing while beta went dark:

```yaml
- name: Install build dependencies
  run: |
    sudo apt-get update
    sudo apt-get install -y protobuf-compiler
```

## Evidence

The two jobs at the head of `main` (52321ae3), differing only in this step:

| | `release.yml` / `prepare-sandbox-context` | `sandbox-images-beta.yml` / `prepare-context` |
|---|---|---|
| installs `protobuf-compiler` | yes | **no** (before this PR) |
| [last run](https://github.com/gotempsh/temps/actions/runs/31148471371) | ✅ success (+ all 6 image builds) | ❌ [failure](https://github.com/gotempsh/temps/actions/runs/31167087007/job/92830307809) |

Full job reproduced locally against merged `main` (52321ae3) with `protoc` present — every step of `prepare-context`, not just the compile:

```console
$ cargo build --example print_dockerfile --example print_bundle -p temps-agents
   Compiling temps-otel v0.1.0-beta.55
   ...
   Compiling temps-agents v0.1.0-beta.55
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 50s

$ for r in node bun python rust go full; do ./target/debug/examples/print_dockerfile "$r" > dockerfiles/$r.Dockerfile; done
rendered: node (196 lines)
rendered: bun (193 lines)
rendered: python (196 lines)
rendered: rust (196 lines)
rendered: go (196 lines)
rendered: full (196 lines)

$ ./target/debug/examples/print_bundle bundle
bundle/pty-agent/{Cargo.toml,sandbox-entrypoint.sh,src/{main,lib,protocol,pty,server}.rs}
bundle/git-credential/{Cargo.toml,src/{lib,helper_protocol,ipc}.rs,src/bin/{helper,daemon}.rs}
```

The failing CI log confirms the compile reached `temps-otel`'s build script with every prior crate green, so `protoc` was the only blocker — and the local run above proves nothing else in the #571 merge broke the helper build.

Real verification is the post-merge `main` run, since the workflow can only fire on `push: main`.

## Scope

One step added to one job. No trigger, path-filter, tag, or cache changes — the beta/stable channel split is untouched.