### PR TITLE
feat(restore): S3/MinIO managed-service restore_in_place

### DIFF
--- a/apps/temps-e2e/src/commands/s3-restore-scenario.ts
+++ b/apps/temps-e2e/src/commands/s3-restore-scenario.ts
@@ -1,0 +1,464 @@
+/**
+ * S3/MinIO managed-service restore scenario — proves the newly added
+ * `restore_in_place` capability is genuinely functional, not just a 2xx.
+ *
+ * Flow:
+ *   1. Provision a real S3/MinIO managed service with KNOWN credentials so the
+ *      test can interact with it directly via Bun.S3Client.
+ *   2. Create two buckets in the live service via a one-shot `mc mb` container
+ *      (same approach restore itself uses) and upload 3 recognisable objects:
+ *      `alpha/file-a.txt`, `alpha/file-b.txt`, `beta/file-c.txt`.
+ *   3. Create an S3 source pointing at the local test MinIO (the backup
+ *      destination, same endpoint backup-restore-scenario uses) and trigger a
+ *      real backup.  This uses the `S3MirrorEngine` (`mc mirror source/ dest/`)
+ *      path — a genuine mc mirror, not a stub.
+ *   4. After the backup completes:
+ *        a. Upload a POST-backup object: `alpha/post-backup.txt`
+ *        b. Delete a PRE-backup object: `alpha/file-b.txt`
+ *      This creates a state divergence between the live service and the backup.
+ *   5. Trigger restore_in_place via `POST /external-services/{id}/restore`.
+ *      The implementation uses `mc mirror --overwrite --remove`, so:
+ *        — `alpha/file-b.txt` must come BACK (was deleted after backup)
+ *        — `alpha/post-backup.txt` must DISAPPEAR (was added after backup)
+ *        — `alpha/file-a.txt` and `beta/file-c.txt` must be present
+ *   6. Assert via the platform read-only data-browser API
+ *      (`GET /external-services/{id}/query/containers/{bucket}/entities`) that
+ *      the live bucket matches the backup-time state exactly — not just that
+ *      the restore run's status flipped to "completed".
+ *   7. Teardown.
+ *
+ * Requires:
+ *   — A running Temps instance (--url / TEMPS_URL)
+ *   — A test MinIO for backup storage (--minio-endpoint, default localhost:9092)
+ *     with the backup bucket already created (--minio-bucket, default temps-e2e-backups)
+ *   — Docker available on the host (the test runs `docker run minio/mc mb` for
+ *     bucket creation in the live service, which has no platform write API)
+ *
+ * ⚠ restore_in_place uses `--remove`: this DELETES live objects absent from the
+ * backup.  Do NOT run this against a production S3 service.
+ *
+ * Bug fixed while building this scenario (root cause, not workaround):
+ *   `restore_from_s3` (the legacy CLI path) used `--skip-errors` which silently
+ *   swallowed mc mirror failures, and did not check mirror exit codes.  The new
+ *   `restore_in_place` override replaces the interactive-exec container pattern
+ *   with a proper one-shot container, drops `--skip-errors`, and propagates
+ *   non-zero exit codes as real errors.
+ */
+import {
+  createS3Source,
+  deleteS3Source,
+  runExternalServiceBackup,
+  listExternalServiceBackups,
+  getBackup,
+  startRestore,
+  getRestoreRun,
+  listEntities,
+  getService,
+} from '@temps-sdk/api'
+import { makeClient, resolveConfig, unwrap } from '../lib/client.ts'
+import { createE2eService, pollUntil, teardown, makeRunId } from '../lib/flows.ts'
+
+export interface S3RestoreScenarioOptions {
+  minioEndpoint?: string
+  minioBucket?: string
+  keep?: boolean
+  json?: boolean
+  connection: { url?: string; apiKey?: string }
+}
+
+interface StepLog {
+  step: string
+  ok: boolean
+  detail?: string
+  ms?: number
+}
+
+interface S3RestoreScenarioResult {
+  runId: string
+  ok: boolean
+  steps: StepLog[]
+}
+
+// ── Bucket operations via one-shot mc container ───────────────────────────────
+
+/** Run a one-shot `docker run --rm minio/mc …` command and return its exit code + output. */
+async function runMc(args: string[], envVars: string[]): Promise<{ code: number; output: string }> {
+  const dockerArgs = [
+    'run',
+    '--rm',
+    '--network',
+    'host',
+    ...envVars.flatMap((e) => ['-e', e]),
+    'minio/mc:latest',
+    ...args,
+  ]
+  const proc = Bun.spawn(['docker', ...dockerArgs], { stdout: 'pipe', stderr: 'pipe' })
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { code, output: (stdout + stderr).trim() }
+}
+
+/** Create a bucket in the live MinIO service (mc mb). Ignores "already exists". */
+async function createBucket(alias: string, bucket: string, envVars: string[]): Promise<void> {
+  const { code, output } = await runMc(['mb', `${alias}/${bucket}`], envVars)
+  if (code !== 0 && !output.includes('already') && !output.includes('exists')) {
+    throw new Error(`mc mb ${alias}/${bucket} failed (exit ${code}): ${output}`)
+  }
+}
+
+// ── Bun.S3Client helpers ──────────────────────────────────────────────────────
+
+function makeLiveS3Client(
+  port: string,
+  accessKey: string,
+  secretKey: string,
+): InstanceType<typeof Bun.S3Client> {
+  return new Bun.S3Client({
+    endpoint: `http://localhost:${port}`,
+    region: 'us-east-1',
+    accessKeyId: accessKey,
+    secretAccessKey: secretKey,
+  })
+}
+
+async function putObject(
+  s3: InstanceType<typeof Bun.S3Client>,
+  bucket: string,
+  key: string,
+  content: string,
+): Promise<void> {
+  await s3.write(`${bucket}/${key}`, content, { type: 'text/plain' })
+}
+
+async function deleteObject(
+  s3: InstanceType<typeof Bun.S3Client>,
+  bucket: string,
+  key: string,
+): Promise<void> {
+  await s3.delete(`${bucket}/${key}`)
+}
+
+// ── Scenario entry point ──────────────────────────────────────────────────────
+
+export async function s3RestoreScenarioCommand(opts: S3RestoreScenarioOptions): Promise<void> {
+  const cfg = resolveConfig(opts.connection)
+  const client = makeClient(cfg)
+  const json = !!opts.json
+  const log = (msg: string) => {
+    if (!json) process.stderr.write(msg + '\n')
+  }
+  if (!json) log(`Temps S3 restore scenario  ->  ${cfg.url}`)
+
+  // The backup destination: a test MinIO that already exists and has the bucket.
+  const backupMinioEndpoint = opts.minioEndpoint ?? 'http://localhost:9092'
+  const backupMinioBucket = opts.minioBucket ?? 'temps-e2e-backups'
+
+  const runId = makeRunId(Date.now())
+  const steps: StepLog[] = []
+  const step = async <T>(name: string, fn: () => Promise<T>): Promise<T> => {
+    const t0 = performance.now()
+    log(`\n▶ ${name}`)
+    try {
+      const r = await fn()
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: true, ms })
+      log(`  ✓ ${name} (${(ms / 1000).toFixed(1)}s)`)
+      return r
+    } catch (e) {
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: false, detail: (e as Error).message, ms })
+      log(`  ✗ ${name}: ${(e as Error).message}`)
+      throw e
+    }
+  }
+
+  // Fixed known credentials so we can talk to the live service directly.
+  const LIVE_ACCESS_KEY = 'e2erestorekey01'
+  const LIVE_SECRET_KEY = 'e2erestoresecret0123456'
+
+  const serviceIds: number[] = []
+  let s3SourceId: number | undefined
+  let livePort: string | undefined
+  let s3: InstanceType<typeof Bun.S3Client> | undefined
+
+  try {
+    // ── 1. Provision the live S3/MinIO service ────────────────────────────────
+    const service = await step('provision live S3/MinIO service with known credentials', () =>
+      createE2eService(client, {
+        name: `${runId}-s3`,
+        serviceType: 's3',
+        parameters: {
+          access_key: LIVE_ACCESS_KEY,
+          secret_key: LIVE_SECRET_KEY,
+        },
+      }),
+    )
+    serviceIds.push(service.id)
+    log(`  service #${service.id}`)
+
+    // ── 2. Fetch the port the container bound to ──────────────────────────────
+    livePort = await step('read live MinIO port from service parameters', async () => {
+      const details = unwrap(
+        await getService({ client, path: { id: service.id } }),
+        'getService',
+      ) as { current_parameters?: { [k: string]: string } | null }
+      const port = details.current_parameters?.port
+      if (!port) throw new Error('port not found in service parameters')
+      log(`  port=${port}`)
+      return port
+    })
+
+    s3 = makeLiveS3Client(livePort, LIVE_ACCESS_KEY, LIVE_SECRET_KEY)
+
+    // Env vars for the one-shot mc container that creates buckets.
+    const liveMcEnv = [
+      `MC_HOST_live=http://${LIVE_ACCESS_KEY}:${LIVE_SECRET_KEY}@localhost:${livePort}`,
+    ]
+
+    // ── 3. Create buckets + upload pre-backup objects ─────────────────────────
+    await step('create bucket alpha and upload pre-backup objects', async () => {
+      await createBucket('live', 'alpha', liveMcEnv)
+      await putObject(s3!, 'alpha', 'file-a.txt', `content-a-${runId}`)
+      await putObject(s3!, 'alpha', 'file-b.txt', `content-b-${runId}`)
+      log('  uploaded alpha/file-a.txt, alpha/file-b.txt')
+    })
+
+    await step('create bucket beta and upload pre-backup object', async () => {
+      await createBucket('live', 'beta', liveMcEnv)
+      await putObject(s3!, 'beta', 'file-c.txt', `content-c-${runId}`)
+      log('  uploaded beta/file-c.txt')
+    })
+
+    // ── 4. Create S3 source + trigger real backup ─────────────────────────────
+    const source = await step('create S3 source for backup destination (test MinIO)', async () => {
+      const res = unwrap(
+        await createS3Source({
+          client,
+          body: {
+            name: `${runId}-bkp`,
+            bucket_name: backupMinioBucket,
+            bucket_path: runId,
+            access_key_id: 'minioadmin',
+            secret_key: 'minioadmin',
+            region: 'us-east-1',
+            endpoint: backupMinioEndpoint,
+            force_path_style: true,
+            is_default: false,
+          },
+        }),
+        'createS3Source',
+      )
+      return res
+    })
+    s3SourceId = source.id
+    log(`  s3 source #${source.id}`)
+
+    await step('trigger real S3 mirror backup (mc mirror source/ dest/)', async () => {
+      unwrap(
+        await runExternalServiceBackup({
+          client,
+          path: { id: service.id },
+          body: { s3_source_id: source.id, backup_type: 'full' },
+        }),
+        'runExternalServiceBackup',
+      )
+    })
+
+    const backupEntry = await step('poll backup to completed state', async () => {
+      const list = await pollUntil(
+        async () =>
+          unwrap(
+            await listExternalServiceBackups({
+              client,
+              path: { service_id: service.id },
+              query: { page: 1, page_size: 5 },
+            }),
+            'listExternalServiceBackups',
+          ),
+        (l) => l.backups.length > 0,
+        { timeoutMs: 60_000, intervalMs: 2_000, label: 'backup row to appear' },
+      )
+      const entry = list.backups[0]!
+      const final = await pollUntil(
+        async () => unwrap(await getBackup({ client, path: { id: entry.backup_id } }), 'getBackup'),
+        (b) => b.state === 'completed' || b.state === 'failed',
+        {
+          timeoutMs: 180_000,
+          intervalMs: 3_000,
+          onPoll: (b) => log(`    ...${b.state}`),
+          label: 'backup to reach terminal state',
+        },
+      )
+      if (final.state !== 'completed') {
+        throw new Error(`backup ${entry.backup_id} ended in state "${final.state}": ${final.error_message}`)
+      }
+      log(`  backup #${entry.id} (${entry.backup_id}) completed`)
+      return entry
+    })
+
+    // ── 5. Diverge: post-backup add + delete ──────────────────────────────────
+    await step('add post-backup object (alpha/post-backup.txt)', async () => {
+      await putObject(s3!, 'alpha', 'post-backup.txt', `post-backup-content-${runId}`)
+      log('  uploaded alpha/post-backup.txt — this object must disappear after restore')
+    })
+
+    await step('delete pre-backup object (alpha/file-b.txt)', async () => {
+      await deleteObject(s3!, 'alpha', 'file-b.txt')
+      log('  deleted alpha/file-b.txt — this object must come back after restore')
+    })
+
+    // Verify divergence before restore (belt-and-suspenders).
+    await step('confirm live state is diverged before restore', async () => {
+      const entities = unwrap(
+        await listEntities({
+          client,
+          path: { service_id: service.id, path: 'alpha' },
+        }),
+        'listEntities (pre-restore)',
+      ) as { entities: Array<{ name: string }> }
+      const keys = entities.entities.map((e) => e.name)
+      log(`  pre-restore alpha objects: ${keys.join(', ')}`)
+      if (!keys.includes('post-backup.txt')) {
+        throw new Error('post-backup.txt should be visible before restore (confirms it was uploaded)')
+      }
+      if (keys.includes('file-b.txt')) {
+        throw new Error('file-b.txt should be ABSENT before restore (confirms it was deleted)')
+      }
+    })
+
+    // ── 6. Restore in-place ───────────────────────────────────────────────────
+    const restoreRun = await step('start restore_in_place (--overwrite --remove)', async () => {
+      const run = unwrap(
+        await startRestore({
+          client,
+          path: { id: service.id },
+          body: { backup_id: backupEntry.id, mode: 'in_place' },
+        }),
+        'startRestore',
+      )
+      log(`  restore run #${run.id}`)
+      return run
+    })
+
+    await step('poll restore run to completed state', async () => {
+      const final = await pollUntil(
+        async () =>
+          unwrap(await getRestoreRun({ client, path: { id: restoreRun.id } }), 'getRestoreRun'),
+        (r) => r.status === 'completed' || r.status === 'failed',
+        {
+          timeoutMs: 180_000,
+          intervalMs: 3_000,
+          onPoll: (r) => log(`    ...${r.status} (${r.phase})`),
+          label: 'restore run to reach terminal state',
+        },
+      )
+      if (final.status !== 'completed') {
+        throw new Error(
+          `restore run ${restoreRun.id} ended in status "${final.status}": ${final.error_message}`,
+        )
+      }
+    })
+
+    // ── 7. Verify via data-browser API ────────────────────────────────────────
+    await step('verify alpha: file-a.txt present (pre-backup, untouched)', async () => {
+      const entities = unwrap(
+        await listEntities({ client, path: { service_id: service.id, path: 'alpha' } }),
+        'listEntities (post-restore alpha)',
+      ) as { entities: Array<{ name: string }> }
+      const keys = entities.entities.map((e) => e.name)
+      log(`  post-restore alpha objects: ${keys.join(', ')}`)
+      if (!keys.includes('file-a.txt')) {
+        throw new Error(
+          `file-a.txt missing after restore — expected it to be present (was in backup). Keys: ${keys.join(', ')}`,
+        )
+      }
+    })
+
+    await step('verify alpha: file-b.txt restored (was deleted post-backup)', async () => {
+      const entities = unwrap(
+        await listEntities({ client, path: { service_id: service.id, path: 'alpha' } }),
+        'listEntities (post-restore alpha file-b)',
+      ) as { entities: Array<{ name: string }> }
+      const keys = entities.entities.map((e) => e.name)
+      if (!keys.includes('file-b.txt')) {
+        throw new Error(
+          `file-b.txt was NOT restored — it was deleted after the backup and restore should have brought it back. Keys: ${keys.join(', ')}`,
+        )
+      }
+      log('  file-b.txt is back — restore reverted the post-backup deletion')
+    })
+
+    await step('verify alpha: post-backup.txt absent (--remove deleted it)', async () => {
+      const entities = unwrap(
+        await listEntities({ client, path: { service_id: service.id, path: 'alpha' } }),
+        'listEntities (post-restore alpha post-backup)',
+      ) as { entities: Array<{ name: string }> }
+      const keys = entities.entities.map((e) => e.name)
+      if (keys.includes('post-backup.txt')) {
+        throw new Error(
+          `post-backup.txt is still present after restore — restore_in_place with --remove should have deleted it. Keys: ${keys.join(', ')}`,
+        )
+      }
+      log('  post-backup.txt is gone — --remove semantics confirmed')
+    })
+
+    await step('verify beta: file-c.txt present (pre-backup, second bucket)', async () => {
+      const entities = unwrap(
+        await listEntities({ client, path: { service_id: service.id, path: 'beta' } }),
+        'listEntities (post-restore beta)',
+      ) as { entities: Array<{ name: string }> }
+      const keys = entities.entities.map((e) => e.name)
+      log(`  post-restore beta objects: ${keys.join(', ')}`)
+      if (!keys.includes('file-c.txt')) {
+        throw new Error(
+          `file-c.txt missing from beta bucket after restore. Keys: ${keys.join(', ')}`,
+        )
+      }
+    })
+
+    await step('verify exact alpha object count (2: file-a + file-b only)', async () => {
+      const entities = unwrap(
+        await listEntities({ client, path: { service_id: service.id, path: 'alpha' } }),
+        'listEntities (post-restore count)',
+      ) as { entities: Array<{ name: string }> }
+      const keys = entities.entities.map((e) => e.name).sort()
+      if (keys.length !== 2 || !keys.includes('file-a.txt') || !keys.includes('file-b.txt')) {
+        throw new Error(
+          `alpha bucket has unexpected contents after restore. Expected [file-a.txt, file-b.txt], got [${keys.join(', ')}]`,
+        )
+      }
+      log(`  alpha has exactly 2 objects: ${keys.join(', ')} ✓`)
+    })
+  } catch {
+    // Failure already recorded in steps; fall through to teardown.
+  } finally {
+    if (opts.keep) {
+      log(
+        `\n(kept: services=${serviceIds.join(',')} s3Source=${s3SourceId ?? '-'})`,
+      )
+    } else {
+      if (s3SourceId !== undefined) {
+        await deleteS3Source({ client, path: { id: s3SourceId } }).catch(() => undefined)
+      }
+      const td = await teardown(client, { serviceIds })
+      log(
+        `\n▶ teardown: deleted ${td.deletedServices} service(s)` +
+          (td.errors.length ? ` (${td.errors.length} errors)` : ''),
+      )
+      for (const e of td.errors) log(`    ! ${e}`)
+    }
+  }
+
+  const ok = steps.length > 0 && steps.every((s) => s.ok)
+  const result: S3RestoreScenarioResult = { runId, ok, steps }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+  } else {
+    log(`\n${ok ? '✅ s3-restore-scenario PASSED' : '❌ s3-restore-scenario FAILED'}`)
+  }
+  if (!ok) process.exitCode = 1
+}

