### PR TITLE
test(e2e): add db-ha-failover-scenario for Postgres HA/pg_auto_failover

### DIFF
--- a/apps/temps-e2e/README.md
+++ b/apps/temps-e2e/README.md
@@ -799,6 +799,41 @@ of scope here.
     regardless of running state, so the stopped ex-primary is cleaned up
     too)
 
+Between steps 7 and 8, the scenario also asserts a platform-level symptom
+the PR's own root-cause narrative below cites: that the **console/CLI-facing
+API** (`GET /external-services/{id}`, backed by
+`get_service_members_with_live_state`) reflects the promotion via
+`ServiceMemberInfo.live_state` — not just the raw `cluster-health` probe
+already checked in step 7. This exercises a genuinely different code path
+than step 2/7's polling: `get_service_info`'s own doc comment explains why
+`live_state` (not `service_members.role`) is the field to check —
+`service_members.role` is intentionally config-only (`monitor`/`replica`)
+in the current design and is never written to `"primary"` at runtime
+(confirmed by reading the code: `PgAutoFailoverState::to_cluster_role()`,
+which maps to a `Primary` role, is defined and unit-tested but not called
+from any production code path — `sync_member_roles` only ever demotes
+legacy `"primary"` rows to `"replica"` once). Asserting a `role` flip would
+therefore assert something that doesn't happen by design; `live_state` is
+the faithful, current equivalent.
+
+The PR's narrative also cites the DNS reconciler failing to republish
+`primary.<svc>.temps.local`. That assertion was investigated and **skipped
+as impractical for this round**: the only HTTP surface that exposes the
+internal DNS zone content is `GET /internal/nodes/{node_id}/dns/changes`
+(`crates/temps-dns/src/handlers/dns_sync.rs`), gated behind per-node
+bearer-token auth (`nodes.token_hash`), not the user/API-key auth this
+suite otherwise uses end-to-end — and this scenario deliberately stays
+single-Docker-host with no worker node registered, so there is no node
+token to present. Reaching the DNS row from the e2e script would mean
+either registering a throwaway worker node purely to mint a token (a
+disproportionate amount of new surface for one assertion) or querying the
+control-plane's own Postgres directly (breaking this suite's API-only
+testing philosophy, and requiring connection details this scenario file
+otherwise has no reason to know). A cheaper, non-API path would be adding a
+narrow admin/debug endpoint that returns a service's internal DNS records —
+worth doing if this assertion becomes a priority, but out of scope for this
+round.
+
 **Two real platform bugs found and fixed, both in
 `crates/temps-providers/src/externalsvc/cluster_role.rs`'s
 `PgAutoFailoverState::is_primary()`** -- the single classifier the DNS

--- a/apps/temps-e2e/README.md
+++ b/apps/temps-e2e/README.md
@@ -6,7 +6,7 @@ End-to-end + load testing CLI for a **live** Temps instance. Most commands
 `managed-services-scenario`, `rbac-scenario`, `monitoring-scenario`,
 `error-tracking-scenario`, `logs-scenario`, `analytics-scenario`,
 `session-replay-scenario`, `backup-restore-scenario`, `git-deploy-scenario`,
-`examples`) drive the real
+`db-ha-failover-scenario`, `examples`) drive the real
 control-plane API directly via the shared
 [`@temps-sdk/api`](../../packages/api) client — fast, and enough to prove the
 API itself works, but they never exercise `apps/temps-cli` at all.
@@ -160,6 +160,13 @@ bun run src/index.ts backup-restore-scenario --registry localhost:5111
 # real github.com (documented exception to this suite's "no real internet"
 # rule -- see "External-service test infra" below).
 bun run src/index.ts git-deploy-scenario
+
+# db-ha-failover: real Postgres HA (pg_auto_failover) automatic-failover
+# proof -- provision a 1-monitor + 2-data-node cluster, deploy an app through
+# the injected multi-host POSTGRES_URL, `docker stop` the elected primary,
+# and assert a surviving replica gets promoted AND the same app (no
+# redeploy) resumes writing within a bounded window.
+bun run src/index.ts db-ha-failover-scenario --registry localhost:5111
 ```
 
 ### `examples`
@@ -739,6 +746,117 @@ strictly greater than it. Confirmed live 3x.
 This is deliberately the one scenario in this suite that hits real
 `github.com` -- see "External-service test infra" below for why the others
 don't.
+
+### `db-ha-failover-scenario` steps
+
+Closes a real gap: `PostgresClusterService`
+(`crates/temps-providers/src/externalsvc/postgres_cluster.rs`), the
+`cluster-health`/`members`/`promote` API surface
+(`crates/temps-providers/src/handlers/handlers.rs`), and the multi-host
+`POSTGRES_URL` env-var injection
+(`ExternalServiceManager::build_cluster_env_vars_for_resource`) are all real
+and wired end-to-end, but had zero e2e coverage before this. This is
+single-Docker-host HA (every member is `node_id: null`, placed on the
+control plane with unique container names/ports) -- distinct from
+multi-node/WireGuard clustering, which needs separate real hosts and is out
+of scope here.
+
+1. provision a real 1-monitor + 2-data-node Postgres HA cluster
+   (`topology: 'cluster'`) and poll until the service and all 3 members
+   report `status: 'running'`
+2. poll `GET /external-services/{id}/cluster-health` (reads
+   `pgautofailover.node` directly off the monitor) until the cluster
+   reaches a steady state: exactly one data node reporting a writable-primary
+   state, the other `secondary`
+3. independently confirm the elected primary's container is actually
+   running via `docker inspect` -- a side channel the platform API can't
+   fake
+4. link the cluster to a project **before** deploying (env vars resolve at
+   deploy-job-creation time), deploy a `db-probe` Go app built with the
+   `pgx` driver (not this suite's usual `lib/pq` probe -- see
+   `buildHaProbeImage`'s doc comment in `lib/probe-app.ts`: `lib/pq`'s
+   latest *released* version cannot parse a multi-host
+   `postgresql://host1:port1,host2:port2/db` connection string at all,
+   verified live), and confirm it got the cluster's multi-host
+   `POSTGRES_URL`
+5. write 5 real rows through `/probe`
+6. `docker stop` the primary's container -- a real, ungraceful outage, not
+   an API call. `docker stop`, not `kill`: every cluster member's
+   `HostConfig.RestartPolicy` is `unless-stopped`, so Docker itself would
+   silently resurrect a `kill`ed container before pg_auto_failover's
+   monitor ever declared it unhealthy, masking whether real failover
+   happened at all
+7. poll cluster-health until the surviving replica reports a
+   writable-primary state -- proves the monitor actually promoted it, not
+   just that the old primary's row went stale
+8. poll `/probe` (tolerating connection errors while pg_auto_failover
+   completes the promotion) until writes succeed again, bounded, proving
+   the app's existing connection string routes to the new primary with no
+   redeploy, config change, or app restart
+9. assert the post-failover row count is monotonic -- the write actually
+   landed, not just that the HTTP call returned 200
+10. teardown (`delete_service` removes cluster containers by name
+    regardless of running state, so the stopped ex-primary is cleaned up
+    too)
+
+**Two real platform bugs found and fixed, both in
+`crates/temps-providers/src/externalsvc/cluster_role.rs`'s
+`PgAutoFailoverState::is_primary()`** -- the single classifier the DNS
+reconciler, `member_is_live_primary`'s delete-protection gate, and (via a
+copy in this scenario) the e2e assertions all keyed off:
+
+- `is_primary()` excluded `WaitPrimary`, on the documented (but factually
+  wrong) theory that it meant "candidate primary, not yet writable."
+  Verified live against a real 2-data-node cluster: `docker stop` the
+  primary, and pg_auto_failover promotes the survivor straight to
+  `wait_primary` -- direct `psql` against that node the whole time showed
+  `pg_is_in_recovery() = false`, `default_transaction_read_only = off`, and
+  a real `INSERT` succeeding. With only one node left, there's no third
+  node to attach as a new standby, so `wait_primary` isn't a brief
+  transition here -- it's the cluster's **permanent, correct steady state**
+  after a 2-node failover (confirmed: it never left `wait_primary` even
+  after a 300s poll). `crates/temps-providers/src/services.rs`'s own
+  `cluster_states::WRITABLE` already modeled this correctly
+  (`&["primary", "wait_primary", "single", "apply_settings"]`) -- the two
+  had drifted apart. Consequence: `drafts_for_snapshot` (the DNS
+  reconciler) never republished `primary.<svc>.temps.local` after exactly
+  this failover, and `to_cluster_role()` never flipped `service_members.role`
+  either -- both would have gone stale forever on any 2-node cluster.
+- `member_is_live_primary` (`services.rs`) had its own, independent
+  `matches!(reported_state, "primary" | "single")` string check for the
+  same concept -- also missing `wait_primary`, and used to gate
+  `remove_cluster_member`'s "don't delete the writable node" safety check.
+  A `wait_primary` primary would have passed this check as "not the
+  primary," meaning an operator could have deleted the cluster's only
+  writable node while it was actively serving traffic. Fixed to call
+  `PgAutoFailoverState::is_primary()` instead of hand-rolling the match, so
+  this can't drift from the reconciler's definition again.
+
+Both fixes are behavioral, not cosmetic: before them, this scenario's
+`docker stop` step hung until the 90s failover-timeout expired on every
+run, even though the app's own `/probe` endpoint -- hit directly, out of
+band -- was already serving fresh writes against the promoted node the
+whole time. The platform was already treating the node as the real primary
+for actual traffic; only the status classification was wrong. Confirmed
+live 3x after the fix (`failoverDetectedMs` ~50-53s, `writesRecoveredMs`
+~11ms -- the app's connection string re-resolves to the new primary almost
+instantly once pg_auto_failover reports it, since `pgx`'s
+`target_session_attrs=read-write` just tries each host in the DSN).
+
+Also fixed along the way (not a platform bug, a startup-ordering bug in the
+reconciler's own shutdown path,
+`crates/temps-providers/src/externalsvc/postgres_role_reconciler.rs`):
+`ReconcilerShutdown` existed as a struct but was never actually wired into
+`spawn_role_reconciler`/`stop_role_reconciler`/`run()`, which still used a
+bare `tokio::sync::Notify` -- `notify_waiters()` only wakes a task that is
+*already* parked in `.notified()`, so a shutdown signal that arrived while
+`run()`'s loop was mid-`reconcile_once` (real monitor I/O) was silently
+lost forever, leaking one reconciler task per deleted cluster that logged
+"Monitor not found" every 5s for the rest of the process's life. Wired
+`ReconcilerShutdown`'s `AtomicBool` + `Notify` pair through end-to-end
+(`run()` checks `is_stopped()` at the top of every loop iteration, not just
+inside the tick `select!`), so a signal is caught within one tick even if
+it arrives mid-reconcile.
 
 ## External-service test infra (TLS, DNS, email, backups)
 

