### PR TITLE
feat(external-plugins): add caller-scoped platform API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12035,6 +12035,7 @@ dependencies = [
  "hyper-util",
  "serde",
  "serde_json",
+ "subtle",
  "tar",
  "temps-core",
  "thiserror 2.0.19",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10668,6 +10668,7 @@ dependencies = [
  "temps-notifications",
  "temps-observability",
  "temps-otel",
+ "temps-plugin-sdk",
  "temps-projects",
  "temps-providers",
  "temps-proxy",
@@ -11263,9 +11264,11 @@ dependencies = [
 name = "temps-external-plugins"
 version = "0.1.0-beta.55"
 dependencies = [
+ "async-trait",
  "axum",
  "chrono",
  "futures",
+ "http-body-util",
  "hyper",
  "hyper-util",
  "libc",

--- a/crates/temps-auth/src/temps_middleware.rs
+++ b/crates/temps-auth/src/temps_middleware.rs
@@ -208,10 +208,7 @@ impl AuthMiddleware {
         if let Some(user) = user {
             req.extensions_mut().insert(user);
         }
-        let principal = auth_context
-            .as_ref()
-            .map(safe_principal)
-            .unwrap_or_else(SafePrincipal::anonymous);
+        let principal = safe_principal_for_request(&req, auth_context.as_ref());
         if let Some(auth_ctx) = auth_context {
             req.extensions_mut().insert(auth_ctx);
         }
@@ -314,6 +311,22 @@ fn safe_principal(auth: &crate::context::AuthContext) -> SafePrincipal {
         source,
         credential_id,
     }
+}
+
+/// Resolve audit attribution from the credential authenticated here or from a
+/// trusted context injected by an in-process caller before the router runs.
+///
+/// Normal HTTP credentials take precedence. A request extension cannot be
+/// supplied by an external HTTP caller, while delegated bridges such as the
+/// external-plugin host API use it to carry their already-verified actor.
+fn safe_principal_for_request(
+    req: &Request,
+    authenticated: Option<&crate::context::AuthContext>,
+) -> SafePrincipal {
+    authenticated
+        .or_else(|| req.extensions().get::<crate::context::AuthContext>())
+        .map(safe_principal)
+        .unwrap_or_else(SafePrincipal::anonymous)
 }
 
 fn matched_route_template(req: &Request) -> String {
@@ -443,6 +456,63 @@ mod tests {
         assert_eq!(event.denial_kind, "insufficient_permission");
         assert_eq!(event.required_permission.as_deref(), Some("projects:write"));
         assert_eq!(event.route, "/projects/{project_id}");
+    }
+
+    #[test]
+    fn delegated_auth_context_is_used_for_denial_attribution() {
+        let auth = crate::context::AuthContext::new_api_key(
+            test_user(),
+            Some(Role::User),
+            Some(vec![Permission::ProjectsRead]),
+            "delegated-plugin-key".to_string(),
+            99,
+        );
+        let mut request = Request::new(axum::body::Body::empty());
+        request.extensions_mut().insert(auth);
+
+        let principal = safe_principal_for_request(&request, None);
+        let response = temps_core::error_builder::ErrorBuilder::new(StatusCode::FORBIDDEN)
+            .permission_denial(
+                PermissionDenialKind::InsufficientPermission,
+                Some("projects:write".to_string()),
+            )
+            .build()
+            .into_response();
+        let event = permission_denial_event(
+            &response,
+            principal,
+            "POST".to_string(),
+            "/projects".to_string(),
+            None,
+            "plugin-channel".to_string(),
+        )
+        .expect("delegated permission denial should be audited");
+
+        assert_eq!(event.principal.user_id, Some(42));
+        assert_eq!(event.principal.source, AuthSourceKind::ApiKey);
+        assert_eq!(event.principal.credential_id, Some(99));
+    }
+
+    #[test]
+    fn authenticated_credential_takes_precedence_over_delegated_context() {
+        let mut delegated_user = test_user();
+        delegated_user.id = 7;
+        let delegated = crate::context::AuthContext::new_api_key(
+            delegated_user,
+            Some(Role::User),
+            Some(vec![Permission::ProjectsRead]),
+            "delegated-key".to_string(),
+            70,
+        );
+        let authenticated = crate::context::AuthContext::new_session(test_user(), Role::Admin);
+        let mut request = Request::new(axum::body::Body::empty());
+        request.extensions_mut().insert(delegated);
+
+        let principal = safe_principal_for_request(&request, Some(&authenticated));
+
+        assert_eq!(principal.user_id, Some(42));
+        assert_eq!(principal.source, AuthSourceKind::Session);
+        assert_eq!(principal.credential_id, None);
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/temps-cli/Cargo.toml
+++ b/crates/temps-cli/Cargo.toml
@@ -138,6 +138,9 @@ tikv-jemallocator = { workspace = true }
 # a real listener. Already present transitively; pinned here for test use.
 tower = { workspace = true }
 tempfile = { workspace = true }
+# Only for `tests/plugin_sdk_conformance.rs`: proves the SDK's hand-written
+# endpoint table still matches the handlers this crate assembles into the API.
+temps-plugin-sdk = { path = "../temps-plugin-sdk" }
 
 [build-dependencies]
 chrono = { workspace = true }

--- a/crates/temps-cli/src/commands/serve/console.rs
+++ b/crates/temps-cli/src/commands/serve/console.rs
@@ -2232,7 +2232,12 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
     let external_plugin_config = temps_external_plugins::manager::ExternalPluginConfig::new(
         config.data_dir.clone(),
         config.database_url.clone(),
-    );
+    )
+    // Where this instance answers HTTP. A plugin's routes are only reachable
+    // through the proxy, so a plugin that has to hand out a URL to something
+    // outside the request (a sandboxed agent, a webhook receiver) cannot
+    // construct one without being told the address the proxy listens on.
+    .with_proxy_address(&config.address);
     let external_plugins_plugin = Box::new(temps_external_plugins::ExternalPluginsPlugin::new(
         external_plugin_config,
     ));
@@ -2973,6 +2978,17 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
     // the admin IP allowlist is active. The public surface is also the one that
     // exists in every topology (single- and dual-listener), so probes work
     // regardless of `console_admin_address`.
+    // The router plugins reach over the platform channel.
+    //
+    // Built from the same public + admin routes the console serves, but
+    // deliberately without the SPA fallback (a plugin wants the API, not
+    // index.html) and without the admin IP gate (that gate exists to keep
+    // browsers off the admin listener from untrusted networks; a channel
+    // call arrives in-process from a plugin the operator installed, and is
+    // authorised by an actor token plus the handler's own permission check).
+    let plugin_api_router =
+        Router::new().nest("/api", public_router.clone().merge(admin_router.clone()));
+
     let public_app = Router::new()
         .merge(health_router(ready_flag.clone()))
         .nest("/api", public_router)
@@ -3033,6 +3049,40 @@ pub async fn start_console_api(params: ConsoleApiParams) -> anyhow::Result<()> {
     let external_plugins_service = plugin_manager
         .service_context()
         .get_service::<temps_external_plugins::ExternalPluginsService>();
+
+    // Join the channel to the router now that both exist. Plugins connect
+    // during startup, before this router could possibly be assembled (it
+    // contains the external-plugin routes), so the bridge is installed into
+    // a shared slot the channel reads per call rather than passed at
+    // connect time.
+    if let Some(service) = external_plugins_service.clone() {
+        match plugin_manager
+            .service_context()
+            .get_service::<temps_auth::UserService>()
+        {
+            Some(user_service) => {
+                let bridge = Arc::new(temps_external_plugins::host_api::RouterHostApi::new(
+                    plugin_api_router,
+                    db.clone(),
+                    cookie_crypto.clone(),
+                    user_service,
+                ));
+                service.set_host_api(bridge).await;
+                // Same key the bridge verifies with, so a token this proxy
+                // mints is one the channel will accept.
+                service.set_actor_crypto(cookie_crypto.clone()).await;
+                info!("Plugin platform API bridge installed");
+            }
+            None => {
+                // Say so rather than leaving the slot empty and letting every
+                // plugin API call fail with a generic error later.
+                tracing::warn!(
+                    "UserService is not registered, so plugins cannot call the platform \
+                     API over the channel; plugin API calls will be refused"
+                );
+            }
+        }
+    }
 
     let shutdown_signal = {
         let svc = external_plugins_service.clone();

--- a/crates/temps-cli/tests/plugin_sdk_conformance.rs
+++ b/crates/temps-cli/tests/plugin_sdk_conformance.rs
@@ -1,0 +1,253 @@
+//! The plugin SDK's endpoint table must describe endpoints that exist.
+//!
+//! `temps-plugin-sdk` declares the platform endpoints it calls as a static
+//! table (`DECLARED_ENDPOINTS`) rather than generating a client from the
+//! OpenAPI document — generating one would be a cycle, since the document is
+//! itself produced from the handlers by utoipa.
+//!
+//! That hand-written table is only safe if something proves it still matches
+//! the API. This is that something. If a route is renamed, moved or changes
+//! verb, this test names the endpoint and fails the build; without it the
+//! first sign would be a 404 during a real deploy, on an operator's machine,
+//! with nothing in the logs but a status code.
+//!
+//! It lives in `temps-cli` because that is the crate that can see every
+//! domain's `ApiDoc`. The SDK cannot depend on them — it is compiled into
+//! every plugin binary and must stay small.
+
+use std::collections::BTreeSet;
+
+use temps_plugin_sdk::api::DECLARED_ENDPOINTS;
+use utoipa::OpenApi;
+
+/// Every operation the platform exposes, as `(METHOD, path)`.
+///
+/// Assembled from the domain `ApiDoc`s that own the routes the SDK declares.
+/// This is deliberately *not* the full unified document — that one is built
+/// from a live `PluginManager` and needs a database. Missing a doc here would
+/// show up as a false failure naming the exact endpoint, which is a good
+/// failure mode: it points at the doc that needs adding.
+fn merged_docs() -> utoipa::openapi::OpenApi {
+    let mut docs = <temps_projects::handlers::ApiDoc as OpenApi>::openapi();
+    docs.merge(<temps_environments::handlers::ApiDoc as OpenApi>::openapi());
+    docs.merge(<temps_deployments::handlers::deployments::DeploymentsApiDoc as OpenApi>::openapi());
+    docs.merge(
+        <temps_deployments::handlers::remote_deployments::RemoteDeploymentsApiDoc as OpenApi>::openapi(),
+    );
+    docs.merge(<temps_providers::handlers::handlers::ExternalServiceApiDoc as OpenApi>::openapi());
+    docs
+}
+
+fn platform_operations() -> BTreeSet<(String, String)> {
+    let docs = merged_docs();
+
+    // `PathItem` exposes one `Option<Operation>` field per verb rather than a
+    // map, so the verbs the SDK can express are listed explicitly. A verb the
+    // channel cannot carry is not worth collecting.
+    let mut operations = BTreeSet::new();
+    for (path, item) in docs.paths.paths.iter() {
+        for (method, operation) in [
+            ("GET", &item.get),
+            ("POST", &item.post),
+            ("PUT", &item.put),
+            ("PATCH", &item.patch),
+            ("DELETE", &item.delete),
+        ] {
+            if operation.is_some() {
+                operations.insert((method.to_string(), path.clone()));
+            }
+        }
+    }
+    operations
+}
+
+/// Path parameter *names* are free to differ between the spec and the SDK —
+/// `{id}` and `{project_id}` address the same segment. The structure is what
+/// a router matches on, so that is what is compared.
+fn normalize(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    let mut in_param = false;
+    for c in path.chars() {
+        match c {
+            '{' => {
+                in_param = true;
+                out.push_str("{}");
+            }
+            '}' => in_param = false,
+            _ if in_param => {}
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[test]
+fn every_declared_sdk_endpoint_exists_on_the_platform() {
+    let operations = platform_operations();
+    assert!(
+        !operations.is_empty(),
+        "No operations were collected from the domain ApiDocs — the merge above is broken, \
+         so this test would pass vacuously"
+    );
+
+    let available: BTreeSet<(String, String)> = operations
+        .iter()
+        .map(|(method, path)| (method.clone(), normalize(path)))
+        .collect();
+
+    let mut missing = Vec::new();
+    for (method, path) in DECLARED_ENDPOINTS {
+        let key = (method.to_uppercase(), normalize(path));
+        if !available.contains(&key) {
+            missing.push(format!("{} {path}", method.to_uppercase()));
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "temps-plugin-sdk declares endpoints the platform does not have:\n  {}\n\n\
+         Either the route moved (update `DECLARED_ENDPOINTS` and the matching method in \
+         `temps-plugin-sdk/src/api.rs`) or its `ApiDoc` is not merged in this test's \
+         `platform_operations()`.\n\nThe platform currently exposes:\n  {}",
+        missing.join("\n  "),
+        operations
+            .iter()
+            .map(|(m, p)| format!("{m} {p}"))
+            .collect::<Vec<_>>()
+            .join("\n  ")
+    );
+}
+
+/// The check above must have teeth.
+///
+/// A comparison built on normalization can go wrong in a way that makes
+/// everything match — a bug in `normalize`, an over-eager `contains` — and
+/// then the conformance test passes forever while the SDK rots. This proves a
+/// route that does not exist is actually detected.
+#[test]
+fn a_route_the_platform_does_not_have_is_detected() {
+    let available: BTreeSet<(String, String)> = platform_operations()
+        .iter()
+        .map(|(method, path)| (method.clone(), normalize(path)))
+        .collect();
+
+    for bogus in [
+        ("GET", "/projects/{id}/does-not-exist"),
+        ("DELETE", "/projects"),
+        // Right path, wrong verb.
+        ("PATCH", "/projects/{id}"),
+        // Right shape, one segment too few: the deployment ID is required.
+        (
+            "GET",
+            "/projects/{project_id}/deployments/{deployment_id}/{extra}",
+        ),
+    ] {
+        let key = (bogus.0.to_string(), normalize(bogus.1));
+        assert!(
+            !available.contains(&key),
+            "{} {} is not a real platform route but the conformance check accepts it",
+            bogus.0,
+            bogus.1
+        );
+    }
+
+    // ...and a route that *is* real must still be accepted, or the check
+    // would be vacuously strict instead of vacuously loose.
+    assert!(available.contains(&("POST".to_string(), normalize("/projects"))));
+}
+
+/// Every field the SDK reads must exist on the schema it claims to project.
+///
+/// Path conformance alone is not enough, and this test exists because of a
+/// concrete near-miss: the deploy endpoints return `RemoteDeploymentResponse`
+/// (`state`, `slug`) while polling one returns `DeploymentResponse`
+/// (`status`, `url`). Both live under `/projects/...`, so a path check passed
+/// while the SDK would have failed to decode the deploy response — on a real
+/// deploy, in a background task, as "Failed to deserialize platform response".
+#[test]
+fn every_projected_field_exists_on_the_schema_it_projects() {
+    use utoipa::openapi::{RefOr, Schema};
+
+    let docs = merged_docs();
+    let components = docs
+        .components
+        .as_ref()
+        .expect("the merged document has no components section");
+
+    let mut problems = Vec::new();
+    for (schema_name, fields) in temps_plugin_sdk::api::DECLARED_PROJECTIONS {
+        let Some(RefOr::T(Schema::Object(object))) = components.schemas.get(*schema_name) else {
+            problems.push(format!(
+                "{schema_name}: not an object schema in the platform's OpenAPI components"
+            ));
+            continue;
+        };
+
+        for (field, required) in *fields {
+            if !object.properties.contains_key(*field) {
+                problems.push(format!(
+                    "{schema_name}.{field}: projected by the SDK but absent from the schema"
+                ));
+                continue;
+            }
+            // A non-`Option` Rust field cannot decode a response that omits
+            // the key, so "present but optional" is a decode failure waiting
+            // for the one response that leaves it out.
+            if *required && !object.required.iter().any(|r| r == field) {
+                problems.push(format!(
+                    "{schema_name}.{field}: the SDK declares it required, but the schema does \
+                     not — make the SDK field `Option<..>` or mark it `required = false`"
+                ));
+            }
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "temps-plugin-sdk projections no longer match the platform's schemas:\n  {}",
+        problems.join("\n  ")
+    );
+}
+
+/// The projection check must have teeth: if schema lookup silently returned
+/// nothing, the loop above would pass while checking nothing at all.
+#[test]
+fn the_projection_check_reads_real_schemas() {
+    use utoipa::openapi::{RefOr, Schema};
+
+    let docs = merged_docs();
+    let components = docs.components.as_ref().expect("no components section");
+    let Some(RefOr::T(Schema::Object(project))) = components.schemas.get("ProjectResponse") else {
+        panic!("ProjectResponse is not an object schema — the check above would be vacuous");
+    };
+    assert!(
+        project.properties.contains_key("slug"),
+        "ProjectResponse has no properties the test can see"
+    );
+    assert!(
+        !project.properties.contains_key("definitely_not_a_field"),
+        "the schema claims to contain a field that does not exist"
+    );
+}
+
+/// Parameter renaming is allowed, but the *number* of path parameters is not:
+/// a segment gained or lost means the SDK is building a URL the router will
+/// never match, which `normalize` alone would not catch if both sides changed.
+#[test]
+fn declared_paths_have_the_same_segment_count_as_the_platform() {
+    let operations = platform_operations();
+    for (method, path) in DECLARED_ENDPOINTS {
+        let normalized = normalize(path);
+        let matched = operations
+            .iter()
+            .find(|(m, p)| m == &method.to_uppercase() && normalize(p) == normalized);
+        let Some((_, spec_path)) = matched else {
+            continue; // reported by the test above
+        };
+        assert_eq!(
+            path.matches('{').count(),
+            spec_path.matches('{').count(),
+            "{method} {path} has a different parameter count than the platform's {spec_path}"
+        );
+    }
+}

--- a/crates/temps-core/src/external_plugin/actor.rs
+++ b/crates/temps-core/src/external_plugin/actor.rs
@@ -1,0 +1,524 @@
+//! Short-lived proof that a plugin is acting for a signed-in user.
+//!
+//! The platform channel lets a plugin call the platform's own HTTP API. That
+//! is only safe if the platform knows *who* the call is for: without it, a
+//! plugin would either act as nobody (and every `permission_guard!` would
+//! fail) or as everybody (and the permission system would mean nothing).
+//!
+//! An *actor token* is the answer. The platform mints one when it proxies an
+//! authenticated request to a plugin, alongside the `x-temps-*` identity
+//! headers, and the plugin echoes it back on any channel call it makes while
+//! serving that request. Because it is encrypted under the instance's auth
+//! secret, a plugin cannot mint one for a user who never called it.
+//!
+//! Two properties are deliberate:
+//!
+//! - **Only the user id and a principal reference travel.** Role and
+//!   permissions are re-read from the database when the token is redeemed,
+//!   so a user demoted after the token was minted cannot keep the old access
+//!   for the rest of its lifetime, and an API key's actual (possibly
+//!   restricted) role/permissions are re-derived from the key row rather than
+//!   inherited from `AuthContext::effective_role`.
+//! - **The token names its plugin.** A token minted while serving plugin `a`
+//!   is rejected on plugin `b`'s channel, so one plugin cannot replay
+//!   another's credential to borrow its users.
+//!
+//! ## Why a principal, not just a user id (v2)
+//!
+//! v1 carried only `user_id`, and redemption rebuilt authority as a full
+//! session (`AuthContext::new_session`) regardless of what actually
+//! authenticated the proxied request. That was a privilege escalation for
+//! anyone holding a role-restricted API key: the key's `role`/`permissions`
+//! never reached the token, so a "read-only" key holder who triggered a
+//! plugin call got the *user's* full role back. It also meant the token
+//! outlived the session that produced it — signing out, or an admin
+//! terminating sessions after a compromise, did nothing to a token already
+//! in flight.
+//!
+//! v2 fixes both by binding the token to a concrete, re-checkable principal:
+//! the browser session that authenticated the request (verified still valid
+//! at redemption — not expired, not MFA-pending), or the API key that did
+//! (verified still active, with its role/permissions re-read from the row
+//! rather than trusted from the token). Anything that cannot be represented
+//! this way — a CLI token today has no revocable backing row wired up in
+//! this codebase — is refused at mint time rather than silently downgraded
+//! to an unlinkable session-shaped grant.
+//!
+//! This lives in `temps-core` because both sides need it: the proxy mints,
+//! the channel verifies, and neither should depend on the other.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use thiserror::Error;
+
+use crate::{CookieCrypto, CryptoError};
+
+/// Domain-separation prefix. Keeps actor tokens from being interchangeable
+/// with any other payload encrypted under the same key — notably preview
+/// session grants, which use the same `CookieCrypto`.
+///
+/// Bumped from `plugin-actor-v1` alongside the principal-binding change:
+/// tokens minted by an older build would otherwise deserialize as v2's
+/// shorter, user-id-only shape and silently lose the principal check rather
+/// than fail loudly. A version bump makes a mixed-build rollout fail closed
+/// (`WrongVersion`) instead of ambiguously.
+pub const PLUGIN_ACTOR_TOKEN_VERSION: &str = "plugin-actor-v2";
+
+/// Default lifetime.
+///
+/// Long enough for a plugin to finish the work one request kicks off
+/// (creating a project, an environment and a deployment in sequence), short
+/// enough that a token captured from a plugin's memory is near-worthless.
+pub const PLUGIN_ACTOR_TOKEN_TTL: Duration = Duration::from_secs(15 * 60);
+
+/// Longest lifetime a minted token may be given.
+pub const PLUGIN_ACTOR_TOKEN_MAX_TTL: Duration = Duration::from_secs(60 * 60);
+
+/// Field separator inside the encrypted payload.
+const SEP: char = '|';
+
+/// The credential that authenticated the request the token was minted from.
+///
+/// Carried in the token as a tag + numeric id (`s<session_id>` /
+/// `k<key_id>`) and re-verified against its backing row at redemption — the
+/// id is a foreign key, never a secret, so storing it in the token leaks
+/// nothing beyond what `x-temps-user-id` already does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActorPrincipal {
+    /// A browser session. Redemption must confirm the session still exists,
+    /// is not expired, and is not MFA-pending — the same gate
+    /// `verify_session_details` applies to a live cookie.
+    Session { session_id: i32 },
+    /// An API key. Redemption must confirm the key is still active and
+    /// re-read its role/permissions from the row — never trust the ones the
+    /// token was minted with, since the key may have been narrowed since.
+    ApiKey { key_id: i32 },
+}
+
+impl ActorPrincipal {
+    const SESSION_TAG: char = 's';
+    const API_KEY_TAG: char = 'k';
+
+    fn encode(self) -> String {
+        match self {
+            ActorPrincipal::Session { session_id } => {
+                format!("{}{session_id}", Self::SESSION_TAG)
+            }
+            ActorPrincipal::ApiKey { key_id } => format!("{}{key_id}", Self::API_KEY_TAG),
+        }
+    }
+
+    fn decode(field: &str) -> Option<Self> {
+        let (tag, rest) = field.split_at_checked(1)?;
+        let id: i32 = rest.parse().ok()?;
+        match tag.chars().next()? {
+            c if c == Self::SESSION_TAG => Some(ActorPrincipal::Session { session_id: id }),
+            c if c == Self::API_KEY_TAG => Some(ActorPrincipal::ApiKey { key_id: id }),
+            _ => None,
+        }
+    }
+}
+
+/// What a verified token authorises: the user, and the principal redemption
+/// must independently re-check before honouring it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VerifiedActor {
+    pub user_id: i32,
+    pub principal: ActorPrincipal,
+}
+
+#[derive(Debug, Error)]
+pub enum PluginActorError {
+    #[error(
+        "Plugin name '{plugin}' contains the reserved field separator and cannot be bound \
+         into an actor token"
+    )]
+    InvalidPluginName { plugin: String },
+
+    #[error("Actor token expiry overflowed the system clock for plugin '{plugin}'")]
+    ExpiryOverflow { plugin: String },
+
+    #[error("System clock is before the Unix epoch while minting an actor token for '{plugin}'")]
+    ClockBeforeUnixEpoch { plugin: String },
+
+    #[error("Failed to encrypt an actor token for plugin '{plugin}': {source}")]
+    Encryption {
+        plugin: String,
+        #[source]
+        source: CryptoError,
+    },
+
+    #[error(
+        "Plugin '{plugin}' presented an actor token that is not valid for this instance \
+         (it did not decrypt under the instance auth secret)"
+    )]
+    Undecryptable { plugin: String },
+
+    #[error(
+        "Plugin '{plugin}' presented a malformed actor token: expected {expected} \
+         '{SEP}'-separated fields, found {found}"
+    )]
+    Malformed {
+        plugin: String,
+        expected: usize,
+        found: usize,
+    },
+
+    #[error(
+        "Plugin '{plugin}' presented an actor token of version '{found}'; \
+         this instance issues '{expected}'"
+    )]
+    WrongVersion {
+        plugin: String,
+        expected: &'static str,
+        found: String,
+    },
+
+    #[error(
+        "Plugin '{plugin}' presented an actor token minted for plugin '{minted_for}' — \
+         a token may only be used by the plugin it was issued to"
+    )]
+    WrongPlugin { plugin: String, minted_for: String },
+
+    #[error("Plugin '{plugin}' presented an actor token with an unreadable user id: '{found}'")]
+    UnreadableUserId { plugin: String, found: String },
+
+    #[error("Plugin '{plugin}' presented an actor token with an unreadable expiry: '{found}'")]
+    UnreadableExpiry { plugin: String, found: String },
+
+    #[error(
+        "Plugin '{plugin}' presented an actor token with an unreadable principal: '{found}' \
+         (expected 's<session_id>' or 'k<api_key_id>')"
+    )]
+    UnreadablePrincipal { plugin: String, found: String },
+
+    #[error("Plugin '{plugin}' presented an actor token that expired {age_secs}s ago")]
+    Expired { plugin: String, age_secs: u64 },
+}
+
+/// Mint a token letting `plugin` act as `user_id`, backed by `principal`.
+///
+/// `ttl` is clamped to [`PLUGIN_ACTOR_TOKEN_MAX_TTL`]. Returns the token and
+/// its absolute expiry, so a caller can surface when it will lapse.
+///
+/// There is deliberately no way to mint a token without a principal. A
+/// caller with an `AuthContext` it cannot express as one — a source with no
+/// revocable backing row — should refuse to mint rather than fall back to
+/// something unlinkable; see the module docs for why.
+pub fn encode_plugin_actor_token(
+    crypto: &CookieCrypto,
+    plugin: &str,
+    user_id: i32,
+    principal: ActorPrincipal,
+    ttl: Duration,
+    now: SystemTime,
+) -> Result<(String, u64), PluginActorError> {
+    // A plugin name containing the separator could shift every later field,
+    // letting a token claim a different user or an arbitrary expiry. Plugin
+    // names are kebab-case in practice — refuse rather than rely on that.
+    if plugin.contains(SEP) {
+        return Err(PluginActorError::InvalidPluginName {
+            plugin: plugin.to_string(),
+        });
+    }
+    let exp = now
+        .checked_add(ttl.min(PLUGIN_ACTOR_TOKEN_MAX_TTL))
+        .ok_or_else(|| PluginActorError::ExpiryOverflow {
+            plugin: plugin.to_string(),
+        })?
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| PluginActorError::ClockBeforeUnixEpoch {
+            plugin: plugin.to_string(),
+        })?
+        .as_secs();
+
+    let principal = principal.encode();
+    let payload = format!(
+        "{PLUGIN_ACTOR_TOKEN_VERSION}{SEP}{plugin}{SEP}{user_id}{SEP}{exp}{SEP}{principal}"
+    );
+    let token = crypto
+        .encrypt(&payload)
+        .map_err(|source| PluginActorError::Encryption {
+            plugin: plugin.to_string(),
+            source,
+        })?;
+    Ok((token, exp))
+}
+
+/// Validate a token and return the actor it authorises.
+///
+/// Every failure names what was wrong: a plugin author debugging a rejected
+/// call alone needs to tell "wrong instance" from "expired" from "not your
+/// token", and a single boolean cannot.
+///
+/// This confirms only that the token was minted by this instance, for this
+/// plugin, and has not expired. It does **not** confirm the principal is
+/// still valid — the caller must independently re-check the session/API-key
+/// row named by `VerifiedActor::principal` before treating the result as
+/// authorization. That extra step is what makes revocation (sign-out,
+/// deactivating a key, deleting a user) take effect immediately rather than
+/// waiting out the token's TTL.
+pub fn verify_plugin_actor_token(
+    crypto: &CookieCrypto,
+    token: &str,
+    plugin: &str,
+    now: SystemTime,
+) -> Result<VerifiedActor, PluginActorError> {
+    let payload = crypto
+        .decrypt(token)
+        .map_err(|_| PluginActorError::Undecryptable {
+            plugin: plugin.to_string(),
+        })?;
+
+    let fields: Vec<&str> = payload.split(SEP).collect();
+    if fields.len() != 5 {
+        return Err(PluginActorError::Malformed {
+            plugin: plugin.to_string(),
+            expected: 5,
+            found: fields.len(),
+        });
+    }
+    if fields[0] != PLUGIN_ACTOR_TOKEN_VERSION {
+        return Err(PluginActorError::WrongVersion {
+            plugin: plugin.to_string(),
+            expected: PLUGIN_ACTOR_TOKEN_VERSION,
+            found: fields[0].to_string(),
+        });
+    }
+    if fields[1] != plugin {
+        return Err(PluginActorError::WrongPlugin {
+            plugin: plugin.to_string(),
+            minted_for: fields[1].to_string(),
+        });
+    }
+    let user_id = fields[2]
+        .parse::<i32>()
+        .map_err(|_| PluginActorError::UnreadableUserId {
+            plugin: plugin.to_string(),
+            found: fields[2].to_string(),
+        })?;
+    let exp = fields[3]
+        .parse::<u64>()
+        .map_err(|_| PluginActorError::UnreadableExpiry {
+            plugin: plugin.to_string(),
+            found: fields[3].to_string(),
+        })?;
+    let principal =
+        ActorPrincipal::decode(fields[4]).ok_or_else(|| PluginActorError::UnreadablePrincipal {
+            plugin: plugin.to_string(),
+            found: fields[4].to_string(),
+        })?;
+
+    let now_secs = now
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| PluginActorError::ClockBeforeUnixEpoch {
+            plugin: plugin.to_string(),
+        })?
+        .as_secs();
+    if now_secs >= exp {
+        return Err(PluginActorError::Expired {
+            plugin: plugin.to_string(),
+            age_secs: now_secs - exp,
+        });
+    }
+
+    Ok(VerifiedActor { user_id, principal })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `CookieCrypto` takes a raw 32-byte key or 64 hex chars; these are
+    // exactly 32 bytes.
+    fn crypto() -> CookieCrypto {
+        CookieCrypto::new("actor-token-test-secret-key-0001").unwrap()
+    }
+
+    fn other_crypto() -> CookieCrypto {
+        CookieCrypto::new("a-different-instance-auth-secret").unwrap()
+    }
+
+    const SESSION: ActorPrincipal = ActorPrincipal::Session { session_id: 7 };
+    const API_KEY: ActorPrincipal = ActorPrincipal::ApiKey { key_id: 9 };
+
+    #[test]
+    fn a_minted_token_authorises_its_user_and_principal() {
+        let c = crypto();
+        let now = SystemTime::now();
+        let (token, exp) = encode_plugin_actor_token(
+            &c,
+            "example-plugin",
+            42,
+            SESSION,
+            PLUGIN_ACTOR_TOKEN_TTL,
+            now,
+        )
+        .unwrap();
+        assert!(exp > 0);
+        let actor = verify_plugin_actor_token(&c, &token, "example-plugin", now).unwrap();
+        assert_eq!(actor.user_id, 42);
+        assert_eq!(actor.principal, SESSION);
+    }
+
+    /// An API-key-backed token round-trips its key id distinctly from a
+    /// session id — the tag, not just the number, is what redemption keys
+    /// its re-check on.
+    #[test]
+    fn an_api_key_principal_round_trips() {
+        let c = crypto();
+        let now = SystemTime::now();
+        let (token, _) = encode_plugin_actor_token(
+            &c,
+            "example-plugin",
+            42,
+            API_KEY,
+            PLUGIN_ACTOR_TOKEN_TTL,
+            now,
+        )
+        .unwrap();
+        let actor = verify_plugin_actor_token(&c, &token, "example-plugin", now).unwrap();
+        assert_eq!(actor.principal, API_KEY);
+    }
+
+    /// The property that stops one plugin borrowing another's users.
+    #[test]
+    fn a_token_is_rejected_by_a_different_plugin() {
+        let c = crypto();
+        let now = SystemTime::now();
+        let (token, _) = encode_plugin_actor_token(
+            &c,
+            "example-plugin",
+            42,
+            SESSION,
+            PLUGIN_ACTOR_TOKEN_TTL,
+            now,
+        )
+        .unwrap();
+        let err = verify_plugin_actor_token(&c, &token, "some-other-plugin", now).unwrap_err();
+        assert!(
+            matches!(&err, PluginActorError::WrongPlugin { minted_for, .. } if minted_for == "example-plugin"),
+            "{err}"
+        );
+    }
+
+    /// The property that stops a token from one instance working on another.
+    #[test]
+    fn a_token_from_another_instance_does_not_decrypt() {
+        let now = SystemTime::now();
+        let (token, _) = encode_plugin_actor_token(
+            &crypto(),
+            "example-plugin",
+            42,
+            SESSION,
+            PLUGIN_ACTOR_TOKEN_TTL,
+            now,
+        )
+        .unwrap();
+        let err =
+            verify_plugin_actor_token(&other_crypto(), &token, "example-plugin", now).unwrap_err();
+        assert!(
+            matches!(err, PluginActorError::Undecryptable { .. }),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn an_expired_token_is_rejected() {
+        let c = crypto();
+        let minted_at = SystemTime::now();
+        let (token, _) = encode_plugin_actor_token(
+            &c,
+            "example-plugin",
+            42,
+            SESSION,
+            Duration::from_secs(30),
+            minted_at,
+        )
+        .unwrap();
+        let later = minted_at + Duration::from_secs(31);
+        let err = verify_plugin_actor_token(&c, &token, "example-plugin", later).unwrap_err();
+        assert!(matches!(err, PluginActorError::Expired { .. }), "{err}");
+    }
+
+    #[test]
+    fn ttl_is_clamped_to_the_maximum() {
+        let c = crypto();
+        let now = SystemTime::now();
+        let (_, exp) = encode_plugin_actor_token(
+            &c,
+            "example-plugin",
+            42,
+            SESSION,
+            PLUGIN_ACTOR_TOKEN_MAX_TTL * 10,
+            now,
+        )
+        .unwrap();
+        let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs();
+        assert!(exp <= now_secs + PLUGIN_ACTOR_TOKEN_MAX_TTL.as_secs());
+    }
+
+    /// A separator in the plugin name could shift the user-id field and let a
+    /// token claim someone else.
+    #[test]
+    fn a_plugin_name_containing_the_separator_is_refused() {
+        let err = encode_plugin_actor_token(
+            &crypto(),
+            "evil|example-plugin",
+            42,
+            SESSION,
+            PLUGIN_ACTOR_TOKEN_TTL,
+            SystemTime::now(),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, PluginActorError::InvalidPluginName { .. }),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn garbage_is_rejected_rather_than_panicking() {
+        let err = verify_plugin_actor_token(
+            &crypto(),
+            "not-a-token",
+            "example-plugin",
+            SystemTime::now(),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, PluginActorError::Undecryptable { .. }),
+            "{err}"
+        );
+    }
+
+    /// A v1 token (four fields, no principal) must not silently pass as if
+    /// it carried one. The exact rejection reason is secondary — `Malformed`
+    /// here, since the field count is checked before the version string —
+    /// what matters is that a mixed-build rollout gets a loud, typed error
+    /// rather than a token quietly redeemed with no principal to re-check.
+    #[test]
+    fn a_v1_shaped_token_is_rejected_rather_than_silently_accepted() {
+        let c = crypto();
+        let now_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 900;
+        let v1_payload = format!("plugin-actor-v1{SEP}example-plugin{SEP}42{SEP}{now_secs}");
+        let token = c.encrypt(&v1_payload).unwrap();
+        let err =
+            verify_plugin_actor_token(&c, &token, "example-plugin", SystemTime::now()).unwrap_err();
+        assert!(matches!(&err, PluginActorError::Malformed { .. }), "{err}");
+    }
+
+    /// The principal field's tag must be one of the two known kinds — a
+    /// digit that looks numeric but has no tag must not silently decode to
+    /// some arbitrary variant.
+    #[test]
+    fn an_unrecognised_principal_tag_is_rejected() {
+        assert_eq!(ActorPrincipal::decode("x7"), None);
+        assert_eq!(ActorPrincipal::decode("s"), None);
+        assert_eq!(ActorPrincipal::decode(""), None);
+    }
+}

--- a/crates/temps-core/src/external_plugin/channel.rs
+++ b/crates/temps-core/src/external_plugin/channel.rs
@@ -1,6 +1,6 @@
 //! Platform channel protocol types.
 //!
-//! Defines the bidirectional JSON message protocol used between Temps and
+//! Defines the bidirectional message protocol used between Temps and
 //! external plugins over a WebSocket connection.  Temps initiates the
 //! connection to the plugin's `/_temps/channel` endpoint after the handshake
 //! completes.
@@ -10,16 +10,29 @@
 //! ```text
 //! Plugin (client role)                Temps (server role)
 //!     │                                    │
-//!     │─── Request { id, method, params } ─>│  plugin asks for data
-//!     │<── Response { id, result/error } ───│  platform responds
+//!     │─── Request { id, call } ──────────>│  plugin asks for data
+//!     │<── Response { id, outcome } ───────│  platform responds
 //!     │                                    │
 //!     │<── Event { event }  ───────────────│  platform pushes event
 //!     │                                    │
 //! ```
 //!
-//! Plugins send [`ChannelMessage::Request`] and receive
-//! [`ChannelMessage::Response`] or [`ChannelMessage::Event`].
+//! ## Why this is typed rather than `method: String` + `params: Value`
+//!
+//! The first version of this protocol carried a method name and a
+//! `serde_json::Value`.  Both sides then hand-built and hand-parsed JSON, so
+//! a renamed field or a misspelled method compiled cleanly on both sides and
+//! failed at runtime, on an operator's machine, as a `MethodNotFound` or a
+//! silent `null`.
+//!
+//! Now a call is a variant of [`PlatformCallRequest`] and its reply is the
+//! matching variant of [`PlatformCallResponse`], paired at compile time by
+//! the [`PlatformCall`] trait.  Adding a call without handling it is a
+//! non-exhaustive-match error in the platform's dispatcher rather than a
+//! runtime surprise.  Serde still puts the bytes on the wire — this is a
+//! JSON WebSocket — but no `serde_json::Value` appears in any signature.
 
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 // ── Wire messages ──────────────────────────────────────────────────────
@@ -28,7 +41,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ChannelMessage {
-    /// Plugin → Platform: request data.
+    /// Plugin → Platform: request data or perform an API call.
     Request(ChannelRequest),
     /// Platform → Plugin: response to a request.
     Response(ChannelResponse),
@@ -41,11 +54,8 @@ pub enum ChannelMessage {
 pub struct ChannelRequest {
     /// Caller-assigned correlation ID (echoed in the response).
     pub id: u64,
-    /// Method name, e.g. `"get_project"`, `"list_environments"`.
-    pub method: String,
-    /// Method-specific parameters.
-    #[serde(default)]
-    pub params: serde_json::Value,
+    /// The typed call being made.
+    pub call: PlatformCallRequest,
 }
 
 /// The platform's response to a [`ChannelRequest`].
@@ -53,15 +63,24 @@ pub struct ChannelRequest {
 pub struct ChannelResponse {
     /// Correlation ID from the original request.
     pub id: u64,
-    /// On success, the result payload.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub result: Option<serde_json::Value>,
-    /// On failure, a structured error.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<ChannelError>,
+    /// Success payload or structured error.
+    pub outcome: CallOutcome,
 }
 
-/// A platform-pushed event (replaces POST to `/_events`).
+/// Either the typed result of a call, or why it could not be served.
+///
+/// The success payload is boxed because it is an order of magnitude larger
+/// than the error: every `ChannelResponse` — including the error ones, which
+/// on a failing plugin are most of them — would otherwise carry the footprint
+/// of the biggest response variant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CallOutcome {
+    Ok(Box<PlatformCallResponse>),
+    Err(ChannelError),
+}
+
+/// A platform-pushed event.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChannelEvent {
     pub event: super::PluginEvent,
@@ -76,31 +95,522 @@ pub struct ChannelError {
     pub message: String,
 }
 
+impl ChannelError {
+    pub fn new(code: ChannelErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for ChannelError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}: {}", self.code, self.message)
+    }
+}
+
 /// Error codes for the channel protocol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ChannelErrorCode {
-    /// The requested method does not exist.
+    /// The requested method does not exist on this platform build.
     MethodNotFound,
     /// The parameters are invalid or missing required fields.
     InvalidParams,
-    /// The plugin does not have permission for this operation.
+    /// The plugin did not declare the capability this call requires, or the
+    /// acting user lacks the permission.
     PermissionDenied,
+    /// The plugin presented no usable actor token for a call that acts on a
+    /// user's behalf.
+    Unauthenticated,
     /// The requested resource was not found.
     NotFound,
     /// An internal platform error occurred.
     Internal,
 }
 
-// ── Convenience constructors ───────────────────────────────────────────
+// ── Typed API calls ────────────────────────────────────────────────────
+
+/// HTTP method for an [`ApiCall`].
+///
+/// An enum rather than a string, so a plugin cannot invent a verb the router
+/// will never match, and so a capability check can tell a read from a write
+/// without parsing anything.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum HttpMethod {
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+}
+
+impl HttpMethod {
+    /// Whether this verb can change state.
+    ///
+    /// Drives capability selection: a read needs only the read capability,
+    /// anything else needs the write one.
+    pub fn is_mutating(self) -> bool {
+        !matches!(self, HttpMethod::Get)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HttpMethod::Get => "GET",
+            HttpMethod::Post => "POST",
+            HttpMethod::Put => "PUT",
+            HttpMethod::Patch => "PATCH",
+            HttpMethod::Delete => "DELETE",
+        }
+    }
+}
+
+/// A JSON document in transit.
+///
+/// Holds already-encoded JSON rather than a `serde_json::Value`, so the
+/// protocol has no untyped hole in it: the typed layer on each side encodes
+/// and decodes concrete structs, and this is only the envelope carrying the
+/// bytes between them.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct JsonBody(String);
+
+impl JsonBody {
+    /// Encode a typed value for transport.
+    pub fn encode<T: Serialize>(value: &T) -> Result<Self, JsonBodyError> {
+        serde_json::to_string(value)
+            .map(Self)
+            .map_err(|e| JsonBodyError::Encode {
+                type_name: std::any::type_name::<T>(),
+                reason: e.to_string(),
+            })
+    }
+
+    /// Decode into the concrete type the caller expects.
+    pub fn decode<T: DeserializeOwned>(&self) -> Result<T, JsonBodyError> {
+        serde_json::from_str(&self.0).map_err(|e| JsonBodyError::Decode {
+            type_name: std::any::type_name::<T>(),
+            reason: e.to_string(),
+            // Bodies carry credentials and customer data, so the payload
+            // itself is never put in the error.
+            len: self.0.len(),
+        })
+    }
+
+    /// Wrap raw JSON text produced elsewhere (e.g. an HTTP response body).
+    pub fn from_raw(raw: impl Into<String>) -> Self {
+        Self(raw.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0.into_bytes()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// Why a [`JsonBody`] could not be encoded or decoded.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum JsonBodyError {
+    #[error("Failed to encode {type_name} for the platform channel: {reason}")]
+    Encode {
+        type_name: &'static str,
+        reason: String,
+    },
+    #[error("Failed to decode {len}-byte channel payload as {type_name}: {reason}")]
+    Decode {
+        type_name: &'static str,
+        reason: String,
+        len: usize,
+    },
+}
+
+/// Proof that a plugin is acting for a specific signed-in user.
+///
+/// Minted by the platform when it proxies an authenticated request to the
+/// plugin, and echoed back by the plugin on any call made on that user's
+/// behalf. A plugin cannot forge one — it is signed with the instance's auth
+/// secret — so a plugin can never act as a user who did not call it, nor
+/// exceed that user's own permissions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ActorToken(String);
+
+impl ActorToken {
+    pub fn new(token: impl Into<String>) -> Self {
+        Self(token.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Opaque binary payload, base64 on the wire.
+///
+/// The channel is a JSON WebSocket, so raw bytes need an encoding. Base64
+/// rather than a `Vec<u8>` because serde_json renders a byte vector as an
+/// array of decimal numbers — roughly 4x the size of base64 and far slower to
+/// parse.
+#[derive(Clone, PartialEq, Eq)]
+pub struct BinaryPayload(Vec<u8>);
+
+impl BinaryPayload {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// Debug prints the length only. Uploads are customer code and customer data;
+/// a `{:?}` in a log line must never dump them.
+impl std::fmt::Debug for BinaryPayload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "BinaryPayload({} bytes)", self.0.len())
+    }
+}
+
+impl Serialize for BinaryPayload {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use base64::Engine as _;
+        serializer.serialize_str(&base64::engine::general_purpose::STANDARD.encode(&self.0))
+    }
+}
+
+impl<'de> Deserialize<'de> for BinaryPayload {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use base64::Engine as _;
+        let encoded = String::deserialize(deserializer)?;
+        base64::engine::general_purpose::STANDARD
+            .decode(encoded.as_bytes())
+            .map(Self)
+            // The bad input is not echoed — it may be a partially-decoded
+            // secret. The length is enough to tell truncation from garbage.
+            .map_err(|e| {
+                serde::de::Error::custom(format!(
+                    "Channel payload of {} base64 characters is not valid base64: {e}",
+                    encoded.len()
+                ))
+            })
+    }
+}
+
+/// One part of a `multipart/form-data` request body.
+///
+/// Declared as data rather than assembled by the plugin, so no plugin ever
+/// writes a MIME boundary — the platform builds the wire format, which means
+/// a boundary can never collide with the payload or be omitted.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MultipartPart {
+    /// Form field name.
+    pub name: String,
+    /// Filename, for parts the handler treats as an upload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+    pub content: PartContent,
+}
+
+/// A multipart part's payload: text for form fields, bytes for uploads.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+pub enum PartContent {
+    Text(String),
+    Binary(BinaryPayload),
+}
+
+impl PartContent {
+    pub fn len(&self) -> usize {
+        match self {
+            PartContent::Text(t) => t.len(),
+            PartContent::Binary(b) => b.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// The request body of an [`ApiCall`].
+///
+/// Two shapes because the platform's API genuinely has two: most endpoints
+/// take JSON, but bundle and image uploads take `multipart/form-data`. A
+/// plugin restricted to JSON could not deploy anything, and one handed a raw
+/// byte buffer plus a content-type would be back to hand-building MIME.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "body", rename_all = "snake_case")]
+pub enum CallBody {
+    Json(JsonBody),
+    Multipart(Vec<MultipartPart>),
+}
+
+impl CallBody {
+    /// Encode a typed value as a JSON body.
+    pub fn json<T: Serialize>(value: &T) -> Result<Self, JsonBodyError> {
+        JsonBody::encode(value).map(CallBody::Json)
+    }
+
+    /// Total payload size, before MIME framing.
+    ///
+    /// Used to reject an over-large body at the call site rather than after
+    /// it has been serialized, buffered and pushed through the socket.
+    pub fn payload_len(&self) -> usize {
+        match self {
+            CallBody::Json(b) => b.as_str().len(),
+            CallBody::Multipart(parts) => parts.iter().map(|p| p.content.len()).sum(),
+        }
+    }
+}
+
+/// Largest request payload a plugin may put on the channel.
+///
+/// The body is base64-encoded into a JSON frame and buffered whole on both
+/// sides, so it costs roughly 4/3 of this in transit and again in the
+/// platform's memory. On the reference 4 GB box that is already generous for
+/// a static bundle, which is what this exists for. Anything larger — a saved
+/// Docker image, a database dump — needs a streaming path, not a bigger
+/// number here.
+pub const MAX_CALL_BODY_BYTES: usize = 32 * 1024 * 1024;
+
+/// A call into the platform's own HTTP API, carried over the channel.
+///
+/// The platform dispatches this into the very router that serves the
+/// console, so a plugin reaches exactly the endpoints the product has, with
+/// the same handlers, the same `permission_guard!` checks and the same audit
+/// logging. There is deliberately no parallel API to keep in sync.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiCall {
+    pub method: HttpMethod,
+    /// API path *below* `/api`, e.g. `/projects/42`.
+    pub path: String,
+    /// Raw query string, without the leading `?`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<CallBody>,
+    /// Who the plugin is acting for.
+    pub actor: ActorToken,
+}
+
+/// The platform's reply to an [`ApiCall`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiCallResult {
+    pub status: u16,
+    pub body: JsonBody,
+}
+
+impl ApiCallResult {
+    pub fn is_success(&self) -> bool {
+        (200..300).contains(&self.status)
+    }
+}
+
+// ── Call parameters ────────────────────────────────────────────────────
+
+/// Parameters for [`PlatformCallRequest::GetProject`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetProject {
+    pub project_id: i32,
+}
+
+/// Parameters for [`PlatformCallRequest::ListProjects`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ListProjects {}
+
+/// Parameters for [`PlatformCallRequest::GetEnvironment`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetEnvironment {
+    pub environment_id: i32,
+}
+
+/// Parameters for [`PlatformCallRequest::ListEnvironments`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListEnvironments {
+    pub project_id: i32,
+}
+
+/// Parameters for [`PlatformCallRequest::GetDeployment`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetDeployment {
+    pub deployment_id: i32,
+}
+
+/// Parameters for [`PlatformCallRequest::GetLastDeployment`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetLastDeployment {
+    pub project_id: i32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment_id: Option<i32>,
+}
+
+/// Parameters for [`PlatformCallRequest::ListDeployments`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListDeployments {
+    pub project_id: i32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment_id: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u64>,
+}
+
+// ── Call/response pairing ──────────────────────────────────────────────
+
+/// Generate the request/response enums and their compile-time pairing.
+///
+/// One entry per call is the whole definition: both wire enums, the
+/// [`PlatformCall`] impl saying which reply belongs to which request, and
+/// the reply extraction. Keeping them in a single macro is what makes it
+/// impossible to add a request without its matching response variant.
+macro_rules! define_platform_calls {
+    (
+        $(
+            $(#[$doc:meta])*
+            $variant:ident($params:ty) -> $output:ty,
+        )*
+    ) => {
+        /// A typed call from a plugin to the platform.
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        #[serde(tag = "method", content = "params", rename_all = "snake_case")]
+        pub enum PlatformCallRequest {
+            $(
+                $(#[$doc])*
+                $variant($params),
+            )*
+        }
+
+        /// The platform's typed reply, one variant per [`PlatformCallRequest`].
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        #[serde(tag = "method", content = "result", rename_all = "snake_case")]
+        pub enum PlatformCallResponse {
+            $(
+                $(#[$doc])*
+                $variant($output),
+            )*
+        }
+
+        impl PlatformCallRequest {
+            /// Method name, for logging and error messages only — never for
+            /// dispatch, which matches on the variant.
+            pub fn method_name(&self) -> &'static str {
+                match self {
+                    $( PlatformCallRequest::$variant(_) => stringify!($variant), )*
+                }
+            }
+        }
+
+        impl PlatformCallResponse {
+            pub fn method_name(&self) -> &'static str {
+                match self {
+                    $( PlatformCallResponse::$variant(_) => stringify!($variant), )*
+                }
+            }
+        }
+
+        $(
+            impl PlatformCall for $params {
+                type Output = $output;
+
+                fn into_request(self) -> PlatformCallRequest {
+                    PlatformCallRequest::$variant(self)
+                }
+
+                fn output_from(
+                    response: PlatformCallResponse,
+                ) -> Result<Self::Output, ProtocolMismatch> {
+                    match response {
+                        PlatformCallResponse::$variant(out) => Ok(out),
+                        other => Err(ProtocolMismatch {
+                            expected: stringify!($variant),
+                            received: other.method_name(),
+                        }),
+                    }
+                }
+            }
+        )*
+    };
+}
+
+define_platform_calls! {
+    /// Fetch one project by ID.
+    GetProject(GetProject) -> ProjectInfo,
+    /// List every non-deleted project.
+    ListProjects(ListProjects) -> Vec<ProjectInfo>,
+    /// Fetch one environment by ID.
+    GetEnvironment(GetEnvironment) -> EnvironmentInfo,
+    /// List a project's environments.
+    ListEnvironments(ListEnvironments) -> Vec<EnvironmentInfo>,
+    /// Fetch one deployment by ID.
+    GetDeployment(GetDeployment) -> DeploymentInfo,
+    /// Most recent deployment for a project, optionally per environment.
+    GetLastDeployment(GetLastDeployment) -> DeploymentInfo,
+    /// List a project's deployments.
+    ListDeployments(ListDeployments) -> Vec<DeploymentInfo>,
+    /// Call the platform's own HTTP API on behalf of a signed-in user.
+    ApiCall(ApiCall) -> ApiCallResult,
+}
+
+/// Ties a request type to the response type it produces.
+///
+/// Implemented by the macro above, never by hand: the pairing only holds
+/// because both enum variants come from one entry.
+pub trait PlatformCall: Serialize + Send + Sync + 'static {
+    /// What the platform returns for this call.
+    type Output: Send;
+
+    /// Wrap into the wire request enum.
+    fn into_request(self) -> PlatformCallRequest;
+
+    /// Extract this call's output from a reply.
+    ///
+    /// A mismatch means the platform answered a different call than the one
+    /// asked, which can only happen if the two sides disagree about the
+    /// protocol — so it is reported as such rather than silently discarded.
+    fn output_from(response: PlatformCallResponse) -> Result<Self::Output, ProtocolMismatch>;
+}
+
+/// The platform replied to a different call than the one that was made.
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+#[error(
+    "Platform channel replied with `{received}` to a `{expected}` request — \
+     the plugin and the platform disagree about the channel protocol; \
+     rebuild the plugin against this Temps version"
+)]
+pub struct ProtocolMismatch {
+    pub expected: &'static str,
+    pub received: &'static str,
+}
 
 impl ChannelResponse {
     /// Build a successful response.
-    pub fn ok(id: u64, result: serde_json::Value) -> Self {
+    pub fn ok(id: u64, result: PlatformCallResponse) -> Self {
         Self {
             id,
-            result: Some(result),
-            error: None,
+            outcome: CallOutcome::Ok(Box::new(result)),
         }
     }
 
@@ -108,11 +618,7 @@ impl ChannelResponse {
     pub fn err(id: u64, code: ChannelErrorCode, message: impl Into<String>) -> Self {
         Self {
             id,
-            result: None,
-            error: Some(ChannelError {
-                code,
-                message: message.into(),
-            }),
+            outcome: CallOutcome::Err(ChannelError::new(code, message)),
         }
     }
 }
@@ -183,46 +689,231 @@ pub struct DeploymentInfo {
 mod tests {
     use super::*;
 
+    fn project_info() -> ProjectInfo {
+        ProjectInfo {
+            id: 42,
+            name: "demo".into(),
+            slug: "demo".into(),
+            repo_name: "demo".into(),
+            repo_owner: "acme".into(),
+            main_branch: "main".into(),
+            preset: "node".into(),
+            source_type: "github".into(),
+            created_at: "2026-01-01T00:00:00Z".into(),
+            updated_at: "2026-01-01T00:00:00Z".into(),
+            last_deployment: None,
+            enable_preview_environments: false,
+        }
+    }
+
     #[test]
-    fn test_request_serialization_roundtrip() {
+    fn request_roundtrips_as_a_typed_call() {
         let msg = ChannelMessage::Request(ChannelRequest {
             id: 1,
-            method: "get_project".into(),
-            params: serde_json::json!({ "project_id": 42 }),
+            call: GetProject { project_id: 42 }.into_request(),
         });
         let json = serde_json::to_string(&msg).unwrap();
         let deser: ChannelMessage = serde_json::from_str(&json).unwrap();
         match deser {
             ChannelMessage::Request(req) => {
                 assert_eq!(req.id, 1);
-                assert_eq!(req.method, "get_project");
-                assert_eq!(req.params["project_id"], 42);
+                match req.call {
+                    PlatformCallRequest::GetProject(p) => assert_eq!(p.project_id, 42),
+                    other => panic!("wrong call: {}", other.method_name()),
+                }
             }
             _ => panic!("Expected Request variant"),
         }
     }
 
     #[test]
-    fn test_response_ok_serialization() {
-        let resp = ChannelResponse::ok(1, serde_json::json!({ "name": "test" }));
-        let msg = ChannelMessage::Response(resp);
-        let json = serde_json::to_string(&msg).unwrap();
-        assert!(json.contains("\"result\""));
-        assert!(!json.contains("\"error\""));
+    fn response_roundtrips_and_pairs_with_its_request() {
+        let resp = ChannelResponse::ok(7, PlatformCallResponse::GetProject(project_info()));
+        let json = serde_json::to_string(&ChannelMessage::Response(resp)).unwrap();
+        let deser: ChannelMessage = serde_json::from_str(&json).unwrap();
+        let ChannelMessage::Response(resp) = deser else {
+            panic!("Expected Response variant")
+        };
+        let CallOutcome::Ok(payload) = resp.outcome else {
+            panic!("Expected Ok outcome")
+        };
+        let project = <GetProject as PlatformCall>::output_from(*payload).unwrap();
+        assert_eq!(project.id, 42);
+    }
+
+    /// The whole point of the pairing: answering the wrong call is caught,
+    /// not silently returned as a default or a `None`.
+    #[test]
+    fn mismatched_reply_is_reported_as_a_protocol_disagreement() {
+        let payload = PlatformCallResponse::ListProjects(vec![project_info()]);
+        let err = <GetProject as PlatformCall>::output_from(payload).unwrap_err();
+        assert_eq!(err.expected, "GetProject");
+        assert_eq!(err.received, "ListProjects");
     }
 
     #[test]
-    fn test_response_err_serialization() {
+    fn error_response_roundtrips() {
         let resp = ChannelResponse::err(2, ChannelErrorCode::NotFound, "Project 99 not found");
-        let msg = ChannelMessage::Response(resp);
-        let json = serde_json::to_string(&msg).unwrap();
-        assert!(json.contains("\"error\""));
-        assert!(!json.contains("\"result\""));
-        assert!(json.contains("not_found"));
+        let json = serde_json::to_string(&resp).unwrap();
+        let deser: ChannelResponse = serde_json::from_str(&json).unwrap();
+        let CallOutcome::Err(err) = deser.outcome else {
+            panic!("Expected Err outcome")
+        };
+        assert_eq!(err.code, ChannelErrorCode::NotFound);
+        assert!(err.message.contains("99"));
     }
 
     #[test]
-    fn test_event_serialization() {
+    fn all_error_codes_roundtrip() {
+        let codes = [
+            ChannelErrorCode::MethodNotFound,
+            ChannelErrorCode::InvalidParams,
+            ChannelErrorCode::PermissionDenied,
+            ChannelErrorCode::Unauthenticated,
+            ChannelErrorCode::NotFound,
+            ChannelErrorCode::Internal,
+        ];
+        for code in codes {
+            let resp = ChannelResponse::err(0, code, "test");
+            let json = serde_json::to_string(&resp).unwrap();
+            let deser: ChannelResponse = serde_json::from_str(&json).unwrap();
+            let CallOutcome::Err(err) = deser.outcome else {
+                panic!("Expected Err outcome")
+            };
+            assert_eq!(err.code, code);
+        }
+    }
+
+    #[test]
+    fn json_body_roundtrips_a_typed_value() {
+        let body = JsonBody::encode(&GetProject { project_id: 9 }).unwrap();
+        let back: GetProject = body.decode().unwrap();
+        assert_eq!(back.project_id, 9);
+    }
+
+    /// A decode failure must name the target type without echoing the body:
+    /// request bodies carry credentials.
+    #[test]
+    fn json_body_decode_error_names_the_type_and_hides_the_payload() {
+        let body = JsonBody::from_raw(r#"{"secret":"hunter2"}"#);
+        let err = body.decode::<GetProject>().unwrap_err();
+        let rendered = err.to_string();
+        assert!(rendered.contains("GetProject"), "{rendered}");
+        assert!(!rendered.contains("hunter2"), "{rendered}");
+    }
+
+    #[test]
+    fn api_call_roundtrips_with_its_actor() {
+        let call = ApiCall {
+            method: HttpMethod::Post,
+            path: "/projects".into(),
+            query: None,
+            body: Some(CallBody::Json(JsonBody::from_raw(r#"{"name":"demo"}"#))),
+            actor: ActorToken::new("signed-token"),
+        };
+        let json = serde_json::to_string(&call.into_request()).unwrap();
+        let deser: PlatformCallRequest = serde_json::from_str(&json).unwrap();
+        match deser {
+            PlatformCallRequest::ApiCall(c) => {
+                assert_eq!(c.method, HttpMethod::Post);
+                assert_eq!(c.actor.as_str(), "signed-token");
+            }
+            other => panic!("wrong call: {}", other.method_name()),
+        }
+    }
+
+    /// Bytes must survive the JSON channel unchanged — including the ones
+    /// that are not valid UTF-8, which is every real tarball.
+    #[test]
+    fn binary_payload_roundtrips_through_json() {
+        let raw: Vec<u8> = (0u8..=255).collect();
+        let call = ApiCall {
+            method: HttpMethod::Post,
+            path: "/projects/1/upload/static".into(),
+            query: None,
+            body: Some(CallBody::Multipart(vec![
+                MultipartPart {
+                    name: "file".into(),
+                    filename: Some("bundle.tar.gz".into()),
+                    content_type: Some("application/gzip".into()),
+                    content: PartContent::Binary(BinaryPayload::new(raw.clone())),
+                },
+                MultipartPart {
+                    name: "content_type".into(),
+                    filename: None,
+                    content_type: None,
+                    content: PartContent::Text("application/gzip".into()),
+                },
+            ])),
+            actor: ActorToken::new("signed-token"),
+        };
+        let json = serde_json::to_string(&call).unwrap();
+        let back: ApiCall = serde_json::from_str(&json).unwrap();
+        let Some(CallBody::Multipart(parts)) = back.body else {
+            panic!("expected a multipart body")
+        };
+        assert_eq!(parts.len(), 2);
+        match &parts[0].content {
+            PartContent::Binary(b) => assert_eq!(b.as_bytes(), raw.as_slice()),
+            other => panic!("expected binary, got {other:?}"),
+        }
+        assert_eq!(parts[0].filename.as_deref(), Some("bundle.tar.gz"));
+        match &parts[1].content {
+            PartContent::Text(t) => assert_eq!(t, "application/gzip"),
+            other => panic!("expected text, got {other:?}"),
+        }
+    }
+
+    /// A body's size must be knowable before it is sent, so an over-large
+    /// upload is refused at the call site instead of after it has been
+    /// buffered twice.
+    #[test]
+    fn payload_len_counts_content_not_framing() {
+        let body = CallBody::Multipart(vec![
+            MultipartPart {
+                name: "file".into(),
+                filename: Some("a.bin".into()),
+                content_type: None,
+                content: PartContent::Binary(BinaryPayload::new(vec![0u8; 1000])),
+            },
+            MultipartPart {
+                name: "note".into(),
+                filename: None,
+                content_type: None,
+                content: PartContent::Text("hello".into()),
+            },
+        ]);
+        assert_eq!(body.payload_len(), 1005);
+        // `{"project_id":1}`
+        let json = CallBody::json(&GetProject { project_id: 1 }).unwrap();
+        assert_eq!(json.payload_len(), 16);
+    }
+
+    /// Debug output is a length, never the payload: uploads are customer
+    /// source code and a `{:?}` in a log line would leak it wholesale.
+    #[test]
+    fn binary_payload_debug_hides_the_bytes() {
+        let payload = BinaryPayload::new(b"super-secret-source".to_vec());
+        let rendered = format!("{payload:?}");
+        assert!(rendered.contains("19 bytes"), "{rendered}");
+        assert!(!rendered.contains("secret"), "{rendered}");
+    }
+
+    #[test]
+    fn only_get_is_non_mutating() {
+        assert!(!HttpMethod::Get.is_mutating());
+        for m in [
+            HttpMethod::Post,
+            HttpMethod::Put,
+            HttpMethod::Patch,
+            HttpMethod::Delete,
+        ] {
+            assert!(m.is_mutating(), "{m:?} must count as mutating");
+        }
+    }
+
+    #[test]
+    fn event_roundtrips() {
         let event = super::super::PluginEvent {
             id: "evt-1".into(),
             event_type: "deployment.succeeded".into(),
@@ -238,23 +929,6 @@ mod tests {
                 assert_eq!(evt.event.event_type, "deployment.succeeded");
             }
             _ => panic!("Expected Event variant"),
-        }
-    }
-
-    #[test]
-    fn test_all_error_codes_serialize() {
-        let codes = [
-            ChannelErrorCode::MethodNotFound,
-            ChannelErrorCode::InvalidParams,
-            ChannelErrorCode::PermissionDenied,
-            ChannelErrorCode::NotFound,
-            ChannelErrorCode::Internal,
-        ];
-        for code in codes {
-            let resp = ChannelResponse::err(0, code, "test");
-            let json = serde_json::to_string(&resp).unwrap();
-            let deser: ChannelResponse = serde_json::from_str(&json).unwrap();
-            assert_eq!(deser.error.unwrap().code, code);
         }
     }
 }

--- a/crates/temps-core/src/external_plugin/channel.rs
+++ b/crates/temps-core/src/external_plugin/channel.rs
@@ -417,6 +417,28 @@ pub struct ApiCall {
     pub actor: ActorToken,
 }
 
+/// In-process proof that a platform HTTP request originated from a verified
+/// external-plugin channel call.
+///
+/// This is inserted into request extensions only after the channel has
+/// verified the plugin-bound actor token. HTTP headers cannot create it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedPluginApiCaller {
+    plugin_name: String,
+}
+
+impl VerifiedPluginApiCaller {
+    pub fn new(plugin_name: impl Into<String>) -> Self {
+        Self {
+            plugin_name: plugin_name.into(),
+        }
+    }
+
+    pub fn plugin_name(&self) -> &str {
+        &self.plugin_name
+    }
+}
+
 /// The platform's reply to an [`ApiCall`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApiCallResult {

--- a/crates/temps-core/src/external_plugin/headers.rs
+++ b/crates/temps-core/src/external_plugin/headers.rs
@@ -1,0 +1,56 @@
+//! Request headers Temps attaches when proxying to an external plugin.
+//!
+//! Both ends of the proxy need these names, so they live here rather than in
+//! either crate that uses them: `temps-external-plugins` injects them in
+//! `forward_to_unix_socket`, and `temps-plugin-sdk` re-exports them from
+//! `protocol::headers` for the `TempsAuth` extractor plugins build on.
+//!
+//! # Trust model
+//!
+//! Everything under the [`PREFIX`] namespace is **asserted by Temps**, never
+//! by the caller. The proxy strips every inbound `x-temps-*` header before
+//! injecting its own, so a client cannot present `x-temps-user-role: admin`
+//! and have it survive to the plugin. A plugin may therefore treat these as
+//! authoritative — but only because it is reachable exclusively through that
+//! proxy. A plugin whose Unix socket is reachable by other local processes
+//! gets no such guarantee from these headers alone.
+
+/// Namespace for every header the proxy asserts. The proxy removes all
+/// inbound headers with this prefix before adding its own.
+pub const PREFIX: &str = "x-temps-";
+
+/// Name of the plugin the request was routed to.
+pub const PLUGIN_NAME: &str = "x-temps-plugin";
+
+/// Authenticated user's database id. Absent when the caller authenticated
+/// with a credential that is not bound to a user (a deployment token).
+pub const USER_ID: &str = "x-temps-user-id";
+
+/// Authenticated user's email address.
+pub const USER_EMAIL: &str = "x-temps-user-email";
+
+/// Caller's effective role, in `Role`'s wire form (`admin`, `user`,
+/// `reader`, …). Always present on a proxied request.
+pub const USER_ROLE: &str = "x-temps-user-role";
+
+/// Comma-separated effective permissions for this request.
+///
+/// This is the already-resolved permission set, not merely the permissions
+/// implied by [`USER_ROLE`]. API keys may narrow a role or carry a custom
+/// permission set, so plugins must authorize against this header rather than
+/// reconstructing permissions from the role name.
+pub const USER_PERMISSIONS: &str = "x-temps-user-permissions";
+
+/// Per-request correlation id, so plugin logs can be joined to Temps' own.
+pub const REQUEST_ID: &str = "x-temps-request-id";
+
+/// The plugin's handshake secret, echoed back so the plugin can confirm the
+/// request came from the Temps process that spawned it rather than from
+/// something else that found its socket.
+pub const AUTH_SIGNATURE: &str = "x-temps-auth-signature";
+
+/// Short-lived proof the plugin echoes back on channel API calls to act as
+/// the caller. Present only when the caller is a real user and the plugin
+/// declared an API capability. See
+/// [`crate::external_plugin::actor`].
+pub const ACTOR_TOKEN: &str = "x-temps-actor-token";

--- a/crates/temps-core/src/external_plugin/headers.rs
+++ b/crates/temps-core/src/external_plugin/headers.rs
@@ -11,9 +11,9 @@
 //! by the caller. The proxy strips every inbound `x-temps-*` header before
 //! injecting its own, so a client cannot present `x-temps-user-role: admin`
 //! and have it survive to the plugin. A plugin may therefore treat these as
-//! authoritative — but only because it is reachable exclusively through that
-//! proxy. A plugin whose Unix socket is reachable by other local processes
-//! gets no such guarantee from these headers alone.
+//! authoritative for requests carrying the staged process secret. This does
+//! not isolate installed plugins from one another under the current shared-UID
+//! host model; installed plugin binaries are trusted host code.
 
 /// Namespace for every header the proxy asserts. The proxy removes all
 /// inbound headers with this prefix before adding its own.

--- a/crates/temps-core/src/external_plugin/manifest.rs
+++ b/crates/temps-core/src/external_plugin/manifest.rs
@@ -236,7 +236,6 @@ impl PluginManifestBuilder {
         self
     }
 
-    /// Hide the console's header strip above this plugin's UI — see
     /// Declare a capability this plugin needs for its channel API calls.
     ///
     /// Without the matching capability a call is refused before it reaches
@@ -249,7 +248,10 @@ impl PluginManifestBuilder {
         self
     }
 
-    /// [`PluginManifest::hide_header`]. For plugins that render their own.
+    /// Hide the console's header strip above this plugin's UI.
+    ///
+    /// See [`PluginManifest::hide_header`]. Use this for plugins that render
+    /// their own full-page header.
     pub fn hide_header(mut self, hide: bool) -> Self {
         self.manifest.hide_header = hide;
         self

--- a/crates/temps-core/src/external_plugin/manifest.rs
+++ b/crates/temps-core/src/external_plugin/manifest.rs
@@ -80,6 +80,47 @@ pub struct PluginManifest {
     /// Health check endpoint path (relative to plugin root)
     #[serde(default = "default_health_path")]
     pub health_path: String,
+    /// Suppress the console's own header strip above this plugin's UI.
+    ///
+    /// The console normally renders the plugin's icon, display name and
+    /// version above the iframe. For a plugin whose UI is a full working
+    /// surface with its own header, that is a second title bar competing
+    /// for the same vertical space — and vertical space is exactly what a
+    /// chat-plus-preview layout has none of. Opt out and the frame gets the
+    /// full height.
+    ///
+    /// The nav entry still names the plugin, so nothing becomes
+    /// unidentifiable by setting this.
+    #[serde(default)]
+    pub hide_header: bool,
+    /// Routes this plugin authenticates itself, which the platform's proxy
+    /// therefore does not gate.
+    ///
+    /// Every other proxied route requires an authenticated caller before it
+    /// reaches the plugin. That is right for anything a signed-in user
+    /// drives, and wrong for the endpoints a plugin exposes to clients that
+    /// hold no platform session — an agent in a sandbox presenting a
+    /// capability token, a share link opened by someone with no account.
+    /// This is the external-plugin counterpart of the in-process
+    /// `configure_public_routes`.
+    ///
+    /// Paths are relative to the plugin's mount point and match by prefix,
+    /// so `/vibe/mcp` covers everything beneath it. A listed route is
+    /// reachable by anyone who can reach the instance: it **must** check its
+    /// own credential. Listing a route that does not is an open door.
+    #[serde(default)]
+    pub public_paths: Vec<String>,
+    /// What this plugin may do with the platform's own API over the channel.
+    ///
+    /// Empty by default, and empty means read-only channel queries and
+    /// nothing else: a plugin that never asks cannot deploy, cannot create
+    /// projects, and cannot provision databases. Declaring a capability is
+    /// not by itself permission to act — every call still runs the real
+    /// handler's `permission_guard!` as the user the plugin is acting for,
+    /// so a capability can only ever narrow what that user could already do
+    /// through the console.
+    #[serde(default)]
+    pub capabilities: Vec<PluginCapability>,
     /// Platform event types the plugin subscribes to.
     ///
     /// When specified, Temps will POST matching events to the plugin's
@@ -103,6 +144,39 @@ fn default_health_path() -> String {
     "/health".to_string()
 }
 
+/// What a plugin is allowed to do with the platform API over the channel.
+///
+/// Coarse on purpose. Fine-grained authorization already exists in the
+/// permission system and is enforced per request against the acting user;
+/// this exists so an operator installing a binary can see at a glance
+/// whether it intends to *write* at all, without reading its source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PluginCapability {
+    /// Read platform resources through the API (`GET`).
+    ApiRead,
+    /// Create, change or delete platform resources through the API.
+    ApiWrite,
+}
+
+impl PluginCapability {
+    /// The capability a given verb requires.
+    pub fn for_method(method: super::channel::HttpMethod) -> Self {
+        if method.is_mutating() {
+            Self::ApiWrite
+        } else {
+            Self::ApiRead
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ApiRead => "api_read",
+            Self::ApiWrite => "api_write",
+        }
+    }
+}
+
 /// Builder for constructing a PluginManifest.
 pub struct PluginManifestBuilder {
     manifest: PluginManifest,
@@ -120,6 +194,11 @@ impl PluginManifest {
                 ui: None,
                 requires_db: true,
                 health_path: "/health".to_string(),
+                // Empty by default: a plugin opts routes out of platform
+                // auth explicitly, never by omission.
+                public_paths: Vec::new(),
+                capabilities: Vec::new(),
+                hide_header: false,
                 events: Vec::new(),
             },
         }
@@ -154,6 +233,33 @@ impl PluginManifestBuilder {
 
     pub fn health_path(mut self, path: impl Into<String>) -> Self {
         self.manifest.health_path = path.into();
+        self
+    }
+
+    /// Hide the console's header strip above this plugin's UI — see
+    /// Declare a capability this plugin needs for its channel API calls.
+    ///
+    /// Without the matching capability a call is refused before it reaches
+    /// the router, and the error names what was missing so a plugin author
+    /// is not left guessing.
+    pub fn capability(mut self, capability: PluginCapability) -> Self {
+        if !self.manifest.capabilities.contains(&capability) {
+            self.manifest.capabilities.push(capability);
+        }
+        self
+    }
+
+    /// [`PluginManifest::hide_header`]. For plugins that render their own.
+    pub fn hide_header(mut self, hide: bool) -> Self {
+        self.manifest.hide_header = hide;
+        self
+    }
+
+    /// Declare a route prefix the platform should not gate, because the
+    /// plugin authenticates it itself. See [`PluginManifest::public_paths`] —
+    /// anything listed here is reachable unauthenticated.
+    pub fn public_path(mut self, path: impl Into<String>) -> Self {
+        self.manifest.public_paths.push(path.into());
         self
     }
 

--- a/crates/temps-core/src/external_plugin/manifest.rs
+++ b/crates/temps-core/src/external_plugin/manifest.rs
@@ -75,8 +75,15 @@ pub struct PluginManifest {
     #[serde(default)]
     pub ui: Option<UiManifest>,
     /// Whether the plugin needs database access
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub requires_db: bool,
+    /// Whether the plugin may read the platform's host data root.
+    ///
+    /// This is a highly privileged capability: the directory can contain
+    /// encryption keys and instance-owned state. It is independent of direct
+    /// database access and defaults to `false`.
+    #[serde(default)]
+    pub requires_host_data_access: bool,
     /// Health check endpoint path (relative to plugin root)
     #[serde(default = "default_health_path")]
     pub health_path: String,
@@ -86,7 +93,7 @@ pub struct PluginManifest {
     /// version above the iframe. For a plugin whose UI is a full working
     /// surface with its own header, that is a second title bar competing
     /// for the same vertical space — and vertical space is exactly what a
-    /// chat-plus-preview layout has none of. Opt out and the frame gets the
+    /// dense full-page layout has none of. Opt out and the frame gets the
     /// full height.
     ///
     /// The nav entry still names the plugin, so nothing becomes
@@ -105,7 +112,7 @@ pub struct PluginManifest {
     /// `configure_public_routes`.
     ///
     /// Paths are relative to the plugin's mount point and match by prefix,
-    /// so `/vibe/mcp` covers everything beneath it. A listed route is
+    /// so `/webhooks/incoming` covers everything beneath it. A listed route is
     /// reachable by anyone who can reach the instance: it **must** check its
     /// own credential. Listing a route that does not is an open door.
     #[serde(default)]
@@ -134,10 +141,6 @@ pub struct PluginManifest {
     /// - `domain.created`, `domain.provisioned`
     #[serde(default)]
     pub events: Vec<String>,
-}
-
-fn default_true() -> bool {
-    true
 }
 
 fn default_health_path() -> String {
@@ -192,7 +195,8 @@ impl PluginManifest {
                 description: None,
                 nav: Vec::new(),
                 ui: None,
-                requires_db: true,
+                requires_db: false,
+                requires_host_data_access: false,
                 health_path: "/health".to_string(),
                 // Empty by default: a plugin opts routes out of platform
                 // auth explicitly, never by omission.
@@ -228,6 +232,16 @@ impl PluginManifestBuilder {
 
     pub fn requires_db(mut self, requires: bool) -> Self {
         self.manifest.requires_db = requires;
+        self
+    }
+
+    /// Request access to the platform's host data root.
+    ///
+    /// This exposes instance key material and other host-owned state. Plugins
+    /// should use their private data directory unless they explicitly need to
+    /// operate on platform-managed files.
+    pub fn requires_host_data_access(mut self, requires: bool) -> Self {
+        self.manifest.requires_host_data_access = requires;
         self
     }
 
@@ -287,6 +301,8 @@ impl PluginManifestBuilder {
 pub struct PluginReady {
     pub ready: bool,
     pub has_ui: bool,
+    /// External-plugin protocol version implemented by the running SDK.
+    pub protocol_version: u32,
     /// Optional OpenAPI schema (serialized JSON) for the plugin's endpoints.
     ///
     /// When present, Temps merges this into the unified API documentation
@@ -295,10 +311,37 @@ pub struct PluginReady {
     pub openapi: Option<serde_json::Value>,
 }
 
+/// First message emitted by a staged plugin process.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginHello {
+    pub protocol_version: u32,
+    pub manifest: Box<PluginManifest>,
+}
+
+/// Configuration sent to the same child after Temps reads its manifest.
+///
+/// Database and host-data fields reflect the manifest's declared needs. They
+/// are operational routing/disclosure controls for trusted installed code,
+/// not a sandbox boundary.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct PluginLaunchConfig {
+    pub protocol_version: u32,
+    pub auth_secret: String,
+    pub database_url: Option<String>,
+    pub host_data_dir: Option<String>,
+}
+
+/// Current process-launch and internal-channel protocol version.
+pub const EXTERNAL_PLUGIN_PROTOCOL_VERSION: u32 = 2;
+
 /// Handshake envelope: tagged union for messages from plugin to Temps.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum HandshakeMessage {
+    #[serde(rename = "hello")]
+    Hello(PluginHello),
+    /// Legacy handshake retained only so the manager can return an actionable
+    /// incompatibility error instead of an opaque JSON parse failure.
     #[serde(rename = "manifest")]
     Manifest(Box<PluginManifest>),
     #[serde(rename = "ready")]
@@ -378,10 +421,32 @@ mod tests {
         assert_eq!(deserialized.name, "my-plugin");
         assert_eq!(deserialized.nav.len(), 1);
         assert_eq!(deserialized.nav[0].section, NavSection::Settings);
+        assert!(!deserialized.requires_db);
+        assert!(!deserialized.requires_host_data_access);
+    }
+
+    #[test]
+    fn host_data_access_is_separate_and_explicit() {
+        let manifest = PluginManifest::builder("privileged-plugin", "1.0.0")
+            .requires_host_data_access(true)
+            .build();
+
+        assert!(manifest.requires_host_data_access);
+        assert!(!manifest.requires_db);
     }
 
     #[test]
     fn test_handshake_message_serialization() {
+        let hello = HandshakeMessage::Hello(PluginHello {
+            protocol_version: EXTERNAL_PLUGIN_PROTOCOL_VERSION,
+            manifest: Box::new(PluginManifest::builder("test", "0.1.0").build()),
+        });
+        let json = serde_json::to_string(&hello).unwrap();
+        assert!(json.contains("\"type\":\"hello\""));
+        assert!(json.contains("\"protocol_version\":2"));
+
+        // Kept parseable so a legacy child gets an upgrade instruction from
+        // the manager instead of an opaque deserialization failure.
         let msg =
             HandshakeMessage::Manifest(Box::new(PluginManifest::builder("test", "0.1.0").build()));
         let json = serde_json::to_string(&msg).unwrap();
@@ -390,10 +455,22 @@ mod tests {
         let ready_msg = HandshakeMessage::Ready(PluginReady {
             ready: true,
             has_ui: false,
+            protocol_version: EXTERNAL_PLUGIN_PROTOCOL_VERSION,
             openapi: None,
         });
         let json = serde_json::to_string(&ready_msg).unwrap();
         assert!(json.contains("\"type\":\"ready\""));
+
+        let launch = PluginLaunchConfig {
+            protocol_version: EXTERNAL_PLUGIN_PROTOCOL_VERSION,
+            auth_secret: "secret".to_string(),
+            database_url: None,
+            host_data_dir: None,
+        };
+        let launch_json = serde_json::to_string(&launch).unwrap();
+        let decoded: PluginLaunchConfig = serde_json::from_str(&launch_json).unwrap();
+        assert_eq!(decoded.protocol_version, EXTERNAL_PLUGIN_PROTOCOL_VERSION);
+        assert_eq!(decoded.auth_secret, "secret");
     }
 
     #[test]

--- a/crates/temps-core/src/external_plugin/mod.rs
+++ b/crates/temps-core/src/external_plugin/mod.rs
@@ -21,9 +21,10 @@ pub use channel::{
     ActorToken, ApiCall, ApiCallResult, CallOutcome, ChannelError, ChannelErrorCode, ChannelEvent,
     ChannelMessage, ChannelRequest, ChannelResponse, DeploymentInfo, EnvironmentInfo, HttpMethod,
     JsonBody, JsonBodyError, PlatformCall, PlatformCallRequest, PlatformCallResponse, ProjectInfo,
-    ProtocolMismatch, PLUGIN_CHANNEL_PATH,
+    ProtocolMismatch, VerifiedPluginApiCaller, PLUGIN_CHANNEL_PATH,
 };
 pub use manifest::{
-    HandshakeMessage, NavEntry, NavSection, PluginCapability, PluginEvent, PluginManifest,
-    PluginManifestBuilder, PluginReady, UiManifest, UiRoute, PLUGIN_EVENTS_PATH,
+    HandshakeMessage, NavEntry, NavSection, PluginCapability, PluginEvent, PluginHello,
+    PluginLaunchConfig, PluginManifest, PluginManifestBuilder, PluginReady, UiManifest, UiRoute,
+    EXTERNAL_PLUGIN_PROTOCOL_VERSION, PLUGIN_EVENTS_PATH,
 };

--- a/crates/temps-core/src/external_plugin/mod.rs
+++ b/crates/temps-core/src/external_plugin/mod.rs
@@ -8,14 +8,22 @@
 //! The actual lifecycle management, proxying, and API handlers live in the
 //! `temps-external-plugins` crate.
 
+pub mod actor;
 pub mod channel;
+pub mod headers;
 pub mod manifest;
 
+pub use actor::{
+    encode_plugin_actor_token, verify_plugin_actor_token, ActorPrincipal, PluginActorError,
+    VerifiedActor, PLUGIN_ACTOR_TOKEN_TTL, PLUGIN_ACTOR_TOKEN_VERSION,
+};
 pub use channel::{
-    ChannelError, ChannelErrorCode, ChannelEvent, ChannelMessage, ChannelRequest, ChannelResponse,
-    DeploymentInfo, EnvironmentInfo, ProjectInfo, PLUGIN_CHANNEL_PATH,
+    ActorToken, ApiCall, ApiCallResult, CallOutcome, ChannelError, ChannelErrorCode, ChannelEvent,
+    ChannelMessage, ChannelRequest, ChannelResponse, DeploymentInfo, EnvironmentInfo, HttpMethod,
+    JsonBody, JsonBodyError, PlatformCall, PlatformCallRequest, PlatformCallResponse, ProjectInfo,
+    ProtocolMismatch, PLUGIN_CHANNEL_PATH,
 };
 pub use manifest::{
-    HandshakeMessage, NavEntry, NavSection, PluginEvent, PluginManifest, PluginManifestBuilder,
-    PluginReady, UiManifest, UiRoute, PLUGIN_EVENTS_PATH,
+    HandshakeMessage, NavEntry, NavSection, PluginCapability, PluginEvent, PluginManifest,
+    PluginManifestBuilder, PluginReady, UiManifest, UiRoute, PLUGIN_EVENTS_PATH,
 };

--- a/crates/temps-deployments/src/handlers/remote_deployments.rs
+++ b/crates/temps-deployments/src/handlers/remote_deployments.rs
@@ -25,6 +25,7 @@ use sea_orm::{
 };
 use serde::{Deserialize, Serialize};
 use temps_auth::{permission_guard, project_access_guard, project_permission_guard, RequireAuth};
+use temps_core::external_plugin::VerifiedPluginApiCaller;
 use temps_core::problemdetails::{self, Problem};
 use temps_core::{AuditContext, DeploymentCreatedJob, Job, RequestMetadata, UtcDateTime};
 use temps_entities::deployments::DeploymentMetadata;
@@ -484,6 +485,11 @@ pub struct DeployFromImageRequest {
     /// External image ID (if already registered). If provided without image_ref,
     /// the image reference will be fetched from the registered external image.
     pub external_image_id: Option<i32>,
+    /// Claim an image already present in the platform host's Docker daemon.
+    /// Temps retags it into a generated project-owned namespace and records
+    /// its immutable image ID. Never set this for a registry image.
+    #[serde(default)]
+    pub claim_local: bool,
     /// Optional deployment metadata
     pub metadata: Option<serde_json::Value>,
     /// Optional HTTP health-check path override (e.g. "/api/healthz").
@@ -493,6 +499,91 @@ pub struct DeployFromImageRequest {
     #[serde(default)]
     #[schema(example = "/api/healthz")]
     pub health_check_path: Option<String>,
+}
+
+const RESERVED_LOCAL_IMAGE_PREFIX: &str = "temps.internal/";
+
+fn platform_local_image_tag(project_id: i32, environment_id: i32, source: &str) -> String {
+    format!(
+        "{RESERVED_LOCAL_IMAGE_PREFIX}project-{project_id}/environment-{environment_id}/{source}-{}:immutable",
+        uuid::Uuid::new_v4().simple()
+    )
+}
+
+fn is_reserved_local_image_ref(image_ref: &str) -> bool {
+    image_ref.starts_with(RESERVED_LOCAL_IMAGE_PREFIX)
+}
+
+fn authorize_local_image_claim(
+    claim_local: bool,
+    caller: Option<&VerifiedPluginApiCaller>,
+) -> Result<(), Problem> {
+    if claim_local && caller.is_none() {
+        return Err(problemdetails::new(StatusCode::FORBIDDEN)
+            .with_title("Local Image Claim Not Permitted")
+            .with_detail(
+                "Local daemon images may be claimed only through a verified external-plugin channel call",
+            ));
+    }
+    Ok(())
+}
+
+async fn claim_local_image(
+    state: &AppState,
+    project_id: i32,
+    environment_id: i32,
+    source_ref: &str,
+) -> Result<(String, String), Problem> {
+    if is_reserved_local_image_ref(source_ref) {
+        return Err(problemdetails::new(StatusCode::BAD_REQUEST)
+            .with_title("Reserved Image Reference")
+            .with_detail("Platform-owned local image references cannot be claimed by name"));
+    }
+
+    let inspected = state
+        .docker
+        .inspect_image(source_ref)
+        .await
+        .map_err(|error| {
+            warn!(image = %source_ref, %error, "Could not inspect claimed local image");
+            problemdetails::new(StatusCode::NOT_FOUND)
+                .with_title("Local Image Not Found")
+                .with_detail(format!("Local image '{source_ref}' was not found"))
+        })?;
+    let image_id = inspected.id.filter(|id| !id.is_empty()).ok_or_else(|| {
+        problemdetails::new(StatusCode::UNPROCESSABLE_ENTITY)
+            .with_title("Local Image Has No Immutable ID")
+            .with_detail(format!(
+                "Docker did not report an immutable ID for local image '{source_ref}'"
+            ))
+    })?;
+
+    let internal_ref = platform_local_image_tag(project_id, environment_id, "claim");
+    let (repository, tag) = internal_ref.rsplit_once(':').ok_or_else(|| {
+        problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
+            .with_title("Internal Image Reference Error")
+            .with_detail("Temps generated an invalid internal image reference")
+    })?;
+    state
+        .docker
+        .tag_image(
+            &image_id,
+            Some(
+                bollard::query_parameters::TagImageOptionsBuilder::new()
+                    .repo(repository)
+                    .tag(tag)
+                    .build(),
+            ),
+        )
+        .await
+        .map_err(|error| {
+            error!(image = %source_ref, image_id = %image_id, %error, "Failed to establish local image claim");
+            problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
+                .with_title("Local Image Claim Failed")
+                .with_detail("Temps could not create the project-owned local image reference")
+        })?;
+
+    Ok((internal_ref, image_id))
 }
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -534,8 +625,8 @@ pub struct PaginationQuery {
 /// Query parameters for deploying from an uploaded image tarball
 #[derive(Debug, Clone, Deserialize, ToSchema, IntoParams)]
 pub struct DeployFromImageUploadQuery {
-    /// Tag to apply to the imported image (e.g., "myapp:v1.0")
-    /// If not provided, a unique tag will be generated
+    /// Deprecated display hint retained for wire compatibility. Temps always
+    /// generates the actual project-scoped internal image reference.
     #[schema(example = "myapp:v1.0")]
     pub tag: Option<String>,
     /// Optional HTTP health-check path override (e.g. "/api/healthz").
@@ -820,6 +911,7 @@ pub async fn deploy_from_image(
     State(state): State<Arc<AppState>>,
     Path((project_id, environment_id)): Path<(i32, i32)>,
     Extension(metadata): Extension<RequestMetadata>,
+    plugin_caller: Option<Extension<VerifiedPluginApiCaller>>,
     Json(req): Json<DeployFromImageRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     project_permission_guard!(
@@ -828,6 +920,10 @@ pub async fn deploy_from_image(
         project_id,
         state.project_access_checker
     );
+    authorize_local_image_claim(
+        req.claim_local,
+        plugin_caller.as_ref().map(|Extension(caller)| caller),
+    )?;
 
     // Validate optional deploy-time health-check path override up front
     if let Some(ref path) = req.health_check_path {
@@ -919,6 +1015,7 @@ pub async fn deploy_from_image(
 
     // 2. Verify environment exists, belongs to project, and is not deleted
     let environment = environments::Entity::find_by_id(environment_id)
+        .filter(environments::Column::ProjectId.eq(project_id))
         .filter(environments::Column::DeletedAt.is_null())
         .one(state.db.as_ref())
         .await
@@ -934,11 +1031,18 @@ pub async fn deploy_from_image(
                 .with_detail(format!("Environment {} not found", environment_id))
         })?;
 
-    if environment.project_id != project_id {
-        return Err(problemdetails::new(StatusCode::BAD_REQUEST)
-            .with_title("Invalid Environment")
-            .with_detail("Environment does not belong to this project"));
-    }
+    let (image_ref, uploaded_image_id) = if req.claim_local {
+        if external_image_id.is_some() {
+            return Err(problemdetails::new(StatusCode::BAD_REQUEST)
+                .with_title("Invalid Local Image Claim")
+                .with_detail("A local image claim cannot use an external_image_id"));
+        }
+        let (internal_ref, image_id) =
+            claim_local_image(&state, project_id, environment_id, &image_ref).await?;
+        (internal_ref, Some(image_id))
+    } else {
+        (image_ref, None)
+    };
 
     // 3. Generate deployment slug using project slug (canonical hostname source —
     //    must match the normal git-push path so URLs read `<project>-<n>`, not `<env>-<n>`)
@@ -955,6 +1059,8 @@ pub async fn deploy_from_image(
         external_image_ref: Some(image_ref.clone()),
         external_image_id,
         deployment_source_type: Some(SourceType::DockerImage),
+        image_uploaded_locally: uploaded_image_id.is_some(),
+        uploaded_image_id,
         health_check_path: req.health_check_path.clone(),
         ..Default::default()
     };
@@ -1163,6 +1269,7 @@ pub async fn deploy_from_static(
 
     // 2. Verify environment exists, belongs to project, and is not deleted
     let environment = environments::Entity::find_by_id(environment_id)
+        .filter(environments::Column::ProjectId.eq(project_id))
         .filter(environments::Column::DeletedAt.is_null())
         .one(state.db.as_ref())
         .await
@@ -1177,12 +1284,6 @@ pub async fn deploy_from_static(
                 .with_title("Environment Not Found")
                 .with_detail(format!("Environment {} not found", environment_id))
         })?;
-
-    if environment.project_id != project_id {
-        return Err(problemdetails::new(StatusCode::BAD_REQUEST)
-            .with_title("Invalid Environment")
-            .with_detail("Environment does not belong to this project"));
-    }
 
     // 3. Verify static bundle exists and belongs to project
     let bundle = state
@@ -1529,15 +1630,11 @@ pub async fn deploy_from_image_upload(
                 .with_detail(e.to_string())
         })?;
 
-    // 5. Generate image tag if not provided
-    let image_tag = query.tag.unwrap_or_else(|| {
-        format!(
-            "temps-{}-{}:upload-{}",
-            project.slug,
-            environment.slug,
-            Utc::now().timestamp()
-        )
-    });
+    // 5. The actual daemon tag is always generated by Temps. A caller-chosen
+    // tag could collide with another project's local claim in the shared
+    // Docker daemon. `query.tag` remains accepted for wire compatibility but
+    // has no authority over the internal reference.
+    let image_tag = platform_local_image_tag(project_id, environment_id, "upload");
 
     // 6. Import the image using docker load
     info!("Importing image from tarball with tag: {}", image_tag);
@@ -1551,12 +1648,32 @@ pub async fn deploy_from_image_upload(
         debug!("Failed to remove temporary file: {}", e);
     }
 
-    let imported_image_id = import_result.map_err(|e| {
+    import_result.map_err(|e| {
         error!("Failed to import image: {}", e);
         problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
             .with_title("Image Import Failed")
             .with_detail(format!("Failed to import Docker image: {}", e))
     })?;
+
+    // `docker load` may report the loaded tag rather than the content ID.
+    // Inspect the generated internal tag and persist the daemon's immutable ID
+    // so VerifyLocalImageJob can detect any later retagging or replacement.
+    let imported_image_id = state
+        .image_builder
+        .inspect_image(&image_tag)
+        .await
+        .map_err(|error| {
+            error!(image = %image_tag, %error, "Failed to inspect imported image");
+            problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
+                .with_title("Imported Image Verification Failed")
+                .with_detail("Temps could not record the imported image's immutable ID")
+        })?
+        .id;
+    if imported_image_id.is_empty() {
+        return Err(problemdetails::new(StatusCode::UNPROCESSABLE_ENTITY)
+            .with_title("Imported Image Has No Immutable ID")
+            .with_detail("Docker did not report an immutable ID for the imported image"));
+    }
 
     info!(
         "Successfully imported image with ID: {}, tag: {}",
@@ -2561,6 +2678,32 @@ mod tests {
     fn uploaded_image_accepted_when_no_cluster_platform_is_known() {
         assert!(uploaded_image_is_runnable("linux/arm64", &[]));
         assert!(uploaded_image_is_runnable("linux/riscv64", &[]));
+    }
+
+    #[test]
+    fn internal_local_image_tags_are_unique_and_project_scoped() {
+        let first = platform_local_image_tag(7, 11, "claim");
+        let second = platform_local_image_tag(8, 11, "claim");
+        let another = platform_local_image_tag(7, 11, "claim");
+
+        assert!(first.starts_with("temps.internal/project-7/environment-11/claim-"));
+        assert!(second.starts_with("temps.internal/project-8/environment-11/claim-"));
+        assert_ne!(
+            first, another,
+            "each claim must get an immutable unique tag"
+        );
+        assert!(is_reserved_local_image_ref(&first));
+        assert!(!is_reserved_local_image_ref("plugin-built-image:latest"));
+    }
+
+    #[test]
+    fn direct_http_callers_cannot_claim_local_daemon_images() {
+        assert!(authorize_local_image_claim(true, None).is_err());
+        assert!(authorize_local_image_claim(false, None).is_ok());
+
+        let verified = VerifiedPluginApiCaller::new("trusted-builder");
+        assert!(authorize_local_image_claim(true, Some(&verified)).is_ok());
+        assert_eq!(verified.plugin_name(), "trusted-builder");
     }
 
     #[test]

--- a/crates/temps-deployments/src/jobs/pull_external_image.rs
+++ b/crates/temps-deployments/src/jobs/pull_external_image.rs
@@ -257,19 +257,75 @@ impl WorkflowTask for PullExternalImageJob {
             }
         }
 
+        // A failed pull is not automatically a failed deploy: the image may
+        // already be in the local daemon. That is how a plugin deploys a
+        // container it built on this host without shipping the whole tarball
+        // through the platform channel, which caps a body at 32 MiB.
+        //
+        // The pull is attempted first and only its *failure* falls back.
+        // Checking locally up front would pin `nginx:latest` to whatever copy
+        // this host happened to have, silently never updating.
+        //
+        // The fallback is restricted to references with no registry host, and
+        // that restriction is load-bearing rather than cosmetic. The daemon is
+        // shared by every tenant and `deploy/image-upload` lets a caller
+        // `docker load` a tarball and tag it with any reference they like. If
+        // a registry-qualified name could resolve locally, one tenant could
+        // plant `ghcr.io/victim/app:v1` and wait: the next time the victim's
+        // own pull failed — an expired credential, a rate limit, a registry
+        // blip — their deploy would silently run the planted image with the
+        // victim's environment variables injected. Refusing to resolve
+        // anything registry-qualified from local state means a name that
+        // *claims* to come from a registry can only ever come from one.
+        //
+        // A bare `nginx:latest` is still plantable this way; closing that
+        // needs uploaded tags namespaced per project, which is a separate
+        // change to the upload endpoint.
         if !pull_succeeded {
             if let Some(error) = last_error {
-                return Ok(JobResult::failure(
-                    context,
-                    format!("Failed to pull image {}: {}", self.image_ref, error),
-                ));
+                let local_ok = registry.is_none();
+                match self.docker.inspect_image(&self.image_ref).await {
+                    Ok(_) if local_ok => {
+                        self.log(
+                            LogLevel::Info,
+                            &format!(
+                                "📦 Could not pull {} ({error}) — using the copy already in \
+                                 this host's Docker. If you expected a registry image, the \
+                                 local one may be stale.",
+                                self.image_ref
+                            ),
+                        )
+                        .await;
+                    }
+                    Ok(_) => {
+                        return Ok(JobResult::failure(
+                            context,
+                            format!(
+                                "Failed to pull image {}: {error}. A copy exists on this host, \
+                                 but it will not be used: the reference names a registry, and \
+                                 resolving that from local state would let an image planted \
+                                 here stand in for the registry's. Push the image, or deploy \
+                                 it under a name with no registry host.",
+                                self.image_ref
+                            ),
+                        ));
+                    }
+                    Err(_) => {
+                        return Ok(JobResult::failure(
+                            context,
+                            format!(
+                                "Failed to pull image {}: {error}. It is not present in this \
+                                 host's Docker either.",
+                                self.image_ref
+                            ),
+                        ));
+                    }
+                }
             }
-            // Check if we can still find the image (might have been pulled previously)
         }
 
         // Inspect the image to get details
-        self.log(LogLevel::Info, "🔍 Inspecting pulled image...")
-            .await;
+        self.log(LogLevel::Info, "🔍 Inspecting image...").await;
 
         let image_inspect = self
             .docker
@@ -392,5 +448,198 @@ mod tests {
         assert_eq!(registry, Some("myregistry.io".to_string()));
         assert_eq!(image_name, "myregistry.io/app");
         assert_eq!(tag, "latest");
+    }
+
+    /// An image built on this host and pushed nowhere still deploys.
+    ///
+    /// This is how a plugin ships a container without pushing the whole
+    /// tarball through the platform channel, which caps bodies at 32 MiB —
+    /// smaller than any image with a real runtime in it. The pull is expected
+    /// to fail here (the tag exists in no registry); the job must fall back to
+    /// the local copy rather than failing the deploy.
+    #[tokio::test]
+    async fn a_locally_built_image_deploys_without_a_registry() {
+        let Ok(docker) = bollard::Docker::connect_with_local_defaults() else {
+            println!("Docker not available, skipping");
+            return;
+        };
+        if docker.ping().await.is_err() {
+            println!("Docker not available, skipping");
+            return;
+        }
+        let docker = Arc::new(docker);
+
+        // `hello-world` is a few KB and is the smallest thing that is
+        // unambiguously a real image.
+        docker
+            .create_image(
+                Some(
+                    CreateImageOptionsBuilder::new()
+                        .from_image("hello-world:latest")
+                        .build(),
+                ),
+                None,
+                None,
+            )
+            .for_each(|_| async {})
+            .await;
+        if docker.inspect_image("hello-world:latest").await.is_err() {
+            println!("Could not fetch a base image (offline?), skipping");
+            return;
+        }
+
+        // A tag that cannot resolve anywhere: no registry has it, and it is
+        // unique per run so a leftover from a previous run cannot mask a
+        // regression.
+        let local_only = format!("temps-local-only-{}:test", uuid::Uuid::new_v4().simple());
+        docker
+            .tag_image(
+                "hello-world:latest",
+                Some(
+                    bollard::query_parameters::TagImageOptionsBuilder::new()
+                        .repo(local_only.split(':').next().unwrap_or(&local_only))
+                        .tag("test")
+                        .build(),
+                ),
+            )
+            .await
+            .expect("tagging a present image should succeed");
+
+        let job = PullExternalImageJob::new(
+            "local-image".to_string(),
+            local_only.clone(),
+            None,
+            docker.clone(),
+        );
+        let context = crate::test_utils::create_test_context("run-1".into(), 1, 1, 1);
+        let result = job.execute(context).await.expect("job should not error");
+
+        let _ = docker
+            .remove_image(
+                &local_only,
+                None::<bollard::query_parameters::RemoveImageOptions>,
+                None,
+            )
+            .await;
+
+        assert_eq!(
+            result.status,
+            temps_core::JobStatus::Success,
+            "a locally-built image must deploy without a registry, got: {:?}",
+            result.message
+        );
+    }
+
+    /// A registry-qualified name must never resolve from local state.
+    ///
+    /// The daemon is shared by every tenant and `deploy/image-upload` lets a
+    /// caller tag a loaded tarball with any reference. If this fell back, one
+    /// tenant could plant `ghcr.io/victim/app:v1` and wait for the victim's
+    /// own pull to fail — an expired credential, a rate limit — at which point
+    /// their deploy would run the planted image with the victim's environment
+    /// variables injected. Cross-tenant, and silent.
+    #[tokio::test]
+    async fn a_registry_qualified_name_never_resolves_from_local_state() {
+        let Ok(docker) = bollard::Docker::connect_with_local_defaults() else {
+            println!("Docker not available, skipping");
+            return;
+        };
+        if docker.ping().await.is_err() {
+            println!("Docker not available, skipping");
+            return;
+        }
+        let docker = Arc::new(docker);
+
+        docker
+            .create_image(
+                Some(
+                    CreateImageOptionsBuilder::new()
+                        .from_image("hello-world:latest")
+                        .build(),
+                ),
+                None,
+                None,
+            )
+            .for_each(|_| async {})
+            .await;
+        if docker.inspect_image("hello-world:latest").await.is_err() {
+            println!("Could not fetch a base image (offline?), skipping");
+            return;
+        }
+
+        // Stand in for the planted image: registry-qualified, present locally,
+        // and pullable from nowhere.
+        let planted_repo = format!("ghcr.io/temps-e2e-victim/{}", uuid::Uuid::new_v4().simple());
+        let planted = format!("{planted_repo}:v1");
+        docker
+            .tag_image(
+                "hello-world:latest",
+                Some(
+                    bollard::query_parameters::TagImageOptionsBuilder::new()
+                        .repo(&planted_repo)
+                        .tag("v1")
+                        .build(),
+                ),
+            )
+            .await
+            .expect("tagging a present image should succeed");
+
+        let job =
+            PullExternalImageJob::new("planted".to_string(), planted.clone(), None, docker.clone());
+        let context = crate::test_utils::create_test_context("run-3".into(), 1, 1, 1);
+        let result = job.execute(context).await.expect("job should not error");
+
+        let _ = docker
+            .remove_image(
+                &planted,
+                None::<bollard::query_parameters::RemoveImageOptions>,
+                None,
+            )
+            .await;
+
+        assert_eq!(
+            result.status,
+            temps_core::JobStatus::Failure,
+            "a registry-qualified reference must not be satisfied by a local image"
+        );
+    }
+
+    /// The local fallback must not swallow a genuinely missing image.
+    ///
+    /// The failure mode it guards against is the worst kind: a typo'd or
+    /// deleted image reference sailing past the pull step and only blowing up
+    /// later, at container creation, with an error that no longer mentions the
+    /// registry.
+    #[tokio::test]
+    async fn an_image_that_exists_nowhere_still_fails() {
+        let Ok(docker) = bollard::Docker::connect_with_local_defaults() else {
+            println!("Docker not available, skipping");
+            return;
+        };
+        if docker.ping().await.is_err() {
+            println!("Docker not available, skipping");
+            return;
+        }
+
+        let missing = format!("temps-nonexistent-{}:test", uuid::Uuid::new_v4().simple());
+        let job = PullExternalImageJob::new(
+            "missing-image".to_string(),
+            missing.clone(),
+            None,
+            Arc::new(docker),
+        );
+        let context = crate::test_utils::create_test_context("run-2".into(), 1, 1, 1);
+        let result = job.execute(context).await.expect("job should not error");
+
+        assert_eq!(
+            result.status,
+            temps_core::JobStatus::Failure,
+            "an image in no registry and not on this host must fail the deploy"
+        );
+        let message = result.message.unwrap_or_default();
+        assert!(
+            message.contains(&missing),
+            "the failure must name the image that could not be found, got: {message}"
+        );
     }
 }

--- a/crates/temps-deployments/src/jobs/pull_external_image.rs
+++ b/crates/temps-deployments/src/jobs/pull_external_image.rs
@@ -257,71 +257,19 @@ impl WorkflowTask for PullExternalImageJob {
             }
         }
 
-        // A failed pull is not automatically a failed deploy: the image may
-        // already be in the local daemon. That is how a plugin deploys a
-        // container it built on this host without shipping the whole tarball
-        // through the platform channel, which caps a body at 32 MiB.
-        //
-        // The pull is attempted first and only its *failure* falls back.
-        // Checking locally up front would pin `nginx:latest` to whatever copy
-        // this host happened to have, silently never updating.
-        //
-        // The fallback is restricted to references with no registry host, and
-        // that restriction is load-bearing rather than cosmetic. The daemon is
-        // shared by every tenant and `deploy/image-upload` lets a caller
-        // `docker load` a tarball and tag it with any reference they like. If
-        // a registry-qualified name could resolve locally, one tenant could
-        // plant `ghcr.io/victim/app:v1` and wait: the next time the victim's
-        // own pull failed — an expired credential, a rate limit, a registry
-        // blip — their deploy would silently run the planted image with the
-        // victim's environment variables injected. Refusing to resolve
-        // anything registry-qualified from local state means a name that
-        // *claims* to come from a registry can only ever come from one.
-        //
-        // A bare `nginx:latest` is still plantable this way; closing that
-        // needs uploaded tags namespaced per project, which is a separate
-        // change to the upload endpoint.
         if !pull_succeeded {
-            if let Some(error) = last_error {
-                let local_ok = registry.is_none();
-                match self.docker.inspect_image(&self.image_ref).await {
-                    Ok(_) if local_ok => {
-                        self.log(
-                            LogLevel::Info,
-                            &format!(
-                                "📦 Could not pull {} ({error}) — using the copy already in \
-                                 this host's Docker. If you expected a registry image, the \
-                                 local one may be stale.",
-                                self.image_ref
-                            ),
-                        )
-                        .await;
-                    }
-                    Ok(_) => {
-                        return Ok(JobResult::failure(
-                            context,
-                            format!(
-                                "Failed to pull image {}: {error}. A copy exists on this host, \
-                                 but it will not be used: the reference names a registry, and \
-                                 resolving that from local state would let an image planted \
-                                 here stand in for the registry's. Push the image, or deploy \
-                                 it under a name with no registry host.",
-                                self.image_ref
-                            ),
-                        ));
-                    }
-                    Err(_) => {
-                        return Ok(JobResult::failure(
-                            context,
-                            format!(
-                                "Failed to pull image {}: {error}. It is not present in this \
-                                 host's Docker either.",
-                                self.image_ref
-                            ),
-                        ));
-                    }
-                }
-            }
+            let error = last_error.unwrap_or_else(|| {
+                "the registry pull ended without confirming a downloaded image".to_string()
+            });
+            return Ok(JobResult::failure(
+                context,
+                format!(
+                    "Failed to pull image {} from its registry: {error}. Local daemon images \
+                     are never used as a fallback; use the authorized local-image claim path \
+                     for an image built on this host.",
+                    self.image_ref
+                ),
+            ));
         }
 
         // Inspect the image to get details
@@ -450,15 +398,10 @@ mod tests {
         assert_eq!(tag, "latest");
     }
 
-    /// An image built on this host and pushed nowhere still deploys.
-    ///
-    /// This is how a plugin ships a container without pushing the whole
-    /// tarball through the platform channel, which caps bodies at 32 MiB —
-    /// smaller than any image with a real runtime in it. The pull is expected
-    /// to fail here (the tag exists in no registry); the job must fall back to
-    /// the local copy rather than failing the deploy.
+    /// Even a bare tag already present locally must never satisfy a registry
+    /// pull. Local images use the separately authorized claim flow.
     #[tokio::test]
-    async fn a_locally_built_image_deploys_without_a_registry() {
+    async fn an_arbitrary_bare_local_tag_never_satisfies_a_failed_pull() {
         let Ok(docker) = bollard::Docker::connect_with_local_defaults() else {
             println!("Docker not available, skipping");
             return;
@@ -522,12 +465,11 @@ mod tests {
             )
             .await;
 
-        assert_eq!(
-            result.status,
-            temps_core::JobStatus::Success,
-            "a locally-built image must deploy without a registry, got: {:?}",
-            result.message
-        );
+        assert_eq!(result.status, temps_core::JobStatus::Failure);
+        assert!(result
+            .message
+            .as_deref()
+            .is_some_and(|message| message.contains("never used as a fallback")));
     }
 
     /// A registry-qualified name must never resolve from local state.

--- a/crates/temps-deployments/src/jobs/verify_local_image.rs
+++ b/crates/temps-deployments/src/jobs/verify_local_image.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use temps_core::{JobResult, WorkflowContext, WorkflowError, WorkflowTask};
 use temps_logs::{LogLevel, LogService};
-use tracing::{debug, error, info};
+use tracing::{error, info};
 
 /// Output from VerifyLocalImageJob
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -181,17 +181,16 @@ impl WorkflowTask for VerifyLocalImageJob {
             let actual_normalized = normalize_id(&image_id);
             let expected_normalized = normalize_id(expected_id);
 
-            if !actual_normalized
-                .starts_with(&expected_normalized[..12.min(expected_normalized.len())])
-            {
-                let warning_msg = format!(
-                    "Image ID mismatch: expected '{}', found '{}'. Proceeding with found image.",
+            if actual_normalized != expected_normalized {
+                let error_msg = format!(
+                    "Image ID mismatch for '{}': expected '{}', found '{}'. Refusing to deploy a changed local image.",
+                    self.image_ref,
                     expected_id, image_id
                 );
-                debug!("{}", warning_msg);
-                self.log(LogLevel::Warning, &format!("⚠️ {}", warning_msg))
+                error!("{}", error_msg);
+                self.log(LogLevel::Error, &format!("❌ {}", error_msg))
                     .await;
-                // Don't fail - the image exists, just log the mismatch
+                return Ok(JobResult::failure(context, error_msg));
             }
         }
 
@@ -279,5 +278,52 @@ mod tests {
         );
 
         assert_eq!(job.extract_tag(), "v1.0");
+    }
+
+    #[tokio::test]
+    async fn immutable_image_id_mismatch_fails_closed() {
+        use bollard::query_parameters::CreateImageOptionsBuilder;
+        use futures::StreamExt;
+
+        let Ok(docker) = bollard::Docker::connect_with_local_defaults() else {
+            println!("Docker not available, skipping");
+            return;
+        };
+        if docker.ping().await.is_err() {
+            println!("Docker not available, skipping");
+            return;
+        }
+
+        docker
+            .create_image(
+                Some(
+                    CreateImageOptionsBuilder::new()
+                        .from_image("hello-world:latest")
+                        .build(),
+                ),
+                None,
+                None,
+            )
+            .for_each(|_| async {})
+            .await;
+        if docker.inspect_image("hello-world:latest").await.is_err() {
+            println!("Could not fetch a test image (offline?), skipping");
+            return;
+        }
+
+        let job = VerifyLocalImageJob::new(
+            "verify-immutable".to_string(),
+            "hello-world:latest".to_string(),
+            Some("sha256:0000000000000000000000000000000000000000000000000000000000000000".into()),
+            Arc::new(docker),
+        );
+        let context = crate::test_utils::create_test_context("run-mismatch".into(), 1, 1, 1);
+        let result = job.execute(context).await.expect("verification result");
+
+        assert_eq!(result.status, temps_core::JobStatus::Failure);
+        assert!(result
+            .message
+            .as_deref()
+            .is_some_and(|message| message.contains("Refusing to deploy a changed local image")));
     }
 }

--- a/crates/temps-environments/src/services/environment_service.rs
+++ b/crates/temps-environments/src/services/environment_service.rs
@@ -1107,11 +1107,11 @@ mod tests {
     fn public_url_preserves_external_http_scheme_and_non_default_port() {
         assert_eq!(
             format_public_url(
-                "sandbox-smoke2-production.localho.st",
-                Some("http://localho.st:8240"),
+                "app-production.example.test",
+                Some("http://example.test:8240"),
                 8240,
             ),
-            "http://sandbox-smoke2-production.localho.st:8240"
+            "http://app-production.example.test:8240"
         );
     }
 

--- a/crates/temps-environments/src/services/environment_service.rs
+++ b/crates/temps-environments/src/services/environment_service.rs
@@ -94,6 +94,35 @@ pub struct DomainEnvironment {
     pub slug: String,
 }
 
+/// Build a browser-reachable URL for a preview-domain hostname.
+///
+/// `external_url` is the public origin of the Temps instance, so its scheme
+/// and explicit port are authoritative. The hostname itself remains the
+/// environment/custom-domain hostname supplied by the caller.
+fn format_public_url(host: &str, external_url: Option<&str>, proxy_port: u16) -> String {
+    let (protocol, port) = match external_url {
+        Some(origin) => match origin.parse::<http::Uri>() {
+            Ok(uri) => (
+                uri.scheme_str().unwrap_or("https").to_owned(),
+                uri.authority().and_then(http::uri::Authority::port_u16),
+            ),
+            Err(_) if origin.starts_with("http://") => ("http".to_owned(), None),
+            Err(_) => ("https".to_owned(), None),
+        },
+        None => ("http".to_owned(), Some(proxy_port)),
+    };
+    let is_default_port = matches!(
+        (protocol.as_str(), port),
+        ("http", Some(80)) | ("https", Some(443))
+    );
+    let port_suffix = match port {
+        Some(_) if is_default_port => String::new(),
+        Some(port) => format!(":{port}"),
+        None => String::new(),
+    };
+    format!("{protocol}://{host}{port_suffix}")
+}
+
 #[derive(Clone)]
 pub struct EnvironmentService {
     db: Arc<temps_database::DbConnection>,
@@ -135,45 +164,11 @@ impl EnvironmentService {
         let domain = PublicHostnameStrategy::Standard
             .environment_hostname(&settings.preview_domain, environment_slug);
 
-        // Determine protocol - use https if external_url is configured, otherwise http
-        let protocol = if settings.external_url.is_some() {
-            "https"
-        } else {
-            "http"
-        };
-
-        // Append the proxy port when it isn't the protocol's default — the
-        // proxy listens on `ServerConfig.address` (e.g. `:8080`), so without
-        // this the URL points at :80/:443 and is unreachable on a local /
-        // non-standard-port instance. Only applies to the preview-domain path:
-        // when `external_url` is set, that URL already encodes the real public
-        // host/port (typically 443) and the internal proxy port is irrelevant.
-        let port_suffix = self.port_suffix(protocol, settings.external_url.is_some());
-
-        // <scheme>://<slug>.<preview_domain>[:port]
-        format!("{}://{}{}", protocol, domain, port_suffix)
-    }
-
-    /// Returns `:<port>` when the proxy listens on a non-default port for the
-    /// given scheme (i.e. not 80 for http, not 443 for https), otherwise an
-    /// empty string. The port comes from the Rust proxy listener address via
-    /// [`ConfigService::proxy_port`] — the single source of truth — rather than
-    /// being parsed out of `preview_domain`.
-    ///
-    /// `external_url_set` short-circuits to no suffix: behind a reverse proxy /
-    /// public domain the externally-visible port is whatever `external_url`
-    /// uses, not the internal proxy listener port.
-    fn port_suffix(&self, protocol: &str, external_url_set: bool) -> String {
-        if external_url_set {
-            return String::new();
-        }
-        let port = self.config_service.proxy_port();
-        let is_default = (protocol == "http" && port == 80) || (protocol == "https" && port == 443);
-        if is_default {
-            String::new()
-        } else {
-            format!(":{}", port)
-        }
+        format_public_url(
+            &domain,
+            settings.external_url.as_deref(),
+            self.config_service.proxy_port(),
+        )
     }
 
     /// Compute the full FQDN for an environment (without protocol)
@@ -188,13 +183,11 @@ impl EnvironmentService {
     /// the input is expected to already be a fully-qualified hostname.
     pub async fn compute_custom_domain_url(&self, domain: &str) -> String {
         let settings = self.config_service.get_settings().await.unwrap_or_default();
-        let protocol = if settings.external_url.is_some() {
-            "https"
-        } else {
-            "http"
-        };
-        let port_suffix = self.port_suffix(protocol, settings.external_url.is_some());
-        format!("{}://{}{}", protocol, domain, port_suffix)
+        format_public_url(
+            domain,
+            settings.external_url.as_deref(),
+            self.config_service.proxy_port(),
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1109,6 +1102,38 @@ impl EnvironmentService {
 mod tests {
     use super::*;
     use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+
+    #[test]
+    fn public_url_preserves_external_http_scheme_and_non_default_port() {
+        assert_eq!(
+            format_public_url(
+                "sandbox-smoke2-production.localho.st",
+                Some("http://localho.st:8240"),
+                8240,
+            ),
+            "http://sandbox-smoke2-production.localho.st:8240"
+        );
+    }
+
+    #[test]
+    fn public_url_preserves_external_https_custom_port() {
+        assert_eq!(
+            format_public_url(
+                "app-production.example.test",
+                Some("https://temps.example.test:8443"),
+                8080,
+            ),
+            "https://app-production.example.test:8443"
+        );
+    }
+
+    #[test]
+    fn public_url_uses_proxy_port_without_external_origin() {
+        assert_eq!(
+            format_public_url("app-production.localho.st", None, 8240),
+            "http://app-production.localho.st:8240"
+        );
+    }
 
     fn make_service(db: sea_orm::DatabaseConnection) -> EnvironmentService {
         let server_config = temps_config::ServerConfig::new(

--- a/crates/temps-external-plugins/Cargo.toml
+++ b/crates/temps-external-plugins/Cargo.toml
@@ -14,9 +14,11 @@ temps-config = { path = "../temps-config" }
 temps-entities = { path = "../temps-entities" }
 temps-presets = { path = "../temps-presets" }
 sea-orm = { workspace = true }
+async-trait = { workspace = true }
 axum = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
+http-body-util = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { version = "0.1", features = ["tokio", "client-legacy"] }
 serde = { workspace = true }

--- a/crates/temps-external-plugins/src/channel.rs
+++ b/crates/temps-external-plugins/src/channel.rs
@@ -24,6 +24,7 @@ use temps_core::external_plugin::manifest::PluginCapability;
 use temps_core::external_plugin::PluginEvent;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::Message;
 use tracing::{debug, error, info, warn};
 
@@ -48,6 +49,7 @@ impl PluginChannel {
         db: Arc<DatabaseConnection>,
         host_api: Arc<HostApiSlot>,
         capabilities: Vec<PluginCapability>,
+        auth_secret: &str,
     ) -> Option<Self> {
         let socket_path_str = socket_path.to_string_lossy().to_string();
 
@@ -79,7 +81,25 @@ impl PluginChannel {
         };
 
         let uri = format!("ws://localhost{}", PLUGIN_CHANNEL_PATH);
-        let ws_stream = match tokio_tungstenite::client_async(&uri, stream).await {
+        let mut request = match uri.into_client_request() {
+            Ok(request) => request,
+            Err(error) => {
+                warn!(plugin = %plugin_name, "Cannot build channel handshake: {error}");
+                return None;
+            }
+        };
+        let auth_header = match auth_secret.parse() {
+            Ok(value) => value,
+            Err(error) => {
+                warn!(plugin = %plugin_name, "Cannot encode channel authentication: {error}");
+                return None;
+            }
+        };
+        request.headers_mut().insert(
+            temps_core::external_plugin::headers::AUTH_SIGNATURE,
+            auth_header,
+        );
+        let ws_stream = match tokio_tungstenite::client_async(request, stream).await {
             Ok((ws, _resp)) => {
                 debug!(
                     plugin = %plugin_name,

--- a/crates/temps-external-plugins/src/channel.rs
+++ b/crates/temps-external-plugins/src/channel.rs
@@ -20,6 +20,7 @@ use futures::stream::StreamExt;
 use futures::SinkExt;
 use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder};
 use temps_core::external_plugin::channel::*;
+use temps_core::external_plugin::manifest::PluginCapability;
 use temps_core::external_plugin::PluginEvent;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -45,6 +46,8 @@ impl PluginChannel {
         socket_path: &Path,
         plugin_name: String,
         db: Arc<DatabaseConnection>,
+        host_api: Arc<HostApiSlot>,
+        capabilities: Vec<PluginCapability>,
     ) -> Option<Self> {
         let socket_path_str = socket_path.to_string_lossy().to_string();
 
@@ -150,17 +153,47 @@ impl PluginChannel {
                 let msg: ChannelMessage = match serde_json::from_str(&text) {
                     Ok(m) => m,
                     Err(e) => {
-                        warn!(
-                            plugin = %reader_plugin_name,
-                            "Invalid channel message from plugin: {}", e
-                        );
+                        // A plugin built against a newer Temps can name a call
+                        // this build has no variant for, and the envelope then
+                        // fails to deserialize as a whole. Answer it: leaving
+                        // the plugin's request unreplied hangs its caller until
+                        // the channel closes, which looks like a freeze rather
+                        // than an incompatibility.
+                        match peek_request_id(&text) {
+                            Some(id) => {
+                                warn!(
+                                    plugin = %reader_plugin_name,
+                                    "Unsupported channel request {}: {}", id, e
+                                );
+                                let _ =
+                                    reader_tx.send(ChannelMessage::Response(ChannelResponse::err(
+                                        id,
+                                        ChannelErrorCode::MethodNotFound,
+                                        format!(
+                                            "This Temps build does not support that channel \
+                                             call ({e}); rebuild the plugin against this version"
+                                        ),
+                                    )));
+                            }
+                            None => warn!(
+                                plugin = %reader_plugin_name,
+                                "Invalid channel message from plugin: {}", e
+                            ),
+                        }
                         continue;
                     }
                 };
 
                 match msg {
                     ChannelMessage::Request(req) => {
-                        let response = dispatch_request(&reader_plugin_name, &db, &req).await;
+                        let response = dispatch_request(
+                            &reader_plugin_name,
+                            &db,
+                            &host_api,
+                            &capabilities,
+                            &req,
+                        )
+                        .await;
                         let _ = reader_tx.send(ChannelMessage::Response(response));
                     }
                     _ => {
@@ -206,314 +239,315 @@ impl Drop for PluginChannel {
     }
 }
 
+/// Recover just the correlation id from a request this build cannot parse.
+///
+/// Deliberately minimal: it must succeed on messages the strongly-typed
+/// deserializer rejected, so it looks at nothing but `id`.
+fn peek_request_id(text: &str) -> Option<u64> {
+    #[derive(serde::Deserialize)]
+    struct IdOnly {
+        id: u64,
+    }
+    serde_json::from_str::<IdOnly>(text).ok().map(|p| p.id)
+}
+
+// ── Host API bridge ────────────────────────────────────────────────────
+
+/// Runs an [`ApiCall`] against the platform's own HTTP router.
+///
+/// A trait rather than a concrete type because this crate must not know how
+/// the console assembles its router — and cannot, since the router contains
+/// this crate's own routes. The console builds the router, then hands an
+/// implementation back through
+/// [`crate::service::ExternalPluginsService::set_host_api`].
+#[async_trait::async_trait]
+pub trait HostApiBridge: Send + Sync {
+    /// Dispatch `call` as `plugin`, resolving the acting user from the
+    /// call's actor token.
+    async fn call(&self, plugin: &str, call: ApiCall) -> Result<ApiCallResult, ChannelError>;
+}
+
+/// Late-bound holder for the [`HostApiBridge`].
+///
+/// Channels are opened while plugins start, which is *before* the console
+/// has finished assembling the router they will call into — the router
+/// contains this crate's own routes, so it cannot exist first. The slot is
+/// therefore shared at connect time and read on each call, so a plugin that
+/// connected during startup still reaches the router once it exists.
+pub type HostApiSlot = tokio::sync::RwLock<Option<Arc<dyn HostApiBridge>>>;
+
 // ── Request dispatch ───────────────────────────────────────────────────
 
-/// Route a plugin request to the appropriate query handler.
+/// Route a plugin request to the handler that serves it.
+///
+/// The match is exhaustive over [`PlatformCallRequest`] with no catch-all
+/// arm: adding a call to the protocol without handling it here is a compile
+/// error, which is the point of the typed protocol. A method this build does
+/// not know cannot reach here at all — it fails to deserialize, and the
+/// reader loop answers `MethodNotFound`.
 async fn dispatch_request(
     plugin_name: &str,
     db: &DatabaseConnection,
+    host_api: &HostApiSlot,
+    capabilities: &[PluginCapability],
     req: &ChannelRequest,
 ) -> ChannelResponse {
     debug!(
         plugin = %plugin_name,
-        method = %req.method,
+        method = %req.call.method_name(),
         id = req.id,
         "Dispatching channel request"
     );
 
-    match req.method.as_str() {
-        "get_project" => handle_get_project(db, req).await,
-        "list_projects" => handle_list_projects(db, req).await,
-        "get_environment" => handle_get_environment(db, req).await,
-        "list_environments" => handle_list_environments(db, req).await,
-        "get_deployment" => handle_get_deployment(db, req).await,
-        "get_last_deployment" => handle_get_last_deployment(db, req).await,
-        "list_deployments" => handle_list_deployments(db, req).await,
-        _ => ChannelResponse::err(
-            req.id,
-            ChannelErrorCode::MethodNotFound,
-            format!("Unknown method: {}", req.method),
-        ),
-    }
-}
-
-// ── Method handlers ────────────────────────────────────────────────────
-
-async fn handle_get_project(db: &DatabaseConnection, req: &ChannelRequest) -> ChannelResponse {
-    let project_id = match req.params.get("project_id").and_then(|v| v.as_i64()) {
-        Some(id) => id as i32,
-        None => {
-            return ChannelResponse::err(
-                req.id,
-                ChannelErrorCode::InvalidParams,
-                "Missing required parameter: project_id",
-            )
+    let outcome = match &req.call {
+        PlatformCallRequest::GetProject(p) => handle_get_project(db, p).await,
+        PlatformCallRequest::ListProjects(p) => handle_list_projects(db, p).await,
+        PlatformCallRequest::GetEnvironment(p) => handle_get_environment(db, p).await,
+        PlatformCallRequest::ListEnvironments(p) => handle_list_environments(db, p).await,
+        PlatformCallRequest::GetDeployment(p) => handle_get_deployment(db, p).await,
+        PlatformCallRequest::GetLastDeployment(p) => handle_get_last_deployment(db, p).await,
+        PlatformCallRequest::ListDeployments(p) => handle_list_deployments(db, p).await,
+        PlatformCallRequest::ApiCall(call) => {
+            handle_api_call(plugin_name, host_api, capabilities, call.clone()).await
         }
     };
 
-    use temps_entities::projects;
-
-    match projects::Entity::find_by_id(project_id)
-        .filter(projects::Column::IsDeleted.eq(false))
-        .one(db)
-        .await
-    {
-        Ok(Some(project)) => {
-            let info = project_to_info(&project);
-            ChannelResponse::ok(req.id, serde_json::to_value(info).unwrap())
-        }
-        Ok(None) => ChannelResponse::err(
-            req.id,
-            ChannelErrorCode::NotFound,
-            format!("Project {} not found", project_id),
-        ),
-        Err(e) => ChannelResponse::err(
-            req.id,
-            ChannelErrorCode::Internal,
-            format!("Database error: {}", e),
-        ),
+    match outcome {
+        Ok(result) => ChannelResponse::ok(req.id, result),
+        Err(err) => ChannelResponse {
+            id: req.id,
+            outcome: CallOutcome::Err(err),
+        },
     }
 }
 
-async fn handle_list_projects(db: &DatabaseConnection, req: &ChannelRequest) -> ChannelResponse {
+/// Serve an [`ApiCall`] through the platform's own router.
+async fn handle_api_call(
+    plugin_name: &str,
+    host_api: &HostApiSlot,
+    capabilities: &[PluginCapability],
+    call: ApiCall,
+) -> Result<PlatformCallResponse, ChannelError> {
+    // Capability first: refuse before the request reaches the router, and
+    // name what is missing. A plugin author debugging this alone cannot
+    // guess "add api_write to your manifest" from a bare 403.
+    let required = PluginCapability::for_method(call.method);
+    if !capabilities.contains(&required) {
+        return Err(ChannelError::new(
+            ChannelErrorCode::PermissionDenied,
+            format!(
+                "Plugin '{plugin_name}' called {} {} but does not declare the '{}' capability;                  add it to the plugin manifest",
+                call.method.as_str(),
+                call.path,
+                required.as_str()
+            ),
+        ));
+    }
+
+    // Say which capability is missing rather than a bare "unavailable": an
+    // operator running an embedding build that never wired the bridge has no
+    // other way to find out why every plugin API call fails.
+    let Some(api) = host_api.read().await.clone() else {
+        return Err(ChannelError::new(
+            ChannelErrorCode::Internal,
+            format!(
+                "This Temps build did not wire the host API bridge, so plugin '{plugin_name}' \
+                 cannot call the platform API over the channel"
+            ),
+        ));
+    };
+    api.call(plugin_name, call)
+        .await
+        .map(PlatformCallResponse::ApiCall)
+}
+
+// ── Method handlers ────────────────────────────────────────────────────
+//
+// Each takes its own parameter struct and returns the response variant that
+// belongs to it. Nothing parses JSON by hand any more: a missing or
+// mistyped field is a deserialization failure on the envelope, reported
+// once, instead of every handler re-implementing "missing required
+// parameter".
+
+async fn handle_get_project(
+    db: &DatabaseConnection,
+    params: &GetProject,
+) -> Result<PlatformCallResponse, ChannelError> {
     use temps_entities::projects;
 
-    let limit = req
-        .params
-        .get("limit")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(100)
-        .min(100);
+    let project = projects::Entity::find_by_id(params.project_id)
+        .filter(projects::Column::IsDeleted.eq(false))
+        .one(db)
+        .await
+        .map_err(|e| db_error("project", e))?
+        .ok_or_else(|| {
+            ChannelError::new(
+                ChannelErrorCode::NotFound,
+                format!("Project {} not found", params.project_id),
+            )
+        })?;
 
-    match projects::Entity::find()
+    Ok(PlatformCallResponse::GetProject(project_to_info(&project)))
+}
+
+async fn handle_list_projects(
+    db: &DatabaseConnection,
+    _params: &ListProjects,
+) -> Result<PlatformCallResponse, ChannelError> {
+    use temps_entities::projects;
+
+    let projects = projects::Entity::find()
         .filter(projects::Column::IsDeleted.eq(false))
         .order_by_asc(projects::Column::Name)
         .all(db)
         .await
-    {
-        Ok(projects) => {
-            let infos: Vec<ProjectInfo> = projects
-                .iter()
-                .take(limit as usize)
-                .map(project_to_info)
-                .collect();
-            ChannelResponse::ok(req.id, serde_json::to_value(infos).unwrap())
-        }
-        Err(e) => ChannelResponse::err(
-            req.id,
-            ChannelErrorCode::Internal,
-            format!("Database error: {}", e),
-        ),
-    }
+        .map_err(|e| db_error("projects", e))?;
+
+    Ok(PlatformCallResponse::ListProjects(
+        projects.iter().map(project_to_info).collect(),
+    ))
 }
 
-async fn handle_get_environment(db: &DatabaseConnection, req: &ChannelRequest) -> ChannelResponse {
-    let environment_id = match req.params.get("environment_id").and_then(|v| v.as_i64()) {
-        Some(id) => id as i32,
-        None => {
-            return ChannelResponse::err(
-                req.id,
-                ChannelErrorCode::InvalidParams,
-                "Missing required parameter: environment_id",
-            )
-        }
-    };
-
+async fn handle_get_environment(
+    db: &DatabaseConnection,
+    params: &GetEnvironment,
+) -> Result<PlatformCallResponse, ChannelError> {
     use temps_entities::environments;
 
-    match environments::Entity::find_by_id(environment_id)
+    let env = environments::Entity::find_by_id(params.environment_id)
         .filter(environments::Column::DeletedAt.is_null())
         .one(db)
         .await
-    {
-        Ok(Some(env)) => {
-            let info = environment_to_info(&env);
-            ChannelResponse::ok(req.id, serde_json::to_value(info).unwrap())
-        }
-        Ok(None) => ChannelResponse::err(
-            req.id,
-            ChannelErrorCode::NotFound,
-            format!("Environment {} not found", environment_id),
-        ),
-        Err(e) => ChannelResponse::err(
-            req.id,
-            ChannelErrorCode::Internal,
-            format!("Database error: {}", e),
-        ),
-    }
+        .map_err(|e| db_error("environment", e))?
+        .ok_or_else(|| {
+            ChannelError::new(
+                ChannelErrorCode::NotFound,
+                format!("Environment {} not found", params.environment_id),
+            )
+        })?;
+
+    Ok(PlatformCallResponse::GetEnvironment(environment_to_info(
+        &env,
+    )))
 }
 
 async fn handle_list_environments(
     db: &DatabaseConnection,
-    req: &ChannelRequest,
-) -> ChannelResponse {
-    let project_id = match req.params.get("project_id").and_then(|v| v.as_i64()) {
-        Some(id) => id as i32,
-        None => {
-            return ChannelResponse::err(
-                req.id,
-                ChannelErrorCode::InvalidParams,
-                "Missing required parameter: project_id",
-            )
-        }
-    };
-
+    params: &ListEnvironments,
+) -> Result<PlatformCallResponse, ChannelError> {
     use temps_entities::environments;
 
-    match environments::Entity::find()
-        .filter(environments::Column::ProjectId.eq(project_id))
+    let envs = environments::Entity::find()
+        .filter(environments::Column::ProjectId.eq(params.project_id))
         .filter(environments::Column::DeletedAt.is_null())
         .order_by_asc(environments::Column::Name)
         .all(db)
         .await
-    {
-        Ok(envs) => {
-            let infos: Vec<EnvironmentInfo> = envs.iter().map(environment_to_info).collect();
-            ChannelResponse::ok(req.id, serde_json::to_value(infos).unwrap())
-        }
-        Err(e) => ChannelResponse::err(
-            req.id,
-            ChannelErrorCode::Internal,
-            format!("Database error: {}", e),
-        ),
-    }
+        .map_err(|e| db_error("environments", e))?;
+
+    Ok(PlatformCallResponse::ListEnvironments(
+        envs.iter().map(environment_to_info).collect(),
+    ))
 }
 
-async fn handle_get_deployment(db: &DatabaseConnection, req: &ChannelRequest) -> ChannelResponse {
-    let deployment_id = match req.params.get("deployment_id").and_then(|v| v.as_i64()) {
-        Some(id) => id as i32,
-        None => {
-            return ChannelResponse::err(
-                req.id,
-                ChannelErrorCode::InvalidParams,
-                "Missing required parameter: deployment_id",
-            )
-        }
-    };
-
+async fn handle_get_deployment(
+    db: &DatabaseConnection,
+    params: &GetDeployment,
+) -> Result<PlatformCallResponse, ChannelError> {
     use temps_entities::deployments;
 
-    match deployments::Entity::find_by_id(deployment_id).one(db).await {
-        Ok(Some(dep)) => {
-            let info = deployment_to_info(&dep);
-            ChannelResponse::ok(req.id, serde_json::to_value(info).unwrap())
-        }
-        Ok(None) => ChannelResponse::err(
-            req.id,
-            ChannelErrorCode::NotFound,
-            format!("Deployment {} not found", deployment_id),
-        ),
-        Err(e) => ChannelResponse::err(
-            req.id,
-            ChannelErrorCode::Internal,
-            format!("Database error: {}", e),
-        ),
-    }
+    let dep = deployments::Entity::find_by_id(params.deployment_id)
+        .one(db)
+        .await
+        .map_err(|e| db_error("deployment", e))?
+        .ok_or_else(|| {
+            ChannelError::new(
+                ChannelErrorCode::NotFound,
+                format!("Deployment {} not found", params.deployment_id),
+            )
+        })?;
+
+    Ok(PlatformCallResponse::GetDeployment(deployment_to_info(
+        &dep,
+    )))
 }
 
 async fn handle_get_last_deployment(
     db: &DatabaseConnection,
-    req: &ChannelRequest,
-) -> ChannelResponse {
-    let project_id = match req.params.get("project_id").and_then(|v| v.as_i64()) {
-        Some(id) => id as i32,
-        None => {
-            return ChannelResponse::err(
-                req.id,
-                ChannelErrorCode::InvalidParams,
-                "Missing required parameter: project_id",
-            )
-        }
-    };
-
-    let environment_id = req
-        .params
-        .get("environment_id")
-        .and_then(|v| v.as_i64())
-        .map(|id| id as i32);
-
+    params: &GetLastDeployment,
+) -> Result<PlatformCallResponse, ChannelError> {
     use temps_entities::deployments;
 
     let mut query = deployments::Entity::find()
-        .filter(deployments::Column::ProjectId.eq(project_id))
+        .filter(deployments::Column::ProjectId.eq(params.project_id))
         .order_by_desc(deployments::Column::CreatedAt);
 
-    if let Some(env_id) = environment_id {
+    if let Some(env_id) = params.environment_id {
         query = query.filter(deployments::Column::EnvironmentId.eq(env_id));
     }
 
-    match query.one(db).await {
-        Ok(Some(dep)) => {
-            let info = deployment_to_info(&dep);
-            ChannelResponse::ok(req.id, serde_json::to_value(info).unwrap())
-        }
-        Ok(None) => ChannelResponse::err(
-            req.id,
-            ChannelErrorCode::NotFound,
-            format!(
-                "No deployments found for project {}{}",
-                project_id,
-                environment_id
-                    .map(|e| format!(" environment {}", e))
-                    .unwrap_or_default()
-            ),
-        ),
-        Err(e) => ChannelResponse::err(
-            req.id,
-            ChannelErrorCode::Internal,
-            format!("Database error: {}", e),
-        ),
-    }
+    let dep = query
+        .one(db)
+        .await
+        .map_err(|e| db_error("deployment", e))?
+        .ok_or_else(|| {
+            ChannelError::new(
+                ChannelErrorCode::NotFound,
+                format!(
+                    "No deployments found for project {}{}",
+                    params.project_id,
+                    params
+                        .environment_id
+                        .map(|e| format!(" environment {e}"))
+                        .unwrap_or_default()
+                ),
+            )
+        })?;
+
+    Ok(PlatformCallResponse::GetLastDeployment(deployment_to_info(
+        &dep,
+    )))
 }
 
-async fn handle_list_deployments(db: &DatabaseConnection, req: &ChannelRequest) -> ChannelResponse {
-    let project_id = match req.params.get("project_id").and_then(|v| v.as_i64()) {
-        Some(id) => id as i32,
-        None => {
-            return ChannelResponse::err(
-                req.id,
-                ChannelErrorCode::InvalidParams,
-                "Missing required parameter: project_id",
-            )
-        }
-    };
-
-    let environment_id = req
-        .params
-        .get("environment_id")
-        .and_then(|v| v.as_i64())
-        .map(|id| id as i32);
-
-    let limit = req
-        .params
-        .get("limit")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(20)
-        .min(100);
-
+async fn handle_list_deployments(
+    db: &DatabaseConnection,
+    params: &ListDeployments,
+) -> Result<PlatformCallResponse, ChannelError> {
     use sea_orm::QuerySelect;
     use temps_entities::deployments;
 
+    // Bounded regardless of what the plugin asks for: this runs against the
+    // control-plane database, and an unbounded fetch on a busy project is a
+    // memory spike on a small box.
+    let limit = params.limit.unwrap_or(20).min(100);
+
     let mut query = deployments::Entity::find()
-        .filter(deployments::Column::ProjectId.eq(project_id))
+        .filter(deployments::Column::ProjectId.eq(params.project_id))
         .order_by_desc(deployments::Column::CreatedAt)
         .limit(limit);
 
-    if let Some(env_id) = environment_id {
+    if let Some(env_id) = params.environment_id {
         query = query.filter(deployments::Column::EnvironmentId.eq(env_id));
     }
 
-    match query.all(db).await {
-        Ok(deps) => {
-            let infos: Vec<DeploymentInfo> = deps.iter().map(deployment_to_info).collect();
-            ChannelResponse::ok(req.id, serde_json::to_value(infos).unwrap())
-        }
-        Err(e) => ChannelResponse::err(
-            req.id,
-            ChannelErrorCode::Internal,
-            format!("Database error: {}", e),
-        ),
-    }
+    let deps = query
+        .all(db)
+        .await
+        .map_err(|e| db_error("deployments", e))?;
+
+    Ok(PlatformCallResponse::ListDeployments(
+        deps.iter().map(deployment_to_info).collect(),
+    ))
+}
+
+/// Database failures are internal errors, and the plugin is told which
+/// lookup failed so a plugin author can tell "no such project" from "the
+/// control plane is unwell".
+fn db_error(what: &str, e: sea_orm::DbErr) -> ChannelError {
+    ChannelError::new(
+        ChannelErrorCode::Internal,
+        format!("Failed to read {what} from the control-plane database: {e}"),
+    )
 }
 
 // ── Entity → DTO converters ────────────────────────────────────────────

--- a/crates/temps-external-plugins/src/event_listener.rs
+++ b/crates/temps-external-plugins/src/event_listener.rs
@@ -378,7 +378,10 @@ impl PluginEventListener {
             .uri(PLUGIN_EVENTS_PATH)
             .header(hyper::header::CONTENT_TYPE, "application/json")
             .header(hyper::header::HOST, "localhost")
-            .header("x-temps-auth", auth_secret)
+            .header(
+                temps_core::external_plugin::headers::AUTH_SIGNATURE,
+                auth_secret,
+            )
             .header("x-temps-request-id", uuid::Uuid::new_v4().to_string())
             .body(Body::from(body))
             .map_err(|e| format!("Failed to build request: {}", e))?;

--- a/crates/temps-external-plugins/src/event_listener.rs
+++ b/crates/temps-external-plugins/src/event_listener.rs
@@ -303,11 +303,14 @@ impl PluginEventListener {
 
         for manifest in manifests {
             if Self::manifest_subscribes_to(&manifest, event_type) {
-                if let Some(socket_path) = manager.socket_path_for(&manifest.name).await {
+                if let (Some(socket_path), Some(auth_secret)) = (
+                    manager.socket_path_for(&manifest.name).await,
+                    manager.auth_secret_for(&manifest.name).await,
+                ) {
                     targets.push(PluginTarget {
                         name: manifest.name.clone(),
                         socket_path,
-                        auth_secret: manager.auth_secret().to_string(),
+                        auth_secret,
                     });
                 }
             }

--- a/crates/temps-external-plugins/src/host_api.rs
+++ b/crates/temps-external-plugins/src/host_api.rs
@@ -493,7 +493,125 @@ impl HostApiBridge for RouterHostApi {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use temps_core::external_plugin::channel::BinaryPayload;
+    use chrono::{Duration as ChronoDuration, Utc};
+    use sea_orm::{DatabaseBackend, MockDatabase};
+    use temps_auth::context::AuthSource;
+    use temps_core::external_plugin::actor::{encode_plugin_actor_token, PLUGIN_ACTOR_TOKEN_TTL};
+    use temps_core::external_plugin::channel::{ActorToken, BinaryPayload, HttpMethod};
+
+    const TEST_PLUGIN: &str = "security-test-plugin";
+
+    fn crypto() -> Arc<CookieCrypto> {
+        Arc::new(
+            CookieCrypto::new("host-api-security-test-key-00001")
+                .expect("test encryption key should be valid"),
+        )
+    }
+
+    fn user() -> temps_entities::users::Model {
+        let now = Utc::now();
+        temps_entities::users::Model {
+            id: 42,
+            name: "Test User".to_string(),
+            email: "test@example.com".to_string(),
+            password_hash: None,
+            email_verified: true,
+            email_verification_token: None,
+            email_verification_expires: None,
+            password_reset_token: None,
+            password_reset_expires: None,
+            must_change_password: false,
+            deleted_at: None,
+            mfa_secret: None,
+            mfa_enabled: false,
+            mfa_recovery_codes: None,
+            oidc_subject: None,
+            oidc_provider_id: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn session() -> temps_entities::sessions::Model {
+        temps_entities::sessions::Model {
+            id: 7,
+            user_id: 42,
+            session_token: "hashed-session-token".to_string(),
+            expires_at: Utc::now() + ChronoDuration::minutes(30),
+            mfa_pending: false,
+            step_up_expires_at: None,
+        }
+    }
+
+    fn api_key(expires_at: Option<chrono::DateTime<Utc>>) -> temps_entities::api_keys::Model {
+        let now = Utc::now();
+        temps_entities::api_keys::Model {
+            id: 9,
+            name: "restricted-plugin-key".to_string(),
+            key_hash: "hash".to_string(),
+            key_prefix: "tk_test".to_string(),
+            user_id: 42,
+            role_type: "custom".to_string(),
+            permissions: Some(r#"["projects:read"]"#.to_string()),
+            is_active: true,
+            expires_at,
+            last_used_at: None,
+            created_at: now,
+            updated_at: now,
+            service_id: None,
+        }
+    }
+
+    fn api_with_database(
+        db: sea_orm::DatabaseConnection,
+        crypto: Arc<CookieCrypto>,
+    ) -> (RouterHostApi, Arc<DatabaseConnection>) {
+        let db = Arc::new(db);
+        let users = Arc::new(UserService::new(db.clone()));
+        (
+            RouterHostApi::new(Router::new(), db.clone(), crypto, users),
+            db,
+        )
+    }
+
+    fn actor_call(crypto: &CookieCrypto, principal: ActorPrincipal) -> ApiCall {
+        let (token, _) = encode_plugin_actor_token(
+            crypto,
+            TEST_PLUGIN,
+            42,
+            principal,
+            PLUGIN_ACTOR_TOKEN_TTL,
+            SystemTime::now(),
+        )
+        .expect("actor token should be minted");
+        ApiCall {
+            method: HttpMethod::Get,
+            path: "/projects".to_string(),
+            query: None,
+            body: None,
+            actor: ActorToken::new(token),
+        }
+    }
+
+    fn transaction_sql(db: Arc<DatabaseConnection>) -> String {
+        Arc::try_unwrap(db)
+            .expect("host API should release the test database")
+            .into_transaction_log()
+            .iter()
+            .flat_map(|transaction| transaction.statements())
+            .map(|statement| statement.sql.clone())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn assert_unauthenticated(error: ChannelError, reason: &str) {
+        assert_eq!(error.code, ChannelErrorCode::Unauthenticated);
+        assert!(
+            error.message.contains(reason),
+            "expected {reason:?} in error: {}",
+            error.message
+        );
+    }
 
     fn upload_parts() -> Vec<MultipartPart> {
         vec![
@@ -588,5 +706,151 @@ mod tests {
         let text = String::from_utf8_lossy(&encoded);
         assert!(!text.contains("X-Injected: yes\r\n"), "{text}");
         assert!(text.contains("filename=\"aX-Injected: yes\""), "{text}");
+    }
+
+    #[tokio::test]
+    async fn valid_session_reconstructs_current_user_authority() {
+        let crypto = crypto();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![user()]])
+            .append_query_results([vec![session()]])
+            // No admin role row: current authority is an ordinary user even
+            // if the actor token was minted before a role change.
+            .append_query_results([Vec::<temps_entities::roles::Model>::new()])
+            .into_connection();
+        let (api, db) = api_with_database(db, crypto.clone());
+        let call = actor_call(crypto.as_ref(), ActorPrincipal::Session { session_id: 7 });
+
+        let auth = api
+            .resolve_actor(TEST_PLUGIN, &call)
+            .await
+            .expect("live session should resolve");
+
+        assert_eq!(auth.user_id_opt(), Some(42));
+        assert_eq!(auth.session_id(), Some(7));
+        assert_eq!(auth.effective_role, Role::User);
+        assert!(auth.has_permission(&Permission::ProjectsRead));
+        drop(api);
+        let sql = transaction_sql(db);
+        assert!(sql.contains("\"sessions\".\"expires_at\" >"), "{sql}");
+        assert!(sql.contains("\"sessions\".\"mfa_pending\" ="), "{sql}");
+    }
+
+    #[tokio::test]
+    async fn revoked_expired_or_mfa_pending_session_fails_closed() {
+        // MockDatabase does not evaluate WHERE predicates. An empty second
+        // result represents each reason the database excludes the row; the
+        // SQL assertions prove all fail-closed predicates are present.
+        for reason in ["revoked", "expired", "MFA-pending"] {
+            let crypto = crypto();
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![user()]])
+                .append_query_results([Vec::<temps_entities::sessions::Model>::new()])
+                .into_connection();
+            let (api, db) = api_with_database(db, crypto.clone());
+            let call = actor_call(crypto.as_ref(), ActorPrincipal::Session { session_id: 7 });
+
+            let error = api
+                .resolve_actor(TEST_PLUGIN, &call)
+                .await
+                .expect_err("non-live session must be rejected");
+            assert_unauthenticated(error, "session 7, but that session is no longer valid");
+            drop(api);
+            let sql = transaction_sql(db);
+            assert!(
+                sql.contains("\"sessions\".\"expires_at\" >"),
+                "{reason}: {sql}"
+            );
+            assert!(
+                sql.contains("\"sessions\".\"mfa_pending\" ="),
+                "{reason}: {sql}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn valid_restricted_api_key_reconstructs_narrowed_permissions() {
+        let crypto = crypto();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![user()]])
+            .append_query_results([vec![api_key(None)]])
+            .into_connection();
+        let (api, db) = api_with_database(db, crypto.clone());
+        let call = actor_call(crypto.as_ref(), ActorPrincipal::ApiKey { key_id: 9 });
+
+        let auth = api
+            .resolve_actor(TEST_PLUGIN, &call)
+            .await
+            .expect("active API key should resolve");
+
+        assert_eq!(auth.user_id_opt(), Some(42));
+        assert_eq!(auth.effective_role, Role::Custom);
+        assert_eq!(
+            auth.custom_permissions,
+            Some(vec![Permission::ProjectsRead])
+        );
+        assert!(auth.has_permission(&Permission::ProjectsRead));
+        assert!(!auth.has_permission(&Permission::ProjectsWrite));
+        assert!(matches!(auth.source, AuthSource::ApiKey { key_id: 9, .. }));
+        drop(api);
+        let sql = transaction_sql(db);
+        assert!(sql.contains("\"api_keys\".\"is_active\" ="), "{sql}");
+    }
+
+    #[tokio::test]
+    async fn revoked_api_key_fails_closed() {
+        let crypto = crypto();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![user()]])
+            .append_query_results([Vec::<temps_entities::api_keys::Model>::new()])
+            .into_connection();
+        let (api, db) = api_with_database(db, crypto.clone());
+        let call = actor_call(crypto.as_ref(), ActorPrincipal::ApiKey { key_id: 9 });
+
+        let error = api
+            .resolve_actor(TEST_PLUGIN, &call)
+            .await
+            .expect_err("revoked API key must be rejected");
+        assert_unauthenticated(error, "key 9, but that key is no longer active");
+        drop(api);
+        let sql = transaction_sql(db);
+        assert!(sql.contains("\"api_keys\".\"is_active\" ="), "{sql}");
+    }
+
+    #[tokio::test]
+    async fn expired_api_key_fails_closed() {
+        let crypto = crypto();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![user()]])
+            .append_query_results([vec![api_key(Some(Utc::now() - ChronoDuration::minutes(1)))]])
+            .into_connection();
+        let (api, _db) = api_with_database(db, crypto.clone());
+        let call = actor_call(crypto.as_ref(), ActorPrincipal::ApiKey { key_id: 9 });
+
+        let error = api
+            .resolve_actor(TEST_PLUGIN, &call)
+            .await
+            .expect_err("expired API key must be rejected");
+        assert_unauthenticated(error, "key 9, but that key has expired");
+    }
+
+    #[tokio::test]
+    async fn deleted_or_missing_user_fails_closed_before_principal_lookup() {
+        let crypto = crypto();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<temps_entities::users::Model>::new()])
+            .into_connection();
+        let (api, db) = api_with_database(db, crypto.clone());
+        let call = actor_call(crypto.as_ref(), ActorPrincipal::Session { session_id: 7 });
+
+        let error = api
+            .resolve_actor(TEST_PLUGIN, &call)
+            .await
+            .expect_err("deleted user must be rejected");
+        assert_unauthenticated(error, "user 42, but that user no longer exists");
+        drop(api);
+        let sql = transaction_sql(db);
+        assert!(sql.contains("\"users\".\"deleted_at\" IS NULL"), "{sql}");
+        assert!(!sql.contains("FROM \"sessions\""), "{sql}");
     }
 }

--- a/crates/temps-external-plugins/src/host_api.rs
+++ b/crates/temps-external-plugins/src/host_api.rs
@@ -1,0 +1,588 @@
+//! Serving plugin API calls from the platform's own router.
+//!
+//! A plugin that needs to create a project or start a deployment has two bad
+//! options and one good one. It could re-implement the platform's services
+//! in its own process (duplicating a service graph that changes underneath
+//! it), or it could be handed a credential and call the API over the network
+//! (a credential to mint, store and leak). Neither is necessary: the
+//! platform is already running the router, so the channel carries the call
+//! into it.
+//!
+//! What that buys, concretely:
+//!
+//! - **One API.** A plugin reaches exactly the endpoints the product has.
+//!   There is no second surface to keep in sync, so an endpoint cannot exist
+//!   for the console and be missing for plugins.
+//! - **Real authorization.** The call runs the real handler, so its
+//!   `permission_guard!` runs, against the real acting user, and its audit
+//!   log is written where every other write is logged.
+//! - **No new credential.** Identity arrives as an actor token the platform
+//!   itself minted (see [`temps_core::external_plugin::actor`]), not as an
+//!   API key the plugin holds.
+//!
+//! ## Why this injects `AuthContext` rather than replaying a session
+//!
+//! The router's auth middleware inserts an `AuthContext` only when it can
+//! authenticate a request, and leaves an existing one alone. So resolving
+//! the actor here and inserting it directly is enough for `RequireAuth` and
+//! `permission_guard!` to work, without minting a session cookie or a token
+//! that would then exist as a second, longer-lived credential.
+//!
+//! The safety of that rests entirely on the actor token being unforgeable
+//! and on this being the only place that inserts an `AuthContext` a request
+//! did not earn.
+
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::Router;
+use http_body_util::BodyExt;
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
+use temps_auth::context::AuthContext;
+use temps_auth::permissions::{Permission, Role};
+use temps_auth::UserService;
+use temps_core::external_plugin::actor::{verify_plugin_actor_token, ActorPrincipal};
+use temps_core::external_plugin::channel::{
+    ApiCall, ApiCallResult, CallBody, ChannelError, ChannelErrorCode, JsonBody, MultipartPart,
+    PartContent, MAX_CALL_BODY_BYTES,
+};
+use temps_core::CookieCrypto;
+use tower::ServiceExt;
+use tracing::{debug, warn};
+
+use crate::channel::HostApiBridge;
+
+/// Largest response body a plugin API call may return.
+///
+/// The whole body is buffered to put it on the channel, so an unbounded
+/// response (a log tail, a big export) would be a memory spike on a small
+/// box. Plugins that need bulk data should page.
+const MAX_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+/// Runs plugin API calls against the console's router.
+pub struct RouterHostApi {
+    router: Router,
+    db: Arc<DatabaseConnection>,
+    crypto: Arc<CookieCrypto>,
+    users: Arc<UserService>,
+}
+
+impl RouterHostApi {
+    pub fn new(
+        router: Router,
+        db: Arc<DatabaseConnection>,
+        crypto: Arc<CookieCrypto>,
+        users: Arc<UserService>,
+    ) -> Self {
+        Self {
+            router,
+            db,
+            crypto,
+            users,
+        }
+    }
+
+    /// Resolve the acting user, or say precisely why not.
+    ///
+    /// Verifying the token's signature only proves the platform minted it; it
+    /// says nothing about whether the session or API key it names is *still*
+    /// good. That is re-checked here, against the row itself, on every call —
+    /// otherwise a logged-out session or a revoked API key would go on
+    /// authorizing plugin calls until the token's TTL expired on its own.
+    async fn resolve_actor(
+        &self,
+        plugin: &str,
+        call: &ApiCall,
+    ) -> Result<AuthContext, ChannelError> {
+        let verified =
+            verify_plugin_actor_token(&self.crypto, call.actor.as_str(), plugin, SystemTime::now())
+                .map_err(|e| {
+                    // Every rejection reason is already spelled out by the error
+                    // type, and a plugin author debugging alone needs it: "expired"
+                    // and "not your token" call for completely different fixes.
+                    warn!(plugin = %plugin, "Rejected plugin actor token: {e}");
+                    ChannelError::new(ChannelErrorCode::Unauthenticated, e.to_string())
+                })?;
+        let user_id = verified.user_id;
+
+        // `deleted_at IS NULL`, matching every other path that resolves a user
+        // from a credential (`auth_service`, `apikey_service`, `oidc_service`).
+        //
+        // Deletion here is soft, so a bare `find_by_id` keeps returning the
+        // row: an administrator could delete an account and the plugin would
+        // go on acting as them until the token aged out — up to the 15-minute
+        // TTL, and longer if the SDK's registry had already remembered it.
+        // Revocation has to take effect at redemption, because that is the
+        // only moment the platform gets to say no.
+        let user = temps_entities::users::Entity::find_by_id(user_id)
+            .filter(temps_entities::users::Column::DeletedAt.is_null())
+            .one(self.db.as_ref())
+            .await
+            .map_err(|e| {
+                ChannelError::new(
+                    ChannelErrorCode::Internal,
+                    format!("Failed to load the acting user {user_id} for plugin '{plugin}': {e}"),
+                )
+            })?
+            .ok_or_else(|| {
+                // The token was valid but the user is gone — deleted between
+                // minting and use. Not an internal error; the plugin simply
+                // has no one to act as any more.
+                ChannelError::new(
+                    ChannelErrorCode::Unauthenticated,
+                    format!(
+                        "Plugin '{plugin}' presented a valid actor token for user {user_id}, \
+                         but that user no longer exists"
+                    ),
+                )
+            })?;
+
+        match verified.principal {
+            ActorPrincipal::Session { session_id } => {
+                // Same shape session middleware checks: the row must exist,
+                // belong to this user, not be expired, and not be a
+                // first-factor-only MFA challenge. Logging out, an admin
+                // force-expiring a session, or the session simply expiring
+                // all show up here as "no matching row" — the token alone can
+                // never outlive the session it was minted from.
+                let session = temps_entities::sessions::Entity::find_by_id(session_id)
+                    .filter(temps_entities::sessions::Column::UserId.eq(user_id))
+                    .filter(temps_entities::sessions::Column::ExpiresAt.gt(chrono::Utc::now()))
+                    .filter(temps_entities::sessions::Column::MfaPending.eq(false))
+                    .one(self.db.as_ref())
+                    .await
+                    .map_err(|e| {
+                        ChannelError::new(
+                            ChannelErrorCode::Internal,
+                            format!(
+                                "Failed to load session {session_id} for plugin '{plugin}': {e}"
+                            ),
+                        )
+                    })?
+                    .ok_or_else(|| {
+                        ChannelError::new(
+                            ChannelErrorCode::Unauthenticated,
+                            format!(
+                                "Plugin '{plugin}' presented an actor token for session \
+                                 {session_id}, but that session is no longer valid"
+                            ),
+                        )
+                    })?;
+
+                // Role is resolved now rather than carried in the token, so a
+                // user demoted after the token was minted does not keep the
+                // old access for the rest of its lifetime.
+                let is_admin = self.users.is_admin(user.id).await.map_err(|e| {
+                    ChannelError::new(
+                        ChannelErrorCode::Internal,
+                        format!(
+                            "Failed to resolve the current role for user {user_id} while \n+                             redeeming an actor token for plugin '{plugin}': {e}"
+                        ),
+                    )
+                })?;
+                let role = if is_admin { Role::Admin } else { Role::User };
+                Ok(AuthContext::new_persisted_session(user, role, session.id))
+            }
+            ActorPrincipal::ApiKey { key_id } => {
+                // Role/permissions are re-parsed fresh from the row, exactly
+                // like `ApiKeyService::validate_api_key` — never trusted from
+                // the token. A restricted key stays restricted for every
+                // plugin call, even though the token only carries its id.
+                let key = temps_entities::api_keys::Entity::find_by_id(key_id)
+                    .filter(temps_entities::api_keys::Column::UserId.eq(user_id))
+                    .filter(temps_entities::api_keys::Column::IsActive.eq(true))
+                    .one(self.db.as_ref())
+                    .await
+                    .map_err(|e| {
+                        ChannelError::new(
+                            ChannelErrorCode::Internal,
+                            format!("Failed to load API key {key_id} for plugin '{plugin}': {e}"),
+                        )
+                    })?
+                    .ok_or_else(|| {
+                        ChannelError::new(
+                            ChannelErrorCode::Unauthenticated,
+                            format!(
+                                "Plugin '{plugin}' presented an actor token for API key \
+                                 {key_id}, but that key is no longer active"
+                            ),
+                        )
+                    })?;
+
+                if let Some(expires_at) = key.expires_at {
+                    if expires_at <= chrono::Utc::now() {
+                        return Err(ChannelError::new(
+                            ChannelErrorCode::Unauthenticated,
+                            format!(
+                                "Plugin '{plugin}' presented an actor token for API key \
+                                 {key_id}, but that key has expired"
+                            ),
+                        ));
+                    }
+                }
+
+                let (role, permissions) = if key.role_type == "custom" {
+                    let perms = if let Some(perms_json) = &key.permissions {
+                        let perm_strings: Vec<String> =
+                            serde_json::from_str(perms_json).map_err(|e| {
+                                ChannelError::new(
+                                    ChannelErrorCode::Internal,
+                                    format!("API key {key_id} has invalid permissions JSON: {e}"),
+                                )
+                            })?;
+                        Some(
+                            perm_strings
+                                .iter()
+                                .filter_map(|s| Permission::from_str(s))
+                                .collect::<Vec<_>>(),
+                        )
+                    } else {
+                        return Err(ChannelError::new(
+                            ChannelErrorCode::Internal,
+                            format!(
+                                "API key {key_id} has a custom role but no permissions defined"
+                            ),
+                        ));
+                    };
+                    (None, perms)
+                } else {
+                    let role = Role::from_str(&key.role_type).ok_or_else(|| {
+                        ChannelError::new(
+                            ChannelErrorCode::Internal,
+                            format!(
+                                "API key {key_id} has an unrecognized role type '{}'",
+                                key.role_type
+                            ),
+                        )
+                    })?;
+                    (Some(role), None)
+                };
+
+                Ok(AuthContext::new_api_key(
+                    user,
+                    role,
+                    permissions,
+                    key.name,
+                    key.id,
+                ))
+            }
+        }
+    }
+}
+
+/// A boundary that provably does not occur in the payload it delimits.
+///
+/// RFC 7578 leaves boundary choice to the sender, and the usual answer is a
+/// random string — which is *probably* absent from the body. Hashing the
+/// content instead makes it deterministic (so the encoder is testable) and
+/// removes the "probably": the hash of the parts is not a substring of the
+/// parts unless they were built to contain it, and the check below catches
+/// even that.
+fn multipart_boundary(parts: &[MultipartPart]) -> String {
+    use std::hash::{DefaultHasher, Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    for part in parts {
+        part.name.hash(&mut hasher);
+        part.filename.hash(&mut hasher);
+        part.content_type.hash(&mut hasher);
+        match &part.content {
+            PartContent::Text(t) => t.hash(&mut hasher),
+            PartContent::Binary(b) => b.as_bytes().hash(&mut hasher),
+        }
+    }
+
+    // Extend with a counter until nothing in the payload contains it. In
+    // practice this loop runs once; it exists so a crafted upload cannot
+    // smuggle an extra part by embedding the boundary.
+    for salt in 0u32.. {
+        let candidate = format!("temps-plugin-{:016x}-{salt}", hasher.finish());
+        let collides = parts.iter().any(|p| match &p.content {
+            PartContent::Text(t) => t.contains(&candidate),
+            PartContent::Binary(b) => find_subslice(b.as_bytes(), candidate.as_bytes()).is_some(),
+        });
+        if !collides {
+            return candidate;
+        }
+    }
+    // `0u32..` is only exhausted after 4 billion collisions, which cannot
+    // happen; the loop above always returns.
+    unreachable!("boundary search exhausted the entire u32 range")
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Render parts as an RFC 7578 `multipart/form-data` body.
+fn encode_multipart(parts: &[MultipartPart], boundary: &str) -> Vec<u8> {
+    let mut out = Vec::new();
+    for part in parts {
+        out.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+
+        let mut disposition = format!("Content-Disposition: form-data; name=\"{}\"", part.name);
+        if let Some(filename) = &part.filename {
+            // Quotes and CR/LF are the only characters that could break out
+            // of the header; stripping them is enough and keeps the filename
+            // recognisable, which matters because handlers log it.
+            let safe: String = filename
+                .chars()
+                .filter(|c| *c != '"' && *c != '\r' && *c != '\n')
+                .collect();
+            disposition.push_str(&format!("; filename=\"{safe}\""));
+        }
+        out.extend_from_slice(disposition.as_bytes());
+        out.extend_from_slice(b"\r\n");
+
+        if let Some(content_type) = &part.content_type {
+            let safe: String = content_type
+                .chars()
+                .filter(|c| *c != '\r' && *c != '\n')
+                .collect();
+            out.extend_from_slice(format!("Content-Type: {safe}\r\n").as_bytes());
+        }
+
+        out.extend_from_slice(b"\r\n");
+        match &part.content {
+            PartContent::Text(t) => out.extend_from_slice(t.as_bytes()),
+            PartContent::Binary(b) => out.extend_from_slice(b.as_bytes()),
+        }
+        out.extend_from_slice(b"\r\n");
+    }
+    out.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+    out
+}
+
+#[async_trait::async_trait]
+impl HostApiBridge for RouterHostApi {
+    async fn call(&self, plugin: &str, call: ApiCall) -> Result<ApiCallResult, ChannelError> {
+        let auth = self.resolve_actor(plugin, &call).await?;
+
+        let uri = match &call.query {
+            Some(q) if !q.is_empty() => format!("/api{}?{}", call.path, q),
+            _ => format!("/api{}", call.path),
+        };
+
+        if let Some(body) = &call.body {
+            let len = body.payload_len();
+            if len > MAX_CALL_BODY_BYTES {
+                return Err(ChannelError::new(
+                    ChannelErrorCode::InvalidParams,
+                    format!(
+                        "Plugin '{plugin}' sent a {len}-byte body for {uri}, over the \
+                         {MAX_CALL_BODY_BYTES}-byte channel limit"
+                    ),
+                ));
+            }
+        }
+
+        let (content_type, body) = match call.body.as_ref() {
+            None => ("application/json".to_string(), Body::empty()),
+            Some(CallBody::Json(json)) => (
+                "application/json".to_string(),
+                Body::from(json.as_str().to_owned()),
+            ),
+            Some(CallBody::Multipart(parts)) => {
+                // The boundary is derived from the payload rather than chosen
+                // at random, so it is reproducible in a test and — because
+                // it is a hash of everything being sent — cannot appear
+                // inside the content it delimits.
+                let boundary = multipart_boundary(parts);
+                let encoded = encode_multipart(parts, &boundary);
+                (
+                    format!("multipart/form-data; boundary={boundary}"),
+                    Body::from(encoded),
+                )
+            }
+        };
+
+        let mut request = Request::builder()
+            .method(call.method.as_str())
+            .uri(&uri)
+            .header("content-type", content_type)
+            .body(body)
+            .map_err(|e| {
+                ChannelError::new(
+                    ChannelErrorCode::InvalidParams,
+                    format!(
+                        "Plugin '{plugin}' asked for {} {uri}, which is not a valid request: {e}",
+                        call.method.as_str()
+                    ),
+                )
+            })?;
+
+        // This is the line that makes the call authenticated. See the module
+        // docs: the middleware will not overwrite it, and nothing else in
+        // the codebase inserts an AuthContext a request did not earn.
+        request.extensions_mut().insert(auth);
+
+        debug!(plugin = %plugin, method = %call.method.as_str(), uri = %uri, "Serving plugin API call");
+
+        let response = self.router.clone().oneshot(request).await.map_err(|e| {
+            ChannelError::new(
+                ChannelErrorCode::Internal,
+                format!("Platform router failed to serve {uri} for plugin '{plugin}': {e}"),
+            )
+        })?;
+
+        let status = response.status().as_u16();
+        let collected = response
+            .into_body()
+            .collect()
+            .await
+            .map_err(|e| {
+                ChannelError::new(
+                    ChannelErrorCode::Internal,
+                    format!("Failed to read the response to {uri} for plugin '{plugin}': {e}"),
+                )
+            })?
+            .to_bytes();
+
+        if collected.len() > MAX_RESPONSE_BYTES {
+            return Err(ChannelError::new(
+                ChannelErrorCode::Internal,
+                format!(
+                    "Response to {uri} for plugin '{plugin}' is {} bytes, over the \
+                     {MAX_RESPONSE_BYTES}-byte channel limit; use a paged endpoint",
+                    collected.len()
+                ),
+            ));
+        }
+
+        // Non-2xx is returned to the plugin rather than raised as a channel
+        // error: a 404 or a 403 from the API is a real answer the plugin
+        // needs to see and act on, not a channel malfunction. Channel errors
+        // are reserved for "the call never happened".
+        let body = String::from_utf8(collected.to_vec()).map_err(|e| {
+            ChannelError::new(
+                ChannelErrorCode::Internal,
+                format!(
+                    "Response to {uri} for plugin '{plugin}' was not valid UTF-8 \
+                     (status {status}): {e}"
+                ),
+            )
+        })?;
+
+        if status == StatusCode::UNAUTHORIZED.as_u16() {
+            // Worth flagging loudly: it means the AuthContext injection is
+            // not reaching handlers, which would otherwise look like a
+            // permissions problem in the plugin.
+            warn!(
+                plugin = %plugin,
+                uri = %uri,
+                "Plugin API call was rejected as unauthenticated despite an injected actor"
+            );
+        }
+
+        Ok(ApiCallResult {
+            status,
+            body: JsonBody::from_raw(body),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use temps_core::external_plugin::channel::BinaryPayload;
+
+    fn upload_parts() -> Vec<MultipartPart> {
+        vec![
+            MultipartPart {
+                name: "file".into(),
+                filename: Some("bundle.tar.gz".into()),
+                content_type: Some("application/gzip".into()),
+                content: PartContent::Binary(BinaryPayload::new(vec![0x1f, 0x8b, 0x00, 0xff])),
+            },
+            MultipartPart {
+                name: "content_type".into(),
+                filename: None,
+                content_type: None,
+                content: PartContent::Text("application/gzip".into()),
+            },
+        ]
+    }
+
+    #[test]
+    fn multipart_body_has_the_rfc_7578_shape() {
+        let parts = upload_parts();
+        let boundary = multipart_boundary(&parts);
+        let encoded = encode_multipart(&parts, &boundary);
+        let text = String::from_utf8_lossy(&encoded);
+
+        assert!(text.starts_with(&format!("--{boundary}\r\n")), "{text}");
+        assert!(text.contains(
+            "Content-Disposition: form-data; name=\"file\"; filename=\"bundle.tar.gz\"\r\n"
+        ));
+        assert!(text.contains("Content-Type: application/gzip\r\n"));
+        assert!(text.contains("Content-Disposition: form-data; name=\"content_type\"\r\n"));
+        assert!(text.ends_with(&format!("--{boundary}--\r\n")), "{text}");
+        // The raw bytes must survive verbatim, including the non-UTF-8 ones.
+        assert!(find_subslice(&encoded, &[0x1f, 0x8b, 0x00, 0xff]).is_some());
+    }
+
+    /// A part with no declared type emits no `Content-Type` header, rather
+    /// than an empty one a strict parser would reject.
+    #[test]
+    fn parts_without_a_content_type_omit_the_header() {
+        let parts = vec![MultipartPart {
+            name: "metadata".into(),
+            filename: None,
+            content_type: None,
+            content: PartContent::Text("{}".into()),
+        }];
+        let encoded = encode_multipart(&parts, "b");
+        let text = String::from_utf8_lossy(&encoded);
+        assert!(!text.contains("Content-Type"), "{text}");
+    }
+
+    /// Same input, same boundary — the encoder must not depend on hidden
+    /// state, or a retry would produce a different body.
+    #[test]
+    fn boundary_is_deterministic() {
+        assert_eq!(
+            multipart_boundary(&upload_parts()),
+            multipart_boundary(&upload_parts())
+        );
+    }
+
+    /// A payload that already contains the natural boundary must get a
+    /// different one, otherwise it could inject a part of its own.
+    #[test]
+    fn boundary_avoids_a_payload_that_embeds_it() {
+        let natural = multipart_boundary(&[]);
+        let parts = vec![MultipartPart {
+            name: "file".into(),
+            filename: None,
+            content_type: None,
+            content: PartContent::Text(format!("--{natural}\r\nContent-Disposition: evil\r\n")),
+        }];
+        let chosen = multipart_boundary(&parts);
+        let encoded = encode_multipart(&parts, &chosen);
+        // Exactly two occurrences: the opening delimiter and the closing one.
+        let count = String::from_utf8_lossy(&encoded)
+            .matches(&format!("--{chosen}"))
+            .count();
+        assert_eq!(count, 2, "boundary {chosen} appears {count} times");
+    }
+
+    /// A filename cannot break out of the Content-Disposition header.
+    #[test]
+    fn filenames_cannot_inject_headers() {
+        let parts = vec![MultipartPart {
+            name: "file".into(),
+            filename: Some("a\"\r\nX-Injected: yes\r\n".into()),
+            content_type: None,
+            content: PartContent::Text("x".into()),
+        }];
+        let encoded = encode_multipart(&parts, "b");
+        let text = String::from_utf8_lossy(&encoded);
+        assert!(!text.contains("X-Injected: yes\r\n"), "{text}");
+        assert!(text.contains("filename=\"aX-Injected: yes\""), "{text}");
+    }
+}

--- a/crates/temps-external-plugins/src/host_api.rs
+++ b/crates/temps-external-plugins/src/host_api.rs
@@ -46,7 +46,7 @@ use temps_auth::UserService;
 use temps_core::external_plugin::actor::{verify_plugin_actor_token, ActorPrincipal};
 use temps_core::external_plugin::channel::{
     ApiCall, ApiCallResult, CallBody, ChannelError, ChannelErrorCode, JsonBody, MultipartPart,
-    PartContent, MAX_CALL_BODY_BYTES,
+    PartContent, VerifiedPluginApiCaller, MAX_CALL_BODY_BYTES,
 };
 use temps_core::CookieCrypto;
 use tower::ServiceExt;
@@ -178,7 +178,8 @@ impl RouterHostApi {
                     ChannelError::new(
                         ChannelErrorCode::Internal,
                         format!(
-                            "Failed to resolve the current role for user {user_id} while \n+                             redeeming an actor token for plugin '{plugin}': {e}"
+                            "Failed to resolve the current role for user {user_id} while \
+                             redeeming an actor token for plugin '{plugin}': {e}"
                         ),
                     )
                 })?;
@@ -420,6 +421,9 @@ impl HostApiBridge for RouterHostApi {
         // docs: the middleware will not overwrite it, and nothing else in
         // the codebase inserts an AuthContext a request did not earn.
         request.extensions_mut().insert(auth);
+        request
+            .extensions_mut()
+            .insert(VerifiedPluginApiCaller::new(plugin));
 
         debug!(plugin = %plugin, method = %call.method.as_str(), uri = %uri, "Serving plugin API call");
 

--- a/crates/temps-external-plugins/src/lib.rs
+++ b/crates/temps-external-plugins/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod channel;
 pub mod event_listener;
 pub mod handler;
+pub mod host_api;
 pub mod manager;
 pub mod plugin;
 pub mod proxy;

--- a/crates/temps-external-plugins/src/manager.rs
+++ b/crates/temps-external-plugins/src/manager.rs
@@ -8,7 +8,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use temps_core::external_plugin::{HandshakeMessage, PluginManifest};
+use temps_core::external_plugin::{
+    HandshakeMessage, PluginLaunchConfig, PluginManifest, EXTERNAL_PLUGIN_PROTOCOL_VERSION,
+};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::RwLock;
@@ -28,8 +30,8 @@ pub struct ExternalPluginProcess {
     pub binary_path: PathBuf,
     /// Unix socket path for communication
     pub socket_path: PathBuf,
-    /// Per-process secret used to authenticate proxy assertions to this
-    /// plugin. It must never be shared with another installed plugin.
+    /// Per-process secret used to bind internal requests to this staged
+    /// plugin launch. This is protocol integrity, not shared-UID isolation.
     auth_secret: String,
     /// Path to the PID file for this process
     pid_file_path: PathBuf,
@@ -94,9 +96,8 @@ pub struct ExternalPluginConfig {
     /// Directory for plugin data files
     pub data_dir: PathBuf,
     /// The instance's own data root — the parent of all the directories
-    /// above. Passed to plugins as `--host-data-dir` so a plugin that also
-    /// receives `--database-url` can reach the platform state that lives on
-    /// disk rather than in the database (sandbox roots, key material).
+    /// above. Disclosed in the typed launch configuration only when a trusted
+    /// plugin declares that privileged requirement.
     pub host_data_dir: PathBuf,
     /// Base URL at which this instance's API answers, passed to plugins as
     /// `--host-api-url`. `None` when the caller did not supply one, in which
@@ -106,7 +107,8 @@ pub struct ExternalPluginConfig {
     pub ui_assets_dir: PathBuf,
     /// Directory for PID files (one per running plugin process)
     pub pids_dir: PathBuf,
-    /// Database URL to pass to plugins
+    /// Database URL disclosed in typed launch configuration to plugins that
+    /// declare direct database access.
     pub database_url: String,
     /// Timeout for plugin handshake (default: 30s)
     pub handshake_timeout: Duration,
@@ -123,6 +125,52 @@ const SUN_PATH_MAX: usize = 108;
 
 fn generate_plugin_auth_secret() -> String {
     uuid::Uuid::new_v4().to_string()
+}
+
+fn legacy_startup_eof_error(binary_name: &str) -> String {
+    format!(
+        "Plugin {binary_name} closed stdout before sending the staged protocol v{EXTERNAL_PLUGIN_PROTOCOL_VERSION} hello. The binary is incompatible or uses a legacy temps-plugin-sdk; rebuild it with protocol v{EXTERNAL_PLUGIN_PROTOCOL_VERSION}"
+    )
+}
+
+#[cfg(unix)]
+fn secure_socket_directory(path: &Path) -> Result<(), std::io::Error> {
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::DirBuilderExt;
+
+    match std::fs::DirBuilder::new().mode(0o700).create(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) => return Err(error),
+    }
+
+    let path = std::ffi::CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "plugin socket directory contains a NUL byte",
+        )
+    })?;
+    // SAFETY: `path` is a valid C string. O_NOFOLLOW rejects a malicious
+    // symlink at the deterministic /tmp path, and OwnedFd closes the result.
+    let raw_fd = unsafe {
+        libc::open(
+            path.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW,
+        )
+    };
+    if raw_fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: `raw_fd` was returned by open above and ownership is transferred
+    // exactly once to OwnedFd.
+    let directory = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+    // SAFETY: fchmod operates on the live directory descriptor and does not
+    // dereference the path again, closing the symlink-swap race.
+    if unsafe { libc::fchmod(directory.as_raw_fd(), 0o700) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 impl ExternalPluginConfig {
@@ -238,9 +286,25 @@ impl ExternalPluginManager {
     ///
     /// Returns the list of successfully started plugin manifests.
     pub async fn discover_and_start(&self) -> Vec<PluginManifest> {
+        #[cfg(unix)]
+        if let Err(error) = secure_socket_directory(&self.config.sockets_dir) {
+            error!(
+                directory = %self.config.sockets_dir.display(),
+                "Failed to create a secure 0700 plugin socket directory: {error}"
+            );
+            return Vec::new();
+        }
+        #[cfg(not(unix))]
+        if let Err(error) = tokio::fs::create_dir_all(&self.config.sockets_dir).await {
+            error!(
+                directory = %self.config.sockets_dir.display(),
+                "Failed to create plugin socket directory: {error}"
+            );
+            return Vec::new();
+        }
+
         for dir in [
             &self.config.plugins_dir,
-            &self.config.sockets_dir,
             &self.config.data_dir,
             &self.config.ui_assets_dir,
             &self.config.pids_dir,
@@ -250,7 +314,6 @@ impl ExternalPluginManager {
                 return Vec::new();
             }
         }
-
         // Kill any stale plugin processes left over from a previous run
         // (e.g. if the server was killed without graceful shutdown).
         self.kill_stale_processes().await;
@@ -449,9 +512,9 @@ impl ExternalPluginManager {
             .sockets_dir
             .join(format!("{}.sock", binary_name));
         let plugin_data_dir = self.config.data_dir.join(binary_name);
-        // A compromised plugin must not be able to forge caller assertions
-        // to a sibling plugin. Generate this before spawn and retain it only
-        // with this process's proxy state.
+        // This authenticates traffic as belonging to the staged child process.
+        // Installed plugins are trusted host code under the current shared-UID
+        // architecture; this is protocol integrity, not a sandbox boundary.
         let auth_secret = generate_plugin_auth_secret();
 
         // Validate that the socket path fits within the OS limit.
@@ -474,62 +537,30 @@ impl ExternalPluginManager {
 
         let pid_file_path = self.config.pids_dir.join(format!("{}.pid", binary_name));
 
-        let mut child = Command::new(binary_path)
+        let mut command = Command::new(binary_path);
+        command
+            .kill_on_drop(true)
             .arg("--socket-path")
             .arg(socket_path.to_str().unwrap_or_default())
-            .arg("--database-url")
-            .arg(&self.config.database_url)
             .arg("--data-dir")
             .arg(plugin_data_dir.to_str().unwrap_or_default())
-            // The platform's own data root, alongside its own database URL.
-            //
-            // `--data-dir` is the plugin's private corner
-            // (`<root>/plugin-data/<binary>`); this is the root itself, where
-            // the instance keeps the state a plugin needs to act *as* the
-            // platform rather than beside it: the sandbox data root, and the
-            // key material that makes the database's encrypted columns and
-            // session cookies readable.
-            //
-            // Only plugins that already receive `--database-url` get anything
-            // new here — with the database alone a plugin holds every
-            // ciphertext but no key. Treat installing a plugin as trusting it
-            // with the instance.
-            .arg("--host-data-dir")
-            .arg(self.config.host_data_dir.to_str().unwrap_or_default())
             .args(
                 self.config
                     .host_api_url
                     .iter()
                     .flat_map(|url| ["--host-api-url", url.as_str()]),
-            )
+            );
+        let mut child = command
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .spawn()
             .map_err(|e| format!("Failed to spawn {}: {}", binary_name, e))?;
 
-        // Deliver the per-process assertion secret through a one-shot pipe,
-        // never argv or environment. Plugins share the host OS user today,
-        // so command-line visibility would collapse per-plugin isolation.
         let mut child_stdin = child
             .stdin
             .take()
-            .ok_or_else(|| format!("Failed to open the authentication pipe for {binary_name}"))?;
-        if let Err(error) = child_stdin
-            .write_all(format!("{auth_secret}\n").as_bytes())
-            .await
-        {
-            let _ = child.start_kill();
-            return Err(format!(
-                "Failed to deliver the request-assertion secret to {binary_name}: {error}"
-            ));
-        }
-        if let Err(error) = child_stdin.shutdown().await {
-            let _ = child.start_kill();
-            return Err(format!(
-                "Failed to close the authentication pipe for {binary_name}: {error}"
-            ));
-        }
+            .ok_or_else(|| format!("Failed to open the launch-config pipe for {binary_name}"))?;
 
         // Write PID file so we can clean up stale processes on restart
         if let Some(pid) = child.id() {
@@ -586,27 +617,34 @@ impl ExternalPluginManager {
             }
         };
 
-        // Read manifest (handshake phase 1)
+        // Stage 1: the already-running child identifies its protocol and
+        // declares which host values it needs. Nothing sensitive or privileged
+        // has been passed to it in argv.
         let manifest = match tokio::time::timeout(self.config.handshake_timeout, async {
             let line = reader
                 .next_line()
                 .await
                 .map_err(|e| format!("Failed to read manifest from {}: {}", binary_name, e))?
-                .ok_or_else(|| {
-                    format!(
-                        "Plugin {} closed stdout before sending manifest",
-                        binary_name
-                    )
-                })?;
+                .ok_or_else(|| legacy_startup_eof_error(binary_name))?;
 
             let msg: HandshakeMessage = serde_json::from_str(&line)
                 .map_err(|e| format!("Invalid manifest JSON from {}: {}", binary_name, e))?;
 
             match msg {
-                HandshakeMessage::Manifest(m) => Ok(*m),
+                HandshakeMessage::Hello(hello)
+                    if hello.protocol_version == EXTERNAL_PLUGIN_PROTOCOL_VERSION =>
+                {
+                    Ok(*hello.manifest)
+                }
+                HandshakeMessage::Hello(hello) => Err(format!(
+                    "Plugin {binary_name} uses external-plugin protocol {}, but this Temps build requires {}; rebuild the plugin with the current temps-plugin-sdk",
+                    hello.protocol_version, EXTERNAL_PLUGIN_PROTOCOL_VERSION
+                )),
+                HandshakeMessage::Manifest(_) => Err(format!(
+                    "Plugin {binary_name} uses the legacy startup handshake; rebuild it with temps-plugin-sdk protocol {EXTERNAL_PLUGIN_PROTOCOL_VERSION}"
+                )),
                 _ => Err(format!(
-                    "Expected manifest message from {}, got something else",
-                    binary_name
+                    "Plugin {binary_name} sent an unexpected startup message; rebuild it with temps-plugin-sdk protocol {EXTERNAL_PLUGIN_PROTOCOL_VERSION}"
                 )),
             }
         })
@@ -629,13 +667,50 @@ impl ExternalPluginManager {
                     task.abort();
                 }
                 return Err(format!(
-                    "Handshake timeout for {}{}",
-                    binary_name, stderr_context
+                    "Plugin {binary_name} did not emit the staged startup hello; rebuild it with temps-plugin-sdk protocol {EXTERNAL_PLUGIN_PROTOCOL_VERSION}{stderr_context}"
                 ));
             }
         };
 
         debug!(plugin = %manifest.name, "Received manifest from plugin");
+
+        // Stage 2: send one typed line to this same child. The manifest flags
+        // control disclosure/routing for trusted installed code; they do not
+        // turn a shared-UID plugin process into a security sandbox.
+        if manifest.requires_host_data_access {
+            warn!(
+                plugin = %manifest.name,
+                "Plugin declares privileged access to the platform host data root"
+            );
+        }
+        let launch_config = PluginLaunchConfig {
+            protocol_version: EXTERNAL_PLUGIN_PROTOCOL_VERSION,
+            auth_secret: auth_secret.clone(),
+            database_url: manifest
+                .requires_db
+                .then(|| self.config.database_url.clone()),
+            host_data_dir: manifest
+                .requires_host_data_access
+                .then(|| self.config.host_data_dir.to_string_lossy().into_owned()),
+        };
+        let launch_json = serde_json::to_string(&launch_config).map_err(|error| {
+            format!("Failed to encode launch configuration for {binary_name}: {error}")
+        })?;
+        if let Err(error) = child_stdin
+            .write_all(format!("{launch_json}\n").as_bytes())
+            .await
+        {
+            let _ = child.start_kill();
+            return Err(format!(
+                "Failed to deliver typed launch configuration to {binary_name}: {error}"
+            ));
+        }
+        if let Err(error) = child_stdin.shutdown().await {
+            let _ = child.start_kill();
+            return Err(format!(
+                "Failed to close the launch-config pipe for {binary_name}: {error}"
+            ));
+        }
 
         // Read ready signal (handshake phase 2)
         let (has_ui, openapi_schema) = match tokio::time::timeout(self.config.handshake_timeout, async {
@@ -655,6 +730,12 @@ impl ExternalPluginManager {
 
             match msg {
                 HandshakeMessage::Ready(r) => {
+                    if r.protocol_version != EXTERNAL_PLUGIN_PROTOCOL_VERSION {
+                        return Err(format!(
+                            "Plugin {binary_name} uses external-plugin protocol {}, but this Temps build requires {}; rebuild the plugin with the current temps-plugin-sdk",
+                            r.protocol_version, EXTERNAL_PLUGIN_PROTOCOL_VERSION
+                        ));
+                    }
                     if r.ready {
                         // Parse the OpenAPI schema if provided
                         let openapi = match r.openapi {
@@ -727,8 +808,18 @@ impl ExternalPluginManager {
             self.db.clone(),
             self.host_api.clone(),
             manifest.capabilities.clone(),
+            &auth_secret,
         )
         .await;
+        let channel = match channel {
+            Some(channel) => channel,
+            None => {
+                let _ = child.start_kill();
+                return Err(format!(
+                    "Plugin {binary_name} did not establish an authenticated platform channel; rebuild it with temps-plugin-sdk protocol {EXTERNAL_PLUGIN_PROTOCOL_VERSION}"
+                ));
+            }
+        };
 
         let process = ExternalPluginProcess {
             manifest,
@@ -738,7 +829,7 @@ impl ExternalPluginManager {
             pid_file_path,
             child,
             has_ui,
-            channel,
+            channel: Some(channel),
             openapi_schema,
         };
 
@@ -935,6 +1026,16 @@ mod tests {
         assert_ne!(first, second);
         assert!(!first.is_empty());
         assert!(!second.is_empty());
+    }
+
+    #[test]
+    fn legacy_startup_eof_is_actionable_and_keeps_stderr_context() {
+        let stderr = "\nPlugin stderr:\n  error: unexpected argument '--socket-path'";
+        let error = format!("{}{}", legacy_startup_eof_error("plugin-v0.0.8"), stderr);
+
+        assert!(error.contains("incompatible or uses a legacy temps-plugin-sdk"));
+        assert!(error.contains("rebuild it with protocol v2"));
+        assert!(error.contains("unexpected argument '--socket-path'"));
     }
 
     #[tokio::test]
@@ -1146,6 +1247,23 @@ mod tests {
             config_a.sockets_dir, config_b.sockets_dir,
             "Different data dirs must produce different socket dirs"
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn secure_socket_directory_uses_private_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let socket_dir = tmp.path().join("sockets");
+        secure_socket_directory(&socket_dir).expect("secure socket directory");
+
+        let mode = std::fs::metadata(socket_dir)
+            .expect("socket directory metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o700);
     }
 
     #[tokio::test]

--- a/crates/temps-external-plugins/src/manager.rs
+++ b/crates/temps-external-plugins/src/manager.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use temps_core::external_plugin::{HandshakeMessage, PluginManifest};
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
@@ -28,6 +28,9 @@ pub struct ExternalPluginProcess {
     pub binary_path: PathBuf,
     /// Unix socket path for communication
     pub socket_path: PathBuf,
+    /// Per-process secret used to authenticate proxy assertions to this
+    /// plugin. It must never be shared with another installed plugin.
+    auth_secret: String,
     /// Path to the PID file for this process
     pid_file_path: PathBuf,
     /// The child process handle
@@ -90,6 +93,15 @@ pub struct ExternalPluginConfig {
     pub sockets_dir: PathBuf,
     /// Directory for plugin data files
     pub data_dir: PathBuf,
+    /// The instance's own data root — the parent of all the directories
+    /// above. Passed to plugins as `--host-data-dir` so a plugin that also
+    /// receives `--database-url` can reach the platform state that lives on
+    /// disk rather than in the database (sandbox roots, key material).
+    pub host_data_dir: PathBuf,
+    /// Base URL at which this instance's API answers, passed to plugins as
+    /// `--host-api-url`. `None` when the caller did not supply one, in which
+    /// case plugins are told nothing rather than guessing.
+    pub host_api_url: Option<String>,
     /// Directory to extract plugin UI assets into
     pub ui_assets_dir: PathBuf,
     /// Directory for PID files (one per running plugin process)
@@ -108,6 +120,10 @@ pub struct ExternalPluginConfig {
 const SUN_PATH_MAX: usize = 104;
 #[cfg(not(target_os = "macos"))]
 const SUN_PATH_MAX: usize = 108;
+
+fn generate_plugin_auth_secret() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
 
 impl ExternalPluginConfig {
     /// Create a config with default settings for a given data directory.
@@ -135,10 +151,34 @@ impl ExternalPluginConfig {
             pids_dir: data_dir.join("run").join("plugin-pids"),
             data_dir: data_dir.join("plugin-data"),
             ui_assets_dir: data_dir.join("plugin-ui"),
+            host_data_dir: data_dir,
+            host_api_url: None,
             database_url,
             handshake_timeout: Duration::from_secs(30),
             health_check_timeout: Duration::from_secs(5),
         }
+    }
+
+    /// Record where the proxy listens, so plugins can be told their own
+    /// externally-reachable base URL.
+    ///
+    /// A bind address is not a URL: `0.0.0.0` means "every interface" to a
+    /// listener but nothing to a client, so it is rewritten to loopback.
+    /// Callers that terminate TLS or sit behind another proxy should set the
+    /// instance's public URL in settings instead of relying on this.
+    pub fn with_proxy_address(mut self, address: &str) -> Self {
+        let address = address.trim();
+        if address.is_empty() {
+            return self;
+        }
+        let host_port = match address.rsplit_once(':') {
+            Some((host, port)) if host == "0.0.0.0" || host == "[::]" || host.is_empty() => {
+                format!("127.0.0.1:{port}")
+            }
+            _ => address.to_string(),
+        };
+        self.host_api_url = Some(format!("http://{host_port}"));
+        self
     }
 }
 
@@ -155,22 +195,43 @@ pub struct ExternalPluginManager {
     config: ExternalPluginConfig,
     /// Running plugin processes, keyed by plugin name
     plugins: Arc<RwLock<HashMap<String, ExternalPluginProcess>>>,
-    /// HMAC auth secret for signing proxied requests
-    auth_secret: String,
     /// Database connection for serving channel requests
     db: Arc<DatabaseConnection>,
+    /// Late-bound bridge into the platform's own HTTP router, shared with
+    /// every channel. Empty until the console finishes assembling the
+    /// router — see [`crate::channel::HostApiSlot`].
+    host_api: Arc<crate::channel::HostApiSlot>,
+    /// Instance key material for minting per-caller actor tokens. Set by the
+    /// console; `None` leaves plugins without one, so their API calls fail
+    /// closed rather than being attributed to nobody.
+    actor_crypto: crate::proxy::ActorCryptoSlot,
 }
 
 impl ExternalPluginManager {
     pub fn new(config: ExternalPluginConfig, db: Arc<DatabaseConnection>) -> Self {
-        let auth_secret = uuid::Uuid::new_v4().to_string();
-
         Self {
             config,
             plugins: Arc::new(RwLock::new(HashMap::new())),
-            auth_secret,
             db,
+            host_api: Arc::new(crate::channel::HostApiSlot::new(None)),
+            actor_crypto: crate::proxy::ActorCryptoSlot::default(),
         }
+    }
+
+    /// Install the bridge plugins use to call the platform's own HTTP API.
+    ///
+    /// Called by the console once its router is assembled. Until then the
+    /// slot is empty and an `ApiCall` is answered with an error naming the
+    /// gap, rather than being silently dropped.
+    pub async fn set_host_api(&self, bridge: Arc<dyn crate::channel::HostApiBridge>) {
+        *self.host_api.write().await = Some(bridge);
+    }
+
+    /// Supply the key material used to mint per-caller actor tokens.
+    pub async fn set_actor_crypto(&self, crypto: Arc<temps_core::CookieCrypto>) {
+        // Every proxy already holds a clone of this slot, so mounted routes
+        // start minting immediately — no rebuild, no ordering requirement.
+        self.actor_crypto.set(crypto);
     }
 
     /// Discover and start all plugins in the plugins directory.
@@ -388,6 +449,10 @@ impl ExternalPluginManager {
             .sockets_dir
             .join(format!("{}.sock", binary_name));
         let plugin_data_dir = self.config.data_dir.join(binary_name);
+        // A compromised plugin must not be able to forge caller assertions
+        // to a sibling plugin. Generate this before spawn and retain it only
+        // with this process's proxy state.
+        let auth_secret = generate_plugin_auth_secret();
 
         // Validate that the socket path fits within the OS limit.
         let socket_path_len = socket_path.as_os_str().len();
@@ -414,14 +479,57 @@ impl ExternalPluginManager {
             .arg(socket_path.to_str().unwrap_or_default())
             .arg("--database-url")
             .arg(&self.config.database_url)
-            .arg("--auth-secret")
-            .arg(&self.auth_secret)
             .arg("--data-dir")
             .arg(plugin_data_dir.to_str().unwrap_or_default())
+            // The platform's own data root, alongside its own database URL.
+            //
+            // `--data-dir` is the plugin's private corner
+            // (`<root>/plugin-data/<binary>`); this is the root itself, where
+            // the instance keeps the state a plugin needs to act *as* the
+            // platform rather than beside it: the sandbox data root, and the
+            // key material that makes the database's encrypted columns and
+            // session cookies readable.
+            //
+            // Only plugins that already receive `--database-url` get anything
+            // new here — with the database alone a plugin holds every
+            // ciphertext but no key. Treat installing a plugin as trusting it
+            // with the instance.
+            .arg("--host-data-dir")
+            .arg(self.config.host_data_dir.to_str().unwrap_or_default())
+            .args(
+                self.config
+                    .host_api_url
+                    .iter()
+                    .flat_map(|url| ["--host-api-url", url.as_str()]),
+            )
+            .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .spawn()
             .map_err(|e| format!("Failed to spawn {}: {}", binary_name, e))?;
+
+        // Deliver the per-process assertion secret through a one-shot pipe,
+        // never argv or environment. Plugins share the host OS user today,
+        // so command-line visibility would collapse per-plugin isolation.
+        let mut child_stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| format!("Failed to open the authentication pipe for {binary_name}"))?;
+        if let Err(error) = child_stdin
+            .write_all(format!("{auth_secret}\n").as_bytes())
+            .await
+        {
+            let _ = child.start_kill();
+            return Err(format!(
+                "Failed to deliver the request-assertion secret to {binary_name}: {error}"
+            ));
+        }
+        if let Err(error) = child_stdin.shutdown().await {
+            let _ = child.start_kill();
+            return Err(format!(
+                "Failed to close the authentication pipe for {binary_name}: {error}"
+            ));
+        }
 
         // Write PID file so we can clean up stale processes on restart
         if let Some(pid) = child.id() {
@@ -613,13 +721,20 @@ impl ExternalPluginManager {
         // Open the platform channel (WebSocket to plugin for queries + events).
         // This is non-fatal: older plugins that don't serve /_temps/channel
         // will simply not get a channel (they can still use POST /_events).
-        let channel =
-            PluginChannel::connect(&socket_path, manifest.name.clone(), self.db.clone()).await;
+        let channel = PluginChannel::connect(
+            &socket_path,
+            manifest.name.clone(),
+            self.db.clone(),
+            self.host_api.clone(),
+            manifest.capabilities.clone(),
+        )
+        .await;
 
         let process = ExternalPluginProcess {
             manifest,
             binary_path: binary_path.to_path_buf(),
             socket_path,
+            auth_secret,
             pid_file_path,
             child,
             has_ui,
@@ -669,7 +784,12 @@ impl ExternalPluginManager {
             PluginProxy::new(
                 process.socket_path.clone(),
                 process.manifest.name.clone(),
-                self.auth_secret.clone(),
+                process.auth_secret.clone(),
+            )
+            .with_public_paths(process.manifest.public_paths.clone())
+            .with_actor_minting(
+                self.actor_crypto.clone(),
+                !process.manifest.capabilities.is_empty(),
             )
         })
     }
@@ -681,6 +801,15 @@ impl ExternalPluginManager {
             .await
             .get(plugin_name)
             .map(|p| p.socket_path.clone())
+    }
+
+    /// Per-process assertion secret for internal event delivery.
+    pub(crate) async fn auth_secret_for(&self, plugin_name: &str) -> Option<String> {
+        self.plugins
+            .read()
+            .await
+            .get(plugin_name)
+            .map(|process| process.auth_secret.clone())
     }
 
     /// Send an event to a specific plugin over its channel.
@@ -772,11 +901,6 @@ impl ExternalPluginManager {
         self.start_plugin(&binary_path).await
     }
 
-    /// Get the auth secret (for creating proxies externally).
-    pub fn auth_secret(&self) -> &str {
-        &self.auth_secret
-    }
-
     /// Get the config.
     pub fn config(&self) -> &ExternalPluginConfig {
         &self.config
@@ -801,7 +925,16 @@ mod tests {
         let manager = ExternalPluginManager::new(config, mock_db());
 
         assert!(manager.manifests().await.is_empty());
-        assert!(!manager.auth_secret().is_empty());
+    }
+
+    #[test]
+    fn plugin_processes_receive_distinct_auth_secrets() {
+        let first = generate_plugin_auth_secret();
+        let second = generate_plugin_auth_secret();
+
+        assert_ne!(first, second);
+        assert!(!first.is_empty());
+        assert!(!second.is_empty());
     }
 
     #[tokio::test]

--- a/crates/temps-external-plugins/src/proxy.rs
+++ b/crates/temps-external-plugins/src/proxy.rs
@@ -10,6 +10,7 @@ use axum::Router;
 use temps_auth::context::{AuthContext, AuthSource};
 use temps_core::external_plugin::actor::ActorPrincipal;
 use temps_core::external_plugin::headers;
+use temps_core::external_plugin::{PLUGIN_CHANNEL_PATH, PLUGIN_EVENTS_PATH};
 use temps_core::problemdetails;
 use tracing::{debug, error, warn};
 
@@ -108,6 +109,24 @@ async fn proxy_handler(State(proxy): State<PluginProxy>, request: Request) -> Re
     let uri = request.uri().clone();
     let path = uri.path();
 
+    // These endpoints accept assertions that only the platform may make.
+    // They remain reachable over the plugin's private Unix socket for event
+    // delivery and channel setup, but must never be exposed through the
+    // wildcard user-facing proxy — doing so would let an external caller
+    // borrow the proxy's trusted signature.
+    if is_reserved_internal_path(path) {
+        warn!(
+            plugin = %proxy.plugin_name,
+            method = %method,
+            path = %path,
+            "Rejecting external request to reserved plugin transport endpoint"
+        );
+        return problemdetails::new(StatusCode::NOT_FOUND)
+            .with_title("Not Found")
+            .with_detail("The requested plugin route does not exist.")
+            .into_response();
+    }
+
     // Authenticate here, because nothing else will. Ordinary routes enforce
     // auth per-handler via the `RequireAuth` extractor; a proxied plugin
     // route has no handler of ours to put that extractor in. The auth
@@ -158,6 +177,22 @@ async fn proxy_handler(State(proxy): State<PluginProxy>, request: Request) -> Re
                 .into_response()
         }
     }
+}
+
+/// Whether a user-facing proxy path targets a platform-only transport route.
+///
+/// Descendants are reserved as well so future nested transport endpoints do
+/// not become reachable accidentally. Segment-boundary matching keeps benign
+/// routes such as `/_events-calendar` available to plugins.
+fn is_reserved_internal_path(path: &str) -> bool {
+    [PLUGIN_EVENTS_PATH, PLUGIN_CHANNEL_PATH]
+        .into_iter()
+        .any(|reserved| {
+            path == reserved
+                || path
+                    .strip_prefix(reserved)
+                    .is_some_and(|rest| rest.starts_with('/'))
+        })
 }
 
 /// Forward an HTTP request to a plugin over its Unix domain socket.
@@ -260,12 +295,11 @@ fn inject_temps_headers(
 ) {
     // The browser's session cookie and any Authorization header are the
     // caller's real platform credential — good for far more than this one
-    // plugin. A plugin process is untrusted third-party code; handing it
-    // that credential would let it act as the user against the platform
-    // directly, bypassing the scoped, single-plugin actor token below
-    // entirely. The plugin gets identity via `x-temps-*` headers and (if it
-    // asked for API access) an actor token bound to it specifically — never
-    // the caller's own credential.
+    // plugin. Installed plugins are trusted host code running under the same
+    // OS user as Temps, so this is defense in depth and least credential
+    // disclosure, not a process-isolation boundary: the plugin should receive
+    // only the scoped, single-plugin actor token it needs. Identity arrives via
+    // `x-temps-*` headers and that actor token, never the caller's credential.
     for name in [
         hyper::header::COOKIE,
         hyper::header::AUTHORIZATION,
@@ -438,6 +472,7 @@ impl ActorCryptoSlot {
 mod tests {
     use super::*;
     use temps_auth::permissions::Role;
+    use tower::ServiceExt;
 
     fn test_proxy() -> PluginProxy {
         PluginProxy::new(
@@ -719,5 +754,141 @@ mod tests {
         );
         assert_eq!(proxy.plugin_name, "test-plugin");
         assert_eq!(proxy.socket_path, PathBuf::from("/tmp/test.sock"));
+    }
+
+    #[test]
+    fn reserved_transport_paths_match_exactly_and_by_segment() {
+        for path in [
+            PLUGIN_EVENTS_PATH,
+            "/_events/forge",
+            PLUGIN_CHANNEL_PATH,
+            "/_temps/channel/upgrade",
+        ] {
+            assert!(is_reserved_internal_path(path), "{path}");
+        }
+
+        for path in [
+            "/_events-calendar",
+            "/_temps/channel-status",
+            "/_temps/channels",
+            "/events",
+        ] {
+            assert!(!is_reserved_internal_path(path), "{path}");
+        }
+    }
+
+    #[tokio::test]
+    async fn external_proxy_rejects_reserved_transport_routes_before_forwarding() {
+        // Even declaring these as public cannot override the platform-only
+        // reservation. The socket does not exist; a 404 therefore proves the
+        // handler rejected before attempting UDS forwarding/signature injection.
+        let router = create_plugin_proxy_router(test_proxy().with_public_paths(vec![
+            PLUGIN_EVENTS_PATH.to_string(),
+            PLUGIN_CHANNEL_PATH.to_string(),
+        ]));
+
+        for uri in [
+            "/_events",
+            "/_events/forge?event=deployment.succeeded",
+            "/_temps/channel",
+            "/_temps/channel/upgrade?transport=websocket",
+        ] {
+            let response = router
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(uri)
+                        .body(Body::empty())
+                        .expect("reserved-path request should build"),
+                )
+                .await
+                .expect("proxy router should respond");
+            assert_eq!(response.status(), StatusCode::NOT_FOUND, "{uri}");
+        }
+    }
+
+    #[tokio::test]
+    async fn direct_uds_delivery_still_reaches_reserved_event_endpoint() {
+        use hyper::service::service_fn;
+        use hyper_util::rt::TokioIo;
+        use tokio::net::UnixListener;
+
+        // Unix socket paths are capped at roughly 100 bytes on macOS; its
+        // per-user temp directory is already long, so keep this unique path
+        // under the short system temp root there. Other platforms use their
+        // configured temp directory rather than assuming macOS' `/private`.
+        #[cfg(target_os = "macos")]
+        let socket_root = PathBuf::from("/private/tmp");
+        #[cfg(not(target_os = "macos"))]
+        let socket_root = std::env::temp_dir();
+        let socket_path = socket_root.join(format!("tp-{}.sock", uuid::Uuid::new_v4()));
+        let listener = match UnixListener::bind(&socket_path) {
+            Ok(listener) => listener,
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+                eprintln!(
+                    "skipping direct UDS delivery test: sandbox forbids socket bind at {}",
+                    socket_path.display()
+                );
+                return;
+            }
+            Err(error) => panic!("test UDS should bind at {}: {error}", socket_path.display()),
+        };
+        let (observed_tx, observed_rx) = tokio::sync::oneshot::channel();
+        let observed_tx = std::sync::Arc::new(std::sync::Mutex::new(Some(observed_tx)));
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("direct UDS connection");
+            let _connection_result = hyper::server::conn::http1::Builder::new()
+                .serve_connection(
+                    TokioIo::new(stream),
+                    service_fn(move |request: hyper::Request<hyper::body::Incoming>| {
+                        let observed_tx = observed_tx.clone();
+                        async move {
+                            let observed = (
+                                request.uri().path().to_string(),
+                                request
+                                    .headers()
+                                    .get(headers::AUTH_SIGNATURE)
+                                    .and_then(|value| value.to_str().ok())
+                                    .map(str::to_string),
+                            );
+                            if let Some(tx) = observed_tx
+                                .lock()
+                                .expect("observation lock should remain available")
+                                .take()
+                            {
+                                let _ = tx.send(observed);
+                            }
+                            Ok::<_, std::convert::Infallible>(
+                                Response::builder()
+                                    .status(StatusCode::NO_CONTENT)
+                                    .body(Body::empty())
+                                    .expect("test response should build"),
+                            )
+                        }
+                    }),
+                )
+                .await;
+        });
+
+        let mut proxy = test_proxy();
+        proxy.socket_path = socket_path.clone();
+        let request = Request::builder()
+            .uri(PLUGIN_EVENTS_PATH)
+            .body(Body::empty())
+            .expect("direct request should build");
+        let response = forward_to_unix_socket(&proxy, None, request, PLUGIN_EVENTS_PATH)
+            .await
+            .expect("platform-internal UDS delivery should remain available");
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        let (observed_path, observed_signature) = observed_rx
+            .await
+            .expect("direct UDS server should observe the request");
+        assert_eq!(observed_path, PLUGIN_EVENTS_PATH);
+        assert_eq!(observed_signature.as_deref(), Some("s3cr3t"));
+        server.await.expect("test UDS server should finish");
+        tokio::fs::remove_file(&socket_path)
+            .await
+            .expect("test UDS socket should be removed");
     }
 }

--- a/crates/temps-external-plugins/src/proxy.rs
+++ b/crates/temps-external-plugins/src/proxy.rs
@@ -20,7 +20,7 @@ pub struct PluginProxy {
     pub socket_path: PathBuf,
     /// Plugin name for header injection
     pub plugin_name: String,
-    /// HMAC secret for authenticating proxied requests
+    /// Per-process assertion secret for authenticating proxied requests.
     pub auth_secret: String,
     /// Route prefixes the plugin authenticates itself, from its manifest.
     /// See [`temps_core::external_plugin::manifest::PluginManifest::public_paths`].
@@ -73,8 +73,8 @@ impl PluginProxy {
 
     /// Whether `path` is one the plugin gates itself.
     ///
-    /// Prefix match, but only at a segment boundary: `/vibe/mcp` must not
-    /// also open `/vibe/mcp-admin`.
+    /// Prefix match, but only at a segment boundary: `/hooks/incoming` must
+    /// not also open `/hooks/incoming-admin`.
     fn is_public(&self, path: &str) -> bool {
         self.public_paths.iter().any(|prefix| {
             let prefix = prefix.trim_end_matches('/');
@@ -152,10 +152,9 @@ async fn proxy_handler(State(proxy): State<PluginProxy>, request: Request) -> Re
                 path = %path,
                 "Failed to proxy request to plugin: {}", e
             );
-            (
-                StatusCode::BAD_GATEWAY,
-                format!("Plugin '{}' unavailable: {}", proxy.plugin_name, e),
-            )
+            problemdetails::new(StatusCode::BAD_GATEWAY)
+                .with_title("Plugin Unavailable")
+                .with_detail("The plugin could not complete the request.")
                 .into_response()
         }
     }
@@ -687,28 +686,28 @@ mod tests {
 
     #[test]
     fn public_paths_match_on_segment_boundaries() {
-        let proxy = test_proxy().with_public_paths(vec!["/vibe/mcp".into()]);
+        let proxy = test_proxy().with_public_paths(vec!["/hooks/incoming".into()]);
 
-        assert!(proxy.is_public("/vibe/mcp"));
-        assert!(proxy.is_public("/vibe/mcp/agents"));
+        assert!(proxy.is_public("/hooks/incoming"));
+        assert!(proxy.is_public("/hooks/incoming/jobs"));
         // The obvious trap: a sibling route whose name merely starts the same.
-        assert!(!proxy.is_public("/vibe/mcp-admin"));
-        assert!(!proxy.is_public("/vibe/apps"));
+        assert!(!proxy.is_public("/hooks/incoming-admin"));
+        assert!(!proxy.is_public("/hooks/outgoing"));
     }
 
     #[test]
     fn no_public_paths_means_everything_is_gated() {
         let proxy = test_proxy();
-        assert!(!proxy.is_public("/vibe/mcp/agents"));
+        assert!(!proxy.is_public("/hooks/incoming/jobs"));
         assert!(!proxy.is_public("/"));
     }
 
     #[test]
     fn trailing_slash_in_manifest_does_not_change_matching() {
-        let proxy = test_proxy().with_public_paths(vec!["/vibe/mcp/".into()]);
-        assert!(proxy.is_public("/vibe/mcp"));
-        assert!(proxy.is_public("/vibe/mcp/agents"));
-        assert!(!proxy.is_public("/vibe/mcp-admin"));
+        let proxy = test_proxy().with_public_paths(vec!["/hooks/incoming/".into()]);
+        assert!(proxy.is_public("/hooks/incoming"));
+        assert!(proxy.is_public("/hooks/incoming/jobs"));
+        assert!(!proxy.is_public("/hooks/incoming-admin"));
     }
 
     #[test]

--- a/crates/temps-external-plugins/src/proxy.rs
+++ b/crates/temps-external-plugins/src/proxy.rs
@@ -7,7 +7,11 @@ use axum::extract::{Request, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Router;
-use tracing::{debug, error};
+use temps_auth::context::{AuthContext, AuthSource};
+use temps_core::external_plugin::actor::ActorPrincipal;
+use temps_core::external_plugin::headers;
+use temps_core::problemdetails;
+use tracing::{debug, error, warn};
 
 /// Proxy configuration for a single external plugin.
 #[derive(Debug, Clone)]
@@ -18,6 +22,27 @@ pub struct PluginProxy {
     pub plugin_name: String,
     /// HMAC secret for authenticating proxied requests
     pub auth_secret: String,
+    /// Route prefixes the plugin authenticates itself, from its manifest.
+    /// See [`temps_core::external_plugin::manifest::PluginManifest::public_paths`].
+    pub public_paths: Vec<String>,
+    /// Instance key material for minting the caller's actor token.
+    ///
+    /// A *shared slot*, not a snapshot, and that distinction is the whole
+    /// point: the proxy router is built once during plugin initialization,
+    /// while the crypto is installed later, when the console router that
+    /// serves plugin API calls finally exists. A cloned `Option` captured at
+    /// build time is `None` forever — which is exactly the bug this replaced,
+    /// and it presented as "no platform actor is available" with nothing in
+    /// the logs, because minting was skipped silently.
+    ///
+    /// Empty on builds that never wired it: the plugin then gets no actor
+    /// header and its API calls fail closed with `Unauthenticated`, rather
+    /// than the proxy inventing an identity.
+    pub actor_crypto: ActorCryptoSlot,
+    /// Whether this plugin asked for any platform API access at all. A
+    /// plugin that declares no capability is never handed an actor token —
+    /// there is nothing it could legitimately do with one.
+    pub wants_api: bool,
 }
 
 impl PluginProxy {
@@ -26,7 +51,38 @@ impl PluginProxy {
             socket_path,
             plugin_name,
             auth_secret,
+            public_paths: Vec::new(),
+            actor_crypto: ActorCryptoSlot::default(),
+            wants_api: false,
         }
+    }
+
+    /// Supply the key material used to mint actor tokens, and whether this
+    /// plugin declared any API capability.
+    pub fn with_actor_minting(mut self, crypto: ActorCryptoSlot, wants_api: bool) -> Self {
+        self.actor_crypto = crypto;
+        self.wants_api = wants_api;
+        self
+    }
+
+    /// Declare the manifest's self-authenticating routes.
+    pub fn with_public_paths(mut self, public_paths: Vec<String>) -> Self {
+        self.public_paths = public_paths;
+        self
+    }
+
+    /// Whether `path` is one the plugin gates itself.
+    ///
+    /// Prefix match, but only at a segment boundary: `/vibe/mcp` must not
+    /// also open `/vibe/mcp-admin`.
+    fn is_public(&self, path: &str) -> bool {
+        self.public_paths.iter().any(|prefix| {
+            let prefix = prefix.trim_end_matches('/');
+            path == prefix
+                || path
+                    .strip_prefix(prefix)
+                    .is_some_and(|rest| rest.starts_with('/'))
+        })
     }
 }
 
@@ -52,16 +108,43 @@ async fn proxy_handler(State(proxy): State<PluginProxy>, request: Request) -> Re
     let uri = request.uri().clone();
     let path = uri.path();
 
+    // Authenticate here, because nothing else will. Ordinary routes enforce
+    // auth per-handler via the `RequireAuth` extractor; a proxied plugin
+    // route has no handler of ours to put that extractor in. The auth
+    // middleware that runs ahead of us only *populates* `AuthContext` for
+    // callers who presented a credential — it lets anonymous requests
+    // through for the public ingest endpoints to handle themselves. So
+    // without this check every `/api/x/<plugin>/…` path is reachable
+    // unauthenticated, whatever the plugin behind it does.
+    let auth = request.extensions().get::<AuthContext>().cloned();
+    if auth.is_none() && !proxy.is_public(path) {
+        warn!(
+            plugin = %proxy.plugin_name,
+            method = %method,
+            path = %path,
+            "Rejecting unauthenticated request to external plugin"
+        );
+        return problemdetails::new(StatusCode::UNAUTHORIZED)
+            .with_title("Authentication Required")
+            .with_detail(format!(
+                "Plugin '{}' is only reachable by an authenticated caller",
+                proxy.plugin_name
+            ))
+            .into_response();
+    }
+
     debug!(
         plugin = %proxy.plugin_name,
         method = %method,
         path = %path,
+        user_id = ?auth.as_ref().and_then(|a| a.user.as_ref()).map(|u| u.id),
+        role = ?auth.as_ref().map(|a| a.effective_role.to_string()),
         "Proxying request to external plugin"
     );
 
     let path_and_query = uri.path_and_query().map(|pq| pq.as_str()).unwrap_or(path);
 
-    match forward_to_unix_socket(&proxy, request, path_and_query).await {
+    match forward_to_unix_socket(&proxy, auth.as_ref(), request, path_and_query).await {
         Ok(response) => response,
         Err(e) => {
             error!(
@@ -81,6 +164,7 @@ async fn proxy_handler(State(proxy): State<PluginProxy>, request: Request) -> Re
 /// Forward an HTTP request to a plugin over its Unix domain socket.
 async fn forward_to_unix_socket(
     proxy: &PluginProxy,
+    auth: Option<&AuthContext>,
     original_request: Request,
     path_and_query: &str,
 ) -> Result<Response, String> {
@@ -112,20 +196,7 @@ async fn forward_to_unix_socket(
 
     let (mut parts, body) = original_request.into_parts();
 
-    parts.headers.insert(
-        "x-temps-plugin",
-        proxy
-            .plugin_name
-            .parse()
-            .unwrap_or_else(|_| hyper::header::HeaderValue::from_static("unknown")),
-    );
-    parts.headers.insert(
-        "x-temps-request-id",
-        uuid::Uuid::new_v4()
-            .to_string()
-            .parse()
-            .unwrap_or_else(|_| hyper::header::HeaderValue::from_static("")),
-    );
+    inject_temps_headers(&mut parts.headers, proxy, auth);
 
     let target_uri: hyper::Uri = path_and_query
         .parse()
@@ -149,9 +220,496 @@ async fn forward_to_unix_socket(
     Ok(Response::from_parts(parts, body))
 }
 
+/// The re-checkable principal behind an `AuthContext`, if the actor-token
+/// format can represent one.
+///
+/// Only credentials backed by a row that redemption can independently
+/// re-query (a session, an API key) get a principal. `CliToken` is dead code
+/// in this repo today, and `DeploymentToken` has no user to act as, so both
+/// fall through to `None` — the plugin then gets no actor token at all rather
+/// than one redemption would have to trust blindly.
+fn actor_principal(auth: &AuthContext) -> Option<ActorPrincipal> {
+    match &auth.source {
+        AuthSource::Session {
+            session_id: Some(session_id),
+            ..
+        } => Some(ActorPrincipal::Session {
+            session_id: *session_id,
+        }),
+        AuthSource::ApiKey { key_id, .. } => Some(ActorPrincipal::ApiKey { key_id: *key_id }),
+        AuthSource::Session {
+            session_id: None, ..
+        }
+        | AuthSource::CliToken { .. }
+        | AuthSource::DeploymentToken { .. } => None,
+    }
+}
+
+/// Replace the `x-temps-*` header namespace with Temps' own assertions.
+///
+/// Stripping first is the security-relevant half: these headers are the
+/// plugin's only source of identity, so a caller who can set them can pick
+/// their own user id and role. An authenticated `reader` sending
+/// `x-temps-user-role: admin` would otherwise be an admin inside every
+/// plugin. Removing the whole prefix — rather than only the names we are
+/// about to set — means a header added to the protocol later cannot be
+/// spoofed by a Temps build that predates it.
+fn inject_temps_headers(
+    headers: &mut hyper::HeaderMap,
+    proxy: &PluginProxy,
+    auth: Option<&AuthContext>,
+) {
+    // The browser's session cookie and any Authorization header are the
+    // caller's real platform credential — good for far more than this one
+    // plugin. A plugin process is untrusted third-party code; handing it
+    // that credential would let it act as the user against the platform
+    // directly, bypassing the scoped, single-plugin actor token below
+    // entirely. The plugin gets identity via `x-temps-*` headers and (if it
+    // asked for API access) an actor token bound to it specifically — never
+    // the caller's own credential.
+    for name in [
+        hyper::header::COOKIE,
+        hyper::header::AUTHORIZATION,
+        hyper::header::PROXY_AUTHORIZATION,
+    ] {
+        if headers.remove(&name).is_some() {
+            debug!(
+                plugin = %proxy.plugin_name,
+                header = %name,
+                "Stripping platform credential header before proxying to plugin"
+            );
+        }
+    }
+
+    let spoofed: Vec<_> = headers
+        .keys()
+        .filter(|name| name.as_str().starts_with(headers::PREFIX))
+        .cloned()
+        .collect();
+    for name in spoofed {
+        warn!(
+            plugin = %proxy.plugin_name,
+            header = %name,
+            "Stripping client-supplied Temps header before proxying to plugin"
+        );
+        headers.remove(&name);
+    }
+
+    let mut set = |name: &'static str, value: String| match value.parse() {
+        Ok(parsed) => {
+            headers.insert(name, parsed);
+        }
+        Err(e) => {
+            // Only reachable if a value contains bytes illegal in a header
+            // (a user email, realistically). Dropping the header is right:
+            // the plugin then sees the field as absent rather than as some
+            // silently mangled substitute.
+            warn!(
+                plugin = %proxy.plugin_name,
+                header = %name,
+                "Skipping unencodable Temps header value: {}", e
+            );
+        }
+    };
+
+    set(headers::PLUGIN_NAME, proxy.plugin_name.clone());
+    set(headers::REQUEST_ID, uuid::Uuid::new_v4().to_string());
+    set(headers::AUTH_SIGNATURE, proxy.auth_secret.clone());
+
+    // No context on a self-authenticating route (see `public_paths`). The
+    // absence of every identity header is the signal: a plugin must not be
+    // able to mistake an anonymous caller for a reader we vouched for.
+    let Some(auth) = auth else {
+        return;
+    };
+
+    // `Role`'s Display is the wire form the SDK's `TempsAuth` parses back.
+    set(headers::USER_ROLE, auth.effective_role.to_string());
+    let effective_permissions = temps_auth::permissions::Permission::all()
+        .into_iter()
+        .filter(|permission| auth.has_permission(permission))
+        .map(|permission| permission.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    set(headers::USER_PERMISSIONS, effective_permissions);
+
+    // Absent for credentials not bound to a user (deployment tokens). The
+    // plugin decides what to do with a roled-but-anonymous caller; we do not
+    // invent an id for it.
+    if let Some(user) = auth.user.as_ref() {
+        set(headers::USER_ID, user.id.to_string());
+        set(headers::USER_EMAIL, user.email.clone());
+
+        // Mint the proof the plugin echoes back on channel API calls. Bound
+        // to this plugin, this user, and a specific principal (a browser
+        // session or an API key) that redemption re-checks — see
+        // `temps_core::external_plugin::actor` for why the principal exists
+        // at all: without it, redemption could only rebuild the *user's*
+        // full role, silently discarding whatever a restricted API key had
+        // scoped the caller down to.
+        if proxy.wants_api {
+            match actor_principal(auth) {
+                Some(principal) => {
+                    if let Some(crypto) = proxy.actor_crypto.get() {
+                        match temps_core::external_plugin::actor::encode_plugin_actor_token(
+                            &crypto,
+                            &proxy.plugin_name,
+                            user.id,
+                            principal,
+                            temps_core::external_plugin::actor::PLUGIN_ACTOR_TOKEN_TTL,
+                            std::time::SystemTime::now(),
+                        ) {
+                            Ok((token, _exp)) => set(headers::ACTOR_TOKEN, token),
+                            Err(e) => warn!(
+                                plugin = %proxy.plugin_name,
+                                "Could not mint an actor token; this plugin's platform API \
+                                 calls will be refused: {e}"
+                            ),
+                        }
+                    } else {
+                        // Say it once per request rather than never: a plugin
+                        // that declared a capability and gets no token will
+                        // fail every API call, and "no actor" on the plugin
+                        // side gives no clue that the platform simply had no
+                        // key to sign with.
+                        warn!(
+                            plugin = %proxy.plugin_name,
+                            "This plugin declared an API capability but the platform has no \
+                             actor signing key installed, so its platform API calls will be \
+                             refused"
+                        );
+                    }
+                }
+                None => {
+                    // Not a bug — a credential that authenticated this
+                    // request but has no revocable row to re-check at
+                    // redemption (today: a CLI token). Minting anyway would
+                    // hand the plugin an unlinkable grant no "sign out" or
+                    // "deactivate" could ever reach; refusing is the correct
+                    // failure. Debug, not warn: this is the expected shape
+                    // for every such request, not an operator-actionable
+                    // problem.
+                    debug!(
+                        plugin = %proxy.plugin_name,
+                        "No actor token minted: this request's credential has no principal \
+                         the token format can represent, so this plugin's platform API calls \
+                         will be refused for it"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Shared, late-filled slot for the instance's actor-token signing key.
+///
+/// See [`PluginProxy::actor_crypto`] for why this is shared rather than
+/// copied: the writer runs after every reader has already been constructed.
+#[derive(Clone, Default)]
+pub struct ActorCryptoSlot(
+    std::sync::Arc<std::sync::RwLock<Option<std::sync::Arc<temps_core::CookieCrypto>>>>,
+);
+
+/// Debug never reveals whether a key is present, let alone the key: the
+/// proxy is `Debug`-printed in request-path logs.
+impl std::fmt::Debug for ActorCryptoSlot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ActorCryptoSlot(..)")
+    }
+}
+
+impl ActorCryptoSlot {
+    pub fn set(&self, crypto: std::sync::Arc<temps_core::CookieCrypto>) {
+        if let Ok(mut slot) = self.0.write() {
+            *slot = Some(crypto);
+        }
+    }
+
+    /// The key, if one has been installed.
+    ///
+    /// A poisoned lock reads as "no key", which fails closed: no token is
+    /// minted and the plugin's API calls are refused, rather than a panic on
+    /// the request path.
+    pub fn get(&self) -> Option<std::sync::Arc<temps_core::CookieCrypto>> {
+        self.0.read().ok().and_then(|slot| slot.clone())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use temps_auth::permissions::Role;
+
+    fn test_proxy() -> PluginProxy {
+        PluginProxy::new(
+            PathBuf::from("/tmp/test.sock"),
+            "example-plugin".to_string(),
+            "s3cr3t".to_string(),
+        )
+    }
+
+    fn test_user(id: i32, email: &str) -> temps_entities::users::Model {
+        let now = chrono::Utc::now();
+        temps_entities::users::Model {
+            id,
+            name: "Test User".to_string(),
+            email: email.to_string(),
+            password_hash: None,
+            email_verified: true,
+            email_verification_token: None,
+            email_verification_expires: None,
+            password_reset_token: None,
+            password_reset_expires: None,
+            must_change_password: false,
+            deleted_at: None,
+            mfa_secret: None,
+            mfa_enabled: false,
+            mfa_recovery_codes: None,
+            oidc_subject: None,
+            oidc_provider_id: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn header(headers: &hyper::HeaderMap, name: &str) -> Option<String> {
+        headers
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string)
+    }
+
+    /// The bug this file's `actor_crypto` doc describes, pinned.
+    ///
+    /// A proxy is built during plugin initialization; the signing key is
+    /// installed later, when the console router exists. If the proxy held a
+    /// snapshot it would mint nothing forever — and it would do so silently,
+    /// surfacing to the user only as "no platform actor is available" from
+    /// inside the plugin, with nothing on the platform side to explain it.
+    #[test]
+    fn a_key_installed_after_the_proxy_was_built_is_still_used() {
+        let slot = ActorCryptoSlot::default();
+        // Built first, exactly as `build_proxy_router_from` does.
+        let proxy = test_proxy().with_actor_minting(slot.clone(), true);
+        let auth =
+            AuthContext::new_persisted_session(test_user(42, "dev@temps.sh"), Role::Admin, 7);
+
+        let mut before = hyper::HeaderMap::new();
+        inject_temps_headers(&mut before, &proxy, Some(&auth));
+        assert!(
+            header(&before, headers::ACTOR_TOKEN).is_none(),
+            "no key installed yet, so there is nothing to sign with"
+        );
+
+        // ...and only now does the console install the key.
+        slot.set(std::sync::Arc::new(
+            temps_core::CookieCrypto::new("0123456789abcdef0123456789abcdef").expect("test key"),
+        ));
+
+        let mut after = hyper::HeaderMap::new();
+        inject_temps_headers(&mut after, &proxy, Some(&auth));
+        let token = header(&after, headers::ACTOR_TOKEN)
+            .expect("the same proxy must mint once the key arrives");
+        let verified = temps_core::external_plugin::actor::verify_plugin_actor_token(
+            &temps_core::CookieCrypto::new("0123456789abcdef0123456789abcdef").expect("test key"),
+            &token,
+            &proxy.plugin_name,
+            std::time::SystemTime::now(),
+        )
+        .expect("the minted token must verify");
+        assert_eq!(verified.user_id, 42);
+        assert_eq!(
+            verified.principal,
+            temps_core::external_plugin::actor::ActorPrincipal::Session { session_id: 7 }
+        );
+    }
+
+    /// A plugin that declared no capability gets no token even with a key
+    /// installed: there is nothing it could legitimately do with one.
+    #[test]
+    fn a_plugin_without_a_capability_is_never_given_an_actor() {
+        let slot = ActorCryptoSlot::default();
+        slot.set(std::sync::Arc::new(
+            temps_core::CookieCrypto::new("0123456789abcdef0123456789abcdef").expect("test key"),
+        ));
+        let proxy = test_proxy().with_actor_minting(slot, false);
+        let auth = AuthContext::new_session(test_user(42, "dev@temps.sh"), Role::Admin);
+
+        let mut headers = hyper::HeaderMap::new();
+        inject_temps_headers(&mut headers, &proxy, Some(&auth));
+        assert!(header(&headers, headers::ACTOR_TOKEN).is_none());
+    }
+
+    #[test]
+    fn injects_identity_from_auth_context() {
+        let auth = AuthContext::new_session(test_user(42, "dev@temps.sh"), Role::Admin);
+        let mut headers = hyper::HeaderMap::new();
+
+        inject_temps_headers(&mut headers, &test_proxy(), Some(&auth));
+
+        assert_eq!(header(&headers, headers::USER_ID).as_deref(), Some("42"));
+        assert_eq!(
+            header(&headers, headers::USER_EMAIL).as_deref(),
+            Some("dev@temps.sh")
+        );
+        assert_eq!(
+            header(&headers, headers::USER_ROLE).as_deref(),
+            Some("admin")
+        );
+        assert!(header(&headers, headers::USER_PERMISSIONS)
+            .is_some_and(|permissions| permissions.contains("projects:write")));
+        assert_eq!(
+            header(&headers, headers::PLUGIN_NAME).as_deref(),
+            Some("example-plugin")
+        );
+        assert_eq!(
+            header(&headers, headers::AUTH_SIGNATURE).as_deref(),
+            Some("s3cr3t")
+        );
+        assert!(header(&headers, headers::REQUEST_ID).is_some());
+    }
+
+    #[test]
+    fn client_supplied_identity_cannot_survive() {
+        // A reader trying to reach the plugin as an admin user.
+        let auth = AuthContext::new_session(test_user(7, "reader@temps.sh"), Role::Reader);
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert(headers::USER_ID, "1".parse().unwrap());
+        headers.insert(headers::USER_EMAIL, "admin@temps.sh".parse().unwrap());
+        headers.insert(headers::USER_ROLE, "admin".parse().unwrap());
+        headers.insert(headers::AUTH_SIGNATURE, "guessed".parse().unwrap());
+        headers.insert(
+            headers::USER_PERMISSIONS,
+            "projects:write,users:manage".parse().unwrap(),
+        );
+
+        inject_temps_headers(&mut headers, &test_proxy(), Some(&auth));
+
+        assert_eq!(header(&headers, headers::USER_ID).as_deref(), Some("7"));
+        assert_eq!(
+            header(&headers, headers::USER_EMAIL).as_deref(),
+            Some("reader@temps.sh")
+        );
+        assert_eq!(
+            header(&headers, headers::USER_ROLE).as_deref(),
+            Some("reader")
+        );
+        assert_eq!(
+            header(&headers, headers::AUTH_SIGNATURE).as_deref(),
+            Some("s3cr3t")
+        );
+        let permissions = header(&headers, headers::USER_PERMISSIONS)
+            .expect("the proxy must inject the reader's resolved permissions");
+        assert!(permissions.split(',').any(|value| value == "projects:read"));
+        assert!(!permissions
+            .split(',')
+            .any(|value| value == "projects:write"));
+        assert!(!permissions.split(',').any(|value| value == "users:manage"));
+    }
+
+    /// The proxy may authenticate a request from either the browser's session
+    /// cookie or an API key, but the plugin must never receive that original,
+    /// platform-wide credential. It receives only the scoped identity headers
+    /// (and, when enabled, its plugin-bound actor token).
+    #[test]
+    fn caller_credentials_are_stripped_before_proxying_to_a_plugin() {
+        let auth = AuthContext::new_session(test_user(7, "reader@temps.sh"), Role::Reader);
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert(
+            hyper::header::COOKIE,
+            "temps_session=platform-secret".parse().unwrap(),
+        );
+        headers.insert(
+            hyper::header::AUTHORIZATION,
+            "Bearer platform-api-key".parse().unwrap(),
+        );
+        headers.insert(
+            hyper::header::PROXY_AUTHORIZATION,
+            "Basic proxy-secret".parse().unwrap(),
+        );
+        headers.insert("x-request-trace", "kept".parse().unwrap());
+
+        inject_temps_headers(&mut headers, &test_proxy(), Some(&auth));
+
+        assert!(!headers.contains_key(hyper::header::COOKIE));
+        assert!(!headers.contains_key(hyper::header::AUTHORIZATION));
+        assert!(!headers.contains_key(hyper::header::PROXY_AUTHORIZATION));
+        assert_eq!(header(&headers, "x-request-trace").as_deref(), Some("kept"));
+        assert_eq!(header(&headers, headers::USER_ID).as_deref(), Some("7"));
+    }
+
+    #[test]
+    fn unknown_temps_prefixed_headers_are_stripped() {
+        let auth = AuthContext::new_session(test_user(7, "reader@temps.sh"), Role::Reader);
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert("x-temps-not-a-real-header", "hello".parse().unwrap());
+        headers.insert("x-other-header", "kept".parse().unwrap());
+
+        inject_temps_headers(&mut headers, &test_proxy(), Some(&auth));
+
+        assert!(header(&headers, "x-temps-not-a-real-header").is_none());
+        assert_eq!(header(&headers, "x-other-header").as_deref(), Some("kept"));
+    }
+
+    #[test]
+    fn deployment_token_forwards_role_but_no_user() {
+        // Deployment tokens carry no user row; the plugin must be able to
+        // tell "authenticated as nobody in particular" from "user 0".
+        let auth = AuthContext::new_deployment_token(1, Some(2), Some(3), 4, "ci".into(), vec![]);
+        let mut headers = hyper::HeaderMap::new();
+
+        inject_temps_headers(&mut headers, &test_proxy(), Some(&auth));
+
+        assert!(header(&headers, headers::USER_ID).is_none());
+        assert!(header(&headers, headers::USER_EMAIL).is_none());
+        assert!(header(&headers, headers::USER_ROLE).is_some());
+    }
+
+    #[test]
+    fn anonymous_route_forwards_no_identity_at_all() {
+        // A self-authenticating route gets no identity headers rather than a
+        // defaulted one — the plugin must not mistake anonymous for a reader.
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert(headers::USER_ID, "1".parse().unwrap());
+        headers.insert(headers::USER_ROLE, "admin".parse().unwrap());
+
+        inject_temps_headers(&mut headers, &test_proxy(), None);
+
+        assert!(header(&headers, headers::USER_ID).is_none());
+        assert!(header(&headers, headers::USER_EMAIL).is_none());
+        assert!(header(&headers, headers::USER_ROLE).is_none());
+        // Still tagged as coming from the proxy.
+        assert_eq!(
+            header(&headers, headers::PLUGIN_NAME).as_deref(),
+            Some("example-plugin")
+        );
+    }
+
+    #[test]
+    fn public_paths_match_on_segment_boundaries() {
+        let proxy = test_proxy().with_public_paths(vec!["/vibe/mcp".into()]);
+
+        assert!(proxy.is_public("/vibe/mcp"));
+        assert!(proxy.is_public("/vibe/mcp/agents"));
+        // The obvious trap: a sibling route whose name merely starts the same.
+        assert!(!proxy.is_public("/vibe/mcp-admin"));
+        assert!(!proxy.is_public("/vibe/apps"));
+    }
+
+    #[test]
+    fn no_public_paths_means_everything_is_gated() {
+        let proxy = test_proxy();
+        assert!(!proxy.is_public("/vibe/mcp/agents"));
+        assert!(!proxy.is_public("/"));
+    }
+
+    #[test]
+    fn trailing_slash_in_manifest_does_not_change_matching() {
+        let proxy = test_proxy().with_public_paths(vec!["/vibe/mcp/".into()]);
+        assert!(proxy.is_public("/vibe/mcp"));
+        assert!(proxy.is_public("/vibe/mcp/agents"));
+        assert!(!proxy.is_public("/vibe/mcp-admin"));
+    }
 
     #[test]
     fn test_plugin_proxy_creation() {

--- a/crates/temps-external-plugins/src/service.rs
+++ b/crates/temps-external-plugins/src/service.rs
@@ -31,6 +31,20 @@ pub struct ExternalPluginsService {
 }
 
 impl ExternalPluginsService {
+    /// Install the bridge plugins use to call the platform's own HTTP API.
+    ///
+    /// The console builds its router *after* plugins start (the router
+    /// contains this crate's routes), so this is how the two are joined up
+    /// once both exist.
+    pub async fn set_host_api(&self, bridge: Arc<dyn crate::channel::HostApiBridge>) {
+        self.manager.set_host_api(bridge).await;
+    }
+
+    /// Supply the key material used to mint per-caller actor tokens.
+    pub async fn set_actor_crypto(&self, crypto: Arc<temps_core::CookieCrypto>) {
+        self.manager.set_actor_crypto(crypto).await;
+    }
+
     /// Create a "shell" service with no discovered plugins yet.
     ///
     /// This returns immediately — plugin discovery (which can take up to

--- a/crates/temps-plugin-sdk/Cargo.toml
+++ b/crates/temps-plugin-sdk/Cargo.toml
@@ -48,6 +48,7 @@ tar = "0.4.45"
 
 # UUID for request IDs
 uuid = { workspace = true }
+subtle = "2.6"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/temps-plugin-sdk/src/api.rs
+++ b/crates/temps-plugin-sdk/src/api.rs
@@ -1,0 +1,778 @@
+//! Typed access to the platform's HTTP API from a plugin.
+//!
+//! [`crate::client::TempsClient::api_call`] can reach any endpoint, but it
+//! takes a path and a verb as data — which is exactly the stringly-typed hole
+//! this protocol set out to remove. This module puts the types back: one
+//! entry per endpoint declares its method, its path, its request body and its
+//! response, and the call site names none of them.
+//!
+//! ```rust,no_run
+//! # use temps_plugin_sdk::prelude::*;
+//! # use temps_plugin_sdk::api::NewProject;
+//! # async fn example(
+//! #     ctx: &PluginContext,
+//! #     auth: &temps_plugin_sdk::protocol::TempsUserContext,
+//! # ) -> Result<(), PluginSdkError> {
+//! let api = ctx.api_for(auth)?;
+//! let project = api.create_project(&NewProject::static_files("demo", "vite")).await?;
+//! println!("created project {} ({})", project.id, project.slug);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Why this is hand-declared rather than generated
+//!
+//! The platform's OpenAPI document is produced *from* its Rust handlers by
+//! utoipa, so generating a Rust client from it would be a cycle: handlers →
+//! spec → client → compiled against those handlers. Breaking the cycle means
+//! committing a spec snapshot, which then goes stale silently.
+//!
+//! So the endpoint table is written by hand and *checked* against the spec
+//! instead — see [`DECLARED_ENDPOINTS`] and the conformance test in
+//! `temps-cli`. Drift becomes a failing build that names the endpoint, rather
+//! than a 404 an operator finds.
+//!
+//! ## Why the response types are narrower than the API's
+//!
+//! `ProjectResponse` has thirty fields; a plugin shipping an app reads four.
+//! Mirroring the full struct would drag `SourceType`, `DeploymentConfig` and
+//! the rest of the platform's internals into every plugin binary, and would
+//! break plugins on every additive change to a field they never touch.
+//!
+//! So each type here is a *projection*: the fields the SDK actually uses,
+//! named exactly as the API names them. Serde ignores the rest. The
+//! conformance test is what makes that safe — it fails if a projected field
+//! stops existing in the spec.
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use temps_core::external_plugin::channel::{
+    ActorToken, ApiCall, ApiCallResult, BinaryPayload, CallBody, HttpMethod, MultipartPart,
+    PartContent, MAX_CALL_BODY_BYTES,
+};
+
+use crate::client::TempsClient;
+use crate::error::PluginSdkError;
+
+// ── Request bodies ─────────────────────────────────────────────────────
+
+/// Create or replace a project.
+///
+/// `POST /projects` and `PUT /projects/{id}` take the same body, which is why
+/// one type serves both. Only the fields a plugin needs are modelled; the API
+/// defaults the rest.
+#[derive(Debug, Clone, Serialize)]
+pub struct NewProject {
+    pub name: String,
+    pub main_branch: String,
+    pub directory: String,
+    pub preset: String,
+    pub automatic_deploy: bool,
+    pub source_type: String,
+    pub storage_service_ids: Vec<i32>,
+}
+
+impl NewProject {
+    /// A project deployed from uploaded static bundles.
+    pub fn static_files(name: impl Into<String>, preset: impl Into<String>) -> Self {
+        Self::with_source(name, preset, "static_files")
+    }
+
+    /// A project deployed from uploaded container images.
+    pub fn docker_image(name: impl Into<String>, preset: impl Into<String>) -> Self {
+        Self::with_source(name, preset, "docker_image")
+    }
+
+    fn with_source(name: impl Into<String>, preset: impl Into<String>, source_type: &str) -> Self {
+        Self {
+            name: name.into(),
+            main_branch: "main".into(),
+            directory: ".".into(),
+            preset: preset.into(),
+            // A plugin ships explicitly, on its own schedule. Leaving
+            // auto-deploy on would let an unrelated git push overwrite what
+            // the plugin just deployed.
+            automatic_deploy: false,
+            source_type: source_type.into(),
+            storage_service_ids: Vec::new(),
+        }
+    }
+}
+
+/// Create a managed service (a database, cache, bucket) on the platform.
+#[derive(Debug, Clone, Serialize)]
+pub struct NewService {
+    pub name: String,
+    /// Platform service type, e.g. `postgres`, `redis`, `mongodb`.
+    pub service_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Type-specific parameters, e.g. `database` and `username` for Postgres.
+    pub parameters: std::collections::HashMap<String, String>,
+    /// `standalone` unless the caller is building a cluster.
+    pub topology: String,
+    pub members: Vec<i32>,
+}
+
+impl NewService {
+    /// A standalone Postgres with an application database and role.
+    pub fn postgres(name: impl Into<String>, database: &str, username: &str) -> Self {
+        let mut parameters = std::collections::HashMap::new();
+        parameters.insert("database".to_string(), database.to_string());
+        parameters.insert("username".to_string(), username.to_string());
+        Self {
+            name: name.into(),
+            service_type: "postgres".into(),
+            version: None,
+            parameters,
+            topology: "standalone".into(),
+            members: Vec::new(),
+        }
+    }
+}
+
+/// Link an existing managed service to a project.
+#[derive(Debug, Clone, Serialize)]
+pub struct LinkService {
+    pub project_id: i32,
+}
+
+/// Start a deployment from an already-uploaded static bundle.
+#[derive(Debug, Clone, Serialize)]
+pub struct DeployStaticBundle {
+    pub static_bundle_id: i32,
+}
+
+/// Start a deployment from a container image the platform can already reach.
+///
+/// "Reach" means a registry it can pull from, *or* an image already present
+/// in the host's Docker — which is the case for one a plugin built there.
+/// Naming the image is what makes that possible: the alternative,
+/// [`PlatformApi::deploy_image_upload`], has to carry the entire tarball
+/// through the platform channel and hits its 32 MiB body cap on any image
+/// with a real runtime in it.
+#[derive(Debug, Clone, Serialize)]
+pub struct DeployImage {
+    pub image_ref: String,
+}
+
+// ── Response projections ───────────────────────────────────────────────
+
+/// A narrow view of one of the API's response types.
+///
+/// Declaring the schema name and the field list as data is what lets the
+/// conformance test check them: it can look the schema up in the platform's
+/// OpenAPI document and verify every projected field is really there, and
+/// really required. Without this the test could only check that the *path*
+/// exists, which would not have caught a deploy endpoint returning `state`
+/// where the SDK expected `status`.
+pub trait ApiProjection {
+    /// The OpenAPI component schema this projects.
+    const SCHEMA: &'static str;
+    /// Fields read from that schema, and whether each must be present.
+    ///
+    /// A field marked required must be in the schema's `required` list — a
+    /// non-`Option` Rust field cannot decode a response that omits it.
+    const FIELDS: &'static [(&'static str, bool)];
+}
+
+/// Define a projection and its conformance metadata from one field list, so
+/// the struct and the list it is checked against cannot drift.
+macro_rules! projection {
+    (
+        $(#[$sdoc:meta])*
+        $name:ident of $schema:literal {
+            $(
+                $(#[$fdoc:meta])*
+                $field:ident: $ty:ty, required = $required:literal;
+            )*
+        }
+    ) => {
+        $(#[$sdoc])*
+        #[derive(Debug, Clone, Deserialize)]
+        pub struct $name {
+            $(
+                $(#[$fdoc])*
+                pub $field: $ty,
+            )*
+        }
+
+        impl ApiProjection for $name {
+            const SCHEMA: &'static str = $schema;
+            const FIELDS: &'static [(&'static str, bool)] =
+                &[$( (stringify!($field), $required), )*];
+        }
+    };
+}
+
+projection! {
+    /// The fields of `ProjectResponse` a plugin needs to deploy into a project.
+    ProjectRef of "ProjectResponse" {
+        id: i32, required = true;
+        name: String, required = true;
+        slug: String, required = true;
+        /// `None` for projects created before presets existed.
+        preset: Option<String>, required = false;
+        repo_name: Option<String>, required = false;
+        repo_owner: Option<String>, required = false;
+        git_url: Option<String>, required = false;
+        main_branch: String, required = true;
+        last_deployment: Option<i64>, required = false;
+        created_at: i64, required = true;
+    }
+}
+
+/// Caller-filtered page returned by `GET /projects`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProjectPage {
+    pub projects: Vec<ProjectRef>,
+    pub total: i64,
+    pub page: i64,
+    pub per_page: i64,
+}
+
+projection! {
+    /// The fields of `EnvironmentResponse` a plugin needs to deploy and to
+    /// tell the user where the result lives.
+    EnvironmentRef of "EnvironmentResponse" {
+        id: i32, required = true;
+        project_id: i32, required = true;
+        name: String, required = true;
+        slug: String, required = true;
+        /// Browser-reachable URL for this environment.
+        main_url: String, required = true;
+    }
+}
+
+projection! {
+    /// The fields of `RemoteDeploymentResponse` — what the *deploy* endpoints
+    /// return.
+    ///
+    /// Deliberately separate from [`DeploymentRef`]: a started deployment
+    /// reports `state` and has a `slug`, while polling one reports `status`
+    /// and has a `url`. They are different types on the platform, and
+    /// pretending otherwise produced a decode failure that only appeared on a
+    /// real deploy.
+    StartedDeployment of "RemoteDeploymentResponse" {
+        id: i32, required = true;
+        project_id: i32, required = true;
+        environment_id: i32, required = true;
+        slug: String, required = true;
+        state: String, required = true;
+    }
+}
+
+projection! {
+    /// The fields of `DeploymentResponse` a plugin needs to follow a
+    /// deployment to its conclusion.
+    DeploymentRef of "DeploymentResponse" {
+        id: i32, required = true;
+        status: String, required = true;
+        url: String, required = true;
+        /// Set when `status` is a failure — the platform's own explanation,
+        /// which is the only thing that tells a user *why* their deploy
+        /// failed.
+        cancelled_reason: Option<String>, required = false;
+    }
+}
+
+projection! {
+    /// The fields of `StaticBundleResponse` a plugin needs to deploy a bundle
+    /// it just uploaded.
+    StaticBundleRef of "StaticBundleResponse" {
+        id: i32, required = true;
+        project_id: i32, required = true;
+        size_bytes: i64, required = true;
+    }
+}
+
+impl DeploymentRef {
+    /// Whether this deployment reached a terminal state.
+    pub fn is_finished(&self) -> bool {
+        self.is_success() || self.is_failure()
+    }
+
+    pub fn is_success(&self) -> bool {
+        matches!(self.status.as_str(), "success" | "completed" | "deployed")
+    }
+
+    pub fn is_failure(&self) -> bool {
+        matches!(self.status.as_str(), "failed" | "error" | "cancelled")
+    }
+}
+
+projection! {
+    /// The fields of `ExternalServiceInfo` a plugin needs after creating a
+    /// managed service.
+    ///
+    /// `service_type` is deliberately absent: the platform types it as an
+    /// enum (`ServiceTypeRoute`), and a plugin that projected it as a
+    /// `String` would break the moment a new service type is added. The
+    /// caller already knows what it asked for.
+    ServiceRef of "ExternalServiceInfo" {
+        id: i32, required = true;
+        name: String, required = true;
+        status: String, required = true;
+    }
+}
+
+projection! {
+    /// The fields of `ProjectServiceInfo` returned when a service is linked
+    /// to a project.
+    ///
+    /// Only the link's own id: the nested `project` and `service` objects
+    /// echo back what the caller already had.
+    ServiceLinkRef of "ProjectServiceInfo" {
+        id: i32, required = true;
+    }
+}
+
+/// Live connection variables for a managed service in one environment.
+///
+/// Not a `projection!`: the platform returns a free-form map keyed by
+/// variable name (`POSTGRES_URL`, `POSTGRES_PASSWORD`, ...), so there are no
+/// fixed fields for the conformance test to check. The endpoint itself is in
+/// [`DECLARED_ENDPOINTS`], which is what would catch it moving.
+#[derive(Deserialize)]
+pub struct RuntimeCredentials {
+    pub variables: std::collections::HashMap<String, String>,
+}
+
+impl RuntimeCredentials {
+    /// The variable a framework is most likely to want, under the name most
+    /// frameworks expect.
+    ///
+    /// Temps emits `POSTGRES_URL`; almost every ORM reads `DATABASE_URL`.
+    /// Translating here rather than in each plugin means one place gets it
+    /// wrong instead of all of them.
+    pub fn database_url(&self) -> Option<&str> {
+        self.variables
+            .get("DATABASE_URL")
+            .or_else(|| self.variables.get("POSTGRES_URL"))
+            .map(String::as_str)
+    }
+
+    /// Variable names only, for logging. There is no accessor that renders
+    /// the values, on purpose.
+    pub fn names(&self) -> Vec<&str> {
+        let mut names: Vec<&str> = self.variables.keys().map(String::as_str).collect();
+        names.sort_unstable();
+        names
+    }
+}
+
+/// Debug prints names only — these are live credentials.
+impl std::fmt::Debug for RuntimeCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RuntimeCredentials {{ variables: {:?} }}", self.names())
+    }
+}
+
+/// Every projection this SDK declares, as `(schema, fields)`.
+///
+/// The conformance test walks this against the platform's OpenAPI components.
+pub const DECLARED_PROJECTIONS: &[(&str, &[(&str, bool)])] = &[
+    (ProjectRef::SCHEMA, ProjectRef::FIELDS),
+    (EnvironmentRef::SCHEMA, EnvironmentRef::FIELDS),
+    (StartedDeployment::SCHEMA, StartedDeployment::FIELDS),
+    (DeploymentRef::SCHEMA, DeploymentRef::FIELDS),
+    (StaticBundleRef::SCHEMA, StaticBundleRef::FIELDS),
+    (ServiceRef::SCHEMA, ServiceRef::FIELDS),
+    (ServiceLinkRef::SCHEMA, ServiceLinkRef::FIELDS),
+];
+
+// ── The client ─────────────────────────────────────────────────────────
+
+/// Typed platform API bound to one acting user.
+///
+/// Obtained from [`crate::context::PluginContext::api_for`], which supplies
+/// the actor token the platform minted for the request being served. There is
+/// no way to build one without an actor, so a plugin cannot accidentally make
+/// an unattributed call.
+#[derive(Clone)]
+pub struct PlatformApi {
+    client: TempsClient,
+    actor: ActorToken,
+}
+
+impl PlatformApi {
+    pub(crate) fn new(client: TempsClient, actor: ActorToken) -> Self {
+        Self { client, actor }
+    }
+
+    /// List projects visible to this caller.
+    ///
+    /// This intentionally uses the platform's HTTP handler rather than the
+    /// legacy channel `ListProjects` call: the handler applies project-access
+    /// filtering and the caller's resolved `projects:read` permission.
+    pub async fn list_projects(
+        &self,
+        page: i64,
+        per_page: i64,
+    ) -> Result<ProjectPage, PluginSdkError> {
+        self.send(
+            HttpMethod::Get,
+            "/projects".to_string(),
+            Some(format!("page={page}&per_page={per_page}")),
+            None,
+        )
+        .await
+    }
+
+    /// Issue a request and decode the response body.
+    async fn send<Res: DeserializeOwned>(
+        &self,
+        method: HttpMethod,
+        path: String,
+        query: Option<String>,
+        body: Option<CallBody>,
+    ) -> Result<Res, PluginSdkError> {
+        if let Some(body) = &body {
+            // Checked here as well as on the platform so an oversized upload
+            // fails before it is base64-encoded and pushed through a socket,
+            // which on a big artifact is the difference between an instant
+            // error and a multi-second stall ending in the same error.
+            let len = body.payload_len();
+            if len > MAX_CALL_BODY_BYTES {
+                return Err(PluginSdkError::BodyTooLarge {
+                    len,
+                    limit: MAX_CALL_BODY_BYTES,
+                    method: method.as_str(),
+                    path,
+                });
+            }
+        }
+
+        let result: ApiCallResult = self
+            .client
+            .api_call(ApiCall {
+                method,
+                path: path.clone(),
+                query,
+                body,
+                actor: self.actor.clone(),
+            })
+            .await?;
+
+        if !result.is_success() {
+            // Surface the platform's own words. A plugin author debugging a
+            // rejected call needs the API's problem-details body, not
+            // "request failed".
+            return Err(PluginSdkError::ApiStatus {
+                status: result.status,
+                method: method.as_str(),
+                path,
+                body: result.body.as_str().to_string(),
+            });
+        }
+
+        result
+            .body
+            .decode()
+            .map_err(|e| PluginSdkError::Deserialization {
+                reason: e.to_string(),
+            })
+    }
+
+    /// Upload a static bundle (a `.tar.gz` of the built output) to a project.
+    ///
+    /// Not part of [`define_api!`] because the endpoint takes
+    /// `multipart/form-data` rather than JSON, and because the archive is the
+    /// one payload big enough to be worth naming its own limit.
+    pub async fn upload_static_bundle(
+        &self,
+        project_id: i32,
+        filename: &str,
+        archive: Vec<u8>,
+    ) -> Result<StaticBundleRef, PluginSdkError> {
+        let parts = vec![
+            MultipartPart {
+                name: "file".into(),
+                filename: Some(filename.to_string()),
+                content_type: Some("application/gzip".into()),
+                content: PartContent::Binary(BinaryPayload::new(archive)),
+            },
+            MultipartPart {
+                name: "content_type".into(),
+                filename: None,
+                content_type: None,
+                content: PartContent::Text("application/gzip".into()),
+            },
+        ];
+        self.send(
+            HttpMethod::Post,
+            format!("/projects/{project_id}/upload/static"),
+            None,
+            Some(CallBody::Multipart(parts)),
+        )
+        .await
+    }
+
+    /// Deploy a container image saved with `docker save`.
+    ///
+    /// `tag` is the image tag inside the tarball, which the platform needs in
+    /// order to know which image it just imported.
+    pub async fn deploy_image_upload(
+        &self,
+        project_id: i32,
+        environment_id: i32,
+        tag: &str,
+        image_tar: Vec<u8>,
+    ) -> Result<StartedDeployment, PluginSdkError> {
+        let parts = vec![MultipartPart {
+            name: "file".into(),
+            filename: Some("image.tar".into()),
+            content_type: Some("application/x-tar".into()),
+            content: PartContent::Binary(BinaryPayload::new(image_tar)),
+        }];
+        self.send(
+            HttpMethod::Post,
+            format!("/projects/{project_id}/environments/{environment_id}/deploy/image-upload"),
+            Some(format!("tag={}", urlencode(tag))),
+            Some(CallBody::Multipart(parts)),
+        )
+        .await
+    }
+}
+
+/// Percent-encode a query-string value.
+///
+/// Hand-rolled rather than pulled in as a dependency: the SDK is compiled
+/// into every plugin binary, and this is the only place it needs escaping.
+/// The unreserved set is RFC 3986 §2.3.
+fn urlencode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char)
+            }
+            other => out.push_str(&format!("%{other:02X}")),
+        }
+    }
+    out
+}
+
+/// Declare an endpoint: its verb, its path, its parameters, its body and its
+/// response.
+///
+/// The generated method fills in everything but the caller's data, so no call
+/// site ever spells a path or a verb. Path parameters are named the same as
+/// in the OpenAPI path template, so the `format!` below captures them
+/// implicitly and the declared path doubles as the conformance key.
+macro_rules! define_api {
+    (
+        $(
+            $(#[$doc:meta])*
+            $name:ident($method:ident $path:literal $(, $param:ident: $ptype:ty)*
+                        $(, @body $req:ty)?) -> $res:ty;
+        )*
+    ) => {
+        impl PlatformApi {
+            $(
+                $(#[$doc])*
+                pub async fn $name(
+                    &self,
+                    $($param: $ptype,)*
+                    $(body: &$req,)?
+                ) -> Result<$res, PluginSdkError> {
+                    // Written only by the optional body arm below; the
+                    // allow covers the bodyless endpoints, where the macro
+                    // expands to a plain `None`.
+                    #[allow(unused_mut, unused_assignments)]
+                    let mut encoded: Option<CallBody> = None;
+                    $(
+                        let typed: &$req = body;
+                        encoded = Some(CallBody::json(typed).map_err(|e| {
+                            PluginSdkError::Deserialization { reason: e.to_string() }
+                        })?);
+                    )?
+                    self.send(HttpMethod::$method, format!($path), None, encoded).await
+                }
+            )*
+        }
+
+        /// Every endpoint this SDK claims the platform has, as
+        /// `(METHOD, path-template)`.
+        ///
+        /// Checked against the platform's OpenAPI document by the conformance
+        /// test in `temps-cli`, so a renamed route or a changed verb fails the
+        /// build instead of 404ing at runtime.
+        pub const DECLARED_ENDPOINTS: &[(&str, &str)] = &[
+            $( (stringify!($method), $path), )*
+            // The multipart endpoints are hand-written above but still belong
+            // in the table — they are exactly the ones whose breakage would be
+            // hardest to spot, since they only run on a real deploy.
+            ("POST", "/projects/{project_id}/upload/static"),
+            ("POST", "/projects/{project_id}/environments/{environment_id}/deploy/image-upload"),
+            ("GET", "/projects"),
+        ];
+    };
+}
+
+define_api! {
+    /// Create a project.
+    create_project(Post "/projects", @body NewProject) -> ProjectRef;
+
+    /// Fetch a project by ID.
+    get_project(Get "/projects/{id}", id: i32) -> ProjectRef;
+
+    /// Replace a project's settings — notably its source type, which decides
+    /// whether it deploys static bundles or container images.
+    update_project(Put "/projects/{id}", id: i32, @body NewProject) -> ProjectRef;
+
+    /// List a project's environments. The first is its default.
+    list_environments(Get "/projects/{project_id}/environments", project_id: i32)
+        -> Vec<EnvironmentRef>;
+
+    /// Start a deployment from an uploaded static bundle.
+    deploy_static(
+        Post "/projects/{project_id}/environments/{environment_id}/deploy/static",
+        project_id: i32,
+        environment_id: i32,
+        @body DeployStaticBundle
+    ) -> StartedDeployment;
+
+    /// Start a deployment from a named container image.
+    ///
+    /// Prefer this over [`PlatformApi::deploy_image_upload`] whenever the
+    /// platform can reach the image by name: it sends a tag instead of a
+    /// tarball, so it is not bounded by the channel's body cap.
+    deploy_image(
+        Post "/projects/{project_id}/environments/{environment_id}/deploy/image",
+        project_id: i32,
+        environment_id: i32,
+        @body DeployImage
+    ) -> StartedDeployment;
+
+    /// Create a managed service (database, cache, bucket).
+    create_service(Post "/external-services", @body NewService) -> ServiceRef;
+
+    /// Link a managed service to a project so deployments can reach it.
+    link_service(
+        Post "/external-services/{id}/projects",
+        id: i32,
+        @body LinkService
+    ) -> ServiceLinkRef;
+
+    /// Issue live connection credentials, provisioning the per-tenant
+    /// database if it does not exist yet.
+    ///
+    /// A POST because it is not a read: it creates a database as a side
+    /// effect, and its response is a live credential. Every call is audited
+    /// on the platform against the acting user.
+    issue_runtime_credentials(
+        Post "/external-services/{id}/projects/{project_id}/environments/{environment_id}/runtime-credentials",
+        id: i32,
+        project_id: i32,
+        environment_id: i32
+    ) -> RuntimeCredentials;
+
+    /// Fetch a deployment, to poll it to completion.
+    get_deployment(
+        Get "/projects/{project_id}/deployments/{deployment_id}",
+        project_id: i32,
+        deployment_id: i32
+    ) -> DeploymentRef;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The table must not contain duplicates: two entries for one endpoint
+    /// means one of them is dead and nobody would notice.
+    #[test]
+    fn declared_endpoints_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for entry in DECLARED_ENDPOINTS {
+            assert!(seen.insert(entry), "duplicate endpoint declared: {entry:?}");
+        }
+    }
+
+    /// Paths are relative to `/api` and must not embed it: the bridge
+    /// prefixes `/api`, so a path that already has it would resolve to
+    /// `/api/api/...` and 404.
+    #[test]
+    fn declared_paths_are_relative_to_the_api_root() {
+        for (method, path) in DECLARED_ENDPOINTS {
+            assert!(path.starts_with('/'), "{method} {path} must start with '/'");
+            assert!(
+                !path.starts_with("/api/"),
+                "{method} {path} must not include the /api prefix; the bridge adds it"
+            );
+        }
+    }
+
+    /// Every declared verb must be one the channel can carry, or the call
+    /// would fail at the far end with an unhelpful parse error.
+    #[test]
+    fn declared_methods_are_transportable() {
+        for (method, path) in DECLARED_ENDPOINTS {
+            assert!(
+                matches!(
+                    *method,
+                    "Get" | "Post" | "Put" | "Patch" | "Delete" | "GET" | "POST"
+                ),
+                "{method} {path} is not a verb HttpMethod can express"
+            );
+        }
+    }
+
+    #[test]
+    fn query_values_are_escaped() {
+        assert_eq!(
+            urlencode("plugin-demo:1730000000"),
+            "plugin-demo%3A1730000000"
+        );
+        assert_eq!(urlencode("a b&c=d"), "a%20b%26c%3Dd");
+        assert_eq!(urlencode("plain-Name_1.0~x"), "plain-Name_1.0~x");
+    }
+
+    /// A project the plugin creates must never inherit git auto-deploy: an
+    /// unrelated push would overwrite what the plugin just shipped.
+    #[test]
+    fn new_projects_never_auto_deploy() {
+        assert!(!NewProject::static_files("demo", "vite").automatic_deploy);
+        assert!(!NewProject::docker_image("demo", "dockerfile").automatic_deploy);
+    }
+
+    #[test]
+    fn deployment_terminal_states_are_recognised() {
+        let at = |status: &str| DeploymentRef {
+            id: 1,
+            status: status.into(),
+            url: String::new(),
+            cancelled_reason: None,
+        };
+        assert!(at("success").is_success() && at("success").is_finished());
+        assert!(at("failed").is_failure() && at("failed").is_finished());
+        assert!(!at("building").is_finished());
+        assert!(!at("queued").is_finished());
+    }
+
+    /// The projections must survive a response carrying the API's full field
+    /// set — that is the whole premise of declaring them narrow.
+    #[test]
+    fn projections_ignore_the_fields_they_do_not_declare() {
+        let full = r#"{
+            "id": 7, "slug": "demo", "name": "Demo", "preset": "vite",
+            "repo_name": null, "repo_owner": null, "directory": ".",
+            "main_branch": "main", "created_at": 0, "updated_at": 0,
+            "attack_mode": false, "source_type": "static_files",
+            "enable_preview_environments": false
+        }"#;
+        let project: ProjectRef = serde_json::from_str(full).unwrap();
+        assert_eq!(project.id, 7);
+        assert_eq!(project.preset.as_deref(), Some("vite"));
+    }
+
+    /// A deployment that has not failed omits `cancelled_reason` entirely in
+    /// some responses; that must not be a decode error.
+    #[test]
+    fn missing_cancelled_reason_decodes_as_none() {
+        let json = r#"{"id":3,"status":"building","url":"https://x.test"}"#;
+        let deployment: DeploymentRef = serde_json::from_str(json).unwrap();
+        assert!(deployment.cancelled_reason.is_none());
+    }
+}

--- a/crates/temps-plugin-sdk/src/api.rs
+++ b/crates/temps-plugin-sdk/src/api.rs
@@ -111,7 +111,17 @@ pub struct NewService {
     pub parameters: std::collections::HashMap<String, String>,
     /// `standalone` unless the caller is building a cluster.
     pub topology: String,
-    pub members: Vec<i32>,
+    /// Cluster member specifications. Required when `topology` is `cluster`.
+    pub members: Vec<ClusterMemberRequest>,
+}
+
+/// Placement and service-specific role for one managed-service cluster member.
+#[derive(Debug, Clone, Serialize)]
+pub struct ClusterMemberRequest {
+    /// Service-type-specific role, such as `primary`, `replica`, or `monitor`.
+    pub role: String,
+    /// Worker node on which to place the member, or the control plane when absent.
+    pub node_id: Option<i32>,
 }
 
 impl NewService {
@@ -735,6 +745,31 @@ mod tests {
     fn new_projects_never_auto_deploy() {
         assert!(!NewProject::static_files("demo", "vite").automatic_deploy);
         assert!(!NewProject::docker_image("demo", "dockerfile").automatic_deploy);
+    }
+
+    #[test]
+    fn cluster_members_serialize_with_role_and_optional_node_id() {
+        let mut service = NewService::postgres("database", "app", "app");
+        service.topology = "cluster".to_string();
+        service.members = vec![
+            ClusterMemberRequest {
+                role: "primary".to_string(),
+                node_id: Some(7),
+            },
+            ClusterMemberRequest {
+                role: "replica".to_string(),
+                node_id: None,
+            },
+        ];
+
+        let json = serde_json::to_value(service).expect("service request should serialize");
+        assert_eq!(
+            json["members"],
+            serde_json::json!([
+                {"role": "primary", "node_id": 7},
+                {"role": "replica", "node_id": null}
+            ])
+        );
     }
 
     #[test]

--- a/crates/temps-plugin-sdk/src/api.rs
+++ b/crates/temps-plugin-sdk/src/api.rs
@@ -145,15 +145,15 @@ pub struct DeployStaticBundle {
 
 /// Start a deployment from a container image the platform can already reach.
 ///
-/// "Reach" means a registry it can pull from, *or* an image already present
-/// in the host's Docker — which is the case for one a plugin built there.
-/// Naming the image is what makes that possible: the alternative,
-/// [`PlatformApi::deploy_image_upload`], has to carry the entire tarball
-/// through the platform channel and hits its 32 MiB body cap on any image
-/// with a real runtime in it.
+/// Set `claim_local` only for an image built in the platform host's Docker.
+/// Temps inspects and retags that image into a project-owned internal name,
+/// then verifies its immutable image ID before deployment. Registry images
+/// must leave it false and are never resolved from local daemon state.
 #[derive(Debug, Clone, Serialize)]
 pub struct DeployImage {
     pub image_ref: String,
+    #[serde(default)]
+    pub claim_local: bool,
 }
 
 // ── Response projections ───────────────────────────────────────────────

--- a/crates/temps-plugin-sdk/src/auth.rs
+++ b/crates/temps-plugin-sdk/src/auth.rs
@@ -14,6 +14,7 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde::{Deserialize, Serialize};
+use subtle::ConstantTimeEq;
 
 use crate::protocol::headers;
 
@@ -211,7 +212,7 @@ pub(crate) fn verify_proxy_headers(
         .headers()
         .get(headers::AUTH_SIGNATURE)
         .and_then(|value| value.to_str().ok());
-    if signature != Some(expected_secret) {
+    if !signature.is_some_and(|provided| secure_secret_matches(provided, expected_secret)) {
         return Err(AuthenticationRequired);
     }
 
@@ -271,6 +272,10 @@ pub(crate) fn verify_proxy_headers(
     Ok(caller)
 }
 
+pub(crate) fn secure_secret_matches(provided: &str, expected: &str) -> bool {
+    provided.as_bytes().ct_eq(expected.as_bytes()).into()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -305,6 +310,8 @@ mod tests {
             .body(axum::body::Body::empty())
             .expect("test request");
         assert!(verify_proxy_headers(&mut request, "secret").is_err());
+        assert!(!secure_secret_matches("secreu", "secret"));
+        assert!(!secure_secret_matches("secret-extra", "secret"));
     }
 
     #[test]

--- a/crates/temps-plugin-sdk/src/auth.rs
+++ b/crates/temps-plugin-sdk/src/auth.rs
@@ -1,0 +1,326 @@
+//! Verified authentication context for external-plugin handlers.
+//!
+//! Temps authenticates the original request and forwards a resolved caller
+//! over the plugin's private Unix socket. The SDK runtime verifies that the
+//! request carries the per-process handshake secret before inserting the
+//! caller into request extensions. Handler extractors read only that
+//! extension; they never trust caller-controlled headers directly.
+
+use std::collections::BTreeSet;
+
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use crate::protocol::headers;
+
+/// SDK-owned representation of a Temps role.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PluginRole {
+    Admin,
+    PlatformAdmin,
+    User,
+    Reader,
+    ApiReader,
+    Custom,
+    MetricsIngest,
+}
+
+impl PluginRole {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "admin" => Some(Self::Admin),
+            "platform_admin" => Some(Self::PlatformAdmin),
+            "user" => Some(Self::User),
+            "reader" => Some(Self::Reader),
+            "api_reader" => Some(Self::ApiReader),
+            "custom" => Some(Self::Custom),
+            "metrics_ingest" => Some(Self::MetricsIngest),
+            _ => None,
+        }
+    }
+}
+
+/// A platform permission in its stable wire form (`projects:read`, etc.).
+///
+/// Kept as a validated opaque value so a newer Temps can add a permission
+/// without making older plugin binaries reject the entire caller context.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PluginPermission(String);
+
+impl PluginPermission {
+    pub const PROJECTS_READ: &'static str = "projects:read";
+    pub const PROJECTS_WRITE: &'static str = "projects:write";
+    pub const PROJECTS_CREATE: &'static str = "projects:create";
+    pub const DEPLOYMENTS_READ: &'static str = "deployments:read";
+    pub const DEPLOYMENTS_CREATE: &'static str = "deployments:create";
+
+    fn parse(value: &str) -> Option<Self> {
+        let value = value.trim();
+        (!value.is_empty()
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte == b'_' || byte == b':'))
+        .then(|| Self(value.to_string()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A caller authenticated by Temps and verified by the SDK runtime.
+#[derive(Clone, Serialize)]
+pub struct AuthenticatedCaller {
+    pub user_id: i32,
+    pub email: String,
+    pub role: PluginRole,
+    pub permissions: BTreeSet<PluginPermission>,
+    pub request_id: String,
+    #[serde(skip)]
+    actor_token: Option<String>,
+}
+
+impl std::fmt::Debug for AuthenticatedCaller {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthenticatedCaller")
+            .field("user_id", &self.user_id)
+            .field("email", &self.email)
+            .field("role", &self.role)
+            .field("permissions", &self.permissions)
+            .field("request_id", &self.request_id)
+            .field(
+                "actor_token",
+                &self.actor_token.as_ref().map(|_| "[REDACTED]"),
+            )
+            .finish()
+    }
+}
+
+impl AuthenticatedCaller {
+    /// Construct a caller for an embedded host adapter or a test.
+    ///
+    /// The resulting caller has no actor token and therefore cannot call the
+    /// platform API through [`crate::PluginContext::api_as_caller`]. External
+    /// plugin requests should always use the runtime extractor instead.
+    pub fn without_platform_delegation<I, S>(
+        user_id: i32,
+        email: impl Into<String>,
+        role: PluginRole,
+        permissions: I,
+    ) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        Self {
+            user_id,
+            email: email.into(),
+            role,
+            permissions: permissions
+                .into_iter()
+                .filter_map(|permission| PluginPermission::parse(permission.as_ref()))
+                .collect(),
+            request_id: String::new(),
+            actor_token: None,
+        }
+    }
+
+    pub fn is_admin(&self) -> bool {
+        self.role == PluginRole::Admin
+    }
+
+    pub fn has_permission(&self, permission: &str) -> bool {
+        self.permissions
+            .iter()
+            .any(|candidate| candidate.as_str() == permission)
+    }
+
+    pub(crate) fn actor_token(&self) -> Option<&str> {
+        self.actor_token.as_deref()
+    }
+}
+
+/// Extractor for routes which may be called anonymously.
+#[derive(Debug, Clone)]
+pub struct OptionalCaller(pub Option<AuthenticatedCaller>);
+
+/// Rejection returned when a protected plugin handler has no verified user.
+#[derive(Debug, Clone)]
+pub struct AuthenticationRequired;
+
+impl IntoResponse for AuthenticationRequired {
+    fn into_response(self) -> Response {
+        (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({
+                "type": "https://temps.sh/problems/plugin-authentication-required",
+                "title": "Authentication Required",
+                "status": StatusCode::UNAUTHORIZED.as_u16(),
+                "detail": "This plugin route requires a caller authenticated by Temps."
+            })),
+        )
+            .into_response()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct VerifiedProxyRequest(pub Option<AuthenticatedCaller>);
+
+impl<S> FromRequestParts<S> for AuthenticatedCaller
+where
+    S: Send + Sync,
+{
+    type Rejection = AuthenticationRequired;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get::<VerifiedProxyRequest>()
+            .and_then(|verified| verified.0.clone())
+            .ok_or(AuthenticationRequired)
+    }
+}
+
+impl<S> FromRequestParts<S> for OptionalCaller
+where
+    S: Send + Sync,
+{
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(Self(
+            parts
+                .extensions
+                .get::<VerifiedProxyRequest>()
+                .and_then(|verified| verified.0.clone()),
+        ))
+    }
+}
+
+pub(crate) fn verify_proxy_headers(
+    request: &mut axum::extract::Request,
+    expected_secret: &str,
+) -> Result<Option<AuthenticatedCaller>, AuthenticationRequired> {
+    let signature = request
+        .headers()
+        .get(headers::AUTH_SIGNATURE)
+        .and_then(|value| value.to_str().ok());
+    if signature != Some(expected_secret) {
+        return Err(AuthenticationRequired);
+    }
+
+    let user_id = request
+        .headers()
+        .get(headers::USER_ID)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<i32>().ok());
+    let email = request
+        .headers()
+        .get(headers::USER_EMAIL)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let role = request
+        .headers()
+        .get(headers::USER_ROLE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(PluginRole::parse);
+
+    let caller = match (user_id, email, role) {
+        (Some(user_id), Some(email), Some(role)) => {
+            let permissions = request
+                .headers()
+                .get(headers::USER_PERMISSIONS)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .split(',')
+                .filter_map(PluginPermission::parse)
+                .collect();
+            let request_id = request
+                .headers()
+                .get(headers::REQUEST_ID)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_string();
+            let actor_token = request
+                .headers()
+                .get(headers::ACTOR_TOKEN)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_string);
+            Some(AuthenticatedCaller {
+                user_id,
+                email,
+                role,
+                permissions,
+                request_id,
+                actor_token,
+            })
+        }
+        (None, None, None) => None,
+        _ => return Err(AuthenticationRequired),
+    };
+
+    request
+        .extensions_mut()
+        .insert(VerifiedProxyRequest(caller.clone()));
+    Ok(caller)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+
+    #[test]
+    fn verified_headers_produce_a_typed_caller() {
+        let mut request = Request::builder()
+            .header(headers::AUTH_SIGNATURE, "secret")
+            .header(headers::USER_ID, "42")
+            .header(headers::USER_EMAIL, "dev@temps.sh")
+            .header(headers::USER_ROLE, "custom")
+            .header(headers::USER_PERMISSIONS, "projects:read")
+            .header(headers::REQUEST_ID, "req-1")
+            .body(axum::body::Body::empty())
+            .expect("test request");
+
+        let caller = verify_proxy_headers(&mut request, "secret")
+            .expect("verified request")
+            .expect("authenticated caller");
+        assert_eq!(caller.user_id, 42);
+        assert!(caller.has_permission(PluginPermission::PROJECTS_READ));
+        assert!(!caller.has_permission(PluginPermission::PROJECTS_WRITE));
+    }
+
+    #[test]
+    fn a_forged_or_missing_signature_is_rejected() {
+        let mut request = Request::builder()
+            .header(headers::USER_ID, "1")
+            .header(headers::USER_EMAIL, "attacker@example.com")
+            .header(headers::USER_ROLE, "admin")
+            .body(axum::body::Body::empty())
+            .expect("test request");
+        assert!(verify_proxy_headers(&mut request, "secret").is_err());
+    }
+
+    #[test]
+    fn an_api_key_permission_set_is_not_widened_from_its_role() {
+        let mut request = Request::builder()
+            .header(headers::AUTH_SIGNATURE, "secret")
+            .header(headers::USER_ID, "7")
+            .header(headers::USER_EMAIL, "reader@temps.sh")
+            .header(headers::USER_ROLE, "admin")
+            .header(headers::USER_PERMISSIONS, "projects:read")
+            .body(axum::body::Body::empty())
+            .expect("test request");
+        let caller = verify_proxy_headers(&mut request, "secret")
+            .expect("verified request")
+            .expect("authenticated caller");
+        assert!(caller.is_admin());
+        assert!(!caller.has_permission(PluginPermission::PROJECTS_WRITE));
+    }
+}

--- a/crates/temps-plugin-sdk/src/client.rs
+++ b/crates/temps-plugin-sdk/src/client.rs
@@ -168,12 +168,12 @@ impl TempsClient {
 
     // ── Low-level request/response ─────────────────────────────────────
 
-    /// Send a request and wait for the response.
-    async fn request(
-        &self,
-        method: &str,
-        params: serde_json::Value,
-    ) -> Result<serde_json::Value, PluginSdkError> {
+    /// Make a typed call and get back exactly that call's output.
+    ///
+    /// The return type is inferred from `C`, so a call and its reply cannot
+    /// drift apart: pairing them is the [`PlatformCall`] impl's job, and
+    /// that impl is generated alongside both wire enums.
+    pub async fn call<C: PlatformCall>(&self, call: C) -> Result<C::Output, PluginSdkError> {
         let id = self.inner.next_id.fetch_add(1, Ordering::Relaxed);
 
         let (tx, rx) = oneshot::channel();
@@ -181,8 +181,7 @@ impl TempsClient {
 
         let msg = ChannelMessage::Request(ChannelRequest {
             id,
-            method: method.to_string(),
-            params,
+            call: call.into_request(),
         });
 
         self.inner
@@ -192,37 +191,33 @@ impl TempsClient {
 
         let resp = rx.await.map_err(|_| PluginSdkError::ChannelClosed)?;
 
-        if let Some(err) = resp.error {
-            return Err(PluginSdkError::PlatformError {
+        match resp.outcome {
+            CallOutcome::Ok(payload) => {
+                C::output_from(*payload).map_err(|e| PluginSdkError::ProtocolMismatch {
+                    reason: e.to_string(),
+                })
+            }
+            CallOutcome::Err(err) => Err(PluginSdkError::PlatformError {
                 code: format!("{:?}", err.code),
                 message: err.message,
-            });
+            }),
         }
-
-        resp.result.ok_or(PluginSdkError::ChannelClosed)
     }
 
     // ── Typed query methods ────────────────────────────────────────────
+    //
+    // Thin wrappers over `call`. They exist for discoverability — a plugin
+    // author should find `list_environments` by typing `client.` — not
+    // because they add behaviour.
 
     /// Get a project by ID.
     pub async fn get_project(&self, project_id: i32) -> Result<ProjectInfo, PluginSdkError> {
-        let value = self
-            .request(
-                "get_project",
-                serde_json::json!({ "project_id": project_id }),
-            )
-            .await?;
-        serde_json::from_value(value).map_err(|e| PluginSdkError::Deserialization {
-            reason: e.to_string(),
-        })
+        self.call(GetProject { project_id }).await
     }
 
     /// List all (non-deleted) projects.
     pub async fn list_projects(&self) -> Result<Vec<ProjectInfo>, PluginSdkError> {
-        let value = self.request("list_projects", serde_json::json!({})).await?;
-        serde_json::from_value(value).map_err(|e| PluginSdkError::Deserialization {
-            reason: e.to_string(),
-        })
+        self.call(ListProjects {}).await
     }
 
     /// Get an environment by ID.
@@ -230,15 +225,7 @@ impl TempsClient {
         &self,
         environment_id: i32,
     ) -> Result<EnvironmentInfo, PluginSdkError> {
-        let value = self
-            .request(
-                "get_environment",
-                serde_json::json!({ "environment_id": environment_id }),
-            )
-            .await?;
-        serde_json::from_value(value).map_err(|e| PluginSdkError::Deserialization {
-            reason: e.to_string(),
-        })
+        self.call(GetEnvironment { environment_id }).await
     }
 
     /// List environments for a project.
@@ -246,15 +233,7 @@ impl TempsClient {
         &self,
         project_id: i32,
     ) -> Result<Vec<EnvironmentInfo>, PluginSdkError> {
-        let value = self
-            .request(
-                "list_environments",
-                serde_json::json!({ "project_id": project_id }),
-            )
-            .await?;
-        serde_json::from_value(value).map_err(|e| PluginSdkError::Deserialization {
-            reason: e.to_string(),
-        })
+        self.call(ListEnvironments { project_id }).await
     }
 
     /// Get a deployment by ID.
@@ -262,15 +241,7 @@ impl TempsClient {
         &self,
         deployment_id: i32,
     ) -> Result<DeploymentInfo, PluginSdkError> {
-        let value = self
-            .request(
-                "get_deployment",
-                serde_json::json!({ "deployment_id": deployment_id }),
-            )
-            .await?;
-        serde_json::from_value(value).map_err(|e| PluginSdkError::Deserialization {
-            reason: e.to_string(),
-        })
+        self.call(GetDeployment { deployment_id }).await
     }
 
     /// Get the most recent deployment for a project, optionally filtered
@@ -280,14 +251,11 @@ impl TempsClient {
         project_id: i32,
         environment_id: Option<i32>,
     ) -> Result<DeploymentInfo, PluginSdkError> {
-        let mut params = serde_json::json!({ "project_id": project_id });
-        if let Some(env_id) = environment_id {
-            params["environment_id"] = serde_json::json!(env_id);
-        }
-        let value = self.request("get_last_deployment", params).await?;
-        serde_json::from_value(value).map_err(|e| PluginSdkError::Deserialization {
-            reason: e.to_string(),
+        self.call(GetLastDeployment {
+            project_id,
+            environment_id,
         })
+        .await
     }
 
     /// List deployments for a project, optionally filtered by environment.
@@ -297,17 +265,21 @@ impl TempsClient {
         environment_id: Option<i32>,
         limit: Option<u64>,
     ) -> Result<Vec<DeploymentInfo>, PluginSdkError> {
-        let mut params = serde_json::json!({ "project_id": project_id });
-        if let Some(env_id) = environment_id {
-            params["environment_id"] = serde_json::json!(env_id);
-        }
-        if let Some(limit) = limit {
-            params["limit"] = serde_json::json!(limit);
-        }
-        let value = self.request("list_deployments", params).await?;
-        serde_json::from_value(value).map_err(|e| PluginSdkError::Deserialization {
-            reason: e.to_string(),
+        self.call(ListDeployments {
+            project_id,
+            environment_id,
+            limit,
         })
+        .await
+    }
+
+    /// Call the platform's own HTTP API as the user who called this plugin.
+    ///
+    /// Prefer the typed helpers on [`crate::api`], which fill in the path
+    /// and method for you; this is the escape hatch for an endpoint the SDK
+    /// has no wrapper for yet.
+    pub async fn api_call(&self, call: ApiCall) -> Result<ApiCallResult, PluginSdkError> {
+        self.call(call).await
     }
 }
 

--- a/crates/temps-plugin-sdk/src/context.rs
+++ b/crates/temps-plugin-sdk/src/context.rs
@@ -16,6 +16,10 @@ pub struct PluginContext {
     plugin_name: String,
     /// Directory for plugin-specific data files
     data_dir: std::path::PathBuf,
+    /// The instance's own data root, when Temps passed one.
+    host_data_dir: Option<std::path::PathBuf>,
+    /// Base URL at which the instance's API answers, when Temps passed one.
+    host_api_url: Option<String>,
     /// HMAC secret for validating requests from Temps
     auth_secret: String,
 }
@@ -26,12 +30,16 @@ impl PluginContext {
         temps_client: TempsClient,
         plugin_name: String,
         data_dir: std::path::PathBuf,
+        host_data_dir: Option<std::path::PathBuf>,
+        host_api_url: Option<String>,
         auth_secret: String,
     ) -> Self {
         Self {
             temps_client,
             plugin_name,
             data_dir,
+            host_data_dir,
+            host_api_url,
             auth_secret,
         }
     }
@@ -56,6 +64,41 @@ impl PluginContext {
         &self.temps_client
     }
 
+    /// Typed platform API, acting as the caller of the request being served.
+    ///
+    /// Takes the actor token from [`crate::protocol::TempsAuth`] rather than
+    /// inventing one: a platform API call is always made *for somebody*, and
+    /// binding it to the caller is what keeps `permission_guard!` meaningful
+    /// on the other side. A plugin cannot widen its own access this way — the
+    /// call runs as that user and no further.
+    pub fn api_for(
+        &self,
+        auth: &crate::protocol::TempsUserContext,
+    ) -> Result<crate::api::PlatformApi, crate::error::PluginSdkError> {
+        let token = auth
+            .actor_token
+            .as_deref()
+            .ok_or(crate::error::PluginSdkError::NoActor)?;
+        Ok(crate::api::PlatformApi::new(
+            self.temps_client.clone(),
+            temps_core::external_plugin::channel::ActorToken::new(token),
+        ))
+    }
+
+    /// Typed platform API acting as a caller verified by the SDK runtime.
+    pub fn api_as_caller(
+        &self,
+        caller: &crate::auth::AuthenticatedCaller,
+    ) -> Result<crate::api::PlatformApi, crate::error::PluginSdkError> {
+        let token = caller
+            .actor_token()
+            .ok_or(crate::error::PluginSdkError::NoActor)?;
+        Ok(crate::api::PlatformApi::new(
+            self.temps_client.clone(),
+            temps_core::external_plugin::channel::ActorToken::new(token),
+        ))
+    }
+
     /// Get the plugin's name.
     pub fn plugin_name(&self) -> &str {
         &self.plugin_name
@@ -67,6 +110,40 @@ impl PluginContext {
     /// The directory is guaranteed to exist when the plugin starts.
     pub fn data_dir(&self) -> &std::path::Path {
         &self.data_dir
+    }
+
+    /// The Temps instance's own data root, if it passed one.
+    ///
+    /// `None` on a Temps predating `--host-data-dir`, so treat it as a
+    /// capability to check rather than assume — a plugin that needs it
+    /// should say so rather than fall back to guessing a path relative to
+    /// [`Self::data_dir`].
+    ///
+    /// This is the platform's directory, not the plugin's: it holds state
+    /// that belongs to the instance (sandbox roots, encryption key, auth
+    /// secret). Read what you need; write only under [`Self::data_dir`].
+    pub fn host_data_dir(&self) -> Option<&std::path::Path> {
+        self.host_data_dir.as_deref()
+    }
+
+    /// Base URL at which the instance's API answers, if it passed one.
+    ///
+    /// Combine with [`Self::plugin_name`] to build a URL for this plugin's
+    /// own routes; [`Self::mount_url`] does that.
+    pub fn host_api_url(&self) -> Option<&str> {
+        self.host_api_url.as_deref()
+    }
+
+    /// This plugin's externally-reachable base URL, e.g.
+    /// `http://127.0.0.1:8080/api/x/my-plugin`.
+    ///
+    /// Use for URLs handed to something that cannot reach the plugin's Unix
+    /// socket — a sandboxed agent, an external webhook sender. `None` on a
+    /// Temps that did not pass `--host-api-url`.
+    pub fn mount_url(&self) -> Option<String> {
+        self.host_api_url
+            .as_deref()
+            .map(|base| format!("{}/api/x/{}", base.trim_end_matches('/'), self.plugin_name))
     }
 
     /// Get the HMAC auth secret for request validation.

--- a/crates/temps-plugin-sdk/src/context.rs
+++ b/crates/temps-plugin-sdk/src/context.rs
@@ -5,9 +5,9 @@ use crate::client::TempsClient;
 /// Runtime context provided to external plugins.
 ///
 /// This is the plugin's window into the Temps ecosystem.
-/// Platform data is accessed exclusively through the [`TempsClient`]
-/// returned by [`temps()`](Self::temps) — the plugin never has
-/// direct database access.
+/// Platform data normally flows through the [`TempsClient`] returned by
+/// [`temps()`](Self::temps). A trusted plugin that explicitly declares
+/// `requires_db` can also receive the direct database URL.
 #[derive(Clone)]
 pub struct PluginContext {
     /// Typed client for querying the Temps platform
@@ -16,11 +16,15 @@ pub struct PluginContext {
     plugin_name: String,
     /// Directory for plugin-specific data files
     data_dir: std::path::PathBuf,
+    /// Direct database URL disclosed only when declared in the manifest.
+    database_url: Option<String>,
     /// The instance's own data root, when Temps passed one.
     host_data_dir: Option<std::path::PathBuf>,
     /// Base URL at which the instance's API answers, when Temps passed one.
     host_api_url: Option<String>,
-    /// HMAC secret for validating requests from Temps
+    /// Per-process assertion secret for validating requests from Temps.
+    /// This is protocol integrity for trusted installed code, not process
+    /// isolation under the shared host user.
     auth_secret: String,
 }
 
@@ -30,6 +34,7 @@ impl PluginContext {
         temps_client: TempsClient,
         plugin_name: String,
         data_dir: std::path::PathBuf,
+        database_url: Option<String>,
         host_data_dir: Option<std::path::PathBuf>,
         host_api_url: Option<String>,
         auth_secret: String,
@@ -38,6 +43,7 @@ impl PluginContext {
             temps_client,
             plugin_name,
             data_dir,
+            database_url,
             host_data_dir,
             host_api_url,
             auth_secret,
@@ -112,15 +118,21 @@ impl PluginContext {
         &self.data_dir
     }
 
+    /// Direct platform database URL for a trusted plugin that declared
+    /// `requires_db`; absent for ordinary plugins.
+    pub fn database_url(&self) -> Option<&str> {
+        self.database_url.as_deref()
+    }
+
     /// The Temps instance's own data root, if it passed one.
     ///
-    /// `None` on a Temps predating `--host-data-dir`, so treat it as a
-    /// capability to check rather than assume — a plugin that needs it
+    /// `None` when the manifest did not declare privileged host-data access,
+    /// so treat it as a capability to check rather than assume — a plugin that needs it
     /// should say so rather than fall back to guessing a path relative to
     /// [`Self::data_dir`].
     ///
     /// This is the platform's directory, not the plugin's: it holds state
-    /// that belongs to the instance (sandbox roots, encryption key, auth
+    /// that belongs to the instance (deployment data roots, encryption key, auth
     /// secret). Read what you need; write only under [`Self::data_dir`].
     pub fn host_data_dir(&self) -> Option<&std::path::Path> {
         self.host_data_dir.as_deref()

--- a/crates/temps-plugin-sdk/src/error.rs
+++ b/crates/temps-plugin-sdk/src/error.rs
@@ -34,4 +34,53 @@ pub enum PluginSdkError {
 
     #[error("Failed to deserialize platform response: {reason}")]
     Deserialization { reason: String },
+
+    /// The platform answered a different call than the one made.
+    ///
+    /// Distinct from `Deserialization` on purpose: this one always means the
+    /// plugin and the platform were built against different versions of the
+    /// channel protocol, and the fix is to rebuild, not to check the data.
+    #[error("{reason}")]
+    ProtocolMismatch { reason: String },
+
+    /// This plugin has no actor token, so it cannot act for a user.
+    ///
+    /// Either the request being served was not made by a signed-in user (a
+    /// self-authenticating `public_paths` route, or a background task with
+    /// no request behind it), or the manifest declares no API capability so
+    /// the platform never minted one.
+    #[error(
+        "No platform actor is available for this call. Platform API calls must be made while \
+         serving a request from a signed-in user, and the plugin manifest must declare an \
+         api_read or api_write capability."
+    )]
+    NoActor,
+
+    /// The request body is larger than the channel will carry.
+    ///
+    /// Rejected before transport rather than after, and named as a limit
+    /// rather than a generic failure, because the fix is always the same:
+    /// send less, or use an endpoint that streams.
+    #[error(
+        "Cannot send a {len}-byte body for {method} {path} over the platform channel \
+         (limit {limit} bytes). Large artifacts must be uploaded another way."
+    )]
+    BodyTooLarge {
+        len: usize,
+        limit: usize,
+        method: &'static str,
+        path: String,
+    },
+
+    /// The platform API answered, but not with success.
+    ///
+    /// The status and body are the API's own, so a plugin can tell a 403
+    /// from a 404 and show the operator what the platform actually said.
+    #[error("Platform API returned {status} for {method} {path}: {body}")]
+    ApiStatus {
+        status: u16,
+        method: &'static str,
+        path: String,
+        body: String,
+    },
 }

--- a/crates/temps-plugin-sdk/src/lib.rs
+++ b/crates/temps-plugin-sdk/src/lib.rs
@@ -52,6 +52,8 @@
 //! temps_plugin_sdk::main!(MyPlugin);
 //! ```
 
+pub mod api;
+pub mod auth;
 pub mod client;
 pub mod context;
 pub mod error;
@@ -59,20 +61,26 @@ pub mod manifest;
 pub mod protocol;
 pub mod runtime;
 
+pub use api::PlatformApi;
+pub use auth::{AuthenticatedCaller, OptionalCaller, PluginPermission, PluginRole};
 pub use client::TempsClient;
 pub use context::PluginContext;
 pub use error::PluginSdkError;
 pub use manifest::{
-    NavEntry, NavSection, PluginEvent, PluginManifest, PluginManifestBuilder, UiManifest,
-    PLUGIN_EVENTS_PATH,
+    NavEntry, NavSection, PluginCapability, PluginEvent, PluginManifest, PluginManifestBuilder,
+    UiManifest, PLUGIN_EVENTS_PATH,
 };
 
 /// Re-export commonly used types
 pub mod prelude {
+    pub use crate::api::PlatformApi;
+    pub use crate::auth::{AuthenticatedCaller, OptionalCaller, PluginPermission, PluginRole};
     pub use crate::client::TempsClient;
     pub use crate::context::PluginContext;
     pub use crate::error::PluginSdkError;
-    pub use crate::manifest::{NavEntry, NavSection, PluginEvent, PluginManifest, UiManifest};
+    pub use crate::manifest::{
+        NavEntry, NavSection, PluginCapability, PluginEvent, PluginManifest, UiManifest,
+    };
     pub use crate::ExternalPlugin;
 
     // Re-export common dependencies for convenience

--- a/crates/temps-plugin-sdk/src/lib.rs
+++ b/crates/temps-plugin-sdk/src/lib.rs
@@ -12,7 +12,7 @@
 //! Temps (main process)
 //!   │
 //!   ├── Scans ~/.temps/plugins/ for binaries
-//!   ├── Spawns each binary with --socket-path and --auth-secret
+//!   ├── Spawns each binary and sends its assertion secret over a one-shot pipe
 //!   ├── Reads JSON manifest from stdout handshake
 //!   ├── Opens WebSocket to plugin's /_temps/channel (bidirectional data channel)
 //!   ├── Proxies /api/x/{plugin_name}/* → Unix socket
@@ -155,7 +155,7 @@ pub trait ExternalPlugin: Send + Sync + 'static {
 /// Macro that generates the `main()` function for a plugin binary.
 ///
 /// This handles:
-/// - Parsing CLI arguments (--socket-path, --auth-secret, --data-dir)
+/// - Parsing host-supplied runtime arguments
 /// - Setting up tracing/logging
 /// - Writing the manifest to stdout (handshake)
 /// - Starting the axum server on the Unix socket

--- a/crates/temps-plugin-sdk/src/protocol.rs
+++ b/crates/temps-plugin-sdk/src/protocol.rs
@@ -56,13 +56,34 @@ pub struct PluginArgs {
     #[arg(long)]
     pub database_url: Option<String>,
 
-    /// HMAC secret for authenticating requests from Temps
-    #[arg(long)]
-    pub auth_secret: String,
+    /// Request-assertion secret populated internally from the host's one-shot
+    /// stdin pipe. It is deliberately not accepted as a CLI argument because
+    /// sibling plugin processes can inspect command lines on the same host.
+    #[arg(skip)]
+    pub auth_secret: Option<String>,
 
     /// Directory for plugin-specific data files
     #[arg(long)]
     pub data_dir: String,
+
+    /// The instance's own data root, of which `data_dir` is a subdirectory.
+    ///
+    /// Optional so a plugin built against a newer SDK still runs on an older
+    /// Temps that does not pass it. Only useful alongside `database_url`:
+    /// together they let a plugin act as the platform (reading sandbox
+    /// roots and key material) rather than merely beside it.
+    #[arg(long)]
+    pub host_data_dir: Option<String>,
+
+    /// Base URL at which the instance's API answers, e.g.
+    /// `http://127.0.0.1:8080`.
+    ///
+    /// A plugin's own routes live under `<this>/api/x/<plugin-name>`. Needed
+    /// whenever a plugin must hand a URL to something that is not the caller
+    /// — a sandboxed process, an external webhook — since such a client
+    /// cannot reach the Unix socket the plugin actually listens on.
+    #[arg(long)]
+    pub host_api_url: Option<String>,
 }
 
 /// User context extracted from Temps proxy headers.
@@ -78,17 +99,23 @@ pub struct TempsUserContext {
     pub role: String,
     /// Request ID for tracing
     pub request_id: String,
+    /// Short-lived proof this plugin may act as the caller on the platform
+    /// channel.
+    ///
+    /// `None` when the route authenticates itself (`public_paths`, so there
+    /// is no platform user to act as) or when the manifest declares no API
+    /// capability, in which case the platform never minted one. Pass it to
+    /// [`crate::context::PluginContext::api_for`] to make platform API
+    /// calls attributed to this caller.
+    pub actor_token: Option<String>,
 }
 
 /// Header names used in the Temps-to-plugin protocol.
-pub mod headers {
-    pub const PLUGIN_NAME: &str = "x-temps-plugin";
-    pub const USER_ID: &str = "x-temps-user-id";
-    pub const USER_EMAIL: &str = "x-temps-user-email";
-    pub const USER_ROLE: &str = "x-temps-user-role";
-    pub const REQUEST_ID: &str = "x-temps-request-id";
-    pub const AUTH_SIGNATURE: &str = "x-temps-auth-signature";
-}
+///
+/// Re-exported from `temps-core` so the injecting side (the platform's
+/// proxy) and the reading side (this SDK) cannot drift apart. See
+/// [`temps_core::external_plugin::headers`] for the trust model.
+pub use temps_core::external_plugin::headers;
 
 /// Axum extractor that reads Temps auth headers from proxied requests.
 ///
@@ -139,11 +166,18 @@ where
             .unwrap_or("")
             .to_string();
 
+        let actor_token = parts
+            .headers
+            .get(headers::ACTOR_TOKEN)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+
         Ok(TempsAuth(TempsUserContext {
             user_id,
             user_email,
             role,
             request_id,
+            actor_token,
         }))
     }
 }
@@ -159,10 +193,22 @@ mod tests {
             user_email: Some("admin@example.com".into()),
             role: "admin".into(),
             request_id: "req-123".into(),
+            actor_token: Some("signed".into()),
         };
         let json = serde_json::to_string(&ctx).unwrap();
         let deser: TempsUserContext = serde_json::from_str(&json).unwrap();
         assert_eq!(deser.user_id, Some(1));
         assert_eq!(deser.role, "admin");
+        assert_eq!(deser.actor_token.as_deref(), Some("signed"));
+    }
+
+    /// A request with no actor header must still parse — that is the normal
+    /// shape for a `public_paths` route, and for any plugin whose manifest
+    /// declares no API capability.
+    #[test]
+    fn a_context_without_an_actor_token_is_valid() {
+        let ctx: TempsUserContext =
+            serde_json::from_str(r#"{"user_id":1,"role":"user","request_id":"r"}"#).unwrap();
+        assert!(ctx.actor_token.is_none());
     }
 }

--- a/crates/temps-plugin-sdk/src/protocol.rs
+++ b/crates/temps-plugin-sdk/src/protocol.rs
@@ -10,11 +10,10 @@
 //!   │                                  │
 //!   │── spawn with args ──────────────>│
 //!   │   --socket-path /tmp/x.sock      │
-//!   │   --database-url postgres://...   │
-//!   │   --auth-secret <hmac_key>       │
 //!   │   --data-dir ~/.temps/plugins/x/ │
 //!   │                                  │
-//!   │<── stdout: manifest JSON ────────│  (plugin writes manifest)
+//!   │<── stdout: protocol + manifest ──│
+//!   │── stdin: typed launch config ───>│  (requested values only)
 //!   │                                  │
 //!   │                                  │── starts axum on socket
 //!   │                                  │
@@ -40,7 +39,7 @@
 //! - `X-Temps-User-Email`: authenticated user email (if available)
 //! - `X-Temps-User-Role`: effective role (admin, user, reader, etc.)
 //! - `X-Temps-Request-Id`: unique request ID for tracing
-//! - `X-Temps-Auth-Signature`: HMAC signature of the request
+//! - `X-Temps-Auth-Signature`: per-process assertion secret
 
 use serde::{Deserialize, Serialize};
 
@@ -51,14 +50,15 @@ pub struct PluginArgs {
     #[arg(long)]
     pub socket_path: String,
 
-    /// Database URL (optional, passed by Temps for plugins that need direct DB access).
+    /// Database URL populated from staged launch configuration for plugins
+    /// that declare direct DB access.
     /// Most plugins should use the WebSocket channel instead of direct database access.
-    #[arg(long)]
+    #[arg(skip)]
     pub database_url: Option<String>,
 
     /// Request-assertion secret populated internally from the host's one-shot
-    /// stdin pipe. It is deliberately not accepted as a CLI argument because
-    /// sibling plugin processes can inspect command lines on the same host.
+    /// stdin pipe. It is not accepted as a CLI argument, so it does not appear
+    /// in ordinary process listings.
     #[arg(skip)]
     pub auth_secret: Option<String>,
 
@@ -68,11 +68,10 @@ pub struct PluginArgs {
 
     /// The instance's own data root, of which `data_dir` is a subdirectory.
     ///
-    /// Optional so a plugin built against a newer SDK still runs on an older
-    /// Temps that does not pass it. Only useful alongside `database_url`:
-    /// together they let a plugin act as the platform (reading sandbox
-    /// roots and key material) rather than merely beside it.
-    #[arg(long)]
+    /// Present only when the manifest explicitly requests the privileged
+    /// `requires_host_data_access` capability. This can expose encryption
+    /// keys and platform-owned state; ordinary plugins must use `data_dir`.
+    #[arg(skip)]
     pub host_data_dir: Option<String>,
 
     /// Base URL at which the instance's API answers, e.g.

--- a/crates/temps-plugin-sdk/src/runtime.rs
+++ b/crates/temps-plugin-sdk/src/runtime.rs
@@ -11,6 +11,7 @@ use axum::{Json, Router};
 use clap::Parser;
 use hyper_util::rt::TokioIo;
 use temps_core::external_plugin::{PluginEvent, PLUGIN_CHANNEL_PATH, PLUGIN_EVENTS_PATH};
+use tokio::io::AsyncBufReadExt;
 use tokio::net::UnixListener;
 use tower::{Service, ServiceExt};
 use tracing::{debug, error, info, warn};
@@ -62,12 +63,42 @@ pub fn run_plugin<P: ExternalPlugin + Default>(plugin: P) {
 
 async fn run_plugin_async<P: ExternalPlugin>(
     plugin: P,
-    args: PluginArgs,
+    mut args: PluginArgs,
 ) -> Result<(), crate::error::PluginSdkError> {
     let manifest = plugin.manifest();
     let plugin_name = manifest.name.clone();
 
     info!(plugin = %plugin_name, "Starting external plugin");
+
+    let auth_secret = match args.auth_secret.take() {
+        Some(secret) if !secret.trim().is_empty() => secret,
+        Some(_) => {
+            return Err(crate::error::PluginSdkError::Initialization {
+                plugin_name,
+                reason: "Temps supplied an empty request-assertion secret".to_string(),
+            });
+        }
+        None => {
+            let mut secret = String::new();
+            let mut stdin = tokio::io::BufReader::new(tokio::io::stdin());
+            stdin.read_line(&mut secret).await.map_err(|error| {
+                crate::error::PluginSdkError::Initialization {
+                    plugin_name: plugin_name.clone(),
+                    reason: format!(
+                        "Failed to read the request-assertion secret from the host pipe: {error}"
+                    ),
+                }
+            })?;
+            let secret = secret.trim_end_matches(['\r', '\n']).to_string();
+            if secret.is_empty() {
+                return Err(crate::error::PluginSdkError::Initialization {
+                    plugin_name,
+                    reason: "Temps closed the request-assertion pipe without a secret".to_string(),
+                });
+            }
+            secret
+        }
+    };
 
     // Step 1: Write manifest to stdout (handshake phase 1)
     // IMPORTANT: stdout is ONLY for handshake messages. Logs go to stderr.
@@ -267,14 +298,27 @@ async fn run_plugin_async<P: ExternalPlugin>(
         temps_client,
         plugin_name.clone(),
         data_dir,
-        args.auth_secret.clone(),
+        args.host_data_dir.as_deref().map(std::path::PathBuf::from),
+        args.host_api_url.clone(),
+        auth_secret.clone(),
     );
 
     // Step 10: Call on_start hook
     plugin.on_start(&ctx)?;
 
     // Step 11: Build the full router with plugin routes
-    let plugin_router = plugin.router(ctx.clone());
+    let plugin_router = plugin.router(ctx.clone()).layer(axum::middleware::from_fn({
+        let auth_secret = auth_secret.clone();
+        move |mut request: axum::extract::Request, next: axum::middleware::Next| {
+            let auth_secret = auth_secret.clone();
+            async move {
+                match crate::auth::verify_proxy_headers(&mut request, &auth_secret) {
+                    Ok(_) => next.run(request).await,
+                    Err(rejection) => rejection.into_response(),
+                }
+            }
+        }
+    }));
 
     // Build the events handler if needed
     let event_state = EventHandlerState {
@@ -528,6 +572,12 @@ fn tungstenite_msg_to_axum(
     }
 }
 
+/// Pull the actor token and its user out of the platform's headers.
+///
+/// Both must be present and agree: a token with no user id cannot be filed
+/// under anyone, and a user id with no token is nothing to remember. Absent
+/// on `public_paths` routes and on plugins that declare no API capability,
+/// which is why this silently does nothing rather than warning.
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/temps-plugin-sdk/src/runtime.rs
+++ b/crates/temps-plugin-sdk/src/runtime.rs
@@ -1,11 +1,12 @@
 //! Plugin binary runtime — handles startup, handshake, and serving.
 
+use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::extract::State;
-use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use clap::Parser;
@@ -18,7 +19,10 @@ use tracing::{debug, error, info, warn};
 
 use crate::client::{EventReceiver, TempsClient};
 use crate::context::PluginContext;
-use crate::manifest::{HandshakeMessage, PluginReady};
+use crate::manifest::{
+    HandshakeMessage, PluginHello, PluginLaunchConfig, PluginReady,
+    EXTERNAL_PLUGIN_PROTOCOL_VERSION,
+};
 use crate::protocol::PluginArgs;
 use crate::ExternalPlugin;
 
@@ -27,11 +31,11 @@ use crate::ExternalPlugin;
 /// This function:
 /// 1. Parses CLI args
 /// 2. Sets up tracing
-/// 3. Writes the manifest to stdout (handshake phase 1)
-/// 4. Starts axum on the Unix socket with a WebSocket endpoint for the platform channel
-/// 5. Writes the ready signal to stdout (handshake phase 2)
-/// 6. Waits for the platform to connect via WebSocket, then creates the PluginContext
-/// 7. Serves until SIGTERM
+/// 3. Emits the protocol hello and manifest
+/// 4. Reads the typed launch configuration from stdin
+/// 5. Starts axum on the Unix socket and emits Ready
+/// 6. Authenticates the platform channel and creates the PluginContext
+/// 7. Serves plugin routes and events until SIGTERM
 pub fn run_plugin<P: ExternalPlugin + Default>(plugin: P) {
     // Parse CLI arguments
     let args = PluginArgs::parse();
@@ -48,10 +52,16 @@ pub fn run_plugin<P: ExternalPlugin + Default>(plugin: P) {
         .init();
 
     // Build tokio runtime
-    let rt = tokio::runtime::Builder::new_multi_thread()
+    let rt = match tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
-        .expect("Failed to build tokio runtime");
+    {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            eprintln!("Failed to build plugin runtime: {error}");
+            std::process::exit(1);
+        }
+    };
 
     rt.block_on(async move {
         if let Err(e) = run_plugin_async(plugin, args).await {
@@ -59,6 +69,15 @@ pub fn run_plugin<P: ExternalPlugin + Default>(plugin: P) {
             std::process::exit(1);
         }
     });
+}
+
+fn write_handshake_message(message: &HandshakeMessage) -> Result<(), crate::error::PluginSdkError> {
+    let json = serde_json::to_string(message)?;
+    let stdout = std::io::stdout();
+    let mut output = stdout.lock();
+    writeln!(output, "{json}")?;
+    output.flush()?;
+    Ok(())
 }
 
 async fn run_plugin_async<P: ExternalPlugin>(
@@ -70,43 +89,62 @@ async fn run_plugin_async<P: ExternalPlugin>(
 
     info!(plugin = %plugin_name, "Starting external plugin");
 
-    let auth_secret = match args.auth_secret.take() {
-        Some(secret) if !secret.trim().is_empty() => secret,
-        Some(_) => {
-            return Err(crate::error::PluginSdkError::Initialization {
-                plugin_name,
-                reason: "Temps supplied an empty request-assertion secret".to_string(),
-            });
-        }
-        None => {
-            let mut secret = String::new();
-            let mut stdin = tokio::io::BufReader::new(tokio::io::stdin());
-            stdin.read_line(&mut secret).await.map_err(|error| {
-                crate::error::PluginSdkError::Initialization {
-                    plugin_name: plugin_name.clone(),
-                    reason: format!(
-                        "Failed to read the request-assertion secret from the host pipe: {error}"
-                    ),
-                }
-            })?;
-            let secret = secret.trim_end_matches(['\r', '\n']).to_string();
-            if secret.is_empty() {
-                return Err(crate::error::PluginSdkError::Initialization {
-                    plugin_name,
-                    reason: "Temps closed the request-assertion pipe without a secret".to_string(),
-                });
-            }
-            secret
-        }
-    };
-
-    // Step 1: Write manifest to stdout (handshake phase 1)
+    // Step 1: identify the protocol and disclose requested privileges before
+    // Temps sends any secret or host-owned path to this same child process.
     // IMPORTANT: stdout is ONLY for handshake messages. Logs go to stderr.
-    let manifest_msg = HandshakeMessage::Manifest(Box::new(manifest.clone()));
-    let manifest_json = serde_json::to_string(&manifest_msg)?;
-    println!("{}", manifest_json);
+    write_handshake_message(&HandshakeMessage::Hello(PluginHello {
+        protocol_version: EXTERNAL_PLUGIN_PROTOCOL_VERSION,
+        manifest: Box::new(manifest.clone()),
+    }))?;
 
-    // Step 2: Ensure data directory exists
+    // Step 2: receive the typed launch configuration. The manager fills only
+    // fields the manifest requested. Installed plugins execute as trusted host
+    // code today; this staged exchange is disclosure control and protocol
+    // integrity, not process isolation.
+    let mut launch_line = String::new();
+    let mut stdin = tokio::io::BufReader::new(tokio::io::stdin());
+    stdin.read_line(&mut launch_line).await.map_err(|error| {
+        crate::error::PluginSdkError::Initialization {
+            plugin_name: plugin_name.clone(),
+            reason: format!("Failed to read typed launch configuration: {error}"),
+        }
+    })?;
+    if launch_line.is_empty() {
+        return Err(crate::error::PluginSdkError::Initialization {
+            plugin_name,
+            reason: "Temps closed stdin before sending typed launch configuration; this plugin and Temps likely use incompatible SDK versions".to_string(),
+        });
+    }
+    let launch: PluginLaunchConfig = serde_json::from_str(launch_line.trim_end())?;
+    if launch.protocol_version != EXTERNAL_PLUGIN_PROTOCOL_VERSION {
+        return Err(crate::error::PluginSdkError::Initialization {
+            plugin_name,
+            reason: format!(
+                "Temps sent external-plugin protocol {}, but this SDK requires {}",
+                launch.protocol_version, EXTERNAL_PLUGIN_PROTOCOL_VERSION
+            ),
+        });
+    }
+    if launch.auth_secret.trim().is_empty() {
+        return Err(crate::error::PluginSdkError::Initialization {
+            plugin_name,
+            reason: "Temps supplied an empty request-assertion secret".to_string(),
+        });
+    }
+    if manifest.requires_db != launch.database_url.is_some()
+        || manifest.requires_host_data_access != launch.host_data_dir.is_some()
+    {
+        return Err(crate::error::PluginSdkError::Initialization {
+            plugin_name,
+            reason: "Temps launch configuration does not match the manifest's declared host access requirements".to_string(),
+        });
+    }
+    let auth_secret = launch.auth_secret;
+    args.auth_secret = Some(auth_secret.clone());
+    args.database_url = launch.database_url;
+    args.host_data_dir = launch.host_data_dir;
+
+    // Step 3: Ensure data directory exists
     let data_dir = PathBuf::from(&args.data_dir);
     tokio::fs::create_dir_all(&data_dir).await.map_err(|e| {
         crate::error::PluginSdkError::Initialization {
@@ -115,10 +153,10 @@ async fn run_plugin_async<P: ExternalPlugin>(
         }
     })?;
 
-    // Step 3: Wrap plugin in Arc for shared access
+    // Step 4: Wrap plugin in Arc for shared access
     let plugin = Arc::new(plugin);
 
-    // Step 4: Remove stale socket file if it exists
+    // Step 5: Remove stale socket file if it exists
     let socket_path = PathBuf::from(&args.socket_path);
     if socket_path.exists() {
         tokio::fs::remove_file(&socket_path).await.map_err(|e| {
@@ -129,12 +167,22 @@ async fn run_plugin_async<P: ExternalPlugin>(
         })?;
     }
 
-    // Step 5: Bind Unix socket
+    // Step 6: Bind Unix socket
     let listener =
         UnixListener::bind(&socket_path).map_err(|e| crate::error::PluginSdkError::SocketBind {
             path: args.socket_path.clone(),
             reason: e.to_string(),
         })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600)).map_err(
+            |error| crate::error::PluginSdkError::SocketBind {
+                path: args.socket_path.clone(),
+                reason: format!("Failed to restrict socket permissions to 0600: {error}"),
+            },
+        )?;
+    }
 
     info!(
         plugin = %plugin_name,
@@ -142,7 +190,7 @@ async fn run_plugin_async<P: ExternalPlugin>(
         "Plugin server listening on Unix socket"
     );
 
-    // Step 6: Signal ready to Temps (handshake phase 2)
+    // Step 7: Signal ready to Temps (handshake phase 2)
     // Include OpenAPI schema if the plugin provides one
     let openapi_json = plugin
         .openapi_schema()
@@ -150,12 +198,12 @@ async fn run_plugin_async<P: ExternalPlugin>(
     let ready_msg = HandshakeMessage::Ready(PluginReady {
         ready: true,
         has_ui: plugin.ui_assets().is_some(),
+        protocol_version: EXTERNAL_PLUGIN_PROTOCOL_VERSION,
         openapi: openapi_json,
     });
-    let ready_json = serde_json::to_string(&ready_msg)?;
-    println!("{}", ready_json);
+    write_handshake_message(&ready_msg)?;
 
-    // Step 7: Wait for the platform to connect via WebSocket on /_temps/channel.
+    // Step 8: Prepare the authenticated platform WebSocket channel.
     //
     // We use a oneshot channel: the first request to /_temps/channel
     // upgrades to WebSocket and sends the stream here, which we use
@@ -170,25 +218,45 @@ async fn run_plugin_async<P: ExternalPlugin>(
 
     let ws_tx_clone = ws_tx.clone();
     let channel_handler_plugin_name = plugin_name.clone();
-    let channel_route = get(move |ws: axum::extract::WebSocketUpgrade| {
-        let ws_tx = ws_tx_clone.clone();
-        let pname = channel_handler_plugin_name.clone();
-        async move {
-            ws.on_upgrade(move |socket| async move {
-                debug!(plugin = %pname, "Platform channel WebSocket connected");
-
-                // Convert axum WebSocket to tokio-tungstenite compatible stream
-                let ws_stream = AxumWsAdapter::new(socket);
-                let (client, event_rx) = TempsClient::from_ws(ws_stream);
-
-                // Send the client to the main task (only the first connection wins)
-                let mut guard = ws_tx.lock().await;
-                if let Some(tx) = guard.take() {
-                    let _ = tx.send((client, event_rx));
+    let channel_secret = auth_secret.clone();
+    let channel_route = get(
+        move |headers: HeaderMap, ws: axum::extract::WebSocketUpgrade| {
+            let ws_tx = ws_tx_clone.clone();
+            let pname = channel_handler_plugin_name.clone();
+            let expected_secret = channel_secret.clone();
+            async move {
+                let supplied_secret = headers
+                    .get(crate::protocol::headers::AUTH_SIGNATURE)
+                    .and_then(|value| value.to_str().ok());
+                if !supplied_secret.is_some_and(|provided| {
+                    crate::auth::secure_secret_matches(provided, &expected_secret)
+                }) {
+                    warn!(plugin = %pname, "Rejected unauthenticated platform channel attempt");
+                    return StatusCode::UNAUTHORIZED.into_response();
                 }
-            })
-        }
-    });
+
+                let sender = {
+                    let mut guard = ws_tx.lock().await;
+                    match guard.take() {
+                        Some(sender) => sender,
+                        None => return StatusCode::CONFLICT.into_response(),
+                    }
+                };
+
+                ws.on_upgrade(move |socket| async move {
+                    debug!(plugin = %pname, "Platform channel WebSocket connected");
+
+                    // Convert axum WebSocket to tokio-tungstenite compatible stream
+                    let ws_stream = AxumWsAdapter::new(socket);
+                    let (client, event_rx) = TempsClient::from_ws(ws_stream);
+
+                    // Send the client to the main task (only the first connection wins)
+                    let _ = sender.send((client, event_rx));
+                })
+                .into_response()
+            }
+        },
+    );
 
     let initial_app = Router::new()
         .route(&manifest.health_path, get(health_handler))
@@ -257,7 +325,7 @@ async fn run_plugin_async<P: ExternalPlugin>(
         }
     });
 
-    // Step 8: Wait for the platform channel to connect (with timeout)
+    // Step 9: Wait for the platform channel to connect (with timeout)
     let (temps_client, event_rx) = match tokio::time::timeout(
         std::time::Duration::from_secs(30),
         ws_rx,
@@ -293,20 +361,21 @@ async fn run_plugin_async<P: ExternalPlugin>(
         }
     };
 
-    // Step 9: Build the PluginContext with the TempsClient
+    // Step 10: Build the PluginContext with the TempsClient
     let ctx = PluginContext::new(
         temps_client,
         plugin_name.clone(),
         data_dir,
+        args.database_url.clone(),
         args.host_data_dir.as_deref().map(std::path::PathBuf::from),
         args.host_api_url.clone(),
         auth_secret.clone(),
     );
 
-    // Step 10: Call on_start hook
+    // Step 11: Call on_start hook
     plugin.on_start(&ctx)?;
 
-    // Step 11: Build the full router with plugin routes
+    // Step 12: Build the full router with plugin routes
     let plugin_router = plugin.router(ctx.clone()).layer(axum::middleware::from_fn({
         let auth_secret = auth_secret.clone();
         move |mut request: axum::extract::Request, next: axum::middleware::Next| {
@@ -324,6 +393,7 @@ async fn run_plugin_async<P: ExternalPlugin>(
     let event_state = EventHandlerState {
         plugin: plugin.clone(),
         ctx: ctx.clone(),
+        auth_secret: auth_secret.clone(),
     };
 
     let mut full_app = Router::new()
@@ -351,13 +421,13 @@ async fn run_plugin_async<P: ExternalPlugin>(
 
     info!(plugin = %plugin_name, "Plugin fully initialized and serving requests");
 
-    // Step 12: Spawn event delivery task (events received via channel)
+    // Step 13: Spawn event delivery task (events received via channel)
     let event_plugin = plugin.clone();
     let event_ctx = ctx.clone();
     let event_plugin_name = plugin_name.clone();
     spawn_event_delivery(event_rx, event_plugin, event_ctx, event_plugin_name);
 
-    // Step 13: Wait for shutdown
+    // Step 14: Wait for shutdown
     shutdown.await.ok();
     info!(plugin = %plugin_name, "Received shutdown signal");
     plugin.on_shutdown();
@@ -399,6 +469,7 @@ async fn health_handler() -> &'static str {
 struct EventHandlerState<P: ExternalPlugin> {
     plugin: Arc<P>,
     ctx: PluginContext,
+    auth_secret: String,
 }
 
 // Manual Clone impl — Arc<P> is always Clone regardless of P's Clone impl.
@@ -407,6 +478,7 @@ impl<P: ExternalPlugin> Clone for EventHandlerState<P> {
         Self {
             plugin: self.plugin.clone(),
             ctx: self.ctx.clone(),
+            auth_secret: self.auth_secret.clone(),
         }
     }
 }
@@ -415,8 +487,18 @@ impl<P: ExternalPlugin> Clone for EventHandlerState<P> {
 /// (Kept for backward compatibility with the HTTP-based event delivery.)
 async fn event_handler<P: ExternalPlugin>(
     State(state): State<EventHandlerState<P>>,
+    headers: HeaderMap,
     Json(event): Json<PluginEvent>,
-) -> impl IntoResponse {
+) -> Response {
+    let supplied_secret = headers
+        .get(crate::protocol::headers::AUTH_SIGNATURE)
+        .and_then(|value| value.to_str().ok());
+    if !supplied_secret
+        .is_some_and(|provided| crate::auth::secure_secret_matches(provided, &state.auth_secret))
+    {
+        warn!(plugin = %state.ctx.plugin_name(), "Rejected unauthenticated internal event");
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
     debug!(
         plugin = %state.ctx.plugin_name(),
         event_type = %event.event_type,
@@ -426,7 +508,7 @@ async fn event_handler<P: ExternalPlugin>(
 
     state.plugin.on_event(&state.ctx, event);
 
-    StatusCode::OK
+    StatusCode::OK.into_response()
 }
 
 // ── Axum WebSocket → tokio-tungstenite adapter ─────────────────────────

--- a/crates/temps-providers/src/handlers/audit.rs
+++ b/crates/temps-providers/src/handlers/audit.rs
@@ -36,6 +36,25 @@ pub struct ExternalServiceEnvironmentVariableRevealedAudit {
     pub variable_name: String,
 }
 
+/// Live connection credentials were issued for a service in an environment,
+/// and the per-tenant database was provisioned if it did not exist.
+///
+/// Separate from [`ExternalServiceEnvironmentVariableRevealedAudit`] because
+/// it is a stronger event: that one reveals a single named variable a human
+/// asked for, this one hands out the whole connection — including the
+/// password — and creates a database as a side effect. The variable *names*
+/// are recorded so an auditor can see what was handed over; the values
+/// obviously are not.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExternalServiceRuntimeCredentialsIssuedAudit {
+    pub context: AuditContext,
+    pub service_id: i32,
+    pub project_id: i32,
+    pub environment_id: i32,
+    /// Names only, sorted. Never the values.
+    pub variable_names: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct ExternalServiceDeletedAudit {
     pub context: AuditContext,
@@ -280,6 +299,29 @@ impl AuditOperation for ExternalServiceParameterRevealedAudit {
 impl AuditOperation for ExternalServiceEnvironmentVariableRevealedAudit {
     fn operation_type(&self) -> String {
         "EXTERNAL_SERVICE_ENVIRONMENT_VARIABLE_REVEALED".to_string()
+    }
+
+    fn user_id(&self) -> Option<i32> {
+        Some(self.context.user_id)
+    }
+
+    fn ip_address(&self) -> Option<String> {
+        self.context.ip_address.clone()
+    }
+
+    fn user_agent(&self) -> &str {
+        &self.context.user_agent
+    }
+
+    fn serialize(&self) -> Result<String> {
+        serde_json::to_string(self)
+            .map_err(|e| anyhow::anyhow!("Failed to serialize audit operation {}", e))
+    }
+}
+
+impl AuditOperation for ExternalServiceRuntimeCredentialsIssuedAudit {
+    fn operation_type(&self) -> String {
+        "EXTERNAL_SERVICE_RUNTIME_CREDENTIALS_ISSUED".to_string()
     }
 
     fn user_id(&self) -> Option<i32> {

--- a/crates/temps-providers/src/handlers/handlers.rs
+++ b/crates/temps-providers/src/handlers/handlers.rs
@@ -2158,7 +2158,9 @@ async fn issue_runtime_credentials(
 fn runtime_credentials_problem(e: crate::services::ExternalServiceError) -> Problem {
     use crate::services::ExternalServiceError as E;
     match e {
-        E::ServiceNotFound { .. } => not_found().detail(e.to_string()).build(),
+        E::ServiceNotFound { .. } | E::EnvironmentNotFound { .. } => {
+            not_found().detail(e.to_string()).build()
+        }
         E::ServiceNotLinkedToProject { .. } => conflict().detail(e.to_string()).build(),
         E::InvalidServiceType { .. } => bad_request().detail(e.to_string()).build(),
         _ => internal_server_error()

--- a/crates/temps-providers/src/handlers/handlers.rs
+++ b/crates/temps-providers/src/handlers/handlers.rs
@@ -26,15 +26,15 @@ use super::audit::{
     ExternalServiceClusterMemberAddedAudit, ExternalServiceClusterMemberPromotedAudit,
     ExternalServiceClusterMemberRemovedAudit, ExternalServiceCreatedAudit,
     ExternalServiceDeletedAudit, ExternalServiceEnvironmentVariableRevealedAudit,
-    ExternalServiceParameterRevealedAudit, ExternalServiceStatusChangedAudit,
-    ExternalServiceUpdatedAudit, ServiceHealthChecked,
+    ExternalServiceParameterRevealedAudit, ExternalServiceRuntimeCredentialsIssuedAudit,
+    ExternalServiceStatusChangedAudit, ExternalServiceUpdatedAudit, ServiceHealthChecked,
 };
 use crate::handlers::types::{
     AddClusterMemberRequest, AvailableContainerInfo, ClusterHealthReportResponse,
     ClusterMemberHealthResponse, CreateExternalServiceRequest, EnvironmentVariableInfo,
     ExternalServiceDetails, ExternalServiceInfo, HealthCheckEntryResponse,
     ImportExternalServiceRequest, LinkServiceRequest, ProjectServiceInfo, ProviderMetadata,
-    RetryClusterRequest, SensitiveValueResponse, ServiceHealthResponse,
+    RetryClusterRequest, RuntimeCredentialsResponse, SensitiveValueResponse, ServiceHealthResponse,
     ServiceHealthStatusBatchResponse, ServiceHealthStatusEntryResponse, ServiceMemberInfo,
     ServiceParameter, ServiceTypeInfo, ServiceTypeRoute, UpdateExternalServiceRequest,
     UpgradeExternalServiceRequest,
@@ -310,6 +310,10 @@ pub fn configure_routes() -> Router<Arc<AppState>> {
         .route(
             "/external-services/{id}/projects/{project_id}/environment",
             get(get_service_environment_variables),
+        )
+        .route(
+            "/external-services/{id}/projects/{project_id}/environments/{environment_id}/runtime-credentials",
+            post(issue_runtime_credentials),
         )
         .route(
             "/external-services/projects/{project_id}/environment",
@@ -2051,6 +2055,118 @@ async fn get_service_environment_variable(
     }
 }
 
+/// Issue live connection credentials for a service in an environment
+///
+/// Provisions the per-tenant database if it does not exist yet, then returns
+/// the connection variables in plaintext — the same values a deployment gets
+/// injected at runtime.
+///
+/// **This is a POST because it is not a read.** It creates a database as a
+/// side effect, and its response is a live credential: a GET would be
+/// prefetchable, cacheable, and liable to end up in a proxy access log with
+/// the whole connection in the URL's neighbourhood. Nothing about it is safe
+/// or idempotent in the HTTP sense.
+///
+/// Intended for callers that need to *connect* an application to a managed
+/// service — the console's own deploy path does this in-process; external
+/// plugins reach it here. For inspecting configuration, use the masked bulk
+/// read or the single-variable reveal instead.
+#[utoipa::path(
+    post,
+    path = "/external-services/{id}/projects/{project_id}/environments/{environment_id}/runtime-credentials",
+    tag = "External Services",
+    responses(
+        (status = 200, description = "Connection credentials issued", body = RuntimeCredentialsResponse),
+        (status = 403, description = "Plaintext secret access is not permitted"),
+        (status = 404, description = "Service, project, or environment not found"),
+        (status = 409, description = "Service is not linked to the project"),
+        (status = 500, description = "Internal server error")
+    ),
+    params(
+        ("id" = i32, Path, description = "External service ID"),
+        ("project_id" = i32, Path, description = "Project ID"),
+        ("environment_id" = i32, Path, description = "Environment ID")
+    ),
+    security(("bearer_auth" = []))
+)]
+async fn issue_runtime_credentials(
+    State(app_state): State<Arc<AppState>>,
+    Path((id, project_id, environment_id)): Path<(i32, i32, i32)>,
+    RequireAuth(auth): RequireAuth,
+    Extension(metadata): Extension<RequestMetadata>,
+) -> Result<impl IntoResponse, Problem> {
+    // Same gate as the single-variable reveal, plus a write permission: this
+    // one provisions. A caller that may only read must not be able to create
+    // a database by asking for its credentials.
+    permission_guard!(auth, ExternalServicesWrite);
+    permission_guard!(auth, SecretsRead);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
+
+    let variables = app_state
+        .external_service_manager
+        .get_runtime_env_vars(id, project_id, environment_id)
+        .await
+        .map_err(runtime_credentials_problem)?;
+
+    let mut variable_names: Vec<String> = variables.keys().cloned().collect();
+    variable_names.sort();
+
+    let audit = ExternalServiceRuntimeCredentialsIssuedAudit {
+        context: AuditContext {
+            user_id: auth.user_id(),
+            ip_address: Some(metadata.ip_address.clone()),
+            user_agent: metadata.user_agent.clone(),
+        },
+        service_id: id,
+        project_id,
+        environment_id,
+        variable_names,
+    };
+    let audit_result = app_state.audit_service.create_audit_log(&audit).await;
+    if let Err(error) = &audit_result {
+        error!(
+            service_id = id,
+            project_id,
+            environment_id,
+            error = %error,
+            "Failed to audit runtime-credential issuance"
+        );
+    }
+    // No credential leaves the process without a durable record of who got
+    // it. Same rule the single-variable reveal applies, and the reason it is
+    // a hard failure rather than a warning: an unaudited credential handout
+    // is indistinguishable afterwards from one that never happened.
+    require_reveal_audit(
+        audit_result,
+        "The connection credentials could not be issued because the audit record failed",
+    )?;
+
+    Ok((
+        StatusCode::OK,
+        [(header::CACHE_CONTROL, "no-store")],
+        Json(RuntimeCredentialsResponse { variables }),
+    ))
+}
+
+/// HTTP mapping for credential issuance.
+///
+/// "Not linked" is a 409 rather than a 404: the service and the project both
+/// exist, and the fix is to link them — a 404 would send the caller looking
+/// for a missing record.
+fn runtime_credentials_problem(e: crate::services::ExternalServiceError) -> Problem {
+    use crate::services::ExternalServiceError as E;
+    match e {
+        E::ServiceNotFound { .. } => not_found().detail(e.to_string()).build(),
+        E::ServiceNotLinkedToProject { .. } => conflict().detail(e.to_string()).build(),
+        E::InvalidServiceType { .. } => bad_request().detail(e.to_string()).build(),
+        _ => internal_server_error()
+            .detail(format!("Failed to issue connection credentials: {e}"))
+            .build(),
+    }
+}
+
 /// Get all environment variables for a service-project pair
 #[utoipa::path(
     get,
@@ -2495,6 +2611,7 @@ async fn update_service_resources(
         list_service_projects,
         list_project_services,
         get_service_environment_variable,
+        issue_runtime_credentials,
         get_service_environment_variables,
         get_project_service_environment_variables,
         get_service_preview_environment_variable_names,

--- a/crates/temps-providers/src/handlers/types.rs
+++ b/crates/temps-providers/src/handlers/types.rs
@@ -600,6 +600,27 @@ impl From<crate::services::ServiceHealthSnapshot> for ServiceHealthResponse {
     }
 }
 
+/// Live connection variables for a service in one environment.
+///
+/// Every value is plaintext — this is the response of the audited issuance
+/// endpoint, not of the masked bulk read. Callers must treat it as a
+/// credential: do not log it, do not cache it, do not put it in an error.
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct RuntimeCredentialsResponse {
+    /// Connection variables, e.g. `POSTGRES_URL`, `POSTGRES_PASSWORD`.
+    pub variables: std::collections::HashMap<String, String>,
+}
+
+/// Debug prints names only. A `{:?}` of a credential response in a log line
+/// would defeat the point of the endpoint being audited.
+impl std::fmt::Debug for RuntimeCredentialsResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut names: Vec<&String> = self.variables.keys().collect();
+        names.sort();
+        write!(f, "RuntimeCredentialsResponse {{ variables: {names:?} }}")
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct EnvironmentVariableInfo {
     pub name: String,

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -88,6 +88,12 @@ pub enum ExternalServiceError {
     #[error("Project {id} not found")]
     ProjectNotFound { id: i32 },
 
+    #[error("Environment {environment_id} not found in project {project_id}")]
+    EnvironmentNotFound {
+        environment_id: i32,
+        project_id: i32,
+    },
+
     #[error("Database error: {reason}")]
     DatabaseError { reason: String },
 
@@ -8114,6 +8120,20 @@ echo "[restore] Pre-seed complete"
             });
         }
 
+        // Resolve the environment inside the authorized project before
+        // decrypting service configuration or provisioning any tenant
+        // resource. An environment ID is not globally sufficient proof of
+        // project ownership, and soft-deleted environments are not targets.
+        let environment = temps_entities::environments::Entity::find_by_id(environment_id)
+            .filter(temps_entities::environments::Column::ProjectId.eq(project_id))
+            .filter(temps_entities::environments::Column::DeletedAt.is_null())
+            .one(self.db.as_ref())
+            .await?
+            .ok_or(ExternalServiceError::EnvironmentNotFound {
+                environment_id,
+                project_id,
+            })?;
+
         let parameters = self.get_service_parameters(service_id_val).await?;
 
         // Compute the per-tenant database name once — both paths use
@@ -8124,12 +8144,6 @@ echo "[restore] Pre-seed complete"
             .one(self.db.as_ref())
             .await?
             .ok_or(ExternalServiceError::ProjectNotFound { id: project_id })?;
-        let environment = temps_entities::environments::Entity::find_by_id(environment_id)
-            .one(self.db.as_ref())
-            .await?
-            .ok_or_else(|| ExternalServiceError::InternalError {
-                reason: format!("Environment {} not found", environment_id),
-            })?;
         let resource_name = crate::externalsvc::postgres::PostgresService::normalize_database_name(
             &format!("{}_{}", project.slug, environment.slug),
         );
@@ -12542,6 +12556,46 @@ mod tests {
             ai_data_access: false,
             container_name: None,
         }
+    }
+
+    #[tokio::test]
+    async fn runtime_credentials_reject_cross_project_environment_before_provisioning() {
+        let service = encrypted_service_model(
+            71,
+            serde_json::json!({
+                "username": "app",
+                "password": "secret",
+                "database": "postgres"
+            }),
+        );
+        let link = project_services::Model {
+            id: 9,
+            project_id: 10,
+            service_id: 71,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let db = sea_orm::MockDatabase::new(sea_orm::DatabaseBackend::Postgres)
+            .append_query_results([vec![service]])
+            .append_query_results([vec![link]])
+            // Environment 20 belongs to another project, so the combined
+            // id + project_id + deleted_at query returns no row.
+            .append_query_results([Vec::<temps_entities::environments::Model>::new()])
+            .into_connection();
+        let manager = mock_service_manager_with_db(Arc::new(db));
+
+        let error = manager
+            .get_runtime_env_vars(71, 10, 20)
+            .await
+            .expect_err("cross-project environment must be rejected");
+
+        assert!(matches!(
+            error,
+            ExternalServiceError::EnvironmentNotFound {
+                environment_id: 20,
+                project_id: 10
+            }
+        ));
     }
 
     #[tokio::test]

--- a/docs/architecture/plugins/page.mdx
+++ b/docs/architecture/plugins/page.mdx
@@ -21,6 +21,8 @@ Temps uses a modular plugin architecture that enables extensibility without modi
 
 > **Looking for working code?** Official external plugins — Lighthouse audits, IndexNow, Google Indexing, and a minimal hello-world — live in the dedicated [`gotempsh/plugins`](https://github.com/gotempsh/plugins) repository. Each one is a standalone Cargo crate you can clone, build, and install as a drop-in binary.
 
+> **Building an external plugin?** See the [External Plugin SDK authentication and platform API reference](/docs/reference/external-plugin-sdk) for protected routes, caller permissions, delegated API calls, manifest capabilities, and public endpoints.
+
 ---
 
 ## Overview {{ anchor: true, id: 'overview' }}

--- a/docs/design/external-plugin-sdk-boundary.md
+++ b/docs/design/external-plugin-sdk-boundary.md
@@ -1,0 +1,77 @@
+# External Plugin Authentication Boundary Plan
+
+Status: Implemented
+Branch: `feat/external-plugin-auth-boundary`
+
+## Objective
+
+Make `temps-plugin-sdk` the mandatory authentication and caller-delegation
+boundary for external plugins. Trusted first-party plugins may still link
+internal runtime crates for in-process platform services, but that trust must
+not allow them to bypass caller authentication or authorization.
+
+## Security contract
+
+Temps owns:
+
+- Authentication of sessions, API keys, and CLI tokens.
+- Resolution of the caller's effective permission set.
+- Removal of caller-supplied `x-temps-*`, `cookie`, `authorization`, and
+  `proxy-authorization` headers.
+- Delivery of identity over the plugin's private Unix socket, authenticated
+  with the per-process handshake secret.
+- Authorization of caller-scoped platform API operations.
+
+The SDK exposes:
+
+- `AuthenticatedCaller` and `OptionalCaller` Axum extractors.
+- SDK-owned role and permission wire types.
+- `PluginContext::api_as_caller` for delegated platform calls.
+- Typed platform projections rather than entity models.
+
+The plugin owns authorization for its own resources after extraction. It must
+not parse forwarded headers itself or reconstruct permissions from role names.
+
+## Runtime trust model
+
+The SDK is not intended to replace every internal Rust service for first-party
+plugins. A private plugin may link internal crates when it needs in-process
+access to configured services. Such a plugin is explicitly trusted and
+version-locked to Temps.
+
+Raw host services and secrets are not part of the general third-party plugin
+contract. Future third-party plugins require narrower host capabilities or a
+separate sandboxed execution model.
+
+## Implemented work
+
+- Added the resolved permission header to the host/plugin protocol.
+- Added typed authenticated and optional caller extractors.
+- Verified proxy assertions in SDK middleware before inserting caller state.
+- Caller-scoped channel clients are captured from the initiating request and
+  carried into background work; there is no mutable user-ID token registry.
+- Added caller-scoped project listing through the platform HTTP handler.
+- Stripped browser credentials and spoofed Temps headers before proxying.
+- Added regression tests for spoofing, narrowed API-key permissions, anonymous
+  requests, and caller extraction.
+
+## Remaining work
+
+- Add protocol-version negotiation and actionable compatibility errors.
+- Add explicit expiry reporting for background delegations so a long-running
+  operation can explain when its initiating actor token has expired.
+- Add multi-user integration coverage proving project isolation.
+- Add generic host APIs only where a concrete plugin requirement justifies
+  them; do not mirror the entire Temps service graph preemptively.
+- Replace unrestricted host-table operations that handle user-scoped resources
+  with authorized SDK calls as concrete requirements arise.
+
+## Verification and release gates
+
+- `cargo check --lib -p temps-plugin-sdk`
+- `cargo check --lib -p temps-external-plugins`
+- Focused unit suites for both crates.
+- Local external-plugin E2E covering SDK caller extraction, delegated platform
+  calls, and generated public URLs.
+- Security-auditor approval before merge.
+- OSS Temps changes merge through a PR with runtime evidence.

--- a/docs/design/external-plugin-sdk-boundary.md
+++ b/docs/design/external-plugin-sdk-boundary.md
@@ -35,19 +35,42 @@ not parse forwarded headers itself or reconstruct permissions from role names.
 ## Runtime trust model
 
 The SDK is not intended to replace every internal Rust service for first-party
-plugins. A private plugin may link internal crates when it needs in-process
-access to configured services. Such a plugin is explicitly trusted and
-version-locked to Temps.
+plugins. Every installed external plugin is fully trusted host code: plugin
+processes currently run as the Temps operating-system user and are not
+sandboxed from the instance filesystem or sibling processes. The caller and
+capability checks in this document protect user requests and prevent accidental
+authority widening; they are not containment against a malicious plugin.
+
+A private plugin may link internal crates when it needs in-process access to
+configured services. Such a plugin is explicitly trusted and version-locked to
+Temps, but it still receives no database credential or host-data path in its
+launch configuration by default.
+
+Direct control-plane database access and host-data access are independent,
+privileged manifest disclosures. `requires_db(true)` asks Temps to supply the
+database URL. `requires_host_data_access(true)` asks it to supply the instance
+data root, which can contain encryption and authentication keys. These flags
+minimize ambient launch data and make privilege visible to operators; they do
+not create an OS security boundary. Ordinary plugins should request neither.
 
 Raw host services and secrets are not part of the general third-party plugin
-contract. Future third-party plugins require narrower host capabilities or a
-separate sandboxed execution model.
+contract. Untrusted third-party plugins require a separate UID, container, or
+sandbox with a private filesystem and plugin-scoped database credentials; that
+containment is not provided by the current runtime.
 
 ## Implemented work
 
 - Added the resolved permission header to the host/plugin protocol.
 - Added typed authenticated and optional caller extractors.
 - Verified proxy assertions in SDK middleware before inserting caller state.
+- Authenticated the internal WebSocket channel and HTTP event fallback before
+  either endpoint consumes plugin state.
+- Restricted the socket directory and socket itself to the host process user.
+- Added a versioned, staged startup handshake. One process publishes its
+  manifest and then receives typed launch configuration through stdin; legacy
+  or mismatched binaries get an actionable rebuild error.
+- Defaulted database and host-data launch values off and supplied them
+  independently from the declared manifest.
 - Caller-scoped channel clients are captured from the initiating request and
   carried into background work; there is no mutable user-ID token registry.
 - Added caller-scoped project listing through the platform HTTP handler.
@@ -57,7 +80,6 @@ separate sandboxed execution model.
 
 ## Remaining work
 
-- Add protocol-version negotiation and actionable compatibility errors.
 - Add explicit expiry reporting for background delegations so a long-running
   operation can explain when its initiating actor token has expired.
 - Add multi-user integration coverage proving project isolation.
@@ -74,4 +96,6 @@ separate sandboxed execution model.
 - Local external-plugin E2E covering SDK caller extraction, delegated platform
   calls, and generated public URLs.
 - Security-auditor approval before merge.
+- Rebuild external plugin binaries against the matching SDK protocol before a
+  host release; legacy binaries fail secure startup preflight.
 - OSS Temps changes merge through a PR with runtime evidence.

--- a/docs/reference/external-plugin-sdk/page.mdx
+++ b/docs/reference/external-plugin-sdk/page.mdx
@@ -1,0 +1,265 @@
+export const metadata = {
+  title: 'External Plugin SDK',
+  description: 'Authenticate external plugin routes and call the Temps platform API with the permissions of the initiating user.',
+  alternates: {
+    canonical: '/docs/reference/external-plugin-sdk',
+  },
+}
+
+export const sections = [
+  { title: 'Security model', id: 'security-model' },
+  { title: 'Before and after', id: 'before-after' },
+  { title: 'Protect a route', id: 'protect-a-route' },
+  { title: 'Check permissions', id: 'check-permissions' },
+  { title: 'Call the platform API', id: 'call-platform-api' },
+  { title: 'Background work', id: 'background-work' },
+  { title: 'Declare capabilities', id: 'declare-capabilities' },
+  { title: 'Public routes', id: 'public-routes' },
+  { title: 'Available operations', id: 'available-operations' },
+  { title: 'Compatibility and errors', id: 'compatibility-errors' },
+]
+
+# External Plugin SDK
+
+Use `temps-plugin-sdk` to authenticate external plugin routes and call the Temps API as the user who started the request. Temps remains responsible for sessions, API keys, roles, and platform authorization. {{ className: 'lead' }}
+
+---
+
+## Security model {{ anchor: true, id: 'security-model' }}
+
+An external plugin runs as a separate process. Temps reaches it through a private Unix socket and mounts its routes at:
+
+```text
+/api/x/{plugin-name}/*
+```
+
+For every proxied request, Temps:
+
+1. Authenticates the browser session, API key, or CLI token.
+2. Resolves the caller's effective permissions.
+3. Removes the original `Cookie`, `Authorization`, `Proxy-Authorization`, and caller-supplied `x-temps-*` headers.
+4. Adds a signed caller assertion for the target plugin process.
+5. Lets the SDK verify that assertion before the plugin router runs.
+
+The result is an important boundary: plugin handlers consume a verified caller object instead of parsing identity headers themselves.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Temps
+    participant SDK
+    participant Handler as Plugin handler
+    participant API as Temps API
+
+    Client->>Temps: Request with session or API key
+    Temps->>Temps: Authenticate and resolve permissions
+    Temps->>SDK: Sanitized request + signed caller assertion
+    SDK->>SDK: Verify target process secret
+    SDK->>Handler: AuthenticatedCaller
+    Handler->>API: PlatformApi bound to caller
+    API->>API: Run normal permission guard
+    API-->>Handler: Authorized response
+```
+
+The SDK does not grant extra access. A delegated call is checked by the same platform handler and permission guard as a direct API request.
+
+---
+
+## Before and after {{ anchor: true, id: 'before-after' }}
+
+Before this boundary, an external plugin could query a limited read-only channel, but it had no safe general way to call the platform API for the current user. A plugin that needed to create a project or deployment had to add a parallel host integration, handle forwarded identity itself, or retain a user token for later work. Those approaches could drift from the main API's authorization rules or select the wrong credential when one user had multiple sessions and API keys.
+
+After this boundary, Temps authenticates once and the SDK exposes the verified result. The plugin receives typed caller data, checks the caller's resolved permissions for plugin-owned resources, and derives a `PlatformApi` bound to that exact request when it needs platform work.
+
+| Before | After |
+| --- | --- |
+| Plugin handlers parsed forwarded identity data | SDK extractors return a verified `AuthenticatedCaller` |
+| A role name could be mistaken for the caller's full authority | The resolved permission set preserves API-key narrowing |
+| Background work could look up a credential by user ID | Background work owns the exact initiating `PlatformApi` |
+| Platform mutations needed parallel integration code | Typed calls reuse existing platform HTTP handlers and permission guards |
+| One shared proxy secret covered every plugin process | Every plugin process has its own secret delivered outside argv and environment variables |
+| Plugins could guess public scheme, host, or port | `mount_url()` uses the host's configured public origin |
+
+---
+
+## Protect a route {{ anchor: true, id: 'protect-a-route' }}
+
+Use `AuthenticatedCaller` as an Axum extractor for a route that requires a signed-in Temps user:
+
+```rust
+use axum::{routing::get, Json, Router};
+use serde_json::{json, Value};
+use temps_plugin_sdk::{AuthenticatedCaller, PluginContext};
+
+async fn profile(caller: AuthenticatedCaller) -> Json<Value> {
+    Json(json!({
+        "user_id": caller.user_id,
+        "email": caller.email,
+        "role": caller.role,
+        "request_id": caller.request_id,
+    }))
+}
+
+fn router(ctx: PluginContext) -> Router {
+    Router::new()
+        .route("/profile", get(profile))
+        .with_state(ctx)
+}
+```
+
+If the request has no verified user, the extractor returns `401 Authentication Required` using a Problem Details response.
+
+For a route that supports both anonymous and authenticated callers, use `OptionalCaller`:
+
+```rust
+use temps_plugin_sdk::OptionalCaller;
+
+async fn landing(OptionalCaller(caller): OptionalCaller) -> String {
+    match caller {
+        Some(caller) => format!("Welcome back, {}", caller.email),
+        None => "Welcome".to_string(),
+    }
+}
+```
+
+Do not read `x-temps-user-*` headers in your handler. The typed extractors only return data inserted after the SDK verifies the request came from Temps.
+
+---
+
+## Check permissions {{ anchor: true, id: 'check-permissions' }}
+
+Authorize plugin-owned resources with `has_permission`:
+
+```rust
+use axum::http::StatusCode;
+use temps_plugin_sdk::{AuthenticatedCaller, PluginPermission};
+
+async fn create_widget(caller: AuthenticatedCaller) -> Result<String, StatusCode> {
+    if !caller.has_permission(PluginPermission::PROJECTS_WRITE) {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    Ok("created".to_string())
+}
+```
+
+Check the resolved permission set, not only the role. An API key can use an administrator account while being intentionally narrowed to `projects:read`. Reconstructing permissions from `caller.role` would silently widen that key.
+
+`PluginPermission` keeps permission names as validated strings. This allows a plugin built with an older SDK to accept new permission names added by a newer Temps release.
+
+---
+
+## Call the platform API {{ anchor: true, id: 'call-platform-api' }}
+
+Convert the verified caller into a typed, caller-scoped `PlatformApi`:
+
+```rust
+use temps_plugin_sdk::{api::ProjectPage, AuthenticatedCaller, PluginContext, PluginSdkError};
+
+async fn load_projects(
+    ctx: &PluginContext,
+    caller: &AuthenticatedCaller,
+) -> Result<ProjectPage, PluginSdkError> {
+    let api = ctx.api_as_caller(caller)?;
+    api.list_projects(1, 50).await
+}
+```
+
+`PlatformApi` carries the short-lived actor issued for this exact request. Temps verifies the actor and executes the existing HTTP handler as that user. Project membership, API-key restrictions, and endpoint permission guards still apply.
+
+Do not construct a platform client from a user ID, store raw actor tokens, or select the "most recent" credential for a user. Those patterns can swap a restricted API key for a broader browser session.
+
+---
+
+## Background work {{ anchor: true, id: 'background-work' }}
+
+Create the `PlatformApi` while the verified request is in scope, then move the typed client into the background task:
+
+```rust
+let api = ctx.api_as_caller(&caller)?;
+
+tokio::spawn(async move {
+    if let Err(error) = run_deployment(api).await {
+        tracing::error!(%error, "background deployment failed");
+    }
+});
+```
+
+This preserves the exact initiating authority without maintaining a global user-to-token registry. The actor is short-lived, so long-running work must surface expiry as an actionable error and ask the user to retry.
+
+---
+
+## Declare capabilities {{ anchor: true, id: 'declare-capabilities' }}
+
+Platform calls require a coarse capability in the plugin manifest:
+
+```rust
+use temps_plugin_sdk::{PluginCapability, PluginManifest};
+
+let manifest = PluginManifest::builder("example-plugin", "1.0.0")
+    .capability(PluginCapability::ApiRead)
+    .capability(PluginCapability::ApiWrite)
+    .build();
+```
+
+| Capability | Allows |
+| --- | --- |
+| `ApiRead` | Calls using HTTP `GET` |
+| `ApiWrite` | Calls that create, update, or delete platform resources |
+
+Capabilities describe the maximum class of calls a plugin intends to make. They never override the caller's permissions. A request must pass both checks:
+
+1. The plugin manifest declares the required capability.
+2. The initiating caller is authorized by the platform endpoint.
+
+Declare only what the plugin needs. A plugin that only lists projects should request `ApiRead`, not `ApiWrite`.
+
+---
+
+## Public routes {{ anchor: true, id: 'public-routes' }}
+
+Protected routes are the default. Use `public_path` only when a route authenticates itself, such as a signed webhook or a capability URL:
+
+```rust
+let manifest = PluginManifest::builder("example-plugin", "1.0.0")
+    .public_path("/webhooks/provider")
+    .build();
+```
+
+The path is relative to the plugin mount and matches by prefix. A public path bypasses Temps user authentication and is reachable by anyone who can reach the instance. The handler must validate its own credential before doing work.
+
+Public requests have no platform user to delegate. `api_as_caller` is therefore unavailable for them.
+
+---
+
+## Available operations {{ anchor: true, id: 'available-operations' }}
+
+The caller-scoped API currently provides typed operations for:
+
+| Area | Operations |
+| --- | --- |
+| Projects | List visible projects, create, fetch, and update a project |
+| Environments | List a project's environments |
+| Deployments | Deploy a static bundle, deploy a named local or registry image, upload an image archive, and poll a deployment |
+| Managed services | Create a service, link it to a project, and issue audited runtime credentials |
+
+Endpoint declarations are checked against Temps' generated OpenAPI schema by `crates/temps-cli/tests/plugin_sdk_conformance.rs`. A renamed route, changed verb, or incompatible response field fails CI instead of becoming a runtime `404` or deserialization error.
+
+For URLs exposed outside the plugin process, use `PluginContext::mount_url()`. It derives the externally reachable `/api/x/{plugin-name}` URL from the host configuration; do not guess the scheme, hostname, or port.
+
+---
+
+## Compatibility and errors {{ anchor: true, id: 'compatibility-errors' }}
+
+Treat these errors separately when presenting them to an operator:
+
+| Error | Meaning |
+| --- | --- |
+| `NoActor` | The request has no caller delegation, usually because it is public or the manifest declares no API capability |
+| `ApiStatus` | Temps rejected the delegated API call; the error includes the HTTP status and Problem Details body |
+| `BodyTooLarge` | A multipart payload exceeds the platform channel limit |
+| `Deserialization` | The response no longer matches the SDK projection |
+
+SDK response types are projections of the platform's public OpenAPI models. Required fields are verified by the conformance test, while optional fields allow compatible additions across releases.
+
+External plugins are separate binaries and must be rebuilt when adopting a breaking SDK protocol change. Keep the plugin SDK revision aligned with the Temps version used to build and test the plugin.

--- a/docs/reference/external-plugin-sdk/page.mdx
+++ b/docs/reference/external-plugin-sdk/page.mdx
@@ -41,7 +41,20 @@ For every proxied request, Temps:
 4. Adds a signed caller assertion for the target plugin process.
 5. Lets the SDK verify that assertion before the plugin router runs.
 
-The result is an important boundary: plugin handlers consume a verified caller object instead of parsing identity headers themselves.
+Temps also authenticates the internal WebSocket channel and event-delivery
+endpoint with the process-specific secret. Socket permissions limit access to
+the host process user, and an unauthenticated connection cannot consume the
+single accepted channel slot.
+
+The result is an important request boundary: plugin handlers consume a
+verified caller object instead of parsing identity headers themselves.
+
+Installed plugins are nevertheless fully trusted host code. They currently
+run as the Temps operating-system user and are not sandboxed from the instance
+filesystem or sibling processes. Per-process secrets and manifest capabilities
+prevent accidental request-authority widening; they do not contain a malicious
+plugin binary. Untrusted plugins require a separate UID, container, or
+equivalent sandbox with plugin-scoped storage and credentials.
 
 ```mermaid
 sequenceDiagram
@@ -78,6 +91,8 @@ After this boundary, Temps authenticates once and the SDK exposes the verified r
 | Background work could look up a credential by user ID | Background work owns the exact initiating `PlatformApi` |
 | Platform mutations needed parallel integration code | Typed calls reuse existing platform HTTP handlers and permission guards |
 | One shared proxy secret covered every plugin process | Every plugin process has its own secret delivered outside argv and environment variables |
+| Plugins received database and host values by default | Privileged launch values are declared independently and disabled by default |
+| An old binary failed after partial startup | A versioned staged handshake returns an actionable incompatibility error |
 | Plugins could guess public scheme, host, or port | `mount_url()` uses the host's configured public origin |
 
 ---
@@ -214,6 +229,24 @@ Capabilities describe the maximum class of calls a plugin intends to make. They 
 
 Declare only what the plugin needs. A plugin that only lists projects should request `ApiRead`, not `ApiWrite`.
 
+Database and host-data access are separate privileged launch disclosures, not
+ordinary API capabilities:
+
+```rust
+let manifest = PluginManifest::builder("trusted-maintenance-plugin", "1.0.0")
+    .requires_db(true)
+    .requires_host_data_access(true)
+    .build();
+```
+
+`requires_db(true)` exposes the control-plane database URL.
+`requires_host_data_access(true)` exposes the instance data root, which may
+contain encryption and authentication keys. The flags minimize supplied data
+and disclose intent; they are not sandbox enforcement under the current
+shared-UID runtime. Use caller-scoped API operations for normal plugins, and
+enable these settings only for audited binaries that cannot function through
+the SDK boundary.
+
 ---
 
 ## Public routes {{ anchor: true, id: 'public-routes' }}
@@ -240,7 +273,7 @@ The caller-scoped API currently provides typed operations for:
 | --- | --- |
 | Projects | List visible projects, create, fetch, and update a project |
 | Environments | List a project's environments |
-| Deployments | Deploy a static bundle, deploy a named local or registry image, upload an image archive, and poll a deployment |
+| Deployments | Deploy a static bundle, deploy a registry image, securely claim a host-local image, upload an image archive, and poll a deployment |
 | Managed services | Create a service, link it to a project, and issue audited runtime credentials |
 
 Endpoint declarations are checked against Temps' generated OpenAPI schema by `crates/temps-cli/tests/plugin_sdk_conformance.rs`. A renamed route, changed verb, or incompatible response field fails CI instead of becoming a runtime `404` or deserialization error.
@@ -263,3 +296,17 @@ Treat these errors separately when presenting them to an operator:
 SDK response types are projections of the platform's public OpenAPI models. Required fields are verified by the conformance test, while optional fields allow compatible additions across releases.
 
 External plugins are separate binaries and must be rebuilt when adopting a breaking SDK protocol change. Keep the plugin SDK revision aligned with the Temps version used to build and test the plugin.
+
+Temps uses a versioned, staged startup handshake. A single plugin process first
+publishes its manifest, then Temps sends typed launch configuration over the
+process's protected stdin. Database credentials and the request-assertion
+secret never appear in command-line arguments, and there is no second binary
+execution between inspection and startup. A legacy binary or protocol mismatch
+is rejected with an explicit rebuild instruction.
+
+For a host-local image built by an explicitly trusted plugin, set
+`claim_local: true` through the typed deploy-image operation. Temps inspects the
+source image, retags it into a generated project/environment namespace, records
+its immutable image ID, and verifies that ID again before deployment. Ordinary
+registry pulls never fall back to an unrelated image already present in the
+shared Docker daemon.


### PR DESCRIPTION
## Summary

- authenticate proxied external-plugin requests with signed, SDK-verified caller assertions
- forward resolved roles and permissions while stripping browser credentials and spoofed platform headers
- expose typed caller-scoped platform APIs over the authenticated plugin channel
- bind delegated work to the initiating actor instead of a mutable user-token registry
- use a protocol-v2 staged startup handshake so secrets and optional host resources are never passed in argv
- make database and host-data access explicit, independently declared plugin capabilities
- verify local deployment images by immutable daemon ID and reject registry-pull fallback
- bind runtime credential lookup to both project and environment
- derive generated environment URLs from the configured public origin
- document the external-plugin trust model, startup protocol, authenticated APIs, capabilities, and deployment behavior

## Security

- installed external plugins are explicitly treated as fully trusted, same-UID host code; capability flags control data delivery but are not a sandbox
- API-key permission narrowing is preserved in forwarded caller permissions
- deleted users, expired actors, wrong-plugin actors, malformed assertions, and unauthenticated channel/event connections fail closed
- authorization, cookie, proxy-authorization, and caller-supplied `x-temps-*` headers are removed before proxying
- per-process secrets are delivered through stdin after manifest verification and never through argv
- the Unix socket directory and socket use private permissions
- direct HTTP callers cannot claim images from the host daemon; only verified in-process plugin calls may use that path
- registry pull failures never fall back to an arbitrary local tag, and claimed images are verified by immutable ID
- runtime credentials reject an environment that does not belong to the requested project
- the final security audit approved the revised boundary with no remaining findings

## Evidence

**Workspace and affected crates**: formatting, compilation, strict linting, and diff hygiene pass.

```bash
cargo fmt --all --check
cargo check --lib
cargo clippy --lib \
  -p temps-core \
  -p temps-plugin-sdk \
  -p temps-external-plugins \
  -p temps-deployments \
  -p temps-providers \
  -p temps-environments \
  -- -D warnings
git diff --check
```

```text
cargo check: finished successfully (workspace)
cargo clippy: 0 errors
git diff --check: clean
```

**Protocol and host boundary**: staged resource disclosure, actionable legacy-binary failure, and private socket permissions are covered by named regressions.

```bash
cargo test -p temps-core host_data_access_is_separate_and_explicit -- --nocapture
cargo test -p temps-external-plugins legacy_startup_eof_is_actionable_and_keeps_stderr_context -- --nocapture
cargo test -p temps-external-plugins secure_socket_directory_uses_private_permissions -- --nocapture
```

```text
cargo test: 1 passed, 344 filtered out
cargo test: 1 passed, 60 filtered out
cargo test: 1 passed, 60 filtered out
```

**Deployment image provenance**: reserved tags are project-scoped, direct HTTP local claims are rejected, registry failures cannot use arbitrary local tags, and immutable-ID mismatches fail closed.

```bash
cargo test -p temps-deployments internal_local_image_tags_are_unique_and_project_scoped -- --nocapture
cargo test -p temps-deployments direct_http_callers_cannot_claim_local_daemon_images -- --nocapture
cargo test -p temps-deployments an_arbitrary_bare_local_tag_never_satisfies_a_failed_pull -- --nocapture
cargo test -p temps-deployments immutable_image_id_mismatch_fails_closed -- --nocapture
```

```text
cargo test: 1 passed, 595 filtered out
cargo test: 1 passed, 595 filtered out
cargo test: 1 passed, 595 filtered out
cargo test: 1 passed, 595 filtered out
```

**Tenant credential isolation**: credential provisioning rejects cross-project environment identifiers.

```bash
cargo test -p temps-providers runtime_credentials_reject_cross_project_environment_before_provisioning -- --nocapture
```

```text
cargo test: 1 passed, 498 filtered out
```

**Delegated request contract and audit attribution**: cluster members use the platform object shape, delegated permission denials retain the verified actor, and ordinary HTTP credentials take precedence over any pre-injected context.

```bash
cargo test -p temps-plugin-sdk cluster_members_serialize_with_role_and_optional_node_id -- --nocapture
cargo test -p temps-auth delegated_auth_context_is_used_for_denial_attribution -- --nocapture
cargo test -p temps-auth authenticated_credential_takes_precedence_over_delegated_context -- --nocapture
```

```text
cargo test: 1 passed, 15 filtered out
cargo test: 1 passed, 381 filtered out
cargo test: 1 passed, 381 filtered out
```

**Internal transport isolation and actor redemption**: user-facing plugin routes cannot reach the reserved event/channel endpoints, direct authenticated UDS delivery remains available, and current session/API-key authority is reconstructed or rejected fail-closed.

```bash
cargo test --lib -p temps-external-plugins
cargo test -p temps-external-plugins direct_uds_delivery_still_reaches_reserved_event_endpoint -- --nocapture
cargo clippy --lib -p temps-external-plugins -- -D warnings
```

```text
cargo test: 70 passed
direct UDS regression: 1 passed, 69 filtered out
cargo clippy: 0 errors
```

The suite covers exact and descendant `/_events` and `/_temps/channel` rejection (including query strings and public-path declarations), lookalike route preservation, live/revoked/expired/MFA-pending session redemption, restricted/revoked/expired API keys, and missing/deleted users.

**Public plugin compatibility**: every public workspace plugin compiles against the revised local SDK.

```bash
cargo check --workspace
```

```text
Finished `dev` profile successfully; all four public plugin crates compile.
```

**Documentation**: updated the SDK reference and design document with the protocol-v2 handshake, trust boundary, authenticated channel behavior, explicit host-resource capabilities, and local-image claim rules.
