### PR TITLE
fix(security): pin PostgreSQL credential destinations

### DIFF
--- a/crates/temps-providers/src/externalsvc/postgres_role_reconciler.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_role_reconciler.rs
@@ -430,10 +430,11 @@ async fn query_monitor(
     host: &str,
     port: i32,
 ) -> Result<Vec<MonitorNode>, ReconcilerError> {
+    // SECURITY: this probe carries no password, and `sslmode=require`
+    // prevents the self-signed connector from silently accepting cleartext.
     // pg_auto_failover only opens hba for `autoctl_node` over SSL
-    // (`hostssl pg_auto_failover autoctl_node 0.0.0.0/0 trust`). Plain
-    // TCP gets rejected with "no pg_hba.conf entry". Use the same
-    // self-signed-accepting TLS connector the cluster_health probe uses.
+    // (`hostssl pg_auto_failover autoctl_node 0.0.0.0/0 trust`), so there is no
+    // reusable credential for a forged monitor endpoint to collect.
     let conn_str = format!(
         "host={host} port={port} user=autoctl_node dbname=pg_auto_failover \
          sslmode=require connect_timeout=3"

--- a/crates/temps-providers/src/pg_stat_statements.rs
+++ b/crates/temps-providers/src/pg_stat_statements.rs
@@ -15,7 +15,9 @@
 
 use std::sync::Arc;
 
-use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseBackend, DbErr, Statement};
+use sea_orm::DbErr;
+#[cfg(test)]
+use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::{debug, error, warn};
@@ -24,6 +26,76 @@ use utoipa::ToSchema;
 use crate::externalsvc::postgres::PostgresInputConfig;
 use crate::externalsvc::ServiceType;
 use crate::services::ExternalServiceManager;
+
+const RESET_FUNCTION_LOOKUP_SQL: &str = r#"
+    SELECT
+        n.nspname AS schema_name,
+        p.pronargs::integer AS argument_count
+    FROM pg_catalog.pg_extension e
+    JOIN pg_catalog.pg_depend d
+      ON d.refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass
+     AND d.refobjid = e.oid
+     AND d.deptype = 'e'
+    JOIN pg_catalog.pg_proc p
+      ON d.classid = 'pg_catalog.pg_proc'::pg_catalog.regclass
+     AND d.objid = p.oid
+    JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+    WHERE e.extname = 'pg_stat_statements'
+      AND p.proname = 'pg_stat_statements_reset'
+      AND p.proargtypes IN (
+          '26 26 20'::pg_catalog.oidvector,
+          '26 26 20 16'::pg_catalog.oidvector
+      )
+    ORDER BY p.pronargs DESC
+    LIMIT 1
+"#;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum PgStatConnectionPolicy {
+    Standard,
+    ManagedPrivate,
+}
+
+impl PgStatConnectionPolicy {
+    async fn connect(
+        self,
+        host: &str,
+        port: u16,
+        username: &str,
+        password: &str,
+        database: &str,
+    ) -> temps_query::Result<tokio_postgres::Client> {
+        match self {
+            Self::Standard => {
+                temps_query_postgres::connect_with_tls_ladder(
+                    host, port, username, password, database,
+                )
+                .await
+            }
+            Self::ManagedPrivate => {
+                temps_query_postgres::connect_with_private_tls_ladder(
+                    host, port, username, password, database,
+                )
+                .await
+            }
+        }
+    }
+}
+
+fn pg_stat_connection_target(
+    cluster_primary: Option<(String, u16)>,
+    standalone_host: String,
+    standalone_port: u16,
+) -> (String, u16, PgStatConnectionPolicy) {
+    match cluster_primary {
+        Some((host, port)) => (host, port, PgStatConnectionPolicy::ManagedPrivate),
+        None => (
+            standalone_host,
+            standalone_port,
+            PgStatConnectionPolicy::Standard,
+        ),
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Error type
@@ -254,13 +326,13 @@ impl PgStatStatementsService {
         }
     }
 
-    /// Build a dedicated `DatabaseConnection` scoped to a single request
-    /// against the user-provisioned Postgres service. The connection is closed
-    /// when it goes out of scope.
+    /// Build a dedicated pinned tokio-postgres client scoped to one request.
+    /// Managed clusters require a private destination; standalone external
+    /// services retain the verified-public TLS policy.
     async fn connect_to_service(
         &self,
         service_id: i32,
-    ) -> Result<(sea_orm::DatabaseConnection, i32), PgStatStatementsError> {
+    ) -> Result<(tokio_postgres::Client, i32), PgStatStatementsError> {
         let service_config = self
             .external_service_manager
             .get_service_config(service_id)
@@ -281,7 +353,7 @@ impl PgStatStatementsService {
             })?;
 
         // Resolve host/port: for clustered services use the primary's address.
-        let (host, port) = match self
+        let (host, port, connection_policy) = match self
             .external_service_manager
             .get_cluster_primary_address(service_id)
             .await
@@ -293,7 +365,11 @@ impl PgStatStatementsService {
                     primary_port,
                     "Using cluster primary for pg_stat_statements query"
                 );
-                (primary_host, primary_port)
+                pg_stat_connection_target(
+                    Some((primary_host, primary_port)),
+                    config.host.clone(),
+                    5432,
+                )
             }
             Ok(None) => {
                 let port_str = config.port.clone().unwrap_or_else(|| "5432".to_string());
@@ -303,7 +379,7 @@ impl PgStatStatementsService {
                         reason: format!("invalid port '{}': {}", port_str, e),
                     }
                 })?;