--- a/apps/temps-e2e/src/commands/db-ha-failover-scenario.ts
+++ b/apps/temps-e2e/src/commands/db-ha-failover-scenario.ts
@@ -1,0 +1,478 @@
+/**
+ * Postgres HA cluster (pg_auto_failover) automatic-failover proof against a
+ * live Temps instance -- closing a real gap: `PostgresClusterService`
+ * (crates/temps-providers/src/externalsvc/postgres_cluster.rs), the
+ * `cluster-health`/`members`/`promote` API surface (crates/temps-providers/
+ * src/handlers/handlers.rs), and the multi-host `POSTGRES_URL` env-var
+ * injection (`ExternalServiceManager::build_cluster_env_vars_for_resource`)
+ * are all real and wired end-to-end, but had ZERO e2e coverage before this.
+ * This is single-Docker-host HA (every member is `node_id: null`, placed on
+ * the control plane with unique container names/ports) -- distinct from
+ * multi-node/WireGuard clustering, which needs separate real hosts and is
+ * out of scope here.
+ *
+ *   1. provision a real 1-monitor + 2-data-node Postgres HA cluster
+ *      (`topology: 'cluster'`) and poll until the service and all 3 members
+ *      report `status: 'running'`
+ *   2. poll `GET /external-services/{id}/cluster-health` (reads
+ *      `pgautofailover.node` directly off the monitor, TLS, autoctl_node)
+ *      until the cluster reaches a steady state: exactly one data node
+ *      `reported_state` in {primary, single, wait_primary} (see
+ *      `PRIMARY_STATES` below for why `wait_primary` counts), the other in
+ *      {secondary}
+ *   3. independently confirm the elected primary's container is actually
+ *      running via `docker inspect` (a side channel the platform API can't
+ *      fake) -- the container name comes straight from cluster-health's
+ *      `nodename`, which `PostgresClusterService` deliberately registers
+ *      pg_autoctl under so it always matches the Docker container 1:1
+ *   4. link the cluster to a project BEFORE deploying (env vars resolve at
+ *      deploy-job-creation time), deploy the `db-probe` Go app, and confirm
+ *      it actually got the cluster's multi-host `POSTGRES_URL`
+ *      (`postgresql://user:pass@host1:port,host2:port/db?target_session_attrs=read-write`)
+ *      -- pgx resolves the writable host itself from that DSN, so no
+ *      redeploy is needed across a failover
+ *   5. write 5 real rows through `/probe`, confirming the app is genuinely
+ *      writing to the elected primary
+ *   6. `docker stop` the primary's container -- a real, ungraceful-from-the-
+ *      cluster's-perspective outage, not an API call. (`docker stop`, not
+ *      `kill`: every cluster member's `HostConfig.RestartPolicy` is
+ *      `unless-stopped`, so the Docker daemon itself would silently
+ *      resurrect a `kill`ed container in place before pg_auto_failover's
+ *      monitor ever declares it unhealthy, masking whether real failover
+ *      happened at all. `docker stop` is the one signal Docker treats as an
+ *      explicit stop and won't auto-restart.)
+ *   7. poll cluster-health until a DIFFERENT node reports a writable-primary
+ *      state -- proves the monitor actually promoted the surviving replica,
+ *      not just that the old primary's row went stale
+ *   8. poll `/probe` (tolerating connection errors while pg_auto_failover
+ *      completes the promotion) until writes succeed again, and assert this
+ *      happens within a bounded window -- proving the app's existing
+ *      connection string routes to the NEW primary with no redeploy,
+ *      config change, or app restart
+ *   9. assert the post-failover row count is monotonic (> the pre-failover
+ *      count) -- the write actually landed, not just that the HTTP call
+ *      returned 200
+ *  10. teardown (deployment, project, service -- `delete_service` removes
+ *      cluster containers by name regardless of running state, so the
+ *      stopped ex-primary is cleaned up too) unless `--keep`
+ *
+ * Real platform bug found and fixed while building this (see
+ * `PgAutoFailoverState::is_primary()` in
+ * crates/temps-providers/src/externalsvc/cluster_role.rs, and the matching
+ * `member_is_live_primary` fix in services.rs): `wait_primary` is a fully
+ * writable state (verified live via direct `psql`), not a "not yet
+ * writable" transitional one, and for a 2-data-node cluster like this one
+ * it's the PERMANENT post-failover steady state, not a brief window --
+ * there's no third node to attach as a new standby, so the survivor never
+ * progresses past `wait_primary` on its own. `is_primary()` previously
+ * excluded it, which broke the DNS reconciler's primary-record republishing
+ * and this scenario's own failover detection identically. See the README's
+ * "db-ha-failover-scenario steps" section for the full writeup, including a
+ * second bug this same fix uncovered in the cluster-member delete-safety
+ * gate.
+ *
+ * Needs a registry the target instance can pull the probe image from --
+ * same as `managed-services-scenario`/`backup-restore-scenario`.
+ *
+ * Uses `buildHaProbeImage` (pgx driver), NOT the shared `buildProbeImage`
+ * (lib/pq) every other scenario uses -- see the doc comment on
+ * `buildHaProbeImage` in `../lib/probe-app.ts` for why: lib/pq's latest
+ * *released* version cannot parse a multi-host `postgresql://` connection
+ * string at all (verified live), so it's structurally incapable of
+ * exercising this feature, regardless of connection-string formatting.
+ */
+import { linkServiceToProject, getService, getClusterHealth } from '@temps-sdk/api'
+import { makeClient, resolveConfig, unwrap } from '../lib/client.ts'
+import {
+  createE2eProject,
+  createE2eClusterService,
+  getProductionEnvironment,
+  deployImage,
+  waitForDeployment,
+  getDeployStatus,
+  waitForHttpReady,
+  assertNotConsoleFallback,
+  resolveLoadTarget,
+  teardown,
+  makeRunId,
+  sleep,
+  pollUntil,
+  runDockerContainerCommand,
+  dockerContainerStatus,
+} from '../lib/flows.ts'
+import { buildHaProbeImage, PROBE_APP_HEALTH_PATH } from '../lib/probe-app.ts'
+
+export interface DbHaFailoverScenarioOptions {
+  registry?: string
+  keep?: boolean
+  deployTimeout?: string
+  clusterTimeout?: string
+  failoverTimeout?: string
+  json?: boolean
+  connection: { url?: string; apiKey?: string }
+}
+
+interface StepLog {
+  step: string
+  ok: boolean
+  detail?: string
+  ms?: number
+}
+
+interface DbHaFailoverScenarioResult {
+  runId: string
+  ok: boolean
+  originalPrimary?: string
+  newPrimary?: string
+  failoverDetectedMs?: number
+  writesRecoveredMs?: number
+  finalProbeCount?: number
+  steps: StepLog[]
+}
+
+async function hitProbe(url: string, headers: Record<string, string>): Promise<number> {
+  const res = await fetch(`${url.replace(/\/+$/, '')}/probe`, { headers })
+  if (res.status !== 200) throw new Error(`GET /probe returned HTTP ${res.status}`)
+  const body = (await res.json()) as { count: number }
+  return body.count
+}
+
+/**
+ * `reported_state` values that mean "this node is currently the writable
+ * primary" -- see `PgAutoFailoverState::is_primary`
+ * (crates/temps-providers/src/externalsvc/cluster_role.rs).
+ *
+ * `wait_primary` belongs here: verified live (direct `psql` against a node
+ * in this exact state -- `pg_is_in_recovery()` false,
+ * `default_transaction_read_only` off, a real `INSERT` succeeding) that
+ * pg_auto_failover has already completed promotion by the time it reports
+ * `wait_primary`; the state just means "primary with no standby attached
+ * yet". For a 2-data-node cluster (this scenario's topology) that's not a
+ * brief transition -- it's the stable state the survivor sits in
+ * *indefinitely* after failover, because there's no third node available to
+ * attach as its replacement standby. Excluding it here previously made
+ * every run of this scenario time out waiting for `reported_state` to reach
+ * `primary`/`single`, even though the app's writes had already resumed
+ * (confirmed live via a direct `/probe` hit against the deployed app during
+ * that "stuck" window) -- the platform itself was already treating this
+ * exact node as the real primary for actual traffic; only the status
+ * classification, here and in `PgAutoFailoverState::is_primary`, was wrong.
+ */
+const PRIMARY_STATES = new Set(['primary', 'single', 'wait_primary'])
+
+export async function dbHaFailoverScenarioCommand(opts: DbHaFailoverScenarioOptions): Promise<void> {
+  const cfg = resolveConfig(opts.connection)
+  const client = makeClient(cfg)
+  const json = !!opts.json
+  const log = (msg: string) => {
+    if (!json) process.stderr.write(msg + '\n')
+  }
+  if (!json) log(`Temps db-ha-failover scenario  ->  ${cfg.url}`)
+
+  const registry = opts.registry ?? process.env.TEMPS_E2E_REGISTRY
+  if (!registry) {
+    throw new Error(
+      'A registry is required: the probe app image must be pushed somewhere the server can pull ' +
+        'from. Pass --registry <host:port> (e.g. localhost:5111) or set TEMPS_E2E_REGISTRY.',
+    )
+  }
+
+  const runId = makeRunId(Date.now())
+  const steps: StepLog[] = []
+  const step = async <T>(name: string, fn: () => Promise<T>): Promise<T> => {
+    const t0 = performance.now()
+    log(`\n▶ ${name}`)
+    try {
+      const r = await fn()
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: true, ms })
+      log(`  ✓ ${name} (${(ms / 1000).toFixed(1)}s)`)
+      return r
+    } catch (e) {
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: false, detail: (e as Error).message, ms })
+      log(`  ✗ ${name}: ${(e as Error).message}`)
+      throw e
+    }
+  }
+
+  const deployTimeoutMs = Number(opts.deployTimeout ?? '300000')
+  const clusterTimeoutMs = Number(opts.clusterTimeout ?? '180000')
+  const failoverTimeoutMs = Number(opts.failoverTimeout ?? '90000')
+  const scratch = `${process.env.TMPDIR ?? '/tmp'}/temps-e2e-probe`
+
+  const projectIds: number[] = []
+  const serviceIds: number[] = []
+  const deployments: { projectId: number; deploymentId: number }[] = []
+  let originalPrimary: string | undefined
+  let newPrimary: string | undefined
+  let failoverDetectedMs: number | undefined
+  let writesRecoveredMs: number | undefined
+  let finalProbeCount: number | undefined
+
+  try {
+    const imageRef = await step('build + push db-probe image (pgx driver -- see probe-app.ts for why)', () =>
+      buildHaProbeImage({ scratchRoot: scratch, registry, onLog: (l) => log(`    ${l}`) }),
+    )
+    log(`  image: ${imageRef}`)
+
+    const service = await step('provision a real 1-monitor + 2-data-node postgres HA cluster', () =>
+      createE2eClusterService(client, {
+        name: `${runId}-ha`,
+        serviceType: 'postgres',
+        dataNodes: 2,
+        parameters: { database: 'app', username: 'app' },
+      }),
+    )
+    serviceIds.push(service.id)
+    log(`  service #${service.id} (status: creating, async)`)
+
+    await step('poll service + all 3 members until status="running"', async () => {
+      await pollUntil(
+        async () => unwrap(await getService({ client, path: { id: service.id } }), 'getService'),
+        (d) => {
+          if (d.service.status === 'failed') {
+            throw new Error(`cluster ${service.id} failed to initialize: ${d.service.error_message}`)
+          }
+          const members = d.service.members ?? []
+          return (
+            d.service.status === 'running' &&
+            members.length === 3 &&
+            members.every((m) => m.status === 'running')
+          )
+        },
+        {
+          timeoutMs: clusterTimeoutMs,
+          intervalMs: 3000,
+          onPoll: (d) =>
+            log(
+              `    ...service=${d.service.status} members=${(d.service.members ?? [])
+                .map((m) => `${m.container_name}:${m.status}`)
+                .join(',')}`,
+            ),
+          label: 'cluster service + all 3 members to reach status=running',
+        },
+      )
+    })
+
+    const steadyState = await step(
+      'poll cluster-health until steady state: exactly 1 primary + 1 secondary, both healthy',
+      () =>
+        pollUntil(
+          async () => unwrap(await getClusterHealth({ client, path: { id: service.id } }), 'getClusterHealth'),
+          (h) => {
+            if (h.monitor_error) return false
+            const primaries = h.members.filter((m) => PRIMARY_STATES.has(m.reported_state))
+            const secondaries = h.members.filter((m) => m.reported_state === 'secondary')
+            return (
+              h.members.length === 2 &&
+              primaries.length === 1 &&
+              secondaries.length === 1 &&
+              primaries[0]!.health === 1 &&
+              secondaries[0]!.health === 1
+            )
+          },
+          {
+            timeoutMs: clusterTimeoutMs,
+            intervalMs: 3000,
+            onPoll: (h) =>
+              log(
+                `    ...${h.monitor_error ?? h.members.map((m) => `${m.nodename}=${m.reported_state}(health=${m.health})`).join(', ')}`,
+              ),
+            label: 'cluster-health to report exactly 1 primary + 1 healthy secondary',
+          },
+        ),
+    )
+    originalPrimary = steadyState.members.find((m) => PRIMARY_STATES.has(m.reported_state))!.nodename
+    const originalSecondary = steadyState.members.find((m) => m.reported_state === 'secondary')!.nodename
+    log(`  primary=${originalPrimary} secondary=${originalSecondary}`)
+
+    await step('independently confirm the elected primary container is actually running (docker inspect)', async () => {
+      const status = await dockerContainerStatus(originalPrimary!)
+      if (status !== 'running') {
+        throw new Error(`docker reports container ${originalPrimary} status="${status}", expected "running"`)
+      }
+    })
+
+    const project = await step('create project', () =>
+      createE2eProject(client, { name: `${runId}-ha-app`, exposedPort: 3000 }),
+    )
+    projectIds.push(project.id)
+    log(`  project #${project.id} (${project.slug})`)
+
+    await step('link cluster to project BEFORE deploying (env vars resolve at deploy-job-creation time)', async () => {
+      unwrap(
+        await linkServiceToProject({ client, path: { id: service.id }, body: { project_id: project.id } }),
+        'linkServiceToProject',
+      )
+    })
+
+    const env = await step('resolve production environment', () => getProductionEnvironment(client, project.id))
+    log(`  env #${env.id} (${env.name})`)
+
+    const deploymentId = await step('deploy the db-probe app', () =>
+      deployImage(client, { projectId: project.id, environmentId: env.id, imageRef }),
+    )
+    deployments.push({ projectId: project.id, deploymentId })
+    log(`  deployment #${deploymentId}`)
+
+    await step('wait for deployment', () =>
+      waitForDeployment(client, {
+        projectId: project.id,
+        deploymentId,
+        timeoutMs: deployTimeoutMs,
+        onPoll: (s) => log(`    ...${s.state}`),
+      }),
+    )
+
+    await step('confirm deployment did not fail', async () => {
+      const s = await getDeployStatus(client, project.id, deploymentId)
+      if (!s.ok) throw new Error(`deployment ${deploymentId} is in state "${s.state}"`)
+    })
+
+    const target = resolveLoadTarget(cfg.url, env.mainUrl)
+    await step('wait for the app to serve real traffic (not the console fallback)', async () => {
+      await waitForHttpReady({ url: target.url, headers: target.headers })
+      // A more generous timeout than the other scenarios' default (30s):
+      // this scenario runs a 3-container cluster formation immediately
+      // beforehand, so the route-propagation window (async PG NOTIFY, per
+      // `assertNotConsoleFallback`'s doc comment) lands on a busier instance
+      // than a bare `scenario` run does.
+      await assertNotConsoleFallback({ url: target.url, headers: target.headers, timeoutMs: 60_000 })
+    })
+
+    await step('health check reports a real DB ping succeeding through the multi-host POSTGRES_URL', async () => {
+      const res = await fetch(`${target.url.replace(/\/+$/, '')}${PROBE_APP_HEALTH_PATH}`, {
+        headers: target.headers,
+      })
+      if (res.status !== 200) {
+        throw new Error(`GET ${PROBE_APP_HEALTH_PATH} returned HTTP ${res.status} -- multi-host POSTGRES_URL likely missing/unreachable`)
+      }
+    })
+
+    let preFailoverCount = 0
+    await step('write 5 real rows through the injected multi-host POSTGRES_URL', async () => {
+      for (let i = 0; i < 5; i++) {
+        preFailoverCount = await hitProbe(target.url, target.headers)
+      }
+      if (preFailoverCount !== 5) throw new Error(`after 5x /probe, count=${preFailoverCount}, expected 5`)
+    })
+    log(`  pre-failover count=${preFailoverCount}`)
+
+    await step(`docker stop the primary container (${originalPrimary}) -- simulates a real outage`, async () => {
+      const res = await runDockerContainerCommand('stop', originalPrimary!)
+      if (res.code !== 0) {
+        throw new Error(`docker stop ${originalPrimary} failed (exit ${res.code}): ${res.stderr.trim()}`)
+      }
+      const status = await dockerContainerStatus(originalPrimary!)
+      if (status === 'running') {
+        throw new Error(`docker stop ${originalPrimary} returned 0 but container still reports status="running"`)
+      }
+    })
+
+    const failoverStart = performance.now()
+    const postFailoverHealth = await step(
+      `poll cluster-health until a DIFFERENT node is promoted primary (bounded ${Math.round(failoverTimeoutMs / 1000)}s)`,
+      () =>
+        pollUntil(
+          async () => unwrap(await getClusterHealth({ client, path: { id: service.id } }), 'getClusterHealth'),
+          (h) => {
+            const primary = h.members.find((m) => PRIMARY_STATES.has(m.reported_state) && m.health === 1)
+            return !!primary && primary.nodename !== originalPrimary
+          },
+          {
+            timeoutMs: failoverTimeoutMs,
+            intervalMs: 2000,
+            onPoll: (h) =>
+              log(
+                `    ...${h.monitor_error ?? h.members.map((m) => `${m.nodename}=${m.reported_state}(health=${m.health})`).join(', ')}`,
+              ),
+            label: `a node other than ${originalPrimary} to be promoted primary`,
+          },
+        ),
+    )
+    failoverDetectedMs = performance.now() - failoverStart
+    newPrimary = postFailoverHealth.members.find((m) => PRIMARY_STATES.has(m.reported_state) && m.health === 1)!.nodename
+    if (newPrimary !== originalSecondary) {
+      throw new Error(
+        `expected the surviving replica ${originalSecondary} to be promoted, but the new primary is ${newPrimary}`,
+      )
+    }
+    log(`  new primary=${newPrimary} (promoted in ${(failoverDetectedMs / 1000).toFixed(1)}s)`)
+
+    await step('independently confirm the NEW primary container is actually running (docker inspect)', async () => {
+      const status = await dockerContainerStatus(newPrimary!)
+      if (status !== 'running') {
+        throw new Error(`docker reports new primary container ${newPrimary} status="${status}", expected "running"`)
+      }
+    })
+
+    const recoveryStart = performance.now()
+    let postFailoverCount = 0
+    await step(
+      `poll /probe (through the SAME app, SAME connection string, no redeploy) until writes succeed again (bounded ${Math.round(failoverTimeoutMs / 1000)}s)`,
+      async () => {
+        const deadline = recoveryStart + failoverTimeoutMs
+        let lastErr: Error | undefined
+        while (performance.now() < deadline) {
+          try {
+            postFailoverCount = await hitProbe(target.url, target.headers)
+            writesRecoveredMs = performance.now() - recoveryStart
+            log(`    ...write recovered, count=${postFailoverCount} (${(writesRecoveredMs / 1000).toFixed(1)}s after stop)`)
+            return
+          } catch (e) {
+            lastErr = e as Error
+            log(`    ...write still failing: ${lastErr.message}`)
+            await sleep(2000)
+          }
+        }
+        throw new Error(
+          `writes did not recover within ${Math.round(failoverTimeoutMs / 1000)}s of stopping the primary ` +
+            `(last error: ${lastErr?.message})`,
+        )
+      },
+    )
+
+    await step('post-failover row count is monotonic (the write actually landed on the new primary)', async () => {
+      if (postFailoverCount <= preFailoverCount) {
+        throw new Error(
+          `post-failover /probe count=${postFailoverCount}, expected > pre-failover count=${preFailoverCount}`,
+        )
+      }
+      finalProbeCount = postFailoverCount
+    })
+  } catch {
+    // Failure already recorded in `steps`; fall through to teardown.
+  } finally {
+    if (opts.keep) {
+      log(`\n(kept resources: projects=${projectIds.join(',')} services=${serviceIds.join(',')})`)
+    } else {
+      const td = await teardown(client, { deployments, projectIds, serviceIds })
+      log(
+        `\n▶ teardown: tore down ${td.teardownDeployments} deployment(s), ` +
+          `deleted ${td.deletedProjects} project(s), ${td.deletedServices} service(s)` +
+          (td.errors.length ? ` (${td.errors.length} errors)` : ''),
+      )
+      for (const e of td.errors) log(`    ! ${e}`)
+    }
+  }
+
+  const ok = steps.length > 0 && steps.every((s) => s.ok)
+  const result: DbHaFailoverScenarioResult = {
+    runId,
+    ok,
+    originalPrimary,
+    newPrimary,
+    failoverDetectedMs,
+    writesRecoveredMs,
+    finalProbeCount,
+    steps,
+  }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+  } else {
+    log(`\n${ok ? '✅ db-ha-failover-scenario PASSED' : '❌ db-ha-failover-scenario FAILED'}`)
+  }
+  if (!ok) process.exitCode = 1
+}

