### PR TITLE
feat(ai-agents): classify plain Googlebot as Google/Mixed

### DIFF
--- a/crates/temps-proxy/src/ai_agent_detector.rs
+++ b/crates/temps-proxy/src/ai_agent_detector.rs
@@ -137,6 +137,28 @@ const AGENT_PATTERNS: &[(&str, AiAgentMatch)] = &[
             purpose: AiAgentPurpose::Mixed,
         },
     ),
+    // Plain Googlebot. Google's own AI-features documentation says AI
+    // Overviews and Gemini's Search-grounded answers are "rooted in our
+    // core Search ranking and quality systems" — there is no separate
+    // crawler for AI answers, they're built from the same index Googlebot
+    // already crawls for regular Search. So this traffic is genuinely
+    // dual-purpose (Search ranking + AI answer citation), not exclusively
+    // a non-AI "Search / SEO crawler" the way Bingbot or YandexBot are.
+    //
+    // Caution: this is by far the highest-volume pattern in this table.
+    // Ordinary Googlebot indexing crawls every page constantly, so this
+    // will typically dominate the AI-agents view by orders of magnitude
+    // over agents like GPTBot or ClaudeBot — expected, not a bug, but
+    // worth knowing before reading the dashboard as "how much AI traffic
+    // do I get."
+    (
+        r"(?i)\bGooglebot\b",
+        AiAgentMatch {
+            provider: "Google",
+            agent: "Googlebot",
+            purpose: AiAgentPurpose::Mixed,
+        },
+    ),
     // Apple
     (
         r"(?i)\bApplebot-Extended\b",
@@ -396,6 +418,23 @@ mod tests {
         let m = detect(Some("meta-externalagent/1.1")).expect("should detect Meta-ExternalAgent");
         assert_eq!(m.provider, "Meta");
         assert_eq!(m.agent, "Meta-ExternalAgent");
+    }
+
+    #[test]
+    fn detects_googlebot_as_mixed() {
+        let m = detect(Some(
+            "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+        ))
+        .expect("should detect Googlebot");
+        assert_eq!(m.provider, "Google");
+        assert_eq!(m.agent, "Googlebot");
+        assert_eq!(m.purpose, AiAgentPurpose::Mixed);
+    }
+
+    #[test]
+    fn detects_googleother_distinct_from_googlebot() {
+        let m = detect(Some("Mozilla/5.0 GoogleOther")).expect("should detect GoogleOther");
+        assert_eq!(m.agent, "GoogleOther");
     }
 
     #[test]

--- a/scripts/backfill-ai-agent-bot-names-clickhouse.sql
+++ b/scripts/backfill-ai-agent-bot-names-clickhouse.sql
@@ -1,0 +1,230 @@
+-- ClickHouse counterpart of backfill-ai-agent-bot-names.sql.
+--
+-- WHY A SEPARATE SCRIPT
+-- ----------------------
+-- `proxy_logs` has two storage backends behind `ProxyLogStorage`
+-- (crates/temps-proxy/src/storage/): TimescaleDB (Postgres) and ClickHouse,
+-- selected at startup by whether TEMPS_CLICKHOUSE_* is set
+-- (ServerConfig::is_clickhouse_enabled()). Deployments on the ClickHouse path
+-- have their own `proxy_logs` table (migrations/clickhouse/0001_proxy_logs.sql)
+-- with different SQL syntax, a different retention mechanism (native TTL, not
+-- a Timescale hypertable), and no shared row store with the Postgres path — so
+-- the Postgres backfill script's UPDATE statement never runs against this data.
+-- This script is that same fix, in ClickHouse's dialect.
+--
+-- WHY THIS IS A MANUAL SCRIPT, NOT CODE
+-- --------------------------------------
+-- Same reasoning as the Postgres version: this is a one-off historical-data
+-- fix for pre-existing rows so the AI Agents analytics page has history. The
+-- going-forward code fix (ai_agent_detector::detect, called before storage in
+-- both proxy_log_batch_writer.rs and proxy_log_service.rs) already classifies
+-- all NEW rows correctly on both backends.
+--
+-- USAGE
+-- -----
+--   clickhouse-client \
+--     --host "$TEMPS_CLICKHOUSE_HOST" \
+--     --user "$TEMPS_CLICKHOUSE_USER" \
+--     --password "$TEMPS_CLICKHOUSE_PASSWORD" \
+--     --database "$TEMPS_CLICKHOUSE_DATABASE" \
+--     --multiquery < scripts/backfill-ai-agent-bot-names-clickhouse.sql
+--
+-- MUTATION, NOT MERGE
+-- --------------------
+-- `ALTER TABLE ... UPDATE` is a ClickHouse "mutation": it rewrites affected
+-- parts in the background (asynchronous — track progress in
+-- `system.mutations WHERE table = 'proxy_logs'`), not a synchronous row-level
+-- UPDATE. This does NOT touch `_version` or the ReplacingMergeTree dedup key
+-- (project_id, timestamp, request_id) — it modifies bot_name/is_bot in place
+-- on existing parts, so there's no risk of it interacting with merge-time
+-- row replacement. It IS idempotent (safe to re-run): the WHERE clause only
+-- matches rows whose bot_name doesn't already equal the freshly computed
+-- value, mirroring the Postgres script's `IS DISTINCT FROM` guard.
+--
+-- The `timestamp >= now() - INTERVAL 7 DAY` scope is not a compression
+-- workaround like the Postgres version's chunk-exclusion reasoning (ClickHouse
+-- has no equivalent to Timescale's compressed-chunk immutability) — it exists
+-- purely to bound mutation cost. Widen it (up to the table's 30-day TTL; rows
+-- older than that are already gone, see 0001_proxy_logs.sql) if you want a
+-- full-table pass.
+--
+-- REGEX SYNTAX
+-- ------------
+-- ClickHouse `match()` uses RE2, the same engine Rust's `regex` crate uses, so
+-- the patterns below are copied verbatim from
+-- temps_proxy::ai_agent_detector::AGENT_PATTERNS (33 agents / 21 providers,
+-- same specificity order — e.g. Applebot-Extended before Applebot,
+-- OAI-SearchBot before openai/) with only the string-literal escaping changed
+-- for ClickHouse's single-quoted strings (`\\b` here is the same `\b` Rust
+-- writes as `\b` inside a raw string).
+--
+-- VERIFIED against a live ClickHouse 26.2.5 instance (the version pinned in
+-- clickhouse.rs's own header comment): applied the real
+-- migrations/clickhouse/0001_proxy_logs.sql schema in a scratch database,
+-- inserted rows covering a real Googlebot UA, GPTBot, GoogleOther, a plain
+-- browser, and Googlebot-Image, then ran STEP 1 and STEP 2 against them.
+-- Confirmed: correct classification per row (including GoogleOther not
+-- being misdetected as Googlebot or vice versa), the plain browser row left
+-- untouched, `\bGooglebot\b` also catching Googlebot-Image (same word-boundary
+-- behavior as the Rust regex — expected, not a bug), and re-running STEP 2 a
+-- second time changed nothing (idempotent). Not run against production data —
+-- this was a throwaway scratch database, dropped after verification.
+
+
+-- ----------------------------------------------------------------------------
+-- STEP 1 (optional, read-only): preview what WOULD change. Run this first.
+-- ----------------------------------------------------------------------------
+-- SELECT detected, count() AS would_change
+-- FROM (
+--     SELECT
+--         bot_name,
+--         multiIf(
+--             match(user_agent, '(?i)\\bGPTBot\\b'),                       'GPTBot',
+--             match(user_agent, '(?i)\\bOAI-SearchBot\\b'),                'OAI-SearchBot',
+--             match(user_agent, '(?i)\\bChatGPT-User\\b'),                 'ChatGPT-User',
+--             match(user_agent, 'openai/'),                                'OpenAI',
+--             match(user_agent, '(?i)\\bClaudeBot\\b'),                    'ClaudeBot',
+--             match(user_agent, '(?i)\\bClaude-SearchBot\\b'),             'Claude-SearchBot',
+--             match(user_agent, '(?i)\\bClaude-User\\b'),                  'Claude-User',
+--             match(user_agent, '(?i)\\banthropic-ai\\b'),                 'anthropic-ai',
+--             match(user_agent, '(?i)\\bPerplexityBot\\b'),                'PerplexityBot',
+--             match(user_agent, '(?i)\\bPerplexity-User\\b'),              'Perplexity-User',
+--             match(user_agent, '(?i)\\bGoogleOther\\b'),                  'GoogleOther',
+--             match(user_agent, '(?i)\\bGooglebot\\b'),                    'Googlebot',
+--             match(user_agent, '(?i)\\bApplebot-Extended\\b'),            'Applebot-Extended',
+--             match(user_agent, '(?i)\\bApplebot\\b'),                     'Applebot',
+--             match(user_agent, '(?i)\\bMeta-ExternalAgent\\b'),           'Meta-ExternalAgent',
+--             match(user_agent, '(?i)\\bMeta-ExternalFetcher\\b'),         'Meta-ExternalFetcher',
+--             match(user_agent, '(?i)\\bAmazonbot\\b'),                    'Amazonbot',
+--             match(user_agent, '(?i)\\bBytespider\\b'),                   'Bytespider',
+--             match(user_agent, '(?i)\\bCCBot\\b'),                        'CCBot',
+--             match(user_agent, '(?i)\\bcohere-training-data-crawler\\b'), 'cohere-training-data-crawler',
+--             match(user_agent, '(?i)\\bcohere-ai\\b'),                    'cohere-ai',
+--             match(user_agent, '(?i)\\bDiffbot\\b'),                      'Diffbot',
+--             match(user_agent, '(?i)\\bYouBot\\b'),                       'YouBot',
+--             match(user_agent, '(?i)\\bDuckAssistBot\\b'),                'DuckAssistBot',
+--             match(user_agent, '(?i)\\bBravebot\\b'),                     'Bravebot',
+--             match(user_agent, '(?i)\\bAndibot\\b'),                      'Andibot',
+--             match(user_agent, '(?i)\\bOmgilibot\\b'),                    'Omgilibot',
+--             match(user_agent, '(?i)\\bomgili\\b'),                       'Omgili',
+--             match(user_agent, '(?i)\\bImagesiftBot\\b'),                 'ImagesiftBot',
+--             match(user_agent, '(?i)\\bTimpibot\\b'),                     'Timpibot',
+--             match(user_agent, '(?i)\\bKangaroo Bot\\b'),                 'Kangaroo Bot',
+--             match(user_agent, '(?i)\\bMistralAI-User\\b'),               'MistralAI-User',
+--             match(user_agent, '(?i)\\bGrokBot\\b'),                      'GrokBot',
+--             NULL
+--         ) AS detected
+--     FROM proxy_logs
+--     WHERE timestamp >= now() - INTERVAL 7 DAY AND user_agent != ''
+-- )
+-- WHERE detected IS NOT NULL AND bot_name != detected
+-- GROUP BY detected ORDER BY would_change DESC;
+
+
+-- ----------------------------------------------------------------------------
+-- STEP 2: the actual backfill.
+-- ----------------------------------------------------------------------------
+ALTER TABLE proxy_logs
+UPDATE
+    bot_name = multiIf(
+        match(user_agent, '(?i)\\bGPTBot\\b'),                       'GPTBot',
+        match(user_agent, '(?i)\\bOAI-SearchBot\\b'),                'OAI-SearchBot',
+        match(user_agent, '(?i)\\bChatGPT-User\\b'),                 'ChatGPT-User',
+        match(user_agent, 'openai/'),                                'OpenAI',
+        match(user_agent, '(?i)\\bClaudeBot\\b'),                    'ClaudeBot',
+        match(user_agent, '(?i)\\bClaude-SearchBot\\b'),             'Claude-SearchBot',
+        match(user_agent, '(?i)\\bClaude-User\\b'),                  'Claude-User',
+        match(user_agent, '(?i)\\banthropic-ai\\b'),                 'anthropic-ai',
+        match(user_agent, '(?i)\\bPerplexityBot\\b'),                'PerplexityBot',
+        match(user_agent, '(?i)\\bPerplexity-User\\b'),              'Perplexity-User',
+        match(user_agent, '(?i)\\bGoogleOther\\b'),                  'GoogleOther',
+        match(user_agent, '(?i)\\bGooglebot\\b'),                    'Googlebot',
+        match(user_agent, '(?i)\\bApplebot-Extended\\b'),            'Applebot-Extended',
+        match(user_agent, '(?i)\\bApplebot\\b'),                     'Applebot',
+        match(user_agent, '(?i)\\bMeta-ExternalAgent\\b'),           'Meta-ExternalAgent',
+        match(user_agent, '(?i)\\bMeta-ExternalFetcher\\b'),         'Meta-ExternalFetcher',
+        match(user_agent, '(?i)\\bAmazonbot\\b'),                    'Amazonbot',
+        match(user_agent, '(?i)\\bBytespider\\b'),                   'Bytespider',
+        match(user_agent, '(?i)\\bCCBot\\b'),                        'CCBot',
+        match(user_agent, '(?i)\\bcohere-training-data-crawler\\b'), 'cohere-training-data-crawler',
+        match(user_agent, '(?i)\\bcohere-ai\\b'),                    'cohere-ai',
+        match(user_agent, '(?i)\\bDiffbot\\b'),                      'Diffbot',
+        match(user_agent, '(?i)\\bYouBot\\b'),                       'YouBot',
+        match(user_agent, '(?i)\\bDuckAssistBot\\b'),                'DuckAssistBot',
+        match(user_agent, '(?i)\\bBravebot\\b'),                     'Bravebot',
+        match(user_agent, '(?i)\\bAndibot\\b'),                      'Andibot',
+        match(user_agent, '(?i)\\bOmgilibot\\b'),                    'Omgilibot',
+        match(user_agent, '(?i)\\bomgili\\b'),                       'Omgili',
+        match(user_agent, '(?i)\\bImagesiftBot\\b'),                 'ImagesiftBot',
+        match(user_agent, '(?i)\\bTimpibot\\b'),                     'Timpibot',
+        match(user_agent, '(?i)\\bKangaroo Bot\\b'),                 'Kangaroo Bot',
+        match(user_agent, '(?i)\\bMistralAI-User\\b'),               'MistralAI-User',
+        match(user_agent, '(?i)\\bGrokBot\\b'),                      'GrokBot',
+        bot_name
+    ),
+    is_bot = 1
+WHERE timestamp >= now() - INTERVAL 7 DAY
+  AND user_agent != ''
+  AND multiMatchAny(user_agent, [
+        '(?i)\\bGPTBot\\b', '(?i)\\bOAI-SearchBot\\b', '(?i)\\bChatGPT-User\\b', 'openai/',
+        '(?i)\\bClaudeBot\\b', '(?i)\\bClaude-SearchBot\\b', '(?i)\\bClaude-User\\b', '(?i)\\banthropic-ai\\b',
+        '(?i)\\bPerplexityBot\\b', '(?i)\\bPerplexity-User\\b',
+        '(?i)\\bGoogleOther\\b', '(?i)\\bGooglebot\\b',
+        '(?i)\\bApplebot-Extended\\b', '(?i)\\bApplebot\\b',
+        '(?i)\\bMeta-ExternalAgent\\b', '(?i)\\bMeta-ExternalFetcher\\b',
+        '(?i)\\bAmazonbot\\b', '(?i)\\bBytespider\\b', '(?i)\\bCCBot\\b',
+        '(?i)\\bcohere-training-data-crawler\\b', '(?i)\\bcohere-ai\\b',
+        '(?i)\\bDiffbot\\b', '(?i)\\bYouBot\\b', '(?i)\\bDuckAssistBot\\b', '(?i)\\bBravebot\\b',
+        '(?i)\\bAndibot\\b', '(?i)\\bOmgilibot\\b', '(?i)\\bomgili\\b', '(?i)\\bImagesiftBot\\b',
+        '(?i)\\bTimpibot\\b', '(?i)\\bKangaroo Bot\\b', '(?i)\\bMistralAI-User\\b', '(?i)\\bGrokBot\\b'
+      ]) = 1
+  AND bot_name != multiIf(
+        match(user_agent, '(?i)\\bGPTBot\\b'),                       'GPTBot',
+        match(user_agent, '(?i)\\bOAI-SearchBot\\b'),                'OAI-SearchBot',
+        match(user_agent, '(?i)\\bChatGPT-User\\b'),                 'ChatGPT-User',
+        match(user_agent, 'openai/'),                                'OpenAI',
+        match(user_agent, '(?i)\\bClaudeBot\\b'),                    'ClaudeBot',
+        match(user_agent, '(?i)\\bClaude-SearchBot\\b'),             'Claude-SearchBot',
+        match(user_agent, '(?i)\\bClaude-User\\b'),                  'Claude-User',
+        match(user_agent, '(?i)\\banthropic-ai\\b'),                 'anthropic-ai',
+        match(user_agent, '(?i)\\bPerplexityBot\\b'),                'PerplexityBot',
+        match(user_agent, '(?i)\\bPerplexity-User\\b'),              'Perplexity-User',
+        match(user_agent, '(?i)\\bGoogleOther\\b'),                  'GoogleOther',
+        match(user_agent, '(?i)\\bGooglebot\\b'),                    'Googlebot',
+        match(user_agent, '(?i)\\bApplebot-Extended\\b'),            'Applebot-Extended',
+        match(user_agent, '(?i)\\bApplebot\\b'),                     'Applebot',
+        match(user_agent, '(?i)\\bMeta-ExternalAgent\\b'),           'Meta-ExternalAgent',
+        match(user_agent, '(?i)\\bMeta-ExternalFetcher\\b'),         'Meta-ExternalFetcher',
+        match(user_agent, '(?i)\\bAmazonbot\\b'),                    'Amazonbot',
+        match(user_agent, '(?i)\\bBytespider\\b'),                   'Bytespider',
+        match(user_agent, '(?i)\\bCCBot\\b'),                        'CCBot',
+        match(user_agent, '(?i)\\bcohere-training-data-crawler\\b'), 'cohere-training-data-crawler',
+        match(user_agent, '(?i)\\bcohere-ai\\b'),                    'cohere-ai',
+        match(user_agent, '(?i)\\bDiffbot\\b'),                      'Diffbot',
+        match(user_agent, '(?i)\\bYouBot\\b'),                       'YouBot',
+        match(user_agent, '(?i)\\bDuckAssistBot\\b'),                'DuckAssistBot',
+        match(user_agent, '(?i)\\bBravebot\\b'),                     'Bravebot',
+        match(user_agent, '(?i)\\bAndibot\\b'),                      'Andibot',
+        match(user_agent, '(?i)\\bOmgilibot\\b'),                    'Omgilibot',
+        match(user_agent, '(?i)\\bomgili\\b'),                       'Omgili',
+        match(user_agent, '(?i)\\bImagesiftBot\\b'),                 'ImagesiftBot',
+        match(user_agent, '(?i)\\bTimpibot\\b'),                     'Timpibot',
+        match(user_agent, '(?i)\\bKangaroo Bot\\b'),                 'Kangaroo Bot',
+        match(user_agent, '(?i)\\bMistralAI-User\\b'),               'MistralAI-User',
+        match(user_agent, '(?i)\\bGrokBot\\b'),                      'GrokBot',
+        bot_name
+      );
+
+-- ----------------------------------------------------------------------------
+-- STEP 3 (optional): confirm. Should now show canonical names, including
+-- Googlebot. Note FINAL is needed for an exact count on a ReplacingMergeTree
+-- if a merge hasn't run yet, but bot_name/is_bot are updated in-place by the
+-- mutation regardless, so plain SELECT already reflects it.
+-- ----------------------------------------------------------------------------
+-- SELECT bot_name, count()
+-- FROM proxy_logs
+-- WHERE timestamp >= now() - INTERVAL 7 DAY
+--   AND bot_name IN ('ClaudeBot','GPTBot','OAI-SearchBot','PerplexityBot','CCBot',
+--                    'Applebot','Applebot-Extended','Amazonbot','Bytespider',
+--                    'Meta-ExternalAgent','Googlebot')
+-- GROUP BY bot_name ORDER BY 2 DESC;

--- a/scripts/backfill-ai-agent-bot-names.sql
+++ b/scripts/backfill-ai-agent-bot-names.sql
@@ -33,7 +33,7 @@
 --     a compressed hypertable.
 --
 -- The CASE mirrors temps_proxy::ai_agent_detector::AGENT_PATTERNS exactly
--- (32 agents / 21 providers) in the same specificity order (e.g.
+-- (33 agents / 21 providers) in the same specificity order (e.g.
 -- Applebot-Extended before Applebot, OAI-SearchBot before openai/). Postgres
 -- `~*` is case-insensitive POSIX regex; `\y` is the word boundary (Rust `\b`).
 
@@ -57,6 +57,7 @@
 --         WHEN user_agent ~* '\yPerplexityBot\y'                THEN 'PerplexityBot'
 --         WHEN user_agent ~* '\yPerplexity-User\y'              THEN 'Perplexity-User'
 --         WHEN user_agent ~* '\yGoogleOther\y'                  THEN 'GoogleOther'
+        WHEN user_agent ~* '\yGooglebot\y'                    THEN 'Googlebot'
 --         WHEN user_agent ~* '\yApplebot-Extended\y'            THEN 'Applebot-Extended'
 --         WHEN user_agent ~* '\yApplebot\y'                     THEN 'Applebot'
 --         WHEN user_agent ~* '\yMeta-ExternalAgent\y'           THEN 'Meta-ExternalAgent'
@@ -104,6 +105,7 @@ SET bot_name = (
         WHEN user_agent ~* '\yPerplexityBot\y'                THEN 'PerplexityBot'
         WHEN user_agent ~* '\yPerplexity-User\y'              THEN 'Perplexity-User'
         WHEN user_agent ~* '\yGoogleOther\y'                  THEN 'GoogleOther'
+        WHEN user_agent ~* '\yGooglebot\y'                    THEN 'Googlebot'
         WHEN user_agent ~* '\yApplebot-Extended\y'            THEN 'Applebot-Extended'
         WHEN user_agent ~* '\yApplebot\y'                     THEN 'Applebot'
         WHEN user_agent ~* '\yMeta-ExternalAgent\y'           THEN 'Meta-ExternalAgent'
@@ -131,7 +133,7 @@ SET bot_name = (
     is_bot = true
 WHERE timestamp >= now() - interval '7 days'
   AND user_agent IS NOT NULL
-  AND user_agent ~* '\y(GPTBot|OAI-SearchBot|ChatGPT-User|ClaudeBot|Claude-SearchBot|Claude-User|anthropic-ai|PerplexityBot|Perplexity-User|GoogleOther|Applebot-Extended|Applebot|Meta-ExternalAgent|Meta-ExternalFetcher|Amazonbot|Bytespider|CCBot|cohere-training-data-crawler|cohere-ai|Diffbot|YouBot|DuckAssistBot|Bravebot|Andibot|Omgilibot|omgili|ImagesiftBot|Timpibot|Kangaroo Bot|MistralAI-User|GrokBot)\y|openai/'
+  AND user_agent ~* '\y(GPTBot|OAI-SearchBot|ChatGPT-User|ClaudeBot|Claude-SearchBot|Claude-User|anthropic-ai|PerplexityBot|Perplexity-User|GoogleOther|Googlebot|Applebot-Extended|Applebot|Meta-ExternalAgent|Meta-ExternalFetcher|Amazonbot|Bytespider|CCBot|cohere-training-data-crawler|cohere-ai|Diffbot|YouBot|DuckAssistBot|Bravebot|Andibot|Omgilibot|omgili|ImagesiftBot|Timpibot|Kangaroo Bot|MistralAI-User|GrokBot)\y|openai/'
   AND bot_name IS DISTINCT FROM (
     CASE
         WHEN user_agent ~* '\yGPTBot\y'                       THEN 'GPTBot'
@@ -145,6 +147,7 @@ WHERE timestamp >= now() - interval '7 days'
         WHEN user_agent ~* '\yPerplexityBot\y'                THEN 'PerplexityBot'
         WHEN user_agent ~* '\yPerplexity-User\y'              THEN 'Perplexity-User'
         WHEN user_agent ~* '\yGoogleOther\y'                  THEN 'GoogleOther'
+        WHEN user_agent ~* '\yGooglebot\y'                    THEN 'Googlebot'
         WHEN user_agent ~* '\yApplebot-Extended\y'            THEN 'Applebot-Extended'
         WHEN user_agent ~* '\yApplebot\y'                     THEN 'Applebot'
         WHEN user_agent ~* '\yMeta-ExternalAgent\y'           THEN 'Meta-ExternalAgent'

--- a/scripts/backfill-ai-agent-bot-names.sql
+++ b/scripts/backfill-ai-agent-bot-names.sql
@@ -1,5 +1,10 @@
 -- Backfill proxy_logs.bot_name with canonical AI-agent names.
 --
+-- This is the TimescaleDB (Postgres) path only. Deployments running the
+-- ClickHouse ProxyLogStorage backend (TEMPS_CLICKHOUSE_* set) have a
+-- separate proxy_logs table with different SQL syntax — use
+-- backfill-ai-agent-bot-names-clickhouse.sql for those.
+--
 -- WHY THIS IS A MANUAL SCRIPT, NOT A MIGRATION
 -- --------------------------------------------
 -- Sea-ORM migrations run inside `establish_connection` (Migrator::up) which

--- a/web/src/components/ui/ai-agent-logo.tsx
+++ b/web/src/components/ui/ai-agent-logo.tsx
@@ -42,6 +42,7 @@ const AGENT_TO_LOGO: Record<string, string> = {
   PerplexityBot: 'perplexity.svg',
   'Perplexity-User': 'perplexity.svg',
   GoogleOther: 'google.svg',
+  Googlebot: 'google.svg',
   Applebot: 'apple.svg',
   'Applebot-Extended': 'apple.svg',
   'Meta-ExternalAgent': 'meta.svg',

--- a/web/src/lib/ai-agents.ts
+++ b/web/src/lib/ai-agents.ts
@@ -17,7 +17,7 @@ export const AI_PROVIDERS: { provider: string; agents: string[] }[] = [
     agents: ['ClaudeBot', 'Claude-SearchBot', 'Claude-User', 'anthropic-ai'],
   },
   { provider: 'Perplexity', agents: ['PerplexityBot', 'Perplexity-User'] },
-  { provider: 'Google', agents: ['GoogleOther'] },
+  { provider: 'Google', agents: ['GoogleOther', 'Googlebot'] },
   { provider: 'Apple', agents: ['Applebot', 'Applebot-Extended'] },
   { provider: 'Meta', agents: ['Meta-ExternalAgent', 'Meta-ExternalFetcher'] },
   { provider: 'Amazon', agents: ['Amazonbot'] },


### PR DESCRIPTION
## Summary

`ai_agent_detector` currently has no pattern for plain `Googlebot`, so it falls through to the generic `CrawlerDetector` and never shows up on the AI Agents dashboard. Per Google's own AI-features documentation, AI Overviews and Gemini's Search-grounded answers are "rooted in our core Search ranking and quality systems" — there's no separate crawler for AI answers, they're built from the same index plain `Googlebot` already crawls for regular Search. `Google-Extended` (already noted in this file's comments) is a robots.txt permission token with no HTTP request user-agent of its own, so it can never show up in `proxy_logs` no matter what we do here — `Googlebot` is the closest real signal available for "Google's AI surfaces touched this page."

- `crates/temps-proxy/src/ai_agent_detector.rs`: new `Googlebot` pattern → provider `Google`, purpose `Mixed` (same purpose as the existing `GoogleOther` entry), plus 2 new tests
- `web/src/lib/ai-agents.ts`, `web/src/components/ui/ai-agent-logo.tsx`: updated the hand-maintained frontend mirrors (per this file's own comment: "Keep in sync when adding providers there")
- `scripts/backfill-ai-agent-bot-names.sql`: kept the historical-backfill CASE/regex in sync with the Rust source, per the script's own header comment ("mirrors AGENT_PATTERNS exactly (33 agents / 21 providers)")
- `scripts/backfill-ai-agent-bot-names-clickhouse.sql` (new): `proxy_logs` has two `ProxyLogStorage` backends — TimescaleDB and ClickHouse (`crates/temps-proxy/src/storage/`). The Postgres backfill script only covers the TimescaleDB path; this is the same fix translated to ClickHouse's `ALTER TABLE ... UPDATE` mutation syntax, so ClickHouse-backend deployments get historical backfill coverage too. **Verified against a live ClickHouse 26.2.5 instance** (applied the real `0001_proxy_logs.sql` schema in a scratch database, inserted rows covering Googlebot/GPTBot/GoogleOther/a plain browser/Googlebot-Image, ran both the preview and the mutation, confirmed correct per-row classification and idempotency on re-run, then dropped the scratch database). Neither backfill script was run against production data.

## ⚠️ Please read before merging

This is a shared `temps-proxy` crate change — it affects the AI-agents dashboard for **every** customer. Plain `Googlebot` indexing crawls every page on every active site constantly, at a volume that dwarfs genuine AI-specific bots. Adding `Googlebot` here will very likely make it the dominant row on most customers' AI-agents dashboards, for a feature whose purpose is surfacing AI-specific crawler activity.

That's not wrong, exactly — the traffic genuinely is Google-AI-surface-adjacent per their own docs — but it changes what the dashboard reads as, from "AI-specific crawler activity" toward "including ordinary Google search indexing too." Worth a product call on whether:
- this is fine as-is (Mixed purpose already signals "not exclusively AI"), or
- the dashboard should visually separate/de-emphasize this volume from lower-volume, unambiguously-AI-specific agents (GPTBot, ClaudeBot, PerplexityBot, etc.)

Neither backfill script (Postgres or ClickHouse) has been run against any production database — that's a manual, idempotent, operator-run step per both scripts' docs, flagged here for whoever owns that call.

## Test plan

```
$ cargo test -p temps-proxy ai_agent_detector
running 9 tests
test ai_agent_detector::tests::ignores_empty_and_missing_ua ... ok
test ai_agent_detector::tests::ignores_regular_browsers ... ok
test ai_agent_detector::tests::detects_perplexity ... ok
test ai_agent_detector::tests::detects_meta_external_agent ... ok
test ai_agent_detector::tests::detects_chatgpt_user_over_generic_openai ... ok
test ai_agent_detector::tests::detects_claudebot ... ok
test ai_agent_detector::tests::detects_googlebot_as_mixed ... ok
test ai_agent_detector::tests::detects_googleother_distinct_from_googlebot ... ok
test ai_agent_detector::tests::detects_gptbot ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 451 filtered out; finished in 0.02s
```

```
$ cargo clippy -p temps-proxy --lib -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.94s
```

- [x] `cargo test -p temps-proxy ai_agent_detector` — 9/9 pass (2 new), output above
- [x] `cargo clippy -p temps-proxy --lib -- -D warnings` — clean, output above
- [x] pre-commit hooks (fmt, clippy, typos) — pass
- [x] ClickHouse backfill script verified end-to-end against a live CH 26.2.5 instance (scratch DB, dropped after)
- [ ] Product/design sign-off on the dashboard-dominance tradeoff above before merge
