### PR TITLE
test(e2e): verify internal application and database DNS

### DIFF
--- a/apps/temps-e2e/README.md
+++ b/apps/temps-e2e/README.md
@@ -1247,15 +1247,24 @@ tears the whole thing down at the end. It does NOT accept `--url`/
     control-plane's proxy (`localhost:18180`) with the app's `Host` header
     and assert the actual `traefik/whoami` response body, not just a
     healthy status field.
-11. drain the worker (`POST /internal/nodes/{id}/drain`), poll
+11. deploy `nginxinc/nginx-unprivileged:alpine` as a second worker-pinned
+    application, then `docker exec` into it and `wget`
+    `http://production.<project>.temps.local`. The response must be the real
+    `whoami` body, proving app-to-app DNS from inside an application container.
+12. provision a real 1-monitor + 2-data-node Postgres HA service, link it to a
+    control-plane probe application, and replace only the injected DSN address
+    with the service member's published `.temps.local` FQDN. The probe must
+    report that DNS host and complete a real INSERT + SELECT. This catches DNS
+    records that resolve but advertise an unreachable IP/port pair.
+13. drain the worker (`POST /internal/nodes/{id}/drain`), poll
     `GET /internal/nodes/{id}/drain` until `drain_complete`, then re-run the
     same `docker ps` side-channel check on both containers to confirm the
     container migrated off the worker. In this 2-node cluster it has
     nowhere to go but the control plane, so this step also implicitly
     re-tests the `Local` scheduling fallback path.
-12. remove the worker node (`DELETE /internal/nodes/{id}`); confirm it's
+14. remove the worker node (`DELETE /internal/nodes/{id}`); confirm it's
     gone from `GET /internal/nodes`.
-13. teardown (in a `finally`, same discipline as every other scenario):
+15. teardown (in a `finally`, same discipline as every other scenario):
     `docker compose down` (no `-v`, so the cargo-registry/cargo-git/
     workspace-target cache volumes survive for a near-instant re-run), then
     explicitly `docker volume rm` the identity/state volumes (postgres

--- a/apps/temps-e2e/src/commands/multinode-join-scenario.ts
+++ b/apps/temps-e2e/src/commands/multinode-join-scenario.ts
@@ -732,7 +732,7 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
           label: 'Postgres service and all members to report running',
         },
       )
-      await pollUntil(
+      const steadyState = await pollUntil(
         async () => unwrap(await getClusterHealth({ client: client!, path: { id: databaseService.id } }), 'getClusterHealth'),
         (health) =>
           !health.monitor_error &&
@@ -746,15 +746,29 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
           label: 'Postgres cluster health and role DNS records to converge',
         },
       )
+      const electedPrimary = steadyState.members.find((member) =>
+        POSTGRES_PRIMARY_STATES.has(member.reported_state),
+      )
+      if (!electedPrimary) {
+        throw new Error('Postgres cluster health returned no elected primary')
+      }
       const detail = unwrap(
         await getService({ client: client!, path: { id: databaseService.id } }),
         'getService',
       )
-      const dataMember = (detail.service.members ?? []).find((member) => member.role !== 'monitor')
-      if (!dataMember || dataMember.port === undefined || dataMember.port === null) {
-        throw new Error('Postgres cluster returned no addressable data member')
+      // pg_auto_failover may elect either data member. POSTGRES_URL retains
+      // target_session_attrs=read-write after we replace its host, so using
+      // "the first replica" makes this scenario depend on election order and
+      // crash-loops the probe whenever that replica is the secondary.
+      const primaryMember = (detail.service.members ?? []).find(
+        (member) => member.container_name === electedPrimary.nodename,
+      )
+      if (!primaryMember || primaryMember.port === undefined || primaryMember.port === null) {
+        throw new Error(
+          `Postgres elected primary ${electedPrimary.nodename}, but the service returned no matching addressable member`,
+        )
       }
-      databaseDnsAddress = `${databaseService.name}-${dataMember.ordinal}.${databaseService.name}.temps.local:${dataMember.port}`
+      databaseDnsAddress = `${databaseService.name}-${primaryMember.ordinal}.${databaseService.name}.temps.local:${primaryMember.port}`
     })
 
     const probeProject = await step('create a control-plane probe application', () =>

--- a/apps/temps-e2e/src/commands/multinode-join-scenario.ts
+++ b/apps/temps-e2e/src/commands/multinode-join-scenario.ts
@@ -836,7 +836,7 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
       )
       if (!databaseInfo.ok) throw new Error(String(databaseInfo.detail))
       if (!databaseInfo.detail.database_host.includes('.temps.local')) {
-        throw new Error(`injected POSTGRES_URL did not contain internal DNS hosts: ${databaseInfo.detail.database_host}`)
+        throw new Error(`database probe did not use an internal DNS host: ${databaseInfo.detail.database_host}`)
       }
 
       const write = await fetch(`${probeTarget.url.replace(/\/+$/, '')}/probe`, { headers: probeTarget.headers })

--- a/apps/temps-e2e/src/commands/multinode-join-scenario.ts
+++ b/apps/temps-e2e/src/commands/multinode-join-scenario.ts
@@ -66,15 +66,22 @@
  *  10. real HTTP proof of life: hit the deployed app through the
  *      control-plane's proxy (localhost:18180) with the app's Host header
  *      and assert a real response body, not just a healthy status field.
- *  11. drain the worker (`POST /internal/nodes/{id}/drain`), poll
+ *  11. enable the opt-in cluster resolver, deploy a second unprivileged
+ *      application on the worker, and `docker exec` its `wget` against
+ *      `production.<project>.temps.local`. This proves application DNS from
+ *      inside a real deployed container, not from the host test process.
+ *  12. create a real Postgres HA service and a linked Go probe application.
+ *      The probe replaces only the linked DSN's address with the published
+ *      service-member FQDN, then performs a real INSERT + SELECT through it.
+ *  13. drain the worker (`POST /internal/nodes/{id}/drain`), poll
  *      `GET /internal/nodes/{id}/drain` until `drain_complete`, then
  *      re-run the same `docker ps` side-channel check on both containers —
  *      in this 2-node cluster the container has nowhere to go but the
  *      control plane, so this also implicitly re-tests the `Local`
  *      fallback scheduling path.
- *  12. remove the worker node (`DELETE /internal/nodes/{id}`) and confirm
+ *  14. remove the worker node (`DELETE /internal/nodes/{id}`) and confirm
  *      it's gone from `GET /internal/nodes`.
