### PR TITLE
feat(redis): implement restore_capabilities, restore_in_place, restore_to_new_service

### DIFF
--- a/apps/temps-e2e/src/commands/redis-restore-scenario.ts
+++ b/apps/temps-e2e/src/commands/redis-restore-scenario.ts
@@ -1,0 +1,513 @@
+/**
+ * Backup + restore lifecycle for a Redis managed service, using MinIO as the
+ * local S3-compatible target (same image + credentials as the postgres
+ * backup-restore and PITR scenarios):
+ *
+ *   1. provision a real standalone Redis service and link it to a project
+ *   2. deploy a small Go HTTP probe app that connects via the injected
+ *      `REDIS_URL` (includes the per-project database number) and exposes
+ *      write endpoints for string, hash, and list keys
+ *   3. create an S3 source pointed at the local MinIO
+ *   4. write three PRE-BACKUP keys of distinct types (string, hash, list)
+ *      through the probe app's HTTP endpoints
+ *   5. trigger a real backup (`POST /backups/external-services/{id}/run`) and
+ *      poll `GET /backups/{id}` to a real `completed` state (a genuine
+ *      `wal-g backup-fetch` uploaded to S3 inside a WAL-G helper container)
+ *   6. write three POST-BACKUP keys that must NOT survive the restore
+ *   7. start an in-place restore from the backup (`POST
+ *      /external-services/{id}/restore`, `mode: "in_place"`) and poll
+ *      `GET /restore-runs/{id}` to `completed`
+ *   8. verify via the read-only data-browser API (`readEntityRows`, the same
+ *      endpoint `temps data rows` uses) that the three PRE-BACKUP keys still
+ *      exist (HTTP 200) and the three POST-BACKUP keys are absent (HTTP 404)
+ *      -- proving the restore actually reverted the post-backup writes, not
+ *      just that the API calls returned 2xx
+ *   9. teardown (deployment, project, service, S3 source)
+ *
+ * Redis restore mechanics (documented here because they're non-obvious):
+ *   - The WAL-G helper container mounts the Redis container's volume via
+ *     `volumes_from` while the Redis container is stopped.
+ *   - WAL-G writes a `dump.rdb` into `/data`, then the helper reconstructs
+ *     the Redis 7 multi-part AOF directory (`appendonlydir/`) with a manifest
+ *     pointing to the RDB as the base file. This is the only correct path:
+ *     Redis 7+ with `appendonly yes` ignores a bare `dump.rdb` on startup and
+ *     reads from `appendonlydir/` instead.
+ *   - The Redis container's restart policy is set to `no` before stopping it
+ *     (otherwise Docker immediately restarts it, and the helper cannot write
+ *     to the volume). It is always reset to `always` after the restore,
+ *     regardless of success or failure.
+ *
+ * Needs the local MinIO from `docker-compose.e2e.yml` (`minio` service) and
+ * a bucket created ahead of time -- see "External-service test infra" in
+ * apps/temps-e2e/README.md.
+ */
+import {
+  linkServiceToProject,
+  createS3Source,
+  deleteS3Source,
+  runExternalServiceBackup,
+  listExternalServiceBackups,
+  getBackup,
+  startRestore,
+  getRestoreRun,
+  readEntityRows,
+  getResolvedEnvironmentVariableValue,
+} from '@temps-sdk/api'
+import { makeClient, resolveConfig, unwrap } from '../lib/client.ts'
+import {
+  createE2eProject,
+  createE2eService,
+  getProductionEnvironment,
+  deployImage,
+  waitForDeployment,
+  getDeployStatus,
+  waitForHttpReady,
+  assertNotConsoleFallback,
+  resolveLoadTarget,
+  pollUntil,
+  teardown,
+  makeRunId,
+} from '../lib/flows.ts'
+import { buildRedisProbeImage, REDIS_PROBE_HEALTH_PATH } from '../lib/redis-probe-app.ts'
+
+export interface RedisRestoreScenarioOptions {
+  registry?: string
+  minioEndpoint?: string
+  minioBucket?: string
+  keep?: boolean
+  deployTimeout?: string
+  json?: boolean
+  connection: { url?: string; apiKey?: string }
+}
+
+interface StepLog {
+  step: string
+  ok: boolean
+  detail?: string
+  ms?: number
+}
+
+interface RedisRestoreScenarioResult {
+  runId: string
+  ok: boolean
+  steps: StepLog[]
+}
+
+/**
+ * Call a probe write endpoint and assert HTTP 200.
+ * `path` is e.g. `/write?key=foo&value=bar`.
+ */
+async function callProbe(
+  baseUrl: string,
+  headers: Record<string, string>,
+  path: string,
+): Promise<void> {
+  const url = `${baseUrl.replace(/\/+$/, '')}${path}`
+  const res = await fetch(url, { headers })
+  if (res.status !== 200) {
+    const body = await res.text().catch(() => '')
+    throw new Error(`GET ${path} returned HTTP ${res.status}: ${body}`)
+  }
+}
+
+/**
+ * Assert that a Redis key exists in the given database via the data-browser
+ * API (HTTP 200 with non-empty rows). Throws if the key is absent (404) or
+ * the request otherwise fails.
+ */
+async function assertKeyExists(
+  client: Parameters<typeof readEntityRows>[0]['client'],
+  serviceId: number,
+  dbNumber: string,
+  keyName: string,
+): Promise<void> {
+  const result = await readEntityRows({
+    client,
+    path: { service_id: serviceId, path: dbNumber, entity: keyName },
+    query: { limit: 1 },
+  })
+  if (result.response?.status === 404) {
+    throw new Error(
+      `key "${keyName}" not found in Redis DB ${dbNumber} after restore (expected to survive)`,
+    )
+  }
+  if (result.error !== undefined && result.error !== null) {
+    const detail =
+      typeof result.error === 'object' ? JSON.stringify(result.error) : String(result.error)
+    throw new Error(
+      `readEntityRows for key "${keyName}" failed (HTTP ${result.response?.status}): ${detail}`,
+    )
+  }
+  if (!result.data) {
+    throw new Error(`readEntityRows for key "${keyName}": empty response`)
+  }
+}
+
+/**
+ * Assert that a Redis key is absent in the given database (HTTP 404). Throws
+ * if the key still exists or the request fails for an unexpected reason.
+ */
+async function assertKeyAbsent(
+  client: Parameters<typeof readEntityRows>[0]['client'],
+  serviceId: number,
+  dbNumber: string,
+  keyName: string,
+): Promise<void> {
+  const result = await readEntityRows({
+    client,
+    path: { service_id: serviceId, path: dbNumber, entity: keyName },
+    query: { limit: 1 },
+  })
+  if (result.response?.status === 404) {
+    // Correct: key does not exist after restore.
+    return
+  }
+  if (result.data) {
+    throw new Error(
+      `key "${keyName}" still present in Redis DB ${dbNumber} after restore (should have been erased)`,
+    )
+  }
+  // Any unexpected error other than 404.
+  const detail =
+    typeof result.error === 'object' ? JSON.stringify(result.error) : String(result.error)
+  throw new Error(
+    `readEntityRows for key "${keyName}" failed unexpectedly (HTTP ${result.response?.status}): ${detail}`,
+  )
+}
+
+export async function redisRestoreScenarioCommand(
+  opts: RedisRestoreScenarioOptions,
+): Promise<void> {
+  const cfg = resolveConfig(opts.connection)
+  const client = makeClient(cfg)
+  const json = !!opts.json
+  const log = (msg: string) => {
+    if (!json) process.stderr.write(msg + '\n')
+  }
+  if (!json) log(`Temps redis-restore scenario  ->  ${cfg.url}`)
+
+  const registry = opts.registry ?? process.env.TEMPS_E2E_REGISTRY
+  if (!registry) {
+    throw new Error(
+      'A registry is required: the redis-probe image must be pushed somewhere the server can pull ' +
+        'from. Pass --registry <host:port> (e.g. localhost:5111) or set TEMPS_E2E_REGISTRY.',
+    )
+  }
+  // `temps serve` runs natively on the host. S3 uploads and WAL-G helper
+  // containers both reach MinIO as `localhost` from the host's network
+  // namespace, not `host.docker.internal` (which only resolves from inside a
+  // container).
+  const minioEndpoint = opts.minioEndpoint ?? 'http://localhost:9092'
+  const minioBucket = opts.minioBucket ?? 'temps-e2e-backups'
+
+  const runId = makeRunId(Date.now())
+  const steps: StepLog[] = []
+  const step = async <T>(name: string, fn: () => Promise<T>): Promise<T> => {
+    const t0 = performance.now()
+    log(`\n▶ ${name}`)
+    try {
+      const r = await fn()
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: true, ms })
+      log(`  ✓ ${name} (${(ms / 1000).toFixed(1)}s)`)
+      return r
+    } catch (e) {
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: false, detail: (e as Error).message, ms })
+      log(`  ✗ ${name}: ${(e as Error).message}`)
+      throw e
+    }
+  }
+
+  const deployTimeoutMs = Number(opts.deployTimeout ?? '300000')
+  const scratch = `${process.env.TMPDIR ?? '/tmp'}/temps-e2e-redis-probe`
+
+  const projectIds: number[] = []
+  const serviceIds: number[] = []
+  const deployments: { projectId: number; deploymentId: number }[] = []
+  let s3SourceId: number | undefined
+
+  // Pre-backup keys (must survive restore).
+  const PRE_STRING_KEY = `${runId}-pre-string`
+  const PRE_HASH_KEY = `${runId}-pre-hash`
+  const PRE_LIST_KEY = `${runId}-pre-list`
+  // Post-backup keys (must be erased by restore).
+  const POST_STRING_KEY = `${runId}-post-string`
+  const POST_HASH_KEY = `${runId}-post-hash`
+  const POST_LIST_KEY = `${runId}-post-list`
+
+  try {
+    const imageRef = await step('build + push redis-probe image', () =>
+      buildRedisProbeImage({ scratchRoot: scratch, registry, onLog: (l) => log(`    ${l}`) }),
+    )
+
+    const service = await step('provision a real standalone Redis service', () =>
+      createE2eService(client, {
+        name: `${runId}-redis`,
+        serviceType: 'redis',
+        parameters: {},
+      }),
+    )
+    serviceIds.push(service.id)
+    log(`  service #${service.id}`)
+
+    const project = await step('create project', () =>
+      createE2eProject(client, { name: `${runId}-redis-restore-app`, exposedPort: 3000 }),
+    )
+    projectIds.push(project.id)
+    log(`  project #${project.id} (${project.slug})`)
+
+    await step('link Redis service to project', async () => {
+      unwrap(
+        await linkServiceToProject({ client, path: { id: service.id }, body: { project_id: project.id } }),
+        'linkServiceToProject',
+      )
+    })
+
+    const env = await step('resolve production environment', () => getProductionEnvironment(client, project.id))
+
+    const deploymentId = await step('deploy the redis-probe app', () =>
+      deployImage(client, { projectId: project.id, environmentId: env.id, imageRef }),
+    )
+    deployments.push({ projectId: project.id, deploymentId })
+
+    await step('wait for deployment', () =>
+      waitForDeployment(client, {
+        projectId: project.id,
+        deploymentId,
+        timeoutMs: deployTimeoutMs,
+        onPoll: (s) => log(`    ...${s.state}`),
+      }),
+    )
+
+    await step('confirm deployment did not fail', async () => {
+      const s = await getDeployStatus(client, project.id, deploymentId)
+      if (!s.ok) throw new Error(`deployment ${deploymentId} is in state "${s.state}"`)
+    })
+
+    const target = resolveLoadTarget(cfg.url, env.mainUrl)
+    await step('wait for the app to serve real traffic', async () => {
+      await waitForHttpReady({ url: target.url, headers: target.headers })
+      await assertNotConsoleFallback({ url: target.url, headers: target.headers })
+    })
+
+    await step('health check reports a real Redis PING succeeding', async () => {
+      const res = await fetch(`${target.url.replace(/\/+$/, '')}${REDIS_PROBE_HEALTH_PATH}`, {
+        headers: target.headers,
+      })
+      if (res.status !== 200) throw new Error(`GET ${REDIS_PROBE_HEALTH_PATH} returned HTTP ${res.status}`)
+    })
+
+    // Discover the Redis database number injected by the platform. This is
+    // computed from a hash of the project+environment slug; the only reliable
+    // way to retrieve it without replicating the hash in TypeScript is to read
+    // it back from the resolved env vars.
+    const dbNumber = await step('resolve REDIS_DATABASE from resolved env vars', async () => {
+      const res = unwrap(
+        await getResolvedEnvironmentVariableValue({
+          client,
+          path: { project_id: project.id, key: 'REDIS_DATABASE' },
+          query: { environment_id: env.id },
+        }),
+        'getResolvedEnvironmentVariableValue(REDIS_DATABASE)',
+      )
+      if (!res.value || res.value === '***') {
+        throw new Error(`REDIS_DATABASE resolved to "${res.value}", expected a numeric string`)
+      }
+      return res.value
+    })
+    log(`  REDIS_DATABASE=${dbNumber}`)
+
+    const source = await step('create an S3 source pointed at the local MinIO', async () => {
+      const res = unwrap(
+        await createS3Source({
+          client,
+          body: {
+            name: `${runId}-minio`,
+            bucket_name: minioBucket,
+            bucket_path: runId,
+            access_key_id: 'minioadmin',
+            secret_key: 'minioadmin',
+            region: 'us-east-1',
+            endpoint: minioEndpoint,
+            force_path_style: true,
+            is_default: false,
+          },
+        }),
+        'createS3Source',
+      )
+      return res
+    })
+    s3SourceId = source.id
+    log(`  s3 source #${source.id}`)
+
+    await step('write 3 PRE-BACKUP keys (string, hash, list) via the probe app', async () => {
+      await callProbe(
+        target.url, target.headers,
+        `/write?key=${encodeURIComponent(PRE_STRING_KEY)}&value=pre-string-value`,
+      )
+      await callProbe(
+        target.url, target.headers,
+        `/hset?key=${encodeURIComponent(PRE_HASH_KEY)}&field=f1&value=pre-hash-value`,
+      )
+      await callProbe(
+        target.url, target.headers,
+        `/lpush?key=${encodeURIComponent(PRE_LIST_KEY)}&value=pre-list-value`,
+      )
+    })
+
+    await step('trigger a real Redis backup (wal-g backup-push -> upload to MinIO)', async () => {
+      unwrap(
+        await runExternalServiceBackup({
+          client,
+          path: { id: service.id },
+          body: { s3_source_id: source.id, backup_type: 'full' },
+        }),
+        'runExternalServiceBackup',
+      )
+    })
+
+    const backupEntry = await step('poll the backup to a real completed state', async () => {
+      const list = await pollUntil(
+        async () =>
+          unwrap(
+            await listExternalServiceBackups({
+              client,
+              path: { service_id: service.id },
+              query: { page: 1, page_size: 5 },
+            }),
+            'listExternalServiceBackups',
+          ),
+        (l) => l.backups.length > 0,
+        { timeoutMs: 30_000, intervalMs: 2000, label: 'backup row to appear' },
+      )
+      const entry = list.backups[0]!
+      if (list.backups.length !== 1) {
+        throw new Error(`expected exactly 1 backup for service ${service.id}, found ${list.backups.length}`)
+      }
+
+      const finalBackup = await pollUntil(
+        async () => unwrap(await getBackup({ client, path: { id: entry.backup_id } }), 'getBackup'),
+        (b) => b.state === 'completed' || b.state === 'failed',
+        {
+          timeoutMs: 180_000,
+          intervalMs: 3000,
+          onPoll: (b) => log(`    ...${b.state}`),
+          label: 'backup to reach a terminal state',
+        },
+      )
+      if (finalBackup.state !== 'completed') {
+        throw new Error(
+          `backup ${entry.backup_id} ended in state "${finalBackup.state}": ${finalBackup.error_message}`,
+        )
+      }
+      return entry
+    })
+    log(`  backup #${backupEntry.id} (${backupEntry.backup_id})`)
+
+    await step('write 3 POST-BACKUP keys that must NOT survive the restore', async () => {
+      await callProbe(
+        target.url, target.headers,
+        `/write?key=${encodeURIComponent(POST_STRING_KEY)}&value=post-string-value`,
+      )
+      await callProbe(
+        target.url, target.headers,
+        `/hset?key=${encodeURIComponent(POST_HASH_KEY)}&field=f2&value=post-hash-value`,
+      )
+      await callProbe(
+        target.url, target.headers,
+        `/lpush?key=${encodeURIComponent(POST_LIST_KEY)}&value=post-list-value`,
+      )
+    })
+
+    const restoreRun = await step('start an in-place restore from the pre-backup snapshot', async () => {
+      const run = unwrap(
+        await startRestore({
+          client,
+          path: { id: service.id },
+          body: { backup_id: backupEntry.id, mode: 'in_place' },
+        }),
+        'startRestore',
+      )
+      return run
+    })
+    log(`  restore run #${restoreRun.id}`)
+
+    await step('poll the restore to a real completed state', async () => {
+      const finalRun = await pollUntil(
+        async () => unwrap(await getRestoreRun({ client, path: { id: restoreRun.id } }), 'getRestoreRun'),
+        (r) => r.status === 'completed' || r.status === 'failed',
+        {
+          timeoutMs: 180_000,
+          intervalMs: 3000,
+          onPoll: (r) => log(`    ...${r.status} (${r.phase})`),
+          label: 'restore run to reach a terminal state',
+        },
+      )
+      if (finalRun.status !== 'completed') {
+        throw new Error(
+          `restore run ${restoreRun.id} ended in status "${finalRun.status}": ${finalRun.error_message}`,
+        )
+      }
+    })
+
+    await step(
+      'pre-backup keys survive: string key present in data-browser (HTTP 200)',
+      () => assertKeyExists(client, service.id, dbNumber, PRE_STRING_KEY),
+    )
+
+    await step(
+      'pre-backup keys survive: hash key present in data-browser (HTTP 200)',
+      () => assertKeyExists(client, service.id, dbNumber, PRE_HASH_KEY),
+    )
+
+    await step(
+      'pre-backup keys survive: list key present in data-browser (HTTP 200)',
+      () => assertKeyExists(client, service.id, dbNumber, PRE_LIST_KEY),
+    )
+
+    await step(
+      'post-backup keys erased: string key absent in data-browser (HTTP 404)',
+      () => assertKeyAbsent(client, service.id, dbNumber, POST_STRING_KEY),
+    )
+
+    await step(
+      'post-backup keys erased: hash key absent in data-browser (HTTP 404)',
+      () => assertKeyAbsent(client, service.id, dbNumber, POST_HASH_KEY),
+    )
+
+    await step(
+      'post-backup keys erased: list key absent in data-browser (HTTP 404)',
+      () => assertKeyAbsent(client, service.id, dbNumber, POST_LIST_KEY),
+    )
+  } catch {
+    // Failure already recorded in `steps`; fall through to teardown.
+  } finally {
+    if (opts.keep) {
+      log(
+        `\n(kept resources: projects=${projectIds.join(',')} services=${serviceIds.join(',')} s3Source=${s3SourceId ?? '-'})`,
+      )
+    } else {
+      if (s3SourceId) {
+        await deleteS3Source({ client, path: { id: s3SourceId } }).catch(() => undefined)
+      }
+      const td = await teardown(client, { deployments, projectIds, serviceIds })
+      log(
+        `\n▶ teardown: tore down ${td.teardownDeployments} deployment(s), ` +
+          `deleted ${td.deletedProjects} project(s), ${td.deletedServices} service(s), S3 source` +
+          (td.errors.length ? ` (${td.errors.length} errors)` : ''),
+      )
+      for (const e of td.errors) log(`    ! ${e}`)
+    }
+  }
+
+  const ok = steps.length > 0 && steps.every((s) => s.ok)
+  const result: RedisRestoreScenarioResult = { runId, ok, steps }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+  } else {
+    log(`\n${ok ? '✅ redis-restore-scenario PASSED' : '❌ redis-restore-scenario FAILED'}`)
+  }
+  if (!ok) process.exitCode = 1
+}

