### PR TITLE
test(e2e): close remaining scenario gaps (mariadb restore, env vars, api keys)

### DIFF
--- a/apps/temps-e2e/README.md
+++ b/apps/temps-e2e/README.md
@@ -7,7 +7,9 @@ End-to-end + load testing CLI for a **live** Temps instance. Most commands
 `error-tracking-scenario`, `logs-scenario`, `analytics-scenario`,
 `session-replay-scenario`, `backup-restore-scenario`, `pitr-scenario`,
 `git-deploy-scenario`, `otel-quota-scenario`, `deploy-lifecycle-scenario`,
-`db-ha-failover-scenario`, `pg-upgrade-scenario`, `examples`) drive the real
+`db-ha-failover-scenario`, `pg-upgrade-scenario`, `redis-restore-scenario`,
+`mongodb-restore-scenario`, `s3-restore-scenario`, `mariadb-restore-scenario`,
+`env-vars-scenario`, `api-key-scenario`, `examples`) drive the real
 control-plane API directly via the shared
 [`@temps-sdk/api`](../../packages/api) client — fast, and enough to prove the
 API itself works, but they never exercise `apps/temps-cli` at all.
@@ -201,6 +203,32 @@ bun run src/index.ts deploy-lifecycle-scenario --keep --json    # inspect afterw
 # value) for the quota half to mean anything -- see its section below.
 bun run src/index.ts otel-quota-scenario
 bun run src/index.ts otel-quota-scenario --max-quota-batches 400 --json
