### PR TITLE
test(e2e): parallel-safe e2e suite + API-key coverage + preview-gateway secret-drift fix

### DIFF
--- a/apps/temps-e2e/src/lib/flows.ts
+++ b/apps/temps-e2e/src/lib/flows.ts
@@ -363,7 +363,18 @@ export async function assertNotConsoleFallback(opts: {
   )
 }
 
-/** A stable, unique-ish run id derived from a timestamp passed in by the caller. */
+/**
+ * A run id derived from a timestamp passed in by the caller, plus a random
+ * suffix.
+ *
+ * The timestamp alone collides when two scenario runs start within the same
+ * millisecond — realistic whenever more than one `scenario`/`examples`
+ * process is launched concurrently (parallel CI shards, a dev running two
+ * terminals). The random suffix makes each call unique regardless of timing;
+ * the timestamp prefix is kept so ids still sort roughly chronologically for
+ * debugging.
+ */
 export function makeRunId(nowMs: number): string {
-  return `e2e-${nowMs.toString(36)}`
+  const rand = Math.random().toString(36).slice(2, 8)
+  return `e2e-${nowMs.toString(36)}-${rand}`
 }

--- a/crates/temps-agents/src/preview_gateway.rs
+++ b/crates/temps-agents/src/preview_gateway.rs
@@ -286,7 +286,7 @@ struct ExistingContainer {
     running: bool,
     host_port_binding: Option<(String, String)>, // (host_ip, host_port)
     network_attached: bool,
-    has_shared_secret_env: bool,
+    shared_secret_env: Option<String>,
 }
 
 async fn inspect(docker: &Docker, name: &str) -> Result<Option<ExistingContainer>> {
@@ -340,25 +340,24 @@ async fn inspect(docker: &Docker, name: &str) -> Result<Option<ExistingContainer
         .map(|nets| nets.contains_key(PREVIEW_GATEWAY_NETWORK))
         .unwrap_or(false);
 
-    let has_shared_secret_env = inspected
+    let shared_secret_env = inspected
         .config
         .as_ref()
         .and_then(|c| c.env.as_ref())
-        .map(|env| {
-            env.iter().any(|v| {
+        .and_then(|env| {
+            env.iter().find_map(|v| {
                 v.strip_prefix("PREVIEW_GATEWAY_SHARED_SECRET=")
-                    .map(|val| !val.is_empty())
-                    .unwrap_or(false)
+                    .filter(|val| !val.is_empty())
+                    .map(|val| val.to_string())
             })
-        })
-        .unwrap_or(false);
+        });
 
     Ok(Some(ExistingContainer {
         image,
         running,
         host_port_binding,
         network_attached,
-        has_shared_secret_env,
+        shared_secret_env,
     }))
 }
 
@@ -369,11 +368,17 @@ fn container_matches(existing: &ExistingContainer, spec: &PreviewGatewaySpec) ->
     if !existing.network_attached {
         return false;
     }
-    // If the spec has a shared secret (it should in all non-legacy boots),
-    // the running container MUST have it in its env — otherwise the gateway
-    // crash-loops on startup with an empty-secret error and restart_policy
-    // masks it as "running".
-    if !spec.shared_secret.is_empty() && !existing.has_shared_secret_env {
+    // The running container's actual secret must equal the one this instance
+    // is about to inject, not merely be present. Presence-only matching can
+    // never detect drift: a container created (or last reconciled) by a
+    // different Temps instance/database keeps whatever secret it was born
+    // with forever, so this instance's proxy injects its own DB secret, the
+    // gateway compares against a different one, and every preview request
+    // gets rejected with "missing or invalid X-Temps-Preview-Token" even
+    // though a secret genuinely is configured — just the wrong one.
+    if !spec.shared_secret.is_empty()
+        && existing.shared_secret_env.as_deref() != Some(spec.shared_secret.as_str())
+    {
         return false;
     }
     match &existing.host_port_binding {

--- a/web/e2e/README.md
+++ b/web/e2e/README.md
@@ -25,21 +25,85 @@ console is clean, and that the core flows a first-run user hits actually work.
 
 ```
 e2e/
-  fixtures.ts              shared fixtures: console-error capture, HTTP failure
-                           capture, login helper, URL matchers
-  auth.setup.ts            logs in once, saves storage state for reuse
-  anonymous/               specs that must NOT have a session
-    console-boot.spec.ts   the #504 regression guard: app mounts, no JS errors
-    auth.spec.ts           login success/failure, route gating
-  authenticated/           specs that reuse the saved session
-    navigation.spec.ts     every sidebar destination renders real content
-    project-create.spec.ts creates a project from a public git URL
+  fixtures.ts                 shared fixtures: console-error capture, HTTP
+                              failure capture, login helper, URL matchers,
+                              uniqueSlug() for parallel-safe resource names
+  auth.setup.ts               logs in once, saves storage state for reuse
+  anonymous/                  specs that must NOT have a session
+    console-boot.spec.ts      the #504 regression guard: app mounts, no JS errors
+    auth.spec.ts              login success/failure, route gating
+    command-palette.spec.ts   command palette search/navigation
+  authenticated/               specs that reuse the saved session
+    navigation.spec.ts        every sidebar destination renders real content
+    project-create.spec.ts    creates a project from a public git URL
+    api-key-create.spec.ts    RBAC role-assignment wizard; the minted secret authenticates
+    user-creation.spec.ts     user creation + team-assignment retry (route-mocked)
+    drop-handoff.spec.ts      empty-state ZIP/folder upload handoff (route-mocked)
+    ai-chat-layout.spec.ts    AI chat page layout
+    preview-share-link.spec.ts sandbox preview share-link minting + redemption
 ```
 
 The anonymous/authenticated split is enforced by `playwright.config.ts` rather
 than by convention, because getting it wrong is silent: an "unauthenticated"
 assertion that quietly inherits a logged-in storage state still passes while
 testing nothing.
+
+## Parallel safety and idempotency
+
+`fullyParallel: true` — specs share one backend, so every spec must be safe to
+run concurrently with itself (retries) and with every other spec:
+
+- **Prefer route-mocking** (`page.route(...)`) for anything that doesn't need
+  to prove a real server-side effect. Most specs here (`user-creation`,
+  `drop-handoff`, `command-palette`) never touch the real backend at all, so
+  they have no shared-state exposure by construction.
+- **Specs that do create real backend state must generate worker/retry-unique
+  names** via `uniqueSlug()` in `fixtures.ts` (not a CI run id alone, which is
+  identical across every worker in one run) **and delete what they created in
+  a `try/finally`**, so a failed assertion still leaves the instance clean —
+  see `project-create.spec.ts` and `preview-share-link.spec.ts` for the
+  pattern. A spec that leaks state doesn't just fail once; it corrupts every
+  later run that lists or counts the same resource type.
+- Genuinely singleton flows (the one seeded admin session `auth.setup.ts`
+  creates) live in their own serial Playwright `project` with a `dependencies`
+  edge, which Playwright always runs to completion before any parallel spec
+  starts — this is the one place serialization is correct rather than a
+  workaround.
+
+## Coverage vs. the feature catalog
+
+Tracks `temps/docs/feature-catalog/README.md`'s 6 subsystems. "CLI" refers to
+`apps/temps-e2e` API-parity scenarios, which also validate the paths
+`bunx @temps-sdk/cli` exercises. This table is the source of truth for gaps —
+update it whenever a spec or scenario is added, rather than letting coverage
+silently drift from the catalog.
+
+| Subsystem | UI (`web/e2e`) | CLI (`apps/temps-e2e`) |
+|---|---|---|
+| Deployment & Infrastructure | `project-create`, `navigation`, `drop-handoff` | `scenario`, `examples` |
+| Observability | — | — |
+| Data & Storage | `navigation` (databases page only) | — |
+| AI | `ai-chat-layout` | — |
+| Security & Auth | `auth`, `user-creation`, `api-key-create` | — |
+| Platform & Commerce | `command-palette`, `preview-share-link` | — |
+
+Rows with only a dash are not covered end-to-end yet — tracked gaps, not
+silently-assumed coverage. Observability, data-storage (beyond the page
+rendering), security-auth (API keys/RBAC, audit logs), and platform-commerce
+(webhooks, notifications, plugins) are the priority next additions.
+
+## Mocking third-party services
+
+[`vercel-labs/emulate`](https://github.com/vercel-labs/emulate) is available
+for test-harness-side use in `apps/temps-e2e` (calling a mocked GitHub/AWS/etc.
+API directly from test setup code), but it **cannot** be wired into temps' own
+server-side provider config (git provider `base_url`/`api_url`, webhook and
+Slack notification targets, custom domains). All of those pass through
+`temps_core::url_validation::validate_external_url`, which deliberately
+rejects loopback/private/link-local addresses as an SSRF guard — that's a
+security boundary, not an oversight, and it is not to be weakened for test
+convenience. Practically: real outbound integrations (git clone-by-URL, etc.)
+keep hitting real, public, stable third parties in these specs.
 
 ## Running locally
 

--- a/web/e2e/authenticated/api-key-create.spec.ts
+++ b/web/e2e/authenticated/api-key-create.spec.ts
@@ -1,0 +1,110 @@
+import { expect, expectAppMounted, test, uniqueSlug } from '../fixtures'
+
+/**
+ * Creates an API key through the 3-step console wizard (Basic Info ->
+ * Permissions -> Review), entirely through the UI.
+ *
+ * This is the security-auth subsystem's first end-to-end coverage: until now
+ * nothing exercised the RBAC role-assignment path or proved a key minted
+ * through the console actually authenticates against the API -- both are
+ * exactly the kind of thing that type-checks and builds fine while being
+ * silently broken at runtime.
+ */
+test.describe('API key creation', () => {
+  test('creates a key with a predefined role and the secret authenticates', async ({
+    page,
+  }, testInfo) => {
+    const name = uniqueSlug('e2e-key', testInfo)
+
+    await page.goto('/settings/keys/new')
+    await expectAppMounted(page)
+    await expect(
+      page.getByRole('heading', { name: 'Create API Key', exact: true })
+    ).toBeVisible()
+
+    // Step 1: Basic Info
+    await page.getByLabel('API Key Name *').fill(name)
+    await page.getByRole('button', { name: 'Next: Permissions' }).click()
+
+    // Step 2: Permissions -- pick whichever predefined role renders first
+    // rather than hardcoding a role name, since the role catalog is backend
+    // data, not something this spec should need to know in advance.
+    // shadcn's CardTitle renders a <div>, not a heading element, so this is
+    // getByText rather than getByRole('heading').
+    await expect(
+      page.getByText('Choose Access Level', { exact: true })
+    ).toBeVisible()
+    const firstRoleCard = page
+      .locator('div.cursor-pointer', { has: page.locator('.font-medium') })
+      .first()
+    const roleName = (
+      await firstRoleCard.locator('.font-medium').first().textContent()
+    )?.trim()
+    expect(
+      roleName,
+      'expected at least one predefined role to be offered'
+    ).toBeTruthy()
+    await firstRoleCard.click()
+    await page.getByRole('button', { name: 'Next: Review' }).click()
+
+    // Step 3: Review -- the chosen role must actually be reflected back.
+    await expect(
+      page.getByText(roleName!, { exact: false }).first()
+    ).toBeVisible()
+
+    let apiKeyId: number | null = null
+    await page.getByRole('button', { name: 'Create API Key' }).click()
+
+    // A fresh, non-MFA-enrolled dev admin is not expected to hit step-up
+    // verification, but if the backend ever changes that policy this should
+    // fail loudly here rather than hang, so assert directly on the outcome.
+    await expect(
+      page.getByText('API Key Created Successfully', { exact: true })
+    ).toBeVisible({ timeout: 15_000 })
+
+    try {
+      // The "Your API Key" label isn't programmatically associated with the
+      // input (no htmlFor/id), so getByLabel can't resolve it -- it's the
+      // one readonly input on this success screen instead.
+      const apiKeySecret = await page
+        .locator('input[readonly]')
+        .first()
+        .inputValue()
+      expect(
+        apiKeySecret.length,
+        'the created key secret should be non-empty'
+      ).toBeGreaterThan(0)
+
+      // The secret must actually authenticate -- creating a row is not the
+      // same as the key working. `whoami`-equivalent: list projects with it.
+      const authedResponse = await page.request.get('/api/projects', {
+        headers: { Authorization: `Bearer ${apiKeySecret}` },
+      })
+      expect(
+        authedResponse.status(),
+        'the newly created key should authenticate'
+      ).toBe(200)
+
+      // And it must be listed, not just usable -- proves the create flow
+      // persisted, not just returned an optimistic response.
+      await page.goto('/settings/keys')
+      await expect(page.getByText(name, { exact: true }).first()).toBeVisible({
+        timeout: 15_000,
+      })
+
+      const listResponse = await page.request.get('/api/api-keys')
+      const { api_keys: keys } = (await listResponse.json()) as {
+        api_keys: { id: number; name: string }[]
+      }
+      apiKeyId = keys.find((k) => k.name === name)?.id ?? null
+      expect(
+        apiKeyId,
+        'the created key should be resolvable by name for cleanup'
+      ).not.toBeNull()
+    } finally {
+      if (apiKeyId !== null) {
+        await page.request.delete(`/api/api-keys/${apiKeyId}`)
+      }
+    }
+  })
+})

--- a/web/e2e/authenticated/project-create.spec.ts
+++ b/web/e2e/authenticated/project-create.spec.ts
@@ -1,4 +1,10 @@
-import { expect, expectAppMounted, test, urlForProject } from '../fixtures'
+import {
+  expect,
+  expectAppMounted,
+  test,
+  uniqueSlug,
+  urlForProject,
+} from '../fixtures'
 
 /**
  * Creates a project from a PUBLIC git repository, entirely through the UI.
@@ -18,24 +24,12 @@ import { expect, expectAppMounted, test, urlForProject } from '../fixtures'
 const PUBLIC_REPO_URL =
   process.env.E2E_REPO_URL ?? 'https://github.com/gotempsh/temps.git'
 
-/**
- * Unique per run AND per retry.
- *
- * The retry index matters: if an attempt creates the project and then fails
- * later in the flow, a retry reusing the same name hits a duplicate-name error
- * and fails permanently -- turning a transient problem into a hard red.
- */
-function projectName(retry: number): string {
-  const run = process.env.GITHUB_RUN_ID ?? String(process.hrtime.bigint())
-  return `e2e-ui-${run.slice(-8)}-${retry}`.toLowerCase().slice(0, 32)
-}
-
 test.describe('project creation', () => {
   test('creates a project from a public git URL', async ({
     page,
     consoleErrors,
   }, testInfo) => {
-    const name = projectName(testInfo.retry)
+    const name = uniqueSlug('e2e-ui', testInfo)
 
     await page.goto('/projects/new')
     await expectAppMounted(page)
@@ -86,21 +80,34 @@ test.describe('project creation', () => {
       .getByRole('button', { name: 'Create Project', exact: true })
       .click()
 
-    // Landing on the project page is the success signal.
-    await page.waitForURL(urlForProject(name), { timeout: 60_000 })
-    await expectAppMounted(page)
-    await expect(
-      page.getByRole('heading', { name, exact: true }).first()
-    ).toBeVisible()
+    try {
+      // Landing on the project page is the success signal.
+      await page.waitForURL(urlForProject(name), { timeout: 60_000 })
+      await expectAppMounted(page)
+      await expect(
+        page.getByRole('heading', { name, exact: true }).first()
+      ).toBeVisible()
 
-    // And it must survive a reload -- i.e. it was actually persisted, not just
-    // rendered optimistically from local state.
-    await page.goto('/projects')
-    await expect(page.getByText(name, { exact: true }).first()).toBeVisible({
-      timeout: 30_000,
-    })
+      // And it must survive a reload -- i.e. it was actually persisted, not
+      // just rendered optimistically from local state.
+      await page.goto('/projects')
+      await expect(page.getByText(name, { exact: true }).first()).toBeVisible({
+        timeout: 30_000,
+      })
 
-    expect(consoleErrors).toEqual([])
+      expect(consoleErrors).toEqual([])
+    } finally {
+      // Every run creates a real project; without cleanup they accumulate
+      // forever and eventually collide with slug uniqueness or pollute the
+      // /projects list other specs assert against. Resolve by slug (the UI
+      // never exposes the numeric id) and delete unconditionally, even on
+      // assertion failure above.
+      const found = await page.request.get(`/api/projects/by-slug/${name}`)
+      if (found.ok()) {
+        const project = (await found.json()) as { id: number }
+        await page.request.delete(`/api/projects/${project.id}`)
+      }
+    }
   })
 
   test('surfaces a clear error for an unreachable repository', async ({

--- a/web/e2e/fixtures.ts
+++ b/web/e2e/fixtures.ts
@@ -1,4 +1,9 @@
-import { test as base, expect, type Page } from '@playwright/test'
+import {
+  test as base,
+  expect,
+  type Page,
+  type TestInfo,
+} from '@playwright/test'
 
 /**
  * Shared fixtures. The important one is `consoleErrors`: every test collects
@@ -165,3 +170,21 @@ export const URL_PROJECTS = /\/projects(?:[?#]|$)/
 export const URL_LOGIN = /\/login(?:[?#]|$)/
 export const urlForProject = (name: string) =>
   new RegExp(`/projects/${name}(?:[/?#]|$)`)
+
+/**
+ * Generates a resource name that is unique across parallel workers, retries,
+ * and CI shards -- not just across runs.
+ *
+ * The CI run id alone (the pattern this replaces) is identical for every
+ * worker in one job, so two workers creating similarly-prefixed resources in
+ * the same run collide the moment `fullyParallel` is on. Mixing in
+ * `parallelIndex` (unique per concurrently-running worker) and a short random
+ * suffix (unique per call, so retries of the same test in the same worker
+ * still get a fresh name) closes both gaps.
+ */
+export function uniqueSlug(prefix: string, testInfo: TestInfo): string {
+  const worker = testInfo.parallelIndex
+  const retry = testInfo.retry
+  const rand = Math.random().toString(36).slice(2, 8)
+  return `${prefix}-${worker}-${retry}-${rand}`.toLowerCase().slice(0, 32)
+}

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -32,10 +32,17 @@ export default defineConfig({
   // slower than a typical UI assertion but is the thing actually worth testing.
   timeout: 120_000,
   expect: { timeout: 15_000 },
-  // A shared Temps instance is mutated by these specs (projects get created), so
-  // running files in parallel against one backend invites cross-test flakiness.
-  fullyParallel: false,
-  workers: 1,
+  // Specs share one Temps instance, so parallel safety depends on every spec
+  // either avoiding real backend mutation (route-mocked specs) or cleaning up
+  // its own resources with a worker/retry-unique name (see `uniqueSlug` in
+  // fixtures.ts and project-create.spec.ts's try/finally). Genuinely singleton
+  // flows (the one seeded admin session) live in the serial `setup` project,
+  // which Playwright always runs to completion before any parallel project
+  // starts. Bounded rather than left at the CPU-count default so a laptop run
+  // doesn't open more browser contexts than the shared backend can usefully
+  // serve at once.
+  fullyParallel: true,
+  workers: process.env.CI ? 4 : 2,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI
@@ -64,12 +71,18 @@ export default defineConfig({
     {
       name: 'chromium-anonymous',
       testDir: './e2e/anonymous',
-      use: { ...devices['Desktop Chrome'], storageState: { cookies: [], origins: [] } },
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: { cookies: [], origins: [] },
+      },
     },
     {
       name: 'chromium',
       testDir: './e2e/authenticated',
-      use: { ...devices['Desktop Chrome'], storageState: 'e2e/.auth/user.json' },
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'e2e/.auth/user.json',
+      },
       dependencies: ['setup'],
     },
   ],


### PR DESCRIPTION
## Summary

- **Parallel-safety for `web/e2e`**: replaced CI-run-id-only resource naming with a worker+retry+random `uniqueSlug()` helper (the old naming was identical across every worker in one run, so it collides the moment specs run concurrently). `project-create.spec.ts` previously never deleted the project it created — added `try/finally` cleanup. Flipped `playwright.config.ts` to `fullyParallel: true`.
- **Parallel-safety for `apps/temps-e2e`**: `makeRunId()` now mixes in a random suffix, not just a millisecond timestamp — concurrent `scenario`/`examples` runs (parallel CI shards, two dev terminals) could otherwise land on the exact same run id.
- **New coverage**: `web/e2e/authenticated/api-key-create.spec.ts` — the security-auth subsystem's first end-to-end spec. Drives the real 3-step RBAC wizard through the UI and, critically, verifies the minted secret actually authenticates against `/api/projects` with a live bearer token, not just that a row was created.
- **Bug fix, found while verifying the above locally**: `crates/temps-agents/src/preview_gateway.rs` — the reconciler that keeps the shared `temps-preview-gateway` Docker container in sync only checked *presence* of `PREVIEW_GATEWAY_SHARED_SECRET`, never its *value*. That container has one fixed name shared across every local `temps serve` instance on a machine, so whichever instance created it first "wins" the secret — every other instance's proxy injects its own DB secret, the gateway holds a different one forever, and every preview request gets rejected with "missing or invalid X-Temps-Preview-Token" with no way to self-heal. `container_matches` now compares the secret value and triggers recreation on drift. Confirmed via log: `preview gateway drift detected — recreating`.
- **Docs**: `web/e2e/README.md` now documents the parallel-safety conventions, a coverage matrix against the feature catalog's 6 subsystems (observability, data-storage RBAC-depth, and platform-commerce webhooks/notifications are the remaining gaps), and why `vercel-labs/emulate` can't be wired into temps' own provider/webhook config — every such URL passes through the deliberate SSRF guard in `validate_external_url`, which is a security boundary, not something to route around for test convenience.

## Test plan

- [x] `cd apps/temps-e2e && bun run typecheck`
- [x] `cd web && bunx tsc --noEmit`
- [x] `cd web && bunx eslint` on all touched files (clean after `--fix` for formatting)
- [x] `$(command -v cargo) clippy -p temps-agents --all-targets -- -D warnings` (0 warnings)
- [x] Brought up a local instance, ran the full `web/e2e` suite with `fullyParallel: true` — 21/21 pass
- [x] Reran the suite 2-3x back-to-back with no DB wipe — 0 leftover projects/keys each time, proving idempotency
- [x] Ran two `apps/temps-e2e scenario` processes concurrently — distinct run ids despite starting in the same millisecond, both torn down cleanly
- [x] `preview_gateway.rs` fix verified live: forced the drift condition, confirmed the reconciler detects and recreates