--- a/apps/temps-e2e/src/index.ts
+++ b/apps/temps-e2e/src/index.ts
@@ -26,6 +26,7 @@ import { gitDeployScenarioCommand } from './commands/git-deploy-scenario.ts'
 import { dbHaFailoverScenarioCommand } from './commands/db-ha-failover-scenario.ts'
 import { deployLifecycleScenarioCommand } from './commands/deploy-lifecycle-scenario.ts'
 import { otelQuotaScenarioCommand } from './commands/otel-quota-scenario.ts'
+import { s3RestoreScenarioCommand } from './commands/s3-restore-scenario.ts'
 
 const program = new Command()
 
@@ -346,6 +347,19 @@ program
   .option('--json', 'machine-readable output')
   .action(async (opts) => {
     await otelQuotaScenarioCommand({ ...opts, connection: connection() })
+  })
+
+program
+  .command('s3-restore-scenario')
+  .description(
+    'S3/MinIO managed-service restore: provision a real MinIO service with known credentials, upload pre-backup objects, mirror-backup via mc, diverge (add + delete), restore in-place with --overwrite --remove, and verify via the platform data-browser API that the live bucket exactly matches the backup-time state (deleted object restored, post-backup object gone)',
+  )
+  .option('--minio-endpoint <url>', 'backup-destination MinIO S3 API endpoint (must already have the bucket)', 'http://localhost:9092')
+  .option('--minio-bucket <name>', 'backup-destination bucket (must already exist)', 'temps-e2e-backups')
+  .option('--keep', 'do not tear down created resources')
+  .option('--json', 'machine-readable output')
+  .action(async (opts) => {
+    await s3RestoreScenarioCommand({ ...opts, connection: connection() })
   })
 
 program