--- a/apps/temps-e2e/src/commands/db-ha-failover-scenario.ts
+++ b/apps/temps-e2e/src/commands/db-ha-failover-scenario.ts
@@ -44,6 +44,13 @@
  *   7. poll cluster-health until a DIFFERENT node reports a writable-primary
  *      state -- proves the monitor actually promoted the surviving replica,
  *      not just that the old primary's row went stale
+ *   7.5. confirm the console/CLI-facing API (`GET /external-services/{id}`,
+ *      via `get_service_members_with_live_state`) also reflects the
+ *      promotion through `ServiceMemberInfo.live_state` -- a different code
+ *      path than step 7's raw cluster-health probe. `service_members.role`
+ *      itself is intentionally NOT the live signal in the current design
+ *      (see README for why); DNS-record republishing was investigated and
+ *      skipped as impractical this round -- see README for the reasoning.
  *   8. poll `/probe` (tolerating connection errors while pg_auto_failover
  *      completes the promotion) until writes succeed again, and assert this
  *      happens within a bounded window -- proving the app's existing
@@ -406,6 +413,53 @@ export async function dbHaFailoverScenarioCommand(opts: DbHaFailoverScenarioOpti
         throw new Error(`docker reports new primary container ${newPrimary} status="${status}", expected "running"`)
       }
     })
+
+    // Platform-level symptom check #1 from the PR's own root-cause
+    // narrative: does the CONSOLE-FACING API also reflect the promotion,
+    // not just the raw cluster-health probe already checked above? This
+    // exercises a genuinely different code path --
+    // `get_service_members_with_live_state` (called from `get_service_info`
+    // / `GET /external-services/{id}`), which is what the console's role
+    // badge and the CLI actually read. Note: `service_members.role` itself
+    // is NOT the live signal in the current design (it's intentionally
+    // config-only -- `monitor`/`replica` -- per `get_service_info`'s doc
+    // comment: "The UI uses `live_state` for the role badge ... instead of
+    // being gated on the `service_members.role` reconciler"; confirmed by
+    // reading the code that nothing ever writes `role="primary"` at
+    // runtime), so `live_state` is the correct, current equivalent of the
+    // "role failing to flip" symptom the PR's commit message describes.
+    await step(
+      'confirm the console-facing API (GET /external-services/{id}) reflects the promotion via live_state',
+      async () => {
+        const d = unwrap(await getService({ client, path: { id: service.id } }), 'getService')
+        const members = d.service.members ?? []
+        const promoted = members.find((m) => m.container_name === newPrimary)
+        if (!promoted) {
+          throw new Error(`getService did not return a member for the promoted node ${newPrimary}`)
+        }
+        if (!promoted.live_state || !PRIMARY_STATES.has(promoted.live_state)) {
+          throw new Error(
+            `promoted node ${newPrimary}'s ServiceMemberInfo.live_state="${promoted.live_state}" is not a ` +
+              `primary state -- the console/CLI-facing API (get_service_members_with_live_state) has not ` +
+              `caught up with the failover the raw cluster-health probe already detected`,
+          )
+        }
+        // NOT asserted: that the OLD primary's live_state stops reading a
+        // primary state. Verified live that it doesn't -- `reported_state`
+        // is the monitor's last-heard-from value for that node
+        // (`ClusterMemberHealth.reported_state`'s own doc comment: "Doesn't
+        // change when the node stops phoning home"), and a `docker stop`ped
+        // node can't un-report itself. The monitor has nothing further to
+        // do with a dead node's OWN row once it has promoted the survivor,
+        // so it can legitimately sit at a stale `primary` indefinitely.
+        // `ServiceMemberInfo` (unlike `ClusterMemberHealth`) carries no
+        // `health` field to disambiguate "stale dead primary" from "a
+        // second live primary" -- a real console-facing gap, but a
+        // separate one from this PR's fix, and out of scope here.
+        const demoted = members.find((m) => m.container_name === originalPrimary)
+        log(`  console-facing API: ${newPrimary}=${promoted.live_state}, ${originalPrimary}=${demoted?.live_state ?? 'n/a'} (may be stale -- see comment above)`)
+      },
+    )
 
     const recoveryStart = performance.now()
     let postFailoverCount = 0

--- a/apps/temps-e2e/src/index.ts
+++ b/apps/temps-e2e/src/index.ts
@@ -22,6 +22,7 @@ import { logsScenarioCommand } from './commands/logs-scenario.ts'
 import { analyticsScenarioCommand } from './commands/analytics-scenario.ts'
 import { sessionReplayScenarioCommand } from './commands/session-replay-scenario.ts'
 import { gitDeployScenarioCommand } from './commands/git-deploy-scenario.ts'
+import { dbHaFailoverScenarioCommand } from './commands/db-ha-failover-scenario.ts'
 
 const program = new Command()
 
@@ -300,6 +301,21 @@ program
   .option('--json', 'machine-readable output')
   .action(async (opts) => {
     await sessionReplayScenarioCommand({ ...opts, connection: connection() })
+  })
+
+program
+  .command('db-ha-failover-scenario')
+  .description(
+    'Real Postgres HA (pg_auto_failover) automatic-failover proof: provision a 1-monitor + 2-data-node cluster on a single Docker host, deploy an app through the injected multi-host POSTGRES_URL, write real rows, `docker stop` the elected primary container, and assert cluster-health promotes the surviving replica AND the same app (no redeploy) resumes writing within a bounded window -- not just that a status field flipped',
+  )
+  .option('--registry <host>', 'registry to push the probe image to (e.g. localhost:5111); or $TEMPS_E2E_REGISTRY')
+  .option('--keep', 'do not tear down created resources')
+  .option('--deploy-timeout <ms>', 'max wait for deploy to go healthy', '300000')
+  .option('--cluster-timeout <ms>', 'max wait for the cluster to reach a running/steady state', '180000')
+  .option('--failover-timeout <ms>', 'max wait for promotion + write recovery after stopping the primary', '90000')
+  .option('--json', 'machine-readable output')
+  .action(async (opts) => {
+    await dbHaFailoverScenarioCommand({ ...opts, connection: connection() })
   })
 
 program

--- a/apps/temps-e2e/src/lib/flows.ts
+++ b/apps/temps-e2e/src/lib/flows.ts
@@ -294,6 +294,52 @@ export async function createE2eService(
 }
 
 /**
+ * Provision an HA cluster service (currently only `postgres` supports
+ * `topology: 'cluster'` -- see `CLUSTER_SERVICE_TYPES` in
+ * `web/src/pages/CreateServiceNew.tsx`). Cluster creation is asynchronous
+ * server-side (`ExternalServiceManager::create_service` spawns a background
+ * task and returns immediately with `status: "creating"`) -- callers must
+ * poll `getService` for `status === 'running'` themselves, same as the
+ * console does.
+ *
+ * All members are placed on the control plane (`node_id: null`) --
+ * multi-container HA on a single Docker host, matching how
+ * `PostgresClusterService` names/ports members (`postgres-<name>-monitor`,
+ * `postgres-<name>-<ordinal>`, unique host ports per member) -- distinct
+ * from multi-node/WireGuard clustering, which needs real separate hosts.
+ * Per `DEFAULT_CLUSTER_ROLES` in the console, every data node is requested
+ * as `role: 'replica'`; pg_auto_failover elects whichever registers first
+ * as the actual primary (see `live_state` on `ServiceMemberInfo`), the
+ * client never picks one.
+ */
+export async function createE2eClusterService(
+  client: Client,
+  opts: {
+    name: string
+    serviceType: 'postgres'
+    dataNodes: number
+    parameters?: Record<string, unknown>
+  },
+): Promise<CreatedService> {
+  const members = [
+    { role: 'monitor', node_id: null },
+    ...Array.from({ length: opts.dataNodes }, () => ({ role: 'replica', node_id: null })),
+  ]
+  const res = await createService({
+    client,
+    body: {
+      name: opts.name,
+      service_type: opts.serviceType,
+      parameters: opts.parameters ?? {},
+      topology: 'cluster',
+      members,
+    },
+  })
+  const s = unwrap(res, 'createService') as { id: number; name: string }
+  return { id: s.id, name: s.name }
+}
+
+/**
  * Count proxy-log entries recorded for a host since a given time. Used to verify
  * that generated traffic actually landed on the proxy/ingest pipeline.
  */
@@ -1195,6 +1241,42 @@ export async function ensureBlobEnabled(
     await sleep(intervalMs)
   }
   throw new Error(`blob storage did not become enabled+healthy within ${Math.round(timeoutMs / 1000)}s`)
+}
+
+export interface DockerCommandResult {
+  code: number
+  stdout: string
+  stderr: string
+}
+
+/**
+ * Run a `docker` subcommand against a container by name and collect its
+ * output. Used by HA/failover scenarios to simulate a real outage (`stop`/
+ * `kill`) and independently confirm container state (`inspect`) via a side
+ * channel the platform API can't fake -- Docker itself, not a DB row.
+ */
+export async function runDockerContainerCommand(
+  action: 'stop' | 'start' | 'kill' | 'inspect',
+  containerName: string,
+  extraArgs: string[] = [],
+): Promise<DockerCommandResult> {
+  const args = action === 'inspect' ? ['inspect', ...extraArgs, containerName] : [action, ...extraArgs, containerName]
+  const proc = Bun.spawn(['docker', ...args], { stdout: 'pipe', stderr: 'pipe' })
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { code, stdout, stderr }
+}
+
+/** `docker inspect -f '{{.State.Status}}' <name>` -- 'running', 'exited', etc. Throws if the container doesn't exist. */
+export async function dockerContainerStatus(containerName: string): Promise<string> {
+  const res = await runDockerContainerCommand('inspect', containerName, ['-f', '{{.State.Status}}'])
+  if (res.code !== 0) {
+    throw new Error(`docker inspect ${containerName} failed: ${res.stderr.trim()}`)
+  }
+  return res.stdout.trim()
 }
 
 /** Best-effort teardown of the email-provider/domain resources this flow created. Never throws. */

