### PR TITLE
fix(cli): align apikeys create role vocabulary with backend Role enum

### DIFF
--- a/apps/temps-cli/src/commands/apikeys/index.ts
+++ b/apps/temps-cli/src/commands/apikeys/index.ts
@@ -16,7 +16,11 @@ import { promptConfirm, promptSelect, promptText } from '../../ui/prompts.js'
 import { withSpinner } from '../../ui/spinner.js'
 import { printTable, statusBadge, type TableColumn } from '../../ui/table.js'
 
-const ROLE_TYPES = ['admin', 'developer', 'viewer', 'readonly']
+// Matches crates/temps-auth/src/permissions.rs's Role enum exactly -- the
+// backend's Role::from_str only ever accepts these strings and 400s
+// ("Invalid role type") on anything else, including the "developer"/"viewer"/
+// "readonly" values this list previously offered.
+const ROLE_TYPES = ['admin', 'platform_admin', 'user', 'reader', 'api_reader', 'custom', 'metrics_ingest']
 
 /** Days-from-now -> ISO expiry, or null if the input isn't a positive integer. */
 export function computeExpiryIso(daysInput: string, from: Date = new Date()): string | null {
@@ -84,7 +88,7 @@ export function registerApiKeysCommands(program: Command): void {
     .alias('add')
     .description('Create a new API key')
     .option('-n, --name <name>', 'API key name')
-    .option('-r, --role <role>', 'Role type (admin, developer, viewer, readonly)')
+    .option('-r, --role <role>', 'Role type (admin, platform_admin, user, reader, api_reader, custom, metrics_ingest)')
     .option('-e, --expires-in <days>', 'Expires in N days (7, 30, 90, 365)')
     .option('-p, --permissions <permissions>', 'Comma-separated list of permissions')
     .option('-y, --yes', 'Skip confirmation prompts (for automation)')
@@ -149,7 +153,7 @@ async function listApiKeysAction(options: { json?: boolean }): Promise<void> {
 
   if (keys.length === 0) {
     info('No API keys found')
-    info('Run: temps apikeys create --name my-key --role developer -y')
+    info('Run: temps apikeys create --name my-key --role user -y')
     newline()
     return
   }


### PR DESCRIPTION
## Summary
Found by the wider docs-inconsistency sweep on temps.sh: `bunx @temps-sdk/cli apikeys create -r developer` (as documented in several temps-landing docs pages, e.g. `/docs/authorization`, `/docs/manage-team-access`) always fails at runtime with a 400 "Invalid role type" — `crates/temps-auth/src/permissions.rs`'s `Role::from_str` only ever accepts `admin`/`platform_admin`/`user`/`reader`/`api_reader`/`custom`/`metrics_ingest`, but `apps/temps-cli/src/commands/apikeys/index.ts`'s `ROLE_TYPES` still offered the old `developer`/`viewer`/`readonly` vocabulary.

- Replace `ROLE_TYPES` with the exact strings `Role::from_str` accepts
- Update the `-r, --role` option help text and the "no keys found" example command accordingly

This mirrors a prior fix already present on `main` for the equivalent `users create` bug (`apps/temps-cli/src/commands/users/index.ts`'s `AVAILABLE_ROLES` and `crates/temps-auth/src/handlers.rs`'s `parse_user_roles`, which now fails loudly instead of silently dropping unrecognized roles) — this PR just applies the same fix to the `apikeys` command, which was missed.

A companion temps-landing PR (#273) updates every documented example command that used the old role/scope vocabulary.

## Test plan
- [x] `bunx tsc --noEmit` in `apps/temps-cli` — clean
- [x] Verified `Role::from_str` in `crates/temps-auth/src/permissions.rs` accepts exactly these 7 strings
- [ ] Manual: `bunx @temps-sdk/cli apikeys create -n test -r user -y` against a local server succeeds