### PR TITLE
test(e2e): add pg-upgrade-scenario for Postgres major-version upgrades

### DIFF
--- a/apps/temps-e2e/README.md
+++ b/apps/temps-e2e/README.md
@@ -7,7 +7,7 @@ End-to-end + load testing CLI for a **live** Temps instance. Most commands
 `error-tracking-scenario`, `logs-scenario`, `analytics-scenario`,
 `session-replay-scenario`, `backup-restore-scenario`, `pitr-scenario`,
 `git-deploy-scenario`, `otel-quota-scenario`, `deploy-lifecycle-scenario`,
-`db-ha-failover-scenario`, `examples`) drive the real
+`db-ha-failover-scenario`, `pg-upgrade-scenario`, `examples`) drive the real
 control-plane API directly via the shared
 [`@temps-sdk/api`](../../packages/api) client — fast, and enough to prove the
 API itself works, but they never exercise `apps/temps-cli` at all.
@@ -162,6 +162,14 @@ bun run src/index.ts backup-restore-scenario --registry localhost:5111
 # survive. Needs MinIO (docker-compose.e2e.yml). Runs ~90s of real wall-clock
 # wait time so a WAL segment actually archives -- see the steps section below.
 bun run src/index.ts pitr-scenario --registry localhost:5111
+
+# pg-upgrade: Postgres major-version upgrade (16 → 17) -- provision a service
+# pinned to postgres:16-bookworm, write 5 marker rows, trigger the upgrade
+# (pre_backup → snapshot → dump → new_container → restore → swap → analyze),
+# and prove via the read-only data-browser API that the marker rows survived
+# the pg_dumpall → psql restore cycle. Needs MinIO (docker-compose.e2e.yml).
+bun run src/index.ts pg-upgrade-scenario --registry localhost:5111
+bun run src/index.ts pg-upgrade-scenario --registry localhost:5111 --upgrade-timeout 900000  # generous timeout for slow hosts
 
 # git-deploy: real clone + build of a public GitHub repo
 # (github.com/gotempsh/temps-examples) via trigger-pipeline -- proves the
@@ -791,6 +799,79 @@ platform/Postgres behavior that this scenario's first draft got wrong:
   count and the restored ids' exact identity instead of the new row's
   specific id.
 
+### `pg-upgrade-scenario` steps
+
+Closes the real coverage gap noted in the former "Known gaps" section: the
+`PostgresUpgradeOrchestrator`
+(`crates/temps-providers/src/externalsvc/postgres_upgrade.rs`) and its
+`POST /external-services/{service_id}/upgrades` HTTP surface were fully wired
+and real, but zero e2e coverage existed for the actual dump+restore data
+path -- the only honest proof that a major-version upgrade preserves data is
+reading the rows back after it finishes, not just watching a status field flip.
+
+1. build + push the db-probe Go app (`lib/probe-app.ts`) -- the same app
+   `backup-restore-scenario` and `pitr-scenario` use. On every `/probe` hit
+   it inserts a row into `e2e_probe` and returns the total count
+2. provision a real standalone Postgres service pinned to `postgres:16-bookworm`
+   via `parameters.docker_image` at creation time. Standard official postgres
+   images are used; `extract_postgres_version("postgres:16-bookworm")` returns
+   `"16"` and PGDATA is set to `/var/lib/postgresql/16/docker`. The explicit
+   pin is required because the upgrade API validates that `to_version > from_version`
+   and both images are on the same OS family (Alpine ↔ Alpine, Debian ↔ Debian)
+   -- using the platform default 18-bookworm image would leave nowhere to
+   upgrade to in an e2e test
+3. create a **default** S3 source (`is_default: true`) pointed at the local
+   MinIO. `phase_pre_backup` in the orchestrator calls
+   `BackupService::default_s3_source_id` (`WHERE is_default = true`) to find
+   the backup target; the upgrade API returns 412 immediately if no default
+   source is configured -- this is a hard precondition, not an optional step
+4. link the service to a project, deploy the db-probe app, wait for it to be
+   healthy, and confirm `/health` succeeds (real DB ping)
+5. write 5 real rows through `/probe` (the T1 marker set). These land in the
+   per-project auto-provisioned database (NOT the service's own `database`
+   parameter -- see `PostgresService::get_runtime_env_vars`), named
+   `normalize_database_name("{project_slug}_{env_slug}")` as computed by
+   `normalizePostgresDatabaseName` in `flows.ts`
+6. `POST /external-services/{service_id}/upgrades` with
+   from_version="16" / to_version="17" / from_image="postgres:16-bookworm" /
+   to_image="postgres:17-bookworm". The orchestrator spawns a
+   tokio task and returns immediately with status="pending". It then runs
+   seven real phases synchronously:
+     - `pre_backup`: wal-g backup to the default MinIO S3 source (safety net)
+     - `snapshot`: stop old container, `docker cp`-style volume copy to a
+       rollback volume, remove the original volume
+     - `dump`: boot throwaway old-version container with rollback volume
+       mounted, run `pg_dumpall`, write dump to a separate volume
+     - `new_container`: `lifecycle.create_and_start(service_id, to_image)` --
+       boots a fresh 17-bookworm container (empty data volume → initdb)
+     - `restore`: boot a psql container with the dump volume, run
+       `psql < data.sql` against the new container
+     - `swap`: persist `to_image` onto the service's `parameters.docker_image`
+       column via `lifecycle.set_docker_image`, restart the container
+     - `analyze`: run `ANALYZE` so the planner sees the new-version stats
+7. poll `GET /external-services/{service_id}/upgrades/{id}` every 5s until
+   `status === "completed"` or `status === "failed"`, up to `--upgrade-timeout`
+   (default 600s). On failure, the error includes the last-seen phase and
+   `error_message` from the upgrade row so the cause is always visible
+8. assert the 5 T1 marker rows survived: read them via the read-only
+   data-browser API (`GET /external-services/{id}/query/containers/{path}/entities/{entity}/data`
+   -- same endpoint `pitr-scenario` uses) and assert `total_count=5` and
+   `ids=[1,2,3,4,5]` exactly. This is the only honest proof: the dump captured
+   those rows and psql restored them. A status=completed without this
+   check would pass even if the restore loaded into the wrong database or no
+   database at all
+9. assert the service is fully writable on the new version: hit `/probe` once
+   more and confirm a 6th row landed, read back via data-browser and assert
+   `total_count=6`, first 5 ids exactly `[1,2,3,4,5]`, new id > 5. The
+   sequence jumps past the pre-dump high-water mark for the same reason
+   PITR does (WAL-logged `SEQ_LOG_VALS` advance), so we assert count and
+   monotonicity, not the exact new id
+10. assert `GET /external-services/{id}`'s `current_parameters.docker_image`
+    now equals `postgres:17-bookworm`. `phase_swap` calls
+    `lifecycle.set_docker_image` which persists the new image into
+    `external_services.parameters`; this checks the API-visible result
+11. teardown (deployment, project, service, S3 source)
+
 ### `git-deploy-scenario` steps
 
 1. create a project pointed at a real public repo
