### PR TITLE
feat(error-tracking): add same-origin Sentry tunnel for browser SDKs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11226,6 +11226,8 @@ dependencies = [
  "temps-migrations",
  "temps-notifications",
  "temps-projects",
+ "temps-proxy",
+ "temps-routes",
  "thiserror 2.0.19",
  "time",
  "tokio",

--- a/crates/temps-deployments/src/services/env_resolver.rs
+++ b/crates/temps-deployments/src/services/env_resolver.rs
@@ -19,7 +19,7 @@ use temps_entities::{deployments, environments, projects};
 use tracing::{debug, info};
 
 use super::deployment_token_service::DeploymentTokenService;
-use super::workflow_planner::public_sentry_dsn_var;
+use super::workflow_planner::{public_sentry_dsn_var, public_sentry_tunnel_var};
 
 /// Resolves the full environment-variable map for a `(project, environment,
 /// deployment)`. Holds the six services the resolution needs; cheap to clone
@@ -210,6 +210,19 @@ impl DeploymentEnvResolver {
                         // convention to the browser bundle, so we mirror that mapping.
                         if let Some(public_var) = public_sentry_dsn_var(project.preset) {
                             env_vars_map.insert(public_var.to_string(), project_dsn.dsn);
+                        }
+
+                        // Add the same-origin tunnel path browser SDKs should pass as
+                        // `Sentry.init({ tunnel })`. The value is a constant (not
+                        // project-specific), but injecting it as an env var — rather
+                        // than hardcoding it in every framework's setup snippet — means
+                        // the path can change in one place (here) without touching
+                        // deployed apps' source or docs.
+                        if let Some(tunnel_var) = public_sentry_tunnel_var(project.preset) {
+                            env_vars_map.insert(
+                                tunnel_var.to_string(),
+                                format!("/api{}", temps_error_tracking::SENTRY_TUNNEL_ROUTE_PATH),
+                            );
                         }
                     }
                     Err(e) => {

--- a/crates/temps-deployments/src/services/workflow_planner.rs
+++ b/crates/temps-deployments/src/services/workflow_planner.rs
@@ -434,6 +434,19 @@ impl WorkflowPlanner {
                         if let Some(public_var) = public_sentry_dsn_var(project.preset) {
                             env_vars_map.insert(public_var.to_string(), project_dsn.dsn);
                         }
+
+                        // Add the same-origin tunnel path browser SDKs should pass as
+                        // `Sentry.init({ tunnel })`. The value is a constant (not
+                        // project-specific), but injecting it as an env var — rather
+                        // than hardcoding it in every framework's setup snippet — means
+                        // the path can change in one place (here) without touching
+                        // deployed apps' source or docs.
+                        if let Some(tunnel_var) = public_sentry_tunnel_var(project.preset) {
+                            env_vars_map.insert(
+                                tunnel_var.to_string(),
+                                format!("/api{}", temps_error_tracking::SENTRY_TUNNEL_ROUTE_PATH),
+                            );
+                        }
                     }
                     Err(e) => {
                         // Warn about Sentry DSN failure but don't fail the deployment
@@ -2347,6 +2360,45 @@ pub(crate) fn public_sentry_dsn_var(
     }
 }
 
+/// Public-prefix env var carrying the same-origin Sentry tunnel path for
+/// browser presets (see `temps_error_tracking::SENTRY_TUNNEL_ROUTE_PATH` for
+/// what it points at and why). Mirrors `public_sentry_dsn_var`'s preset
+/// groups exactly — a browser bundle that gets the DSN gets the tunnel path
+/// too, under the same public prefix, so both env vars land in the same
+/// `Sentry.init({ dsn, tunnel })` call. `None` for the same presets that get
+/// no public DSN var (server-only, or no build-time public-prefix
+/// convention).
+pub(crate) fn public_sentry_tunnel_var(
+    preset: temps_entities::preset::Preset,
+) -> Option<&'static str> {
+    use temps_entities::preset::Preset;
+    match preset {
+        Preset::NextJs => Some("NEXT_PUBLIC_SENTRY_TUNNEL"),
+        Preset::Nuxt => Some("NUXT_PUBLIC_SENTRY_TUNNEL"),
+        Preset::Vite | Preset::React | Preset::Vue | Preset::SolidStart | Preset::Remix => {
+            Some("VITE_SENTRY_TUNNEL")
+        }
+        Preset::SvelteKit | Preset::Astro | Preset::Rsbuild => Some("PUBLIC_SENTRY_TUNNEL"),
+        Preset::Docusaurus => Some("REACT_APP_SENTRY_TUNNEL"),
+        Preset::Angular
+        | Preset::Python
+        | Preset::FastApi
+        | Preset::Flask
+        | Preset::Django
+        | Preset::Rails
+        | Preset::Go
+        | Preset::Rust
+        | Preset::Java
+        | Preset::Laravel
+        | Preset::NodeJs
+        | Preset::Dockerfile
+        | Preset::DockerCompose
+        | Preset::Nixpacks
+        | Preset::Autopack
+        | Preset::Static => None,
+    }
+}
+
 /// Extract a release identifier (tag or digest) from a container image
 /// reference. This is the deployed artifact's identity for image deploys —
 /// used as SENTRY_RELEASE / OTEL_SERVICE_VERSION.
@@ -3337,6 +3389,69 @@ mod tests {
                 public_sentry_dsn_var(preset),
                 None,
                 "expected no public DSN var for {:?}",
+                preset
+            );
+        }
+    }
+
+    #[test]
+    fn public_sentry_tunnel_var_mirrors_dsn_var_presets() {
+        use temps_entities::preset::Preset;
+
+        // Every preset that gets a public DSN var must also get a tunnel
+        // var, under the same public prefix — they're both read by the same
+        // `Sentry.init({ dsn, tunnel })` call in the browser bundle.
+        for preset in [
+            Preset::NextJs,
+            Preset::Nuxt,
+            Preset::Vite,
+            Preset::React,
+            Preset::Vue,
+            Preset::SolidStart,
+            Preset::Remix,
+            Preset::SvelteKit,
+            Preset::Astro,
+            Preset::Rsbuild,
+            Preset::Docusaurus,
+        ] {
+            let dsn_var = public_sentry_dsn_var(preset);
+            let tunnel_var = public_sentry_tunnel_var(preset);
+            assert!(
+                dsn_var.is_some() && tunnel_var.is_some(),
+                "expected both DSN and tunnel vars for {:?}",
+                preset
+            );
+            assert_eq!(
+                dsn_var.unwrap().replace("_DSN", "_TUNNEL"),
+                tunnel_var.unwrap(),
+                "tunnel var must share the DSN var's public prefix for {:?}",
+                preset
+            );
+        }
+
+        // Presets with no public DSN var get no tunnel var either.
+        for preset in [
+            Preset::Angular,
+            Preset::Python,
+            Preset::FastApi,
+            Preset::Flask,
+            Preset::Django,
+            Preset::Rails,
+            Preset::Go,
+            Preset::Rust,
+            Preset::Java,
+            Preset::Laravel,
+            Preset::NodeJs,
+            Preset::Dockerfile,
+            Preset::DockerCompose,
+            Preset::Nixpacks,
+            Preset::Autopack,
+            Preset::Static,
+        ] {
+            assert_eq!(
+                public_sentry_tunnel_var(preset),
+                None,
+                "expected no tunnel var for {:?}",
                 preset
             );
         }

--- a/crates/temps-error-tracking/Cargo.toml
+++ b/crates/temps-error-tracking/Cargo.toml
@@ -17,6 +17,8 @@ temps-geo = { path = "../temps-geo" }
 temps-notifications = { path = "../temps-notifications" }
 temps-projects = { path = "../temps-projects" }
 temps-config = { path = "../temps-config" }
+temps-proxy = { path = "../temps-proxy" }
+temps-routes = { path = "../temps-routes" }
 futures = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }

