### PR TITLE
test(e2e): add multinode mTLS coverage and scenario CI

### DIFF
--- a/.github/scripts/run-temps-e2e-shard.sh
+++ b/.github/scripts/run-temps-e2e-shard.sh
@@ -22,14 +22,14 @@ run_scenario() {
 
 case "$SHARD" in
   core)
-    run_scenario scenario --with-db --requests 50 --concurrency 10
+    run_scenario scenario --image traefik/whoami:latest --port 80 --with-db --requests 50 --concurrency 10
     run_scenario cli-scenario
     run_scenario flags-scenario
     run_scenario audit-scenario
     run_scenario error-tracking-scenario
     run_scenario env-vars-scenario --registry "$REGISTRY"
     run_scenario api-key-scenario --temps-root "$PWD" --database-url "$DATABASE_URL"
-    run_scenario rbac-scenario --temps-root "$PWD" --database-url "$DATABASE_URL"
+    run_scenario rbac-scenario --image traefik/whoami:latest --temps-root "$PWD" --database-url "$DATABASE_URL"
     ;;
   observability)
     run_scenario logs-scenario --registry "$REGISTRY"
@@ -55,7 +55,7 @@ case "$SHARD" in
     run_scenario pg-upgrade-scenario --registry "$REGISTRY" --upgrade-timeout 900000
     ;;
   edge)
-    run_scenario tls-scenario --tls-port 3443
+    run_scenario tls-scenario --image traefik/whoami:latest --port 80 --tls-port 3443
     run_scenario dns01-wildcard-scenario
     run_scenario email-scenario
     run_scenario git-deploy-scenario

--- a/.github/scripts/run-temps-e2e-shard.sh
+++ b/.github/scripts/run-temps-e2e-shard.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SHARD="${1:?usage: run-temps-e2e-shard.sh <core|observability|services|recovery|edge|examples>}"
+E2E_DIR="${TEMPS_E2E_DIR:-apps/temps-e2e}"
+REGISTRY="${TEMPS_E2E_REGISTRY:-localhost:5111}"
+DATABASE_URL="${TEMPS_DATABASE_URL:-postgresql://temps:temps@localhost:5432/temps}"
+
+run_scenario() {
+  local name="$1"
+  shift
+  echo
+  echo "================================================================"
+  echo "Running apps/temps-e2e: $name"
+  echo "================================================================"
+  (
+    cd "$E2E_DIR"
+    bun run src/index.ts "$name" "$@" --json
+  )
+}
+
+case "$SHARD" in
+  core)
+    run_scenario scenario --with-db --requests 50 --concurrency 10
+    run_scenario cli-scenario
+    run_scenario flags-scenario
+    run_scenario audit-scenario
+    run_scenario error-tracking-scenario
+    run_scenario env-vars-scenario --registry "$REGISTRY"
+    run_scenario api-key-scenario --temps-root "$PWD" --database-url "$DATABASE_URL"
+    run_scenario rbac-scenario --temps-root "$PWD" --database-url "$DATABASE_URL"
+    ;;
+  observability)
+    run_scenario logs-scenario --registry "$REGISTRY"
+    run_scenario analytics-scenario --registry "$REGISTRY"
+    run_scenario session-replay-scenario --registry "$REGISTRY"
+    run_scenario monitoring-scenario --registry "$REGISTRY"
+    run_scenario otel-quota-scenario
+    ;;
+  services)
+    run_scenario managed-services-scenario --registry "$REGISTRY"
+    run_scenario kv-scenario
+    run_scenario blob-scenario
+    run_scenario db-ha-failover-scenario --registry "$REGISTRY"
+    run_scenario deploy-lifecycle-scenario --registry "$REGISTRY"
+    ;;
+  recovery)
+    run_scenario backup-restore-scenario --registry "$REGISTRY"
+    run_scenario pitr-scenario --registry "$REGISTRY"
+    run_scenario redis-restore-scenario --registry "$REGISTRY"
+    run_scenario mongodb-restore-scenario
+    run_scenario s3-restore-scenario
+    run_scenario mariadb-restore-scenario
+    run_scenario pg-upgrade-scenario --registry "$REGISTRY" --upgrade-timeout 900000
+    ;;
+  edge)
+    run_scenario tls-scenario --tls-port 3443
+    run_scenario dns01-wildcard-scenario
+    run_scenario email-scenario
+    run_scenario git-deploy-scenario
+    ;;
+  examples)
+    run_scenario examples --all --registry "$REGISTRY" --requests 25 --concurrency 5
+    ;;
+  *)
+    echo "Unknown E2E shard: $SHARD" >&2
+    exit 2
+    ;;
+esac

--- a/.github/workflows/apps-e2e-tests.yml
+++ b/.github/workflows/apps-e2e-tests.yml
@@ -135,6 +135,7 @@ jobs:
           ACME_DIRECTORY_URL: https://localhost:14000/dir
           ACME_INSECURE: "1"
           TEMPS_ALLOW_PEBBLE_PROVIDER: "1"
+          TEMPS_OTEL_QUOTA_GB: "1"
         run: |
           "$TEMPS_BIN" serve \
             --database-url "$DATABASE_URL" \
@@ -147,6 +148,11 @@ jobs:
             > /tmp/temps-scenarios.log 2>&1 &
           echo $! > /tmp/temps-scenarios.pid
           timeout 180 bash -c 'until curl -sf http://localhost:5002/ >/dev/null; do sleep 2; done'
+          # WAL-G runs inside managed-service containers. Put MinIO on the
+          # same network so endpoint resolution uses its container address
+          # instead of host.docker.internal, which plain Linux Docker does
+          # not define for arbitrary managed-service containers.
+          docker network connect temps-app-network temps-e2e-minio-1
 
       - name: Mint masked scenario credential
         run: |
@@ -179,6 +185,19 @@ jobs:
           path: /tmp/temps-scenarios.log
           retention-days: 7
           if-no-files-found: ignore
+
+      - name: Show Docker diagnostics on failure
+        if: failure()
+        run: |
+          docker ps -a
+          docker network inspect temps-app-network || true
+          docker ps -aq --filter label=sh.temps.service=true | while IFS= read -r container; do
+            # Restrict inspect output to operational fields. A full inspect
+            # includes container environment variables and would leak managed
+            # service credentials into the Actions log.
+            docker inspect --format '{{json .Name}} {{json .State}} {{json .NetworkSettings.Ports}} {{json .NetworkSettings.Networks}}' "$container" || true
+            docker logs --tail 200 "$container" || true
+          done
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/apps-e2e-tests.yml
+++ b/.github/workflows/apps-e2e-tests.yml
@@ -228,6 +228,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7.0.1
 
+      - name: Download temps binary
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.binary-artifact }}
+          path: ci-prebuilt
+
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -248,20 +254,33 @@ jobs:
           bun run typecheck
 
       - name: Run dedicated multinode scenario
+        env:
+          DEV_CLUSTER_PREBUILT_TEMPS_BIN: /workspace/ci-prebuilt/temps
         run: |
           # Compose overlays writable named volumes below a read-only
           # /workspace bind. On a clean checkout these gitignored mountpoints
           # do not exist, and runc cannot create them through the read-only
           # parent mount.
           mkdir -p target crates/temps-cli/dist
+          chmod +x ci-prebuilt/temps
           cd apps/temps-e2e
-          bun run src/index.ts multinode-join-scenario --json --build-timeout 2400000
+          # Keep the topology until the always() cleanup step so a failed
+          # scenario still has containers available for diagnostic logs.
+          bun run src/index.ts multinode-join-scenario --json --keep --build-timeout 600000
 
       - name: Collect multinode logs on failure
         if: failure()
         run: |
-          docker compose -f tools/e2e-multinode-cluster/docker-compose.yml -p temps-e2e-mn ps -a || true
-          docker compose -f tools/e2e-multinode-cluster/docker-compose.yml -p temps-e2e-mn logs --no-color > /tmp/temps-multinode.log 2>&1 || true
+          {
+            docker compose -f tools/e2e-multinode-cluster/docker-compose.yml -p temps-e2e-mn ps -a || true
+            docker compose -f tools/e2e-multinode-cluster/docker-compose.yml -p temps-e2e-mn logs --no-color || true
+            for node in temps-e2e-mn-control-plane temps-e2e-mn-worker-1; do
+              echo "===== $node: inner docker ps ====="
+              docker exec "$node" docker ps -a --format '{{.ID}} {{.Names}} {{.Image}} {{.Status}}' || true
+              echo "===== $node: inner dockerd log ====="
+              docker exec "$node" tail -n 300 /var/log/docker.log || true
+            done
+          } > /tmp/temps-multinode.log 2>&1
 
       - name: Upload multinode logs
         if: failure()

--- a/.github/workflows/apps-e2e-tests.yml
+++ b/.github/workflows/apps-e2e-tests.yml
@@ -111,6 +111,12 @@ jobs:
             -c 'until mc alias set backup http://minio:9000 minioadmin minioadmin; do sleep 2; done; mc mb --ignore-existing backup/temps-e2e-backups'
 
       - name: Prepare Temps instance
+        # Authenticate public GitHub API requests made by the git-deploy
+        # scenario. GitHub-hosted runners share the anonymous 60 req/hour
+        # quota, so --skip-git makes this scenario inherently flaky. The
+        # workflow token is read-only, job-scoped, and automatically masked.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           mkdir -p "$TEMPS_DATA_DIR"
           cp crates/temps-cli/GeoLite2-City.mmdb "$TEMPS_DATA_DIR/GeoLite2-City.mmdb"
@@ -127,7 +133,7 @@ jobs:
             --wildcard-domain "*.localho.st" \
             --wildcard-domain-cert /tmp/localho.st.crt \
             --wildcard-domain-key /tmp/localho.st.key \
-            --skip-dns-records --skip-git --skip-geolite2-download \
+            --skip-dns-records --skip-geolite2-download \
             --output-format json
 
       - name: Start Temps
@@ -242,7 +248,14 @@ jobs:
           bun run typecheck
 
       - name: Run dedicated multinode scenario
-        run: cd apps/temps-e2e && bun run src/index.ts multinode-join-scenario --json --build-timeout 2400000
+        run: |
+          # Compose overlays writable named volumes below a read-only
+          # /workspace bind. On a clean checkout these gitignored mountpoints
+          # do not exist, and runc cannot create them through the read-only
+          # parent mount.
+          mkdir -p target crates/temps-cli/dist
+          cd apps/temps-e2e
+          bun run src/index.ts multinode-join-scenario --json --build-timeout 2400000
 
       - name: Collect multinode logs on failure
         if: failure()

--- a/.github/workflows/apps-e2e-tests.yml
+++ b/.github/workflows/apps-e2e-tests.yml
@@ -1,0 +1,247 @@
+name: Temps Scenario E2E Tests
+
+# Reusable from rust-tests.yml so every shard consumes the exact musl binary
+# already built for the current commit. This is intentionally separate from
+# e2e-tests.yml, which owns Playwright and the small example-deployment smoke.
+on:
+  workflow_call:
+    inputs:
+      binary-artifact:
+        description: Name of the artifact holding the prebuilt temps binary
+        required: false
+        default: temps-binary-musl-fast
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  DATABASE_URL: postgresql://temps:temps@localhost:5432/temps
+  TEMPS_DATABASE_URL: postgresql://temps:temps@localhost:5432/temps
+  TEMPS_DATA_DIR: /tmp/temps-scenario-data
+  TEMPS_URL: http://localhost:5002
+  TEMPS_E2E_REGISTRY: localhost:5111
+  TEMPS_TELEMETRY: "0"
+  TEMPS_BIN: ${{ github.workspace }}/ci-prebuilt/temps
+  ADMIN_EMAIL: admin@localho.st
+  ADMIN_PASSWORD: E2eScenarioPass123!
+
+jobs:
+  scenarios:
+    name: Scenarios (${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ matrix.timeout }}
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        include:
+          - shard: core
+            timeout: 75
+          - shard: observability
+            timeout: 90
+          - shard: services
+            timeout: 100
+          - shard: recovery
+            timeout: 180
+          - shard: edge
+            timeout: 75
+          - shard: examples
+            timeout: 120
+
+    services:
+      timescaledb:
+        image: timescale/timescaledb-ha:pg18
+        env:
+          POSTGRES_DB: temps
+          POSTGRES_USER: temps
+          POSTGRES_PASSWORD: temps
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U temps -d temps"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+
+      - name: Checkout code
+        uses: actions/checkout@v7.0.1
+
+      - name: Download temps binary
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.binary-artifact }}
+          path: ci-prebuilt
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Build and link scenario SDK dependencies
+        run: |
+          chmod +x "$TEMPS_BIN"
+          cd packages/api
+          bun install --frozen-lockfile
+          bun run build
+          bun link
+          cd ../../sdks/node/packages/node-sdk
+          bun install
+          bun run build
+          bun link
+          cd ../../../../apps/temps-cli
+          bun install --frozen-lockfile
+          cd ../temps-e2e
+          bun install --frozen-lockfile
+          bun run typecheck
+
+      - name: Start registry and external-service fixtures
+        run: |
+          docker run -d --name temps-e2e-registry -p 5111:5000 registry:2
+          docker compose -p temps-e2e -f apps/temps-e2e/docker-compose.e2e.yml up -d
+          timeout 90 bash -c 'until nc -z localhost 14000 && nc -z localhost 8056 && nc -z localhost 1025 && nc -z localhost 8025 && nc -z localhost 9092; do sleep 2; done'
+          docker run --rm --network temps-e2e_default --entrypoint /bin/sh minio/mc \
+            -c 'until mc alias set backup http://minio:9000 minioadmin minioadmin; do sleep 2; done; mc mb --ignore-existing backup/temps-e2e-backups'
+
+      - name: Prepare Temps instance
+        run: |
+          mkdir -p "$TEMPS_DATA_DIR"
+          cp crates/temps-cli/GeoLite2-City.mmdb "$TEMPS_DATA_DIR/GeoLite2-City.mmdb"
+          openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+            -keyout /tmp/localho.st.key -out /tmp/localho.st.crt -days 1 -nodes \
+            -subj "/CN=localho.st" -addext "subjectAltName=DNS:localho.st,DNS:*.localho.st"
+          sudo cp /tmp/localho.st.crt /usr/local/share/ca-certificates/temps-localhost.crt
+          sudo update-ca-certificates
+          "$TEMPS_BIN" setup --non-interactive \
+            --database-url "$DATABASE_URL" \
+            --data-dir "$TEMPS_DATA_DIR" \
+            --admin-email "$ADMIN_EMAIL" \
+            --admin-password "$ADMIN_PASSWORD" \
+            --wildcard-domain "*.localho.st" \
+            --wildcard-domain-cert /tmp/localho.st.crt \
+            --wildcard-domain-key /tmp/localho.st.key \
+            --skip-dns-records --skip-git --skip-geolite2-download \
+            --output-format json
+
+      - name: Start Temps
+        env:
+          ACME_DIRECTORY_URL: https://localhost:14000/dir
+          ACME_INSECURE: "1"
+          TEMPS_ALLOW_PEBBLE_PROVIDER: "1"
+        run: |
+          "$TEMPS_BIN" serve \
+            --database-url "$DATABASE_URL" \
+            --data-dir "$TEMPS_DATA_DIR" \
+            --address 0.0.0.0:5002 \
+            --tls-address 0.0.0.0:3443 \
+            --console-address 127.0.0.1:8081 \
+            --disable-https-redirect \
+            --screenshot-provider noop \
+            > /tmp/temps-scenarios.log 2>&1 &
+          echo $! > /tmp/temps-scenarios.pid
+          timeout 180 bash -c 'until curl -sf http://localhost:5002/ >/dev/null; do sleep 2; done'
+
+      - name: Mint masked scenario credential
+        run: |
+          if ! API_OUTPUT=$("$TEMPS_BIN" api-key \
+            --database-url "$DATABASE_URL" \
+            --name "scenario-${{ matrix.shard }}" \
+            --role admin \
+            --user-email "$ADMIN_EMAIL" \
+            --output-format json 2>/dev/null); then
+            echo "Failed to create scenario API key (credential-bearing stdout/stderr suppressed)"
+            exit 1
+          fi
+          API_KEY=$(echo "$API_OUTPUT" | jq -r '.api_key // empty')
+          if [ -z "$API_KEY" ]; then
+            echo "Credential output did not contain an API key (output suppressed)"
+            exit 1
+          fi
+          echo "::add-mask::$API_KEY"
+          printf 'TEMPS_API_KEY=%s\n' "$API_KEY" >> "$GITHUB_ENV"
+          echo "Created masked API key for shard ${{ matrix.shard }}"
+
+      - name: Run scenario shard
+        run: bash .github/scripts/run-temps-e2e-shard.sh "${{ matrix.shard }}"
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: temps-scenario-${{ matrix.shard }}-logs
+          path: /tmp/temps-scenarios.log
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Cleanup
+        if: always()
+        run: |
+          if [ -f /tmp/temps-scenarios.pid ]; then
+            kill "$(cat /tmp/temps-scenarios.pid)" 2>/dev/null || true
+          fi
+          docker compose -p temps-e2e -f apps/temps-e2e/docker-compose.e2e.yml down -v 2>/dev/null || true
+          docker rm -f temps-e2e-registry 2>/dev/null || true
+          docker system prune -af --volumes 2>/dev/null || true
+
+  multinode:
+    name: Scenario (multinode mTLS)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+
+      - name: Checkout code
+        uses: actions/checkout@v7.0.1
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Build and link scenario SDK dependencies
+        run: |
+          cd packages/api
+          bun install --frozen-lockfile
+          bun run build
+          bun link
+          cd ../../sdks/node/packages/node-sdk
+          bun install
+          bun run build
+          bun link
+          cd ../../../../apps/temps-e2e
+          bun install --frozen-lockfile
+          bun run typecheck
+
+      - name: Run dedicated multinode scenario
+        run: cd apps/temps-e2e && bun run src/index.ts multinode-join-scenario --json --build-timeout 2400000
+
+      - name: Collect multinode logs on failure
+        if: failure()
+        run: |
+          docker compose -f tools/e2e-multinode-cluster/docker-compose.yml -p temps-e2e-mn ps -a || true
+          docker compose -f tools/e2e-multinode-cluster/docker-compose.yml -p temps-e2e-mn logs --no-color > /tmp/temps-multinode.log 2>&1 || true
+
+      - name: Upload multinode logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: temps-multinode-logs
+          path: /tmp/temps-multinode.log
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Cleanup multinode topology
+        if: always()
+        run: |
+          docker compose -f tools/e2e-multinode-cluster/docker-compose.yml -p temps-e2e-mn down -v 2>/dev/null || true
+          docker system prune -af --volumes 2>/dev/null || true

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,6 +17,9 @@ on:
         default: temps-binary-musl-fast
         type: string
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -130,9 +133,9 @@ jobs:
 
       - name: Prepare data directory
         run: |
-          mkdir -p $TEMPS_DATA_DIR
+          mkdir -p "$TEMPS_DATA_DIR"
           # GeoLite2 database is checked into the repo
-          cp crates/temps-cli/GeoLite2-City.mmdb $TEMPS_DATA_DIR/GeoLite2-City.mmdb
+          cp crates/temps-cli/GeoLite2-City.mmdb "$TEMPS_DATA_DIR/GeoLite2-City.mmdb"
 
       - name: Verify TimescaleDB is ready
         run: |
@@ -252,7 +255,7 @@ jobs:
           echo "Temps server started with PID $(cat /tmp/temps.pid)"
           # Give it a moment to either start or crash
           sleep 3
-          if ! kill -0 $(cat /tmp/temps.pid) 2>/dev/null; then
+          if ! kill -0 "$(cat /tmp/temps.pid)" 2>/dev/null; then
             echo "ERROR: Temps server died immediately. Logs:"
             cat /tmp/temps.log
             exit 1
@@ -297,32 +300,38 @@ jobs:
       - name: Create API key via CLI
         id: auth
         run: |
-          API_OUTPUT=$("$TEMPS_BIN" api-key \
+          if ! API_OUTPUT=$("$TEMPS_BIN" api-key \
             --database-url "$DATABASE_URL" \
             --name "e2e-test" \
             --role admin \
-            --output-format json 2>&1)
-          echo "CLI output: $API_OUTPUT"
-
-          API_KEY=$(echo "$API_OUTPUT" | jq -r '.api_key // empty' 2>/dev/null)
-          if [ -z "$API_KEY" ]; then
-            echo "Failed to extract API key from CLI output"
+            --output-format json 2>/dev/null); then
+            echo "Failed to create the E2E API key (credential-bearing stdout/stderr suppressed)"
             exit 1
           fi
 
-          echo "API key created: ${API_KEY:0:12}..."
-          echo "api_key=$API_KEY" >> $GITHUB_OUTPUT
+          API_KEY=$(echo "$API_OUTPUT" | jq -r '.api_key // empty' 2>/dev/null)
+          if [ -z "$API_KEY" ]; then
+            echo "Failed to extract API key from credential-bearing CLI output (output suppressed)"
+            exit 1
+          fi
+
+          echo "::add-mask::$API_KEY"
+          KEY_ID=$(echo "$API_OUTPUT" | jq -r '.id // "unknown"')
+          KEY_PREFIX=$(echo "$API_OUTPUT" | jq -r '.key_prefix // "unknown"')
+          echo "API key created: id=$KEY_ID prefix=$KEY_PREFIX"
+          printf 'api_key=%s\n' "$API_KEY" >> "$GITHUB_OUTPUT"
 
       - name: Deploy example applications
         env:
           API_KEY: ${{ steps.auth.outputs.api_key }}
+          SOURCE_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
           set -euo pipefail
 
           REPO_URL="https://github.com/${{ github.repository }}.git"
           REPO_OWNER="${{ github.repository_owner }}"
           REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
-          BRANCH="${{ github.head_ref || github.ref_name }}"
+          BRANCH="$SOURCE_BRANCH"
 
           # Define example apps: name|directory|preset
           APPS=(
@@ -506,7 +515,7 @@ jobs:
           if [ -f /tmp/temps.pid ]; then
             PID=$(cat /tmp/temps.pid)
             echo "Temps PID: $PID"
-            ps aux | grep temps || true
+            pgrep -af temps || true
           fi
 
           echo ""
@@ -528,6 +537,6 @@ jobs:
         if: always()
         run: |
           if [ -f /tmp/temps.pid ]; then
-            kill $(cat /tmp/temps.pid) 2>/dev/null || true
+            kill "$(cat /tmp/temps.pid)" 2>/dev/null || true
           fi
           docker system prune -f 2>/dev/null || true

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -7,6 +7,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# PR-controlled build scripts and privileged E2E containers do not need a
+# repository-write token. Keep the run read-only even if repository defaults
+# are later broadened.
+permissions:
+  contents: read
+
 # Superseded PR pushes used to leave the previous run's jobs going to
 # completion — including an 80-minute cold musl build whose output nobody
 # would ever look at, while the new commit's jobs queued behind it. Cancel
@@ -164,6 +170,16 @@ jobs:
     name: E2E
     needs: build-binary
     uses: ./.github/workflows/e2e-tests.yml
+    with:
+      binary-artifact: temps-binary-musl-fast
+
+  # The existing E2E workflow above covers Playwright and three example
+  # deployments. This separate matrix runs the real apps/temps-e2e scenario
+  # CLI in isolated shards, including the dedicated multinode/mTLS topology.
+  scenario-e2e:
+    name: Scenario E2E
+    needs: build-binary
+    uses: ./.github/workflows/apps-e2e-tests.yml
     with:
       binary-artifact: temps-binary-musl-fast
 

--- a/apps/temps-e2e/README.md
+++ b/apps/temps-e2e/README.md
@@ -1179,6 +1179,108 @@ lost forever, leaking one reconciler task per deleted cluster that logged
 inside the tick `select!`), so a signal is caught within one tick even if
 it arrives mid-reconcile.
 
