### PR TITLE
ci(cli): enforce canonical openapi.json in a hook and in CI

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -314,6 +314,28 @@ jobs:
       - name: Type check
         run: cd web && bunx tsc --noEmit
 
+  openapi-canonical:
+    name: OpenAPI Spec Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7.0.1
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # No `bun install`: the check reads the committed file and needs nothing
+      # but Bun itself, so it reports in seconds on every pull request.
+      #
+      # What it catches: the CLI's client is generated from a *committed* spec,
+      # and the server serves that document minified on one line. Writing the
+      # response straight to the file turns ~92,000 lines into 1, so the diff
+      # reports ~92,000 deletions and the real change becomes unreviewable.
+      - name: Check openapi.json is canonical
+        run: bun apps/temps-cli/scripts/check-openapi.ts
+
   clippy:
     name: Clippy (advisory)
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,16 @@ repos:
         files: ^CHANGELOG\.md$
         pass_filenames: false
 
+      - id: openapi-canonical
+        name: openapi.json is canonical
+        # Catches the raw server response (minified, one line) being committed
+        # over the formatted file, which reports ~92,000 deletions and buries
+        # the real change. Reads only the file: no server, no network.
+        entry: bun apps/temps-cli/scripts/check-openapi.ts
+        language: system
+        files: ^apps/temps-cli/openapi\.json$
+        pass_filenames: false
+
       - id: cargo-fmt
         name: cargo fmt
         entry: cargo fmt --

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,16 @@ hundred changed lines, never tens of thousands:
 git diff --numstat -- apps/temps-cli/openapi.json
 ```
 
+You do not have to remember any of this. `bun run spec:check` verifies
+the committed file and runs automatically as a pre-commit hook and as the
+**OpenAPI Spec Format** CI job, so a minified or reordered spec fails
+before review rather than after. It reads only the file on disk — no
+server, no network, no `bun install`.
+
+If it fails and the API did *not* change, `bun run spec:check --fix`
+reformats in place. If the API *did* change, `bun run spec:update` is
+what you want, since `--fix` never fetches.
+
 `web/src/api/client/` has no committed spec; it is generated straight
 from the live server by `bun run openapi-ts` (see above), so it does not
 have this failure mode.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -751,8 +751,22 @@ only supported way to write it. Sorting is what keeps a diff proportional to
 the API change instead of to serde's iteration order, which is not stable
 between builds.
 
-Verify before committing -- adding a few endpoints is a few hundred changed
-lines, never tens of thousands:
+This is enforced, not just documented. `bun run spec:check` verifies the
+committed file -- it reads only what is on disk, so it needs no server and no
+`bun install`, and it runs both as a pre-commit hook and as the
+**OpenAPI Spec Format** job on every pull request:
+
+```bash
+cd apps/temps-cli
+bun run spec:check          # verify; exits 1 with the reason
+bun run spec:check --fix    # reformat what is already committed (does not fetch)
+```
+
+`--fix` only reformats. When the API itself changed you still need
+`bun run spec:update` against a running server, then `bun run generate:api`.
+
+Sanity-check the size before committing -- adding a few endpoints is a few
+hundred changed lines, never tens of thousands:
 
 ```bash
 git diff --numstat -- apps/temps-cli/openapi.json

--- a/apps/temps-cli/package.json
+++ b/apps/temps-cli/package.json
@@ -16,6 +16,7 @@
     "build": "bun build src/index.ts --outdir dist --target node && sed -i '' '1s|#!/usr/bin/env bun|#!/usr/bin/env node|' dist/index.js && chmod +x dist/index.js",
     "build:bin": "bun build src/index.ts --compile --outfile bin/temps",
     "spec:update": "bun run scripts/update-openapi.ts",
+    "spec:check": "bun run scripts/check-openapi.ts",
     "generate:api": "bun openapi-ts",
     "generate:docs": "bun run scripts/generate-docs.ts",
     "generate:docs:mdx": "bun run scripts/generate-docs.ts --format mdx",

