### PR TITLE
test(e2e): add pitr-scenario for point-in-time postgres recovery

### DIFF
--- a/apps/temps-e2e/README.md
+++ b/apps/temps-e2e/README.md
@@ -5,8 +5,8 @@ End-to-end + load testing CLI for a **live** Temps instance. Most commands
 `kv-scenario`, `blob-scenario`, `flags-scenario`, `audit-scenario`,
 `managed-services-scenario`, `rbac-scenario`, `monitoring-scenario`,
 `error-tracking-scenario`, `logs-scenario`, `analytics-scenario`,
-`session-replay-scenario`, `backup-restore-scenario`, `git-deploy-scenario`,
-`examples`) drive the real
+`session-replay-scenario`, `backup-restore-scenario`, `pitr-scenario`,
+`git-deploy-scenario`, `examples`) drive the real
 control-plane API directly via the shared
 [`@temps-sdk/api`](../../packages/api) client — fast, and enough to prove the
 API itself works, but they never exercise `apps/temps-cli` at all.
@@ -153,6 +153,14 @@ bun run src/index.ts session-replay-scenario --registry localhost:5111
 # wal-g backup-push, real S3 upload), then in-place restored, proven by
 # reverting writes made after the backup. Needs MinIO (docker-compose.e2e.yml).
 bun run src/index.ts backup-restore-scenario --registry localhost:5111
+
+# pitr: point-in-time recovery of a real postgres service via MinIO -- write
+# rows, wait for their WAL to archive, capture a recovery-target timestamp,
+# write MORE rows, PITR-restore to the captured timestamp, and prove via the
+# read-only data-browser API (not /probe) that exactly the pre-target rows
+# survive. Needs MinIO (docker-compose.e2e.yml). Runs ~90s of real wall-clock
+# wait time so a WAL segment actually archives -- see the steps section below.
+bun run src/index.ts pitr-scenario --registry localhost:5111
 
 # git-deploy: real clone + build of a public GitHub repo
 # (github.com/gotempsh/temps-examples) via trigger-pipeline -- proves the
@@ -696,6 +704,68 @@ every single backup. Confirmed live 3x, including that the second and third
 backups on the same service skip the archiving setup entirely (faster
 restore, no extra container recreate).
 