--- a/crates/temps-providers/src/externalsvc/s3.rs
+++ b/crates/temps-providers/src/externalsvc/s3.rs
@@ -201,8 +201,49 @@ pub struct S3Service {
 }
 
 impl S3Service {
-    /// MinIO Client (mc) utility image - used for temporary operations like migration and copy
+    /// MinIO Client (mc) utility image - used for temporary operations like migration and copy.
+    /// Pinned to an immutable release tag — never use `:latest` here to prevent
+    /// supply-chain / MITM attacks on floating tags.
     const MC_IMAGE: &'static str = "minio/mc:RELEASE.2025-08-13T08-35-41Z";
+
+    /// Shell script executed inside a disposable mc container by `restore_in_place`.
+    ///
+    /// SECURITY: This is a compile-time constant. It MUST NOT be changed to a
+    /// runtime `format!()` string that interpolates user-supplied values. All
+    /// dynamic values arrive via Docker environment variables:
+    ///   - `RESTORE_PREFIX` — user-influenced backup path (via `backup_location`)
+    ///   - `MC_HOST_bkp`, `MC_HOST_live` — S3 credentials
+    ///
+    /// The shell expands `${RESTORE_PREFIX}` safely — environment variable values
+    /// are never re-parsed as shell commands, so a value containing `'` or other
+    /// shell metacharacters cannot escape the quoting context and inject commands.
+    ///
+    /// Word-splitting fix: bucket names are iterated with `while IFS= read -r`
+    /// from a temp file, avoiding glob expansion on whitespace in names.
+    const RESTORE_IN_PLACE_SCRIPT: &'static str = r#"set -e
+DEST='live'
+if [ -z "${RESTORE_PREFIX}" ]; then
+  echo '[restore] RESTORE_PREFIX is empty — aborting'
+  exit 1
+fi
+echo "[restore] listing ${RESTORE_PREFIX}"
+BUCKET_LIST=$(mktemp)
+mc ls "${RESTORE_PREFIX}" | awk '{print $NF}' | grep '/$' | sed 's|/$||' > "${BUCKET_LIST}" || true
+if [ ! -s "${BUCKET_LIST}" ]; then
+  rm -f "${BUCKET_LIST}"
+  echo '[restore] no bucket directories found — nothing to restore'
+  exit 0
+fi
+while IFS= read -r bucket; do
+  [ -z "${bucket}" ] && continue
+  echo "[restore] ensuring ${DEST}/${bucket} exists"
+  mc mb "${DEST}/${bucket}" 2>&1 || true
+  echo "[restore] mirroring ${RESTORE_PREFIX}${bucket}/ -> ${DEST}/${bucket}/ (--overwrite --remove)"
+  mc mirror --overwrite --remove "${RESTORE_PREFIX}${bucket}/" "${DEST}/${bucket}/"
+  echo "[restore] done: ${bucket}"
+done < "${BUCKET_LIST}"
+rm -f "${BUCKET_LIST}"
+echo '[restore] complete'"#;
 
     pub fn new(
         name: String,
@@ -1917,18 +1958,6 @@ impl ExternalService for S3Service {
         let bkp_endpoint = ctx.s3_source.endpoint.as_deref().unwrap_or("");
         let (bkp_scheme, bkp_hostpath) = mc_strip_scheme(bkp_endpoint);
 
-        let env_vars = vec![
-            format!(
-                "MC_HOST_bkp={}://{}:{}@{}",
-                bkp_scheme, ctx.s3_source.access_key_id, ctx.s3_source.secret_key, bkp_hostpath,
-            ),
-            // Live service is always reached via localhost in host-network mode.
-            format!(
-                "MC_HOST_live=http://{}:{}@localhost:{}",
-                s3_config.access_key, s3_config.secret_key, s3_config.port
-            ),
-        ];
-
         // ── Restore shell script ─────────────────────────────────────────────
         // The S3MirrorEngine backup engine mirrors:
         //   source/<bucket>/ -> bkp/<bkp_bucket>/<prefix>/<original_bucket>/
@@ -1941,32 +1970,53 @@ impl ExternalService for S3Service {
         //
         // The script discovers those bucket folders via `mc ls`, creates each in
         // the live service, and mirrors their contents with --overwrite --remove.
+        //
+        // SECURITY (injection prevention): `ctx.backup_location` is user-supplied
+        // and is passed as the Docker env var `RESTORE_PREFIX` rather than being
+        // interpolated into the shell script string via Rust format!(). The shell
+        // expands `${RESTORE_PREFIX}` safely — env var values are never re-parsed
+        // as shell commands, so single-quotes or other metacharacters in the value
+        // cannot break out of the quoting context and inject commands.
+        // See `RESTORE_IN_PLACE_SCRIPT` for the static script text.
+        //
+        // TODO(security): No service-identity validation — a caller with
+        // BackupsWrite + ExternalServicesWrite can restore service A's backup
+        // onto service B's live MinIO. A full fix needs an optional
+        // `confirm_target_service_id` field on `StartRestoreRequest` checked
+        // against the URL `{id}`. Deferred because it requires the shared
+        // restore-framework code well beyond S3's scope (tracked: PR #595
+        // description, "MINOR: no service-identity binding" finding).
         let backup_prefix = format!(
             "bkp/{}/{}",
             ctx.s3_source.bucket_name,
             ctx.backup_location.trim_matches('/')
         );
-        let script = format!(
-            "set -e\n\
-             BACKUP_PREFIX='{prefix}/'\n\
-             DEST='live'\n\
-             echo \"[restore] listing $BACKUP_PREFIX\"\n\
-             BUCKETS=$(mc ls \"$BACKUP_PREFIX\" | awk '{{print $NF}}' | grep '/$' | sed 's|/$||')\n\
-             if [ -z \"$BUCKETS\" ]; then\n\
-               echo \"[restore] no bucket directories found — nothing to restore\"\n\
-               exit 0\n\
-             fi\n\
-             echo \"[restore] buckets: $BUCKETS\"\n\
-             for bucket in $BUCKETS; do\n\
-               echo \"[restore] ensuring $DEST/$bucket exists\"\n\
-               mc mb \"$DEST/$bucket\" 2>&1 || true\n\
-               echo \"[restore] mirroring $BACKUP_PREFIX$bucket/ -> $DEST/$bucket/ (--overwrite --remove)\"\n\
-               mc mirror --overwrite --remove \"$BACKUP_PREFIX$bucket/\" \"$DEST/$bucket/\"\n\
-               echo \"[restore] done: $bucket\"\n\
-             done\n\
-             echo \"[restore] complete\"",
-            prefix = backup_prefix,
-        );
+
+        // SECURITY (docker inspect exposure): MC_HOST_* env vars embed plaintext
+        // credentials in the container's environment for the container's lifetime.
+        // This is the same pattern the S3MirrorEngine backup engine uses (accepted
+        // design). The container is removed immediately after the script exits (see
+        // the remove_container call below), bounding the exposure to the restore
+        // execution window. Anyone with Docker socket access has equivalent trust
+        // to these credentials for that window.
+        let env_vars = vec![
+            format!(
+                "MC_HOST_bkp={}://{}:{}@{}",
+                bkp_scheme, ctx.s3_source.access_key_id, ctx.s3_source.secret_key, bkp_hostpath,
+            ),
+            // Live service is always reached via localhost in host-network mode.
+            format!(
+                "MC_HOST_live=http://{}:{}@localhost:{}",
+                s3_config.access_key, s3_config.secret_key, s3_config.port
+            ),
+            // RESTORE_PREFIX carries the user-influenced backup_location value.
+            // It is passed as an env var — never interpolated into shell syntax —
+            // so shell metacharacters in the value cannot cause injection.
+            format!("RESTORE_PREFIX={}/", backup_prefix),
+        ];
+
+        // Static script constant — no user-supplied values are interpolated here.
+        let script = Self::RESTORE_IN_PLACE_SCRIPT.to_string();
 
         // ── Spin up and wait ─────────────────────────────────────────────────
         let container_name = format!("temps-s3restore-{}", uuid::Uuid::new_v4());
@@ -2157,6 +2207,12 @@ impl ExternalService for S3Service {
         self.pull_mc_image(&self.docker).await?;
 
         let mc_container_name = format!("mc-restore-new-{}", uuid::Uuid::new_v4());
+        // SECURITY (docker inspect exposure): MC_HOST_* env vars embed plaintext
+        // credentials in the container environment for the container's lifetime.
+        // The container is removed immediately after all mirror operations complete
+        // (see the remove_container call at the end of this function), bounding
+        // the exposure window to the restore execution time. Anyone with Docker
+        // socket access has equivalent trust to these credentials for that window.
         let env_vars = [
             format!(
                 "MC_HOST_source=http://{}:{}@{}",
@@ -2273,10 +2329,19 @@ impl ExternalService for S3Service {
                         }),
                     )
                     .await;
+                // SECURITY: `mc alias set` argv positions 5+ are plaintext
+                // access_key / secret_key. Never log the real `cmd` — use a
+                // redacted copy so credentials don't appear in error messages
+                // or the `restore_runs.error` DB column.
+                let redacted_cmd: Vec<&str> = cmd
+                    .iter()
+                    .enumerate()
+                    .map(|(i, s)| if i >= 5 { "***" } else { *s })
+                    .collect();
                 return Err(anyhow::anyhow!(
                     "mc alias setup failed with exit code {} for command {:?}",
                     exit_code,
-                    cmd
+                    redacted_cmd
                 ));
             }
         }
@@ -3410,5 +3475,142 @@ mod tests {
         let var = format!("MC_HOST_bkp={}://key:secret@{}", scheme, host);
         assert!(!var.contains("http://http://"), "double-scheme detected");
         assert_eq!(var, "MC_HOST_bkp=http://key:secret@minio.example.com:9000");
+    }
+
+    /// Verify the CRITICAL shell-injection fix in `restore_in_place`.
+    ///
+    /// Before the fix `backup_location` was interpolated into the shell script
+    /// via Rust `format!()` inside POSIX single-quotes:
+    ///   `BACKUP_PREFIX='{prefix}/'`
+    /// A value containing `'` (e.g. `"foo'; env; #"`) breaks out of the quoted
+    /// context and injects arbitrary shell commands that run with host-network
+    /// access and plaintext S3 credentials in the environment.
+    ///
+    /// After the fix `backup_location` travels only as the value of the Docker
+    /// env var `RESTORE_PREFIX`. Environment variable values are never re-parsed
+    /// as shell syntax, so metacharacters are handled safely.
+    #[test]
+    fn test_restore_in_place_injection_safety() {
+        // Classic single-quote injection payload.
+        let injection_payload = "foo'; env; echo INJECTED; #";
+
+        // Simulate what restore_in_place does to produce the RESTORE_PREFIX env var.
+        let bucket_name = "backup-bucket";
+        let backup_prefix = format!(
+            "bkp/{}/{}",
+            bucket_name,
+            injection_payload.trim_matches('/')
+        );
+        let env_var = format!("RESTORE_PREFIX={}/", backup_prefix);
+
+        // 1. The env var MUST carry the raw, unescaped value so that mc can reach
+        //    the correct path.  This is safe: Docker env var values are byte
+        //    sequences passed directly to the process, never re-parsed as shell.
+        assert!(
+            env_var.contains(injection_payload),
+            "RESTORE_PREFIX env var must carry the raw backup_location value \
+             (including metacharacters); got: {:?}",
+            env_var
+        );
+
+        // 2. The static script MUST NOT contain any part of the injection payload.
+        //    It is a compile-time constant — there is no code path that embeds
+        //    user-supplied data into it.
+        let script = S3Service::RESTORE_IN_PLACE_SCRIPT;
+
+        assert!(
+            !script.contains("foo"),
+            "static script must not contain any user-supplied value"
+        );
+        assert!(
+            !script.contains("INJECTED"),
+            "injection payload must not appear in the static script"
+        );
+        assert!(
+            !script.contains("'; env;"),
+            "shell-injection snippet must not appear in the static script"
+        );
+
+        // 3. The script must reference RESTORE_PREFIX via ${RESTORE_PREFIX}
+        //    (shell env var expansion), not any Rust-interpolated literal.
+        assert!(
+            script.contains("${RESTORE_PREFIX}"),
+            "script must reference RESTORE_PREFIX via shell env var expansion"
+        );
+
+        // 4. Confirm the script uses `while IFS= read -r` instead of
+        //    `for bucket in $BUCKETS` to prevent word-splitting on bucket names.
+        assert!(
+            script.contains("while IFS= read -r bucket"),
+            "script must use 'while IFS= read -r' to avoid word-splitting"
+        );
+        assert!(
+            !script.contains("for bucket in $"),
+            "script must not use bare 'for bucket in $VAR' (word-splitting risk)"
+        );
+    }
+
+    /// Verify that the `mc alias set` error path in `restore_to_new_service`
+    /// never exposes plaintext credentials in the error message.
+    ///
+    /// `mc alias set <name> <endpoint> <access_key> <secret_key>` puts credentials
+    /// at argv positions 5 and 6.  Before the fix, a failed alias setup included
+    /// the full `cmd` (with real keys) in the anyhow error that propagates into
+    /// `restore_runs.error` in the DB and `error!`-level logs.
+    #[test]
+    fn test_alias_setup_error_redacts_credentials() {
+        let access_key = "AKIAIOSFODNN7EXAMPLE";
+        let secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+        let endpoint = "http://s3.amazonaws.com";
+
+        // Simulate the argv the production code builds.
+        let cmd: Vec<&str> = vec![
+            "mc",
+            "alias",
+            "set",
+            "backup-source",
+            endpoint,
+            access_key, // position 5 — must be redacted
+            secret_key, // position 6 — must be redacted
+        ];
+
+        // Apply the same redaction logic used in restore_to_new_service.
+        let redacted_cmd: Vec<&str> = cmd
+            .iter()
+            .enumerate()
+            .map(|(i, s)| if i >= 5 { "***" } else { *s })
+            .collect();
+
+        let error_msg = format!(
+            "mc alias setup failed with exit code {} for command {:?}",
+            1, redacted_cmd
+        );
+
+        // The error message must NOT contain either credential.
+        assert!(
+            !error_msg.contains(access_key),
+            "error message must not contain plaintext access_key; got: {:?}",
+            error_msg
+        );
+        assert!(
+            !error_msg.contains(secret_key),
+            "error message must not contain plaintext secret_key; got: {:?}",
+            error_msg
+        );
+        // The sentinel must appear instead.
+        assert!(
+            error_msg.contains("***"),
+            "error message must contain redaction sentinel '***'; got: {:?}",
+            error_msg
+        );
+        // Non-sensitive positional args must still appear for debuggability.
+        assert!(
+            error_msg.contains("backup-source"),
+            "error message must retain the alias name for context"
+        );
+        assert!(
+            error_msg.contains(endpoint),
+            "error message must retain the endpoint for context"
+        );
     }
 }

--- a/crates/temps-providers/src/externalsvc/s3.rs
+++ b/crates/temps-providers/src/externalsvc/s3.rs
@@ -2,7 +2,9 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use aws_sdk_s3::config::Region;
 use aws_sdk_s3::Client;
-use bollard::query_parameters::{InspectContainerOptions, StopContainerOptions};
+use bollard::query_parameters::{
+    InspectContainerOptions, LogsOptionsBuilder, StopContainerOptions, WaitContainerOptions,
+};
 use bollard::Docker;
 use futures::TryStreamExt;
 use rand::RngExt;
@@ -1680,7 +1682,7 @@ impl ExternalService for S3Service {
                     output_str.push_str(&String::from_utf8_lossy(&message));
                 }
             }
-            println!("Output buckets {:?}", output_str);
+            info!("mc ls output: {}", output_str);
             // Parse all JSON objects from the output
             let json_objects = parse_multiline_json_output(&output_str)?;
 
@@ -1753,11 +1755,15 @@ impl ExternalService for S3Service {
                 s3_source.bucket_name, backup_location, bucket_name
             );
             let dest_bucket_loc = format!("dest/{}", bucket_name);
-            // Mirror command for this bucket
+            // Mirror command for this bucket.
+            // --overwrite: replace existing objects.
+            // No --remove here: the CLI restore path does not guarantee the
+            // live bucket only contains pre-backup objects (the caller may
+            // have additional context). The API path (restore_in_place) uses
+            // --remove for a stricter point-in-time guarantee.
             let mirror_cmd = vec![
                 "mc",
                 "mirror",
-                "--skip-errors",
                 "--overwrite",
                 &source_bucket_loc,
                 &dest_bucket_loc,
@@ -1768,7 +1774,7 @@ impl ExternalService for S3Service {
                 bucket_name, mirror_cmd
             );
 
-            let exec = docker
+            let mirror_exec = docker
                 .create_exec(
                     &container.id,
                     bollard::exec::CreateExecOptions {
@@ -1780,20 +1786,50 @@ impl ExternalService for S3Service {
                 )
                 .await?;
 
+            let mut mirror_stdout = String::new();
+            let mut mirror_stderr = String::new();
             if let bollard::exec::StartExecResults::Attached { mut output, .. } =
-                docker.start_exec(&exec.id, None).await?
+                docker.start_exec(&mirror_exec.id, None).await?
             {
                 while let Ok(Some(output)) = output.try_next().await {
                     match output {
                         bollard::container::LogOutput::StdOut { message } => {
-                            info!("stdout: {}", String::from_utf8_lossy(&message));
+                            let msg = String::from_utf8_lossy(&message).into_owned();
+                            info!("mirror stdout: {}", msg);
+                            mirror_stdout.push_str(&msg);
                         }
                         bollard::container::LogOutput::StdErr { message } => {
-                            error!("stderr: {}", String::from_utf8_lossy(&message));
+                            let msg = String::from_utf8_lossy(&message).into_owned();
+                            error!("mirror stderr: {}", msg);
+                            mirror_stderr.push_str(&msg);
                         }
                         _ => {}
                     }
                 }
+            }
+
+            let mirror_exit = docker
+                .inspect_exec(&mirror_exec.id)
+                .await?
+                .exit_code
+                .unwrap_or(-1);
+            if mirror_exit != 0 {
+                let _ = docker
+                    .remove_container(
+                        &container.id,
+                        Some(bollard::query_parameters::RemoveContainerOptions {
+                            force: true,
+                            ..Default::default()
+                        }),
+                    )
+                    .await;
+                return Err(anyhow::anyhow!(
+                    "mc mirror failed for bucket '{}' with exit code {}. stdout: {}. stderr: {}",
+                    bucket_name,
+                    mirror_exit,
+                    mirror_stdout.trim(),
+                    mirror_stderr.trim(),
+                ));
             }
         }
 
@@ -1825,6 +1861,208 @@ impl ExternalService for S3Service {
             earliest_pitr_time: None,
             latest_pitr_time: None,
         })
+    }
+
+    /// Restore the live S3/MinIO service from a backup using a one-shot mc container.
+    ///
+    /// ## Semantics: `--overwrite --remove` (true point-in-time restore)
+    ///
+    /// The mirror runs with both `--overwrite` (replace existing objects with
+    /// their backed-up versions) **and** `--remove` (delete live objects that are
+    /// absent from the backup). Together these guarantee the live bucket matches
+    /// the backup exactly at the object level.
+    ///
+    /// ⚠ **Destructive**: objects written to the live service after the backup
+    /// was taken **will be permanently deleted**. This is intentional — an
+    /// in-place restore that leaves post-backup writes in place is not a
+    /// restore, it is a partial merge. Callers that want additive-only behaviour
+    /// should use `restore_to_new_service` instead.
+    ///
+    /// ## What `--remove` does and does NOT remove
+    ///
+    /// `mc mirror --remove` removes objects within each mirrored bucket. It does
+    /// NOT remove extra buckets in the live service that were not present at
+    /// backup time — those are left in place. A future enhancement could enumerate
+    /// and drop them, but that increases blast radius substantially and is deferred.
+    ///
+    /// ## Container pattern
+    ///
+    /// A disposable `minio/mc` container runs in host-network mode so it can
+    /// reach both the backup S3 source (typically an internet endpoint or a local
+    /// MinIO used for e2e) and the live MinIO service (typically `localhost:<port>`).
+    /// Credentials are passed exclusively via `MC_HOST_*` environment variables —
+    /// the same pattern the `S3MirrorEngine` backup engine uses.
+    async fn restore_in_place(&self, ctx: super::RestoreContext<'_>) -> Result<()> {
+        info!(
+            service = %ctx.source_service.name,
+            backup_location = ctx.backup_location,
+            "S3 restore_in_place: starting one-shot mc mirror (--overwrite --remove)"
+        );
+
+        // Ensure the live MinIO container is running before writing to it.
+        self.start().await?;
+
+        let s3_config = self.get_s3_config(ctx.source_config)?;
+        let docker = &self.docker;
+
+        self.pull_mc_image(docker).await?;
+
+        // ── MC_HOST env vars ─────────────────────────────────────────────────
+        // The backup-source endpoint already carries a scheme (http:// / https://).
+        // Strip it before embedding in the MC_HOST string to avoid the malformed
+        // `http://...@http://...` double-scheme that would otherwise result.
+        //
+        // Credentials are ALREADY DECRYPTED by the orchestrator (RestoreContext
+        // contract). Never call EncryptionService::decrypt_string on them here.
+        let bkp_endpoint = ctx.s3_source.endpoint.as_deref().unwrap_or("");
+        let (bkp_scheme, bkp_hostpath) = mc_strip_scheme(bkp_endpoint);
+
+        let env_vars = vec![
+            format!(
+                "MC_HOST_bkp={}://{}:{}@{}",
+                bkp_scheme, ctx.s3_source.access_key_id, ctx.s3_source.secret_key, bkp_hostpath,
+            ),
+            // Live service is always reached via localhost in host-network mode.
+            format!(
+                "MC_HOST_live=http://{}:{}@localhost:{}",
+                s3_config.access_key, s3_config.secret_key, s3_config.port
+            ),
+        ];
+
+        // ── Restore shell script ─────────────────────────────────────────────
+        // The S3MirrorEngine backup engine mirrors:
+        //   source/<bucket>/ -> bkp/<bkp_bucket>/<prefix>/<original_bucket>/
+        //
+        // For S3Service the source bucket name is always "" (no per-bucket config
+        // on the service row), so the backup prefix contains one folder per
+        // original MinIO bucket:
+        //   bkp/<bkp_bucket>/<prefix>/bucket1/...
+        //   bkp/<bkp_bucket>/<prefix>/bucket2/...
+        //
+        // The script discovers those bucket folders via `mc ls`, creates each in
+        // the live service, and mirrors their contents with --overwrite --remove.
+        let backup_prefix = format!(
+            "bkp/{}/{}",
+            ctx.s3_source.bucket_name,
+            ctx.backup_location.trim_matches('/')
+        );
+        let script = format!(
+            "set -e\n\
+             BACKUP_PREFIX='{prefix}/'\n\
+             DEST='live'\n\
+             echo \"[restore] listing $BACKUP_PREFIX\"\n\
+             BUCKETS=$(mc ls \"$BACKUP_PREFIX\" | awk '{{print $NF}}' | grep '/$' | sed 's|/$||')\n\
+             if [ -z \"$BUCKETS\" ]; then\n\
+               echo \"[restore] no bucket directories found — nothing to restore\"\n\
+               exit 0\n\
+             fi\n\
+             echo \"[restore] buckets: $BUCKETS\"\n\
+             for bucket in $BUCKETS; do\n\
+               echo \"[restore] ensuring $DEST/$bucket exists\"\n\
+               mc mb \"$DEST/$bucket\" 2>&1 || true\n\
+               echo \"[restore] mirroring $BACKUP_PREFIX$bucket/ -> $DEST/$bucket/ (--overwrite --remove)\"\n\
+               mc mirror --overwrite --remove \"$BACKUP_PREFIX$bucket/\" \"$DEST/$bucket/\"\n\
+               echo \"[restore] done: $bucket\"\n\
+             done\n\
+             echo \"[restore] complete\"",
+            prefix = backup_prefix,
+        );
+
+        // ── Spin up and wait ─────────────────────────────────────────────────
+        let container_name = format!("temps-s3restore-{}", uuid::Uuid::new_v4());
+        let container_config = bollard::models::ContainerCreateBody {
+            image: Some(Self::MC_IMAGE.to_string()),
+            env: Some(env_vars),
+            // One-shot: `sh -c <script>` exits when the script does.
+            entrypoint: Some(vec!["sh".to_string(), "-c".to_string()]),
+            cmd: Some(vec![script]),
+            host_config: Some(bollard::models::HostConfig {
+                // Host network so mc can reach both localhost (live MinIO)
+                // and the remote backup S3 endpoint without extra routing.
+                network_mode: Some("host".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let container = docker
+            .create_container(
+                Some(
+                    bollard::query_parameters::CreateContainerOptionsBuilder::new()
+                        .name(&container_name)
+                        .build(),
+                ),
+                container_config,
+            )
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to create mc restore container '{}': {}",
+                    container_name,
+                    e
+                )
+            })?;
+
+        docker
+            .start_container(
+                &container.id,
+                None::<bollard::query_parameters::StartContainerOptions>,
+            )
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to start mc restore container '{}': {}",
+                    container_name,
+                    e
+                )
+            })?;
+
+        // Block until the container exits and capture its exit code.
+        let exit_code = docker
+            .wait_container(&container.id, None::<WaitContainerOptions>)
+            .try_collect::<Vec<_>>()
+            .await
+            .ok()
+            .and_then(|v| v.into_iter().next().map(|r| r.status_code))
+            .unwrap_or(1);
+
+        // Collect logs for diagnostics (best-effort — don't let a log-fetch
+        // failure mask the actual result).
+        let logs = docker
+            .logs(
+                &container.id,
+                Some(LogsOptionsBuilder::new().stdout(true).stderr(true).build()),
+            )
+            .try_collect::<Vec<_>>()
+            .await
+            .map(|v| v.into_iter().map(|c| c.to_string()).collect::<String>())
+            .unwrap_or_default();
+
+        // Best-effort cleanup — don't let removal failure mask the real result.
+        let _ = docker
+            .remove_container(
+                &container.id,
+                Some(bollard::query_parameters::RemoveContainerOptions {
+                    force: true,
+                    ..Default::default()
+                }),
+            )
+            .await;
+
+        if exit_code != 0 {
+            return Err(anyhow::anyhow!(
+                "S3 restore failed: mc mirror exited with code {} for service '{}'. Logs:\n{}",
+                exit_code,
+                ctx.source_service.name,
+                logs.trim(),
+            ));
+        }
+
+        info!(
+            service = %ctx.source_service.name,
+            "S3 restore_in_place: completed successfully"
+        );
+        Ok(())
     }
 
     /// Provision a fresh S3/MinIO service and mirror a backup into it.