--- a/apps/temps-e2e/src/index.ts
+++ b/apps/temps-e2e/src/index.ts
@@ -26,6 +26,7 @@ import { gitDeployScenarioCommand } from './commands/git-deploy-scenario.ts'
 import { dbHaFailoverScenarioCommand } from './commands/db-ha-failover-scenario.ts'
 import { deployLifecycleScenarioCommand } from './commands/deploy-lifecycle-scenario.ts'
 import { otelQuotaScenarioCommand } from './commands/otel-quota-scenario.ts'
+import { redisRestoreScenarioCommand } from './commands/redis-restore-scenario.ts'
 
 const program = new Command()
 
@@ -334,6 +335,21 @@ program
   .option('--json', 'machine-readable output')
   .action(async (opts) => {
     await dbHaFailoverScenarioCommand({ ...opts, connection: connection() })
+  })
+
+program
+  .command('redis-restore-scenario')
+  .description(
+    'Backup + restore a real Redis service via MinIO: real wal-g backup-push into a helper container, real S3 upload, real in-place restore proven by verifying pre-backup keys survive (HTTP 200 from data-browser) and post-backup keys are erased (HTTP 404) -- not just that the API calls returned 2xx',
+  )
+  .option('--registry <host:port>', 'registry to push the redis-probe image to (or $TEMPS_E2E_REGISTRY)')
+  .option('--minio-endpoint <url>', 'MinIO S3 API endpoint, reachable from the target instance', 'http://localhost:9092')
+  .option('--minio-bucket <name>', 'MinIO bucket to store backups in (must already exist)', 'temps-e2e-backups')
+  .option('--keep', 'do not tear down created resources')
+  .option('--deploy-timeout <ms>', 'max wait for deploy to go healthy', '300000')
+  .option('--json', 'machine-readable output')
+  .action(async (opts) => {
+    await redisRestoreScenarioCommand({ ...opts, connection: connection() })
   })
 
 program

