### PR TITLE
fix: correct dual-license metadata and stale redirect status doc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ members = [
 [workspace.package]
 version = "0.1.0-beta.55"
 edition = "2021"
-license = "Apache-2.0"
+license = "MIT OR Apache-2.0"
 authors = ["Temps Contributors"]
 repository = "https://github.com/gotempsh/temps"
 homepage = "https://github.com/gotempsh/temps"

--- a/crates/temps-email/src/handlers/tracking.rs
+++ b/crates/temps-email/src/handlers/tracking.rs
@@ -131,7 +131,7 @@ pub async fn track_open(
     get,
     path = "/emails/{email_id}/track/click/{link_index}",
     responses(
-        (status = 302, description = "Redirect to original URL"),
+        (status = 307, description = "Redirect to original URL"),
         (status = 404, description = "Link not found")
     ),
     params(


### PR DESCRIPTION
## Summary

- `Cargo.toml`: workspace `license` field said `"Apache-2.0"` only, but the project is dual-licensed MIT OR Apache-2.0 per `README.md` and the presence of both `LICENSE` (Apache 2.0) and `LICENSE-MIT` in the repo root. Fixed the metadata to match.
- `crates/temps-email/src/handlers/tracking.rs`: the `utoipa` doc comment for the click-tracking redirect endpoint said `status = 302`, but the handler actually returns `Redirect::temporary(...)`, which is HTTP 307. Fixed the OpenAPI doc annotation to match actual behavior.

Found via a docs/marketing verification sweep triggered by [gotempsh/temps#594](https://github.com/gotempsh/temps/discussions/594) (Docker Compose support inconsistency) — companion fixes to the marketing/docs content live in a separate temps-landing PR.

## Test plan

- [x] `cargo check --lib -p temps-email` passes with 0 errors
- [x] Metadata-only change to `Cargo.toml`, no code path affected