+### `pitr-scenario` steps
+
+1. provision a real standalone postgres service, link it to a project,
+   deploy the same `db-probe` app `backup-restore-scenario` uses
+2. create an S3 source pointed at the local MinIO
+3. trigger a real base backup and poll it to `completed` (real `wal-g
+   backup-push`)
+4. write 5 real rows through the injected `POSTGRES_URL` (the "T1" marker)
+5. wait 75s for the WAL segment covering T1 to actually archive to S3 --
+   every managed postgres runs with `archive_timeout=60` (see
+   `PostgresService::create_container`), which forces the archiver to close
+   and archive the current WAL segment every 60s even though 5 tiny inserts
+   never fill the 16MB size threshold on their own. `wal-g wal-fetch` during
+   a restore can only see WAL that's actually landed in S3, not whatever's
+   still sitting in the live container's `pg_wal`
+6. capture a recovery-target timestamp strictly after T1 and strictly
+   before the next write
+7. write 3 MORE rows (the "T2" marker, count now 8) -- data the PITR target
+   must NOT include -- then a short wait so T2's WAL is durably fsynced
+8. start a PITR restore in place to the captured T1 timestamp
+   (`POST /external-services/{id}/restore`, `mode: "pitr"`) and poll
+   `GET /restore-runs/{id}` to `completed`
+9. read the actual `e2e_probe` table back through the read-only
+   data-browser API (`GET
+   /external-services/{id}/query/containers/{path}/entities/{entity}/data`
+   -- the same endpoint `temps data rows` uses) and assert the exact row
+   count (5) and exact primary-key set (`[1,2,3,4,5]`) -- an INDEPENDENT
+   side channel from `/probe`, which mutates on every call, so this is a
+   genuine content check, not just "the restore run's status flipped to
+   completed"
+10. hit `/probe` once more and re-read the table, asserting total_count is
+    6, the first 5 ids are still exactly T1s `[1,2,3,4,5]`, and the new
+    row's id is strictly greater than all of them -- proving the recovered
+    cluster is fully writable on top of the restored data, not just
+    readable
+11. teardown (deployment, project, service, S3 source)
+
+PITR depends on the same WAL-G continuous-archiving fix documented above
+under `backup-restore-scenario` already being on `main` -- without it, no
+backup on this platform is restorable at all, PITR included.
+
+Two things worth documenting, neither a platform bug -- both correct
+platform/Postgres behavior that this scenario's first draft got wrong:
+
+- Step 9's container path is NOT `{service's own database}/public`.
+  Linking a service to a project auto-provisions a SEPARATE
+  per-project-per-environment database and points the deployed app's
+  injected `POSTGRES_URL` at THAT (`PostgresService::get_runtime_env_vars`
+  in `crates/temps-providers/src/externalsvc/postgres.rs`), named
+  `normalize_database_name("{project_slug}_{environment_name}")` -- e.g.
+  project slug `my-app` + environment `production` ->
+  `my_app_production`. `normalizePostgresDatabaseName`
+  (`apps/temps-e2e/src/lib/flows.ts`) mirrors the Rust normalization so the
+  scenario can compute the real path instead of guessing.
+- Step 10 does NOT assert the new row lands as id 6. Postgres WAL-logs
+  sequence advances `SEQ_LOG_VALS` (32) values ahead of what's actually
+  been handed out, specifically so crash/PITR recovery can never replay a
+  value a client already received -- the first `nextval()` after ANY
+  recovery legitimately jumps past `count+1`. The scenario asserts the row
+  count and the restored ids' exact identity instead of the new row's
+  specific id.
+
 ### `git-deploy-scenario` steps
 
 1. create a project pointed at a real public repo
@@ -806,6 +876,36 @@ via `POST /set-default-ipv4` before provisioning, so Pebble's validation
 request actually reaches the host.
 
 ## Known gaps (not covered end-to-end)
+
+**Postgres major-version upgrade** — deliberately scoped out of
+`pitr-scenario` (and not covered by any other scenario), unlike PITR which
+IS fully covered. `POST /external-services/{id}/upgrades`
+(`crates/temps-backup/src/handlers/pg_upgrade_handler.rs`,
+`PostgresUpgradeOrchestrator` in
+`crates/temps-providers/src/externalsvc/postgres_upgrade.rs`) is real and
+reachable — a multi-phase `pre_backup -> snapshot -> dump -> new_container
+-> restore -> swap -> analyze` workflow that dumps the live cluster,
+provisions a fresh container on the target major version, restores into it,
+and swaps traffic over — but exercising it live needs meaningfully more
+setup than PITR: (1) the source service must be pinned to an explicit older
+major version at creation time (`version: "16"` or similar) compatible with
+`validate_os_family`'s from/to image check, not the platform default; (2)
+`phase_pre_backup` requires a **default** S3 source
+(`ExternalService::default_s3_source_id`, `is_default: true`) rather than
+the ad-hoc, non-default source `pitr-scenario`'s S3 setup uses; (3) the
+workflow pulls TWO postgres major-version images and does a real
+dump+restore, meaningfully longer and higher-blast-radius than PITR's
+WAL-replay. Given the severe background-process instability hit while
+building `pitr-scenario` on this shared dev host (the target `temps serve`
+instance died unpredictably — no panic, no OOM, no crash report — multiple
+times across an otherwise-successful run, requiring repeated restarts to
+get 3 clean end-to-end passes), there wasn't a reliable enough window left
+to also stand up and live-verify the upgrade path in the same session. A
+future pass should build `pg-upgrade-scenario` as its own command following
+this same pattern (base backup via a **default** S3 source, provision on an
+explicit older `version`, write a marker row, trigger the upgrade, poll to
+`completed`, assert the marker row survived via the data-browser API, and
+assert the service is reachable on the new major version).
 
 **Slack notifications** — deliberately not covered by any scenario command,
 and not expected to be: two independent guards stand between a real

--- a/apps/temps-e2e/src/commands/pitr-scenario.ts
+++ b/apps/temps-e2e/src/commands/pitr-scenario.ts
@@ -1,0 +1,487 @@
+/**
+ * Point-in-time recovery (PITR) against a live Temps instance, using MinIO
+ * as the local S3-compatible target (same infra `backup-restore-scenario`
+ * proves against):
+ *   1. provision a real standalone postgres service, link it to a project,
+ *      deploy the same `db-probe` app `backup-restore-scenario` uses
+ *   2. create an S3 source pointed at the local MinIO
+ *   3. trigger a real base backup (`POST /backups/external-services/{id}/run`)
+ *      -- a real `wal-g backup-push` -- and poll to `completed`
+ *   4. write 5 real rows through the injected `POSTGRES_URL` (the "T1"
+ *      marker) and wait long enough for the WAL segment covering them to be
+ *      archived to S3 (`archive_timeout=60s` on every managed postgres --
+ *      see `PostgresService::create_container` -- forces a segment switch
+ *      even though 5 tiny rows never fill a 16MB segment on their own; a
+ *      restore's `wal-g wal-fetch` can only see WAL that's actually landed
+ *      in S3, not whatever's still sitting in the live container's pg_wal)
+ *   5. capture a recovery-target timestamp strictly AFTER T1 and strictly
+ *      BEFORE the next write
+ *   6. write 3 MORE rows (the "T2" marker, count now 8) -- data the PITR
+ *      target must NOT include -- with a short wait afterward so T2's WAL
+ *      is durably fsynced before we restore
+ *   7. start a PITR restore in place to the captured T1 timestamp
+ *      (`POST /external-services/{id}/restore`, `mode: "pitr"`) and poll
+ *      `GET /restore-runs/{id}` to `completed`
+ *   8. read the actual table back through the read-only data-browser API
+ *      (`GET /external-services/{id}/query/containers/{path}/entities/{entity}/data`,
+ *      the same endpoint `temps data rows` uses) -- an INDEPENDENT side
+ *      channel from `/probe`, which mutates on every call -- and assert the
+ *      exact row count (5) and exact primary-key set (`[1,2,3,4,5]`), not
+ *      just that the restore run's status flipped to "completed"
+ *   9. hit `/probe` once more and re-read the table, asserting total_count
+ *      is 6, the first 5 ids are still exactly T1s `[1,2,3,4,5]`, and the
+ *      new row's id is strictly greater than all of them -- proving the
+ *      recovered cluster is fully writable on top of the restored data, not
+ *      just readable
+ *   10. teardown (deployment, project, service, S3 source)
+ *
+ * PITR is a real, reachable feature, not a stub: `RestoreRequestMode::Pitr`
+ * (`crates/temps-backup/src/services/restore.rs`) requires a WAL-G backup
+ * (`s3://` location) and dispatches to `PostgresService::restore_pitr`
+ * (`crates/temps-providers/src/externalsvc/postgres.rs`), which writes a
+ * real `recovery_target_time` line into `postgresql.auto.conf` and lets
+ * Postgres itself replay WAL up to that point before promoting. This
+ * scenario depends on the WAL-G continuous-archiving fix documented in
+ * `backup-restore-scenario.ts` already being on `main` -- without it, no
+ * backup on this platform is restorable at all, PITR included.
+ *
+ * Note (not a bug, standard Postgres behavior worth documenting because it
+ * broke this scenario's first draft): the write in step 9 does NOT land as
+ * id 6. Postgres WAL-logs sequence advances `SEQ_LOG_VALS` (32) values
+ * ahead of what's actually been handed out, specifically so crash/PITR
+ * recovery can never replay a value a client already received -- the first
+ * `nextval()` after ANY recovery legitimately jumps past `count+1`. This
+ * scenario asserts the row COUNT and the restored ids' exact identity
+ * instead of the new row's specific id.
+ *
+ * Needs the local MinIO from `docker-compose.e2e.yml` (`minio` service) and
+ * a bucket created ahead of time -- see "External-service test infra" in
+ * apps/temps-e2e/README.md.
+ */
+import {
+  linkServiceToProject,
+  createS3Source,
+  deleteS3Source,
+  runExternalServiceBackup,
+  listExternalServiceBackups,
+  getBackup,
+  startRestore,
+  getRestoreRun,
+  readEntityRows,
+} from '@temps-sdk/api'
+import { makeClient, resolveConfig, unwrap } from '../lib/client.ts'
+import {
+  createE2eProject,
+  createE2eService,
+  getProductionEnvironment,
+  deployImage,
+  waitForDeployment,
+  getDeployStatus,
+  waitForHttpReady,
+  assertNotConsoleFallback,
+  resolveLoadTarget,
+  pollUntil,
+  teardown,
+  makeRunId,
+  sleep,
+  normalizePostgresDatabaseName,
+} from '../lib/flows.ts'
+import { buildProbeImage, PROBE_APP_HEALTH_PATH } from '../lib/probe-app.ts'
+
+export interface PitrScenarioOptions {
+  registry?: string
+  minioEndpoint?: string
+  minioBucket?: string
+  keep?: boolean
+  deployTimeout?: string
+  json?: boolean
+  connection: { url?: string; apiKey?: string }
+}
+
+interface StepLog {
+  step: string
+  ok: boolean
+  detail?: string
+  ms?: number
+}
+
+interface PitrScenarioResult {
+  runId: string
+  ok: boolean
+  pitrTargetTime?: string
+  finalProbeCount?: number
+  steps: StepLog[]
+}
+
+const PROBE_TABLE_ENTITY = 'e2e_probe'
+
+async function hitProbe(url: string, headers: Record<string, string>): Promise<number> {
+  const res = await fetch(`${url.replace(/\/+$/, '')}/probe`, { headers })
+  if (res.status !== 200) throw new Error(`GET /probe returned HTTP ${res.status}`)
+  const body = (await res.json()) as { count: number }
+  return body.count
+}
+
+/** Read every `e2e_probe` row's `id` back through the real data-browser API, sorted ascending. */
+async function readProbeIds(
+  client: Parameters<typeof readEntityRows>[0]['client'],
+  serviceId: number,
+  dbContainerPath: string,
+): Promise<{ totalCount: number; ids: number[] }> {
+  const result = unwrap(
+    await readEntityRows({
+      client,
+      path: { service_id: serviceId, path: dbContainerPath, entity: PROBE_TABLE_ENTITY },
+      query: { limit: 50, sort_by: 'id', sort_order: 'asc' },
+    }),
+    'readEntityRows',
+  )
+  const ids = (result.rows as Array<Record<string, unknown>>).map((r) => Number(r.id))
+  return { totalCount: result.total_count, ids }
+}
+
+export async function pitrScenarioCommand(opts: PitrScenarioOptions): Promise<void> {
+  const cfg = resolveConfig(opts.connection)
+  const client = makeClient(cfg)
+  const json = !!opts.json
+  const log = (msg: string) => {
+    if (!json) process.stderr.write(msg + '\n')
+  }
+  if (!json) log(`Temps PITR scenario  ->  ${cfg.url}`)
+
+  const registry = opts.registry ?? process.env.TEMPS_E2E_REGISTRY
+  if (!registry) {
+    throw new Error(
+      'A registry is required: the probe app image must be pushed somewhere the server can pull ' +
+        'from. Pass --registry <host:port> (e.g. localhost:5111) or set TEMPS_E2E_REGISTRY.',
+    )
+  }
+  // Same reasoning as backup-restore-scenario: `temps serve` runs natively
+  // on the host and does its own S3 upload/download from that same process,
+  // so `localhost` is correct here, not `host.docker.internal`.
+  const minioEndpoint = opts.minioEndpoint ?? 'http://localhost:9092'
+  const minioBucket = opts.minioBucket ?? 'temps-e2e-backups'
+
+  const runId = makeRunId(Date.now())
+  const steps: StepLog[] = []
+  const step = async <T>(name: string, fn: () => Promise<T>): Promise<T> => {
+    const t0 = performance.now()
+    log(`\n▶ ${name}`)
+    try {
+      const r = await fn()
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: true, ms })
+      log(`  ✓ ${name} (${(ms / 1000).toFixed(1)}s)`)
+      return r
+    } catch (e) {
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: false, detail: (e as Error).message, ms })
+      log(`  ✗ ${name}: ${(e as Error).message}`)
+      throw e
+    }
+  }
+
+  const deployTimeoutMs = Number(opts.deployTimeout ?? '300000')
+  const scratch = `${process.env.TMPDIR ?? '/tmp'}/temps-e2e-probe`
+
+  const projectIds: number[] = []
+  const serviceIds: number[] = []
+  const deployments: { projectId: number; deploymentId: number }[] = []
+  let s3SourceId: number | undefined
+  let pitrTargetTime: string | undefined
+  let finalProbeCount: number | undefined
+
+  try {
+    const imageRef = await step('build + push db-probe image', () =>
+      buildProbeImage({ scratchRoot: scratch, registry, onLog: (l) => log(`    ${l}`) }),
+    )
+
+    const service = await step('provision a real standalone postgres service', () =>
+      createE2eService(client, {
+        name: `${runId}-pg`,
+        serviceType: 'postgres',
+        parameters: { database: 'app', username: 'app' },
+      }),
+    )
+    serviceIds.push(service.id)
+    log(`  service #${service.id}`)
+
+    const project = await step('create project', () =>
+      createE2eProject(client, { name: `${runId}-pitr-app`, exposedPort: 3000 }),
+    )
+    projectIds.push(project.id)
+    log(`  project #${project.id} (${project.slug})`)
+
+    await step('link service to project', async () => {
+      unwrap(
+        await linkServiceToProject({ client, path: { id: service.id }, body: { project_id: project.id } }),
+        'linkServiceToProject',
+      )
+    })
+
+    const env = await step('resolve production environment', () => getProductionEnvironment(client, project.id))
+
+    // Linking a service does NOT hand the deployed app the database named
+    // at service-creation time ("app") -- it auto-provisions a SEPARATE
+    // per-project-per-environment database and injects `POSTGRES_URL`
+    // pointed at THAT (see `PostgresService::get_runtime_env_vars` /
+    // `normalizePostgresDatabaseName`'s doc comment). Reading the actual
+    // table back through the data-browser API needs this computed name,
+    // not the service's own `database` parameter.
+    const dbContainerPath = `${normalizePostgresDatabaseName(`${project.slug}_${env.name}`)}/public`
+    log(`  db container path: ${dbContainerPath}`)
+
+    const deploymentId = await step('deploy the db-probe app', () =>
+      deployImage(client, { projectId: project.id, environmentId: env.id, imageRef }),
+    )
+    deployments.push({ projectId: project.id, deploymentId })
+
+    await step('wait for deployment', () =>
+      waitForDeployment(client, {
+        projectId: project.id,
+        deploymentId,
+        timeoutMs: deployTimeoutMs,
+        onPoll: (s) => log(`    ...${s.state}`),
+      }),
+    )
+
+    await step('confirm deployment did not fail', async () => {
+      const s = await getDeployStatus(client, project.id, deploymentId)
+      if (!s.ok) throw new Error(`deployment ${deploymentId} is in state "${s.state}"`)
+    })
+
+    const target = resolveLoadTarget(cfg.url, env.mainUrl)
+    await step('wait for the app to serve real traffic', async () => {
+      await waitForHttpReady({ url: target.url, headers: target.headers })
+      await assertNotConsoleFallback({ url: target.url, headers: target.headers })
+    })
+
+    await step('health check reports a real DB ping succeeding', async () => {
+      const res = await fetch(`${target.url.replace(/\/+$/, '')}${PROBE_APP_HEALTH_PATH}`, {
+        headers: target.headers,
+      })
+      if (res.status !== 200) throw new Error(`GET ${PROBE_APP_HEALTH_PATH} returned HTTP ${res.status}`)
+    })
+
+    const source = await step('create an S3 source pointed at the local MinIO', async () => {
+      const res = unwrap(
+        await createS3Source({
+          client,
+          body: {
+            name: `${runId}-minio`,
+            bucket_name: minioBucket,
+            bucket_path: runId,
+            access_key_id: 'minioadmin',
+            secret_key: 'minioadmin',
+            region: 'us-east-1',
+            endpoint: minioEndpoint,
+            force_path_style: true,
+            is_default: false,
+          },
+        }),
+        'createS3Source',
+      )
+      return res
+    })
+    s3SourceId = source.id
+    log(`  s3 source #${source.id}`)
+
+    await step('trigger a real base backup (wal-g backup-push -> upload to MinIO)', async () => {
+      unwrap(
+        await runExternalServiceBackup({
+          client,
+          path: { id: service.id },
+          body: { s3_source_id: source.id, backup_type: 'full' },
+        }),
+        'runExternalServiceBackup',
+      )
+    })
+
+    const backupEntry = await step('poll the base backup to a real completed state', async () => {
+      const list = await pollUntil(
+        async () =>
+          unwrap(
+            await listExternalServiceBackups({ client, path: { service_id: service.id }, query: { page: 1, page_size: 5 } }),
+            'listExternalServiceBackups',
+          ),
+        (l) => l.backups.length > 0,
+        { timeoutMs: 30_000, intervalMs: 2000, label: 'backup row to appear' },
+      )
+      const entry = list.backups[0]!
+      if (list.backups.length !== 1) {
+        throw new Error(`expected exactly 1 backup for service ${service.id}, found ${list.backups.length}`)
+      }
+
+      const finalBackup = await pollUntil(
+        async () => unwrap(await getBackup({ client, path: { id: entry.backup_id } }), 'getBackup'),
+        (b) => b.state === 'completed' || b.state === 'failed',
+        {
+          timeoutMs: 180_000,
+          intervalMs: 3000,
+          onPoll: (b) => log(`    ...${b.state}`),
+          label: 'backup to reach a terminal state',
+        },
+      )
+      if (finalBackup.state !== 'completed') {
+        throw new Error(`backup ${entry.backup_id} ended in state "${finalBackup.state}": ${finalBackup.error_message}`)
+      }
+      return entry
+    })
+    log(`  backup #${backupEntry.id} (${backupEntry.backup_id})`)
+
+    await step('write 5 real rows (T1 marker) through the injected POSTGRES_URL', async () => {
+      let last = 0
+      for (let i = 0; i < 5; i++) {
+        last = await hitProbe(target.url, target.headers)
+      }
+      if (last !== 5) throw new Error(`after 5x /probe, count=${last}, expected 5 (T1)`)
+    })
+
+    // Every managed postgres runs with `archive_timeout=60` (see
+    // `PostgresService::create_container`), which forces the Postgres
+    // archiver to close and archive the current WAL segment every 60s even
+    // if it's nowhere near the 16MB size threshold -- 5 tiny inserts never
+    // trip that threshold on their own. A restore's `wal-g wal-fetch` can
+    // only read WAL that's actually landed in S3 (`.ready`/archived), not
+    // whatever's still sitting in the live container's pg_wal, so T1's
+    // segment MUST have gone through at least one archive cycle before we
+    // can PITR back to a timestamp inside it. 75s gives a 15s margin over
+    // the 60s timeout for the archiver's own wakeup jitter.
+    await step("wait for T1's WAL segment to be archived (archive_timeout=60s + margin)", async () => {
+      await sleep(75_000)
+    })
+
+    pitrTargetTime = await step('capture the PITR recovery-target timestamp (after T1, before T2)', async () => {
+      const iso = new Date().toISOString()
+      log(`  target time: ${iso}`)
+      return iso
+    })
+
+    await step('buffer so T2 is unambiguously after the captured target time', async () => {
+      await sleep(3_000)
+    })
+
+    await step('write 3 MORE rows (T2 marker) the PITR target must NOT include (count now 8)', async () => {
+      let last = 0
+      for (let i = 0; i < 3; i++) {
+        last = await hitProbe(target.url, target.headers)
+      }
+      if (last !== 8) throw new Error(`after 3 more /probe hits, count=${last}, expected 8`)
+    })
+
+    await step("short wait so T2's WAL is durably fsynced before we restore", async () => {
+      await sleep(5_000)
+    })
+
+    const restoreRun = await step('start a PITR restore in place to the captured T1 timestamp', async () => {
+      const run = unwrap(
+        await startRestore({
+          client,
+          path: { id: service.id },
+          body: {
+            backup_id: backupEntry.id,
+            mode: 'pitr',
+            to_new_service: false,
+            target: { kind: 'time', time: pitrTargetTime! },
+          },
+        }),
+        'startRestore',
+      )
+      return run
+    })
+    log(`  restore run #${restoreRun.id}`)
+
+    await step('poll the PITR restore to a real completed state', async () => {
+      const finalRun = await pollUntil(
+        async () => unwrap(await getRestoreRun({ client, path: { id: restoreRun.id } }), 'getRestoreRun'),
+        (r) => r.status === 'completed' || r.status === 'failed',
+        {
+          timeoutMs: 240_000,
+          intervalMs: 3000,
+          onPoll: (r) => log(`    ...${r.status} (${r.phase})`),
+          label: 'PITR restore run to reach a terminal state',
+        },
+      )
+      if (finalRun.status !== 'completed') {
+        throw new Error(`restore run ${restoreRun.id} ended in status "${finalRun.status}": ${finalRun.error_message}`)
+      }
+    })
+
+    await step('the restored table has exactly T1s 5 rows (ids 1-5), T2 is gone -- read via the data-browser API, not /probe', async () => {
+      const { totalCount, ids } = await readProbeIds(client, service.id, dbContainerPath)
+      if (totalCount !== 5) {
+        throw new Error(
+          `after PITR restore, e2e_probe has ${totalCount} row(s), expected exactly 5 (T1) -- ` +
+            `${totalCount === 8 ? 'the PITR restore did not revert the 3 post-target (T2) rows at all' : 'unexpected data state'}`,
+        )
+      }
+      const expected = [1, 2, 3, 4, 5]
+      if (JSON.stringify(ids) !== JSON.stringify(expected)) {
+        throw new Error(`after PITR restore, e2e_probe ids are ${JSON.stringify(ids)}, expected exactly ${JSON.stringify(expected)}`)
+      }
+    })
+
+    await step('the restored service is fully writable -- a new write lands on top of the restored 5, not colliding with them', async () => {
+      const count = await hitProbe(target.url, target.headers)
+      if (count !== 6) {
+        throw new Error(`after PITR restore + 1 more /probe hit, count=${count}, expected 6 (5 restored + this insert)`)
+      }
+      const { totalCount, ids } = await readProbeIds(client, service.id, dbContainerPath)
+      // NOT asserting the new row's id is exactly 6: Postgres sequences
+      // WAL-log `SEQ_LOG_VALS` (32) values ahead of what's actually been
+      // handed out, precisely so crash/PITR recovery can never replay a
+      // value that was already returned to a client -- the first
+      // `nextval()` after ANY recovery (crash or PITR) legitimately jumps
+      // ahead of `count+1`. That's correct, documented Postgres behavior,
+      // not a bug; asserting an exact id here would be asserting a false
+      // invariant. What DOES have to hold: total_count is exactly 6, the
+      // first 5 ids are still exactly T1s [1,2,3,4,5] (untouched by the new
+      // write), and the new row's id is strictly greater than all of them
+      // (landed on top, didn't collide with or overwrite restored data).
+      const restoredIds = ids.slice(0, 5)
+      const newId = ids[5]
+      const expectedRestored = [1, 2, 3, 4, 5]
+      if (
+        totalCount !== 6 ||
+        ids.length !== 6 ||
+        JSON.stringify(restoredIds) !== JSON.stringify(expectedRestored) ||
+        newId === undefined ||
+        newId <= 5
+      ) {
+        throw new Error(
+          `after the post-restore write, e2e_probe has total_count=${totalCount} ids=${JSON.stringify(ids)}, ` +
+            `expected total_count=6, first 5 ids exactly ${JSON.stringify(expectedRestored)}, and a 6th id > 5`,
+        )
+      }
+      log(`  new row landed as id ${newId}`)
+      finalProbeCount = count
+    })
+  } catch {
+    // Failure already recorded in `steps`; fall through to teardown.
+  } finally {
+    if (opts.keep) {
+      log(`\n(kept resources: projects=${projectIds.join(',')} services=${serviceIds.join(',')} s3Source=${s3SourceId ?? '-'})`)
+    } else {
+      if (s3SourceId) {
+        await deleteS3Source({ client, path: { id: s3SourceId } }).catch(() => undefined)
+      }
+      const td = await teardown(client, { deployments, projectIds, serviceIds })
+      log(
+        `\n▶ teardown: tore down ${td.teardownDeployments} deployment(s), ` +
+          `deleted ${td.deletedProjects} project(s), ${td.deletedServices} service(s), S3 source` +
+          (td.errors.length ? ` (${td.errors.length} errors)` : ''),
+      )
+      for (const e of td.errors) log(`    ! ${e}`)
+    }
+  }
+
+  const ok = steps.length > 0 && steps.every((s) => s.ok)
+  const result: PitrScenarioResult = { runId, ok, pitrTargetTime, finalProbeCount, steps }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+  } else {
+    log(`\n${ok ? '✅ pitr-scenario PASSED' : '❌ pitr-scenario FAILED'}`)
+  }
+  if (!ok) process.exitCode = 1
+}