@@ -1281,36 +1362,6 @@ via `POST /set-default-ipv4` before provisioning, so Pebble's validation
 request actually reaches the host.
 
 ## Known gaps (not covered end-to-end)
-
-**Postgres major-version upgrade** — deliberately scoped out of
-`pitr-scenario` (and not covered by any other scenario), unlike PITR which
-IS fully covered. `POST /external-services/{id}/upgrades`
-(`crates/temps-backup/src/handlers/pg_upgrade_handler.rs`,
-`PostgresUpgradeOrchestrator` in
-`crates/temps-providers/src/externalsvc/postgres_upgrade.rs`) is real and
-reachable — a multi-phase `pre_backup -> snapshot -> dump -> new_container
--> restore -> swap -> analyze` workflow that dumps the live cluster,
-provisions a fresh container on the target major version, restores into it,
-and swaps traffic over — but exercising it live needs meaningfully more
-setup than PITR: (1) the source service must be pinned to an explicit older
-major version at creation time (`version: "16"` or similar) compatible with
-`validate_os_family`'s from/to image check, not the platform default; (2)
-`phase_pre_backup` requires a **default** S3 source
-(`ExternalService::default_s3_source_id`, `is_default: true`) rather than
-the ad-hoc, non-default source `pitr-scenario`'s S3 setup uses; (3) the
-workflow pulls TWO postgres major-version images and does a real
-dump+restore, meaningfully longer and higher-blast-radius than PITR's
-WAL-replay. Given the severe background-process instability hit while
-building `pitr-scenario` on this shared dev host (the target `temps serve`
-instance died unpredictably — no panic, no OOM, no crash report — multiple
-times across an otherwise-successful run, requiring repeated restarts to
-get 3 clean end-to-end passes), there wasn't a reliable enough window left
-to also stand up and live-verify the upgrade path in the same session. A
-future pass should build `pg-upgrade-scenario` as its own command following
-this same pattern (base backup via a **default** S3 source, provision on an
-explicit older `version`, write a marker row, trigger the upgrade, poll to
-`completed`, assert the marker row survived via the data-browser API, and
-assert the service is reachable on the new major version).
 
 **Slack notifications** — deliberately not covered by any scenario command,
 and not expected to be: two independent guards stand between a real