+### `multinode-join-scenario` steps
+
+The first-ever e2e coverage for temps's multi-node/WireGuard clustering
+feature. Before this, the only coverage anywhere was Rust unit tests
+against a `MockDatabase`
+(`crates/temps-deployments/tests/multinode_integration_test.rs`) and a
+manual, non-automated dev tool (`tools/dev-cluster/`) a human has to run
+and eyeball. Nothing asserted that a second real node actually joins the
+mesh, that a deployment pinned to it actually lands there, or that drain/
+removal actually work.
+
+**Why this scenario owns its entire cluster instead of using the shared
+instance.** Every other scenario in this suite points `--url`/`--api-key`
+at an already-running `temps serve` (started via the `start-temps` skill)
+and drives it over HTTP. Multi-node clustering can't be proven that way:
+it needs a genuinely SEPARATE node — its own Docker daemon, its own binary,
+its own network identity — registering into the first node's mesh over
+real mTLS. `tls-scenario` already established the precedent that a
+scenario can need "a dedicated instance on a fixed port, not a normal dev
+slot" (see that section above) because of Pebble's hardcoded port; this
+scenario takes the same idea further: it brings up its own 2-node
+Docker-in-Docker cluster (`tools/e2e-multinode-cluster/docker-compose.yml`
+— a trimmed, re-subnetted clone of `tools/dev-cluster/`'s topology, safe to
+run alongside a developer's own dev-cluster instance or any other local
+service; see that compose file's header comment for the exact isolation
+guarantees), mints its own admin credential once the cluster is up, and
+tears the whole thing down at the end. It does NOT accept `--url`/
+`--api-key` — there is no "target instance" to point at.
+
+1. `docker compose up -d --build` the 2-node cluster. First run compiles
+   the full `temps` binary from source TWICE (once per DinD container) —
+   budget 15-20+ minutes; this is streamed to the scenario's own log output
+   line-by-line (prefixed `[compose]`) specifically so a long first build
+   is visibly progressing, not indistinguishable from a hang. Bounded by
+   `--build-timeout` (default 30 min).
+2. poll `docker inspect --format '{{.State.Health.Status}}'` on the
+   control-plane container until `healthy`.
+3. mint an admin API key directly from the DB: `docker exec ... temps
+   api-key --database-url=... --name=e2e-multinode --role=admin
+   --user-email=admin@local.dev --output-format=json` — the same DB-direct
+   pattern this README documents under "Auth" and `db-apikey.ts`/
+   `rbac-scenario` already use elsewhere in this suite. Works because
+   `role-control-plane.sh`'s `temps setup --auto` guarantees
+   `admin@local.dev` exists by the time the healthcheck passes.
+4. from here on, drive everything through the normal `@temps-sdk/api`
+   client against `http://localhost:18180`, same as every other scenario.
+5. poll `GET /internal/nodes` until a node named `worker-1` reports
+   `status: "active"` — the real proof `POST /internal/nodes/register`
+   completed a genuine registration, not a mocked one. Bounded by the same
+   generous timeout: the worker also compiles its own binary from scratch.
+6. create a throwaway project, resolve its production environment.
+7. `PUT /projects/{id}/environments/{id}/settings` with
+   `target_nodes: [worker_node_id]` — pins every future deploy in this
+   environment to the worker, never the control plane.
+8. deploy `traefik/whoami:latest` (same image other scenarios in this repo
+   already use for basic deploys) and poll it to a terminal state.
+9. the core assertion: `docker exec temps-e2e-mn-worker-1 docker ps` shows
+   the deployed container; `docker exec temps-e2e-mn-control-plane docker
+   ps` does not — a side channel the platform API can't fake, mirroring how
+   `db-ha-failover-scenario` proves promotion via `docker inspect`.
+10. real HTTP proof of life: hit the deployed app through the
+    control-plane's proxy (`localhost:18180`) with the app's `Host` header
+    and assert the actual `traefik/whoami` response body, not just a
+    healthy status field.
+11. drain the worker (`POST /internal/nodes/{id}/drain`), poll
+    `GET /internal/nodes/{id}/drain` until `drain_complete`, then re-run the
+    same `docker ps` side-channel check on both containers to confirm the
+    container migrated off the worker. In this 2-node cluster it has
+    nowhere to go but the control plane, so this step also implicitly
+    re-tests the `Local` scheduling fallback path.
+12. remove the worker node (`DELETE /internal/nodes/{id}`); confirm it's
+    gone from `GET /internal/nodes`.
+13. teardown (in a `finally`, same discipline as every other scenario):
+    `docker compose down` (no `-v`, so the cargo-registry/cargo-git/
+    workspace-target cache volumes survive for a near-instant re-run), then
+    explicitly `docker volume rm` the identity/state volumes (postgres
+    data, both containers' `/var/lib/docker` + `/var/lib/temps`, the
+    worker's `/root`) so the next run proves a genuinely fresh
+    registration/join rather than silently skipping it via one of the role
+    scripts' own idempotency marker files. `--keep` skips all of this —
+    unlike every other scenario's `--keep`, this leaves an entire running
+    2-node cluster behind, not just one container.
+
+**What makes step 9 work without a registry.** Unlike most `--registry`-
+requiring scenarios in this suite, deploying a bare public image tag to a
+remote node needs no registry at all: `ensure_image_on_remote` in
+`crates/temps-deployments/src/jobs/deploy_image.rs` has the control plane's
+own `DockerImageBuilder` pull (if needed) and `docker save` the image to a
+tar, stream it to the worker agent's `POST /agent/images/import`, and the
+agent `docker load`s it there. `image_builder` is injected into the deploy
+job per `workflow_execution_service.rs` (`builder.image_builder(...)`,
+around the node-scheduler wiring) specifically for this transfer path. So
+`traefik/whoami:latest` works exactly as described in this section's
+design with zero extra image-transfer complexity — this was verified by
+reading the actual remote-deploy code path, not assumed.
+
+```bash
+bun run src/index.ts multinode-join-scenario
+bun run src/index.ts multinode-join-scenario --keep --json    # inspect the running cluster after (CI)
+bun run src/index.ts multinode-join-scenario --build-timeout 2400000   # more generous on a slow machine
+```
+
 ### `deploy-lifecycle-scenario` steps
 
 Rollback / pause / resume / promote are the platform's primary safety valve

--- a/apps/temps-e2e/README.md
+++ b/apps/temps-e2e/README.md
@@ -1181,7 +1181,7 @@ it arrives mid-reconcile.
 
 ### `multinode-join-scenario` steps
 
-The first-ever e2e coverage for temps's multi-node/WireGuard clustering
+The first-ever e2e coverage for temps's direct-underlay multi-node clustering
 feature. Before this, the only coverage anywhere was Rust unit tests
 against a `MockDatabase`
 (`crates/temps-deployments/tests/multinode_integration_test.rs`) and a
@@ -1196,7 +1196,8 @@ at an already-running `temps serve` (started via the `start-temps` skill)
 and drives it over HTTP. Multi-node clustering can't be proven that way:
 it needs a genuinely SEPARATE node — its own Docker daemon, its own binary,
 its own network identity — registering into the first node's mesh over
-real mTLS. `tls-scenario` already established the precedent that a
+single-use enrollment and real mTLS. WireGuard relay enrollment is a separate
+topology and is not claimed by this scenario. `tls-scenario` already established the precedent that a
 scenario can need "a dedicated instance on a fixed port, not a normal dev
 slot" (see that section above) because of Pebble's hardcoded port; this
 scenario takes the same idea further: it brings up its own 2-node
@@ -1229,6 +1230,9 @@ tears the whole thing down at the end. It does NOT accept `--url`/
    `status: "active"` — the real proof `POST /internal/nodes/register`
    completed a genuine registration, not a mocked one. Bounded by the same
    generous timeout: the worker also compiles its own binary from scratch.
+   Then verify the node endpoint uses HTTPS, the worker persisted its mTLS
+   leaf/key/CA, legacy shared enrollment is disabled, and the node-bound
+   single-use enrollment token has exactly one use.
 6. create a throwaway project, resolve its production environment.
 7. `PUT /projects/{id}/environments/{id}/settings` with
    `target_nodes: [worker_node_id]` — pins every future deploy in this

--- a/apps/temps-e2e/src/commands/git-deploy-scenario.ts
+++ b/apps/temps-e2e/src/commands/git-deploy-scenario.ts
@@ -28,14 +28,12 @@
  * git-clone-and-build pipeline work against a real repo host" that would
  * actually prove this.
  */
-import { getDeployStatus, waitForDeployment } from '../lib/flows.ts'
+import { getDeployStatus, pollUntil, waitForDeployment } from '../lib/flows.ts'
 import {
   createE2eGitProject,
   getProductionEnvironment,
   triggerPipelineAndGetDeploymentId,
   resolveLoadTarget,
-  waitForHttpReady,
-  assertNotConsoleFallback,
   teardown,
   makeRunId,
 } from '../lib/flows.ts'
@@ -96,6 +94,11 @@ export async function gitDeployScenarioCommand(opts: GitDeployScenarioOptions): 
   // Real clone + real build (not a prebuilt-image pull), so this needs more
   // headroom than the other scenarios' 300000ms default.
   const deployTimeoutMs = Number(opts.deployTimeout ?? '600000')
+  // A deployment can report healthy just before the proxy's asynchronously
+  // rebuilt route table reaches every request handler. Keep polling the data
+  // plane for a meaningful window instead of falling back to the helper's
+  // short default and racing route propagation on busy CI runners.
+  const appReadyTimeoutMs = Math.min(deployTimeoutMs, 120_000)
 
   const projectIds: number[] = []
   const deployments: { projectId: number; deploymentId: number }[] = []
@@ -138,8 +141,32 @@ export async function gitDeployScenarioCommand(opts: GitDeployScenarioOptions): 
 
     const target = resolveLoadTarget(cfg.url, env.mainUrl)
     await step('wait for the app to serve real traffic', async () => {
-      await waitForHttpReady({ url: target.url, headers: target.headers })
-      await assertNotConsoleFallback({ url: target.url, headers: target.headers })
+      const expected = { message: 'Hello from Go on Temps!' }
+      await pollUntil(
+        async () => {
+          try {
+            const res = await fetch(target.url, { headers: target.headers })
+            const body = await res.text()
+            return { status: res.status, body }
+          } catch (error) {
+            return { status: 0, body: (error as Error).message }
+          }
+        },
+        ({ status, body }) => {
+          if (status !== 200) return false
+          try {
+            return JSON.stringify(JSON.parse(body)) === JSON.stringify(expected)
+          } catch {
+            return false
+          }
+        },
+        {
+          timeoutMs: appReadyTimeoutMs,
+          intervalMs: 1500,
+          onPoll: ({ status }) => log(`    ...app HTTP ${status || '(connection failed)'}`),
+          label: 'git deployment to serve the exact expected application response',
+        },
+      )
     })
 
     await step('/ returns the exact body baked into the real repo source', async () => {

--- a/apps/temps-e2e/src/commands/multinode-join-scenario.ts
+++ b/apps/temps-e2e/src/commands/multinode-join-scenario.ts
@@ -102,7 +102,6 @@ import {
   waitForDeployment,
   getDeployStatus,
   resolveLoadTarget,
-  assertNotConsoleFallback,
   teardown,
   makeRunId,
   pollUntil,
@@ -157,6 +156,7 @@ async function runStreamed(
   timeoutMs?: number,
 ): Promise<void> {
   const proc = Bun.spawn(args, { stdout: 'pipe', stderr: 'pipe' })
+  const outputTail: string[] = []
   let timedOut = false
   const timeout = timeoutMs === undefined
     ? undefined
@@ -174,9 +174,18 @@ async function runStreamed(
       buf += decoder.decode(value, { stream: true })
       const lines = buf.split('\n')
       buf = lines.pop() ?? ''
-      for (const l of lines) if (l.trim()) onLog(l)
+      for (const l of lines) {
+        if (!l.trim()) continue
+        onLog(l)
+        outputTail.push(l)
+        if (outputTail.length > 60) outputTail.shift()
+      }
     }
-    if (buf.trim()) onLog(buf)
+    if (buf.trim()) {
+      onLog(buf)
+      outputTail.push(buf)
+      if (outputTail.length > 60) outputTail.shift()
+    }
   }
   const [, , code] = await Promise.all([pump(proc.stdout), pump(proc.stderr), proc.exited])
   if (timeout !== undefined) clearTimeout(timeout)
@@ -184,7 +193,8 @@ async function runStreamed(
     throw new Error(`${what} did not finish within ${Math.round(timeoutMs! / 1000)}s and was terminated`)
   }
   if (code !== 0) {
-    throw new Error(`${what} failed (exit ${code})`)
+    const detail = outputTail.length ? `\n${outputTail.join('\n')}` : ''
+    throw new Error(`${what} failed (exit ${code})${detail}`)
   }
 }
 
@@ -224,6 +234,29 @@ async function dockerPsNames(containerName: string): Promise<string[]> {
     .split('\n')
     .map((l) => l.trim())
     .filter(Boolean)
+}
+
+/** Wait until the proxy serves the actual whoami container, not a transient 404/console route. */
+async function waitForWhoami(
+  target: ReturnType<typeof resolveLoadTarget>,
+  timeoutMs = 60_000,
+): Promise<void> {
+  await pollUntil(
+    async () => {
+      try {
+        const res = await fetch(target.url, { headers: target.headers })
+        return { status: res.status, body: (await res.text()).slice(0, 200) }
+      } catch (error) {
+        return { status: 0, body: (error as Error).message }
+      }
+    },
+    (response) => response.status === 200 && response.body.includes('Hostname'),
+    {
+      timeoutMs,
+      intervalMs: 1000,
+      label: 'control-plane proxy to serve the traefik/whoami deployment',
+    },
+  )
 }
 
 export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOptions): Promise<void> {
@@ -499,16 +532,7 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
     })
 
     const target = resolveLoadTarget(cfg.url, env.mainUrl)
-    await step('real HTTP proof of life through the control-plane proxy', async () => {
-      await assertNotConsoleFallback({ url: target.url, headers: target.headers, timeoutMs: 60_000 })
-      const res = await fetch(target.url, { headers: target.headers })
-      const body = await res.text()
-      if (res.status !== 200 || !body.includes('Hostname')) {
-        throw new Error(
-          `expected a real traefik/whoami response (status 200, body containing "Hostname"), got HTTP ${res.status}: ${body.slice(0, 200)}`,
-        )
-      }
-    })
+    await step('real HTTP proof of life through the control-plane proxy', () => waitForWhoami(target))
 
     await step('drain the worker', async () => {
       unwrap(
@@ -577,7 +601,7 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
       }
       log(`  post-drain: worker-1=[${workerContainers.join(', ')}] control-plane=[${cpContainers.join(', ')}]`)
 
-      await assertNotConsoleFallback({ url: target.url, headers: target.headers, timeoutMs: 60_000 })
+      await waitForWhoami(target)
     })
 
     await step('remove the worker node', async () => {

--- a/apps/temps-e2e/src/commands/multinode-join-scenario.ts
+++ b/apps/temps-e2e/src/commands/multinode-join-scenario.ts
@@ -1,0 +1,529 @@
+/**
+ * The first-ever e2e test for temps's multi-node/WireGuard clustering
+ * feature. Nothing tests this today — only Rust unit tests with
+ * MockDatabase (`crates/temps-deployments/tests/multinode_integration_test.rs`)
+ * and a manual, non-automated dev tool (`tools/dev-cluster/`).
+ *
+ * Every other scenario in this suite points `--url`/`--api-key` at an
+ * ALREADY-RUNNING `temps serve` instance (started via the `start-temps`
+ * skill) and drives it over HTTP. This one can't: it has to prove a SECOND,
+ * genuinely separate node (its own Docker daemon, its own binary, its own
+ * network identity) joins the first node's mesh — that needs its own
+ * Docker-in-Docker (DinD) 2-node cluster with real WireGuard/mTLS
+ * registration, exactly what `tools/dev-cluster/` already proves works,
+ * just not automated or asserted against. So this scenario does NOT use the
+ * global `--url`/`--api-key`/`connection()` the way every other scenario
+ * does (the one precedent for a scenario driving its own topology is
+ * `tls-scenario`'s dedicated fixed-port Pebble instance, taken further
+ * here: this scenario owns its ENTIRE cluster, brings it up, mints its own
+ * credentials, asserts against it, tears it down).
+ *
+ * Steps:
+ *   1. `docker compose up -d --build` the 2-node cluster
+ *      (tools/e2e-multinode-cluster/docker-compose.yml — a trimmed,
+ *      re-subnetted clone of tools/dev-cluster/docker-compose.yml; see that
+ *      file's own header comment for why it's safe to run alongside a real
+ *      dev-cluster instance).
+ *   2. poll `docker inspect` for the control-plane container's health
+ *      status until `healthy` — first boot compiles the full Rust
+ *      workspace from source inside the container, so this is bounded by a
+ *      generous `--build-timeout` (default 30 min), not the usual
+ *      30s-90s window other scenarios use.
+ *   3. mint an admin API key directly from the DB
+ *      (`docker exec ... temps api-key --database-url=...`), the same
+ *      DB-direct minting pattern `db-apikey.ts`/`rbac-scenario` use — this
+ *      works because `role-control-plane.sh`'s `temps setup --auto`
+ *      guarantees `admin@local.dev` exists by the time the healthcheck
+ *      passes.
+ *   4. build `cfg = { url: 'http://localhost:18180', apiKey }` and drive
+ *      everything from here on through the normal `@temps-sdk/api` client,
+ *      same as every other scenario.
+ *   5. poll `GET /internal/nodes` until a node named `worker-1` (the
+ *      `WORKER_NAME` the compose file sets) appears with `status: "active"`
+ *      — this is the real proof `POST /internal/nodes/register` completed
+ *      a genuine mTLS-registered join, not a mocked one. Bounded by the
+ *      same generous timeout: the worker ALSO compiles its own binary from
+ *      scratch on first boot.
+ *   6. create a throwaway project + resolve its production environment.
+ *   7. `PUT .../environments/{id}/settings` with `target_nodes: [worker
+ *      node id]` — pins every future deploy in this environment to the
+ *      worker, never the control plane.
+ *   8. deploy `traefik/whoami:latest` (same image other scenarios in this
+ *      repo already use for basic deploys) and poll it to healthy.
+ *   9. the core assertion: `docker exec` into BOTH containers and confirm
+ *      the deployed container's name shows up in `worker-1`'s `docker ps`
+ *      and NOT in the control plane's. See `ensure_image_on_remote` in
+ *      `crates/temps-deployments/src/jobs/deploy_image.rs` for how this
+ *      actually works without a registry: the control plane's own
+ *      `DockerImageBuilder::save_image` pulls (if needed) and `docker
+ *      save`s the image to a tar, streams it to the worker's agent
+ *      (`POST /agent/images/import`), and the agent `docker load`s it —
+ *      that's why a bare public image tag works here with zero registry
+ *      setup, unlike most other scenarios in this suite that need
+ *      `--registry`.
+ *  10. real HTTP proof of life: hit the deployed app through the
+ *      control-plane's proxy (localhost:18180) with the app's Host header
+ *      and assert a real response body, not just a healthy status field.
+ *  11. drain the worker (`POST /internal/nodes/{id}/drain`), poll
+ *      `GET /internal/nodes/{id}/drain` until `drain_complete`, then
+ *      re-run the same `docker ps` side-channel check on both containers —
+ *      in this 2-node cluster the container has nowhere to go but the
+ *      control plane, so this also implicitly re-tests the `Local`
+ *      fallback scheduling path.
+ *  12. remove the worker node (`DELETE /internal/nodes/{id}`) and confirm
+ *      it's gone from `GET /internal/nodes`.
+ *  13. teardown (in a `finally`, matching every other scenario's
+ *      discipline): `docker compose down` (no `-v`, so the cache volumes —
+ *      cargo registry/git + workspace target/ — survive for a fast
+ *      re-run), then explicitly `docker volume rm` the identity/state
+ *      volumes (postgres data, both containers' `/var/lib/docker` +
+ *      `/var/lib/temps`, the worker's `/root`) so the NEXT run proves a
+ *      genuinely fresh join rather than skipping registration via one of
+ *      the role scripts' own marker files. `--keep` skips all of this —
+ *      unlike every other scenario, that leaves an entire running 2-node
+ *      cluster behind, not just one container.
+ */
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import {
+  updateEnvironmentSettings,
+  deployFromImage,
+  adminListNodes,
+  adminDrainNode,
+  adminDrainStatus,
+  adminRemoveNode,
+} from '@temps-sdk/api'
+import { makeClient, unwrap } from '../lib/client.ts'
+import {
+  createE2eProject,
+  getProductionEnvironment,
+  waitForDeployment,
+  getDeployStatus,
+  resolveLoadTarget,
+  assertNotConsoleFallback,
+  teardown,
+  makeRunId,
+  sleep,
+  pollUntil,
+} from '../lib/flows.ts'
+import type { Client } from '@temps-sdk/api/client'
+
+// apps/temps-e2e/src/commands/ -> repo root is 4 levels up.
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..')
+const DEFAULT_COMPOSE_FILE = path.join(REPO_ROOT, 'tools/e2e-multinode-cluster/docker-compose.yml')
+const COMPOSE_PROJECT = 'temps-e2e-mn'
+const CONTROL_PLANE_CONTAINER = 'temps-e2e-mn-control-plane'
+const WORKER_CONTAINER = 'temps-e2e-mn-worker-1'
+const WORKER_NAME = 'worker-1'
+const CONTROL_PLANE_URL = 'http://localhost:18180'
+const POSTGRES_DIRECT_URL = 'postgres://temps:temps@10.52.0.5:5432/temps'
+const IDENTITY_VOLUMES = [
+  'temps-e2e-mn-postgres-data',
+  'temps-e2e-mn-cp-docker',
+  'temps-e2e-mn-cp-data',
+  'temps-e2e-mn-worker1-docker',
+  'temps-e2e-mn-worker1-data',
+  'temps-e2e-mn-worker1-home',
+]
+
+export interface MultinodeJoinScenarioOptions {
+  composeFile?: string
+  buildTimeout?: string
+  keep?: boolean
+  json?: boolean
+}
+
+interface StepLog {
+  step: string
+  ok: boolean
+  detail?: string
+  ms?: number
+}
+
+interface MultinodeJoinScenarioResult {
+  runId: string
+  ok: boolean
+  workerNodeId?: number
+  steps: StepLog[]
+}
+
+/** Run a subcommand, streaming stdout/stderr line-by-line through onLog; throws on non-zero exit. */
+async function runStreamed(
+  args: string[],
+  onLog: (line: string) => void,
+  what: string,
+): Promise<void> {
+  const proc = Bun.spawn(args, { stdout: 'pipe', stderr: 'pipe' })
+  const pump = async (stream: ReadableStream<Uint8Array>) => {
+    const reader = stream.getReader()
+    const decoder = new TextDecoder()
+    let buf = ''
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buf += decoder.decode(value, { stream: true })
+      const lines = buf.split('\n')
+      buf = lines.pop() ?? ''
+      for (const l of lines) if (l.trim()) onLog(l)
+    }
+    if (buf.trim()) onLog(buf)
+  }
+  await Promise.all([pump(proc.stdout), pump(proc.stderr)])
+  const code = await proc.exited
+  if (code !== 0) {
+    throw new Error(`${what} failed (exit ${code})`)
+  }
+}
+
+/** Run a subcommand to completion and collect its output (no streaming). */
+async function runCaptured(
+  args: string[],
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(args, { stdout: 'pipe', stderr: 'pipe' })
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { code, stdout, stderr }
+}
+
+/** `docker inspect --format '{{.State.Health.Status}}' <name>`. Returns '' if the container doesn't exist yet. */
+async function containerHealthStatus(containerName: string): Promise<string> {
+  const res = await runCaptured([
+    'docker',
+    'inspect',
+    '--format',
+    '{{.State.Health.Status}}',
+    containerName,
+  ])
+  if (res.code !== 0) return ''
+  return res.stdout.trim()
+}
+
+/** `docker exec <container> docker ps --format '{{.Names}}'` — lists container names on that node's OWN Docker daemon (DinD). */
+async function dockerPsNames(containerName: string): Promise<string[]> {
+  const res = await runCaptured(['docker', 'exec', containerName, 'docker', 'ps', '--format', '{{.Names}}'])
+  if (res.code !== 0) {
+    throw new Error(`docker exec ${containerName} docker ps failed: ${res.stderr.trim()}`)
+  }
+  return res.stdout
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+}
+
+export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOptions): Promise<void> {
+  const composeFile = opts.composeFile ?? DEFAULT_COMPOSE_FILE
+  const buildTimeoutMs = Number(opts.buildTimeout ?? '1800000')
+  const json = !!opts.json
+  const log = (msg: string) => {
+    if (!json) process.stderr.write(msg + '\n')
+  }
+  if (!json) log(`Temps multinode-join scenario  ->  dedicated 2-node cluster (${composeFile})`)
+
+  const composeArgs = ['docker', 'compose', '-f', composeFile, '-p', COMPOSE_PROJECT]
+
+  const runId = makeRunId(Date.now())
+  const steps: StepLog[] = []
+  const step = async <T>(name: string, fn: () => Promise<T>): Promise<T> => {
+    const t0 = performance.now()
+    log(`\n▶ ${name}`)
+    try {
+      const r = await fn()
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: true, ms })
+      log(`  ✓ ${name} (${(ms / 1000).toFixed(1)}s)`)
+      return r
+    } catch (e) {
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: false, detail: (e as Error).message, ms })
+      log(`  ✗ ${name}: ${(e as Error).message}`)
+      throw e
+    }
+  }
+
+  let client: Client | undefined
+  let cfg: { url: string; apiKey: string } | undefined
+  const projectIds: number[] = []
+  const deployments: { projectId: number; deploymentId: number }[] = []
+  let workerNodeId: number | undefined
+  let clusterUp = false
+
+  try {
+    await step(
+      `bring up the 2-node cluster (docker compose up -d --build, bounded ${Math.round(buildTimeoutMs / 1000)}s — first-run compile is ~15-20 min, this is NOT hung)`,
+      async () => {
+        const t0 = performance.now()
+        const run = runStreamed(
+          [...composeArgs, 'up', '-d', '--build'],
+          (line) => log(`    [compose] ${line}`),
+          'docker compose up -d --build',
+        )
+        const timeout = sleep(buildTimeoutMs).then(() => {
+          throw new Error(`docker compose up did not finish within ${Math.round(buildTimeoutMs / 1000)}s`)
+        })
+        await Promise.race([run, timeout])
+        clusterUp = true
+        log(`    cluster containers started in ${((performance.now() - t0) / 1000).toFixed(1)}s (images may still be compiling in the background)`)
+      },
+    )
+
+    await step(
+      `wait for control-plane container to report healthy (bounded ${Math.round(buildTimeoutMs / 1000)}s — compiles the full Rust workspace from source on first boot)`,
+      () =>
+        pollUntil(
+          () => containerHealthStatus(CONTROL_PLANE_CONTAINER),
+          (status) => status === 'healthy',
+          {
+            timeoutMs: buildTimeoutMs,
+            intervalMs: 5000,
+            onPoll: (status) => log(`    ...control-plane health=${status || '(container not found yet)'}`),
+            label: 'control-plane container to report health=healthy',
+          },
+        ),
+    )
+
+    const apiKey = await step('mint an admin API key directly from the DB (docker exec ... temps api-key)', async () => {
+      const res = await runCaptured([
+        'docker',
+        'exec',
+        CONTROL_PLANE_CONTAINER,
+        '/usr/local/bin/temps',
+        'api-key',
+        `--database-url=${POSTGRES_DIRECT_URL}`,
+        '--name=e2e-multinode',
+        '--role=admin',
+        '--user-email=admin@local.dev',
+        '--output-format=json',
+      ])
+      if (res.code !== 0) {
+        throw new Error(`temps api-key exited ${res.code}\nstdout: ${res.stdout}\nstderr: ${res.stderr}`)
+      }
+      const jsonStart = res.stdout.indexOf('{')
+      if (jsonStart === -1) {
+        throw new Error(`temps api-key produced no JSON on stdout:\n${res.stdout}`)
+      }
+      let parsed: { api_key: string }
+      try {
+        parsed = JSON.parse(res.stdout.slice(jsonStart))
+      } catch (e) {
+        throw new Error(`temps api-key produced unparsable JSON: ${(e as Error).message}\nstdout: ${res.stdout}`)
+      }
+      return parsed.api_key
+    })
+
+    cfg = { url: CONTROL_PLANE_URL, apiKey }
+    client = makeClient(cfg)
+    log(`  cfg: ${cfg.url}`)
+
+    workerNodeId = await step(
+      `wait for worker '${WORKER_NAME}' to register + go active (bounded ${Math.round(buildTimeoutMs / 1000)}s — the worker also compiles its own binary from scratch)`,
+      async () => {
+        const node = await pollUntil(
+          async () => {
+            const res = await adminListNodes({ client: client! })
+            if (res.error || !res.data) return undefined
+            return res.data.nodes.find((n) => n.name === WORKER_NAME)
+          },
+          (n) => n !== undefined && n.status === 'active',
+          {
+            timeoutMs: buildTimeoutMs,
+            intervalMs: 5000,
+            onPoll: (n) => log(`    ...${WORKER_NAME}=${n ? n.status : '(not registered yet)'}`),
+            label: `node '${WORKER_NAME}' to register and report status=active`,
+          },
+        )
+        return node!.id
+      },
+    )
+    log(`  worker node id=${workerNodeId}`)
+
+    const project = await step('create a throwaway project', () =>
+      createE2eProject(client!, { name: `${runId}-mn`, exposedPort: 80 }),
+    )
+    projectIds.push(project.id)
+    log(`  project #${project.id} (${project.slug})`)
+
+    const env = await step('resolve production environment', () => getProductionEnvironment(client!, project.id))
+    log(`  env #${env.id} (${env.name})`)
+
+    await step(`pin deploys to the worker (PUT .../settings target_nodes=[${workerNodeId}])`, async () => {
+      unwrap(
+        await updateEnvironmentSettings({
+          client: client!,
+          path: { project_id: project.id, env_id: env.id },
+          body: { target_nodes: [workerNodeId!] },
+        }),
+        'updateEnvironmentSettings',
+      )
+    })
+
+    const deploymentId = await step('deploy traefik/whoami:latest', () =>
+      deployFromImage({
+        client: client!,
+        path: { project_id: project.id, environment_id: env.id },
+        body: { image_ref: 'traefik/whoami:latest' },
+      }).then((res) => unwrap(res, 'deployFromImage').id),
+    )
+    deployments.push({ projectId: project.id, deploymentId })
+    log(`  deployment #${deploymentId}`)
+
+    await step('wait for deployment (real docker save/tar transfer to the worker agent, no registry needed)', () =>
+      waitForDeployment(client!, {
+        projectId: project.id,
+        deploymentId,
+        timeoutMs: 300_000,
+        onPoll: (s) => log(`    ...${s.state}`),
+      }),
+    )
+
+    await step('confirm deployment did not fail', async () => {
+      const s = await getDeployStatus(client!, project.id, deploymentId)
+      if (!s.ok) throw new Error(`deployment ${deploymentId} is in state "${s.state}"`)
+    })
+
+    await step("assert the container landed on worker-1's own Docker daemon, NOT the control plane's", async () => {
+      // The deployment API reports "healthy" once the proxy route is
+      // registered, which can land a moment before the container is
+      // actually created/started on the REMOTE worker's own Docker daemon
+      // (image transfer + docker load/create/start all happen after the
+      // route is wired) -- so this polls briefly rather than checking once.
+      let workerContainers: string[] = []
+      let cpContainers: string[] = []
+      await pollUntil(
+        async () => {
+          ;[workerContainers, cpContainers] = await Promise.all([
+            dockerPsNames(WORKER_CONTAINER),
+            dockerPsNames(CONTROL_PLANE_CONTAINER),
+          ])
+          return workerContainers.some((n) => n.includes(runId))
+        },
+        (found) => found,
+        {
+          timeoutMs: 20_000,
+          intervalMs: 1000,
+          onPoll: (found) => log(`    ...container on worker-1=${found}`),
+          label: "deployment container to appear on worker-1's docker ps",
+        },
+      )
+      const onControlPlane = cpContainers.some((n) => n.includes(runId))
+      if (onControlPlane) {
+        throw new Error(
+          `deployment container unexpectedly found on the control plane's docker ps (containers: ${cpContainers.join(', ') || '(none)'}) -- target_nodes pinning did not take effect`,
+        )
+      }
+      log(`  worker-1 docker ps: ${workerContainers.join(', ')}`)
+    })
+
+    const target = resolveLoadTarget(cfg.url, env.mainUrl)
+    await step('real HTTP proof of life through the control-plane proxy', async () => {
+      await assertNotConsoleFallback({ url: target.url, headers: target.headers, timeoutMs: 60_000 })
+      const res = await fetch(target.url, { headers: target.headers })
+      const body = await res.text()
+      if (res.status !== 200 || !body.includes('Hostname')) {
+        throw new Error(
+          `expected a real traefik/whoami response (status 200, body containing "Hostname"), got HTTP ${res.status}: ${body.slice(0, 200)}`,
+        )
+      }
+    })
+
+    await step('drain the worker', async () => {
+      unwrap(
+        await adminDrainNode({ client: client!, path: { node_id: workerNodeId! } }),
+        'adminDrainNode',
+      )
+    })
+
+    await step('poll drain status until complete', () =>
+      pollUntil(
+        async () =>
+          unwrap(
+            await adminDrainStatus({ client: client!, path: { node_id: workerNodeId! } }),
+            'adminDrainStatus',
+          ),
+        (s) => s.drain_complete,
+        {
+          timeoutMs: 180_000,
+          intervalMs: 3000,
+          onPoll: (s) => log(`    ...drain_complete=${s.drain_complete} remaining=${s.remaining_containers}`),
+          label: 'drain to complete',
+        },
+      ),
+    )
+
+    await step('confirm the container migrated off the worker (2-node cluster: only place left is the control plane)', async () => {
+      const [workerContainers, cpContainers] = await Promise.all([
+        dockerPsNames(WORKER_CONTAINER),
+        dockerPsNames(CONTROL_PLANE_CONTAINER),
+      ])
+      const onWorker = workerContainers.some((n) => n.includes(runId))
+      if (onWorker) {
+        throw new Error(
+          `deployment container still present on worker-1's docker ps after drain (containers: ${workerContainers.join(', ')})`,
+        )
+      }
+      log(`  post-drain: worker-1=[${workerContainers.join(', ')}] control-plane=[${cpContainers.join(', ')}]`)
+    })
+
+    await step('remove the worker node', async () => {
+      unwrap(
+        await adminRemoveNode({ client: client!, path: { node_id: workerNodeId! } }),
+        'adminRemoveNode',
+      )
+    })
+
+    await step('confirm the node is gone from GET /internal/nodes', async () => {
+      const res = unwrap(await adminListNodes({ client: client! }), 'adminListNodes')
+      if (res.nodes.some((n) => n.id === workerNodeId)) {
+        throw new Error(`node ${workerNodeId} still present in GET /internal/nodes after DELETE`)
+      }
+    })
+  } catch {
+    // Failure already recorded in `steps`; fall through to teardown.
+  } finally {
+    if (opts.keep) {
+      log(`\n(kept: entire 2-node cluster left running -- 'docker compose -f ${composeFile} -p ${COMPOSE_PROJECT} down' to stop it)`)
+    } else {
+      // Best-effort SDK-level teardown first (project/deployments), then tear
+      // down the cluster itself.
+      if (client) {
+        const td = await teardown(client, { deployments, projectIds })
+        log(
+          `\n▶ teardown: tore down ${td.teardownDeployments} deployment(s), deleted ${td.deletedProjects} project(s)` +
+            (td.errors.length ? ` (${td.errors.length} errors)` : ''),
+        )
+        for (const e of td.errors) log(`    ! ${e}`)
+      }
+      if (clusterUp) {
+        log('\n▶ teardown: docker compose down (preserving cache volumes for a fast re-run)')
+        try {
+          await runStreamed(
+            [...composeArgs, 'down'],
+            (line) => log(`    [compose] ${line}`),
+            'docker compose down',
+          )
+        } catch (e) {
+          log(`    ! docker compose down failed: ${(e as Error).message}`)
+        }
+        log('▶ teardown: removing identity/state volumes so the next run proves a genuinely fresh join')
+        for (const vol of IDENTITY_VOLUMES) {
+          const res = await runCaptured(['docker', 'volume', 'rm', '-f', vol])
+          if (res.code !== 0) {
+            log(`    ! docker volume rm ${vol} failed: ${res.stderr.trim()}`)
+          }
+        }
+      }
+    }
+  }
+
+  const ok = steps.length > 0 && steps.every((s) => s.ok)
+  const result: MultinodeJoinScenarioResult = { runId, ok, workerNodeId, steps }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+  } else {
+    log(`\n${ok ? '✅ multinode-join-scenario PASSED' : '❌ multinode-join-scenario FAILED'}`)
+  }
+  if (!ok) process.exitCode = 1
+}

