### PR TITLE
feat(otel): add OtelRelay extension point for telemetry forwarding plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11975,6 +11975,7 @@ name = "temps-otel"
 version = "0.1.0-beta.55"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "aws-config",
  "aws-sdk-s3",

--- a/crates/temps-otel/Cargo.toml
+++ b/crates/temps-otel/Cargo.toml
@@ -74,6 +74,9 @@ clickhouse = { version = "0.15", features = ["uuid", "chrono"] }
 tokio-util = { workspace = true }
 moka = { version = "0.12", features = ["future"] }
 
+# Write-once ArcSwap handle for the OtelRelay extension point.
+arc-swap = "1.7"
+
 [build-dependencies]
 prost-build = "0.13"
 

--- a/crates/temps-otel/src/handlers/ingest_handler.rs
+++ b/crates/temps-otel/src/handlers/ingest_handler.rs
@@ -526,6 +526,25 @@ async fn do_ingest_metrics(
     let points = decode::decode_metrics_request(&data, ctx.project_id, ctx.deployment_id)?;
     let count = points.len();
 
+    // Fire decoded batch at the relay extension point (non-blocking).
+    // `data.clone()` is O(1) — bytes::Bytes is ref-counted. The relay channel
+    // is bounded; try_send drops silently on full rather than blocking.
+    if let Some(tx) = &state.otel_relay_tx {
+        let msg = crate::relay::OtelRelayMessage {
+            project_id: ctx.project_id,
+            environment_id: ctx.environment_id,
+            deployment_id: ctx.deployment_id,
+            signal: crate::relay::OtelSignal::Metrics,
+            payload: data.clone(),
+        };
+        if tx.try_send(msg).is_err() {
+            tracing::warn!(
+                project_id = ctx.project_id,
+                "otel relay channel full; metrics batch dropped (backpressure)"
+            );
+        }
+    }
+
     for point in &points {
         debug!(
             project_id = ctx.project_id,
@@ -608,6 +627,23 @@ async fn do_ingest_traces(
     let data = decode::decompress(body, content_encoding(headers))?;
     let spans = decode::decode_traces_request(&data, ctx.project_id, ctx.deployment_id)?;
     let count = spans.len();
+
+    // Fire decoded batch at the relay extension point (non-blocking).
+    if let Some(tx) = &state.otel_relay_tx {
+        let msg = crate::relay::OtelRelayMessage {
+            project_id: ctx.project_id,
+            environment_id: ctx.environment_id,
+            deployment_id: ctx.deployment_id,
+            signal: crate::relay::OtelSignal::Traces,
+            payload: data.clone(),
+        };
+        if tx.try_send(msg).is_err() {
+            tracing::warn!(
+                project_id = ctx.project_id,
+                "otel relay channel full; traces batch dropped (backpressure)"
+            );
+        }
+    }
 
     // Log each span at debug level so operators can see what arrived
     for span in &spans {
@@ -699,6 +735,23 @@ async fn do_ingest_logs(
     let data = decode::decompress(body, content_encoding(headers))?;
     let records = decode::decode_logs_request(&data, ctx.project_id, ctx.deployment_id)?;
     let count = records.len();
+
+    // Fire decoded batch at the relay extension point (non-blocking).
+    if let Some(tx) = &state.otel_relay_tx {
+        let msg = crate::relay::OtelRelayMessage {
+            project_id: ctx.project_id,
+            environment_id: ctx.environment_id,
+            deployment_id: ctx.deployment_id,
+            signal: crate::relay::OtelSignal::Logs,
+            payload: data.clone(),
+        };
+        if tx.try_send(msg).is_err() {
+            tracing::warn!(
+                project_id = ctx.project_id,
+                "otel relay channel full; logs batch dropped (backpressure)"
+            );
+        }
+    }
 
     for record in &records {
         debug!(
@@ -1499,6 +1552,68 @@ mod tests {
         };
         // The service_id is what gets written as source_id in service_metrics
         assert_eq!(auth.service_id, 42);
+    }
+
+    // ── Relay channel backpressure ──────────────────────────────────────
+    //
+    // Verifies that a full or closed relay channel does NOT propagate as an
+    // ingest error. The do_ingest_* handlers only call try_send and warn on
+    // Err — the OTLP HTTP response must still succeed.
+    //
+    // A full HTTP-level test would require constructing a real OtelAppState
+    // (which needs OtelService, storage backends, a live DB, etc.). Instead,
+    // this focused unit test exercises the exact try_send-then-discard pattern
+    // used in the handlers, confirming the Err is not propagated.
+
+    #[test]
+    fn relay_channel_full_try_send_returns_err_not_panic() {
+        use crate::relay::{OtelRelayMessage, OtelSignal};
+
+        // Capacity-1 channel: fill it with the first send.
+        let (tx, _rx) = tokio::sync::mpsc::channel::<OtelRelayMessage>(1);
+
+        let make_msg = |project_id: i32| OtelRelayMessage {
+            project_id,
+            environment_id: None,
+            deployment_id: None,
+            signal: OtelSignal::Metrics,
+            payload: bytes::Bytes::new(),
+        };
+
+        // Fill the channel (capacity = 1).
+        assert!(tx.try_send(make_msg(1)).is_ok(), "first send must succeed");
+
+        // Second send: channel is full. Must return Err, must not panic.
+        let result = tx.try_send(make_msg(2));
+        assert!(
+            result.is_err(),
+            "try_send on a full channel must return Err; handlers discard this error (warn-only)"
+        );
+        // Reaching here confirms no panic — the backpressure path is safe.
+    }
+
+    #[test]
+    fn relay_channel_closed_try_send_returns_err_not_panic() {
+        use crate::relay::{OtelRelayMessage, OtelSignal};
+
+        // Drop the receiver immediately — channel is closed.
+        let (tx, rx) = tokio::sync::mpsc::channel::<OtelRelayMessage>(10);
+        drop(rx);
+
+        let msg = OtelRelayMessage {
+            project_id: 1,
+            environment_id: None,
+            deployment_id: None,
+            signal: OtelSignal::Traces,
+            payload: bytes::Bytes::new(),
+        };
+
+        let result = tx.try_send(msg);
+        assert!(
+            result.is_err(),
+            "try_send on a closed channel must return Err; handlers discard this error (warn-only)"
+        );
+        // Reaching here confirms no panic — the closed-channel path is safe.
     }
 
     #[test]

--- a/crates/temps-otel/src/lib.rs
+++ b/crates/temps-otel/src/lib.rs
@@ -35,6 +35,7 @@ pub mod handlers;
 pub mod ingest;
 pub mod plugin;
 pub mod proto;
+pub mod relay;
 pub mod services;
 pub mod sidecar;
 pub mod storage;
@@ -99,6 +100,17 @@ pub struct OtelAppState {
     /// banner) and `GET /otel/global/traces/{trace_id}` (Phase 2 unified
     /// waterfall) query handlers.
     pub cross_project_service: std::sync::Arc<crate::services::CrossProjectTraceService>,
+    /// Bounded sender for fire-and-forget relay of decoded OTLP batches.
+    ///
+    /// After a successful decode in each `do_ingest_*` function, the handler
+    /// sends an [`crate::relay::OtelRelayMessage`] here via `try_send` (never
+    /// blocking). A dedicated background consumer calls
+    /// [`crate::relay::OtelRelaySlot::relay`], which dispatches to whichever
+    /// [`crate::relay::OtelRelay`] implementation was registered by a plugin
+    /// (defaulting to the no-op). When the channel is full the batch is
+    /// silently dropped and a warning is emitted — relay loss is non-fatal and
+    /// must never add latency to the OTLP HTTP response.
+    pub otel_relay_tx: Option<tokio::sync::mpsc::Sender<crate::relay::OtelRelayMessage>>,
     /// Optional checker for team-based project access (human sessions only).
     pub project_access_checker: Option<std::sync::Arc<dyn temps_core::ProjectAccessChecker>>,
 }

--- a/crates/temps-otel/src/plugin.rs
+++ b/crates/temps-otel/src/plugin.rs
@@ -20,6 +20,7 @@ use crate::handlers::metric_alert_handler;
 use crate::handlers::query_handler;
 use crate::ingest::auth::OtelAuthService;
 use crate::ingest::rate_limit::RateLimiter;
+use crate::relay::OtelRelay;
 use crate::services::cross_project::{prune_stale_hints, CrossProjectTraceService, TraceHintMsg};
 use crate::services::health_service::HealthComputeService;
 use crate::services::OtelService;
@@ -323,12 +324,21 @@ pub struct OtelPlugin {
     /// per-project retention) gets a chance to provide a resolver — same
     /// two-phase handoff `DeploymentsPlugin` uses for `DeploymentGate`.
     retention_resolver_slot: tokio::sync::OnceCell<Arc<temps_core::RetentionResolverSlot>>,
+    /// Handle to the `OtelRelaySlot` captured in `register_services` and
+    /// written into from `initialize_plugin_services` — same two-phase
+    /// handoff as `retention_resolver_slot`. The background relay consumer
+    /// (spawned in `register_services`) holds its own `Arc` clone and calls
+    /// `relay_slot.relay(msg)` for each batch received from `otel_relay_tx`.
+    /// When no plugin provides an `Arc<dyn OtelRelay>`, the slot stays loaded
+    /// with `NoopOtelRelay` and the relay loop is a cheap no-op.
+    relay_slot: tokio::sync::OnceCell<Arc<crate::relay::OtelRelaySlot>>,
 }
 
 impl OtelPlugin {
     pub fn new() -> Self {
         Self {
             retention_resolver_slot: tokio::sync::OnceCell::new(),
+            relay_slot: tokio::sync::OnceCell::new(),
         }
     }
 }
@@ -521,6 +531,22 @@ impl TempsPlugin for OtelPlugin {
             let (trace_hint_tx, mut trace_hint_rx) =
                 tokio::sync::mpsc::channel::<TraceHintMsg>(1000);
 
+            // ── OtelRelay extension point ────────────────────────────────────
+            //
+            // Slot defaults to NoopOtelRelay; a plugin (e.g. one implementing
+            // OTLP batch forwarding) is wired in later from
+            // `initialize_plugin_services` — see `relay_slot` field doc for
+            // why a direct `get_service` call here would never find it.
+            let relay_slot = Arc::new(crate::relay::OtelRelaySlot::new_default());
+            let _ = self.relay_slot.set(relay_slot.clone());
+
+            // Bounded channel (capacity 1 000 messages) for fire-and-forget
+            // relay of decoded OTLP batches. Ingest handlers call `try_send`
+            // (non-blocking); when the channel is full the batch is dropped
+            // and a warning is emitted — relay loss is non-fatal.
+            let (otel_relay_tx, mut otel_relay_rx) =
+                tokio::sync::mpsc::channel::<crate::relay::OtelRelayMessage>(1000);
+
             let cross_project_service =
                 Arc::new(CrossProjectTraceService::new(db.clone(), storage.clone()));
             context.register_service(cross_project_service.clone());
@@ -588,6 +614,7 @@ impl TempsPlugin for OtelPlugin {
                 audit_service: audit_service.clone(),
                 trace_hint_tx: Some(trace_hint_tx),
                 cross_project_service: cross_project_service.clone(),
+                otel_relay_tx: Some(otel_relay_tx),
                 project_access_checker: None,
             };
             context.register_service(Arc::new(app_state.clone()));
@@ -660,6 +687,23 @@ impl TempsPlugin for OtelPlugin {
                         }
                     }
                     info!("Cross-project trace hint writer consumer stopped (channel closed)");
+                });
+            }
+
+            // 1c-relay. Background consumer for the OtelRelay extension point.
+            //
+            // Drains `otel_relay_rx` and calls `relay_slot.relay(msg)` for
+            // each batch, dispatching to whichever `OtelRelay` implementation
+            // was registered by a plugin (NoopOtelRelay when none registered).
+            // Errors are not possible here (relay is infallible by contract).
+            // The task exits cleanly when all senders drop.
+            {
+                tokio::spawn(async move {
+                    info!("OTel relay consumer started");
+                    while let Some(msg) = otel_relay_rx.recv().await {
+                        relay_slot.relay(msg).await;
+                    }
+                    info!("OTel relay consumer stopped (channel closed)");
                 });
             }
 
@@ -760,6 +804,24 @@ impl TempsPlugin for OtelPlugin {
                     }
                 }
             }
+
+            // Wire in an optional OtelRelay implementation registered by a
+            // plugin. When no plugin registers one, the slot stays loaded with
+            // NoopOtelRelay and the relay background consumer is a cheap no-op.
+            if let Some(slot) = self.relay_slot.get() {
+                if let Some(relay) = context.get_service::<dyn crate::relay::OtelRelay>() {
+                    if slot.set(relay) {
+                        debug!("otel: OtelRelay wired in from a registered plugin");
+                    } else {
+                        tracing::warn!(
+                            "otel: OtelRelay slot was already claimed; \
+                             this plugin's relay was NOT installed. \
+                             Check plugin registration order."
+                        );
+                    }
+                }
+            }
+
             Ok(())
         })
     }

