### PR TITLE
feat(e2e): otel-quota-scenario + fix silently-inert OTel storage quota

### DIFF
--- a/apps/temps-e2e/README.md
+++ b/apps/temps-e2e/README.md
@@ -6,7 +6,7 @@ End-to-end + load testing CLI for a **live** Temps instance. Most commands
 `managed-services-scenario`, `rbac-scenario`, `monitoring-scenario`,
 `error-tracking-scenario`, `logs-scenario`, `analytics-scenario`,
 `session-replay-scenario`, `backup-restore-scenario`, `git-deploy-scenario`,
-`examples`) drive the real
+`otel-quota-scenario`, `examples`) drive the real
 control-plane API directly via the shared
 [`@temps-sdk/api`](../../packages/api) client — fast, and enough to prove the
 API itself works, but they never exercise `apps/temps-cli` at all.
@@ -160,6 +160,15 @@ bun run src/index.ts backup-restore-scenario --registry localhost:5111
 # real github.com (documented exception to this suite's "no real internet"
 # rule -- see "External-service test infra" below).
 bun run src/index.ts git-deploy-scenario
+
+# otel-quota: real OTLP/HTTP protobuf traces/metrics/logs (hand-encoded, no
+# @opentelemetry/* SDK) round-tripped through the query API + Observe feed,
+# then real storage-quota enforcement pushed past a configured
+# TEMPS_OTEL_QUOTA_GB until ingestion is actually rejected (413). The target
+# instance MUST be launched with TEMPS_OTEL_QUOTA_GB=1 (the smallest nonzero
+# value) for the quota half to mean anything -- see its section below.
+bun run src/index.ts otel-quota-scenario
+bun run src/index.ts otel-quota-scenario --max-quota-batches 400 --json
 ```
 
 ### `examples`
@@ -739,6 +748,137 @@ strictly greater than it. Confirmed live 3x.
 This is deliberately the one scenario in this suite that hits real
 `github.com` -- see "External-service test infra" below for why the others
 don't.
+
+### `otel-quota-scenario` steps
+
+Requires the target instance to be launched with `TEMPS_OTEL_QUOTA_GB=1`
+(the smallest nonzero value the knob accepts -- it's parsed as a whole
+`u64` GB count, see `crates/temps-otel/src/plugin.rs`). Without it, quota
+is disabled instance-wide and step 5 fails fast with a clear "you didn't
+configure this" error instead of a false pass.
+
+1. create a project. OTel's `tk_` (API-key) ingest path authenticates with a
+   bearer `tk_` token plus `X-Temps-Project-Id`
+   (`crates/temps-otel/src/ingest/auth.rs::authenticate_api_key`) -- the same
+   shape the harness's own control-plane calls already use, so this scenario
+   ingests with that same key rather than minting a fresh one via
+   `POST /api-keys`: creating an API key is a `SensitiveAction::CreateApiKey`
+   that the OSS `RequireVerificationAuthorizer` always downgrades to "needs
+   interactive step-up verification" for every principal type, including an
+   already-authenticated API key, by design (so a leaked `tk_` key can't mint
+   itself more credentials). A scriptable run has no session to step up
+   with, so it uses the credential it was given -- exactly what a real
+   deployed collector does.
+2. hand-encode one real root span, one gauge metric point, and one log
+   record as raw OTLP/HTTP protobuf (`apps/temps-e2e/src/lib/otlp.ts` --
+   field numbers copied directly from the vendored `.proto` files at
+   `crates/temps-otel/proto/opentelemetry/proto/**`, not guessed) and POST
+   each to `/otel/v1/{traces,metrics,logs}`
+3. read them all back through the real query API -- `GET /otel/traces`
+   (by `trace_id`), `GET /otel/traces/{project_id}/{trace_id}`,
+   `GET /otel/logs` (body + trace correlation), `GET /otel/metrics` (exact
+   value) -- asserting decoded field values, not just "a row exists"
+4. confirm the root span appears in the unified Observe feed
+   (`GET /projects/{id}/observe/events?kinds=span`), and that
+   `kinds=log` is rejected 400 (there is no `Log` variant in
+   `ObservabilityEvent` by design -- logs have their own page; see the bug
+   fix below)
+5. read `GET /otel/quota/{project_id}` and confirm a fresh project starts
+   well under 100% with a nonzero configured limit
+6. push ~9 MB OTLP trace batches (one span each, one giant filler
+   attribute) in a loop, polling the **uncached** `GET /otel/quota`
+   endpoint after every batch, until `usage_pct >= 100` (capped at
+   `--max-quota-batches`, default 250)
+7. sleep past the ingest-time quota cache TTL (30s, see
+   `crates/temps-otel/src/ingest/quota_cache.rs::QUOTA_CACHE_TTL`) --
+   `check_quota` on the hot ingest path deliberately reuses a cached
+   result for up to 30s (an exact per-project `COUNT(*)`-based estimate on
+   every request would be too expensive), so a burst inside that window
+   can legitimately land after crossing 100%; that's a documented
+   accuracy/hot-path tradeoff, not a bug, and pushing through it would
+   make the next assertion flaky
+8. send one more (small) batch with a unique canary span name and assert
+   it's rejected with HTTP 413 (`OtelError::QuotaExceeded`, body mentions
+   "quota") -- twice, to rule out a one-off race
+9. query `GET /otel/traces` for the canary span name and confirm it never
+   landed -- proves the rejection is real (the row didn't get written),
+   not just that the HTTP call happened to error while ingestion secretly
+   continued
+10. teardown: delete the project
+
+**Real bug found and fixed (the headline one): quota enforcement was
+silently inert for every project.** `TimescaleDbStorage::get_storage_quota`
+(`crates/temps-otel/src/storage/timescaledb.rs`) estimates a project's
+share of each OTel hypertable as `hypertable_size * (project_rows /
+approximate_row_count(hypertable))` -- but the code being fixed called
+`pg_total_relation_size('otel_spans')` (etc.) instead of
+`hypertable_size('otel_spans'::regclass)`. A hypertable's "root" relation
+(the name you create it under) holds no rows and almost no bytes of its
+own -- TimescaleDB partitions all actual data into child "chunk" tables
+under `_timescaledb_internal`, and `pg_total_relation_size` on the root
+name measures only that root's tiny catalog/index footprint. Verified live:
+with `TEMPS_OTEL_QUOTA_GB=1` configured, pushing over 2GB of real OTLP
+trace data into one project (250 batches, `--max-quota-batches`'s cap)
+never moved `total_bytes` past ~15MB or `usage_pct` past ~1.5% -- the quota
+could not be crossed no matter how much was ingested. `hypertable_size()`
+is TimescaleDB's chunk-aware equivalent (sums every chunk's own
+`pg_total_relation_size`, still cheap -- proportional to chunk count, not
+row count). After the fix, the same volume test trips the quota
+consistently at ~110 batches / ~990MB sent against a 1024MB (1 GiB)
+configured limit, across 4 consecutive clean runs. This is the exact
+160GB/day-flood failure mode the quota exists to prevent, and it could not
+have been caught by unit tests against a mocked storage layer -- only a
+real TimescaleDB instance has real chunk partitioning to get wrong.
+Alongside this, `LEAST(1.0, ratio)` was added around each per-table
+proportion: `approximate_row_count` is a planner-statistics estimate that
+can lag the true count right after a write burst, and without the clamp a
+stale (too-low) denominator could compute a per-project share above 100%
+of the table, inflating `total_bytes` past what the table itself reports.
+
+**Residual limitation found (not fixed here, documented as a known
+follow-up)**: because `approximate_row_count` is planner-statistics-based
+and shared across every project on the same hypertable, a project that
+checks its quota shortly after a DIFFERENT project on the same instance
+just finished a large write burst can be told it's already near/over 100%
+usage from a handful of its own rows -- the stale (too-low) row-count
+denominator combined with the `LEAST(1.0, ..)` clamp above conservatively
+(but incorrectly) attributes the whole table to whichever project asks
+first. Reproduced live: running this scenario twice back-to-back against
+the *same* database (no fresh project/DB in between) makes the second
+run's very first quota check fail with `usage_pct` already `>100` on a
+project with only its own 3 initial spans. It self-heals once
+autovacuum/`ANALYZE` catches up (seconds, in practice), and does not
+recur when each run gets an isolated database (the normal way this suite
+runs, and how CI would run it). A proper fix -- e.g. a periodic background
+`ANALYZE` of the three OTel hypertables, decoupled from any single
+project's request path -- is a bigger design/cost tradeoff than fits this
+PR; flagged here rather than silently patched around or ignored.
+
+**Real bug found and fixed (secondary)**: `EventsQuery.kinds`'s doc comment
+(which `utoipa` surfaces into the OpenAPI spec, and from there into
+`@temps-sdk/api`'s generated docs) advertised `log` as a valid Observe
+`kinds` filter value alongside `request,span,error,revenue`. It never was
+-- `ObservabilityEvent` has no `Log` variant (a deliberate, documented
+design choice: runtime logs are too high-volume to interleave with
+business signals, and have their own retention/storage model), and
+`EventKind::parse("log")` returns `None`, so `kinds=log` has always 400'd
+with `InvalidKindsFilter`. Fixed the doc comment in
+`crates/temps-observability/src/handlers/events.rs` to match what the code
+has always actually done, instead of leaving a promise nothing implements
+for the next reader (human or agent) to trip over. Step 4 asserts the real
+behavior directly: `kinds=span` finds the span, `kinds=log` 400s.
+
+**Real bug found and fixed (third, minor)**: `query_traces`'s utoipa
+`#[utoipa::path(params(...))]` list (`crates/temps-otel/src/handlers/query_handler.rs`)
+was missing `attributes` and `name_pattern` -- both real, functioning query
+params on `TraceQueryParams` (and both already correctly documented on the
+neighboring `query_trace_summaries` handler a few lines below), silently
+absent from the generated OpenAPI spec and therefore from `@temps-sdk/api`'s
+typed `queryTraces()` signature: a real server capability the typed SDK
+couldn't express. Fixed by adding both to the params list. This scenario
+doesn't depend on the fix (it filters the quota canary span by `trace_id`,
+which was already typed correctly) -- found while checking why `name_pattern`
+wasn't available on the typed client during development.
 
 ## External-service test infra (TLS, DNS, email, backups)
 

--- a/apps/temps-e2e/src/commands/otel-quota-scenario.ts
+++ b/apps/temps-e2e/src/commands/otel-quota-scenario.ts
@@ -1,0 +1,481 @@
+/**
+ * OTel ingestion + storage-quota enforcement against a live Temps instance --
+ * proves real OTLP/HTTP protobuf payloads (traces/metrics/logs) actually land
+ * through the ingest endpoints and are readable back through the real query
+ * API and the unified Observe feed, then proves the quota cutoff documented
+ * in `crates/temps-otel/src/services/otel_service.rs::check_quota` (born from
+ * a real production incident: a 160GB/day OTel span flood before quota
+ * enforcement existed) actually stops ingestion once a project's storage
+ * crosses its configured limit -- not just that the config knob exists.
+ *
+ *   1. create a project. OTel's `tk_` (API-key) ingest path authenticates
+ *      exactly like the harness's own control-plane calls -- a bearer `tk_`
+ *      token plus `X-Temps-Project-Id` (`crates/temps-otel/src/ingest/auth.rs`'s
+ *      `authenticate_api_key`) -- so this scenario ingests with the SAME
+ *      `tk_` key the harness already authenticates with, rather than minting
+ *      a fresh one: `POST /api-keys` is a `SensitiveAction::CreateApiKey`
+ *      that the OSS `RequireVerificationAuthorizer` always downgrades to
+ *      "needs interactive step-up verification" for EVERY principal type,
+ *      including an already-authenticated API key -- by design, so a leaked
+ *      `tk_` key can't mint itself more credentials for persistence. A
+ *      scriptable e2e run has no session to step up with, so it uses the
+ *      credential it was given, exactly as a real deployed collector would.
+ *   2. hand-encode (no `@opentelemetry/*` SDK -- see `lib/otlp.ts`) and POST
+ *      one real root span, one gauge metric point, and one log record as raw
+ *      OTLP/HTTP protobuf to `/otel/v1/{traces,metrics,logs}`
+ *   3. read them back through the REAL query API -- `GET /otel/traces`,
+ *      `GET /otel/traces/{project_id}/{trace_id}`, `GET /otel/logs`,
+ *      `GET /otel/metrics` -- asserting on decoded field values (span name,
+ *      attributes, trace/span id, metric value, log body), not just "some
+ *      row exists"
+ *   4. confirm the root span shows up in the unified Observe feed
+ *      (`GET /projects/{id}/observe/events?kinds=span`) -- the merge point
+ *      `crates/temps-observability/src/handlers/events.rs` is supposed to
+ *      expose alongside error/request/revenue signals
+ *   5. quota: the target instance is launched with `TEMPS_OTEL_QUOTA_GB=1`
+ *      (the smallest nonzero value the knob accepts -- see
+ *      `crates/temps-otel/src/plugin.rs`), so quota enforcement is live from
+ *      boot. Push large (~9 MB) trace batches in a loop, polling the
+ *      UNCACHED `GET /otel/quota/{project_id}` admin endpoint after each one
+ *      (ingest-time enforcement (`check_quota`) reuses a 30s-TTL cache --
+ *      see `ingest/quota_cache.rs` -- so a burst inside that window can
+ *      legitimately land after crossing 100%; this is a documented
+ *      hot-path/accuracy tradeoff, not a bug) until usage_pct reaches >=100
+ *   6. wait past the 30s ingest-time cache TTL, then push one more (small)
+ *      batch carrying a unique canary span name and assert it is REJECTED
+ *      with HTTP 413 (`OtelError::QuotaExceeded`) -- twice, to rule out a
+ *      one-off flake -- and that the canary span never actually landed
+ *      (queried back via `GET /otel/traces`, not just "the HTTP call
+ *      errored")
+ *   7. teardown: delete the project
+ *
+ * REAL BUG FOUND + FIXED (headline finding): quota enforcement was silently
+ * inert for every project. `TimescaleDbStorage::get_storage_quota`
+ * (`crates/temps-otel/src/storage/timescaledb.rs`) estimates a project's
+ * share of each OTel hypertable as `table_size * (project_rows /
+ * approximate_row_count(hypertable))`, but computed `table_size` via
+ * `pg_total_relation_size('otel_spans')` on the hypertable's ROOT relation --
+ * which holds no rows and almost no bytes of its own (TimescaleDB partitions
+ * all actual data into child "chunk" tables under `_timescaledb_internal`),
+ * so `table_size` never grew with real ingest volume. Verified live: with
+ * `TEMPS_OTEL_QUOTA_GB=1`, pushing 2GB+ of real OTLP data into one project
+ * never moved `usage_pct` past ~1.5%. Fixed by switching to
+ * `hypertable_size('otel_spans'::regclass)`, TimescaleDB's chunk-aware
+ * equivalent (still cheap -- proportional to chunk count, not row count).
+ * After the fix, this scenario trips the quota consistently at ~110 batches
+ * / ~990MB against a 1024MB configured limit across 4 consecutive clean
+ * runs. Also added `LEAST(1.0, ratio)` around each per-table proportion:
+ * `approximate_row_count` can lag the true count right after a write burst,
+ * and without the clamp a stale denominator could compute a share above
+ * 100% of the table.
+ *
+ * RESIDUAL LIMITATION found, NOT fixed here (documented, not silently
+ * patched around): `approximate_row_count` is shared across every project on
+ * the same hypertable, so a project checking quota shortly after a
+ * DIFFERENT project's write burst can be told it's near/over 100% from a
+ * handful of its own rows (reproduced live by running this scenario twice
+ * back-to-back against the same database with no fresh project/DB in
+ * between). Self-heals within seconds as autovacuum/ANALYZE catches up, and
+ * doesn't recur with an isolated database per run (how this suite -- and CI
+ * -- actually runs it). A proper fix (e.g. a periodic background ANALYZE of
+ * the three OTel hypertables) is a bigger cost/design tradeoff than fits
+ * this PR.
+ *
+ * Real bug found + fixed (secondary): `EventsQuery.kinds`'s doc comment
+ * (surfaced into the OpenAPI spec via utoipa, and from there into
+ * `@temps-sdk/api`'s generated docs) advertised `log` as a valid Observe
+ * `kinds` filter value alongside request/span/error/revenue. It never was:
+ * `ObservabilityEvent` has no `Log` variant (a deliberate design choice,
+ * documented on the enum itself -- logs are too high-volume to interleave
+ * with business signals) and `EventKind::parse("log")` returns `None`, so
+ * `kinds=log` has always been rejected with 400 `InvalidKindsFilter`. Fixed
+ * in `crates/temps-observability/src/handlers/events.rs` by correcting the
+ * doc comment to match the code instead of leaving the code to eventually
+ * "catch up" to a promise nothing implements. Step 4 asserts the real
+ * (correct) behavior: `kinds=span` finds the span, `kinds=log` 400s.
+ *
+ * Real bug found + fixed (third, minor): `query_traces`'s utoipa
+ * `#[utoipa::path(params(...))]` list (`crates/temps-otel/src/handlers/
+ * query_handler.rs`) was missing `attributes` and `name_pattern` -- both
+ * real, functioning query params on `TraceQueryParams` (and both already
+ * correctly documented on the neighboring `query_trace_summaries` handler),
+ * silently absent from the generated OpenAPI spec and therefore from
+ * `@temps-sdk/api`'s typed `queryTraces()` signature. A real capability the
+ * typed SDK couldn't express. Fixed by adding both to the params list.
+ */
+import {
+  queryTraces,
+  getTrace,
+  queryLogs,
+  queryMetrics,
+  getQuota,
+  observabilityListEvents,
+} from '@temps-sdk/api'
+import { makeClient, normalizeApiUrl, resolveConfig, unwrap } from '../lib/client.ts'
+import { createE2eProject, teardown, makeRunId, sleep } from '../lib/flows.ts'
+import {
+  buildTraceExportRequest,
+  buildMetricsExportRequest,
+  buildLogsExportRequest,
+  defaultResourceAttrs,
+  randomTraceId,
+  randomSpanId,
+  randomFillerAscii,
+  sendOtlp,
+} from '../lib/otlp.ts'
+
+export interface OtelQuotaScenarioOptions {
+  keep?: boolean
+  json?: boolean
+  /** Max ingest batches to push while hunting for the quota cutoff (safety cap). */
+  maxQuotaBatches?: string
+  connection: { url?: string; apiKey?: string }
+}
+
+interface StepLog {
+  step: string
+  ok: boolean
+  detail?: string
+  ms?: number
+}
+
+interface OtelQuotaScenarioResult {
+  runId: string
+  ok: boolean
+  steps: StepLog[]
+  quota?: {
+    limitBytes: number
+    bytesSentByClientAtTrip: number
+    reportedTotalBytesAtTrip: number
+    batchesSent: number
+  }
+}
+
+/** `check_quota`'s ingest-time cache TTL (`ingest/quota_cache.rs::QUOTA_CACHE_TTL`), plus margin. */
+const QUOTA_CACHE_TTL_MS = 30_000
+const QUOTA_WAIT_MARGIN_MS = 5_000
+
+/** Bytes of filler-attribute payload per over-quota-hunting batch (stays under the 10 MiB decompressed / 12 MiB body cap). */
+const BATCH_FILLER_BYTES = 9 * 1024 * 1024
+
+export async function otelQuotaScenarioCommand(opts: OtelQuotaScenarioOptions): Promise<void> {
+  const cfg = resolveConfig(opts.connection)
+  const client = makeClient(cfg)
+  const apiBaseUrl = normalizeApiUrl(cfg.url)
+  const json = !!opts.json
+  const log = (msg: string) => {
+    if (!json) process.stderr.write(msg + '\n')
+  }
+  if (!json) log(`Temps otel-quota scenario  ->  ${cfg.url}`)
+
+  const runId = makeRunId(Date.now())
+  const maxQuotaBatches = Number(opts.maxQuotaBatches ?? 250)
+  const steps: StepLog[] = []
+  const step = async <T>(name: string, fn: () => Promise<T>): Promise<T> => {
+    const t0 = performance.now()
+    log(`\n▶ ${name}`)
+    try {
+      const r = await fn()
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: true, ms })
+      log(`  ✓ ${name} (${(ms / 1000).toFixed(1)}s)`)
+      return r
+    } catch (e) {
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: false, detail: (e as Error).message, ms })
+      log(`  ✗ ${name}: ${(e as Error).message}`)
+      throw e
+    }
+  }
+
+  const projectIds: number[] = []
+  let quotaSummary: OtelQuotaScenarioResult['quota']
+
+  try {
+    const project = await step('create project', () =>
+      createE2eProject(client, { name: `${runId}-otel-quota` }),
+    )
+    projectIds.push(project.id)
+    log(`  project #${project.id} (${project.slug})`)
+
+    // OTel's tk_ ingest auth path is checked against the SAME api_keys row
+    // the harness itself authenticates with (see this file's header comment
+    // for why a fresh key isn't minted here) -- so this is that key,
+    // scoped to this project via X-Temps-Project-Id per request.
+    const ingestKey = cfg.apiKey
+
+    const resourceAttrs = defaultResourceAttrs(`${runId}-app`, { 'e2e.run_id': runId })
+    const traceId = randomTraceId()
+    const rootSpanId = randomSpanId()
+    const rootSpanName = `otel-quota-e2e-root-${runId}`
+    const metricName = `otel_quota_e2e_gauge_${runId.replace(/[^a-zA-Z0-9_.:-]/g, '_')}`
+    const metricValue = 4242
+    const logBody = `otel-quota-e2e log line ${runId}`
+
+    await step('POST a real OTLP trace batch (one root span) to /otel/v1/traces', async () => {
+      const payload = buildTraceExportRequest({
+        resourceAttrs,
+        spans: [
+          {
+            traceId,
+            spanId: rootSpanId,
+            name: rootSpanName,
+            attributes: { 'e2e.run_id': runId, 'e2e.marker': 'trace' },
+            statusCode: 1, // OK
+          },
+        ],
+      })
+      const res = await sendOtlp({ apiBaseUrl, apiKey: ingestKey, projectId: project.id, signal: 'traces', payload })
+      if (res.status !== 200) throw new Error(`ingest traces returned HTTP ${res.status}: ${res.bodyText}`)
+    })
+
+    await step('POST a real OTLP metrics batch (one gauge point) to /otel/v1/metrics', async () => {
+      const payload = buildMetricsExportRequest({
+        resourceAttrs,
+        metrics: [
+          {
+            name: metricName,
+            unit: '1',
+            dataPoints: [{ asDouble: metricValue, attributes: { 'e2e.run_id': runId } }],
+          },
+        ],
+      })
+      const res = await sendOtlp({ apiBaseUrl, apiKey: ingestKey, projectId: project.id, signal: 'metrics', payload })
+      if (res.status !== 200) throw new Error(`ingest metrics returned HTTP ${res.status}: ${res.bodyText}`)
+    })
+
+    await step('POST a real OTLP logs batch (one record, correlated to the span) to /otel/v1/logs', async () => {
+      const payload = buildLogsExportRequest({
+        resourceAttrs,
+        records: [
+          {
+            body: logBody,
+            attributes: { 'e2e.run_id': runId },
+            traceId,
+            spanId: rootSpanId,
+          },
+        ],
+      })
+      const res = await sendOtlp({ apiBaseUrl, apiKey: ingestKey, projectId: project.id, signal: 'logs', payload })
+      if (res.status !== 200) throw new Error(`ingest logs returned HTTP ${res.status}: ${res.bodyText}`)
+    })
+
+    await step('the span round-trips through GET /otel/traces (query by trace_id)', async () => {
+      const res = unwrap(
+        await queryTraces({ client, query: { project_id: project.id, trace_id: traceId } }),
+        'queryTraces',
+      )
+      if (res.data.length !== 1) throw new Error(`expected 1 span for trace_id=${traceId}, got ${res.data.length}`)
+      const span = res.data[0]!
+      if (span.name !== rootSpanName) throw new Error(`span.name="${span.name}", expected "${rootSpanName}"`)
+      if (span.span_id !== rootSpanId) throw new Error(`span.span_id="${span.span_id}", expected "${rootSpanId}"`)
+      if (span.parent_span_id) throw new Error(`span.parent_span_id="${span.parent_span_id}", expected root (null/empty)`)
+      if (span.attributes['e2e.run_id'] !== runId) throw new Error(`span attributes did not round-trip: ${JSON.stringify(span.attributes)}`)
+      if (span.status_code !== 'OK') throw new Error(`span.status_code="${span.status_code}", expected OK`)
+    })
+
+    await step('the same trace round-trips through GET /otel/traces/{project_id}/{trace_id}', async () => {
+      const res = unwrap(
+        await getTrace({ client, path: { project_id: project.id, trace_id: traceId } }),
+        'getTrace',
+      )
+      if (res.data.length !== 1 || res.data[0]!.trace_id !== traceId) {
+        throw new Error(`getTrace did not return the expected single span: ${JSON.stringify(res.data)}`)
+      }
+    })
+
+    await step('the log round-trips through GET /otel/logs (correct body + trace correlation)', async () => {
+      const res = unwrap(
+        await queryLogs({ client, query: { project_id: project.id, trace_id: traceId } }),
+        'queryLogs',
+      )
+      if (res.data.length !== 1) throw new Error(`expected 1 log for trace_id=${traceId}, got ${res.data.length}`)
+      const record = res.data[0]!
+      if (record.body !== logBody) throw new Error(`log.body="${record.body}", expected "${logBody}"`)
+      if (record.span_id !== rootSpanId) throw new Error(`log.span_id="${record.span_id}", expected "${rootSpanId}"`)
+    })
+
+    await step('the metric point round-trips through GET /otel/metrics with the exact value', async () => {
+      const res = unwrap(
+        await queryMetrics({ client, query: { project_id: project.id, metric_name: metricName } }),
+        'queryMetrics',
+      )
+      if (res.data.length < 1) throw new Error(`expected at least 1 bucket for metric_name=${metricName}, got 0`)
+      const bucket = res.data[0]!
+      const value = bucket.value ?? bucket.avg_value
+      if (value !== metricValue) throw new Error(`metric bucket value=${value}, expected ${metricValue}`)
+    })
+
+    await step('the root span shows up in the unified Observe feed (kinds=span)', async () => {
+      const res = unwrap(
+        await observabilityListEvents({
+          client,
+          path: { project_id: project.id },
+          query: { kinds: 'span', search: rootSpanName },
+        }),
+        'observabilityListEvents',
+      )
+      const match = res.events.find((e) => e.type === 'span' && e.trace_id === traceId)
+      if (!match) {
+        throw new Error(`root span not found in Observe feed: ${JSON.stringify(res.events)}`)
+      }
+    })
+
+    await step('kinds=log is rejected 400 (no Log variant in the Observe feed, by design -- not silently ignored)', async () => {
+      const res = await observabilityListEvents({
+        client,
+        path: { project_id: project.id },
+        query: { kinds: 'log' },
+      })
+      const status = res.response?.status
+      if (status !== 400) {
+        throw new Error(`observe/events?kinds=log returned HTTP ${status}, expected 400`)
+      }
+    })
+
+    // ── Quota enforcement ────────────────────────────────────────────
+    //
+    // The target instance is expected to be launched with
+    // TEMPS_OTEL_QUOTA_GB=1 (see this file's header comment) so the quota
+    // is live for every project from boot, including this one.
+
+    const initialQuota = await step('quota starts well under 100% for a fresh project', async () => {
+      const res = unwrap(await getQuota({ client, path: { project_id: project.id } }), 'getQuota')
+      log(`  limit_bytes=${res.quota.limit_bytes} total_bytes=${res.quota.total_bytes} usage_pct=${res.quota.usage_pct.toFixed(4)}`)
+      if (res.quota.limit_bytes <= 0) {
+        throw new Error(
+          `quota.limit_bytes=${res.quota.limit_bytes} -- the target instance must be launched with TEMPS_OTEL_QUOTA_GB set (>=1) for this scenario to mean anything`,
+        )
+      }
+      if (res.quota.usage_pct >= 100) {
+        throw new Error(`quota.usage_pct=${res.quota.usage_pct} already >= 100 before any volume was pushed -- unclean project`)
+      }
+      return res.quota
+    })
+
+    let bytesSentByClient = 0
+    let batchesSent = 0
+    let trippedAtBytes: number | undefined
+    let trippedAtReportedTotal: number | undefined
+
+    await step(
+      `push large OTLP trace batches (~${(BATCH_FILLER_BYTES / 1024 / 1024).toFixed(1)}MB each) until quota.usage_pct >= 100 (uncached GET /otel/quota read), capped at ${maxQuotaBatches} batches`,
+      async () => {
+        // High-entropy, not a repeated character: Postgres TOASTs large
+        // JSONB attribute values through pglz, which would crush a repeated
+        // byte down to a few KB regardless of BATCH_FILLER_BYTES and make
+        // the quota's hypertable_size()-based math look wrong for a reason
+        // that has nothing to do with the quota code (see randomFillerAscii's
+        // doc comment).
+        const filler = randomFillerAscii(BATCH_FILLER_BYTES)
+        for (let i = 0; i < maxQuotaBatches; i++) {
+          const payload = buildTraceExportRequest({
+            resourceAttrs,
+            spans: [
+              {
+                traceId: randomTraceId(),
+                spanId: randomSpanId(),
+                name: `otel-quota-e2e-filler-${runId}-${i}`,
+                attributes: { 'e2e.run_id': runId, filler },
+              },
+            ],
+          })
+          const res = await sendOtlp({ apiBaseUrl, apiKey: ingestKey, projectId: project.id, signal: 'traces', payload })
+          batchesSent++
+          if (res.status === 200) {
+            bytesSentByClient += payload.byteLength
+          } else if (res.status !== 413) {
+            throw new Error(`unexpected ingest status while pushing volume: HTTP ${res.status}: ${res.bodyText}`)
+          }
+
+          const q = unwrap(await getQuota({ client, path: { project_id: project.id } }), 'getQuota')
+          log(
+            `  batch ${i + 1}: ingest=${res.status} sent_so_far=${(bytesSentByClient / 1024 / 1024).toFixed(1)}MB ` +
+              `reported_total=${(q.quota.total_bytes / 1024 / 1024).toFixed(1)}MB usage_pct=${q.quota.usage_pct.toFixed(2)}`,
+          )
+          if (q.quota.usage_pct >= 100 || res.status === 413) {
+            trippedAtBytes = bytesSentByClient
+            trippedAtReportedTotal = q.quota.total_bytes
+            return
+          }
+        }
+        throw new Error(
+          `quota never reached 100% after ${maxQuotaBatches} batches (~${(bytesSentByClient / 1024 / 1024).toFixed(0)}MB sent, limit=${initialQuota.limit_bytes} bytes)`,
+        )
+      },
+    )
+
+    quotaSummary = {
+      limitBytes: initialQuota.limit_bytes,
+      bytesSentByClientAtTrip: trippedAtBytes ?? bytesSentByClient,
+      reportedTotalBytesAtTrip: trippedAtReportedTotal ?? 0,
+      batchesSent,
+    }
+    log(
+      `  quota crossed 100% after ~${((trippedAtBytes ?? 0) / 1024 / 1024).toFixed(1)}MB client-sent ` +
+        `(configured limit ${(initialQuota.limit_bytes / 1024 / 1024).toFixed(0)}MB) in ${batchesSent} batch(es)`,
+    )
+
+    await step(
+      `wait out the ${(QUOTA_CACHE_TTL_MS / 1000).toFixed(0)}s ingest-time quota cache TTL so the next ingest call re-checks storage live`,
+      () => sleep(QUOTA_CACHE_TTL_MS + QUOTA_WAIT_MARGIN_MS),
+    )
+
+    const canarySpanName = `otel-quota-e2e-REJECTED-canary-${runId}`
+    const canaryTraceId = randomTraceId()
+    await step('a batch sent once over quota is REJECTED with HTTP 413 (not silently accepted)', async () => {
+      const payload = buildTraceExportRequest({
+        resourceAttrs,
+        spans: [{ traceId: canaryTraceId, spanId: randomSpanId(), name: canarySpanName }],
+      })
+      const res = await sendOtlp({ apiBaseUrl, apiKey: ingestKey, projectId: project.id, signal: 'traces', payload })
+      if (res.status !== 413) {
+        throw new Error(`expected HTTP 413 (QuotaExceeded) once over quota, got HTTP ${res.status}: ${res.bodyText}`)
+      }
+      if (!/quota/i.test(res.bodyText)) {
+        throw new Error(`413 response body did not mention "quota": ${res.bodyText}`)
+      }
+    })
+
+    await step('rejection persists on a second attempt (not a one-off)', async () => {
+      const payload = buildTraceExportRequest({
+        resourceAttrs,
+        spans: [{ traceId: randomTraceId(), spanId: randomSpanId(), name: `${canarySpanName}-2` }],
+      })
+      const res = await sendOtlp({ apiBaseUrl, apiKey: ingestKey, projectId: project.id, signal: 'traces', payload })
+      if (res.status !== 413) {
+        throw new Error(`expected HTTP 413 again on the second over-quota attempt, got HTTP ${res.status}: ${res.bodyText}`)
+      }
+    })
+
+    await step('the rejected canary span never actually landed (queried back, not just "the HTTP call errored")', async () => {
+      const res = unwrap(
+        await queryTraces({ client, query: { project_id: project.id, trace_id: canaryTraceId } }),
+        'queryTraces',
+      )
+      if (res.data.length !== 0) {
+        throw new Error(`rejected canary span WAS stored despite the 413: ${JSON.stringify(res.data)}`)
+      }
+    })
+  } catch {
+    // Failure already recorded in `steps`; fall through to teardown.
+  } finally {
+    if (opts.keep) {
+      log(`\n(kept resources: projects=${projectIds.join(',')})`)
+    } else {
+      const td = await teardown(client, { projectIds })
+      log(`\n▶ teardown: deleted ${td.deletedProjects} project(s)` + (td.errors.length ? ` (${td.errors.length} errors)` : ''))
+      for (const e of td.errors) log(`    ! ${e}`)
+    }
+  }
+
+  const ok = steps.length > 0 && steps.every((s) => s.ok)
+  const result: OtelQuotaScenarioResult = { runId, ok, steps, quota: quotaSummary }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+  } else {
+    log(`\n${ok ? '✅ otel-quota-scenario PASSED' : '❌ otel-quota-scenario FAILED'}`)
+  }
+  if (!ok) process.exitCode = 1
+}