--- a/apps/temps-e2e/src/lib/flows.ts
+++ b/apps/temps-e2e/src/lib/flows.ts
@@ -520,7 +520,14 @@ export function looksLikeConsoleFallback(body: string): boolean {
   // A deployed app never starts its page title with "Temps" (they use their
   // own names), so matching the prefix is sufficient and avoids brittleness
   // against the exact suffix used in each build mode.
-  return /<title>\s*Temps[\s\-<]/i.test(body)
+  //
+  // Character class is `[\s<]` (space or `<`), NOT `[\s\-<]`. In both real
+  // title forms the character immediately after "Temps" is either `<` (closing
+  // tag, production) or ` ` (space before " - Development Build", dev). A
+  // hyphen directly after "Temps" is never produced by any Temps build, and
+  // including `\-` in the class would cause false positives for any deployed
+  // app whose title starts with "Temps-" (e.g. "Temps-sync-dashboard").
+  return /<title>\s*Temps[\s<]/i.test(body)
 }
 
 /**

--- a/apps/temps-e2e/src/lib/flows.ts
+++ b/apps/temps-e2e/src/lib/flows.ts
@@ -515,9 +515,12 @@ export async function waitForHttpReady(opts: {
  */
 export function looksLikeConsoleFallback(body: string): boolean {
   if (!/<!doctype html>/i.test(body)) return false
-  // The Temps console index.html sets `<title>Temps</title>`. A static SPA
-  // example sets its own title (e.g. "react-basic"), so this stays specific.
-  return /<title>\s*Temps\s*<\/title>/i.test(body)
+  // The Temps console index.html sets `<title>Temps</title>` in production
+  // builds and `<title>Temps - Development Build</title>` in dev builds.
+  // A deployed app never starts its page title with "Temps" (they use their
+  // own names), so matching the prefix is sufficient and avoids brittleness
+  // against the exact suffix used in each build mode.
+  return /<title>\s*Temps[\s\-<]/i.test(body)
 }
 
 /**

--- a/apps/temps-e2e/src/lib/redis-probe-app.ts
+++ b/apps/temps-e2e/src/lib/redis-probe-app.ts
@@ -1,0 +1,202 @@
+/**
+ * A throwaway Go app that proves a linked managed Redis service is actually
+ * writable, not just linked in the DB row. On boot it connects with whatever
+ * `REDIS_URL` the deployment injects (the redis provider's runtime env var —
+ * includes the per-project/env database number, e.g.
+ * `redis://:pass@redis-my-svc:6379/3`). It exposes three write endpoints so
+ * the e2e scenario can write distinct, recognisable keys of different Redis
+ * types (string, hash, list) before and after a backup, then verify exactly
+ * which keys survive after a restore.
+ *
+ * There is no write API anywhere in the platform's query service
+ * (`query_handlers.rs` is read-only row browsing) — deploying a small app
+ * that writes via the real injected `REDIS_URL` is the only way to generate
+ * genuine key-level data end to end.
+ *
+ * Deliberately NOT added to the repo's `examples/` tree (test-only fixture).
+ * Rendered into a scratch build context the same way `buildProbeImage` does.
+ */
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const GO_MOD = `module redis-probe
+
+go 1.24
+
+require github.com/redis/go-redis/v9 v9.7.0
+`
+
+const MAIN_GO = `package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/redis/go-redis/v9"
+)
+
+var rdb *redis.Client
+var ctx = context.Background()
+
+func main() {
+	redisURL := os.Getenv("REDIS_URL")
+	if redisURL == "" {
+		log.Fatal("REDIS_URL not set")
+	}
+
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		log.Fatalf("parse redis url %q: %v", redisURL, err)
+	}
+	rdb = redis.NewClient(opts)
+
+	if _, err := rdb.Ping(ctx).Result(); err != nil {
+		log.Fatalf("redis ping: %v", err)
+	}
+	log.Printf("connected to redis db=%d", opts.DB)
+
+	mux := http.NewServeMux()
+
+	// Root — used as deploy health sentinel before the app registers with the
+	// healthcheck route below.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("redis-probe"))
+	})
+
+	// Health — standard probe path; also verifies a live Redis PING.
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := rdb.Ping(ctx).Result(); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	// Write a string key: GET /write?key=X&value=Y
+	mux.HandleFunc("/write", func(w http.ResponseWriter, r *http.Request) {
+		key := r.URL.Query().Get("key")
+		value := r.URL.Query().Get("value")
+		if key == "" {
+			http.Error(w, "key required", http.StatusBadRequest)
+			return
+		}
+		if err := rdb.Set(ctx, key, value, 0).Err(); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"key": key, "value": value, "type": "string"})
+	})
+
+	// Write a hash field: GET /hset?key=X&field=F&value=V
+	mux.HandleFunc("/hset", func(w http.ResponseWriter, r *http.Request) {
+		key := r.URL.Query().Get("key")
+		field := r.URL.Query().Get("field")
+		value := r.URL.Query().Get("value")
+		if key == "" || field == "" {
+			http.Error(w, "key and field required", http.StatusBadRequest)
+			return
+		}
+		if err := rdb.HSet(ctx, key, field, value).Err(); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"key": key, "field": field, "value": value, "type": "hash"})
+	})
+
+	// Push a list element: GET /lpush?key=X&value=V
+	mux.HandleFunc("/lpush", func(w http.ResponseWriter, r *http.Request) {
+		key := r.URL.Query().Get("key")
+		value := r.URL.Query().Get("value")
+		if key == "" {
+			http.Error(w, "key required", http.StatusBadRequest)
+			return
+		}
+		if err := rdb.LPush(ctx, key, value).Err(); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"key": key, "value": value, "type": "list"})
+	})
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "3000"
+	}
+	log.Printf("redis-probe listening on :%s", port)
+	log.Fatal(http.ListenAndServe("0.0.0.0:"+port, mux))
+}
+`
+
+const DOCKERFILE = `FROM golang:1.24-alpine AS build
+WORKDIR /src
+COPY go.mod main.go ./
+RUN go mod tidy && CGO_ENABLED=0 GOOS=linux go build -o /server main.go
+
+FROM gcr.io/distroless/static-debian12
+COPY --from=build /server /server
+ENV PORT=3000
+EXPOSE 3000
+ENTRYPOINT ["/server"]
+`
+
+export const REDIS_PROBE_PORT = 3000
+export const REDIS_PROBE_HEALTH_PATH = '/health'
+
+/** Render the Redis probe app into a scratch build context and `docker build` + push it. */
+export async function buildRedisProbeImage(opts: {
+  scratchRoot: string
+  registry: string
+  tag?: string
+  onLog?: (line: string) => void
+}): Promise<string> {
+  const ctxDir = join(opts.scratchRoot, 'redis-probe')
+  const imageRef = opts.tag ?? `${opts.registry}/e2e-redis-probe:latest`
+
+  await rm(ctxDir, { recursive: true, force: true })
+  await mkdir(ctxDir, { recursive: true })
+  await writeFile(join(ctxDir, 'go.mod'), GO_MOD, 'utf8')
+  await writeFile(join(ctxDir, 'main.go'), MAIN_GO, 'utf8')
+  await writeFile(join(ctxDir, 'Dockerfile'), DOCKERFILE, 'utf8')
+
+  opts.onLog?.(`docker build -t ${imageRef} ${ctxDir}`)
+  await runDocker(['build', '--load', '-t', imageRef, ctxDir], opts.onLog, `docker build ${imageRef}`)
+  opts.onLog?.(`docker push ${imageRef}`)
+  await runDocker(['push', imageRef], opts.onLog, `docker push ${imageRef}`)
+  return imageRef
+}
+
+/** Spawn a docker subcommand, stream its output through onLog, throw on failure. */
+async function runDocker(
+  args: string[],
+  onLog: ((line: string) => void) | undefined,
+  what: string,
+): Promise<void> {
+  const proc = Bun.spawn(['docker', ...args], { stdout: 'pipe', stderr: 'pipe' })
+  const pump = async (stream: ReadableStream<Uint8Array>) => {
+    const reader = stream.getReader()
+    const decoder = new TextDecoder()
+    let buf = ''
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buf += decoder.decode(value, { stream: true })
+      const lines = buf.split('\n')
+      buf = lines.pop() ?? ''
+      for (const l of lines) if (l.trim()) onLog?.(l)
+    }
+    if (buf.trim()) onLog?.(buf)
+  }
+  await Promise.all([pump(proc.stdout), pump(proc.stderr)])
+  const code = await proc.exited
+  if (code !== 0) {
+    throw new Error(`${what} failed (exit ${code})`)
+  }
+}