--- a/crates/temps-otel/src/relay.rs
+++ b/crates/temps-otel/src/relay.rs
@@ -1,0 +1,271 @@
+//! Extension point for observing or relaying decoded OTLP ingest batches.
+//!
+//! OSS registers [`NoopOtelRelay`] at startup, which discards every message.
+//! A plugin can supply an alternative implementation — e.g. one that enqueues
+//! decoded OTLP batches for delivery to an external OTLP-compatible collector —
+//! by registering an `Arc<dyn OtelRelay>` via the service registry before the
+//! OTel plugin wires up its background consumer in `initialize_plugin_services`.
+//!
+//! [`OtelRelaySlot`] exists because `register_services` runs in
+//! plugin-registration order: the relay background consumer is started (and
+//! captures its reference to the slot) before a later-registered plugin gets
+//! a chance to provide an implementation — same two-phase handoff that
+//! [`temps_core::RetentionResolverSlot`] and `DeploymentGate` use.
+
+use std::sync::Arc;
+
+/// Which OTLP signal type a relay batch belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OtelSignal {
+    /// OpenTelemetry Metrics (OTLP ExportMetricsServiceRequest).
+    Metrics,
+    /// OpenTelemetry Traces (OTLP ExportTraceServiceRequest).
+    Traces,
+    /// OpenTelemetry Logs (OTLP ExportLogsServiceRequest).
+    Logs,
+}
+
+/// A single decoded OTLP ingest batch delivered to an [`OtelRelay`].
+///
+/// `payload` holds the **decompressed** OTLP protobuf bytes exactly as they
+/// arrived after decompression, before any conversion to this crate's domain
+/// types. A relaying plugin can therefore re-POST the bytes verbatim to any
+/// OTLP/HTTP-compatible collector endpoint without lossy round-tripping through
+/// this crate's internal representation. The `bytes::Bytes` clone produced on
+/// the ingest path is O(1) — a refcount increment, not a data copy.
+pub struct OtelRelayMessage {
+    /// Project that owns this batch of telemetry.
+    pub project_id: i32,
+    /// Environment the telemetry was ingested for, when known.
+    pub environment_id: Option<i32>,
+    /// Deployment the telemetry was ingested for, when known.
+    pub deployment_id: Option<i32>,
+    /// OTLP signal type (Metrics / Traces / Logs).
+    pub signal: OtelSignal,
+    /// Decompressed OTLP protobuf bytes (see module-level note).
+    pub payload: bytes::Bytes,
+}
+
+/// Extension point for observing or relaying decoded OTLP batches.
+///
+/// OSS registers [`NoopOtelRelay`] by default (a true no-op). A plugin that
+/// wants to observe or forward batches registers an `Arc<dyn OtelRelay>` via
+/// the service registry, and [`OtelRelaySlot`] swaps it in once all services
+/// have registered.
+///
+/// # Contract
+///
+/// `relay` **must return promptly**. Implementations must enqueue `msg` onto
+/// their own internal buffer or channel and return immediately. Performing
+/// blocking network I/O, holding a mutex for an extended duration, or
+/// synchronously awaiting a remote endpoint inside `relay` is forbidden: a
+/// slow or unreachable destination must never add latency to OTLP ingestion.
+/// The ingest path performs only an O(1) non-blocking `try_send` into a
+/// bounded channel; implementations own the actual work in a separate
+/// background task.
+#[async_trait::async_trait]
+pub trait OtelRelay: Send + Sync {
+    /// Observe or relay a decoded OTLP batch.
+    ///
+    /// Implementations must return promptly. See the trait-level contract.
+    async fn relay(&self, msg: OtelRelayMessage);
+}
+
+/// Default [`OtelRelay`] implementation — discards every message.
+///
+/// Registered at startup when no plugin provides an alternative. The OTel
+/// ingest path has no observable relay side-effect when only this
+/// implementation is active.
+pub struct NoopOtelRelay;
+
+#[async_trait::async_trait]
+impl OtelRelay for NoopOtelRelay {
+    async fn relay(&self, _msg: OtelRelayMessage) {
+        // Intentional no-op.
+    }
+}
+
+/// Deferred-registration handle for an [`OtelRelay`].
+///
+/// Constructed with [`NoopOtelRelay`] loaded by default and held by the OTel
+/// plugin from `register_services` onwards. Once every plugin has finished
+/// `register_services`, whichever plugin supplies an alternative relay calls
+/// [`Self::set`] from `initialize_plugin_services` to swap it in — see the
+/// module-level note for why this indirection exists. `relay` reads are
+/// lock-free (`ArcSwap::load`).
+///
+/// **Write-once semantics:** only the first call to [`Self::set`] takes
+/// effect. A second caller cannot silently overwrite a relay that was already
+/// installed — the call is a no-op and returns `false`. This prevents a buggy
+/// or late-registered plugin from replacing a correctly wired relay after the
+/// fact.
+pub struct OtelRelaySlot {
+    /// Holds `Arc<Arc<dyn OtelRelay>>` so the outer Arc is what ArcSwap
+    /// manages and the inner Arc is what callers clone on load.
+    inner: arc_swap::ArcSwap<Arc<dyn OtelRelay>>,
+    /// Flipped to `true` by the first successful [`Self::set`] call.
+    claimed: std::sync::atomic::AtomicBool,
+}
+
+impl OtelRelaySlot {
+    /// Start with [`NoopOtelRelay`] loaded.
+    pub fn new_default() -> Self {
+        Self {
+            inner: arc_swap::ArcSwap::new(Arc::new(Arc::new(NoopOtelRelay) as Arc<dyn OtelRelay>)),
+            claimed: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+
+    /// Swap in a relay provided by a plugin, but only once.
+    ///
+    /// Returns `true` if the swap was applied, `false` if a relay was already
+    /// set and this call was a no-op.
+    pub fn set(&self, relay: Arc<dyn OtelRelay>) -> bool {
+        if self
+            .claimed
+            .compare_exchange(
+                false,
+                true,
+                std::sync::atomic::Ordering::SeqCst,
+                std::sync::atomic::Ordering::SeqCst,
+            )
+            .is_ok()
+        {
+            self.inner.store(Arc::new(relay));
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl OtelRelay for OtelRelaySlot {
+    async fn relay(&self, msg: OtelRelayMessage) {
+        // Clone the inner Arc<dyn OtelRelay> so it stays alive across the
+        // await without holding the ArcSwap guard. `*guard` derefs Guard to
+        // Arc<Arc<dyn OtelRelay>>; `**guard` derefs that to Arc<dyn OtelRelay>.
+        let current = Arc::clone(&**self.inner.load());
+        current.relay(msg).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::Mutex;
+
+    fn sample_msg(signal: OtelSignal) -> OtelRelayMessage {
+        OtelRelayMessage {
+            project_id: 1,
+            environment_id: None,
+            deployment_id: None,
+            signal,
+            payload: bytes::Bytes::from_static(b"test-payload"),
+        }
+    }
+
+    // ── Test double ──────────────────────────────────────────────────────
+
+    /// A relay that records the signal type of every message it receives.
+    struct RecordingRelay {
+        received: Mutex<Vec<OtelSignal>>,
+    }
+
+    impl RecordingRelay {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                received: Mutex::new(Vec::new()),
+            })
+        }
+
+        async fn signals(&self) -> Vec<OtelSignal> {
+            self.received.lock().await.clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl OtelRelay for RecordingRelay {
+        async fn relay(&self, msg: OtelRelayMessage) {
+            self.received.lock().await.push(msg.signal);
+        }
+    }
+
+    // ── NoopOtelRelay ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn noop_relay_does_not_panic() {
+        let relay = NoopOtelRelay;
+        relay.relay(sample_msg(OtelSignal::Metrics)).await;
+        relay.relay(sample_msg(OtelSignal::Traces)).await;
+        relay.relay(sample_msg(OtelSignal::Logs)).await;
+    }
+
+    // ── OtelRelaySlot defaults ───────────────────────────────────────────
+
+    #[tokio::test]
+    async fn slot_defaults_to_noop_and_does_not_panic() {
+        let slot = OtelRelaySlot::new_default();
+        // Calling relay on the default slot must not panic.
+        slot.relay(sample_msg(OtelSignal::Metrics)).await;
+        slot.relay(sample_msg(OtelSignal::Traces)).await;
+        slot.relay(sample_msg(OtelSignal::Logs)).await;
+    }
+
+    // ── set() overrides the default ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn slot_set_overrides_the_default() {
+        let recorder = RecordingRelay::new();
+        let slot = OtelRelaySlot::new_default();
+
+        let swapped = slot.set(recorder.clone());
+        assert!(swapped, "first set() must return true");
+
+        slot.relay(sample_msg(OtelSignal::Traces)).await;
+        slot.relay(sample_msg(OtelSignal::Logs)).await;
+
+        let signals = recorder.signals().await;
+        assert_eq!(signals, vec![OtelSignal::Traces, OtelSignal::Logs]);
+    }
+
+    // ── second set() is a no-op ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn slot_second_set_is_noop() {
+        let first = RecordingRelay::new();
+        let second = RecordingRelay::new();
+        let slot = OtelRelaySlot::new_default();
+
+        // First set: succeeds.
+        let ok1 = slot.set(first.clone());
+        assert!(ok1, "first set() must return true");
+
+        // Second set: must be a no-op, returns false.
+        let ok2 = slot.set(second.clone());
+        assert!(!ok2, "second set() must return false (write-once)");
+
+        // A message sent through the slot must reach only the first relay.
+        slot.relay(sample_msg(OtelSignal::Metrics)).await;
+
+        assert_eq!(
+            first.signals().await,
+            vec![OtelSignal::Metrics],
+            "first relay must receive the message"
+        );
+        assert!(
+            second.signals().await.is_empty(),
+            "second relay must not receive messages after rejected set()"
+        );
+    }
+
+    // ── OtelSignal derives ───────────────────────────────────────────────
+
+    #[test]
+    fn otel_signal_clone_copy_eq() {
+        let s = OtelSignal::Traces;
+        let s2 = s; // Copy
+        assert_eq!(s, s2);
+        assert_ne!(OtelSignal::Metrics, OtelSignal::Logs);
+    }
+}

--- a/crates/temps-otel/tests/dynamic_alert_integration_test.rs
+++ b/crates/temps-otel/tests/dynamic_alert_integration_test.rs
@@ -689,6 +689,7 @@ async fn test_delete_alert_rejects_cross_project_rule_id_before_touching_evaluat
         audit_service: Arc::new(NoOpAuditLogger),
         cross_project_service,
         trace_hint_tx: None,
+        otel_relay_tx: None,
         project_access_checker: None,
     };
 

--- a/crates/temps-otel/tests/e2e_http_test.rs
+++ b/crates/temps-otel/tests/e2e_http_test.rs
@@ -230,6 +230,7 @@ async fn setup_e2e() -> Option<(
         audit_service: Arc::new(NoOpAuditLogger),
         cross_project_service,
         trace_hint_tx: None,
+        otel_relay_tx: None,
         project_access_checker: None,
     };
 

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -111,6 +111,7 @@
     "js-yaml": "^4.3.1",
     "lodash": "^4.17.24",
     "minimatch": "^10.2.5",
+    "nanoid": "^3.3.17",
     "picomatch": "^2.3.2",
     "postcss": "^8.5.18",
     "tar": "^7.5.7",
@@ -1224,7 +1225,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@6.0.0", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-mkUH+rPkwU2qPadJ0oJZOjeZ5Mxn8Q1UhevwkTRWNuUZzyia3h4rhzK39hxaHTk0o2OxB8W2SQ6A8k23ZDi1pQ=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
@@ -1655,8 +1656,6 @@
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
-
-    "postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -138,6 +138,7 @@
     "js-yaml": "^4.3.1",
     "lodash": "^4.17.24",
     "minimatch": "^10.2.5",
+    "nanoid": "^3.3.17",
     "picomatch": "^2.3.2",
     "postcss": "^8.5.18",
     "tar": "^7.5.7"


### PR DESCRIPTION
## Summary
- Adds a small, generic, vendor-agnostic extension point to `temps-otel` so an optional plugin can observe/relay successfully-decoded OTLP ingest batches (e.g. to forward telemetry to an external OTLP-compatible destination).
- `OtelRelay` trait + `OtelRelaySlot` (write-once `ArcSwap` handle) mirrors the existing `RetentionResolver`/`RetentionResolverSlot` two-phase registration pattern in `temps-core`.
- `OtelAppState.otel_relay_tx` is a bounded, `try_send`-only channel — a full or absent relay never adds latency to OTLP ingestion, matching the existing `metrics_write_tx`/`trace_hint_tx` precedent.
- Wired into `do_ingest_metrics`/`do_ingest_traces`/`do_ingest_logs` only (not the infra `service_metrics` path, which has no project context).
- No installation-visible behavior change: default relay is a true no-op.

## Test plan
- [x] `cargo check --lib -p temps-otel` — 0 errors, 0 new warnings
- [x] `cargo test --lib -p temps-otel` — 456 tests pass, including new `relay.rs` slot tests (defaults-to-noop, set-once, second-set-is-noop) and two `ingest_handler.rs` backpressure tests (full/closed channel `try_send` behavior)