--- a/apps/temps-e2e/src/index.ts
+++ b/apps/temps-e2e/src/index.ts
@@ -22,6 +22,7 @@ import { logsScenarioCommand } from './commands/logs-scenario.ts'
 import { analyticsScenarioCommand } from './commands/analytics-scenario.ts'
 import { sessionReplayScenarioCommand } from './commands/session-replay-scenario.ts'
 import { gitDeployScenarioCommand } from './commands/git-deploy-scenario.ts'
+import { otelQuotaScenarioCommand } from './commands/otel-quota-scenario.ts'
 
 const program = new Command()
 
@@ -300,6 +301,18 @@ program
   .option('--json', 'machine-readable output')
   .action(async (opts) => {
     await sessionReplayScenarioCommand({ ...opts, connection: connection() })
+  })
+
+program
+  .command('otel-quota-scenario')
+  .description(
+    'Real OTLP/HTTP protobuf ingestion (traces/metrics/logs, hand-encoded, no @opentelemetry/* SDK) round-tripped through the real query API and the unified Observe feed, then real storage-quota enforcement: push volume past a configured TEMPS_OTEL_QUOTA_GB until GET /otel/quota crosses 100%, and assert ingestion is actually rejected with 413 (and the rejected data never lands) once the ingest-time quota cache re-checks -- not just that the config knob exists',
+  )
+  .option('--max-quota-batches <n>', 'safety cap on ~9MB batches pushed while hunting for the quota cutoff', '250')
+  .option('--keep', 'do not tear down created resources')
+  .option('--json', 'machine-readable output')
+  .action(async (opts) => {
+    await otelQuotaScenarioCommand({ ...opts, connection: connection() })
   })
 
 program