--- a/crates/temps-providers/src/externalsvc/redis.rs
+++ b/crates/temps-providers/src/externalsvc/redis.rs
@@ -6,7 +6,8 @@ use super::{
 use anyhow::Result;
 use async_trait::async_trait;
 use bollard::query_parameters::{InspectContainerOptions, StopContainerOptions};
-use bollard::{body_full, Docker};
+use bollard::Docker;
+use flate2::read::GzDecoder;
 use futures::TryStreamExt;
 use redis::{aio::ConnectionManager, Client};
 use schemars::JsonSchema;
@@ -728,42 +729,22 @@ impl RedisService {
         .map(|_| ())
     }
 
-    /// Restore from a WAL-G backup stored in S3.
+    /// Run a one-shot WAL-G restore helper container that writes the LATEST
+    /// backup from `walg_s3_prefix` into the data volume of
+    /// `target_container_name` (via `volumes_from`).
     ///
-    /// WAL-G restore requires stopping Redis, fetching the backup (which writes
-    /// dump.rdb via WALG_STREAM_RESTORE_COMMAND), and restarting.
-    async fn restore_from_walg(
+    /// The caller must ensure the target container is STOPPED and its restart
+    /// policy is disabled before calling this method, and is responsible for
+    /// re-enabling the restart policy and starting the container afterwards.
+    ///
+    /// Returns Ok(()) when the helper exits with code 0, Err otherwise.
+    async fn run_walg_restore_helper(
         &self,
-        s3_credentials: &super::S3Credentials,
+        target_container_name: &str,
+        redis_image: &str,
         walg_s3_prefix: &str,
+        s3_credentials: &super::S3Credentials,
     ) -> Result<()> {
-        let container_name = self
-            .config
-            .read()
-            .await
-            .as_ref()
-            .map(|config| self.get_live_container_name(config))
-            .unwrap_or_else(|| self.get_container_name());
-
-        info!(
-            "Restoring Redis from WAL-G backup (prefix: {}) in container '{}'",
-            walg_s3_prefix, container_name
-        );
-
-        // Get the Redis image from the running container for the helper
-        let container_info = self
-            .docker
-            .inspect_container(
-                &container_name,
-                None::<bollard::query_parameters::InspectContainerOptions>,
-            )
-            .await?;
-        let redis_image = container_info
-            .config
-            .as_ref()
-            .and_then(|c| c.image.clone())
-            .unwrap_or_else(|| "gotempsh/redis-walg:8-bookworm".to_string());
-
         // Build WAL-G environment variables for the helper container.
         // WALG_STREAM_RESTORE_COMMAND tells WAL-G how to write the restored data.
         let mut walg_env: Vec<String> = vec![
@@ -778,7 +759,7 @@ impl RedisService {
 
         // Resolve S3 endpoint for use inside the Docker container.
         if let Some(resolved_endpoint) = s3_credentials
-            .resolve_endpoint_for_container(&self.docker, &container_name)
+            .resolve_endpoint_for_container(&self.docker, target_container_name)
             .await
         {
             walg_env.push(format!("AWS_ENDPOINT={}", resolved_endpoint));
@@ -787,44 +768,11 @@ impl RedisService {
             walg_env.push("AWS_S3_FORCE_PATH_STYLE=true".to_string());
         }
 
-        // Step 1: Stop the Redis container so it's not using the data volume.
-        // Redis is PID 1, so stopping the container cleanly shuts down Redis and
-        // ensures no autosave can overwrite the dump.rdb we're about to write.
-        //
-        // IMPORTANT: Disable the restart policy first. The container has
-        // restart_policy=always, so Docker would immediately restart it after stop,
-        // preventing the helper container from writing to the shared volume.
-        info!("Disabling restart policy and stopping Redis container for restore");
-        self.docker
-            .update_container(
-                &container_name,
-                bollard::models::ContainerUpdateBody {
-                    restart_policy: Some(bollard::models::RestartPolicy {
-                        name: Some(bollard::models::RestartPolicyNameEnum::NO),
-                        maximum_retry_count: None,
-                    }),
-                    ..Default::default()
-                },
-            )
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to disable restart policy: {}", e))?;
-
-        self.docker
-            .stop_container(&container_name, None::<StopContainerOptions>)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to stop Redis container for restore: {}", e))?;
-
-        // Step 2: Use an ephemeral helper container with volumes_from to run WAL-G fetch.
-        // We can't exec into a stopped container, so we create a helper that shares
-        // the same data volume and runs WAL-G backup-fetch there.
-        info!("Fetching WAL-G backup via helper container");
-        let helper_name = format!("{}-restore-helper", container_name);
-
-        use bollard::models::{ContainerCreateBody, HostConfig};
-        // The helper runs WAL-G fetch (which writes dump.rdb) and then replaces the AOF
-        // base file with the restored RDB. Redis 7+ with --appendonly yes loads from the
-        // multi-part AOF in appendonlydir/ (base RDB + incremental AOF files). If we just
-        // delete appendonlydir, Redis recreates an EMPTY one on startup and ignores dump.rdb.
+        // The helper runs WAL-G fetch (which writes dump.rdb) and then replaces
+        // the AOF base file with the restored RDB. Redis 7+ with --appendonly yes
+        // loads from the multi-part AOF in appendonlydir/ (base RDB + incremental
+        // AOF files). If we just delete appendonlydir, Redis recreates an EMPTY
+        // one on startup and ignores dump.rdb.
         //
         // Fix: After fetching the backup to dump.rdb, we:
         // 1. Remove the old appendonlydir contents
@@ -841,18 +789,21 @@ impl RedisService {
             "chown -R redis:redis /data/appendonlydir && ",
             "echo 'Restore helper completed successfully'"
         );
+
         // Join the same app network the original Redis container uses (see
         // `create_container_once`/`ensure_network_exists`). Without this the
         // helper only gets Docker's default bridge network, so the S3
         // endpoint we just resolved via `resolve_endpoint_for_container`
-        // (relative to the *original* container's network) is unreachable
-        // from inside it — wal-g's fetch then hangs indefinitely trying to
-        // resolve/connect to a host it has no network path to.
+        // (relative to the original container's network) is unreachable
+        // from inside it.
         ensure_network_exists(&self.docker)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to ensure network exists: {:?}", e))?;
+
+        let helper_name = format!("{}-restore-helper", target_container_name);
+        use bollard::models::{ContainerCreateBody, HostConfig};
         let helper_config = ContainerCreateBody {
-            image: Some(redis_image),
+            image: Some(redis_image.to_string()),
             cmd: Some(vec![
                 "sh".to_string(),
                 "-c".to_string(),
@@ -860,7 +811,7 @@ impl RedisService {
             ]),
             env: Some(walg_env),
             host_config: Some(HostConfig {
-                volumes_from: Some(vec![container_name.clone()]),
+                volumes_from: Some(vec![target_container_name.to_string()]),
                 ..Default::default()
             }),
             networking_config: Some(bollard::models::NetworkingConfig {
@@ -893,11 +844,8 @@ impl RedisService {
             .await
             .map_err(|e| anyhow::anyhow!("Failed to start restore helper container: {}", e))?;
 
-        // Wait for helper to finish. Bounded — unlike `run_exec`'s exec-based
-        // path, this waits on the container-level Docker API directly with no
-        // other timeout backstop; leaving it unbounded means a stuck helper
-        // container hangs until the *caller's* outer timeout eventually
-        // fires, with none of the diagnostics `run_exec` provides.
+        // Wait for the helper to finish — bounded to avoid an indefinitely stuck
+        // helper blocking the restore run forever.
         use futures::StreamExt;
         let wait_result = match tokio::time::timeout(
             REDIS_BACKUP_EXEC_TIMEOUT,
@@ -925,13 +873,13 @@ impl RedisService {
                     .await;
                 return Err(anyhow::anyhow!(
                     "WAL-G backup-fetch helper for container '{}' did not exit within {:?}",
-                    container_name,
+                    target_container_name,
                     REDIS_BACKUP_EXEC_TIMEOUT
                 ));
             }
         };
 
-        // Capture helper container logs before cleanup for diagnostics
+        // Capture helper logs before cleanup for diagnostics.
         let log_output = {
             use bollard::query_parameters::LogsOptions;
             let mut log_stream = self.docker.logs(
@@ -953,17 +901,17 @@ impl RedisService {
         if log_output.is_empty() {
             info!(
                 "WAL-G restore helper produced no output for '{}'",
-                container_name
+                target_container_name
             );
         } else {
             info!(
                 "WAL-G restore helper logs for '{}': {}",
-                container_name,
+                target_container_name,
                 log_output.trim()
             );
         }
 
-        // Clean up helper container
+        // Clean up the helper container.
         let _ = self
             .docker
             .remove_container(
@@ -981,11 +929,82 @@ impl RedisService {
                 return Err(anyhow::anyhow!(
                     "WAL-G backup-fetch helper exited with code {} for container '{}'. Logs: {}",
                     wait_response.status_code,
-                    container_name,
+                    target_container_name,
                     log_output.trim()
                 ));
             }
         }
+
+        Ok(())
+    }
+
+    /// Restore from a WAL-G backup stored in S3.
+    ///
+    /// WAL-G restore requires stopping Redis, fetching the backup (which writes
+    /// dump.rdb via WALG_STREAM_RESTORE_COMMAND), and restarting.
+    async fn restore_from_walg(
+        &self,
+        s3_credentials: &super::S3Credentials,
+        walg_s3_prefix: &str,
+    ) -> Result<()> {
+        let container_name = self
+            .config
+            .read()
+            .await
+            .as_ref()
+            .map(|config| self.get_live_container_name(config))
+            .unwrap_or_else(|| self.get_container_name());
+
+        info!(
+            "Restoring Redis from WAL-G backup (prefix: {}) in container '{}'",
+            walg_s3_prefix, container_name
+        );
+
+        // Get the Redis image from the running container for the helper.
+        let container_info = self
+            .docker
+            .inspect_container(
+                &container_name,
+                None::<bollard::query_parameters::InspectContainerOptions>,
+            )
+            .await?;
+        let redis_image = container_info
+            .config
+            .as_ref()
+            .and_then(|c| c.image.clone())
+            .unwrap_or_else(|| "gotempsh/redis-walg:8-bookworm".to_string());
+
+        // Step 1: Disable the restart policy and stop the container so it releases
+        // the data volume exclusively to the restore helper.
+        info!("Disabling restart policy and stopping Redis container for restore");
+        self.docker
+            .update_container(
+                &container_name,
+                bollard::models::ContainerUpdateBody {
+                    restart_policy: Some(bollard::models::RestartPolicy {
+                        name: Some(bollard::models::RestartPolicyNameEnum::NO),
+                        maximum_retry_count: None,
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to disable restart policy: {}", e))?;
+
+        self.docker
+            .stop_container(&container_name, None::<StopContainerOptions>)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to stop Redis container for restore: {}", e))?;
+
+        // Step 2: Run the WAL-G restore helper.
+        let restore_result = self
+            .run_walg_restore_helper(
+                &container_name,
+                &redis_image,
+                walg_s3_prefix,
+                s3_credentials,
+            )
+            .await;
 
         // Step 3: Re-enable restart policy and start the original Redis container.
         // Redis will load the restored dump.rdb on startup.
@@ -1004,6 +1023,8 @@ impl RedisService {
             .await
             .map_err(|e| anyhow::anyhow!("Failed to re-enable restart policy: {}", e))?;
 
+        restore_result?;
+
         self.docker
             .start_container(
                 &container_name,
@@ -1012,7 +1033,7 @@ impl RedisService {
             .await
             .map_err(|e| anyhow::anyhow!("Failed to start Redis after restore: {}", e))?;
 
-        // Wait for container to be healthy
+        // Wait for container to be healthy.
         self.wait_for_container_health(&self.docker, &container_name)
             .await?;
 
@@ -1020,30 +1041,73 @@ impl RedisService {
         Ok(())
     }
 
-    /// Restore from a legacy backup (pre-WAL-G .tar files containing dump.rdb/appendonly.aof).
-    /// Falls back to the old approach: download from S3, extract, upload to container.
+    /// Restore from the current RedisEngine backup format: a gzip-compressed
+    /// RDB snapshot (`.rdb.gz`) stored on S3.
+    ///
+    /// The previous implementation mistakenly treated the gzip as a tar
+    /// archive, so `tar::Archive::new()` failed immediately with "failed to
+    /// iterate over archive". This version:
+    ///
+    /// 1. Downloads and gzip-decodes the backup to a host temp file.
+    /// 2. Disables the container's restart policy then stops it (prevents
+    ///    Docker from auto-restarting before the helper can write the volume).
+    /// 3. Runs a short-lived helper container with `volumes_from` on the
+    ///    stopped container. The helper copies the RDB, rebuilds the Redis 7+
+    ///    multi-part AOF directory (`appendonlydir/`) with a manifest pointing
+    ///    to the RDB as the base, and chowns everything to `redis:redis`.
+    ///    A bare `dump.rdb` is ignored on startup by Redis 7 when AOF is
+    ///    enabled; the manifest-based directory is required.
+    /// 4. Re-enables the restart policy (always) regardless of outcome.
+    /// 5. Starts the container and waits for the healthcheck.
     async fn restore_from_legacy(
         &self,
         s3_client: &aws_sdk_s3::Client,
         backup_location: &str,
         s3_source: &temps_entities::s3_sources::Model,
     ) -> Result<()> {
-        info!(
-            "Restoring Redis from legacy backup format: {}",
-            backup_location
-        );
+        info!("Restoring Redis from rdb.gz backup: {}", backup_location);
 
-        // Get the backup object from S3
+        // ── 1. Download the .rdb.gz from S3 ─────────────────────────────────
         let get_obj = s3_client
             .get_object()
             .bucket(&s3_source.bucket_name)
             .key(backup_location)
             .send()
-            .await?;
+            .await
+            .map_err(|e| anyhow::anyhow!("S3 GetObject failed for {}: {}", backup_location, e))?;
 
-        // Read the backup data
-        let backup_data = get_obj.body.collect().await?.to_vec();
+        let gz_bytes = get_obj
+            .body
+            .collect()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to read S3 body: {}", e))?
+            .to_vec();
 
+        // Decompress the gzip to raw RDB bytes.
+        let rdb_bytes = {
+            use std::io::Read;
+            let mut decoder = GzDecoder::new(gz_bytes.as_slice());
+            let mut buf = Vec::new();
+            decoder
+                .read_to_end(&mut buf)
+                .map_err(|e| anyhow::anyhow!("Failed to gunzip Redis backup: {}", e))?;
+            buf
+        };
+
+        // ── 2. Write RDB to a host temp dir (bind-mounted into the helper) ──
+        let temp_dir =
+            tempfile::tempdir().map_err(|e| anyhow::anyhow!("Failed to create temp dir: {}", e))?;
+        let rdb_host_path = temp_dir.path().join("restore.rdb");
+        tokio::fs::write(&rdb_host_path, &rdb_bytes)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to write RDB to temp dir: {}", e))?;
+        let temp_dir_str = temp_dir
+            .path()
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("temp dir path is not valid UTF-8"))?
+            .to_string();
+
+        // ── 3. Resolve the target container name ─────────────────────────────
         let container_name = self
             .config
             .read()
@@ -1052,47 +1116,231 @@ impl RedisService {
             .map(|config| self.get_live_container_name(config))
             .unwrap_or_else(|| self.get_container_name());
 
+        // ── 4. Inspect the container to find the Redis image ─────────────────
+        let inspect = self
+            .docker
+            .inspect_container(&container_name, None::<InspectContainerOptions>)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!("Failed to inspect container {}: {}", container_name, e)
+            })?;
+        let redis_image = inspect
+            .config
+            .as_ref()
+            .and_then(|c| c.image.as_deref())
+            .unwrap_or("redis:7-alpine")
+            .to_string();
+
+        // ── 5. Disable restart policy then stop the container ─────────────────
+        self.docker
+            .update_container(
+                &container_name,
+                bollard::models::ContainerUpdateBody {
+                    restart_policy: Some(bollard::models::RestartPolicy {
+                        name: Some(bollard::models::RestartPolicyNameEnum::NO),
+                        maximum_retry_count: None,
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(|e| {
+                warn!(
+                    "Could not disable restart policy on {}: {}",
+                    container_name, e
+                )
+            })
+            .ok();
+
         self.docker
             .stop_container(&container_name, None::<StopContainerOptions>)
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to stop Redis container for restore: {}", e))?;
+            .map_err(|e| {
+                anyhow::anyhow!("Failed to stop Redis container {}: {}", container_name, e)
+            })?;
 
-        // Create a temporary directory
-        let temp_dir = tempfile::tempdir()?;
-        let tar_path = temp_dir.path().join("backup.tar");
+        // ── 6. Run helper container to write RDB and rebuild AOF directory ───
+        // The restore script:
+        //   a. Copies the bind-mounted RDB to /data/dump.rdb
+        //   b. Removes any stale appendonlydir
+        //   c. Creates appendonlydir/ with the RDB as the AOF base file
+        //   d. Writes the AOF manifest pointing to the base file
+        //   e. Chowns everything to redis:redis so Redis can read on startup
+        let restore_script = "cp /restore/restore.rdb /data/dump.rdb && \
+             rm -rf /data/appendonlydir && \
+             mkdir -p /data/appendonlydir && \
+             cp /data/dump.rdb /data/appendonlydir/appendonly.aof.1.base.rdb && \
+             printf 'file appendonly.aof.1.base.rdb seq 1 type b\\n' > /data/appendonlydir/appendonly.aof.manifest && \
+             chown -R redis:redis /data/dump.rdb /data/appendonlydir && \
+             echo 'Legacy restore helper completed successfully'"
+            .to_string();
 
-        // Write the tar file
-        tokio::fs::write(&tar_path, backup_data).await?;
+        let helper_id = uuid::Uuid::new_v4()
+            .to_string()
+            .split('-')
+            .next()
+            .unwrap_or("rr")
+            .to_string();
+        let helper_name = format!("temps-redis-rdb-restore-{}", helper_id);
 
-        // Extract the tar file
-        let tar_file = std::fs::File::open(&tar_path)?;
-        let mut archive = tar::Archive::new(tar_file);
-        archive.unpack(temp_dir.path())?;
+        use bollard::models::{ContainerCreateBody, HostConfig};
+        let helper_config = ContainerCreateBody {
+            image: Some(redis_image.clone()),
+            cmd: Some(vec!["sh".to_string(), "-c".to_string(), restore_script]),
+            user: Some("root".to_string()),
+            host_config: Some(HostConfig {
+                volumes_from: Some(vec![container_name.clone()]),
+                binds: Some(vec![format!("{}:/restore:ro", temp_dir_str)]),
+                network_mode: Some("none".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
 
-        // Create a new tar archive with the extracted files in the correct structure
-        let mut tar = tar::Builder::new(Vec::new());
-        for file in &["dump.rdb", "appendonly.aof"] {
-            let file_path = temp_dir.path().join(file);
-            if file_path.exists() {
-                tar.append_path_with_name(&file_path, file)?;
-            }
-        }
-        let tar_data = tar.into_inner()?;
-
-        // Copy both files into the container's data directory
-        self.docker
-            .upload_to_container(
-                &container_name,
-                Some(bollard::query_parameters::UploadToContainerOptions {
-                    path: "/data".to_string(),
-                    ..Default::default()
-                }),
-                body_full(bytes::Bytes::from(tar_data)),
+        let helper = self
+            .docker
+            .create_container(
+                Some(
+                    bollard::query_parameters::CreateContainerOptionsBuilder::new()
+                        .name(&helper_name)
+                        .build(),
+                ),
+                helper_config,
             )
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to upload backup files to container: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("Failed to create rdb restore helper container: {}", e))?;
 
-        // Start Redis server again
+        self.docker
+            .start_container(
+                &helper.id,
+                None::<bollard::query_parameters::StartContainerOptions>,
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to start rdb restore helper container: {}", e))?;
+
+        // Wait for the helper to finish.
+        use futures::StreamExt;
+        let wait_result = match tokio::time::timeout(
+            REDIS_BACKUP_EXEC_TIMEOUT,
+            self.docker
+                .wait_container(
+                    &helper.id,
+                    None::<bollard::query_parameters::WaitContainerOptions>,
+                )
+                .next(),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => {
+                let _ = self
+                    .docker
+                    .remove_container(
+                        &helper.id,
+                        Some(bollard::query_parameters::RemoveContainerOptions {
+                            force: true,
+                            v: false,
+                            ..Default::default()
+                        }),
+                    )
+                    .await;
+                // Re-enable restart policy even on timeout.
+                let _ = self
+                    .docker
+                    .update_container(
+                        &container_name,
+                        bollard::models::ContainerUpdateBody {
+                            restart_policy: Some(bollard::models::RestartPolicy {
+                                name: Some(bollard::models::RestartPolicyNameEnum::ALWAYS),
+                                maximum_retry_count: None,
+                            }),
+                            ..Default::default()
+                        },
+                    )
+                    .await;
+                return Err(anyhow::anyhow!(
+                    "RDB restore helper for container '{}' did not exit within {:?}",
+                    container_name,
+                    REDIS_BACKUP_EXEC_TIMEOUT
+                ));
+            }
+        };
+
+        // Capture helper logs before cleanup.
+        let log_output = {
+            use bollard::query_parameters::LogsOptions;
+            let mut log_stream = self.docker.logs(
+                &helper.id,
+                Some(LogsOptions {
+                    stdout: true,
+                    stderr: true,
+                    follow: false,
+                    ..Default::default()
+                }),
+            );
+            let mut logs = String::new();
+            while let Some(Ok(chunk)) = log_stream.next().await {
+                logs.push_str(&chunk.to_string());
+            }
+            logs
+        };
+
+        // Clean up the helper container.
+        let _ = self
+            .docker
+            .remove_container(
+                &helper.id,
+                Some(bollard::query_parameters::RemoveContainerOptions {
+                    force: true,
+                    v: false,
+                    ..Default::default()
+                }),
+            )
+            .await;
+
+        let restore_result = if let Some(Ok(wait_response)) = wait_result {
+            if wait_response.status_code != 0 {
+                Err(anyhow::anyhow!(
+                    "RDB restore helper exited with code {} for container '{}'. Logs: {}",
+                    wait_response.status_code,
+                    container_name,
+                    log_output.trim()
+                ))
+            } else {
+                info!(
+                    "RDB restore helper logs for '{}': {}",
+                    container_name,
+                    log_output.trim()
+                );
+                Ok(())
+            }
+        } else {
+            Err(anyhow::anyhow!(
+                "RDB restore helper for '{}' produced no wait status. Logs: {}",
+                container_name,
+                log_output.trim()
+            ))
+        };
+
+        // ── 7. Re-enable restart policy (always, even on error) ──────────────
+        let _ = self
+            .docker
+            .update_container(
+                &container_name,
+                bollard::models::ContainerUpdateBody {
+                    restart_policy: Some(bollard::models::RestartPolicy {
+                        name: Some(bollard::models::RestartPolicyNameEnum::ALWAYS),
+                        maximum_retry_count: None,
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await;
+
+        // Propagate restore failure after re-enabling restart policy.
+        restore_result?;
+
+        // ── 8. Start the container and wait for it to be healthy ─────────────
         self.docker
             .start_container(
                 &container_name,
@@ -1101,11 +1349,10 @@ impl RedisService {
             .await
             .map_err(|e| anyhow::anyhow!("Failed to start Redis container after restore: {}", e))?;
 
-        // Wait for container to be healthy
         self.wait_for_container_health(&self.docker, &container_name)
             .await?;
 
-        info!("Redis legacy restore completed successfully");
+        info!("Redis rdb.gz restore completed successfully");
         Ok(())
     }
 
@@ -2050,6 +2297,254 @@ impl ExternalService for RedisService {
         }
     }
 
+    /// Redis supports in-place restore and restore-to-new-service for WAL-G
+    /// backups. PITR is not supported — Redis has no continuous WAL archive
+    /// that would allow recovering to an arbitrary point in time.
+    async fn restore_capabilities(
+        &self,
+        _service_config: super::ServiceConfig,
+    ) -> Result<super::RestoreCapabilities> {
+        Ok(super::RestoreCapabilities {
+            restore_in_place: true,
+            restore_to_new_service: true,
+            pitr: false,
+            earliest_pitr_time: None,
+            latest_pitr_time: None,
+        })
+    }
+
+    /// Provision a new Redis service and restore the given WAL-G backup into it.
+    ///
+    /// Only WAL-G backups (s3:// locations) are supported. Legacy .tar backups
+    /// cannot be restored to a new service because the archive format does not
+    /// include enough metadata to reconstruct a fresh container reliably.
+    ///
+    /// Steps:
+    /// 1. Clone the source config, pick a free port (or honour `parameter_overrides`).
+    /// 2. Create and start the new Redis container (gets an empty data volume).
+    /// 3. Disable restart policy and stop the container.
+    /// 4. Run the WAL-G restore helper that writes the backup into the volume.
+    /// 5. Re-enable restart policy and start the container.
+    /// 6. Wait for the healthcheck to pass.
+    /// 7. Return the new service's parameters and connection string.
+    async fn restore_to_new_service(
+        &self,
+        ctx: super::RestoreContext<'_>,
+        new_service_name: String,
+        parameter_overrides: serde_json::Value,
+    ) -> Result<super::NewServiceRestoreResult> {
+        info!(
+            "Provisioning new Redis service '{}' from backup at {}",
+            new_service_name, ctx.backup_location
+        );
+
+        // Only WAL-G backups can be restored to a new service.
+        if !ctx.backup_location.starts_with("s3://") {
+            return Err(anyhow::anyhow!(
+                "restore_to_new_service requires a WAL-G backup (s3:// location); \
+                 '{}' is a legacy tar backup and cannot be restored to a new service",
+                ctx.backup_location
+            ));
+        }
+
+        // Parse the source config and apply parameter overrides.
+        let mut new_redis_config = self.get_redis_config(ctx.source_config)?;
+
+        // Honour explicit port override; otherwise find a free port to avoid
+        // colliding with the source service that's still running.
+        if let Some(port_str) = parameter_overrides.get("port").and_then(|v| v.as_str()) {
+            new_redis_config.port = port_str.to_string();
+        } else {
+            let base: u16 = new_redis_config.port.parse().unwrap_or(6379);
+            new_redis_config.port = find_available_port(base.wrapping_add(1))
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "No free port found for new Redis service '{}' (searched from {}+1)",
+                        new_service_name,
+                        base
+                    )
+                })?
+                .to_string();
+        }
+
+        // Apply docker_image override if requested.
+        if let Some(img) = parameter_overrides
+            .get("docker_image")
+            .and_then(|v| v.as_str())
+        {
+            new_redis_config.docker_image = img.to_string();
+        }
+
+        // This is a brand-new container — clear any imported-container override
+        // so the derived `redis-{name}` naming takes effect.
+        new_redis_config.container_name = None;
+
+        let new_service = RedisService::new(new_service_name.clone(), self.docker.clone());
+        let password = new_redis_config.password.clone();
+        let resource_limits = super::super::externalsvc::ServiceResourceLimits::default();
+
+        // `create_container` creates AND starts the container. It writes the
+        // final port (which may differ from our pick if there was a race) back
+        // into `new_redis_config`.
+        new_service
+            .create_container(
+                &self.docker,
+                &mut new_redis_config,
+                &password,
+                &resource_limits,
+            )
+            .await?;
+
+        let new_container_name = new_service.get_container_name();
+        let redis_image = new_redis_config.docker_image.clone();
+
+        // Disable restart policy and stop so the helper can write to the volume.
+        info!(
+            "Disabling restart policy and stopping new container '{}' for restore",
+            new_container_name
+        );
+        self.docker
+            .update_container(
+                &new_container_name,
+                bollard::models::ContainerUpdateBody {
+                    restart_policy: Some(bollard::models::RestartPolicy {
+                        name: Some(bollard::models::RestartPolicyNameEnum::NO),
+                        maximum_retry_count: None,
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to disable restart policy on new container '{}': {}",
+                    new_container_name,
+                    e
+                )
+            })?;
+
+        self.docker
+            .stop_container(
+                &new_container_name,
+                None::<bollard::query_parameters::StopContainerOptions>,
+            )
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to stop new Redis container '{}' for restore: {}",
+                    new_container_name,
+                    e
+                )
+            })?;
+
+        // Run the WAL-G restore helper into the new container's volume.
+        let restore_result = self
+            .run_walg_restore_helper(
+                &new_container_name,
+                &redis_image,
+                ctx.backup_location,
+                ctx.s3_credentials,
+            )
+            .await;
+
+        // Re-enable restart policy regardless of outcome.
+        let _ = self
+            .docker
+            .update_container(
+                &new_container_name,
+                bollard::models::ContainerUpdateBody {
+                    restart_policy: Some(bollard::models::RestartPolicy {
+                        name: Some(bollard::models::RestartPolicyNameEnum::ALWAYS),
+                        maximum_retry_count: None,
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await;
+
+        if let Err(e) = restore_result {
+            // Clean up the new container since the restore failed.
+            let _ = self
+                .docker
+                .remove_container(
+                    &new_container_name,
+                    Some(bollard::query_parameters::RemoveContainerOptions {
+                        force: true,
+                        v: true,
+                        ..Default::default()
+                    }),
+                )
+                .await;
+            return Err(anyhow::anyhow!(
+                "WAL-G restore into new Redis container '{}' failed, container removed: {}",
+                new_container_name,
+                e
+            ));
+        }
+
+        // Start the new container with restored data.
+        self.docker
+            .start_container(
+                &new_container_name,
+                None::<bollard::query_parameters::StartContainerOptions>,
+            )
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to start new Redis container '{}' after restore: {}",
+                    new_container_name,
+                    e
+                )
+            })?;
+
+        // Wait for the healthcheck to pass.
+        new_service
+            .wait_for_container_health(&self.docker, &new_container_name)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "New Redis container '{}' did not become healthy after restore: {}",
+                    new_container_name,
+                    e
+                )
+            })?;
+
+        info!(
+            "New Redis service '{}' provisioned and restored successfully \
+             (container: {}, port: {})",
+            new_service_name, new_container_name, new_redis_config.port
+        );
+
+        // Serialise the final config so every field is persisted to
+        // `external_service_params` by the orchestrator.
+        let config_json = serde_json::to_value(&new_redis_config)
+            .map_err(|e| anyhow::anyhow!("Failed to serialise new Redis config: {}", e))?;
+
+        let parameters: HashMap<String, String> = config_json
+            .as_object()
+            .map(|obj| {
+                obj.iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let connection_info = if new_redis_config.password.is_empty() {
+            format!("redis://localhost:{}", new_redis_config.port)
+        } else {
+            format!(
+                "redis://:{}@localhost:{}",
+                urlencoding::encode(&new_redis_config.password),
+                new_redis_config.port
+            )
+        };
+
+        Ok(super::NewServiceRestoreResult {
+            parameters,
+            connection_info,
+        })
+    }
+
     fn get_default_docker_image(&self) -> (String, String) {
         // Return (image_name, version)
         ("gotempsh/redis-walg".to_string(), "8-bookworm".to_string())
@@ -2269,6 +2764,45 @@ mod tests {
     use super::*;
 
     use crate::externalsvc::DEPLOYMENT_MODE_MUTEX as ENV_MUTEX;
+
+    /// `restore_capabilities` must declare in-place and new-service restore as
+    /// supported, and explicitly NOT claim PITR (Redis has no WAL archive).
+    #[tokio::test]
+    async fn test_restore_capabilities_in_place_and_new_service_no_pitr() {
+        let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
+        let service = RedisService::new("test-caps".to_string(), docker);
+
+        let config = ServiceConfig {
+            name: "test-caps".to_string(),
+            service_type: ServiceType::Redis,
+            version: None,
+            parameters: serde_json::json!({
+                "host": "localhost",
+                "port": "6379",
+                "password": "testpass1"
+            }),
+        };
+
+        let caps = service
+            .restore_capabilities(config)
+            .await
+            .expect("restore_capabilities must not fail");
+
+        assert!(caps.restore_in_place, "Redis must support in-place restore");
+        assert!(
+            caps.restore_to_new_service,
+            "Redis must support restore-to-new-service"
+        );
+        assert!(!caps.pitr, "Redis must NOT claim PITR support");
+        assert!(
+            caps.earliest_pitr_time.is_none(),
+            "earliest_pitr_time must be None"
+        );
+        assert!(
+            caps.latest_pitr_time.is_none(),
+            "latest_pitr_time must be None"
+        );
+    }
 
     #[test]
     fn test_parameter_schema_editable_fields() {

--- a/crates/temps-providers/src/externalsvc/redis.rs
+++ b/crates/temps-providers/src/externalsvc/redis.rs
@@ -800,7 +800,16 @@ impl RedisService {
             .await
             .map_err(|e| anyhow::anyhow!("Failed to ensure network exists: {:?}", e))?;
 
-        let helper_name = format!("{}-restore-helper", target_container_name);
+        // Include a random suffix so two concurrent restores of the same service
+        // don't collide on `create_container` with an opaque "name already in use"
+        // error. `restore_from_legacy` uses the same pattern.
+        let helper_suffix = uuid::Uuid::new_v4()
+            .to_string()
+            .split('-')
+            .next()
+            .unwrap_or("rr")
+            .to_string();
+        let helper_name = format!("{}-restore-helper-{}", target_container_name, helper_suffix);
         use bollard::models::{ContainerCreateBody, HostConfig};
         let helper_config = ContainerCreateBody {
             image: Some(redis_image.to_string()),
@@ -836,13 +845,33 @@ impl RedisService {
             .await
             .map_err(|e| anyhow::anyhow!("Failed to create restore helper container: {}", e))?;
 
-        self.docker
+        // If `start_container` fails, the created container persists in Docker
+        // with its S3 credentials visible via `docker inspect`. Always force-remove
+        // the container on this path to avoid credential leaks.
+        if let Err(e) = self
+            .docker
             .start_container(
                 &helper.id,
                 None::<bollard::query_parameters::StartContainerOptions>,
             )
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to start restore helper container: {}", e))?;
+        {
+            let _ = self
+                .docker
+                .remove_container(
+                    &helper.id,
+                    Some(bollard::query_parameters::RemoveContainerOptions {
+                        force: true,
+                        v: false,
+                        ..Default::default()
+                    }),
+                )
+                .await;
+            return Err(anyhow::anyhow!(
+                "Failed to start restore helper container: {}",
+                e
+            ));
+        }
 
         // Wait for the helper to finish — bounded to avoid an indefinitely stuck
         // helper blocking the restore run forever.
@@ -1008,8 +1037,15 @@ impl RedisService {
 
         // Step 3: Re-enable restart policy and start the original Redis container.
         // Redis will load the restored dump.rdb on startup.
+        //
+        // Re-enable restart policy regardless of the restore outcome — a transient
+        // Docker API error here must NOT propagate via `?` and strand the container
+        // with restart_policy=NO (which prevents auto-recovery from crashes or
+        // daemon restarts). Both sibling functions (`restore_from_legacy`,
+        // `restore_to_new_service`) use `let _ =` here for the same reason.
         info!("Starting Redis with restored data");
-        self.docker
+        let _ = self
+            .docker
             .update_container(
                 &container_name,
                 bollard::models::ContainerUpdateBody {
@@ -1020,8 +1056,7 @@ impl RedisService {
                     ..Default::default()
                 },
             )
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to re-enable restart policy: {}", e))?;
+            .await;
 
         restore_result?;
 


### PR DESCRIPTION
## Summary

Implements full restore support for managed Redis services. Before this PR the
`restore_capabilities`, `restore_in_place`, and `restore_to_new_service` methods
all returned unimplemented errors. The restore API existed but did nothing.

## What changed

### `crates/temps-providers/src/externalsvc/redis.rs`

**`restore_capabilities`** — reports `in_place: true`, `to_new_service: true`,
`pitr: false`. Redis restore uses the SYNC-triggered RDB path; point-in-time is
not supported.

**`restore_in_place`** / **`restore_to_new_service`** — both dispatch into
`restore_from_s3`, which detects the backup format (plain S3 key → `rdb.gz`
path; `s3://`-prefixed key → WAL-G path) and delegates accordingly.

**`restore_from_legacy`** (the operative path for all current backups — the
`RedisEngine` in `temps-backup` always produces `.rdb.gz` files):
1. Downloads the `.rdb.gz` from S3.
2. Gunzips with `flate2::GzDecoder` → raw RDB bytes on the host tmpdir.
3. Inspects the live Redis container to pick the correct helper image.
4. Sets the container's restart policy to `no` before stopping it. Without
   this, Docker immediately restarts `always`-policy containers, preventing
   the helper from writing to the volume.
5. Runs a one-shot helper container with `volumes_from=[redis-container]`
   plus a bind-mount of the host tmpdir. The helper:
   - Copies the RDB to `/data/dump.rdb`
   - Removes any stale `appendonlydir/`
   - Creates `appendonlydir/appendonly.aof.1.base.rdb` (the RDB) and
     `appendonlydir/appendonly.aof.manifest` pointing to it as the base
   > **Why the AOF directory?** Redis 7+ with `appendonly yes` silently
   > ignores a bare `dump.rdb` on startup and reads from `appendonlydir/`
   > instead. A restore that only copies `dump.rdb` completes with exit 0
   > but leaves Redis with its pre-restore data.
   - Chowns everything to `redis:redis`
6. Always re-enables the restart policy (`ALWAYS`) after the helper exits.
7. Starts the Redis container and waits for it to pass its health check.

Unit test: `test_restore_capabilities_in_place_and_new_service_no_pitr`.

### `apps/temps-e2e/src/commands/redis-restore-scenario.ts` (new)

End-to-end scenario proving the full backup+restore cycle with real key-level
before/after verification via the data-browser API (`readEntityRows`):
PRE-BACKUP keys → HTTP 200, POST-BACKUP keys → HTTP 404.

### `apps/temps-e2e/src/lib/redis-probe-app.ts` (new)

Go HTTP probe image builder that renders `go.mod + main.go + Dockerfile` into a
scratch build context, runs `docker build --load` + `docker push`.

### `apps/temps-e2e/src/lib/flows.ts`

Fixed `looksLikeConsoleFallback`: dev builds serve
`<title>Temps - Development Build</title>`, not `<title>Temps</title>`.
The previous exact-match regex let the console fallback through in dev mode — all
probe writes were silently routed to the console, which returns HTTP 200 for every
path, so keys were never written to Redis and backups were provably empty. The
original PR widened the regex to `[\s\-<]`; security-auditor review further
narrowed it to `[\s<]` (see Review fixes below).

## Bugs found during live verification

| # | Symptom | Root cause | Fix |
|---|---------|------------|-----|
| 1 | "failed to iterate over archive" | Original stub called `tar::Archive::new()` on a `.rdb.gz` | Use `flate2::GzDecoder` |
| 2 | Restore completes but Redis has pre-restore data | Bare `dump.rdb` ignored by Redis 7+ `appendonly yes` | Reconstruct `appendonlydir/` with manifest |
| 3 | Helper can't write to volume | Docker restarts `always`-policy containers immediately on stop | Set policy to `no` before stop, restore to `always` after |
| 4 | Backup RDB was empty | `looksLikeConsoleFallback` didn't match dev build title suffix | Widen regex to prefix-match `Temps` |

**On bug 4 ("confirmed by hex dump")**: the empty-RDB backup was ~182 bytes
based on the S3 object metadata size. The hex dump of that specific S3 artifact
was not preserved and cannot be reproduced after the fix. The description of
"zero SELECTDB opcodes confirmed by hex dump" should be read as "the S3 object
size was consistent with an empty RDB; exact hex output not retained."

## Security note (requesting security-auditor review)

This PR includes destructive restore-in-place logic:
stop container → write new data to the volume → restart. A helper container
with `volumes_from` is the minimum-privilege approach (no Docker-socket
exposure, no host filesystem access beyond the tmpdir bind-mount). The restart
policy is always restored in a finally-equivalent block regardless of success or
failure.

## Evidence

Live-verified 3× against a real temps instance (slot 26, `gotempsh/redis-walg:8-bookworm`, MinIO at `localhost:9092`, real Docker):

```
Run 1 — all 18 steps pass  redis-restore-scenario PASSED
Run 2 — all 18 steps pass  redis-restore-scenario PASSED
Run 3 — all 18 steps pass (backup polled to completed in 9.1s)  redis-restore-scenario PASSED
```

Key steps from run 1 (abridged):
```
✓ provision a real standalone Redis service (3.4s)
✓ wait for the app to serve real traffic (4.5s)
✓ health check reports a real Redis PING succeeding
✓ REDIS_DATABASE=2
✓ write 3 PRE-BACKUP keys (string, hash, list) via the probe app
✓ poll the backup to a real completed state (6.0s)
✓ write 3 POST-BACKUP keys that must NOT survive the restore
✓ poll the restore to a real completed state (3.0s)
✓ pre-backup keys survive: string key present in data-browser (HTTP 200)
✓ pre-backup keys survive: hash key present in data-browser (HTTP 200)
✓ pre-backup keys survive: list key present in data-browser (HTTP 200)
✓ post-backup keys erased: string key absent in data-browser (HTTP 404)
✓ post-backup keys erased: hash key absent in data-browser (HTTP 404)
✓ post-backup keys erased: list key absent in data-browser (HTTP 404)
```

---

## Review fixes (commit 8e6ec565)

Applied in response to security-auditor findings. **This PR is not claimed as
ready to merge — awaiting security-auditor re-confirmation.**

### [BLOCKING] `restore_from_walg` restart-policy stranding — FIXED

`restore_from_walg` re-enabled `restart_policy=ALWAYS` using `?`, so a
transient Docker API error on that single call would return early and leave the
container permanently stuck with `restart_policy=NO` — meaning it would not
auto-recover from crashes or daemon restarts. Both sibling functions
(`restore_from_legacy`, `restore_to_new_service`) correctly used `let _ =` here.

Fix: changed to `let _ = self.docker.update_container(...).await;` with an
explanatory comment. One-line change, matching the sibling pattern exactly.
`cargo check --lib -p temps-providers` and `cargo clippy -p temps-providers --lib -- -D warnings` both clean.

### [MAJOR] Orphaned credential-bearing container on `start_container` failure — FIXED

In `run_walg_restore_helper`, if `create_container` succeeded but
`start_container` failed, the function returned via `?` with no cleanup — leaving
the stopped helper container in `docker ps -a` with `AWS_ACCESS_KEY_ID` and
`AWS_SECRET_ACCESS_KEY` visible via `docker inspect`. The timeout path already
force-removed the container; only the `start_container` error path was missing it.

Fix: converted to `if let Err(e) = ...` with an explicit `remove_container(force=true)`
before returning the error, matching the timeout path's cleanup pattern.

### [MINOR] Deterministic helper container name collision — FIXED

The WAL-G helper container name was `format!("{}-restore-helper", target_container_name)`.
Two concurrent restores of the same service would collide on `create_container` with
an opaque "name already in use" Docker error. `restore_from_legacy` already appended a
UUID short-segment for uniqueness.

Fix: appended a `uuid::Uuid::new_v4()` short-segment, identical pattern to
`restore_from_legacy`.

### [MAJOR] `flows.ts` regex `[\s\-<]` → `[\s<]` — FIXED

The `\-` in the `looksLikeConsoleFallback` character class was unnecessary and
caused false positives: any deployed app whose page title starts with `Temps-`
(e.g. `Temps-sync-dashboard`, `Temps-cloud-lite`) would be misidentified as the
console fallback, causing `assertNotConsoleFallback` to time out rather than pass.

Both real console titles have a non-hyphen character immediately after `Temps`:
- Production build: `<title>Temps</title>` → next char is `<`
- Dev build: `<title>Temps - Development Build</title>` → next char is ` ` (space before ` - `)

Confirmed by checking `crates/temps-cli/build.rs` (the source of the dev build
title string) and `web/src/hooks/usePageTitle.ts` (which sets dynamic page titles
as `${page} - Temps`, trailing not leading, so they don't start with `Temps`).

**Blast-radius note for reviewers**: `assertNotConsoleFallback` is used by 12
scenario files beyond `redis-restore-scenario.ts`. None of these run in CI (only
Playwright `web/e2e` runs there). The regex change is a narrowing of what counts
as "fallback", so the direction of failure is: if anything, `assertNotConsoleFallback`
will now pass MORE readily for apps with `Temps-`-prefixed titles that were
previously (incorrectly) treated as fallbacks. It cannot silently suppress a
real failure; it can only surface one that the old regex was hiding.

Affected scenario files:
- `analytics-scenario.ts`
- `backup-restore-scenario.ts`
- `db-ha-failover-scenario.ts`
- `deploy-lifecycle-scenario.ts`
- `git-deploy-scenario.ts`
- `logs-scenario.ts`
- `managed-services-scenario.ts`
- `monitoring-scenario.ts`
- `pitr-scenario.ts`
- `redis-restore-scenario.ts`
- `scenario.ts`
- `session-replay-scenario.ts`

`bun x tsc --noEmit -p .` in `apps/temps-e2e` passes cleanly.

### [Evidence gap] Hex dump claim — CORRECTED

The original PR body stated the empty backup was "confirmed by hex dump of the
actual S3 object showing 182-byte gzipped RDB with only metadata headers, zero
SELECTDB opcodes." The ~182-byte size came from the S3 object metadata. The exact
hex dump of that specific artifact was not preserved and cannot be reproduced after
the fix. The PR description has been updated to accurately reflect what evidence
exists ("~182 bytes based on S3 object metadata size; exact hex output not retained").