-                (config.host.clone(), port)
+                pg_stat_connection_target(None, config.host.clone(), port)
             }
             Err(e) => {
                 return Err(PgStatStatementsError::ConnectionFailed {
@@ -315,33 +391,18 @@ impl PgStatStatementsService {
             }
         };
 
-        let password = config.password.clone().unwrap_or_default();
+        let password = config.password.unwrap_or_default();
+        let connection = connection_policy
+            .connect(&host, port, &config.username, &password, &config.database)
+            .await
+            .map_err(|error| PgStatStatementsError::ConnectionFailed {
+                service_id,
+                host: host.clone(),
+                port,
+                reason: error.to_string(),
+            })?;
 
-        // Use urlencoding for the password so special characters don't break the URL.
-        let url = format!(
-            "postgres://{}:{}@{}:{}/{}",
-            urlencoding::encode(&config.username),
-            urlencoding::encode(&password),
-            host,
-            port,
-            urlencoding::encode(&config.database),
-        );
-
-        let mut opts = ConnectOptions::new(url);
-        // Single connection — this is a one-off admin query, not a connection pool.
-        opts.max_connections(1).min_connections(0);
-
-        let db =
-            Database::connect(opts)
-                .await
-                .map_err(|e| PgStatStatementsError::ConnectionFailed {
-                    service_id,
-                    host: host.clone(),
-                    port,
-                    reason: e.to_string(),
-                })?;
-
-        Ok((db, service_id))
+        Ok((connection, service_id))
     }
 
     /// Enable `pg_stat_statements` on a standalone Postgres service by
@@ -415,10 +476,86 @@ impl PgStatStatementsService {
         &self,
         service_id: i32,
     ) -> Result<(), PgStatStatementsError> {
-        let (db, service_id) = self.connect_to_service(service_id).await?;
-        Self::reset_on_connection(&db, service_id).await
+        let (client, service_id) = self.connect_to_service(service_id).await?;
+        Self::reset_on_client(&client, service_id).await
     }
 
+    async fn reset_on_client(
+        client: &tokio_postgres::Client,
+        service_id: i32,
+    ) -> Result<(), PgStatStatementsError> {
+        let function_row = client
+            .query_opt(RESET_FUNCTION_LOOKUP_SQL, &[])
+            .await
+            .map_err(|db_error| {
+                error!(
+                    service_id,
+                    error = %db_error,
+                    "Failed to resolve the extension-owned pg_stat_statements reset function"
+                );
+                PgStatStatementsError::ResetFailed { service_id }
+            })?
+            .ok_or(PgStatStatementsError::ExtensionNotAvailable { service_id })?;
+
+        let schema_name: String = function_row.try_get("schema_name").map_err(|db_error| {
+            error!(
+                service_id,
+                error = %db_error,
+                "Failed to read pg_stat_statements extension schema"
+            );
+            PgStatStatementsError::ResetFailed { service_id }
+        })?;
+        let argument_count: i32 = function_row.try_get("argument_count").map_err(|db_error| {
+            error!(
+                service_id,
+                error = %db_error,
+                "Failed to read pg_stat_statements reset function signature"
+            );
+            PgStatStatementsError::ResetFailed { service_id }
+        })?;
+        let reset_sql = Self::build_reset_sql(&schema_name, argument_count, service_id)?;
+
+        client.execute(&reset_sql, &[]).await.map_err(|db_error| {
+            error!(
+                service_id,
+                extension_schema = schema_name,
+                error = %db_error,
+                "Target Postgres rejected pg_stat_statements reset"
+            );
+            PgStatStatementsError::ResetFailed { service_id }
+        })?;
+        Ok(())
+    }
+
+    fn build_reset_sql(
+        schema_name: &str,
+        argument_count: i32,
+        service_id: i32,
+    ) -> Result<String, PgStatStatementsError> {
+        // The function is resolved through its pg_extension dependency, not
+        // merely by schema and name, so an unrelated same-schema overload
+        // cannot influence the selected signature. The schema is still quoted
+        // as an identifier so unusual extension schemas remain valid.
+        let quoted_schema = format!("\"{}\"", schema_name.replace('"', "\"\""));
+        match argument_count {
+            3 => Ok(format!(
+                "SELECT {quoted_schema}.pg_stat_statements_reset(0::oid, 0::oid, 0::bigint)"
+            )),
+            4 => Ok(format!(
+                "SELECT {quoted_schema}.pg_stat_statements_reset(0::oid, 0::oid, 0::bigint, false::boolean)"
+            )),
+            _ => {
+                error!(
+                    service_id,
+                    argument_count,
+                    "Resolved an unsupported pg_stat_statements reset function signature"
+                );
+                Err(PgStatStatementsError::ResetFailed { service_id })
+            }
+        }
+    }
+
+    #[cfg(test)]
     async fn reset_on_connection<C>(db: &C, service_id: i32) -> Result<(), PgStatStatementsError>
     where
         C: ConnectionTrait,
@@ -426,29 +563,7 @@ impl PgStatStatementsService {
         let function_row = db
             .query_one(Statement::from_string(
                 DatabaseBackend::Postgres,
-                r#"
-                SELECT
-                    n.nspname AS schema_name,
-                    p.pronargs::integer AS argument_count
-                FROM pg_catalog.pg_extension e
-                JOIN pg_catalog.pg_depend d
-                  ON d.refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass
-                 AND d.refobjid = e.oid
-                 AND d.deptype = 'e'
-                JOIN pg_catalog.pg_proc p
-                  ON d.classid = 'pg_catalog.pg_proc'::pg_catalog.regclass
-                 AND d.objid = p.oid
-                JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-                WHERE e.extname = 'pg_stat_statements'
-                  AND p.proname = 'pg_stat_statements_reset'
-                  AND p.proargtypes IN (
-                      '26 26 20'::pg_catalog.oidvector,
-                      '26 26 20 16'::pg_catalog.oidvector
-                  )
-                ORDER BY p.pronargs DESC
-                LIMIT 1
-                "#
-                .to_owned(),
+                RESET_FUNCTION_LOOKUP_SQL.to_owned(),
             ))
             .await
             .map_err(|db_error| {
@@ -483,27 +598,7 @@ impl PgStatStatementsService {
                     PgStatStatementsError::ResetFailed { service_id }
                 })?;
 
-        // The function is resolved through its pg_extension dependency, not
-        // merely by schema and name, so an unrelated same-schema overload
-        // cannot influence the selected signature. The schema is still quoted
-        // as an identifier so unusual extension schemas remain valid.
-        let quoted_schema = format!("\"{}\"", schema_name.replace('"', "\"\""));
-        let reset_sql = match argument_count {
-            3 => format!(
-                "SELECT {quoted_schema}.pg_stat_statements_reset(0::oid, 0::oid, 0::bigint)"
-            ),
-            4 => format!(
-                "SELECT {quoted_schema}.pg_stat_statements_reset(0::oid, 0::oid, 0::bigint, false::boolean)"
-            ),
-            _ => {
-                error!(
-                    service_id,
-                    argument_count,
-                    "Resolved an unsupported pg_stat_statements reset function signature"
-                );
-                return Err(PgStatStatementsError::ResetFailed { service_id });
-            }
-        };
+        let reset_sql = Self::build_reset_sql(&schema_name, argument_count, service_id)?;
 
         db.execute(Statement::from_string(DatabaseBackend::Postgres, reset_sql))
             .await
@@ -550,19 +645,23 @@ impl PgStatStatementsService {
             });
         }
 
+        let (client, service_id) = self.connect_to_service(service_id).await?;
+        Self::top_slow_queries_on_client(&client, service_id, pagination).await
+    }
+
+    async fn top_slow_queries_on_client(
+        client: &tokio_postgres::Client,
+        service_id: i32,
+        pagination: SlowQueryPage,
+    ) -> Result<(Vec<SlowQueryRow>, u64), PgStatStatementsError> {
         let limit = pagination.page_size;
         let offset = (pagination.page - 1) * pagination.page_size;
-
-        let (db, service_id) = self.connect_to_service(service_id).await?;
 
         // Ensure the extension is installed. This is idempotent and fast when
         // it's already present. It will fail if shared_preload_libraries does
         // not yet include pg_stat_statements (requires a container restart).
-        if let Err(e) = db
-            .execute(Statement::from_string(
-                DatabaseBackend::Postgres,
-                "CREATE EXTENSION IF NOT EXISTS pg_stat_statements".to_owned(),
-            ))
+        if let Err(e) = client
+            .batch_execute("CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
             .await
         {
             warn!(
@@ -576,11 +675,8 @@ impl PgStatStatementsService {
 
         // Verify the view is accessible (the library may not be loaded yet on
         // older containers even if the extension row exists).
-        let view_check = db
-            .execute(Statement::from_string(
-                DatabaseBackend::Postgres,
-                "SELECT 1 FROM pg_stat_statements LIMIT 0".to_owned(),
-            ))
+        let view_check = client
+            .query("SELECT 1 FROM pg_stat_statements LIMIT 0", &[])
             .await;
 
         if view_check.is_err() {
@@ -589,11 +685,8 @@ impl PgStatStatementsService {
 
         // Total count for pagination controls.
         let count_sql = "SELECT COUNT(*)::bigint AS n FROM pg_stat_statements WHERE calls > 0";
-        let count_row = db
-            .query_one(Statement::from_string(
-                DatabaseBackend::Postgres,
-                count_sql.to_owned(),
-            ))
+        let count_row = client
+            .query_opt(count_sql, &[])
             .await
             .map_err(|e| PgStatStatementsError::QueryError {
                 service_id,
@@ -605,7 +698,7 @@ impl PgStatStatementsService {
             })?;
         let total_count: i64 =
             count_row
-                .try_get("", "n")
+                .try_get("n")
                 .map_err(|e| PgStatStatementsError::QueryError {
                     service_id,
                     reason: format!("failed to read count: {}", e),
@@ -626,14 +719,14 @@ impl PgStatStatementsService {
                 s.mean_exec_time,
                 s.rows,
                 COALESCE(d.datname, '(dropped database)') AS database,
-                CASE
+                (CASE
                     WHEN (s.shared_blks_hit + s.shared_blks_read) = 0 THEN NULL
                     ELSE ROUND(
                         (s.shared_blks_hit::numeric /
                          (s.shared_blks_hit + s.shared_blks_read)) * 100,
                         2
                     ) / 100.0
-                END AS cache_hit_ratio
+                END)::double precision AS cache_hit_ratio
             FROM pg_stat_statements s
             LEFT JOIN pg_database d ON d.oid = s.dbid
             WHERE s.calls > 0
@@ -643,49 +736,50 @@ impl PgStatStatementsService {
             "#
         );
 
-        let rows = db
-            .query_all(Statement::from_string(DatabaseBackend::Postgres, sql))
-            .await
-            .map_err(|e| PgStatStatementsError::QueryError {
-                service_id,
-                reason: e.to_string(),
-            })?;
+        let rows =
+            client
+                .query(&sql, &[])
+                .await
+                .map_err(|e| PgStatStatementsError::QueryError {
+                    service_id,
+                    reason: e.to_string(),
+                })?;
 
         let mut result = Vec::with_capacity(rows.len());
         for row in rows {
             let query: String =
-                row.try_get("", "query")
+                row.try_get("query")
                     .map_err(|e| PgStatStatementsError::QueryError {
                         service_id,
                         reason: format!("failed to read 'query' column: {}", e),
                     })?;
             let calls: i64 =
-                row.try_get("", "calls")
+                row.try_get("calls")
                     .map_err(|e| PgStatStatementsError::QueryError {
                         service_id,
                         reason: format!("failed to read 'calls' column: {}", e),
                     })?;
-            let total_exec_time: f64 = row.try_get("", "total_exec_time").map_err(|e| {
-                PgStatStatementsError::QueryError {
-                    service_id,
-                    reason: format!("failed to read 'total_exec_time' column: {}", e),
-                }
-            })?;
-            let mean_exec_time: f64 = row.try_get("", "mean_exec_time").map_err(|e| {
-                PgStatStatementsError::QueryError {
-                    service_id,
-                    reason: format!("failed to read 'mean_exec_time' column: {}", e),
-                }
-            })?;
+            let total_exec_time: f64 =
+                row.try_get("total_exec_time")
+                    .map_err(|e| PgStatStatementsError::QueryError {
+                        service_id,
+                        reason: format!("failed to read 'total_exec_time' column: {}", e),
+                    })?;
+            let mean_exec_time: f64 =
+                row.try_get("mean_exec_time")
+                    .map_err(|e| PgStatStatementsError::QueryError {
+                        service_id,
+                        reason: format!("failed to read 'mean_exec_time' column: {}", e),
+                    })?;
             let rows_count: i64 =
-                row.try_get("", "rows")
+                row.try_get("rows")
                     .map_err(|e| PgStatStatementsError::QueryError {
                         service_id,
                         reason: format!("failed to read 'rows' column: {}", e),
                     })?;
-            let cache_hit_ratio: Option<f64> = row.try_get("", "cache_hit_ratio").ok();
+            let cache_hit_ratio: Option<f64> = row.try_get("cache_hit_ratio").ok();
             let database: String =
-                row.try_get("", "database")
+                row.try_get("database")
                     .map_err(|e| PgStatStatementsError::QueryError {
                         service_id,
                         reason: format!("failed to read 'database' column: {}", e),
@@ -715,6 +809,26 @@ mod tests {
     use super::*;
     use sea_orm::{MockDatabase, MockExecResult, Value};
     use std::collections::BTreeMap;
+    use testcontainers::{
+        core::{ContainerPort, WaitFor},
+        runners::AsyncRunner,
+        GenericImage, ImageExt,
+    };
+
+    fn container_runtime_unavailable(error: &str) -> bool {
+        let message = error.to_ascii_lowercase();
+        [
+            "hyper legacy client: client error (connect)",
+            "failed to connect to docker",
+            "error connecting to docker",
+            "docker daemon is unavailable",
+            "docker client is unavailable",
+            "could not find docker environment",
+            "docker socket",
+        ]
+        .iter()
+        .any(|marker| message.contains(marker))
+    }
 
     fn extension_function_row(schema_name: &str, argument_count: i32) -> BTreeMap<String, Value> {
         let mut row = BTreeMap::new();
@@ -727,6 +841,130 @@ mod tests {
             Value::Int(Some(argument_count)),
         );
         row
+    }
+
+    #[test]
+    fn test_pg_stat_connection_target_selects_policy_from_cluster_primary() {
+        let cluster = pg_stat_connection_target(
+            Some(("10.0.0.9".to_string(), 6432)),
+            "public.example".to_string(),
+            5432,
+        );
+        assert_eq!(cluster.0, "10.0.0.9");
+        assert_eq!(cluster.1, 6432);
+        assert_eq!(cluster.2, PgStatConnectionPolicy::ManagedPrivate);
+
+        let standalone = pg_stat_connection_target(None, "public.example".to_string(), 5433);
+        assert_eq!(standalone.0, "public.example");
+        assert_eq!(standalone.1, 5433);
+        assert_eq!(standalone.2, PgStatConnectionPolicy::Standard);
+    }
+
+    #[tokio::test]
+    async fn test_pg_stat_connection_policy_managed_private_rejects_public_credentials() {
+        let error = PgStatConnectionPolicy::ManagedPrivate
+            .connect(
+                "203.0.113.10",
+                5432,
+                "cluster_admin",
+                "secret host=attacker.example sslmode=disable",
+                "postgres",
+            )
+            .await
+            .expect_err("managed cluster statistics must reject a public endpoint");
+
+        assert!(
+            error
+                .to_string()
+                .contains("refusing to send cluster credentials even over verified TLS"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn production_client_lists_and_resets_pg_stat_statements() {
+        let container = match GenericImage::new("postgres", "18-alpine")
+            .with_exposed_port(ContainerPort::Tcp(5432))
+            .with_wait_for(WaitFor::message_on_stderr(
+                "database system is ready to accept connections",
+            ))
+            .with_env_var("POSTGRES_DB", "postgres")
+            .with_env_var("POSTGRES_USER", "postgres")
+            .with_env_var("POSTGRES_HOST_AUTH_METHOD", "trust")
+            .with_cmd([
+                "postgres".to_owned(),
+                "-c".to_owned(),
+                "shared_preload_libraries=pg_stat_statements".to_owned(),
+            ])
+            .start()
+            .await
+        {
+            Ok(container) => container,
+            Err(error) if container_runtime_unavailable(&error.to_string()) => {
+                eprintln!(
+                    "Docker unavailable; skipping pg_stat_statements production-client test: {error}"
+                );
+                return;
+            }
+            Err(error) => panic!("failed to start pg_stat_statements test container: {error}"),
+        };
+
+        let host = container
+            .get_host()
+            .await
+            .expect("started PostgreSQL container must expose its host")
+            .to_string();
+        let port = container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("started PostgreSQL container must expose port 5432");
+
+        let client = PgStatConnectionPolicy::ManagedPrivate
+            .connect(&host, port, "postgres", "", "postgres")
+            .await
+            .expect("private transport should connect to the local PostgreSQL container");
+        client
+            .batch_execute("CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
+            .await
+            .expect("pg_stat_statements should be available in the stock PostgreSQL image");
+        for _ in 0..3 {
+            client
+                .query("SELECT 42::integer /* temps_pgstat_reset_probe */", &[])
+                .await
+                .expect("sample query should be recorded");
+        }
+
+        let (rows, total_count) = PgStatStatementsService::top_slow_queries_on_client(
+            &client,
+            42,
+            SlowQueryPage::default(),
+        )
+        .await
+        .expect("production tokio-postgres row decoding should succeed");
+        assert!(total_count > 0, "sample queries should produce statistics");
+        assert!(!rows.is_empty(), "statistics page should contain rows");
+        assert!(rows.iter().all(|row| row.calls > 0));
+        assert!(
+            rows.iter()
+                .any(|row| row.query.contains("temps_pgstat_reset_probe")),
+            "statistics page should decode the tagged sample query"
+        );
+
+        PgStatStatementsService::reset_on_client(&client, 42)
+            .await
+            .expect("production reset lookup and invocation should succeed");
+        let reset_probe_count: i64 = client
+            .query_one(
+                "SELECT COUNT(*)::bigint FROM pg_stat_statements WHERE query LIKE $1",
+                &[&"%temps_pgstat_reset_probe%"],
+            )
+            .await
+            .expect("statistics should remain queryable after reset")
+            .get(0);
+        assert_eq!(
+            reset_probe_count, 0,
+            "reset should clear the tagged sample query statistics"
+        );
     }
 
     #[test]

--- a/crates/temps-providers/src/query_service.rs
+++ b/crates/temps-providers/src/query_service.rs
@@ -23,6 +23,47 @@ use crate::ExternalServiceManager;
 /// Cache of active connections by (service_id, database_name)
 type ConnectionCache = HashMap<(i32, String), Arc<dyn DataSource>>;
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum PostgresConnectionPolicy {
+    Standard,
+    ManagedPrivate,
+}
+
+impl PostgresConnectionPolicy {
+    async fn connect(
+        self,
+        host: &str,
+        port: u16,
+        username: &str,
+        password: &str,
+        database: &str,
+    ) -> Result<PostgresSource> {
+        match self {
+            Self::Standard => {
+                PostgresSource::connect(host, port, username, password, database).await
+            }
+            Self::ManagedPrivate => {
+                PostgresSource::connect_private(host, port, username, password, database).await
+            }
+        }
+    }
+}
+
+fn postgres_connection_target(
+    cluster_primary: Option<(String, u16)>,
+    standalone_host: String,
+    standalone_port: u16,
+) -> (String, u16, PostgresConnectionPolicy) {
+    match cluster_primary {
+        Some((host, port)) => (host, port, PostgresConnectionPolicy::ManagedPrivate),
+        None => (
+            standalone_host,
+            standalone_port,
+            PostgresConnectionPolicy::Standard,
+        ),
+    }
+}
+
 /// Wall-clock ceiling applied to a data-browser query when the caller does not
 /// supply one.
 ///
@@ -76,6 +117,7 @@ impl QueryService {
         admin_user: &str,
         admin_password: &str,
         database: &str,
+        connection_policy: PostgresConnectionPolicy,
     ) -> std::result::Result<String, DataError> {
         // Deterministic password derived from admin password so it's stable across calls
         use std::collections::hash_map::DefaultHasher;
@@ -85,7 +127,8 @@ impl QueryService {
         let explorer_password = format!("te_{:x}", hasher.finish());
 
         // Connect as admin to the target database
-        let pg_source = PostgresSource::connect(host, port, admin_user, admin_password, database)
+        let pg_source = connection_policy
+            .connect(host, port, admin_user, admin_password, database)
             .await
             .map_err(|e| {
                 DataError::ConnectionFailed(format!(
@@ -253,7 +296,7 @@ impl QueryService {
                 // `<svc>.temps.local` because they run on the overlay and
                 // resolve via the local Hickory listener — but that's the
                 // app's path, not ours.
-                let (host, port) = match self
+                let (host, port, connection_policy) = match self
                     .external_service_manager
                     .get_cluster_primary_address(service_id)
                     .await
@@ -263,7 +306,11 @@ impl QueryService {
                             "Using cluster primary {}:{} for service {} explorer",
                             primary_host, primary_port, service_id
                         );
-                        (primary_host, primary_port)
+                        postgres_connection_target(
+                            Some((primary_host, primary_port)),
+                            config.host.clone(),
+                            5432,
+                        )
                     }
                     Ok(None) => {
                         // Standalone service — use config host/port as before
@@ -277,7 +324,7 @@ impl QueryService {
                                     e
                                 ))
                             })?;
-                        (config.host.clone(), port)
+                        postgres_connection_target(None, config.host.clone(), port)
                     }
                     Err(e) => {
                         return Err(DataError::ConnectionFailed(format!(
@@ -298,6 +345,7 @@ impl QueryService {
                     &config.username,
                     &admin_password,
                     database,
+                    connection_policy,
                 )
                 .await
                 {
@@ -312,21 +360,16 @@ impl QueryService {
                 };
 
                 // Connect to the specified database with the explorer (or fallback admin) user
-                let pg_source = PostgresSource::connect(
-                    &host,
-                    port,
-                    &connect_user,
-                    &connect_password,
-                    database,
-                )
-                .await
-                .map_err(|e| {
-                    error!(
-                        "Failed to connect to PostgreSQL service {} database {}: {}",
-                        service_id, database, e
-                    );
-                    e
-                })?;
+                let pg_source = connection_policy
+                    .connect(&host, port, &connect_user, &connect_password, database)
+                    .await
+                    .map_err(|e| {
+                        error!(
+                            "Failed to connect to PostgreSQL service {} database {}: {}",
+                            service_id, database, e
+                        );
+                        e
+                    })?;
 
                 Arc::new(pg_source)
             }
@@ -1101,5 +1144,50 @@ impl QueryService {
             }
         })
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_postgres_connection_target_selects_policy_from_cluster_primary() {
+        let cluster = postgres_connection_target(
+            Some(("10.0.0.8".to_string(), 6432)),
+            "public.example".to_string(),
+            5432,
+        );
+        assert_eq!(cluster.0, "10.0.0.8");
+        assert_eq!(cluster.1, 6432);
+        assert_eq!(cluster.2, PostgresConnectionPolicy::ManagedPrivate);
+
+        let standalone = postgres_connection_target(None, "public.example".to_string(), 5433);
+        assert_eq!(standalone.0, "public.example");
+        assert_eq!(standalone.1, 5433);
+        assert_eq!(standalone.2, PostgresConnectionPolicy::Standard);
+    }
+
+    #[tokio::test]
+    async fn test_postgres_connection_policy_managed_private_rejects_public_credentials() {
+        for (username, password) in [
+            ("cluster_admin", "admin-secret"),
+            (QueryService::EXPLORER_USER, "explorer-secret"),
+        ] {
+            let result = PostgresConnectionPolicy::ManagedPrivate
+                .connect("203.0.113.10", 5432, username, password, "postgres")
+                .await;
+            let error = match result {
+                Ok(_) => panic!("managed cluster credentials must reject a public endpoint"),
+                Err(error) => error,
+            };
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("refusing to send cluster credentials even over verified TLS"),
+                "unexpected error for {username}: {error}"
+            );
+        }
     }
 }

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -2617,20 +2617,27 @@ impl ExternalServiceManager {
                         member.container_name
                     ),
                 })?;
-        let port = u16::try_from(raw_port).map_err(|_| {
-            ExternalServiceError::ParameterValidationFailed {
+        let port = u16::try_from(raw_port)
+            .ok()
+            .filter(|port| *port != 0)
+            .ok_or_else(|| ExternalServiceError::ParameterValidationFailed {
                 service_id,
                 reason: format!(
-                    "Persisted port {} for cluster member '{}' is outside the valid TCP range",
+                    "Persisted port {} for cluster member '{}' is outside the valid TCP range 1-65535",
                     raw_port, member.container_name
                 ),
-            }
-        })?;
+            })?;
 
         let host = if let Some(node_id) = member.node_id {
             let node = nodes::Entity::find_by_id(node_id)
                 .one(self.db.as_ref())
-                .await?
+                .await
+                .map_err(|error| ExternalServiceError::DatabaseError {
+                    reason: format!(
+                        "Failed to resolve node {} for cluster member '{}' in service {}: {}",
+                        node_id, member.container_name, service_id, error
+                    ),
+                })?
                 .ok_or_else(|| ExternalServiceError::InternalError {
                     reason: format!(
                         "Cannot resolve cluster member '{}' for service {}: node {} was not found",
@@ -4275,11 +4282,10 @@ echo "[restore] Pre-seed complete"
     /// primary if it doesn't already exist. Idempotent — uses
     /// `pg_database` lookup before issuing CREATE.
     ///
-    /// Connects to the cluster the same way Browse Data does:
-    /// resolve the primary's host:port via the monitor, dial it
-    /// through the existing `temps-query-postgres` TLS-then-plain
-    /// fallback. The CP can reach worker-mapped ports because they
-    /// bind to the worker's underlay IP.
+    /// The monitor selects the primary by persisted member identity; the
+    /// credential destination is then rebuilt from stored topology and dialed
+    /// through the pinned private-only PostgreSQL ladder. The control plane can
+    /// reach worker-mapped ports because they bind to the worker's underlay IP.
     async fn ensure_cluster_app_database(
         &self,
         service_id: i32,
@@ -10338,6 +10344,139 @@ mod tests {
         assert!(trusted_primary_member(&duplicates, "cluster-node-5").is_none());
     }
 
+    #[tokio::test]
+    async fn stored_member_endpoint_resolves_local_and_remote_members() {
+        let remote_node = nodes::Model {
+            id: 17,
+            name: "worker-17".to_owned(),
+            token_hash: "hash".to_owned(),
+            token_encrypted: None,
+            address: "https://worker-17:3100".to_owned(),
+            private_address: "10.100.0.17".to_owned(),
+            public_endpoint: None,
+            wg_public_key: None,
+            role: "worker".to_owned(),
+            status: "active".to_owned(),
+            labels: serde_json::json!({}),
+            capacity: serde_json::json!({}),
+            last_heartbeat: None,
+            edge_public_key: None,
+            compute_cidr: None,
+            architecture: None,
+            underlay_address: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        let manager = mock_service_manager_with_db(Arc::new(
+            sea_orm::MockDatabase::new(sea_orm::DatabaseBackend::Postgres)
+                .append_query_results([vec![remote_node]])
+                .into_connection(),
+        ));
+
+        let local = service_member_info(1, "cluster-node-1", "node", "running");
+        assert_eq!(
+            manager
+                .stored_member_endpoint(41, &local)
+                .await
+                .expect("local persisted member should resolve"),
+            ("localhost".to_owned(), 5432)
+        );
+
+        let mut remote = service_member_info(2, "cluster-node-2", "node", "running");
+        remote.node_id = Some(17);
+        remote.port = Some(6432);
+        assert_eq!(
+            manager
+                .stored_member_endpoint(41, &remote)
+                .await
+                .expect("remote persisted member should resolve through its stored node"),
+            ("10.100.0.17".to_owned(), 6432)
+        );
+    }
+
+    #[tokio::test]
+    async fn stored_member_endpoint_rejects_missing_and_invalid_ports() {
+        let manager = mock_service_manager(vec![]);
+        let mut member = service_member_info(1, "cluster-node-1", "node", "running");
+
+        member.port = None;
+        let missing = manager
+            .stored_member_endpoint(52, &member)
+            .await
+            .expect_err("member without a stored port must be rejected");
+        assert!(matches!(
+            missing,
+            ExternalServiceError::ParameterValidationFailed { service_id: 52, .. }
+        ));
+
+        member.port = Some(70_000);
+        let invalid = manager
+            .stored_member_endpoint(52, &member)
+            .await
+            .expect_err("member with an invalid TCP port must be rejected");
+        assert!(matches!(
+            invalid,
+            ExternalServiceError::ParameterValidationFailed { service_id: 52, .. }
+        ));
+
+        member.port = Some(0);
+        let zero = manager
+            .stored_member_endpoint(52, &member)
+            .await
+            .expect_err("TCP port zero must be rejected");
+        assert!(matches!(
+            zero,
+            ExternalServiceError::ParameterValidationFailed { service_id: 52, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn stored_member_endpoint_reports_missing_node_with_context() {
+        let manager = mock_service_manager_with_db(Arc::new(
+            sea_orm::MockDatabase::new(sea_orm::DatabaseBackend::Postgres)
+                .append_query_results([Vec::<nodes::Model>::new()])
+                .into_connection(),
+        ));
+        let mut member = service_member_info(1, "cluster-node-1", "node", "running");
+        member.node_id = Some(404);
+
+        let error = manager
+            .stored_member_endpoint(63, &member)
+            .await
+            .expect_err("missing persisted node must be reported");
+        assert!(matches!(
+            error,
+            ExternalServiceError::InternalError { ref reason }
+                if reason.contains("cluster-node-1")
+                    && reason.contains("service 63")
+                    && reason.contains("node 404")
+        ));
+    }
+
+    #[tokio::test]
+    async fn stored_member_endpoint_preserves_database_failure_context() {
+        let manager = mock_service_manager_with_db(Arc::new(
+            sea_orm::MockDatabase::new(sea_orm::DatabaseBackend::Postgres)
+                .append_query_errors([sea_orm::DbErr::Custom("connection lost".to_owned())])
+                .into_connection(),
+        ));
+        let mut member = service_member_info(1, "cluster-node-1", "node", "running");
+        member.node_id = Some(17);
+
+        let error = manager
+            .stored_member_endpoint(74, &member)
+            .await
+            .expect_err("database failure must retain endpoint lookup context");
+        assert!(matches!(
+            error,
+            ExternalServiceError::DatabaseError { ref reason }
+                if reason.contains("node 17")
+                    && reason.contains("cluster-node-1")
+                    && reason.contains("service 74")
+                    && reason.contains("connection lost")
+        ));
+    }
+
     /// The total-outage case, and the reason `health` is read at all: when
     /// every node dies at once the monitor has nothing to promote, so it never
     /// demotes anyone and `reportedstate` still says primary/secondary. Judging
@@ -11976,11 +12115,14 @@ mod tests {
     fn mock_service_manager(
         query_results: Vec<Vec<external_services::Model>>,
     ) -> ExternalServiceManager {
-        let db = Arc::new(
+        mock_service_manager_with_db(Arc::new(
             sea_orm::MockDatabase::new(sea_orm::DatabaseBackend::Postgres)
                 .append_query_results(query_results)
                 .into_connection(),
-        );
+        ))
+    }
+
+    fn mock_service_manager_with_db(db: Arc<DatabaseConnection>) -> ExternalServiceManager {
         ExternalServiceManager::new(
             db.clone(),
             Arc::new(EncryptionService::new_from_password(

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -423,6 +423,27 @@ impl ServiceMemberInfo {
     }
 }
 
+/// Match monitor-reported primary identity to exactly one persisted member.
+///
+/// The monitor is authoritative for transient role state, but it is not an
+/// authority for credential destinations. Duplicate, missing, stopped, or
+/// non-data matches fail closed by returning `None`.
+fn trusted_primary_member<'a>(
+    members: &'a [ServiceMemberInfo],
+    monitor_nodename: &str,
+) -> Option<&'a ServiceMemberInfo> {
+    let mut matches = members.iter().filter(|member| {
+        member.is_data_member()
+            && member.status == "running"
+            && member.container_name == monitor_nodename
+    });
+    let member = matches.next()?;
+    if matches.next().is_some() {
+        return None;
+    }
+    Some(member)
+}
+
 /// Parse a raw role string (TEXT column / spec) into the typed enum.
 /// Returns `None` for unknown values; callers should use the
 /// classification helpers below for `is_monitor()` / `is_data_member()`
@@ -2574,6 +2595,58 @@ impl ExternalServiceManager {
             .collect())
     }
 
+    /// Resolve a persisted cluster member to the control plane endpoint that
+    /// was authorized during provisioning.
+    ///
+    /// Monitor rows are deliberately not accepted here. The monitor is queried
+    /// over trust-authenticated, self-signed TLS and can report arbitrary
+    /// `nodehost`/`nodeport` values if that channel is forged. Those values are
+    /// health data, not authorization to send the cluster password somewhere.
+    async fn stored_member_endpoint(
+        &self,
+        service_id: i32,
+        member: &ServiceMemberInfo,
+    ) -> Result<(String, u16), ExternalServiceError> {
+        let raw_port =
+            member
+                .port
+                .ok_or_else(|| ExternalServiceError::ParameterValidationFailed {
+                    service_id,
+                    reason: format!(
+                        "Persisted cluster member '{}' has no authorized TCP port",
+                        member.container_name
+                    ),
+                })?;
+        let port = u16::try_from(raw_port).map_err(|_| {
+            ExternalServiceError::ParameterValidationFailed {
+                service_id,
+                reason: format!(
+                    "Persisted port {} for cluster member '{}' is outside the valid TCP range",
+                    raw_port, member.container_name
+                ),
+            }
+        })?;
+
+        let host = if let Some(node_id) = member.node_id {
+            let node = nodes::Entity::find_by_id(node_id)
+                .one(self.db.as_ref())
+                .await?
+                .ok_or_else(|| ExternalServiceError::InternalError {
+                    reason: format!(
+                        "Cannot resolve cluster member '{}' for service {}: node {} was not found",
+                        member.container_name, service_id, node_id
+                    ),
+                })?;
+            node.private_address
+        } else {
+            // Local members publish their container port on the control-plane
+            // host; Docker-internal names and addresses are not host-routable.
+            "localhost".to_string()
+        };
+
+        Ok((host, port))
+    }
+
     /// Find the live primary among a cluster's members by asking the
     /// monitor for the current FSM state.
     ///
@@ -2771,11 +2844,11 @@ impl ExternalServiceManager {
         };
         let monitor_port = monitor.port.unwrap_or(5432);
 
-        // pg_auto_failover requires SSL for the autoctl_node user (the
-        // hba rule is `hostssl ... trust`). We use PostgresSource which
-        // tries TLS-with-self-signed-accept first, then falls back to
-        // plain. Empty password is correct: autoctl_node is trust-auth'd
-        // from 0.0.0.0/0 once SSL is established.
+        // SECURITY: this probe carries no password, and `sslmode=require`
+        // prevents tokio-postgres from silently accepting a cleartext socket.
+        // pg_auto_failover trust-authenticates `autoctl_node` only after SSL is
+        // established, so accepting the monitor's self-signed certificate does
+        // not expose a reusable credential.
         let conn_str = format!(
             "host={monitor_host} port={monitor_port} user=autoctl_node \
              dbname=pg_auto_failover sslmode=require connect_timeout=3"
@@ -2879,8 +2952,8 @@ impl ExternalServiceManager {
     /// 1. `pgautofailover.node` from the monitor (TLS, autoctl_node) —
     ///    authoritative for `reportedstate` / `candidatepriority` /
     ///    `replicationquorum`.
-    /// 2. `pg_stat_replication` from the current primary (TLS,
-    ///    autoctl_node) — gives `sync_state` and `replay_lag` per
+    /// 2. `pg_stat_replication` from the current primary (credential-safe TLS
+    ///    ladder, application user) — gives `sync_state` and `replay_lag` per
     ///    streaming replica, joined to step 1 by `application_name = nodename`.
     ///
     /// Best-effort on (2): if the primary is briefly unreachable mid-failover,
@@ -2945,6 +3018,9 @@ impl ExternalServiceManager {
         };
         let monitor_port = monitor.port.unwrap_or(5432);
 
+        // SECURITY: this monitor probe carries no password. Keep
+        // `sslmode=require`: the self-signed connector may skip certificate
+        // authentication, but it must never downgrade this socket to cleartext.
         let monitor_conn_str = format!(
             "host={monitor_host} port={monitor_port} user=autoctl_node \
              dbname=pg_auto_failover sslmode=require connect_timeout=3"
@@ -3028,7 +3104,7 @@ impl ExternalServiceManager {
         // sync_state / replay_lag_ms in the next step from the primary.
         let mut by_name: std::collections::HashMap<String, ClusterMemberHealth> =
             std::collections::HashMap::new();
-        let mut primary_endpoint: Option<(String, i32)> = None;
+        let mut primary_member_name: Option<String> = None;
         for row in &nodes_rows {
             let nodename: String = row.get(0);
             let nodehost: String = row.get(1);
@@ -3049,7 +3125,7 @@ impl ExternalServiceManager {
                 && health == 1
                 && seconds_since_report < 30
             {
-                primary_endpoint = Some((nodehost.clone(), nodeport));
+                primary_member_name = Some(nodename.clone());
             }
 
             by_name.insert(
@@ -3082,7 +3158,20 @@ impl ExternalServiceManager {
         // `pgautofailover_standby_<nodeid>`, which doesn't match our
         // friendly `node-1`/`node-2` names. `client_addr` matches
         // `pgautofailover.node.nodehost`, which we already have.
-        if let Some((primary_host, primary_port)) = primary_endpoint {
+        // SECURITY: the monitor decides which persisted member is primary, but
+        // never where credentials are sent. Resolve the selected nodename back
+        // to the member row and its provisioned node address/port. A forged
+        // monitor can therefore lie about state, but cannot redirect the
+        // application password to its own `nodehost`/`nodeport`.
+        let trusted_primary_endpoint = match primary_member_name
+            .as_deref()
+            .and_then(|name| trusted_primary_member(&members, name))
+        {
+            Some(member) => self.stored_member_endpoint(service.id, member).await.ok(),
+            None => None,
+        };
+
+        if let Some((primary_host, primary_port)) = trusted_primary_endpoint {
             let app_creds = self
                 .get_service_parameters(service.id)
                 .await
@@ -3107,13 +3196,15 @@ impl ExternalServiceManager {
                 });
 
             if let Some((user, password, database)) = app_creds {
-                let primary_conn_str = format!(
-                    "host={primary_host} port={primary_port} user={user} password={password} \
-                     dbname={database} sslmode=require connect_timeout=3"
-                );
                 if let Ok(Ok(primary_client)) = tokio::time::timeout(
                     PROBE_TIMEOUT,
-                    temps_query_postgres::connect_with_self_signed_tls(&primary_conn_str),
+                    temps_query_postgres::connect_with_private_tls_ladder(
+                        &primary_host,
+                        primary_port,
+                        &user,
+                        &password,
+                        &database,
+                    ),
                 )
                 .await
                 {
@@ -4149,29 +4240,9 @@ echo "[restore] Pre-seed complete"
         });
 
         if let Some(primary) = primary {
-            let port = primary.port.unwrap_or(5432) as u16;
-
-            // For local members (no node_id), the hostname is a Docker-internal IP
-            // (e.g. 192.168.1.x) which is unreachable from the host. Since the
-            // container port is mapped to the same host port, use localhost instead.
-            // For remote members, use the node's private address.
-            let host = if let Some(node_id) = primary.node_id {
-                // Remote node — resolve via node's private address
-                let node = nodes::Entity::find_by_id(node_id)
-                    .one(self.db.as_ref())
-                    .await?;
-                node.map(|n| n.private_address).unwrap_or_else(|| {
-                    primary
-                        .hostname
-                        .clone()
-                        .unwrap_or_else(|| primary.container_name.clone())
-                })
-            } else {
-                // Local node — use localhost since Docker maps host_port:container_port
-                "localhost".to_string()
-            };
-
-            Ok(Some((host, port)))
+            self.stored_member_endpoint(service_id, primary)
+                .await
+                .map(Some)
         } else {
             Err(ExternalServiceError::InternalError {
                 reason: format!(
@@ -4252,44 +4323,28 @@ echo "[restore] Pre-seed complete"
             }
         };
 
-        // Dial the primary using the same connection helper as Browse
-        // Data so TLS/plain fallback + chained-error reporting are
-        // shared.
-        let conn_str = format!(
-            "host={} port={} user={} password={} dbname={}",
-            host,
+        // SECURITY: use typed config setters so none of these values can inject
+        // libpq connection-string parameters. The shared ladder resolves the
+        // host once, pins the approved addresses, requires TLS on both TLS
+        // rungs, and permits an unverified certificate or cleartext only for
+        // those exact private addresses.
+        let client = temps_query_postgres::connect_with_private_tls_ladder(
+            &host,
             port,
             admin_user,
             admin_password,
-            // Connect to the cluster's bootstrap DB ("postgres" by
-            // default) to issue CREATE DATABASE — you can't create
-            // a DB while connected to it.
+            // Connect to the bootstrap DB to issue CREATE DATABASE; PostgreSQL
+            // cannot create the database currently in use.
             "postgres",
-        );
-
-        let client = match temps_query_postgres::connect_with_self_signed_tls(&conn_str).await {
-            Ok(c) => c,
-            Err(tls_err) => {
-                use tokio_postgres::NoTls;
-                tokio_postgres::connect(&conn_str, NoTls)
-                    .await
-                    .map(|(client, conn)| {
-                        tokio::spawn(async move {
-                            if let Err(e) = conn.await {
-                                warn!("Cluster admin connection error: {}", e);
-                            }
-                        });
-                        client
-                    })
-                    .map_err(|plain_err| ExternalServiceError::InternalError {
-                        reason: format!(
-                            "Failed to connect to cluster {} primary at {}:{} \
-                             (TLS error: {}, plain error: {})",
-                            service_id, host, port, tls_err, plain_err
-                        ),
-                    })?
-            }
-        };
+        )
+        .await
+        .map_err(|error| ExternalServiceError::InternalError {
+            reason: format!(
+                "Failed to connect to cluster {} primary at {}:{} while provisioning database \
+                 '{}': {}",
+                service_id, host, port, db_name, error
+            ),
+        })?;
 
         let exists: bool = client
             .query_one(
@@ -10236,6 +10291,51 @@ mod tests {
                 health: *h,
             })
             .collect()
+    }
+
+    fn service_member_info(id: i32, name: &str, role: &str, status: &str) -> ServiceMemberInfo {
+        ServiceMemberInfo {
+            id,
+            role: role.to_string(),
+            node_id: None,
+            container_name: name.to_string(),
+            hostname: Some(format!("{name}.cluster.temps.local")),
+            port: Some(5432),
+            status: status.to_string(),
+            ordinal: id,
+            compute_ip: Some(format!("172.20.0.{id}")),
+            provisioning_step: None,
+            provisioning_error: None,
+            live_state: None,
+        }
+    }
+
+    #[test]
+    fn monitor_primary_identity_cannot_authorize_an_unstored_endpoint() {
+        let members = vec![
+            service_member_info(1, "cluster-node-1", "node", "running"),
+            service_member_info(2, "cluster-node-2", "node", "running"),
+            service_member_info(3, "cluster-monitor", "monitor", "running"),
+        ];
+
+        let selected = trusted_primary_member(&members, "cluster-node-1")
+            .expect("a unique persisted running data member should be selected");
+        assert_eq!(selected.id, 1);
+
+        // A forged monitor row can supply any nodehost/nodeport, but only its
+        // nodename crosses this boundary. An identity not persisted for this
+        // service cannot become a credential destination.
+        assert!(trusted_primary_member(&members, "attacker.example").is_none());
+        assert!(trusted_primary_member(&members, "cluster-monitor").is_none());
+
+        let stopped = vec![service_member_info(4, "cluster-node-4", "node", "stopped")];
+        assert!(trusted_primary_member(&stopped, "cluster-node-4").is_none());
+
+        let duplicates = vec![
+            service_member_info(5, "cluster-node-5", "node", "running"),
+            service_member_info(6, "cluster-node-5", "node", "running"),
+        ];
+        assert!(trusted_primary_member(&duplicates, "cluster-node-5").is_none());
     }
 
     /// The total-outage case, and the reason `health` is read at all: when

--- a/crates/temps-query-postgres/src/lib.rs
+++ b/crates/temps-query-postgres/src/lib.rs
@@ -314,114 +314,11 @@ impl PostgresSource {
         // messages and to reject nonsense early.
         Self::validate_database_identifier(database)?;
 
-        // SECURITY: every TLS rung must carry `SslMode::Require`.
-        //
-        // tokio-postgres defaults to `SslMode::Prefer` (see `Config::default`),
-        // and under Prefer `connect_tls` returns `Ok(MaybeTlsStream::Raw)` — an
-        // ordinary cleartext socket — whenever the server answers anything but
-        // `S` to the SSLRequest. That made the previous version of this ladder
-        // inert: rung 1 "succeeded" over an unencrypted connection, logged
-        // "Connected to PostgreSQL with verified TLS", and rungs 2 and 3 never
-        // ran, so the `host_is_private` guard below was dead code. An on-path
-        // attacker forced it by answering `N` — an SSL-strip needing no
-        // certificate at all. Require makes a server that will not do TLS an
-        // error, which is what lets the explicit cleartext rung stay the only
-        // way to reach an unencrypted socket.
-        let tls_cfg = |ssl_mode| {
-            connect_config_with_ssl_mode(host, port, username, password, database, ssl_mode)
-        };
-        let cfg = tls_cfg(tokio_postgres::config::SslMode::Require);
-
         debug!(
             "Connecting to PostgreSQL: {}@{}:{}/{}",
             username, host, port, database
         );
-
-        // SECURITY: try genuine certificate verification first, and only give
-        // up one rung at a time.
-        //
-        // This used to go straight to `AcceptAllVerifier` and then, on any
-        // failure at all, silently to cleartext. Both steps sent this service's
-        // admin password to whoever answered: accept-all authenticates nothing,
-        // and the plaintext fallback put the password on the wire in the clear
-        // for any observer. Nothing in the UI showed which of the three had
-        // happened.
-        //
-        // Now: verified TLS → self-signed TLS → cleartext. The last TWO rungs
-        // are restricted to private hosts. Rung 2 needs the restriction as much
-        // as rung 3 does: an active attacker never presents a properly-issued
-        // certificate, they present a self-signed one, so an unrestricted
-        // accept-anything rung hands over the password on exactly the same
-        // terms as cleartext — it just requires an active rather than a passive
-        // attacker. Temps-managed clusters use self-signed certs and live on
-        // loopback or the mesh, so gating rung 2 on the same predicate keeps
-        // them working while closing the public-internet case. Each downgrade
-        // logs which rung landed and why.
-        let client = match connect_with_verified_tls(&cfg).await {
-            Ok(client) => {
-                debug!(host = %host, "Connected to PostgreSQL with verified TLS");
-                client
-            }
-            Err(verified_err) => {
-                // Both remaining rungs are restricted to private hosts, so the
-                // check happens once here rather than in each arm.
-                if !host_is_private(host).await {
-                    return Err(DataError::ConnectionFailed(format!(
-                        "PostgreSQL at '{host}' did not present a certificate that validates \
-                         against the system roots, and the host does not resolve to a private \
-                         network. Refusing to fall back to an unverified certificate or to \
-                         cleartext, because either would hand this service's password to whoever \
-                         answered. Install a valid certificate, or reach the database over a \
-                         private address or the Temps mesh. (error: {})",
-                        format_chain(&verified_err),
-                    )));
-                }
-
-                match Self::connect_with_tls(&cfg).await {
-                    Ok(client) => {
-                        warn!(
-                            host = %host,
-                            "PostgreSQL certificate did not validate against the system roots ({}); \
-                             connected with an unverified (self-signed) certificate. Traffic is \
-                             encrypted but the server is NOT authenticated. Permitted only because \
-                             the host is loopback or private.",
-                            format_chain(&verified_err)
-                        );
-                        client
-                    }
-                    Err(tls_err) => {
-                        // Cleartext carries the password in the clear. Reached only
-                        // for a private host (checked above), and only with an
-                        // explicitly non-Require config so the downgrade is a
-                        // deliberate step rather than something `Prefer` did for us.
-                        warn!(
-                            host = %host,
-                            "PostgreSQL refused TLS ({}); falling back to an UNENCRYPTED connection. \
-                             Permitted only because the host is loopback or private.",
-                            format_chain(&tls_err)
-                        );
-
-                        let cfg = tls_cfg(tokio_postgres::config::SslMode::Disable);
-
-                        let (client, connection) = cfg.connect(NoTls).await.map_err(|e| {
-                            DataError::ConnectionFailed(format!(
-                                "PostgreSQL connection failed (TLS error: {}, plain error: {})",
-                                format_chain(&tls_err),
-                                format_chain(&e),
-                            ))
-                        })?;
-
-                        tokio::spawn(async move {
-                            if let Err(e) = connection.await {
-                                error!("PostgreSQL connection error: {}", e);
-                            }
-                        });
-
-                        client
-                    }
-                }
-            }
-        };
+        let client = connect_with_tls_ladder(host, port, username, password, database).await?;
 
         debug!(
             "Successfully connected to PostgreSQL database: {}",
@@ -443,14 +340,6 @@ impl PostgresSource {
             .await
             .map_err(|e| DataError::QueryFailed(format!("Execute failed: {}", e)))?;
         Ok(())
-    }
-
-    /// Attempt a TLS connection using rustls configured to accept self-signed certificates.
-    /// Returns the Client after spawning the connection task.
-    async fn connect_with_tls(
-        config: &tokio_postgres::Config,
-    ) -> std::result::Result<Client, tokio_postgres::Error> {
-        connect_with_self_signed_tls_config(config).await
     }
 }
 
@@ -564,26 +453,84 @@ pub fn reject_subqueries_and_function_calls(without_strings: &str) -> Result<()>
     Ok(())
 }
 
-/// Whether `token` appears in `sql` as a whole SQL token.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ResolvedHost {
+    UnixSocket(String),
+    Tcp {
+        hostname: String,
+        addresses: Vec<std::net::IpAddr>,
+    },
+}
+
+impl ResolvedHost {
+    fn permits_unverified_transport(&self) -> bool {
+        match self {
+            Self::UnixSocket(_) => true,
+            Self::Tcp { addresses, .. } => {
+                !addresses.is_empty() && addresses.iter().all(|address| ip_is_private(*address))
+            }
+        }
+    }
+}
+
+/// Resolve a PostgreSQL host exactly once for the whole TLS ladder.
 ///
-/// Shared by the PostgreSQL and MariaDB denylists, which previously used a raw
-/// `contains(" keyword ")`. Substring matching produced false *rejections* on
-/// ordinary columns — `payload = 'x'` matched `"load "`, `charset = 'utf8'`
-/// matched `"set "`, and any Postgres column literally named `commit`, `update`
-/// or `copy` was unfilterable. That is not a cosmetic problem: a validator that
-/// blocks legitimate queries is a validator someone eventually switches off.
+/// The resulting addresses are installed in `Config::hostaddr`, so
+/// tokio-postgres dials the addresses approved here instead of resolving the
+/// hostname again after the private-network decision. The original hostname
+/// remains in `Config::host` for certificate/SNI verification.
+async fn resolve_host_once(host: &str, port: u16) -> Result<ResolvedHost> {
+    let host = host.trim();
+    if host.is_empty() {
+        return Err(DataError::ConnectionFailed(
+            "PostgreSQL host cannot be empty".to_string(),
+        ));
+    }
+
+    if host.starts_with('/') {
+        return Ok(ResolvedHost::UnixSocket(host.to_string()));
+    }
+
+    let hostname = host
+        .strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(host)
+        .to_string();
+    let resolved = tokio::net::lookup_host((hostname.as_str(), port))
+        .await
+        .map_err(|error| {
+            DataError::ConnectionFailed(format!(
+                "Failed to resolve PostgreSQL host '{hostname}' on port {port}: {error}"
+            ))
+        })?;
+
+    let mut addresses = Vec::new();
+    for address in resolved {
+        if !addresses.contains(&address.ip()) {
+            addresses.push(address.ip());
+        }
+    }
+    if addresses.is_empty() {
+        return Err(DataError::ConnectionFailed(format!(
+            "PostgreSQL host '{hostname}' resolved to no addresses"
+        )));
+    }
+
+    Ok(ResolvedHost::Tcp {
+        hostname,
+        addresses,
+    })
+}
+
+/// Build the connection config for a resolved host and a given SSL mode.
 ///
-/// Expects already-lowercased, whitespace-normalised, string-stripped input.
-/// A token boundary is anything that cannot continue an identifier, matching
-/// the rule `starts_with_sql_keyword` uses at the other end.
-/// Build the connection config for a given SSL mode.
-///
-/// Named rather than inlined so the TLS regression test can assert against the
-/// *production* config instead of a hand-rolled copy — the first version of
-/// that test built its own and therefore could not observe `.ssl_mode(...)`
-/// being removed from the real path.
+/// Each original hostname is paired with one pre-resolved `hostaddr`. This
+/// preserves hostname-based certificate verification while preventing a
+/// second DNS lookup from changing the address between authorization and use.
+/// Named rather than inlined so security regression tests assert against the
+/// production config instead of a hand-rolled copy.
 fn connect_config_with_ssl_mode(
-    host: &str,
+    resolved_host: &ResolvedHost,
     port: u16,
     username: &str,
     password: &str,
@@ -591,8 +538,20 @@ fn connect_config_with_ssl_mode(
     ssl_mode: tokio_postgres::config::SslMode,
 ) -> tokio_postgres::Config {
     let mut cfg = tokio_postgres::Config::new();
-    cfg.host(host)
-        .port(port)
+    match resolved_host {
+        ResolvedHost::UnixSocket(path) => {
+            cfg.host(path);
+        }
+        ResolvedHost::Tcp {
+            hostname,
+            addresses,
+        } => {
+            for address in addresses {
+                cfg.host(hostname).hostaddr(*address);
+            }
+        }
+    }
+    cfg.port(port)
         .user(username)
         .password(password)
         .dbname(database)
@@ -605,14 +564,14 @@ fn connect_config_with_ssl_mode(
 /// against a different SSL mode than production uses.
 #[cfg(test)]
 fn connect_config_for(
-    host: &str,
+    resolved_host: &ResolvedHost,
     port: u16,
     username: &str,
     password: &str,
     database: &str,
 ) -> tokio_postgres::Config {
     connect_config_with_ssl_mode(
-        host,
+        resolved_host,
         port,
         username,
         password,
@@ -621,6 +580,161 @@ fn connect_config_for(
     )
 }
 
+/// Connect with the credential-safe PostgreSQL transport ladder.
+///
+/// The hostname is resolved once, then the exact approved addresses are used
+/// for every rung: verified TLS, self-signed TLS, and (for private addresses
+/// only) cleartext. This prevents DNS rebinding between the private-network
+/// check and the credential-bearing connection.
+pub async fn connect_with_tls_ladder(
+    host: &str,
+    port: u16,
+    username: &str,
+    password: &str,
+    database: &str,
+) -> Result<Client> {
+    connect_with_tls_ladder_policy(
+        host,
+        port,
+        username,
+        password,
+        database,
+        TransportPolicy::VerifiedPublicAllowed,
+    )
+    .await
+}
+
+/// Connect to a managed PostgreSQL endpoint that must remain private even when
+/// it presents a publicly trusted certificate.
+///
+/// Managed cluster credentials never need to leave the operator's own host or
+/// mesh. Rejecting public addresses before the first TLS rung prevents stored
+/// topology mistakes or forged control-plane data from turning verified TLS
+/// into authorization to release those credentials.
+pub async fn connect_with_private_tls_ladder(
+    host: &str,
+    port: u16,
+    username: &str,
+    password: &str,
+    database: &str,
+) -> Result<Client> {
+    connect_with_tls_ladder_policy(
+        host,
+        port,
+        username,
+        password,
+        database,
+        TransportPolicy::PrivateOnly,
+    )
+    .await
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum TransportPolicy {
+    VerifiedPublicAllowed,
+    PrivateOnly,
+}
+
+async fn connect_with_tls_ladder_policy(
+    host: &str,
+    port: u16,
+    username: &str,
+    password: &str,
+    database: &str,
+    policy: TransportPolicy,
+) -> Result<Client> {
+    let resolved_host = resolve_host_once(host, port).await?;
+    if policy == TransportPolicy::PrivateOnly && !resolved_host.permits_unverified_transport() {
+        return Err(DataError::ConnectionFailed(format!(
+            "Managed PostgreSQL endpoint '{host}' resolved outside the private network; refusing \
+             to send cluster credentials even over verified TLS"
+        )));
+    }
+    let config = |ssl_mode| {
+        connect_config_with_ssl_mode(&resolved_host, port, username, password, database, ssl_mode)
+    };
+
+    // SECURITY: every TLS rung must carry `SslMode::Require`.
+    // tokio-postgres defaults to `Prefer`, which silently accepts a raw socket
+    // when a server refuses TLS and would bypass the explicit downgrade gate.
+    let tls_config = config(tokio_postgres::config::SslMode::Require);
+
+    match connect_with_verified_tls(&tls_config).await {
+        Ok(client) => {
+            debug!(host = %host, "Connected to PostgreSQL with verified TLS");
+            Ok(client)
+        }
+        Err(verified_error) => {
+            // Both weaker rungs are restricted to the exact addresses resolved
+            // above. The driver receives those same addresses through
+            // `hostaddr`, so DNS cannot change the destination after this gate.
+            if !resolved_host.permits_unverified_transport() {
+                return Err(DataError::ConnectionFailed(format!(
+                    "PostgreSQL at '{host}' did not present a certificate that validates \
+                     against the system roots, and at least one resolved address is outside \
+                     the private network. Refusing to fall back to an unverified certificate \
+                     or to cleartext, because either would hand this service's password to \
+                     whoever answered. Install a valid certificate, or reach the database over \
+                     a private address or the Temps mesh. (error: {})",
+                    format_chain(&verified_error),
+                )));
+            }
+
+            match connect_with_self_signed_tls_config(&tls_config).await {
+                Ok(client) => {
+                    warn!(
+                        host = %host,
+                        "PostgreSQL certificate did not validate against the system roots ({}); \
+                         connected with an unverified (self-signed) certificate. Traffic is \
+                         encrypted but the server is NOT authenticated. Permitted only because \
+                         every resolved address is loopback or private.",
+                        format_chain(&verified_error)
+                    );
+                    Ok(client)
+                }
+                Err(tls_error) => {
+                    warn!(
+                        host = %host,
+                        "PostgreSQL refused TLS ({}); falling back to an UNENCRYPTED connection. \
+                         Permitted only because every resolved address is loopback or private.",
+                        format_chain(&tls_error)
+                    );
+
+                    let plain_config = config(tokio_postgres::config::SslMode::Disable);
+                    let (client, connection) =
+                        plain_config.connect(NoTls).await.map_err(|error| {
+                            DataError::ConnectionFailed(format!(
+                                "PostgreSQL connection to '{host}:{port}/{database}' failed \
+                             (TLS error: {}, plain error: {})",
+                                format_chain(&tls_error),
+                                format_chain(&error),
+                            ))
+                        })?;
+
+                    tokio::spawn(async move {
+                        if let Err(error) = connection.await {
+                            error!("PostgreSQL connection error: {}", error);
+                        }
+                    });
+                    Ok(client)
+                }
+            }
+        }
+    }
+}
+
+/// Whether `token` appears in `sql` as a whole SQL token.
+///
+/// Shared by the PostgreSQL and MariaDB denylists, which previously used a raw
+/// `contains(" keyword ")`. Substring matching produced false *rejections* on
+/// ordinary columns — `payload = 'x'` matched `"load "`, `charset = 'utf8'`
+/// matched `"set "`, and any Postgres column literally named `commit`, `update`
+/// or `copy` was unfilterable. That is not a cosmetic problem: a validator that
+/// blocks legitimate queries is a validator someone eventually switches off.
+///
+/// Expects already-lowercased, whitespace-normalised, string-stripped input.
+/// A token boundary is anything that cannot continue an identifier, matching
+/// the rule `starts_with_sql_keyword` uses at the other end.
 pub fn contains_sql_token(sql: &str, token: &str) -> bool {
     let is_ident_char =
         |c: char| c.is_ascii_alphanumeric() || c == '_' || c == '$' || !c.is_ascii();
@@ -701,63 +815,9 @@ pub async fn connect_with_self_signed_tls(
 /// Preferred whenever any component of the connection is caller-supplied: a
 /// `Config` carries values, so nothing in it can be mistaken for connection
 /// syntax the way an interpolated keyword/value string can.
-/// Whether cleartext to this host stays inside the operator's own machine or
-/// private network.
-///
-/// Used to decide whether an unencrypted fallback is tolerable. A Temps-managed
-/// database is a container on the same host, or a peer on the WireGuard mesh —
-/// its traffic never touches a network the operator does not control, so
-/// cleartext there leaks nothing new. A public hostname is the opposite case:
-/// the password would cross the open internet in the clear.
-///
-/// SECURITY: this resolves the host and classifies the resulting addresses. It
-/// deliberately does NOT classify the hostname string.
-///
-/// Classifying the string was wrong in a way that inverted the guard. A host of
-/// `134744072` is not dotted-quad, so `IpAddr::parse` rejects it, and the old
-/// "no dot means it's a container name" rule then called it private — but
-/// `getaddrinfo`/`inet_aton` accepts the integer form and resolves it to
-/// `8.8.8.8`. Same for `0x08080808`. Someone with `ExternalServicesWrite` but
-/// no credential-reveal rights could set a service host to that, force TLS to
-/// fail, and collect the password at a listener they control. A bare
-/// single-label name is also not reliably private: it resolves through the
-/// resolver's DNS search domain, which need not be.
-///
-/// Every resolved address must be private — one public address in the set is
-/// enough to refuse, since we do not control which the driver picks. Resolution
-/// failure is also a refusal: this decides whether a password may cross the
-/// network in cleartext, so the unknown case has to fail closed.
-async fn host_is_private(host: &str) -> bool {
-    let host = host.trim().trim_start_matches('[').trim_end_matches(']');
-
-    if host.is_empty() {
-        return false;
-    }
-
-    // A unix socket path never touches a network.
-    if host.starts_with('/') {
-        return true;
-    }
-
-    // Port is irrelevant to the classification; `lookup_host` needs one.
-    let Ok(addrs) = tokio::net::lookup_host((host, 5432u16)).await else {
-        return false;
-    };
-
-    let mut saw_any = false;
-    for addr in addrs {
-        saw_any = true;
-        if !ip_is_private(addr.ip()) {
-            return false;
-        }
-    }
-
-    saw_any
-}
-
 /// Whether an address is one the operator's own machine or private network.
 ///
-/// Split out from [`host_is_private`] so the classification itself is
+/// Split out from [`ResolvedHost::permits_unverified_transport`] so the classification itself is
 /// synchronous and unit-testable without a resolver.
 fn ip_is_private(ip: std::net::IpAddr) -> bool {
     match ip {
@@ -2543,23 +2603,102 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn host_is_private_resolves_before_classifying() {
+    async fn resolved_host_classifies_the_addresses_that_will_be_dialed() {
         // Loopback and unix sockets stay private...
-        assert!(host_is_private("127.0.0.1").await);
-        assert!(host_is_private("localhost").await);
-        assert!(host_is_private("/var/run/postgresql").await);
+        for host in ["127.0.0.1", "localhost", "/var/run/postgresql"] {
+            assert!(
+                resolve_host_once(host, 5432)
+                    .await
+                    .expect("private test host should resolve")
+                    .permits_unverified_transport(),
+                "should permit private host: {host}"
+            );
+        }
 
         // ...and the numeric-IPv4 forms that defeated string classification are
         // now resolved and rejected. `134744072` == 0x08080808 == 8.8.8.8:
         // `IpAddr::parse` rejects it, so the old "no dot means container name"
         // rule called it private, while getaddrinfo resolves it publicly.
-        assert!(!host_is_private("134744072").await);
-        assert!(!host_is_private("0x08080808").await);
+        for host in ["134744072", "0x08080808"] {
+            assert!(
+                !resolve_host_once(host, 5432)
+                    .await
+                    .expect("numeric public host should resolve")
+                    .permits_unverified_transport(),
+                "should reject public host: {host}"
+            );
+        }
 
         // Unresolvable is a refusal, not a pass: this decides whether a
         // password may cross the network in cleartext.
-        assert!(!host_is_private("no-such-host.invalid").await);
-        assert!(!host_is_private("").await);
+        assert!(resolve_host_once("no-such-host.invalid", 5432)
+            .await
+            .is_err());
+        assert!(resolve_host_once("", 5432).await.is_err());
+    }
+
+    #[test]
+    fn connection_config_pins_every_preapproved_address() {
+        let addresses = vec![
+            "10.0.0.8".parse().expect("test IPv4 address should parse"),
+            "fd00::8".parse().expect("test IPv6 address should parse"),
+        ];
+        let resolved = ResolvedHost::Tcp {
+            hostname: "database.internal".to_string(),
+            addresses: addresses.clone(),
+        };
+
+        let config = connect_config_for(&resolved, 6432, "admin", "secret", "postgres");
+
+        assert_eq!(config.get_hostaddrs(), addresses.as_slice());
+        assert_eq!(config.get_hosts().len(), addresses.len());
+        assert!(config.get_hosts().iter().all(|host| {
+            matches!(host, tokio_postgres::config::Host::Tcp(name) if name == "database.internal")
+        }));
+        assert_eq!(config.get_ports(), &[6432]);
+    }
+
+    #[test]
+    fn connection_config_treats_credentials_as_values_and_requires_tls() {
+        let resolved = ResolvedHost::Tcp {
+            hostname: "database.internal".to_string(),
+            addresses: vec!["10.0.0.8".parse().expect("test IPv4 address should parse")],
+        };
+        let username = "admin host=attacker.example sslmode=disable";
+        let password = "secret dbname=postgres host=attacker.example";
+        let database = "postgres sslmode=disable";
+
+        let config = connect_config_for(&resolved, 5432, username, password, database);
+
+        assert_eq!(config.get_user(), Some(username));
+        assert_eq!(config.get_password(), Some(password.as_bytes()));
+        assert_eq!(config.get_dbname(), Some(database));
+        assert_eq!(
+            config.get_ssl_mode(),
+            tokio_postgres::config::SslMode::Require
+        );
+        assert_eq!(config.get_hosts().len(), 1);
+        assert_eq!(config.get_hostaddrs().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn private_ladder_rejects_a_public_address_before_connecting() {
+        let error = connect_with_private_tls_ladder(
+            "203.0.113.10",
+            5432,
+            "cluster-admin",
+            "secret",
+            "postgres",
+        )
+        .await
+        .expect_err("a managed-cluster credential must never be sent to a public address");
+
+        assert!(
+            error
+                .to_string()
+                .contains("refusing to send cluster credentials even over verified TLS"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]
@@ -3043,7 +3182,10 @@ mod tests {
         // production path left the test still passing, since it was asserting
         // against its own copy. A regression test that cannot observe the
         // regression is worse than none: it reports safety it never checked.
-        let cfg = connect_config_for(&host, port, "postgres", "", "postgres");
+        let resolved_host = resolve_host_once(&host, port)
+            .await
+            .expect("started PostgreSQL container host should resolve");
+        let cfg = connect_config_for(&resolved_host, port, "postgres", "", "postgres");
 
         // Retry while the server finishes coming up, so a slow start is not
         // mistaken for the TLS refusal we are actually asserting.

--- a/crates/temps-query-postgres/src/lib.rs
+++ b/crates/temps-query-postgres/src/lib.rs
@@ -293,6 +293,29 @@ impl PostgresSource {
         password: &str,
         database: &str,
     ) -> Result<Self> {
+        Self::connect_with_policy(host, port, username, password, database, false).await
+    }
+
+    /// Create a PostgreSQL data source for a managed endpoint that must remain
+    /// on the operator's private network.
+    pub async fn connect_private(
+        host: &str,
+        port: u16,
+        username: &str,
+        password: &str,
+        database: &str,
+    ) -> Result<Self> {
+        Self::connect_with_policy(host, port, username, password, database, true).await
+    }
+
+    async fn connect_with_policy(
+        host: &str,
+        port: u16,
+        username: &str,
+        password: &str,
+        database: &str,
+        private_only: bool,
+    ) -> Result<Self> {
         // SECURITY: build the config with typed setters, never `format!`.
         //
         // This used to interpolate into a libpq keyword/value string:
@@ -318,7 +341,11 @@ impl PostgresSource {
             "Connecting to PostgreSQL: {}@{}:{}/{}",
             username, host, port, database
         );
-        let client = connect_with_tls_ladder(host, port, username, password, database).await?;
+        let client = if private_only {
+            connect_with_private_tls_ladder(host, port, username, password, database).await?
+        } else {
+            connect_with_tls_ladder(host, port, username, password, database).await?
+        };
 
         debug!(
             "Successfully connected to PostgreSQL database: {}",


### PR DESCRIPTION
## Summary

- resolve PostgreSQL hosts once and pin every approved address with `hostaddr` across the TLS ladder while preserving the original hostname for certificate verification and SNI
- replace interpolated cluster-admin connection strings and the ungated `NoTls` fallback with typed configuration and a private-only credential transport policy
- apply that private-only policy to query-service admin provisioning, explorer fallback, and `pg_stat_statements`; each operation stays on its single policy-selected pinned client
- treat monitor rows as state only: a primary nodename must uniquely match a persisted running data member, and credential destinations come exclusively from persisted member/node topology
- preserve service/member/node context on persisted endpoint lookup failures and reject missing, zero, or out-of-range ports

## Security properties

- DNS rebinding cannot change the destination between private-address authorization and connection
- both TLS rungs use `SslMode::Require`; only the explicit pinned private rung can use cleartext
- managed-cluster credentials are rejected for public addresses before verified TLS is attempted
- monitor-supplied `nodehost` and `nodeport` never authorize a credential destination
- username, password, database, and host are values in typed `tokio_postgres::Config`, not connection-string syntax
- query exploration and statistics do not bypass the managed-cluster policy through secondary connections

Independent `security-auditor` final review: **APPROVED**, with no blocking, major, or minor findings.

## Evidence

**DNS authorization and dialing use the same pinned addresses**

```bash
cargo test -p temps-query-postgres connection_config_pins_every_preapproved_address -- --nocapture
```

```text
cargo test: 1 passed, 71 filtered out (1 suite, 0.00s)
```

**Connection-string injection text remains credential data and TLS stays required**

```bash
cargo test -p temps-query-postgres connection_config_treats_credentials_as_values_and_requires_tls -- --nocapture
```

```text
cargo test: 1 passed, 71 filtered out (1 suite, 0.00s)
```

**Managed-cluster policy selection and public-address refusal cover query and statistics consumers**

```bash
cargo test --lib -p temps-providers connection_target_selects_policy_from_cluster_primary
cargo test --lib -p temps-providers managed_private_rejects_public_credentials
```

```text
cargo test: 2 passed, 460 filtered out (1 suite, 0.00s)
cargo test: 2 passed, 460 filtered out (1 suite, 0.00s)
```

**The production pinned client lists and resets real `pg_stat_statements` data**

```bash
cargo test --lib -p temps-providers production_client_lists_and_resets_pg_stat_statements -- --nocapture
```

```text
cargo test: 1 passed, 461 filtered out (1 suite, 1.54s)
```

The test starts PostgreSQL 18 with `pg_stat_statements`, verifies tagged statistics decode through the production client, invokes the production reset helper, and proves the tagged row is gone.

**Persisted member endpoints cover local/remote success and fail with contextual errors**

```bash
cargo test --lib -p temps-providers stored_member_endpoint -- --nocapture
```

```text
cargo test: 4 passed, 462 filtered out (1 suite, 0.01s)
```

**Crate suites**

```bash
cargo test --lib -p temps-query-postgres
cargo test --lib -p temps-providers
```

```text
cargo test: 72 passed (1 suite, 0.01s)
cargo test: 466 passed (1 suite, 4.92s)
```

**Build and lint gates**

```bash
cargo check --lib
cargo clippy --lib -p temps-query-postgres -p temps-providers -- -D warnings
cargo fmt --all -- --check
git diff --check
```

```text
cargo build: 0 errors
cargo clippy: 0 errors
formatting: clean
diff check: clean
```

Closes #560
Closes #561