--- a/apps/temps-cli/scripts/check-openapi.ts
+++ b/apps/temps-cli/scripts/check-openapi.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env bun
+/**
+ * Verify that the committed `openapi.json` is in canonical shape.
+ *
+ * This is the gate that stops the ~92,000-line diff from coming back. It reads
+ * only the file on disk — no server, no network, no `bun install` — so the same
+ * command runs in a pre-commit hook and in CI on every pull request.
+ *
+ * Usage:
+ *   bun run scripts/check-openapi.ts          # verify, exit 1 if not canonical
+ *   bun run scripts/check-openapi.ts --fix    # rewrite it in place
+ *
+ * `--fix` reformats what is already committed. It does not fetch, so it cannot
+ * pick up API changes — use `bun run spec:update` for that.
+ */
+
+import { SPEC_PATH, pathCount, serialize } from './openapi-canonical'
+
+const fix = process.argv.slice(2).includes('--fix')
+const file = Bun.file(SPEC_PATH)
+
+if (!(await file.exists())) {
+  console.error(`Missing ${SPEC_PATH}`)
+  process.exit(1)
+}
+
+const actual = await file.text()
+
+let spec: unknown
+try {
+  spec = JSON.parse(actual)
+} catch (error) {
+  console.error(`${SPEC_PATH} is not valid JSON: ${String(error)}`)
+  console.error('Regenerate it with: cd apps/temps-cli && bun run spec:update')
+  process.exit(1)
+}
+
+const paths = pathCount(spec)
+if (paths === 0) {
+  console.error(`${SPEC_PATH} declares no paths — that is not a usable spec.`)
+  console.error('Regenerate it with: cd apps/temps-cli && bun run spec:update')
+  process.exit(1)
+}
+
+const expected = serialize(spec)
+
+if (actual === expected) {
+  console.log(`openapi.json is canonical (${paths} paths)`)
+  process.exit(0)
+}
+
+if (fix) {
+  await Bun.write(SPEC_PATH, expected)
+  console.log(`Reformatted openapi.json (${paths} paths)`)
+  console.log('Review the diff, then run: bun run generate:api')
+  process.exit(0)
+}
+
+// Name the shape of the problem rather than just "differs". The single-line
+// case is the one that costs ~92,000 deletions, and it should say so.
+const actualLines = actual.split('\n').length
+const expectedLines = expected.split('\n').length
+
+console.error(`${SPEC_PATH} is not in canonical shape.`)
+if (actualLines <= 2 && expectedLines > 1000) {
+  console.error(
+    `\nIt is minified: ${actualLines} line(s) where canonical is ${expectedLines}. ` +
+      'This is what a raw server response written straight to the file looks like, and it ' +
+      `reports ~${expectedLines} deletions, burying the real change.`
+  )
+} else {
+  console.error(
+    `\nOn disk: ${actualLines} lines. Canonical: ${expectedLines} lines. ` +
+      'Canonical is: keys sorted recursively, two-space indent, trailing newline.'
+  )
+}
+console.error('\nFix it with either:')
+console.error('  cd apps/temps-cli && bun run spec:check --fix   # reformat what is committed')
+console.error('  cd apps/temps-cli && bun run spec:update        # refetch from a running server')
+console.error('then: bun run generate:api')
+process.exit(1)

