### PR TITLE
feat(teams): add ProjectAccessChecker::invalidate_permissions_cache

### DIFF
--- a/crates/temps-core/src/project_access.rs
+++ b/crates/temps-core/src/project_access.rs
@@ -119,6 +119,35 @@ pub trait ProjectAccessChecker: Send + Sync {
     ) -> Result<Option<Vec<i32>>, Box<dyn std::error::Error + Send + Sync>> {
         Ok(None)
     }
+
+    /// Flushes any cache this checker keeps for `effective_project_permissions`
+    /// (and, transitively, for whatever a registered
+    /// [`MembershipPermissionResolver`] answers).
+    ///
+    /// A checker that caches per-`(user, project)` permission sets — as the
+    /// recommended implementation does, since `effective_project_permissions`
+    /// is on the hot path of every `project_permission_guard!` call — becomes
+    /// a second cache layer sitting in front of a
+    /// [`MembershipPermissionResolver`] plugin's own cache. When that plugin's
+    /// answer for a membership changes (a role definition is edited, a
+    /// membership's role assignment is created/updated/deleted), the plugin
+    /// can invalidate its own cache, but it holds only `Arc<dyn
+    /// ProjectAccessChecker>` — the trait, not this checker's concrete type —
+    /// so it has no way to reach this cache without this method.
+    ///
+    /// Defaults to a no-op so existing implementations of this trait
+    /// (compiled against an older version of it, or a checker that caches
+    /// nothing) keep behaving exactly as they do today.
+    ///
+    /// Deliberately synchronous and coarse (whole-cache flush, no
+    /// per-project or per-user granularity): the moka-backed reference
+    /// implementation's own `invalidate_all` is lazy and cheap to call from a
+    /// resolver plugin's write path without needing `.await` there, and a
+    /// resolver plugin has no way to know which `(user, project)` pairs are
+    /// affected by e.g. a role permission-set edit — that set is unbounded
+    /// from the resolver's point of view, so a full flush is the only
+    /// correct granularity available to it.
+    fn invalidate_permissions_cache(&self) {}
 }
 
 /// Optional extension point for overriding what a single team membership

--- a/crates/temps-teams/src/checker.rs
+++ b/crates/temps-teams/src/checker.rs
@@ -625,6 +625,10 @@ impl ProjectAccessChecker for TeamProjectAccessChecker {
 
         Ok(resolved)
     }
+
+    fn invalidate_permissions_cache(&self) {
+        self.invalidate_all();
+    }
 }
 
 #[cfg(test)]
@@ -1237,6 +1241,35 @@ mod tests {
 
         // If the permissions cache weren't cleared, this would panic on
         // exhausted MockDatabase results instead of re-querying.
+        assert_eq!(
+            checker.effective_project_permissions(1, 42).await.unwrap(),
+            None
+        );
+    }
+
+    /// `invalidate_permissions_cache` (the `ProjectAccessChecker` trait
+    /// method) must reach the same cache `invalidate_all` does — this is
+    /// the only path a `MembershipPermissionResolver` plugin has back into
+    /// this checker's cache, since it holds `Arc<dyn ProjectAccessChecker>`
+    /// (the trait), never this concrete type.
+    #[tokio::test]
+    async fn invalidate_permissions_cache_trait_method_clears_permissions_cache() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![Vec::<project_team_access::Model>::new()])
+            .append_query_results(vec![Vec::<project_team_access::Model>::new()])
+            .into_connection();
+        let checker: Arc<dyn ProjectAccessChecker> = Arc::new(new_checker(db));
+
+        assert_eq!(
+            checker.effective_project_permissions(1, 42).await.unwrap(),
+            None
+        );
+
+        checker.invalidate_permissions_cache();
+
+        // Same assertion as `invalidate_all_clears_permissions_cache_too`,
+        // but called through the trait object a resolver plugin actually
+        // holds, not the concrete type.
         assert_eq!(
             checker.effective_project_permissions(1, 42).await.unwrap(),
             None


### PR DESCRIPTION
## Summary
- Adds a default no-op `invalidate_permissions_cache(&self)` method to `ProjectAccessChecker` (`temps-core`), overridden by `TeamProjectAccessChecker` to call its existing `invalidate_all()`.
- Closes a cache-invalidation gap: a plugin implementing `MembershipPermissionResolver` only ever holds `Arc<dyn ProjectAccessChecker>` (the trait), never the checker's concrete type, so it had no way to flush the checker's own `effective_project_permissions` cache after a write that changes what the resolver answers (e.g. a role's permission set changes, or a membership's resolver-visible assignment changes). Without this, the checker could serve a stale, wider-than-intended permission set for up to its cache TTL after such a write.

## Test plan
- [x] `cargo check --lib -p temps-core -p temps-teams`
- [x] `cargo test --lib -p temps-teams` — 66/66 passing, including two new tests: `invalidate_permissions_cache_trait_method_clears_permissions_cache` (calls the new method through the trait object, the same way a plugin would) and the pre-existing `invalidate_all_clears_permissions_cache_too`
- [x] `cargo clippy --lib -p temps-core -p temps-teams -- -D warnings` — clean
- [x] Backward compatible: default no-op method, no existing call sites changed