+
+# redis-restore / mongodb-restore / s3-restore: backup + in-place restore of
+# each managed service via MinIO, proven by verifying pre-backup data
+# survives and post-backup-only data is erased. Needs MinIO (docker-compose.e2e.yml).
+bun run src/index.ts redis-restore-scenario --registry localhost:5111
+bun run src/index.ts mongodb-restore-scenario
+bun run src/index.ts s3-restore-scenario
+
+# mariadb-restore: backup + in-place restore of a real MariaDB service --
+# insert pre-backup rows via docker exec, real backup (physical or logical,
+# engine-selected) to MinIO, insert post-backup rows, restore in place, and
+# verify via the data-browser API that only the pre-backup rows survive.
+# Needs MinIO (docker-compose.e2e.yml).
+bun run src/index.ts mariadb-restore-scenario
+
+# env-vars: create/update/delete a project env var and redeploy after each
+# change, asserting the RUNNING CONTAINER (an echo-server app, not just the
+# API response) reflects the new/updated/removed value, plus an
+# environment-scoping check.
+bun run src/index.ts env-vars-scenario --registry localhost:5111
+
+# api-key: a second low-privilege user creates a scoped API key over real
+# HTTP, the key gets 200 on an in-scope request and 403 on an out-of-scope
+# one, then revocation makes an immediate retry fail. Needs DB-direct access
+# to mint the second user's initial session, same as rbac-scenario.
+bun run src/index.ts api-key-scenario --temps-root /path/to/temps --database-url postgres://...
 ```
 
 ### `examples`
@@ -872,6 +900,95 @@ reading the rows back after it finishes, not just watching a status field flip.
     `external_services.parameters`; this checks the API-visible result
 11. teardown (deployment, project, service, S3 source)
 
+### `mariadb-restore-scenario` steps
+
+Closes the last remaining gap in the backup/restore engine parity story:
+Postgres (`backup-restore-scenario`, `pitr-scenario`, `pg-upgrade-scenario`),
+Redis, MongoDB, and S3 all have restore e2e coverage; MariaDB had the engine
+code (`crates/temps-providers/src/externalsvc/mariadb.rs`'s
+`restore_capabilities`/`restore_to_new_service`/`restore_pitr`, all fully
+wired to the trait) but no live-server proof until now.
+
+1. provision a real MariaDB service and read its root password directly off
+   the container via `docker inspect` (`MARIADB_ROOT_PASSWORD`, per
+   `MariaDbService::get_container_name`)
+2. insert 3 pre-backup rows into a real table via `docker exec mariadb -uroot
+   -p... -e ...` -- no synthetic DB rows, the same discipline every other
+   restore scenario holds itself to
+3. create a MinIO S3 source and trigger a real backup; the backup engine
+   auto-selects physical or logical (`crates/temps-backup/src/engines/dispatch.rs`)
+4. insert 2 more rows post-backup, to prove restore reverts state rather than
+   just leaving current state alone
+5. start an in-place restore and poll until it completes
+6. verify via the read-only data-browser API (not a direct DB read) that the
+   3 pre-backup rows are present with correct values, the 2 post-backup rows
+   are absent, and exactly 3 rows remain
+7. teardown (S3 source, service)
+
+### `env-vars-scenario` steps
+
+Proves environment-variable changes actually propagate into the running
+container -- not just that the API round-trips the value. App env vars have
+**no hot-reload**: a changed value only takes effect after a redeploy, so
+the scenario redeploys after every change and asserts on the live
+container's own response, never the database row.
+
+1. create a project, deploy `examples/echo-server` (its response body
+   includes `env: process.env`, so it directly surfaces the real container's
+   environment)
+2. create an env var scoped to production with a distinct marker value;
+   assert the create response round-trips it in plaintext (list responses
+   mask non-secret values as `"***"` -- only create/update return plaintext)
+3. redeploy, then poll the live container's own response until
+   `env["E2E_ENV_VAR_MARKER"]` actually equals the new value
+4. update the var to a second marker value, redeploy again, assert the
+   response reflects the NEW value (not the stale one) -- proves updates,
+   not just creates
+5. delete the var, redeploy, assert the key is genuinely absent from the
+   running container's environment
+6. lightweight, deploy-free check: a var scoped only to production must not
+   appear when `GET .../env-vars` is filtered by a second (staging)
+   environment's id, but must appear when filtered by production
+7. teardown (env vars, deployments, project)
+
+### `api-key-scenario` steps
+
+Promotes `web/e2e/authenticated/api-key-create.spec.ts` (UI-only: open
+dialog, fill name, submit, see the key once) to a real API round trip,
+covering what only an API-level test can prove: scope enforcement and
+revocation actually cutting off access, not just that api-key CRUD returns
+2xx.
+
+A real constraint shaped this scenario: `POST /api-keys` is gated by
+`SensitiveAction::CreateApiKey`, and `DefaultSensitiveActionAuthorizer`
+denies every machine (API-key-authenticated) principal outright
+(`machine_principals_are_denied_by_default`,
+`crates/temps-auth/src/sensitive_action.rs`) -- so this suite's own primary
+bearer-key identity can never call it. Same wall `rbac-scenario` already
+documented. The fix here: mint a second, low-privilege user via DB-direct
+`temps api-key` (needs `--temps-root`/`--database-url`, same as
+`rbac-scenario`), log it in for real via `POST /auth/login`, and drive key
+creation/revocation with the resulting `session` cookie via raw `fetch` --
+the SDK client always attaches a Bearer header, so it can't be used for this
+leg.
+
+1. create a project (primary bearer identity)
+2. create + log in a second, low-privilege user; capture its `session` cookie
+3. `POST /api-keys` (session-cookie authenticated) with a custom key scoped
+   to `projects:read` only; capture the plaintext key (returned only once)
+4. use the scoped key (`Authorization: Bearer tk_...`) against `GET
+   /projects/{id}` -- assert 200
+5. use the same key against `PATCH /projects/{id}` -- assert 403 with
+   `required_permission: "projects:write"`
+6. revoke the key (`POST /api-keys/{id}/deactivate`, session-cookie
+   authenticated)
+7. immediately retry the previously-200 request with the revoked key --
+   assert it now fails. Revocation is instant (`ApiKeyService::validate_api_key`
+   queries `IsActive.eq(true)` directly on every call; the only cache
+   throttles `last_used_at` write-back, never the pass/fail read), so this
+   is a single request, not a poll
+8. teardown (key, second user, project)
+
 ### `git-deploy-scenario` steps
 
 1. create a project pointed at a real public repo
@@ -1380,6 +1497,32 @@ HTTP-driven e2e run. `vercel-labs/emulate` (used elsewhere in this repo for
 mocking third-party APIs test-harness-side) can't help here either, for the
 same reason — see `web/e2e/README.md`'s "Mocking third-party services"
 section, which documents the identical constraint for the console UI tests.
+
+**Generic outbound webhooks** — same guard, same conclusion, no
+`webhook-scenario` command. `POST /projects/{project_id}/webhooks` runs every
+URL (create *and* update) through
+`WebhookService::validate_webhook_url` (`crates/temps-webhooks/src/service.rs`),
+which calls the exact same `temps_core::url_validation::validate_external_url`
+Slack goes through, then `validate_domain_async` for the DNS-resolved case.
+Unlike the DNS-01/Pebble guard in `crates/temps-dns/src/providers/pebble.rs`
+(which has an explicit `TEMPS_ALLOW_PEBBLE_PROVIDER=1` opt-in for exactly this
+kind of test), there is no dev/test bypass anywhere in the webhooks path —
+grepped `crates/temps-webhooks/` and `crates/temps-core/src/url_validation.rs`
+for `TEMPS_ALLOW*`, `debug_assertions`, `is_dev`/`dev_mode`/`test_mode`, and
+found nothing. A local receiver is also unreachable via the DNS-rebinding
+route: actual delivery in `deliver_webhook` re-resolves and pins the HTTP
+client to the validated IPs (`delivery_client_for`), so a domain that
+resolves publicly at create-time and privately at delivery-time is rejected
+too. Net effect: no loopback, RFC1918, or link-local target — including
+anything inside `docker-compose.e2e.yml`'s bridge network — can ever be a
+legal webhook URL against a real instance, create or update. The signing math
+(`sha256=` HMAC over `{timestamp}.{payload}`) is covered by
+`test_signature_generation` in `crates/temps-webhooks/src/service.rs`, which
+is the right layer for that piece, same as Slack's `wiremock` unit test one
+section up. Proving actual delivery end-to-end would need a real public receiver (e.g. a
+tunnel or hosted catcher) wired into the harness, which does not exist in
+this repo today. It was deliberately not added, and the SSRF guard was not
+weakened, for test convenience — the same call made for Slack above.
 
 ## Notes
 

--- a/apps/temps-e2e/src/commands/api-key-scenario.ts
+++ b/apps/temps-e2e/src/commands/api-key-scenario.ts
@@ -247,7 +247,10 @@ export async function apiKeyScenarioCommand(opts: ApiKeyScenarioOptions): Promis
         }
         const body = (await res.json()) as CreateApiKeyHttpResponse
         if (!body.api_key || !body.api_key.startsWith('tk_')) {
-          throw new Error(`POST /api-keys returned no usable plaintext secret: ${JSON.stringify(body)}`)
+          const preview = body.api_key ? `${body.api_key.slice(0, 6)}...` : '(missing)'
+          throw new Error(
+            `POST /api-keys returned api_key ${preview}, expected a 'tk_'-prefixed plaintext secret`,
+          )
         }
         return body
       },

--- a/apps/temps-e2e/src/commands/api-key-scenario.ts
+++ b/apps/temps-e2e/src/commands/api-key-scenario.ts
@@ -1,0 +1,366 @@
+/**
+ * API key management lifecycle against a live Temps instance -- proving the
+ * actual HTTP-level round trip (create -> scoped 200/403 -> revoke -> cut
+ * off), not just that the console wizard can mint one.
+ *
+ * `web/e2e/authenticated/api-key-create.spec.ts` already covers the
+ * browser-only path: open the 3-step wizard, pick the first predefined
+ * role, submit, and confirm the returned secret authenticates a single
+ * `GET /projects` call. That is real coverage but narrow -- it never tries
+ * a *scoped* (non-predefined-role) key, never checks that the scope is
+ * actually enforced as a ceiling (200 inside it, 403 outside it), and never
+ * revokes anything. This scenario is deliberately the complement: it skips
+ * the UI and drives `POST /api-keys` -> use -> revoke -> use-again entirely
+ * through the real API, the same way `rbac-scenario.ts` complements the
+ * team/access UI.
+ *
+ * Real constraint discovered while building this (not a bug -- a deliberate
+ * anti-privilege-escalation boundary, see
+ * `crates/temps-auth/src/sensitive_action.rs`'s `DefaultSensitiveActionAuthorizer`):
+ * `POST /api-keys` is gated behind `SensitiveAction::CreateApiKey`, and the
+ * default policy DENIES every principal that isn't an interactive
+ * `UserSession` -- API keys, CLI tokens, and deployment tokens are all
+ * machine principals and get `Deny { reason: "interactive_verification_required" }`
+ * outright (not even the 428 step-up flow; see
+ * `machine_principals_are_denied_by_default` in that file's own tests).
+ * Since every SDK client `apps/temps-e2e` builds via `makeClient()` is
+ * Bearer-API-key-authenticated (see `lib/client.ts`), the PRIMARY e2e
+ * identity can never itself call `POST /api-keys` -- exactly the same wall
+ * `rbac-scenario.ts` hit when it needed a second user's OWN bearer key
+ * (its comment: "minting a NEW key while already authenticated via API key
+ * is deliberately blocked"). rbac-scenario routes around this by minting
+ * DB-direct; that shortcut is unusable HERE because the entire point of
+ * this scenario is to prove the real `POST /api-keys` HTTP endpoint works.
+ *
+ * The only principal type the default policy allows through is a real
+ * interactive browser session, so this scenario creates a throwaway
+ * low-privilege second user (via the CLI, same as rbac-scenario), logs it
+ * in for real against `POST /auth/login`, and uses the resulting session
+ * cookie -- NOT a bearer token -- to drive key creation and revocation.
+ * Two more things had to be confirmed by reading the actual production
+ * auth path rather than assuming from names:
+ *
+ *   - The session cookie is named plain `session` (see
+ *     `AuthService::create_session_cookie` and
+ *     `AuthMiddleware::extract_user_session_from_cookies`, the middleware
+ *     actually wired into the router via the plugin system). A same-named
+ *     `SESSION_ID_COOKIE_NAME = "_temps_sid"` constant exists in
+ *     `crates/temps-auth/src/middleware.rs`, but that file's
+ *     `auth_middleware` free function is NOT the one registered as
+ *     `TempsMiddleware` -- `_temps_sid` is actually the visitor/session
+ *     *tracking* cookie a Temps-deployed customer app reads (see
+ *     `packages/api` -- `X-Temps-...` / `_temps_visitor_id` analytics
+ *     docs), an unrelated feature that happens to reuse the string
+ *     "session". Sending `Cookie: _temps_sid=...` to the console API does
+ *     nothing; only `Cookie: session=...` authenticates.
+ *   - The cookie-vs-bearer branches are mutually exclusive at the
+ *     middleware level: an `Authorization` header of ANY kind (even one
+ *     that fails to parse as `tk_`/`dt_`) skips the cookie-session branch
+ *     entirely (see the `if let Some(auth_header) = ... else { try cookie }`
+ *     shape in `execute_auth_middleware_logic`). So the login + create/
+ *     revoke calls below are raw `fetch()`, never the SDK client (which
+ *     unconditionally attaches a Bearer header via its request
+ *     interceptor).
+ *
+ * Revocation immediacy: `ApiKeyService::validate_api_key` (the function the
+ * auth middleware calls on every `tk_...`-bearing request) queries
+ * `api_keys` directly with `IsActive.eq(true)` on every single call -- no
+ * cache, no TTL, nothing in between the DB row and the auth decision (the
+ * only caching in this service, `LastUsedThrottle`, only throttles the
+ * `last_used_at` write-back, never the read that decides pass/fail). So the
+ * revoke -> immediate-retry assertion below is a single request, not a
+ * poll -- confirmed by reading the query, not assumed from a doc comment.
+ */
+import { getProject, updateProject, deleteUser } from '@temps-sdk/api'
+import { makeClient, normalizeApiUrl, resolveConfig, unwrap } from '../lib/client.ts'
+import { createE2eProject, teardown, makeRunId } from '../lib/flows.ts'
+import { runCliOk, runCliJson } from '../lib/cli-exec.ts'
+
+export interface ApiKeyScenarioOptions {
+  tempsRoot?: string
+  databaseUrl?: string
+  keep?: boolean
+  json?: boolean
+  connection: { url?: string; apiKey?: string }
+}
+
+interface StepLog {
+  step: string
+  ok: boolean
+  detail?: string
+  ms?: number
+}
+
+interface ApiKeyScenarioResult {
+  runId: string
+  ok: boolean
+  steps: StepLog[]
+}
+
+interface CreateApiKeyHttpResponse {
+  id: number
+  name: string
+  key_prefix: string
+  role_type: string
+  permissions: string[] | null
+  api_key: string
+  expires_at: string | null
+  created_at: string
+}
+
+/** Extract the `session=...` cookie value pair from a Set-Cookie response header set. */
+function extractSessionCookie(setCookieValues: string[]): string {
+  for (const raw of setCookieValues) {
+    // Each Set-Cookie header value looks like `session=<value>; Path=/; ...`
+    const match = /^session=([^;]+)/.exec(raw.trim())
+    if (match) return `session=${match[1]}`
+  }
+  throw new Error(
+    `no "session" cookie found in login response Set-Cookie headers: ${JSON.stringify(setCookieValues)}`,
+  )
+}
+
+/**
+ * Bun's `fetch` Response exposes multiple Set-Cookie header values via
+ * `headers.getSetCookie()` (Node/Bun-specific -- the raw Fetch spec's
+ * `Headers.get('set-cookie')` folds them into one comma-joined string,
+ * which would corrupt cookie parsing since cookie attributes themselves
+ * contain commas in `Expires=`). Falls back to a single `get()` call for
+ * environments where `getSetCookie` isn't available.
+ */
+function getSetCookieValues(headers: Headers): string[] {
+  const withGetSetCookie = headers as Headers & { getSetCookie?: () => string[] }
+  if (typeof withGetSetCookie.getSetCookie === 'function') {
+    return withGetSetCookie.getSetCookie()
+  }
+  const single = headers.get('set-cookie')
+  return single ? [single] : []
+}
+
+export async function apiKeyScenarioCommand(opts: ApiKeyScenarioOptions): Promise<void> {
+  const cfg = resolveConfig(opts.connection)
+  const client = makeClient(cfg)
+  const json = !!opts.json
+  const log = (msg: string) => {
+    if (!json) process.stderr.write(msg + '\n')
+  }
+  if (!json) log(`Temps API key scenario  ->  ${cfg.url}`)
+
+  const tempsRoot = opts.tempsRoot ?? process.env.TEMPS_ROOT
+  const databaseUrl = opts.databaseUrl ?? process.env.TEMPS_DATABASE_URL
+  if (!tempsRoot || !databaseUrl) {
+    throw new Error(
+      'API key testing needs a real interactive login (POST /api-keys denies every machine ' +
+        'principal by default, including the bearer key this harness itself uses) -- pass ' +
+        '--temps-root <checkout> --database-url <postgres url>, or set TEMPS_ROOT / ' +
+        'TEMPS_DATABASE_URL, so a throwaway user can be created via the CLI. See ' +
+        'apps/temps-e2e/README.md.',
+    )
+  }
+
+  const apiBase = normalizeApiUrl(cfg.url)
+
+  const runId = makeRunId(Date.now())
+  const steps: StepLog[] = []
+  const step = async <T>(name: string, fn: () => Promise<T>): Promise<T> => {
+    const t0 = performance.now()
+    log(`\n▶ ${name}`)
+    try {
+      const r = await fn()
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: true, ms })
+      log(`  ✓ ${name} (${(ms / 1000).toFixed(1)}s)`)
+      return r
+    } catch (e) {
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: false, detail: (e as Error).message, ms })
+      log(`  ✗ ${name}: ${(e as Error).message}`)
+      throw e
+    }
+  }
+
+  const secondUsername = `${runId}-keyuser`.replace(/[^a-z0-9-]/gi, '-').slice(0, 32)
+  const secondEmail = `${runId}-second@e2e.test`
+  const secondPassword = `E2e!${runId}Aa1`
+  const keyName = `${runId}-scoped-key`
+
+  const projectIds: number[] = []
+  let secondUserId: number | undefined
+  let sessionCookie: string | undefined
+  let scopedApiKeyId: number | undefined
+  let scopedApiKey: string | undefined
+  let scopedApiKeyRevoked = false
+
+  try {
+    const project = await step('create a throwaway project (primary bearer identity)', () =>
+      createE2eProject(client, { name: `${runId}-apikey-app` }),
+    )
+    projectIds.push(project.id)
+    log(`  project #${project.id} (${project.slug})`)
+
+    await step('create a low-privilege second user (role: user, via CLI)', () =>
+      runCliOk(
+        ['users', 'create', '-u', secondUsername, '-e', secondEmail, '-p', secondPassword, '-r', 'user', '-y'],
+        cfg,
+      ),
+    )
+
+    secondUserId = await step("resolve the second user's id (users create has no --json output)", async () => {
+      const users = await runCliJson<Array<{ user: { id: number; email: string } }>>(['users', 'list'], cfg)
+      const match = users.find((u) => u.user.email === secondEmail)
+      if (!match) throw new Error(`created user ${secondEmail} not found in users list`)
+      return match.user.id
+    })
+    log(`  second user #${secondUserId} (${secondEmail})`)
+
+    sessionCookie = await step(
+      'log the second user in for real (POST /auth/login) -- the only principal type POST /api-keys accepts',
+      async () => {
+        const res = await fetch(`${apiBase}/auth/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: secondEmail, password: secondPassword }),
+        })
+        if (!res.ok) {
+          throw new Error(`POST /auth/login failed: HTTP ${res.status} ${await res.text()}`)
+        }
+        const setCookies = getSetCookieValues(res.headers)
+        return extractSessionCookie(setCookies)
+      },
+    )
+
+    const created = await step(
+      'POST /api-keys (session-cookie auth): a custom key scoped to ONLY projects:read',
+      async () => {
+        const res = await fetch(`${apiBase}/api-keys`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Cookie: sessionCookie! },
+          body: JSON.stringify({
+            name: keyName,
+            role_type: 'custom',
+            permissions: ['projects:read'],
+            expires_at: null,
+          }),
+        })
+        if (res.status !== 201) {
+          throw new Error(`POST /api-keys failed: HTTP ${res.status} ${await res.text()}`)
+        }
+        const body = (await res.json()) as CreateApiKeyHttpResponse
+        if (!body.api_key || !body.api_key.startsWith('tk_')) {
+          throw new Error(`POST /api-keys returned no usable plaintext secret: ${JSON.stringify(body)}`)
+        }
+        return body
+      },
+    )
+    scopedApiKeyId = created.id
+    scopedApiKey = created.api_key
+    log(`  scoped key #${created.id} (${created.key_prefix}...)`)
+
+    await step('scoped key: in-scope read succeeds (200, real project fields)', async () => {
+      const scopedClient = makeClient({ url: cfg.url, apiKey: scopedApiKey! })
+      const read = unwrap(await getProject({ client: scopedClient, path: { id: project.id } }), 'getProject')
+      if (read.id !== project.id) {
+        throw new Error(`GET /projects/${project.id} with scoped key returned id=${read.id}`)
+      }
+    })
+
+    await step('scoped key: out-of-scope write is 403 naming projects:write', async () => {
+      const scopedClient = makeClient({ url: cfg.url, apiKey: scopedApiKey! })
+      const write = await updateProject({
+        client: scopedClient,
+        path: { id: project.id },
+        body: {
+          name: `${project.name}-renamed`,
+          directory: '.',
+          main_branch: 'main',
+          preset: 'dockerfile',
+          storage_service_ids: [],
+          source_type: 'docker_image',
+          is_web_app: true,
+        },
+      })
+      if (!write.error || write.response?.status !== 403) {
+        throw new Error(`PATCH with a projects:read-only key returned HTTP ${write.response?.status}, expected 403`)
+      }
+      const body = write.error as { required_permission?: string } | undefined
+      if (body?.required_permission !== 'projects:write') {
+        throw new Error(
+          `PATCH-with-scoped-key 403 body.required_permission="${body?.required_permission}", expected "projects:write"`,
+        )
+      }
+    })
+
+    await step('revoke the key (POST /api-keys/{id}/deactivate, session-cookie auth)', async () => {
+      const res = await fetch(`${apiBase}/api-keys/${scopedApiKeyId}/deactivate`, {
+        method: 'POST',
+        headers: { Cookie: sessionCookie! },
+      })
+      if (!res.ok) {
+        throw new Error(`POST /api-keys/${scopedApiKeyId}/deactivate failed: HTTP ${res.status} ${await res.text()}`)
+      }
+      const body = (await res.json()) as { is_active: boolean }
+      if (body.is_active !== false) {
+        throw new Error(`deactivate response reports is_active=${body.is_active}, expected false`)
+      }
+      scopedApiKeyRevoked = true
+    })
+
+    await step(
+      'revoked key: the VERY NEXT request with it is rejected (401) -- validate_api_key reads is_active straight ' +
+        'from the DB on every call, no cache to wait out',
+      async () => {
+        const scopedClient = makeClient({ url: cfg.url, apiKey: scopedApiKey! })
+        const res = await getProject({ client: scopedClient, path: { id: project.id } })
+        if (!res.error || res.response?.status !== 401) {
+          throw new Error(
+            `GET /projects/${project.id} with a just-revoked key returned HTTP ${res.response?.status}, expected 401`,
+          )
+        }
+      },
+    )
+  } catch {
+    // Failure already recorded in `steps`; fall through to teardown.
+  } finally {
+    if (opts.keep) {
+      log(
+        `\n(kept resources: projects=${projectIds.join(',')} secondUser=${secondUserId} ` +
+          `apiKey=${scopedApiKeyId})`,
+      )
+    } else {
+      if (scopedApiKeyId !== undefined && !scopedApiKeyRevoked && sessionCookie) {
+        // Best-effort: the deactivate step itself may be what failed.
+        await fetch(`${apiBase}/api-keys/${scopedApiKeyId}/deactivate`, {
+          method: 'POST',
+          headers: { Cookie: sessionCookie },
+        }).catch(() => undefined)
+      }
+      if (scopedApiKeyId !== undefined && sessionCookie) {
+        await fetch(`${apiBase}/api-keys/${scopedApiKeyId}`, {
+          method: 'DELETE',
+          headers: { Cookie: sessionCookie },
+        }).catch(() => undefined)
+      }
+      if (secondUserId !== undefined) {
+        // `deleteUser` needs the primary identity's own permissions, not the
+        // throwaway second user's -- same as rbac-scenario's teardown.
+        await deleteUser({ client, path: { user_id: secondUserId } }).catch(() => undefined)
+      }
+      const td = await teardown(client, { projectIds })
+      log(
+        `\n▶ teardown: deleted ${td.deletedProjects} project(s), removed second user + api key` +
+          (td.errors.length ? ` (${td.errors.length} errors)` : ''),
+      )
+      for (const e of td.errors) log(`    ! ${e}`)
+    }
+  }
+
+  const ok = steps.length > 0 && steps.every((s) => s.ok)
+  const result: ApiKeyScenarioResult = { runId, ok, steps }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+  } else {
+    log(`\n${ok ? '✅ api-key-scenario PASSED' : '❌ api-key-scenario FAILED'}`)
+  }
+  if (!ok) process.exitCode = 1
+}