--- a/apps/temps-cli/scripts/openapi-canonical.ts
+++ b/apps/temps-cli/scripts/openapi-canonical.ts
@@ -1,0 +1,61 @@
+/**
+ * The canonical on-disk shape of `apps/temps-cli/openapi.json`.
+ *
+ * The CLI's client is generated from a *committed* copy of the spec, unlike
+ * `web/`, which generates straight from a running server. That makes the file
+ * a reviewable artifact — and it only stays reviewable if its shape is a
+ * function of the API alone.
+ *
+ * Two things break that:
+ *
+ *   - The server serves the document minified on one line. Writing that
+ *     straight to disk turns ~92,000 lines into 1, so the pull request reports
+ *     ~92,000 deletions and the real change is invisible.
+ *   - Key order comes from serde and is not stable between builds, so even a
+ *     pretty-printed dump reorders large unrelated blocks.
+ *
+ * Sorting keys recursively removes both. Shared by `spec:update` (which
+ * fetches) and `spec:check` (which verifies), so the writer and the gate can
+ * never disagree about what canonical means.
+ */
+
+export const SPEC_PATH = new URL('../openapi.json', import.meta.url).pathname
+
+/** Recursively sort object keys so on-disk order never depends on the server. */
+export function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    // Array order is meaningful in OpenAPI (parameter lists, enum values) —
+    // sort the contents, never the sequence.
+    return value.map(canonicalize)
+  }
+  if (value && typeof value === 'object') {
+    const source = value as Record<string, unknown>
+    return Object.fromEntries(
+      Object.keys(source)
+        .sort()
+        .map((key) => [key, canonicalize(source[key])])
+    )
+  }
+  return value
+}
+
+/** Canonical text for a parsed spec: sorted keys, two-space indent, trailing newline. */
+export function serialize(spec: unknown): string {
+  return `${JSON.stringify(canonicalize(spec), null, 2)}\n`
+}
+
+/**
+ * How many paths a parsed document declares; `0` for anything unusable.
+ *
+ * A spec with no paths means something answered but the document was never
+ * assembled. Writing that would silently delete the entire committed client
+ * and the generated SDK would compile to nothing, so both the writer and the
+ * checker treat zero as fatal.
+ */
+export function pathCount(spec: unknown): number {
+  const paths = (spec as { paths?: unknown } | null)?.paths
+  if (!paths || typeof paths !== 'object') {
+    return 0
+  }
+  return Object.keys(paths).length
+}

--- a/apps/temps-cli/scripts/update-openapi.ts
+++ b/apps/temps-cli/scripts/update-openapi.ts
@@ -2,16 +2,9 @@
 /**
  * Refresh `openapi.json` from a running temps server, in a canonical shape.
  *
- * Why this exists: the server emits the spec minified and with whatever key
- * order serde produced. Writing that straight to disk replaces a ~92,000-line
- * pretty-printed file with a single line, so the pull request reports ~-92,000
- * deletions and the real change is invisible to reviewers. Key order is not
- * stable across builds either, so even a pretty-printed dump reorders large
- * blocks for no reason.
- *
- * Canonical form is therefore: keys sorted, two-space indent, trailing
- * newline. Sorting is what makes the diff proportional to the API change
- * rather than to serde's iteration order.
+ * Why this exists, and what "canonical" means, is documented once in
+ * `openapi-canonical.ts` — this script is the fetching half, `check-openapi.ts`
+ * is the verifying half, and both share that definition so they cannot drift.
  *
  * Usage:
  *   bun run scripts/update-openapi.ts                     # localhost:8080
@@ -22,26 +15,9 @@
  *   bun run generate:api
  */
 
-const DEFAULT_URL = 'http://localhost:8080/api/api-docs/openapi.json'
-const OUTPUT = new URL('../openapi.json', import.meta.url).pathname
+import { SPEC_PATH, pathCount, serialize } from './openapi-canonical'
 