@@ -2129,6 +2367,11 @@ impl ExternalService for S3Service {
             }
 
             // Mirror bucket contents into the fresh bucket.
+            // --overwrite: replace any objects that landed during container
+            // startup (none expected, but be defensive).
+            // No --remove: the destination bucket was just created so there is
+            // nothing extra to remove; --remove would be a no-op at best and
+            // could race with startup writes at worst.
             let source_bucket_loc = format!(
                 "backup-source/{}/{}/{}",
                 ctx.s3_source.bucket_name, ctx.backup_location, bucket_name
@@ -2136,13 +2379,15 @@ impl ExternalService for S3Service {
             let mirror_cmd = vec![
                 "mc",
                 "mirror",
-                "--skip-errors",
                 "--overwrite",
                 &source_bucket_loc,
                 &dest_location,
             ];
 
-            info!("Mirroring bucket {} -> new service", bucket_name);
+            info!(
+                "Mirroring bucket {} -> new service '{}'",
+                bucket_name, new_service_name
+            );
             let mirror_exec = self
                 .docker
                 .create_exec(
@@ -2155,20 +2400,54 @@ impl ExternalService for S3Service {
                     },
                 )
                 .await?;
+            let mut new_mirror_stdout = String::new();
+            let mut new_mirror_stderr = String::new();
             if let bollard::exec::StartExecResults::Attached { mut output, .. } =
                 self.docker.start_exec(&mirror_exec.id, None).await?
             {
                 while let Ok(Some(chunk)) = output.try_next().await {
                     match chunk {
                         bollard::container::LogOutput::StdOut { message } => {
-                            info!("mirror stdout: {}", String::from_utf8_lossy(&message));
+                            let msg = String::from_utf8_lossy(&message).into_owned();
+                            info!("mirror stdout: {}", msg);
+                            new_mirror_stdout.push_str(&msg);
                         }
                         bollard::container::LogOutput::StdErr { message } => {
-                            error!("mirror stderr: {}", String::from_utf8_lossy(&message));
+                            let msg = String::from_utf8_lossy(&message).into_owned();
+                            error!("mirror stderr: {}", msg);
+                            new_mirror_stderr.push_str(&msg);
                         }
                         _ => {}
                     }
                 }
+            }
+
+            let mirror_exit = self
+                .docker
+                .inspect_exec(&mirror_exec.id)
+                .await?
+                .exit_code
+                .unwrap_or(-1);
+            if mirror_exit != 0 {
+                let _ = self
+                    .docker
+                    .remove_container(
+                        &container.id,
+                        Some(bollard::query_parameters::RemoveContainerOptions {
+                            force: true,
+                            ..Default::default()
+                        }),
+                    )
+                    .await;
+                return Err(anyhow::anyhow!(
+                    "mc mirror failed for bucket '{}' into new service '{}' with exit code {}. \
+                     stdout: {}. stderr: {}",
+                    bucket_name,
+                    new_service_name,
+                    mirror_exit,
+                    new_mirror_stdout.trim(),
+                    new_mirror_stderr.trim(),
+                ));
             }
         }
 
@@ -2442,6 +2721,26 @@ impl ExternalService for S3Service {
             config.name
         );
         Ok(config)
+    }
+}
+
+/// Strip the URL scheme from an S3 endpoint so it can be embedded in an
+/// `MC_HOST_<alias>=<scheme>://<key>:<secret>@<host>` env var without
+/// producing a malformed double-scheme like `http://key:secret@http://host`.
+///
+/// Returns `(scheme, host_and_path)`.  When the endpoint carries no scheme
+/// it is assumed to be a bare `host:port` and `"http"` is used.
+fn mc_strip_scheme(endpoint: &str) -> (&'static str, &str) {
+    if let Some(rest) = endpoint.strip_prefix("https://") {
+        ("https", rest)
+    } else if let Some(rest) = endpoint.strip_prefix("http://") {
+        ("http", rest)
+    } else if endpoint.is_empty() {
+        // No endpoint configured; fall back to a sensible default.
+        ("http", "localhost:9000")
+    } else {
+        // Bare host:port — assume plain HTTP (internal/MinIO default).
+        ("http", endpoint)
     }
 }
 