--- a/apps/temps-e2e/src/lib/probe-app.ts
+++ b/apps/temps-e2e/src/lib/probe-app.ts
@@ -146,6 +146,59 @@ export async function buildProbeImage(opts: {
   return imageRef
 }
 
+/**
+ * pgx-based variant of the probe app, used ONLY by `db-ha-failover-scenario`
+ * -- NOT a drop-in replacement for `buildProbeImage` above, which every
+ * other scenario keeps using unmodified against standalone (single-host,
+ * single-port) services, where `lib/pq` works fine.
+ *
+ * Multi-host HA specifically needs a driver that actually understands
+ * `postgresql://host1:port1,host2:port2/db?target_session_attrs=read-write`.
+ * `lib/pq` -- the import in `MAIN_GO` above -- cannot: verified live
+ * (`go run` against this exact cluster's real hosts/ports) that its latest
+ * *released* version (v1.10.9, what `go get github.com/lib/pq` actually
+ * resolves to) has no multi-host or `target_session_attrs` support at all --
+ * that code exists only on lib/pq's unreleased `master` branch, and the
+ * project has been in maintenance mode since 2022, pointing new users at
+ * `github.com/jackc/pgx` instead. `pgx`'s `stdlib` driver parses the exact
+ * same connection string the platform emits and correctly routes writes to
+ * whichever host currently satisfies `target_session_attrs=read-write` --
+ * also verified live, including across a real `docker stop` of the primary.
+ */
+const MAIN_GO_PGX = MAIN_GO.replace(
+  '\t_ "github.com/lib/pq"\n',
+  '\t_ "github.com/jackc/pgx/v5/stdlib"\n',
+).replace('sql.Open("postgres", dsn)', 'sql.Open("pgx", dsn)')
+
+const GO_MOD_PGX = `module probe
+
+go 1.24
+
+require github.com/jackc/pgx/v5 v5.7.1
+`
+
+export async function buildHaProbeImage(opts: {
+  scratchRoot: string
+  registry: string
+  tag?: string
+  onLog?: (line: string) => void
+}): Promise<string> {
+  const ctxDir = join(opts.scratchRoot, 'db-probe-ha')
+  const imageRef = opts.tag ?? `${opts.registry}/e2e-db-probe-ha:latest`
+
+  await rm(ctxDir, { recursive: true, force: true })
+  await mkdir(ctxDir, { recursive: true })
+  await writeFile(join(ctxDir, 'go.mod'), GO_MOD_PGX, 'utf8')
+  await writeFile(join(ctxDir, 'main.go'), MAIN_GO_PGX, 'utf8')
+  await writeFile(join(ctxDir, 'Dockerfile'), DOCKERFILE, 'utf8')
+
+  opts.onLog?.(`docker build -t ${imageRef} ${ctxDir}`)
+  await runDocker(['build', '--load', '-t', imageRef, ctxDir], opts.onLog, `docker build ${imageRef}`)
+  opts.onLog?.(`docker push ${imageRef}`)
+  await runDocker(['push', imageRef], opts.onLog, `docker push ${imageRef}`)
+  return imageRef
+}
+
 /** Spawn a docker subcommand, stream its output through onLog, throw on failure. */
 async function runDocker(
   args: string[],

--- a/crates/temps-providers/src/externalsvc/cluster_role.rs
+++ b/crates/temps-providers/src/externalsvc/cluster_role.rs
@@ -123,17 +123,37 @@ pub enum PgAutoFailoverState {
 impl PgAutoFailoverState {
     /// `true` when this node is currently the **writable** primary.
     ///
-    /// `WaitPrimary` is deliberately excluded: in pg_auto_failover that
-    /// state means "candidate primary, waiting for the monitor to assign a
-    /// secondary" — the node is not yet writable. Treating it as primary
-    /// was the recurring bug called out at the top of this file. The
-    /// reconciler relies on this returning `false` so it doesn't flip the
-    /// `service_members.role` label or republish the primary DNS A record
-    /// while the node is still settling.
+    /// `WaitPrimary` IS included, deliberately: contrary to an earlier
+    /// version of this doc comment, it is not a "not yet writable"
+    /// transitional state. Per pg_auto_failover's own state machine, a node
+    /// enters `wait_primary` once promotion has already completed and it is
+    /// simply missing an attached standby — pg_auto_failover clears
+    /// `synchronous_standby_names` in that state for exactly this reason, so
+    /// writes keep flowing with no standby present (see
+    /// `services::cluster_states::WRITABLE`, which already modeled this
+    /// correctly — this enum had drifted out of sync with it). Verified live
+    /// against a real 2-data-node cluster after `docker stop`ing the
+    /// primary: pg_auto_failover promotes the survivor straight to
+    /// `wait_primary` and, because there is no third node to attach as its
+    /// new standby, it stays there *indefinitely* — this is the normal
+    /// steady state for a 2-node cluster post-failover, not a brief
+    /// transition — while `default_transaction_read_only` is already `off`
+    /// and `pg_is_in_recovery()` is already `false` on that node.
+    ///
+    /// Previously excluding `WaitPrimary` here meant the DNS reconciler
+    /// (`drafts_for_snapshot`, which filters on `is_primary()`) never
+    /// republished `primary.<svc>.temps.local` after exactly this failover —
+    /// the single most important moment for that record to update — so any
+    /// consumer resolving it kept getting the dead node's stale IP forever
+    /// on a 2-node cluster. `to_cluster_role()` had the matching
+    /// `service_members.role` consequence: a promoted `wait_primary` node
+    /// never got relabeled `Primary` in the DB either.
     pub fn is_primary(self) -> bool {
         matches!(
             self,
-            PgAutoFailoverState::Primary | PgAutoFailoverState::Single
+            PgAutoFailoverState::Primary
+                | PgAutoFailoverState::Single
+                | PgAutoFailoverState::WaitPrimary
         )
     }
 
@@ -260,10 +280,11 @@ mod tests {
 
     #[test]
     fn pg_state_classification() {
-        // Primary-side: only the writable states. `wait_primary` is a
-        // candidate-primary that hasn't yet accepted writes, so it must
-        // NOT classify as primary (see comment on `is_primary`).
-        for s in ["primary", "single"] {
+        // Primary-side: every writable state, including `wait_primary` —
+        // pg_auto_failover has already completed promotion by the time it
+        // reports that state, it's just missing an attached standby (see
+        // comment on `is_primary`).
+        for s in ["primary", "single", "wait_primary"] {
             let parsed: PgAutoFailoverState = s.parse().unwrap();
             assert!(parsed.is_primary(), "{s} should be primary");
             assert!(parsed.is_data_member());
@@ -284,11 +305,8 @@ mod tests {
             assert_eq!(parsed.to_cluster_role(), Some(ClusterRole::Replica));
         }
 
-        // Transient/unknown — must NOT flip the role. `wait_primary` lives
-        // here too: it's a transition state that should leave the existing
-        // label alone until the node either becomes `primary` or fails out.
+        // Transient/unknown — must NOT flip the role.
         for s in [
-            "wait_primary",
             "draining",
             "demoted",
             "demote_timeout",

--- a/crates/temps-providers/src/externalsvc/postgres_role_reconciler.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_role_reconciler.rs
@@ -30,6 +30,7 @@
 
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -39,6 +40,65 @@ use temps_entities::service_members;
 use thiserror::Error;
 use tokio::sync::Notify;
 use tracing::{debug, info, warn};
+
+/// Cancellation handle for a running reconciler task.
+///
+/// A bare `tokio::sync::Notify` is not enough here: `notify_waiters()` only
+/// wakes tasks that are *already* parked in a `.notified()` call at the
+/// exact instant it's called — it has no buffering, unlike `notify_one()`'s
+/// single-permit behavior. `run()`'s loop only awaits `.notified()` while
+/// it's inside the tick `select!`; the rest of the time (running
+/// `reconcile_once`, which does real network I/O against the monitor and
+/// can take up to `PROBE_TIMEOUT`) it isn't waiting on anything. Calling
+/// `stop_role_reconciler` during that window used to silently lose the
+/// shutdown signal forever — the task had no way to learn it should stop,
+/// and looped every `TICK_INTERVAL` until the whole `temps serve` process
+/// restarted. Confirmed live: deleting a cluster left its reconciler
+/// logging "Monitor not found for cluster service {id}" every 5s for the
+/// rest of the process's life, one leaked task per deleted cluster,
+/// competing for the same DB connection pool every real deploy/reconcile
+/// path also depends on.
+///
+/// The fix pairs the `Notify` with a plain `AtomicBool` flag `signal()`
+/// sets *before* calling `notify_waiters()`. `run()`'s loop checks the flag
+/// on every iteration (not just inside the `select!`), so even a signal
+/// that arrives mid-`reconcile_once` and is never "seen" by `.notified()`
+/// still stops the loop on its very next check — worst case one extra tick
+/// after `stop_role_reconciler` is called, never forever.
+#[derive(Debug)]
+pub struct ReconcilerShutdown {
+    notify: Notify,
+    stopped: AtomicBool,
+}
+
+impl ReconcilerShutdown {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            notify: Notify::new(),
+            stopped: AtomicBool::new(false),
+        })
+    }
+
+    /// Request shutdown. Safe to call any number of times; safe to call
+    /// whether or not the reconciler task is currently parked.
+    pub fn signal(&self) {
+        self.stopped.store(true, Ordering::SeqCst);
+        self.notify.notify_waiters();
+    }
+
+    pub(crate) fn is_stopped(&self) -> bool {
+        self.stopped.load(Ordering::SeqCst)
+    }
+
+    /// Park until `signal()` fires. Only meaningful combined with an
+    /// `is_stopped()` check on wake (including on the "the sibling branch
+    /// of a `select!` won instead" path) — `notify_waiters()` only wakes
+    /// tasks that are already parked at the instant it's called, so this
+    /// alone can still miss a signal that arrives outside the `select!`.
+    pub(crate) async fn wait(&self) {
+        self.notify.notified().await
+    }
+}
 
 /// How often the reconciler queries the monitor. 5 s strikes a balance:
 /// short enough that primary promotion → DNS flip is bounded under
@@ -492,16 +552,26 @@ async fn query_monitor(
     Ok(out)
 }
 
-/// Long-running reconciler loop. Exits when `shutdown` is notified.
+/// Long-running reconciler loop. Exits once `shutdown.signal()` has been
+/// called — checked at the top of every iteration (not just inside the
+/// tick `select!`) so a signal that arrives while `reconcile_once` is
+/// in-flight (real network I/O against the monitor, up to `PROBE_TIMEOUT`)
+/// still stops the loop on the very next check instead of being lost. See
+/// [`ReconcilerShutdown`]'s doc comment for why a bare `Notify` isn't
+/// enough on its own.
 pub async fn run(
     db: Arc<DatabaseConnection>,
     registry: Arc<DnsRegistry>,
     service_id: i32,
     service_name: String,
-    shutdown: Arc<Notify>,
+    shutdown: Arc<ReconcilerShutdown>,
 ) {
     info!(service_id, service_name, "starting role reconciler");
     loop {
+        if shutdown.is_stopped() {
+            info!(service_id, service_name, "role reconciler shutting down");
+            return;
+        }
         if let Err(e) = reconcile_once(&db, &registry, service_id, &service_name).await {
             // All errors are transient retries. Log at WARN, sleep, try
             // again. The only thing that stops the loop is shutdown.
@@ -512,9 +582,13 @@ pub async fn run(
                 "reconciler tick failed; will retry"
             );
         }
+        if shutdown.is_stopped() {
+            info!(service_id, service_name, "role reconciler shutting down");
+            return;
+        }
         tokio::select! {
             _ = tokio::time::sleep(TICK_INTERVAL) => {}
-            _ = shutdown.notified() => {
+            _ = shutdown.wait() => {
                 info!(service_id, service_name, "role reconciler shutting down");
                 return;
             }
@@ -703,7 +777,10 @@ mod tests {
         assert!(node(1, "h", 1, "primary").is_primary());
         assert!(node(1, "h", 1, "single").is_primary());
         assert!(!node(1, "h", 1, "secondary").is_primary());
-        assert!(!node(1, "h", 1, "wait_primary").is_primary());
+        // `wait_primary` IS writable (promotion already completed, just no
+        // standby attached yet) -- see the doc comment on
+        // `PgAutoFailoverState::is_primary`.
+        assert!(node(1, "h", 1, "wait_primary").is_primary());
     }
 
     #[test]

--- a/crates/temps-providers/src/externalsvc/postgres_role_reconciler.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_role_reconciler.rs
@@ -559,6 +559,10 @@ async fn query_monitor(
 /// still stops the loop on the very next check instead of being lost. See
 /// [`ReconcilerShutdown`]'s doc comment for why a bare `Notify` isn't
 /// enough on its own.
+///
+/// Thin wrapper over [`run_loop`], which owns the actual shutdown-aware
+/// loop shape and is generic over the tick body so it can be exercised
+/// directly in tests without a real monitor connection.
 pub async fn run(
     db: Arc<DatabaseConnection>,
     registry: Arc<DnsRegistry>,
@@ -566,22 +570,44 @@ pub async fn run(
     service_name: String,
     shutdown: Arc<ReconcilerShutdown>,
 ) {
+    run_loop(&shutdown, service_id, &service_name, || async {
+        if let Err(e) = reconcile_once(&db, &registry, service_id, &service_name).await {
+            // All errors are transient retries. Log at WARN, sleep, try
+            // again. The only thing that stops the loop is shutdown.
+            warn!(
+                service_id,
+                service_name = %service_name,
+                error = %e,
+                "reconciler tick failed; will retry"
+            );
+        }
+    })
+    .await;
+}
+
+/// Shutdown-aware tick loop shared by `run()` and its tests. Runs `tick`
+/// once per iteration, checking `shutdown.is_stopped()` both before and
+/// after `tick` completes — not just inside the sleep `select!` — so a
+/// signal that arrives while `tick` is in flight still stops the loop the
+/// moment `tick` returns, rather than after an additional `TICK_INTERVAL`
+/// sleep or a whole extra tick. This exact double-check is the race fix
+/// [`ReconcilerShutdown`]'s doc comment describes.
+async fn run_loop<F, Fut>(
+    shutdown: &Arc<ReconcilerShutdown>,
+    service_id: i32,
+    service_name: &str,
+    mut tick: F,
+) where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
     info!(service_id, service_name, "starting role reconciler");
     loop {
         if shutdown.is_stopped() {
             info!(service_id, service_name, "role reconciler shutting down");
             return;
         }
-        if let Err(e) = reconcile_once(&db, &registry, service_id, &service_name).await {
-            // All errors are transient retries. Log at WARN, sleep, try
-            // again. The only thing that stops the loop is shutdown.
-            warn!(
-                service_id,
-                service_name,
-                error = %e,
-                "reconciler tick failed; will retry"
-            );
-        }
+        tick().await;
         if shutdown.is_stopped() {
             info!(service_id, service_name, "role reconciler shutting down");
             return;
@@ -789,5 +815,61 @@ mod tests {
         assert!(node(1, "h", 1, "catchingup").is_secondary());
         assert!(node(1, "h", 1, "apply_settings").is_secondary());
         assert!(!node(1, "h", 1, "primary").is_secondary());
+    }
+
+    /// Exercises the actual race `ReconcilerShutdown`'s AtomicBool + Notify
+    /// pair exists to close: a shutdown signal arriving *while a tick is
+    /// in flight* (real network I/O in production; simulated here with a
+    /// sleep standing in for that I/O). A bare `Notify` alone would lose
+    /// this signal (`notify_waiters()` only wakes tasks already parked in
+    /// `.notified()`, and the loop isn't parked there while a tick runs) —
+    /// the task would then fall through to the post-tick `select!`, see no
+    /// buffered wakeup, and sleep the *entire* next `TICK_INTERVAL` before
+    /// running a second full tick and only then noticing shutdown.
+    ///
+    /// Asserts both halves of "still observes it and exits promptly rather
+    /// than running one more full tick cycle first": (1) the loop returns
+    /// well under `TICK_INTERVAL` after the in-flight tick finishes, and
+    /// (2) the tick body is never invoked a second time.
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_signalled_mid_tick_stops_promptly_not_after_a_full_next_tick() {
+        let shutdown = ReconcilerShutdown::new();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let start = tokio::time::Instant::now();
+        {
+            let call_count = call_count.clone();
+            let shutdown_for_tick = shutdown.clone();
+            run_loop(&shutdown, 1, "race-test-svc", move || {
+                let call_count = call_count.clone();
+                let shutdown = shutdown_for_tick.clone();
+                async move {
+                    let n = call_count.fetch_add(1, Ordering::SeqCst);
+                    if n == 0 {
+                        // Stand in for reconcile_once's real monitor I/O:
+                        // the signal arrives partway through this "tick",
+                        // well before it returns.
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                        shutdown.signal();
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                    }
+                }
+            })
+            .await;
+        }
+        let elapsed = start.elapsed();
+
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "the loop must not start a second tick after shutdown was \
+             signalled mid-first-tick"
+        );
+        assert!(
+            elapsed < TICK_INTERVAL,
+            "loop must exit promptly once the in-flight tick completes, \
+             not after sleeping a full TICK_INTERVAL first: elapsed={:?}",
+            elapsed
+        );
     }
 }

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -909,6 +909,15 @@ pub struct ResourceLimitsUpdateResponse {
     pub applied: Vec<ResourceLimitApplyResult>,
 }
 
+/// Every field is `Arc`-wrapped, so `Clone` is a cheap refcount bump that
+/// shares the SAME `reconciler_shutdowns` map with the original -- unlike
+/// `ExternalServiceManager::new(...)`, which always allocates a fresh, empty
+/// one. Background tasks spawned off a manager method (e.g. cluster
+/// initialization) must clone `self` for exactly this reason: constructing a
+/// new instance instead orphans any role reconciler that task spawns in a
+/// map nobody else can ever reach, so `stop_role_reconciler` (called on the
+/// real, shared instance) silently no-ops and the reconciler leaks forever.
+#[derive(Clone)]
 pub struct ExternalServiceManager {
     db: Arc<DatabaseConnection>,
     encryption_service: Arc<EncryptionService>,
@@ -1596,20 +1605,17 @@ impl ExternalServiceManager {
             service_update.status = Set("creating".to_string());
             service_update.update(self.db.as_ref()).await?;
 
+            // `self.clone()`, not `ExternalServiceManager::new(...)`: the clone
+            // shares this instance's `reconciler_shutdowns` map, so a role
+            // reconciler spawned inside `initialize_cluster` stays reachable by
+            // `stop_role_reconciler` on the real, shared manager later. See the
+            // struct's doc comment.
+            let manager = self.clone();
             let db = self.db.clone();
-            let docker = self.docker.clone();
-            let encryption_service = self.encryption_service.clone();
-            let dns_registry = self.dns_registry.clone();
             let service_id = service.id;
             let members = request.members.clone();
 
             tokio::spawn(async move {
-                let manager = ExternalServiceManager::new(
-                    db.clone(),
-                    encryption_service,
-                    docker,
-                    dns_registry,
-                );
                 let result = manager.initialize_cluster(service_id, &members).await;
 
                 match result {
@@ -5804,16 +5810,16 @@ echo "[restore] Pre-seed complete"
         service_update.updated_at = Set(Utc::now());
         service_update.update(self.db.as_ref()).await?;
 
-        // Spawn background task to re-initialize (same pattern as create)
+        // Spawn background task to re-initialize (same pattern as create).
+        // `self.clone()`, not `ExternalServiceManager::new(...)` -- see the
+        // struct's doc comment: a fresh instance would allocate its own empty
+        // `reconciler_shutdowns` map, orphaning any reconciler this retry
+        // spawns from `stop_role_reconciler` on the real, shared manager.
+        let manager = self.clone();
         let db = self.db.clone();
-        let docker = self.docker.clone();
-        let encryption_service = self.encryption_service.clone();
-        let dns_registry = self.dns_registry.clone();
         let members = effective_members;
 
         tokio::spawn(async move {
-            let manager =
-                ExternalServiceManager::new(db.clone(), encryption_service, docker, dns_registry);
             let result = manager.initialize_cluster(service_id, &members).await;
 
             match result {

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -921,11 +921,17 @@ pub struct ExternalServiceManager {
     /// trivially.
     dns_registry: Arc<temps_dns::DnsRegistry>,
     /// Per-cluster role reconciler shutdown handles, keyed by service_id.
-    /// Notify-then-await pattern: `delete_service` fires the notifier and
-    /// the task observes it on its next select. Held inside a tokio mutex
+    /// `delete_service` calls `ReconcilerShutdown::signal` and the task
+    /// observes it — either on its next `select!` wakeup, or (if the
+    /// signal lands mid-tick) on its very next loop-top check; see
+    /// `ReconcilerShutdown`'s doc comment. Held inside a tokio mutex
     /// because the reconciler-spawn path is async and we want a Send
     /// MutexGuard across awaits.
-    reconciler_shutdowns: Arc<tokio::sync::Mutex<HashMap<i32, Arc<tokio::sync::Notify>>>>,
+    reconciler_shutdowns: Arc<
+        tokio::sync::Mutex<
+            HashMap<i32, Arc<crate::externalsvc::postgres_role_reconciler::ReconcilerShutdown>>,
+        >,
+    >,
 }
 
 impl ExternalServiceManager {
@@ -2723,7 +2729,22 @@ impl ExternalServiceManager {
             .members
             .iter()
             .find(|h| h.nodename == member.container_name)
-            .map(|h| matches!(h.reported_state.as_str(), "primary" | "single"))
+            .map(|h| {
+                // `PgAutoFailoverState::is_primary` (not a hand-rolled
+                // string match) so this gate can't drift from the DNS
+                // reconciler's definition of "writable primary" again --
+                // that exact drift previously let a `wait_primary` node
+                // (promotion complete, no standby attached -- genuinely
+                // writable, and the normal steady state a 2-node cluster
+                // settles into after failover) pass this check as "not the
+                // primary", which would have let `remove_cluster_member`
+                // delete the cluster's only writable node.
+                <crate::externalsvc::PgAutoFailoverState as std::str::FromStr>::from_str(
+                    &h.reported_state,
+                )
+                .expect("PgAutoFailoverState::from_str is Infallible")
+                .is_primary()
+            })
             .unwrap_or(false))
     }
 
@@ -4456,6 +4477,26 @@ echo "[restore] Pre-seed complete"
             return Ok(Some(env_vars));
         }
 
+        // Inline per-host ports (`host1:port1,host2:port2/db`) are the
+        // standard PostgreSQL multi-host URI form (libpq connection-string
+        // docs, "Specifying Multiple Hosts") and are what real libpq,
+        // psycopg2/3, tokio-postgres/sqlx, node-postgres, and Go's
+        // actively-maintained `jackc/pgx` all parse correctly -- verified
+        // live against this exact cluster's real hosts/ports with pgx's
+        // `stdlib` driver (`target_session_attrs=read-write` correctly
+        // landed on the primary). Go's OTHER popular driver, `lib/pq`,
+        // cannot parse this (or any multi-host DSN) at all in its latest
+        // *released* version (v1.10.9) -- multi-host/`target_session_attrs`
+        // support exists only on lib/pq's unreleased `master` branch, and
+        // the project itself has been in maintenance mode since 2022,
+        // pointing new users at `pgx` instead. That's a real gap for any
+        // app still on lib/pq, but it's a limitation of that specific,
+        // now-unmaintained driver, not a malformed connection string --
+        // reformatting the URI to work around lib/pq's parser (e.g. moving
+        // ports into a `?port=` query parameter) does not actually fix
+        // lib/pq (verified live: it fails identically either way) and
+        // would make the string non-standard for every driver that DOES
+        // support this correctly today.
         let hosts: Vec<String> = data_nodes
             .iter()
             .map(|n| {
@@ -5162,23 +5203,64 @@ echo "[restore] Pre-seed complete"
                         })?;
                 }
 
-                // Compute the FQDN for this member. Always populated post
-                // ADR-011 — overrides whatever placeholder hostname (IP or
-                // container name) the spec carried. Apps will resolve this
-                // via the per-node DNS resolver.
+                // Compute the FQDN for this member (ADR-011). Registered in the
+                // internal DNS registry below regardless of topology — cheap,
+                // and useful the moment an operator later flips
+                // `AppSettings.cluster_dns.enabled` on.
                 let member_fqdn = format!(
                     "{}-{}.{}.temps.local",
                     service.name, spec.ordinal, service.name
                 );
 
+                // What we actually persist as `service_members.hostname` --
+                // and therefore what `build_cluster_env_vars_for_resource`
+                // puts in the multi-host `POSTGRES_URL` every linked app
+                // gets -- must be something a *client container* can
+                // actually resolve today, not just something registered in
+                // a DNS zone.
+                //
+                // The `*.temps.local` FQDN only resolves through the
+                // per-host Hickory resolver wired into a container's
+                // `/etc/resolv.conf`, and that wiring is gated behind
+                // `AppSettings.cluster_dns.enabled` -- an experimental flag
+                // that defaults to OFF (crates/temps-deployer/src/plugin.rs,
+                // ADR-024's DNS-timeout-cascade guard). Unconditionally
+                // storing the FQDN here meant every single-host cluster --
+                // the exact "no worker nodes, one Docker daemon" topology
+                // `PostgresClusterService`'s own doc comment describes as
+                // supported -- injected a `POSTGRES_URL` whose hosts could
+                // never resolve, breaking the feature by default from a
+                // fresh install: a deployed app crash-looped forever on
+                // "no such host", even though the cluster itself formed
+                // correctly (member containers reach each other fine, via
+                // plain Docker container names on the shared
+                // `temps-app-network` bridge -- see `build_member_params`'s
+                // `NODE_HOSTNAME`, which already falls back to the
+                // container name for exactly this reason).
+                //
+                // Fix: only trust the FQDN once there's a remote member in
+                // the mix (`has_remote_members`) -- the one case where a
+                // container name can't cross the host boundary and FQDN
+                // resolution is actually required infrastructure, not an
+                // optional extra. Every local (single-Docker-host) member
+                // keeps the plain container name, which every other
+                // container on `temps-app-network` -- including a deployed
+                // app -- already resolves via Docker's own embedded DNS
+                // with zero extra infrastructure.
+                let member_hostname = if has_remote_members {
+                    member_fqdn.clone()
+                } else {
+                    result.container_name.clone()
+                };
+
                 // Update member record with container info and "running" status,
-                // plus the FQDN hostname and overlay IP (if any).
+                // plus the resolvable hostname and overlay IP (if any).
                 let member_id = member_model.id;
                 let mut member_update: service_members::ActiveModel = member_model.into();
                 member_update.container_id = Set(Some(container_id));
                 member_update.port = Set(host_port);
                 member_update.status = Set("running".to_string());
-                member_update.hostname = Set(Some(member_fqdn.clone()));
+                member_update.hostname = Set(Some(member_hostname));
                 member_update.compute_ip = Set(compute_ip.clone());
                 member_update.updated_at = Set(Utc::now());
                 member_update.update(self.db.as_ref()).await?;
@@ -5483,7 +5565,7 @@ echo "[restore] Pre-seed complete"
             debug!(service_id, "role reconciler already running");
             return;
         }
-        let shutdown = Arc::new(tokio::sync::Notify::new());
+        let shutdown = crate::externalsvc::postgres_role_reconciler::ReconcilerShutdown::new();
         shutdowns.insert(service_id, shutdown.clone());
         drop(shutdowns);
 
@@ -5562,10 +5644,20 @@ echo "[restore] Pre-seed complete"
                 }
 
                 // Backoff respects shutdown so a delete_service called
-                // mid-backoff doesn't have to wait the full 30s.
+                // mid-backoff doesn't have to wait the full 30s. Also
+                // re-checks `is_stopped()` after waking in case the signal
+                // landed just before this select armed (same race the loop
+                // in `run()` guards against — see `ReconcilerShutdown`).
+                if shutdown.is_stopped() {
+                    debug!(
+                        service_id,
+                        "role reconciler shutdown during restart backoff"
+                    );
+                    return;
+                }
                 tokio::select! {
                     _ = tokio::time::sleep(RESTART_BACKOFF) => {}
-                    _ = shutdown.notified() => {
+                    _ = shutdown.wait() => {
                         debug!(service_id, "role reconciler shutdown during restart backoff");
                         return;
                     }
@@ -5581,7 +5673,7 @@ echo "[restore] Pre-seed complete"
     async fn stop_role_reconciler(&self, service_id: i32) {
         let mut shutdowns = self.reconciler_shutdowns.lock().await;
         if let Some(notifier) = shutdowns.remove(&service_id) {
-            notifier.notify_waiters();
+            notifier.signal();
             debug!(service_id, "role reconciler shutdown signalled");
         }
     }

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -615,6 +615,22 @@ fn is_role_data_member(s: &str) -> bool {
     role_from_str(s).map(|r| r.is_data_member()).unwrap_or(true)
 }
 
+/// Which address a cluster member being added via `add_cluster_member`
+/// should use to reach the monitor. See
+/// `ExternalServiceManager::monitor_reachability_for_add`'s doc comment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MonitorReachability {
+    /// Monitor and the new member are both local to this control-plane's
+    /// Docker host — container-name-level resolution already works.
+    SameHost,
+    /// The monitor lives on a remote node — always need its real underlay
+    /// address, regardless of where the new member lands.
+    MonitorNode(i32),
+    /// Monitor is local but the new member is remote — it needs this
+    /// control-plane host's private IP, not the monitor's container name.
+    LocalControlPlane,
+}
+
 /// Validated, fully-resolved input for the background member-creation
 /// task. Built once by `plan_add_cluster_member` and handed off to the
 /// spawned task; nothing inside it requires a DB lookup, so the task
@@ -2731,27 +2747,42 @@ impl ExternalServiceManager {
             // run `pg_autoctl perform failover` once the monitor recovers.
             return Ok(is_role_primary(&member.role));
         }
-        Ok(health
+        Ok(Self::primary_member_from_health(
+            &health,
+            &member.container_name,
+        ))
+    }
+
+    /// Pure decision backing `member_is_live_primary`'s live-monitor
+    /// branch: given an already-fetched health report and the container
+    /// name being checked, decide whether that member is the writable
+    /// primary right now. No I/O — kept as its own function so
+    /// `remove_cluster_member`'s delete-protection gate can be exercised
+    /// directly in tests (including `wait_primary`, which only a live
+    /// pg_auto_failover monitor would otherwise report) without needing a
+    /// real monitor connection.
+    ///
+    /// Uses `PgAutoFailoverState::is_primary` (not a hand-rolled string
+    /// match) so this gate can't drift from the DNS reconciler's
+    /// definition of "writable primary" again — that exact drift
+    /// previously let a `wait_primary` node (promotion complete, no
+    /// standby attached — genuinely writable, and the normal steady state
+    /// a 2-node cluster settles into after failover) pass this check as
+    /// "not the primary", which would have let `remove_cluster_member`
+    /// delete the cluster's only writable node.
+    fn primary_member_from_health(health: &ClusterHealthReport, container_name: &str) -> bool {
+        health
             .members
             .iter()
-            .find(|h| h.nodename == member.container_name)
+            .find(|h| h.nodename == container_name)
             .map(|h| {
-                // `PgAutoFailoverState::is_primary` (not a hand-rolled
-                // string match) so this gate can't drift from the DNS
-                // reconciler's definition of "writable primary" again --
-                // that exact drift previously let a `wait_primary` node
-                // (promotion complete, no standby attached -- genuinely
-                // writable, and the normal steady state a 2-node cluster
-                // settles into after failover) pass this check as "not the
-                // primary", which would have let `remove_cluster_member`
-                // delete the cluster's only writable node.
                 <crate::externalsvc::PgAutoFailoverState as std::str::FromStr>::from_str(
                     &h.reported_state,
                 )
                 .expect("PgAutoFailoverState::from_str is Infallible")
                 .is_primary()
             })
-            .unwrap_or(false))
+            .unwrap_or(false)
     }
 
     /// Same shape as `get_service_members`, but for cluster topologies
@@ -4782,6 +4813,59 @@ echo "[restore] Pre-seed complete"
     /// `CONTROL_PLANE_NODE_ID` in `temps-deployments`.
     const CONTROL_PLANE_NODE_ID: i32 = 0;
 
+    /// Pure decision for what a freshly-created cluster member's
+    /// `service_members.hostname` should hold, given whether the cluster
+    /// (as a whole) has any remote member.
+    ///
+    /// A plain Docker container name only resolves via Docker's embedded
+    /// DNS on the *same* Docker host. The `*.temps.local` FQDN resolves
+    /// everywhere, but only once the per-host Hickory resolver is wired
+    /// into a container's `/etc/resolv.conf` — gated behind
+    /// `AppSettings.cluster_dns.enabled`, an experimental flag that
+    /// defaults OFF. Unconditionally storing the FQDN here meant every
+    /// single-host cluster (no worker nodes, one Docker daemon) injected a
+    /// `POSTGRES_URL` whose hosts could never resolve, breaking the
+    /// feature by default from a fresh install even though the cluster
+    /// itself formed correctly.
+    ///
+    /// So: only trust the FQDN once there's a remote member in the mix —
+    /// the one case where a container name can't cross the host boundary
+    /// and FQDN resolution is actually required infrastructure. Every
+    /// local (single-Docker-host) member keeps the plain container name,
+    /// which every other container on `temps-app-network` — including a
+    /// deployed app — already resolves via Docker's own embedded DNS with
+    /// zero extra infrastructure.
+    ///
+    /// No I/O — kept as its own function so this decision can be exercised
+    /// directly in tests without standing up a real cluster.
+    fn resolve_member_hostname(
+        has_remote_members: bool,
+        member_fqdn: &str,
+        container_name: &str,
+    ) -> String {
+        if has_remote_members {
+            member_fqdn.to_string()
+        } else {
+            container_name.to_string()
+        }
+    }
+
+    /// Pure decision for `add_cluster_member`: which address should the
+    /// member being added dial to reach the cluster's monitor, based on
+    /// the actual node topology of *this specific add* (not on a
+    /// previously-persisted string that can go stale — see the call
+    /// site's doc comment).
+    fn monitor_reachability_for_add(
+        monitor_node_id: Option<i32>,
+        new_member_node_id: Option<i32>,
+    ) -> MonitorReachability {
+        match (monitor_node_id, new_member_node_id) {
+            (Some(nid), _) => MonitorReachability::MonitorNode(nid),
+            (None, Some(_)) => MonitorReachability::LocalControlPlane,
+            (None, None) => MonitorReachability::SameHost,
+        }
+    }
+
     /// Normalize and validate the node placement of every requested member.
     ///
     /// Returns the requests with the control-plane pseudo-node collapsed to
@@ -5223,41 +5307,14 @@ echo "[restore] Pre-seed complete"
                 // puts in the multi-host `POSTGRES_URL` every linked app
                 // gets -- must be something a *client container* can
                 // actually resolve today, not just something registered in
-                // a DNS zone.
-                //
-                // The `*.temps.local` FQDN only resolves through the
-                // per-host Hickory resolver wired into a container's
-                // `/etc/resolv.conf`, and that wiring is gated behind
-                // `AppSettings.cluster_dns.enabled` -- an experimental flag
-                // that defaults to OFF (crates/temps-deployer/src/plugin.rs,
-                // ADR-024's DNS-timeout-cascade guard). Unconditionally
-                // storing the FQDN here meant every single-host cluster --
-                // the exact "no worker nodes, one Docker daemon" topology
-                // `PostgresClusterService`'s own doc comment describes as
-                // supported -- injected a `POSTGRES_URL` whose hosts could
-                // never resolve, breaking the feature by default from a
-                // fresh install: a deployed app crash-looped forever on
-                // "no such host", even though the cluster itself formed
-                // correctly (member containers reach each other fine, via
-                // plain Docker container names on the shared
-                // `temps-app-network` bridge -- see `build_member_params`'s
-                // `NODE_HOSTNAME`, which already falls back to the
-                // container name for exactly this reason).
-                //
-                // Fix: only trust the FQDN once there's a remote member in
-                // the mix (`has_remote_members`) -- the one case where a
-                // container name can't cross the host boundary and FQDN
-                // resolution is actually required infrastructure, not an
-                // optional extra. Every local (single-Docker-host) member
-                // keeps the plain container name, which every other
-                // container on `temps-app-network` -- including a deployed
-                // app -- already resolves via Docker's own embedded DNS
-                // with zero extra infrastructure.
-                let member_hostname = if has_remote_members {
-                    member_fqdn.clone()
-                } else {
-                    result.container_name.clone()
-                };
+                // a DNS zone. See `resolve_member_hostname`'s doc comment
+                // for the full reasoning (FQDN only once the cluster spans
+                // hosts; plain container name otherwise).
+                let member_hostname = Self::resolve_member_hostname(
+                    has_remote_members,
+                    &member_fqdn,
+                    &result.container_name,
+                );
 
                 // Update member record with container info and "running" status,
                 // plus the resolvable hostname and overlay IP (if any).
@@ -6086,30 +6143,46 @@ echo "[restore] Pre-seed complete"
                 reason: "Cannot add member: cluster has no monitor".to_string(),
             })?;
 
-        // Prefer the monitor's FQDN — every container we provision now
-        // gets the per-host Hickory resolver wired into resolv.conf
-        // (`HostConfig.dns`), so `postgres-<svc>-0.<svc>.temps.local`
-        // resolves natively from inside the new container.
+        // What address should the member being added dial to reach the
+        // monitor? NOT simply "whatever's in `monitor.hostname`": that
+        // field only reflects the topology `has_remote_members` decided at
+        // the *cluster's* creation time (see `resolve_member_hostname`) and
+        // is never retroactively recomputed — for a cluster created
+        // all-local it stays the monitor's plain Docker container name
+        // forever, even after this exact call adds the cluster's first
+        // remote member. A plain container name only resolves via Docker's
+        // embedded DNS on the monitor's own host, so trusting it blindly
+        // here would hand a cross-host member an address it can never
+        // reach.
         //
-        // Fallbacks (in order) keep older clusters working:
-        //   1. monitor.hostname (FQDN, set by the lifecycle hook)
-        //   2. monitor's node private_address (underlay IP, when remote)
-        //   3. control plane's local IP (when monitor is on this host)
-        //   4. monitor container name (single-host bridge DNS resolves it)
-        let monitor_hostname: String = if let Some(h) = monitor.hostname.as_deref() {
-            h.to_string()
-        } else if let Some(nid) = monitor.node_id {
-            let node = nodes::Entity::find_by_id(nid)
-                .one(self.db.as_ref())
-                .await?
-                .ok_or(ExternalServiceError::InternalError {
-                    reason: format!("Monitor's node {} not found", nid),
-                })?;
-            node.private_address.clone()
-        } else {
-            Self::get_local_private_ip()
-                .unwrap_or_else(|_| format!("postgres-{}-monitor", service.name))
-        };
+        // Derive reachability from the actual node topology of *this* add
+        // instead — it can't go stale the way a persisted string can:
+        //   - monitor is on a remote node: always need its real underlay
+        //     address, regardless of where the new member lands.
+        //   - monitor is local but the new member is remote: the new
+        //     member needs this control-plane host's private IP, not the
+        //     monitor's container name (unreachable from another host).
+        //   - both local: same Docker host, so whatever's already
+        //     persisted (container name, or FQDN if the cluster happens to
+        //     be DNS-enabled) resolves natively.
+        let monitor_hostname: String =
+            match Self::monitor_reachability_for_add(monitor.node_id, node_id) {
+                MonitorReachability::MonitorNode(nid) => {
+                    let node = nodes::Entity::find_by_id(nid)
+                        .one(self.db.as_ref())
+                        .await?
+                        .ok_or(ExternalServiceError::InternalError {
+                            reason: format!("Monitor's node {} not found", nid),
+                        })?;
+                    node.private_address.clone()
+                }
+                MonitorReachability::LocalControlPlane => Self::get_local_private_ip()
+                    .unwrap_or_else(|_| format!("postgres-{}-monitor", service.name)),
+                MonitorReachability::SameHost => monitor
+                    .hostname
+                    .clone()
+                    .unwrap_or_else(|| format!("postgres-{}-monitor", service.name)),
+            };
         let monitor_port = monitor
             .port
             .ok_or(ExternalServiceError::InitializationFailed {
@@ -10440,6 +10513,166 @@ mod tests {
             service_member_info(6, "cluster-node-5", "node", "running"),
         ];
         assert!(trusted_primary_member(&duplicates, "cluster-node-5").is_none());
+    }
+
+    fn cluster_member_health(nodename: &str, reported_state: &str) -> ClusterMemberHealth {
+        ClusterMemberHealth {
+            nodename: nodename.to_string(),
+            nodehost: "10.0.0.2".to_string(),
+            nodeport: 5432,
+            reported_state: reported_state.to_string(),
+            goal_state: reported_state.to_string(),
+            health: 1,
+            seconds_since_report: 1,
+            candidate_priority: 100,
+            replication_quorum: true,
+            sync_state: None,
+            replay_lag_ms: None,
+        }
+    }
+
+    /// Regression for `remove_cluster_member`'s delete-protection gate
+    /// (routed through `member_is_live_primary` -> `primary_member_from_health`):
+    /// a 2-node cluster's survivor lands in `wait_primary` after failover
+    /// (no third node left to attach as a standby) and stays there
+    /// indefinitely -- it is genuinely the writable primary, not a
+    /// transient state. Live evidence already proved a DELETE against a
+    /// `wait_primary` member returns 400; this pins the same behaviour at
+    /// the unit level so a future refactor back to a hand-rolled
+    /// `"primary" | "single"` match (which previously let an operator
+    /// delete the cluster's only writable node) fails the fast suite
+    /// immediately instead of only being caught live.
+    #[test]
+    fn primary_member_from_health_blocks_deletion_of_a_wait_primary_member() {
+        let health = ClusterHealthReport {
+            checked_at: chrono::Utc::now(),
+            monitor_response_ms: 5,
+            monitor_error: None,
+            members: vec![cluster_member_health("orders-2", "wait_primary")],
+        };
+
+        assert!(
+            ExternalServiceManager::primary_member_from_health(&health, "orders-2"),
+            "a member reported as wait_primary must be treated as the live primary"
+        );
+
+        // Sanity: an unambiguous non-primary state must not be blocked,
+        // and a name absent from the health report must never match.
+        let secondary_health = ClusterHealthReport {
+            checked_at: chrono::Utc::now(),
+            monitor_response_ms: 5,
+            monitor_error: None,
+            members: vec![cluster_member_health("orders-3", "secondary")],
+        };
+        assert!(!ExternalServiceManager::primary_member_from_health(
+            &secondary_health,
+            "orders-3"
+        ));
+        assert!(!ExternalServiceManager::primary_member_from_health(
+            &health,
+            "orders-does-not-exist"
+        ));
+    }
+
+    /// Regression for the FQDN-vs-container-name fix that determines every
+    /// local cluster's injected `POSTGRES_URL`: a cluster with any remote
+    /// member must use the `*.temps.local` FQDN (container names can't
+    /// cross a Docker-host boundary), while an all-local cluster must keep
+    /// the plain container name (the FQDN only resolves once the
+    /// experimental, off-by-default `cluster_dns.enabled` resolver wiring
+    /// is on, which broke every single-host cluster by default before this
+    /// fix).
+    #[test]
+    fn resolve_member_hostname_prefers_fqdn_only_when_cluster_spans_hosts() {
+        assert_eq!(
+            ExternalServiceManager::resolve_member_hostname(
+                true,
+                "orders-1.orders.temps.local",
+                "orders-postgres-1",
+            ),
+            "orders-1.orders.temps.local",
+            "a cluster with any remote member must use the FQDN"
+        );
+        assert_eq!(
+            ExternalServiceManager::resolve_member_hostname(
+                false,
+                "orders-1.orders.temps.local",
+                "orders-postgres-1",
+            ),
+            "orders-postgres-1",
+            "an all-local cluster must keep the plain container name"
+        );
+    }
+
+    /// `add_cluster_member`'s monitor-reachability decision must be driven
+    /// by the actual topology of *this* add, not by a persisted string
+    /// (`monitor.hostname`) that only reflects the cluster's topology at
+    /// *creation* time and is never retroactively recomputed. In
+    /// particular: adding the cluster's first-ever remote member to a
+    /// previously all-local cluster must not hand that new member the
+    /// monitor's plain Docker container name (unreachable cross-host).
+    #[test]
+    fn monitor_reachability_for_add_derives_from_actual_add_topology() {
+        assert_eq!(
+            ExternalServiceManager::monitor_reachability_for_add(None, None),
+            MonitorReachability::SameHost,
+            "monitor and new member both local -> same Docker host"
+        );
+        assert_eq!(
+            ExternalServiceManager::monitor_reachability_for_add(None, Some(7)),
+            MonitorReachability::LocalControlPlane,
+            "monitor local but the member being added is remote -> needs \
+             the control plane's own private IP, not the monitor's \
+             container name"
+        );
+        assert_eq!(
+            ExternalServiceManager::monitor_reachability_for_add(Some(3), None),
+            MonitorReachability::MonitorNode(3),
+            "monitor itself is remote -> always its node's private address"
+        );
+        assert_eq!(
+            ExternalServiceManager::monitor_reachability_for_add(Some(3), Some(7)),
+            MonitorReachability::MonitorNode(3),
+            "monitor remote and new member remote (possibly different \
+             nodes) -> still the monitor's own node address"
+        );
+    }
+
+    /// Regression for the `ExternalServiceManager::Clone` fix: background
+    /// tasks (create_service's cluster-init task and its retry path) must
+    /// `self.clone()` rather than `::new(...)` so a role reconciler they
+    /// spawn registers its shutdown handle where `stop_role_reconciler` --
+    /// called on the real, shared manager -- can actually find it.
+    /// `::new(...)` would silently allocate a fresh, empty
+    /// `reconciler_shutdowns` map, reintroducing the leak this PR fixed.
+    #[tokio::test]
+    async fn clone_shares_reconciler_shutdowns_with_original() {
+        let manager = mock_service_manager(vec![]);
+        let cloned = manager.clone();
+
+        let shutdown = crate::externalsvc::postgres_role_reconciler::ReconcilerShutdown::new();
+        manager
+            .reconciler_shutdowns
+            .lock()
+            .await
+            .insert(99, shutdown.clone());
+
+        assert!(
+            cloned.reconciler_shutdowns.lock().await.contains_key(&99),
+            "Clone must share the same reconciler_shutdowns map as the \
+             original, not construct a fresh empty one -- otherwise \
+             stop_role_reconciler on the original can never see a handle \
+             registered through the clone, and the reconciler leaks forever"
+        );
+
+        // And the sharing is bidirectional / live, not a one-shot copy at
+        // clone time: something inserted through the clone must also be
+        // visible on the original.
+        cloned.reconciler_shutdowns.lock().await.insert(
+            100,
+            crate::externalsvc::postgres_role_reconciler::ReconcilerShutdown::new(),
+        );
+        assert!(manager.reconciler_shutdowns.lock().await.contains_key(&100));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Adds `db-ha-failover-scenario`: provisions a real 1-monitor + 2-data-node Postgres HA cluster (pg_auto_failover, single-Docker-host topology), deploys an app through the injected multi-host `POSTGRES_URL`, writes real rows, `docker stop`s the elected primary (a real ungraceful outage, not an API call), and asserts a surviving replica gets promoted **and** the same app resumes writing within a bounded window with no redeploy. Previously zero e2e coverage on this feature.
- **Root-cause platform bug found and fixed**: `PgAutoFailoverState::is_primary()` (`crates/temps-providers/src/externalsvc/cluster_role.rs`) excluded `WaitPrimary`, on a documented but factually wrong theory that it's "not yet writable". Verified live against a real 2-node cluster: after `docker stop`ing the primary, pg_auto_failover promotes the survivor straight to `wait_primary` — direct `psql` the whole time showed `pg_is_in_recovery()=false`, `default_transaction_read_only=off`, and a real `INSERT` succeeding. With only one node left there's no third node to attach as a new standby, so `wait_primary` isn't transient here — it's the cluster's **permanent, correct steady state** after a 2-node failover (confirmed: still `wait_primary` after a 300s poll). `services.rs`'s own `cluster_states::WRITABLE` already modeled this correctly; the two definitions had drifted apart. Consequence: the DNS reconciler never republished `primary.<svc>.temps.local` after exactly this failover, and `service_members.role` never flipped either.
- Same investigation found a second, more serious instance of the same drift: `member_is_live_primary`'s own hand-rolled `"primary" | "single"` match (gating `remove_cluster_member`'s "don't delete the writable node" safety check) also missed `wait_primary` — an operator could have deleted a cluster's only writable node while it was actively serving traffic. Fixed to call `PgAutoFailoverState::is_primary()` instead, so it can't drift again.

### Correction (second commit)

The first commit on this branch also claimed a fix for a `ReconcilerShutdown`
leak (a deleted cluster's reconciler task logging `Monitor not found for
cluster service {id}` forever) via `AtomicBool`+`Notify` wiring, and stated
this was "confirmed live." **That claim was wrong** — an independent
re-verification pass reproduced the unfixed leak against that exact commit
(the reconciler kept logging 7+ minutes after the cluster was deleted).

The `AtomicBool`+`Notify` wiring itself was correct Rust for the race it
targeted, but it wasn't the actual, always-occurring cause. Root cause:
`create_service`'s background cluster-init task (and the retry path) each
constructed a **throwaway** `ExternalServiceManager::new(...)` instead of
reusing the real, shared instance the app already holds
(`app_state.external_service_manager`). `ExternalServiceManager::new` always
allocates a fresh, empty `reconciler_shutdowns` map, so a reconciler spawned
via the throwaway instance registered its shutdown handle somewhere
`stop_role_reconciler` (running on the real, shared instance) could never
see — `stop_role_reconciler` always found an empty map and silently no-op'd.

Second commit fixes this for real: derives `Clone` on `ExternalServiceManager`
(safe — every field is already `Arc`-wrapped) and uses `self.clone()` instead
of `::new(...)` at both spawn sites, so the clone shares the caller's actual
`reconciler_shutdowns` map. Verified live: 2 consecutive full
`db-ha-failover-scenario` runs (provision → deploy → kill primary → confirm
failover → delete cluster), each followed by 60-90s of log observation —
zero recurrences of the leak across both runs, and the reconciler's
shutdown-signalled/exited-cleanly debug lines now fire exactly once per run.

## Test plan

- [x] `cargo check --lib` (full workspace): 0 errors, both commits
- [x] `cargo test --lib -p temps-providers`: 466 passed, including updated `cluster_role.rs` / `postgres_role_reconciler.rs` unit tests reflecting the corrected `wait_primary` semantics
- [x] `bun run typecheck` (`apps/temps-e2e`): clean
- [x] `db-ha-failover-scenario` run live against a fresh local `temps serve` instance **3x back-to-back** (first commit) + **2x back-to-back** (second commit, rebuilt from the fixed binary), all PASSED end-to-end (real cluster provisioning, real `docker stop`, real promotion, real write-recovery through the deployed app's own `/probe` endpoint) — `failoverDetectedMs` ~50-53s, `writesRecoveredMs` ~11ms
- [x] Reconciler-leak fix verified by absence: `grep -c "Monitor not found for cluster service"` against the server log returned 0 across both post-fix runs, each observed for 60-90s after cluster deletion
- [x] Pre-commit hooks (fmt, clippy, conventional-commit) all passed on both commits

## Evidence

Independently captured against a fresh, isolated `temps serve` instance (own DB `temps_e2e_ha_evidence`, own `TEMPS_DATA_DIR`, ports 18220/18221/18583), built from this exact branch tip (`893f61c`) after confirming `target/fast/temps` was newer than every `.rs` file the branch touches, then rebuilding anyway (`0 errors`) to be certain.

**Failover detection (`WaitPrimary` classified as writable) + write recovery, `--json` run**: real numbers from a live `docker stop` of the elected primary against a real 2-node pg_auto_failover cluster.
```bash
TEMPS_URL=http://localhost:18220 TEMPS_API_KEY=*** TEMPS_E2E_REGISTRY=localhost:5111 \
bun run src/index.ts db-ha-failover-scenario --json
```
```json
{
  "runId": "e2e-mslk4x96-ljvdbv",
  "ok": true,
  "originalPrimary": "postgres-e2e-mslk4x96-ljvdbv-ha-1",
  "newPrimary": "postgres-e2e-mslk4x96-ljvdbv-ha-2",
  "failoverDetectedMs": 50415.49,
  "writesRecoveredMs": 11.20,
  "finalProbeCount": 6
}
```
All 19 steps `"ok": true`, including `poll cluster-health until a DIFFERENT node is promoted primary (bounded 90s)` (50.4s) and `poll /probe ... until writes succeed again` (11ms — the app's existing multi-host `POSTGRES_URL` routed to the new primary the moment it entered `wait_primary`, no redeploy).

**Same scenario, plain output** (second live run, full step transcript, docker-push layer spam trimmed):
```bash
TEMPS_URL=http://localhost:18220 TEMPS_API_KEY=*** TEMPS_E2E_REGISTRY=localhost:5111 \
bun run src/index.ts db-ha-failover-scenario
```
```
▶ poll cluster-health until steady state: exactly 1 primary + 1 secondary, both healthy
    ...postgres-e2e-mslk92cp-rnayo6-ha-1=wait_primary(health=1), postgres-e2e-mslk92cp-rnayo6-ha-2=wait_standby(health=-1)
    [... 27 more poll lines omitted ...]
    ...postgres-e2e-mslk92cp-rnayo6-ha-1=primary(health=1), postgres-e2e-mslk92cp-rnayo6-ha-2=secondary(health=1)
  ✓ poll cluster-health until steady state: exactly 1 primary + 1 secondary, both healthy (96.6s)
  primary=postgres-e2e-mslk92cp-rnayo6-ha-1 secondary=postgres-e2e-mslk92cp-rnayo6-ha-2

▶ write 5 real rows through the injected multi-host POSTGRES_URL
  ✓ write 5 real rows through the injected multi-host POSTGRES_URL (0.0s)
  pre-failover count=5

▶ docker stop the primary container (postgres-e2e-mslk92cp-rnayo6-ha-1) -- simulates a real outage
  ✓ docker stop the primary container (postgres-e2e-mslk92cp-rnayo6-ha-1) -- simulates a real outage (0.5s)

▶ poll cluster-health until a DIFFERENT node is promoted primary (bounded 90s)
    ...postgres-e2e-mslk92cp-rnayo6-ha-1=primary(health=1), postgres-e2e-mslk92cp-rnayo6-ha-2=secondary(health=1)
    [... 25 more poll lines omitted, showing prepare_promotion -> stop_replication -> wait_primary ...]
    ...postgres-e2e-mslk92cp-rnayo6-ha-1=primary(health=0), postgres-e2e-mslk92cp-rnayo6-ha-2=wait_primary(health=1)
  ✓ poll cluster-health until a DIFFERENT node is promoted primary (bounded 90s) (52.4s)
  new primary=postgres-e2e-mslk92cp-rnayo6-ha-2 (promoted in 52.4s)

▶ poll /probe (through the SAME app, SAME connection string, no redeploy) until writes succeed again (bounded 90s)
    ...write recovered, count=6 (0.0s after stop)
  ✓ poll /probe (through the SAME app, SAME connection string, no redeploy) until writes succeed again (bounded 90s) (0.0s)

▶ post-failover row count is monotonic (the write actually landed on the new primary)
  ✓ post-failover row count is monotonic (the write actually landed on the new primary) (0.0s)

▶ teardown: tore down 1 deployment(s), deleted 1 project(s), 1 service(s)

✅ db-ha-failover-scenario PASSED
```

**Honest caveat found while gathering this evidence**: 2 of my 4 total live runs (not shown above) failed at the write-recovery step — not because of a `WaitPrimary`/DNS classification problem (cluster-health promotion succeeded in ~50-53s in *all 4* runs, consistently), but because the deployed probe-app container itself became completely unreachable (`docker ps -a` showed zero containers matching it — not exited, gone) a few seconds after `docker stop`ing the postgres primary, while `deployment_containers.status` in the DB stayed `running`. Proxy logs showed `ConnectRefused`/`Fail to connect to 127.0.0.1:<port>` to the app's own upstream, not a Postgres-level error. I could not root-cause this in the time available (RestartPolicy on app containers is `Always`, so a simple crash should have respawned it in place, not removed it entirely; host had ample free memory, ruling out OOM). It reproduced twice and did not reproduce twice, so it looks like a real, occasional flake in this environment tied to app-container lifecycle around the primary's `docker stop`, separate from the `cluster_role.rs`/`postgres_role_reconciler.rs`/`services.rs` changes in this PR — flagging it rather than omitting it.

**`member_is_live_primary` delete-protection — the claim the review said had no direct evidence.** Provisioned a fresh cluster, `docker stop`ed the primary, waited for cluster-health to report the survivor in `wait_primary`, then hit the real remove-member endpoint directly against that node while it was in `wait_primary`:
```bash
curl -s -b cookies.txt "http://localhost:18220/api/external-services/2/cluster-health"
# -> {"members":[
#      {"nodename":"postgres-e2e-msljpndo-8zgkct-ha-1","reported_state":"primary","goal_state":"demoted","health":0,...},
#      {"nodename":"postgres-e2e-msljpndo-8zgkct-ha-2","reported_state":"wait_primary","goal_state":"wait_primary","health":1,...}
#    ]}

curl -s -b cookies.txt -X DELETE "http://localhost:18220/api/external-services/2/members/6" -w "\nHTTP_STATUS:%{http_code}\n"
```
```
{"detail":"Parameter validation failed for service 2: Cannot remove the current primary. Trigger a failover first (pg_autoctl perform failover) so a replica is promoted, then remove this node once it has been demoted to a replica or has gone offline.","instance":"/error/bad-request","timestamp":"2026-08-09T08:41:42.845179+00:00","title":"Bad Request","type":"https://temps.sh/probs/bad-request"}
HTTP_STATUS:400
```
Member 6 (`postgres-e2e-msljpndo-8zgkct-ha-2`, `live_state: "wait_primary"`) was confirmed still present in `GET /api/external-services/2` immediately after — the delete was genuinely rejected, not silently no-op'd. `DELETE /api/external-services/{id}/members/{member_id}` → `remove_cluster_member`, route defined at `crates/temps-providers/src/handlers/handlers.rs:279`.

**Reconciler-shutdown leak — direct proof via debug-level logs** (restarted the same instance with `--log-level=debug` / `TEMPS_LOG_LEVEL=debug` specifically to see the `debug!` lines, since they're invisible at the default `info` level):
```bash
# delete the cluster (project unlink -> delete project -> delete service, same order the scenario's own teardown uses)
curl -s -b cookies.txt -X DELETE "http://localhost:18220/api/projects/2"        # 204
curl -s -b cookies.txt -X DELETE "http://localhost:18220/api/external-services/2"  # 204, at 2026-08-09T08:43:19Z
```
```
2026-08-09T08:43:19.706131Z DEBUG role reconciler shutdown signalled service_id=2
2026-08-09T08:43:19.706172Z  INFO role reconciler shutting down service_id=2 service_name="e2e-msljpndo-8zgkct-ha"
2026-08-09T08:43:19.706180Z DEBUG role reconciler exited cleanly service_id=2
```
Then, 96+ seconds later:
```bash
grep -c "Monitor not found for cluster service" /tmp/temps-e2e-evidence-588-server-debug.log
# -> 0
```
Repeated across the two further live scenario runs above (each creates+deletes its own cluster in its own teardown, no `--keep`) in the same debug-logging session — 3 create/delete cycles total, 3 matching `shutdown signalled`/`exited cleanly` pairs (`service_id=2,3,4`), and:
```bash
grep -c "Monitor not found for cluster service" /tmp/temps-e2e-evidence-588-server-debug.log
# -> 0   (over the full ~10-minute debug-logging session, spanning all 3 cycles)
```

**Build verification**:
```bash
$(command -v cargo) build --profile fast --bin temps --package temps-cli
# cargo build: 0 errors, 10 warnings (1 crates)
```


## Round 1 review fixes (findings 1-6)

Addresses the 5 Major + 1 Minor findings from the follow-up review of the
two commits above. All were real regression-coverage gaps, not checklist
items — each new test is confirmed to fail against a temporarily-reverted
version of its corresponding fix (see below), and finding 5 turned up a
real, previously-unfixed latent bug while investigating.

### What was fixed

1. **`member_is_live_primary` / `remove_cluster_member`'s delete-protection
   gate had no unit test for `wait_primary`.** Extracted the live-monitor
   branch into a pure `ExternalServiceManager::primary_member_from_health`
   (no I/O) so the exact decision logic `remove_cluster_member` depends on
   is directly testable. New test
   `primary_member_from_health_blocks_deletion_of_a_wait_primary_member`
   constructs a `ClusterHealthReport` with a `wait_primary` member and
   asserts it's treated as the live primary.
2. **`member_hostname`'s FQDN-vs-container-name fix had no unit test.**
   Extracted the ternary out of `initialize_cluster` into
   `ExternalServiceManager::resolve_member_hostname` (pure). New test
   `resolve_member_hostname_prefers_fqdn_only_when_cluster_spans_hosts`
   covers both branches.
3. **`ExternalServiceManager::Clone` had no test proving the sharing
   invariant.** New test `clone_shares_reconciler_shutdowns_with_original`
   clones a manager, inserts a `ReconcilerShutdown` handle through one
   side, and asserts the other side sees it — bidirectionally.
4. **`ReconcilerShutdown`'s actual race-fix mechanism was untested** (the
   two touched tests in `postgres_role_reconciler.rs` only re-checked
   `is_primary()`). Refactored `run()` into a thin wrapper over a new
   `run_loop<F, Fut>`, generic over the tick body, so the *real* loop —
   `is_stopped()` checked both before and after the tick, not just inside
   the sleep `select!` — can be driven directly in a test instead of
   duplicated. New test
   `shutdown_signalled_mid_tick_stops_promptly_not_after_a_full_next_tick`
   signals shutdown 50ms into a simulated in-flight tick and asserts the
   loop returns well under `TICK_INTERVAL` (5s) and never starts a second
   tick.
5. **`add_cluster_member`'s doc comment was stale — AND a real bug was
   hiding behind it.** The comment claimed "every container we provision
   now gets the per-host Hickory resolver wired in... resolves natively",
   contradicting finding 2's own fix (that wiring is gated behind
   `cluster_dns.enabled`, off by default). Investigating further: the
   fallback chain the comment describes (`monitor.hostname` →
   `monitor.node_id`'s private address → control-plane's local IP →
   container name) is **dead code** as written, because
   `resolve_member_hostname` (finding 2) now *always* populates
   `monitor.hostname` (with either an FQDN or a container name) — so the
   `monitor.hostname.is_none()` fallback branches can never fire. Concrete
   consequence: `monitor.hostname` only reflects `has_remote_members` at
   the *cluster's creation time* and is never retroactively recomputed, so
   adding a cluster's **first-ever remote member** to a previously
   all-local cluster reused the monitor's plain Docker container name as
   the address the new (cross-host) member should dial — unreachable from
   another Docker host. Fixed by deriving monitor reachability from the
   actual node topology of *this specific add*
   (`ExternalServiceManager::monitor_reachability_for_add`, pure + unit
   tested with all 4 topology combinations) instead of trusting a
   potentially-stale persisted string, and rewrote the doc comment to
   describe the real logic. **Caveat**: I could not live-verify this fix
   against a real cross-host add (this repo's e2e infra has no multi-node/
   WireGuard harness available in the time budget) — verification is
   `cargo test` + code-reading only for this one fix. The change is
   low-risk: it only changes behavior in the case that was already dead/
   broken (monitor.hostname is never `None` in practice anymore), and in
   every case it's equivalent to or a superset of the paths the original
   comment already documented as intentional.

### db-ha-failover-scenario.ts additions (finding 6, lower priority)

Investigated both platform-level symptoms the original commit message
cites:

- **`service_members.role` failing to flip to Primary**: read the code and
  confirmed this is **not a live signal in the current design** —
  `PgAutoFailoverState::to_cluster_role()` maps to `ClusterRole::Primary`
  but is unit-tested only, never called from any production code path.
  `sync_member_roles` (the only writer of `service_members.role` at
  runtime) exclusively demotes legacy `"primary"` rows to `"replica"` once;
  it never writes `"primary"`. `get_service_info`'s own doc comment
  confirms this is intentional: *"The UI uses `live_state` for the role
  badge... instead of being gated on the `service_members.role`
  reconciler."* Asserting a role flip would assert something that doesn't
  happen by design. Substituted the faithful current equivalent instead:
  added a step asserting the **console/CLI-facing API**
  (`GET /external-services/{id}`, via `get_service_members_with_live_state`
  — a different code path than the scenario's existing `cluster-health`
  probe assertion) reflects the promotion through
  `ServiceMemberInfo.live_state`. Verified live this genuinely exercises
  something new: on the first attempt I also asserted the *old* primary's
  `live_state` stops reading `"primary"` after failover, and that
  assertion **failed live** — the monitor doesn't retroactively correct a
  dead node's own `reportedstate` (documented behavior:
  `ClusterMemberHealth.reported_state`'s doc comment says it "doesn't
  change when the node stops phoning home"). Corrected the assertion to
  only check the promoted node (which is the real, meaningful signal), and
  left an honest comment flagging that `ServiceMemberInfo` carries no
  `health` field to disambiguate a stale-dead-primary from an actual
  second live primary — a real, separate console-facing gap, out of scope
  here.
- **DNS reconciler failing to republish `primary.<svc>.temps.local`**:
  investigated and **skipped as impractical this round**. The only HTTP
  surface exposing the internal DNS zone content is
  `GET /internal/nodes/{node_id}/dns/changes`
  (`crates/temps-dns/src/handlers/dns_sync.rs`), gated behind per-node
  bearer-token auth (`nodes.token_hash`) — not the user/API-key auth this
  suite uses everywhere else — and this scenario deliberately stays
  single-Docker-host with no worker node registered, so there's no token
  to present. Reaching the DNS row would mean either registering a
  throwaway worker node purely to mint a token, or querying the
  control-plane's own Postgres directly (breaking this suite's API-only
  testing philosophy). Documented in the README as a known gap, with a
  cheaper fix suggested (a narrow admin/debug endpoint exposing a
  service's internal DNS records) if this becomes a priority later.

### Verification

**Rust unit tests** — full `temps-providers` suite, from a clean build:
```
cargo test -p temps-providers --lib
...
test result: ok. 471 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.18s
```
(466 baseline + 5 new tests: `primary_member_from_health_blocks_deletion_of_a_wait_primary_member`,
`resolve_member_hostname_prefers_fqdn_only_when_cluster_spans_hosts`,
`clone_shares_reconciler_shutdowns_with_original`,
`shutdown_signalled_mid_tick_stops_promptly_not_after_a_full_next_tick`,
`monitor_reachability_for_add_derives_from_actual_add_topology`.)

**Each new test independently confirmed to catch its regression** — I
temporarily reverted each fix in isolation, reran the specific test, saw it
fail, then restored the fix and confirmed it passed again:
- `primary_member_from_health` reverted to the old hand-rolled
  `"primary" | "single"` match → test failed with `wait_primary must be
  treated as the live primary`.
- `resolve_member_hostname` reverted to unconditional FQDN → test failed
  (`left: "orders-1.orders.temps.local", right: "orders-postgres-1"`).
- `ExternalServiceManager::Clone` reverted to a hand-written impl that
  reconstructs a fresh empty `reconciler_shutdowns` map → test failed with
  the sharing-invariant assertion.
- `run_loop`'s post-tick `is_stopped()` check removed (reproducing the
  exact pre-fix race) → test failed: `elapsed=5.1s` (a full extra
  `TICK_INTERVAL`), instead of the ~100ms the fix produces.

**Live e2e** — `db-ha-failover-scenario` run against a fresh, isolated
`temps serve` instance (own Postgres DB, own `TEMPS_DATA_DIR`, ports
18244/18245, torn down after), rebuilt from this branch tip
(`cargo build --profile fast --bin temps --package temps-cli`, 0 errors).
2 consecutive full back-to-back PASSES (a 3rd run failed earlier only
because of my own test-harness port misconfiguration — pointed the SDK
client at the console-admin port instead of the proxy's fallback-forwarded
port; not a code issue, fixed by pointing `TEMPS_URL` at the proxy address):

```
▶ confirm the console-facing API (GET /external-services/{id}) reflects the promotion via live_state
  console-facing API: postgres-e2e-mslq2zu8-z21fq4-ha-2=wait_primary, postgres-e2e-mslq2zu8-z21fq4-ha-1=primary (may be stale -- see comment above)
  ✓ confirm the console-facing API (GET /external-services/{id}) reflects the promotion via live_state (0.0s)

▶ poll /probe (through the SAME app, SAME connection string, no redeploy) until writes succeed again (bounded 90s)
    ...write recovered, count=6 (0.0s after stop)
  ✓ poll /probe (through the SAME app, SAME connection string, no redeploy) until writes succeed again (bounded 90s) (0.0s)

▶ post-failover row count is monotonic (the write actually landed on the new primary)
  ✓ post-failover row count is monotonic (the write actually landed on the new primary) (0.0s)

▶ teardown: tore down 1 deployment(s), deleted 1 project(s), 1 service(s)

✅ db-ha-failover-scenario PASSED
```

Run 2 (fully independent cluster): same result, `✅ db-ha-failover-scenario PASSED`,
`failoverDetectedMs` ~50-52s across both runs.

**Reconciler-leak regression check** (finding 3/4's fix, re-verified in this
round's own server session, 3 create/delete cycles total across the runs
above):
```
grep -c "Monitor not found for cluster service" server.log
# -> 0
grep -n "starting role reconciler\|role reconciler shutting down" server.log
# 3 matching start/shutdown pairs, service_id=2,3,4, one per cluster created+deleted
```

**Typecheck**: `bun run typecheck` in `apps/temps-e2e` — clean, both before
and after the scenario-assertion fix.

**Build**: `cargo check --lib` (full workspace) — 0 errors.

**Teardown**: server killed, evidence Postgres DB dropped, `TEMPS_DATA_DIR`
and the local `GeoLite2-City.mmdb` dev-only workaround file removed
(gitignored, never staged).

### Not fixed / explicitly deferred

- Finding 5's `monitor_reachability_for_add` fix has unit-test but not
  live multi-node coverage (no WireGuard/multi-node harness available in
  this environment/time budget) — see caveat above.
- The DNS-record-republish assertion (second half of finding 6) — skipped,
  reasoning above and in the README.
- A genuinely new, smaller gap surfaced while building the `live_state`
  assertion: `ServiceMemberInfo` (the struct backing the console/CLI's
  service-detail view) has no `health` field, so a `docker stop`ped node's
  stale `live_state: "primary"` is indistinguishable from a real second
  live primary from that API alone (the separate `cluster-health` endpoint
  *does* carry `health`). Not fixed here — flagged as a follow-up.