-/** Recursively sort object keys so the on-disk order never depends on the server. */
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    // Array order is meaningful in OpenAPI (parameter lists, enum values) —
-    // sort the contents, never the sequence.
-    return value.map(canonicalize)
-  }
-  if (value && typeof value === 'object') {
-    const source = value as Record<string, unknown>
-    return Object.fromEntries(
-      Object.keys(source)
-        .sort()
-        .map((key) => [key, canonicalize(source[key])])
-    )
-  }
-  return value
-}
+const DEFAULT_URL = 'http://localhost:8080/api/api-docs/openapi.json'
 
 function parseArgs(argv: string[]): { url: string } {
   const index = argv.indexOf('--url')
@@ -76,13 +52,14 @@ if (!response.ok) {
 }
 
 const spec = await response.json()
-if (!spec?.paths || Object.keys(spec.paths).length === 0) {
+const paths = pathCount(spec)
+if (paths === 0) {
   // A spec with no paths means the server answered but the doc was not
   // assembled — writing it would silently delete the entire committed client.
   console.error('Refusing to write: the fetched spec has no paths.')
   process.exit(1)
 }
 
-await Bun.write(OUTPUT, `${JSON.stringify(canonicalize(spec), null, 2)}\n`)
-console.log(`Wrote ${OUTPUT} (${Object.keys(spec.paths).length} paths)`)
+await Bun.write(SPEC_PATH, serialize(spec))
+console.log(`Wrote ${SPEC_PATH} (${paths} paths)`)
 console.log('Now run: bun run generate:api')


### PR DESCRIPTION
## Problem

`apps/temps-cli/src/api/` is generated from a **committed** copy of the spec at `apps/temps-cli/openapi.json`. The server serves that same document **minified on one line**; the committed file is ~92,000 lines of formatted JSON.

So `curl .../openapi.json > openapi.json` turns 92,000 lines into 1, and the pull request reports **~92,000 deletions**. That happened on #564. Pretty-printing alone does not fix it either: key order comes from serde and is not stable between builds, so an unsorted dump reorders large unrelated blocks.

#564 established the canonical shape (keys sorted recursively, two-space indent, trailing newline) and documented the rule. This PR makes it **enforced**, because a documented rule does not help when the failure is silent and only visible as a diff nobody can read.

## What this adds

- **`scripts/openapi-canonical.ts`** — one definition of "canonical", shared by the writer and the checker so they cannot drift.
- **`scripts/check-openapi.ts`** (`bun run spec:check`) — verifies the committed file. Reads only what is on disk: no server, no network, no `bun install`. `--fix` reformats in place; it deliberately never fetches, so it cannot mask an out-of-date spec.
- **Pre-commit hook** `openapi-canonical`, scoped to `^apps/temps-cli/openapi\.json$`.
- **CI job** `OpenAPI Spec Format` in `rust-tests.yml` — runs in seconds on every PR.
- `update-openapi.ts` rewired onto the shared module.
- CLAUDE.md / AGENTS.md updated to point at the check and at `--fix` vs `spec:update`.

The messages name the failure rather than reporting a mismatch:

```
apps/temps-cli/openapi.json is not in canonical shape.

It is minified: 1 line(s) where canonical is 92714. This is what a raw server
response written straight to the file looks like, and it reports ~92714
deletions, burying the real change.

Fix it with either:
  cd apps/temps-cli && bun run spec:check --fix   # reformat what is committed
  cd apps/temps-cli && bun run spec:update        # refetch from a running server
then: bun run generate:api
```

## Verification

Each case run against the real spec:

| Case | Result |
|---|---|
| Committed file as-is | passes, `673 paths` |
| Minified (the original bug) | fails, names it as minified |
| Pretty-printed but reordered | fails, explains canonical form |
| `paths: {}` | fails — would otherwise delete the whole client |
| Invalid JSON | fails with the parse error |
| `--fix` after minifying | restores the file **byte-for-byte** (empty `git diff`) |

Hook wiring confirmed with `prek run openapi-canonical`: fires on `openapi.json`, skipped for unrelated files, and blocks the commit when the spec is minified.

`bun run typecheck` in `apps/temps-cli` reports the same 4 pre-existing errors as `main` — none from these files.

## Note

This does not check that `src/api/` is regenerated from the spec — a different drift, not the one that costs 92,000 lines.