@@ -3070,5 +3369,46 @@ mod tests {
         let _ = backup_minio.cleanup().await;
 
         println!("S3 MinIO backup and restore-to-new-service test passed");
+    }
+
+    // ── mc_strip_scheme ───────────────────────────────────────────────────────
+
+    #[test]
+    fn strip_scheme_removes_http_prefix() {
+        let (scheme, host) = mc_strip_scheme("http://localhost:9092");
+        assert_eq!(scheme, "http");
+        assert_eq!(host, "localhost:9092");
+    }
+
+    #[test]
+    fn strip_scheme_removes_https_prefix() {
+        let (scheme, host) = mc_strip_scheme("https://my-bucket.s3.amazonaws.com");
+        assert_eq!(scheme, "https");
+        assert_eq!(host, "my-bucket.s3.amazonaws.com");
+    }
+
+    #[test]
+    fn strip_scheme_bare_host_port() {
+        let (scheme, host) = mc_strip_scheme("192.168.1.10:9000");
+        assert_eq!(scheme, "http");
+        assert_eq!(host, "192.168.1.10:9000");
+    }
+
+    #[test]
+    fn strip_scheme_empty_endpoint_falls_back() {
+        let (scheme, host) = mc_strip_scheme("");
+        assert_eq!(scheme, "http");
+        assert_eq!(host, "localhost:9000");
+    }
+
+    #[test]
+    fn strip_scheme_mc_host_var_format_no_double_scheme() {
+        // Regression: before mc_strip_scheme, an http:// endpoint produced
+        // MC_HOST=http://key:secret@http://host — invalid and rejected by mc.
+        let endpoint = "http://minio.example.com:9000";
+        let (scheme, host) = mc_strip_scheme(endpoint);
+        let var = format!("MC_HOST_bkp={}://key:secret@{}", scheme, host);
+        assert!(!var.contains("http://http://"), "double-scheme detected");
+        assert_eq!(var, "MC_HOST_bkp=http://key:secret@minio.example.com:9000");
     }
 }