--- a/apps/temps-e2e/src/lib/otlp.ts
+++ b/apps/temps-e2e/src/lib/otlp.ts
@@ -1,0 +1,415 @@
+/**
+ * Minimal hand-rolled OTLP/HTTP protobuf encoder.
+ *
+ * Builds real `ExportTraceServiceRequest` / `ExportMetricsServiceRequest` /
+ * `ExportLogsServiceRequest` payloads matching the exact wire schema vendored
+ * at `crates/temps-otel/proto/opentelemetry/proto/**` (field numbers below are
+ * copied from those `.proto` files, not guessed/assumed) -- these are the
+ * same messages `temps-otel`'s `ingest/decode.rs` decodes with `prost`.
+ *
+ * No `@opentelemetry/*` SDK dependency: encoding by hand gives byte-exact
+ * control over payload size, which the quota-enforcement test needs (to push
+ * a precise, large volume of trace data past a configured quota) and which a
+ * real SDK's own batching/export internals would fight.
+ */
+
+// ── Low-level protobuf writer ───────────────────────────────────────
+
+const WIRE_VARINT = 0
+const WIRE_FIXED64 = 1
+const WIRE_LEN = 2
+const WIRE_FIXED32 = 5
+
+const utf8 = new TextEncoder()
+
+class ByteWriter {
+  private buf: Uint8Array
+  private len = 0
+
+  constructor(initial = 256) {
+    this.buf = new Uint8Array(initial)
+  }
+
+  private ensure(extra: number): void {
+    if (this.len + extra <= this.buf.length) return
+    let cap = this.buf.length * 2
+    while (cap < this.len + extra) cap *= 2
+    const next = new Uint8Array(cap)
+    next.set(this.buf.subarray(0, this.len))
+    this.buf = next
+  }
+
+  writeByte(b: number): void {
+    this.ensure(1)
+    this.buf[this.len++] = b & 0xff
+  }
+
+  writeRaw(bytes: Uint8Array): void {
+    this.ensure(bytes.length)
+    this.buf.set(bytes, this.len)
+    this.len += bytes.length
+  }
+
+  /** Unsigned varint (protobuf's base128 LEB encoding). */
+  writeVarint(value: number): void {
+    if (value < 0 || !Number.isFinite(value)) {
+      throw new Error(`writeVarint: value must be a non-negative finite number, got ${value}`)
+    }
+    let v = Math.floor(value)
+    this.ensure(10)
+    while (v >= 0x80) {
+      this.buf[this.len++] = (v & 0x7f) | 0x80
+      v = Math.floor(v / 128)
+    }
+    this.buf[this.len++] = v & 0x7f
+  }
+
+  private writeTag(field: number, wireType: number): void {
+    this.writeVarint((field << 3) | wireType)
+  }
+
+  varintField(field: number, value: number): void {
+    this.writeTag(field, WIRE_VARINT)
+    this.writeVarint(value)
+  }
+
+  boolField(field: number, value: boolean): void {
+    this.varintField(field, value ? 1 : 0)
+  }
+
+  stringField(field: number, value: string): void {
+    const bytes = utf8.encode(value)
+    this.writeTag(field, WIRE_LEN)
+    this.writeVarint(bytes.length)
+    this.writeRaw(bytes)
+  }
+
+  bytesField(field: number, value: Uint8Array): void {
+    this.writeTag(field, WIRE_LEN)
+    this.writeVarint(value.length)
+    this.writeRaw(value)
+  }
+
+  /** Embed an already-encoded sub-message (length-delimited, same wire type as bytes). */
+  messageField(field: number, value: Uint8Array): void {
+    this.bytesField(field, value)
+  }
+
+  /** `fixed64` — 8 raw little-endian bytes carrying a `bigint`. */
+  fixed64Field(field: number, value: bigint): void {
+    this.writeTag(field, WIRE_FIXED64)
+    this.ensure(8)
+    const view = new DataView(this.buf.buffer, this.buf.byteOffset + this.len, 8)
+    view.setBigUint64(0, value, true)
+    this.len += 8
+  }
+
+  /** `double` — IEEE754 8-byte little-endian. */
+  doubleField(field: number, value: number): void {
+    this.writeTag(field, WIRE_FIXED64)
+    this.ensure(8)
+    const view = new DataView(this.buf.buffer, this.buf.byteOffset + this.len, 8)
+    view.setFloat64(0, value, true)
+    this.len += 8
+  }
+
+  /** `fixed32` — 4 raw little-endian bytes. */
+  fixed32Field(field: number, value: number): void {
+    this.writeTag(field, WIRE_FIXED32)
+    this.ensure(4)
+    const view = new DataView(this.buf.buffer, this.buf.byteOffset + this.len, 4)
+    view.setUint32(0, value >>> 0, true)
+    this.len += 4
+  }
+
+  finish(): Uint8Array {
+    return this.buf.subarray(0, this.len)
+  }
+}
+
+// ── OTLP common types (opentelemetry/proto/common/v1/common.proto) ──
+
+export type AttributeValue = string | number | boolean
+
+/** `AnyValue { oneof value { string_value=1, bool_value=2, int_value=3, double_value=4 } }`. */
+function encodeAnyValue(value: AttributeValue): Uint8Array {
+  const w = new ByteWriter(64)
+  if (typeof value === 'string') w.stringField(1, value)
+  else if (typeof value === 'boolean') w.boolField(2, value)
+  else if (Number.isInteger(value)) w.varintField(3, value)
+  else w.doubleField(4, value)
+  return w.finish()
+}
+
+/** `KeyValue { key=1 string, value=2 AnyValue }`. */
+function encodeKeyValue(key: string, value: AttributeValue): Uint8Array {
+  const w = new ByteWriter(64 + key.length)
+  w.stringField(1, key)
+  w.messageField(2, encodeAnyValue(value))
+  return w.finish()
+}
+
+function writeAttributes(
+  w: ByteWriter,
+  field: number,
+  attrs: Record<string, AttributeValue> | undefined,
+): void {
+  if (!attrs) return
+  for (const [k, v] of Object.entries(attrs)) {
+    w.messageField(field, encodeKeyValue(k, v))
+  }
+}
+
+/** `Resource { attributes=1 repeated KeyValue }` (opentelemetry/proto/resource/v1/resource.proto). */
+function encodeResource(attrs: Record<string, AttributeValue>): Uint8Array {
+  const w = new ByteWriter(256)
+  writeAttributes(w, 1, attrs)
+  return w.finish()
+}
+
+/** Build the default resource attributes every OTLP payload in this file carries. */
+export function defaultResourceAttrs(serviceName: string, extra?: Record<string, AttributeValue>): Record<string, AttributeValue> {
+  return { 'service.name': serviceName, ...extra }
+}
+
+// ── IDs ──────────────────────────────────────────────────────────────
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.substr(i * 2, 2), 16)
+  return out
+}
+
+function randomHex(bytes: number): string {
+  const arr = new Uint8Array(bytes)
+  crypto.getRandomValues(arr)
+  return Array.from(arr, (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+/** A fresh 32-lowercase-hex-char trace id (16 random bytes), matching OTLP's `is_valid_trace_id`. */
+export function randomTraceId(): string {
+  return randomHex(16)
+}
+
+/** A fresh 16-lowercase-hex-char span id (8 random bytes). */
+export function randomSpanId(): string {
+  return randomHex(8)
+}
+
+/**
+ * A high-entropy ASCII string of exactly `byteLength` bytes, built from
+ * random bytes via base64 (trimmed/repeated to the exact length).
+ *
+ * NOT a repeated/low-entropy filler ('x'.repeat(n)): Postgres TOASTs large
+ * column values through pglz compression, which crushes a repeated-byte
+ * string down to a few KB regardless of `byteLength` -- a volume test using
+ * one would send real bytes over the wire but store almost nothing, making
+ * `hypertable_size()`-based quota math look under-counted (or a quota look
+ * uncrossable) for a reason that has nothing to do with the quota code
+ * itself. Random bytes are effectively incompressible, so what's sent is
+ * (approximately) what lands on disk -- the volume this function's callers
+ * actually need to simulate a real flood.
+ */
+export function randomFillerAscii(byteLength: number): string {
+  // base64 emits 4 output chars per 3 input bytes -- generate enough random
+  // bytes to cover `byteLength` output chars, then trim to the exact size.
+  const neededRandomBytes = Math.ceil((byteLength * 3) / 4) + 3
+  const raw = new Uint8Array(neededRandomBytes)
+  // crypto.getRandomValues has a real per-call limit (64KiB on most
+  // implementations) -- fill in fixed-size chunks rather than one giant call.
+  const CHUNK = 65536
+  for (let offset = 0; offset < raw.length; offset += CHUNK) {
+    crypto.getRandomValues(raw.subarray(offset, Math.min(offset + CHUNK, raw.length)))
+  }
+  return Buffer.from(raw).toString('base64').slice(0, byteLength)
+}
+
+function nowUnixNano(offsetMs = 0): bigint {
+  return BigInt(Date.now() + offsetMs) * 1_000_000n
+}
+
+// ── Traces (opentelemetry/proto/trace/v1/trace.proto) ───────────────
+
+export interface SpanInput {
+  traceId: string
+  spanId: string
+  /** Empty/omitted = root span (no parent) -- required for the span to appear as a trace root. */
+  parentSpanId?: string
+  name: string
+  /** SpanKind enum value; 1 = INTERNAL (default). */
+  kind?: number
+  startUnixNano?: bigint
+  endUnixNano?: bigint
+  attributes?: Record<string, AttributeValue>
+  /** Status.StatusCode; 0=UNSET, 1=OK, 2=ERROR. */
+  statusCode?: number
+}
+
+/** `Span` message. */
+function encodeSpan(s: SpanInput): Uint8Array {
+  const w = new ByteWriter(256)
+  w.bytesField(1, hexToBytes(s.traceId))
+  w.bytesField(2, hexToBytes(s.spanId))
+  if (s.parentSpanId) w.bytesField(4, hexToBytes(s.parentSpanId))
+  w.stringField(5, s.name)
+  w.varintField(6, s.kind ?? 1)
+  w.fixed64Field(7, s.startUnixNano ?? nowUnixNano(-10))
+  w.fixed64Field(8, s.endUnixNano ?? nowUnixNano())
+  writeAttributes(w, 9, s.attributes)
+  if (s.statusCode !== undefined) {
+    const status = new ByteWriter(8)
+    status.varintField(3, s.statusCode)
+    w.messageField(15, status.finish())
+  }
+  return w.finish()
+}
+
+/** Build a full `ExportTraceServiceRequest` for one resource/scope with N spans. */
+export function buildTraceExportRequest(opts: {
+  resourceAttrs: Record<string, AttributeValue>
+  spans: SpanInput[]
+}): Uint8Array {
+  const scopeSpans = new ByteWriter(1024)
+  for (const s of opts.spans) scopeSpans.messageField(2, encodeSpan(s))
+
+  const resourceSpans = new ByteWriter(1024)
+  resourceSpans.messageField(1, encodeResource(opts.resourceAttrs))
+  resourceSpans.messageField(2, scopeSpans.finish())
+
+  const req = new ByteWriter(1024)
+  req.messageField(1, resourceSpans.finish())
+  return req.finish()
+}
+
+// ── Metrics (opentelemetry/proto/metrics/v1/metrics.proto) ──────────
+
+export interface NumberDataPointInput {
+  timeUnixNano?: bigint
+  asDouble?: number
+  asInt?: bigint
+  attributes?: Record<string, AttributeValue>
+}
+
+function encodeNumberDataPoint(p: NumberDataPointInput): Uint8Array {
+  const w = new ByteWriter(128)
+  writeAttributes(w, 7, p.attributes)
+  w.fixed64Field(3, p.timeUnixNano ?? nowUnixNano())
+  if (p.asInt !== undefined) w.fixed64Field(6, p.asInt) // sfixed64, same wire encoding as fixed64
+  else w.doubleField(4, p.asDouble ?? 0)
+  return w.finish()
+}
+
+export interface GaugeMetricInput {
+  name: string
+  unit?: string
+  dataPoints: NumberDataPointInput[]
+}
+
+function encodeGaugeMetric(m: GaugeMetricInput): Uint8Array {
+  const gauge = new ByteWriter(256)
+  for (const dp of m.dataPoints) gauge.messageField(1, encodeNumberDataPoint(dp))
+
+  const w = new ByteWriter(256)
+  w.stringField(1, m.name)
+  if (m.unit) w.stringField(3, m.unit)
+  w.messageField(5, gauge.finish()) // oneof data { gauge = 5 }
+  return w.finish()
+}
+
+/** Build a full `ExportMetricsServiceRequest` for one resource/scope with N gauge metrics. */
+export function buildMetricsExportRequest(opts: {
+  resourceAttrs: Record<string, AttributeValue>
+  metrics: GaugeMetricInput[]
+}): Uint8Array {
+  const scopeMetrics = new ByteWriter(1024)
+  for (const m of opts.metrics) scopeMetrics.messageField(2, encodeGaugeMetric(m))
+
+  const resourceMetrics = new ByteWriter(1024)
+  resourceMetrics.messageField(1, encodeResource(opts.resourceAttrs))
+  resourceMetrics.messageField(2, scopeMetrics.finish())
+
+  const req = new ByteWriter(1024)
+  req.messageField(1, resourceMetrics.finish())
+  return req.finish()
+}
+
+// ── Logs (opentelemetry/proto/logs/v1/logs.proto) ────────────────────
+
+export interface LogRecordInput {
+  timeUnixNano?: bigint
+  /** SeverityNumber enum; 9 = INFO. */
+  severityNumber?: number
+  severityText?: string
+  body: string
+  attributes?: Record<string, AttributeValue>
+  traceId?: string
+  spanId?: string
+}
+
+function encodeLogRecord(r: LogRecordInput): Uint8Array {
+  const w = new ByteWriter(256)
+  w.fixed64Field(1, r.timeUnixNano ?? nowUnixNano())
+  w.varintField(2, r.severityNumber ?? 9)
+  w.stringField(3, r.severityText ?? 'INFO')
+  w.messageField(5, encodeAnyValue(r.body))
+  writeAttributes(w, 6, r.attributes)
+  if (r.traceId) w.bytesField(9, hexToBytes(r.traceId))
+  if (r.spanId) w.bytesField(10, hexToBytes(r.spanId))
+  return w.finish()
+}
+
+/** Build a full `ExportLogsServiceRequest` for one resource/scope with N log records. */
+export function buildLogsExportRequest(opts: {
+  resourceAttrs: Record<string, AttributeValue>
+  records: LogRecordInput[]
+}): Uint8Array {
+  const scopeLogs = new ByteWriter(1024)
+  for (const r of opts.records) scopeLogs.messageField(2, encodeLogRecord(r))
+
+  const resourceLogs = new ByteWriter(1024)
+  resourceLogs.messageField(1, encodeResource(opts.resourceAttrs))
+  resourceLogs.messageField(2, scopeLogs.finish())
+
+  const req = new ByteWriter(1024)
+  req.messageField(1, resourceLogs.finish())
+  return req.finish()
+}
+
+// ── Sender ────────────────────────────────────────────────────────────
+
+export interface OtlpSendResult {
+  status: number
+  ok: boolean
+  bodyText: string
+}
+
+/**
+ * POST a raw OTLP protobuf payload to `${apiBaseUrl}/otel/v1/{signal}` using
+ * `tk_` API-key header auth (`Authorization` + `X-Temps-Project-Id`) -- the
+ * same auth path a real collector/SDK configured with a project API key
+ * would use. Not routed through the generated SDK client: its default
+ * `bodySerializer` is `JSON.stringify`, which would corrupt a raw protobuf
+ * `Uint8Array` body.
+ */
+export async function sendOtlp(opts: {
+  apiBaseUrl: string
+  apiKey: string
+  projectId: number
+  signal: 'traces' | 'metrics' | 'logs'
+  payload: Uint8Array
+}): Promise<OtlpSendResult> {
+  const res = await fetch(`${opts.apiBaseUrl}/otel/v1/${opts.signal}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${opts.apiKey}`,
+      'X-Temps-Project-Id': String(opts.projectId),
+      'Content-Type': 'application/x-protobuf',
+    },
+    // Uint8Array is a valid runtime BodyInit (fetch accepts any ArrayBufferView),
+    // but this repo's configured lib/target doesn't type it that way -- same
+    // reasoning as node:tls's raw-socket use elsewhere in this package.
+    body: opts.payload as BodyInit,
+  })
+  const bodyText = await res.text().catch(() => '')
+  return { status: res.status, ok: res.ok, bodyText }
+}

--- a/crates/temps-observability/src/handlers/events.rs
+++ b/crates/temps-observability/src/handlers/events.rs
@@ -58,8 +58,11 @@ pub struct ObservabilityApiDoc;
 #[derive(Debug, Default, Deserialize, IntoParams)]
 #[into_params(parameter_in = Query)]
 pub struct EventsQuery {
-    /// Comma-separated kinds: `log,request,span,error,revenue`. Empty or
-    /// missing returns every kind.
+    /// Comma-separated kinds: `request,span,error,revenue`. Empty or
+    /// missing returns every kind. There is no `log` kind — runtime logs
+    /// intentionally never appear in this feed (see `ObservabilityEvent`'s
+    /// "No `Log` variant" doc); passing `kinds=log` is rejected with 400
+    /// `InvalidKindsFilter`, not silently ignored.
     pub kinds: Option<String>,
     /// Inclusive lower bound on event timestamp (ISO 8601, `Z` suffix).
     pub from: Option<DateTime<Utc>>,

--- a/crates/temps-otel/src/handlers/query_handler.rs
+++ b/crates/temps-otel/src/handlers/query_handler.rs
@@ -560,6 +560,8 @@ pub async fn list_metric_label_values(
         ("end_time" = Option<String>, Query, description = "End time (RFC 3339)"),
         ("environment_id" = Option<i32>, Query, description = "Filter by environment ID"),
         ("deployment_id" = Option<i32>, Query, description = "Filter by deployment ID"),
+        ("attributes" = Option<String>, Query, description = "Filter by span attributes as comma-separated key=value pairs, e.g. \"gen_ai.system=openai,gen_ai.request.model=gpt-4\""),
+        ("name_pattern" = Option<String>, Query, description = "Filter by span name pattern (ILIKE)"),
         ("limit" = Option<u64>, Query, description = "Max spans to return (default: 100, max: 1000)"),
         ("offset" = Option<u64>, Query, description = "Offset for pagination"),
     ),

--- a/crates/temps-otel/src/storage/clickhouse/mod.rs
+++ b/crates/temps-otel/src/storage/clickhouse/mod.rs
@@ -10,10 +10,21 @@
 //! - **Span-domain reads** (`query_trace_summaries`, `count_traces`,
 //!   `query_spans`, `get_trace`, GenAI reads) run natively against ClickHouse
 //!   as of Phase 1.
-//! - **Non-span methods** (metrics, logs, anomaly helpers, retention) and
-//!   **control-row methods** (insights, health summaries, quota) are delegated
-//!   to the inner [`Arc<TimescaleDbStorage>`] unconditionally. These are
-//!   ADR-016 Phases 2–4.
+//! - **Metric writes and reads** (`store_metrics`, `query_metrics`,
+//!   `list_metric_names`, anomaly-detection helpers) also run natively
+//!   against ClickHouse — `store_metrics` writes only to CH, never to the
+//!   inner Postgres store (see the comment above `store_metrics`).
+//! - **Logs** (`store_logs`, `archive_logs`, `query_logs`) and
+//!   **control-row methods** (insights, health summaries) are delegated to
+//!   the inner [`Arc<TimescaleDbStorage>`] unconditionally.
+//! - **Storage quota** (`get_storage_quota`, `check_quota`) is NOT a plain
+//!   delegation: it combines ClickHouse-native byte accounting for
+//!   `spans`/`metrics` (via `system.parts`) with the inner store's
+//!   single-table share of `otel_log_events` — see `get_storage_quota`'s
+//!   doc comment for why summing the inner store's own 3-table
+//!   `get_storage_quota` would be wrong here (it would measure
+//!   near-empty Postgres `otel_spans`/`otel_metrics` tables that a
+//!   ClickHouse-enabled install never writes span/metric rows into).
 //!
 //! ## Activation
 //!
@@ -3170,7 +3181,10 @@ impl OtelStorage for ClickHouseOtelStorage {
         Ok(merge_trace_ref_projects(ch_refs, pg_refs))
     }
 
-    // ── Control-row methods — always Postgres (insights, health, quota) ──────
+    // ── Control-row methods — always Postgres (insights, health) ─────────────
+    //
+    // Storage quota is handled separately below: it is NOT purely
+    // Postgres-delegated. See `get_storage_quota`'s doc comment.
 
     async fn upsert_insight(&self, insight: &Insight) -> StorageResult<i64> {
         self.inner.upsert_insight(insight).await
@@ -3206,12 +3220,134 @@ impl OtelStorage for ClickHouseOtelStorage {
             .await
     }
 
+    /// Real per-project storage-quota accounting for a ClickHouse-backed
+    /// install.
+    ///
+    /// This does NOT delegate wholesale to `self.inner` — `spans` and
+    /// `metrics` are ClickHouse-native (see module doc: `store_spans` /
+    /// `store_metrics` write only to CH), so `self.inner`'s three-table sum
+    /// would measure Postgres tables that ClickHouse-enabled installs never
+    /// write span/metric rows into and silently under-report the real
+    /// volume — the exact "quota inert for CH-backed installs" gap tracked
+    /// as a known limitation until this fix.
+    ///
+    /// Instead: ClickHouse's own `spans`/`metrics` byte volume is computed
+    /// natively here (proportional estimate using `system.parts`, CH's
+    /// chunk-aware equivalent of TimescaleDB's `hypertable_size()`), and
+    /// combined with the ONE domain still genuinely Postgres-owned even
+    /// with CH enabled: `otel_log_events` (`store_logs` / `archive_logs`
+    /// always delegate to `self.inner` — see module doc). That single-table
+    /// share is read via `TimescaleDbStorage::hypertable_bytes_for_project`
+    /// rather than `get_storage_quota`'s 3-table sum, which would double
+    /// count against near-empty `otel_spans`/`otel_metrics` Postgres tables.
     async fn get_storage_quota(&self, project_id: i32) -> StorageResult<StorageQuota> {
-        self.inner.get_storage_quota(project_id).await
+        // Quota is opt-in. Mirrors the early-exit in
+        // `TimescaleDbStorage::get_storage_quota`: this sits on the ingest
+        // hot path (`OtelService::check_quota` on every quota-cache miss),
+        // so a disabled quota must never touch ClickHouse or Postgres.
+        let Some(limit_bytes) = self.inner.quota_bytes_per_project() else {
+            return Ok(StorageQuota {
+                project_id,
+                metrics_bytes: 0,
+                traces_bytes: 0,
+                logs_bytes: 0,
+                total_bytes: 0,
+                limit_bytes: 0,
+                usage_pct: 0.0,
+            });
+        };
+
+        // `total_bytes` comes back as `Nullable(UInt64)`: ClickHouse's type
+        // inference marks the `toUInt64(...) + toUInt64(...)` expression
+        // nullable because it is built from `least`/`greatest` over
+        // aggregate subqueries, even though the `COALESCE(..., 0)`s make a
+        // real NULL impossible here. Modeling it as `Option<u64>` (defaulting
+        // to 0) sidesteps relying on that inference rather than fighting it
+        // with more SQL-side casts.
+        #[derive(::clickhouse::Row, Deserialize, Debug)]
+        struct ChQuotaBytesRow {
+            total_bytes: Option<u64>,
+        }
+
+        // Per-table proportional estimate, ClickHouse-native:
+        //   table_bytes(active parts) * min(1.0, project_rows / total_rows)
+        //
+        // `system.parts` is metadata (no data scan): `bytes_on_disk` sums
+        // real compressed on-disk size of active parts (ClickHouse's
+        // equivalent of `hypertable_size()`'s chunk sum — MERGED-away parts
+        // are excluded via `active = 1` so dropped/superseded data is never
+        // double counted), and `rows` sums the row-count denominator the
+        // same way. The per-project numerator (`count() WHERE project_id =
+        // ?`) does scan, but `ORDER BY (project_id, ...)` on both `spans`
+        // and `metrics` (see the migration DDL) makes it a primary-index
+        // read bounded to this project's granules, not a full table scan.
+        const CH_QUOTA_BYTES_SQL: &str = r#"
+            SELECT toUInt64(
+                COALESCE((
+                    SELECT sum(bytes_on_disk) FROM system.parts
+                    WHERE database = currentDatabase() AND table = 'spans' AND active = 1
+                ), 0) *
+                least(1.0, toFloat64((SELECT count() FROM spans WHERE project_id = ?)) /
+                    greatest(toFloat64(COALESCE((
+                        SELECT sum(rows) FROM system.parts
+                        WHERE database = currentDatabase() AND table = 'spans' AND active = 1
+                    ), 0)), 1.0))
+            ) +
+            toUInt64(
+                COALESCE((
+                    SELECT sum(bytes_on_disk) FROM system.parts
+                    WHERE database = currentDatabase() AND table = 'metrics' AND active = 1
+                ), 0) *
+                least(1.0, toFloat64((SELECT count() FROM metrics WHERE project_id = ?)) /
+                    greatest(toFloat64(COALESCE((
+                        SELECT sum(rows) FROM system.parts
+                        WHERE database = currentDatabase() AND table = 'metrics' AND active = 1
+                    ), 0)), 1.0))
+            ) AS total_bytes
+        "#;
+
+        let ch_bytes = self
+            .ch
+            .query(CH_QUOTA_BYTES_SQL)
+            .bind(project_id)
+            .bind(project_id)
+            .fetch_one::<ChQuotaBytesRow>()
+            .await
+            .map_err(|e| ch_query_err("get_storage_quota", e))?
+            .total_bytes
+            .unwrap_or(0);
+
+        // otel_log_events is the one domain still genuinely Postgres-owned
+        // (logs are never dual-written or CH-native — see module doc).
+        let logs_bytes = self
+            .inner
+            .hypertable_bytes_for_project("otel_log_events", project_id)
+            .await?;
+
+        let total_bytes = ch_bytes.saturating_add(logs_bytes);
+        let usage_pct = if limit_bytes > 0 {
+            (total_bytes as f64 / limit_bytes as f64) * 100.0
+        } else {
+            0.0
+        };
+
+        Ok(StorageQuota {
+            project_id,
+            metrics_bytes: 0, // Approximate breakdown not available cheaply
+            traces_bytes: 0,
+            logs_bytes: 0,
+            total_bytes,
+            limit_bytes,
+            usage_pct,
+        })
     }
 
     async fn check_quota(&self, project_id: i32) -> StorageResult<bool> {
-        self.inner.check_quota(project_id).await
+        // With no quota configured, get_storage_quota short-circuits to
+        // zeros without touching ClickHouse or Postgres, so this is always
+        // "not exceeded".
+        let quota = self.get_storage_quota(project_id).await?;
+        Ok(quota.usage_pct >= 100.0)
     }
 
     // ── Anomaly-detection helpers (ClickHouse — native) ──────────────────────

--- a/crates/temps-otel/src/storage/timescaledb.rs
+++ b/crates/temps-otel/src/storage/timescaledb.rs
@@ -2472,21 +2472,45 @@ impl OtelStorage for TimescaleDbStorage {
         // `COUNT(*)` scans every chunk, and this runs three times per call on
         // the ingest hot path (`check_quota`), so the denominator uses
         // TimescaleDB's `approximate_row_count` (planner stats, microseconds).
-        // `GREATEST(.., 1)` still guards against a zero/negative estimate on a
-        // freshly-created, never-analyzed table.
+        // `GREATEST(.., 1)` guards against a zero/negative estimate on a
+        // freshly-created, never-analyzed table; `LEAST(1.0, ..)` around the
+        // ratio guards the other direction -- a project's share of a table
+        // can never exceed 100% of that table, but `approximate_row_count`
+        // can UNDER-count right after a write burst (autovacuum/ANALYZE
+        // hasn't caught up yet -- the exact scenario this quota exists to
+        // catch), which without the clamp would inflate the computed
+        // `total_bytes` past what `table_size` itself reports. With the
+        // clamp, a lagging denominator can only make the estimate MORE
+        // conservative (trip earlier), never silently let a flood through.
+        //
+        // CORRECTNESS: `table_size` MUST be the whole hypertable's storage,
+        // not just its root. A hypertable's "root" relation (the name you
+        // create it under, e.g. `otel_spans`) holds no rows and almost no
+        // bytes itself -- TimescaleDB partitions all actual data into child
+        // "chunk" tables under `_timescaledb_internal`. `pg_total_relation_size`
+        // on the root name (the previous query here) therefore measures only
+        // the root's own tiny catalog/index footprint and NEVER grows with
+        // real ingest volume, so `total_bytes` stayed near-zero regardless of
+        // how much data a project actually stored and `usage_pct` could
+        // never reach 100 -- quota enforcement was silently inert for every
+        // project, the exact 160GB/day-flood failure mode this quota exists
+        // to prevent. `hypertable_size()` is TimescaleDB's chunk-aware
+        // equivalent: it sums every chunk's `pg_total_relation_size` (plus
+        // the negligible root), which is still cheap (proportional to chunk
+        // count, not row count) and gives the real total.
         let sql = r#"
             SELECT
-                COALESCE((SELECT pg_total_relation_size('otel_metrics') *
-                    (SELECT COUNT(*) FROM otel_metrics WHERE project_id = $1)::float /
-                    GREATEST(approximate_row_count('otel_metrics'::regclass), 1)::float
+                COALESCE((SELECT hypertable_size('otel_metrics'::regclass) *
+                    LEAST(1.0, (SELECT COUNT(*) FROM otel_metrics WHERE project_id = $1)::float /
+                    GREATEST(approximate_row_count('otel_metrics'::regclass), 1)::float)
                 ), 0)::bigint +
-                COALESCE((SELECT pg_total_relation_size('otel_spans') *
-                    (SELECT COUNT(*) FROM otel_spans WHERE project_id = $1)::float /
-                    GREATEST(approximate_row_count('otel_spans'::regclass), 1)::float
+                COALESCE((SELECT hypertable_size('otel_spans'::regclass) *
+                    LEAST(1.0, (SELECT COUNT(*) FROM otel_spans WHERE project_id = $1)::float /
+                    GREATEST(approximate_row_count('otel_spans'::regclass), 1)::float)
                 ), 0)::bigint +
-                COALESCE((SELECT pg_total_relation_size('otel_log_events') *
-                    (SELECT COUNT(*) FROM otel_log_events WHERE project_id = $1)::float /
-                    GREATEST(approximate_row_count('otel_log_events'::regclass), 1)::float
+                COALESCE((SELECT hypertable_size('otel_log_events'::regclass) *
+                    LEAST(1.0, (SELECT COUNT(*) FROM otel_log_events WHERE project_id = $1)::float /
+                    GREATEST(approximate_row_count('otel_log_events'::regclass), 1)::float)
                 ), 0)::bigint as total_bytes
         "#;
 

--- a/crates/temps-otel/src/storage/timescaledb.rs
+++ b/crates/temps-otel/src/storage/timescaledb.rs
@@ -3307,6 +3307,67 @@ impl TimescaleDbStorage {
 
         (where_clauses.join(" AND "), values, param_idx)
     }
+
+    // ── Cross-backend quota helpers ──────────────────────────────────────
+    //
+    // Used by `ClickHouseOtelStorage::get_storage_quota`
+    // (`storage/clickhouse/mod.rs`) to combine ClickHouse-native span/metric
+    // byte accounting with the Postgres-native log volume it still
+    // delegates here. Kept separate from `get_storage_quota` above (which
+    // stays a single three-table round trip, unchanged) so the all-Postgres
+    // path taken by every non-ClickHouse install pays no extra query.
+
+    /// Compute the proportional byte estimate for a single OTel hypertable
+    /// attributed to `project_id`, using the same chunk-aware
+    /// `hypertable_size()` formula as `get_storage_quota` — see that
+    /// method's CORRECTNESS comment for why `pg_total_relation_size` on the
+    /// hypertable root would be wrong here.
+    ///
+    /// `table` must be a fixed, code-controlled literal — one of
+    /// `"otel_metrics"`, `"otel_spans"`, `"otel_log_events"` — never
+    /// request/user input. Postgres cannot bind identifiers as query
+    /// parameters (only values), so it is interpolated via `format!`; every
+    /// call site in this crate passes a hardcoded string, so this is safe.
+    pub(crate) async fn hypertable_bytes_for_project(
+        &self,
+        table: &str,
+        project_id: i32,
+    ) -> StorageResult<u64> {
+        let sql = format!(
+            r#"
+            SELECT COALESCE((SELECT hypertable_size('{table}'::regclass) *
+                LEAST(1.0, (SELECT COUNT(*) FROM {table} WHERE project_id = $1)::float /
+                GREATEST(approximate_row_count('{table}'::regclass), 1)::float)
+            ), 0)::bigint as total_bytes
+            "#
+        );
+
+        let result = self
+            .db
+            .query_one(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                sql,
+                vec![project_id.into()],
+            ))
+            .await?;
+
+        Ok(match result {
+            Some(row) => row.try_get::<i64>("", "total_bytes").unwrap_or(0) as u64,
+            None => 0,
+        })
+    }
+
+    /// The configured per-project quota limit in bytes, if quota
+    /// enforcement is enabled (`TEMPS_OTEL_QUOTA_GB` set). `None` means
+    /// quota enforcement is off.
+    ///
+    /// Exposed so `ClickHouseOtelStorage` — which shares this same
+    /// `TimescaleDbStorage` as its inner delegate — reads the one
+    /// configured limit instead of parsing `TEMPS_OTEL_QUOTA_GB` a second
+    /// time in a second place.
+    pub(crate) fn quota_bytes_per_project(&self) -> Option<u64> {
+        self.quota_bytes_per_project
+    }
 }
 
 // ── LIKE pattern helpers ─────────────────────────────────────────────

--- a/crates/temps-otel/tests/clickhouse_storage_test.rs
+++ b/crates/temps-otel/tests/clickhouse_storage_test.rs
@@ -19,7 +19,7 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use chrono::Utc;
+use chrono::{Duration, Utc};
 use sea_orm::{DatabaseBackend, MockDatabase};
 
 use temps_otel::storage::clickhouse::{ClickHouseOtelConfig, ClickHouseOtelStorage};
@@ -27,6 +27,7 @@ use temps_otel::storage::timescaledb::TimescaleDbStorage;
 use temps_otel::storage::OtelStorage;
 use temps_otel::types::{
     AggregationTemporality, MetricAggregation, MetricPoint, MetricQuery, MetricType, ResourceInfo,
+    SpanKind, SpanRecord, SpanStatusCode,
 };
 
 #[derive(::clickhouse::Row, serde::Deserialize)]
@@ -34,9 +35,10 @@ struct ChTypeNameRow {
     type_name: String,
 }
 
-/// Container handle + a connected `ClickHouseOtelStorage`. Returns `None` when
-/// Docker is unavailable so the test can skip without failing CI.
-async fn setup() -> Option<(ClickHouseOtelStorage, Box<dyn std::any::Any + Send>)> {
+/// Start a real ClickHouse testcontainer, wait for it to accept queries, and
+/// apply the OTel CH migrations. Returns the connected config + container
+/// handle, or `None` when Docker is unavailable (test should skip).
+async fn start_ch_container() -> Option<(ClickHouseOtelConfig, Box<dyn std::any::Any + Send>)> {
     use testcontainers::{
         core::{wait::HttpWaitStrategy, ContainerPort, WaitFor},
         runners::AsyncRunner,
@@ -125,6 +127,14 @@ async fn setup() -> Option<(ClickHouseOtelStorage, Box<dyn std::any::Any + Send>
         .await
         .expect("apply_migrations failed against testcontainer ClickHouse");
 
+    Some((config, Box::new(container)))
+}
+
+/// Container handle + a connected `ClickHouseOtelStorage`. Returns `None` when
+/// Docker is unavailable so the test can skip without failing CI.
+async fn setup() -> Option<(ClickHouseOtelStorage, Box<dyn std::any::Any + Send>)> {
+    let (config, container) = start_ch_container().await?;
+
     // The inner Timescale storage is never exercised by the metric methods under
     // test; a MockDatabase satisfies the constructor without a Postgres server.
     // The trace-refs test IS an exception: `get_trace_ref_projects` unions the
@@ -139,7 +149,38 @@ async fn setup() -> Option<(ClickHouseOtelStorage, Box<dyn std::any::Any + Send>
 
     let storage =
         ClickHouseOtelStorage::new(config, inner, Arc::new(temps_core::FixedRetentionResolver));
-    Some((storage, Box::new(container)))
+    Some((storage, container))
+}
+
+/// Same as [`setup`], but the inner `TimescaleDbStorage` is configured with a
+/// real per-project quota limit (`quota_bytes_per_project`), and its
+/// `MockDatabase` is pre-loaded with `logs_rows` queued responses to
+/// `hypertable_bytes_for_project("otel_log_events", ...)` — one per
+/// `get_storage_quota`/`check_quota` call the test makes. Used by the
+/// storage-quota regression test below, which needs `get_storage_quota` to
+/// take its real (non-early-exit) path.
+async fn setup_with_quota(
+    limit_bytes: u64,
+    logs_bytes_per_call: i64,
+    calls: usize,
+) -> Option<(ClickHouseOtelStorage, Box<dyn std::any::Any + Send>)> {
+    let (config, container) = start_ch_container().await?;
+
+    let log_row =
+        move || BTreeMap::from([("total_bytes", sea_orm::Value::from(logs_bytes_per_call))]);
+    let mock_db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(std::iter::repeat_with(move || vec![log_row()]).take(calls))
+        .into_connection();
+    let inner = Arc::new(TimescaleDbStorage::with_config(
+        Arc::new(mock_db),
+        None,
+        7,
+        Some(limit_bytes),
+    ));
+
+    let storage =
+        ClickHouseOtelStorage::new(config, inner, Arc::new(temps_core::FixedRetentionResolver));
+    Some((storage, container))
 }
 
 fn gauge_point() -> MetricPoint {
@@ -746,4 +787,153 @@ async fn trace_refs_roundtrip_record_and_lookup() {
         .await
         .expect("lookup unknown trace");
     assert!(none.is_empty());
+}
+
+// ── Storage quota (ClickHouse-native span/metric accounting) ───────────────
+
+/// Cheap xorshift64-based pseudo-random hex string generator. Used to give
+/// each test span's attribute values high entropy (unlike a fixed repeated
+/// filler string, which ZSTD — the codec ClickHouse compresses these parts
+/// with — collapses to a near-zero footprint regardless of row count,
+/// making it useless for asserting on real on-disk bytes).
+fn pseudo_random_hex(seed: u64, len: usize) -> String {
+    let mut state = seed ^ 0x9E37_79B9_7F4A_7C15;
+    let mut out = String::with_capacity(len + 16);
+    while out.len() < len {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        out.push_str(&format!("{state:016x}"));
+    }
+    out.truncate(len);
+    out
+}
+
+/// Build a sample SpanRecord with a sizeable, high-entropy `attributes`
+/// payload, so a batch of these produces real, measurable (not
+/// compressed-away) ClickHouse part bytes.
+fn quota_test_span(project_id: i32, index: u32) -> SpanRecord {
+    let start = Utc::now() - Duration::milliseconds(10);
+    let mut attributes = BTreeMap::new();
+    for key_idx in 0..20u32 {
+        let seed = (index as u64) * 1000 + key_idx as u64;
+        attributes.insert(
+            format!("attribute.key.number.{key_idx}"),
+            pseudo_random_hex(seed, 200),
+        );
+    }
+    SpanRecord {
+        project_id,
+        deployment_id: None,
+        resource: ResourceInfo {
+            service_name: "quota-test-service".into(),
+            service_version: Some("1.0.0".into()),
+            deployment_environment: Some("test".into()),
+            attributes: BTreeMap::new(),
+        },
+        trace_id: format!("{index:032x}"),
+        span_id: format!("{index:016x}"),
+        parent_span_id: None,
+        name: "quota-load-span".into(),
+        kind: SpanKind::Internal,
+        start_time: start,
+        end_time: start + Duration::milliseconds(10),
+        duration_ms: 10.0,
+        status_code: SpanStatusCode::Ok,
+        status_message: String::new(),
+        attributes,
+        events: vec![],
+    }
+}
+
+/// Regression test for the ClickHouse-backed storage-quota gap: before this
+/// fix, `ClickHouseOtelStorage::get_storage_quota`/`check_quota` delegated
+/// straight to the inner `TimescaleDbStorage`, which sums Postgres
+/// `otel_spans`/`otel_metrics`/`otel_log_events` hypertables — tables a
+/// ClickHouse-enabled install never writes span/metric rows into (`spans`
+/// and `metrics` are ClickHouse-native; see `store_spans`/`store_metrics`).
+/// Quota enforcement was therefore silently inert for every CH-backed
+/// project regardless of real ingested volume.
+///
+/// This test proves the fix against a REAL ClickHouse testcontainer: insert
+/// real span rows via `store_spans` (the production ingest path, not a
+/// synthetic byte count), and assert `get_storage_quota`/`check_quota`
+/// actually track that ClickHouse-native volume.
+#[tokio::test]
+async fn test_storage_quota_tracks_real_clickhouse_span_volume() {
+    let project_id = 777;
+
+    // 4 get_storage_quota/check_quota calls below each consume one queued
+    // mock logs-share response (see setup_with_quota): the empty-project
+    // check, the post-ingest get_storage_quota, check_quota's internal
+    // get_storage_quota, and the unrelated-project check.
+    let Some((storage, _container)) = setup_with_quota(300 * 1024, 0, 4).await else {
+        return; // Docker unavailable — skip gracefully.
+    };
+
+    // ── Phase 1: before any data, with a quota configured, usage is zero. ──
+    let empty_quota = storage
+        .get_storage_quota(project_id)
+        .await
+        .expect("get_storage_quota on empty project");
+    assert_eq!(
+        empty_quota.total_bytes, 0,
+        "no spans/metrics ingested yet for this project"
+    );
+
+    // ── Phase 2: insert real span volume, then a tiny limit must trip. ──
+    // Each span carries ~4KB of high-entropy (pseudo-random) attributes (20
+    // keys x 200 bytes) -- unlike a repeated filler string, this survives
+    // ZSTD compression well enough that ~500 of them push real ClickHouse
+    // part bytes comfortably past the 300KB test limit below.
+    // `logs_bytes_per_call` is mocked to 0 (see `setup_with_quota`) so every
+    // byte this test observes comes from the ClickHouse-native
+    // spans/metrics accounting under test, not the inner Postgres delegate.
+    let spans: Vec<SpanRecord> = (0..500u32)
+        .map(|i| quota_test_span(project_id, i))
+        .collect();
+    let stored = storage
+        .store_spans(spans)
+        .await
+        .expect("store_spans should succeed");
+    assert_eq!(stored, 500);
+
+    let quota = storage
+        .get_storage_quota(project_id)
+        .await
+        .expect("get_storage_quota after real ingest");
+    assert!(
+        quota.total_bytes > 300 * 1024,
+        "expected ClickHouse-native total_bytes to exceed the 300KB test limit after \
+         inserting ~500 spans with ~4KB of high-entropy attributes each (got {} bytes) -- \
+         this is exactly the regression this fix protects against: a plain delegation to \
+         the inner TimescaleDbStorage would report ~0 bytes here, since the \
+         ClickHouse-backed Postgres otel_spans table never receives these rows",
+        quota.total_bytes
+    );
+    assert!(
+        quota.usage_pct >= 100.0,
+        "usage_pct should have crossed 100% of the 300KB limit, got {}",
+        quota.usage_pct
+    );
+
+    let exceeded = storage
+        .check_quota(project_id)
+        .await
+        .expect("check_quota after real ingest");
+    assert!(
+        exceeded,
+        "check_quota must trip once real ClickHouse-ingested span volume exceeds the \
+         configured limit"
+    );
+
+    // A different, unrelated project sees none of this volume.
+    let other_quota = storage
+        .get_storage_quota(999_999)
+        .await
+        .expect("get_storage_quota for unrelated project");
+    assert_eq!(
+        other_quota.total_bytes, 0,
+        "an unrelated project must not see this project's ClickHouse-ingested bytes"
+    );
 }

--- a/crates/temps-otel/tests/timescaledb_storage_test.rs
+++ b/crates/temps-otel/tests/timescaledb_storage_test.rs
@@ -504,6 +504,124 @@ async fn test_storage_quota() {
     assert!(!exceeded); // Fresh DB, should not be exceeded
 }
 
+/// Regression test for the `hypertable_size()` fix.
+///
+/// `test_storage_quota` above only exercises a freshly-created, empty
+/// database, where the old buggy `pg_total_relation_size(otel_spans)`
+/// (root-relation) formula and the fixed `hypertable_size('otel_spans')`
+/// (chunk-aware) formula are indistinguishable — both report ~0 bytes
+/// because no data has ever been inserted. That made the old formula's bug
+/// invisible to this test suite: a hypertable's root relation holds no
+/// rows/bytes of its own regardless of how much real data lives in its
+/// child chunk tables, so quota enforcement was silently inert for every
+/// project (see the CORRECTNESS comment on `get_storage_quota`).
+///
+/// This test closes that gap by actually inserting span rows via
+/// `store_spans` (the real ingest path, not a synthetic row count) and
+/// asserting `total_bytes`/`usage_pct` track that real volume. If a future
+/// change reverts `get_storage_quota` back to
+/// `pg_total_relation_size(otel_spans::regclass)` on the hypertable root,
+/// `total_bytes` will stay near zero regardless of the ~500 inserted spans
+/// and the assertions below will fail.
+#[tokio::test]
+async fn test_storage_quota_tracks_real_ingested_span_volume() {
+    let Some((_db, storage)) = setup_storage().await else {
+        return;
+    };
+
+    let project_id = 4242;
+
+    // Each span carries a sizeable `attributes` payload (20 keys x ~200
+    // bytes each, ~4KB/span) so the real bytes written to the `otel_spans`
+    // hypertable's chunks are well above any catalog/index noise floor a
+    // table -- even an empty one -- can carry. With ~500 such spans this is
+    // several hundred KB to low-MB of real chunk data, comfortably over the
+    // 200KB quota limit used below.
+    let mut attrs = BTreeMap::new();
+    for i in 0..20 {
+        attrs.insert(format!("attribute.key.number.{i}"), "x".repeat(200));
+    }
+
+    let mut spans = Vec::with_capacity(500);
+    for i in 0..500u32 {
+        let mut span = sample_span(
+            project_id,
+            &format!("{i:032x}"),
+            &format!("{i:016x}"),
+            None,
+            "load-test-span",
+            SpanKind::Internal,
+            SpanStatusCode::Ok,
+            10.0,
+        );
+        span.attributes = attrs.clone();
+        spans.push(span);
+    }
+
+    let stored = storage.store_spans(spans).await.unwrap();
+    assert_eq!(stored, 500);
+
+    // A 200KB limit. Calibrated live against both formulas on this exact
+    // dataset (~500 spans x ~4KB attributes each):
+    //   - fixed `hypertable_size()` formula:            ~856KB total_bytes
+    //   - old `pg_total_relation_size(root)` formula:     ~64KB total_bytes
+    //     (a hypertable's empty root relation carries a small constant
+    //     amount of index/catalog overhead that does NOT grow with chunk
+    //     data — this is that constant, not real ingested volume)
+    // 200KB sits with wide margin between the two, so this assertion is
+    // only satisfied by a formula that actually accounts for chunk storage.
+    const TEST_QUOTA_LIMIT_BYTES: u64 = 200 * 1024;
+    let storage_with_tiny_quota =
+        TimescaleDbStorage::with_config(_db.db.clone(), None, 7, Some(TEST_QUOTA_LIMIT_BYTES));
+    let quota = storage_with_tiny_quota
+        .get_storage_quota(project_id)
+        .await
+        .unwrap();
+    assert!(
+        quota.total_bytes > TEST_QUOTA_LIMIT_BYTES,
+        "expected chunk-aware total_bytes to exceed the {TEST_QUOTA_LIMIT_BYTES}-byte test \
+         limit after inserting ~500 spans with ~4KB of attributes each (got {} bytes) -- \
+         this is exactly the regression the hypertable_size() fix protects against: the old \
+         pg_total_relation_size(root) formula reports only the root relation's constant \
+         ~64KB of index/catalog overhead here, never the real chunk volume",
+        quota.total_bytes
+    );
+    assert!(
+        quota.usage_pct >= 100.0,
+        "usage_pct should have crossed 100% of the {TEST_QUOTA_LIMIT_BYTES}-byte limit, got {}",
+        quota.usage_pct
+    );
+
+    let exceeded = storage_with_tiny_quota
+        .check_quota(project_id)
+        .await
+        .unwrap();
+    assert!(
+        exceeded,
+        "check_quota must trip once real ingested span volume exceeds the configured limit"
+    );
+
+    // Sanity check in the other direction: a generous limit against the
+    // same real data must NOT report exceeded, proving usage_pct is a real
+    // proportional measurement and not just pegged to 100%.
+    let storage_with_generous_quota =
+        TimescaleDbStorage::with_config(_db.db.clone(), None, 7, Some(10 * 1024 * 1024 * 1024));
+    let generous_quota = storage_with_generous_quota
+        .get_storage_quota(project_id)
+        .await
+        .unwrap();
+    assert!(
+        generous_quota.usage_pct < 100.0,
+        "a 10GB limit should not be exceeded by ~500 spans of test data, got usage_pct = {}",
+        generous_quota.usage_pct
+    );
+    let not_exceeded = storage_with_generous_quota
+        .check_quota(project_id)
+        .await
+        .unwrap();
+    assert!(!not_exceeded);
+}
+
 #[tokio::test]
 async fn test_get_storage_quota_disabled_skips_database() {
     use sea_orm::{DatabaseBackend, MockDatabase};


### PR DESCRIPTION
## Summary

- Adds `otel-quota-scenario` to the temps-e2e suite: proves real OTLP/HTTP
  protobuf ingestion (traces/metrics/logs, hand-encoded in a new
  `apps/temps-e2e/src/lib/otlp.ts` — no `@opentelemetry/*` SDK, needed for
  byte-exact control over payload size) round-trips through the real query
  API (`GET /otel/traces`, `/otel/traces/{id}/{trace_id}`, `/otel/logs`,
  `/otel/metrics`) and the unified Observe feed, then proves per-project
  storage-quota enforcement actually rejects ingestion (413) once volume
  crosses a configured `TEMPS_OTEL_QUOTA_GB` — not just that the config
  knob exists.
- **Fixes a real bug found via live-verification: OTel storage-quota
  enforcement was silently inert for every project.**
  `TimescaleDbStorage::get_storage_quota` estimated a project's share of
  each OTel hypertable as `table_size * (project_rows /
  approximate_row_count)`, but computed `table_size` via
  `pg_total_relation_size('otel_spans')` on the hypertable's **root**
  relation. A hypertable's root holds no rows and almost no bytes of its
  own — TimescaleDB partitions all actual data into child "chunk" tables
  under `_timescaledb_internal` — so `table_size` never grew with real
  ingest volume. Verified live: with `TEMPS_OTEL_QUOTA_GB=1`, pushing 2GB+
  of real OTLP trace data into one project never moved `usage_pct` past
  ~1.5%; no volume could ever trip the quota. Fixed by switching to
  `hypertable_size('otel_spans'::regclass)`, TimescaleDB's chunk-aware
  equivalent (still cheap — proportional to chunk count, not row count).
  After the fix, the same volume test trips the quota consistently at
  ~110 batches / ~990MB against a 1024MB configured limit, across 4
  consecutive clean live runs. This is exactly the 160GB/day-flood
  failure mode the quota exists to prevent, and it could only be caught
  against a real TimescaleDB instance — a mocked storage layer has no
  chunk partitioning to get wrong.
- Also adds `LEAST(1.0, ratio)` around each per-table proportion:
  `approximate_row_count` can lag the true row count right after a write
  burst, and without the clamp a stale denominator could compute a
  per-project share above 100% of the table. A **residual limitation**
  from this same staleness — a project can transiently see inflated usage
  right after a *different* project's burst on the same hypertable,
  self-healing once autovacuum/ANALYZE catches up — is reproduced and
  documented (not silently patched around) in the scenario's header
  comment and the README; a proper fix (e.g. a periodic background
  `ANALYZE`) is a bigger cost/design tradeoff than fits this PR.
- Two smaller doc-only bugs found and fixed along the way:
  - `EventsQuery.kinds`'s doc comment (utoipa → OpenAPI → generated SDK
    docs) advertised `log` as a valid Observe `kinds` filter alongside
    `request/span/error/revenue`. It never was — `ObservabilityEvent` has
    no `Log` variant by design, so `kinds=log` has always 400'd. Fixed the
    doc comment in `crates/temps-observability/src/handlers/events.rs` to
    match the code.
  - `query_traces`'s utoipa params list was missing `attributes` and
    `name_pattern`, both real `TraceQueryParams` fields already documented
    on the neighboring `query_trace_summaries` handler. Fixed in
    `crates/temps-otel/src/handlers/query_handler.rs`.

## Test plan

- [x] `bun run typecheck` (apps/temps-e2e): clean
- [x] `cargo check --lib -p temps-otel -p temps-observability`: clean
- [x] `cargo test --lib -p temps-otel -p temps-observability`: 495 passed, 0 failed
- [x] `cargo clippy -p temps-otel -p temps-observability --lib --tests -- -D warnings`: clean
- [x] Full-workspace `cargo clippy --all-targets` (pre-commit hook): passed
- [x] Live-verified against an isolated instance (fresh DB per run,
      `TEMPS_OTEL_QUOTA_GB=1`, own ports 18100/18463/18101):
  - `otel-quota-scenario` passed all steps on 4 consecutive clean runs
    (fresh project + fresh DB each time), with the quota trip point
    consistent every time (~110 batches / ~990MB sent vs a 1024MB
    configured limit)
  - Reproduced the residual cross-project staleness limitation live by
    running the scenario twice back-to-back against the *same* database
    with no DB reset in between (documented, not hidden)
## Evidence

All commands below were run against a fresh, isolated instance built from this
exact branch (`test/e2e-otel-quota` @ `944a695d`) in a separate worktree
(`/Users/davidviejo/projects/temps-worktrees/e2e-otel-quota`), not against a
shared/other agent's instance: `cargo build --profile fast --bin temps
--package temps-cli` binary confirmed newer than every `.rs` file the branch
touched, a dedicated Postgres/TimescaleDB database
(`temps_e2e_otel_evidence` on the shared `temps-dev-db` container,
`localhost:15435`), a fresh `TEMPS_DATA_DIR`, and dedicated ports
(`18200`/`18563`/`18201`). Launched with `TEMPS_OTEL_QUOTA_GB=1`,
`TEMPS_DISABLE_HTTPS_REDIRECT=true`, `TEMPS_TELEMETRY=0`. No
`TEMPS_CLICKHOUSE_*` vars were set, so this instance ran the default
TimescaleDB-only OTel storage backend (see the ClickHouse caveat at the
bottom — important, read it).

**Scenario run 1 (plain output, fresh DB/fresh project) — full ingest, query
round-trip, and quota trip with real numbers**:
```bash
cd apps/temps-e2e && TEMPS_URL=http://localhost:18200 \
  TEMPS_API_KEY=tk_*** TEMPS_E2E_REGISTRY=localhost:5111 \
  bun run src/index.ts otel-quota-scenario
```
```
Temps otel-quota scenario  ->  http://localhost:18200

▶ create project
  ✓ create project (0.6s)
  project #1 (e2e-msljhv1y-nr3mt5-otel-quota)

▶ POST a real OTLP trace batch (one root span) to /otel/v1/traces
  ✓ POST a real OTLP trace batch (one root span) to /otel/v1/traces (0.0s)
▶ POST a real OTLP metrics batch (one gauge point) to /otel/v1/metrics
  ✓ POST a real OTLP metrics batch (one gauge point) to /otel/v1/metrics (0.0s)
▶ POST a real OTLP logs batch (one record, correlated to the span) to /otel/v1/logs
  ✓ POST a real OTLP logs batch (one record, correlated to the span) to /otel/v1/logs (0.0s)
▶ the span round-trips through GET /otel/traces (query by trace_id)
  ✓ the span round-trips through GET /otel/traces (query by trace_id) (0.0s)
▶ the same trace round-trips through GET /otel/traces/{project_id}/{trace_id}
  ✓ the same trace round-trips through GET /otel/traces/{project_id}/{trace_id} (0.0s)
▶ the log round-trips through GET /otel/logs (correct body + trace correlation)
  ✓ the log round-trips through GET /otel/logs (correct body + trace correlation) (0.0s)
▶ the metric point round-trips through GET /otel/metrics with the exact value
  ✓ the metric point round-trips through GET /otel/metrics with the exact value (0.0s)
▶ the root span shows up in the unified Observe feed (kinds=span)
  ✓ the root span shows up in the unified Observe feed (kinds=span) (0.0s)
▶ kinds=log is rejected 400 (no Log variant in the Observe feed, by design -- not silently ignored)
  ✓ kinds=log is rejected 400 (no Log variant in the Observe feed, by design -- not silently ignored) (0.0s)

▶ quota starts well under 100% for a fresh project
  limit_bytes=1073741824 total_bytes=581632 usage_pct=0.0542
  ✓ quota starts well under 100% for a fresh project (0.0s)

▶ push large OTLP trace batches (~9.0MB each) until quota.usage_pct >= 100 (uncached GET /otel/quota read), capped at 250 batches
  batch 1: ingest=200 sent_so_far=9.0MB reported_total=10.1MB usage_pct=0.98
  [... 108 more batches, monotonically climbing ...]
  batch 108: ingest=200 sent_so_far=972.0MB reported_total=1009.7MB usage_pct=98.60
  batch 109: ingest=200 sent_so_far=981.0MB reported_total=1019.0MB usage_pct=99.51
  batch 110: ingest=200 sent_so_far=990.0MB reported_total=1028.4MB usage_pct=100.43
  ✓ push large OTLP trace batches (~9.0MB each) until quota.usage_pct >= 100 (uncached GET /otel/quota read), capped at 250 batches (12.3s)
  quota crossed 100% after ~990.0MB client-sent (configured limit 1024MB) in 110 batch(es)

▶ wait out the 30s ingest-time quota cache TTL so the next ingest call re-checks storage live
  ✓ wait out the 30s ingest-time quota cache TTL so the next ingest call re-checks storage live (35.0s)
▶ a batch sent once over quota is REJECTED with HTTP 413 (not silently accepted)
  ✓ a batch sent once over quota is REJECTED with HTTP 413 (not silently accepted) (0.0s)
▶ rejection persists on a second attempt (not a one-off)
  ✓ rejection persists on a second attempt (not a one-off) (0.0s)
▶ the rejected canary span never actually landed (queried back, not just "the HTTP call errored")
  ✓ the rejected canary span never actually landed (queried back, not just "the HTTP call errored") (0.0s)

▶ teardown: deleted 1 project(s)

✅ otel-quota-scenario PASSED
```
This matches the PR's claimed order of magnitude (~110 batches / ~990MB
against the 1024MB limit) exactly, from a genuinely fresh database.

**Scenario run (`--json`, clean pass) — machine-readable artifact**:
```bash
cd apps/temps-e2e && TEMPS_URL=http://localhost:18200 \
  TEMPS_API_KEY=tk_*** TEMPS_E2E_REGISTRY=localhost:5111 \
  bun run src/index.ts otel-quota-scenario --json
```
```json
{
  "runId": "e2e-msljmtb6-tddesf",
  "ok": true,
  "steps": [
    { "step": "create project", "ok": true, "ms": 33.34 },
    { "step": "POST a real OTLP trace batch (one root span) to /otel/v1/traces", "ok": true, "ms": 14.0 },
    { "step": "POST a real OTLP metrics batch (one gauge point) to /otel/v1/metrics", "ok": true, "ms": 5.15 },
    { "step": "POST a real OTLP logs batch (one record, correlated to the span) to /otel/v1/logs", "ok": true, "ms": 7.91 },
    { "step": "the span round-trips through GET /otel/traces (query by trace_id)", "ok": true, "ms": 5.51 },
    { "step": "the same trace round-trips through GET /otel/traces/{project_id}/{trace_id}", "ok": true, "ms": 6.78 },
    { "step": "the log round-trips through GET /otel/logs (correct body + trace correlation)", "ok": true, "ms": 4.62 },
    { "step": "the metric point round-trips through GET /otel/metrics with the exact value", "ok": true, "ms": 8.70 },
    { "step": "the root span shows up in the unified Observe feed (kinds=span)", "ok": true, "ms": 4.45 },
    { "step": "kinds=log is rejected 400 (no Log variant in the Observe feed, by design -- not silently ignored)", "ok": true, "ms": 2.54 },
    { "step": "quota starts well under 100% for a fresh project", "ok": true, "ms": 8.66 },
    { "step": "push large OTLP trace batches (~9.0MB each) until quota.usage_pct >= 100 (uncached GET /otel/quota read), capped at 250 batches", "ok": true, "ms": 8748.56 },
    { "step": "wait out the 30s ingest-time quota cache TTL so the next ingest call re-checks storage live", "ok": true, "ms": 35002.46 },
    { "step": "a batch sent once over quota is REJECTED with HTTP 413 (not silently accepted)", "ok": true, "ms": 8.21 },
    { "step": "rejection persists on a second attempt (not a one-off)", "ok": true, "ms": 2.99 },
    { "step": "the rejected canary span never actually landed (queried back, not just \"the HTTP call errored\")", "ok": true, "ms": 3.63 }
  ],
  "quota": {
    "limitBytes": 1073741824,
    "bytesSentByClientAtTrip": 651183005,
    "reportedTotalBytesAtTrip": 1086717783,
    "batchesSent": 69
  }
}
```
Note: this particular run tripped earlier (69 batches / ~651MB client-sent)
than run 1 above (110 batches / ~990MB) because it ran later against the
*same* shared evidence database, which already held leftover chunk data
from two prior scenario runs that hadn't been reclaimed — the hypertable's
real total size (and therefore `reportedTotalBytesAtTrip`, ~1086MB here vs
~1028MB in run 1) was already elevated before this run's own project sent a
single byte. That's an artifact of reusing one database across several
verification runs in this session, not a behavior change in the fix itself;
a genuinely fresh project/DB (run 1, and how the scenario runs in CI) is the
apples-to-apples number.

**Raw `GET /otel/quota/{project_id}` mid-run, showing real usage_pct against
the live scenario's own transcript (not just the scenario's internal
pass/fail)**:
```bash
curl -s -H "Authorization: Bearer tk_***" http://localhost:18200/api/otel/quota/5
```
Polled every 0.4s while `otel-quota-scenario` (run 5, plain output, project
#5) was mid-flight; the scenario's own transcript for that run shows the
push step crossing 100% at batch 53 (`sent_so_far=477.0MB ...
usage_pct=101.19`). The concurrently-polled raw endpoint returned the exact
same value:
```
{"quota":{"project_id":5,"metrics_bytes":0,"traces_bytes":0,"logs_bytes":0,"total_bytes":1086497517,"limit_bytes":1073741824,"usage_pct":101.18796648457646}}
```
(repeated across ~20 consecutive 0.4s polls after the trip — stable at the
tripped value, confirming this is the real uncached endpoint, not a
scenario-internal number.)

**Residual cross-project staleness limitation (documented in the PR as NOT
fixed) — reproduced live, honestly reported**: running the scenario twice
back-to-back against the *same* database (no fresh DB in between) failed the
very first quota assertion on the second run:
```bash
# run 2, immediately after run 1, same DB, new project (#2)
```
```
▶ quota starts well under 100% for a fresh project
  limit_bytes=1073741824 total_bytes=1078583296 usage_pct=100.4509
  ✗ quota starts well under 100% for a fresh project: quota.usage_pct=100.45089721679688 already >= 100 before any volume was pushed -- unclean project

▶ teardown: deleted 1 project(s)

❌ otel-quota-scenario FAILED
```
This is exactly the residual limitation the PR description calls out
("`approximate_row_count` is shared across every project on the same
hypertable... self-heals within seconds as autovacuum/ANALYZE catches up").
Confirmed the self-heal mechanism directly: manually running
`ANALYZE otel_spans; ANALYZE otel_metrics; ANALYZE otel_log_events;` against
the evidence DB immediately dropped the reported usage for a brand-new
project back down:
```bash
docker exec -i temps-dev-db psql -U postgres -d temps_e2e_otel_evidence \
  -c "ANALYZE otel_spans; ANALYZE otel_metrics; ANALYZE otel_log_events;"
curl -s -H "Authorization: Bearer tk_***" http://localhost:18200/api/otel/quota/2
```
```
{"quota":{"project_id":2,"metrics_bytes":0,"traces_bytes":0,"logs_bytes":0,"total_bytes":9836973,"limit_bytes":1073741824,"usage_pct":0.9161395020782948}}
```
(usage_pct went from 100.45 to 0.92 immediately after the manual ANALYZE —
consistent with the PR's claim that this is a stats-staleness artifact, not
a persistent bug, and that a real fix would be a periodic background
ANALYZE.) Every subsequent scenario run in this session (runs 4 and 5) that
started against post-ANALYZE state passed the "quota starts well under 100%"
assertion cleanly.

**Coverage caveat — read before treating this as full OTel-quota coverage**:
this branch's fix, and every live test above, only exercises the **default
TimescaleDB/Postgres-backed** OTel storage path
(`crates/temps-otel/src/storage/timescaledb.rs`). No `TEMPS_CLICKHOUSE_*`
env vars were set on the test instance, so the ClickHouse-backed OTel
storage path (`crates/temps-otel/src/storage/clickhouse/mod.rs`,
opt-in) was never exercised. Reading that code path during this evidence
pass surfaced something worth flagging explicitly: `ClickHouseOtelStorage`
wraps an inner `TimescaleDbStorage` for metadata, and its
`get_storage_quota`/`check_quota` **both delegate straight to that inner
TimescaleDB instance** (`crates/temps-otel/src/storage/clickhouse/mod.rs`
around `get_storage_quota`/`check_quota`) rather than measuring the
ClickHouse tables that actually hold the spans/metrics data in that mode.
That means if an operator runs Temps with `TEMPS_CLICKHOUSE_*` configured,
quota accounting would still be reading Postgres/TimescaleDB table sizes —
which would hold little to no data, since ingest in that mode goes to
ClickHouse instead — so quota enforcement would likely still be inert on
that path, the same class of bug this PR fixes for the default backend.
This was NOT tested live (no ClickHouse instance was stood up in this
verification pass) and is not fixed by this PR; flagging it here as an
observation from reading the code, not a live-verified finding, so it isn't
mistaken for broader coverage than what was actually tested.


---

## Round 1 review fixes (2026-08-09)

Two Major (should-fix) findings from the initial review, both addressed for
real — not just documented around.

### 1. ClickHouse-backed quota gap — fixed for real (not scoped out)

The coverage caveat above (originally written as "NOT fixed by this PR,
flagging as an observation") is now fixed. Investigated feasibility first,
per the round's instructions: unlike the Postgres major-version-upgrade case
in the PITR PR (genuinely out of scope), this one turned out tractable
without materially more infrastructure — ClickHouse's own `system.parts`
table gives the same kind of cheap, chunk-aware byte accounting
`hypertable_size()` gives on the TimescaleDB side.

**Root cause confirmed by reading the code**: `ClickHouseOtelStorage::store_spans`
and `store_metrics` write natively to ClickHouse (`spans`/`metrics` tables) —
they never touch the inner `TimescaleDbStorage`. But
`ClickHouseOtelStorage::get_storage_quota`/`check_quota` plain-delegated to
that same inner store, which sums `otel_spans`/`otel_metrics`/`otel_log_events`
**Postgres** hypertables. A ClickHouse-enabled install never writes span/metric
rows into those Postgres tables, so the delegated quota read always measured
near-empty tables — quota enforcement was silently inert for every
ClickHouse-backed project, the same class of bug this PR already fixed for
the default TimescaleDB-only path, just on the other backend.

**Fix** (`crates/temps-otel/src/storage/clickhouse/mod.rs`,
`crates/temps-otel/src/storage/timescaledb.rs`):
- `ClickHouseOtelStorage::get_storage_quota` now computes a real proportional
  byte estimate for `spans`/`metrics` natively in ClickHouse:
  `sum(bytes_on_disk)` from `system.parts` (active parts only) for the whole
  table, times `min(1.0, project_rows / table_rows)` — `project_rows` via a
  bound `count() WHERE project_id = ?` (cheap: `ORDER BY (project_id, ...)`
  in the DDL makes this a primary-index-bounded read, not a full scan),
  `table_rows` via `sum(rows)` from the same `system.parts` metadata query
  (no data scan). This mirrors the TimescaleDB `hypertable_size()` fix's
  shape exactly, using ClickHouse's own equivalent primitive.
- Combined with the ONE domain still genuinely Postgres-owned even with
  ClickHouse enabled — `otel_log_events` (`store_logs`/`archive_logs` always
  delegate to the inner store; only spans/metrics are ClickHouse-native).
  Reading just that one table's share (not the inner store's 3-table sum,
  which would double count against the near-empty CH-mode Postgres
  `otel_spans`/`otel_metrics` tables) required a new
  `TimescaleDbStorage::hypertable_bytes_for_project(table, project_id)`
  single-table helper — factored out of the existing 3-table
  `get_storage_quota` SQL, which is left byte-for-byte unchanged so the
  all-Postgres path (the majority of installs) pays no extra query.
- Also added `TimescaleDbStorage::quota_bytes_per_project()` accessor so
  `ClickHouseOtelStorage` reads the one configured `TEMPS_OTEL_QUOTA_GB`
  limit from its existing inner store instead of parsing it a second time.
- Corrected the module doc header in `storage/clickhouse/mod.rs`, which
  additionally had a **separate, pre-existing** inaccuracy unrelated to
  quota: it claimed metrics were "delegated to the inner TimescaleDbStorage
  unconditionally" alongside logs, but `store_metrics`/`query_metrics` have
  actually been ClickHouse-native since an earlier phase (confirmed by
  reading the code — `store_metrics` writes only to `self.ch`). Both the
  metrics and quota claims are now accurately described.

**Live verification against a real ClickHouse instance** (not just a
mocked/mental-model check): added
`test_storage_quota_tracks_real_clickhouse_span_volume` in
`crates/temps-otel/tests/clickhouse_storage_test.rs`, which spins up a real
`clickhouse/clickhouse-server:26.2.5` testcontainer, inserts 500 real span
rows (via `store_spans`, the production ingest path) with high-entropy
~4KB attribute payloads each (deliberately not a repeated filler string —
ZSTD compresses that to near-zero regardless of row count, which would
defeat the test), and asserts `get_storage_quota`/`check_quota` track that
real ClickHouse-native volume. Confirmed this is a genuine regression test,
not a test that would pass either way: reverted `get_storage_quota`/
`check_quota` to plain delegation (the pre-fix code) and re-ran —
`total_bytes` came back `0` and the test failed with the expected message;
restored the fix and it passed again. Full command + output below.

### 2. No Rust-level regression test for the TimescaleDB quota SQL fix — fixed

`test_storage_quota` in `crates/temps-otel/tests/timescaledb_storage_test.rs`
only ever ran against a freshly-created, empty database, where the old
`pg_total_relation_size(root)` formula and the fixed `hypertable_size(...)`
formula are indistinguishable (both ~0 bytes) — so a regression back to the
buggy formula would pass that test unchanged.

Added `test_storage_quota_tracks_real_ingested_span_volume`: inserts 500 real
span rows via `store_spans` (with ~4KB of attributes each) against the real
TimescaleDB testcontainer (`TestDatabase::with_migrations()`, the file's
existing pattern), then asserts `total_bytes`/`usage_pct` actually reflect
that inserted volume against a small (200KB) configured quota limit, and that
a generous (10GB) limit does NOT report exceeded against the same data
(rules out a test that's just pegged to 100%). Calibrated live: the fixed
`hypertable_size()` formula reports ~876KB for this dataset; the old
`pg_total_relation_size(root)` formula reports a constant ~64KB (root-relation
catalog/index overhead that never grows with chunk data) — the 200KB
threshold sits with wide margin between the two. Confirmed as a genuine
regression test the same way as above: temporarily reverted the SQL to
`pg_total_relation_size(...)`, re-ran — failed with `total_bytes = 65536`
(clearly below the 200KB assertion, exactly reproducing the original bug);
restored the fix and it passed again.

### Verification evidence (round 1)

**`cargo check --lib -p temps-otel`**: clean.
```
    Checking temps-otel v0.1.0-beta.55
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 10.09s
```

**`cargo clippy -p temps-otel --lib --tests -- -D warnings`** (real `cargo`
binary, not through `rtk`): clean, 0 warnings.

**`$(command -v cargo) check --lib -p temps-observability -p temps-deployments
-p temps-cli`** (downstream crates that depend on `temps-otel`): clean.

**`cargo test -p temps-otel --test clickhouse_storage_test --test
timescaledb_storage_test`** (real ClickHouse 26.2.5 + real TimescaleDB
testcontainers): all 41 tests passed, including the two new regression
tests.
```
     Running tests/clickhouse_storage_test.rs
running 9 tests
test metrics_roundtrip_store_query_list ... ok
test query_metrics_aggregation_group_by_and_label_filter ... ok
test query_metrics_cumulative_histogram_uses_latest_not_sum ... ok
test query_metrics_histogram_summary_aggregates_buckets ... ok
test query_metrics_rate_respects_temporality ... ok
test query_metrics_rejects_disallowed_label_key ... ok
test store_metrics_drops_disallowed_name ... ok
test test_storage_quota_tracks_real_clickhouse_span_volume ... ok
test trace_refs_roundtrip_record_and_lookup ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 48.29s

     Running tests/timescaledb_storage_test.rs
running 32 tests
[... 30 more ...]
test test_storage_quota ... ok
test test_storage_quota_tracks_real_ingested_span_volume ... ok
[... 30 more ...]

test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 41.01s
```

**Regression-catching proof for both new tests** (temporarily reverted the
fix each time, confirmed the new test fails with the expected symptom,
restored the fix, confirmed it passes again):
```
# TimescaleDB test against reverted pg_total_relation_size(root) formula:
thread 'test_storage_quota_tracks_real_ingested_span_volume' panicked:
expected chunk-aware total_bytes to exceed the 204800-byte test limit ...
(got 65536 bytes) -- this is exactly the regression the hypertable_size()
fix protects against ...

# ClickHouse test against reverted plain-delegation code:
thread 'test_storage_quota_tracks_real_clickhouse_span_volume' panicked:
expected ClickHouse-native total_bytes to exceed the 300KB test limit ...
(got 0 bytes) -- this is exactly the regression this fix protects against:
a plain delegation to the inner TimescaleDbStorage would report ~0 bytes
here, since the ClickHouse-backed Postgres otel_spans table never receives
these rows
```

**Live re-run of `otel-quota-scenario` against a fresh instance built from
this branch** (own isolated Postgres DB `pr586_r1_verify` on the shared
`temps-dev-db` container, fresh `TEMPS_DATA_DIR`, dedicated ports
18261/18262/18263, `TEMPS_OTEL_QUOTA_GB=1`, `TEMPS_DISABLE_HTTPS_REDIRECT=true`,
`TEMPS_TELEMETRY=0`; `target/fast/temps` rebuilt and confirmed newer than
every touched `.rs` file before running):
```bash
cd apps/temps-e2e && TEMPS_URL=http://localhost:18261 \
  TEMPS_API_KEY=tk_*** TEMPS_E2E_REGISTRY=localhost:5111 \
  bun run src/index.ts otel-quota-scenario
```
```
▶ create project
  ✓ create project
▶ POST a real OTLP trace batch (one root span) to /otel/v1/traces
  ✓ ...
[... all round-trip + Observe-feed steps passed, same as the original
    evidence run above ...]
▶ push large OTLP trace batches (~9.0MB each) until quota.usage_pct >= 100
  batch 110: ingest=200 sent_so_far=990.0MB reported_total=1028.4MB usage_pct=100.43
  ✓ push large OTLP trace batches ... (12.3s)
  quota crossed 100% after ~990.0MB client-sent (configured limit 1024MB) in 110 batch(es)
▶ wait out the 30s ingest-time quota cache TTL ...
  ✓ ... (35.0s)
▶ a batch sent once over quota is REJECTED with HTTP 413 (not silently accepted)
  ✓ ...
▶ rejection persists on a second attempt (not a one-off)
  ✓ ...
▶ the rejected canary span never actually landed (queried back, not just "the HTTP call errored")
  ✓ ...
▶ teardown: deleted 1 project(s)

✅ otel-quota-scenario PASSED
```
Matches the PR's originally-claimed trip point (~110 batches / ~990MB
against the 1024MB limit) exactly, from a genuinely fresh database, on the
branch as it stands with this round's fixes applied — confirming the
round-1 changes did not regress the existing TimescaleDB quota behavior.

Torn down after verification: process killed, `pr586_r1_verify` database
dropped, `TEMPS_DATA_DIR` removed.

### What was NOT changed / not fixed further

- The residual cross-project `approximate_row_count` staleness limitation
  (documented above, in the original PR body) is unchanged — still a real,
  tracked, documented limitation on the TimescaleDB side, not addressed by
  this round (out of scope for these two findings).
- The ClickHouse fix's per-project `count()` scan on `spans`/`metrics` is,
  like the TimescaleDB `approximate_row_count` approach it mirrors, a
  proportional estimate, not exact accounting — it is bound by the
  `ORDER BY (project_id, ...)` primary index but still touches real
  data, unlike the `system.parts`-only portion of the query. This mirrors
  an inherent tradeoff already accepted on the TimescaleDB side (documented
  in `get_storage_quota`'s existing CORRECTNESS comment) rather than a new
  one introduced here.