--- a/crates/temps-error-tracking/src/lib.rs
+++ b/crates/temps-error-tracking/src/lib.rs
@@ -7,7 +7,10 @@ pub mod services;
 // Re-export main types but not the types modules to avoid ambiguity
 pub use handlers::handler;
 pub use providers::*;
-pub use sentry::{DSNService, Envelope, EnvelopeError, EnvelopeItem, SentryIngestionService};
+pub use sentry::{
+    DSNService, Envelope, EnvelopeError, EnvelopeItem, SentryIngestionService,
+    SENTRY_TUNNEL_ROUTE_PATH,
+};
 pub use services::*;
 
 // Export plugin

--- a/crates/temps-error-tracking/src/plugin.rs
+++ b/crates/temps-error-tracking/src/plugin.rs
@@ -304,6 +304,8 @@ impl TempsPlugin for ErrorTrackingPlugin {
             .get_service::<dyn temps_core::telemetry::TelemetryReporter>()
             .unwrap_or_else(|| Arc::new(temps_core::telemetry::NoopTelemetryReporter));
 
+        let route_table = context.require_service::<temps_proxy::CachedPeerTable>();
+
         let sentry_state = Arc::new(crate::sentry::handlers::AppState {
             sentry_provider: sentry_provider.clone(),
             error_tracking_service: error_tracking_service.clone(),
@@ -311,6 +313,8 @@ impl TempsPlugin for ErrorTrackingPlugin {
             ip_address_service,
             db: sentry_db,
             telemetry,
+            route_table,
+            rate_limiter: crate::sentry::rate_limiter::IngestRateLimiter::new(),
         });
         let sentry_routes = crate::sentry::handlers::configure_routes().with_state(sentry_state);
 

--- a/crates/temps-error-tracking/src/providers/mod.rs
+++ b/crates/temps-error-tracking/src/providers/mod.rs
@@ -52,6 +52,10 @@ pub struct AuthContext {
     pub project_id: i32,
     pub environment_id: Option<i32>,
     pub deployment_id: Option<i32>,
+    /// Ingest rate limit to enforce for this request, if any. `None` for
+    /// providers/paths that don't carry a per-project limit (e.g. resolved
+    /// from Host rather than a specific DSN row).
+    pub rate_limit_per_minute: Option<i32>,
 }
 
 /// Parsed error event from provider

--- a/crates/temps-error-tracking/src/providers/sentry.rs
+++ b/crates/temps-error-tracking/src/providers/sentry.rs
@@ -40,6 +40,7 @@ impl ErrorProvider for SentryProvider {
             project_id: dsn.project_id,
             environment_id: dsn.environment_id,
             deployment_id: dsn.deployment_id,
+            rate_limit_per_minute: dsn.rate_limit_per_minute,
         })
     }
 
@@ -110,12 +111,11 @@ impl ErrorProvider for SentryProvider {
             }
         }
 
-        if parsed_events.is_empty() {
-            return Err(ProviderError::Validation(
-                "No valid events found in envelope".to_string(),
-            ));
-        }
-
+        // An envelope containing only unmapped item types (client_report, session,
+        // session aggregates, span, transaction) is not an error — real Sentry
+        // relays accept these and return 200. Erroring here made every
+        // client_report-only envelope (which SDKs send periodically to report
+        // dropped/sampled events) look like a transport failure in SDK logs.
         Ok(parsed_events)
     }
 

--- a/crates/temps-error-tracking/src/sentry/dsn_service.rs
+++ b/crates/temps-error-tracking/src/sentry/dsn_service.rs
@@ -91,6 +91,7 @@ impl DSNService {
             created_at: dsn_model.created_at,
             is_active: dsn_model.is_active,
             event_count: dsn_model.event_count,
+            rate_limit_per_minute: dsn_model.rate_limit_per_minute,
         })
     }
 
@@ -135,6 +136,7 @@ impl DSNService {
                 created_at: existing_dsn.created_at,
                 is_active: existing_dsn.is_active,
                 event_count: existing_dsn.event_count,
+                rate_limit_per_minute: existing_dsn.rate_limit_per_minute,
             });
         }
 
@@ -275,6 +277,7 @@ impl DSNService {
             created_at: dsn_record.created_at,
             is_active: dsn_record.is_active,
             event_count: dsn_record.event_count,
+            rate_limit_per_minute: dsn_record.rate_limit_per_minute,
         })
     }
 
@@ -333,6 +336,7 @@ impl DSNService {
             created_at: updated_dsn.created_at,
             is_active: updated_dsn.is_active,
             event_count: updated_dsn.event_count,
+            rate_limit_per_minute: updated_dsn.rate_limit_per_minute,
         })
     }
 
@@ -373,6 +377,7 @@ impl DSNService {
                 created_at: dsn.created_at,
                 is_active: dsn.is_active,
                 event_count: dsn.event_count,
+                rate_limit_per_minute: dsn.rate_limit_per_minute,
             })
             .collect())
     }