### PR DESCRIPTION
## What

S3/blob/MinIO managed services now have a working `restore_in_place` implementation. Before this PR the S3MirrorEngine backup path worked, but every restore attempt returned \"not implemented\" — a genuine product gap.

## Changes

### Rust — `crates/temps-providers/src/externalsvc/s3.rs`

**New `restore_in_place` override** (previously the default delegated to `restore_from_s3`, which had its own bugs; this replaces the entire interactive-exec container pattern with a proper one-shot container):

- Calls `self.start()` first so the live service is running before we try to mirror into it.
- Builds two `MC_HOST_*` env vars using the new `mc_strip_scheme()` helper (see below).
- Runs a shell script in a one-shot `minio/mc:RELEASE.2025-08-13T08-35-41Z` container (host network mode, same as the backup engine):
  1. `mc ls` the backup prefix to discover which buckets were in the backup.
  2. `mc mb` each bucket on the live service (idempotent — ignores \"already exists\").
  3. `mc mirror --overwrite --remove` each bucket from backup to live.
- Waits via `docker.wait_container(...)` (synchronous, proper exit-code detection) rather than polling.
- Collects stdout+stderr on failure for actionable error messages.
- Removes the helper container best-effort after the script finishes.

**`mc_strip_scheme()` helper** — prevents double-scheme `MC_HOST` URLs. If the stored endpoint is `http://localhost:9092`, the naive format string `http://key:secret@http://localhost:9092` is invalid and breaks mc silently. The helper strips the scheme, returns it separately, and lets the caller rebuild a clean `scheme://key:secret@host:port`.

**Bug fixes in existing restore paths** (root cause, not workaround):

| Bug | Location | Fix |
|-----|----------|-----|
| `--skip-errors` silently swallowed mc mirror transfer errors | `restore_from_s3`, `restore_to_new_service` | Removed `--skip-errors` from both |
| Mirror exec exit code never checked — failures were ignored | `restore_from_s3`, `restore_to_new_service` | Added `inspect_exec + exit_code` check; `Err` on non-zero |
| Debug `println!` in production path | `restore_from_s3` | Replaced with `info!()` |

**Unit tests** (7 total, in `#[cfg(test)] mod tests`):
- `strip_scheme_removes_http_prefix`
- `strip_scheme_removes_https_prefix`
- `strip_scheme_bare_host_port`
- `strip_scheme_empty_endpoint_falls_back`
- `strip_scheme_mc_host_var_format_no_double_scheme` (regression for the double-scheme bug)
- `test_restore_in_place_injection_safety` (new — security)
- `test_alias_setup_error_redacts_credentials` (new — security)

### TypeScript — `apps/temps-e2e/src/commands/s3-restore-scenario.ts` (new)

Full before/after object verification — not just \"restore run status is completed\":

1. Provision a real S3/MinIO managed service with known credentials.
2. Fetch the dynamically assigned port from `current_parameters`.
3. Create two buckets (`alpha`, `beta`) via a one-shot `docker run minio/mc mb` container.
4. Upload 3 pre-backup objects via `Bun.S3Client`.
5. Create an S3 source pointing at the local test MinIO and trigger a real backup (S3MirrorEngine).
6. Diverge the live service: upload `alpha/post-backup.txt`, delete `alpha/file-b.txt`.
7. Call `startRestore(mode: \"in_place\")` and poll the restore run to completed.
8. Assert via the platform read-only data-browser API (`listEntities`):
   - `alpha/file-a.txt` present (untouched pre-backup object)
   - `alpha/file-b.txt` present (deleted post-backup, must be restored)
   - `alpha/post-backup.txt` absent (written after backup, must be removed by --remove)
   - `beta/gamma.txt` present (second bucket fully intact)

## Overwrite-vs-remove decision

`restore_in_place` uses `mc mirror --overwrite --remove`.

`--remove` makes the live bucket an exact replica of the backup-time state: objects absent from the backup are deleted from live. This is what \"restore in place\" means. An in-place restore that leaves post-backup writes intact is not a restore — it is a partial merge, and the caller has no way to know which objects survived. The e2e scenario explicitly verifies both sides of this: a post-backup object disappears AND a deleted object comes back.

`restore_to_new_service` (the pre-existing helper) uses `--overwrite` only, since the destination starts empty — `--remove` on an empty-backed mirror is a no-op, so the distinction does not matter there, but the new service is not the live service so there is no live data to delete.

## Security fixes (post-audit, commit 066bc169)

A security audit of this PR identified five findings. All are addressed in the follow-up commit.

### [CRITICAL] Shell injection via backup_location in restore_in_place — FIXED

**Root cause**: `backup_location` (user-supplied via `BackupSelector::Location`) was interpolated into the shell script string via Rust `format!()` inside POSIX single-quotes: `BACKUP_PREFIX='{prefix}/'`. A value containing `'` (e.g. `foo'; env; #`) breaks out of the quoted context and executes arbitrary shell commands in a container with `--network host` and plaintext S3 credentials in the environment.

**Fix**: `backup_prefix` is now passed as a Docker environment variable `RESTORE_PREFIX` and the shell script is a compile-time constant (`RESTORE_IN_PLACE_SCRIPT`). The shell expands `${RESTORE_PREFIX}` safely — env var values are never re-parsed as shell commands, so metacharacters in `backup_location` cannot break out of the quoting context.

**Evidence**: `test_restore_in_place_injection_safety` constructs `backup_location = \"foo'; env; echo INJECTED; #\"` and asserts:
1. The RESTORE_PREFIX env var carries the raw value (safe — Docker env vars are byte sequences, not shell).
2. `RESTORE_IN_PLACE_SCRIPT` contains `${RESTORE_PREFIX}` (env var reference, not literal value).
3. The static script does not contain `foo`, `INJECTED`, or `'; env;` at compile time.
4. The script uses `while IFS= read -r bucket` not `for bucket in $BUCKETS`.

```
test externalsvc::s3::tests::test_restore_in_place_injection_safety ... ok
```

### [HIGH] Plaintext credentials exposed via docker inspect — DOCUMENTED/MITIGATED

**Finding**: `MC_HOST_*` env vars embed `access_key:secret_key` in the container environment, readable via `docker inspect` for the container's lifetime.

**Fix**: The container is already removed immediately after the script/exec completes in both `restore_in_place` and `restore_to_new_service`. This bounds the exposure window to the restore execution time. Added explicit `SECURITY (docker inspect exposure)` comments at both sites documenting the accepted risk pattern (identical to the existing S3MirrorEngine backup engine) and confirming the immediate-removal guarantee.

A fully hermetic fix (writing credentials to a tmpfs-mounted config file instead of env vars) would require restructuring both the container startup and the mc alias configuration flow. Given that the window is bounded, the pattern is consistent with the backup engine, and the remediation is documented, this is accepted risk with a clear paper trail.

### [HIGH] Error message leaked plaintext credentials in restore_to_new_service — FIXED

**Root cause**: When `mc alias set` failed, the error message included `{:?}` of the full `cmd` argv, which contains `access_key` and `secret_key` at positions 5–6. This propagated into `error!`-level logs and the `restore_runs.error` DB column.

**Fix**: Build a `redacted_cmd: Vec<&str>` where positions `>= 5` are replaced with `\"***\"` and use that in the `anyhow::anyhow!` error instead of the real `cmd`.

**Evidence**:
```
test externalsvc::s3::tests::test_alias_setup_error_redacts_credentials ... ok
```
The test asserts the error message does not contain the real access_key or secret_key, contains `***`, and still contains the alias name and endpoint for debuggability.

### [MEDIUM] Word-splitting / glob expansion on bucket names — FIXED

**Root cause**: The original script used `BUCKETS=$(mc ls ... | awk ...)` then `for bucket in $BUCKETS` (unquoted). Whitespace or glob characters in bucket names caused word-splitting or glob expansion instead of iterating intended names.

**Fix**: Replaced with `while IFS= read -r bucket; do ... done < \"${BUCKET_LIST}\"` using a temp file from `mktemp`. All variable expansions in the script are double-quoted throughout.

### [MINOR] No service-identity binding — TODO TRACKED

**Finding**: A caller with `BackupsWrite + ExternalServicesWrite` can restore service A's backup onto service B's live MinIO bucket.

**Decision**: Deferred. A full fix requires an optional `confirm_target_service_id` field on `StartRestoreRequest` validated against the URL `{id}`, which touches the shared restore-framework code well beyond S3's scope. Added an explicit `TODO(security)` comment in `restore_in_place` with this rationale for the next framework-level security pass.

### [MINOR] minio/mc image pinning — ALREADY FIXED (pre-audit)

`MC_IMAGE` was already `minio/mc:RELEASE.2025-08-13T08-35-41Z` (immutable release tag, not `:latest`). The PR description previously said `:latest` — that was a documentation error. Added a clarifying doc comment on the constant.

## Evidence (post-fix)

```
$ cargo check --lib -p temps-providers
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 22s
    # zero errors

$ $(command -v cargo) clippy -p temps-providers --lib -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 23.27s
    # zero warnings from our code

$ cargo test -p temps-providers --lib -- externalsvc::s3::tests
running 18 tests
test externalsvc::s3::tests::test_parameter_schema_editable_fields ... ok
test externalsvc::s3::tests::test_default_docker_image ... ok
test externalsvc::s3::tests::test_image_field_in_configuration ... ok
test externalsvc::s3::tests::test_get_effective_address_docker_mode_uses_imported_container_name ... ok
test externalsvc::s3::tests::test_container_name_is_not_a_user_input ... ok
test externalsvc::s3::tests::test_minio_version_upgrade_config ... ok
test externalsvc::s3::tests::test_import_service_config_creation ... ok
test externalsvc::s3::tests::test_import_s3_version_extraction ... ok
test externalsvc::s3::tests::test_import_validates_required_credentials ... ok
test externalsvc::s3::tests::test_import_credential_extraction ... ok
test externalsvc::s3::tests::test_import_s3_endpoint_validation ... ok
test externalsvc::s3::tests::strip_scheme_removes_http_prefix ... ok
test externalsvc::s3::tests::strip_scheme_removes_https_prefix ... ok
test externalsvc::s3::tests::strip_scheme_bare_host_port ... ok
test externalsvc::s3::tests::strip_scheme_empty_endpoint_falls_back ... ok
test externalsvc::s3::tests::strip_scheme_mc_host_var_format_no_double_scheme ... ok
test externalsvc::s3::tests::test_restore_in_place_injection_safety ... ok
test externalsvc::s3::tests::test_alias_setup_error_redacts_credentials ... ok
test result: ok. 18 passed; 0 failed; 0 ignored; 0 filtered out

$ git push origin feat/restore-s3
   e5378e44..066bc169  feat/restore-s3 -> feat/restore-s3
```

**NOTE: This PR is NOT safe to merge without security-auditor re-confirmation of all findings above, particularly the CRITICAL injection fix and the accepted-risk decision on docker inspect credential exposure.**

## Security — REQUIRES SECURITY-AUDITOR REVIEW BEFORE MERGE

**`restore_in_place` uses `mc mirror --remove`, which DELETES live S3 objects.**

Specifically: any object present in the live MinIO service that was NOT present at backup time will be permanently deleted by a restore. There is no dry-run, no preview, no recycle bin. The restore run is triggered by a single authenticated API call with no secondary confirmation step at the platform level.

Risk surface:
- An operator calling `POST /external-services/{id}/restore` with `mode: \"in_place\"` on a live production S3 service will destroy any data written after the backup was taken.
- A compromised API key with write access to external services could trigger a restore and wipe the live bucket silently.

Existing mitigations that apply:
- The endpoint is authenticated (`Bearer` required) and RBAC-gated by `permission_guard!` (inherits from the service-write permission in the handlers layer).
- All write operations go through the audit log (the existing service restore handler records the restore run; the run's `started_at`/`finished_at`/`status` are queryable).
- `restore_capabilities` returns `restore_in_place: true` only for S3/MinIO services, not for Postgres/Redis/MongoDB — those have their own restore paths with different destructive semantics.

Items that should be reviewed before merge:
1. Is a single authenticated call sufficient authorization for a destructive in-place restore, or should there be a confirm step?
2. Should the restore endpoint require a narrower permission (e.g. `service:admin`) rather than the current `service:write`?
3. Should `--remove` semantics be opt-in (a request body flag `destructive_remove: bool`) rather than always-on for in-place restores?