--- a/apps/temps-e2e/src/commands/env-vars-scenario.ts
+++ b/apps/temps-e2e/src/commands/env-vars-scenario.ts
@@ -1,0 +1,525 @@
+/**
+ * Project/app environment-variable management against a live Temps
+ * instance -- proving the full lifecycle (create / update / delete / scope
+ * to a specific environment) actually reaches a real running container, not
+ * just that the API round-trips a row.
+ *
+ * The one thing that makes this worth testing end to end: there is NO
+ * hot-reload. `crates/temps-environments/src/services/env_var_service.rs`
+ * only ever writes the `env_vars` / `env_var_environments` tables -- a
+ * running container keeps whatever environment it was started with until
+ * the next deploy re-resolves and re-injects env vars at container-start
+ * time (`temps-deployments/src/services/env_resolver.rs`). A scenario that
+ * only asserts "the API returned the value I just wrote" would pass even if
+ * that injection path were completely broken. This scenario instead:
+ *
+ *   1. deploys the repo's `examples/echo-server` image, which responds to
+ *      every request with a JSON body that includes `env: process.env` --
+ *      i.e. the ACTUAL environment the container process sees, not
+ *      anything the platform claims it set.
+ *   2. creates a project env var with a distinct marker value, scoped to
+ *      production only, and asserts the CREATE response returns the
+ *      plaintext value (round-trip).
+ *   3. redeploys (a fresh `deployFromImage` call against the same image --
+ *      the only way env var changes ever take effect) and polls the live
+ *      container's own JSON response until `env["<key>"]` actually equals
+ *      the marker value -- proving propagation into the real process, not a
+ *      DB row.
+ *   4. updates the var to a NEW marker value and redeploys again, asserting
+ *      the live container now reflects the new value -- proves updates
+ *      propagate on redeploy, not just creates.
+ *   5. deletes the var and redeploys once more, asserting the key is now
+ *      absent from the container's environment entirely (not just masked or
+ *      empty-stringed).
+ *   6. a lighter-weight, deploy-free check of environment scoping: a var
+ *      created with `environment_ids: [production]` must NOT appear when
+ *      `GET .../env-vars` is filtered by a second (staging) environment's
+ *      id, proving `get_environment_variables`'s environment_id filter
+ *      (crates/temps-environments/src/services/env_var_service.rs ~line
+ *      140) actually excludes unscoped vars rather than just annotating
+ *      them.
+ *
+ * The list endpoint (`GET /projects/{id}/env-vars`) always masks non-secret
+ * values with `"***"` (handler.rs `get_environment_variables`, deliberately
+ * -- see its comment about not bulk-dumping plaintext over a single GET), so
+ * plaintext round-trip assertions here use the CREATE/UPDATE responses
+ * instead, which do return `var.value` verbatim.
+ */
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  createEnvironment,
+  createEnvironmentVariable,
+  updateEnvironmentVariable,
+  deleteEnvironmentVariable,
+  getEnvironmentVariables,
+} from '@temps-sdk/api'
+import { makeClient, resolveConfig, unwrap } from '../lib/client.ts'
+import {
+  createE2eProject,
+  getProductionEnvironment,
+  deployImage,
+  waitForDeployment,
+  getDeployStatus,
+  waitForHttpReady,
+  assertNotConsoleFallback,
+  fetchBody,
+  resolveLoadTarget,
+  teardown,
+  makeRunId,
+  sleep,
+} from '../lib/flows.ts'
+
+export interface EnvVarsScenarioOptions {
+  registry?: string
+  keep?: boolean
+  deployTimeout?: string
+  json?: boolean
+  connection: { url?: string; apiKey?: string }
+}
+
+interface StepLog {
+  step: string
+  ok: boolean
+  detail?: string
+  ms?: number
+}
+
+interface EnvVarsScenarioResult {
+  runId: string
+  ok: boolean
+  steps: StepLog[]
+}
+
+/** The container port `examples/echo-server` listens on ($PORT, defaults to 8080). */
+const ECHO_SERVER_PORT = 8080
+
+/** Locate the repo's `examples/echo-server` dir relative to this app (apps/temps-e2e). */
+function echoServerSourceDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url)) // .../apps/temps-e2e/src/commands
+  return resolve(here, '../../../../examples/echo-server')
+}
+
+/**
+ * `docker build` (+ push) the repo's existing `examples/echo-server` image
+ * as-is -- it already ships its own Dockerfile and has zero npm
+ * dependencies (see its package.json), so unlike `versioned-app.ts`/
+ * `probe-app.ts` there is no scratch-context rendering step: this builds
+ * directly against the committed source tree (read-only; docker build never
+ * mutates the context) and reuses the platform's own example gallery entry
+ * instead of inventing a parallel test-only fixture.
+ */
+async function buildEchoServerImage(opts: {
+  registry: string
+  tag?: string
+  onLog?: (line: string) => void
+}): Promise<string> {
+  const srcDir = echoServerSourceDir()
+  const imageRef = opts.tag ?? `${opts.registry}/e2e-echo-server:latest`
+
+  opts.onLog?.(`docker build -t ${imageRef} ${srcDir}`)
+  await runDocker(['build', '--load', '-t', imageRef, srcDir], opts.onLog, `docker build ${imageRef}`)
+  opts.onLog?.(`docker push ${imageRef}`)
+  await runDocker(['push', imageRef], opts.onLog, `docker push ${imageRef}`)
+  return imageRef
+}
+
+/** Spawn a docker subcommand, stream its output through onLog, throw on failure. */
+async function runDocker(
+  args: string[],
+  onLog: ((line: string) => void) | undefined,
+  what: string,
+): Promise<void> {
+  const proc = Bun.spawn(['docker', ...args], { stdout: 'pipe', stderr: 'pipe' })
+  const pump = async (stream: ReadableStream<Uint8Array>) => {
+    const reader = stream.getReader()
+    const decoder = new TextDecoder()
+    let buf = ''
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buf += decoder.decode(value, { stream: true })
+      const lines = buf.split('\n')
+      buf = lines.pop() ?? ''
+      for (const l of lines) if (l.trim()) onLog?.(l)
+    }
+    if (buf.trim()) onLog?.(buf)
+  }
+  await Promise.all([pump(proc.stdout), pump(proc.stderr)])
+  const code = await proc.exited
+  if (code !== 0) {
+    throw new Error(`${what} failed (exit ${code})`)
+  }
+}
+
+/** Shape of `examples/echo-server`'s JSON response body (only the fields this scenario reads). */
+interface EchoServerBody {
+  env?: Record<string, string>
+}
+
+/**
+ * Poll a live `echo-server` target until its OWN reported `env["<key>"]`
+ * matches `expected` (or, when `expected` is `undefined`, until the key is
+ * genuinely absent), or time out. Unlike a plain HTTP-ready check, this
+ * reads the value back out of the deployed container's real process
+ * environment on every poll -- proving propagation, not just that a new
+ * deployment reached a terminal state.
+ */
+async function waitForEnvValue(
+  target: { url: string; headers?: Record<string, string> },
+  key: string,
+  expected: string | undefined,
+  opts: { timeoutMs?: number; intervalMs?: number; label: string },
+): Promise<void> {
+  const timeoutMs = opts.timeoutMs ?? 90_000
+  const intervalMs = opts.intervalMs ?? 2000
+  const start = performance.now()
+  let lastValue: string | undefined
+  let lastStatus = 0
+  while (performance.now() - start < timeoutMs) {
+    try {
+      const { status, body } = await fetchBody(target.url, target.headers, 10_000)
+      lastStatus = status
+      if (status >= 200 && status < 300) {
+        const parsed = JSON.parse(body) as EchoServerBody
+        lastValue = parsed.env?.[key]
+        if (lastValue === expected) return
+      }
+    } catch {
+      // transient (connection reset / non-JSON body during route flap) -- retry
+    }
+    await sleep(intervalMs)
+  }
+  throw new Error(
+    `${opts.label}: expected env["${key}"] to be ${JSON.stringify(expected)}, ` +
+      `last observed ${JSON.stringify(lastValue)} (HTTP ${lastStatus}) after ${Math.round(timeoutMs / 1000)}s`,
+  )
+}
+
+export async function envVarsScenarioCommand(opts: EnvVarsScenarioOptions): Promise<void> {
+  const cfg = resolveConfig(opts.connection)
+  const client = makeClient(cfg)
+  const json = !!opts.json
+  const log = (msg: string) => {
+    if (!json) process.stderr.write(msg + '\n')
+  }
+  if (!json) log(`Temps env-vars scenario  ->  ${cfg.url}`)
+
+  const registry = opts.registry ?? process.env.TEMPS_E2E_REGISTRY
+  if (!registry) {
+    throw new Error(
+      'A registry is required: the echo-server image must be pushed somewhere the server can ' +
+        'pull from. Pass --registry <host:port> (e.g. localhost:5111) or set TEMPS_E2E_REGISTRY. ' +
+        'Start a local one with: docker run -d -p 5111:5000 --name temps-e2e-registry registry:2',
+    )
+  }
+
+  const runId = makeRunId(Date.now())
+  const deployTimeoutMs = Number(opts.deployTimeout ?? '300000')
+  const markerKey = 'E2E_ENV_VAR_MARKER'
+  const valueA = `temps-e2e-env-var-A-${runId}`
+  const valueB = `temps-e2e-env-var-B-${runId}`
+  const scopeKey = 'E2E_ENV_VAR_SCOPE_TEST'
+  const scopeValue = `temps-e2e-scope-${runId}`
+
+  const steps: StepLog[] = []
+  const step = async <T>(name: string, fn: () => Promise<T>): Promise<T> => {
+    const t0 = performance.now()
+    log(`\n▶ ${name}`)
+    try {
+      const r = await fn()
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: true, ms })
+      log(`  ✓ ${name} (${(ms / 1000).toFixed(1)}s)`)
+      return r
+    } catch (e) {
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: false, detail: (e as Error).message, ms })
+      log(`  ✗ ${name}: ${(e as Error).message}`)
+      throw e
+    }
+  }
+
+  const projectIds: number[] = []
+  const deployments: { projectId: number; deploymentId: number }[] = []
+  const envVarIds: { projectId: number; varId: number }[] = []
+  let stagingEnvId: number | undefined
+
+  try {
+    const project = await step('create project', () =>
+      createE2eProject(client, { name: `${runId}-envvars`, exposedPort: ECHO_SERVER_PORT }),
+    )
+    projectIds.push(project.id)
+    log(`  project #${project.id} (${project.slug})`)
+
+    const env = await step('resolve production environment', () =>
+      getProductionEnvironment(client, project.id),
+    )
+    log(`  env #${env.id} (${env.name})  url=${env.mainUrl}`)
+    const target = resolveLoadTarget(cfg.url, env.mainUrl)
+
+    const image = await step('build + push echo-server image', () =>
+      buildEchoServerImage({ registry, onLog: (l) => log(`    ${l}`) }),
+    )
+    log(`  image: ${image}`)
+
+    // --- 1. initial deploy, no marker set yet ---
+    const deploymentId1 = await step('deploy echo-server', () =>
+      deployImage(client, { projectId: project.id, environmentId: env.id, imageRef: image }),
+    )
+    deployments.push({ projectId: project.id, deploymentId: deploymentId1 })
+    log(`  deployment #${deploymentId1}`)
+
+    await step('wait for initial deployment', () =>
+      waitForDeployment(client, {
+        projectId: project.id,
+        deploymentId: deploymentId1,
+        timeoutMs: deployTimeoutMs,
+        onPoll: (s) => log(`    ...${s.state}`),
+      }),
+    )
+    await step('confirm initial deployment did not fail', async () => {
+      const s = await getDeployStatus(client, project.id, deploymentId1)
+      if (!s.ok) throw new Error(`deployment ${deploymentId1} is in state "${s.state}"`)
+    })
+    await step('wait for HTTP ready', () =>
+      waitForHttpReady({ url: target.url, headers: target.headers, timeoutMs: 120_000 }),
+    )
+    await step('assert not console fallback', () =>
+      assertNotConsoleFallback({ url: target.url, headers: target.headers }),
+    )
+    await step('assert marker key is absent before any env var exists', () =>
+      waitForEnvValue(target, markerKey, undefined, {
+        label: 'echo-server env before create',
+        timeoutMs: 20_000,
+      }),
+    )
+
+    // --- 2. create the env var, scoped to production only ---
+    const varId = await step('create env var (scoped to production)', async () => {
+      const res = unwrap(
+        await createEnvironmentVariable({
+          client,
+          path: { project_id: project.id },
+          body: { key: markerKey, value: valueA, environment_ids: [env.id] },
+        }),
+        'createEnvironmentVariable',
+      )
+      if (res.value !== valueA) {
+        throw new Error(
+          `create response did not round-trip the plaintext value: expected ${JSON.stringify(valueA)}, got ${JSON.stringify(res.value)}`,
+        )
+      }
+      return res.id
+    })
+    envVarIds.push({ projectId: project.id, varId })
+    log(`  env var #${varId} = ${valueA}`)
+
+    // --- 3. redeploy, assert the RUNNING container actually sees it ---
+    const deploymentId2 = await step('redeploy after create', () =>
+      deployImage(client, { projectId: project.id, environmentId: env.id, imageRef: image }),
+    )
+    deployments.push({ projectId: project.id, deploymentId: deploymentId2 })
+    log(`  deployment #${deploymentId2}`)
+
+    await step('wait for redeploy (after create)', () =>
+      waitForDeployment(client, {
+        projectId: project.id,
+        deploymentId: deploymentId2,
+        timeoutMs: deployTimeoutMs,
+        onPoll: (s) => log(`    ...${s.state}`),
+      }),
+    )
+    await step('confirm redeploy did not fail (after create)', async () => {
+      const s = await getDeployStatus(client, project.id, deploymentId2)
+      if (!s.ok) throw new Error(`deployment ${deploymentId2} is in state "${s.state}"`)
+    })
+    await step(
+      'assert the RUNNING container reflects the new env var (real propagation, not just a DB row)',
+      () => waitForEnvValue(target, markerKey, valueA, { label: 'echo-server env after create + redeploy' }),
+    )
+
+    // --- 4. update the value, redeploy, assert the running container updated ---
+    await step('update env var to a new value', async () => {
+      const res = unwrap(
+        await updateEnvironmentVariable({
+          client,
+          path: { project_id: project.id, var_id: varId },
+          body: { key: markerKey, value: valueB, environment_ids: [env.id] },
+        }),
+        'updateEnvironmentVariable',
+      )
+      if (res.value !== valueB) {
+        throw new Error(
+          `update response did not round-trip the new plaintext value: expected ${JSON.stringify(valueB)}, got ${JSON.stringify(res.value)}`,
+        )
+      }
+    })
+
+    const deploymentId3 = await step('redeploy after update', () =>
+      deployImage(client, { projectId: project.id, environmentId: env.id, imageRef: image }),
+    )
+    deployments.push({ projectId: project.id, deploymentId: deploymentId3 })
+    log(`  deployment #${deploymentId3}`)
+
+    await step('wait for redeploy (after update)', () =>
+      waitForDeployment(client, {
+        projectId: project.id,
+        deploymentId: deploymentId3,
+        timeoutMs: deployTimeoutMs,
+        onPoll: (s) => log(`    ...${s.state}`),
+      }),
+    )
+    await step('confirm redeploy did not fail (after update)', async () => {
+      const s = await getDeployStatus(client, project.id, deploymentId3)
+      if (!s.ok) throw new Error(`deployment ${deploymentId3} is in state "${s.state}"`)
+    })
+    await step(
+      'assert the RUNNING container reflects the UPDATED value (not the stale original)',
+      () => waitForEnvValue(target, markerKey, valueB, { label: 'echo-server env after update + redeploy' }),
+    )
+
+    // --- 5. delete the env var, redeploy, assert it's genuinely gone ---
+    await step('delete env var', async () => {
+      await deleteEnvironmentVariable({ client, path: { project_id: project.id, var_id: varId } })
+    })
+    // Deleted -- don't attempt to delete it again in teardown.
+    envVarIds.splice(
+      envVarIds.findIndex((v) => v.varId === varId),
+      1,
+    )
+
+    const deploymentId4 = await step('redeploy after delete', () =>
+      deployImage(client, { projectId: project.id, environmentId: env.id, imageRef: image }),
+    )
+    deployments.push({ projectId: project.id, deploymentId: deploymentId4 })
+    log(`  deployment #${deploymentId4}`)
+
+    await step('wait for redeploy (after delete)', () =>
+      waitForDeployment(client, {
+        projectId: project.id,
+        deploymentId: deploymentId4,
+        timeoutMs: deployTimeoutMs,
+        onPoll: (s) => log(`    ...${s.state}`),
+      }),
+    )
+    await step('confirm redeploy did not fail (after delete)', async () => {
+      const s = await getDeployStatus(client, project.id, deploymentId4)
+      if (!s.ok) throw new Error(`deployment ${deploymentId4} is in state "${s.state}"`)
+    })
+    await step(
+      'assert the RUNNING container no longer has the deleted var (falls back to unset)',
+      () => waitForEnvValue(target, markerKey, undefined, { label: 'echo-server env after delete + redeploy' }),
+    )
+
+    // --- 6. lightweight API-only check: environment scoping, no deploy needed ---
+    const staging = await step('create a second (staging) environment', async () => {
+      const res = unwrap(
+        await createEnvironment({
+          client,
+          path: { project_id: project.id },
+          body: { name: `staging-${runId}`, branch: `staging-${runId}` },
+        }),
+        'createEnvironment',
+      )
+      return { id: res.id }
+    })
+    stagingEnvId = staging.id
+    log(`  staging env #${staging.id}`)
+
+    const scopeVarId = await step('create env var scoped to production ONLY', async () => {
+      const res = unwrap(
+        await createEnvironmentVariable({
+          client,
+          path: { project_id: project.id },
+          body: { key: scopeKey, value: scopeValue, environment_ids: [env.id] },
+        }),
+        'createEnvironmentVariable',
+      )
+      return res.id
+    })
+    envVarIds.push({ projectId: project.id, varId: scopeVarId })
+    log(`  scope-test env var #${scopeVarId}`)
+
+    await step('assert it does NOT appear when filtered by the staging environment', async () => {
+      const vars = unwrap(
+        await getEnvironmentVariables({
+          client,
+          path: { project_id: project.id },
+          query: { environment_id: staging.id },
+        }),
+        'getEnvironmentVariables(staging)',
+      )
+      const found = vars.find((v) => v.id === scopeVarId)
+      if (found) {
+        throw new Error(
+          `env var #${scopeVarId} (scoped to production only) was returned when filtering by staging env #${staging.id} -- environment scoping is not actually enforced`,
+        )
+      }
+    })
+    await step('assert it DOES appear when filtered by production', async () => {
+      const vars = unwrap(
+        await getEnvironmentVariables({
+          client,
+          path: { project_id: project.id },
+          query: { environment_id: env.id },
+        }),
+        'getEnvironmentVariables(production)',
+      )
+      const found = vars.find((v) => v.id === scopeVarId)
+      if (!found) {
+        throw new Error(
+          `env var #${scopeVarId} was NOT returned when filtering by its own environment (production env #${env.id})`,
+        )
+      }
+    })
+
+    await step('delete scope-test env var', async () => {
+      await deleteEnvironmentVariable({ client, path: { project_id: project.id, var_id: scopeVarId } })
+    })
+    envVarIds.splice(
+      envVarIds.findIndex((v) => v.varId === scopeVarId),
+      1,
+    )
+  } catch {
+    // Failure already recorded in `steps`; fall through to teardown.
+  } finally {
+    if (opts.keep) {
+      log(`\n(kept resources: projects=${projectIds.join(',')} staging_env=${stagingEnvId ?? '-'})`)
+    } else {
+      const envVarErrors: string[] = []
+      for (const v of envVarIds) {
+        try {
+          await deleteEnvironmentVariable({ client, path: { project_id: v.projectId, var_id: v.varId } })
+        } catch (e) {
+          envVarErrors.push(`deleteEnvironmentVariable(${v.varId}): ${(e as Error).message}`)
+        }
+      }
+      // No explicit environment delete: `DELETE .../environments/{id}` is
+      // gated behind `require_sensitive_action` (browser-session-only, see
+      // temps-auth/src/sensitive_action.rs -- an API key is deliberately
+      // denied), so it can never succeed from this API-key-driven harness.
+      // `deleteProject` below cascades environments (and their env vars,
+      // deployments) via `ON DELETE CASCADE` regardless, same as every
+      // other scenario in this suite.
+      const td = await teardown(client, { deployments, projectIds })
+      log(
+        `\n▶ teardown: deleted ${envVarIds.length - envVarErrors.length} env var(s), ` +
+          `tore down ${td.teardownDeployments} deployment(s), ` +
+          `deleted ${td.deletedProjects} project(s)` +
+          (td.errors.length + envVarErrors.length ? ` (${td.errors.length + envVarErrors.length} errors)` : ''),
+      )
+      for (const e of [...envVarErrors, ...td.errors]) log(`    ! ${e}`)
+    }
+  }
+
+  const ok = steps.length > 0 && steps.every((s) => s.ok)
+  const result: EnvVarsScenarioResult = { runId, ok, steps }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+  } else {
+    log(`\n${ok ? '✅ env-vars-scenario PASSED' : '❌ env-vars-scenario FAILED'}`)
+  }
+  if (!ok) process.exitCode = 1
+}