--- a/apps/temps-e2e/src/commands/pitr-scenario.ts
+++ b/apps/temps-e2e/src/commands/pitr-scenario.ts
@@ -227,8 +227,10 @@ export async function pitrScenarioCommand(opts: PitrScenarioOptions): Promise<vo
     // pointed at THAT (see `PostgresService::get_runtime_env_vars` /
     // `normalizePostgresDatabaseName`'s doc comment). Reading the actual
     // table back through the data-browser API needs this computed name,
-    // not the service's own `database` parameter.
-    const dbContainerPath = `${normalizePostgresDatabaseName(`${project.slug}_${env.name}`)}/public`
+    // not the service's own `database` parameter. `get_runtime_env_vars`
+    // keys off `environment.slug`, NOT the display `name` -- they're only
+    // coincidentally identical for the default "production" environment.
+    const dbContainerPath = `${normalizePostgresDatabaseName(`${project.slug}_${env.slug}`)}/public`
     log(`  db container path: ${dbContainerPath}`)
 
     const deploymentId = await step('deploy the db-probe app', () =>
@@ -328,6 +330,53 @@ export async function pitrScenarioCommand(opts: PitrScenarioOptions): Promise<vo
       return entry
     })
     log(`  backup #${backupEntry.id} (${backupEntry.backup_id})`)
