### PR TITLE
fix(projects): normalize blank directory so compose deployments stop failing

### DIFF
--- a/crates/temps-deployments/src/services/workflow_execution_service.rs
+++ b/crates/temps-deployments/src/services/workflow_execution_service.rs
@@ -2316,10 +2316,16 @@ impl WorkflowExecutionService {
                 )
                 .map_err(|e| WorkflowExecutionError::InvalidJobConfig(e.to_string()))?;
 
+                // Projects created before directory normalization was applied on
+                // every write path can hold "" or "/" here. Both are rejected by
+                // the job's path confinement, so normalize to the repo root
+                // marker instead of failing the deployment.
                 let directory = config
                     .get("directory")
                     .and_then(|v| v.as_str())
-                    .unwrap_or("./")
+                    .map(|d| d.trim().trim_start_matches('/'))
+                    .filter(|d| !d.is_empty())
+                    .unwrap_or(".")
                     .to_string();
 
                 // Get dependencies to find the download job ID

--- a/crates/temps-projects/src/services/project.rs
+++ b/crates/temps-projects/src/services/project.rs
@@ -1359,7 +1359,7 @@ impl ProjectService {
                 active_project.preset_config = Set(Some(merged));
             }
             if let Some(dir) = directory {
-                active_project.directory = Set(dir);
+                active_project.directory = Set(normalize_project_directory(&dir)?);
             }
 
             let updated_project = active_project.update(self.db.as_ref()).await?;
@@ -1524,7 +1524,7 @@ impl ProjectService {
         active_project.main_branch = Set(main_branch.clone());
         active_project.repo_owner = Set(repo_owner.clone());
         active_project.repo_name = Set(repo_name.clone());
-        active_project.directory = Set(directory);
+        active_project.directory = Set(normalize_project_directory(&directory)?);
         // Configuring a Git repository makes this a Git-source project — this is
         // how a docker_image / static_files project is converted to Git (the
         // reverse conversion goes through `set_source_type`).
@@ -4763,6 +4763,115 @@ mod tests {
             !matches!(result, Err(ProjectError::NotFound(_))),
             "caller_user_id with no connection_id must not be rejected by the ownership guard"
         );
+    }
+
+    #[tokio::test]
+    async fn test_update_project_settings_normalizes_blank_directory() {
+        // Regression: saving project settings with an empty "Base directory"
+        // used to persist "" verbatim, after which every deployment failed with
+        // "directory must be a non-empty relative path (got '')".
+        let test_db = TestDatabase::with_migrations().await.unwrap();
+        let db = test_db.db.clone();
+        let mock_queue = Arc::new(MockJobQueue::new());
+        let project_service = create_test_services(db.clone(), mock_queue.clone()).await;
+
+        let inserted_project = temps_entities::projects::ActiveModel {
+            name: Set("Blank Dir Project".to_string()),
+            slug: Set("blank-dir-project".to_string()),
+            repo_name: Set("blank-dir-repo".to_string()),
+            repo_owner: Set("test-owner".to_string()),
+            directory: Set("apps/web".to_string()),
+            git_provider_connection_id: Set(None),
+            main_branch: Set("main".to_string()),
+            preset: Set(Preset::DockerCompose),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .unwrap();
+
+        project_service
+            .update_project_settings(
+                inserted_project.id,
+                None,
+                None,
+                Some("main".to_string()),
+                None,
+                None,
+                None,
+                Some(String::new()), // directory: blank field from the settings form
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None, // cross_project_trace_sharing
+                None, // error_source_context_enabled
+                None, // error_source_root
+            )
+            .await
+            .expect("update_project_settings should succeed");
+
+        let stored = temps_entities::projects::Entity::find_by_id(inserted_project.id)
+            .one(db.as_ref())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            stored.directory, ".",
+            "a blank directory must be stored as the repo-root marker, not \"\""
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_git_settings_normalizes_blank_directory() {
+        let test_db = TestDatabase::with_migrations().await.unwrap();
+        let db = test_db.db.clone();
+        let mock_queue = Arc::new(MockJobQueue::new());
+        let project_service = create_test_services(db.clone(), mock_queue.clone()).await;
+
+        let inserted_project = temps_entities::projects::ActiveModel {
+            name: Set("Blank Git Dir Project".to_string()),
+            slug: Set("blank-git-dir-project".to_string()),
+            repo_name: Set("blank-git-dir-repo".to_string()),
+            repo_owner: Set("test-owner".to_string()),
+            directory: Set("apps/web".to_string()),
+            git_provider_connection_id: Set(None),
+            main_branch: Set("main".to_string()),
+            preset: Set(Preset::DockerCompose),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .unwrap();
+
+        project_service
+            .update_git_settings(
+                inserted_project.id,
+                1,
+                None,
+                "main".to_string(),
+                "test-owner".to_string(),
+                "blank-git-dir-repo".to_string(),
+                None,
+                "/".to_string(), // absolute root, equally invalid downstream
+                None,
+                Some("https://github.com/test-owner/blank-git-dir-repo".to_string()),
+                Some(true),
+            )
+            .await
+            .expect("update_git_settings should succeed");
+
+        let stored = temps_entities::projects::Entity::find_by_id(inserted_project.id)
+            .one(db.as_ref())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.directory, ".");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A Docker Compose deployment fails with:

```
Workflow error: Job execution failed: Required job 'deploy_compose' failed:
Some("Job validation failed: directory must be a non-empty relative path (got '')")
```

## Root cause

`DeployComposeJob` confines user-supplied paths to the repo checkout and rejects empty/absolute values (`validate_relative_path`, `crates/temps-deployments/src/jobs/deploy_compose.rs`). The value comes straight from `projects.directory` via the workflow planner.

`normalize_project_directory` was applied on **create** and `update_project`, but **not** on `update_project_settings` or `update_git_settings` — both wrote the raw string. Saving the project settings form with a blank "Base directory" therefore persisted `""`, and from that point on every deployment of that project failed validation. A stored `"/"` (also present on existing rows) is equally fatal, since it is absolute.

## Fix

- Route both remaining write paths through `normalize_project_directory`, so no code path can persist `""`/`"/"` again. The existing helper already rejects `..` escapes, so this also closes those two paths against traversal input.
- Normalize defensively when `directory` is read out of the deploy job config in `WorkflowExecutionService`. Without this, projects that *already* hold a bad value stay broken until someone re-saves them.

## Tests

Two regression tests, one per previously-unnormalized path:

- `test_update_project_settings_normalizes_blank_directory` — blank form field → stored as `.`
- `test_update_git_settings_normalizes_blank_directory` — `"/"` → stored as `.`

```
test services::project::tests::test_update_git_settings_normalizes_blank_directory ... ok
test services::project::tests::test_update_project_settings_normalizes_blank_directory ... ok
test result: ok. 2 passed; 0 failed
```

`cargo check --lib -p temps-projects -p temps-deployments` clean; fmt + clippy pre-commit hooks pass.

## Workaround for anyone hitting this before the fix ships

Set the project's Base directory to `.` and redeploy.