--- a/apps/temps-e2e/src/commands/mariadb-restore-scenario.ts
+++ b/apps/temps-e2e/src/commands/mariadb-restore-scenario.ts
@@ -1,0 +1,527 @@
+/**
+ * MariaDB backup + restore lifecycle against a live Temps instance.
+ *
+ * MariaDB restore is fully implemented (`crates/temps-providers/src/
+ * externalsvc/mariadb.rs`): `restore_capabilities()` reports
+ * `restore_in_place: true`, `restore_to_new_service: true`, `pitr: true`,
+ * and the default `restore_in_place` trait method dispatches to
+ * `restore_from_s3`, which auto-detects a physical (`mariadb-backup`
+ * mbstream) base vs a logical `mariadb-dump` and restores accordingly. This
+ * scenario proves the in-place path end to end with genuine before/after
+ * data verification — not just that the API calls returned 2xx.
+ *
+ * Flow:
+ *   1. Provision a real standalone MariaDB service.
+ *   2. Insert 3 recognizable "pre-backup" rows via `docker exec mariadb`
+ *      (the real CLI client shipped in the `mariadb:lts` image — see
+ *      `MariaDbService::execute_sql`'s own `command -v mariadb` check at
+ *      mariadb.rs:880).
+ *   3. Create an S3 source (MinIO) and trigger a real backup via the backup
+ *      engine (`crates/temps-backup/src/engines/dispatch.rs` auto-selects
+ *      `mariadb_physical` when `mariadb-backup`/`mariadb-binlog` are present
+ *      in the container, which they are in the stock `mariadb:lts` image).
+ *   4. Poll the backup to a real `completed` state.
+ *   5. Insert 2 more "post-backup" rows (distinct id / column values).
+ *   6. Verify all 5 rows are present before restore (sanity check).
+ *   7. Start an in-place restore (`POST /external-services/{id}/restore`,
+ *      mode: "in_place") and poll `GET /restore-runs/{id}` to `completed`.
+ *   8. Read back rows via the read-only data-browser API (`readEntityRows`):
+ *      assert the 3 pre-backup rows are present with the correct column
+ *      values AND the 2 post-backup rows are ABSENT. This is the key
+ *      correctness assertion — the restore actually reverted state, not
+ *      just left current state in place.
+ *   9. Teardown (service, S3 source).
+ *
+ * Needs:
+ * - MinIO running (from docker-compose.e2e.yml, port 9092).
+ * - A bucket named `temps-e2e-backups` already created in MinIO.
+ * - Docker accessible from the host running this test (for the mariadb exec).
+ */
+
+import {
+  createS3Source,
+  deleteS3Source,
+  runExternalServiceBackup,
+  listExternalServiceBackups,
+  getBackup,
+  startRestore,
+  getRestoreRun,
+  readEntityRows,
+  getService,
+} from '@temps-sdk/api'
+import { makeClient, resolveConfig, unwrap } from '../lib/client.ts'
+import {
+  createE2eService,
+  pollUntil,
+  teardown,
+  makeRunId,
+  sleep,
+} from '../lib/flows.ts'
+
+export interface MariadbRestoreScenarioOptions {
+  minioEndpoint?: string
+  minioBucket?: string
+  keep?: boolean
+  json?: boolean
+  connection: { url?: string; apiKey?: string }
+}
+
+interface StepLog {
+  step: string
+  ok: boolean
+  detail?: string
+  ms?: number
+}
+
+interface MariadbRestoreScenarioResult {
+  runId: string
+  ok: boolean
+  steps: StepLog[]
+}
+
+// The database and table we write rows into.
+const MARIADB_DATABASE = 'e2etest'
+const MARIADB_TABLE = 'restore_probe'
+
+interface ProbeRow {
+  id: number
+  label: string
+  value: number
+}
+
+// Pre-backup rows: inserted before the backup, must survive restore.
+const PRE_BACKUP_ROWS: ProbeRow[] = [
+  { id: 1, label: 'pre-backup-alpha', value: 100 },
+  { id: 2, label: 'pre-backup-beta', value: 200 },
+  { id: 3, label: 'pre-backup-gamma', value: 300 },
+]
+
+// Post-backup rows: inserted after the backup, must be ABSENT after restore.
+const POST_BACKUP_ROWS: ProbeRow[] = [
+  { id: 4, label: 'post-backup-delta', value: 400 },
+  { id: 5, label: 'post-backup-epsilon', value: 500 },
+]
+
+/** Escape a single-quoted SQL string literal (our own controlled values only). */
+function sqlQuote(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`
+}
+
+/**
+ * Run `docker exec <container> mariadb -uroot -p<password> -N -B -e <script>
+ *   <database>`.
+ *
+ * `-N -B` (skip column names, batch/tab-separated output) makes results easy
+ * to parse. Credentials are passed as separate argv tokens (not through a
+ * shell string), so special characters cannot cause injection. Returns
+ * stdout trimmed. Throws on non-zero exit.
+ */
+async function mariadbExec(
+  containerName: string,
+  rootPassword: string,
+  database: string,
+  script: string,
+): Promise<string> {
+  const proc = Bun.spawn(
+    [
+      'docker',
+      'exec',
+      containerName,
+      'mariadb',
+      '-uroot',
+      `-p${rootPassword}`,
+      '-N',
+      '-B',
+      '-e',
+      script,
+      database,
+    ],
+    { stdout: 'pipe', stderr: 'pipe' },
+  )
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  if (code !== 0) {
+    throw new Error(
+      `mariadb exec in '${containerName}' exited ${code}.\nstdout: ${stdout.trim()}\nstderr: ${stderr.trim()}`,
+    )
+  }
+  return stdout.trim()
+}
+
+/** Create the probe table (idempotent) and insert a batch of rows in one INSERT. */
+async function insertRows(
+  containerName: string,
+  rootPassword: string,
+  rows: ProbeRow[],
+): Promise<void> {
+  const values = rows
+    .map((r) => `(${r.id}, ${sqlQuote(r.label)}, ${r.value})`)
+    .join(', ')
+  const script =
+    `CREATE TABLE IF NOT EXISTS ${MARIADB_TABLE} ` +
+    `(id INT PRIMARY KEY, label VARCHAR(255) NOT NULL, value INT NOT NULL); ` +
+    `INSERT INTO ${MARIADB_TABLE} (id, label, value) VALUES ${values};`
+  await mariadbExec(containerName, rootPassword, MARIADB_DATABASE, script)
+}
+
+/** Count rows in the probe table whose `id` is in the given set. */
+async function countRowsByIds(
+  containerName: string,
+  rootPassword: string,
+  ids: number[],
+): Promise<number> {
+  const script = `SELECT COUNT(*) FROM ${MARIADB_TABLE} WHERE id IN (${ids.join(',')});`
+  const out = await mariadbExec(containerName, rootPassword, MARIADB_DATABASE, script)
+  const n = parseInt(out, 10)
+  if (isNaN(n)) throw new Error(`SELECT COUNT(*) returned non-numeric: "${out}"`)
+  return n
+}
+
+/**
+ * Read rows via the data-browser API (read-only, no Docker exec).
+ *
+ * MariaDB path layout in the data-browser: depth-1 path = database name,
+ * entity = table name (see `database_from_path` in
+ * `crates/temps-providers/src/mariadb_query.rs`).
+ */
+async function readTableViaApi(
+  client: Parameters<typeof readEntityRows>[0]['client'],
+  serviceId: number,
+  limit = 50,
+): Promise<Array<Record<string, unknown>>> {
+  const result = unwrap(
+    await readEntityRows({
+      client,
+      path: { service_id: serviceId, path: MARIADB_DATABASE, entity: MARIADB_TABLE },
+      query: { limit, sort_by: 'id', sort_order: 'asc' },
+    }),
+    'readEntityRows(mariadb)',
+  )
+  return (result.rows ?? []) as Array<Record<string, unknown>>
+}
+
+export async function mariadbRestoreScenarioCommand(
+  opts: MariadbRestoreScenarioOptions,
+): Promise<void> {
+  const cfg = resolveConfig(opts.connection)
+  const client = makeClient(cfg)
+  const json = !!opts.json
+  const log = (msg: string) => {
+    if (!json) process.stderr.write(msg + '\n')
+  }
+
+  if (!json) log(`Temps MariaDB restore scenario  ->  ${cfg.url}`)
+
+  const minioEndpoint = opts.minioEndpoint ?? 'http://localhost:9092'
+  const minioBucket = opts.minioBucket ?? 'temps-e2e-backups'
+
+  const runId = makeRunId(Date.now())
+  const steps: StepLog[] = []
+  const step = async <T>(name: string, fn: () => Promise<T>): Promise<T> => {
+    const t0 = performance.now()
+    log(`\n▶ ${name}`)
+    try {
+      const r = await fn()
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: true, ms })
+      log(`  ✓ ${name} (${(ms / 1000).toFixed(1)}s)`)
+      return r
+    } catch (e) {
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: false, detail: (e as Error).message, ms })
+      log(`  ✗ ${name}: ${(e as Error).message}`)
+      throw e
+    }
+  }
+
+  const serviceIds: number[] = []
+  let s3SourceId: number | undefined
+  let mariadbContainerName: string | undefined
+  let mariadbRootPassword: string | undefined
+
+  try {
+    // ── Step 1: provision MariaDB service ─────────────────────────────────
+    const svcName = `${runId}-mariadb`
+    const service = await step('provision a real standalone MariaDB service', () =>
+      createE2eService(client, {
+        name: svcName,
+        serviceType: 'mariadb',
+        parameters: {
+          database: MARIADB_DATABASE,
+          username: 'app',
+        },
+      }),
+    )
+    serviceIds.push(service.id)
+    log(`  service #${service.id}`)
+
+    unwrap(await getService({ client, path: { id: service.id } }), 'getService')
+
+    // Container name is derived as `mariadb-{name}` (see
+    // `MariaDbService::get_container_name` in externalsvc/mariadb.rs).
+    mariadbContainerName = `mariadb-${svcName}`
+
+    // Read the real root password from the container's env vars via docker
+    // inspect -- `current_parameters` on the service masks it to "***".
+    mariadbRootPassword = await (async () => {
+      const proc = Bun.spawn(
+        [
+          'docker',
+          'inspect',
+          '--format',
+          '{{range .Config.Env}}{{println .}}{{end}}',
+          mariadbContainerName!,
+        ],
+        { stdout: 'pipe', stderr: 'pipe' },
+      )
+      const [out, , code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ])
+      if (code !== 0) throw new Error(`docker inspect failed for container ${mariadbContainerName}`)
+      for (const line of out.split('\n')) {
+        if (line.startsWith('MARIADB_ROOT_PASSWORD=')) {
+          return line.slice('MARIADB_ROOT_PASSWORD='.length).trim()
+        }
+      }
+      throw new Error(
+        `MARIADB_ROOT_PASSWORD not found in container env vars for ${mariadbContainerName}`,
+      )
+    })()
+
+    log(`  container: ${mariadbContainerName}`)
+
+    // ── Step 2: insert pre-backup rows ─────────────────────────────────────
+    await step('insert 3 pre-backup rows via docker exec mariadb', async () => {
+      await insertRows(mariadbContainerName!, mariadbRootPassword!, PRE_BACKUP_ROWS)
+      const count = await countRowsByIds(
+        mariadbContainerName!,
+        mariadbRootPassword!,
+        PRE_BACKUP_ROWS.map((r) => r.id),
+      )
+      if (count !== 3) {
+        throw new Error(`expected 3 pre-backup rows, found ${count}`)
+      }
+    })
+
+    // ── Step 3: create S3 source + trigger backup ──────────────────────────
+    const source = await step('create an S3 source pointed at the local MinIO', async () => {
+      return unwrap(
+        await createS3Source({
+          client,
+          body: {
+            name: `${runId}-minio-mariadb`,
+            bucket_name: minioBucket,
+            bucket_path: runId,
+            access_key_id: 'minioadmin',
+            secret_key: 'minioadmin',
+            region: 'us-east-1',
+            endpoint: minioEndpoint,
+            force_path_style: true,
+            is_default: false,
+          },
+        }),
+        'createS3Source',
+      )
+    })
+    s3SourceId = source.id
+    log(`  s3 source #${source.id}`)
+
+    await step(
+      'trigger a real MariaDB backup (mariadb-backup/mariadb-dump → MinIO)',
+      async () => {
+        unwrap(
+          await runExternalServiceBackup({
+            client,
+            path: { id: service.id },
+            body: { s3_source_id: source.id, backup_type: 'full' },
+          }),
+          'runExternalServiceBackup',
+        )
+      },
+    )
+
+    // ── Step 4: poll backup to completed ──────────────────────────────────
+    const backupEntry = await step('poll the backup to a real completed state', async () => {
+      const list = await pollUntil(
+        async () =>
+          unwrap(
+            await listExternalServiceBackups({
+              client,
+              path: { service_id: service.id },
+              query: { page: 1, page_size: 5 },
+            }),
+            'listExternalServiceBackups',
+          ),
+        (l) => l.backups.length > 0,
+        { timeoutMs: 60_000, intervalMs: 2000, label: 'backup row to appear' },
+      )
+      const entry = list.backups[0]!
+      const finalBackup = await pollUntil(
+        async () => unwrap(await getBackup({ client, path: { id: entry.backup_id } }), 'getBackup'),
+        (b) => b.state === 'completed' || b.state === 'failed',
+        {
+          timeoutMs: 180_000,
+          intervalMs: 3000,
+          onPoll: (b) => log(`    ...${b.state}`),
+          label: 'backup to reach a terminal state',
+        },
+      )
+      if (finalBackup.state !== 'completed') {
+        throw new Error(
+          `backup ${entry.backup_id} ended in state "${finalBackup.state}": ${finalBackup.error_message}`,
+        )
+      }
+      return entry
+    })
+    log(`  backup #${backupEntry.id} (backup_id=${backupEntry.backup_id})`)
+
+    // ── Step 5: insert post-backup rows ────────────────────────────────────
+    await step('insert 2 post-backup rows (must be ABSENT after restore)', async () => {
+      await insertRows(mariadbContainerName!, mariadbRootPassword!, POST_BACKUP_ROWS)
+      const count = await countRowsByIds(
+        mariadbContainerName!,
+        mariadbRootPassword!,
+        POST_BACKUP_ROWS.map((r) => r.id),
+      )
+      if (count !== 2) {
+        throw new Error(`expected 2 post-backup rows, found ${count}`)
+      }
+    })
+
+    // ── Step 6: sanity-check all 5 rows present before restore ────────────
+    await step('verify all 5 rows (3 pre + 2 post) are present before restore', async () => {
+      const allIds = [...PRE_BACKUP_ROWS, ...POST_BACKUP_ROWS].map((r) => r.id)
+      const count = await countRowsByIds(mariadbContainerName!, mariadbRootPassword!, allIds)
+      if (count !== 5) {
+        throw new Error(`expected 5 total rows before restore, found ${count}`)
+      }
+    })
+
+    // ── Step 7: start in-place restore ────────────────────────────────────
+    const restoreRun = await step(
+      'start an in-place restore from the backup taken before post-backup rows',
+      async () => {
+        return unwrap(
+          await startRestore({
+            client,
+            path: { id: service.id },
+            body: {
+              backup_id: backupEntry.id,
+              mode: 'in_place',
+            },
+          }),
+          'startRestore',
+        )
+      },
+    )
+    log(`  restore run #${restoreRun.id}`)
+
+    await step('poll the restore run to a real completed state', async () => {
+      const finalRun = await pollUntil(
+        async () => unwrap(await getRestoreRun({ client, path: { id: restoreRun.id } }), 'getRestoreRun'),
+        (r) => r.status === 'completed' || r.status === 'failed',
+        {
+          timeoutMs: 240_000,
+          intervalMs: 3000,
+          onPoll: (r) => log(`    ...${r.status} (${r.phase})`),
+          label: 'restore run to reach a terminal state',
+        },
+      )
+      if (finalRun.status !== 'completed') {
+        throw new Error(
+          `restore run ${restoreRun.id} ended in status "${finalRun.status}": ${finalRun.error_message}`,
+        )
+      }
+    })
+
+    // Give mariadbd a moment to settle after restore before querying.
+    await sleep(3_000)
+
+    // ── Step 8: verify correctness via data-browser API ───────────────────
+    await step(
+      'data-browser API: 3 pre-backup rows present with correct values, 2 post-backup rows absent',
+      async () => {
+        const rows = await readTableViaApi(client, service.id)
+        log(`  data-browser returned ${rows.length} row(s) in table`)
+
+        const byId = new Map<string, Record<string, unknown>>()
+        for (const row of rows) {
+          byId.set(String(row['id']), row)
+        }
+
+        // Pre-backup rows must be present with correct column values.
+        for (const expected of PRE_BACKUP_ROWS) {
+          const row = byId.get(String(expected.id))
+          if (!row) {
+            throw new Error(
+              `pre-backup row id=${expected.id} is MISSING after restore — ` +
+                'restore_in_place did not revert to backup state',
+            )
+          }
+          const label = row['label'] as string | undefined
+          const value = Number(row['value'])
+          if (label !== expected.label || value !== expected.value) {
+            throw new Error(
+              `pre-backup row id=${expected.id} has label="${label}" value=${value}, ` +
+                `expected label="${expected.label}" value=${expected.value}`,
+            )
+          }
+          log(`  ✓ pre-backup row id=${expected.id} present with correct values`)
+        }
+
+        // Post-backup rows must be absent (restore reverted to the pre-backup base).
+        for (const absent of POST_BACKUP_ROWS) {
+          if (byId.has(String(absent.id))) {
+            throw new Error(
+              `post-backup row id=${absent.id} is STILL PRESENT after restore — ` +
+                'restore did not revert state; this is a correctness failure',
+            )
+          }
+          log(`  ✓ post-backup row id=${absent.id} correctly absent`)
+        }
+
+        if (rows.length !== PRE_BACKUP_ROWS.length) {
+          throw new Error(
+            `after restore, table has ${rows.length} row(s), ` +
+              `expected exactly ${PRE_BACKUP_ROWS.length} (the 3 pre-backup rows)`,
+          )
+        }
+      },
+    )
+  } catch {
+    // Failure already recorded in `steps`; fall through to teardown.
+  } finally {
+    if (opts.keep) {
+      log(`\n(kept resources: services=${serviceIds.join(',')} s3Source=${s3SourceId ?? '-'})`)
+    } else {
+      if (s3SourceId) {
+        await deleteS3Source({ client, path: { id: s3SourceId } }).catch(() => undefined)
+      }
+      const td = await teardown(client, { deployments: [], projectIds: [], serviceIds })
+      log(`\n▶ teardown: removed ${td.deletedServices} service(s)`)
+    }
+  }
+
+  const ok = steps.length > 0 && steps.every((s) => s.ok)
+  const result: MariadbRestoreScenarioResult = { runId, ok, steps }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+  } else {
+    const total = steps.length
+    const passed = steps.filter((s) => s.ok).length
+    log(`\n${ok ? '✅' : '❌'} MariaDB restore scenario: ${passed}/${total} steps passed`)
+    if (!ok) {
+      for (const s of steps.filter((s) => !s.ok)) {
+        log(`  ✗ ${s.step}: ${s.detail ?? '(no detail)'}`)
+      }
+    }
+  }
+
+  if (!ok) process.exitCode = 1
+}