--- a/crates/temps-error-tracking/src/sentry/handlers.rs
+++ b/crates/temps-error-tracking/src/sentry/handlers.rs
@@ -1,8 +1,8 @@
 use axum::{
     body::Bytes,
     extract::{ConnectInfo, DefaultBodyLimit, Extension, Path, Query, State},
-    http::{HeaderMap, StatusCode},
-    response::IntoResponse,
+    http::{header, HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
     routing::post,
     Json, Router,
 };
@@ -14,16 +14,39 @@ use tower_http::cors::{Any, CorsLayer};
 use tracing::debug;
 use utoipa::OpenApi;
 
-use crate::providers::{sentry::SentryProvider, ErrorProvider};
+use crate::providers::{sentry::SentryProvider, AuthContext, ErrorProvider};
+use crate::sentry::rate_limiter::IngestRateLimiter;
 use crate::sentry::types::{SentryEventRequest, SentryEventResponse};
 use crate::services::error_tracking_service::ErrorTrackingService;
 use temps_geo::IpAddressService;
+use temps_proxy::CachedPeerTable;
+
+/// Route suffix (relative to this plugin's public router — the server nests
+/// it under `/api` before mounting) that browser Sentry SDKs POST tunneled
+/// envelopes to. Resolved to a project/environment/deployment from `Host`,
+/// no DSN credential required — mirroring how `/api/_temps/event` (analytics)
+/// resolves via `CachedPeerTable`. The proxy forwards anything under
+/// `/api/_temps` to the console regardless of `Host`
+/// (`temps-proxy::services::ROUTE_PREFIX_TEMPS`), so this path reaches the
+/// console on every domain a project is deployed to.
+///
+/// This exact string is also used to build the browser-visible tunnel env var
+/// value (see `temps-deployments::services::env_resolver`) — import this
+/// constant there rather than hardcoding the path a second time.
+pub const SENTRY_TUNNEL_ROUTE_PATH: &str = "/_temps/sentry/envelope";
+
+/// Rate limit applied to tunneled ingest, which has no DSN row to read a
+/// per-project limit from (the project is resolved from `Host`, not a
+/// credential). Matches the default assigned to newly created DSNs
+/// (see `dsn_service::generate_project_dsn`).
+const TUNNEL_DEFAULT_RATE_LIMIT_PER_MINUTE: i32 = 1000;
 
 #[derive(OpenApi)]
 #[openapi(
     paths(
         ingest_sentry_event,
         ingest_sentry_envelope,
+        ingest_tunneled_envelope,
     ),
     components(schemas(
         SentryEventRequest,
@@ -43,6 +66,10 @@ pub struct AppState {
     pub ip_address_service: Option<Arc<IpAddressService>>,
     pub db: Option<Arc<sea_orm::DatabaseConnection>>,
     pub telemetry: Arc<dyn temps_core::telemetry::TelemetryReporter>,
+    /// Host -> project/environment/deployment resolution for the tunneled
+    /// ingest route, which has no DSN to authenticate with.
+    pub route_table: Arc<CachedPeerTable>,
+    pub rate_limiter: IngestRateLimiter,
 }
 
 /// Maximum compressed body size for Sentry ingest routes (2 MiB).
@@ -65,6 +92,7 @@ pub fn configure_routes() -> Router<Arc<AppState>> {
     Router::new()
         .route("/{project_id}/store/", post(ingest_sentry_event))
         .route("/{project_id}/envelope/", post(ingest_sentry_envelope))
+        .route(SENTRY_TUNNEL_ROUTE_PATH, post(ingest_tunneled_envelope))
         // Fix #3: cap compressed body to 2 MiB before any buffering occurs.
         // This prevents slow-POST DoS where a client drip-feeds a large body
         // to hold a Tokio worker thread indefinitely.
@@ -123,6 +151,18 @@ async fn ingest_sentry_event(
             return (StatusCode::UNAUTHORIZED, e.to_string()).into_response();
         }
     };
+
+    if !state
+        .rate_limiter
+        .check(auth.project_id, auth.rate_limit_per_minute)
+        .await
+    {
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            "Rate limit exceeded".to_string(),
+        )
+            .into_response();
+    }
 
     // Parse event using the provider
     let mut parsed_event = match state.sentry_provider.parse_json_event(event, &auth).await {
@@ -249,34 +289,191 @@ async fn ingest_sentry_envelope(
         }
     };
 
-    // Parse envelope using the provider
-    let parsed_events = match state
-        .sentry_provider
-        .parse_events(&decompressed_body, &auth)
+    if !state
+        .rate_limiter
+        .check(auth.project_id, auth.rate_limit_per_minute)
         .await
     {
-        Ok(events) => events,
-        Err(e) => {
-            tracing::error!(
-                "Failed to parse envelope for project {}: {:?}",
-                project_id,
-                e
-            );
-            return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
-        }
-    };
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            "Rate limit exceeded".to_string(),
+        )
+            .into_response();
+    }
 
     // Fix #2: resolve the real client IP using proxy-trust logic.
     // XFF is honored only when the direct TCP peer is loopback (our trusted Pingora proxy).
     let peer = connect_info.map(|ext| ext.0 .0);
     let client_ip = temps_auth::resolve_client_ip(&headers, peer);
 