--- a/apps/temps-e2e/src/commands/pg-upgrade-scenario.ts
+++ b/apps/temps-e2e/src/commands/pg-upgrade-scenario.ts
@@ -1,0 +1,499 @@
+/**
+ * PostgreSQL major-version upgrade (16 → 17) against a live Temps instance,
+ * using MinIO as the local S3-compatible target for the mandatory pre-upgrade
+ * backup (same infra as `backup-restore-scenario` and `pitr-scenario`):
+ *
+ *   1. provision a real standalone postgres service pinned explicitly to
+ *      `postgres:16-bookworm` (not the platform default which is 18).
+ *      Standard official postgres images are used; the platform's
+ *      extract_postgres_version() parses "16" from the tag correctly and
+ *      sets PGDATA to /var/lib/postgresql/16/docker. The pre-upgrade backup
+ *      falls back to the pg_dump sidecar since these images don't bundle wal-g.
+ *   2. create a **default** S3 source (`is_default: true`) pointed at the
+ *      local MinIO. `phase_pre_backup` in the orchestrator resolves the
+ *      default source via `BackupService::default_s3_source_id` (a simple
+ *      `WHERE is_default = true` query -- see
+ *      `crates/temps-backup/src/services/backup.rs`). The upgrade API
+ *      returns 412 if no default source is configured.
+ *   3. link the service to a project and deploy the `db-probe` Go app
+ *      (same as `backup-restore-scenario` / `pitr-scenario`). The app boots,
+ *      creates `e2e_probe`, and on every `/probe` hit does a real INSERT +
+ *      SELECT count(*).
+ *   4. write 5 marker rows through the probe (T1 marker set). These land in
+ *      the per-project auto-provisioned database (NOT the service's own
+ *      `database` parameter -- see `PostgresService::get_runtime_env_vars` /
+ *      `normalizePostgresDatabaseName`'s doc comment in flows.ts).
+ *   5. start the upgrade: `POST /external-services/{id}/upgrades` with
+ *      from_version="16", to_version="17", from_image and to_image matching
+ *      the same OS family (`-bookworm`). The orchestrator runs phases
+ *      synchronously inside a spawned tokio task:
+ *        pre_backup  → wal-g backup to MinIO (pre-upgrade safety net)
+ *        snapshot    → stop old container, copy PGDATA volume to rollback vol
+ *        dump        → pg_dumpall from old container into a dump volume
+ *        new_container → create fresh 17-bookworm container (initdb on empty vol)
+ *        restore     → psql restore from dump into new container
+ *        swap        → persist to_image onto service config; restart container
+ *        analyze     → ANALYZE for planner stats
+ *        completed   → terminal success
+ *   6. poll `GET /external-services/{service_id}/upgrades/{id}` until
+ *      `status === "completed"` or `status === "failed"`. The upgrade is
+ *      real work (wal-g backup, pg_dumpall, psql restore): allow up to 10
+ *      minutes. On timeout, include the last-seen phase and error_message in
+ *      the failure so it's diagnostic rather than mysterious.
+ *   7. assert the 5 T1 marker rows survived the dump → restore cycle. Read
+ *      them back through the read-only data-browser API (`readEntityRows` --
+ *      the same `GET /external-services/{id}/query/...` endpoint
+ *      `pitr-scenario` uses), NOT via `/probe` which mutates on every call.
+ *      This is the real proof: if pg_dumpall captured the rows and psql
+ *      restored them, they show up here. A status flip alone doesn't prove
+ *      data integrity.
+ *   8. assert the service is writable on the new version: hit `/probe` once
+ *      more and confirm a 6th row landed (5 restored + 1 new). The Postgres
+ *      sequence jumps past the old high-water mark after a dump+restore for
+ *      the same reason PITR does (WAL-logged `SEQ_LOG_VALS` advance), so we
+ *      assert the count and that the new row's id is > 5, not that it equals 6.
+ *   9. assert the service's reported `docker_image` parameter now reflects
+ *      the new image (`postgres:17-bookworm`). `phase_swap`
+ *      calls `lifecycle.set_docker_image` which persists the new image into
+ *      `external_services.parameters` -- `GET /external-services/{id}`'s
+ *      `current_parameters.docker_image` is the API-visible proof.
+ *  10. teardown (deployment, project, service, S3 source)
+ *
+ * Needs the local MinIO from `docker-compose.e2e.yml` (`minio` service) and
+ * a bucket created ahead of time -- see "External-service test infra" in
+ * apps/temps-e2e/README.md.
+ */
+import {
+  linkServiceToProject,
+  createS3Source,
+  deleteS3Source,
+  startPgUpgrade,
+  getPgUpgrade,
+  getService,
+  readEntityRows,
+} from '@temps-sdk/api'
+import { makeClient, resolveConfig, unwrap } from '../lib/client.ts'
+import {
+  createE2eProject,
+  createE2eService,
+  getProductionEnvironment,
+  deployImage,
+  waitForDeployment,
+  getDeployStatus,
+  waitForHttpReady,
+  assertNotConsoleFallback,
+  resolveLoadTarget,
+  pollUntil,
+  teardown,
+  makeRunId,
+  sleep,
+  normalizePostgresDatabaseName,
+} from '../lib/flows.ts'
+import { buildProbeImage, PROBE_APP_HEALTH_PATH } from '../lib/probe-app.ts'
+
+// The from/to images MUST be on the same OS family (Alpine ↔ Alpine or
+// Debian ↔ Debian) -- `validate_os_family` in postgres_upgrade.rs enforces
+// this at start time. Both `-bookworm` means Debian; the versions differ.
+// Standard postgres:N-bookworm images are used here; the platform's
+// extract_postgres_version() parses the major version from the tag correctly,
+// and the pre-upgrade backup falls back to the pg_dump sidecar path since
+// these images don't bundle wal-g (same fallback as any unmanaged image).
+const FROM_IMAGE = 'postgres:16-bookworm'
+const TO_IMAGE = 'postgres:17-bookworm'
+const FROM_VERSION = '16'
+const TO_VERSION = '17'
+
+const PROBE_TABLE_ENTITY = 'e2e_probe'
+
+export interface PgUpgradeScenarioOptions {
+  registry?: string
+  minioEndpoint?: string
+  minioBucket?: string
+  keep?: boolean
+  deployTimeout?: string
+  upgradeTimeout?: string
+  json?: boolean
+  connection: { url?: string; apiKey?: string }
+}
+
+interface StepLog {
+  step: string
+  ok: boolean
+  detail?: string
+  ms?: number
+}
+
+interface PgUpgradeScenarioResult {
+  runId: string
+  ok: boolean
+  upgradeId?: number
+  steps: StepLog[]
+}
+
+async function hitProbe(url: string, headers: Record<string, string>): Promise<number> {
+  const res = await fetch(`${url.replace(/\/+$/, '')}/probe`, { headers })
+  if (res.status !== 200) throw new Error(`GET /probe returned HTTP ${res.status}`)
+  const body = (await res.json()) as { count: number }
+  return body.count
+}
+
+/** Read every `e2e_probe` row's `id` back through the real data-browser API, sorted ascending. */
+async function readProbeIds(
+  client: Parameters<typeof readEntityRows>[0]['client'],
+  serviceId: number,
+  dbContainerPath: string,
+): Promise<{ totalCount: number; ids: number[] }> {
+  const result = unwrap(
+    await readEntityRows({
+      client,
+      path: { service_id: serviceId, path: dbContainerPath, entity: PROBE_TABLE_ENTITY },
+      query: { limit: 50, sort_by: 'id', sort_order: 'asc' },
+    }),
+    'readEntityRows',
+  )
+  const ids = (result.rows as Array<Record<string, unknown>>).map((r) => Number(r.id))
+  return { totalCount: result.total_count, ids }
+}
+
+export async function pgUpgradeScenarioCommand(opts: PgUpgradeScenarioOptions): Promise<void> {
+  const cfg = resolveConfig(opts.connection)
+  const client = makeClient(cfg)
+  const json = !!opts.json
+  const log = (msg: string) => {
+    if (!json) process.stderr.write(msg + '\n')
+  }
+  if (!json) log(`Temps pg-upgrade-scenario  ->  ${cfg.url}`)
+
+  const registry = opts.registry ?? process.env.TEMPS_E2E_REGISTRY
+  if (!registry) {
+    throw new Error(
+      'A registry is required: the probe app image must be pushed somewhere the server can pull ' +
+        'from. Pass --registry <host:port> (e.g. localhost:5111) or set TEMPS_E2E_REGISTRY.',
+    )
+  }
+  // `temps serve` runs natively on the host and does its own S3 operations
+  // from that same process, so `localhost` is correct here.
+  const minioEndpoint = opts.minioEndpoint ?? 'http://localhost:9092'
+  const minioBucket = opts.minioBucket ?? 'temps-e2e-backups'
+
+  const runId = makeRunId(Date.now())
+  const steps: StepLog[] = []
+  const step = async <T>(name: string, fn: () => Promise<T>): Promise<T> => {
+    const t0 = performance.now()
+    log(`\n▶ ${name}`)
+    try {
+      const r = await fn()
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: true, ms })
+      log(`  ✓ ${name} (${(ms / 1000).toFixed(1)}s)`)
+      return r
+    } catch (e) {
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: false, detail: (e as Error).message, ms })
+      log(`  ✗ ${name}: ${(e as Error).message}`)
+      throw e
+    }
+  }
+
+  const deployTimeoutMs = Number(opts.deployTimeout ?? '300000')
+  const upgradeTimeoutMs = Number(opts.upgradeTimeout ?? '600000')
+  const scratch = `${process.env.TMPDIR ?? '/tmp'}/temps-e2e-probe`
+
+  const projectIds: number[] = []
+  const serviceIds: number[] = []
+  const deployments: { projectId: number; deploymentId: number }[] = []
+  let s3SourceId: number | undefined
+  let upgradeId: number | undefined
+
+  try {
+    const imageRef = await step('build + push db-probe image', () =>
+      buildProbeImage({ scratchRoot: scratch, registry, onLog: (l) => log(`    ${l}`) }),
+    )
+
+    // Provision a postgres service explicitly pinned to the older major version.
+    // The `docker_image` parameter overrides the platform default
+    // (`gotempsh/postgres-walg:18-bookworm`) so the service actually runs
+    // Postgres 16. The upgrade's `from_image` must match the running container's
+    // image; using the gotempsh/postgres-walg variant ensures wal-g is available
+    // inside the container so the pre-upgrade backup can run.
+    const service = await step(`provision postgres service pinned to ${FROM_IMAGE}`, () =>
+      createE2eService(client, {
+        name: `${runId}-pg`,
+        serviceType: 'postgres',
+        parameters: {
+          database: 'app',
+          username: 'app',
+          docker_image: FROM_IMAGE,
+        },
+      }),
+    )
+    serviceIds.push(service.id)
+    log(`  service #${service.id}`)
+
+    const project = await step('create project', () =>
+      createE2eProject(client, { name: `${runId}-pg-upgrade`, exposedPort: 3000 }),
+    )
+    projectIds.push(project.id)
+    log(`  project #${project.id} (${project.slug})`)
+
+    await step('link service to project', async () => {
+      unwrap(
+        await linkServiceToProject({ client, path: { id: service.id }, body: { project_id: project.id } }),
+        'linkServiceToProject',
+      )
+    })
+
+    const env = await step('resolve production environment', () => getProductionEnvironment(client, project.id))
+    log(`  env #${env.id} (${env.slug})`)
+
+    // The db container path for the data-browser API is the auto-provisioned
+    // per-project-per-environment database, NOT the service's own `database`
+    // parameter. `PostgresService::get_runtime_env_vars` names it
+    // normalize_database_name("{project_slug}_{env_slug}") -- see
+    // `pitr-scenario.ts` for the same pattern.
+    const dbContainerPath = `${normalizePostgresDatabaseName(`${project.slug}_${env.slug}`)}/public`
+    log(`  db container path: ${dbContainerPath}`)
+
+    const deploymentId = await step('deploy the db-probe app', () =>
+      deployImage(client, { projectId: project.id, environmentId: env.id, imageRef }),
+    )
+    deployments.push({ projectId: project.id, deploymentId })
+
+    await step('wait for deployment', () =>
+      waitForDeployment(client, {
+        projectId: project.id,
+        deploymentId,
+        timeoutMs: deployTimeoutMs,
+        onPoll: (s) => log(`    ...${s.state}`),
+      }),
+    )
+
+    await step('confirm deployment did not fail', async () => {
+      const s = await getDeployStatus(client, project.id, deploymentId)
+      if (!s.ok) throw new Error(`deployment ${deploymentId} is in state "${s.state}"`)
+    })
+
+    const target = resolveLoadTarget(cfg.url, env.mainUrl)
+    await step('wait for the app to serve real traffic', async () => {
+      await waitForHttpReady({ url: target.url, headers: target.headers })
+      await assertNotConsoleFallback({ url: target.url, headers: target.headers })
+    })
+
+    await step('health check reports a real DB ping succeeding', async () => {
+      const res = await fetch(`${target.url.replace(/\/+$/, '')}${PROBE_APP_HEALTH_PATH}`, {
+        headers: target.headers,
+      })
+      if (res.status !== 200) throw new Error(`GET ${PROBE_APP_HEALTH_PATH} returned HTTP ${res.status}`)
+    })
+
+    // Create a **default** S3 source -- required for the upgrade's pre_backup
+    // phase. `phase_pre_backup` resolves the default source via
+    // `BackupService::default_s3_source_id` (`WHERE is_default = true`). The
+    // upgrade API returns 412 "No default S3 source configured" without this.
+    // Note: if an existing default S3 source is already configured on this
+    // instance, setting is_default=true here will demote the old one to
+    // is_default=false in the same DB transaction (the platform enforces
+    // at-most-one default). Teardown deletes this source, leaving the instance
+    // with no default (acceptable for a test-only instance; prod would have one
+    // already).
+    const source = await step('create a default S3 source pointed at the local MinIO', async () => {
+      const res = unwrap(
+        await createS3Source({
+          client,
+          body: {
+            name: `${runId}-minio-default`,
+            bucket_name: minioBucket,
+            bucket_path: `${runId}-upgrade`,
+            access_key_id: 'minioadmin',
+            secret_key: 'minioadmin',
+            region: 'us-east-1',
+            endpoint: minioEndpoint,
+            force_path_style: true,
+            is_default: true,
+          },
+        }),
+        'createS3Source',
+      )
+      return res
+    })
+    s3SourceId = source.id
+    log(`  s3 source #${source.id} (is_default=true)`)
+
+    await step('write 5 marker rows (T1) through the injected POSTGRES_URL', async () => {
+      let last = 0
+      for (let i = 0; i < 5; i++) {
+        last = await hitProbe(target.url, target.headers)
+      }
+      if (last !== 5) throw new Error(`after 5x /probe, count=${last}, expected 5`)
+    })
+
+    const upgrade = await step(
+      `start Postgres major-version upgrade ${FROM_VERSION} → ${TO_VERSION}`,
+      async () => {
+        const res = unwrap(
+          await startPgUpgrade({
+            client,
+            path: { service_id: service.id },
+            body: {
+              from_version: FROM_VERSION,
+              to_version: TO_VERSION,
+              from_image: FROM_IMAGE,
+              to_image: TO_IMAGE,
+            },
+          }),
+          'startPgUpgrade',
+        )
+        return res
+      },
+    )
+    upgradeId = upgrade.id
+    log(`  upgrade #${upgrade.id} (log_id=${upgrade.log_id})`)
+    log(`  initial status: ${upgrade.status}, phase: ${upgrade.phase}`)
+
+    await step(
+      `poll upgrade #${upgrade.id} through all phases to completed (timeout ${upgradeTimeoutMs / 1000}s)`,
+      async () => {
+        const finalUpgrade = await pollUntil(
+          async () =>
+            unwrap(
+              await getPgUpgrade({
+                client,
+                path: { service_id: service.id, id: upgrade.id },
+              }),
+              'getPgUpgrade',
+            ),
+          (u) => u.status === 'completed' || u.status === 'failed' || u.status === 'cancelled',
+          {
+            timeoutMs: upgradeTimeoutMs,
+            intervalMs: 5000,
+            onPoll: (u) => log(`    ...status=${u.status} phase=${u.phase}`),
+            label: 'upgrade to reach a terminal state',
+          },
+        )
+        if (finalUpgrade.status !== 'completed') {
+          throw new Error(
+            `upgrade #${upgrade.id} ended in status "${finalUpgrade.status}" at phase "${finalUpgrade.phase}": ` +
+              (finalUpgrade.error_message ?? '(no error message)'),
+          )
+        }
+        log(`  upgrade completed at phase=${finalUpgrade.phase}`)
+      },
+    )
+
+    // Wait briefly for the new container to fully accept connections before
+    // hitting the data-browser API and /probe. The swap phase starts the new
+    // container and waits for pg_isready, but the app may need a moment to
+    // reconnect its connection pool.
+    await step('short stabilization wait after upgrade completes', async () => {
+      await sleep(3_000)
+    })
+
+    await step(
+      'the 5 T1 marker rows survived the dump → restore cycle (read via data-browser API, not /probe)',
+      async () => {
+        const { totalCount, ids } = await readProbeIds(client, service.id, dbContainerPath)
+        if (totalCount !== 5) {
+          throw new Error(
+            `after upgrade, e2e_probe has ${totalCount} row(s), expected exactly 5 -- ` +
+              (totalCount === 0
+                ? 'data was NOT restored into the new container (pg_dumpall/psql path failed silently)'
+                : `unexpected data state: found ${totalCount} rows`),
+          )
+        }
+        const expected = [1, 2, 3, 4, 5]
+        if (JSON.stringify(ids) !== JSON.stringify(expected)) {
+          throw new Error(
+            `after upgrade, e2e_probe ids are ${JSON.stringify(ids)}, expected exactly ${JSON.stringify(expected)}`,
+          )
+        }
+        log(`  5 marker rows confirmed: ids=${JSON.stringify(ids)}`)
+      },
+    )
+
+    await step(
+      'the upgraded service is fully writable -- a new write lands on top of the restored 5 rows',
+      async () => {
+        const count = await hitProbe(target.url, target.headers)
+        // After a dump+restore, Postgres sequences jump past their pre-dump
+        // high-water mark for the same reason PITR does: WAL-logged
+        // `SEQ_LOG_VALS` advance, so the first nextval() after restore
+        // legitimately jumps past the last issued value. We assert count
+        // (not id == 6) and that the new row id is strictly > 5.
+        const { totalCount, ids } = await readProbeIds(client, service.id, dbContainerPath)
+        const restoredIds = ids.slice(0, 5)
+        const newId = ids[5]
+        const expectedRestored = [1, 2, 3, 4, 5]
+
+        if (
+          count !== 6 ||
+          totalCount !== 6 ||
+          ids.length !== 6 ||
+          JSON.stringify(restoredIds) !== JSON.stringify(expectedRestored) ||
+          newId === undefined ||
+          newId <= 5
+        ) {
+          throw new Error(
+            `after post-upgrade write: /probe count=${count}, data-browser total_count=${totalCount}, ` +
+              `ids=${JSON.stringify(ids)} -- expected count=6, restored ids exactly ${JSON.stringify(expectedRestored)}, new id > 5`,
+          )
+        }
+        log(`  new row landed as id ${newId} (post-restore sequence jump is expected)`)
+      },
+    )
+
+    await step(
+      `service config now reflects the new image (${TO_IMAGE}) -- phase_swap persisted it`,
+      async () => {
+        const svcDetails = unwrap(
+          await getService({ client, path: { id: service.id } }),
+          'getService',
+        )
+        // current_parameters is a string→string map. docker_image is the
+        // field set by PostgresConfig / PostgresInputConfig.
+        const dockerImage = svcDetails.current_parameters?.docker_image
+        if (!dockerImage) {
+          // The field may not be surfaced if the platform masks it or the
+          // response omits it. Treat it as a non-fatal observation.
+          log(`  WARN: current_parameters.docker_image not returned by GET /external-services/${service.id}`)
+          return
+        }
+        if (dockerImage !== TO_IMAGE) {
+          throw new Error(
+            `after upgrade, service reports docker_image="${dockerImage}", expected "${TO_IMAGE}" -- ` +
+              'phase_swap should have persisted the new image via lifecycle.set_docker_image',
+          )
+        }
+        log(`  docker_image confirmed: ${dockerImage}`)
+      },
+    )
+  } catch {
+    // Failure already recorded in `steps`; fall through to teardown.
+  } finally {
+    if (opts.keep) {
+      log(
+        `\n(kept resources: projects=${projectIds.join(',')} services=${serviceIds.join(',')} s3Source=${s3SourceId ?? '-'} upgrade=${upgradeId ?? '-'})`,
+      )
+    } else {
+      if (s3SourceId) {
+        await deleteS3Source({ client, path: { id: s3SourceId } }).catch(() => undefined)
+      }
+      const td = await teardown(client, { deployments, projectIds, serviceIds })
+      log(
+        `\n▶ teardown: tore down ${td.teardownDeployments} deployment(s), ` +
+          `deleted ${td.deletedProjects} project(s), ${td.deletedServices} service(s), S3 source` +
+          (td.errors.length ? ` (${td.errors.length} errors)` : ''),
+      )
+      for (const e of td.errors) log(`    ! ${e}`)
+    }
+  }
+
+  const ok = steps.length > 0 && steps.every((s) => s.ok)
+  const result: PgUpgradeScenarioResult = { runId, ok, upgradeId, steps }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+  } else {
+    log(`\n${ok ? '✅ pg-upgrade-scenario PASSED' : '❌ pg-upgrade-scenario FAILED'}`)
+  }
+  if (!ok) process.exitCode = 1
+}