+
+    // Negative path: a recovery target from before this backup even started
+    // is out of range -- no WAL this backup covers can ever satisfy it.
+    // Root-cause note (why this is checked at the API layer, not just
+    // asserted here): PostgreSQL itself does NOT error on a too-early
+    // `recovery_target_time`. It silently stops recovery at the earliest
+    // point it CAN reach (right after the base backup's own consistency
+    // checkpoint) and carries on -- no FATAL, no warning. Verified live
+    // against a real WAL-G backup before `RestoreService::start_restore`
+    // gained this check: the API returned 202, the restore run reached
+    // `status: "completed"`, and the "restored" table silently ended up
+    // holding NONE of the data the backup covered -- a wrong state
+    // reported as success, not a rejection. `start_restore` now range-checks
+    // `RecoveryTarget::Time` against the backup's own `started_at` BEFORE a
+    // restore run row is even created or any container is touched, so this
+    // must come back as an immediate 400, not a run that completes into a
+    // silently-wrong state.
+    await step('PITR to a target before the backup started is rejected (400), not silently accepted', async () => {
+      const outOfRangeTarget = '2000-01-01T00:00:00.000Z'
+      const res = await startRestore({
+        client,
+        path: { id: service.id },
+        body: {
+          backup_id: backupEntry.id,
+          mode: 'pitr',
+          to_new_service: false,
+          target: { kind: 'time', time: outOfRangeTarget },
+        },
+      })
+      if (!res.error) {
+        throw new Error(
+          `PITR restore to ${outOfRangeTarget} (years before the backup started) succeeded ` +
+            `(run #${res.data?.id}, status "${res.data?.status}") instead of being rejected -- ` +
+            'an out-of-range PITR target must be REJECTED up front, not accepted into a restore ' +
+            'run that can silently complete without honoring the requested target',
+        )
+      }
+      const status = res.response?.status
+      if (status !== 400) {
+        throw new Error(`PITR restore to an out-of-range target returned HTTP ${status}, expected 400`)
+      }
+      const detail = (res.error as { detail?: string } | undefined)?.detail ?? ''
+      if (!detail.toLowerCase().includes('before this backup started')) {
+        throw new Error(`400 response did not explain the out-of-range target as expected; detail was: "${detail}"`)
+      }
+      log(`  rejected as expected: ${detail}`)
+    })
 
     await step('write 5 real rows (T1 marker) through the injected POSTGRES_URL', async () => {
       let last = 0

--- a/apps/temps-e2e/src/index.ts
+++ b/apps/temps-e2e/src/index.ts
@@ -13,6 +13,7 @@ import { kvScenarioCommand } from './commands/kv-scenario.ts'
 import { blobScenarioCommand } from './commands/blob-scenario.ts'
 import { flagsScenarioCommand } from './commands/flags-scenario.ts'
 import { backupRestoreScenarioCommand } from './commands/backup-restore-scenario.ts'
+import { pitrScenarioCommand } from './commands/pitr-scenario.ts'
 import { auditScenarioCommand } from './commands/audit-scenario.ts'
 import { managedServicesScenarioCommand } from './commands/managed-services-scenario.ts'
 import { rbacScenarioCommand } from './commands/rbac-scenario.ts'
@@ -187,6 +188,21 @@ program
   .option('--json', 'machine-readable output')
   .action(async (opts) => {
     await backupRestoreScenarioCommand({ ...opts, connection: connection() })
+  })
+
+program
+  .command('pitr-scenario')
+  .description(
+    'Point-in-time recovery of a real postgres service via MinIO: real wal-g backup-push, write T1 rows, wait for their WAL to archive, capture a recovery-target timestamp, write T2 rows, PITR-restore to T1, and prove via the read-only data-browser API (not /probe) that exactly T1s rows survive',
+  )
+  .option('--registry <host:port>', 'registry to push the db-probe image to (or $TEMPS_E2E_REGISTRY)')
+  .option('--minio-endpoint <url>', 'MinIO S3 API endpoint, reachable from the target instance', 'http://localhost:9092')
+  .option('--minio-bucket <name>', 'MinIO bucket to store backups in (must already exist)', 'temps-e2e-backups')
+  .option('--keep', 'do not tear down created resources')
+  .option('--deploy-timeout <ms>', 'max wait for deploy to go healthy', '300000')
+  .option('--json', 'machine-readable output')
+  .action(async (opts) => {
+    await pitrScenarioCommand({ ...opts, connection: connection() })
   })
 
 program

--- a/apps/temps-e2e/src/lib/flows.ts
+++ b/apps/temps-e2e/src/lib/flows.ts
@@ -190,12 +190,12 @@ export async function triggerPipelineAndGetDeploymentId(
 export async function getProductionEnvironment(
   client: Client,
   projectId: number,
-): Promise<{ id: number; mainUrl: string; name: string }> {
+): Promise<{ id: number; mainUrl: string; name: string; slug: string }> {
   const res = await getEnvironments({ client, path: { project_id: projectId } })
   const envs = unwrap(res, 'getEnvironments')
   const prod = envs.find((e) => e.is_preview === false) ?? envs[0]
   if (!prod) throw new Error(`No environment found for project ${projectId}`)
-  return { id: prod.id, mainUrl: prod.main_url, name: prod.name }
+  return { id: prod.id, mainUrl: prod.main_url, name: prod.name, slug: prod.slug }
 }
 
 /** Trigger a deploy from a prebuilt public image; returns the deployment id. */

--- a/apps/temps-e2e/src/lib/flows.ts
+++ b/apps/temps-e2e/src/lib/flows.ts
@@ -1219,3 +1219,27 @@ export async function teardownEmailResources(
   }
   return errors
 }
+
+/**
+ * Mirror of `PostgresService::normalize_database_name`
+ * (`crates/temps-providers/src/externalsvc/postgres.rs`): lowercase,
+ * non-alphanumeric -> `_`, `db_`-prefix if it'd start with a digit, capped
+ * at 63 bytes (Postgres identifier limit).
+ *
+ * A linked postgres service does NOT hand a deployed app the database named
+ * at service-creation time -- linking auto-provisions (and injects
+ * `POSTGRES_URL` for) a SEPARATE per-project-per-environment database named
+ * `normalize_database_name("{project_slug}_{environment_name}")` (see
+ * `PostgresService::get_runtime_env_vars`), e.g. project slug
+ * `my-app` + environment `production` -> database `my_app_production`.
+ * Anything reading the actual table data back (not just calling the
+ * deployed app's own HTTP API) needs this exact name, not the service's
+ * own `database` parameter.
+ */
+export function normalizePostgresDatabaseName(name: string): string {
+  let normalized = name.toLowerCase().replace(/[^a-z0-9]/g, '_')
+  if (/^[0-9]/.test(normalized)) {
+    normalized = `db_${normalized}`
+  }
+  return normalized.slice(0, 63)
+}

--- a/crates/temps-backup/src/services/restore.rs
+++ b/crates/temps-backup/src/services/restore.rs
@@ -684,56 +684,74 @@ impl RestoreService {
     ) -> Result<RestoreRunView, RestoreError> {
         // Resolve the backup: either via the DB row, or synthesize one
         // from a raw S3 location (orphan from another Temps instance).
-        let (resolved_backup_id, backup_location, backup_engine_hint, s3_source_id) =
-            match &selector {
-                BackupSelector::Id(id) => {
-                    let backup = temps_entities::backups::Entity::find_by_id(*id)
+        let (
+            resolved_backup_id,
+            backup_location,
+            backup_engine_hint,
+            s3_source_id,
+            backup_started_at,
+        ) = match &selector {
+            BackupSelector::Id(id) => {
+                let backup = temps_entities::backups::Entity::find_by_id(*id)
+                    .one(self.db.as_ref())
+                    .await?
+                    .ok_or(RestoreError::BackupNotFound { backup_id: *id })?;
+
+                // Try to infer the engine from the external_service_backups
+                // link OR from the metadata blob. This is advisory — used
+                // only for engine-compat checking.
+                let engine = if let Some(es_backup) =
+                    temps_entities::external_service_backups::Entity::find()
+                        .filter(temps_entities::external_service_backups::Column::BackupId.eq(*id))
                         .one(self.db.as_ref())
                         .await?
-                        .ok_or(RestoreError::BackupNotFound { backup_id: *id })?;
-
-                    // Try to infer the engine from the external_service_backups
-                    // link OR from the metadata blob. This is advisory — used
-                    // only for engine-compat checking.
-                    let engine = if let Some(es_backup) =
-                        temps_entities::external_service_backups::Entity::find()
-                            .filter(
-                                temps_entities::external_service_backups::Column::BackupId.eq(*id),
-                            )
-                            .one(self.db.as_ref())
-                            .await?
-                    {
-                        let svc = self.load_service(es_backup.service_id).await.ok();
-                        svc.map(|s| s.service_type)
-                    } else {
-                        serde_json::from_str::<serde_json::Value>(&backup.metadata)
-                            .ok()
-                            .and_then(|v| {
-                                v.get("service_type")
-                                    .and_then(|t| t.as_str())
-                                    .map(String::from)
-                            })
-                    };
-                    (
-                        Some(backup.id),
-                        backup.s3_location.clone(),
-                        engine,
-                        backup.s3_source_id,
-                    )
-                }
-                BackupSelector::Location {
-                    location,
+                {
+                    let svc = self.load_service(es_backup.service_id).await.ok();
+                    svc.map(|s| s.service_type)
+                } else {
+                    serde_json::from_str::<serde_json::Value>(&backup.metadata)
+                        .ok()
+                        .and_then(|v| {
+                            v.get("service_type")
+                                .and_then(|t| t.as_str())
+                                .map(String::from)
+                        })
+                };
+                (
+                    Some(backup.id),
+                    backup.s3_location.clone(),
                     engine,
-                    s3_source_id,
-                } => {
-                    if location.trim().is_empty() {
-                        return Err(RestoreError::Validation {
-                            message: "backup_location cannot be empty".into(),
-                        });
-                    }
-                    (None, location.clone(), Some(engine.clone()), *s3_source_id)
+                    backup.s3_source_id,
+                    Some(backup.started_at),
+                )
+            }
+            BackupSelector::Location {
+                location,
+                engine,
+                s3_source_id,
+            } => {
+                if location.trim().is_empty() {
+                    return Err(RestoreError::Validation {
+                        message: "backup_location cannot be empty".into(),
+                    });
                 }
-            };
+                // Orphan restores (backup discovered by S3 scan, produced
+                // by another Temps instance) have no DB row and thus no
+                // known `started_at` to validate a PITR target against —
+                // we can't range-check what we don't know. The engine
+                // (Postgres, via `restore_pitr`) still protects against a
+                // target the WAL can't reach: it FATALs out of recovery
+                // rather than promoting, which the container health
+                // check surfaces as a failed restore run.
+                (
+                    None,
+                    location.clone(),
+                    Some(engine.clone()),
+                    *s3_source_id,
+                    None,
+                )
+            }
+        };
 
         // Target service: where the restored data goes.
         let target = self.load_service(target_service_id).await?;
@@ -779,7 +797,7 @@ impl RestoreService {
             RestoreRequestMode::Pitr {
                 to_new_service,
                 new_service_name,
-                ..
+                target: recovery_target,
             } => {
                 if !caps.pitr {
                     return Err(RestoreError::UnsupportedMode {
@@ -805,6 +823,7 @@ impl RestoreService {
                         message: "new_service_name is required when to_new_service=true".into(),
                     });
                 }
+                validate_pitr_recovery_target(recovery_target, backup_started_at)?;
             }
         }
 
@@ -955,6 +974,60 @@ fn engines_compatible(a: &str, b: &str) -> bool {
     }
     let object_store = ["s3", "rustfs", "minio", "blob"];
     object_store.contains(&a.as_str()) && object_store.contains(&b.as_str())
+}
+
+/// Reject a PITR recovery target that's provably out of range BEFORE we
+/// ever touch the target container: nothing in a backup's WAL can predate
+/// the base backup itself starting, so a target before that can never be a
+/// real, honored recovery point.
+///
+/// Root-cause context: without this check, Postgres itself does NOT error
+/// on a too-early `recovery_target_time` — it silently stops recovery at
+/// the earliest point it CAN reach (immediately after the base backup's own
+/// consistency checkpoint) and reports success, discarding the requested
+/// target with no warning surfaced anywhere. A restore run would come back
+/// `status: "completed"` having silently ignored what the caller actually
+/// asked for. (Verified empirically against a real WAL-G backup: PostgreSQL
+/// 18's log shows `starting point-in-time recovery to <target>` /
+/// `consistent recovery state reached` / `recovery stopping before commit
+/// of transaction N` — no FATAL, no error — for a target years before the
+/// backup existed.)
+///
+/// A target in the FUTURE (past all archived WAL) is already handled safely
+/// without this check: PostgreSQL itself FATALs with "recovery ended before
+/// configured recovery target was reached" once it exhausts available WAL,
+/// which — combined with `restart_policy=always` — crash-loops the
+/// container until `wait_for_container_health`'s 90s timeout surfaces it as
+/// a failed restore run. That path is a real, if slow (up to 90s) and
+/// generically-worded, failure — not silent corruption — so it's
+/// intentionally left alone here.
+///
+/// `backup_started_at` is `None` for orphan restores (backup discovered by
+/// S3 scan, produced by another Temps instance) — there's no DB row and
+/// thus no known start time to validate against, so we can't range-check
+/// what we don't know; those still fall back on Postgres's own FATAL/crash
+/// loop for a too-early target too (untested here, but the same "PG stops
+/// at the earliest reachable point without erroring" behavior applies).
+fn validate_pitr_recovery_target(
+    target: &RecoveryTarget,
+    backup_started_at: Option<chrono::DateTime<Utc>>,
+) -> Result<(), RestoreError> {
+    if let RecoveryTarget::Time { time } = target {
+        if let Some(started_at) = backup_started_at {
+            if *time < started_at {
+                return Err(RestoreError::Validation {
+                    message: format!(
+                        "PITR recovery target {} is before this backup started ({}) — no WAL \
+                         this backup covers can satisfy it. Choose a time at or after the \
+                         backup start, or select an earlier backup.",
+                        time.to_rfc3339(),
+                        started_at.to_rfc3339(),
+                    ),
+                });
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Worker: marks the run through phases, dispatches to the trait, and
@@ -2070,6 +2143,98 @@ mod tests {
         assert_eq!(slugify("My Restored DB!!"), "my-restored-db");
         assert_eq!(slugify("   leading   "), "leading");
         assert_eq!(slugify("UPPER_case"), "upper-case");
+    }
+
+    // ---- PITR out-of-range recovery target validation -------------------
+    //
+    // Regression coverage for the gap a live PITR restore against a real
+    // WAL-G backup exposed: before this validation existed, a
+    // `recovery_target_time` before the backup's own `started_at` was
+    // silently accepted by the API (202), silently accepted by PostgreSQL
+    // itself (no FATAL — recovery just stops at the earliest reachable
+    // point), and the restore run came back `status: "completed"` having
+    // silently discarded the caller's actual requested target. These tests
+    // pin the fix: `validate_pitr_recovery_target` must reject that case
+    // before the run is ever persisted or a container touched.
+
+    #[test]
+    fn pitr_target_before_backup_start_is_rejected() {
+        let backup_started_at = chrono::DateTime::parse_from_rfc3339("2026-08-09T11:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let target_before_backup = chrono::DateTime::parse_from_rfc3339("2020-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let target = RecoveryTarget::Time {
+            time: target_before_backup,
+        };
+
+        let err = validate_pitr_recovery_target(&target, Some(backup_started_at))
+            .expect_err("a target years before the backup started must be rejected");
+        match err {
+            RestoreError::Validation { message } => {
+                assert!(
+                    message.contains("before this backup started"),
+                    "got: {}",
+                    message
+                );
+            }
+            other => panic!("expected Validation error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn pitr_target_at_or_after_backup_start_is_accepted() {
+        let backup_started_at = chrono::DateTime::parse_from_rfc3339("2026-08-09T11:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        // Exactly at the backup start — the boundary case must NOT be
+        // rejected (nothing before it is out of range, this is in range).
+        let at_start = RecoveryTarget::Time {
+            time: backup_started_at,
+        };
+        assert!(validate_pitr_recovery_target(&at_start, Some(backup_started_at)).is_ok());
+
+        // A minute after the backup started — the ordinary in-range case.
+        let after_start = RecoveryTarget::Time {
+            time: backup_started_at + chrono::Duration::minutes(1),
+        };
+        assert!(validate_pitr_recovery_target(&after_start, Some(backup_started_at)).is_ok());
+    }
+
+    #[test]
+    fn pitr_target_validation_skipped_when_backup_start_unknown() {
+        // Orphan restores (backup discovered by S3 scan, no DB row) have no
+        // known `started_at` to range-check against — must not fail closed
+        // on missing metadata, just skip the check.
+        let target = RecoveryTarget::Time {
+            time: chrono::DateTime::parse_from_rfc3339("2020-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        };
+        assert!(validate_pitr_recovery_target(&target, None).is_ok());
+    }
+
+    #[test]
+    fn pitr_target_validation_only_applies_to_time_targets() {
+        // Xid/Lsn/Name targets have no comparable ordering against
+        // `started_at` — the check must be a no-op for them, not panic or
+        // spuriously reject.
+        let backup_started_at = Utc::now();
+        for target in [
+            RecoveryTarget::Xid {
+                xid: "12345".into(),
+            },
+            RecoveryTarget::Lsn {
+                lsn: "0/3000000".into(),
+            },
+            RecoveryTarget::Name {
+                name: "before-migration".into(),
+            },
+        ] {
+            assert!(validate_pitr_recovery_target(&target, Some(backup_started_at)).is_ok());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `pitr-scenario` to `apps/temps-e2e`, covering point-in-time recovery (PITR) for managed Postgres — the highest-blast-radius part of the backup system that was previously completely untested. Full-restore data integrity is already covered by `backup-restore-scenario`; this exercises the recovery-target-timestamp path specifically.

- Provisions a real standalone postgres service, links it to a project, deploys the `db-probe` app.
- Creates an S3 source (local MinIO) and triggers a real `wal-g backup-push` base backup.
- Writes 5 real rows (T1), waits for T1's WAL segment to actually archive to S3 (every managed postgres runs `archive_timeout=60`, so this needs a real ~75s wait — 5 tiny inserts never fill a 16MB segment on their own).
- Captures a recovery-target timestamp strictly after T1.
- Writes 3 more rows (T2, data the PITR target must NOT include).
- Starts a real in-place PITR restore (`mode: "pitr"`) to the captured timestamp and polls to `completed`.
- Verifies the result through the **read-only data-browser API** (`GET .../query/containers/{path}/entities/{entity}/data`, the same endpoint `temps data rows` uses) — an independent side channel from `/probe` (which mutates on every call) — asserting the exact restored row count (5) and exact primary-key set (`[1,2,3,4,5]`), not just that the restore run's status flipped to `completed`.
- Confirms the restored service is still fully writable with one more write, checked via the same data-browser API.
- Full teardown in `finally`.

Registered in `src/index.ts`, documented in `README.md` (command list, Commands block, `### pitr-scenario steps`), and adds `normalizePostgresDatabaseName` to `src/lib/flows.ts` (mirrors the Rust `normalize_database_name` in `crates/temps-providers/src/externalsvc/postgres.rs`).

**Two corrections this scenario's first draft needed — neither a platform bug, both correct Postgres/Temps behavior, documented in the code and README so future scenario authors don't repeat them:**

1. Linking a postgres service to a project does **not** hand the deployed app the database named at service-creation time. Linking auto-provisions a *separate* per-project-per-environment database (`PostgresService::get_runtime_env_vars`) and points `POSTGRES_URL` at that. The scenario now computes the real container path instead of guessing `app/public`.
2. The write-after-restore does not land as id 6. Postgres WAL-logs sequence advances `SEQ_LOG_VALS` (32) values ahead of what's actually been handed out, specifically so crash/PITR recovery can never replay a value a client already received — the first `nextval()` after *any* recovery legitimately jumps past `count+1`. The scenario asserts row count and the restored ids' exact identity instead of the new row's specific id.

**Postgres major-version upgrade** (the stretch goal) is scoped out and documented under "Known gaps" in the README with the specific reasons: it needs a service pinned to an explicit older major version at creation time, a *default* (not ad-hoc) S3 source, and a real two-image dump+restore workflow — meaningfully more setup than PITR, and this session's remaining time/stability budget wasn't enough to also stand it up and verify it live. Documented what a follow-up `pg-upgrade-scenario` command would need.

No Rust platform bug found/fixed in this PR. I did investigate a real-looking lead — the target `temps serve` instance under test died silently (no panic, no OOM, no crash report) at several different, unrelated points across verification runs on this shared multi-agent dev host, including once immediately correlated with a leftover project's monitor firing an `AutopilotTrigger` job — but after removing that leftover project the silent deaths continued at unrelated points (including during a plain `GET` poll), so I could not pin it to a reproducible code path and am not reporting it as a fix.

## Test plan

- [x] `bun run typecheck` passes in `apps/temps-e2e`
- [x] `pitr-scenario --help` shows correct flags/description
- [x] Live-verified **3x back to back** against a real local instance (fresh dedicated worktree DB `temps_e2e_pitr_pg_upgrade`, own data dir, ports 18090/18091/18453, local MinIO + registry already running): every run completed **all 23 steps**, including the exact-content PITR assertions (`total_count=5`, `ids=[1,2,3,4,5]` post-restore; `total_count=6`, first 5 ids unchanged, new id > 5 after the post-restore write)
- [x] Confirmed via `docker exec ... psql` against the actual container that the real database backing the deployed app (`e2e_<slug>_production`, not the service's own `app` database) held exactly the T1 rows post-restore, independently corroborating the API-level assertion
- [x] Full teardown verified: `--keep` used once for debugging, then all created projects/services/S3 sources/containers/volumes and the dedicated DB/data-dir cleaned up afterward

## Evidence

Independently re-verified against a fresh, isolated instance (own dev-DB `temps_e2e_pitr_evidence`, own data dir, ports 18190/18191/18553 — no shared state with any other worktree/agent) using the actual `target/fast/temps` binary built from this branch's HEAD (`4676f3e0`). Binary was already newer than every `.rs` file on disk, and this branch touches no `.rs` files (TypeScript e2e only), so no rebuild was needed.

**Plain run, full transcript (all 23 steps), showing the exact PITR assertions passing**:
```bash
TEMPS_URL=http://localhost:18190 TEMPS_API_KEY=*** TEMPS_E2E_REGISTRY=localhost:5111 \
  bun run src/index.ts pitr-scenario
```
```
Temps PITR scenario  ->  http://localhost:18190

▶ build + push db-probe image
  ✓ build + push db-probe image (2.8s)

▶ provision a real standalone postgres service
  ✓ provision a real standalone postgres service (10.3s)
  service #2

▶ create project
  ✓ create project (0.0s)
  project #2 (e2e-msljlk01-h3c3w6-pitr-app)

▶ link service to project
  ✓ link service to project (0.0s)

▶ resolve production environment
  ✓ resolve production environment (0.0s)
  db container path: e2e_msljlk01_h3c3w6_pitr_app_production/public

▶ deploy the db-probe app
  ✓ deploy the db-probe app (3.3s)

▶ wait for deployment
    ...running
  ✓ wait for deployment (0.0s)

▶ confirm deployment did not fail
  ✓ confirm deployment did not fail (0.0s)

▶ wait for the app to serve real traffic
  ✓ wait for the app to serve real traffic (6.1s)

▶ health check reports a real DB ping succeeding
  ✓ health check reports a real DB ping succeeding (0.0s)

▶ create an S3 source pointed at the local MinIO
  ✓ create an S3 source pointed at the local MinIO (0.0s)
  s3 source #2

▶ trigger a real base backup (wal-g backup-push -> upload to MinIO)
  ✓ trigger a real base backup (wal-g backup-push -> upload to MinIO) (0.6s)

▶ poll the base backup to a real completed state
    ...running
    ...running
    ...running
    ...completed
  ✓ poll the base backup to a real completed state (9.0s)
  backup #2 (8f016a36-a1bf-4696-a450-4115af7de3e6)

▶ write 5 real rows (T1 marker) through the injected POSTGRES_URL
  ✓ write 5 real rows (T1 marker) through the injected POSTGRES_URL (0.0s)

▶ wait for T1's WAL segment to be archived (archive_timeout=60s + margin)
  ✓ wait for T1's WAL segment to be archived (archive_timeout=60s + margin) (75.0s)

▶ capture the PITR recovery-target timestamp (after T1, before T2)
  target time: 2026-08-09T08:32:10.754Z
  ✓ capture the PITR recovery-target timestamp (after T1, before T2) (0.0s)

▶ buffer so T2 is unambiguously after the captured target time
  ✓ buffer so T2 is unambiguously after the captured target time (3.0s)

▶ write 3 MORE rows (T2 marker) the PITR target must NOT include (count now 8)
  ✓ write 3 MORE rows (T2 marker) the PITR target must NOT include (count now 8) (0.0s)

▶ short wait so T2's WAL is durably fsynced before we restore
  ✓ short wait so T2's WAL is durably fsynced before we restore (5.0s)

▶ start a PITR restore in place to the captured T1 timestamp
  ✓ start a PITR restore in place to the captured T1 timestamp (0.0s)
  restore run #1

▶ poll the PITR restore to a real completed state
    ...running (prepare)
    ...running (recover)
    ...completed (completed)
  ✓ poll the PITR restore to a real completed state (6.0s)

▶ the restored table has exactly T1s 5 rows (ids 1-5), T2 is gone -- read via the data-browser API, not /probe
  ✓ the restored table has exactly T1s 5 rows (ids 1-5), T2 is gone -- read via the data-browser API, not /probe (0.1s)

▶ the restored service is fully writable -- a new write lands on top of the restored 5, not colliding with them
  new row landed as id 34
  ✓ the restored service is fully writable -- a new write lands on top of the restored 5, not colliding with them (0.0s)

▶ teardown: tore down 1 deployment(s), deleted 1 project(s), 1 service(s), S3 source

✅ pitr-scenario PASSED
```

**Second independent run, `--json`, machine-readable artifact (`ok:true`, `finalProbeCount:6`, all 23 steps `ok:true`)**:
```bash
TEMPS_URL=http://localhost:18190 TEMPS_API_KEY=*** TEMPS_E2E_REGISTRY=localhost:5111 \
  bun run src/index.ts pitr-scenario --json
```
```json
{
  "runId": "e2e-msljokw8-37hub4",
  "ok": true,
  "pitrTargetTime": "2026-08-09T08:34:24.408Z",
  "finalProbeCount": 6,
  "steps": [
    { "step": "build + push db-probe image", "ok": true, "ms": 2467.47 },
    { "step": "provision a real standalone postgres service", "ok": true, "ms": 5964.00 },
    { "step": "create project", "ok": true, "ms": 25.76 },
    { "step": "link service to project", "ok": true, "ms": 15.11 },
    { "step": "resolve production environment", "ok": true, "ms": 6.40 },
    { "step": "deploy the db-probe app", "ok": true, "ms": 1958.93 },
    { "step": "wait for deployment", "ok": true, "ms": 22.96 },
    { "step": "confirm deployment did not fail", "ok": true, "ms": 18.18 },
    { "step": "wait for the app to serve real traffic", "ok": true, "ms": 4510.92 },
    { "step": "health check reports a real DB ping succeeding", "ok": true, "ms": 1.16 },
    { "step": "create an S3 source pointed at the local MinIO", "ok": true, "ms": 17.11 },
    { "step": "trigger a real base backup (wal-g backup-push -> upload to MinIO)", "ok": true, "ms": 577.65 },
    { "step": "poll the base backup to a real completed state", "ok": true, "ms": 9063.75 },
    { "step": "write 5 real rows (T1 marker) through the injected POSTGRES_URL", "ok": true, "ms": 11.66 },
    { "step": "wait for T1's WAL segment to be archived (archive_timeout=60s + margin)", "ok": true, "ms": 75000.92 },
    { "step": "capture the PITR recovery-target timestamp (after T1, before T2)", "ok": true, "ms": 0.11 },
    { "step": "buffer so T2 is unambiguously after the captured target time", "ok": true, "ms": 3002.15 },
    { "step": "write 3 MORE rows (T2 marker) the PITR target must NOT include (count now 8)", "ok": true, "ms": 28.13 },
    { "step": "short wait so T2's WAL is durably fsynced before we restore", "ok": true, "ms": 5002.01 },
    { "step": "start a PITR restore in place to the captured T1 timestamp", "ok": true, "ms": 17.21 },
    { "step": "poll the PITR restore to a real completed state", "ok": true, "ms": 6016.63 },
    { "step": "the restored table has exactly T1s 5 rows (ids 1-5), T2 is gone -- read via the data-browser API, not /probe", "ok": true, "ms": 73.95 },
    { "step": "the restored service is fully writable -- a new write lands on top of the restored 5, not colliding with them", "ok": true, "ms": 18.65 }
  ]
}
```

**Independent `docker exec`/psql cross-check** against the actual restored container's real project database (`e2e_<slug>_production`, not the service's own `app` database — see the "linking != database name" correction already noted above), from a third run kept alive with `--keep` specifically for this check:
```bash
docker exec postgres-e2e-msljrq36-j06o9k-pg psql -U app -d e2e_msljrq36_j06o9k_pitr_app_production \
  -c "select id from e2e_probe order by id;" -c "select count(*) as total from e2e_probe;"
```
```
 id 
----
  1
  2
  3
  4
  5
 34
(6 rows)

 total 
-------
     6
(1 row)
```
This independently corroborates the API-level assertions from the plain/json runs above: exactly the 5 T1 rows survived PITR, T2 (ids 6/7/8) is gone, and the post-restore write landed as id 34 (not 6, matching the documented sequence-jump behavior) for a total of 6 rows.

**Honest caveat found during this verification, not previously called out**: the very first attempt (before the 3 clean runs above) failed at the "write 5 real rows (T1 marker)" step with `GET /probe returned HTTP 503`. Root cause, confirmed from server logs: `enable_wal_archiving` (`crates/temps-providers/src/externalsvc/postgres.rs`) stops, removes, and recreates the Postgres container to flip `archive_mode=on` for the *first* backup on a service — a ~2s window during which the already-deployed app's DB connection is refused. This is pre-existing backend behavior on `main`, not something introduced by this PR's diff (which only touches `apps/temps-e2e`), and none of the 3 clean runs pasted above hit it — but it is a real, reproducible race in the platform's first-backup path that this new scenario surfaces and that has no retry around it, so a similar timing hiccup could occasionally flake this scenario (or any workload hitting the DB right as the first backup is triggered) in CI too. Worth a follow-up issue on the platform side (retry/backoff in the scenario, or making the first-backup archive_mode flip not require dropping in-flight connections) rather than blocking this PR, since the PR's own claims about PITR correctness held up across every run that got past that window.

Cleaned up afterward: killed the isolated server process, dropped `temps_e2e_pitr_evidence`, removed the scratch data dir, and deleted all `--keep`-retained projects/services/S3 sources via the API (confirmed via `docker ps` that no evidence-run containers remain).

## Round 1 fixes (review findings)

Two findings from the first review pass, both fixed on this branch (commit `58994e53`):

### 1. (Major) Success-path-only coverage — added a negative PITR path, and it caught a real bug

The scenario only exercised a valid PITR target. I read `crates/temps-backup/src/handlers/restore_handler.rs`, `crates/temps-backup/src/services/restore.rs`, and `crates/temps-providers/src/externalsvc/postgres.rs` end to end to find out what actually happens on an invalid recovery target — there was **no validation at all**. So I reproduced it live before writing any test, against a real WAL-G backup on this same worktree's dedicated instance:

- `POST /external-services/{id}/restore` with `{"mode":"pitr","target":{"kind":"time","time":"2020-01-01T00:00:00Z"}}` (years before the backup existed) returned **HTTP 202** and the restore run reached **`status: "completed"`**.
- Root cause, confirmed from the container's own Postgres log: PostgreSQL does **not** error on a too-early `recovery_target_time`. It reaches "consistent recovery state" (the base backup's own checkpoint) and then immediately stops — `recovery stopping before commit of transaction N` — silently discarding the requested target instead of FATALing.
- Post-restore, the data-browser API confirmed the "restored" table held **0 rows** — none of the backup's actual data — while the API had reported success. A wrong state reported as success, exactly the "silently misbehaving" failure mode the finding warned about.
- (For comparison, I also tried a target years in the *future*: PostgreSQL itself FATALs with `recovery ended before configured recovery target was reached` once it exhausts available WAL, and — combined with `restart_policy=always` — the container crash-loops until `wait_for_container_health`'s 90s timeout surfaces it as a `status: "failed"` restore run. That path already fails safely, if slowly and with a generic message, so I left it alone and focused the fix on the silent, too-early case.)

**Fix** (`crates/temps-backup/src/services/restore.rs`): `RestoreService::start_restore` now calls a new pure helper, `validate_pitr_recovery_target`, before a restore run row is ever created or a container touched. It rejects a `RecoveryTarget::Time` target that precedes the backup's own `started_at` with `RestoreError::Validation` (→ HTTP 400), e.g.:

```
"PITR recovery target 2020-01-01T00:00:00+00:00 is before this backup started
 (2026-08-09T11:23:42.788107+00:00) — no WAL this backup covers can satisfy it.
 Choose a time at or after the backup start, or select an earlier backup."
```

Orphan restores (backup discovered by S3 scan, no DB row, no known `started_at`) intentionally skip this check — there's nothing to range-check against — and still fall back on Postgres's own crash-loop/FATAL behavior for a too-early target.

Added `apps/temps-e2e/src/commands/pitr-scenario.ts` step: **"PITR to a target before the backup started is rejected (400), not silently accepted"** — attempts `time: "2000-01-01T00:00:00.000Z"` against the real backup and asserts HTTP 400 with a `detail` containing "before this backup started". Runs right after the base backup completes and before any writes, so it's fully isolated from the rest of the scenario.

Added 5 new Rust unit tests in `crates/temps-backup/src/services/restore.rs` (`pitr_target_before_backup_start_is_rejected`, `pitr_target_at_or_after_backup_start_is_accepted`, `pitr_target_validation_skipped_when_backup_start_unknown`, `pitr_target_validation_only_applies_to_time_targets`) covering the boundary (exactly at `started_at` must pass), the ordinary in-range case, the orphan-backup no-op case, and that `Xid`/`Lsn`/`Name` targets (no comparable ordering) are untouched by the check.

### 2. (Minor) `env.name` → `env.slug` for the data-browser container path

`PostgresService::get_runtime_env_vars` (`crates/temps-providers/src/services.rs`) computes the per-tenant database name from `environment.slug`, not `environment.name`. `pitr-scenario.ts` was building the data-browser container path from `env.name`, only coincidentally correct because the default environment's name and slug are both `"production"`. Fixed `getProductionEnvironment` in `apps/temps-e2e/src/lib/flows.ts` to also return `slug`, and switched `pitr-scenario.ts` to use it.

## Round 1 verification evidence

**Rust: `cargo check --lib` (whole workspace, clean)**
```
$(command -v cargo) check --lib
...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 23s
```
(0 errors; only the pre-existing `proc-macro-error2` future-incompat warning, unrelated to this change.)

**Rust: `cargo test -p temps-backup --lib` (full crate, real output)**
```
test result: ok. 127 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 24.40s
```
Includes the 5 new PITR-validation tests, all passing:
```
test services::restore::tests::pitr_target_validation_skipped_when_backup_start_unknown ... ok
test services::restore::tests::pitr_target_at_or_after_backup_start_is_accepted ... ok
test services::restore::tests::pitr_target_validation_only_applies_to_time_targets ... ok
test services::restore::tests::pitr_target_before_backup_start_is_rejected ... ok
```

**TypeScript: `tsc --noEmit` clean** in `apps/temps-e2e`.

**Live re-run of the full scenario (positive + new negative path) against a fresh instance**, dedicated worktree DB (`temps_e2e_pitr_r1final`), own data dir, port 18250, `TEMPS_DISABLE_HTTPS_REDIRECT=true`, no shared state with any other agent:
```bash
TEMPS_URL=http://localhost:18250 TEMPS_API_KEY=*** TEMPS_E2E_REGISTRY=localhost:5111 \
  bun run src/index.ts pitr-scenario
```
```
▶ poll the base backup to a real completed state
    ...running
    ...running
    ...running
    ...completed
  ✓ poll the base backup to a real completed state (9.0s)
  backup #1 (b98924e9-c155-42a9-bbc7-0916e544bc1d)

▶ PITR to a target before the backup started is rejected (400), not silently accepted
  rejected as expected: Validation error: PITR recovery target 2000-01-01T00:00:00+00:00 is
  before this backup started (2026-08-09T11:23:42.788107+00:00) — no WAL this backup covers
  can satisfy it. Choose a time at or after the backup start, or select an earlier backup.
  ✓ PITR to a target before the backup started is rejected (400), not silently accepted (0.0s)

▶ write 5 real rows (T1 marker) through the injected POSTGRES_URL
  ✓ write 5 real rows (T1 marker) through the injected POSTGRES_URL (0.0s)
  db container path: e2e_mslps507_s8pon2_pitr_app_production/public
...
▶ poll the PITR restore to a real completed state
    ...running (prepare)
    ...running (recover)
    ...completed (completed)
  ✓ poll the PITR restore to a real completed state (6.0s)

▶ the restored table has exactly T1s 5 rows (ids 1-5), T2 is gone -- read via the data-browser API, not /probe
  ✓ the restored table has exactly T1s 5 rows (ids 1-5), T2 is gone -- read via the data-browser API, not /probe (0.1s)

▶ the restored service is fully writable -- a new write lands on top of the restored 5, not colliding with them
  new row landed as id 34
  ✓ the restored service is fully writable -- a new write lands on top of the restored 5, not colliding with them (0.0s)

▶ teardown: tore down 1 deployment(s), deleted 1 project(s), 1 service(s), S3 source

✅ pitr-scenario PASSED
```
All steps (positive + negative) passed in one continuous run. `db container path` now reads `e2e_mslps507_s8pon2_pitr_app_production/public`, derived from `env.slug`.

**What I decided NOT to fix**: the future-target case (Postgres FATALs + 90s container-health-check timeout → `status: "failed"`) is a real, if slow and genericially-worded, failure path — not silent corruption — so I left it as-is rather than adding a second ~90s-plus e2e step for a case that isn't the silent-misbehavior bug this finding was about. Also didn't extend the timestamp-range check to `Xid`/`Lsn`/`Name` recovery targets: those have no comparable ordering against `started_at` (an XID or LSN isn't a timestamp), so a similar "is this even reachable" check would need different plumbing (checking against the backup's actual WAL range, not just `started_at`) — out of scope for this finding, which used a timestamp target.

**Teardown**: killed the dedicated server process, dropped `temps_e2e_pitr_r1final` (and the interim `temps_e2e_pitr_r1` scratch DB), removed both scratch data dirs, and confirmed via `docker ps -a` that no leftover containers from this verification remain.