+    process_parsed_envelope(&state, &auth, &decompressed_body, &client_ip).await
+}
+
+/// Ingest a browser-tunneled Sentry envelope.
+///
+/// No DSN credential — the project/environment/deployment are resolved from
+/// the `Host` header via the proxy's route table, the same way
+/// `/api/_temps/event` (analytics) resolves. Browser SDKs reach this path via
+/// `Sentry.init({ tunnel: SENTRY_TUNNEL_ROUTE_PATH })`, which the proxy
+/// forwards to the console from any domain a project is deployed on
+/// (`ROUTE_PREFIX_TEMPS`), so it works on custom domains and previews without
+/// per-domain DSN configuration.
+///
+/// Since there is no credential, an `Origin`/`Referer` check stands in for
+/// authentication: the request must claim to come from the same host it
+/// resolves to, or it is rejected. This is weaker than a DSN (both are
+/// visible to anyone who can read the page), but it closes the trivial case
+/// of a script targeting an arbitrary victim domain with no recon at all.
+#[utoipa::path(
+    post,
+    path = "/_temps/sentry/envelope",
+    request_body(content = String, description = "Sentry envelope as binary data", content_type = "application/octet-stream"),
+    responses(
+        (status = 200, description = "Envelope ingested"),
+        (status = 204, description = "Host resolved to a route with no attributable project (sandbox/orphan)"),
+        (status = 400, description = "Bad request"),
+        (status = 403, description = "Origin/Referer does not match the resolved host"),
+        (status = 404, description = "Unknown host"),
+        (status = 413, description = "Request body too large (exceeds 2 MiB)"),
+        (status = 429, description = "Rate limit exceeded"),
+    ),
+    tag = "sentry-ingestor"
+)]
+async fn ingest_tunneled_envelope(
+    State(state): State<Arc<AppState>>,
+    Extension(metadata): Extension<temps_core::RequestMetadata>,
+    connect_info: Option<Extension<ConnectInfo<SocketAddr>>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    let host = metadata.host.clone();
+    if host.is_empty() {
+        return (StatusCode::BAD_REQUEST, "Missing Host header".to_string()).into_response();
+    }
+
+    if !origin_matches_host(&headers, &host) {
+        tracing::warn!(
+            "Sentry tunnel: Origin/Referer does not match resolved host {}",
+            host
+        );
+        return (
+            StatusCode::FORBIDDEN,
+            "Origin does not match host".to_string(),
+        )
+            .into_response();
+    }
+
+    let route = match state.route_table.get_route(&host) {
+        Some(route) => route,
+        None => {
+            tracing::debug!("Sentry tunnel: host {} not found in route table", host);
+            return StatusCode::NOT_FOUND.into_response();
+        }
+    };
+
+    // A route without a project is a sandbox/orphaned route — nothing to
+    // attribute this to. Drop silently (204), mirroring how
+    // `record_event_metrics` (analytics) handles the same case.
+    let Some(project) = route.project.as_ref() else {
+        debug!(
+            "Sentry tunnel: dropping envelope for host {} — route has no associated project",
+            host
+        );
+        return StatusCode::NO_CONTENT.into_response();
+    };
+
+    if !state
+        .rate_limiter
+        .check(project.id, Some(TUNNEL_DEFAULT_RATE_LIMIT_PER_MINUTE))
+        .await
+    {
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            "Rate limit exceeded".to_string(),
+        )
+            .into_response();
+    }
+
+    let decompressed_body = match decompress_if_needed(&headers, &body) {
+        Ok(data) => data,
+        Err(e) => {
+            tracing::warn!("Failed to decompress tunneled envelope: {}", e);
+            return (
+                StatusCode::BAD_REQUEST,
+                format!("Failed to decompress envelope: {}", e),
+            )
+                .into_response();
+        }
+    };
+
+    let auth = AuthContext {
+        project_id: project.id,
+        environment_id: route.environment.as_ref().map(|e| e.id),
+        deployment_id: route.deployment.as_ref().map(|d| d.id),
+        // No DSN row was selected for this request — see the fixed default
+        // rate-limit check above instead.
+        rate_limit_per_minute: None,
+    };
+
+    let peer = connect_info.map(|ext| ext.0 .0);
+    let client_ip = temps_auth::resolve_client_ip(&headers, peer);
+
+    process_parsed_envelope(&state, &auth, &decompressed_body, &client_ip).await
+}
+
+/// Returns `true` if the request's `Origin` (falling back to `Referer`) host
+/// matches `expected_host`. Missing both headers is rejected: modern
+/// browsers attach `Origin` to every non-GET `fetch`, including same-origin
+/// ones, so a legitimate tunneled POST always carries one — a request with
+/// neither is either an ancient browser or a script deliberately omitting it
+/// to bypass this check, and defaulting to deny is the safer read of that.
+fn origin_matches_host(headers: &HeaderMap, expected_host: &str) -> bool {
+    let candidate = headers
+        .get(header::ORIGIN)
+        .and_then(|v| v.to_str().ok())
+        .or_else(|| headers.get(header::REFERER).and_then(|v| v.to_str().ok()));
+
+    let Some(candidate) = candidate else {
+        return false;
+    };
+
+    url::Url::parse(candidate)
+        .ok()
+        .and_then(|u| u.host_str().map(|h| h.eq_ignore_ascii_case(expected_host)))
+        .unwrap_or(false)
+}
+
+/// Parse and store the events in an already-authenticated/resolved envelope.
+/// Shared by the DSN-authenticated and Host-resolved (tunneled) ingest paths.
+async fn process_parsed_envelope(
+    state: &AppState,
+    auth: &AuthContext,
+    decompressed_body: &Bytes,
+    client_ip: &str,
+) -> Response {
+    // Parse envelope using the provider
+    let parsed_events = match state
+        .sentry_provider
+        .parse_events(decompressed_body, auth)
+        .await
+    {
+        Ok(events) => events,
+        Err(e) => {
+            tracing::error!(
+                "Failed to parse envelope for project {}: {:?}",
+                auth.project_id,
+                e
+            );
+            return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
+        }
+    };
+
     // Store each event using the error tracking service
     for mut event in parsed_events {
         // Enrich with IP geolocation and visitor correlation
         enrich_error_event(
             &mut event.error_data,
-            Some(client_ip.as_str()),
+            Some(client_ip),
             state.ip_address_service.as_ref(),
             state.db.as_ref(),
         )
@@ -483,8 +680,41 @@ mod tests {
     struct TestContext {
         app_state: Arc<AppState>,
         project_id: i32,
+        project: Arc<temps_entities::projects::Model>,
         dsn_key: String,
+        route_table: Arc<temps_proxy::CachedPeerTable>,
         _db: TestDatabase, // Keep database alive
+    }
+
+    /// Test-only middleware that fills in `Extension<temps_core::RequestMetadata>`
+    /// from the request's `Host` header, mirroring the shape (not the full
+    /// logic) of `temps_core::RequestMetadataMiddleware`, which runs globally
+    /// in production but isn't layered onto `configure_routes()`'s bare
+    /// router under test.
+    async fn inject_test_request_metadata(
+        mut req: axum::extract::Request,
+        next: axum::middleware::Next,
+    ) -> axum::response::Response {
+        let host = req
+            .headers()
+            .get(http::header::HOST)
+            .and_then(|v| v.to_str().ok())
+            .map(|h| temps_core::host_without_port(h).to_string())
+            .unwrap_or_default();
+
+        req.extensions_mut().insert(temps_core::RequestMetadata {
+            ip_address: "127.0.0.1".to_string(),
+            user_agent: String::new(),
+            headers: HeaderMap::new(),
+            visitor_id_cookie: None,
+            session_id_cookie: None,
+            base_url: format!("https://{}", host),
+            scheme: "https".to_string(),
+            host,
+            is_secure: true,
+        });
+
+        next.run(req).await
     }
 
     async fn create_test_context() -> TestContext {
@@ -531,6 +761,7 @@ mod tests {
 
         let sentry_provider = Arc::new(SentryProvider::new(dsn_service.clone()));
         let audit_service = Arc::new(MockAuditLogger) as Arc<dyn temps_core::AuditLogger>;
+        let route_table = Arc::new(temps_proxy::CachedPeerTable::new(db.connection_arc()));
 
         let app_state = Arc::new(AppState {
             sentry_provider,
@@ -539,12 +770,16 @@ mod tests {
             ip_address_service: None,
             db: None,
             telemetry: Arc::new(temps_core::telemetry::NoopTelemetryReporter),
+            route_table: route_table.clone(),
+            rate_limiter: crate::sentry::rate_limiter::IngestRateLimiter::new(),
         });
 
         TestContext {
             app_state,
             project_id: project.id,
+            project: Arc::new(project),
             dsn_key: dsn.public_key,
+            route_table,
             _db: db,
         }
     }
@@ -933,5 +1168,193 @@ mod tests {
             2 * 1024 * 1024,
             "Sentry ingest body limit must be 2 MiB (2 * 1024 * 1024 bytes)"
         );
+    }
+
+    // === client_report-only envelopes must not 400 (real Sentry accepts these) ===
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_envelope_endpoint_client_report_only_returns_ok() {
+        let ctx = create_test_context().await;
+        let app = configure_routes().with_state(ctx.app_state);
+        let server = TestServer::new(app).expect("Failed to create test server");
+
+        // A real client_report envelope — no `event`/`transaction` item at all.
+        // Before the fix, `parse_events` errored with "No valid events found in
+        // envelope" and the handler turned that into a 400, even though this is
+        // exactly what SDKs send when they've sampled/dropped events locally.
+        let envelope_data = "{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\"}\n{\"type\":\"client_report\"}\n{\"timestamp\":\"2023-06-28T14:30:00.000Z\",\"discarded_events\":[{\"reason\":\"sample_rate\",\"category\":\"transaction\",\"quantity\":1}]}\n";
+        let auth_header = format!("Sentry sentry_key={},sentry_version=7", ctx.dsn_key);
+
+        let response = server
+            .post(&format!("/{}/envelope/", ctx.project_id))
+            .content_type("application/octet-stream")
+            .add_header(
+                HeaderName::from_static("x-sentry-auth"),
+                HeaderValue::from_str(&auth_header).unwrap(),
+            )
+            .bytes(Bytes::from(envelope_data))
+            .await;
+
+        assert_eq!(
+            response.status_code(),
+            StatusCode::OK,
+            "client_report-only envelope must be accepted, not treated as a parse failure: {}",
+            response.text()
+        );
+    }
+
+    // === Browser tunnel route (Host-resolved, no DSN) ===
+
+    /// Layers the test-only `Extension<RequestMetadata>` middleware onto the
+    /// plugin's router — production gets this from the global
+    /// `RequestMetadataMiddleware`, which isn't present on the bare router
+    /// under test.
+    fn configure_tunnel_test_router(state: Arc<AppState>) -> Router<()> {
+        configure_routes()
+            .layer(axum::middleware::from_fn(inject_test_request_metadata))
+            .with_state(state)
+    }
+
+    fn test_route_info(project: Arc<temps_entities::projects::Model>) -> temps_routes::RouteInfo {
+        temps_routes::RouteInfo {
+            backend: temps_routes::BackendType::StaticDir {
+                path: "/tmp".to_string(),
+            },
+            redirect_to: None,
+            status_code: None,
+            project: Some(project),
+            environment: None,
+            deployment: None,
+            cert_eligible: false,
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_tunnel_endpoint_unknown_host_returns_404() {
+        let ctx = create_test_context().await;
+        let app = configure_tunnel_test_router(ctx.app_state);
+        let server = TestServer::new(app).expect("Failed to create test server");
+
+        let response = server
+            .post(SENTRY_TUNNEL_ROUTE_PATH)
+            .content_type("application/octet-stream")
+            .add_header(
+                HeaderName::from_static("host"),
+                HeaderValue::from_static("unknown.example.com"),
+            )
+            .add_header(
+                HeaderName::from_static("origin"),
+                HeaderValue::from_static("https://unknown.example.com"),
+            )
+            .bytes(Bytes::new())
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_tunnel_endpoint_mismatched_origin_returns_403() {
+        let ctx = create_test_context().await;
+        ctx.route_table
+            .insert_route_for_test("app.example.com", test_route_info(ctx.project.clone()));
+        let app = configure_tunnel_test_router(ctx.app_state);
+        let server = TestServer::new(app).expect("Failed to create test server");
+
+        let response = server
+            .post(SENTRY_TUNNEL_ROUTE_PATH)
+            .content_type("application/octet-stream")
+            .add_header(
+                HeaderName::from_static("host"),
+                HeaderValue::from_static("app.example.com"),
+            )
+            .add_header(
+                HeaderName::from_static("origin"),
+                HeaderValue::from_static("https://evil.example.com"),
+            )
+            .bytes(Bytes::new())
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_tunnel_endpoint_missing_origin_returns_403() {
+        let ctx = create_test_context().await;
+        ctx.route_table
+            .insert_route_for_test("app.example.com", test_route_info(ctx.project.clone()));
+        let app = configure_tunnel_test_router(ctx.app_state);
+        let server = TestServer::new(app).expect("Failed to create test server");
+
+        // No Origin, no Referer — must default-deny, not fail open.
+        let response = server
+            .post(SENTRY_TUNNEL_ROUTE_PATH)
+            .content_type("application/octet-stream")
+            .add_header(
+                HeaderName::from_static("host"),
+                HeaderValue::from_static("app.example.com"),
+            )
+            .bytes(Bytes::new())
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_tunnel_endpoint_valid_request_ingests_event() {
+        let ctx = create_test_context().await;
+        ctx.route_table
+            .insert_route_for_test("app.example.com", test_route_info(ctx.project.clone()));
+        let app = configure_tunnel_test_router(ctx.app_state);
+        let server = TestServer::new(app).expect("Failed to create test server");
+
+        let envelope_data = "{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\"}\n{\"type\":\"event\"}\n{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"timestamp\":1687962600.0,\"platform\":\"javascript\",\"level\":\"error\",\"exception\":{\"values\":[{\"type\":\"Error\",\"value\":\"Tunneled test error\"}]}}\n";
+
+        let response = server
+            .post(SENTRY_TUNNEL_ROUTE_PATH)
+            .content_type("application/octet-stream")
+            .add_header(
+                HeaderName::from_static("host"),
+                HeaderValue::from_static("app.example.com"),
+            )
+            .add_header(
+                HeaderName::from_static("origin"),
+                HeaderValue::from_static("https://app.example.com"),
+            )
+            .bytes(Bytes::from(envelope_data))
+            .await;
+
+        assert_eq!(
+            response.status_code(),
+            StatusCode::OK,
+            "Expected the tunneled envelope to be accepted: {}",
+            response.text()
+        );
+    }
+
+    #[test]
+    fn test_origin_matches_host() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::ORIGIN,
+            HeaderValue::from_static("https://app.example.com"),
+        );
+        assert!(origin_matches_host(&headers, "app.example.com"));
+        assert!(!origin_matches_host(&headers, "other.example.com"));
+
+        // Falls back to Referer when Origin is absent.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::REFERER,
+            HeaderValue::from_static("https://app.example.com/some/page"),
+        );
+        assert!(origin_matches_host(&headers, "app.example.com"));
+
+        // Neither header present — default deny.
+        assert!(!origin_matches_host(&HeaderMap::new(), "app.example.com"));
     }
 }

--- a/crates/temps-error-tracking/src/sentry/handlers.rs
+++ b/crates/temps-error-tracking/src/sentry/handlers.rs
@@ -363,7 +363,11 @@ async fn ingest_tunneled_envelope(
             .into_response();
     }
 
-    let route = match state.route_table.get_route(&host) {
+    // Exact + wildcard resolution, matching the precedence the proxy itself
+    // used to route this request here in the first place (`services.rs`'s
+    // `get_route_by_host`) — the narrower `get_route` (legacy map only)
+    // would 404 wildcard custom routes that the proxy successfully forwards.
+    let route = match state.route_table.get_route_by_host(&host) {
         Some(route) => route,
         None => {
             tracing::debug!("Sentry tunnel: host {} not found in route table", host);
@@ -485,9 +489,13 @@ async fn process_parsed_envelope(
             .await
         {
             tracing::error!("Failed to store event {}: {:?}", event.event_id, e);
+            // Shared by the DSN-authenticated AND the credential-free tunnel
+            // path — never echo `e` (a `DbErr` Display leaks table/column/
+            // constraint names) to a caller that reached this with no auth
+            // at all.
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to store event: {}", e),
+                "Internal server error".to_string(),
             )
                 .into_response();
         }

--- a/crates/temps-error-tracking/src/sentry/mod.rs
+++ b/crates/temps-error-tracking/src/sentry/mod.rs
@@ -39,12 +39,14 @@ pub mod dsn_service;
 pub mod envelope;
 pub mod handlers;
 pub mod mapper;
+pub mod rate_limiter;
 pub mod service;
 pub mod types;
 
 // Re-exports for convenience
 pub use dsn_service::DSNService;
 pub use envelope::{Envelope, EnvelopeError, EnvelopeItem};
+pub use handlers::SENTRY_TUNNEL_ROUTE_PATH;
 pub use service::SentryIngestionService;
 pub use types::{
     CreateDSNRequest, DSNResponse, ParsedDSN, ProjectDSN, SentryEventRequest, SentryEventResponse,

--- a/crates/temps-error-tracking/src/sentry/rate_limiter.rs
+++ b/crates/temps-error-tracking/src/sentry/rate_limiter.rs
@@ -1,0 +1,102 @@
+//! In-memory sliding-window rate limiter for Sentry ingest, keyed by project id.
+//!
+//! Cardinality is bounded by the number of projects with error tracking
+//! enabled — not by visitor/IP, which is unbounded — so a plain
+//! `Mutex<HashMap>` is safe to hold here even though ingest is a public,
+//! unauthenticated-by-credential surface (the tunnel route resolves the
+//! project from `Host` with no DSN check). This is not the proxy hot path;
+//! it runs at the same order of magnitude as `temps-auth`'s per-IP limiter.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+const WINDOW: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Clone)]
+pub struct IngestRateLimiter {
+    entries: Arc<Mutex<HashMap<i32, Vec<Instant>>>>,
+}
+
+impl Default for IngestRateLimiter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IngestRateLimiter {
+    pub fn new() -> Self {
+        Self {
+            entries: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Returns `true` if a request for `project_id` is allowed under
+    /// `limit_per_minute`. `None` or a non-positive limit is treated as
+    /// unlimited (fail open) — matches the semantics of the DSN column,
+    /// where `NULL`/pre-existing rows have never been rate limited.
+    pub async fn check(&self, project_id: i32, limit_per_minute: Option<i32>) -> bool {
+        let limit = match limit_per_minute {
+            Some(limit) if limit > 0 => limit as usize,
+            _ => return true,
+        };
+
+        let now = Instant::now();
+        let window_start = now - WINDOW;
+
+        let mut entries = self.entries.lock().await;
+        let timestamps = entries.entry(project_id).or_default();
+        timestamps.retain(|t| *t > window_start);
+
+        if timestamps.len() >= limit {
+            return false;
+        }
+
+        timestamps.push(now);
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn allows_requests_within_limit() {
+        let limiter = IngestRateLimiter::new();
+        for _ in 0..5 {
+            assert!(limiter.check(1, Some(5)).await);
+        }
+    }
+
+    #[tokio::test]
+    async fn blocks_requests_over_limit() {
+        let limiter = IngestRateLimiter::new();
+        for _ in 0..3 {
+            assert!(limiter.check(1, Some(3)).await);
+        }
+        assert!(!limiter.check(1, Some(3)).await);
+    }
+
+    #[tokio::test]
+    async fn different_projects_are_independent() {
+        let limiter = IngestRateLimiter::new();
+        for _ in 0..2 {
+            assert!(limiter.check(1, Some(2)).await);
+        }
+        assert!(!limiter.check(1, Some(2)).await);
+        // Project 2 has its own budget, unaffected by project 1's usage.
+        assert!(limiter.check(2, Some(2)).await);
+    }
+
+    #[tokio::test]
+    async fn none_and_non_positive_limits_fail_open() {
+        let limiter = IngestRateLimiter::new();
+        for _ in 0..100 {
+            assert!(limiter.check(1, None).await);
+            assert!(limiter.check(1, Some(0)).await);
+            assert!(limiter.check(1, Some(-1)).await);
+        }
+    }
+}

--- a/crates/temps-error-tracking/src/sentry/types.rs
+++ b/crates/temps-error-tracking/src/sentry/types.rs
@@ -69,6 +69,10 @@ pub struct ProjectDSN {
     pub created_at: UtcDateTime,
     pub is_active: bool,
     pub event_count: i64,
+    /// Ingest rate limit for this DSN, enforced per project at ingest time.
+    /// `None` means unlimited (pre-existing rows created before this column
+    /// was enforced; new DSNs default to `Some(1000)`, see `generate_project_dsn`).
+    pub rate_limit_per_minute: Option<i32>,
 }
 
 /// Parsed DSN components

--- a/skills/add-error-tracking/SKILL.md
+++ b/skills/add-error-tracking/SKILL.md
@@ -73,6 +73,49 @@ Always store the DSN in an environment variable. The exact variable name depends
 SENTRY_DSN=https://<public_key>@<temps-host>/<project_id>
 ```
 
+## Browser SDKs: also pass `tunnel`
+
+For every **browser** platform (Next.js client config, React, Vue, Svelte,
+vanilla JS — not server-side SDKs, not React Native/Flutter), also pass
+`tunnel` in the same `Sentry.init` call:
+
+```ts
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  tunnel: process.env.NEXT_PUBLIC_SENTRY_TUNNEL,
+});
+```
+
+Why: without `tunnel`, the SDK POSTs straight to the DSN's host (the Temps
+console), which is a third-party, cross-origin request from the app's own
+domain — ad blockers commonly block it, and it costs a CORS preflight on
+every event. With `tunnel` set to a same-origin path, the browser posts to
+the app's own domain instead; Temps' proxy forwards anything under
+`/api/_temps` to the console regardless of which project domain it arrived
+on, so this works unmodified on custom domains and preview URLs.
+
+The value is a fixed path, not a secret — Temps injects it automatically as
+an env var alongside the DSN, under the same bundler-specific public prefix
+(so if the DSN reaches the client bundle, the tunnel path does too):
+
+| Platform | DSN env var | Tunnel env var |
+|---|---|---|
+| Next.js | `NEXT_PUBLIC_SENTRY_DSN` | `NEXT_PUBLIC_SENTRY_TUNNEL` |
+| Vite / React / Vue | `VITE_SENTRY_DSN` | `VITE_SENTRY_TUNNEL` |
+| SvelteKit | `PUBLIC_SENTRY_DSN` | `PUBLIC_SENTRY_TUNNEL` |
+| Angular | `SENTRY_DSN` (via `environment.ts`) | *(none — no public-prefix convention; skip `tunnel`)* |
+
+If deploying outside Temps (or the tunnel var isn't set for some other
+reason), just omit `tunnel` — the SDK falls back to posting straight to the
+DSN host, which still works, just cross-origin.
+
+Leave out `Sentry.replayIntegration()` and `tracesSampleRate` for browser
+projects unless you specifically want them — Temps doesn't yet ingest Sentry
+session replay or performance transactions, so that traffic would be
+uploaded (through the tunnel, using the visitor's bandwidth) and discarded
+server-side. Use Temps' own session replay and analytics SDKs for those
+instead (see the `add-session-recording` and `add-react-analytics` skills).
+
 ## Platform setup
 
 Every snippet below reads the DSN from an env var — do not hardcode it.
@@ -90,19 +133,23 @@ npm install @sentry/nextjs
 ```
 
 ```ts
-// sentry.client.config.ts
+// sentry.client.config.ts (or instrumentation-client.ts on newer @sentry/nextjs)
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  tracesSampleRate: 1.0,
-  replaysSessionSampleRate: 0.1,
-  replaysOnErrorSampleRate: 1.0,
-  integrations: [Sentry.replayIntegration()],
+  tunnel: process.env.NEXT_PUBLIC_SENTRY_TUNNEL,
 });
 ```
 
-Mirror the config in `sentry.server.config.ts` and `sentry.edge.config.ts` (same `dsn`, no replay).
+Mirror the `dsn` (no `tunnel`, no replay) in `sentry.server.config.ts` and
+`sentry.edge.config.ts` — those run server-side and post directly to the
+console.
+
+**Do not** set `tunnelRoute` in `withSentryConfig` — it's a different
+mechanism (forwards through a Next.js server route) and its own docs state
+it doesn't work with self-hosted Sentry, which is what Temps' DSN
+compatibility layer is. Use the `tunnel` option shown above instead.
 
 ### React (Vite, Remix, CRA)
 
@@ -116,11 +163,8 @@ import * as Sentry from '@sentry/react';
 
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
+  tunnel: import.meta.env.VITE_SENTRY_TUNNEL,
   environment: import.meta.env.MODE,
-  integrations: [Sentry.replayIntegration()],
-  tracesSampleRate: 1.0,
-  replaysSessionSampleRate: 0.1,
-  replaysOnErrorSampleRate: 1.0,
 });
 ```
 
@@ -143,7 +187,7 @@ const app = createApp(App);
 Sentry.init({
   app,
   dsn: import.meta.env.VITE_SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tunnel: import.meta.env.VITE_SENTRY_TUNNEL,
 });
 
 app.mount('#app');
@@ -158,11 +202,11 @@ npx @sentry/wizard@latest -i sveltekit
 ```ts
 // src/hooks.client.ts
 import * as Sentry from '@sentry/sveltekit';
-import { PUBLIC_SENTRY_DSN } from '$env/static/public';
+import { PUBLIC_SENTRY_DSN, PUBLIC_SENTRY_TUNNEL } from '$env/static/public';
 
 Sentry.init({
   dsn: PUBLIC_SENTRY_DSN,
-  tracesSampleRate: 1.0,
+  tunnel: PUBLIC_SENTRY_TUNNEL,
 });
 
 export const handleError = Sentry.handleErrorWithSentry();
@@ -188,6 +232,8 @@ Sentry.init({
 ```
 
 Populate `environment.sentryDsn` from `process.env.SENTRY_DSN` at build time.
+No public-prefix tunnel var is injected for Angular (no bundler convention to
+mirror) — skip `tunnel` here; the SDK posts directly to the DSN host.
 
 ### Vanilla JavaScript (browser)
 
@@ -200,8 +246,7 @@ import * as Sentry from '@sentry/browser';
 
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
-  tracesSampleRate: 1.0,
-  integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
+  tunnel: import.meta.env.VITE_SENTRY_TUNNEL,
 });
 ```
 
@@ -513,3 +558,5 @@ After wiring up:
 - **Minified stack traces**: Upload source maps (see above).
 - **Browser apps not reporting**: Make sure the env var uses the bundler's public prefix (`NEXT_PUBLIC_`, `VITE_`, `PUBLIC_`) so it reaches the client bundle.
 - **Events missing in production**: Confirm the deployment environment sets the DSN env var — local `.env` files are not copied automatically.
+- **Tunneled requests get 403**: the tunnel endpoint checks that the request's `Origin` (or `Referer`) matches the domain it arrived on — this rejects a script sending forged events to someone else's project, but also anything proxying/rewriting the request in a way that drops or rewrites `Origin`. Confirm nothing between the browser and the app strips that header.
+- **Tunneled requests get 404**: the tunnel resolves the project from the `Host` header via Temps' routing table — this only works for the domain(s) actually deployed on Temps. A `tunnel` env var used on a domain temps doesn't serve (e.g. testing against a different environment's URL) has nowhere to resolve to.


### PR DESCRIPTION
## Summary

Browser Sentry SDKs currently POST cross-origin straight to the console's DSN host, which ad blockers commonly block and which pays a CORS preflight on every event. This adds a same-origin **tunnel** ingest path, `/api/_temps/sentry/envelope`, that resolves project/environment/deployment from the `Host` header via the proxy's route table — the same mechanism `/api/_temps/event` (analytics) already uses. No DSN credential is needed on this path: the proxy already forwards `/api/_temps/*` to the console regardless of `Host`.

- New Host-resolved tunnel handler (`ingest_tunneled_envelope`) with Origin/Referer validation: 403 on mismatch or missing header, 404 for an unknown host, 204 for a sandbox/orphan route with no project to attribute to.
- Injects `NEXT_PUBLIC_SENTRY_TUNNEL` / `VITE_SENTRY_TUNNEL` / `PUBLIC_SENTRY_TUNNEL` / etc. alongside the existing DSN env vars, mirroring the per-preset public-prefix mapping, so `Sentry.init({ dsn, tunnel })` needs no manual wiring.
- Fixes `client_report`-only (and other unmapped-item-only) envelopes returning 400 instead of 200 — real Sentry accepts these, and tunneled traffic hits this constantly since replay/transaction items are also unmapped today.
- Enforces `project_dsns.rate_limit_per_minute`, which was written on DSN creation but never read anywhere. The tunnel path especially needs this since it has no credential to gate on.
- Adds `temps-proxy`/`temps-routes` deps to `temps-error-tracking` for `CachedPeerTable`-based Host resolution (no circular dependency — `temps-proxy` does not depend on `temps-error-tracking`).
- Updates the `add-error-tracking` skill's browser snippets (Next.js, React, Vue, SvelteKit) with the `tunnel` option, and documents why Angular and server-side SDKs don't get one, and why `tunnelRoute` (Next.js's own mechanism) must not be used instead.

## Evidence

Verified end-to-end against a live local instance (`start-temps`, slot 15) rather than relying on unit tests alone:

1. Created a real project (`preset: nextjs`) and deployed a real container via `bunx @temps-sdk/cli deploy:image`.
2. Confirmed the container actually receives the injected env var:
   ```
   $ docker inspect sentry-tunnel-e2e-5 --format '{{range .Config.Env}}{{println .}}{{end}}' | grep -i sentry
   SENTRY_DSN=http://<key>@localho.st/1
   NEXT_PUBLIC_SENTRY_TUNNEL=/api/_temps/sentry/envelope
   NEXT_PUBLIC_SENTRY_DSN=http://<key>@localho.st/1
   SENTRY_RELEASE=latest
   ```
3. Exercised the running proxy + console with curl for every case:
   ```
   $ curl -X POST http://localhost:8230/api/_temps/sentry/envelope \
       -H "Host: sentry-tunnel-e2e-production.localho.st" \
       -H "Origin: http://sentry-tunnel-e2e-production.localho.st" \
       --data-binary "$VALID_ERROR_ENVELOPE"
   -> 200

   $ curl ... -H "Origin: http://evil.example.com" ...          -> 403
   $ curl ... (no Origin/Referer header) ...                    -> 403
   $ curl ... -H "Host: nonexistent-project.localho.st" ...     -> 404
   $ curl ... --data-binary "$CLIENT_REPORT_ONLY_ENVELOPE" ...  -> 200 (both tunnel and DSN routes)
   ```
4. Confirmed the tunneled event actually landed and is queryable:
   ```
   $ bunx @temps-sdk/cli errors list --project-id 1
   ID │ Title                         │ Type  │ Count │ Status  │ Last Seen
   1  │ Error: E2E tunnel test error  │ Error │ 1     │ ● error │ just now
   ```

**This e2e pass caught a real bug that unit tests and code review missed**: `workflow_planner.rs` (used by docker-image deploys) contains a second, independent copy of the Sentry-DSN env-var injection block, duplicating `env_resolver.rs` (used by git-based deploys). The tunnel var was only injected in the copy I'd initially found; a full deploy via the CLI showed the var missing from the container, which traced to the second copy. Both are now fixed identically.

Also ran the full unit test suites for both touched crates:
```
cargo test --lib -p temps-error-tracking   -> 124 passed
cargo test --lib -p temps-deployments      -> 544 passed, 3 ignored
```

## Test plan

- [x] `cargo check --lib --workspace` clean
- [x] `cargo test --lib -p temps-error-tracking` (124 passed, includes new tunnel-route and client_report tests)
- [x] `cargo test --lib -p temps-deployments` (544 passed, includes new `public_sentry_tunnel_var` preset-mirroring test)
- [x] Live e2e: real project + real deployment, env var injection verified via `docker inspect`
- [x] Live e2e: tunnel route curl'd directly against the running proxy for all 5 cases above
- [x] Live e2e: tunneled error event confirmed queryable via `errors list`
- [x] `cargo fmt` / `cargo clippy` clean (pre-commit hooks passed)