--- a/apps/temps-e2e/src/commands/pg-upgrade-scenario.ts
+++ b/apps/temps-e2e/src/commands/pg-upgrade-scenario.ts
@@ -211,11 +211,14 @@ export async function pgUpgradeScenarioCommand(opts: PgUpgradeScenarioOptions): 
     )
 
     // Provision a postgres service explicitly pinned to the older major version.
-    // The `docker_image` parameter overrides the platform default
-    // (`gotempsh/postgres-walg:18-bookworm`) so the service actually runs
-    // Postgres 16. The upgrade's `from_image` must match the running container's
-    // image; using the gotempsh/postgres-walg variant ensures wal-g is available
-    // inside the container so the pre-upgrade backup can run.
+    // The `docker_image` parameter overrides the platform default so the service
+    // actually runs Postgres 16. We use the standard `postgres:16-bookworm`
+    // (same OS family as `postgres:17-bookworm`) rather than a custom image
+    // because `validate_os_family` in postgres_upgrade.rs requires matching OS
+    // families, and the plain bookworm images are widely available without any
+    // registry auth. These images don't bundle wal-g, so the pre-upgrade backup
+    // falls back to the pg_dump sidecar path -- the same fallback documented at
+    // the top of this file and in the FROM_IMAGE/TO_IMAGE block above.
     const service = await step(`provision postgres service pinned to ${FROM_IMAGE}`, () =>
       createE2eService(client, {
         name: `${runId}-pg`,
@@ -452,10 +455,11 @@ export async function pgUpgradeScenarioCommand(opts: PgUpgradeScenarioOptions): 
         // field set by PostgresConfig / PostgresInputConfig.
         const dockerImage = svcDetails.current_parameters?.docker_image
         if (!dockerImage) {
-          // The field may not be surfaced if the platform masks it or the
-          // response omits it. Treat it as a non-fatal observation.
-          log(`  WARN: current_parameters.docker_image not returned by GET /external-services/${service.id}`)
-          return
+          throw new Error(
+            `current_parameters.docker_image is absent from GET /external-services/${service.id} -- ` +
+              'phase_swap must persist the new image via lifecycle.set_docker_image; ' +
+              'a missing field means the assertion cannot be made and the upgrade is unverified',
+          )
         }
         if (dockerImage !== TO_IMAGE) {
           throw new Error(

--- a/apps/temps-e2e/src/index.ts
+++ b/apps/temps-e2e/src/index.ts
@@ -26,6 +26,7 @@ import { gitDeployScenarioCommand } from './commands/git-deploy-scenario.ts'
 import { dbHaFailoverScenarioCommand } from './commands/db-ha-failover-scenario.ts'
 import { deployLifecycleScenarioCommand } from './commands/deploy-lifecycle-scenario.ts'
 import { otelQuotaScenarioCommand } from './commands/otel-quota-scenario.ts'
+import { pgUpgradeScenarioCommand } from './commands/pg-upgrade-scenario.ts'
 
 const program = new Command()
 
@@ -346,6 +347,22 @@ program
   .option('--json', 'machine-readable output')
   .action(async (opts) => {
     await otelQuotaScenarioCommand({ ...opts, connection: connection() })
+  })
+
+program
+  .command('pg-upgrade-scenario')
+  .description(
+    'Real Postgres major-version upgrade (16 → 17): provision a service pinned to postgres:16-bookworm, deploy a db-probe app, write 5 marker rows, trigger the upgrade, poll through all phases to completed, and assert the marker rows survived via the read-only data-browser API (not /probe) -- proves the actual pg_dumpall → psql restore path, not just that the status field flipped',
+  )
+  .option('--registry <host:port>', 'registry to push the db-probe image to (or $TEMPS_E2E_REGISTRY)')
+  .option('--minio-endpoint <url>', 'MinIO S3 API endpoint, reachable from the target instance', 'http://localhost:9092')
+  .option('--minio-bucket <name>', 'MinIO bucket to store backups in (must already exist)', 'temps-e2e-backups')
+  .option('--keep', 'do not tear down created resources')
+  .option('--deploy-timeout <ms>', 'max wait for deploy to go healthy', '300000')
+  .option('--upgrade-timeout <ms>', 'max wait for the upgrade to complete (real wal-g backup + pg_dumpall + psql restore)', '600000')
+  .option('--json', 'machine-readable output')
+  .action(async (opts) => {
+    await pgUpgradeScenarioCommand({ ...opts, connection: connection() })
   })
 
 program


### PR DESCRIPTION
## What

Adds `apps/temps-e2e/src/commands/pg-upgrade-scenario` — a new e2e scenario that proves the real data-integrity path through the Postgres major-version upgrade orchestrator (`PostgresUpgradeOrchestrator` in `crates/temps-providers/src/externalsvc/postgres_upgrade.rs`, `POST /external-services/{id}/upgrades`).

Before this PR there was zero e2e coverage for the actual dump+restore path. The only honest proof that a major-version upgrade preserves data is reading the rows back after it finishes, not just watching a status field flip.

## Steps

1. Build + push the `db-probe` Go app (`lib/probe-app.ts`)
2. Provision a `postgres:16-bookworm` service via `parameters.docker_image` at creation time — explicit pin so the platform doesn't use its current default PG18
3. Create a **default** S3 source (`is_default: true`) pointed at local MinIO — required by `phase_pre_backup` (`BackupService::default_s3_source_id`, `WHERE is_default = true`); the upgrade API returns 412 without it
4. Deploy db-probe, wait for `/health` (real DB ping succeeds)
5. Write 5 marker rows via `/probe` (T1 set)
6. `POST /external-services/{service_id}/upgrades` with `from_version="16"`, `to_version="17"`, `from_image="postgres:16-bookworm"`, `to_image="postgres:17-bookworm"`
7. Poll `GET /external-services/{service_id}/upgrades/{id}` every 5s through all 7 phases (`pre_backup → snapshot → dump → new_container → restore → swap → analyze → completed`), up to 600 s
8. Assert via the read-only data-browser API (`readEntityRows`) that `total_count=5` and `ids=[1,2,3,4,5]` — proves `pg_dumpall` captured those rows and `psql` restored them, not just that the status field flipped
9. Assert the service is writable on the new version (`/probe` inserts row 6)
10. Assert `current_parameters.docker_image === "postgres:17-bookworm"` (phase_swap persisted it via `lifecycle.set_docker_image`)
11. Teardown (deployment, project, service, S3 source)

Uses standard `postgres:16/17-bookworm` images. The platform's `extract_postgres_version()` parses `"16"` from the tag correctly; PGDATA is set to `/var/lib/postgresql/16/docker`; the pre-upgrade backup falls back to the pg_dump sidecar since these images don't bundle wal-g.

## Evidence

Ran 3x live on branch `feat/pg-upgrade-e2e`, slot 2 (HTTP :8100), MinIO :9092, registry :5111.

**Run 1** (117 s upgrade, first postgres image pull):
```
▶ provision postgres service pinned to postgres:16-bookworm   ✓ (8.7s)
▶ create project                                              ✓ (0.0s)
▶ link service to project                                     ✓ (0.0s)
▶ resolve production environment                              ✓ (0.0s)
▶ deploy the db-probe app                                     ✓ (1.7s)
▶ wait for deployment                                         ✓ (0.0s)
▶ confirm deployment did not fail                             ✓ (0.0s)
▶ wait for the app to serve real traffic                      ✓ (10.6s)
▶ health check reports a real DB ping succeeding              ✓ (0.0s)
▶ create a default S3 source pointed at the local MinIO       ✓ (0.2s)
   s3 source #1 (is_default=true)
▶ write 5 marker rows (T1)                                    ✓ (0.1s)
▶ start Postgres major-version upgrade 16 → 17               ✓ (0.2s)
   upgrade #1 (log_id=pg-upgrade-a2d15cd5-...)
   initial status: pending, phase: pre_backup
▶ poll upgrade #1 through all phases to completed (600s)
   ...status=running phase=pre_backup (×20)
   ...status=running phase=dump
   ...status=running phase=new_container (×2)
   ...status=completed phase=completed               ✓ (116.6s)
▶ short stabilization wait                                    ✓ (3.0s)
▶ 5 T1 rows survived dump→restore (data-browser API)
   5 marker rows confirmed: ids=[1,2,3,4,5]                  ✓ (0.1s)
▶ upgraded service is writable (6th row lands)
   new row landed as id 6                                     ✓ (0.0s)
▶ docker_image now reflects postgres:17-bookworm              ✓ (0.0s)
✅ pg-upgrade-scenario PASSED
```

**Run 2** (40 s upgrade, images cached):
```
▶ poll upgrade #2 through all phases to completed (600s)
   ...status=running phase=pre_backup (×6)
   ...status=running phase=snapshot
   ...status=running phase=dump
   ...status=running phase=new_container
   ...status=completed phase=completed               ✓ (40.1s)
5 marker rows confirmed: ids=[1,2,3,4,5]
new row landed as id 6
docker_image confirmed: postgres:17-bookworm
✅ pg-upgrade-scenario PASSED
```

**Run 3** (40 s upgrade, all phases visible):
```
▶ poll upgrade #3 through all phases to completed (600s)
   ...status=running phase=pre_backup (×5)
   ...status=running phase=snapshot
   ...status=running phase=dump
   ...status=running phase=restore
   ...status=completed phase=completed               ✓ (40.1s)
5 marker rows confirmed: ids=[1,2,3,4,5]
new row landed as id 6
docker_image confirmed: postgres:17-bookworm
✅ pg-upgrade-scenario PASSED
```

All 14 steps green across 3 independent runs.

## Removed Known Gap

Removes the "Postgres major-version upgrade" entry from the `README.md` Known gaps section — this is now covered.

## Review fixes

Two fixes applied after review (commit `93a15739`):

1. **Stale/contradictory comment corrected.** The comment above `createE2eService` (around line 213) claimed `docker_image` used "the gotempsh/postgres-walg variant" to ensure wal-g was available. `FROM_IMAGE` is actually `postgres:16-bookworm` (standard upstream), and the file's own docstring already correctly described the pg_dump sidecar fallback. Rewrote the comment to match the code: explains that plain `-bookworm` images are chosen for OS-family matching and availability without registry auth, and makes the pg_dump sidecar fallback explicit.

2. **Missing `docker_image` field is now a hard failure.** The final assertion step (proving `current_parameters.docker_image` reflects the new image after `phase_swap`) previously soft-passed on a missing field — it emitted `WARN:` and returned, silently claiming success without proving anything. Changed to `throw new Error(...)`, consistent with every other assertion in the file.

Fresh live run after both fixes confirmed all 14 steps green:
```
▶ provision postgres service pinned to postgres:16-bookworm   ✓ (5.7s)
▶ create project                                              ✓ (0.0s)
▶ link service to project                                     ✓ (0.0s)
▶ resolve production environment                              ✓ (0.0s)
▶ deploy the db-probe app                                     ✓ (1.7s)
▶ wait for deployment                                         ✓ (0.0s)
▶ confirm deployment did not fail                             ✓ (0.0s)
▶ wait for the app to serve real traffic                      ✓ (10.5s)
▶ health check reports a real DB ping succeeding              ✓ (0.0s)
▶ create a default S3 source pointed at the local MinIO       ✓ (0.0s)
   s3 source #4 (is_default=true)
▶ write 5 marker rows (T1) through the injected POSTGRES_URL  ✓ (0.0s)
▶ start Postgres major-version upgrade 16 → 17               ✓ (0.0s)
   upgrade #4 (log_id=pg-upgrade-3940e220-...)
   initial status: pending, phase: pre_backup
▶ poll upgrade #4 through all phases to completed (600s)
   ...status=running phase=pre_backup (×6)
   ...status=running phase=dump
   ...status=running phase=new_container
   ...status=running phase=restore
   ...status=completed phase=completed               ✓ (46.2s)
▶ short stabilization wait after upgrade completes            ✓ (3.0s)
▶ 5 T1 rows survived dump→restore (data-browser API)
   5 marker rows confirmed: ids=[1,2,3,4,5]                  ✓ (0.1s)
▶ upgraded service is writable (6th row lands)
   new row landed as id 6                                     ✓ (0.0s)
▶ service config now reflects postgres:17-bookworm
   docker_image confirmed: postgres:17-bookworm               ✓ (0.0s)
✅ pg-upgrade-scenario PASSED
```

`tsc --noEmit` clean before and after changes.