--- a/apps/temps-e2e/src/commands/multinode-join-scenario.ts
+++ b/apps/temps-e2e/src/commands/multinode-join-scenario.ts
@@ -1,5 +1,5 @@
 /**
- * The first-ever e2e test for temps's multi-node/WireGuard clustering
+ * The first-ever e2e test for temps's direct-underlay multi-node clustering
  * feature. Nothing tests this today — only Rust unit tests with
  * MockDatabase (`crates/temps-deployments/tests/multinode_integration_test.rs`)
  * and a manual, non-automated dev tool (`tools/dev-cluster/`).
@@ -9,8 +9,8 @@
  * skill) and drives it over HTTP. This one can't: it has to prove a SECOND,
  * genuinely separate node (its own Docker daemon, its own binary, its own
  * network identity) joins the first node's mesh — that needs its own
- * Docker-in-Docker (DinD) 2-node cluster with real WireGuard/mTLS
- * registration, exactly what `tools/dev-cluster/` already proves works,
+ * Docker-in-Docker (DinD) 2-node cluster with real single-use enrollment and
+ * mTLS registration. WireGuard relay enrollment remains a separate topology,
  * just not automated or asserted against. So this scenario does NOT use the
  * global `--url`/`--api-key`/`connection()` the way every other scenario
  * does (the one precedent for a scenario driving its own topology is
@@ -41,7 +41,9 @@
  *   5. poll `GET /internal/nodes` until a node named `worker-1` (the
  *      `WORKER_NAME` the compose file sets) appears with `status: "active"`
  *      — this is the real proof `POST /internal/nodes/register` completed
- *      a genuine mTLS-registered join, not a mocked one. Bounded by the
+ *      a genuine mTLS-registered join, not a mocked one, then assert that the
+ *      stored node endpoint is HTTPS, cert material exists, legacy enrollment
+ *      is disabled, and the single-use token was consumed. Bounded by the
  *      same generous timeout: the worker ALSO compiles its own binary from
  *      scratch on first boot.
  *   6. create a throwaway project + resolve its production environment.
@@ -103,7 +105,6 @@ import {
   assertNotConsoleFallback,
   teardown,
   makeRunId,
-  sleep,
   pollUntil,
 } from '../lib/flows.ts'
 import type { Client } from '@temps-sdk/api/client'
@@ -124,6 +125,7 @@ const IDENTITY_VOLUMES = [
   'temps-e2e-mn-worker1-docker',
   'temps-e2e-mn-worker1-data',
   'temps-e2e-mn-worker1-home',
+  'temps-e2e-mn-bootstrap-state',
 ]
 
 export interface MultinodeJoinScenarioOptions {
@@ -152,8 +154,16 @@ async function runStreamed(
   args: string[],
   onLog: (line: string) => void,
   what: string,
+  timeoutMs?: number,
 ): Promise<void> {
   const proc = Bun.spawn(args, { stdout: 'pipe', stderr: 'pipe' })
+  let timedOut = false
+  const timeout = timeoutMs === undefined
+    ? undefined
+    : setTimeout(() => {
+        timedOut = true
+        proc.kill()
+      }, timeoutMs)
   const pump = async (stream: ReadableStream<Uint8Array>) => {
     const reader = stream.getReader()
     const decoder = new TextDecoder()
@@ -168,8 +178,11 @@ async function runStreamed(
     }
     if (buf.trim()) onLog(buf)
   }
-  await Promise.all([pump(proc.stdout), pump(proc.stderr)])
-  const code = await proc.exited
+  const [, , code] = await Promise.all([pump(proc.stdout), pump(proc.stderr), proc.exited])
+  if (timeout !== undefined) clearTimeout(timeout)
+  if (timedOut) {
+    throw new Error(`${what} did not finish within ${Math.round(timeoutMs! / 1000)}s and was terminated`)
+  }
   if (code !== 0) {
     throw new Error(`${what} failed (exit ${code})`)
   }
@@ -216,6 +229,9 @@ async function dockerPsNames(containerName: string): Promise<string[]> {
 export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOptions): Promise<void> {
   const composeFile = opts.composeFile ?? DEFAULT_COMPOSE_FILE
   const buildTimeoutMs = Number(opts.buildTimeout ?? '1800000')
+  if (!Number.isFinite(buildTimeoutMs) || buildTimeoutMs <= 0) {
+    throw new Error(`--build-timeout must be a positive number of milliseconds, got "${opts.buildTimeout}"`)
+  }
   const json = !!opts.json
   const log = (msg: string) => {
     if (!json) process.stderr.write(msg + '\n')
@@ -248,23 +264,47 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
   const projectIds: number[] = []
   const deployments: { projectId: number; deploymentId: number }[] = []
   let workerNodeId: number | undefined
-  let clusterUp = false
+  let clusterStartAttempted = false
+  const revokeTemporaryApiKey = async () => {
+    if (!clusterStartAttempted) return
+    const revoke = await runCaptured([
+      'docker',
+      'exec',
+      'temps-e2e-mn-postgres',
+      'psql',
+      '-U',
+      'temps',
+      '-d',
+      'temps',
+      '-c',
+      "UPDATE api_keys SET is_active = false, updated_at = now() WHERE name = 'e2e-multinode' AND is_active = true",
+    ])
+    if (revoke.code !== 0) log('    ! temporary API-key revocation failed; cluster teardown will remove its database')
+  }
 
   try {
+    await step('remove any stale multinode E2E topology and identity state', async () => {
+      const down = await runCaptured([...composeArgs, 'down'])
+      if (down.code !== 0) {
+        throw new Error(`preflight docker compose down failed: ${down.stderr.trim()}`)
+      }
+      for (const volume of IDENTITY_VOLUMES) {
+        // Missing volumes are expected on a genuinely fresh run.
+        await runCaptured(['docker', 'volume', 'rm', '-f', volume])
+      }
+    })
+
     await step(
       `bring up the 2-node cluster (docker compose up -d --build, bounded ${Math.round(buildTimeoutMs / 1000)}s — first-run compile is ~15-20 min, this is NOT hung)`,
       async () => {
         const t0 = performance.now()
-        const run = runStreamed(
+        clusterStartAttempted = true
+        await runStreamed(
           [...composeArgs, 'up', '-d', '--build'],
           (line) => log(`    [compose] ${line}`),
           'docker compose up -d --build',
+          buildTimeoutMs,
         )
-        const timeout = sleep(buildTimeoutMs).then(() => {
-          throw new Error(`docker compose up did not finish within ${Math.round(buildTimeoutMs / 1000)}s`)
-        })
-        await Promise.race([run, timeout])
-        clusterUp = true
         log(`    cluster containers started in ${((performance.now() - t0) / 1000).toFixed(1)}s (images may still be compiling in the background)`)
       },
     )
@@ -298,17 +338,17 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
         '--output-format=json',
       ])
       if (res.code !== 0) {
-        throw new Error(`temps api-key exited ${res.code}\nstdout: ${res.stdout}\nstderr: ${res.stderr}`)
+        throw new Error(`temps api-key exited ${res.code}; credential-bearing output suppressed`)
       }
       const jsonStart = res.stdout.indexOf('{')
       if (jsonStart === -1) {
-        throw new Error(`temps api-key produced no JSON on stdout:\n${res.stdout}`)
+        throw new Error('temps api-key produced no JSON; credential-bearing output suppressed')
       }
       let parsed: { api_key: string }
       try {
         parsed = JSON.parse(res.stdout.slice(jsonStart))
       } catch (e) {
-        throw new Error(`temps api-key produced unparsable JSON: ${(e as Error).message}\nstdout: ${res.stdout}`)
+        throw new Error(`temps api-key produced unparsable JSON: ${(e as Error).message}; credential-bearing output suppressed`)
       }
       return parsed.api_key
     })
@@ -326,18 +366,60 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
             if (res.error || !res.data) return undefined
             return res.data.nodes.find((n) => n.name === WORKER_NAME)
           },
-          (n) => n !== undefined && n.status === 'active',
+          // `temps join` creates the node before the agent has started with
+          // its issued leaf certificate. The first agent heartbeat upgrades
+          // the provisional HTTP address to its final HTTPS endpoint, so wait
+          // for both states instead of racing that hand-off.
+          (n) => n !== undefined && n.status === 'active' && n.address.startsWith('https://'),
           {
             timeoutMs: buildTimeoutMs,
             intervalMs: 5000,
-            onPoll: (n) => log(`    ...${WORKER_NAME}=${n ? n.status : '(not registered yet)'}`),
-            label: `node '${WORKER_NAME}' to register and report status=active`,
+            onPoll: (n) =>
+              log(
+                `    ...${WORKER_NAME}=${n ? `${n.status} ${n.address}` : '(not registered yet)'}`,
+              ),
+            label: `node '${WORKER_NAME}' to register, report active, and publish its HTTPS agent endpoint`,
           },
         )
         return node!.id
       },
     )
     log(`  worker node id=${workerNodeId}`)
+
+    await step('verify worker registration negotiated mTLS', async () => {
+      const nodes = unwrap(await adminListNodes({ client: client! }), 'adminListNodes')
+      const worker = nodes.nodes.find((node) => node.id === workerNodeId)
+      if (!worker?.address.startsWith('https://')) {
+        throw new Error(`worker address is ${worker?.address ?? '(missing)'}, expected an https:// mTLS endpoint`)
+      }
+      const certCheck = await runCaptured([
+        'docker',
+        'exec',
+        WORKER_CONTAINER,
+        'bash',
+        '-c',
+        'test -s /root/.temps/node.cert.pem && test -s /root/.temps/node.key.pem && test -s /root/.temps/cluster-ca.pem',
+      ])
+      if (certCheck.code !== 0) {
+        throw new Error('worker did not persist its mTLS leaf, private key, and cluster CA')
+      }
+      const posture = await runCaptured([
+        'docker',
+        'exec',
+        'temps-e2e-mn-postgres',
+        'psql',
+        '-At',
+        '-U',
+        'temps',
+        '-d',
+        'temps',
+        '-c',
+        "SELECT data::jsonb->'multi_node'->>'require_mtls', data::jsonb->'multi_node'->>'legacy_shared_token_enabled', used_count, max_uses FROM settings CROSS JOIN node_enrollment_tokens WHERE settings.id = 1",
+      ])
+      if (posture.code !== 0 || posture.stdout.trim() !== 'true|false|1|1') {
+        throw new Error(`unexpected enrollment posture: ${posture.stdout.trim() || posture.stderr.trim() || '(no output)'}`)
+      }
+    })
 
     const project = await step('create a throwaway project', () =>
       createE2eProject(client!, { name: `${runId}-mn`, exposedPort: 80 }),
@@ -453,17 +535,49 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
     )
 
     await step('confirm the container migrated off the worker (2-node cluster: only place left is the control plane)', async () => {
-      const [workerContainers, cpContainers] = await Promise.all([
-        dockerPsNames(WORKER_CONTAINER),
-        dockerPsNames(CONTROL_PLANE_CONTAINER),
-      ])
+      // `drain_complete` means the source node has no remaining containers
+      // and is safe to remove. The replacement deployment is queued
+      // asynchronously, so its Docker container can appear a few seconds
+      // later. Poll the actual data plane instead of racing that queue.
+      let workerContainers: string[] = []
+      let cpContainers: string[] = []
+      await pollUntil(
+        async () => {
+          ;[workerContainers, cpContainers] = await Promise.all([
+            dockerPsNames(WORKER_CONTAINER),
+            dockerPsNames(CONTROL_PLANE_CONTAINER),
+          ])
+          return {
+            onWorker: workerContainers.some((n) => n.includes(runId)),
+            onControlPlane: cpContainers.some((n) => n.includes(runId)),
+          }
+        },
+        (placement) => !placement.onWorker && placement.onControlPlane,
+        {
+          timeoutMs: 60_000,
+          intervalMs: 1000,
+          onPoll: (placement) =>
+            log(
+              `    ...post-drain placement worker=${placement.onWorker} control-plane=${placement.onControlPlane}`,
+            ),
+          label: 'replacement container to become visible on the control plane after drain',
+        },
+      )
       const onWorker = workerContainers.some((n) => n.includes(runId))
+      const onControlPlane = cpContainers.some((n) => n.includes(runId))
       if (onWorker) {
         throw new Error(
           `deployment container still present on worker-1's docker ps after drain (containers: ${workerContainers.join(', ')})`,
         )
       }
+      if (!onControlPlane) {
+        throw new Error(
+          `deployment container was not recreated on the control plane after drain (containers: ${cpContainers.join(', ') || '(none)'})`,
+        )
+      }
       log(`  post-drain: worker-1=[${workerContainers.join(', ')}] control-plane=[${cpContainers.join(', ')}]`)
+
+      await assertNotConsoleFallback({ url: target.url, headers: target.headers, timeoutMs: 60_000 })
     })
 
     await step('remove the worker node', async () => {
@@ -471,6 +585,20 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
         await adminRemoveNode({ client: client!, path: { node_id: workerNodeId! } }),
         'adminRemoveNode',
       )
+    })
+
+    await step('reject replay of the consumed enrollment token after node removal', async () => {
+      const replay = await runCaptured([
+        'docker',
+        'exec',
+        WORKER_CONTAINER,
+        'bash',
+        '-c',
+        'read -r token < /run/temps-bootstrap/join_token.txt; TEMPS_JOIN_TOKEN="$token" /usr/local/bin/temps join http://10.52.0.10:80 "$token" --name worker-1 --private-address 10.52.0.21 --agent-address 0.0.0.0:3100',
+      ])
+      if (replay.code === 0) {
+        throw new Error('consumed single-use enrollment token unexpectedly registered the removed node again')
+      }
     })
 
     await step('confirm the node is gone from GET /internal/nodes', async () => {
@@ -483,6 +611,7 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
     // Failure already recorded in `steps`; fall through to teardown.
   } finally {
     if (opts.keep) {
+      await revokeTemporaryApiKey()
       log(`\n(kept: entire 2-node cluster left running -- 'docker compose -f ${composeFile} -p ${COMPOSE_PROJECT} down' to stop it)`)
     } else {
       // Best-effort SDK-level teardown first (project/deployments), then tear
@@ -495,7 +624,8 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
         )
         for (const e of td.errors) log(`    ! ${e}`)
       }
-      if (clusterUp) {
+      await revokeTemporaryApiKey()
+      if (clusterStartAttempted) {
         log('\n▶ teardown: docker compose down (preserving cache volumes for a fast re-run)')
         try {
           await runStreamed(

--- a/apps/temps-e2e/src/index.ts
+++ b/apps/temps-e2e/src/index.ts
@@ -33,6 +33,7 @@ import { pgUpgradeScenarioCommand } from './commands/pg-upgrade-scenario.ts'
 import { mariadbRestoreScenarioCommand } from './commands/mariadb-restore-scenario.ts'
 import { envVarsScenarioCommand } from './commands/env-vars-scenario.ts'
 import { apiKeyScenarioCommand } from './commands/api-key-scenario.ts'
+import { multinodeJoinScenarioCommand } from './commands/multinode-join-scenario.ts'
 
 const program = new Command()
 
@@ -488,6 +489,25 @@ program
   .option('--json', 'machine-readable output')
   .action(async (opts) => {
     await apiKeyScenarioCommand({ ...opts, connection: connection() })
+  })
+
+program
+  .command('multinode-join-scenario')
+  .description(
+    'Real multi-node/WireGuard clustering proof: brings up its OWN dedicated 2-node DinD cluster ' +
+      '(tools/e2e-multinode-cluster/, not the shared instance -- no --url/--api-key), waits for a real ' +
+      'worker to register via POST /internal/nodes/register, pins a deployment to it via target_nodes, ' +
+      'proves the container actually landed on the worker (not the control plane) via a docker-exec side ' +
+      'channel, drains the worker, and removes it from the cluster -- the first e2e coverage this feature ' +
+      'has ever had. First run compiles the temps binary from source TWICE (once per node) inside Docker, ' +
+      'so budget 15-20+ minutes; subsequent runs are fast (cargo/target caches persist across runs).',
+  )
+  .option('--compose-file <path>', 'path to the cluster docker-compose.yml', undefined)
+  .option('--build-timeout <ms>', 'max wait for the cluster/worker to come up (real cargo build inside Docker)', '1800000')
+  .option('--keep', 'do not tear down the cluster (leaves the entire 2-node cluster running, not just one container)')
+  .option('--json', 'machine-readable output')
+  .action(async (opts) => {
+    await multinodeJoinScenarioCommand(opts)
   })
 
 program.parseAsync().catch((err: unknown) => {

--- a/apps/temps-e2e/src/index.ts
+++ b/apps/temps-e2e/src/index.ts
@@ -494,7 +494,7 @@ program
 program
   .command('multinode-join-scenario')
   .description(
-    'Real multi-node/WireGuard clustering proof: brings up its OWN dedicated 2-node DinD cluster ' +
+    'Real direct-underlay multi-node/mTLS proof: brings up its OWN dedicated 2-node DinD cluster ' +
       '(tools/e2e-multinode-cluster/, not the shared instance -- no --url/--api-key), waits for a real ' +
       'worker to register via POST /internal/nodes/register, pins a deployment to it via target_nodes, ' +
       'proves the container actually landed on the worker (not the control plane) via a docker-exec side ' +

--- a/apps/temps-e2e/src/lib/db-apikey.ts
+++ b/apps/temps-e2e/src/lib/db-apikey.ts
@@ -17,6 +17,8 @@ export interface DbApiKeyConfig {
   tempsRoot: string
   /** Postgres URL the `temps` binary can reach directly. */
   databaseUrl: string