--- a/apps/temps-e2e/src/index.ts
+++ b/apps/temps-e2e/src/index.ts
@@ -30,6 +30,9 @@ import { s3RestoreScenarioCommand } from './commands/s3-restore-scenario.ts'
 import { redisRestoreScenarioCommand } from './commands/redis-restore-scenario.ts'
 import { mongodbRestoreScenarioCommand } from './commands/mongodb-restore-scenario.ts'
 import { pgUpgradeScenarioCommand } from './commands/pg-upgrade-scenario.ts'
+import { mariadbRestoreScenarioCommand } from './commands/mariadb-restore-scenario.ts'
+import { envVarsScenarioCommand } from './commands/env-vars-scenario.ts'
+import { apiKeyScenarioCommand } from './commands/api-key-scenario.ts'
 
 const program = new Command()
 
@@ -439,6 +442,52 @@ program
   .option('--json', 'machine-readable output')
   .action(async (opts) => {
     await deployLifecycleScenarioCommand({ ...opts, connection: connection() })
+  })
+
+program
+  .command('mariadb-restore-scenario')
+  .description(
+    'MariaDB backup + in-place restore: provision a MariaDB service, insert pre-backup rows via docker exec mariadb, ' +
+      'run a real backup (physical or logical, engine-selected) to MinIO, insert post-backup rows, restore in place, ' +
+      'and verify via the data-browser API that pre-backup rows are present and post-backup rows are absent',
+  )
+  .option('--minio-endpoint <url>', 'MinIO S3 API endpoint, reachable from the target instance', 'http://localhost:9092')
+  .option('--minio-bucket <name>', 'MinIO bucket to store backups in (must already exist)', 'temps-e2e-backups')
+  .option('--keep', 'do not tear down created resources')
+  .option('--json', 'machine-readable output')
+  .action(async (opts) => {
+    await mariadbRestoreScenarioCommand({ ...opts, connection: connection() })
+  })
+
+program
+  .command('env-vars-scenario')
+  .description(
+    'Real environment-variable lifecycle: deploy an echo-server app, create/update/delete a project env var, ' +
+      'redeploy after each change, and assert the RUNNING CONTAINER reflects the new/updated/removed value ' +
+      '(not just that the API round-trips it) -- plus a lightweight environment-scoping check via the list endpoint',
+  )
+  .option('--registry <host>', 'registry to push the echo-server image to (e.g. localhost:5111); or $TEMPS_E2E_REGISTRY')
+  .option('--keep', 'do not tear down created resources')
+  .option('--deploy-timeout <ms>', 'max wait for deploy to go healthy', '300000')
+  .option('--json', 'machine-readable output')
+  .action(async (opts) => {
+    await envVarsScenarioCommand({ ...opts, connection: connection() })
+  })
+
+program
+  .command('api-key-scenario')
+  .description(
+    'Real API-key lifecycle via HTTP: a second low-privilege user creates a scoped API key through POST /api-keys ' +
+      '(session-cookie authenticated, since machine principals cannot create keys), the key gets 200 on an ' +
+      'in-scope request and 403 on an out-of-scope one, then revocation makes an immediate retry fail -- ' +
+      'not just that api-key CRUD returns 2xx',
+  )
+  .option('--temps-root <path>', 'checkout root (needs crates/temps-cli) to mint the second user\'s bearer key via DB-direct `temps api-key`; or $TEMPS_ROOT')
+  .option('--database-url <url>', 'Postgres URL the temps binary can reach directly; or $TEMPS_DATABASE_URL')
+  .option('--keep', 'do not tear down created resources')
+  .option('--json', 'machine-readable output')
+  .action(async (opts) => {
+    await apiKeyScenarioCommand({ ...opts, connection: connection() })
   })
 
 program.parseAsync().catch((err: unknown) => {

--- a/apps/temps-e2e/src/lib/cli-exec.ts
+++ b/apps/temps-e2e/src/lib/cli-exec.ts
@@ -92,6 +92,21 @@ export function runCli(
  * full stdout/stderr on failure -- every scenario step should fail loudly
  * with the real CLI output, not a generic "expected 0" message.
  */
+/**
+ * Redacts the value following a `-p`/`--password` flag so error messages
+ * (which land in CI logs and --json `steps[].detail`) never echo a
+ * credential back out, even a throwaway scenario-generated one.
+ */
+function redactPasswordArgs(args: string[]): string[] {
+  const redacted = [...args]
+  for (let i = 0; i < redacted.length - 1; i++) {
+    if (redacted[i] === '-p' || redacted[i] === '--password') {
+      redacted[i + 1] = '***'
+    }
+  }
+  return redacted
+}
+
 export async function runCliOk(
   args: string[],
   cfg: CliConfig,
@@ -100,7 +115,7 @@ export async function runCliOk(
   const result = await runCli(args, cfg, opts)
   if (result.exitCode !== 0) {
     throw new Error(
-      `temps ${args.join(' ')} exited ${result.exitCode}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+      `temps ${redactPasswordArgs(args).join(' ')} exited ${result.exitCode}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
     )
   }
   return result

--- a/apps/temps-e2e/src/lib/flows.ts
+++ b/apps/temps-e2e/src/lib/flows.ts
@@ -275,7 +275,7 @@ export async function createE2eService(
   client: Client,
   opts: {
     name: string
-    serviceType: 'postgres' | 'redis' | 'mongodb' | 's3' | 'kv' | 'blob' | 'rustfs' | 'minio'
+    serviceType: 'postgres' | 'redis' | 'mongodb' | 'mariadb' | 's3' | 'kv' | 'blob' | 'rustfs' | 'minio'
     version?: string
     parameters?: Record<string, unknown>
   },


### PR DESCRIPTION
## Summary

Closes 3 of the 4 remaining e2e coverage gaps identified after the last batch (#593 Postgres upgrade, #595 S3 restore, #596 MongoDB restore, #597 Redis restore):

- **`mariadb-restore-scenario`** — backup + in-place restore of a real MariaDB service via MinIO, proven by pre-backup rows surviving and post-backup rows being erased. Backend was already complete (`restore_capabilities`/`restore_to_new_service`/`restore_pitr` fully wired in `mariadb.rs`) — this closes the last gap in the backup-engine parity story (Postgres, Redis, MongoDB, S3, now MariaDB all have restore e2e coverage).
- **`env-vars-scenario`** — create/update/delete an app env var and redeploy after each change, asserting the **running container** (not just the API response) reflects the new/updated/removed value — app env vars have no hot-reload.
- **`api-key-scenario`** — promotes the UI-only `api-key-create.spec.ts` Playwright test to a real HTTP round trip: a second low-privilege user creates a scoped key, gets 200 on an in-scope request and 403 on an out-of-scope one, then revocation makes an immediate retry fail (no cache to wait out).

The 4th gap, **generic outbound webhooks**, was investigated and found to be a hard, permanent blocker identical to Slack's: `WebhookService::validate_webhook_url` runs every URL through the same `validate_external_url` SSRF guard, with no dev/test bypass anywhere in the webhooks path, and delivery-time re-resolution (`delivery_client_for`) closes the DNS-rebinding route too. Documented in the README's "Known gaps" section next to the existing Slack entry rather than building a scenario that can't legally exist.

**No production Rust code changed** — MariaDB restore, webhooks, env vars, and API keys were all already fully implemented backend-side; this is e2e test coverage only. `flows.ts` gained `'mariadb'` to `createE2eService`'s `serviceType` union (it was missing despite being a valid `service_type`).

## Test plan

- [x] `cd apps/temps-e2e && bun run typecheck` — clean, 0 errors
- [x] `mariadb-restore-scenario` — 10/10 steps passed, 2 clean live runs against a local instance
- [x] `api-key-scenario` — PASSED (all 10 steps), 2 clean live runs
- [x] `env-vars-scenario` — PASSED (all steps incl. real container-propagation proof), 2 clean live runs
- [x] Confirmed no Rust production code touched (`git diff --stat` — only `apps/temps-e2e/`)