- *  13. teardown (in a `finally`, matching every other scenario's
+ *  15. teardown (in a `finally`, matching every other scenario's
  *      discipline): `docker compose down` (no `-v`, so the cache volumes —
  *      cargo registry/git + workspace target/ — survive for a fast
  *      re-run), then explicitly `docker volume rm` the identity/state
@@ -86,10 +93,16 @@
  *      cluster behind, not just one container.
  */
 import { fileURLToPath } from 'node:url'
+import { mkdir } from 'node:fs/promises'
 import path from 'node:path'
 import {
   updateEnvironmentSettings,
   deployFromImage,
+  createEnvironmentVariable,
+  createService,
+  getService,
+  getClusterHealth,
+  linkServiceToProject,
   adminListNodes,
   adminDrainNode,
   adminDrainStatus,
@@ -106,6 +119,7 @@ import {
   makeRunId,
   pollUntil,
 } from '../lib/flows.ts'
+import { buildHaProbeImage } from '../lib/probe-app.ts'
 import type { Client } from '@temps-sdk/api/client'
 
 // apps/temps-e2e/src/commands/ -> repo root is 4 levels up.
@@ -117,6 +131,8 @@ const WORKER_CONTAINER = 'temps-e2e-mn-worker-1'
 const WORKER_NAME = 'worker-1'
 const CONTROL_PLANE_URL = 'http://localhost:18180'
 const POSTGRES_DIRECT_URL = 'postgres://temps:temps@10.52.0.5:5432/temps'
+const PROBE_SCRATCH_ROOT = path.join(process.env.TMPDIR ?? '/tmp', 'temps-e2e-multinode-dns')
+const POSTGRES_PRIMARY_STATES = new Set(['primary', 'single', 'wait_primary'])
 const IDENTITY_VOLUMES = [
   'temps-e2e-mn-postgres-data',
   'temps-e2e-mn-cp-docker',
@@ -146,6 +162,10 @@ interface MultinodeJoinScenarioResult {
   ok: boolean
   workerNodeId?: number
   steps: StepLog[]
+}
+
+interface DatabaseInfoResponse {
+  database_host: string
 }
 
 /** Run a subcommand, streaming stdout/stderr line-by-line through onLog; throws on non-zero exit. */
@@ -209,6 +229,45 @@ async function runCaptured(
     proc.exited,
   ])
   return { code, stdout, stderr }
+}
+
+/** Upload a host-built Docker image through Temps's registry-free image-upload API. */
+async function deployUploadedImage(opts: {
+  cfg: { url: string; apiKey: string }
+  projectId: number
+  environmentId: number
+  imageRef: string
+  runId: string
+}): Promise<number> {
+  await mkdir(PROBE_SCRATCH_ROOT, { recursive: true })
+  const hostTar = path.join(PROBE_SCRATCH_ROOT, `${opts.runId}.tar`)
+  try {
+    await runStreamed(
+      ['docker', 'save', '--output', hostTar, opts.imageRef],
+      () => {},
+      `docker save ${opts.imageRef}`,
+    )
+    const form = new FormData()
+    form.append('file', Bun.file(hostTar), `${opts.runId}.tar`)
+    const baseUrl = opts.cfg.url.replace(/\/+$/, '')
+    const query = new URLSearchParams({ tag: opts.imageRef, health_check_path: '/health' })
+    const response = await fetch(
+      `${baseUrl}/api/projects/${opts.projectId}/environments/${opts.environmentId}/deploy/image-upload?${query}`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${opts.cfg.apiKey}` },
+        body: form,
+      },
+    )
+    if (!response.ok) {
+      throw new Error(`image upload deployment failed (HTTP ${response.status}): ${await response.text()}`)
+    }
+    const deployment = (await response.json()) as { id?: number }
+    if (typeof deployment.id !== 'number') throw new Error('image upload deployment returned no deployment id')
+    return deployment.id
+  } finally {
+    await Bun.file(hostTar).delete().catch(() => {})
+  }
 }
 
 /** `docker inspect --format '{{.State.Health.Status}}' <name>`. Returns '' if the container doesn't exist yet. */
@@ -295,8 +354,10 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
   let client: Client | undefined
   let cfg: { url: string; apiKey: string } | undefined
   const projectIds: number[] = []
+  const serviceIds: number[] = []
   const deployments: { projectId: number; deploymentId: number }[] = []
   let workerNodeId: number | undefined
+  let databaseDnsAddress: string | undefined
   let clusterStartAttempted = false
   const revokeTemporaryApiKey = async () => {
     if (!clusterStartAttempted) return
@@ -325,6 +386,13 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
         // Missing volumes are expected on a genuinely fresh run.
         await runCaptured(['docker', 'volume', 'rm', '-f', volume])
       }
+      // These named volumes are mounted below the read-only /workspace bind.
+      // runc cannot create their mountpoints through that parent on a clean
+      // checkout, so make the gitignored directories before Compose starts.
+      await Promise.all([
+        mkdir(path.join(REPO_ROOT, 'target'), { recursive: true }),
+        mkdir(path.join(REPO_ROOT, 'crates/temps-cli/dist'), { recursive: true }),
+      ])
     })
 
     await step(
@@ -447,9 +515,9 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
         '-d',
         'temps',
         '-c',
-        "SELECT data::jsonb->'multi_node'->>'require_mtls', data::jsonb->'multi_node'->>'legacy_shared_token_enabled', used_count, max_uses FROM settings CROSS JOIN node_enrollment_tokens WHERE settings.id = 1",
+        "SELECT data::jsonb->'multi_node'->>'require_mtls', data::jsonb->'multi_node'->>'legacy_shared_token_enabled', data::jsonb->'cluster_dns'->>'enabled', used_count, max_uses FROM settings CROSS JOIN node_enrollment_tokens WHERE settings.id = 1",
       ])
-      if (posture.code !== 0 || posture.stdout.trim() !== 'true|false|1|1') {
+      if (posture.code !== 0 || posture.stdout.trim() !== 'true|false|true|1|1') {
         throw new Error(`unexpected enrollment posture: ${posture.stdout.trim() || posture.stderr.trim() || '(no output)'}`)
       }
     })
@@ -512,7 +580,7 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
             dockerPsNames(WORKER_CONTAINER),
             dockerPsNames(CONTROL_PLANE_CONTAINER),
           ])
-          return workerContainers.some((n) => n.includes(runId))
+          return workerContainers.some((n) => n.includes(project.slug))
         },
         (found) => found,
         {
@@ -522,7 +590,7 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
           label: "deployment container to appear on worker-1's docker ps",
         },
       )
-      const onControlPlane = cpContainers.some((n) => n.includes(runId))
+      const onControlPlane = cpContainers.some((n) => n.includes(project.slug))
       if (onControlPlane) {
         throw new Error(
           `deployment container unexpectedly found on the control plane's docker ps (containers: ${cpContainers.join(', ') || '(none)'}) -- target_nodes pinning did not take effect`,
@@ -533,6 +601,275 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
 
     const target = resolveLoadTarget(cfg.url, env.mainUrl)
     await step('real HTTP proof of life through the control-plane proxy', () => waitForWhoami(target))
+
+    const dnsClientProject = await step('create a second application for app-to-app DNS', () =>
+      createE2eProject(client!, { name: `${runId}-dns-client`, exposedPort: 8080 }),
+    )
+    projectIds.push(dnsClientProject.id)
+    const dnsClientEnv = await step('resolve the DNS client production environment', () =>
+      getProductionEnvironment(client!, dnsClientProject.id),
+    )
+    await step('pin the DNS client application to the worker', async () => {
+      unwrap(
+        await updateEnvironmentSettings({
+          client: client!,
+          path: { project_id: dnsClientProject.id, env_id: dnsClientEnv.id },
+          body: { target_nodes: [workerNodeId!] },
+        }),
+        'updateEnvironmentSettings',
+      )
+    })
+    const dnsClientDeploymentId = await step('deploy unprivileged Nginx as the DNS client application', () =>
+      deployFromImage({
+        client: client!,
+        path: { project_id: dnsClientProject.id, environment_id: dnsClientEnv.id },
+        body: { image_ref: 'nginxinc/nginx-unprivileged:alpine' },
+      }).then((res) => unwrap(res, 'deployFromImage').id),
+    )
+    deployments.push({ projectId: dnsClientProject.id, deploymentId: dnsClientDeploymentId })
+    await step('wait for the DNS client deployment on the worker', async () => {
+      await waitForDeployment(client!, {
+        projectId: dnsClientProject.id,
+        deploymentId: dnsClientDeploymentId,
+        timeoutMs: 300_000,
+        onPoll: (status) => log(`    ...${status.state}`),
+      })
+      const status = await getDeployStatus(client!, dnsClientProject.id, dnsClientDeploymentId)
+      if (!status.ok) throw new Error(`DNS client deployment ${dnsClientDeploymentId} is in state "${status.state}"`)
+    })
+
+    await step('prove one deployed application reaches another through *.temps.local DNS', async () => {
+      const clientContainer = await pollUntil(
+        async () => (await dockerPsNames(WORKER_CONTAINER)).find((name) => name.includes(dnsClientProject.slug)),
+        (name) => name !== undefined,
+        { timeoutMs: 30_000, intervalMs: 1000, label: 'DNS client container to appear on the worker' },
+      )
+      const appUrl = `http://production.${project.slug}.temps.local`
+      const request = await pollUntil(
+        () =>
+          runCaptured([
+            'docker',
+            'exec',
+            WORKER_CONTAINER,
+            'docker',
+            'exec',
+            clientContainer!,
+            'wget',
+            '-qO-',
+            appUrl,
+          ]),
+        (result) => result.code === 0,
+        {
+          timeoutMs: 60_000,
+          intervalMs: 2000,
+          onPoll: (result) => log(`    ...wget exit=${result.code}`),
+          label: `worker application to GET ${appUrl}`,
+        },
+      )
+      if (!request.stdout.includes('Hostname:')) {
+        throw new Error(`worker application received an unexpected response from ${appUrl}: ${request.stdout}`)
+      }
+      log(`  ${clientContainer} -> ${appUrl}`)
+    })
+
+    await step('remove the temporary DNS client application', async () => {
+      const cleanup = await teardown(client!, {
+        deployments: [{ projectId: dnsClientProject.id, deploymentId: dnsClientDeploymentId }],
+        projectIds: [dnsClientProject.id],
+      })
+      if (cleanup.errors.length) throw new Error(cleanup.errors.join('; '))
+      deployments.splice(deployments.findIndex((d) => d.deploymentId === dnsClientDeploymentId), 1)
+      projectIds.splice(projectIds.indexOf(dnsClientProject.id), 1)
+    })
+
+    const probeImage = await step('build the DNS/database probe image on the host', () =>
+      buildHaProbeImage({
+        scratchRoot: PROBE_SCRATCH_ROOT,
+        registry: 'unused',
+        tag: `temps-e2e-multinode-dns:${runId}`,
+        push: false,
+        onLog: (line) => log(`    [probe-build] ${line}`),
+      }),
+    )
+
+    const databaseService = await step('provision a real Postgres HA service with internal DNS', async () => {
+      const created = unwrap(
+        await createService({
+          client: client!,
+          body: {
+            name: `${runId}-dns-db`,
+            service_type: 'postgres',
+            topology: 'cluster',
+            parameters: { database: 'app', username: 'app' },
+            members: [
+              { role: 'monitor', node_id: null },
+              { role: 'replica', node_id: null },
+              { role: 'replica', node_id: null },
+            ],
+          },
+        }),
+        'createService',
+      ) as { id: number; name: string }
+      serviceIds.push(created.id)
+      return created
+    })
+
+    await step('wait for the Postgres cluster and DNS records to converge', async () => {
+      await pollUntil(
+        async () => unwrap(await getService({ client: client!, path: { id: databaseService.id } }), 'getService'),
+        (detail) => {
+          if (detail.service.status === 'failed') {
+            throw new Error(`cluster failed: ${detail.service.error_message ?? 'no error detail'}`)
+          }
+          const members = detail.service.members ?? []
+          return detail.service.status === 'running' && members.length === 3 && members.every((m) => m.status === 'running')
+        },
+        {
+          timeoutMs: 240_000,
+          intervalMs: 3000,
+          onPoll: (detail) =>
+            log(`    ...service=${detail.service.status} members=${(detail.service.members ?? []).map((m) => `${m.container_name}:${m.status}`).join(',')}`),
+          label: 'Postgres service and all members to report running',
+        },
+      )
+      await pollUntil(
+        async () => unwrap(await getClusterHealth({ client: client!, path: { id: databaseService.id } }), 'getClusterHealth'),
+        (health) =>
+          !health.monitor_error &&
+          health.members.length === 2 &&
+          health.members.filter((m) => POSTGRES_PRIMARY_STATES.has(m.reported_state)).length === 1 &&
+          health.members.every((m) => m.health === 1),
+        {
+          timeoutMs: 240_000,
+          intervalMs: 3000,
+          onPoll: (health) => log(`    ...${health.monitor_error ?? health.members.map((m) => `${m.nodename}:${m.reported_state}`).join(',')}`),
+          label: 'Postgres cluster health and role DNS records to converge',
+        },
+      )
+      const detail = unwrap(
+        await getService({ client: client!, path: { id: databaseService.id } }),
+        'getService',
+      )
+      const dataMember = (detail.service.members ?? []).find((member) => member.role !== 'monitor')
+      if (!dataMember || dataMember.port === undefined || dataMember.port === null) {
+        throw new Error('Postgres cluster returned no addressable data member')
+      }
+      databaseDnsAddress = `${databaseService.name}-${dataMember.ordinal}.${databaseService.name}.temps.local:${dataMember.port}`
+    })
+
+    const probeProject = await step('create a control-plane probe application', () =>
+      createE2eProject(client!, { name: `${runId}-dns-probe`, exposedPort: 3000 }),
+    )
+    projectIds.push(probeProject.id)
+    const probeEnv = await step('resolve the probe production environment', () =>
+      getProductionEnvironment(client!, probeProject.id),
+    )
+    await step('pin the database probe to the control plane and link the database', async () => {
+      unwrap(
+        await updateEnvironmentSettings({
+          client: client!,
+          path: { project_id: probeProject.id, env_id: probeEnv.id },
+          body: { target_nodes: [0] },
+        }),
+        'updateEnvironmentSettings',
+      )
+      unwrap(
+        await linkServiceToProject({
+          client: client!,
+          path: { id: databaseService.id },
+          body: { project_id: probeProject.id },
+        }),
+        'linkServiceToProject',
+      )
+      unwrap(
+        await createEnvironmentVariable({
+          client: client!,
+          path: { project_id: probeProject.id },
+          body: {
+            key: 'POSTGRES_DNS_ADDRESS',
+            value: databaseDnsAddress!,
+            environment_ids: [probeEnv.id],
+          },
+        }),
+        'createEnvironmentVariable',
+      )
+    })
+
+    const probeDeploymentId = await step('upload and deploy the probe image on the control plane', () =>
+      deployUploadedImage({
+        cfg: cfg!,
+        projectId: probeProject.id,
+        environmentId: probeEnv.id,
+        imageRef: probeImage,
+        runId,
+      }),
+    )
+    deployments.push({ projectId: probeProject.id, deploymentId: probeDeploymentId })
+    await step('wait for the DNS/database probe deployment', () =>
+      waitForDeployment(client!, {
+        projectId: probeProject.id,
+        deploymentId: probeDeploymentId,
+        timeoutMs: 300_000,
+        onPoll: (status) => log(`    ...${status.state}`),
+      }),
+    )
+
+    const probeTarget = resolveLoadTarget(cfg.url, probeEnv.mainUrl)
+    await step('prove the deployed application accesses Postgres through *.temps.local DNS', async () => {
+      const databaseInfo = await pollUntil(
+        async () => {
+          try {
+            const res = await fetch(`${probeTarget.url.replace(/\/+$/, '')}/database-info`, { headers: probeTarget.headers })
+            if (!res.ok) return { ok: false as const, detail: `HTTP ${res.status}: ${await res.text()}` }
+            return { ok: true as const, detail: (await res.json()) as DatabaseInfoResponse }
+          } catch (error) {
+            return { ok: false as const, detail: (error as Error).message }
+          }
+        },
+        (result) => result.ok,
+        {
+          timeoutMs: 90_000,
+          intervalMs: 2000,
+          onPoll: (result) => log(`    ...${result.ok ? 'connected' : result.detail}`),
+          label: 'probe application to reach Postgres through internal DNS',
+        },
+      )
+      if (!databaseInfo.ok) throw new Error(String(databaseInfo.detail))
+      if (!databaseInfo.detail.database_host.includes('.temps.local')) {
+        throw new Error(`injected POSTGRES_URL did not contain internal DNS hosts: ${databaseInfo.detail.database_host}`)
+      }
+
+      const write = await fetch(`${probeTarget.url.replace(/\/+$/, '')}/probe`, { headers: probeTarget.headers })
+      if (!write.ok) throw new Error(`database INSERT/SELECT probe failed (HTTP ${write.status}): ${await write.text()}`)
+      const body = (await write.json()) as { count?: number }
+      if (typeof body.count !== 'number' || body.count < 1) {
+        throw new Error(`database INSERT/SELECT returned an invalid row count: ${JSON.stringify(body)}`)
+      }
+      log(`  database=${databaseInfo.detail.database_host} rows=${body.count}`)
+    })
+
+    await step('remove DNS probe resources before draining the worker', async () => {
+      const cleanup = await teardown(client!, {
+        deployments: [{ projectId: probeProject.id, deploymentId: probeDeploymentId }],
+        projectIds: [probeProject.id],
+        serviceIds: [databaseService.id],
+      })
+      if (cleanup.errors.length) throw new Error(cleanup.errors.join('; '))
+      deployments.splice(deployments.findIndex((d) => d.deploymentId === probeDeploymentId), 1)
+      projectIds.splice(projectIds.indexOf(probeProject.id), 1)
+      serviceIds.splice(serviceIds.indexOf(databaseService.id), 1)
+      await pollUntil(
+        async () => {
+          const [worker, controlPlane] = await Promise.all([
+            dockerPsNames(WORKER_CONTAINER),
+            dockerPsNames(CONTROL_PLANE_CONTAINER),
+          ])
+          return [...worker, ...controlPlane].some((name) => name.includes(databaseService.name) || name.includes(probeProject.slug))
+        },
+        (found) => !found,
+        { timeoutMs: 90_000, intervalMs: 2000, label: 'probe and database containers to stop' },
+      )
+    })
 
     await step('drain the worker', async () => {
       unwrap(
@@ -572,8 +909,8 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
             dockerPsNames(CONTROL_PLANE_CONTAINER),
           ])
           return {
-            onWorker: workerContainers.some((n) => n.includes(runId)),
-            onControlPlane: cpContainers.some((n) => n.includes(runId)),
+            onWorker: workerContainers.some((n) => n.includes(project.slug)),
+            onControlPlane: cpContainers.some((n) => n.includes(project.slug)),
           }
         },
         (placement) => !placement.onWorker && placement.onControlPlane,
@@ -587,8 +924,8 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
           label: 'replacement container to become visible on the control plane after drain',
         },
       )
-      const onWorker = workerContainers.some((n) => n.includes(runId))
-      const onControlPlane = cpContainers.some((n) => n.includes(runId))
+      const onWorker = workerContainers.some((n) => n.includes(project.slug))
+      const onControlPlane = cpContainers.some((n) => n.includes(project.slug))
       if (onWorker) {
         throw new Error(
           `deployment container still present on worker-1's docker ps after drain (containers: ${workerContainers.join(', ')})`,
@@ -641,9 +978,9 @@ export async function multinodeJoinScenarioCommand(opts: MultinodeJoinScenarioOp
       // Best-effort SDK-level teardown first (project/deployments), then tear
       // down the cluster itself.
       if (client) {
-        const td = await teardown(client, { deployments, projectIds })
+        const td = await teardown(client, { deployments, projectIds, serviceIds })
         log(
-          `\n▶ teardown: tore down ${td.teardownDeployments} deployment(s), deleted ${td.deletedProjects} project(s)` +
+          `\n▶ teardown: tore down ${td.teardownDeployments} deployment(s), deleted ${td.deletedProjects} project(s), deleted ${td.deletedServices} service(s)` +
             (td.errors.length ? ` (${td.errors.length} errors)` : ''),
         )
         for (const e of td.errors) log(`    ! ${e}`)

--- a/apps/temps-e2e/src/index.ts
+++ b/apps/temps-e2e/src/index.ts
@@ -498,7 +498,8 @@ program
       '(tools/e2e-multinode-cluster/, not the shared instance -- no --url/--api-key), waits for a real ' +
       'worker to register via POST /internal/nodes/register, pins a deployment to it via target_nodes, ' +
       'proves the container actually landed on the worker (not the control plane) via a docker-exec side ' +
-      'channel, drains the worker, and removes it from the cluster -- the first e2e coverage this feature ' +
+      'channel, proves app-to-app and managed-Postgres *.temps.local DNS from deployed containers, drains ' +
+      'the worker, and removes it from the cluster -- the first e2e coverage this feature ' +
       'has ever had. First run compiles the temps binary from source TWICE (once per node) inside Docker, ' +
       'so budget 15-20+ minutes; subsequent runs are fast (cargo/target caches persist across runs).',
   )

--- a/apps/temps-e2e/src/lib/probe-app.ts
+++ b/apps/temps-e2e/src/lib/probe-app.ts
@@ -35,6 +35,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -47,6 +48,17 @@ func main() {
 	dsn := os.Getenv("POSTGRES_URL")
 	if dsn == "" {
 		log.Fatal("POSTGRES_URL not set")
+	}
+	// DNS-focused scenarios can preserve every injected credential/database
+	// field while replacing only the address with a published *.temps.local
+	// service-member record.
+	if dnsAddress := os.Getenv("POSTGRES_DNS_ADDRESS"); dnsAddress != "" {
+		parsed, err := url.Parse(dsn)
+		if err != nil {
+			log.Fatalf("parse POSTGRES_URL: %v", err)
+		}
+		parsed.Host = dnsAddress
+		dsn = parsed.String()
 	}
 	// The injected DSN carries no sslmode param, and lib/pq defaults to
 	// requiring SSL -- the managed container is plain internal Docker
@@ -93,6 +105,21 @@ func main() {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]int{"count": count})
+	})
+	mux.HandleFunc("/database-info", func(w http.ResponseWriter, r *http.Request) {
+		parsedDSN, err := url.Parse(dsn)
+		if err != nil {
+			http.Error(w, "invalid POSTGRES_URL", http.StatusInternalServerError)
+			return
+		}
+		if err := db.PingContext(r.Context()); err != nil {
+			http.Error(w, "database ping failed", http.StatusBadGateway)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"database_host": parsedDSN.Host,
+		})
 	})
 
 	port := os.Getenv("PORT")
@@ -181,6 +208,7 @@ export async function buildHaProbeImage(opts: {
   scratchRoot: string
   registry: string
   tag?: string
+  push?: boolean
   onLog?: (line: string) => void
 }): Promise<string> {
   const ctxDir = join(opts.scratchRoot, 'db-probe-ha')
@@ -194,8 +222,10 @@ export async function buildHaProbeImage(opts: {
 
   opts.onLog?.(`docker build -t ${imageRef} ${ctxDir}`)
   await runDocker(['build', '--load', '-t', imageRef, ctxDir], opts.onLog, `docker build ${imageRef}`)
-  opts.onLog?.(`docker push ${imageRef}`)
-  await runDocker(['push', imageRef], opts.onLog, `docker push ${imageRef}`)
+  if (opts.push !== false) {
+    opts.onLog?.(`docker push ${imageRef}`)
+    await runDocker(['push', imageRef], opts.onLog, `docker push ${imageRef}`)
+  }
   return imageRef
 }
 

--- a/crates/temps-deployments/src/jobs/deploy_image.rs
+++ b/crates/temps-deployments/src/jobs/deploy_image.rs
@@ -1492,17 +1492,10 @@ impl DeployImageJob {
         environment_vars.insert("TEMPS_REPLICA".to_string(), (replica_index + 1).to_string());
 
         tracing::info!(
-            "Deploying container with {} env vars, POSTGRES_HOST={:?}, POSTGRES_URL={:?}",
+            "Deploying container with {} env vars (Postgres host configured: {}, URL configured: {})",
             environment_vars.len(),
-            environment_vars.get("POSTGRES_HOST"),
-            environment_vars.get("POSTGRES_URL").map(|u| {
-                // Truncate for logging (may contain password)
-                if u.len() > 60 {
-                    format!("{}...", &u[..60])
-                } else {
-                    u.clone()
-                }
-            })
+            environment_vars.contains_key("POSTGRES_HOST"),
+            environment_vars.contains_key("POSTGRES_URL")
         );
 
         // Create unique container name for each replica

--- a/crates/temps-deployments/src/services/workflow_planner.rs
+++ b/crates/temps-deployments/src/services/workflow_planner.rs
@@ -753,14 +753,15 @@ impl WorkflowPlanner {
                     for (key, value) in remote_vars.iter_mut() {
                         // Replace container_name:internal_port → private_address:host_port
                         if value.contains(&container_name) {
-                            let old_value = value.clone();
                             *value = value
                                 .replace(
                                     &format!("{}:{}", container_name, internal_port),
                                     &format!("{}:{}", private_address, host_port),
                                 )
                                 .replace(&container_name, &private_address);
-                            info!("Rewrote {}={} -> {}", key, old_value, value);
+                            // Connection strings contain credentials. Log the
+                            // affected key, never either secret-bearing value.
+                            info!("Rewrote environment variable {} for remote deployment", key);
                             rewritten_count += 1;
                         }
                     }

--- a/crates/temps-providers/src/externalsvc/cluster_role.rs
+++ b/crates/temps-providers/src/externalsvc/cluster_role.rs
@@ -92,7 +92,7 @@ pub enum PgAutoFailoverState {
     Primary,
     /// Single-node mode (no replica yet); still writable.
     Single,
-    /// About to be promoted to primary; not yet writable.
+    /// Promotion completed and writable, but no standby is currently attached.
     WaitPrimary,
     /// Streaming from the primary; healthy.
     Secondary,

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -42,6 +42,37 @@ const NONCE_LENGTH: usize = 12;
 /// to IPv6 first on Linux even though Docker is only listening on 127.0.0.1.
 pub(crate) const LOCAL_CLUSTER_HOST: &str = "127.0.0.1";
 
+/// Select the network endpoint advertised for a managed cluster member.
+///
+/// The local application-network address is deliberately considered only for
+/// control-plane members (`node_id = None`). Docker bridge addresses are local
+/// to one daemon and must never replace a remote member's overlay/underlay
+/// address.
+fn select_member_dns_endpoint(
+    node_id: Option<i32>,
+    overlay_ip: Option<&str>,
+    local_network_ip: Option<&str>,
+    underlay_endpoint: Option<(String, i32)>,
+    container_port: u16,
+) -> Option<(String, i32)> {
+    let valid_ip = |ip: &str| {
+        let trimmed = ip.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    };
+
+    if let Some(ip) = overlay_ip.and_then(valid_ip) {
+        return Some((ip, container_port as i32));
+    }
+
+    if node_id.is_none() {
+        return local_network_ip
+            .and_then(valid_ip)
+            .map(|ip| (ip, container_port as i32));
+    }
+
+    underlay_endpoint
+}
+
 #[derive(Error, Debug)]
 pub enum ExternalServiceError {
     #[error("Service {id} not found")]
@@ -5335,25 +5366,22 @@ echo "[restore] Pre-seed complete"
 
                 // Register the per-member A record (ADR-011, Tier 2).
                 //
-                // Prefer the overlay IP when the container is on
-                // `temps0` — that points other containers straight at
-                // each other on the multi-host bridge. If the overlay
-                // isn't attached (single-host setups, or the monitor on
-                // a control plane that's not in the allocator), fall
-                // back to the underlay address + the published host
-                // port so dialing through Docker's port forward still
-                // works. This is what makes `MONITOR_URI=<fqdn>:<port>`
-                // resolve from inside any container.
-                let (record_ip, record_port) = match compute_ip.clone() {
-                    Some(ip) => (Some(ip), member_port as i32),
-                    None => match self
-                        .resolve_member_underlay(spec.node_id, host_port, member_port)
-                        .await
-                    {
-                        Some((ip, port)) => (Some(ip), port),
-                        None => (None, member_port as i32),
-                    },
-                };
+                // Local members are directly reachable from application
+                // containers on `temps-app-network`; their loopback-only host
+                // port is intentionally *not* reachable through the node's
+                // underlay address. Remote members still prefer their overlay
+                // IP and otherwise use the underlay/host-port fallback.
+                let (record_ip, record_port) = self
+                    .resolve_member_dns_endpoint(
+                        spec.node_id,
+                        compute_ip.as_deref(),
+                        &result.container_name,
+                        host_port,
+                        member_port,
+                    )
+                    .await
+                    .map(|(ip, port)| (Some(ip), port))
+                    .unwrap_or((None, member_port as i32));
 
                 if let Some(ip) = record_ip {
                     let draft = temps_dns::EndpointDraft {
@@ -6419,21 +6447,19 @@ echo "[restore] Pre-seed complete"
             return;
         }
 
-        // Register Tier-2 DNS A record. Prefer the overlay IP; fall
-        // back to (node_underlay, host_port) so the FQDN still works
-        // when the overlay isn't attached. Best-effort: a failed
-        // registration logs loudly but doesn't mark the member as
-        // failed — the role reconciler will try again on its next tick.
-        let (record_ip, record_port) = match compute_ip.clone() {
-            Some(ip) => (Some(ip), plan.member_port as i32),
-            None => match self
-                .resolve_member_underlay(plan.spec.node_id, host_port, plan.member_port)
-                .await
-            {
-                Some((ip, port)) => (Some(ip), port),
-                None => (None, plan.member_port as i32),
-            },
-        };
+        // Register Tier-2 DNS A record using the same topology-aware
+        // selection as initial cluster creation.
+        let (record_ip, record_port) = self
+            .resolve_member_dns_endpoint(
+                plan.spec.node_id,
+                compute_ip.as_deref(),
+                &plan.container_name,
+                host_port,
+                plan.member_port,
+            )
+            .await
+            .map(|(ip, port)| (Some(ip), port))
+            .unwrap_or((None, plan.member_port as i32));
         if let Some(ip) = record_ip {
             let draft = temps_dns::EndpointDraft {
                 fqdn: plan.member_fqdn.clone(),
@@ -7174,6 +7200,88 @@ echo "[restore] Pre-seed complete"
         }?;
 
         Some((ip, port))
+    }
+
+    /// Resolve the address published for a service-member FQDN.
+    ///
+    /// Local managed-service ports bind to `127.0.0.1` for security, so the
+    /// control-plane underlay address plus host port is not reachable from an
+    /// application container. Local members instead publish their container
+    /// address on the shared application network and the container port.
+    /// Remote members retain the overlay-first, underlay-fallback behavior.
+    async fn resolve_member_dns_endpoint(
+        &self,
+        node_id: Option<i32>,
+        overlay_ip: Option<&str>,
+        container_name: &str,
+        host_port: Option<i32>,
+        container_port: u16,
+    ) -> Option<(String, i32)> {
+        if let Some(endpoint) =
+            select_member_dns_endpoint(node_id, overlay_ip, None, None, container_port)
+        {
+            return Some(endpoint);
+        }
+
+        if node_id.is_none() {
+            let local_network_ip = self
+                .lookup_container_network_ip(container_name, &temps_core::NETWORK_NAME)
+                .await;
+            if let Some(endpoint) = select_member_dns_endpoint(
+                node_id,
+                None,
+                local_network_ip.as_deref(),
+                None,
+                container_port,
+            ) {
+                return Some(endpoint);
+            }
+        }
+
+        if node_id.is_some() {
+            let underlay = self
+                .resolve_member_underlay(node_id, host_port, container_port)
+                .await;
+            return select_member_dns_endpoint(node_id, None, None, underlay, container_port);
+        }
+
+        // Publishing the control plane's underlay address here would be
+        // actively misleading: local managed-service ports bind only to
+        // 127.0.0.1, so application containers cannot reach that address.
+        None
+    }
+
+    async fn lookup_container_network_ip(
+        &self,
+        container_name: &str,
+        network_name: &str,
+    ) -> Option<String> {
+        use bollard::query_parameters::InspectContainerOptions;
+
+        match self
+            .docker
+            .inspect_container(container_name, None::<InspectContainerOptions>)
+            .await
+        {
+            Ok(info) => info
+                .network_settings
+                .as_ref()
+                .and_then(|settings| settings.networks.as_ref())
+                .and_then(|networks| networks.get(network_name))
+                .and_then(|endpoint| endpoint.ip_address.as_deref())
+                .map(str::trim)
+                .filter(|ip| !ip.is_empty())
+                .map(str::to_string),
+            Err(error) => {
+                warn!(
+                    container = container_name,
+                    network = network_name,
+                    error = %error,
+                    "Failed to inspect local cluster member network address"
+                );
+                None
+            }
+        }
     }
 
     /// Look up the gateway IP of the multi-host overlay docker network
@@ -14600,5 +14708,52 @@ mod tests {
             .expect("the exposed dynamic port must have a matching host binding");
         assert_eq!(binding.host_ip.as_deref(), Some("127.0.0.1"));
         assert_eq!(binding.host_port.as_deref(), Some("6040"));
+    }
+
+    #[test]
+    fn local_member_dns_uses_shared_network_ip_and_container_port() {
+        let endpoint = select_member_dns_endpoint(
+            None,
+            None,
+            Some("172.19.0.7"),
+            Some(("10.52.0.10".to_string(), 6011)),
+            5432,
+        );
+
+        assert_eq!(endpoint, Some(("172.19.0.7".to_string(), 5432)));
+    }
+
+    #[test]
+    fn local_member_dns_never_publishes_loopback_only_underlay_fallback() {
+        let endpoint = select_member_dns_endpoint(
+            None,
+            None,
+            None,
+            Some(("10.52.0.10".to_string(), 6011)),
+            5432,
+        );
+
+        assert_eq!(endpoint, None);
+    }
+
+    #[test]
+    fn remote_member_dns_preserves_overlay_then_underlay_behavior() {
+        let overlay = select_member_dns_endpoint(
+            Some(7),
+            Some("10.99.0.12"),
+            Some("172.19.0.7"),
+            Some(("10.52.0.11".to_string(), 6012)),
+            5432,
+        );
+        assert_eq!(overlay, Some(("10.99.0.12".to_string(), 5432)));
+
+        let underlay = select_member_dns_endpoint(
+            Some(7),
+            None,
+            Some("172.19.0.7"),
+            Some(("10.52.0.11".to_string(), 6012)),
+            5432,
+        );
+        assert_eq!(underlay, Some(("10.52.0.11".to_string(), 6012)));
     }
 }

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -8,7 +8,8 @@ use crate::externalsvc::{
     rustfs::RustfsService,
     s3::S3Service,
     AvailableContainer, ClusterMemberResult, ClusterMemberSpec, ExternalService, HealthProbeStatus,
-    ManagedS3BackendKind, ManagedS3BackendSelection, ServiceConfig, ServiceType,
+    ManagedS3BackendKind, ManagedS3BackendSelection, PgAutoFailoverState, ServiceConfig,
+    ServiceType,
 };
 use crate::parameter_strategies;
 use crate::remote_service_client::{
@@ -41,6 +42,39 @@ const NONCE_LENGTH: usize = 12;
 /// Keep control-plane connections on the same address: `localhost` may resolve
 /// to IPv6 first on Linux even though Docker is only listening on 127.0.0.1.
 pub(crate) const LOCAL_CLUSTER_HOST: &str = "127.0.0.1";
+
+/// Whether a live pg_auto_failover state identifies a node that accepts writes.
+///
+/// Keep connection planning, backups, deletion guards, and DNS reconciliation
+/// on the typed state model. In particular, `wait_primary` is writable: it is
+/// the stable state of a promoted node that currently has no standby attached.
+fn live_state_is_writable_primary(state: Option<&str>) -> bool {
+    state
+        .and_then(|state| state.parse::<PgAutoFailoverState>().ok())
+        .is_some_and(PgAutoFailoverState::is_primary)
+}
+
+/// Return the monitor identity of the sole healthy, recently reporting writer.
+///
+/// pg_auto_failover retains a stopped node's last `reported_state`, so a stale
+/// unhealthy `primary` can coexist with the promoted healthy `wait_primary`.
+/// Selecting solely by state and member order can therefore route connections
+/// or backups to the dead node. Ambiguous reports fail closed.
+fn healthy_writable_primary_nodename(health: &ClusterHealthReport) -> Option<&str> {
+    if health.monitor_error.is_some() {
+        return None;
+    }
+    let mut candidates = health.members.iter().filter(|member| {
+        member.health == 1
+            && member.seconds_since_report < 30
+            && live_state_is_writable_primary(Some(&member.reported_state))
+    });
+    let candidate = candidates.next()?;
+    if candidates.next().is_some() {
+        return None;
+    }
+    Some(&candidate.nodename)
+}
 
 /// Select the network endpoint advertised for a managed cluster member.
 ///
@@ -2725,7 +2759,7 @@ impl ExternalServiceManager {
     ///   - the service isn't a cluster
     ///   - the monitor is unreachable (callers should treat this as
     ///     "primary unknown" rather than "no primary")
-    ///   - the monitor knows of no node in `primary | single` state
+    ///   - the monitor knows of no node in a writable-primary state
     ///
     /// Replaces the old `members.iter().find(|m| m.role == "primary")`
     /// pattern, which broke the moment we stopped storing the primary
@@ -2742,15 +2776,19 @@ impl ExternalServiceManager {
         if health.monitor_error.is_some() {
             return Ok(None);
         }
-        let primary_name = health
-            .members
-            .iter()
-            .find(|h| matches!(h.reported_state.as_str(), "primary" | "single"))
-            .map(|h| h.nodename.clone());
-        let Some(name) = primary_name else {
+        let Some(name) = healthy_writable_primary_nodename(&health) else {
             return Ok(None);
         };
-        Ok(members.iter().find(|m| m.container_name == name))
+        let mut matches = members.iter().filter(|member| {
+            is_role_data_member(&member.role)
+                && member.status == "running"
+                && member.container_name == name
+        });
+        let member = matches.next();
+        if matches.next().is_some() {
+            return Ok(None);
+        }
+        Ok(member)
     }
 
     /// Live primary check: ask the pg_auto_failover monitor whether the
@@ -2811,14 +2849,7 @@ impl ExternalServiceManager {
             .members
             .iter()
             .find(|h| h.nodename == container_name)
-            .map(|h| {
-                <crate::externalsvc::PgAutoFailoverState as std::str::FromStr>::from_str(
-                    &h.reported_state,
-                )
-                .expect("PgAutoFailoverState::from_str is Infallible")
-                .is_primary()
-            })
-            .unwrap_or(false)
+            .is_some_and(|h| live_state_is_writable_primary(Some(&h.reported_state)))
     }
 
     /// Same shape as `get_service_members`, but for cluster topologies
@@ -3222,7 +3253,7 @@ impl ExternalServiceManager {
             // AND the node is healthy. A stale ghost-primary
             // (`reportedstate='primary'` but `health<=0`) would otherwise
             // route us to a dead host and the panel would lose sync data.
-            if matches!(reported_state.as_str(), "primary" | "single")
+            if live_state_is_writable_primary(Some(&reported_state))
                 && health == 1
                 && seconds_since_report < 30
             {
@@ -3409,21 +3440,16 @@ impl ExternalServiceManager {
             });
         }
 
-        let members = self.get_service_members_with_live_state(service.id).await?;
-        // `live_state` is the runtime FSM state from pg_auto_failover.
-        // Backup must run against the writable primary; "single" is the
-        // single-node form pg_auto_failover uses before a replica
-        // catches up — also writable. Anything else (secondary,
-        // catchingup, report_lsn, …) is a replica.
-        let primary = members
-            .iter()
-            .find(|m| {
-                m.status == "running"
-                    && matches!(m.live_state.as_deref(), Some("primary") | Some("single"))
-            })
+        let members = self.get_service_members(service.id).await?;
+        let health = self.cluster_health(service).await;
+        // Resolve the sole healthy, fresh writer back through persisted member
+        // identity. Monitor state is authoritative for role, but never for a
+        // credential destination.
+        let primary = healthy_writable_primary_nodename(&health)
+            .and_then(|nodename| trusted_primary_member(&members, nodename))
             .ok_or(ExternalServiceError::InitializationFailed {
                 id: service.id,
-                reason: "Cannot run backup: cluster has no running primary (monitor unreachable or no node in primary state)".to_string(),
+                reason: "Cannot run backup: cluster has no unique healthy, recently reporting primary (monitor unreachable, election incomplete, or primary state ambiguous)".to_string(),
             })?;
 
         // Write the external_service_backups row up front so the UI's
@@ -4334,11 +4360,10 @@ echo "[restore] Pre-seed complete"
         // Using the stored role here would have produced the same lag
         // bug the UI hit — Browse Data and other callers would dial a
         // freshly-demoted node post-failover.
-        let members = self.get_service_members_with_live_state(service_id).await?;
-        let primary = members.iter().find(|m| {
-            m.status == "running"
-                && matches!(m.live_state.as_deref(), Some("primary") | Some("single"))
-        });
+        let members = self.get_service_members(service_id).await?;
+        let health = self.cluster_health(&service).await;
+        let primary = healthy_writable_primary_nodename(&health)
+            .and_then(|nodename| trusted_primary_member(&members, nodename));
 
         if let Some(primary) = primary {
             self.stored_member_endpoint(service_id, primary)
@@ -4347,7 +4372,7 @@ echo "[restore] Pre-seed complete"
         } else {
             Err(ExternalServiceError::InternalError {
                 reason: format!(
-                    "Cluster service {} has no running primary data node",
+                    "Cluster service {} has no unique healthy, recently reporting primary data node",
                     service_id
                 ),
             })
@@ -10656,6 +10681,82 @@ mod tests {
             sync_state: None,
             replay_lag_ms: None,
         }
+    }
+
+    /// Regression for deployment environment resolution and cluster backups:
+    /// both paths used to hand-match only `primary | single`, so an application
+    /// deployment could fail with "no running primary data node" during the
+    /// normal writable `wait_primary` state even though cluster health passed.
+    #[test]
+    fn writable_primary_live_state_includes_wait_primary() {
+        for state in ["primary", "single", "wait_primary"] {
+            assert!(
+                live_state_is_writable_primary(Some(state)),
+                "{state} must be accepted as a writable primary"
+            );
+        }
+
+        for state in ["secondary", "catchingup", "demoted", "unknown"] {
+            assert!(
+                !live_state_is_writable_primary(Some(state)),
+                "{state} must not be accepted as a writable primary"
+            );
+        }
+        assert!(!live_state_is_writable_primary(None));
+    }
+
+    /// A dead node keeps its last reported `primary` state in the monitor.
+    /// Selection must ignore that stale row, choose the healthy promoted
+    /// `wait_primary`, and fail closed if two live writers are ever reported.
+    #[test]
+    fn healthy_primary_selection_ignores_stale_rows_and_rejects_ambiguity() {
+        let mut unhealthy_primary = cluster_member_health("orders-1", "primary");
+        unhealthy_primary.health = 0;
+        unhealthy_primary.seconds_since_report = 1;
+        let promoted = cluster_member_health("orders-2", "wait_primary");
+        let unhealthy_report = ClusterHealthReport {
+            checked_at: chrono::Utc::now(),
+            monitor_response_ms: 5,
+            monitor_error: None,
+            members: vec![unhealthy_primary, promoted.clone()],
+        };
+        assert_eq!(
+            healthy_writable_primary_nodename(&unhealthy_report),
+            Some("orders-2")
+        );
+
+        let mut stale_primary = cluster_member_health("orders-1", "primary");
+        stale_primary.health = 1;
+        stale_primary.seconds_since_report = 30;
+        let stale_report = ClusterHealthReport {
+            checked_at: chrono::Utc::now(),
+            monitor_response_ms: 5,
+            monitor_error: None,
+            members: vec![stale_primary, promoted],
+        };
+        assert_eq!(
+            healthy_writable_primary_nodename(&stale_report),
+            Some("orders-2")
+        );
+
+        let ambiguous = ClusterHealthReport {
+            checked_at: chrono::Utc::now(),
+            monitor_response_ms: 5,
+            monitor_error: None,
+            members: vec![
+                cluster_member_health("orders-1", "primary"),
+                cluster_member_health("orders-2", "wait_primary"),
+            ],
+        };
+        assert!(healthy_writable_primary_nodename(&ambiguous).is_none());
+
+        let unreachable = ClusterHealthReport {
+            checked_at: chrono::Utc::now(),
+            monitor_response_ms: 0,
+            monitor_error: Some("monitor unavailable".to_string()),
+            members: vec![cluster_member_health("orders-2", "wait_primary")],
+        };
+        assert!(healthy_writable_primary_nodename(&unreachable).is_none());
     }
 
     /// Regression for `remove_cluster_member`'s delete-protection gate

--- a/tools/dev-cluster/role-control-plane.sh
+++ b/tools/dev-cluster/role-control-plane.sh
@@ -160,6 +160,23 @@ if [[ ! -f "$MARKER" ]]; then
     " >/dev/null
   fi
 
+  # Internal *.temps.local resolution is still opt-in. Dedicated E2E
+  # topologies enable it before `temps serve` starts so both the control
+  # plane and joining workers launch their per-node DNS resolver. Keep the
+  # shared development cluster's default unchanged unless explicitly asked.
+  if [[ "${DEV_CLUSTER_ENABLE_DNS:-false}" == "true" ]]; then
+    PGPASSWORD="$DB_PASS" psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1 -c "
+      UPDATE settings
+         SET data = jsonb_set(
+                      COALESCE(data::jsonb, '{}'::jsonb),
+                      '{cluster_dns,enabled}',
+                      'true'::jsonb
+                    )::json
+       WHERE id = 1
+    " >/dev/null
+    log "enabled internal *.temps.local DNS for this cluster"
+  fi
+
   printf '%s\n' "$JOIN_TOKEN" > "$JOIN_TOKEN_FILE"
   chmod 600 "$JOIN_TOKEN_FILE"
 

--- a/tools/e2e-multinode-cluster/docker-compose.yml
+++ b/tools/e2e-multinode-cluster/docker-compose.yml
@@ -153,6 +153,7 @@ services:
       DEV_CLUSTER_STATE_DIR: /run/temps-bootstrap
       DEV_CLUSTER_USE_ENROLLMENT_TOKEN: "true"
       DEV_CLUSTER_ENROLLMENT_NODE_NAME: worker-1
+      DEV_CLUSTER_ENABLE_DNS: "true"
       # CI passes the musl binary already built for this commit. Local runs
       # leave this empty and the shared role script builds from source.
       DEV_CLUSTER_PREBUILT_TEMPS_BIN: ${DEV_CLUSTER_PREBUILT_TEMPS_BIN:-}


### PR DESCRIPTION
## Summary

- enable the opt-in internal resolver in the dedicated multinode E2E topology
- prove one deployed application can call another through its `*.temps.local` hostname from inside a worker container
- prove a deployed application can connect to the elected primary of a real managed Postgres HA service through its published `*.temps.local` hostname and perform an INSERT + SELECT
- fix local managed-service DNS records so they publish the shared application-network container IP and internal port instead of an unreachable underlay IP with a loopback-only host port
- make the multinode scenario self-contained on clean worktrees and keep placement assertions scoped to the application under test
- select the primary reported by cluster health instead of assuming the first data member is writable
- consistently recognize pg_auto_failover's writable `wait_primary` state across deployment connection planning, backup, restore, and deletion protection
- require one healthy, recently reporting writer and resolve its monitor identity through a unique persisted member before using a connection or backup destination
- prevent deployment diagnostics from logging database hosts, URLs, usernames, or passwords

## Evidence

**Multinode runtime:** application DNS, elected-primary Postgres DNS, SQL write/read, drain migration, and node removal all pass in the dedicated two-node DinD topology.

```bash
cd apps/temps-e2e
bun run src/index.ts multinode-join-scenario --json --keep --build-timeout 600000
```

```json
{
  "runId": "e2e-msoj5pi6-cr7ewz",
  "ok": true,
  "steps": [
    { "step": "prove one deployed application reaches another through *.temps.local DNS", "ok": true },
    { "step": "wait for the Postgres cluster and DNS records to converge", "ok": true },
    { "step": "prove the deployed application accesses Postgres through *.temps.local DNS", "ok": true },
    { "step": "confirm the container migrated off the worker (2-node cluster: only place left is the control plane)", "ok": true },
    { "step": "reject replay of the consumed enrollment token after node removal", "ok": true },
    { "step": "confirm the node is gone from GET /internal/nodes", "ok": true }
  ]
}
```

**Native local HA runtime (`/start-temps`, slot 19):** the final patched native server provisioned a real monitor plus two Postgres data nodes, deployed an application with the generated database environment, wrote through the original primary, promoted the survivor after a forced outage, and resumed writes without redeployment.

```bash
TEMPS_URL=http://localhost:8270 \
TEMPS_API_KEY="$TEMPS_API_KEY" \
TEMPS_E2E_REGISTRY=localhost:5111 \
bun run src/index.ts db-ha-failover-scenario --json \
  --cluster-timeout 300000 --deploy-timeout 300000 --failover-timeout 120000
```

```json
{
  "runId": "e2e-msop3bhb-nk1ktf",
  "ok": true,
  "originalPrimary": "postgres-e2e-msop3bhb-nk1ktf-ha-1",
  "newPrimary": "postgres-e2e-msop3bhb-nk1ktf-ha-2",
  "failoverDetectedMs": 46061.82887499999,
  "writesRecoveredMs": 125.08799999998882,
  "finalProbeCount": 6
}
```

**Writable-primary regression:** `primary`, `single`, and `wait_primary` are accepted; stale/unhealthy rows, reports at the 30-second freshness boundary, ambiguous writers, monitor errors, and untrusted persisted identities fail closed.

```bash
cargo test --lib -p temps-providers writable_primary_live_state_includes_wait_primary -- --nocapture
cargo test --lib -p temps-providers healthy_primary_selection_ignores_stale_rows_and_rejects_ambiguity -- --nocapture
cargo test --lib -p temps-providers
cargo check --lib -p temps-providers
cargo clippy --lib -p temps-providers -- -D warnings
```

```text
writable-primary regression: 1 passed, 493 filtered out
healthy/fresh/unique selection regression: 1 passed, 493 filtered out
full temps-providers library suite: 494 passed, 0 failed
cargo check: passed
cargo clippy: 0 code errors
```

**Deployment logging regression:** the deployment crate compiles cleanly, passes Clippy, and its full library suite passes after replacing secret-bearing URL logs with presence-only diagnostics.

```bash
cargo check --lib -p temps-deployments
cargo clippy --lib -p temps-deployments -- -D warnings
cargo test --lib -p temps-deployments
```

```text
cargo check: passed
cargo clippy: passed with -D warnings
cargo test: 543 passed, 3 ignored
```

**E2E/static validation:**

```bash
cd apps/temps-e2e && bun run typecheck
bash -n tools/dev-cluster/role-control-plane.sh
docker compose -f tools/e2e-multinode-cluster/docker-compose.yml -p temps-e2e-mn config --quiet
cargo fmt --all -- --check
git diff --check
```

All commands passed. Rust, security, and test-coverage review gates approve the final primary-selection diff.