+  /** Optional prebuilt binary. Falls back to TEMPS_BIN, then cargo run. */
+  tempsBinary?: string
 }
 
 export interface MintedApiKey {
@@ -25,37 +27,41 @@ export interface MintedApiKey {
   userEmail: string
 }
 
-/** Runs `cargo run --profile fast --bin temps -- api-key ...` and parses the minted key. */
+/** Runs the prebuilt binary (or cargo fallback) and parses the minted key. */
 export async function mintDbApiKey(
   cfg: DbApiKeyConfig,
   opts: { name: string; role: 'admin' | 'user'; userEmail: string; timeoutMs?: number },
 ): Promise<MintedApiKey> {
   const timeoutMs = opts.timeoutMs ?? 120_000
   const cwd = `${cfg.tempsRoot.replace(/\/+$/, '')}/crates/temps-cli`
+  const binary = cfg.tempsBinary ?? process.env.TEMPS_BIN
+  const apiKeyArgs = [
+    'api-key',
+    `--database-url=${cfg.databaseUrl}`,
+    `--name=${opts.name}`,
+    `--role=${opts.role}`,
+    `--user-email=${opts.userEmail}`,
+    '--output-format=json',
+  ]
+  const command = binary
+    ? [binary, ...apiKeyArgs]
+    : [
+        'cargo',
+        'run',
+        '--profile',
+        'fast',
+        '--bin',
+        'temps',
+        '--package',
+        'temps-cli',
+        '--',
+        ...apiKeyArgs,
+      ]
 
-  const proc = Bun.spawn(
-    [
-      'cargo',
-      'run',
-      '--profile',
-      'fast',
-      '--bin',
-      'temps',
-      '--package',
-      'temps-cli',
-      '--',
-      'api-key',
-      `--database-url=${cfg.databaseUrl}`,
-      `--name=${opts.name}`,
-      `--role=${opts.role}`,
-      `--user-email=${opts.userEmail}`,
-      '--output-format=json',
-    ],
-    { cwd, stdout: 'pipe', stderr: 'pipe' },
-  )
+  const proc = Bun.spawn(command, { cwd, stdout: 'pipe', stderr: 'pipe' })
 
   const timer = setTimeout(() => proc.kill(), timeoutMs)
-  const [stdout, stderr, code] = await Promise.all([
+  const [stdout, , code] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
     proc.exited,
@@ -63,21 +69,30 @@ export async function mintDbApiKey(
   clearTimeout(timer)
 
   if (code !== 0) {
-    throw new Error(`temps api-key (${opts.userEmail}) exited ${code}\nstdout: ${stdout}\nstderr: ${stderr}`)
+    throw new Error(
+      `temps api-key (${opts.userEmail}) exited ${code}; credential-bearing stdout/stderr suppressed`,
+    )
   }
 
   // `cargo run` prints build progress to stdout/stderr; the JSON payload is
   // the last well-formed JSON object in stdout.
   const jsonStart = stdout.lastIndexOf('{')
   if (jsonStart === -1) {
-    throw new Error(`temps api-key (${opts.userEmail}) produced no JSON on stdout:\n${stdout}`)
+    throw new Error(
+      `temps api-key (${opts.userEmail}) produced no JSON; credential-bearing stdout suppressed`,
+    )
   }
   let parsed: { api_key: string; user_id: number; user_email: string }
   try {
     parsed = JSON.parse(stdout.slice(jsonStart))
   } catch (e) {
     throw new Error(
-      `temps api-key (${opts.userEmail}) produced unparsable JSON: ${(e as Error).message}\nstdout: ${stdout}`,
+      `temps api-key (${opts.userEmail}) produced unparsable credential output: ${(e as Error).message}; stdout suppressed`,
+    )
+  }
+  if (!parsed.api_key || !parsed.user_id || !parsed.user_email) {
+    throw new Error(
+      `temps api-key (${opts.userEmail}) returned incomplete credential output; stdout suppressed`,
     )
   }
   return { apiKey: parsed.api_key, userId: parsed.user_id, userEmail: parsed.user_email }

--- a/apps/temps-e2e/src/lib/examples.ts
+++ b/apps/temps-e2e/src/lib/examples.ts
@@ -48,7 +48,7 @@ export const EXAMPLES: ExampleProject[] = [
     port: 3000,
     healthPath: '/health',
     weight: 'light',
-    dockerfile: `FROM golang:1.24-alpine AS build
+    dockerfile: `FROM golang:1.25-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
@@ -229,6 +229,7 @@ async function runDocker(
   what: string,
 ): Promise<void> {
   const proc = Bun.spawn(['docker', ...args], { stdout: 'pipe', stderr: 'pipe' })
+  const outputTail: string[] = []
   const pump = async (stream: ReadableStream<Uint8Array>) => {
     const reader = stream.getReader()
     const decoder = new TextDecoder()
@@ -239,13 +240,23 @@ async function runDocker(
       buf += decoder.decode(value, { stream: true })
       const lines = buf.split('\n')
       buf = lines.pop() ?? ''
-      for (const l of lines) if (l.trim()) onLog?.(l)
+      for (const l of lines) {
+        if (!l.trim()) continue
+        onLog?.(l)
+        outputTail.push(l)
+        if (outputTail.length > 40) outputTail.shift()
+      }
     }
-    if (buf.trim()) onLog?.(buf)
+    if (buf.trim()) {
+      onLog?.(buf)
+      outputTail.push(buf)
+      if (outputTail.length > 40) outputTail.shift()
+    }
   }
   await Promise.all([pump(proc.stdout), pump(proc.stderr)])
   const code = await proc.exited
   if (code !== 0) {
-    throw new Error(`${what} failed (exit ${code})`)
+    const detail = outputTail.length ? `\n${outputTail.join('\n')}` : ''
+    throw new Error(`${what} failed (exit ${code})${detail}`)
   }
 }

--- a/apps/temps-e2e/src/lib/flows.ts
+++ b/apps/temps-e2e/src/lib/flows.ts
@@ -677,28 +677,45 @@ export async function registerPebbleDefaultIp(opts?: {
   const network = opts?.network ?? 'temps-e2e-pebble-net'
   const managementUrl = opts?.managementUrl ?? 'http://localhost:8056'
 
-  const proc = Bun.spawn(
-    [
-      'docker',
-      'run',
-      '--rm',
-      '--network',
-      network,
-      'alpine:latest',
-      'getent',
-      'hosts',
-      'host.docker.internal',
-    ],
-    { stdout: 'pipe', stderr: 'pipe' },
-  )
-  const [out, err, code] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ])
-  if (code !== 0) {
-    throw new Error(`failed to resolve host.docker.internal via throwaway container: ${err}`)
+  const resolve = async (extraArgs: string[] = []) => {
+    const proc = Bun.spawn(
+      [
+        'docker',
+        'run',
+        '--rm',
+        '--network',
+        network,
+        ...extraArgs,
+        'alpine:latest',
+        'getent',
+        'hosts',
+        'host.docker.internal',
+      ],
+      { stdout: 'pipe', stderr: 'pipe' },
+    )
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    return { stdout, stderr, code }
   }
+
+  // Docker Desktop defines host.docker.internal automatically. Plain Linux
+  // dockerd (including GitHub-hosted runners) does not, so retry with
+  // host-gateway exactly as the established Playwright E2E preflight does.
+  let resolved = await resolve()
+  if (resolved.code !== 0 || !resolved.stdout.trim()) {
+    resolved = await resolve(['--add-host', 'host.docker.internal:host-gateway'])
+  }
+  if (resolved.code !== 0) {
+    const detail = [resolved.stdout, resolved.stderr].filter((s) => s.trim()).join('\n').trim()
+    throw new Error(
+      `failed to resolve host.docker.internal via throwaway container (exit ${resolved.code})` +
+        (detail ? `: ${detail}` : ''),
+    )
+  }
+  const out = resolved.stdout
   const ip = out.trim().split(/\s+/)[0]
   if (!ip) {
     throw new Error(`could not parse host IP from getent output: ${JSON.stringify(out)}`)

--- a/crates/temps-cli/src/commands/setup.rs
+++ b/crates/temps-cli/src/commands/setup.rs
@@ -608,40 +608,164 @@ async fn verify_cloudflare_token(token: &str) -> anyhow::Result<bool> {
 #[derive(Debug, Clone)]
 pub struct GitHubUserInfo {
     pub username: String,
+    pub identity_warning: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum GitHubTokenVerificationError {
+    #[error(
+        "GitHub rejected the credential as invalid or expired. GitHub said: {provider_message}"
+    )]
+    InvalidCredential { provider_message: String },
+    #[error(
+        "GitHub denied permission to {capability}. Grant '{required_permission}' to the token or GitHub App. GitHub said: {provider_message}"
+    )]
+    PermissionDenied {
+        capability: String,
+        required_permission: String,
+        provider_message: String,
+    },
+    #[error("GitHub API rate limit exhausted while validating the credential. Retry after the limit resets or use a different credential.")]
+    RateLimited,
+    #[error("Could not contact GitHub while validating the credential: {reason}")]
+    RequestFailed { reason: String },
+    #[error("GitHub returned an unexpected response while validating the credential: HTTP {status}. GitHub said: {provider_message}")]
+    Upstream {
+        status: reqwest::StatusCode,
+        provider_message: String,
+    },
+}
+
+fn github_error_message(body: &serde_json::Value) -> String {
+    body.get("message")
+        .and_then(|message| message.as_str())
+        .unwrap_or("no additional details")
+        .to_string()
+}
+
+fn validate_github_token_probe(
+    status: reqwest::StatusCode,
+    rate_limit_remaining: Option<u64>,
+    provider_message: String,
+) -> Result<(), GitHubTokenVerificationError> {
+    match status {
+        status if status.is_success() => Ok(()),
+        reqwest::StatusCode::UNAUTHORIZED => {
+            Err(GitHubTokenVerificationError::InvalidCredential { provider_message })
+        }
+        reqwest::StatusCode::FORBIDDEN if rate_limit_remaining == Some(0) => {
+            Err(GitHubTokenVerificationError::RateLimited)
+        }
+        reqwest::StatusCode::FORBIDDEN => Err(GitHubTokenVerificationError::PermissionDenied {
+            capability: "validate the credential".to_string(),
+            required_permission: "Metadata: read".to_string(),
+            provider_message,
+        }),
+        reqwest::StatusCode::TOO_MANY_REQUESTS => Err(GitHubTokenVerificationError::RateLimited),
+        status => Err(GitHubTokenVerificationError::Upstream {
+            status,
+            provider_message,
+        }),
+    }
+}
+
+fn github_identity_from_response(
+    status: reqwest::StatusCode,
+    body: &serde_json::Value,
+    account_hint: Option<&str>,
+) -> Result<GitHubUserInfo, GitHubTokenVerificationError> {
+    if status.is_success() {
+        let username = body
+            .get("login")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| GitHubTokenVerificationError::Upstream {
+                status,
+                provider_message: "successful /user response did not contain a login".to_string(),
+            })?;
+        return Ok(GitHubUserInfo {
+            username: username.to_string(),
+            identity_warning: None,
+        });
+    }
+
+    match status {
+        reqwest::StatusCode::UNAUTHORIZED => Err(GitHubTokenVerificationError::InvalidCredential {
+            provider_message: github_error_message(body),
+        }),
+        reqwest::StatusCode::FORBIDDEN => {
+            // Repository-scoped and GitHub Actions installation tokens are
+            // valid credentials but cannot call the user-identity endpoint.
+            let username = account_hint
+                .filter(|hint| !hint.trim().is_empty())
+                .unwrap_or("repository-scoped-token")
+                .to_string();
+            Ok(GitHubUserInfo {
+                username,
+                identity_warning: Some(
+                    "GitHub user identity is unavailable for this repository-scoped credential. Repository permissions will be checked per operation."
+                        .to_string(),
+                ),
+            })
+        }
+        reqwest::StatusCode::TOO_MANY_REQUESTS => Err(GitHubTokenVerificationError::RateLimited),
+        status => Err(GitHubTokenVerificationError::Upstream {
+            status,
+            provider_message: github_error_message(body),
+        }),
+    }
 }
 
 async fn verify_github_token(token: &str) -> anyhow::Result<GitHubUserInfo> {
     let client = reqwest::Client::new();
-    let response = client
+    let probe_response = client
+        .get("https://api.github.com/rate_limit")
+        .header("Authorization", format!("Bearer {}", token))
+        .header("User-Agent", "temps-setup")
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+        .map_err(|error| GitHubTokenVerificationError::RequestFailed {
+            reason: error.to_string(),
+        })?;
+
+    let probe_status = probe_response.status();
+    let rate_limit_remaining = probe_response
+        .headers()
+        .get("x-ratelimit-remaining")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse().ok());
+    let probe_body = probe_response
+        .json::<serde_json::Value>()
+        .await
+        .unwrap_or_else(|_| serde_json::json!({}));
+    validate_github_token_probe(
+        probe_status,
+        rate_limit_remaining,
+        github_error_message(&probe_body),
+    )?;
+
+    let identity_response = client
         .get("https://api.github.com/user")
         .header("Authorization", format!("Bearer {}", token))
         .header("User-Agent", "temps-setup")
         .header("Accept", "application/vnd.github+json")
         .send()
         .await
-        .map_err(|e| anyhow::anyhow!("Failed to verify GitHub token: {}", e))?;
+        .map_err(|error| GitHubTokenVerificationError::RequestFailed {
+            reason: error.to_string(),
+        })?;
+    let identity_status = identity_response.status();
+    let identity_body = identity_response
+        .json::<serde_json::Value>()
+        .await
+        .unwrap_or_else(|_| serde_json::json!({}));
+    let account_hint = std::env::var("GITHUB_ACTOR").ok();
 
-    if response.status().is_success() {
-        let json: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to parse GitHub user response: {}", e))?;
-
-        let username = json
-            .get("login")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| anyhow::anyhow!("GitHub response missing 'login' field"))?
-            .to_string();
-
-        Ok(GitHubUserInfo { username })
-    } else {
-        Err(anyhow::anyhow!(
-            "GitHub token is invalid or does not have required permissions (HTTP {}).\n\
-             Required scopes: 'repo' (full access) and 'read:user'.\n\
-             Create a token at: https://github.com/settings/tokens/new",
-            response.status()
-        ))
-    }
+    Ok(github_identity_from_response(
+        identity_status,
+        &identity_body,
+        account_hint.as_deref(),
+    )?)
 }
 
 /// Auto-detect the server's public IP address using external services
@@ -1664,10 +1788,10 @@ impl SetupCommand {
 
             println!("   Verifying GitHub token...");
             let github_user = rt.block_on(verify_github_token(github_token))?;
-            print_success(&format!(
-                "GitHub token verified (user: {})",
-                github_user.username
-            ));
+            print_success(&format!("GitHub token verified ({})", github_user.username));
+            if let Some(warning) = github_user.identity_warning.as_deref() {
+                print_warning(warning);
+            }
 
             let git_result = rt.block_on(create_git_provider(
                 db.as_ref(),
@@ -2854,6 +2978,89 @@ fn finish_setup(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn repository_scoped_github_token_does_not_require_user_identity() {
+        validate_github_token_probe(
+            reqwest::StatusCode::OK,
+            Some(4_999),
+            "no additional details".to_string(),
+        )
+        .expect("the token-compatible probe should accept the credential");
+
+        let identity = github_identity_from_response(
+            reqwest::StatusCode::FORBIDDEN,
+            &serde_json::json!({"message": "Resource not accessible by integration"}),
+            Some("ci-actor"),
+        )
+        .expect("missing user identity must not invalidate a repository-scoped token");
+
+        assert_eq!(identity.username, "ci-actor");
+        assert!(identity
+            .identity_warning
+            .as_deref()
+            .is_some_and(|warning| warning.contains("Repository permissions will be checked")));
+    }
+
+    #[test]
+    fn github_token_probe_distinguishes_permission_and_rate_limit_failures() {
+        let denied = validate_github_token_probe(
+            reqwest::StatusCode::FORBIDDEN,
+            Some(4_999),
+            "Resource not accessible by integration".to_string(),
+        )
+        .expect_err("a non-rate-limited 403 must be a permission error");
+        assert!(matches!(
+            denied,
+            GitHubTokenVerificationError::PermissionDenied { .. }
+        ));
+        assert!(denied.to_string().contains("Metadata: read"));
+
+        let limited = validate_github_token_probe(
+            reqwest::StatusCode::FORBIDDEN,
+            Some(0),
+            "API rate limit exceeded".to_string(),
+        )
+        .expect_err("an exhausted rate-limit response must stay distinct");
+        assert!(matches!(limited, GitHubTokenVerificationError::RateLimited));
+    }
+
+    #[test]
+    fn github_token_probe_reports_invalid_credentials_without_scope_claims() {
+        let error = validate_github_token_probe(
+            reqwest::StatusCode::UNAUTHORIZED,
+            None,
+            "Bad credentials".to_string(),
+        )
+        .expect_err("401 must reject the credential");
+
+        let message = error.to_string();
+        assert!(message.contains("invalid or expired"));
+        assert!(message.contains("Bad credentials"));
+        assert!(!message.contains("repo' (full access)"));
+    }
+
+    #[test]
+    fn github_identity_probe_does_not_hide_upstream_or_rate_limit_failures() {
+        let upstream = github_identity_from_response(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            &serde_json::json!({"message": "server error"}),
+            Some("ci-actor"),
+        )
+        .expect_err("an upstream failure must not be presented as verified identity metadata");
+        assert!(matches!(
+            upstream,
+            GitHubTokenVerificationError::Upstream { .. }
+        ));
+
+        let limited = github_identity_from_response(
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            &serde_json::json!({"message": "rate limit"}),
+            Some("ci-actor"),
+        )
+        .expect_err("a rate-limit failure must remain actionable");
+        assert!(matches!(limited, GitHubTokenVerificationError::RateLimited));
+    }
 
     /// Pins the dashed spelling. Reverting this to the dotted form still
     /// compiles and passes every other check, while silently making every

--- a/crates/temps-core/src/jobs.rs
+++ b/crates/temps-core/src/jobs.rs
@@ -51,6 +51,10 @@ pub struct GitPushEventJob {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DeployImageRequestedJob {
     pub project_id: i32,
+    /// Restrict the deployment to one environment. `None` preserves the
+    /// project-wide template/import behavior for older queued jobs.
+    #[serde(default)]
+    pub target_environment_id: Option<i32>,
     /// Docker image reference to pull and run (e.g. "ghcr.io/org/app:latest").
     pub image_ref: String,
     /// Optional HTTP health-check path probed after the container starts.

--- a/crates/temps-deployments/src/handlers/nodes.rs
+++ b/crates/temps-deployments/src/handlers/nodes.rs
@@ -273,7 +273,8 @@ pub struct DrainStatusResponse {
     pub status: String,
     /// Number of containers still on this node
     pub remaining_containers: usize,
-    /// Whether the drain is complete (all containers migrated)
+    /// Whether the source node is empty and safe to remove. Replacement
+    /// deployments may still be converging asynchronously on other nodes.
     pub drain_complete: bool,
     /// Can the node be safely removed?
     pub can_remove: bool,
@@ -2065,7 +2066,7 @@ async fn admin_drain_node(
             // All replicas are on this node — must redeploy to maintain availability
             match app_state
                 .deployment_service
-                .redeploy_environment(dep.project_id, dep.environment_id)
+                .redeploy_environment(dep.project_id, dep.environment_id, dep.deployment_id)
                 .await
             {
                 Ok(_) => {

--- a/crates/temps-deployments/src/jobs/mark_deployment_complete.rs
+++ b/crates/temps-deployments/src/jobs/mark_deployment_complete.rs
@@ -7,8 +7,8 @@
 
 use async_trait::async_trait;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder,
-    QuerySelect, Set,
+    ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, EntityTrait, QueryFilter,
+    QueryOrder, QuerySelect, Set,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -227,7 +227,8 @@ impl MarkDeploymentCompleteJob {
         // graceful stop per container) and doesn't need serialization —
         // the route table already points to the new deployment.
         if result.is_ok() {
-            self.cancel_previous_deployments(environment_id).await;
+            self.cancel_previous_deployments(environment_id, deployment.created_at)
+                .await;
         }
 
         result
@@ -1532,14 +1533,18 @@ impl MarkDeploymentCompleteJob {
     /// teardown passes — bounding this work regardless of how much deployment
     /// history accumulates. The route table already points at the new
     /// deployment (via `environments.current_deployment_id`) before this runs.
-    async fn cancel_previous_deployments(&self, environment_id: i32) {
+    async fn cancel_previous_deployments(
+        &self,
+        environment_id: i32,
+        current_created_at: chrono::DateTime<chrono::Utc>,
+    ) {
         use sea_orm::Set;
 
         self.log("Checking for previous deployments to teardown...".to_string())
             .await
             .ok();
 
-        // Find previous active deployments for this environment (excluding the new one).
+        // Find active deployments that are chronologically older than this one.
         //
         // "failed" is intentionally excluded to preserve error history. Once a
         // deployment is torn down here its state is flipped to "stopped" (see
@@ -1552,9 +1557,21 @@ impl MarkDeploymentCompleteJob {
         // The result is additionally capped (newest-first) so that even a large
         // backlog of un-processed rows can't make a single pass run for minutes;
         // anything beyond the cap is handled by the next deployment's sweep.
+        // Filtering only `id != current` lets a slower older workflow tear down
+        // a newer deployment that completed while the older job was waiting on
+        // route propagation. Compare creation order explicitly; ID is the
+        // deterministic tie-breaker for equal timestamps.
         let previous_deployments = match deployments::Entity::find()
             .filter(deployments::Column::EnvironmentId.eq(environment_id))
-            .filter(deployments::Column::Id.ne(self.deployment_id))
+            .filter(
+                Condition::any()
+                    .add(deployments::Column::CreatedAt.lt(current_created_at))
+                    .add(
+                        Condition::all()
+                            .add(deployments::Column::CreatedAt.eq(current_created_at))
+                            .add(deployments::Column::Id.lt(self.deployment_id)),
+                    ),
+            )
             .filter(deployments::Column::State.is_in(vec![
                 "pending",
                 "running",
@@ -2105,7 +2122,8 @@ mod teardown_tests {
         let deployer = Arc::new(RecordingDeployer::new());
         let job = make_job(db.clone(), new.id, deployer.clone());
 
-        job.cancel_previous_deployments(env.id).await;
+        job.cancel_previous_deployments(env.id, new.created_at)
+            .await;
 
         // The previous deployment is now "stopped" and won't be re-scanned.
         let prev_after = deployments::Entity::find_by_id(prev.id)
@@ -2135,7 +2153,8 @@ mod teardown_tests {
 
         // A second teardown pass finds nothing to do — proving the scan is
         // bounded and "stopped" deployments are not re-processed.
-        job.cancel_previous_deployments(env.id).await;
+        job.cancel_previous_deployments(env.id, new.created_at)
+            .await;
         assert_eq!(
             deployer.stopped.lock().unwrap().len(),
             1,
@@ -2161,7 +2180,8 @@ mod teardown_tests {
 
         let deployer = Arc::new(RecordingDeployer::new());
         let job = make_job(db.clone(), new.id, deployer.clone());
-        job.cancel_previous_deployments(env.id).await;
+        job.cancel_previous_deployments(env.id, new.created_at)
+            .await;
 
         let failed_after = deployments::Entity::find_by_id(failed.id)
             .one(db.as_ref())
@@ -2173,5 +2193,40 @@ mod teardown_tests {
             "failed deployments must be left untouched"
         );
         assert!(deployer.stopped.lock().unwrap().is_empty());
+    }
+
+    /// A slow older completion must never tear down a newer deployment that
+    /// became healthy while the old job was waiting for route propagation.
+    #[tokio::test]
+    async fn test_teardown_from_older_job_preserves_newer_deployment() {
+        let test_db = match TestDatabase::with_migrations().await {
+            Ok(db) => db,
+            Err(_) => {
+                println!("Postgres not available, skipping");
+                return;
+            }
+        };
+        let db = test_db.connection_arc();
+
+        let (project, env) = seed_project_env(&db).await;
+        let old = insert_deployment(&db, project.id, env.id, "old-deploy", "completed").await;
+        insert_container(&db, old.id, "old-container").await;
+        let newer = insert_deployment(&db, project.id, env.id, "newer-deploy", "completed").await;
+        insert_container(&db, newer.id, "newer-container").await;
+
+        let deployer = Arc::new(RecordingDeployer::new());
+        let stale_job = make_job(db.clone(), old.id, deployer.clone());
+        stale_job
+            .cancel_previous_deployments(env.id, old.created_at)
+            .await;
+
+        let newer_after = deployments::Entity::find_by_id(newer.id)
+            .one(db.as_ref())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(newer_after.state, "completed");
+        assert!(deployer.stopped.lock().unwrap().is_empty());
+        assert!(deployer.removed.lock().unwrap().is_empty());
     }
 }

--- a/crates/temps-deployments/src/jobs/node_health_check.rs
+++ b/crates/temps-deployments/src/jobs/node_health_check.rs
@@ -470,7 +470,7 @@ pub async fn failover_offline_nodes(
             if dep.needs_redeploy() {
                 // All replicas were on this node — must redeploy
                 match deployment_service
-                    .redeploy_environment(dep.project_id, dep.environment_id)
+                    .redeploy_environment(dep.project_id, dep.environment_id, dep.deployment_id)
                     .await
                 {
                     Ok(_) => {

--- a/crates/temps-deployments/src/services/job_processor.rs
+++ b/crates/temps-deployments/src/services/job_processor.rs
@@ -75,6 +75,22 @@ pub struct JobProcessorService {
 }
 
 impl JobProcessorService {
+    async fn resolve_image_target_environments(
+        db: &DbConnection,
+        project_id: i32,
+        target_environment_id: Option<i32>,
+    ) -> Result<Vec<temps_entities::environments::Model>, sea_orm::DbErr> {
+        let mut query = temps_entities::environments::Entity::find()
+            .filter(temps_entities::environments::Column::ProjectId.eq(project_id))
+            .filter(temps_entities::environments::Column::DeletedAt.is_null());
+        query = if let Some(environment_id) = target_environment_id {
+            query.filter(temps_entities::environments::Column::Id.eq(environment_id))
+        } else {
+            query.filter(temps_entities::environments::Column::IsPreview.eq(false))
+        };
+        query.all(db).await
+    }
+
     /// Atomically admit a pending deployment only while both owners are active.
     pub(crate) async fn try_admit_deployment(
         db: &DbConnection,
@@ -321,14 +337,15 @@ impl JobProcessorService {
             }
         };
 
-        // Target the project's non-preview (production) environment(s). A fresh
-        // template project has exactly one.
-        let environments = match temps_entities::environments::Entity::find()
-            .filter(temps_entities::environments::Column::ProjectId.eq(job.project_id))
-            .filter(temps_entities::environments::Column::DeletedAt.is_null())
-            .filter(temps_entities::environments::Column::IsPreview.eq(false))
-            .all(db.as_ref())
-            .await
+        // A drain/failover job names the exact affected environment. Legacy
+        // project-wide template/import jobs continue targeting non-preview
+        // environments.
+        let environments = match Self::resolve_image_target_environments(
+            db.as_ref(),
+            job.project_id,
+            job.target_environment_id,
+        )
+        .await
         {
             Ok(envs) => envs,
             Err(e) => {
@@ -342,8 +359,9 @@ impl JobProcessorService {
 
         if environments.is_empty() {
             error!(
-                "DeployImageRequested: project {} has no deployable (non-preview) environment",
-                job.project_id
+                "DeployImageRequested: project {} has no matching deployable environment (target_environment_id={:?})",
+                job.project_id,
+                job.target_environment_id
             );
             return;
         }
@@ -1777,6 +1795,67 @@ mod tests {
             "a deployment denied admission must not receive a start timestamp"
         );
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn image_deployment_target_is_scoped_to_one_environment(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        if !database_integration_tests_available().await {
+            eprintln!("Docker unavailable; skipping image target integration test");
+            return Ok(());
+        }
+
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+        let project = temps_entities::projects::ActiveModel {
+            name: Set("Image Target Project".to_string()),
+            slug: Set("image-target-project".to_string()),
+            repo_owner: Set("temps-e2e".to_string()),
+            repo_name: Set("image-target-project".to_string()),
+            preset: Set(Preset::Dockerfile),
+            directory: Set("/".to_string()),
+            main_branch: Set("main".to_string()),
+            created_at: Set(Utc::now()),
+            updated_at: Set(Utc::now()),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await?;
+
+        let make_environment = |name: &str, slug: &str| temps_entities::environments::ActiveModel {
+            project_id: Set(project.id),
+            name: Set(name.to_string()),
+            slug: Set(slug.to_string()),
+            host: Set(format!("{slug}.example.com")),
+            upstreams: Set(UpstreamList::default()),
+            subdomain: Set(format!("{slug}.example.com")),
+            created_at: Set(Utc::now()),
+            updated_at: Set(Utc::now()),
+            ..Default::default()
+        };
+        let production = make_environment("Production", "production")
+            .insert(db.as_ref())
+            .await?;
+        let staging = make_environment("Staging", "staging")
+            .insert(db.as_ref())
+            .await?;
+
+        let targeted = JobProcessorService::resolve_image_target_environments(
+            db.as_ref(),
+            project.id,
+            Some(staging.id),
+        )
+        .await?;
+        assert_eq!(targeted.len(), 1);
+        assert_eq!(targeted[0].id, staging.id);
+
+        let project_wide =
+            JobProcessorService::resolve_image_target_environments(db.as_ref(), project.id, None)
+                .await?;
+        assert_eq!(project_wide.len(), 2);
+        assert!(project_wide.iter().any(|env| env.id == production.id));
+        assert!(project_wide.iter().any(|env| env.id == staging.id));
         Ok(())
     }
 

--- a/crates/temps-deployments/src/services/node_service.rs
+++ b/crates/temps-deployments/src/services/node_service.rs
@@ -495,7 +495,7 @@ impl NodeService {
 
             tracing::info!(
                 node_id = node_id,
-                "Node drain complete — all containers migrated, status set to drained"
+                "Node drain source cleanup complete — no containers remain, status set to drained"
             );
             return Ok(true);
         }

--- a/crates/temps-deployments/src/services/services.rs
+++ b/crates/temps-deployments/src/services/services.rs
@@ -1416,6 +1416,7 @@ impl DeploymentService {
     pub async fn trigger_image_deployment(
         &self,
         project_id: i32,
+        target_environment_id: Option<i32>,
         image_ref: String,
         health_check_path: Option<String>,
     ) -> Result<(), DeploymentError> {
@@ -1434,6 +1435,7 @@ impl DeploymentService {
             .send(temps_core::Job::DeployImageRequested(
                 temps_core::DeployImageRequestedJob {
                     project_id,
+                    target_environment_id,
                     image_ref,
                     health_check_path,
                 },
@@ -1448,65 +1450,50 @@ impl DeploymentService {
         Ok(())
     }
 
-    /// Redeploy an environment using the context (branch, tag, commit) from its
-    /// latest successful deployment.  Used by node drain and failover — these
-    /// operations need to reschedule existing workloads, not start a fresh
-    /// deployment from scratch.
-    ///
-    /// Falls back to the environment's configured branch when no prior
-    /// deployment exists.
+    /// Redeploy the exact workload affected by node drain or failover.
     pub async fn redeploy_environment(
         &self,
         project_id: i32,
         environment_id: i32,
+        deployment_id: i32,
     ) -> Result<(), DeploymentError> {
-        // Find the most recent deployment for this environment regardless of
-        // state. Node drain/failover can fire seconds after a deploy reports
-        // "running" at the proxy — well before its `deployments.state` row
-        // settles into a terminal value ("deployed"/"completed"/"ready") —
-        // so filtering on terminal states here made this query race the
-        // deployment pipeline's own state transition and silently see no
-        // rows, which fell through to the git-only path below.
-        let latest = deployments::Entity::find()
+        // Use the deployment that owns the affected containers. Selecting the
+        // newest row can race a concurrent failed/cancelled deploy and restore
+        // the wrong workload during failover.
+        let deploy = deployments::Entity::find_by_id(deployment_id)
             .filter(deployments::Column::ProjectId.eq(project_id))
             .filter(deployments::Column::EnvironmentId.eq(environment_id))
-            .order_by_desc(deployments::Column::CreatedAt)
             .one(self.db.as_ref())
             .await
-            .map_err(|e| DeploymentError::Other(e.to_string()))?;
+            .map_err(|e| DeploymentError::Other(format!(
+                "Failed to load deployment {deployment_id} for project {project_id}, environment {environment_id}: {e}"
+            )))?
+            .ok_or_else(|| {
+                DeploymentError::NotFound(format!(
+                    "Deployment {deployment_id} was not found in project {project_id}, environment {environment_id}"
+                ))
+            })?;
 
         // Git-less deployments (docker_image source, e.g. imports or
         // `deployFromImage`) have no branch/tag/commit to rebuild from —
         // `trigger_pipeline` requires `repo_owner`/`repo_name` and fails with
         // "Project repo_owner is missing" for these. Redeploy them from the
         // same image instead, mirroring `trigger_image_deployment`.
-        if let Some(ref deploy) = latest {
-            if let Some(image_ref) = deploy
-                .metadata
-                .as_ref()
-                .and_then(|m| m.external_image_ref.clone())
-            {
-                return self
-                    .trigger_image_deployment(project_id, image_ref, None)
-                    .await;
-            }
+        if let Some(image_ref) = deploy
+            .metadata
+            .as_ref()
+            .and_then(|m| m.external_image_ref.clone())
+        {
+            return self
+                .trigger_image_deployment(project_id, Some(environment_id), image_ref, None)
+                .await;
         }
 
-        let (branch, tag, commit) = if let Some(ref deploy) = latest {
-            (
-                deploy.branch_ref.clone(),
-                deploy.tag_ref.clone(),
-                deploy.commit_sha.clone(),
-            )
-        } else {
-            // No prior deployment — fall back to environment's branch
-            let env = temps_entities::environments::Entity::find_by_id(environment_id)
-                .one(self.db.as_ref())
-                .await
-                .map_err(|e| DeploymentError::Other(e.to_string()))?;
-            let branch = env.and_then(|e| e.branch.filter(|b| !b.is_empty()));
-            (branch, None, None)
-        };
+        let (branch, tag, commit) = (
+            deploy.branch_ref.clone(),
+            deploy.tag_ref.clone(),
+            deploy.commit_sha.clone(),
+        );
 
         self.trigger_pipeline(project_id, environment_id, branch, tag, commit)
             .await
@@ -7143,7 +7130,7 @@ mod tests {
         let deployment_service = create_deployment_service_for_test(db);
 
         let result = deployment_service
-            .trigger_image_deployment(1, String::new(), None)
+            .trigger_image_deployment(1, None, String::new(), None)
             .await;
 
         assert!(matches!(result, Err(DeploymentError::InvalidInput(_))));
@@ -7162,6 +7149,7 @@ mod tests {
         deployment_service
             .trigger_image_deployment(
                 42,
+                Some(7),
                 "ghcr.io/org/app:latest".to_string(),
                 Some("/healthz".to_string()),
             )
@@ -7179,8 +7167,76 @@ mod tests {
         };
 
         assert_eq!(job.project_id, 42);
+        assert_eq!(job.target_environment_id, Some(7));
         assert_eq!(job.image_ref, "ghcr.io/org/app:latest");
         assert_eq!(job.health_check_path.as_deref(), Some("/healthz"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn redeploy_environment_uses_affected_deployment_and_target_environment(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+        let (project, environment, affected, _) = setup_test_deployment(&db).await?;
+
+        let mut affected_active: deployments::ActiveModel = affected.clone().into();
+        affected_active.metadata = Set(Some(temps_entities::deployments::DeploymentMetadata {
+            external_image_ref: Some("registry.example/app:known-good".to_string()),
+            ..Default::default()
+        }));
+        affected_active.update(db.as_ref()).await?;
+
+        // A newer failed deployment must never supersede the workload whose
+        // container is actually being migrated.
+        deployments::ActiveModel {
+            project_id: Set(project.id),
+            environment_id: Set(environment.id),
+            state: Set("failed".to_string()),
+            slug: Set("failed-newer-deployment".to_string()),
+            metadata: Set(Some(temps_entities::deployments::DeploymentMetadata {
+                external_image_ref: Some("registry.example/app:failed".to_string()),
+                ..Default::default()
+            })),
+            created_at: Set(Utc::now() + chrono::Duration::seconds(1)),
+            updated_at: Set(Utc::now() + chrono::Duration::seconds(1)),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await?;
+
+        let service = create_deployment_service_for_test(db);
+        let mut receiver = service.queue_service.subscribe();
+        service
+            .redeploy_environment(project.id, environment.id, affected.id)
+            .await?;
+
+        let job = loop {
+            match receiver.recv().await {
+                Ok(temps_core::Job::DeployImageRequested(job)) => break job,
+                Ok(_) => continue,
+                Err(e) => panic!("queue closed before DeployImageRequested arrived: {}", e),
+            }
+        };
+        assert_eq!(job.project_id, project.id);
+        assert_eq!(job.target_environment_id, Some(environment.id));
+        assert_eq!(job.image_ref, "registry.example/app:known-good");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn redeploy_environment_rejects_deployment_from_another_environment(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let test_db = TestDatabase::with_migrations().await?;
+        let db = test_db.connection_arc();
+        let (project, environment, deployment, _) = setup_test_deployment(&db).await?;
+        let service = create_deployment_service_for_test(db);
+
+        let result = service
+            .redeploy_environment(project.id, environment.id + 1, deployment.id)
+            .await;
+
+        assert!(matches!(result, Err(DeploymentError::NotFound(_))));
         Ok(())
     }
 }

--- a/crates/temps-deployments/src/services/services.rs
+++ b/crates/temps-deployments/src/services/services.rs
@@ -1460,15 +1460,37 @@ impl DeploymentService {
         project_id: i32,
         environment_id: i32,
     ) -> Result<(), DeploymentError> {
-        // Find the latest successful deployment for this environment
+        // Find the most recent deployment for this environment regardless of
+        // state. Node drain/failover can fire seconds after a deploy reports
+        // "running" at the proxy — well before its `deployments.state` row
+        // settles into a terminal value ("deployed"/"completed"/"ready") —
+        // so filtering on terminal states here made this query race the
+        // deployment pipeline's own state transition and silently see no
+        // rows, which fell through to the git-only path below.
         let latest = deployments::Entity::find()
             .filter(deployments::Column::ProjectId.eq(project_id))
             .filter(deployments::Column::EnvironmentId.eq(environment_id))
-            .filter(deployments::Column::State.is_in(vec!["deployed", "completed", "ready"]))
             .order_by_desc(deployments::Column::CreatedAt)
             .one(self.db.as_ref())
             .await
             .map_err(|e| DeploymentError::Other(e.to_string()))?;
+
+        // Git-less deployments (docker_image source, e.g. imports or
+        // `deployFromImage`) have no branch/tag/commit to rebuild from —
+        // `trigger_pipeline` requires `repo_owner`/`repo_name` and fails with
+        // "Project repo_owner is missing" for these. Redeploy them from the
+        // same image instead, mirroring `trigger_image_deployment`.
+        if let Some(ref deploy) = latest {
+            if let Some(image_ref) = deploy
+                .metadata
+                .as_ref()
+                .and_then(|m| m.external_image_ref.clone())
+            {
+                return self
+                    .trigger_image_deployment(project_id, image_ref, None)
+                    .await;
+            }
+        }
 
         let (branch, tag, commit) = if let Some(ref deploy) = latest {
             (

--- a/crates/temps-deployments/src/services/workflow_execution_service.rs
+++ b/crates/temps-deployments/src/services/workflow_execution_service.rs
@@ -2,7 +2,7 @@
 //!
 //! Executes deployment jobs as workflows using the WorkflowExecutor
 
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
+use sea_orm::{ColumnTrait, Condition, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
 use std::sync::Arc;
 use temps_core::{
     Job, JobQueue, WorkflowBuilder, WorkflowCancellationProvider, WorkflowError, WorkflowExecutor,
@@ -845,7 +845,7 @@ impl WorkflowExecutionService {
                     .teardown_previous_deployment(
                         deployment.project_id,
                         deployment.environment_id,
-                        deployment_id,
+                        &deployment,
                     )
                     .await
                 {
@@ -2730,11 +2730,13 @@ impl WorkflowExecutionService {
         &self,
         project_id: i32,
         environment_id: i32,
-        current_deployment_id: i32,
+        current_deployment: &deployments::Model,
     ) -> Result<Option<String>, WorkflowExecutionError> {
         use temps_entities::deployment_containers;
 
-        // Find previous deployments in this environment (excluding the current one).
+        // Find active deployments that are chronologically older than the
+        // current one. An older workflow can finish after a newer workflow;
+        // `id != current` would let it tear the newer deployment back down.
         //
         // Scope this to active states and cap the result, newest-first. This is a
         // safety net that runs in addition to MarkDeploymentCompleteJob's own
@@ -2749,7 +2751,15 @@ impl WorkflowExecutionService {
         let previous_deployments = deployments::Entity::find()
             .filter(deployments::Column::ProjectId.eq(project_id))
             .filter(deployments::Column::EnvironmentId.eq(environment_id))
-            .filter(deployments::Column::Id.ne(current_deployment_id)) // Exclude current deployment
+            .filter(
+                Condition::any()
+                    .add(deployments::Column::CreatedAt.lt(current_deployment.created_at))
+                    .add(
+                        Condition::all()
+                            .add(deployments::Column::CreatedAt.eq(current_deployment.created_at))
+                            .add(deployments::Column::Id.lt(current_deployment.id)),
+                    ),
+            )
             .filter(deployments::Column::State.is_in(vec![
                 "pending",
                 "running",
@@ -4077,6 +4087,34 @@ mod tests {
         .insert(db.as_ref())
         .await?;
 
+        // Simulate a newer deployment completing while this older workflow is
+        // still in its post-success cleanup. It must not be selected as a
+        // "previous" deployment merely because its ID differs.
+        let newer_deployment = deployments::ActiveModel {
+            project_id: Set(project.id),
+            environment_id: Set(environment.id),
+            slug: Set("newer-deployment".to_string()),
+            state: Set("completed".to_string()),
+            metadata: Set(Some(
+                temps_entities::deployments::DeploymentMetadata::default(),
+            )),
+            created_at: Set(Utc::now() + chrono::Duration::minutes(5)),
+            updated_at: Set(Utc::now()),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await?;
+        let newer_container = deployment_containers::ActiveModel {
+            deployment_id: Set(newer_deployment.id),
+            container_id: Set("newer-container-1".to_string()),
+            container_name: Set("newer-container-1".to_string()),
+            container_port: Set(3000),
+            deployed_at: Set(Utc::now()),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await?;
+
         let (queue, _receiver) = temps_queue::BroadcastQueueService::create_broadcast_channel(100);
         let queue = Arc::new(queue) as Arc<dyn temps_core::JobQueue>;
         let git_provider = Arc::new(MockGitProvider);
@@ -4111,7 +4149,7 @@ mod tests {
         );
 
         let stopped_container_id = service
-            .teardown_previous_deployment(project.id, environment.id, current_deployment.id)
+            .teardown_previous_deployment(project.id, environment.id, &current_deployment)
             .await?;
 
         assert_eq!(stopped_container_id, Some("old-container-1".to_string()));
@@ -4122,6 +4160,15 @@ mod tests {
             .expect("container row still exists");
         assert!(refreshed.deleted_at.is_some());
         assert_eq!(refreshed.status.as_deref(), Some("deleted"));
+
+        let newer_refreshed = deployment_containers::Entity::find_by_id(newer_container.id)
+            .one(db.as_ref())
+            .await?
+            .expect("newer container row still exists");
+        assert!(
+            newer_refreshed.deleted_at.is_none(),
+            "an older workflow cleanup must not remove a newer deployment's container"
+        );
 
         Ok(())
     }

--- a/crates/temps-geo/Cargo.toml
+++ b/crates/temps-geo/Cargo.toml
@@ -24,6 +24,7 @@ temps-entities = { path = "../temps-entities" }
 temps-auth = { path = "../temps-auth" }
 utoipa = "5.1"
 tracing = { workspace = true }
+tokio = { version = "1.0", features = ["time"] }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }

--- a/crates/temps-geo/src/geoip_service.rs
+++ b/crates/temps-geo/src/geoip_service.rs
@@ -184,6 +184,35 @@ pub enum GeoIpService {
     Mock(MockGeoIpService),
 }
 
+/// Resolves an mmdb filename the same way `validate_geolite2_database`
+/// (temps-cli's serve startup check) does: current working directory first,
+/// falling back to `TEMPS_DATA_DIR` if the CWD candidate doesn't exist. The
+/// two resolution orders must stay in sync -- when they diverged (this
+/// function previously only checked CWD), `temps serve` could pass its own
+/// startup validation (which checks + downloads to `TEMPS_DATA_DIR`) and
+/// then fail to actually open the database here, because a process whose
+/// working directory isn't its data directory (e.g. any Docker/systemd
+/// deployment that doesn't `cd` into `TEMPS_DATA_DIR` before running) would
+/// have downloaded the file to `TEMPS_DATA_DIR` but only ever looked in CWD.
+pub(crate) fn resolve_mmdb_path(filename: &str) -> std::path::PathBuf {
+    if let Ok(cwd) = std::env::current_dir() {
+        let cwd_path = cwd.join(filename);
+        if cwd_path.exists() {
+            return cwd_path;
+        }
+    }
+    if let Ok(data_dir) = std::env::var("TEMPS_DATA_DIR") {
+        let data_dir_path = std::path::PathBuf::from(data_dir).join(filename);
+        if data_dir_path.exists() {
+            return data_dir_path;
+        }
+    }
+    // Neither exists -- fall back to the CWD path so the resulting error
+    // message names a location relative to where the process was started
+    // (unchanged behavior for the common case of no TEMPS_DATA_DIR set).
+    std::env::current_dir().unwrap_or_default().join(filename)
+}
+
 impl GeoIpService {
     pub fn new() -> Result<Self, GeoIpError> {
         // Check if we should use mock service for local development
@@ -196,7 +225,7 @@ impl GeoIpService {
             return Ok(Self::Mock(MockGeoIpService::new()));
         }
 
-        let db_path = std::env::current_dir()?.join("GeoLite2-City.mmdb");
+        let db_path = resolve_mmdb_path("GeoLite2-City.mmdb");
         debug!("Loading MaxMind database from: {:?}", db_path);
         let reader = maxminddb::Reader::open_readfile(&db_path).map_err(|e| {
             GeoIpError::Other(format!(
@@ -210,7 +239,7 @@ impl GeoIpService {
         // (asn_org/is_hosting_provider stay None) rather than failing startup when
         // the operator hasn't provisioned it, same as the City database's own
         // optional-file convention in Dockerfile/docker-compose.
-        let asn_db_path = std::env::current_dir()?.join("GeoLite2-ASN.mmdb");
+        let asn_db_path = resolve_mmdb_path("GeoLite2-ASN.mmdb");
         let asn_reader = match maxminddb::Reader::open_readfile(&asn_db_path) {
             Ok(reader) => {
                 info!("Loaded MaxMind ASN database from: {:?}", asn_db_path);

--- a/crates/temps-geo/src/geoip_service.rs
+++ b/crates/temps-geo/src/geoip_service.rs
@@ -195,22 +195,25 @@ pub enum GeoIpService {
 /// deployment that doesn't `cd` into `TEMPS_DATA_DIR` before running) would
 /// have downloaded the file to `TEMPS_DATA_DIR` but only ever looked in CWD.
 pub(crate) fn resolve_mmdb_path(filename: &str) -> std::path::PathBuf {
-    if let Ok(cwd) = std::env::current_dir() {
-        let cwd_path = cwd.join(filename);
-        if cwd_path.exists() {
-            return cwd_path;
-        }
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let data_dir = std::env::var_os("TEMPS_DATA_DIR").map(std::path::PathBuf::from);
+    resolve_mmdb_path_from(filename, &cwd, data_dir.as_deref())
+}
+
+fn resolve_mmdb_path_from(
+    filename: &str,
+    cwd: &std::path::Path,
+    data_dir: Option<&std::path::Path>,
+) -> std::path::PathBuf {
+    let cwd_path = cwd.join(filename);
+    if cwd_path.exists() {
+        return cwd_path;
     }
-    if let Ok(data_dir) = std::env::var("TEMPS_DATA_DIR") {
-        let data_dir_path = std::path::PathBuf::from(data_dir).join(filename);
-        if data_dir_path.exists() {
-            return data_dir_path;
-        }
-    }
-    // Neither exists -- fall back to the CWD path so the resulting error
-    // message names a location relative to where the process was started
-    // (unchanged behavior for the common case of no TEMPS_DATA_DIR set).
-    std::env::current_dir().unwrap_or_default().join(filename)
+
+    // When neither file exists yet, prefer the configured data directory:
+    // startup downloads there. Returning the absent CWD candidate would make
+    // the plugin wait loop watch a path that can never receive the download.
+    data_dir.map(|path| path.join(filename)).unwrap_or(cwd_path)
 }
 
 impl GeoIpService {
@@ -452,5 +455,40 @@ mod tests {
     fn test_case_insensitive_match() {
         assert!(is_hosting_org("SUBNET DIGITAL LLC"));
         assert!(is_hosting_org("subnet digital llc"));
+    }
+
+    #[test]
+    fn mmdb_resolution_watches_data_dir_when_download_is_pending() {
+        let unique = format!(
+            "temps-geo-resolution-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock after Unix epoch")
+                .as_nanos()
+        );
+        let cwd = std::env::temp_dir().join(&unique).join("cwd");
+        let data_dir = std::env::temp_dir().join(&unique).join("data");
+
+        assert_eq!(
+            resolve_mmdb_path_from("GeoLite2-City.mmdb", &cwd, Some(&data_dir)),
+            data_dir.join("GeoLite2-City.mmdb")
+        );
+    }
+
+    #[test]
+    fn mmdb_resolution_keeps_existing_cwd_file_precedence() {
+        let root = std::env::temp_dir().join(format!("temps-geo-existing-{}", std::process::id()));
+        let cwd = root.join("cwd");
+        let data_dir = root.join("data");
+        std::fs::create_dir_all(&cwd).expect("create test cwd");
+        let cwd_file = cwd.join("GeoLite2-City.mmdb");
+        std::fs::write(&cwd_file, b"test").expect("write test mmdb placeholder");
+
+        assert_eq!(
+            resolve_mmdb_path_from("GeoLite2-City.mmdb", &cwd, Some(&data_dir)),
+            cwd_file
+        );
+
+        std::fs::remove_dir_all(&root).expect("remove test directories");
     }
 }

--- a/crates/temps-geo/src/plugin.rs
+++ b/crates/temps-geo/src/plugin.rs
@@ -43,6 +43,34 @@ impl TempsPlugin for GeoPlugin {
             // Get required dependencies from the service registry
             let db = context.require_service::<sea_orm::DatabaseConnection>();
 
+            // `temps serve`'s console-API startup path downloads
+            // GeoLite2-City.mmdb in the background (see
+            // `validate_geolite2_database` in temps-cli's serve/console.rs)
+            // concurrently with plugin registration. `GeoIpService::new()`
+            // itself only opens whatever's on disk right now -- it doesn't
+            // download -- so on a fresh instance with no pre-provisioned
+            // database, registration can race the download and fail even
+            // though the file appears moments later. Wait for it (bounded)
+            // before handing off to the sync constructor, unless mock mode
+            // is enabled (which never touches the filesystem).
+            let use_mock = std::env::var("TEMPS_GEO_MOCK")
+                .map(|v| v.to_lowercase() == "true")
+                .unwrap_or(false);
+            if !use_mock {
+                let city_db_path = crate::geoip_service::resolve_mmdb_path("GeoLite2-City.mmdb");
+                if !city_db_path.exists() {
+                    tracing::info!(
+                        path = %city_db_path.display(),
+                        "GeoLite2-City.mmdb not present yet -- waiting up to 30s for the \
+                         concurrent startup download to finish before registering the geo plugin",
+                    );
+                    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+                    while !city_db_path.exists() && tokio::time::Instant::now() < deadline {
+                        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                    }
+                }
+            }
+
             // Create GeoIpService
             let geo_ip_service = Arc::new(GeoIpService::new().map_err(|e| {
                 PluginError::PluginRegistrationFailed {

--- a/crates/temps-git/src/handlers/base.rs
+++ b/crates/temps-git/src/handlers/base.rs
@@ -151,6 +151,19 @@ impl From<GitProviderError> for Problem {
                 .with_type("https://docs.temps.sh/errors/authentication_failed")
                 .with_title("Authentication Failed")
                 .with_detail(msg),
+            GitProviderError::PermissionDenied {
+                operation,
+                required_permission,
+                provider_message,
+            } => problem_new(StatusCode::FORBIDDEN)
+                .with_type("https://docs.temps.sh/errors/git_provider_permission_required")
+                .with_title("Git Provider Permission Required")
+                .with_detail(format!(
+                    "The git provider denied permission to {}. Grant '{}' to the credential for the target repository. Provider response: {}",
+                    operation, required_permission, provider_message
+                ))
+                .with_value("operation", operation)
+                .with_value("required_permission", required_permission),
             GitProviderError::ApiError(msg) => problem_new(StatusCode::BAD_GATEWAY)
                 .with_type("https://docs.temps.sh/errors/api_error")
                 .with_title("API Error")
@@ -2786,6 +2799,9 @@ pub struct ValidationResponse {
     request_body = UpdateTokenRequest,
     responses(
         (status = 200, description = "Token updated successfully", body = UpdateTokenResponse),
+        (status = 400, description = "Invalid token configuration"),
+        (status = 403, description = "Git provider permission required"),
+        (status = 429, description = "Git provider rate limit exceeded"),
         (status = 404, description = "Connection not found"),
         (status = 401, description = "Unauthorized"),
         (status = 500, description = "Internal server error")
@@ -2823,6 +2839,8 @@ pub async fn update_connection_token(
     ),
     responses(
         (status = 200, description = "Connection validation result", body = ValidationResponse),
+        (status = 403, description = "Git provider permission required"),
+        (status = 429, description = "Git provider rate limit exceeded"),
         (status = 404, description = "Connection not found"),
         (status = 401, description = "Unauthorized"),
         (status = 500, description = "Internal server error")
@@ -2896,4 +2914,34 @@ pub async fn run_connection_health_check(
         .await?;
 
     Ok(Json(ConnectionResponse::from(connection)))
+}
+
+#[cfg(test)]
+mod permission_error_tests {
+    use super::*;
+
+    #[test]
+    fn permission_denied_becomes_human_readable_forbidden_problem() {
+        let problem = Problem::from(GitProviderError::PermissionDenied {
+            operation: "list branches for owner/repo".to_string(),
+            required_permission: "Contents: read".to_string(),
+            provider_message: "Resource not accessible by integration".to_string(),
+        });
+
+        assert_eq!(problem.status_code, StatusCode::FORBIDDEN);
+        assert_eq!(
+            problem.body.get("title").and_then(|value| value.as_str()),
+            Some("Git Provider Permission Required")
+        );
+        assert!(problem
+            .body
+            .get("detail")
+            .and_then(|value| value.as_str())
+            .is_some_and(|detail| detail.contains("Contents: read")));
+        assert!(problem
+            .body
+            .get("detail")
+            .and_then(|value| value.as_str())
+            .is_some_and(|detail| detail.contains("Resource not accessible by integration")));
+    }
 }

--- a/crates/temps-git/src/handlers/public.rs
+++ b/crates/temps-git/src/handlers/public.rs
@@ -100,9 +100,26 @@ fn map_error(err: PublicRepoError, owner: &str, repo: &str) -> Problem {
                 "Repository {}/{} not found or is not public: {}",
                 owner, repo, msg
             )),
+        PublicRepoError::RepositoryNotPublic(_) => problem_new(StatusCode::NOT_FOUND)
+            .with_title("Repository Not Found")
+            .with_detail(format!(
+                "Repository {}/{} was not found or is not public.",
+                owner, repo
+            )),
         PublicRepoError::RateLimitExceeded => problem_new(StatusCode::TOO_MANY_REQUESTS)
             .with_title("Rate Limit Exceeded")
-            .with_detail("API rate limit exceeded for unauthenticated requests. Try again later."),
+            .with_detail("The git provider API rate limit is exhausted. Try again after it resets."),
+        PublicRepoError::PermissionDenied {
+            operation,
+            required_permission,
+        } => problem_new(StatusCode::FORBIDDEN)
+            .with_title("Git Provider Permission Required")
+            .with_detail(format!(
+                "The git provider denied permission to {}. Grant '{}' to the credential for this repository.",
+                operation, required_permission
+            ))
+            .with_value("operation", operation)
+            .with_value("required_permission", required_permission),
         PublicRepoError::BranchNotFound(branch) => problem_new(StatusCode::NOT_FOUND)
             .with_title("Branch Not Found")
             .with_detail(format!("Branch '{}' not found in repository", branch)),
@@ -134,6 +151,7 @@ fn map_error(err: PublicRepoError, owner: &str, repo: &str) -> Problem {
     responses(
         (status = 200, description = "List of branches", body = BranchListResponse),
         (status = 400, description = "Provider not supported"),
+        (status = 403, description = "Git provider permission required"),
         (status = 404, description = "Repository not found"),
         (status = 429, description = "API rate limit exceeded"),
         (status = 500, description = "Internal server error")
@@ -148,6 +166,21 @@ pub async fn get_public_branches(
 ) -> Result<Json<BranchListResponse>, Problem> {
     // Create cache key for public repos
     let cache_key = PublicBranchCacheKey::new(provider.clone(), owner.clone(), repo.clone());
+
+    let token = if provider == "github" {
+        get_github_token_from_connections(&state, auth.as_ref()).await
+    } else {
+        None
+    };
+    let repo_provider = PublicRepoProviderFactory::create_with_token(&provider, token)
+        .map_err(|e| map_error(e, &owner, &repo))?;
+
+    // Check current visibility before consulting the branch cache. Otherwise a
+    // repository made private after caching would remain visible until expiry.
+    repo_provider
+        .get_repository(&owner, &repo)
+        .await
+        .map_err(|e| map_error(e, &owner, &repo))?;
 
     // Try cache first (unless fresh=true)
     if !params.fresh {
@@ -165,18 +198,6 @@ pub async fn get_public_branches(
             }));
         }
     }
-
-    // Try to get a token from any existing GitHub connection for higher rate limits
-    // (authenticated callers only — see get_github_token_from_connections)
-    let token = if provider == "github" {
-        get_github_token_from_connections(&state, auth.is_some()).await
-    } else {
-        None
-    };
-
-    // Create provider with token if available
-    let repo_provider = PublicRepoProviderFactory::create_with_token(&provider, token)
-        .map_err(|e| map_error(e, &owner, &repo))?;
 
     // Fetch branches from provider
     let provider_branches = repo_provider
@@ -228,6 +249,7 @@ pub async fn get_public_branches(
     responses(
         (status = 200, description = "Detected presets", body = PublicPresetResponse),
         (status = 400, description = "Provider not supported"),
+        (status = 403, description = "Git provider permission required"),
         (status = 404, description = "Repository or branch not found"),
         (status = 429, description = "API rate limit exceeded"),
         (status = 500, description = "Internal server error")
@@ -243,7 +265,7 @@ pub async fn detect_public_presets(
     // Try to get a token from any existing GitHub connection for higher rate limits
     // (authenticated callers only — see get_github_token_from_connections)
     let token = if provider == "github" {
-        get_github_token_from_connections(&state, auth.is_some()).await
+        get_github_token_from_connections(&state, auth.as_ref()).await
     } else {
         None
     };
@@ -252,16 +274,18 @@ pub async fn detect_public_presets(
     let repo_provider = PublicRepoProviderFactory::create_with_token(&provider, token)
         .map_err(|e| map_error(e, &owner, &repo))?;
 
+    // Always resolve repository metadata first. Besides supplying the default
+    // branch, this prevents an authenticated token from turning this public
+    // endpoint into a private-repository metadata oracle.
+    let repo_info = repo_provider
+        .get_repository(&owner, &repo)
+        .await
+        .map_err(|e| map_error(e, &owner, &repo))?;
+
     // Get repository info to determine default branch if not specified
     let target_branch = if let Some(branch) = params.branch.clone() {
         branch
     } else {
-        // Fetch repository info to get default branch
-        let repo_info = repo_provider
-            .get_repository(&owner, &repo)
-            .await
-            .map_err(|e| map_error(e, &owner, &repo))?;
-
         repo_info.default_branch
     };
 
@@ -358,6 +382,7 @@ pub async fn detect_public_presets(
     responses(
         (status = 200, description = "Repository information", body = PublicRepositoryInfo),
         (status = 400, description = "Provider not supported"),
+        (status = 403, description = "Git provider permission required"),
         (status = 404, description = "Repository not found"),
         (status = 429, description = "API rate limit exceeded"),
         (status = 500, description = "Internal server error")
@@ -372,7 +397,7 @@ pub async fn get_public_repository(
     // Try to get a token from any existing GitHub connection for higher rate limits
     // (authenticated callers only — see get_github_token_from_connections)
     let token = if provider == "github" {
-        get_github_token_from_connections(&state, auth.is_some()).await
+        get_github_token_from_connections(&state, auth.as_ref()).await
     } else {
         None
     };
@@ -440,7 +465,7 @@ pub fn configure_routes() -> Router<Arc<AppState>> {
 )]
 pub struct PublicRepositoriesApiDoc;
 
-/// Try to get a GitHub access token from any configured GitHub connection.
+/// Try to get a GitHub access token from the caller's GitHub connections.
 /// This avoids the 60 req/hr unauthenticated rate limit by using an existing token (5000 req/hr).
 ///
 /// Only ever returns a token for authenticated callers. These routes are
@@ -450,12 +475,13 @@ pub struct PublicRepositoriesApiDoc;
 /// GitHub's unauthenticated rate limit instead.
 async fn get_github_token_from_connections(
     state: &AppState,
-    is_authenticated: bool,
+    auth: Option<&Extension<AuthContext>>,
 ) -> Option<String> {
-    if !is_authenticated {
-        return None;
-    }
-    state.git_provider_manager.get_any_github_token().await
+    let user_id = auth.and_then(|Extension(context)| context.user_id_opt())?;
+    state
+        .git_provider_manager
+        .get_github_token_for_user(user_id)
+        .await
 }
 
 #[cfg(test)]
@@ -769,10 +795,41 @@ mod tests {
     }
 
     #[test]
+    fn test_private_repository_is_hidden_as_not_found() {
+        let err = PublicRepoError::RepositoryNotPublic("owner/private".to_string());
+        let problem = map_error(err, "owner", "private");
+        assert_eq!(problem.status_code, StatusCode::NOT_FOUND);
+        assert!(!problem
+            .body
+            .get("detail")
+            .and_then(|value| value.as_str())
+            .is_some_and(|detail| detail.contains("credential") || detail.contains("token")));
+    }
+
+    #[test]
     fn test_error_mapping_rate_limit() {
         let err = PublicRepoError::RateLimitExceeded;
         let problem = map_error(err, "owner", "repo");
         assert_eq!(problem.status_code, StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[test]
+    fn test_error_mapping_permission_denied() {
+        let err = PublicRepoError::PermissionDenied {
+            operation: "list branches for owner/repo".to_string(),
+            required_permission: "Contents: read".to_string(),
+        };
+        let problem = map_error(err, "owner", "repo");
+        assert_eq!(problem.status_code, StatusCode::FORBIDDEN);
+        assert_eq!(
+            problem.body.get("title").and_then(|value| value.as_str()),
+            Some("Git Provider Permission Required")
+        );
+        assert!(problem
+            .body
+            .get("detail")
+            .and_then(|value| value.as_str())
+            .is_some_and(|detail| detail.contains("Contents: read")));
     }
 
     #[test]

--- a/crates/temps-git/src/handlers/repositories.rs
+++ b/crates/temps-git/src/handlers/repositories.rs
@@ -124,6 +124,7 @@ fn provider_lookup_principal(auth: &AuthContext) -> String {
     responses(
         (status = 200, description = "List of branches", body = BranchListResponse),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Git provider permission required"),
         (status = 404, description = "Repository not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -231,6 +232,7 @@ pub async fn get_repository_branches(
     responses(
         (status = 200, description = "List of tags", body = TagListResponse),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Git provider permission required"),
         (status = 404, description = "Repository not found"),
         (status = 429, description = "Fresh tag lookup rate limit exceeded"),
         (status = 500, description = "Internal server error")
@@ -330,12 +332,7 @@ pub async fn get_repository_tags(
     let tags = provider_service
         .list_tags(&access_token, &owner, &repo)
         .await
-        .map_err(|e| {
-            ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
-                .title("Failed to fetch tags")
-                .detail(format!("Error fetching tags from git provider: {}", e))
-                .build()
-        })?;
+        .map_err(Problem::from)?;
 
     // Cache the result
     state.cache_manager.tags.set(cache_key, tags.clone()).await;
@@ -362,6 +359,7 @@ pub async fn get_repository_tags(
     responses(
         (status = 200, description = "List of branches", body = BranchListResponse),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Git provider permission required"),
         (status = 404, description = "Repository not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -450,12 +448,7 @@ pub async fn get_branches_by_repository_id(
     let branches = provider_service
         .list_branches(&access_token, &repository.owner, &repository.name)
         .await
-        .map_err(|e| {
-            ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
-                .title("Failed to fetch branches")
-                .detail(format!("Error fetching branches from git provider: {}", e))
-                .build()
-        })?;
+        .map_err(Problem::from)?;
 
     // Cache the result
     state
@@ -489,6 +482,7 @@ pub async fn get_branches_by_repository_id(
     responses(
         (status = 200, description = "List of tags", body = TagListResponse),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Git provider permission required"),
         (status = 404, description = "Repository not found"),
         (status = 429, description = "Fresh tag lookup rate limit exceeded"),
         (status = 500, description = "Internal server error")
@@ -591,12 +585,7 @@ pub async fn get_tags_by_repository_id(
     let tags = provider_service
         .list_tags(&access_token, &repository.owner, &repository.name)
         .await
-        .map_err(|e| {
-            ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
-                .title("Failed to fetch tags")
-                .detail(format!("Error fetching tags from git provider: {}", e))
-                .build()
-        })?;
+        .map_err(Problem::from)?;
 
     // Cache the result
     state.cache_manager.tags.set(cache_key, tags.clone()).await;
@@ -741,7 +730,9 @@ pub async fn check_commit_exists(
             state.cache_manager.commits.set(cache_key, None).await;
             Ok(Json(CommitExistsResponse::missing()))
         }
-        Err(error @ GitProviderError::RateLimitExceeded) => Err(error.into()),
+        Err(error @ GitProviderError::RateLimitExceeded)
+        | Err(error @ GitProviderError::PermissionDenied { .. })
+        | Err(error @ GitProviderError::AuthenticationFailed(_)) => Err(error.into()),
         Err(error) => {
             warn!(
                 repository_id,
@@ -811,6 +802,7 @@ pub struct CommitListResponse {
     responses(
         (status = 200, description = "List of commits", body = CommitListResponse),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Git provider permission required"),
         (status = 404, description = "Repository not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -882,12 +874,7 @@ pub async fn list_commits_by_repository_id(
             per_page,
         )
         .await
-        .map_err(|e| {
-            ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
-                .title("Failed to fetch commits")
-                .detail(format!("Error fetching commits from git provider: {}", e))
-                .build()
-        })?;
+        .map_err(Problem::from)?;
 
     let commit_infos: Vec<CommitInfo> = commits
         .into_iter()

--- a/crates/temps-git/src/services/git_provider.rs
+++ b/crates/temps-git/src/services/git_provider.rs
@@ -20,6 +20,15 @@ pub enum GitProviderError {
     #[error("Authentication failed: {0}")]
     AuthenticationFailed(String),
 
+    #[error(
+        "Permission denied while trying to {operation}. Required permission: {required_permission}. Git provider response: {provider_message}"
+    )]
+    PermissionDenied {
+        operation: String,
+        required_permission: String,
+        provider_message: String,
+    },
+
     #[error("API error: {0}")]
     ApiError(String),
 

--- a/crates/temps-git/src/services/git_provider_manager.rs
+++ b/crates/temps-git/src/services/git_provider_manager.rs
@@ -177,6 +177,57 @@ pub struct GitProviderManager {
 }
 
 impl GitProviderManager {
+    fn url_has_origin(url: &str, expected_host: &str) -> bool {
+        let Ok(url) = Url::parse(url) else {
+            return false;
+        };
+
+        url.scheme() == "https"
+            && url.host_str() == Some(expected_host)
+            && url.port_or_known_default() == Some(443)
+            && url.username().is_empty()
+            && url.password().is_none()
+    }
+
+    /// Public-repository requests below are sent to github.com. A credential
+    /// configured for GitHub Enterprise must never cross that provider origin.
+    fn is_github_dot_com_provider(provider: &git_providers::Model) -> bool {
+        if provider.provider_type != "github" && provider.provider_type != "github_app" {
+            return false;
+        }
+
+        let api_is_public = provider
+            .api_url
+            .as_deref()
+            .map(|url| Self::url_has_origin(url, "api.github.com"))
+            .unwrap_or_else(|| {
+                provider
+                    .base_url
+                    .as_deref()
+                    .map(|url| Self::url_has_origin(url, "github.com"))
+                    .unwrap_or(true)
+            });
+        let web_is_public = provider
+            .base_url
+            .as_deref()
+            .map(|url| Self::url_has_origin(url, "github.com"))
+            .unwrap_or(true);
+
+        api_is_public && web_is_public
+    }
+
+    async fn get_active_connections_for_user(
+        &self,
+        user_id: i32,
+    ) -> Result<Vec<git_provider_connections::Model>, sea_orm::DbErr> {
+        git_provider_connections::Entity::find()
+            .filter(git_provider_connections::Column::IsActive.eq(true))
+            .filter(git_provider_connections::Column::UserId.eq(Some(user_id)))
+            .order_by_desc(git_provider_connections::Column::CreatedAt)
+            .all(self.db.as_ref())
+            .await
+    }
+
     pub fn new(
         db: Arc<DatabaseConnection>,
         encryption_service: Arc<temps_core::EncryptionService>,
@@ -220,13 +271,7 @@ impl GitProviderManager {
     /// user's connection would let the caller spend that user's API quota and
     /// could expose repositories only that credential can access.
     pub async fn get_github_token_for_user(&self, user_id: i32) -> Option<String> {
-        let connections = git_provider_connections::Entity::find()
-            .filter(git_provider_connections::Column::IsActive.eq(true))
-            .filter(git_provider_connections::Column::UserId.eq(Some(user_id)))
-            .order_by_desc(git_provider_connections::Column::CreatedAt)
-            .all(self.db.as_ref())
-            .await
-            .ok()?;
+        let connections = self.get_active_connections_for_user(user_id).await.ok()?;
 
         self.get_github_token_from_connections(connections).await
     }
@@ -249,12 +294,11 @@ impl GitProviderManager {
                 .ok()
                 .flatten();
 
-            let is_github = provider
-                .as_ref()
-                .map(|p| p.provider_type == "github" || p.provider_type == "github_app")
-                .unwrap_or(false);
+            let Some(provider) = provider else {
+                continue;
+            };
 
-            if !is_github {
+            if !Self::is_github_dot_com_provider(&provider) {
                 continue;
             }
 
@@ -5559,6 +5603,160 @@ mod tests {
     use temps_core::{async_trait::async_trait, Job, JobReceiver, QueueError};
     use temps_database::test_utils::TestDatabase;
     use temps_entities::{git_provider_connections, git_providers};
+
+    fn provider_model(
+        provider_type: &str,
+        base_url: Option<&str>,
+        api_url: Option<&str>,
+    ) -> git_providers::Model {
+        let now = chrono::Utc::now();
+        git_providers::Model {
+            id: 1,
+            name: "test-provider".to_string(),
+            provider_type: provider_type.to_string(),
+            base_url: base_url.map(str::to_string),
+            api_url: api_url.map(str::to_string),
+            auth_method: "pat".to_string(),
+            auth_config: serde_json::json!({}),
+            webhook_secret: None,
+            is_active: true,
+            is_default: false,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn public_github_token_selection_rejects_enterprise_origins() {
+        assert!(GitProviderManager::is_github_dot_com_provider(
+            &provider_model(
+                "github",
+                Some("https://github.com/acme"),
+                Some("https://api.github.com")
+            )
+        ));
+        assert!(GitProviderManager::is_github_dot_com_provider(
+            &provider_model("github_app", None, None)
+        ));
+
+        for provider in [
+            provider_model(
+                "github",
+                Some("https://github.enterprise.example"),
+                Some("https://github.enterprise.example/api/v3"),
+            ),
+            provider_model(
+                "github_app",
+                Some("https://github.enterprise.example"),
+                Some("https://api.github.com"),
+            ),
+            provider_model(
+                "github",
+                Some("https://github.com.evil.example"),
+                Some("https://api.github.com.evil.example"),
+            ),
+        ] {
+            assert!(
+                !GitProviderManager::is_github_dot_com_provider(&provider),
+                "a non-GitHub.com credential must be rejected before token decryption or validation"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn request_scoped_connection_lookup_isolates_users_and_inactive_rows() {
+        use temps_entities::users;
+
+        let test_db = match TestDatabase::with_migrations().await {
+            Ok(db) => db,
+            Err(error) => {
+                eprintln!("Postgres unavailable; skipping connection-isolation test: {error}");
+                return;
+            }
+        };
+        let db = test_db.connection_arc();
+        let now = chrono::Utc::now();
+
+        let make_user = |email: &str| users::ActiveModel {
+            email: Set(email.to_string()),
+            password_hash: Set(Some("hash".to_string())),
+            name: Set(email.to_string()),
+            created_at: Set(now),
+            updated_at: Set(now),
+            ..Default::default()
+        };
+        let user_a = make_user("github-token-a@example.com")
+            .insert(db.as_ref())
+            .await
+            .unwrap();
+        let user_b = make_user("github-token-b@example.com")
+            .insert(db.as_ref())
+            .await
+            .unwrap();
+
+        let provider = git_providers::ActiveModel {
+            name: Set("GitHub.com".to_string()),
+            provider_type: Set("github".to_string()),
+            base_url: Set(Some("https://github.com".to_string())),
+            api_url: Set(Some("https://api.github.com".to_string())),
+            auth_method: Set("pat".to_string()),
+            auth_config: Set(serde_json::json!({})),
+            webhook_secret: Set(None),
+            is_active: Set(true),
+            is_default: Set(false),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .unwrap();
+
+        for (user_id, account_name, is_active) in [
+            (Some(user_a.id), "user-a-active", true),
+            (Some(user_a.id), "user-a-inactive", false),
+            (Some(user_b.id), "user-b-active", true),
+            (None, "ownerless-active", true),
+        ] {
+            git_provider_connections::ActiveModel {
+                provider_id: Set(provider.id),
+                user_id: Set(user_id),
+                account_name: Set(account_name.to_string()),
+                account_type: Set("User".to_string()),
+                access_token: Set(None),
+                refresh_token: Set(None),
+                token_expires_at: Set(None),
+                refresh_token_expires_at: Set(None),
+                installation_id: Set(None),
+                metadata: Set(None),
+                is_active: Set(is_active),
+                is_expired: Set(false),
+                syncing: Set(false),
+                last_synced_at: Set(None),
+                ..Default::default()
+            }
+            .insert(db.as_ref())
+            .await
+            .unwrap();
+        }
+
+        let manager = GitProviderManager::new(
+            db.clone(),
+            Arc::new(
+                temps_core::EncryptionService::new(
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                )
+                .unwrap(),
+            ),
+            Arc::new(MockJobQueue) as Arc<dyn JobQueue>,
+            create_test_config_service(db),
+        );
+
+        let connections = manager
+            .get_active_connections_for_user(user_a.id)
+            .await
+            .unwrap();
+        assert_eq!(connections.len(), 1);
+        assert_eq!(connections[0].account_name, "user-a-active");
+    }
 
     #[test]
     fn is_auth_failure_recognizes_common_messages() {

--- a/crates/temps-git/src/services/git_provider_manager.rs
+++ b/crates/temps-git/src/services/git_provider_manager.rs
@@ -209,9 +209,33 @@ impl GitProviderManager {
     /// Used for public repo API calls to avoid unauthenticated rate limits (60 → 5000 req/hr).
     /// Validates the token against GitHub's API before returning it.
     pub async fn get_any_github_token(&self) -> Option<String> {
-        use temps_entities::git_providers;
-
         let connections = self.get_user_connections().await.ok()?;
+
+        self.get_github_token_from_connections(connections).await
+    }
+
+    /// Get an access token from an active GitHub connection owned by `user_id`.
+    ///
+    /// This must be used for request-scoped operations. Falling back to another
+    /// user's connection would let the caller spend that user's API quota and
+    /// could expose repositories only that credential can access.
+    pub async fn get_github_token_for_user(&self, user_id: i32) -> Option<String> {
+        let connections = git_provider_connections::Entity::find()
+            .filter(git_provider_connections::Column::IsActive.eq(true))
+            .filter(git_provider_connections::Column::UserId.eq(Some(user_id)))
+            .order_by_desc(git_provider_connections::Column::CreatedAt)
+            .all(self.db.as_ref())
+            .await
+            .ok()?;
+
+        self.get_github_token_from_connections(connections).await
+    }
+
+    async fn get_github_token_from_connections(
+        &self,
+        connections: Vec<git_provider_connections::Model>,
+    ) -> Option<String> {
+        use temps_entities::git_providers;
 
         for conn in connections {
             if !conn.is_active {
@@ -1860,11 +1884,18 @@ impl GitProviderManager {
         status: reqwest::StatusCode,
         operation: &str,
     ) -> GitProviderError {
-        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        if status == reqwest::StatusCode::UNAUTHORIZED {
             GitProviderError::AuthenticationFailed(format!(
                 "provider rejected the stored credential while trying to {}: HTTP {}",
                 operation, status
             ))
+        } else if status == reqwest::StatusCode::FORBIDDEN {
+            GitProviderError::PermissionDenied {
+                operation: operation.to_string(),
+                required_permission:
+                    "repository access with the permission required by this operation".to_string(),
+                provider_message: format!("HTTP {}", status),
+            }
         } else {
             GitProviderError::ApiError(format!("Failed to {}: HTTP {}", operation, status))
         }
@@ -3473,7 +3504,9 @@ impl GitProviderManager {
         // This allows users to update a GitHub App installation connection to use a PAT
         let provider = self.get_provider(connection.provider_id).await?;
 
-        // Validate the new access token as a PAT (using /user endpoint)
+        // Validate the new access token as a PAT. GitHub's `/rate_limit`
+        // authenticates repository-scoped and Actions credentials without
+        // requiring user-profile access; GitLab still uses `/user`.
         let client = reqwest::Client::new();
         let api_url = provider
             .api_url
@@ -3481,7 +3514,11 @@ impl GitProviderManager {
             .unwrap_or("https://api.github.com");
         let validation_endpoint =
             if provider.provider_type == "github" || provider.provider_type == "gitlab" {
-                format!("{}/user", api_url)
+                if provider.provider_type == "github" {
+                    format!("{}/rate_limit", api_url)
+                } else {
+                    format!("{}/user", api_url)
+                }
             } else {
                 // For other providers, use the provider service's validate_token
                 let provider_service = self.get_provider_service(connection.provider_id).await?;
@@ -3549,20 +3586,39 @@ impl GitProviderManager {
                 ));
             }
             status => {
-                let error_text = response
-                    .text()
+                let provider_message = response
+                    .json::<serde_json::Value>()
                     .await
-                    .unwrap_or_else(|_| "Unknown error".to_string());
+                    .ok()
+                    .and_then(|body| {
+                        body.get("message")
+                            .and_then(|value| value.as_str())
+                            .map(str::to_string)
+                    })
+                    .unwrap_or_else(|| format!("HTTP {}", status));
                 tracing::warn!(
                     "Error validating new access token for connection {}: {} - {}",
                     connection_id,
                     status,
-                    error_text
+                    provider_message
                 );
-                return Err(GitProviderManagerError::InvalidConfiguration(format!(
-                    "Failed to validate the provided access token: {} - {}",
-                    status, error_text
-                )));
+                let error = match status {
+                    reqwest::StatusCode::FORBIDDEN => GitProviderError::PermissionDenied {
+                        operation: "validate the replacement credential".to_string(),
+                        required_permission: if provider.provider_type == "github" {
+                            "Metadata: read".to_string()
+                        } else {
+                            "read_user".to_string()
+                        },
+                        provider_message,
+                    },
+                    reqwest::StatusCode::TOO_MANY_REQUESTS => GitProviderError::RateLimitExceeded,
+                    _ => GitProviderError::ApiError(format!(
+                        "{} returned HTTP {} while validating the replacement credential: {}",
+                        provider.provider_type, status, provider_message
+                    )),
+                };
+                return Err(error.into());
             }
         }
 
@@ -3747,14 +3803,17 @@ impl GitProviderManager {
             return Ok(false);
         };
 
-        // Try to get user info to validate the token
-        match provider_service.get_user(&access_token).await {
-            Ok(_) => Ok(true),
-            Err(_) => {
+        match provider_service.validate_token(&access_token).await {
+            Ok(true) => Ok(true),
+            Ok(false) => {
                 // Token is invalid, mark connection as inactive
                 self.deactivate_connection(connection_id).await?;
                 Ok(false)
             }
+            // A provider outage, rate limit, or missing operation permission
+            // does not prove that the credential is invalid. Preserve the
+            // typed error and keep the connection active.
+            Err(error) => Err(error.into()),
         }
     }
 
@@ -5434,18 +5493,20 @@ mod classify_provider_response_error_tests {
         );
     }
 
-    /// 403 is the other shape a revoked/insufficient credential takes
-    /// (GitHub returns it for token scope problems and some rate limits).
+    /// A valid credential that lacks a repository capability is not an
+    /// authentication failure: clients must tell the operator which grant to
+    /// add instead of asking them to reconnect the same credential.
     #[test]
-    fn forbidden_is_classified_as_authentication_failure() {
+    fn forbidden_is_classified_as_permission_denied() {
         let err = GitProviderManager::classify_provider_response_error(
             reqwest::StatusCode::FORBIDDEN,
             "get tree for owner/repo@main",
         );
         assert!(
-            matches!(err, GitProviderError::AuthenticationFailed(_)),
-            "403 must map to AuthenticationFailed, got {err:?}"
+            matches!(err, GitProviderError::PermissionDenied { .. }),
+            "403 must map to PermissionDenied, got {err:?}"
         );
+        assert!(err.to_string().contains("owner/repo@main"));
     }
 
     /// Everything else stays a generic API error — a provider outage is not

--- a/crates/temps-git/src/services/github_provider.rs
+++ b/crates/temps-git/src/services/github_provider.rs
@@ -17,6 +17,114 @@ const MAX_GITHUB_TAG_PAGES: usize = 10;
 const MAX_GITHUB_BRANCHES: usize = 1_000;
 const MAX_GITHUB_BRANCH_PAGES: usize = 10;
 
+fn github_status_error(
+    status: reqwest::StatusCode,
+    rate_limit_remaining: Option<u64>,
+    provider_message: String,
+    operation: impl Into<String>,
+    required_permission: impl Into<String>,
+) -> GitProviderError {
+    let is_rate_limit_message = provider_message.to_ascii_lowercase().contains("rate limit");
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        GitProviderError::AuthenticationFailed(format!(
+            "GitHub rejected the credential as invalid or expired while trying to {}. GitHub said: {}",
+            operation.into(), provider_message
+        ))
+    } else if status == reqwest::StatusCode::TOO_MANY_REQUESTS
+        || (status == reqwest::StatusCode::FORBIDDEN
+            && (rate_limit_remaining == Some(0) || is_rate_limit_message))
+    {
+        GitProviderError::RateLimitExceeded
+    } else if status == reqwest::StatusCode::FORBIDDEN {
+        GitProviderError::PermissionDenied {
+            operation: operation.into(),
+            required_permission: required_permission.into(),
+            provider_message,
+        }
+    } else {
+        GitProviderError::ApiError(format!(
+            "GitHub failed the '{}' operation with HTTP {}: {}",
+            operation.into(),
+            status,
+            provider_message
+        ))
+    }
+}
+
+async fn github_response_error(
+    response: reqwest::Response,
+    operation: impl Into<String>,
+    required_permission: impl Into<String>,
+) -> GitProviderError {
+    let status = response.status();
+    let rate_limit_remaining = response
+        .headers()
+        .get("x-ratelimit-remaining")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok());
+    let provider_message = response
+        .json::<serde_json::Value>()
+        .await
+        .ok()
+        .and_then(|body| {
+            body.get("message")
+                .and_then(|message| message.as_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| format!("HTTP {status}"));
+
+    github_status_error(
+        status,
+        rate_limit_remaining,
+        provider_message,
+        operation,
+        required_permission,
+    )
+}
+
+fn github_octocrab_error(
+    error: octocrab::Error,
+    operation: impl Into<String>,
+    required_permission: impl Into<String>,
+) -> GitProviderError {
+    let operation = operation.into();
+    let required_permission = required_permission.into();
+    match error {
+        octocrab::Error::GitHub { source, .. }
+            if source.status_code == reqwest::StatusCode::UNAUTHORIZED =>
+        {
+            GitProviderError::AuthenticationFailed(format!(
+                "GitHub rejected the credential as invalid or expired while trying to {}. GitHub said: {}",
+                operation, source.message
+            ))
+        }
+        octocrab::Error::GitHub { source, .. }
+            if source.status_code == reqwest::StatusCode::FORBIDDEN
+                && source.message.to_ascii_lowercase().contains("rate limit") =>
+        {
+            GitProviderError::RateLimitExceeded
+        }
+        octocrab::Error::GitHub { source, .. }
+            if source.status_code == reqwest::StatusCode::FORBIDDEN =>
+        {
+            GitProviderError::PermissionDenied {
+                operation,
+                required_permission,
+                provider_message: source.message.clone(),
+            }
+        }
+        octocrab::Error::GitHub { source, .. }
+            if source.status_code == reqwest::StatusCode::TOO_MANY_REQUESTS =>
+        {
+            GitProviderError::RateLimitExceeded
+        }
+        error => GitProviderError::ApiError(format!(
+            "GitHub failed the '{}' operation: {}",
+            operation, error
+        )),
+    }
+}
+
 fn append_github_tags(
     tags: &mut Vec<GitProviderTag>,
     page_items: Vec<octocrab::models::repos::Tag>,
@@ -686,11 +794,13 @@ impl GitHubProvider {
         let client = self.get_client();
         let headers = self.get_headers(access_token);
 
-        // Use the /user endpoint to validate the token (for OAuth/PAT)
-        // For GitHub Apps, we use /app endpoint
+        // `/rate_limit` authenticates OAuth, PAT, Actions, and installation
+        // credentials without requiring user-profile access. GitHub Apps use
+        // their installation repository endpoint because it also confirms the
+        // installation can access at least one selected repository.
         let endpoint = match &self.auth_method {
             AuthMethod::GitHubApp { .. } => format!("{}/installation/repositories", self.api_url),
-            _ => format!("{}/user", self.api_url),
+            _ => format!("{}/rate_limit", self.api_url),
         };
 
         let response = self
@@ -714,7 +824,17 @@ impl GitHubProvider {
                 {
                     Err(GitProviderError::RateLimitExceeded)
                 } else {
-                    Ok(false) // Token might be invalid or lack permissions
+                    Err(github_response_error(
+                        response,
+                        "validate the GitHub connection",
+                        match &self.auth_method {
+                            AuthMethod::GitHubApp { .. } => {
+                                "Metadata: read and access to at least one selected repository"
+                            }
+                            _ => "Metadata: read",
+                        },
+                    )
+                    .await)
                 }
             }
             status => {
@@ -798,7 +918,7 @@ impl GitProviderService for GitHubProvider {
                 ..
             } => {
                 let auth_url = format!(
-                    "https://github.com/login/oauth/authorize?client_id={}&redirect_uri={}&state={}&scope=repo,user",
+                    "https://github.com/login/oauth/authorize?client_id={}&redirect_uri={}&state={}&scope=repo",
                     client_id, redirect_uri, state
                 );
                 Ok(auth_url)
@@ -816,56 +936,15 @@ impl GitProviderService for GitHubProvider {
         match self.validate_token(access_token).await {
             Ok(true) => false, // Token is valid, no refresh needed
             Ok(false) => true, // Token is invalid, needs refresh
-            Err(_) => true,    // Error validating, assume it needs refresh
+            // Permission, rate-limit, network, and provider failures do not
+            // prove expiry. Let the requested operation return its typed error
+            // instead of persistently marking a usable token as expired.
+            Err(_) => false,
         }
     }
 
     async fn validate_token(&self, access_token: &str) -> Result<bool, GitProviderError> {
-        let client = self.get_client();
-        let headers = self.get_headers(access_token);
-
-        // Use the /user endpoint to validate the token (for OAuth/PAT)
-        // For GitHub Apps, we use /app endpoint
-        let endpoint = match &self.auth_method {
-            AuthMethod::GitHubApp { .. } => format!("{}/installation/repositories", self.api_url),
-            _ => format!("{}/user", self.api_url),
-        };
-
-        let response = self
-            .send_with_retry(|| client.get(&endpoint).headers(headers.clone()))
-            .await?;
-
-        // Token is valid if we get a 200 OK
-        // 401 means unauthorized (invalid token)
-        // 403 could mean rate limited or token lacks scopes
-        match response.status() {
-            status if status.is_success() => Ok(true),
-            status if status.as_u16() == 401 => Ok(false),
-            status if status.as_u16() == 403 => {
-                // Check if it's rate limiting
-                if response
-                    .headers()
-                    .get("X-RateLimit-Remaining")
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|s| s.parse::<i32>().ok())
-                    == Some(0)
-                {
-                    Err(GitProviderError::RateLimitExceeded)
-                } else {
-                    Ok(false) // Token might be invalid or lack permissions
-                }
-            }
-            status => {
-                let error_text = response
-                    .text()
-                    .await
-                    .unwrap_or_else(|_| "Unknown error".to_string());
-                Err(GitProviderError::ApiError(format!(
-                    "Unexpected response validating token: {} - {}",
-                    status, error_text
-                )))
-            }
-        }
+        GitHubProvider::validate_token(self, access_token).await
     }
 
     async fn validate_and_refresh_token(
@@ -1056,13 +1135,12 @@ impl GitProviderService for GitHubProvider {
                 .await?;
 
             if !response.status().is_success() {
-                let status = response.status();
-                let error_text = response.text().await.unwrap_or_default();
-                error!("Failed to list repositories: {} - {}", status, error_text);
-                return Err(GitProviderError::ApiError(format!(
-                    "Failed to list repositories: {} - {}",
-                    status, error_text
-                )));
+                return Err(github_response_error(
+                    response,
+                    "list repositories available to this connection",
+                    "Metadata: read, Contents: read, and access to the selected repositories",
+                )
+                .await);
             }
 
             // GitHub App installation endpoint returns a different structure
@@ -1152,10 +1230,12 @@ impl GitProviderService for GitHubProvider {
             .await?;
 
         if !response.status().is_success() {
-            return Err(GitProviderError::ApiError(format!(
-                "Failed to get repository: {}",
-                response.status()
-            )));
+            return Err(github_response_error(
+                response,
+                format!("read repository {owner}/{repo}"),
+                "Contents: read and access to the target repository",
+            )
+            .await);
         }
 
         #[derive(Deserialize)]
@@ -1235,7 +1315,13 @@ impl GitProviderService for GitHubProvider {
             .per_page(100)
             .send()
             .await
-            .map_err(|e| GitProviderError::ApiError(format!("Failed to list branches: {}", e)))?;
+            .map_err(|error| {
+                github_octocrab_error(
+                    error,
+                    format!("list branches for {owner}/{repo}"),
+                    "Contents: read and access to the target repository",
+                )
+            })?;
 
         let all = collect_guarded_github_pages(
             &octocrab,
@@ -1275,10 +1361,11 @@ impl GitProviderService for GitHubProvider {
             .send()
             .await
             .map_err(|error| {
-                GitProviderError::ApiError(format!(
-                    "Failed to list tags for {}/{} (page 1): {}",
-                    owner, repo, error
-                ))
+                github_octocrab_error(
+                    error,
+                    format!("list tags for {owner}/{repo}"),
+                    "Contents: read and access to the target repository",
+                )
             })?;
 
         // GitHub defaults to 30 tags and the previous implementation silently
@@ -1332,10 +1419,12 @@ impl GitProviderService for GitHubProvider {
             .await?;
 
         if !response.status().is_success() {
-            return Err(GitProviderError::ApiError(format!(
-                "Failed to get file content: {}",
-                response.status()
-            )));
+            return Err(github_response_error(
+                response,
+                format!("read file '{path}' from {owner}/{repo}"),
+                "Contents: read and access to the target repository",
+            )
+            .await);
         }
 
         #[derive(Deserialize)]
@@ -1390,10 +1479,12 @@ impl GitProviderService for GitHubProvider {
             .await?;
 
         if !response.status().is_success() {
-            return Err(GitProviderError::ApiError(format!(
-                "Failed to list directory '{path}' in {owner}/{repo}: {}",
-                response.status()
-            )));
+            return Err(github_response_error(
+                response,
+                format!("list directory '{path}' in {owner}/{repo}"),
+                "Contents: read and access to the target repository",
+            )
+            .await);
         }
 
         // The Contents API returns either a JSON array (directory) or a single
@@ -1475,10 +1566,12 @@ impl GitProviderService for GitHubProvider {
             .await?;
 
         if !response.status().is_success() {
-            return Err(GitProviderError::ApiError(format!(
-                "Failed to get latest commit: {}",
-                response.status()
-            )));
+            return Err(github_response_error(
+                response,
+                format!("read the latest commit from {owner}/{repo}@{branch}"),
+                "Contents: read and access to the target repository",
+            )
+            .await);
         }
 
         #[derive(Deserialize)]
@@ -1559,10 +1652,12 @@ impl GitProviderService for GitHubProvider {
             .await?;
 
         if !response.status().is_success() {
-            return Err(GitProviderError::ApiError(format!(
-                "Failed to create webhook: {}",
-                response.status()
-            )));
+            return Err(github_response_error(
+                response,
+                format!("create a webhook for {owner}/{repo}"),
+                "Webhooks: write (or classic PAT repo scope) and access to the target repository",
+            )
+            .await);
         }
 
         let hook: HookResponse = response
@@ -1593,10 +1688,12 @@ impl GitProviderService for GitHubProvider {
             .await?;
 
         if !response.status().is_success() {
-            return Err(GitProviderError::ApiError(format!(
-                "Failed to delete webhook: {}",
-                response.status()
-            )));
+            return Err(github_response_error(
+                response,
+                format!("delete webhook {webhook_id} from {owner}/{repo}"),
+                "Webhooks: write (or classic PAT repo scope) and access to the target repository",
+            )
+            .await);
         }
 
         Ok(())
@@ -1623,10 +1720,12 @@ impl GitProviderService for GitHubProvider {
             .await?;
 
         if !response.status().is_success() {
-            return Err(GitProviderError::ApiError(format!(
-                "Failed to get user: {}",
-                response.status()
-            )));
+            return Err(github_response_error(
+                response,
+                "read the GitHub account identity",
+                "Metadata: read",
+            )
+            .await);
         }
 
         #[derive(Deserialize)]
@@ -1739,14 +1838,12 @@ impl GitProviderService for GitHubProvider {
                     commit_sha: reference.to_string(),
                 });
             }
-            let error_text = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
-            return Err(GitProviderError::ApiError(format!(
-                "Failed to get commit: {} - {}",
-                status, error_text
-            )));
+            return Err(github_response_error(
+                response,
+                format!("read commit {reference} from {owner}/{repo}"),
+                "Contents: read and access to the target repository",
+            )
+            .await);
         }
 
         #[derive(Deserialize)]
@@ -1813,16 +1910,12 @@ impl GitProviderService for GitHubProvider {
         match response.status() {
             status if status.is_success() => Ok(true),
             status if status == 404 => Ok(false),
-            _ => {
-                let error_text = response
-                    .text()
-                    .await
-                    .unwrap_or_else(|_| "Unknown error".to_string());
-                Err(GitProviderError::ApiError(format!(
-                    "Failed to check commit: {}",
-                    error_text
-                )))
-            }
+            _ => Err(github_response_error(
+                response,
+                format!("check commit {commit_sha} in {owner}/{repo}"),
+                "Contents: read and access to the target repository",
+            )
+            .await),
         }
     }
 
@@ -1847,10 +1940,12 @@ impl GitProviderService for GitHubProvider {
             .await?;
 
         if !response.status().is_success() {
-            return Err(GitProviderError::ApiError(format!(
-                "Failed to list commits: {}",
-                response.status()
-            )));
+            return Err(github_response_error(
+                response,
+                format!("list commits for {owner}/{repo}@{branch}"),
+                "Contents: read and access to the target repository",
+            )
+            .await);
         }
 
         #[derive(Deserialize)]
@@ -1980,15 +2075,12 @@ impl GitProviderService for GitHubProvider {
         };
 
         if !response.status().is_success() {
-            let status = response.status();
-            let error_text = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
-            return Err(GitProviderError::ApiError(format!(
-                "Failed to download archive: {} - {}",
-                status, error_text
-            )));
+            return Err(github_response_error(
+                response,
+                format!("download source archive for {owner}/{repo}@{ref_spec}"),
+                "Contents: read and access to the target repository",
+            )
+            .await);
         }
 
         // Cap the total bytes written: the client `.timeout()` bounds idle/stall
@@ -2116,6 +2208,11 @@ impl GitProviderService for GitHubProvider {
 
         if !response.status().is_success() {
             let status = response.status();
+            let rate_limit_remaining = response
+                .headers()
+                .get("x-ratelimit-remaining")
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.parse::<u64>().ok());
             let error_text = response
                 .text()
                 .await
@@ -2150,10 +2247,17 @@ impl GitProviderService for GitHubProvider {
                 }
             }
 
-            return Err(GitProviderError::ApiError(format!(
-                "Failed to create repository: {} - {}",
-                status, error_text
-            )));
+            return Err(github_status_error(
+                status,
+                rate_limit_remaining,
+                error_text,
+                format!("create repository '{name}'"),
+                if owner.is_some() {
+                    "Administration: write for the target organization"
+                } else {
+                    "permission to create repositories for the authenticated user"
+                },
+            ));
         }
 
         let github_repo: GitHubRepo = response
@@ -2243,7 +2347,7 @@ impl GitProviderService for GitHubProvider {
                     GitProviderError::ApiError(format!("Failed to parse ref: {}", e))
                 })?;
                 git_ref.object.sha
-            } else {
+            } else if ref_response.status() == reqwest::StatusCode::NOT_FOUND {
                 // Branch doesn't exist — get the default branch SHA and create the new branch
                 // Try "main" first, then "master"
                 let mut base_sha = None;
@@ -2261,6 +2365,13 @@ impl GitProviderService for GitHubProvider {
                         })?;
                         base_sha = Some(git_ref.object.sha);
                         break;
+                    } else if base_response.status() != reqwest::StatusCode::NOT_FOUND {
+                        return Err(github_response_error(
+                            base_response,
+                            format!("read base branch '{}' for {}/{}", base_branch, owner, repo),
+                            "Contents: read",
+                        )
+                        .await);
                     }
                 }
 
@@ -2284,16 +2395,23 @@ impl GitProviderService for GitHubProvider {
                     .await?;
 
                 if !create_response.status().is_success() {
-                    let status = create_response.status();
-                    let error_text = create_response.text().await.unwrap_or_default();
-                    return Err(GitProviderError::ApiError(format!(
-                        "Failed to create branch '{}': {} - {}",
-                        branch, status, error_text
-                    )));
+                    return Err(github_response_error(
+                        create_response,
+                        format!("create branch '{}' in {}/{}", branch, owner, repo),
+                        "Contents: write",
+                    )
+                    .await);
                 }
 
                 info!("Created new branch '{}' from SHA {}", branch, &sha);
                 sha
+            } else {
+                return Err(github_response_error(
+                    ref_response,
+                    format!("read branch '{}' for {}/{}", branch, owner, repo),
+                    "Contents: read",
+                )
+                .await);
             };
         debug!("Base commit SHA: {}", base_commit_sha);
 
@@ -2306,6 +2424,15 @@ impl GitProviderService for GitHubProvider {
         let commit_response = self
             .send_with_retry(|| client.get(&commit_url).headers(headers.clone()))
             .await?;
+
+        if !commit_response.status().is_success() {
+            return Err(github_response_error(
+                commit_response,
+                format!("read base commit for {}/{}", owner, repo),
+                "Contents: read",
+            )
+            .await);
+        }
 
         #[derive(Deserialize)]
         struct GitCommitResponse {
@@ -2352,15 +2479,12 @@ impl GitProviderService for GitHubProvider {
                 .await?;
 
             if !blob_response.status().is_success() {
-                let status = blob_response.status();
-                let error_text = blob_response
-                    .text()
-                    .await
-                    .unwrap_or_else(|_| "Unknown error".to_string());
-                return Err(GitProviderError::ApiError(format!(
-                    "Failed to create blob for {}: {} - {}",
-                    path, status, error_text
-                )));
+                return Err(github_response_error(
+                    blob_response,
+                    format!("create blob '{}' in {}/{}", path, owner, repo),
+                    "Contents: write",
+                )
+                .await);
             }
 
             #[derive(Deserialize)]
@@ -2401,15 +2525,12 @@ impl GitProviderService for GitHubProvider {
             .await?;
 
         if !tree_response.status().is_success() {
-            let status = tree_response.status();
-            let error_text = tree_response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
-            return Err(GitProviderError::ApiError(format!(
-                "Failed to create tree: {} - {}",
-                status, error_text
-            )));
+            return Err(github_response_error(
+                tree_response,
+                format!("create tree in {}/{}", owner, repo),
+                "Contents: write",
+            )
+            .await);
         }
 
         #[derive(Deserialize)]
@@ -2443,15 +2564,12 @@ impl GitProviderService for GitHubProvider {
             .await?;
 
         if !new_commit_response.status().is_success() {
-            let status = new_commit_response.status();
-            let error_text = new_commit_response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
-            return Err(GitProviderError::ApiError(format!(
-                "Failed to create commit: {} - {}",
-                status, error_text
-            )));
+            return Err(github_response_error(
+                new_commit_response,
+                format!("create commit in {}/{}", owner, repo),
+                "Contents: write",
+            )
+            .await);
         }
 
         #[derive(Deserialize)]
@@ -2496,15 +2614,12 @@ impl GitProviderService for GitHubProvider {
             .await?;
 
         if !update_ref_response.status().is_success() {
-            let status = update_ref_response.status();
-            let error_text = update_ref_response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
-            return Err(GitProviderError::ApiError(format!(
-                "Failed to update branch reference: {} - {}",
-                status, error_text
-            )));
+            return Err(github_response_error(
+                update_ref_response,
+                format!("update branch '{}' in {}/{}", branch, owner, repo),
+                "Contents: write",
+            )
+            .await);
         }
 
         info!(
@@ -2571,19 +2686,12 @@ impl GitProviderService for GitHubProvider {
             .await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let error_text = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
-            error!(
-                "Failed to create pull request in {}/{}: {} - {}",
-                owner, repo, status, error_text
-            );
-            return Err(GitProviderError::ApiError(format!(
-                "Failed to create pull request in {}/{}: {} - {}",
-                owner, repo, status, error_text
-            )));
+            return Err(github_response_error(
+                response,
+                format!("create a pull request in {owner}/{repo}"),
+                "Pull requests: write and access to the target repository",
+            )
+            .await);
         }
 
         #[derive(Deserialize)]
@@ -3259,5 +3367,58 @@ mod signature_tests {
     fn wrong_length_signature_is_rejected() {
         // ct_eq handles unequal lengths without panicking and returns false.
         assert!(!github_webhook_signature_matches(PAYLOAD, "sha256=deadbeef", SECRET).unwrap());
+    }
+}
+
+#[cfg(test)]
+mod token_permission_tests {
+    use super::*;
+
+    fn provider(api_url: String) -> GitHubProvider {
+        GitHubProvider::new(
+            Some(api_url),
+            AuthMethod::PersonalAccessToken {
+                token: "test-token".to_string(),
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn validate_token_accepts_repository_scoped_credentials_without_user_access() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/rate_limit")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("x-ratelimit-remaining", "4999")
+            .with_body(r#"{"resources":{"core":{"remaining":4999}}}"#)
+            .create_async()
+            .await;
+
+        let valid = GitProviderService::validate_token(&provider(server.url()), "token")
+            .await
+            .expect("a repository-scoped credential should validate without /user access");
+
+        mock.assert_async().await;
+        assert!(valid);
+    }
+
+    #[tokio::test]
+    async fn validate_token_keeps_invalid_credentials_distinct_from_permissions() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/rate_limit")
+            .with_status(401)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"message":"Bad credentials"}"#)
+            .create_async()
+            .await;
+
+        let valid = GitProviderService::validate_token(&provider(server.url()), "token")
+            .await
+            .expect("401 is represented by false for the existing validation contract");
+
+        mock.assert_async().await;
+        assert!(!valid);
     }
 }

--- a/crates/temps-git/src/services/public_repo.rs
+++ b/crates/temps-git/src/services/public_repo.rs
@@ -13,8 +13,19 @@ pub enum PublicRepoError {
     #[error("Repository not found: {0}")]
     NotFound(String),
 
+    #[error("Repository is not public: {0}")]
+    RepositoryNotPublic(String),
+
     #[error("Rate limit exceeded")]
     RateLimitExceeded,
+
+    #[error(
+        "Permission denied while trying to {operation}. Required permission: {required_permission}"
+    )]
+    PermissionDenied {
+        operation: String,
+        required_permission: String,
+    },
 
     #[error("API error: {0}")]
     ApiError(String),
@@ -98,6 +109,29 @@ pub struct GitHubPublicProvider {
     token: Option<String>,
 }
 
+fn github_rate_limit_remaining(response: &reqwest::Response) -> Option<u64> {
+    response
+        .headers()
+        .get("x-ratelimit-remaining")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse().ok())
+}
+
+fn ensure_repository_is_public(
+    is_public: bool,
+    owner: &str,
+    repo: &str,
+) -> Result<(), PublicRepoError> {
+    if is_public {
+        Ok(())
+    } else {
+        Err(PublicRepoError::RepositoryNotPublic(format!(
+            "{}/{}",
+            owner, repo
+        )))
+    }
+}
+
 impl GitHubPublicProvider {
     pub fn new() -> Self {
         let client = reqwest::Client::builder()
@@ -179,12 +213,24 @@ impl GitHubPublicProvider {
 
     fn check_response_status(
         status: reqwest::StatusCode,
+        rate_limit_remaining: Option<u64>,
+        authenticated: bool,
         context: &str,
     ) -> Result<(), PublicRepoError> {
         match status.as_u16() {
             200..=299 => Ok(()),
             404 => Err(PublicRepoError::NotFound(context.to_string())),
-            403 | 429 => Err(PublicRepoError::RateLimitExceeded),
+            429 => Err(PublicRepoError::RateLimitExceeded),
+            403 if rate_limit_remaining == Some(0) => Err(PublicRepoError::RateLimitExceeded),
+            403 => Err(PublicRepoError::PermissionDenied {
+                operation: context.to_string(),
+                required_permission: if authenticated {
+                    "Contents: read and access to the target repository".to_string()
+                } else {
+                    "authenticate with a token that has Contents: read and access to the target repository"
+                        .to_string()
+                },
+            }),
             _ => Err(PublicRepoError::ApiError(format!(
                 "{}: HTTP {}",
                 context, status
@@ -214,7 +260,12 @@ impl PublicRepoProvider for GitHubPublicProvider {
 
         let response = self.send_with_retry(|| self.client.get(&url)).await?;
 
-        Self::check_response_status(response.status(), &format!("Repository {}/{}", owner, repo))?;
+        Self::check_response_status(
+            response.status(),
+            github_rate_limit_remaining(&response),
+            self.token.is_some(),
+            &format!("read repository {}/{}", owner, repo),
+        )?;
 
         #[derive(Deserialize)]
         struct GitHubRepo {
@@ -226,6 +277,7 @@ impl PublicRepoProvider for GitHubPublicProvider {
             stargazers_count: Option<u32>,
             forks_count: Option<u32>,
             owner: Option<GitHubOwner>,
+            private: bool,
         }
 
         #[derive(Deserialize)]
@@ -237,6 +289,8 @@ impl PublicRepoProvider for GitHubPublicProvider {
             .json()
             .await
             .map_err(|e| PublicRepoError::ApiError(format!("Failed to parse response: {}", e)))?;
+
+        ensure_repository_is_public(!repo_data.private, owner, repo)?;
 
         Ok(PublicRepoInfo {
             owner: repo_data
@@ -288,7 +342,9 @@ impl PublicRepoProvider for GitHubPublicProvider {
 
             Self::check_response_status(
                 response.status(),
-                &format!("Branches for {}/{}", owner, repo),
+                github_rate_limit_remaining(&response),
+                self.token.is_some(),
+                &format!("list branches for {}/{}", owner, repo),
             )?;
 
             let branches: Vec<GitHubBranch> = response.json().await.map_err(|e| {
@@ -327,7 +383,9 @@ impl PublicRepoProvider for GitHubPublicProvider {
 
         Self::check_response_status(
             response.status(),
-            &format!("File tree for {}/{} at {}", owner, repo, reference),
+            github_rate_limit_remaining(&response),
+            self.token.is_some(),
+            &format!("read the file tree for {}/{} at {}", owner, repo, reference),
         )?;
 
         #[derive(Deserialize)]
@@ -429,7 +487,11 @@ impl GitLabPublicProvider {
         match status.as_u16() {
             200..=299 => Ok(()),
             404 => Err(PublicRepoError::NotFound(context.to_string())),
-            403 | 429 => Err(PublicRepoError::RateLimitExceeded),
+            403 => Err(PublicRepoError::PermissionDenied {
+                operation: context.to_string(),
+                required_permission: "read_api and read_repository".to_string(),
+            }),
+            429 => Err(PublicRepoError::RateLimitExceeded),
             _ => Err(PublicRepoError::ApiError(format!(
                 "{}: HTTP {}",
                 context, status
@@ -475,6 +537,7 @@ impl PublicRepoProvider for GitLabPublicProvider {
             star_count: Option<i32>,
             forks_count: Option<i32>,
             namespace: Option<GitLabNamespace>,
+            visibility: String,
         }
 
         #[derive(Deserialize)]
@@ -486,6 +549,8 @@ impl PublicRepoProvider for GitLabPublicProvider {
             .json()
             .await
             .map_err(|e| PublicRepoError::ApiError(format!("Failed to parse response: {}", e)))?;
+
+        ensure_repository_is_public(project.visibility == "public", owner, repo)?;
 
         Ok(PublicRepoInfo {
             owner: project
@@ -708,6 +773,43 @@ pub fn detect_presets_from_files(files: &[String]) -> Vec<DetectedPreset> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn authenticated_public_provider_rejects_private_repository_metadata() {
+        let error = ensure_repository_is_public(false, "owner", "private")
+            .expect_err("private repositories must never pass through public endpoints");
+        assert!(matches!(
+            error,
+            PublicRepoError::RepositoryNotPublic(name) if name == "owner/private"
+        ));
+    }
+
+    #[test]
+    fn github_forbidden_response_is_not_misreported_as_rate_limit() {
+        let error = GitHubPublicProvider::check_response_status(
+            reqwest::StatusCode::FORBIDDEN,
+            Some(4_999),
+            true,
+            "list branches for owner/repo",
+        )
+        .expect_err("a non-rate-limited 403 must report the missing permission");
+
+        assert!(matches!(error, PublicRepoError::PermissionDenied { .. }));
+        assert!(error.to_string().contains("Contents: read"));
+    }
+
+    #[test]
+    fn github_exhausted_rate_limit_remains_rate_limit_error() {
+        let error = GitHubPublicProvider::check_response_status(
+            reqwest::StatusCode::FORBIDDEN,
+            Some(0),
+            true,
+            "list branches for owner/repo",
+        )
+        .expect_err("an exhausted GitHub limit must report rate limiting");
+
+        assert!(matches!(error, PublicRepoError::RateLimitExceeded));
+    }
 
     // =============================================================================
     // Unit Tests - Provider Factory

--- a/crates/temps-import/src/services/deployment_verifier.rs
+++ b/crates/temps-import/src/services/deployment_verifier.rs
@@ -144,7 +144,7 @@ impl DeploymentVerifier {
             let trigger_result = match image_ref {
                 Some(image_ref) => {
                     self.deployment_service
-                        .trigger_image_deployment(project_id, image_ref, None)
+                        .trigger_image_deployment(project_id, None, image_ref, None)
                         .await
                 }
                 None => {

--- a/crates/temps-projects/src/handlers/handlers.rs
+++ b/crates/temps-projects/src/handlers/handlers.rs
@@ -2133,6 +2133,7 @@ pub async fn create_project_from_template(
         let deploy_job =
             temps_core::Job::DeployImageRequested(temps_core::DeployImageRequestedJob {
                 project_id: project.id,
+                target_environment_id: None,
                 image_ref: image_ref.clone(),
                 health_check_path: template.health_check_path.clone(),
             });

--- a/crates/temps-projects/src/services/project.rs
+++ b/crates/temps-projects/src/services/project.rs
@@ -3066,6 +3066,19 @@ impl ProjectService {
                     ))
                 })?;
 
+            // A shared credential may be able to see private repositories.
+            // `is_public_repo` must never turn that credential into a private
+            // repository oracle, so verify visibility before reading branches.
+            provider
+                .get_repository(&project.repo_owner, &project.repo_name)
+                .await
+                .map_err(|e| {
+                    ProjectError::Other(format!(
+                        "Failed to verify that repository {}/{} is public: {}",
+                        project.repo_owner, project.repo_name, e
+                    ))
+                })?;
+
             let branches = provider
                 .list_branches(&project.repo_owner, &project.repo_name)
                 .await

--- a/crates/temps-providers/src/externalsvc/postgres_role_reconciler.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_role_reconciler.rs
@@ -298,8 +298,10 @@ pub async fn reconcile_once(
     //      and typically isn't in production either.
     //   2. `nodes.private_address` — the worker's underlay IP, always
     //      reachable from the control plane.
-    //   3. "localhost" — single-host clusters where the monitor runs on
-    //      the control-plane host and binds the host port.
+    //   3. IPv4 loopback — single-host clusters where the monitor runs on
+    //      the control-plane host and binds the host port. Do not use
+    //      `localhost`: Ubuntu may resolve it to ::1 while Docker publishes
+    //      this port only on 127.0.0.1.
     //
     // We deliberately do NOT fall back to `member.hostname` (the FQDN)
     // because it only resolves on hosts running the per-node Hickory
@@ -317,7 +319,7 @@ pub async fn reconcile_once(
             }
         }
     } else {
-        "localhost".to_string()
+        crate::services::LOCAL_CLUSTER_HOST.to_string()
     };
     let monitor_port = monitor.port.unwrap_or(5432);
 

--- a/crates/temps-providers/src/externalsvc/rustfs.rs
+++ b/crates/temps-providers/src/externalsvc/rustfs.rs
@@ -258,6 +258,91 @@ fn default_secret_key() -> String {
         .collect()
 }
 
+/// Build the `mc mirror` command used by RustFS restores.
+///
+/// In-place restores must exactly reproduce every bucket present in the
+/// backup: objects created later inside those buckets are removed and any
+/// mirror error fails the restore. Destination-only buckets are intentionally
+/// retained to avoid deleting an entire bucket outside the selected backup's
+/// scope. A newly provisioned target is empty, so it does not need `--remove`.
+fn restore_mirror_command<'a>(
+    source: &'a str,
+    destination: &'a str,
+    remove_extraneous: bool,
+) -> Vec<&'a str> {
+    let mut command = vec!["mc", "mirror", "--overwrite"];
+    if remove_extraneous {
+        command.push("--remove");
+    }
+    command.extend([source, destination]);
+    command
+}
+
+/// Remove credentials from external-client output before it reaches logs,
+/// persisted restore errors, or API responses. Replacing the individual key
+/// values also redacts them when `mc` echoes a credential-bearing URL.
+fn redact_sensitive_output(output: &str, sensitive_values: &[&str]) -> String {
+    sensitive_values
+        .iter()
+        .filter(|value| !value.is_empty())
+        .fold(output.to_string(), |redacted, value| {
+            redacted.replace(value, "***")
+        })
+}
+
+fn docker_error_is_not_found(error: &bollard::errors::Error) -> bool {
+    matches!(
+        error,
+        bollard::errors::Error::DockerResponseServerError {
+            status_code: 404,
+            ..
+        }
+    )
+}
+
+/// Best-effort cleanup for a restore target that has no database owner yet.
+/// `remove_container` must only be true after this invocation successfully
+/// created that exact container; this prevents a name collision from deleting
+/// another service's data.
+async fn cleanup_unowned_rustfs_resources(
+    docker: &Docker,
+    container_name: &str,
+    volume_names: &[&str],
+    remove_container: bool,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+    if remove_container {
+        if let Err(error) = docker
+            .remove_container(
+                container_name,
+                Some(bollard::query_parameters::RemoveContainerOptions {
+                    force: true,
+                    ..Default::default()
+                }),
+            )
+            .await
+        {
+            if !docker_error_is_not_found(&error) {
+                errors.push(format!("container '{}': {}", container_name, error));
+            }
+        }
+    }
+    for volume_name in volume_names {
+        if let Err(error) = docker
+            .remove_volume(
+                volume_name,
+                None::<bollard::query_parameters::RemoveVolumeOptions>,
+            )
+            .await
+        {
+            if !docker_error_is_not_found(&error) {
+                errors.push(format!("volume '{}': {}", volume_name, error));
+            }
+        }
+    }
+    errors
+}
+
 // Schema example functions
 fn example_port() -> &'static str {
     "9000"
@@ -465,14 +550,10 @@ impl RustfsService {
             while let Ok(Some(output)) = output.try_next().await {
                 match output {
                     bollard::container::LogOutput::StdOut { message } => {
-                        let msg = String::from_utf8_lossy(&message);
-                        info!("stdout: {}", msg);
-                        stdout.push_str(&msg);
+                        stdout.push_str(&String::from_utf8_lossy(&message));
                     }
                     bollard::container::LogOutput::StdErr { message } => {
-                        let msg = String::from_utf8_lossy(&message);
-                        error!("stderr: {}", msg);
-                        stderr.push_str(&msg);
+                        stderr.push_str(&String::from_utf8_lossy(&message));
                     }
                     _ => {}
                 }
@@ -489,6 +570,7 @@ impl RustfsService {
         docker: &Docker,
         config: &RustfsConfig,
         resource_limits: &ServiceResourceLimits,
+        require_new: bool,
     ) -> Result<()> {
         // Pull the image first
         info!("Pulling RustFS image {}", config.docker_image);
@@ -518,21 +600,6 @@ impl RustfsService {
         let data_volume_name = format!("rustfs_{}_data", self.name);
         let logs_volume_name = format!("rustfs_{}_logs", self.name);
 
-        // Create volumes if they don't exist
-        docker
-            .create_volume(bollard::models::VolumeCreateRequest {
-                name: Some(data_volume_name.clone()),
-                ..Default::default()
-            })
-            .await?;
-
-        docker
-            .create_volume(bollard::models::VolumeCreateRequest {
-                name: Some(logs_volume_name.clone()),
-                ..Default::default()
-            })
-            .await?;
-
         // Check if container already exists
         let containers = docker
             .list_containers(Some(bollard::query_parameters::ListContainersOptions {
@@ -546,7 +613,19 @@ impl RustfsService {
             .await?;
 
         if !containers.is_empty() {
-            let container = containers.first().unwrap();
+            if require_new {
+                return Err(anyhow::anyhow!(
+                    "Cannot create restored RustFS service '{}': Docker container '{}' already exists",
+                    self.name,
+                    container_name
+                ));
+            }
+            let container = containers.first().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Docker reported a RustFS container collision for '{}' without container details",
+                    container_name
+                )
+            })?;
             let existing_image = container.image.as_deref().unwrap_or("");
             let is_running =
                 container.state == Some(bollard::models::ContainerSummaryStateEnum::RUNNING);
@@ -581,6 +660,70 @@ impl RustfsService {
                     }),
                 )
                 .await?;
+        }
+
+        if require_new {
+            for volume_name in [&data_volume_name, &logs_volume_name] {
+                match docker.inspect_volume(volume_name).await {
+                    Ok(_) => {
+                        return Err(anyhow::anyhow!(
+                            "Cannot create restored RustFS service '{}': derived Docker volume '{}' already exists",
+                            self.name,
+                            volume_name
+                        ));
+                    }
+                    Err(error) if docker_error_is_not_found(&error) => {}
+                    Err(error) => {
+                        return Err(anyhow::anyhow!(
+                            "Cannot verify Docker volume '{}' is available for restored RustFS service '{}': {}",
+                            volume_name,
+                            self.name,
+                            error
+                        ));
+                    }
+                }
+            }
+        }
+
+        ensure_network_exists(docker)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to ensure network exists: {:?}", e))?;
+
+        docker
+            .create_volume(bollard::models::VolumeCreateRequest {
+                name: Some(data_volume_name.clone()),
+                ..Default::default()
+            })
+            .await?;
+
+        if let Err(error) = docker
+            .create_volume(bollard::models::VolumeCreateRequest {
+                name: Some(logs_volume_name.clone()),
+                ..Default::default()
+            })
+            .await
+        {
+            let cleanup_errors = if require_new {
+                cleanup_unowned_rustfs_resources(
+                    docker,
+                    &container_name,
+                    &[&data_volume_name],
+                    false,
+                )
+                .await
+            } else {
+                Vec::new()
+            };
+            return Err(anyhow::anyhow!(
+                "Failed to create RustFS logs volume '{}': {}{}",
+                logs_volume_name,
+                error,
+                if cleanup_errors.is_empty() {
+                    String::new()
+                } else {
+                    format!(". Cleanup also failed: {}", cleanup_errors.join("; "))
+                }
+            ));
         }
 
         let service_label_key = format!("{}service_type", temps_core::DOCKER_LABEL_PREFIX);
@@ -628,10 +771,6 @@ impl RustfsService {
             env_vars.push("RUSTFS_OBS_TRACES_EXPORT_ENABLED=false".to_string());
             env_vars.push("RUSTFS_OBS_LOGS_EXPORT_ENABLED=false".to_string());
         }
-
-        ensure_network_exists(docker)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to ensure network exists: {:?}", e))?;
 
         let networking_config = Some(bollard::models::NetworkingConfig {
             endpoints_config: Some(HashMap::from([(
@@ -706,7 +845,7 @@ impl RustfsService {
             ..Default::default()
         };
 
-        let container = docker
+        let container = match docker
             .create_container(
                 Some(
                     bollard::query_parameters::CreateContainerOptionsBuilder::new()
@@ -716,15 +855,62 @@ impl RustfsService {
                 container_config,
             )
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to create RustFS container: {}", e))?;
+        {
+            Ok(container) => container,
+            Err(error) => {
+                let cleanup_errors = if require_new {
+                    cleanup_unowned_rustfs_resources(
+                        docker,
+                        &container_name,
+                        &[&data_volume_name, &logs_volume_name],
+                        false,
+                    )
+                    .await
+                } else {
+                    Vec::new()
+                };
+                return Err(anyhow::anyhow!(
+                    "Failed to create RustFS container '{}': {}{}",
+                    container_name,
+                    error,
+                    if cleanup_errors.is_empty() {
+                        String::new()
+                    } else {
+                        format!(". Cleanup also failed: {}", cleanup_errors.join("; "))
+                    }
+                ));
+            }
+        };
 
-        docker
+        if let Err(error) = docker
             .start_container(
                 &container.id,
                 None::<bollard::query_parameters::StartContainerOptions>,
             )
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to start RustFS container: {}", e))?;
+        {
+            let cleanup_errors = if require_new {
+                cleanup_unowned_rustfs_resources(
+                    docker,
+                    &container_name,
+                    &[&data_volume_name, &logs_volume_name],
+                    true,
+                )
+                .await
+            } else {
+                Vec::new()
+            };
+            return Err(anyhow::anyhow!(
+                "Failed to start RustFS container '{}': {}{}",
+                container_name,
+                error,
+                if cleanup_errors.is_empty() {
+                    String::new()
+                } else {
+                    format!(". Cleanup also failed: {}", cleanup_errors.join("; "))
+                }
+            ));
+        }
 
         // Spawn health check as background task (non-blocking)
         let container_id = container.id.clone();
@@ -916,7 +1102,7 @@ impl ExternalService for RustfsService {
             )
             .await;
 
-        self.create_container(&self.docker, &config, &resource_limits)
+        self.create_container(&self.docker, &config, &resource_limits, false)
             .await
     }
 
@@ -954,7 +1140,7 @@ impl ExternalService for RustfsService {
             .await;
 
         // create_container pulls the new image and mounts the existing volume.
-        self.create_container(&self.docker, &new_cfg, &resource_limits)
+        self.create_container(&self.docker, &new_cfg, &resource_limits, false)
             .await?;
 
         info!(
@@ -1005,7 +1191,7 @@ impl ExternalService for RustfsService {
         }
 
         // Create container
-        self.create_container(&self.docker, &runtime_config, &resource_limits)
+        self.create_container(&self.docker, &runtime_config, &resource_limits, false)
             .await?;
 
         // Create S3 client
@@ -1554,6 +1740,12 @@ impl ExternalService for RustfsService {
 
         let mut success = true;
         let mut error_logs = Vec::new();
+        let sensitive_values = [
+            rustfs_config.access_key.as_str(),
+            rustfs_config.secret_key.as_str(),
+            decrypted_access_key.as_str(),
+            decrypted_secret_key.as_str(),
+        ];
 
         for cmd in commands {
             // Log only the subcommand — args may contain credentials (e.g. `mc alias set`).
@@ -1567,7 +1759,7 @@ impl ExternalService for RustfsService {
                 .await?;
 
             if !ok {
-                error_logs.push(stderr);
+                error_logs.push(redact_sensitive_output(&stderr, &sensitive_values));
                 success = false;
                 break;
             }
@@ -1732,6 +1924,12 @@ impl ExternalService for RustfsService {
                 &rustfs_config.secret_key,
             ],
         ];
+        let sensitive_values = [
+            source_access_key,
+            source_secret_key,
+            rustfs_config.access_key.as_str(),
+            rustfs_config.secret_key.as_str(),
+        ];
 
         for cmd in setup_commands {
             let (ok, _stdout, stderr) = self.exec_in_container(docker, &container.id, cmd).await?;
@@ -1748,7 +1946,7 @@ impl ExternalService for RustfsService {
                     .await?;
                 return Err(anyhow::anyhow!(
                     "Failed to set up mc aliases for RustFS restore: {}",
-                    stderr
+                    redact_sensitive_output(&stderr, &sensitive_values)
                 ));
             }
         }
@@ -1760,9 +1958,25 @@ impl ExternalService for RustfsService {
         );
         let list_command = vec!["mc", "ls", "--json", &source_backup_location];
 
-        let (_, list_stdout, _) = self
+        let (list_ok, list_stdout, list_stderr) = self
             .exec_in_container(docker, &container.id, list_command)
             .await?;
+        if !list_ok {
+            let _ = docker
+                .remove_container(
+                    &container.id,
+                    Some(bollard::query_parameters::RemoveContainerOptions {
+                        force: true,
+                        ..Default::default()
+                    }),
+                )
+                .await;
+            return Err(anyhow::anyhow!(
+                "RustFS in-place restore could not list backup location '{}': {}",
+                source_backup_location,
+                redact_sensitive_output(&list_stderr, &sensitive_values).trim()
+            ));
+        }
 
         // Parse bucket listing from JSON output
         let mut buckets = Vec::new();
@@ -1797,20 +2011,15 @@ impl ExternalService for RustfsService {
                 );
             }
 
-            // Mirror the bucket contents
+            // An in-place restore must reproduce the selected backup exactly.
+            // Do not use --skip-errors: a partial mirror cannot be reported as
+            // a completed restore.
             let source_bucket_loc = format!(
                 "backup-source/{}/{}/{}",
                 s3_source.bucket_name, backup_location, bucket_name
             );
             let dest_bucket_loc = format!("dest/{}", bucket_name);
-            let mirror_cmd = vec![
-                "mc",
-                "mirror",
-                "--skip-errors",
-                "--overwrite",
-                &source_bucket_loc,
-                &dest_bucket_loc,
-            ];
+            let mirror_cmd = restore_mirror_command(&source_bucket_loc, &dest_bucket_loc, true);
 
             info!(
                 "Executing mirror command for bucket {}: {:?}",
@@ -1822,8 +2031,22 @@ impl ExternalService for RustfsService {
                 .await?;
 
             if !ok {
-                error!("Mirror failed for bucket {}: {}", bucket_name, stderr);
-                // Continue with other buckets rather than failing entirely
+                let safe_stderr = redact_sensitive_output(&stderr, &sensitive_values);
+                error!("Mirror failed for bucket {}: {}", bucket_name, safe_stderr);
+                let _ = docker
+                    .remove_container(
+                        &container.id,
+                        Some(bollard::query_parameters::RemoveContainerOptions {
+                            force: true,
+                            ..Default::default()
+                        }),
+                    )
+                    .await;
+                return Err(anyhow::anyhow!(
+                    "RustFS in-place restore failed while mirroring bucket '{}': {}",
+                    bucket_name,
+                    safe_stderr.trim()
+                ));
             }
         }
 
@@ -1921,190 +2144,281 @@ impl ExternalService for RustfsService {
         *new_service.config.write().await = Some(new_config.clone());
         *new_service.resource_limits.write().await = cloned_limits.clone();
 
+        if temps_entities::external_services::Entity::find()
+            .filter(temps_entities::external_services::Column::Name.eq(&new_service_name))
+            .one(ctx.pool)
+            .await?
+            .is_some()
+        {
+            return Err(anyhow::anyhow!(
+                "Cannot restore to new RustFS service '{}': a service with that name already exists",
+                new_service_name
+            ));
+        }
+
         new_service
-            .create_container(&self.docker, &new_config, &cloned_limits)
+            .create_container(&self.docker, &new_config, &cloned_limits, true)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to create new RustFS container: {}", e))?;
 
-        // Orchestrator already decrypted into the plaintext s3_source copy.
-        // Re-decrypting would fail because these are no longer ciphertext.
-        let source_access_key = ctx.s3_source.access_key_id.clone();
-        let source_secret_key = ctx.s3_source.secret_key.clone();
-        let source_endpoint = ctx
-            .s3_source
-            .endpoint
-            .as_deref()
-            .unwrap_or("s3.amazonaws.com");
-
-        self.pull_mc_image(&self.docker).await?;
-
-        let mc_container_name = format!("mc-restore-new-{}", uuid::Uuid::new_v4());
-        let env_vars = [
-            format!(
-                "MC_HOST_source=http://{}:{}@{}",
-                source_access_key, source_secret_key, source_endpoint
-            ),
-            format!(
-                "MC_HOST_dest=http://{}:{}@localhost:{}",
-                new_config.access_key, new_config.secret_key, new_config.port
-            ),
-        ];
-
-        let mc_config = bollard::models::ContainerCreateBody {
-            image: Some(Self::MC_IMAGE.to_string()),
-            env: Some(env_vars.iter().map(|s| s.as_str().to_string()).collect()),
-            entrypoint: Some(vec!["sh".to_string()]),
-            tty: Some(true),
-            attach_stdin: Some(true),
-            attach_stdout: Some(true),
-            attach_stderr: Some(true),
-            host_config: Some(bollard::models::HostConfig {
-                network_mode: Some("host".to_string()),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-
-        let container = self
-            .docker
-            .create_container(
-                Some(
-                    bollard::query_parameters::CreateContainerOptionsBuilder::new()
-                        .name(&mc_container_name)
-                        .build(),
-                ),
-                mc_config,
-            )
-            .await?;
-
-        self.docker
-            .start_container(
-                &container.id,
-                None::<bollard::query_parameters::StartContainerOptions>,
-            )
-            .await?;
-
-        let dest_endpoint = format!("http://localhost:{}", new_config.port);
-        let setup_commands: Vec<Vec<&str>> = vec![
-            vec![
-                "mc",
-                "alias",
-                "set",
-                "backup-source",
-                source_endpoint,
-                &source_access_key,
-                &source_secret_key,
-            ],
-            vec![
-                "mc",
-                "alias",
-                "set",
-                "dest",
-                &dest_endpoint,
-                &new_config.access_key,
-                &new_config.secret_key,
-            ],
-        ];
-
-        for cmd in setup_commands {
-            let (ok, _stdout, stderr) = self
-                .exec_in_container(&self.docker, &container.id, cmd)
-                .await?;
-            if !ok {
-                let _ = self
-                    .docker
-                    .remove_container(
-                        &container.id,
-                        Some(bollard::query_parameters::RemoveContainerOptions {
-                            force: true,
-                            ..Default::default()
-                        }),
-                    )
-                    .await;
-                return Err(anyhow::anyhow!(
-                    "Failed to set up mc aliases for new RustFS restore: {}",
-                    stderr
-                ));
-            }
-        }
-
-        // List buckets at the backup prefix.
-        let source_backup_location = format!(
-            "backup-source/{}/{}",
-            ctx.s3_source.bucket_name, ctx.backup_location
-        );
-        let list_command = vec!["mc", "ls", "--json", &source_backup_location];
-        let (_, list_stdout, _) = self
-            .exec_in_container(&self.docker, &container.id, list_command)
-            .await?;
-
-        let mut buckets: Vec<String> = Vec::new();
-        let json_objects = parse_multiline_json_output(&list_stdout)?;
-        for listing in json_objects {
-            if let (Some("folder"), Some(key)) = (
-                listing.get("type").and_then(|t| t.as_str()),
-                listing.get("key").and_then(|k| k.as_str()),
-            ) {
-                buckets.push(key.to_string());
-            }
-        }
-
-        info!(
-            "Restoring {} bucket(s) into new RustFS service '{}'",
-            buckets.len(),
-            new_service_name
-        );
-
-        for bucket in buckets {
-            let bucket_name = bucket.trim_end_matches('/');
-            let dest_location = format!("dest/{}", bucket_name);
-
-            let mb_cmd = vec!["mc", "mb", &dest_location];
-            let (ok, stdout_mb, _) = self
-                .exec_in_container(&self.docker, &container.id, mb_cmd)
-                .await?;
-            if !ok && !stdout_mb.contains("already") {
-                info!(
-                    "mc mb returned non-zero for bucket {}, continuing: {}",
-                    bucket_name, stdout_mb
-                );
-            }
-
-            let source_bucket_loc = format!(
-                "backup-source/{}/{}/{}",
-                ctx.s3_source.bucket_name, ctx.backup_location, bucket_name
-            );
-            let mirror_cmd = vec![
-                "mc",
-                "mirror",
-                "--skip-errors",
-                "--overwrite",
-                &source_bucket_loc,
-                &dest_location,
+        let mut mc_container_id: Option<String> = None;
+        let restore_result: Result<()> = async {
+            // Orchestrator already decrypted into the plaintext s3_source copy.
+            // Re-decrypting would fail because these are no longer ciphertext.
+            let source_access_key = ctx.s3_source.access_key_id.clone();
+            let source_secret_key = ctx.s3_source.secret_key.clone();
+            let source_endpoint = ctx
+                .s3_source
+                .endpoint
+                .as_deref()
+                .unwrap_or("s3.amazonaws.com");
+            let sensitive_values = [
+                source_access_key.as_str(),
+                source_secret_key.as_str(),
+                new_config.access_key.as_str(),
+                new_config.secret_key.as_str(),
             ];
 
-            info!("Mirroring bucket {} -> new RustFS service", bucket_name);
-            let (ok, _stdout, stderr) = self
-                .exec_in_container(&self.docker, &container.id, mirror_cmd)
-                .await?;
-            if !ok {
-                error!("Mirror failed for bucket {}: {}", bucket_name, stderr);
-            }
-        }
+            self.pull_mc_image(&self.docker).await?;
 
-        let _ = self
-            .docker
-            .remove_container(
-                &container.id,
-                Some(bollard::query_parameters::RemoveContainerOptions {
-                    force: true,
+            let mc_container_name = format!("mc-restore-new-{}", uuid::Uuid::new_v4());
+            let env_vars = [
+                format!(
+                    "MC_HOST_source=http://{}:{}@{}",
+                    source_access_key, source_secret_key, source_endpoint
+                ),
+                format!(
+                    "MC_HOST_dest=http://{}:{}@localhost:{}",
+                    new_config.access_key, new_config.secret_key, new_config.port
+                ),
+            ];
+
+            let mc_config = bollard::models::ContainerCreateBody {
+                image: Some(Self::MC_IMAGE.to_string()),
+                env: Some(env_vars.iter().map(|s| s.as_str().to_string()).collect()),
+                entrypoint: Some(vec!["sh".to_string()]),
+                tty: Some(true),
+                attach_stdin: Some(true),
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                host_config: Some(bollard::models::HostConfig {
+                    network_mode: Some("host".to_string()),
                     ..Default::default()
                 }),
+                ..Default::default()
+            };
+
+            let container = self
+                .docker
+                .create_container(
+                    Some(
+                        bollard::query_parameters::CreateContainerOptionsBuilder::new()
+                            .name(&mc_container_name)
+                            .build(),
+                    ),
+                    mc_config,
+                )
+                .await?;
+            mc_container_id = Some(container.id.clone());
+
+            self.docker
+                .start_container(
+                    &container.id,
+                    None::<bollard::query_parameters::StartContainerOptions>,
+                )
+                .await?;
+
+            let dest_endpoint = format!("http://localhost:{}", new_config.port);
+            let setup_commands: Vec<Vec<&str>> = vec![
+                vec![
+                    "mc",
+                    "alias",
+                    "set",
+                    "backup-source",
+                    source_endpoint,
+                    &source_access_key,
+                    &source_secret_key,
+                ],
+                vec![
+                    "mc",
+                    "alias",
+                    "set",
+                    "dest",
+                    &dest_endpoint,
+                    &new_config.access_key,
+                    &new_config.secret_key,
+                ],
+            ];
+
+            for cmd in setup_commands {
+                let (ok, _stdout, stderr) = self
+                    .exec_in_container(&self.docker, &container.id, cmd)
+                    .await?;
+                if !ok {
+                    Err(anyhow::anyhow!(
+                        "Failed to set up mc aliases for new RustFS restore: {}",
+                        redact_sensitive_output(&stderr, &sensitive_values)
+                    ))?;
+                }
+            }
+
+            // List buckets at the backup prefix.
+            let source_backup_location = format!(
+                "backup-source/{}/{}",
+                ctx.s3_source.bucket_name, ctx.backup_location
+            );
+            let list_command = vec!["mc", "ls", "--json", &source_backup_location];
+            let (list_ok, list_stdout, list_stderr) = self
+                .exec_in_container(&self.docker, &container.id, list_command)
+                .await?;
+            if !list_ok {
+                Err(anyhow::anyhow!(
+                    "RustFS restore to new service '{}' could not list backup location '{}': {}",
+                    new_service_name,
+                    source_backup_location,
+                    redact_sensitive_output(&list_stderr, &sensitive_values).trim()
+                ))?;
+            }
+
+            let mut buckets: Vec<String> = Vec::new();
+            let json_objects = parse_multiline_json_output(&list_stdout)?;
+            for listing in json_objects {
+                if let (Some("folder"), Some(key)) = (
+                    listing.get("type").and_then(|t| t.as_str()),
+                    listing.get("key").and_then(|k| k.as_str()),
+                ) {
+                    buckets.push(key.to_string());
+                }
+            }
+
+            info!(
+                "Restoring {} bucket(s) into new RustFS service '{}'",
+                buckets.len(),
+                new_service_name
+            );
+
+            for bucket in buckets {
+                let bucket_name = bucket.trim_end_matches('/');
+                let dest_location = format!("dest/{}", bucket_name);
+
+                let mb_cmd = vec!["mc", "mb", &dest_location];
+                let (ok, stdout_mb, _) = self
+                    .exec_in_container(&self.docker, &container.id, mb_cmd)
+                    .await?;
+                if !ok && !stdout_mb.contains("already") {
+                    info!(
+                        "mc mb returned non-zero for bucket {}, continuing: {}",
+                        bucket_name, stdout_mb
+                    );
+                }
+
+                let source_bucket_loc = format!(
+                    "backup-source/{}/{}/{}",
+                    ctx.s3_source.bucket_name, ctx.backup_location, bucket_name
+                );
+                let mirror_cmd = restore_mirror_command(&source_bucket_loc, &dest_location, false);
+
+                info!("Mirroring bucket {} -> new RustFS service", bucket_name);
+                let (ok, _stdout, stderr) = self
+                    .exec_in_container(&self.docker, &container.id, mirror_cmd)
+                    .await?;
+                if !ok {
+                    let safe_stderr = redact_sensitive_output(&stderr, &sensitive_values);
+                    error!("Mirror failed for bucket {}: {}", bucket_name, safe_stderr);
+                    Err(anyhow::anyhow!(
+                        "RustFS restore to new service '{}' failed while mirroring bucket '{}': {}",
+                        new_service_name,
+                        bucket_name,
+                        safe_stderr.trim()
+                    ))?;
+                }
+            }
+
+            Ok(())
+        }
+        .await;
+
+        // Always remove the credential-bearing helper. On failure, also remove
+        // the not-yet-owned target container and volumes: the orchestrator only
+        // creates its service row after this method succeeds.
+        let helper_cleanup_error = if let Some(container_id) = mc_container_id {
+            match self
+                .docker
+                .remove_container(
+                    &container_id,
+                    Some(bollard::query_parameters::RemoveContainerOptions {
+                        force: true,
+                        ..Default::default()
+                    }),
+                )
+                .await
+            {
+                Ok(()) => None,
+                Err(error) if docker_error_is_not_found(&error) => None,
+                Err(error) => Some(anyhow::anyhow!(
+                    "failed to remove credential-bearing mc helper container '{}': {}",
+                    container_id,
+                    error
+                )),
+            }
+        } else {
+            None
+        };
+        let restore_result = match (restore_result, helper_cleanup_error) {
+            (Ok(()), None) => Ok(()),
+            (Err(error), None) => Err(error),
+            (Ok(()), Some(cleanup_error)) => Err(cleanup_error),
+            (Err(error), Some(cleanup_error)) => Err(anyhow::anyhow!(
+                "{}. Credential-helper cleanup also failed: {}",
+                error,
+                cleanup_error
+            )),
+        };
+        if let Err(error) = restore_result {
+            let data_volume_name = format!("rustfs_{}_data", new_service_name);
+            let logs_volume_name = format!("rustfs_{}_logs", new_service_name);
+            let cleanup_errors = cleanup_unowned_rustfs_resources(
+                &self.docker,
+                &new_service.get_container_name(),
+                &[&data_volume_name, &logs_volume_name],
+                true,
             )
             .await;
+            if !cleanup_errors.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "RustFS restore to new service '{}' failed: {}. Cleanup of the unowned target also failed: {}",
+                    new_service_name,
+                    error,
+                    cleanup_errors.join("; ")
+                ));
+            }
+            return Err(error);
+        }
 
-        let runtime_json = serde_json::to_value(&new_config)
-            .map_err(|e| anyhow::anyhow!("Failed to serialize runtime config: {}", e))?;
+        let runtime_json = match serde_json::to_value(&new_config) {
+            Ok(runtime_json) => runtime_json,
+            Err(error) => {
+                let data_volume_name = format!("rustfs_{}_data", new_service_name);
+                let logs_volume_name = format!("rustfs_{}_logs", new_service_name);
+                let cleanup_errors = cleanup_unowned_rustfs_resources(
+                    &self.docker,
+                    &new_service.get_container_name(),
+                    &[&data_volume_name, &logs_volume_name],
+                    true,
+                )
+                .await;
+                return Err(anyhow::anyhow!(
+                    "Failed to serialize restored RustFS service '{}' configuration: {}{}",
+                    new_service_name,
+                    error,
+                    if cleanup_errors.is_empty() {
+                        String::new()
+                    } else {
+                        format!(". Cleanup also failed: {}", cleanup_errors.join("; "))
+                    }
+                ));
+            }
+        };
         let mut parameters = HashMap::new();
         if let Some(obj) = runtime_json.as_object() {
             for (k, v) in obj {
@@ -2155,6 +2469,44 @@ mod tests {
     use super::*;
 
     const TEST_IMAGE: &str = "rustfs/rustfs:1.0.0-alpha.98";
+
+    #[test]
+    fn external_client_output_redacts_keys_and_credential_urls() {
+        let output =
+            "request to http://access-key:secret-key@backup.internal failed for access-key";
+
+        let redacted = redact_sensitive_output(output, &["access-key", "secret-key"]);
+
+        assert_eq!(
+            redacted,
+            "request to http://***:***@backup.internal failed for ***"
+        );
+        assert!(!redacted.contains("access-key"));
+        assert!(!redacted.contains("secret-key"));
+    }
+
+    #[test]
+    fn in_place_restore_mirror_is_exact_and_does_not_hide_errors() {
+        assert_eq!(
+            restore_mirror_command("backup/bucket", "live/bucket", true),
+            vec![
+                "mc",
+                "mirror",
+                "--overwrite",
+                "--remove",
+                "backup/bucket",
+                "live/bucket",
+            ]
+        );
+    }
+
+    #[test]
+    fn new_service_restore_does_not_remove_concurrent_writes() {
+        assert_eq!(
+            restore_mirror_command("backup/bucket", "new/bucket", false),
+            vec!["mc", "mirror", "--overwrite", "backup/bucket", "new/bucket"]
+        );
+    }
 
     fn inspect_response(
         status: bollard::models::ContainerStateStatusEnum,

--- a/crates/temps-providers/src/mariadb_query.rs
+++ b/crates/temps-providers/src/mariadb_query.rs
@@ -1458,16 +1458,51 @@ mod tests {
         let host = container.get_host().await?.to_string();
         let port = container.get_host_port_ipv4(3306).await?;
         let mut source = None;
-        for _ in 0..20 {
-            match MariaDbSource::connect(&host, port, "root", "test", "app").await {
-                Ok(connected) => {
+        let mut last_connect_error = None;
+        // The image readiness message can precede the host-published socket
+        // becoming reachable on loaded GitHub runners. Give that final
+        // network hand-off a bounded 30-second window.
+        let readiness_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+        while tokio::time::Instant::now() < readiness_deadline {
+            let remaining =
+                readiness_deadline.saturating_duration_since(tokio::time::Instant::now());
+            let attempt_timeout = remaining.min(std::time::Duration::from_secs(3));
+            match tokio::time::timeout(
+                attempt_timeout,
+                MariaDbSource::connect(&host, port, "root", "test", "app"),
+            )
+            .await
+            {
+                Ok(Ok(connected)) => {
                     source = Some(connected);
                     break;
                 }
-                Err(_) => tokio::time::sleep(std::time::Duration::from_millis(250)).await,
+                Ok(Err(error)) => {
+                    last_connect_error = Some(error.to_string());
+                }
+                Err(_) => {
+                    last_connect_error = Some(format!(
+                        "connection attempt exceeded {}ms",
+                        attempt_timeout.as_millis()
+                    ))
+                }
+            }
+            let remaining =
+                readiness_deadline.saturating_duration_since(tokio::time::Instant::now());
+            if !remaining.is_zero() {
+                tokio::time::sleep(remaining.min(std::time::Duration::from_millis(500))).await;
             }
         }
-        let source = source.ok_or_else(|| anyhow::anyhow!("MariaDB did not become reachable"))?;
+        let source = source.ok_or_else(|| {
+            anyhow::anyhow!(
+                "MariaDB at {}:{} did not become reachable within 30s: {}",
+                host,
+                port,
+                last_connect_error
+                    .as_deref()
+                    .unwrap_or("no connection error captured")
+            )
+        })?;
         sqlx::query("CREATE TABLE rows_budget (id BIGINT PRIMARY KEY, payload LONGTEXT NOT NULL)")
             .execute(&source.pool)
             .await?;

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -7284,14 +7284,10 @@ echo "[restore] Pre-seed complete"
         // Port bindings: map the container port to the same host port.
         // Each cluster member uses a unique port assigned by the manager so
         // there are no conflicts even when multiple members run on the same host.
-        let mut port_bindings = std::collections::HashMap::new();
         let container_port_key = format!("{}/tcp", params.container_port);
-        port_bindings.insert(
-            container_port_key.clone(),
-            Some(vec![PortBinding {
-                host_ip: Some("0.0.0.0".to_string()),
-                host_port: Some(params.container_port.to_string()),
-            }]),
+        let port_bindings = crate::utils::local_port_binding(
+            &container_port_key,
+            &params.container_port.to_string(),
         );
 
         // Wire the per-host Hickory resolver into the container's

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -37,6 +37,11 @@ use temps_core::EncryptionService;
 #[allow(dead_code)]
 const NONCE_LENGTH: usize = 12;
 
+/// Local cluster ports are published on Docker's IPv4 loopback interface.
+/// Keep control-plane connections on the same address: `localhost` may resolve
+/// to IPv6 first on Linux even though Docker is only listening on 127.0.0.1.
+pub(crate) const LOCAL_CLUSTER_HOST: &str = "127.0.0.1";
+
 #[derive(Error, Debug)]
 pub enum ExternalServiceError {
     #[error("Service {id} not found")]
@@ -2676,7 +2681,7 @@ impl ExternalServiceManager {
         } else {
             // Local members publish their container port on the control-plane
             // host; Docker-internal names and addresses are not host-routable.
-            "localhost".to_string()
+            LOCAL_CLUSTER_HOST.to_string()
         };
 
         Ok((host, port))
@@ -2886,7 +2891,7 @@ impl ExternalServiceManager {
         };
 
         // Resolve the monitor host: prefer overlay IP, fall back to the
-        // node's underlay address, then localhost. The monitor's host port
+        // node's underlay address, then the IPv4 loopback address. The monitor's host port
         // is `service_id * 10 + 6000` for the dev cluster; in general
         // `monitor.port` is what the lifecycle hook stored.
         let monitor_host: String = if let Some(ip) = monitor.compute_ip.as_deref() {
@@ -2905,7 +2910,7 @@ impl ExternalServiceManager {
                 }
             }
         } else {
-            "localhost".to_string()
+            LOCAL_CLUSTER_HOST.to_string()
         };
         let monitor_port = monitor.port.unwrap_or(5432);
 
@@ -3079,7 +3084,7 @@ impl ExternalServiceManager {
                 }
             }
         } else {
-            "localhost".to_string()
+            LOCAL_CLUSTER_HOST.to_string()
         };
         let monitor_port = monitor.port.unwrap_or(5432);
 
@@ -7284,11 +7289,7 @@ echo "[restore] Pre-seed complete"
         // Port bindings: map the container port to the same host port.
         // Each cluster member uses a unique port assigned by the manager so
         // there are no conflicts even when multiple members run on the same host.
-        let container_port_key = format!("{}/tcp", params.container_port);
-        let port_bindings = crate::utils::local_port_binding(
-            &container_port_key,
-            &params.container_port.to_string(),
-        );
+        let (exposed_ports, port_bindings) = cluster_member_port_config(params.container_port);
 
         // Wire the per-host Hickory resolver into the container's
         // resolv.conf so it can resolve `*.temps.local` natively
@@ -7318,6 +7319,14 @@ echo "[restore] Pre-seed complete"
             image: Some(params.image.clone()),
             env: Some(env),
             cmd: params.command.clone(),
+            // The postgres-ha image only declares 5432/tcp, while HA members
+            // listen on dynamically assigned ports (for example 6040-6042).
+            // Docker's create API requires the dynamic port in ExposedPorts as
+            // well as HostConfig.PortBindings. Docker Desktop happens to
+            // tolerate the binding alone, but Linux engines may leave it
+            // unpublished, producing a healthy container behind a refused
+            // localhost socket.
+            exposed_ports: Some(exposed_ports),
             host_config: Some(cluster_host_config),
             labels: Some(HashMap::from([
                 ("sh.temps.managed".to_string(), "true".to_string()),
@@ -10130,6 +10139,20 @@ echo "[restore] Pre-seed complete"
     }
 }
 
+/// Build the two matching pieces Docker requires to publish a cluster
+/// member's dynamically assigned port.
+fn cluster_member_port_config(
+    container_port: u16,
+) -> (
+    Vec<String>,
+    HashMap<String, Option<Vec<bollard::models::PortBinding>>>,
+) {
+    let container_port_key = format!("{container_port}/tcp");
+    let port_bindings =
+        crate::utils::local_port_binding(&container_port_key, &container_port.to_string());
+    (vec![container_port_key], port_bindings)
+}
+
 /// Map our `ServiceResourceLimits` onto a bollard `ContainerUpdateBody`.
 ///
 /// CRITICAL: Docker uses `0` (not `null`) as the special value for
@@ -10706,7 +10729,7 @@ mod tests {
                 .stored_member_endpoint(41, &local)
                 .await
                 .expect("local persisted member should resolve"),
-            ("localhost".to_owned(), 5432)
+            (LOCAL_CLUSTER_HOST.to_owned(), 5432)
         );
 
         let mut remote = service_member_info(2, "cluster-node-2", "node", "running");
@@ -14563,5 +14586,19 @@ mod tests {
             "stopped member must be rejected: {}",
             msg
         );
+    }
+
+    #[test]
+    fn cluster_member_dynamic_port_is_exposed_and_bound_to_loopback() {
+        let (exposed_ports, bindings) = cluster_member_port_config(6040);
+
+        assert_eq!(exposed_ports, vec!["6040/tcp"]);
+        let binding = bindings
+            .get("6040/tcp")
+            .and_then(Option::as_ref)
+            .and_then(|entries| entries.first())
+            .expect("the exposed dynamic port must have a matching host binding");
+        assert_eq!(binding.host_ip.as_deref(), Some("127.0.0.1"));
+        assert_eq!(binding.host_port.as_deref(), Some("6040"));
     }
 }

--- a/tools/dev-cluster/role-control-plane.sh
+++ b/tools/dev-cluster/role-control-plane.sh
@@ -99,10 +99,24 @@ if [[ ! -f "$MARKER" ]]; then
   JOIN_TOKEN_HASH="$(printf '%s' "$JOIN_TOKEN" | sha256sum | awk '{print $1}')"
   log "minting join token (hash $(echo "$JOIN_TOKEN_HASH" | cut -c1-12)…)"
 
+  # Derive psql connection args from TEMPS_DATABASE_URL rather than a
+  # hardcoded IP, so this script stays reusable by any compose topology
+  # that re-subnets this cluster (e.g. apps/temps-e2e's
+  # multinode-join-scenario, which clones this compose file onto
+  # 10.52.0.0/24 instead of 10.42.0.0/24).
+  DB_URL_NO_SCHEME="${TEMPS_DATABASE_URL#postgres://}"
+  DB_USER="${DB_URL_NO_SCHEME%%:*}"
+  DB_REST="${DB_URL_NO_SCHEME#*:}"
+  DB_PASS="${DB_REST%%@*}"
+  DB_HOSTPORT_DB="${DB_REST#*@}"
+  DB_HOSTPORT="${DB_HOSTPORT_DB%%/*}"
+  DB_HOST="${DB_HOSTPORT%%:*}"
+  DB_NAME="${DB_HOSTPORT_DB#*/}"
+
   # The settings.data column is plain JSON (not JSONB). Cast to jsonb for
   # the merge, cast back when writing — same effect as
   # POST /settings/join-token/generate but without needing an admin login.
-  PGPASSWORD=temps psql -h 10.42.0.5 -U temps -d temps -v ON_ERROR_STOP=1 -c "
+  PGPASSWORD="$DB_PASS" psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1 -c "
     UPDATE settings
        SET data = jsonb_set(
                     COALESCE(data::jsonb, '{}'::jsonb),
@@ -123,5 +137,5 @@ fi
 # 4. Run the API server. This is the long-running command compose
 #    keeps alive.
 # ---------------------------------------------------------------------------
-log "starting temps serve on $TEMPS_ADDRESS (TLS on $TEMPS_TLS_ADDRESS)"
+log "starting temps serve on $TEMPS_ADDRESS (TLS on ${TEMPS_TLS_ADDRESS:-none})"
 exec "$BIN" serve

--- a/tools/dev-cluster/role-control-plane.sh
+++ b/tools/dev-cluster/role-control-plane.sh
@@ -16,7 +16,6 @@ set -euo pipefail
 WORKSPACE=/workspace
 BIN=/usr/local/bin/temps
 MARKER=/var/lib/temps/.dev-cluster-setup-done
-ADMIN_PASSWORD_FILE=/workspace/tools/dev-cluster/.state/admin.txt
 
 log() { printf '\033[1;36m[control-plane]\033[0m %s\n' "$*"; }
 
@@ -56,12 +55,14 @@ log "temps binary at $BIN ($($BIN --version 2>/dev/null || echo 'unknown'))"
 # 3. First-boot setup. We mark completion so a `down`/`up` of the same
 #    postgres volume short-circuits straight to `serve`.
 # ---------------------------------------------------------------------------
-STATE_DIR="$WORKSPACE/tools/dev-cluster/.state"
+STATE_DIR="${DEV_CLUSTER_STATE_DIR:-$WORKSPACE/tools/dev-cluster/.state}"
+ADMIN_PASSWORD_FILE="$STATE_DIR/admin.txt"
 JOIN_TOKEN_FILE="$STATE_DIR/join_token.txt"
 
 if [[ ! -f "$MARKER" ]]; then
   log "first boot: running temps setup --auto"
   mkdir -p "$STATE_DIR"
+  chmod 700 "$STATE_DIR"
 
   # --auto implies non-interactive, skip-ssl, skip-dns-records, skip-git.
   # We pass --server-ip 10.42.0.10 because auto-detect probes the public
@@ -90,11 +91,9 @@ if [[ ! -f "$MARKER" ]]; then
   printf 'admin@local.dev\n%s\n' "$ADMIN_PASSWORD" > "$ADMIN_PASSWORD_FILE"
   chmod 600 "$ADMIN_PASSWORD_FILE"
 
-  # Generate a join token for the workers. Writing to network_config /
-  # settings via the API requires login, which is itself fiddly to
-  # script. Cheat: insert the hash directly into the settings table
-  # using psql, mirroring what `POST /settings/join-token/generate`
-  # does internally.
+  # Generate a bootstrap token for the workers. Dedicated security E2E
+  # topologies use a short-lived enrollment token; the normal dev cluster
+  # retains its backwards-compatible shared-token behavior.
   JOIN_TOKEN="$(head -c 32 /dev/urandom | xxd -p -c 999)"
   JOIN_TOKEN_HASH="$(printf '%s' "$JOIN_TOKEN" | sha256sum | awk '{print $1}')"
   log "minting join token (hash $(echo "$JOIN_TOKEN_HASH" | cut -c1-12)…)"
@@ -113,21 +112,45 @@ if [[ ! -f "$MARKER" ]]; then
   DB_HOST="${DB_HOSTPORT%%:*}"
   DB_NAME="${DB_HOSTPORT_DB#*/}"
 
-  # The settings.data column is plain JSON (not JSONB). Cast to jsonb for
-  # the merge, cast back when writing — same effect as
-  # POST /settings/join-token/generate but without needing an admin login.
-  PGPASSWORD="$DB_PASS" psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1 -c "
-    UPDATE settings
-       SET data = jsonb_set(
-                    COALESCE(data::jsonb, '{}'::jsonb),
-                    '{multi_node,join_token_hash}',
-                    to_jsonb('${JOIN_TOKEN_HASH}'::text)
-                  )::json
-     WHERE id = 1
-  " >/dev/null
+  if [[ "${DEV_CLUSTER_USE_ENROLLMENT_TOKEN:-false}" == "true" ]]; then
+    BOUND_NODE_NAME="${DEV_CLUSTER_ENROLLMENT_NODE_NAME:-worker-1}"
+    if [[ ! "$BOUND_NODE_NAME" =~ ^[A-Za-z0-9._-]+$ ]]; then
+      log "invalid DEV_CLUSTER_ENROLLMENT_NODE_NAME '$BOUND_NODE_NAME'"
+      exit 1
+    fi
+    PGPASSWORD="$DB_PASS" psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1 -c "
+      UPDATE settings
+         SET data = jsonb_set(
+                      jsonb_set(COALESCE(data::jsonb, '{}'::jsonb),
+                                '{multi_node,require_mtls}', 'true'::jsonb),
+                      '{multi_node,legacy_shared_token_enabled}', 'false'::jsonb
+                    )::json
+       WHERE id = 1;
+      INSERT INTO node_enrollment_tokens
+        (token_hash, max_uses, used_count, expires_at, bound_node_name,
+         created_at, updated_at)
+      VALUES
+        ('${JOIN_TOKEN_HASH}', 1, 0, now() + interval '1 hour',
+         '${BOUND_NODE_NAME}', now(), now());
+    " >/dev/null
+    log "minted single-use enrollment token bound to $BOUND_NODE_NAME; mTLS required"
+  else
+    # The settings.data column is plain JSON (not JSONB). Cast to jsonb for
+    # the merge, cast back when writing — same effect as the legacy join-token
+    # API without needing an admin login.
+    PGPASSWORD="$DB_PASS" psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1 -c "
+      UPDATE settings
+         SET data = jsonb_set(
+                      COALESCE(data::jsonb, '{}'::jsonb),
+                      '{multi_node,join_token_hash}',
+                      to_jsonb('${JOIN_TOKEN_HASH}'::text)
+                    )::json
+       WHERE id = 1
+    " >/dev/null
+  fi
 
   printf '%s\n' "$JOIN_TOKEN" > "$JOIN_TOKEN_FILE"
-  chmod 644 "$JOIN_TOKEN_FILE"
+  chmod 600 "$JOIN_TOKEN_FILE"
 
   touch "$MARKER"
   log "setup complete; admin credentials in ${ADMIN_PASSWORD_FILE#$WORKSPACE/}, join token in ${JOIN_TOKEN_FILE#$WORKSPACE/}"

--- a/tools/dev-cluster/role-control-plane.sh
+++ b/tools/dev-cluster/role-control-plane.sh
@@ -24,12 +24,16 @@ log() { printf '\033[1;36m[control-plane]\033[0m %s\n' "$*"; }
 #    on first boot. Cheap to re-check.
 # ---------------------------------------------------------------------------
 for _ in $(seq 1 30); do
-  docker info >/dev/null 2>&1 && break || sleep 1
+  if docker info >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
 done
 
 # ---------------------------------------------------------------------------
-# 2. Build the temps binary if missing or stale. Fast on subsequent
-#    boots thanks to the cargo registry cache + workspace target/.
+# 2. Install a caller-supplied Linux binary when available (CI builds one
+#    once and shares it with every scenario); otherwise build from source.
+#    The local dev-cluster path remains unchanged and uses Cargo's caches.
 # ---------------------------------------------------------------------------
 build_temps() {
   log "building temps binary (cargo build --bin temps)"
@@ -38,7 +42,14 @@ build_temps() {
   install -m 0755 "target/debug/temps" "$BIN"
 }
 
-if [[ ! -x "$BIN" ]]; then
+if [[ -n "${DEV_CLUSTER_PREBUILT_TEMPS_BIN:-}" ]]; then
+  if [[ ! -x "$DEV_CLUSTER_PREBUILT_TEMPS_BIN" ]]; then
+    log "prebuilt temps binary is not executable: $DEV_CLUSTER_PREBUILT_TEMPS_BIN"
+    exit 1
+  fi
+  log "installing prebuilt temps binary from $DEV_CLUSTER_PREBUILT_TEMPS_BIN"
+  install -m 0755 "$DEV_CLUSTER_PREBUILT_TEMPS_BIN" "$BIN"
+elif [[ ! -x "$BIN" ]]; then
   build_temps
 else
   # Check whether the source has changed since the binary was built.
@@ -153,7 +164,7 @@ if [[ ! -f "$MARKER" ]]; then
   chmod 600 "$JOIN_TOKEN_FILE"
 
   touch "$MARKER"
-  log "setup complete; admin credentials in ${ADMIN_PASSWORD_FILE#$WORKSPACE/}, join token in ${JOIN_TOKEN_FILE#$WORKSPACE/}"
+  log "setup complete; admin credentials in ${ADMIN_PASSWORD_FILE#"$WORKSPACE"/}, join token in ${JOIN_TOKEN_FILE#"$WORKSPACE"/}"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tools/dev-cluster/role-worker.sh
+++ b/tools/dev-cluster/role-worker.sh
@@ -27,17 +27,30 @@ log() { printf '\033[1;33m[%s]\033[0m %s\n' "$WORKER_NAME" "$*"; }
 
 # 1. dockerd
 for _ in $(seq 1 30); do
-  docker info >/dev/null 2>&1 && break || sleep 1
+  if docker info >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
 done
 
-# 2. binary
-cd "$WORKSPACE"
-log "ensuring temps binary is up to date"
-cargo build --bin temps >&2
-install -m 0755 "$WORKSPACE/target/debug/temps" "$BIN"
+# 2. binary. CI supplies the same already-tested Linux binary used by the
+# other scenario shards; local dev-cluster runs continue to build from source.
+if [[ -n "${DEV_CLUSTER_PREBUILT_TEMPS_BIN:-}" ]]; then
+  if [[ ! -x "$DEV_CLUSTER_PREBUILT_TEMPS_BIN" ]]; then
+    log "prebuilt temps binary is not executable: $DEV_CLUSTER_PREBUILT_TEMPS_BIN"
+    exit 1
+  fi
+  log "installing prebuilt temps binary from $DEV_CLUSTER_PREBUILT_TEMPS_BIN"
+  install -m 0755 "$DEV_CLUSTER_PREBUILT_TEMPS_BIN" "$BIN"
+else
+  cd "$WORKSPACE"
+  log "ensuring temps binary is up to date"
+  cargo build --bin temps >&2
+  install -m 0755 "$WORKSPACE/target/debug/temps" "$BIN"
+fi
 
 # 3. wait for join token (control plane writes it during its first boot)
-log "waiting for join token at ${JOIN_TOKEN_FILE#$WORKSPACE/}"
+log "waiting for join token at ${JOIN_TOKEN_FILE#"$WORKSPACE"/}"
 for _ in $(seq 1 120); do
   if [[ -f "$JOIN_TOKEN_FILE" ]]; then break; fi
   sleep 1

--- a/tools/dev-cluster/role-worker.sh
+++ b/tools/dev-cluster/role-worker.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 
 WORKSPACE=/workspace
 BIN=/usr/local/bin/temps
-STATE_DIR="$WORKSPACE/tools/dev-cluster/.state"
+STATE_DIR="${DEV_CLUSTER_STATE_DIR:-$WORKSPACE/tools/dev-cluster/.state}"
 JOIN_TOKEN_FILE="$STATE_DIR/join_token.txt"
 JOIN_MARKER="/var/lib/temps/.dev-cluster-join-done"
 
@@ -70,16 +70,27 @@ if [[ ! -f "$JOIN_MARKER" ]]; then
     sleep 2
   done
 
-  log "joining cluster as $WORKER_NAME ($WORKER_UNDERLAY_IP)"
-  TEMPS_JOIN_TOKEN="$JOIN_TOKEN" "$BIN" join \
-    "$CONTROL_PLANE_URL" "$JOIN_TOKEN" \
-    --name "$WORKER_NAME" \
-    --private-address "$WORKER_UNDERLAY_IP" \
-    --agent-address "0.0.0.0:3100" \
-    || {
-      log "join failed; will retry on next container start"
-      exit 1
-    }
+  # The proxy listener becomes reachable before the background console API is
+  # ready. A one-shot join can therefore receive the proxy's temporary 503,
+  # exit the role script, and force a full DinD container restart. Retry in the
+  # same boot instead; failed pre-readiness requests do not consume the token.
+  joined=false
+  for attempt in $(seq 1 90); do
+    log "joining cluster as $WORKER_NAME ($WORKER_UNDERLAY_IP), attempt $attempt/90"
+    if TEMPS_JOIN_TOKEN="$JOIN_TOKEN" "$BIN" join \
+      "$CONTROL_PLANE_URL" "$JOIN_TOKEN" \
+      --name "$WORKER_NAME" \
+      --private-address "$WORKER_UNDERLAY_IP" \
+      --agent-address "0.0.0.0:3100"; then
+      joined=true
+      break
+    fi
+    sleep 2
+  done
+  if [[ "$joined" != true ]]; then
+    log "join failed after 90 attempts"
+    exit 1
+  fi
   touch "$JOIN_MARKER"
   log "joined cluster successfully"
 else

--- a/tools/e2e-multinode-cluster/docker-compose.yml
+++ b/tools/e2e-multinode-cluster/docker-compose.yml
@@ -64,6 +64,12 @@ volumes:
   # containers, with a working fingerprint cache.
   workspace-target:
     name: temps-e2e-mn-workspace-target
+  # temps-cli's debug build creates a placeholder dist/index.html for
+  # include_dir!. The source checkout is intentionally read-only, so give
+  # that generated directory its own writable volume (fresh CI checkouts do
+  # not contain the gitignored dist directory developers often have locally).
+  cli-dist:
+    name: temps-e2e-mn-cli-dist
 
   # Shared only between the control plane and worker during bootstrap. Contains
   # the one-time enrollment token and generated admin password; never touches
@@ -157,6 +163,7 @@ services:
     volumes:
       - ../../:/workspace:ro
       - workspace-target:/workspace/target
+      - cli-dist:/workspace/crates/temps-cli/dist
       - cargo-cache:/usr/local/cargo/registry
       - cargo-git:/usr/local/cargo/git
       - cp-docker:/var/lib/docker
@@ -213,6 +220,7 @@ services:
     volumes:
       - ../../:/workspace:ro
       - workspace-target:/workspace/target
+      - cli-dist:/workspace/crates/temps-cli/dist
       - cargo-cache:/usr/local/cargo/registry
       - cargo-git:/usr/local/cargo/git
       - worker1-docker:/var/lib/docker

--- a/tools/e2e-multinode-cluster/docker-compose.yml
+++ b/tools/e2e-multinode-cluster/docker-compose.yml
@@ -1,0 +1,217 @@
+# Isolated, throwaway 2-node Temps cluster for the `multinode-join-scenario`
+# e2e test (apps/temps-e2e/src/commands/multinode-join-scenario.ts).
+#
+# This is a TRIMMED, RE-SUBNETTED clone of ../dev-cluster/docker-compose.yml
+# (postgres + 1 control-plane + 1 worker, not 3 workers) with every name,
+# subnet, and host port changed so it can run ALONGSIDE a developer's own
+# `tools/dev-cluster` instance (or any other local service) with zero
+# collision:
+#
+#   - network `temps-e2e-mn-underlay`, subnet 10.52.0.0/24 (dev-cluster uses
+#     10.42.0.0/24 -- different octet, no overlap)
+#   - every container/volume name is prefixed `temps-e2e-mn-` (dev-cluster
+#     uses `temps-dev-`)
+#   - the control plane's HTTP port is published on the host as 18180, a
+#     range that collides with nothing else on this machine: dev slots use
+#     8080-8370, TLS scenarios use 8443-8733, the web dev server uses
+#     3000-3029, EE uses 9080/9081/9443/9100. No 443 is published at all --
+#     this scenario doesn't need TLS.
+#
+# The role scripts (`role-control-plane.sh`, `role-worker.sh`,
+# `entrypoint.sh`) and the DinD build image (`Dockerfile.dind-temps`) are
+# reused UNMODIFIED from ../dev-cluster -- see this compose file's `build:`
+# blocks (`context: ../dev-cluster`) and `command:` entries (which reach
+# into `/workspace/tools/dev-cluster/...`, workspace-relative, so it doesn't
+# matter which tool directory's compose file invoked them). Do not fork
+# those scripts here; if scenario behavior needs to change, change what this
+# compose file asks them to do (env vars), not the scripts themselves.
+#
+# The temps source tree is mounted read-write at /workspace in both
+# containers, same as dev-cluster, so the binary each one builds from source
+# on first boot is real, current code -- never a stale prebuilt image.
+
+name: temps-e2e-mn
+
+networks:
+  underlay:
+    name: temps-e2e-mn-underlay
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 10.52.0.0/24
+
+volumes:
+  # ── Cache volumes ─────────────────────────────────────────────────────
+  # These SURVIVE `docker compose down` (the scenario's teardown step never
+  # removes them) so re-running the scenario is near-instant after the
+  # first ~10-20 min compile. Shared by both containers via Docker's
+  # storage backend.
+  cargo-cache:
+    name: temps-e2e-mn-cargo-cache
+  # Cargo's git-dep cache (cloned source for `git = ...` Cargo.toml deps).
+  # Without this, cargo re-clones every git dependency from scratch on
+  # every fresh container -- can take minutes on its own.
+  cargo-git:
+    name: temps-e2e-mn-cargo-git
+  # Shared workspace `target/` directory. MUST be a named volume, not part
+  # of the /workspace bind mount: macOS bind-mount mtime semantics (gRPC
+  # FUSE / VirtioFS) defeat cargo's fingerprint cache, and mixing native
+  # macOS Mach-O artifacts with Linux ELF artifacts in one tree breaks the
+  # build outright. Mounting a named volume *over* /workspace/target inside
+  # each container keeps the source tree hot-reloadable from the host while
+  # target/ stays a clean Linux-native directory, shared across both
+  # containers, with a working fingerprint cache.
+  workspace-target:
+    name: temps-e2e-mn-workspace-target
+
+  # ── Identity/state volumes ────────────────────────────────────────────
+  # These are torn down EVERY scenario run (the scenario's teardown step
+  # explicitly `docker volume rm`s them after `compose down`) so each run
+  # proves a genuinely fresh registration/join, never a skip via one of the
+  # role scripts' own marker files (`.dev-cluster-setup-done`,
+  # `.dev-cluster-join-done`). Keeping these around between runs would mean
+  # the second run onward never re-exercises `POST /internal/nodes/register`
+  # at all -- the exact thing this scenario exists to prove.
+  postgres-data:
+    name: temps-e2e-mn-postgres-data
+  cp-docker:
+    name: temps-e2e-mn-cp-docker
+  cp-data:
+    name: temps-e2e-mn-cp-data
+  worker1-docker:
+    name: temps-e2e-mn-worker1-docker
+  worker1-data:
+    name: temps-e2e-mn-worker1-data
+  # Worker's /root (~/.temps/agent.json, written by `temps join`). Without
+  # this named volume, a container recreate wipes the join credential and
+  # the agent can't reconnect.
+  worker1-home:
+    name: temps-e2e-mn-worker1-home
+
+services:
+  postgres:
+    image: timescale/timescaledb-ha:pg18
+    container_name: temps-e2e-mn-postgres
+    networks:
+      underlay:
+        ipv4_address: 10.52.0.5
+    environment:
+      POSTGRES_DB: temps
+      POSTGRES_USER: temps
+      POSTGRES_PASSWORD: temps
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - postgres-data:/home/postgres/pgdata
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "temps", "-d", "temps"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  control-plane:
+    build:
+      context: ../dev-cluster
+      dockerfile: Dockerfile.dind-temps
+    image: temps-e2e-mn-cluster/dind-temps:latest
+    container_name: temps-e2e-mn-control-plane
+    privileged: true
+    hostname: control-plane
+    # Required for the inner dockerd (DinD) to manage child cgroups on a
+    # cgroupv2 host (e.g. Docker Desktop) -- same fix dev-cluster applies.
+    cgroup: private
+    networks:
+      underlay:
+        ipv4_address: 10.52.0.10
+    ports:
+      # HTTP only -- no TLS testing in this scenario, so no 443 published.
+      # 18180 is well outside every port range already reserved on this
+      # machine (see the header comment above).
+      - "18180:80"
+    environment:
+      TEMPS_DATABASE_URL: postgres://temps:temps@10.52.0.5:5432/temps
+      TEMPS_ADDRESS: 0.0.0.0:80
+      TEMPS_DATA_DIR: /var/lib/temps
+      TEMPS_LOG_LEVEL: info
+      TEMPS_NETWORK_NAME: temps-app-network
+      # This is a throwaway local test cluster, not a real self-hosted
+      # instance -- never report product telemetry for it.
+      TEMPS_TELEMETRY: "0"
+      # No TLS listener in this cluster -- disable the HTTP->HTTPS redirect
+      # so the scenario can hit plain http://localhost:18180 directly.
+      # TEMPS_TLS_ADDRESS is deliberately NOT set: `temps serve` reads it as
+      # a real --tls-address value (clap `env = "TEMPS_TLS_ADDRESS"`), so any
+      # placeholder string here would make pingora try to bind a TLS
+      # listener to it and panic. Leaving it unset -> `tls_address: None` ->
+      # no TLS listener, which is what this cluster actually wants.
+      ROLE: control-plane
+    volumes:
+      - ../../:/workspace:rw
+      - workspace-target:/workspace/target
+      - cargo-cache:/usr/local/cargo/registry
+      - cargo-git:/usr/local/cargo/git
+      - cp-docker:/var/lib/docker
+      - cp-data:/var/lib/temps
+    depends_on:
+      postgres:
+        condition: service_healthy
+    # role-control-plane.sh is reused unmodified from tools/dev-cluster --
+    # it's workspace-relative and doesn't care which compose file invoked
+    # it. Builds the binary from source, runs `temps setup --auto`, mints a
+    # join token via direct psql UPDATE (documented shortcut in the script
+    # itself), then execs `temps serve`.
+    command: ["bash", "/workspace/tools/dev-cluster/role-control-plane.sh"]
+    healthcheck:
+      # TCP-only probe (bash /dev/tcp) -- the admin API requires auth on
+      # every route, so we only care that the listener accepts a
+      # connection. start_period is generous: first boot compiles the full
+      # Rust workspace from scratch inside the container, which can take
+      # 15-20+ minutes on a cold cargo cache.
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/80"]
+      interval: 5s
+      timeout: 2s
+      retries: 60
+      start_period: 900s
+
+  worker-1:
+    build:
+      context: ../dev-cluster
+      dockerfile: Dockerfile.dind-temps
+    image: temps-e2e-mn-cluster/dind-temps:latest
+    container_name: temps-e2e-mn-worker-1
+    privileged: true
+    hostname: worker-1
+    # Workers can race the control plane's mid-boot state (e.g. the join
+    # token file not written yet) -- retry instead of leaving the container
+    # in `Exited` state forever.
+    restart: on-failure:5
+    cgroup: private
+    networks:
+      underlay:
+        ipv4_address: 10.52.0.21
+    environment:
+      ROLE: worker
+      WORKER_NAME: worker-1
+      WORKER_UNDERLAY_IP: 10.52.0.21
+      CONTROL_PLANE_URL: http://10.52.0.10:80
+      TEMPS_LOG_LEVEL: info
+      TEMPS_NETWORK_NAME: temps-app-network
+      TEMPS_OVERLAY_NETWORK: temps0
+      TEMPS_AGENT_ADDRESS: 0.0.0.0:3100
+      TEMPS_TELEMETRY: "0"
+    volumes:
+      - ../../:/workspace:rw
+      - workspace-target:/workspace/target
+      - cargo-cache:/usr/local/cargo/registry
+      - cargo-git:/usr/local/cargo/git
+      - worker1-docker:/var/lib/docker
+      - worker1-data:/var/lib/temps
+      - worker1-home:/root
+    depends_on:
+      control-plane:
+        condition: service_healthy
+    # role-worker.sh is reused unmodified from tools/dev-cluster -- builds
+    # the binary from source, polls for the join token file the control
+    # plane writes, runs `temps join` (idempotent via its own marker file),
+    # then execs `temps agent`.
+    command: ["bash", "/workspace/tools/dev-cluster/role-worker.sh"]

--- a/tools/e2e-multinode-cluster/docker-compose.yml
+++ b/tools/e2e-multinode-cluster/docker-compose.yml
@@ -65,6 +65,12 @@ volumes:
   workspace-target:
     name: temps-e2e-mn-workspace-target
 
+  # Shared only between the control plane and worker during bootstrap. Contains
+  # the one-time enrollment token and generated admin password; never touches
+  # the host worktree and is removed after every run.
+  bootstrap-state:
+    name: temps-e2e-mn-bootstrap-state
+
   # ── Identity/state volumes ────────────────────────────────────────────
   # These are torn down EVERY scenario run (the scenario's teardown step
   # explicitly `docker volume rm`s them after `compose down`) so each run
@@ -127,7 +133,7 @@ services:
       # HTTP only -- no TLS testing in this scenario, so no 443 published.
       # 18180 is well outside every port range already reserved on this
       # machine (see the header comment above).
-      - "18180:80"
+      - "127.0.0.1:18180:80"
     environment:
       TEMPS_DATABASE_URL: postgres://temps:temps@10.52.0.5:5432/temps
       TEMPS_ADDRESS: 0.0.0.0:80
@@ -137,6 +143,9 @@ services:
       # This is a throwaway local test cluster, not a real self-hosted
       # instance -- never report product telemetry for it.
       TEMPS_TELEMETRY: "0"
+      DEV_CLUSTER_STATE_DIR: /run/temps-bootstrap
+      DEV_CLUSTER_USE_ENROLLMENT_TOKEN: "true"
+      DEV_CLUSTER_ENROLLMENT_NODE_NAME: worker-1
       # No TLS listener in this cluster -- disable the HTTP->HTTPS redirect
       # so the scenario can hit plain http://localhost:18180 directly.
       # TEMPS_TLS_ADDRESS is deliberately NOT set: `temps serve` reads it as
@@ -146,20 +155,21 @@ services:
       # no TLS listener, which is what this cluster actually wants.
       ROLE: control-plane
     volumes:
-      - ../../:/workspace:rw
+      - ../../:/workspace:ro
       - workspace-target:/workspace/target
       - cargo-cache:/usr/local/cargo/registry
       - cargo-git:/usr/local/cargo/git
       - cp-docker:/var/lib/docker
       - cp-data:/var/lib/temps
+      - bootstrap-state:/run/temps-bootstrap
     depends_on:
       postgres:
         condition: service_healthy
     # role-control-plane.sh is reused unmodified from tools/dev-cluster --
     # it's workspace-relative and doesn't care which compose file invoked
     # it. Builds the binary from source, runs `temps setup --auto`, mints a
-    # join token via direct psql UPDATE (documented shortcut in the script
-    # itself), then execs `temps serve`.
+    # single-use enrollment token via direct psql (documented shortcut in the
+    # script itself), enables mTLS, then execs `temps serve`.
     command: ["bash", "/workspace/tools/dev-cluster/role-control-plane.sh"]
     healthcheck:
       # TCP-only probe (bash /dev/tcp) -- the admin API requires auth on
@@ -199,14 +209,16 @@ services:
       TEMPS_OVERLAY_NETWORK: temps0
       TEMPS_AGENT_ADDRESS: 0.0.0.0:3100
       TEMPS_TELEMETRY: "0"
+      DEV_CLUSTER_STATE_DIR: /run/temps-bootstrap
     volumes:
-      - ../../:/workspace:rw
+      - ../../:/workspace:ro
       - workspace-target:/workspace/target
       - cargo-cache:/usr/local/cargo/registry
       - cargo-git:/usr/local/cargo/git
       - worker1-docker:/var/lib/docker
       - worker1-data:/var/lib/temps
       - worker1-home:/root
+      - bootstrap-state:/run/temps-bootstrap
     depends_on:
       control-plane:
         condition: service_healthy

--- a/tools/e2e-multinode-cluster/docker-compose.yml
+++ b/tools/e2e-multinode-cluster/docker-compose.yml
@@ -19,16 +19,17 @@
 #
 # The role scripts (`role-control-plane.sh`, `role-worker.sh`,
 # `entrypoint.sh`) and the DinD build image (`Dockerfile.dind-temps`) are
-# reused UNMODIFIED from ../dev-cluster -- see this compose file's `build:`
+# shared with ../dev-cluster -- see this compose file's `build:`
 # blocks (`context: ../dev-cluster`) and `command:` entries (which reach
 # into `/workspace/tools/dev-cluster/...`, workspace-relative, so it doesn't
 # matter which tool directory's compose file invoked them). Do not fork
 # those scripts here; if scenario behavior needs to change, change what this
 # compose file asks them to do (env vars), not the scripts themselves.
 #
-# The temps source tree is mounted read-write at /workspace in both
-# containers, same as dev-cluster, so the binary each one builds from source
-# on first boot is real, current code -- never a stale prebuilt image.
+# The source tree is mounted read-only at /workspace. Local runs build the
+# current checkout inside the nodes; CI installs the same commit-specific musl
+# artifact already exercised by the other jobs, avoiding two cold workspace
+# builds without weakening commit provenance.
 
 name: temps-e2e-mn
 
@@ -152,6 +153,9 @@ services:
       DEV_CLUSTER_STATE_DIR: /run/temps-bootstrap
       DEV_CLUSTER_USE_ENROLLMENT_TOKEN: "true"
       DEV_CLUSTER_ENROLLMENT_NODE_NAME: worker-1
+      # CI passes the musl binary already built for this commit. Local runs
+      # leave this empty and the shared role script builds from source.
+      DEV_CLUSTER_PREBUILT_TEMPS_BIN: ${DEV_CLUSTER_PREBUILT_TEMPS_BIN:-}
       # No TLS listener in this cluster -- disable the HTTP->HTTPS redirect
       # so the scenario can hit plain http://localhost:18180 directly.
       # TEMPS_TLS_ADDRESS is deliberately NOT set: `temps serve` reads it as
@@ -217,6 +221,7 @@ services:
       TEMPS_AGENT_ADDRESS: 0.0.0.0:3100
       TEMPS_TELEMETRY: "0"
       DEV_CLUSTER_STATE_DIR: /run/temps-bootstrap
+      DEV_CLUSTER_PREBUILT_TEMPS_BIN: ${DEV_CLUSTER_PREBUILT_TEMPS_BIN:-}
     volumes:
       - ../../:/workspace:ro
       - workspace-target:/workspace/target


### PR DESCRIPTION
## Summary

- Adds `multinode-join-scenario`, a dedicated two-node Docker-in-Docker E2E topology covering direct-underlay worker enrollment with single-use, node-bound tokens and real mTLS.
- Proves worker registration, node-targeted placement, proxy traffic, drain migration to the control plane, node removal, and enrollment-token replay rejection.
- Adds a reusable CI workflow that runs every `apps/temps-e2e` lifecycle scenario across six isolated shards, plus a dedicated multinode/mTLS job. It is invoked by `rust-tests.yml` for pull requests and `main`.
- Fixes drain/failover image redeployment so only the exact affected deployment and environment are restored.
- Fixes a deployment completion race where an older workflow could tear down a newer healthy deployment.
- Hardens bootstrap cleanup, loopback exposure, repository mounts, credential masking/revocation, workflow token permissions, and worker join retries.
- Fixes GeoLite2 startup path resolution and download/plugin registration ordering.

WireGuard relay enrollment is a separate topology and is not claimed by this scenario.

## Security

- Control-plane host exposure is loopback-only.
- Repository mounts are read-only.
- Bootstrap credentials live in an isolated volume with restrictive permissions.
- Enrollment is single-use, node-bound, mTLS-required, and replay-tested.
- API-key stdout/stderr is suppressed and keys are masked before GitHub outputs.
- Temporary admin keys are revoked during teardown.
- CI uses explicit `permissions: contents: read`.

Final security-auditor verdict: **APPROVED — no remaining security blockers**.

## Evidence

**Multinode runtime lifecycle**

```bash
cd apps/temps-e2e
bun run src/index.ts multinode-join-scenario --json --build-timeout 2400000
```

```text
"ok": true
20/20 steps passed, including:
- worker registration with HTTPS/mTLS
- worker-only container placement
- real HTTP proxy response
- drain migration to the control plane
- worker removal
- consumed enrollment-token replay rejected
```

**Deployments crate regression suite**

```bash
cargo test --lib -p temps-deployments
```

```text
cargo test: 543 passed, 3 ignored (1 suite, 134.31s)
```

The ignored tests are the crate's pre-existing Docker/network tests explicitly marked ignored.

**Focused deployment-order regressions**

```bash
cargo test --lib -p temps-deployments test_teardown_from_older_job_preserves_newer_deployment -- --nocapture
cargo test --lib -p temps-deployments test_teardown_previous_deployment_marks_deleted_before_stopping_container -- --nocapture
cargo test --lib -p temps-deployments image_deployment_target_is_scoped_to_one_environment -- --nocapture
```

```text
1 passed; 0 failed (each focused run)
```

**Compilation and linting**

```bash
cargo check --lib -p temps-core -p temps-deployments -p temps-import -p temps-projects -p temps-geo
cargo clippy --lib -p temps-core -p temps-deployments -p temps-import -p temps-projects -p temps-geo -- -D warnings
bun run --cwd apps/temps-e2e typecheck
docker run --rm -v "$PWD:/repo:ro" -w /repo rhysd/actionlint:latest -color \
  .github/workflows/apps-e2e-tests.yml \
  .github/workflows/e2e-tests.yml \
  .github/workflows/rust-tests.yml
```

```text
cargo check: 0 crate errors
cargo clippy: 0 errors
TypeScript: tsc --noEmit passed
actionlint: passed with no findings
```

## CI coverage

The new scenario workflow runs these isolated shards:

- `core`: lifecycle, CLI, flags, audit, errors, environment variables, API keys, RBAC
- `observability`: logs, analytics, session replay, monitoring, OTel quota
- `services`: managed services, KV, blob, DB HA, deployment lifecycle
- `recovery`: backups, PITR, Redis, MongoDB, S3, MariaDB, PostgreSQL upgrade
- `edge`: TLS, DNS-01, email, git deployment
- `examples`: every registered example
- dedicated multinode/mTLS topology

The existing E2E workflow continues to own Playwright and example-deployment smoke coverage.
