### PR TITLE
feat(cli): add otel-forward commands for OTLP relay destinations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -776,6 +776,16 @@ Merge conflicts in either client are conflicts in build output. Never
 hand-merge them: take one side to clear the conflict, then regenerate from a
 server built off the merged source and typecheck both packages.
 
+**Never add a plugin-only route or schema to `apps/temps-cli/openapi.json`.**
+Some backend endpoints are served by a plugin crate that isn't part of this
+repository, so their schema doesn't exist in the spec this file's generated
+client is built from, and it must stay that way. For CLI parity on those
+endpoints, hand-write local request/response interfaces mirroring the
+plugin's shapes and call the shared `client` object directly via its generic
+`.get/.post/.patch/.delete` methods — same call shape every generated SDK
+function already uses, just without codegen. See
+`apps/temps-cli/src/commands/otel-forward/index.ts` for the pattern.
+
 ### Permission System
 
 ```rust

--- a/apps/temps-cli/src/cli.ts
+++ b/apps/temps-cli/src/cli.ts
@@ -31,6 +31,7 @@ import { registerDocsCommand } from './commands/docs.js'
 import { registerTokensCommands } from './commands/tokens/index.js'
 import { registerErrorsCommands } from './commands/errors/index.js'
 import { registerTracesCommands } from './commands/traces/index.js'
+import { registerOtelForwardCommands } from './commands/otel-forward/index.js'
 import { registerKvCommands } from './commands/kv/index.js'
 import { registerFlagsCommands } from './commands/flags/index.js'
 import { registerDataCommands } from './commands/data/index.js'
@@ -174,6 +175,7 @@ export function createProgram(): Command {
   registerTokensCommands(program)
   registerErrorsCommands(program)
   registerTracesCommands(program)
+  registerOtelForwardCommands(program)
   registerKvCommands(program)
   registerFlagsCommands(program)
   registerDataCommands(program)

--- a/apps/temps-cli/src/commands/otel-forward/index.test.ts
+++ b/apps/temps-cli/src/commands/otel-forward/index.test.ts
@@ -1,0 +1,183 @@
+import { test, expect, describe } from 'bun:test'
+import {
+  parseHeaderPairs,
+  resolveEnabledFlag,
+  buildCreateDestinationBody,
+  buildUpdateDestinationBody,
+} from './index.js'
+
+describe('parseHeaderPairs', () => {
+  test('parses a single KEY=VALUE pair', () => {
+    expect(parseHeaderPairs(['DD-API-KEY=abc123'])).toEqual({ 'DD-API-KEY': 'abc123' })
+  })
+
+  test('parses multiple pairs', () => {
+    expect(parseHeaderPairs(['a=1', 'b=2'])).toEqual({ a: '1', b: '2' })
+  })
+
+  test('only splits on the first "=" — values may contain "="', () => {
+    expect(parseHeaderPairs(['Authorization=Bearer abc=def'])).toEqual({
+      Authorization: 'Bearer abc=def',
+    })
+  })
+
+  test('returns an empty object for undefined input', () => {
+    expect(parseHeaderPairs(undefined)).toEqual({})
+  })
+
+  test('returns an empty object for an empty array', () => {
+    expect(parseHeaderPairs([])).toEqual({})
+  })
+
+  test('throws on a pair with no "="', () => {
+    expect(() => parseHeaderPairs(['not-a-pair'])).toThrow(
+      "Invalid --header 'not-a-pair': expected KEY=VALUE"
+    )
+  })
+
+  test('throws on a pair with an empty key (leading "=")', () => {
+    expect(() => parseHeaderPairs(['=value'])).toThrow(
+      "Invalid --header '=value': expected KEY=VALUE"
+    )
+  })
+
+  test('allows an empty value', () => {
+    expect(parseHeaderPairs(['key='])).toEqual({ key: '' })
+  })
+})
+
+describe('resolveEnabledFlag', () => {
+  test('returns undefined when neither flag is passed', () => {
+    expect(resolveEnabledFlag({})).toBeUndefined()
+  })
+
+  test('returns true when --enabled is passed', () => {
+    expect(resolveEnabledFlag({ enabled: true })).toBe(true)
+  })
+
+  test('returns false when --disabled is passed', () => {
+    expect(resolveEnabledFlag({ disabled: true })).toBe(false)
+  })
+
+  test('--disabled takes precedence if somehow both are set', () => {
+    expect(resolveEnabledFlag({ enabled: true, disabled: true })).toBe(false)
+  })
+})
+
+describe('buildCreateDestinationBody', () => {
+  const baseOptions = {
+    projectId: '1',
+    name: 'datadog-prod',
+    vendor: 'datadog',
+    endpointUrl: 'https://otlp.datadoghq.com',
+  }
+
+  test('includes only the required fields when nothing else is passed', () => {
+    expect(buildCreateDestinationBody(1, baseOptions)).toEqual({
+      project_id: 1,
+      name: 'datadog-prod',
+      vendor_preset: 'datadog',
+      endpoint_url: 'https://otlp.datadoghq.com',
+    })
+  })
+
+  test('includes headers only when at least one --header was passed', () => {
+    const body = buildCreateDestinationBody(1, {
+      ...baseOptions,
+      header: ['DD-API-KEY=abc123', 'X-Custom=Value=With=Equals'],
+    })
+    expect(body.headers).toEqual({
+      'DD-API-KEY': 'abc123',
+      'X-Custom': 'Value=With=Equals',
+    })
+  })
+
+  test('omits headers when --header was never passed', () => {
+    const body = buildCreateDestinationBody(1, baseOptions)
+    expect(body.headers).toBeUndefined()
+  })
+
+  test('includes forward_traces/metrics/logs only when explicitly set', () => {
+    const body = buildCreateDestinationBody(1, { ...baseOptions, traces: false, logs: true })
+    expect(body.forward_traces).toBe(false)
+    expect(body.forward_logs).toBe(true)
+    expect(body.forward_metrics).toBeUndefined()
+  })
+
+  test('sets enabled from --disabled', () => {
+    const body = buildCreateDestinationBody(1, { ...baseOptions, disabled: true })
+    expect(body.enabled).toBe(false)
+  })
+
+  test('omits enabled when neither --enabled nor --disabled passed', () => {
+    const body = buildCreateDestinationBody(1, baseOptions)
+    expect(body.enabled).toBeUndefined()
+  })
+
+  test('sets allow_private_network only when the flag is passed', () => {
+    expect(buildCreateDestinationBody(1, baseOptions).allow_private_network).toBeUndefined()
+    expect(
+      buildCreateDestinationBody(1, { ...baseOptions, allowPrivateNetwork: true }).allow_private_network
+    ).toBe(true)
+  })
+})
+
+describe('buildUpdateDestinationBody', () => {
+  test('returns an empty object when no fields are passed', () => {
+    expect(buildUpdateDestinationBody({})).toEqual({})
+  })
+
+  test('includes only the fields that were actually passed', () => {
+    expect(buildUpdateDestinationBody({ name: 'renamed' })).toEqual({ name: 'renamed' })
+    expect(buildUpdateDestinationBody({ endpointUrl: 'https://example.com' })).toEqual({
+      endpoint_url: 'https://example.com',
+    })
+    expect(buildUpdateDestinationBody({ vendor: 'honeycomb' })).toEqual({ vendor_preset: 'honeycomb' })
+  })
+
+  test('includes headers only when --header was passed at least once', () => {
+    expect(buildUpdateDestinationBody({}).headers).toBeUndefined()
+    expect(buildUpdateDestinationBody({ header: [] }).headers).toBeUndefined()
+    expect(buildUpdateDestinationBody({ header: ['a=1'] }).headers).toEqual({ a: '1' })
+  })
+
+  test('a header value of exactly "***" round-trips as a literal value (server interprets the sentinel)', () => {
+    expect(buildUpdateDestinationBody({ header: ['token=***'] }).headers).toEqual({ token: '***' })
+  })
+
+  test('includes forward_traces/metrics/logs only when explicitly set', () => {
+    const body = buildUpdateDestinationBody({ traces: true })
+    expect(body.forward_traces).toBe(true)
+    expect(body.forward_metrics).toBeUndefined()
+    expect(body.forward_logs).toBeUndefined()
+  })
+
+  test('includes enabled only when --enabled or --disabled was passed', () => {
+    expect(buildUpdateDestinationBody({}).enabled).toBeUndefined()
+    expect(buildUpdateDestinationBody({ enabled: true }).enabled).toBe(true)
+    expect(buildUpdateDestinationBody({ disabled: true }).enabled).toBe(false)
+  })
+
+  test('includes allow_private_network only when explicitly set (true or false)', () => {
+    expect(buildUpdateDestinationBody({}).allow_private_network).toBeUndefined()
+    expect(buildUpdateDestinationBody({ allowPrivateNetwork: true }).allow_private_network).toBe(true)
+    expect(buildUpdateDestinationBody({ allowPrivateNetwork: false }).allow_private_network).toBe(false)
+  })
+
+  test('builds a full partial body with every kind of field mixed', () => {
+    const body = buildUpdateDestinationBody({
+      name: 'new-name',
+      header: ['a=1', 'b=2'],
+      logs: false,
+      disabled: true,
+      allowPrivateNetwork: true,
+    })
+    expect(body).toEqual({
+      name: 'new-name',
+      headers: { a: '1', b: '2' },
+      forward_logs: false,
+      enabled: false,
+      allow_private_network: true,
+    })
+  })
+})

--- a/apps/temps-cli/src/commands/otel-forward/index.test.ts
+++ b/apps/temps-cli/src/commands/otel-forward/index.test.ts
@@ -1,50 +1,82 @@
-import { test, expect, describe } from 'bun:test'
+import { afterAll, beforeAll, test, expect, describe } from 'bun:test'
 import {
-  parseHeaderPairs,
+  parseHeaderEnvPairs,
+  maskHeaders,
+  sanitizeDestinationForOutput,
+  sanitizeTextForOutput,
+  sanitizeUrlForOutput,
+  validateEndpointUrl,
   resolveEnabledFlag,
   buildCreateDestinationBody,
   buildUpdateDestinationBody,
   buildCreateInstanceDefaultBody,
   buildUpdateInstanceDefaultBody,
+  type DestinationResponse,
 } from './index.js'
 
-describe('parseHeaderPairs', () => {
-  test('parses a single KEY=VALUE pair', () => {
-    expect(parseHeaderPairs(['DD-API-KEY=abc123'])).toEqual({ 'DD-API-KEY': 'abc123' })
+const TEST_ENVIRONMENT = {
+  TEMPS_OTEL_TEST_A: '1',
+  TEMPS_OTEL_TEST_B: '2',
+  TEMPS_OTEL_TEST_DD_KEY: 'synthetic-dd-secret',
+  TEMPS_OTEL_TEST_CUSTOM: 'Value=With=Equals',
+  TEMPS_OTEL_TEST_ORG: 'synthetic-org',
+  TEMPS_OTEL_TEST_AUTH: 'Bearer synthetic-auth-secret',
+  TEMPS_OTEL_TEST_SENTINEL: '***',
+}
+
+beforeAll(() => Object.assign(process.env, TEST_ENVIRONMENT))
+afterAll(() => {
+  for (const name of Object.keys(TEST_ENVIRONMENT)) delete process.env[name]
+})
+
+describe('parseHeaderEnvPairs', () => {
+  const environment = {
+    DD_KEY: 'synthetic-dd-secret',
+    AUTH_VALUE: 'Bearer synthetic-auth-secret',
+    FIRST_VALUE: 'one',
+    SECOND_VALUE: 'two',
+  }
+
+  test('resolves a single KEY=ENV_VAR pair', () => {
+    expect(parseHeaderEnvPairs(['DD-API-KEY=DD_KEY'], environment)).toEqual({
+      'DD-API-KEY': 'synthetic-dd-secret',
+    })
   })
 
   test('parses multiple pairs', () => {
-    expect(parseHeaderPairs(['a=1', 'b=2'])).toEqual({ a: '1', b: '2' })
-  })
-
-  test('only splits on the first "=" — values may contain "="', () => {
-    expect(parseHeaderPairs(['Authorization=Bearer abc=def'])).toEqual({
-      Authorization: 'Bearer abc=def',
+    expect(parseHeaderEnvPairs(['a=FIRST_VALUE', 'b=SECOND_VALUE'], environment)).toEqual({
+      a: 'one',
+      b: 'two',
     })
   })
 
   test('returns an empty object for undefined input', () => {
-    expect(parseHeaderPairs(undefined)).toEqual({})
+    expect(parseHeaderEnvPairs(undefined, environment)).toEqual({})
   })
 
   test('returns an empty object for an empty array', () => {
-    expect(parseHeaderPairs([])).toEqual({})
+    expect(parseHeaderEnvPairs([], environment)).toEqual({})
   })
 
-  test('throws on a pair with no "=", without echoing the raw value', () => {
-    expect(() => parseHeaderPairs(['not-a-pair'])).toThrow(
-      "Invalid --header: expected KEY=VALUE (got no '=' or an empty key)"
+  test('throws on a pair with no "="', () => {
+    expect(() => parseHeaderEnvPairs(['not-a-pair'], environment)).toThrow(
+      'Invalid --header-env: expected KEY=ENV_VAR'
     )
   })
 
-  test('throws on a pair with an empty key (leading "="), without echoing the raw value', () => {
-    expect(() => parseHeaderPairs(['=value'])).toThrow(
-      "Invalid --header: expected KEY=VALUE (got no '=' or an empty key)"
+  test('throws on an empty header or environment name', () => {
+    expect(() => parseHeaderEnvPairs(['=DD_KEY'], environment)).toThrow(
+      'Invalid --header-env: expected KEY=ENV_VAR'
+    )
+    expect(() => parseHeaderEnvPairs(['DD-API-KEY='], environment)).toThrow(
+      'Invalid --header-env: expected KEY=ENV_VAR'
     )
   })
 
-  test('allows an empty value', () => {
-    expect(parseHeaderPairs(['key='])).toEqual({ key: '' })
+  test('throws without exposing a missing environment variable value', () => {
+    expect(() => parseHeaderEnvPairs(['Authorization=MISSING_SECRET'], environment)).toThrow(
+      'Environment variable MISSING_SECRET is not set'
+    )
   })
 })
 
@@ -83,18 +115,21 @@ describe('buildCreateDestinationBody', () => {
     })
   })
 
-  test('includes headers only when at least one --header was passed', () => {
+  test('includes headers only when at least one --header-env was passed', () => {
     const body = buildCreateDestinationBody(1, {
       ...baseOptions,
-      header: ['DD-API-KEY=abc123', 'X-Custom=Value=With=Equals'],
+      headerEnv: [
+        'DD-API-KEY=TEMPS_OTEL_TEST_DD_KEY',
+        'X-Custom=TEMPS_OTEL_TEST_CUSTOM',
+      ],
     })
     expect(body.headers).toEqual({
-      'DD-API-KEY': 'abc123',
+      'DD-API-KEY': 'synthetic-dd-secret',
       'X-Custom': 'Value=With=Equals',
     })
   })
 
-  test('omits headers when --header was never passed', () => {
+  test('omits headers when --header-env was never passed', () => {
     const body = buildCreateDestinationBody(1, baseOptions)
     expect(body.headers).toBeUndefined()
   })
@@ -137,14 +172,18 @@ describe('buildUpdateDestinationBody', () => {
     expect(buildUpdateDestinationBody({ vendor: 'honeycomb' })).toEqual({ vendor_preset: 'honeycomb' })
   })
 
-  test('includes headers only when --header was passed at least once', () => {
+  test('includes headers only when --header-env was passed at least once', () => {
     expect(buildUpdateDestinationBody({}).headers).toBeUndefined()
-    expect(buildUpdateDestinationBody({ header: [] }).headers).toBeUndefined()
-    expect(buildUpdateDestinationBody({ header: ['a=1'] }).headers).toEqual({ a: '1' })
+    expect(buildUpdateDestinationBody({ headerEnv: [] }).headers).toBeUndefined()
+    expect(
+      buildUpdateDestinationBody({ headerEnv: ['a=TEMPS_OTEL_TEST_A'] }).headers
+    ).toEqual({ a: '1' })
   })
 
-  test('a header value of exactly "***" round-trips as a literal value (server interprets the sentinel)', () => {
-    expect(buildUpdateDestinationBody({ header: ['token=***'] }).headers).toEqual({ token: '***' })
+  test('a header value of exactly "***" round-trips from the environment', () => {
+    expect(
+      buildUpdateDestinationBody({ headerEnv: ['token=TEMPS_OTEL_TEST_SENTINEL'] }).headers
+    ).toEqual({ token: '***' })
   })
 
   test('includes forward_traces/metrics/logs only when explicitly set', () => {
@@ -169,7 +208,7 @@ describe('buildUpdateDestinationBody', () => {
   test('builds a full partial body with every kind of field mixed', () => {
     const body = buildUpdateDestinationBody({
       name: 'new-name',
-      header: ['a=1', 'b=2'],
+      headerEnv: ['a=TEMPS_OTEL_TEST_A', 'b=TEMPS_OTEL_TEST_B'],
       logs: false,
       disabled: true,
       allowPrivateNetwork: true,
@@ -201,14 +240,17 @@ describe('buildCreateInstanceDefaultBody', () => {
     expect('project_id' in body).toBe(false)
   })
 
-  test('includes headers only when at least one --header was passed', () => {
+  test('includes headers only when at least one --header-env was passed', () => {
     const body = buildCreateInstanceDefaultBody({
       ...baseOptions,
-      header: ['X-Org=acme', 'Authorization=Bearer abc'],
+      headerEnv: [
+        'X-Org=TEMPS_OTEL_TEST_ORG',
+        'Authorization=TEMPS_OTEL_TEST_AUTH',
+      ],
     })
     expect(body.headers).toEqual({
-      'X-Org': 'acme',
-      Authorization: 'Bearer abc',
+      'X-Org': 'synthetic-org',
+      Authorization: 'Bearer synthetic-auth-secret',
     })
   })
 
@@ -242,10 +284,12 @@ describe('buildUpdateInstanceDefaultBody', () => {
     expect('project_id' in body).toBe(false)
   })
 
-  test('a header value of exactly "***" round-trips as a literal value (server interprets the sentinel)', () => {
-    expect(buildUpdateInstanceDefaultBody({ header: ['x-api-key=***'] }).headers).toEqual({
-      'x-api-key': '***',
-    })
+  test('a header value of exactly "***" round-trips from the environment', () => {
+    expect(
+      buildUpdateInstanceDefaultBody({
+        headerEnv: ['x-api-key=TEMPS_OTEL_TEST_SENTINEL'],
+      }).headers
+    ).toEqual({ 'x-api-key': '***' })
   })
 
   test('includes allow_private_network only when explicitly set (true or false)', () => {
@@ -256,7 +300,7 @@ describe('buildUpdateInstanceDefaultBody', () => {
   test('builds a full partial body with every kind of field mixed', () => {
     const body = buildUpdateInstanceDefaultBody({
       name: 'renamed-default',
-      header: ['a=1'],
+      headerEnv: ['a=TEMPS_OTEL_TEST_A'],
       traces: false,
       enabled: true,
     })
@@ -266,5 +310,105 @@ describe('buildUpdateInstanceDefaultBody', () => {
       forward_traces: false,
       enabled: true,
     })
+  })
+})
+
+describe('output sanitization', () => {
+  test('masks every header value, including vendor-specific and arbitrary names', () => {
+    expect(
+      maskHeaders({
+        'x-honeycomb-team': 'synthetic-honeycomb-secret',
+        'X-Org': 'synthetic-client-identifier',
+        Authorization: 'Bearer synthetic-auth-secret',
+      })
+    ).toEqual({
+      'x-honeycomb-team': '***',
+      'X-Org': '***',
+      Authorization: '***',
+    })
+  })
+
+  test('redacts URL credentials, all query values, and fragments', () => {
+    const sanitized = sanitizeUrlForOutput(
+      'https://user:synthetic-password@collector.example.com/otlp?tenant=synthetic-client&sig=synthetic-signature#private'
+    )
+    expect(sanitized).toContain('collector.example.com/otlp')
+    expect(sanitized).not.toContain('user')
+    expect(sanitized).not.toContain('synthetic-password')
+    expect(sanitized).not.toContain('synthetic-client')
+    expect(sanitized).not.toContain('synthetic-signature')
+    expect(sanitized).not.toContain('private')
+  })
+
+  test('sanitizes URLs embedded in error text', () => {
+    const sanitized = sanitizeTextForOutput(
+      'delivery to https://user:synthetic-password@example.com/v1/traces?sig=synthetic-signature failed'
+    )
+    expect(sanitized).toContain('delivery to https://example.com/v1/traces')
+    expect(sanitized).not.toContain('synthetic-password')
+    expect(sanitized).not.toContain('synthetic-signature')
+  })
+
+  test('sanitizes destination objects used by both human and JSON output', () => {
+    const destination: DestinationResponse = {
+      id: 1,
+      project_id: 2,
+      name: 'synthetic-destination',
+      vendor_preset: 'honeycomb',
+      endpoint_url: 'https://collector.example.com/otlp?tenant=synthetic-client',
+      headers: { 'x-honeycomb-team': 'synthetic-honeycomb-secret', 'X-Org': 'synthetic-client' },
+      forward_traces: true,
+      forward_metrics: true,
+      forward_logs: true,
+      enabled: true,
+      allow_private_network: false,
+      last_success_at: null,
+      last_error_at: '2026-08-10T12:00:00Z',
+      last_error: 'request to https://user:synthetic-password@example.com/?sig=synthetic-signature failed',
+      consecutive_failures: 1,
+      status: 'failing',
+      created_at: '2026-08-10T10:00:00Z',
+      updated_at: '2026-08-10T12:00:00Z',
+    }
+
+    const serialized = JSON.stringify(sanitizeDestinationForOutput(destination))
+    expect(serialized).toContain('x-honeycomb-team')
+    expect(serialized).toContain('***')
+    expect(serialized).not.toContain('synthetic-honeycomb-secret')
+    expect(serialized).not.toContain('synthetic-client')
+    expect(serialized).not.toContain('synthetic-password')
+    expect(serialized).not.toContain('synthetic-signature')
+  })
+})
+
+describe('endpoint URL validation', () => {
+  test('allows credential-free HTTP(S) collector URLs', () => {
+    expect(validateEndpointUrl('https://collector.example.com/otlp')).toBe(
+      'https://collector.example.com/otlp'
+    )
+  })
+
+  test('rejects userinfo without echoing it', () => {
+    expect(() =>
+      validateEndpointUrl('https://user:synthetic-password@collector.example.com/otlp')
+    ).toThrow('URL credentials are not allowed')
+  })
+
+  test('rejects query parameters and fragments', () => {
+    expect(() => validateEndpointUrl('https://collector.example.com/otlp?sig=synthetic-secret')).toThrow(
+      'query parameters are not allowed'
+    )
+    expect(() => validateEndpointUrl('https://collector.example.com/otlp#synthetic-secret')).toThrow(
+      'fragments are not allowed'
+    )
+  })
+
+  test('rejects non-HTTP and malformed URLs', () => {
+    expect(() => validateEndpointUrl('file:///tmp/collector')).toThrow(
+      'only HTTP(S) URLs are supported'
+    )
+    expect(() => validateEndpointUrl('not-a-url')).toThrow(
+      'expected an absolute HTTP(S) URL'
+    )
   })
 })

--- a/apps/temps-cli/src/commands/otel-forward/index.test.ts
+++ b/apps/temps-cli/src/commands/otel-forward/index.test.ts
@@ -29,15 +29,15 @@ describe('parseHeaderPairs', () => {
     expect(parseHeaderPairs([])).toEqual({})
   })
 
-  test('throws on a pair with no "="', () => {
+  test('throws on a pair with no "=", without echoing the raw value', () => {
     expect(() => parseHeaderPairs(['not-a-pair'])).toThrow(
-      "Invalid --header 'not-a-pair': expected KEY=VALUE"
+      "Invalid --header: expected KEY=VALUE (got no '=' or an empty key)"
     )
   })
 
-  test('throws on a pair with an empty key (leading "=")', () => {
+  test('throws on a pair with an empty key (leading "="), without echoing the raw value', () => {
     expect(() => parseHeaderPairs(['=value'])).toThrow(
-      "Invalid --header '=value': expected KEY=VALUE"
+      "Invalid --header: expected KEY=VALUE (got no '=' or an empty key)"
     )
   })
 

--- a/apps/temps-cli/src/commands/otel-forward/index.test.ts
+++ b/apps/temps-cli/src/commands/otel-forward/index.test.ts
@@ -4,6 +4,8 @@ import {
   resolveEnabledFlag,
   buildCreateDestinationBody,
   buildUpdateDestinationBody,
+  buildCreateInstanceDefaultBody,
+  buildUpdateInstanceDefaultBody,
 } from './index.js'
 
 describe('parseHeaderPairs', () => {
@@ -178,6 +180,91 @@ describe('buildUpdateDestinationBody', () => {
       forward_logs: false,
       enabled: false,
       allow_private_network: true,
+    })
+  })
+})
+
+describe('buildCreateInstanceDefaultBody', () => {
+  const baseOptions = {
+    name: 'instance-openobserve',
+    vendor: 'generic_otlp',
+    endpointUrl: 'https://openobserve.internal',
+  }
+
+  test('includes only the required fields when nothing else is passed, with no project_id', () => {
+    const body = buildCreateInstanceDefaultBody(baseOptions)
+    expect(body).toEqual({
+      name: 'instance-openobserve',
+      vendor_preset: 'generic_otlp',
+      endpoint_url: 'https://openobserve.internal',
+    })
+    expect('project_id' in body).toBe(false)
+  })
+
+  test('includes headers only when at least one --header was passed', () => {
+    const body = buildCreateInstanceDefaultBody({
+      ...baseOptions,
+      header: ['X-Org=acme', 'Authorization=Bearer abc'],
+    })
+    expect(body.headers).toEqual({
+      'X-Org': 'acme',
+      Authorization: 'Bearer abc',
+    })
+  })
+
+  test('includes forward_traces/metrics/logs only when explicitly set', () => {
+    const body = buildCreateInstanceDefaultBody({ ...baseOptions, metrics: false })
+    expect(body.forward_metrics).toBe(false)
+    expect(body.forward_traces).toBeUndefined()
+    expect(body.forward_logs).toBeUndefined()
+  })
+
+  test('sets enabled from --disabled', () => {
+    expect(buildCreateInstanceDefaultBody({ ...baseOptions, disabled: true }).enabled).toBe(false)
+  })
+
+  test('sets allow_private_network only when the flag is passed', () => {
+    expect(buildCreateInstanceDefaultBody(baseOptions).allow_private_network).toBeUndefined()
+    expect(
+      buildCreateInstanceDefaultBody({ ...baseOptions, allowPrivateNetwork: true }).allow_private_network
+    ).toBe(true)
+  })
+})
+
+describe('buildUpdateInstanceDefaultBody', () => {
+  test('returns an empty object when no fields are passed', () => {
+    expect(buildUpdateInstanceDefaultBody({})).toEqual({})
+  })
+
+  test('includes only the fields that were actually passed, with no project_id ever present', () => {
+    const body = buildUpdateInstanceDefaultBody({ endpointUrl: 'https://example.com' })
+    expect(body).toEqual({ endpoint_url: 'https://example.com' })
+    expect('project_id' in body).toBe(false)
+  })
+
+  test('a header value of exactly "***" round-trips as a literal value (server interprets the sentinel)', () => {
+    expect(buildUpdateInstanceDefaultBody({ header: ['x-api-key=***'] }).headers).toEqual({
+      'x-api-key': '***',
+    })
+  })
+
+  test('includes allow_private_network only when explicitly set (true or false)', () => {
+    expect(buildUpdateInstanceDefaultBody({}).allow_private_network).toBeUndefined()
+    expect(buildUpdateInstanceDefaultBody({ allowPrivateNetwork: false }).allow_private_network).toBe(false)
+  })
+
+  test('builds a full partial body with every kind of field mixed', () => {
+    const body = buildUpdateInstanceDefaultBody({
+      name: 'renamed-default',
+      header: ['a=1'],
+      traces: false,
+      enabled: true,
+    })
+    expect(body).toEqual({
+      name: 'renamed-default',
+      headers: { a: '1' },
+      forward_traces: false,
+      enabled: true,
     })
   })
 })

--- a/apps/temps-cli/src/commands/otel-forward/index.ts
+++ b/apps/temps-cli/src/commands/otel-forward/index.ts
@@ -80,6 +80,59 @@ export interface TestDeliveryResponse {
   error: string | null
 }
 
+// Instance-level default destinations. Same shape as a project destination
+// minus project_id — the relay engine falls back to these for any project
+// with zero enabled destinations of its own.
+
+export interface CreateInstanceDefaultBody {
+  name: string
+  vendor_preset: string
+  endpoint_url: string
+  headers?: Record<string, string>
+  forward_traces?: boolean
+  forward_metrics?: boolean
+  forward_logs?: boolean
+  enabled?: boolean
+  allow_private_network?: boolean
+}
+
+export interface UpdateInstanceDefaultBody {
+  name?: string
+  vendor_preset?: string
+  endpoint_url?: string
+  headers?: Record<string, string>
+  forward_traces?: boolean
+  forward_metrics?: boolean
+  forward_logs?: boolean
+  enabled?: boolean
+  allow_private_network?: boolean
+}
+
+export interface InstanceDefaultResponse {
+  id: number
+  name: string
+  vendor_preset: string
+  endpoint_url: string
+  headers: Record<string, string>
+  forward_traces: boolean
+  forward_metrics: boolean
+  forward_logs: boolean
+  enabled: boolean
+  allow_private_network: boolean
+  last_success_at: string | null
+  last_error_at: string | null
+  last_error: string | null
+  consecutive_failures: number
+  status: DestinationStatus
+  created_at: string
+  updated_at: string
+}
+
+export interface InstanceDefaultListResponse {
+  items: InstanceDefaultResponse[]
+  total: number
+}
+
 const VENDOR_PRESET_HINT = 'datadog, honeycomb, new_relic, grafana_cloud, generic_otlp'
 
 /**
@@ -243,6 +296,83 @@ export function buildUpdateDestinationBody(options: UpdateOptions): UpdateDestin
   return body
 }
 
+interface CreateInstanceDefaultOptions {
+  name: string
+  vendor: string
+  endpointUrl: string
+  header?: string[]
+  traces?: boolean
+  metrics?: boolean
+  logs?: boolean
+  enabled?: boolean
+  disabled?: boolean
+  allowPrivateNetwork?: boolean
+  json?: boolean
+}
+
+interface UpdateInstanceDefaultOptions {
+  name?: string
+  vendor?: string
+  endpointUrl?: string
+  header?: string[]
+  traces?: boolean
+  metrics?: boolean
+  logs?: boolean
+  enabled?: boolean
+  disabled?: boolean
+  allowPrivateNetwork?: boolean
+  json?: boolean
+}
+
+/** Build the POST body from `instance-default create`'s options. Omitted flags are left out entirely so the server applies its own defaults. */
+export function buildCreateInstanceDefaultBody(options: CreateInstanceDefaultOptions): CreateInstanceDefaultBody {
+  const body: CreateInstanceDefaultBody = {
+    name: options.name,
+    vendor_preset: options.vendor,
+    endpoint_url: options.endpointUrl,
+  }
+
+  const headers = parseHeaderPairs(options.header)
+  if (Object.keys(headers).length > 0) {
+    body.headers = headers
+  }
+
+  if (options.traces !== undefined) body.forward_traces = options.traces
+  if (options.metrics !== undefined) body.forward_metrics = options.metrics
+  if (options.logs !== undefined) body.forward_logs = options.logs
+
+  const enabled = resolveEnabledFlag(options)
+  if (enabled !== undefined) body.enabled = enabled
+
+  if (options.allowPrivateNetwork) body.allow_private_network = true
+
+  return body
+}
+
+/** Build the PATCH body from `instance-default update`'s options — only fields the user actually passed are included. */
+export function buildUpdateInstanceDefaultBody(options: UpdateInstanceDefaultOptions): UpdateInstanceDefaultBody {
+  const body: UpdateInstanceDefaultBody = {}
+
+  if (options.name !== undefined) body.name = options.name
+  if (options.vendor !== undefined) body.vendor_preset = options.vendor
+  if (options.endpointUrl !== undefined) body.endpoint_url = options.endpointUrl
+
+  if (options.header && options.header.length > 0) {
+    body.headers = parseHeaderPairs(options.header)
+  }
+
+  if (options.traces !== undefined) body.forward_traces = options.traces
+  if (options.metrics !== undefined) body.forward_metrics = options.metrics
+  if (options.logs !== undefined) body.forward_logs = options.logs
+
+  const enabled = resolveEnabledFlag(options)
+  if (enabled !== undefined) body.enabled = enabled
+
+  if (options.allowPrivateNetwork !== undefined) body.allow_private_network = options.allowPrivateNetwork
+
+  return body
+}
+
 // ============================================================================
 // Display helpers
 // ============================================================================
@@ -279,6 +409,40 @@ function printDestinationDetails(destination: DestinationResponse): void {
   }
   keyValue('Created', formatDate(destination.created_at))
   keyValue('Updated', formatDate(destination.updated_at))
+  newline()
+}
+
+function printInstanceDefaultDetails(instanceDefault: InstanceDefaultResponse): void {
+  newline()
+  header(`${icons.info} ${instanceDefault.name} (instance default)`)
+  keyValue('ID', instanceDefault.id)
+  keyValue('Vendor', instanceDefault.vendor_preset)
+  keyValue('Endpoint', instanceDefault.endpoint_url)
+  keyValue('Status', statusBadge(instanceDefault.status))
+  keyValue('Enabled', instanceDefault.enabled ? colors.success('yes') : colors.muted('no'))
+  keyValue('Forward traces', instanceDefault.forward_traces ? 'yes' : 'no')
+  keyValue('Forward metrics', instanceDefault.forward_metrics ? 'yes' : 'no')
+  keyValue('Forward logs', instanceDefault.forward_logs ? 'yes' : 'no')
+  keyValue('Allow private network', instanceDefault.allow_private_network ? 'yes' : 'no')
+
+  const headerEntries = Object.entries(instanceDefault.headers)
+  if (headerEntries.length > 0) {
+    keyValue(
+      'Headers',
+      headerEntries
+        .map(([k, v]) => `${k}=${isSensitiveHeaderName(k) ? '***' : v}`)
+        .join(', ')
+    )
+  }
+
+  keyValue('Consecutive failures', instanceDefault.consecutive_failures)
+  keyValue('Last success', instanceDefault.last_success_at ? formatDate(instanceDefault.last_success_at) : colors.muted('never'))
+  keyValue('Last error', instanceDefault.last_error_at ? formatDate(instanceDefault.last_error_at) : colors.muted('never'))
+  if (instanceDefault.last_error) {
+    keyValue('Last error detail', instanceDefault.last_error)
+  }
+  keyValue('Created', formatDate(instanceDefault.created_at))
+  keyValue('Updated', formatDate(instanceDefault.updated_at))
   newline()
 }
 
@@ -362,6 +526,84 @@ export function registerOtelForwardCommands(program: Command): void {
     .description('Send a test delivery to an OTel forwarding destination')
     .option('--json', 'Output in JSON format')
     .action(testDestinationAction)
+
+  const instanceDefault = otelForward
+    .command('instance-default')
+    .description(
+      'Manage instance-wide default forwarding destinations — applied automatically to any ' +
+        'project with zero enabled destinations of its own. As soon as a project has one of its ' +
+        'own destinations, instance defaults stop applying to that project.'
+    )
+
+  instanceDefault
+    .command('list')
+    .alias('ls')
+    .description('List instance-wide default forwarding destinations')
+    .option('--json', 'Output in JSON format')
+    .action(listInstanceDefaultsAction)
+
+  instanceDefault
+    .command('create')
+    .description('Create a new instance-wide default forwarding destination')
+    .requiredOption('--name <name>', 'Destination name')
+    .requiredOption('--vendor <preset>', `Vendor preset (${VENDOR_PRESET_HINT})`)
+    .requiredOption('--endpoint-url <url>', 'OTLP-compatible collector endpoint URL')
+    .option('--header <k=v>', 'HTTP header sent with every export (repeatable)', collectHeader, [] as string[])
+    .option('--traces', 'Forward traces (default: true)')
+    .option('--no-traces', 'Do not forward traces')
+    .option('--metrics', 'Forward metrics (default: true)')
+    .option('--no-metrics', 'Do not forward metrics')
+    .option('--logs', 'Forward logs (default: true)')
+    .option('--no-logs', 'Do not forward logs')
+    .option('--enabled', 'Create the destination enabled (default)')
+    .option('--disabled', 'Create the destination disabled')
+    .option('--allow-private-network', 'Allow the endpoint URL to resolve to private/loopback/link-local IPs')
+    .option('--json', 'Output in JSON format')
+    .action(createInstanceDefaultAction)
+
+  instanceDefault
+    .command('show <id>')
+    .description('Show instance default destination details')
+    .option('--json', 'Output in JSON format')
+    .action(showInstanceDefaultAction)
+
+  instanceDefault
+    .command('update <id>')
+    .description('Update an instance default forwarding destination')
+    .option('--name <name>', 'Destination name')
+    .option('--vendor <preset>', `Vendor preset (${VENDOR_PRESET_HINT})`)
+    .option('--endpoint-url <url>', 'OTLP-compatible collector endpoint URL')
+    .option(
+      '--header <k=v>',
+      'HTTP header sent with every export (repeatable); a value of exactly "***" keeps that header\'s existing value',
+      collectHeader,
+      [] as string[]
+    )
+    .option('--traces', 'Forward traces')
+    .option('--no-traces', 'Do not forward traces')
+    .option('--metrics', 'Forward metrics')
+    .option('--no-metrics', 'Do not forward metrics')
+    .option('--logs', 'Forward logs')
+    .option('--no-logs', 'Do not forward logs')
+    .option('--enabled', 'Enable the destination')
+    .option('--disabled', 'Disable the destination')
+    .option('--allow-private-network', 'Allow the endpoint URL to resolve to private/loopback/link-local IPs')
+    .option('--no-allow-private-network', 'Disallow private/loopback/link-local endpoint URLs')
+    .option('--json', 'Output in JSON format')
+    .action(updateInstanceDefaultAction)
+
+  instanceDefault
+    .command('remove <id>')
+    .description('Remove an instance default forwarding destination')
+    .option('-f, --force', 'Skip confirmation')
+    .option('-y, --yes', 'Skip confirmation prompts (alias for --force)')
+    .action(removeInstanceDefaultAction)
+
+  instanceDefault
+    .command('test <id>')
+    .description('Send a test delivery to an instance default forwarding destination')
+    .option('--json', 'Output in JSON format')
+    .action(testInstanceDefaultAction)
 }
 
 // ============================================================================
@@ -592,6 +834,256 @@ async function testDestinationAction(id: string, options: { json?: boolean }): P
     const { data, error, response } = await client.post<TestDeliveryResponse, ProblemDetails>({
       url: 'ee/otel-forward/destinations/{id}/test',
       path: { id: destinationId },
+    })
+    if (error || !data) {
+      throwDestinationError(response, error)
+    }
+    return data
+  })
+
+  if (options.json) {
+    json(result)
+    return
+  }
+
+  newline()
+  const statusSuffix = result.http_status !== null ? ` (HTTP ${result.http_status})` : ''
+  if (result.success) {
+    success(`Test delivery succeeded${statusSuffix}`)
+  } else {
+    warning(`Test delivery failed${statusSuffix}`)
+    if (result.error) {
+      warning(result.error)
+    }
+  }
+  newline()
+}
+
+// ============================================================================
+// Instance default actions
+// ============================================================================
+
+async function listInstanceDefaultsAction(options: { json?: boolean }): Promise<void> {
+  await requireAuth()
+  await setupClient()
+
+  const result = await withSpinner('Fetching instance default forwarding destinations...', async () => {
+    const { data, error, response } = await client.get<InstanceDefaultListResponse, ProblemDetails>({
+      url: 'ee/otel-forward/instance-defaults',
+    })
+    if (error || !data) {
+      throwDestinationError(response, error)
+    }
+    return data
+  })
+
+  if (options.json) {
+    json(result)
+    return
+  }
+
+  newline()
+  header(`${icons.info} Instance Default Forwarding Destinations (${result.total})`)
+
+  if (result.items.length === 0) {
+    info('No instance default forwarding destinations configured')
+    info(
+      'Run: temps otel-forward instance-default create --name <name> --vendor <preset> --endpoint-url <url>'
+    )
+    newline()
+    return
+  }
+
+  const columns: TableColumn<InstanceDefaultResponse>[] = [
+    { header: 'ID', key: 'id', width: 6 },
+    { header: 'Name', key: 'name', color: (v) => colors.bold(v) },
+    { header: 'Vendor', key: 'vendor_preset' },
+    { header: 'Endpoint', key: 'endpoint_url', color: (v) => colors.muted(v) },
+    { header: 'Status', accessor: (d) => d.status, color: (v) => statusBadge(v) },
+    {
+      header: 'Failures',
+      accessor: (d) => d.consecutive_failures.toString(),
+      color: (v) => (parseInt(v, 10) > 0 ? colors.error(v) : colors.muted(v)),
+    },
+  ]
+
+  printTable(result.items, columns, { style: 'minimal' })
+  newline()
+}
+
+async function createInstanceDefaultAction(options: CreateInstanceDefaultOptions): Promise<void> {
+  await requireAuth()
+  await setupClient()
+
+  let body: CreateInstanceDefaultBody
+  try {
+    body = buildCreateInstanceDefaultBody(options)
+  } catch (err) {
+    warning(getErrorMessage(err))
+    return
+  }
+
+  const instanceDefault = await withSpinner(
+    `Creating instance default forwarding destination "${options.name}"...`,
+    async () => {
+      const { data, error, response } = await client.post<InstanceDefaultResponse, ProblemDetails>({
+        url: 'ee/otel-forward/instance-defaults',
+        body,
+      })
+      if (error || !data) {
+        throwDestinationError(response, error)
+      }
+      return data
+    }
+  )
+
+  if (options.json) {
+    json(instanceDefault)
+    return
+  }
+
+  success(`Instance default forwarding destination "${instanceDefault.name}" created`)
+  printInstanceDefaultDetails(instanceDefault)
+}
+
+async function showInstanceDefaultAction(id: string, options: { json?: boolean }): Promise<void> {
+  await requireAuth()
+  await setupClient()
+
+  const instanceDefaultId = parseInt(id, 10)
+  if (isNaN(instanceDefaultId)) {
+    warning('Invalid instance default ID')
+    return
+  }
+
+  const instanceDefault = await withSpinner('Fetching instance default forwarding destination...', async () => {
+    const { data, error, response } = await client.get<InstanceDefaultResponse, ProblemDetails>({
+      url: 'ee/otel-forward/instance-defaults/{id}',
+      path: { id: instanceDefaultId },
+    })
+    if (error || !data) {
+      throwDestinationError(response, error)
+    }
+    return data
+  })
+
+  if (options.json) {
+    json(instanceDefault)
+    return
+  }
+
+  printInstanceDefaultDetails(instanceDefault)
+}
+
+async function updateInstanceDefaultAction(id: string, options: UpdateInstanceDefaultOptions): Promise<void> {
+  await requireAuth()
+  await setupClient()
+
+  const instanceDefaultId = parseInt(id, 10)
+  if (isNaN(instanceDefaultId)) {
+    warning('Invalid instance default ID')
+    return
+  }
+
+  let body: UpdateInstanceDefaultBody
+  try {
+    body = buildUpdateInstanceDefaultBody(options)
+  } catch (err) {
+    warning(getErrorMessage(err))
+    return
+  }
+
+  if (Object.keys(body).length === 0) {
+    warning('No fields to update — pass at least one option (e.g. --name, --endpoint-url, --enabled)')
+    return
+  }
+
+  const instanceDefault = await withSpinner('Updating instance default forwarding destination...', async () => {
+    const { data, error, response } = await client.patch<InstanceDefaultResponse, ProblemDetails>({
+      url: 'ee/otel-forward/instance-defaults/{id}',
+      path: { id: instanceDefaultId },
+      body,
+    })
+    if (error || !data) {
+      throwDestinationError(response, error)
+    }
+    return data
+  })
+
+  if (options.json) {
+    json(instanceDefault)
+    return
+  }
+
+  success(`Instance default forwarding destination #${instanceDefaultId} updated`)
+  printInstanceDefaultDetails(instanceDefault)
+}
+
+async function removeInstanceDefaultAction(id: string, options: { force?: boolean; yes?: boolean }): Promise<void> {
+  await requireAuth()
+  await setupClient()
+
+  const instanceDefaultId = parseInt(id, 10)
+  if (isNaN(instanceDefaultId)) {
+    warning('Invalid instance default ID')
+    return
+  }
+
+  const { data: instanceDefault, error: getError, response: getResponse } = await client.get<
+    InstanceDefaultResponse,
+    ProblemDetails
+  >({
+    url: 'ee/otel-forward/instance-defaults/{id}',
+    path: { id: instanceDefaultId },
+  })
+
+  if (getError || !instanceDefault) {
+    warning(destinationErrorMessage(getResponse, getError))
+    return
+  }
+
+  const skipConfirmation = options.force || options.yes
+
+  if (!skipConfirmation) {
+    const confirmed = await promptConfirm({
+      message:
+        `Remove instance default "${instanceDefault.name}" (${instanceDefault.vendor_preset})? ` +
+        'Any project with no destinations of its own will stop receiving forwarded telemetry.',
+      default: false,
+    })
+    if (!confirmed) {
+      info('Cancelled')
+      return
+    }
+  }
+
+  await withSpinner('Removing instance default forwarding destination...', async () => {
+    const { error, response } = await client.delete<void, ProblemDetails>({
+      url: 'ee/otel-forward/instance-defaults/{id}',
+      path: { id: instanceDefaultId },
+    })
+    if (error) {
+      throwDestinationError(response, error)
+    }
+  })
+
+  success('Instance default forwarding destination removed')
+}
+
+async function testInstanceDefaultAction(id: string, options: { json?: boolean }): Promise<void> {
+  await requireAuth()
+  await setupClient()
+
+  const instanceDefaultId = parseInt(id, 10)
+  if (isNaN(instanceDefaultId)) {
+    warning('Invalid instance default ID')
+    return
+  }
+
+  const result = await withSpinner('Sending test delivery...', async () => {
+    const { data, error, response } = await client.post<TestDeliveryResponse, ProblemDetails>({
+      url: 'ee/otel-forward/instance-defaults/{id}/test',
+      path: { id: instanceDefaultId },
     })
     if (error || !data) {
       throwDestinationError(response, error)

--- a/apps/temps-cli/src/commands/otel-forward/index.ts
+++ b/apps/temps-cli/src/commands/otel-forward/index.ts
@@ -135,17 +135,51 @@ export interface InstanceDefaultListResponse {
 
 const VENDOR_PRESET_HINT = 'datadog, honeycomb, new_relic, grafana_cloud, generic_otlp'
 
-/**
- * The server masks sensitive header values as `"***"` in every response, so
- * this shouldn't ever see a real secret — but the human-readable display
- * path doesn't rely on that alone. Any header whose name looks like it
- * carries a credential is always shown as `***` here regardless of what the
- * response actually contained, so a server-side regression in masking can't
- * turn into a secret printed to a terminal / CI log. `--json` output is a
- * deliberate raw passthrough for scripting and isn't redacted here.
+/** Mask every returned header value. Header names are not a reliable signal
+ * of sensitivity (`x-honeycomb-team`, for example, is an API credential), so
+ * output must be fail-closed for both human-readable and JSON modes.
  */
-function isSensitiveHeaderName(name: string): boolean {
-  return /token|secret|key|password|authorization/i.test(name)
+export function maskHeaders(headers: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(Object.keys(headers).map((name) => [name, '***']))
+}
+
+/** Remove URL credentials and redact every query value before display. */
+export function sanitizeUrlForOutput(value: string): string {
+  try {
+    const url = new URL(value)
+    url.username = ''
+    url.password = ''
+    for (const name of [...url.searchParams.keys()]) {
+      url.searchParams.set(name, '***')
+    }
+    url.hash = ''
+    return url.toString()
+  } catch {
+    return '[invalid URL redacted]'
+  }
+}
+
+/** Sanitize URLs embedded in server and transport error strings. */
+export function sanitizeTextForOutput(value: string): string {
+  return value.replace(/https?:\/\/[^\s"'<>]+/gi, (url) => sanitizeUrlForOutput(url))
+}
+
+export function sanitizeDestinationForOutput<T extends DestinationResponse | InstanceDefaultResponse>(
+  destination: T
+): T {
+  return {
+    ...destination,
+    endpoint_url: sanitizeUrlForOutput(destination.endpoint_url),
+    headers: maskHeaders(destination.headers),
+    last_error: destination.last_error ? sanitizeTextForOutput(destination.last_error) : null,
+  }
+}
+
+function sanitizeTestDeliveryForOutput(result: TestDeliveryResponse): TestDeliveryResponse {
+  return {
+    ...result,
+    error: result.error ? sanitizeTextForOutput(result.error) : null,
+  }
 }
 
 // ============================================================================
@@ -165,7 +199,7 @@ function destinationErrorMessage(response: Response | undefined, error: unknown)
   if (response?.status === 404) {
     return OTEL_FORWARD_UNAVAILABLE_MESSAGE
   }
-  return getErrorMessage(error)
+  return sanitizeTextForOutput(getErrorMessage(error))
 }
 
 function throwDestinationError(response: Response | undefined, error: unknown): never {
@@ -176,34 +210,60 @@ function throwDestinationError(response: Response | undefined, error: unknown): 
 // Option parsing helpers (unit tested)
 // ============================================================================
 
-/** Collect repeatable `--header` values into an array. */
-export function collectHeader(value: string, previous: string[]): string[] {
+/** Collect repeatable `--header-env` references into an array. */
+export function collectHeaderEnv(value: string, previous: string[]): string[] {
   return [...previous, value]
 }
 
 /**
- * Parse repeated `--header KEY=VALUE` options into an object. Values may
- * contain `=` (only the first `=` splits).
+ * Resolve repeated `--header-env KEY=ENV_VAR` options without putting the
+ * credential itself in argv or shell history.
  */
-export function parseHeaderPairs(pairs: string[] | undefined): Record<string, string> {
+export function parseHeaderEnvPairs(
+  pairs: string[] | undefined,
+  environment: NodeJS.ProcessEnv = process.env
+): Record<string, string> {
   const out: Record<string, string> = {}
   if (!pairs) return out
   for (const pair of pairs) {
     const idx = pair.indexOf('=')
-    if (idx <= 0) {
-      // Deliberately doesn't echo the malformed value back: the most likely
-      // way to hit this is pasting a bare credential with no `=` (or a
-      // leading `=`) into --header, and printing it back would put that
-      // credential in the terminal/CI log we're trying to avoid it landing in.
-      throw new Error(
-        "Invalid --header: expected KEY=VALUE (got no '=' or an empty key)"
-      )
+    if (idx <= 0 || idx === pair.length - 1) {
+      throw new Error("Invalid --header-env: expected KEY=ENV_VAR")
     }
     const key = pair.slice(0, idx)
-    const value = pair.slice(idx + 1)
+    const environmentName = pair.slice(idx + 1)
+    const value = environment[environmentName]
+    if (value === undefined) {
+      throw new Error(`Environment variable ${environmentName} is not set`)
+    }
     out[key] = value
   }
   return out
+}
+
+/** Reject endpoint URL components that commonly carry credentials and would
+ * otherwise be exposed through argv, persisted configuration, or errors.
+ */
+export function validateEndpointUrl(value: string): string {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error('Invalid --endpoint-url: expected an absolute HTTP(S) URL')
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('Invalid --endpoint-url: only HTTP(S) URLs are supported')
+  }
+  if (url.username || url.password) {
+    throw new Error('Invalid --endpoint-url: URL credentials are not allowed; use --header-env')
+  }
+  if (url.search) {
+    throw new Error('Invalid --endpoint-url: query parameters are not allowed; use --header-env')
+  }
+  if (url.hash) {
+    throw new Error('Invalid --endpoint-url: fragments are not allowed')
+  }
+  return value
 }
 
 /**
@@ -222,7 +282,7 @@ interface CreateOptions {
   name: string
   vendor: string
   endpointUrl: string
-  header?: string[]
+  headerEnv?: string[]
   traces?: boolean
   metrics?: boolean
   logs?: boolean
@@ -236,7 +296,7 @@ interface UpdateOptions {
   name?: string
   vendor?: string
   endpointUrl?: string
-  header?: string[]
+  headerEnv?: string[]
   traces?: boolean
   metrics?: boolean
   logs?: boolean
@@ -252,10 +312,10 @@ export function buildCreateDestinationBody(projectId: number, options: CreateOpt
     project_id: projectId,
     name: options.name,
     vendor_preset: options.vendor,
-    endpoint_url: options.endpointUrl,
+    endpoint_url: validateEndpointUrl(options.endpointUrl),
   }
 
-  const headers = parseHeaderPairs(options.header)
+  const headers = parseHeaderEnvPairs(options.headerEnv)
   if (Object.keys(headers).length > 0) {
     body.headers = headers
   }
@@ -278,10 +338,10 @@ export function buildUpdateDestinationBody(options: UpdateOptions): UpdateDestin
 
   if (options.name !== undefined) body.name = options.name
   if (options.vendor !== undefined) body.vendor_preset = options.vendor
-  if (options.endpointUrl !== undefined) body.endpoint_url = options.endpointUrl
+  if (options.endpointUrl !== undefined) body.endpoint_url = validateEndpointUrl(options.endpointUrl)
 
-  if (options.header && options.header.length > 0) {
-    body.headers = parseHeaderPairs(options.header)
+  if (options.headerEnv && options.headerEnv.length > 0) {
+    body.headers = parseHeaderEnvPairs(options.headerEnv)
   }
 
   if (options.traces !== undefined) body.forward_traces = options.traces
@@ -300,7 +360,7 @@ interface CreateInstanceDefaultOptions {
   name: string
   vendor: string
   endpointUrl: string
-  header?: string[]
+  headerEnv?: string[]
   traces?: boolean
   metrics?: boolean
   logs?: boolean
@@ -314,7 +374,7 @@ interface UpdateInstanceDefaultOptions {
   name?: string
   vendor?: string
   endpointUrl?: string
-  header?: string[]
+  headerEnv?: string[]
   traces?: boolean
   metrics?: boolean
   logs?: boolean
@@ -329,10 +389,10 @@ export function buildCreateInstanceDefaultBody(options: CreateInstanceDefaultOpt
   const body: CreateInstanceDefaultBody = {
     name: options.name,
     vendor_preset: options.vendor,
-    endpoint_url: options.endpointUrl,
+    endpoint_url: validateEndpointUrl(options.endpointUrl),
   }
 
-  const headers = parseHeaderPairs(options.header)
+  const headers = parseHeaderEnvPairs(options.headerEnv)
   if (Object.keys(headers).length > 0) {
     body.headers = headers
   }
@@ -355,10 +415,10 @@ export function buildUpdateInstanceDefaultBody(options: UpdateInstanceDefaultOpt
 
   if (options.name !== undefined) body.name = options.name
   if (options.vendor !== undefined) body.vendor_preset = options.vendor
-  if (options.endpointUrl !== undefined) body.endpoint_url = options.endpointUrl
+  if (options.endpointUrl !== undefined) body.endpoint_url = validateEndpointUrl(options.endpointUrl)
 
-  if (options.header && options.header.length > 0) {
-    body.headers = parseHeaderPairs(options.header)
+  if (options.headerEnv && options.headerEnv.length > 0) {
+    body.headers = parseHeaderEnvPairs(options.headerEnv)
   }
 
   if (options.traces !== undefined) body.forward_traces = options.traces
@@ -378,71 +438,63 @@ export function buildUpdateInstanceDefaultBody(options: UpdateInstanceDefaultOpt
 // ============================================================================
 
 function printDestinationDetails(destination: DestinationResponse): void {
+  const safeDestination = sanitizeDestinationForOutput(destination)
   newline()
-  header(`${icons.info} ${destination.name}`)
-  keyValue('ID', destination.id)
-  keyValue('Project ID', destination.project_id)
-  keyValue('Vendor', destination.vendor_preset)
-  keyValue('Endpoint', destination.endpoint_url)
-  keyValue('Status', statusBadge(destination.status))
-  keyValue('Enabled', destination.enabled ? colors.success('yes') : colors.muted('no'))
-  keyValue('Forward traces', destination.forward_traces ? 'yes' : 'no')
-  keyValue('Forward metrics', destination.forward_metrics ? 'yes' : 'no')
-  keyValue('Forward logs', destination.forward_logs ? 'yes' : 'no')
-  keyValue('Allow private network', destination.allow_private_network ? 'yes' : 'no')
+  header(`${icons.info} ${safeDestination.name}`)
+  keyValue('ID', safeDestination.id)
+  keyValue('Project ID', safeDestination.project_id)
+  keyValue('Vendor', safeDestination.vendor_preset)
+  keyValue('Endpoint', safeDestination.endpoint_url)
+  keyValue('Status', statusBadge(safeDestination.status))
+  keyValue('Enabled', safeDestination.enabled ? colors.success('yes') : colors.muted('no'))
+  keyValue('Forward traces', safeDestination.forward_traces ? 'yes' : 'no')
+  keyValue('Forward metrics', safeDestination.forward_metrics ? 'yes' : 'no')
+  keyValue('Forward logs', safeDestination.forward_logs ? 'yes' : 'no')
+  keyValue('Allow private network', safeDestination.allow_private_network ? 'yes' : 'no')
 
-  const headerEntries = Object.entries(destination.headers)
+  const headerEntries = Object.entries(safeDestination.headers)
   if (headerEntries.length > 0) {
-    keyValue(
-      'Headers',
-      headerEntries
-        .map(([k, v]) => `${k}=${isSensitiveHeaderName(k) ? '***' : v}`)
-        .join(', ')
-    )
+    keyValue('Headers', headerEntries.map(([k, v]) => `${k}=${v}`).join(', '))
   }
 
-  keyValue('Consecutive failures', destination.consecutive_failures)
-  keyValue('Last success', destination.last_success_at ? formatDate(destination.last_success_at) : colors.muted('never'))
-  keyValue('Last error', destination.last_error_at ? formatDate(destination.last_error_at) : colors.muted('never'))
-  if (destination.last_error) {
-    keyValue('Last error detail', destination.last_error)
+  keyValue('Consecutive failures', safeDestination.consecutive_failures)
+  keyValue('Last success', safeDestination.last_success_at ? formatDate(safeDestination.last_success_at) : colors.muted('never'))
+  keyValue('Last error', safeDestination.last_error_at ? formatDate(safeDestination.last_error_at) : colors.muted('never'))
+  if (safeDestination.last_error) {
+    keyValue('Last error detail', safeDestination.last_error)
   }
-  keyValue('Created', formatDate(destination.created_at))
-  keyValue('Updated', formatDate(destination.updated_at))
+  keyValue('Created', formatDate(safeDestination.created_at))
+  keyValue('Updated', formatDate(safeDestination.updated_at))
   newline()
 }
 
 function printInstanceDefaultDetails(instanceDefault: InstanceDefaultResponse): void {
+  const safeInstanceDefault = sanitizeDestinationForOutput(instanceDefault)
   newline()
-  header(`${icons.info} ${instanceDefault.name} (instance default)`)
-  keyValue('ID', instanceDefault.id)
-  keyValue('Vendor', instanceDefault.vendor_preset)
-  keyValue('Endpoint', instanceDefault.endpoint_url)
-  keyValue('Status', statusBadge(instanceDefault.status))
-  keyValue('Enabled', instanceDefault.enabled ? colors.success('yes') : colors.muted('no'))
-  keyValue('Forward traces', instanceDefault.forward_traces ? 'yes' : 'no')
-  keyValue('Forward metrics', instanceDefault.forward_metrics ? 'yes' : 'no')
-  keyValue('Forward logs', instanceDefault.forward_logs ? 'yes' : 'no')
-  keyValue('Allow private network', instanceDefault.allow_private_network ? 'yes' : 'no')
+  header(`${icons.info} ${safeInstanceDefault.name} (instance default)`)
+  keyValue('ID', safeInstanceDefault.id)
+  keyValue('Vendor', safeInstanceDefault.vendor_preset)
+  keyValue('Endpoint', safeInstanceDefault.endpoint_url)
+  keyValue('Status', statusBadge(safeInstanceDefault.status))
+  keyValue('Enabled', safeInstanceDefault.enabled ? colors.success('yes') : colors.muted('no'))
+  keyValue('Forward traces', safeInstanceDefault.forward_traces ? 'yes' : 'no')
+  keyValue('Forward metrics', safeInstanceDefault.forward_metrics ? 'yes' : 'no')
+  keyValue('Forward logs', safeInstanceDefault.forward_logs ? 'yes' : 'no')
+  keyValue('Allow private network', safeInstanceDefault.allow_private_network ? 'yes' : 'no')
 
-  const headerEntries = Object.entries(instanceDefault.headers)
+  const headerEntries = Object.entries(safeInstanceDefault.headers)
   if (headerEntries.length > 0) {
-    keyValue(
-      'Headers',
-      headerEntries
-        .map(([k, v]) => `${k}=${isSensitiveHeaderName(k) ? '***' : v}`)
-        .join(', ')
-    )
+    keyValue('Headers', headerEntries.map(([k, v]) => `${k}=${v}`).join(', '))
   }
 
-  keyValue('Consecutive failures', instanceDefault.consecutive_failures)
-  keyValue('Last success', instanceDefault.last_success_at ? formatDate(instanceDefault.last_success_at) : colors.muted('never'))
-  keyValue('Last error', instanceDefault.last_error_at ? formatDate(instanceDefault.last_error_at) : colors.muted('never'))
-  if (instanceDefault.last_error) {
-    keyValue('Last error detail', instanceDefault.last_error)
+  keyValue('Consecutive failures', safeInstanceDefault.consecutive_failures)
+  keyValue('Last success', safeInstanceDefault.last_success_at ? formatDate(safeInstanceDefault.last_success_at) : colors.muted('never'))
+  keyValue('Last error', safeInstanceDefault.last_error_at ? formatDate(safeInstanceDefault.last_error_at) : colors.muted('never'))
+  if (safeInstanceDefault.last_error) {
+    keyValue('Last error detail', safeInstanceDefault.last_error)
   }
-  keyValue('Created', formatDate(instanceDefault.created_at))
-  keyValue('Updated', formatDate(instanceDefault.updated_at))
+  keyValue('Created', formatDate(safeInstanceDefault.created_at))
+  keyValue('Updated', formatDate(safeInstanceDefault.updated_at))
   newline()
 }
 
@@ -470,7 +522,7 @@ export function registerOtelForwardCommands(program: Command): void {
     .requiredOption('--name <name>', 'Destination name')
     .requiredOption('--vendor <preset>', `Vendor preset (${VENDOR_PRESET_HINT})`)
     .requiredOption('--endpoint-url <url>', 'OTLP-compatible collector endpoint URL')
-    .option('--header <k=v>', 'HTTP header sent with every export (repeatable)', collectHeader, [] as string[])
+    .option('--header-env <k=env>', 'HTTP header sourced from an environment variable (repeatable)', collectHeaderEnv, [] as string[])
     .option('--traces', 'Forward traces (default: true)')
     .option('--no-traces', 'Do not forward traces')
     .option('--metrics', 'Forward metrics (default: true)')
@@ -496,9 +548,9 @@ export function registerOtelForwardCommands(program: Command): void {
     .option('--vendor <preset>', `Vendor preset (${VENDOR_PRESET_HINT})`)
     .option('--endpoint-url <url>', 'OTLP-compatible collector endpoint URL')
     .option(
-      '--header <k=v>',
-      'HTTP header sent with every export (repeatable); a value of exactly "***" keeps that header\'s existing value',
-      collectHeader,
+      '--header-env <k=env>',
+      'HTTP header sourced from an environment variable (repeatable)',
+      collectHeaderEnv,
       [] as string[]
     )
     .option('--traces', 'Forward traces')
@@ -548,7 +600,7 @@ export function registerOtelForwardCommands(program: Command): void {
     .requiredOption('--name <name>', 'Destination name')
     .requiredOption('--vendor <preset>', `Vendor preset (${VENDOR_PRESET_HINT})`)
     .requiredOption('--endpoint-url <url>', 'OTLP-compatible collector endpoint URL')
-    .option('--header <k=v>', 'HTTP header sent with every export (repeatable)', collectHeader, [] as string[])
+    .option('--header-env <k=env>', 'HTTP header sourced from an environment variable (repeatable)', collectHeaderEnv, [] as string[])
     .option('--traces', 'Forward traces (default: true)')
     .option('--no-traces', 'Do not forward traces')
     .option('--metrics', 'Forward metrics (default: true)')
@@ -574,9 +626,9 @@ export function registerOtelForwardCommands(program: Command): void {
     .option('--vendor <preset>', `Vendor preset (${VENDOR_PRESET_HINT})`)
     .option('--endpoint-url <url>', 'OTLP-compatible collector endpoint URL')
     .option(
-      '--header <k=v>',
-      'HTTP header sent with every export (repeatable); a value of exactly "***" keeps that header\'s existing value',
-      collectHeader,
+      '--header-env <k=env>',
+      'HTTP header sourced from an environment variable (repeatable)',
+      collectHeaderEnv,
       [] as string[]
     )
     .option('--traces', 'Forward traces')
@@ -630,16 +682,20 @@ async function listDestinationsAction(options: { projectId: string; json?: boole
     }
     return data
   })
+  const safeResult: DestinationListResponse = {
+    ...result,
+    items: result.items.map(sanitizeDestinationForOutput),
+  }
 
   if (options.json) {
-    json(result)
+    json(safeResult)
     return
   }
 
   newline()
-  header(`${icons.info} OTel Forwarding Destinations for Project ${projectId} (${result.total})`)
+  header(`${icons.info} OTel Forwarding Destinations for Project ${projectId} (${safeResult.total})`)
 
-  if (result.items.length === 0) {
+  if (safeResult.items.length === 0) {
     info('No OTel forwarding destinations configured')
     info('Run: temps otel-forward create --project-id ' + projectId + ' --name <name> --vendor <preset> --endpoint-url <url>')
     newline()
@@ -659,7 +715,7 @@ async function listDestinationsAction(options: { projectId: string; json?: boole
     },
   ]
 
-  printTable(result.items, columns, { style: 'minimal' })
+  printTable(safeResult.items, columns, { style: 'minimal' })
   newline()
 }
 
@@ -693,7 +749,7 @@ async function createDestinationAction(options: CreateOptions): Promise<void> {
   })
 
   if (options.json) {
-    json(destination)
+    json(sanitizeDestinationForOutput(destination))
     return
   }
 
@@ -723,7 +779,7 @@ async function showDestinationAction(id: string, options: { json?: boolean }): P
   })
 
   if (options.json) {
-    json(destination)
+    json(sanitizeDestinationForOutput(destination))
     return
   }
 
@@ -766,7 +822,7 @@ async function updateDestinationAction(id: string, options: UpdateOptions): Prom
   })
 
   if (options.json) {
-    json(destination)
+    json(sanitizeDestinationForOutput(destination))
     return
   }
 
@@ -840,20 +896,21 @@ async function testDestinationAction(id: string, options: { json?: boolean }): P
     }
     return data
   })
+  const safeResult = sanitizeTestDeliveryForOutput(result)
 
   if (options.json) {
-    json(result)
+    json(safeResult)
     return
   }
 
   newline()
-  const statusSuffix = result.http_status !== null ? ` (HTTP ${result.http_status})` : ''
-  if (result.success) {
+  const statusSuffix = safeResult.http_status !== null ? ` (HTTP ${safeResult.http_status})` : ''
+  if (safeResult.success) {
     success(`Test delivery succeeded${statusSuffix}`)
   } else {
     warning(`Test delivery failed${statusSuffix}`)
-    if (result.error) {
-      warning(result.error)
+    if (safeResult.error) {
+      warning(safeResult.error)
     }
   }
   newline()
@@ -876,16 +933,20 @@ async function listInstanceDefaultsAction(options: { json?: boolean }): Promise<
     }
     return data
   })
+  const safeResult: InstanceDefaultListResponse = {
+    ...result,
+    items: result.items.map(sanitizeDestinationForOutput),
+  }
 
   if (options.json) {
-    json(result)
+    json(safeResult)
     return
   }
 
   newline()
-  header(`${icons.info} Instance Default Forwarding Destinations (${result.total})`)
+  header(`${icons.info} Instance Default Forwarding Destinations (${safeResult.total})`)
 
-  if (result.items.length === 0) {
+  if (safeResult.items.length === 0) {
     info('No instance default forwarding destinations configured')
     info(
       'Run: temps otel-forward instance-default create --name <name> --vendor <preset> --endpoint-url <url>'
@@ -907,7 +968,7 @@ async function listInstanceDefaultsAction(options: { json?: boolean }): Promise<
     },
   ]
 
-  printTable(result.items, columns, { style: 'minimal' })
+  printTable(safeResult.items, columns, { style: 'minimal' })
   newline()
 }
 
@@ -938,7 +999,7 @@ async function createInstanceDefaultAction(options: CreateInstanceDefaultOptions
   )
 
   if (options.json) {
-    json(instanceDefault)
+    json(sanitizeDestinationForOutput(instanceDefault))
     return
   }
 
@@ -968,7 +1029,7 @@ async function showInstanceDefaultAction(id: string, options: { json?: boolean }
   })
 
   if (options.json) {
-    json(instanceDefault)
+    json(sanitizeDestinationForOutput(instanceDefault))
     return
   }
 
@@ -1011,7 +1072,7 @@ async function updateInstanceDefaultAction(id: string, options: UpdateInstanceDe
   })
 
   if (options.json) {
-    json(instanceDefault)
+    json(sanitizeDestinationForOutput(instanceDefault))
     return
   }
 
@@ -1090,20 +1151,21 @@ async function testInstanceDefaultAction(id: string, options: { json?: boolean }
     }
     return data
   })
+  const safeResult = sanitizeTestDeliveryForOutput(result)
 
   if (options.json) {
-    json(result)
+    json(safeResult)
     return
   }
 
   newline()
-  const statusSuffix = result.http_status !== null ? ` (HTTP ${result.http_status})` : ''
-  if (result.success) {
+  const statusSuffix = safeResult.http_status !== null ? ` (HTTP ${safeResult.http_status})` : ''
+  if (safeResult.success) {
     success(`Test delivery succeeded${statusSuffix}`)
   } else {
     warning(`Test delivery failed${statusSuffix}`)
-    if (result.error) {
-      warning(result.error)
+    if (safeResult.error) {
+      warning(safeResult.error)
     }
   }
   newline()

--- a/apps/temps-cli/src/commands/otel-forward/index.ts
+++ b/apps/temps-cli/src/commands/otel-forward/index.ts
@@ -1,0 +1,593 @@
+import type { Command } from 'commander'
+import { requireAuth } from '../../config/store.js'
+import { setupClient, client, getErrorMessage } from '../../lib/api-client.js'
+import type { ProblemDetails } from '../../api/types.gen.js'
+import { withSpinner } from '../../ui/spinner.js'
+import { printTable, statusBadge, type TableColumn } from '../../ui/table.js'
+import { promptConfirm } from '../../ui/prompts.js'
+import {
+  newline, header, icons, json, colors, success, info, warning,
+  keyValue, formatDate,
+} from '../../ui/output.js'
+
+// ============================================================================
+// Hand-written request/response shapes
+// ============================================================================
+//
+// This feature is implemented by a plugin crate that is not part of this
+// repository, so its schema does not exist in `openapi.json` and must never
+// be added there (see apps/temps-cli/CLAUDE.md). These interfaces are
+// hand-maintained to mirror the plugin's serde structs exactly — keep them in
+// sync by hand if that shape ever changes.
+
+export interface CreateDestinationBody {
+  project_id: number
+  name: string
+  vendor_preset: string
+  endpoint_url: string
+  headers?: Record<string, string>
+  forward_traces?: boolean
+  forward_metrics?: boolean
+  forward_logs?: boolean
+  enabled?: boolean
+  allow_private_network?: boolean
+}
+
+export interface UpdateDestinationBody {
+  name?: string
+  vendor_preset?: string
+  endpoint_url?: string
+  headers?: Record<string, string>
+  forward_traces?: boolean
+  forward_metrics?: boolean
+  forward_logs?: boolean
+  enabled?: boolean
+  allow_private_network?: boolean
+}
+
+export type DestinationStatus = 'healthy' | 'degraded' | 'failing' | 'disabled' | 'never_delivered'
+
+export interface DestinationResponse {
+  id: number
+  project_id: number
+  name: string
+  vendor_preset: string
+  endpoint_url: string
+  headers: Record<string, string>
+  forward_traces: boolean
+  forward_metrics: boolean
+  forward_logs: boolean
+  enabled: boolean
+  allow_private_network: boolean
+  last_success_at: string | null
+  last_error_at: string | null
+  last_error: string | null
+  consecutive_failures: number
+  status: DestinationStatus
+  created_at: string
+  updated_at: string
+}
+
+export interface DestinationListResponse {
+  items: DestinationResponse[]
+  total: number
+}
+
+export interface TestDeliveryResponse {
+  success: boolean
+  http_status: number | null
+  error: string | null
+}
+
+const VENDOR_PRESET_HINT = 'datadog, honeycomb, new_relic, grafana_cloud, generic_otlp'
+
+// ============================================================================
+// 404 handling
+// ============================================================================
+//
+// This routes through a plugin that may not be installed/enabled on a given
+// server. On a plain OSS instance (or one without this plugin), every one of
+// these routes 404s because the route simply doesn't exist — that's a
+// deliberate case to handle clearly rather than surface as a generic error.
+
+const OTEL_FORWARD_UNAVAILABLE_MESSAGE =
+  "OTel forwarding isn't available on this server — the endpoint returned 404. " +
+  'This feature may require a plugin that isn\'t installed on this Temps instance.'
+
+function destinationErrorMessage(response: Response | undefined, error: unknown): string {
+  if (response?.status === 404) {
+    return OTEL_FORWARD_UNAVAILABLE_MESSAGE
+  }
+  return getErrorMessage(error)
+}
+
+function throwDestinationError(response: Response | undefined, error: unknown): never {
+  throw new Error(destinationErrorMessage(response, error))
+}
+
+// ============================================================================
+// Option parsing helpers (unit tested)
+// ============================================================================
+
+/** Collect repeatable `--header` values into an array. */
+export function collectHeader(value: string, previous: string[]): string[] {
+  return [...previous, value]
+}
+
+/**
+ * Parse repeated `--header KEY=VALUE` options into an object. Values may
+ * contain `=` (only the first `=` splits).
+ */
+export function parseHeaderPairs(pairs: string[] | undefined): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (!pairs) return out
+  for (const pair of pairs) {
+    const idx = pair.indexOf('=')
+    if (idx <= 0) {
+      throw new Error(`Invalid --header '${pair}': expected KEY=VALUE`)
+    }
+    const key = pair.slice(0, idx)
+    const value = pair.slice(idx + 1)
+    out[key] = value
+  }
+  return out
+}
+
+/**
+ * Resolve the tri-state `enabled` flag from the separate `--enabled` /
+ * `--disabled` commander options. Returns `undefined` when neither was
+ * passed, so callers can tell "not specified" apart from "explicitly false".
+ */
+export function resolveEnabledFlag(options: { enabled?: boolean; disabled?: boolean }): boolean | undefined {
+  if (options.disabled) return false
+  if (options.enabled) return true
+  return undefined
+}
+
+interface CreateOptions {
+  projectId: string
+  name: string
+  vendor: string
+  endpointUrl: string
+  header?: string[]
+  traces?: boolean
+  metrics?: boolean
+  logs?: boolean
+  enabled?: boolean
+  disabled?: boolean
+  allowPrivateNetwork?: boolean
+  json?: boolean
+}
+
+interface UpdateOptions {
+  name?: string
+  vendor?: string
+  endpointUrl?: string
+  header?: string[]
+  traces?: boolean
+  metrics?: boolean
+  logs?: boolean
+  enabled?: boolean
+  disabled?: boolean
+  allowPrivateNetwork?: boolean
+  json?: boolean
+}
+
+/** Build the POST body from `create`'s options. Omitted flags are left out entirely so the server applies its own defaults. */
+export function buildCreateDestinationBody(projectId: number, options: CreateOptions): CreateDestinationBody {
+  const body: CreateDestinationBody = {
+    project_id: projectId,
+    name: options.name,
+    vendor_preset: options.vendor,
+    endpoint_url: options.endpointUrl,
+  }
+
+  const headers = parseHeaderPairs(options.header)
+  if (Object.keys(headers).length > 0) {
+    body.headers = headers
+  }
+
+  if (options.traces !== undefined) body.forward_traces = options.traces
+  if (options.metrics !== undefined) body.forward_metrics = options.metrics
+  if (options.logs !== undefined) body.forward_logs = options.logs
+
+  const enabled = resolveEnabledFlag(options)
+  if (enabled !== undefined) body.enabled = enabled
+
+  if (options.allowPrivateNetwork) body.allow_private_network = true
+
+  return body
+}
+
+/** Build the PATCH body from `update`'s options — only fields the user actually passed are included. */
+export function buildUpdateDestinationBody(options: UpdateOptions): UpdateDestinationBody {
+  const body: UpdateDestinationBody = {}
+
+  if (options.name !== undefined) body.name = options.name
+  if (options.vendor !== undefined) body.vendor_preset = options.vendor
+  if (options.endpointUrl !== undefined) body.endpoint_url = options.endpointUrl
+
+  if (options.header && options.header.length > 0) {
+    body.headers = parseHeaderPairs(options.header)
+  }
+
+  if (options.traces !== undefined) body.forward_traces = options.traces
+  if (options.metrics !== undefined) body.forward_metrics = options.metrics
+  if (options.logs !== undefined) body.forward_logs = options.logs
+
+  const enabled = resolveEnabledFlag(options)
+  if (enabled !== undefined) body.enabled = enabled
+
+  if (options.allowPrivateNetwork !== undefined) body.allow_private_network = options.allowPrivateNetwork
+
+  return body
+}
+
+// ============================================================================
+// Display helpers
+// ============================================================================
+
+function printDestinationDetails(destination: DestinationResponse): void {
+  newline()
+  header(`${icons.info} ${destination.name}`)
+  keyValue('ID', destination.id)
+  keyValue('Project ID', destination.project_id)
+  keyValue('Vendor', destination.vendor_preset)
+  keyValue('Endpoint', destination.endpoint_url)
+  keyValue('Status', statusBadge(destination.status))
+  keyValue('Enabled', destination.enabled ? colors.success('yes') : colors.muted('no'))
+  keyValue('Forward traces', destination.forward_traces ? 'yes' : 'no')
+  keyValue('Forward metrics', destination.forward_metrics ? 'yes' : 'no')
+  keyValue('Forward logs', destination.forward_logs ? 'yes' : 'no')
+  keyValue('Allow private network', destination.allow_private_network ? 'yes' : 'no')
+
+  const headerEntries = Object.entries(destination.headers)
+  if (headerEntries.length > 0) {
+    keyValue('Headers', headerEntries.map(([k, v]) => `${k}=${v}`).join(', '))
+  }
+
+  keyValue('Consecutive failures', destination.consecutive_failures)
+  keyValue('Last success', destination.last_success_at ? formatDate(destination.last_success_at) : colors.muted('never'))
+  keyValue('Last error', destination.last_error_at ? formatDate(destination.last_error_at) : colors.muted('never'))
+  if (destination.last_error) {
+    keyValue('Last error detail', destination.last_error)
+  }
+  keyValue('Created', formatDate(destination.created_at))
+  keyValue('Updated', formatDate(destination.updated_at))
+  newline()
+}
+
+// ============================================================================
+// Commander wiring
+// ============================================================================
+
+export function registerOtelForwardCommands(program: Command): void {
+  const otelForward = program
+    .command('otel-forward')
+    .description('Manage OTel forwarding destinations that relay ingested traces, metrics, and logs to an external OTLP-compatible collector')
+
+  otelForward
+    .command('list')
+    .alias('ls')
+    .description('List OTel forwarding destinations for a project')
+    .requiredOption('--project-id <id>', 'Project ID')
+    .option('--json', 'Output in JSON format')
+    .action(listDestinationsAction)
+
+  otelForward
+    .command('create')
+    .description('Create a new OTel forwarding destination')
+    .requiredOption('--project-id <id>', 'Project ID')
+    .requiredOption('--name <name>', 'Destination name')
+    .requiredOption('--vendor <preset>', `Vendor preset (${VENDOR_PRESET_HINT})`)
+    .requiredOption('--endpoint-url <url>', 'OTLP-compatible collector endpoint URL')
+    .option('--header <k=v>', 'HTTP header sent with every export (repeatable)', collectHeader, [] as string[])
+    .option('--traces', 'Forward traces (default: true)')
+    .option('--no-traces', 'Do not forward traces')
+    .option('--metrics', 'Forward metrics (default: true)')
+    .option('--no-metrics', 'Do not forward metrics')
+    .option('--logs', 'Forward logs (default: true)')
+    .option('--no-logs', 'Do not forward logs')
+    .option('--enabled', 'Create the destination enabled (default)')
+    .option('--disabled', 'Create the destination disabled')
+    .option('--allow-private-network', 'Allow the endpoint URL to resolve to private/loopback/link-local IPs')
+    .option('--json', 'Output in JSON format')
+    .action(createDestinationAction)
+
+  otelForward
+    .command('show <id>')
+    .description('Show OTel forwarding destination details')
+    .option('--json', 'Output in JSON format')
+    .action(showDestinationAction)
+
+  otelForward
+    .command('update <id>')
+    .description('Update an OTel forwarding destination')
+    .option('--name <name>', 'Destination name')
+    .option('--vendor <preset>', `Vendor preset (${VENDOR_PRESET_HINT})`)
+    .option('--endpoint-url <url>', 'OTLP-compatible collector endpoint URL')
+    .option(
+      '--header <k=v>',
+      'HTTP header sent with every export (repeatable); a value of exactly "***" keeps that header\'s existing value',
+      collectHeader,
+      [] as string[]
+    )
+    .option('--traces', 'Forward traces')
+    .option('--no-traces', 'Do not forward traces')
+    .option('--metrics', 'Forward metrics')
+    .option('--no-metrics', 'Do not forward metrics')
+    .option('--logs', 'Forward logs')
+    .option('--no-logs', 'Do not forward logs')
+    .option('--enabled', 'Enable the destination')
+    .option('--disabled', 'Disable the destination')
+    .option('--allow-private-network', 'Allow the endpoint URL to resolve to private/loopback/link-local IPs')
+    .option('--no-allow-private-network', 'Disallow private/loopback/link-local endpoint URLs')
+    .option('--json', 'Output in JSON format')
+    .action(updateDestinationAction)
+
+  otelForward
+    .command('remove <id>')
+    .description('Remove an OTel forwarding destination')
+    .option('-f, --force', 'Skip confirmation')
+    .option('-y, --yes', 'Skip confirmation prompts (alias for --force)')
+    .action(removeDestinationAction)
+
+  otelForward
+    .command('test <id>')
+    .description('Send a test delivery to an OTel forwarding destination')
+    .option('--json', 'Output in JSON format')
+    .action(testDestinationAction)
+}
+
+// ============================================================================
+// Actions
+// ============================================================================
+
+async function listDestinationsAction(options: { projectId: string; json?: boolean }): Promise<void> {
+  await requireAuth()
+  await setupClient()
+
+  const projectId = parseInt(options.projectId, 10)
+  if (isNaN(projectId)) {
+    warning('Invalid project ID')
+    return
+  }
+
+  const result = await withSpinner('Fetching OTel forwarding destinations...', async () => {
+    const { data, error, response } = await client.get<DestinationListResponse, ProblemDetails>({
+      url: 'ee/otel-forward/destinations',
+      query: { project_id: projectId },
+    })
+    if (error || !data) {
+      throwDestinationError(response, error)
+    }
+    return data
+  })
+
+  if (options.json) {
+    json(result)
+    return
+  }
+
+  newline()
+  header(`${icons.info} OTel Forwarding Destinations for Project ${projectId} (${result.total})`)
+
+  if (result.items.length === 0) {
+    info('No OTel forwarding destinations configured')
+    info('Run: temps otel-forward create --project-id ' + projectId + ' --name <name> --vendor <preset> --endpoint-url <url>')
+    newline()
+    return
+  }
+
+  const columns: TableColumn<DestinationResponse>[] = [
+    { header: 'ID', key: 'id', width: 6 },
+    { header: 'Name', key: 'name', color: (v) => colors.bold(v) },
+    { header: 'Vendor', key: 'vendor_preset' },
+    { header: 'Endpoint', key: 'endpoint_url', color: (v) => colors.muted(v) },
+    { header: 'Status', accessor: (d) => d.status, color: (v) => statusBadge(v) },
+    {
+      header: 'Failures',
+      accessor: (d) => d.consecutive_failures.toString(),
+      color: (v) => (parseInt(v, 10) > 0 ? colors.error(v) : colors.muted(v)),
+    },
+  ]
+
+  printTable(result.items, columns, { style: 'minimal' })
+  newline()
+}
+
+async function createDestinationAction(options: CreateOptions): Promise<void> {
+  await requireAuth()
+  await setupClient()
+
+  const projectId = parseInt(options.projectId, 10)
+  if (isNaN(projectId)) {
+    warning('Invalid project ID')
+    return
+  }
+
+  let body: CreateDestinationBody
+  try {
+    body = buildCreateDestinationBody(projectId, options)
+  } catch (err) {
+    warning(getErrorMessage(err))
+    return
+  }
+
+  const destination = await withSpinner(`Creating OTel forwarding destination "${options.name}"...`, async () => {
+    const { data, error, response } = await client.post<DestinationResponse, ProblemDetails>({
+      url: 'ee/otel-forward/destinations',
+      body,
+    })
+    if (error || !data) {
+      throwDestinationError(response, error)
+    }
+    return data
+  })
+
+  if (options.json) {
+    json(destination)
+    return
+  }
+
+  success(`OTel forwarding destination "${destination.name}" created`)
+  printDestinationDetails(destination)
+}
+
+async function showDestinationAction(id: string, options: { json?: boolean }): Promise<void> {
+  await requireAuth()
+  await setupClient()
+
+  const destinationId = parseInt(id, 10)
+  if (isNaN(destinationId)) {
+    warning('Invalid destination ID')
+    return
+  }
+
+  const destination = await withSpinner('Fetching OTel forwarding destination...', async () => {
+    const { data, error, response } = await client.get<DestinationResponse, ProblemDetails>({
+      url: 'ee/otel-forward/destinations/{id}',
+      path: { id: destinationId },
+    })
+    if (error || !data) {
+      throwDestinationError(response, error)
+    }
+    return data
+  })
+
+  if (options.json) {
+    json(destination)
+    return
+  }
+
+  printDestinationDetails(destination)
+}
+
+async function updateDestinationAction(id: string, options: UpdateOptions): Promise<void> {
+  await requireAuth()
+  await setupClient()
+
+  const destinationId = parseInt(id, 10)
+  if (isNaN(destinationId)) {
+    warning('Invalid destination ID')
+    return
+  }
+
+  let body: UpdateDestinationBody
+  try {
+    body = buildUpdateDestinationBody(options)
+  } catch (err) {
+    warning(getErrorMessage(err))
+    return
+  }
+
+  if (Object.keys(body).length === 0) {
+    warning('No fields to update — pass at least one option (e.g. --name, --endpoint-url, --enabled)')
+    return
+  }
+
+  const destination = await withSpinner('Updating OTel forwarding destination...', async () => {
+    const { data, error, response } = await client.patch<DestinationResponse, ProblemDetails>({
+      url: 'ee/otel-forward/destinations/{id}',
+      path: { id: destinationId },
+      body,
+    })
+    if (error || !data) {
+      throwDestinationError(response, error)
+    }
+    return data
+  })
+
+  if (options.json) {
+    json(destination)
+    return
+  }
+
+  success(`OTel forwarding destination #${destinationId} updated`)
+  printDestinationDetails(destination)
+}
+
+async function removeDestinationAction(id: string, options: { force?: boolean; yes?: boolean }): Promise<void> {
+  await requireAuth()
+  await setupClient()
+
+  const destinationId = parseInt(id, 10)
+  if (isNaN(destinationId)) {
+    warning('Invalid destination ID')
+    return
+  }
+
+  const { data: destination, error: getError, response: getResponse } = await client.get<DestinationResponse, ProblemDetails>({
+    url: 'ee/otel-forward/destinations/{id}',
+    path: { id: destinationId },
+  })
+
+  if (getError || !destination) {
+    warning(destinationErrorMessage(getResponse, getError))
+    return
+  }
+
+  const skipConfirmation = options.force || options.yes
+
+  if (!skipConfirmation) {
+    const confirmed = await promptConfirm({
+      message: `Remove OTel forwarding destination "${destination.name}" (${destination.vendor_preset})?`,
+      default: false,
+    })
+    if (!confirmed) {
+      info('Cancelled')
+      return
+    }
+  }
+
+  await withSpinner('Removing OTel forwarding destination...', async () => {
+    const { error, response } = await client.delete<void, ProblemDetails>({
+      url: 'ee/otel-forward/destinations/{id}',
+      path: { id: destinationId },
+    })
+    if (error) {
+      throwDestinationError(response, error)
+    }
+  })
+
+  success('OTel forwarding destination removed')
+}
+
+async function testDestinationAction(id: string, options: { json?: boolean }): Promise<void> {
+  await requireAuth()
+  await setupClient()
+
+  const destinationId = parseInt(id, 10)
+  if (isNaN(destinationId)) {
+    warning('Invalid destination ID')
+    return
+  }
+
+  const result = await withSpinner('Sending test delivery...', async () => {
+    const { data, error, response } = await client.post<TestDeliveryResponse, ProblemDetails>({
+      url: 'ee/otel-forward/destinations/{id}/test',
+      path: { id: destinationId },
+    })
+    if (error || !data) {
+      throwDestinationError(response, error)
+    }
+    return data
+  })
+
+  if (options.json) {
+    json(result)
+    return
+  }
+
+  newline()
+  const statusSuffix = result.http_status !== null ? ` (HTTP ${result.http_status})` : ''
+  if (result.success) {
+    success(`Test delivery succeeded${statusSuffix}`)
+  } else {
+    warning(`Test delivery failed${statusSuffix}`)
+    if (result.error) {
+      warning(result.error)
+    }
+  }
+  newline()
+}

--- a/apps/temps-cli/src/commands/otel-forward/index.ts
+++ b/apps/temps-cli/src/commands/otel-forward/index.ts
@@ -16,9 +16,10 @@ import {
 //
 // This feature is implemented by a plugin crate that is not part of this
 // repository, so its schema does not exist in `openapi.json` and must never
-// be added there (see apps/temps-cli/CLAUDE.md). These interfaces are
-// hand-maintained to mirror the plugin's serde structs exactly — keep them in
-// sync by hand if that shape ever changes.
+// be added there (see "Regenerating the OpenAPI clients" in the root
+// CLAUDE.md). These interfaces are hand-maintained to mirror the plugin's
+// serde structs exactly — keep them in sync by hand if that shape ever
+// changes.
 
 export interface CreateDestinationBody {
   project_id: number
@@ -81,6 +82,19 @@ export interface TestDeliveryResponse {
 
 const VENDOR_PRESET_HINT = 'datadog, honeycomb, new_relic, grafana_cloud, generic_otlp'
 
+/**
+ * The server masks sensitive header values as `"***"` in every response, so
+ * this shouldn't ever see a real secret — but the human-readable display
+ * path doesn't rely on that alone. Any header whose name looks like it
+ * carries a credential is always shown as `***` here regardless of what the
+ * response actually contained, so a server-side regression in masking can't
+ * turn into a secret printed to a terminal / CI log. `--json` output is a
+ * deliberate raw passthrough for scripting and isn't redacted here.
+ */
+function isSensitiveHeaderName(name: string): boolean {
+  return /token|secret|key|password|authorization/i.test(name)
+}
+
 // ============================================================================
 // 404 handling
 // ============================================================================
@@ -124,7 +138,13 @@ export function parseHeaderPairs(pairs: string[] | undefined): Record<string, st
   for (const pair of pairs) {
     const idx = pair.indexOf('=')
     if (idx <= 0) {
-      throw new Error(`Invalid --header '${pair}': expected KEY=VALUE`)
+      // Deliberately doesn't echo the malformed value back: the most likely
+      // way to hit this is pasting a bare credential with no `=` (or a
+      // leading `=`) into --header, and printing it back would put that
+      // credential in the terminal/CI log we're trying to avoid it landing in.
+      throw new Error(
+        "Invalid --header: expected KEY=VALUE (got no '=' or an empty key)"
+      )
     }
     const key = pair.slice(0, idx)
     const value = pair.slice(idx + 1)
@@ -243,7 +263,12 @@ function printDestinationDetails(destination: DestinationResponse): void {
 
   const headerEntries = Object.entries(destination.headers)
   if (headerEntries.length > 0) {
-    keyValue('Headers', headerEntries.map(([k, v]) => `${k}=${v}`).join(', '))
+    keyValue(
+      'Headers',
+      headerEntries
+        .map(([k, v]) => `${k}=${isSensitiveHeaderName(k) ? '***' : v}`)
+        .join(', ')
+    )
   }
 
   keyValue('Consecutive failures', destination.consecutive_failures)

--- a/apps/temps-cli/src/ui/table.ts
+++ b/apps/temps-cli/src/ui/table.ts
@@ -214,6 +214,10 @@ export function statusBadge(status: string): string {
     error: chalk.red,
     unhealthy: chalk.red,
     cancelled: chalk.red,
+    degraded: chalk.yellow,
+    failing: chalk.red,
+    disabled: chalk.gray,
+    never_delivered: chalk.gray,
   }
 
   const colorFn = statusColors[safeStatus.toLowerCase()] ?? chalk.white


### PR DESCRIPTION
## Summary
- Adds CLI parity for the OTel Forward plugin's project destination and instance-default CRUD/test APIs.
- Commands use the shared authenticated API client with hand-maintained plugin request/response types; the plugin schema intentionally remains outside OSS `openapi.json`.
- Surfaces a clear plugin-unavailable message when the EE routes return 404.
- Extends shared status rendering with `degraded`, `failing`, `disabled`, and `never_delivered`.

## Credential-safety guarantees
- Collector credentials are sourced with repeatable `--header-env KEY=ENV_VAR`; literal header values never enter argv or shell history.
- Every returned header value is rendered as `***`, regardless of header name, in both human-readable and `--json` output. This includes vendor-specific credentials such as `x-honeycomb-team`.
- Collector endpoint input rejects URL userinfo, query parameters, fragments, malformed URLs, and non-HTTP(S) schemes.
- Endpoint URLs and URLs embedded in API, delivery, or stored error strings are sanitized before human or JSON output.
- Malformed input errors never echo credential values.

## Verification
```text
$ bun run typecheck
$ tsc --noEmit

$ bun test src/commands/otel-forward/index.test.ts
44 pass
0 fail
78 expect() calls

$ bun run build
Bundled 678 modules

$ gitleaks dir --no-banner --redact apps/temps-cli/src/commands/otel-forward
no leaks found
```

Registered-command help was also exercised for both project and instance-default creation and shows only `--header-env <k=env>`. A live local EE request reached the server but returned 401 because the saved local EE CLI contexts have stale tokens; authenticated CRUD evidence still needs to be captured before merge.

Security re-review after commit `50623e41`: approved with all prior HIGH/MEDIUM findings resolved and no Gala/customer identifier introduced.
