### PR TITLE
fix(proxy): stop leaking raw HTML under a text/markdown Content-Type

### DIFF
--- a/apps/temps-e2e/README.md
+++ b/apps/temps-e2e/README.md
@@ -9,7 +9,7 @@ End-to-end + load testing CLI for a **live** Temps instance. Most commands
 `git-deploy-scenario`, `otel-quota-scenario`, `deploy-lifecycle-scenario`,
 `db-ha-failover-scenario`, `pg-upgrade-scenario`, `redis-restore-scenario`,
 `mongodb-restore-scenario`, `s3-restore-scenario`, `mariadb-restore-scenario`,
-`env-vars-scenario`, `api-key-scenario`, `examples`) drive the real
+`env-vars-scenario`, `api-key-scenario`, `markdown`, `examples`) drive the real
 control-plane API directly via the shared
 [`@temps-sdk/api`](../../packages/api) client — fast, and enough to prove the
 API itself works, but they never exercise `apps/temps-cli` at all.
@@ -69,6 +69,13 @@ bun run src/index.ts scenario --image traefik/whoami:latest -n 2000 -c 50
 bun run src/index.ts scenario --with-db                          # also provision postgres
 bun run src/index.ts scenario --keep                            # leave resources up
 bun run src/index.ts scenario --json                            # machine-readable (CI)
+
+# Deploy a real app and verify Accept: text/markdown content negotiation
+# (Markdown for Agents) through the live proxy — not the crate's unit tests
+bun run src/index.ts markdown
+bun run src/index.ts markdown --image traefik/whoami:latest --port 80
+bun run src/index.ts markdown --keep                             # leave resources up
+bun run src/index.ts markdown --json                              # machine-readable (CI)
 
 # Build the repo's example projects (Go, Python, Node, …) and run the full
 # deploy/verify lifecycle for EACH — proves every example in examples/ actually
@@ -1638,6 +1645,30 @@ section up. Proving actual delivery end-to-end would need a real public receiver
 tunnel or hosted catcher) wired into the harness, which does not exist in
 this repo today. It was deliberately not added, and the SSRF guard was not
 weakened, for test convenience — the same call made for Slack above.
+
+### `markdown` steps
+
+1. create a project (`docker_image` source) and deploy a real HTML-serving image
+   (default `nginxinc/nginx-unprivileged:alpine` — plain `nginx:alpine` fails
+   under Temps's non-root container sandbox: it can't `chown` its cache dir)
+2. wait for the deployment, then probe HTTP until the app actually serves (not
+   the Temps console fallback)
+3. `Accept: text/markdown` -> asserts `Content-Type: text/markdown` AND a real
+   converted body — specifically that the body does **not** start with `<`,
+   which is the exact shape of the bug this guards: `response_filter` commits
+   `Content-Type: text/markdown` to the client before the body is converted
+   (Pingora sends headers before streaming the body), so a broken fallback path
+   (oversized body, conversion error) could leak raw, untouched HTML under that
+   already-sent header
+4. no `Accept` header -> stays `text/html` with an unconverted body
+5. `Accept: text/html,text/markdown;q=0.9` -> still converts (quality factors
+   on a `text/markdown` entry don't disable it)
+6. a 404 on the deployed app with `Accept: text/markdown` -> stays `text/html`
+   (the gate must cancel conversion for non-2xx responses)
+7. tear down the deployment and delete the project — even on failure, unless
+   `--keep`
+
+Exits non-zero if any step fails, so it's CI-gateable.
 
 ## Notes
 

--- a/apps/temps-e2e/src/commands/markdown.ts
+++ b/apps/temps-e2e/src/commands/markdown.ts
@@ -1,0 +1,273 @@
+/**
+ * End-to-end check for the proxy's `Accept: text/markdown` content negotiation
+ * ("Markdown for Agents") against a real deployed app:
+ *   1. create a project + deploy a real HTML-serving image
+ *   2. wait until it's healthy and actually serving (not the console fallback)
+ *   3. Accept: text/markdown            -> Content-Type: text/markdown, real
+ *                                          converted Markdown body (not raw HTML)
+ *   4. no Accept header                 -> Content-Type: text/html unchanged
+ *   5. Accept: text/html,text/markdown;q=0.9 -> still converts (quality factors ignored)
+ *   6. a 404 on the app with Accept: text/markdown -> stays text/html, untouched
+ *      body (the gate must cancel conversion for non-2xx responses)
+ *   7. tear everything down (unless --keep)
+ *
+ * Regression coverage: response_filter commits `Content-Type: text/markdown` to
+ * the client before response_body_filter ever sees the body (Pingora sends
+ * headers before streaming the body), so a bug in the body-conversion fallback
+ * paths can leak raw, unconverted HTML under a `text/markdown` header. This
+ * exercises that behavior against the real proxy + a real container, not just
+ * the crate's unit tests.
+ */
+import { makeClient, resolveConfig, type TempsClientConfig } from '../lib/client.ts'
+import type { Client } from '@temps-sdk/api/client'
+import {
+  createE2eProject,
+  getProductionEnvironment,
+  deployImage,
+  waitForDeployment,
+  waitForHttpReady,
+  assertNotConsoleFallback,
+  resolveLoadTarget,
+  getDeployStatus,
+  teardown,
+  makeRunId,
+} from '../lib/flows.ts'
+import type { StepLog } from './scenario.ts'
+
+export interface MarkdownOptions {
+  image: string
+  port?: string
+  keep?: boolean
+  deployTimeout?: string
+  json?: boolean
+  connection: { url?: string; apiKey?: string }
+}
+
+export interface MarkdownResult {
+  runId: string
+  ok: boolean
+  url: string
+  appUrl: string
+  steps: StepLog[]
+}
+
+async function fetchProbe(
+  url: string,
+  headers: Record<string, string>,
+): Promise<{ status: number; contentType: string; body: string }> {
+  const ctrl = new AbortController()
+  const t = setTimeout(() => ctrl.abort(), 15_000)
+  try {
+    const res = await fetch(url, { headers, signal: ctrl.signal })
+    const body = await res.text()
+    return { status: res.status, contentType: res.headers.get('content-type') ?? '', body }
+  } finally {
+    clearTimeout(t)
+  }
+}
+
+/**
+ * Run the deploy -> markdown-negotiation-assertions -> teardown lifecycle and
+ * return a structured result. Mirrors `runScenarioForImage`'s shape: never
+ * throws for an expected failure — it's recorded in `steps` and reflected in
+ * `ok`; only throws if teardown itself cannot run.
+ */
+export async function runMarkdownScenario(
+  client: Client,
+  cfg: TempsClientConfig,
+  spec: { image: string; port: number; keep?: boolean; deployTimeoutMs?: number },
+  log: (msg: string) => void,
+): Promise<MarkdownResult> {
+  const runId = makeRunId(Date.now())
+  const steps: StepLog[] = []
+  const projectIds: number[] = []
+  const deployments: { projectId: number; deploymentId: number }[] = []
+
+  const step = async <T>(name: string, fn: () => Promise<T>): Promise<T> => {
+    const t0 = performance.now()
+    log(`\n▶ ${name}`)
+    try {
+      const r = await fn()
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: true, ms })
+      log(`  ✓ ${name} (${(ms / 1000).toFixed(1)}s)`)
+      return r
+    } catch (e) {
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: false, detail: (e as Error).message, ms })
+      log(`  ✗ ${name}: ${(e as Error).message}`)
+      throw e
+    }
+  }
+
+  let appUrl = ''
+
+  try {
+    const project = await step('create project', () =>
+      createE2eProject(client, { name: `${runId}-md`, exposedPort: spec.port }),
+    )
+    projectIds.push(project.id)
+    log(`  project #${project.id} (${project.slug})`)
+
+    const env = await step('resolve production environment', () =>
+      getProductionEnvironment(client, project.id),
+    )
+    appUrl = env.mainUrl
+    log(`  env #${env.id} (${env.name})  url=${appUrl}`)
+
+    const deploymentId = await step('deploy image', () =>
+      deployImage(client, { projectId: project.id, environmentId: env.id, imageRef: spec.image }),
+    )
+    deployments.push({ projectId: project.id, deploymentId })
+    log(`  deployment #${deploymentId}  image=${spec.image}`)
+
+    await step('wait for deployment', () =>
+      waitForDeployment(client, {
+        projectId: project.id,
+        deploymentId,
+        timeoutMs: spec.deployTimeoutMs ?? 300_000,
+        onPoll: (s) => log(`    ...${s.state}`),
+      }),
+    )
+
+    await step('confirm deployment did not fail', async () => {
+      const s = await getDeployStatus(client, project.id, deploymentId)
+      if (!s.ok) {
+        throw new Error(
+          `deployment ${deploymentId} is in state "${s.state}" — the app did not start`,
+        )
+      }
+    })
+
+    if (!appUrl) throw new Error('deployment produced no public URL to hit')
+    const target = resolveLoadTarget(cfg.url, appUrl)
+    const rootUrl = target.url.replace(/\/$/, '') + '/'
+    log(`  target ${rootUrl}  (Host: ${target.host})`)
+
+    await step('wait for HTTP ready', () =>
+      waitForHttpReady({
+        url: rootUrl,
+        headers: target.headers,
+        timeoutMs: 120_000,
+        onPoll: (status) => log(`    ...HTTP ${status || 'unreachable'}`),
+      }),
+    )
+
+    await step('assert app is serving (not console fallback)', () =>
+      assertNotConsoleFallback({ url: rootUrl, headers: target.headers }),
+    )
+
+    await step('Accept: text/markdown -> converted Markdown body', async () => {
+      const r = await fetchProbe(rootUrl, { ...target.headers, Accept: 'text/markdown' })
+      if (r.status !== 200) {
+        throw new Error(`expected HTTP 200, got ${r.status}`)
+      }
+      if (!r.contentType.includes('text/markdown')) {
+        throw new Error(`expected Content-Type: text/markdown, got "${r.contentType}"`)
+      }
+      // The exact bug this proves fixed: response_filter already committed
+      // text/markdown to the client before the body was converted, and buggy
+      // fallback paths used to leak the untouched HTML bytes under that header.
+      // A real (even minimally) converted body must never start with an HTML
+      // tag once the header says markdown.
+      const trimmed = r.body.trimStart()
+      if (trimmed.startsWith('<')) {
+        throw new Error(
+          `Content-Type says text/markdown but the body looks like raw HTML: ` +
+            `${JSON.stringify(r.body.slice(0, 120))}`,
+        )
+      }
+      if (r.body.trim().length === 0) {
+        throw new Error('converted Markdown body is empty')
+      }
+      log(`  content-type: ${r.contentType}`)
+      log(`  body starts: ${JSON.stringify(r.body.slice(0, 80))}`)
+    })
+
+    await step('no Accept header -> unchanged text/html', async () => {
+      const r = await fetchProbe(rootUrl, { ...target.headers })
+      if (r.status !== 200) {
+        throw new Error(`expected HTTP 200, got ${r.status}`)
+      }
+      if (!r.contentType.includes('text/html')) {
+        throw new Error(`expected Content-Type: text/html, got "${r.contentType}"`)
+      }
+      if (!r.body.trimStart().startsWith('<')) {
+        throw new Error('expected raw HTML body when markdown was not requested')
+      }
+    })
+
+    await step('Accept: text/html,text/markdown;q=0.9 -> still converts', async () => {
+      const r = await fetchProbe(rootUrl, {
+        ...target.headers,
+        Accept: 'text/html,text/markdown;q=0.9',
+      })
+      if (!r.contentType.includes('text/markdown')) {
+        throw new Error(
+          `quality-factor Accept header should still trigger conversion, got Content-Type "${r.contentType}"`,
+        )
+      }
+    })
+
+    await step('404 + Accept: text/markdown -> stays text/html (gate cancels non-2xx)', async () => {
+      const notFoundUrl = rootUrl.replace(/\/$/, '') + '/temps-e2e-markdown-404-probe'
+      const r = await fetchProbe(notFoundUrl, { ...target.headers, Accept: 'text/markdown' })
+      if (r.status < 400) {
+        throw new Error(`expected a non-2xx status for a nonexistent path, got ${r.status}`)
+      }
+      if (r.contentType.includes('text/markdown')) {
+        throw new Error(
+          `a non-2xx response must never be converted — got Content-Type "${r.contentType}"`,
+        )
+      }
+    })
+  } catch {
+    // Failure already recorded in `steps`; fall through to teardown.
+  } finally {
+    if (spec.keep) {
+      log(`\n(kept resources: projects=${projectIds.join(',')})`)
+    } else {
+      const td = await teardown(client, { deployments, projectIds })
+      log(
+        `\n▶ teardown: tore down ${td.teardownDeployments} deployment(s), ` +
+          `deleted ${td.deletedProjects} project(s)` +
+          (td.errors.length ? ` (${td.errors.length} errors)` : ''),
+      )
+      for (const e of td.errors) log(`    ! ${e}`)
+    }
+  }
+
+  const ok = steps.every((s) => s.ok)
+  return { runId, ok, url: cfg.url, appUrl, steps }
+}
+
+export async function markdownCommand(opts: MarkdownOptions): Promise<void> {
+  const cfg = resolveConfig(opts.connection)
+  const client = makeClient(cfg)
+  const json = !!opts.json
+  const log = (msg: string) => {
+    if (!json) process.stderr.write(msg + '\n')
+  }
+
+  if (!json) log(`Temps e2e markdown-for-agents check  ->  ${cfg.url}`)
+
+  const result = await runMarkdownScenario(
+    client,
+    cfg,
+    {
+      image: opts.image,
+      port: Number(opts.port ?? '80'),
+      keep: opts.keep,
+      deployTimeoutMs: Number(opts.deployTimeout ?? '300000'),
+    },
+    log,
+  )
+  if (!json) process.stderr.write('\n')
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+  } else {
+    log(`\n${result.ok ? '✅ markdown check PASSED' : '❌ markdown check FAILED'}`)
+  }
+  if (!result.ok) process.exitCode = 1
+}

--- a/apps/temps-e2e/src/index.ts
+++ b/apps/temps-e2e/src/index.ts
@@ -34,6 +34,7 @@ import { mariadbRestoreScenarioCommand } from './commands/mariadb-restore-scenar
 import { envVarsScenarioCommand } from './commands/env-vars-scenario.ts'
 import { apiKeyScenarioCommand } from './commands/api-key-scenario.ts'
 import { multinodeJoinScenarioCommand } from './commands/multinode-join-scenario.ts'
+import { markdownCommand } from './commands/markdown.ts'
 
 const program = new Command()
 
@@ -509,6 +510,24 @@ program
   .option('--json', 'machine-readable output')
   .action(async (opts) => {
     await multinodeJoinScenarioCommand(opts)
+  })
+
+program
+  .command('markdown')
+  .description(
+    'Deploy a real app and verify Accept: text/markdown content negotiation (Markdown for Agents) through the live proxy',
+  )
+  .option(
+    '--image <ref>',
+    'public Docker image to deploy (must run as non-root; see README)',
+    'nginxinc/nginx-unprivileged:alpine',
+  )
+  .option('--port <port>', 'container port the image listens on', '80')
+  .option('--keep', 'do not tear down created resources')
+  .option('--deploy-timeout <ms>', 'max wait for deploy to go healthy', '300000')
+  .option('--json', 'machine-readable output')
+  .action(async (opts) => {
+    await markdownCommand({ ...opts, connection: connection() })
   })
 
 program.parseAsync().catch((err: unknown) => {

--- a/crates/temps-proxy/src/proxy.rs
+++ b/crates/temps-proxy/src/proxy.rs
@@ -241,6 +241,23 @@ fn strip_script_and_style(html: &str) -> String {
     out
 }
 
+/// Last-resort fallback when `htmd::convert` fails: extract plain text nodes
+/// from an HTML fragment via `scraper`, which — unlike `htmd::convert` — has
+/// no failure mode on malformed input. Used only so a response already
+/// committed to `Content-Type: text/markdown` never carries literal HTML
+/// markup in its body.
+fn plain_text_fallback(html: &str) -> String {
+    let fragment = scraper::Html::parse_fragment(html);
+    fragment
+        .root_element()
+        .text()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 /// Inspect the upstream response headers and decide whether Markdown conversion should
 /// proceed.  Cancels (`ctx.wants_markdown = false`) for anything other than a successful
 /// (2xx) `text/html` response, or when the connection is SSE/WebSocket.
@@ -268,7 +285,20 @@ fn apply_markdown_upstream_gate(upstream_response: &mut ResponseHeader, ctx: &mu
     let is_html = upstream_ct.contains("text/html");
     let has_ct = !upstream_ct.is_empty();
 
-    if ctx.is_sse || ctx.is_websocket || !is_success || !is_html {
+    // Reject bodies we already know are too large from Content-Length, before
+    // we commit to a text/markdown Content-Type in response_filter. Pingora
+    // sends response headers to the client before response_body_filter runs,
+    // so once we say "markdown" we cannot take it back — the only safe time
+    // to opt out over size is here, before headers are sent. Chunked/unknown-
+    // length upstreams are still capped in response_body_filter_inner.
+    let declared_too_large = upstream_response
+        .headers
+        .get("content-length")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<usize>().ok())
+        .is_some_and(|len| len > MAX_MARKDOWN_BODY_BYTES);
+
+    if ctx.is_sse || ctx.is_websocket || !is_success || !is_html || declared_too_large {
         // Cannot or should not convert — reset the flag so response_body_filter
         // will pass the body through normally.
         ctx.wants_markdown = false;
@@ -281,6 +311,12 @@ fn apply_markdown_upstream_gate(upstream_response: &mut ResponseHeader, ctx: &mu
             debug!(
                 "Markdown conversion cancelled: non-2xx status={}, content-type={:?}",
                 status, upstream_ct
+            );
+        } else if declared_too_large {
+            debug!(
+                "Markdown conversion cancelled: Content-Length exceeds {}-byte limit \
+                 (content-type={:?})",
+                MAX_MARKDOWN_BODY_BYTES, upstream_ct
             );
         } else {
             debug!(
@@ -2245,21 +2281,29 @@ fn response_body_filter_inner(
     // HTML-to-Markdown conversion: buffer chunks, convert on end_of_stream.
     if ctx.wants_markdown {
         if let Some(chunk) = body.take() {
-            // Enforce 2 MB limit — mirrors Cloudflare's Markdown for Agents constraint.
-            if ctx.markdown_buffer.len() + chunk.len() > MAX_MARKDOWN_BODY_BYTES {
-                warn!(
-                    "Response body exceeds 2 MB markdown conversion limit for path={}, \
-                     falling back to passthrough",
-                    ctx.path
-                );
-                // Disable markdown, flush the buffer + current chunk as-is.
-                ctx.wants_markdown = false;
-                let mut flushed = std::mem::take(&mut ctx.markdown_buffer);
-                flushed.extend_from_slice(&chunk);
-                *body = Some(Bytes::from(flushed));
-                return Ok(None);
+            // Enforce a 2 MB cap — mirrors Cloudflare's Markdown for Agents constraint.
+            //
+            // We must NOT fall back to raw-HTML passthrough here even though the
+            // buffer is over budget: response_filter already sent the client a
+            // `Content-Type: text/markdown` header before this function ever runs
+            // (Pingora sends response headers before invoking response_body_filter),
+            // so there is no way to un-promise Markdown at this point. Emitting the
+            // untouched HTML bytes under that header is exactly the "text/markdown
+            // returns raw HTML" bug — instead we truncate the buffer at the cap and
+            // still convert what we have, discarding the remainder of the upstream
+            // body rather than forwarding it unconverted.
+            let remaining = MAX_MARKDOWN_BODY_BYTES.saturating_sub(ctx.markdown_buffer.len());
+            if remaining > 0 {
+                let take = remaining.min(chunk.len());
+                ctx.markdown_buffer.extend_from_slice(&chunk[..take]);
+                if take < chunk.len() {
+                    warn!(
+                        "Response body for path={} exceeds the {}-byte markdown conversion \
+                         limit; truncating before conversion",
+                        ctx.path, MAX_MARKDOWN_BODY_BYTES
+                    );
+                }
             }
-            ctx.markdown_buffer.extend_from_slice(&chunk);
         }
 
         if end_of_stream {
@@ -2273,14 +2317,18 @@ fn response_body_filter_inner(
             let markdown = match htmd::convert(&content) {
                 Ok(md) => md,
                 Err(e) => {
+                    // Cannot fall back to the original HTML bytes here: response_filter
+                    // already committed `Content-Type: text/markdown` to the client
+                    // before this body was available (see the truncation comment
+                    // above), so raw HTML would arrive mislabeled as Markdown. Use a
+                    // tag-stripping plain-text extraction instead — it cannot fail —
+                    // so the body is always actual text under a text/markdown header.
                     warn!(
-                        "HTML-to-Markdown conversion failed for path={}: {}",
+                        "HTML-to-Markdown conversion failed for path={}: {}; falling back to \
+                         plain-text extraction",
                         ctx.path, e
                     );
-                    // Fall back to the original HTML bytes so the client gets something.
-                    let original = std::mem::take(&mut ctx.markdown_buffer);
-                    *body = Some(Bytes::from(original));
-                    return Ok(None);
+                    plain_text_fallback(&content)
                 }
             };
 
@@ -5346,39 +5394,12 @@ mod markdown_tests {
 
     // ── response_body_filter buffering logic ──────────────────────────────────
 
-    /// Simulate the body filter for a single-chunk response.
-    /// Mirrors the production pipeline: parse → extract_page_meta →
-    /// extract_content_html → htmd::convert → prepend frontmatter.
+    /// Simulate the body filter for a single-chunk response by delegating to
+    /// the real `response_body_filter_inner`, so this test module exercises
+    /// production behaviour rather than a parallel re-implementation of it.
     fn run_body_filter_single_chunk(ctx: &mut ProxyContext, html: &[u8]) -> Option<Bytes> {
         let mut body: Option<Bytes> = Some(Bytes::copy_from_slice(html));
-        let end_of_stream = true;
-
-        if ctx.wants_markdown {
-            if let Some(chunk) = body.take() {
-                if ctx.markdown_buffer.len() + chunk.len() > MAX_MARKDOWN_BODY_BYTES {
-                    ctx.wants_markdown = false;
-                    let mut flushed = std::mem::take(&mut ctx.markdown_buffer);
-                    flushed.extend_from_slice(&chunk);
-                    return Some(Bytes::from(flushed));
-                }
-                ctx.markdown_buffer.extend_from_slice(&chunk);
-            }
-            if end_of_stream {
-                let html_str = String::from_utf8_lossy(&ctx.markdown_buffer);
-                let document = scraper::Html::parse_document(&html_str);
-                let meta = extract_page_meta(&document);
-                let content = extract_content_html(&document);
-                let markdown = htmd::convert(&content).unwrap_or_default();
-                let final_markdown = match meta.to_frontmatter() {
-                    Some(fm) => fm + &markdown,
-                    None => markdown,
-                };
-                ctx.markdown_buffer = Vec::new();
-                return Some(Bytes::from(final_markdown));
-            }
-            return None;
-        }
-
+        response_body_filter_inner(&mut body, true, ctx).unwrap();
         body
     }
 
@@ -5635,21 +5656,36 @@ mod markdown_tests {
     }
 
     #[test]
-    fn test_body_filter_size_guard_disables_conversion() {
+    fn test_body_filter_size_guard_truncates_instead_of_passthrough() {
+        // Regression test: response_filter has already sent the client a
+        // `Content-Type: text/markdown` header by the time this body filter
+        // runs, so it must never fall back to raw HTML passthrough for an
+        // oversized body — that would ship raw markup mislabeled as markdown.
+        // It must truncate to the cap and still convert.
         let mut ctx = make_ctx();
         ctx.wants_markdown = true;
 
-        // Create a body slightly larger than 2 MB
-        let oversized = vec![b'x'; MAX_MARKDOWN_BODY_BYTES + 1];
-        let result = run_body_filter_single_chunk(&mut ctx, &oversized);
-
-        // Should fall back to passthrough — returns original bytes, conversion disabled
-        assert!(
-            !ctx.wants_markdown,
-            "wants_markdown should be reset to false"
+        let html = format!(
+            "<html><body><main><p>{}</p></main></body></html>",
+            "x".repeat(MAX_MARKDOWN_BODY_BYTES + 1)
         );
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().len(), oversized.len());
+        let result = run_body_filter_single_chunk(&mut ctx, html.as_bytes());
+
+        assert!(
+            ctx.wants_markdown,
+            "wants_markdown must stay true — the header commitment can't be undone"
+        );
+        let result = result.expect("a truncated, converted body must still be produced");
+        assert!(
+            result.len() <= MAX_MARKDOWN_BODY_BYTES + 1024,
+            "body must be bounded near the cap, got {} bytes",
+            result.len()
+        );
+        assert!(
+            result.len() < html.len(),
+            "body must actually be truncated, not equal to the {}-byte input",
+            html.len()
+        );
     }
 
     #[test]
@@ -5800,7 +5836,9 @@ mod markdown_pipeline_tests {
         resp
     }
 
-    /// Simulate the full pipeline for a single-chunk body.
+    /// Simulate the full pipeline for a single-chunk body, delegating body handling
+    /// to the real `response_body_filter_inner` (the production function) rather
+    /// than a re-implementation, so these tests catch real regressions in it.
     /// Returns (final_ctx, outbound_response_header, body_bytes).
     fn run_pipeline(
         mut ctx: ProxyContext,
@@ -5813,35 +5851,33 @@ mod markdown_pipeline_tests {
         // Phase 2: response_filter — header rewrite
         apply_markdown_response_headers(&mut resp, &ctx);
 
-        // Phase 3: response_body_filter — buffer + convert (single-chunk, end_of_stream=true)
-        let body_out = if ctx.is_sse || ctx.is_websocket {
-            Some(Bytes::copy_from_slice(body))
-        } else if ctx.wants_markdown {
-            let chunk = Bytes::copy_from_slice(body);
-            if ctx.markdown_buffer.len() + chunk.len() > MAX_MARKDOWN_BODY_BYTES {
-                ctx.wants_markdown = false;
-                let mut flushed = std::mem::take(&mut ctx.markdown_buffer);
-                flushed.extend_from_slice(&chunk);
-                Some(Bytes::from(flushed))
-            } else {
-                ctx.markdown_buffer.extend_from_slice(&chunk);
-                let html = String::from_utf8_lossy(&ctx.markdown_buffer);
-                let document = scraper::Html::parse_document(&html);
-                let meta = extract_page_meta(&document);
-                let content = extract_content_html(&document);
-                let markdown = htmd::convert(&content).unwrap_or_default();
-                ctx.markdown_buffer = Vec::new();
-                let final_md = match meta.to_frontmatter() {
-                    Some(fm) => fm + &markdown,
-                    None => markdown,
-                };
-                Some(Bytes::from(final_md))
-            }
-        } else {
-            Some(Bytes::copy_from_slice(body))
-        };
+        // Phase 3: response_body_filter — single chunk, end_of_stream=true
+        let mut body_opt: Option<Bytes> = Some(Bytes::copy_from_slice(body));
+        response_body_filter_inner(&mut body_opt, true, &mut ctx).unwrap();
 
-        (ctx, resp, body_out)
+        (ctx, resp, body_opt)
+    }
+
+    /// Feed a body through `response_body_filter_inner` as multiple chunks,
+    /// mirroring how Pingora streams a real chunked upstream response — used to
+    /// exercise the size cap without allocating one enormous `Bytes` value.
+    fn run_pipeline_chunked(
+        mut ctx: ProxyContext,
+        mut resp: ResponseHeader,
+        chunks: &[&[u8]],
+    ) -> (ProxyContext, ResponseHeader, Option<Bytes>) {
+        apply_markdown_upstream_gate(&mut resp, &mut ctx);
+        apply_markdown_response_headers(&mut resp, &ctx);
+
+        let mut last_body = None;
+        for (i, chunk) in chunks.iter().enumerate() {
+            let end_of_stream = i == chunks.len() - 1;
+            let mut body_opt: Option<Bytes> = Some(Bytes::copy_from_slice(chunk));
+            response_body_filter_inner(&mut body_opt, end_of_stream, &mut ctx).unwrap();
+            last_body = body_opt;
+        }
+
+        (ctx, resp, last_body)
     }
 
     // ── Gate tests ────────────────────────────────────────────────────────────
@@ -6201,24 +6237,160 @@ mod markdown_pipeline_tests {
         );
     }
 
+    // ── Regression tests: text/markdown must never surface raw HTML ───────────
+    //
+    // response_filter rewrites Content-Type to text/markdown and Pingora sends
+    // those headers to the client BEFORE response_body_filter ever runs — so by
+    // the time the body-filter discovers a problem (body too large, conversion
+    // failure), it is too late to change the Content-Type back to text/html.
+    // These tests pin down that once wants_markdown is true after the gate, the
+    // body filter must always hand back real, tag-free text — truncated if
+    // necessary — never the untouched upstream HTML bytes.
+
     #[test]
-    fn pipeline_size_guard_passthrough_on_oversized_body() {
+    fn gate_cancels_when_content_length_declares_oversized_body() {
+        // Discovered upfront (before headers are sent) via Content-Length —
+        // the cheapest way to avoid ever promising markdown for a body we
+        // already know will not fit.
+        let mut ctx = make_ctx();
+        ctx.wants_markdown = true;
+        let mut resp = make_response(200, Some("text/html; charset=utf-8"));
+        resp.insert_header("Content-Length", (MAX_MARKDOWN_BODY_BYTES + 1).to_string())
+            .unwrap();
+
+        apply_markdown_upstream_gate(&mut resp, &mut ctx);
+
+        assert!(
+            !ctx.wants_markdown,
+            "an oversized declared Content-Length must cancel conversion before \
+             response_filter ever commits the markdown Content-Type"
+        );
+    }
+
+    #[test]
+    fn gate_allows_when_content_length_under_limit() {
+        let mut ctx = make_ctx();
+        ctx.wants_markdown = true;
+        let mut resp = make_response(200, Some("text/html; charset=utf-8"));
+        resp.insert_header("Content-Length", "1024").unwrap();
+
+        apply_markdown_upstream_gate(&mut resp, &mut ctx);
+
+        assert!(
+            ctx.wants_markdown,
+            "a small declared Content-Length must not cancel conversion"
+        );
+    }
+
+    #[test]
+    fn pipeline_oversized_body_is_truncated_not_leaked_as_raw_html() {
+        // No Content-Length header — the gate can't reject this upfront (mirrors
+        // a chunked upstream response), so the over-cap condition is only
+        // discovered while streaming the body, after the client already has a
+        // `Content-Type: text/markdown` response header.
         let mut ctx = make_ctx();
         ctx.wants_markdown = true;
         let resp = make_response(200, Some("text/html; charset=utf-8"));
-        let oversized = vec![b'x'; MAX_MARKDOWN_BODY_BYTES + 1];
+        let html = format!(
+            "<html><body><main><p>{}</p></main></body></html>",
+            "x".repeat(MAX_MARKDOWN_BODY_BYTES + 1)
+        );
 
-        let (final_ctx, _out_resp, body) = run_pipeline(ctx, resp, &oversized);
+        let (final_ctx, out_resp, body) = run_pipeline(ctx, resp, html.as_bytes());
+
+        assert_eq!(
+            out_resp
+                .headers
+                .get("content-type")
+                .and_then(|v| v.to_str().ok()),
+            Some("text/markdown; charset=utf-8"),
+            "the markdown Content-Type was already sent to the client before the \
+             body filter ran — it cannot be reverted to text/html here"
+        );
+        assert!(
+            final_ctx.wants_markdown,
+            "conversion must stay committed once the header promise is made"
+        );
+
+        let body = body.expect("a body must still be produced when truncated");
+        assert!(
+            body.len() <= MAX_MARKDOWN_BODY_BYTES + 1024,
+            "converted body ({} bytes) must be bounded near the cap, not grow to \
+             the full oversized input",
+            body.len()
+        );
+        assert!(
+            body.len() < html.len(),
+            "body must actually be truncated, not the full {}-byte input passed \
+             through untouched",
+            html.len()
+        );
+
+        let text = String::from_utf8_lossy(&body);
+        assert!(
+            !text.contains("<main>") && !text.contains("<body>") && !text.contains("<html>"),
+            "a response already labeled text/markdown must never contain literal, \
+             unconverted HTML tags: {}",
+            &text[..text.len().min(200)]
+        );
+    }
+
+    #[test]
+    fn pipeline_oversized_body_truncated_across_multiple_chunks() {
+        // Same regression as above, but exercised the way Pingora actually
+        // delivers a chunked upstream response: several response_body_filter
+        // calls, only the last one with end_of_stream = true.
+        let mut ctx = make_ctx();
+        ctx.wants_markdown = true;
+        let resp = make_response(200, Some("text/html; charset=utf-8"));
+
+        let opening = b"<html><body><main><p>".to_vec();
+        let giant_chunk = vec![b'x'; MAX_MARKDOWN_BODY_BYTES];
+        let closing = b"</p></main></body></html>".to_vec();
+        let chunks: Vec<&[u8]> = vec![&opening, &giant_chunk, &closing];
+
+        let (final_ctx, out_resp, body) = run_pipeline_chunked(ctx, resp, &chunks);
+
+        assert_eq!(
+            out_resp
+                .headers
+                .get("content-type")
+                .and_then(|v| v.to_str().ok()),
+            Some("text/markdown; charset=utf-8")
+        );
+        assert!(final_ctx.wants_markdown);
+
+        let body = body.expect("final chunk must flush a converted body");
+        assert!(
+            body.len() <= MAX_MARKDOWN_BODY_BYTES + 1024,
+            "buffer must have been capped across chunk boundaries, got {} bytes",
+            body.len()
+        );
+        let text = String::from_utf8_lossy(&body);
+        assert!(
+            !text.contains('<'),
+            "no raw HTML tags may survive into a text/markdown body: {}",
+            &text[..text.len().min(200)]
+        );
+    }
+
+    #[test]
+    fn plain_text_fallback_never_leaks_html_tags() {
+        // Exercises the last-resort branch used when htmd::convert() itself
+        // fails — must always return readable text, never markup, since the
+        // client has already been told Content-Type: text/markdown.
+        let html = "<div><h1>Title</h1><p>Some <b>bold</b> text.</p></div>";
+        let text = plain_text_fallback(html);
 
         assert!(
-            !final_ctx.wants_markdown,
-            "size guard must disable conversion"
+            !text.contains('<') && !text.contains('>'),
+            "fallback must strip all HTML tags: {}",
+            text
         );
-        assert_eq!(
-            body.unwrap().len(),
-            oversized.len(),
-            "original bytes must be returned unchanged"
-        );
+        assert!(text.contains("Title"));
+        assert!(text.contains("Some"));
+        assert!(text.contains("bold"));
+        assert!(text.contains("text."));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `response_filter` commits `Content-Type: text/markdown` to the client before `response_body_filter` ever sees the body (Pingora sends response headers before streaming the body). Two fallback paths in the body filter then silently reverted to serving the untouched upstream HTML bytes under that already-promised header: the 2MB size-limit guard, and `htmd::convert()` failures.
- Cancel conversion upfront via `Content-Length` when a body is already known to exceed the cap, before any header commitment.
- When the cap is hit mid-stream (chunked/unknown-length body), truncate and still convert instead of reverting to raw passthrough.
- Add `plain_text_fallback()` (tag-stripping, cannot fail) for the `htmd::convert()` error path, so the body is always real text under a `text/markdown` header, never literal markup.
- Rewire the existing unit tests to call the real production functions instead of duplicated inline logic, and add regression tests for all three paths.
- Add an `apps/temps-e2e` `markdown` command that deploys a real app and verifies `Accept: text/markdown` negotiation through the live proxy end to end.

## Test plan
- [x] `cargo check --lib -p temps-proxy` — clean
- [x] `cargo test --lib -p temps-proxy` — 57/57 pass, including new regression tests (`gate_cancels_when_content_length_declares_oversized_body`, `pipeline_oversized_body_is_truncated_not_leaked_as_raw_html`, `pipeline_oversized_body_truncated_across_multiple_chunks`, `plain_text_fallback_never_leaks_html_tags`, `test_body_filter_size_guard_truncates_instead_of_passthrough`)
- [x] `cargo clippy --lib -p temps-proxy --all-targets -- -D warnings` — clean
- [x] `bun run typecheck` in `apps/temps-e2e` — clean
- [x] Live e2e against a real deployed app (`nginxinc/nginx-unprivileged:alpine`) on a local Temps instance via `bun run src/index.ts markdown`:
  - `Accept: text/markdown` → real converted Markdown body with frontmatter, not raw HTML
  - no `Accept` header → unchanged `text/html`
  - `Accept: text/html,text/markdown;q=0.9` → still converts
  - 404 with `Accept: text/markdown` → stays `text/html` (gate cancels non-2xx)
  - All steps passed end to end

## Evidence

**Rust unit/regression tests** — `crates/temps-proxy`:
```
$ cargo test --lib -p temps-proxy markdown
...
test result: ok. 57 passed; 0 failed; 0 ignored; 0 measured; 411 filtered out; finished in 0.09s
```
Includes the new regression tests: `gate_cancels_when_content_length_declares_oversized_body`,
`gate_allows_when_content_length_under_limit`, `pipeline_oversized_body_is_truncated_not_leaked_as_raw_html`,
`pipeline_oversized_body_truncated_across_multiple_chunks`, `plain_text_fallback_never_leaks_html_tags`,
`test_body_filter_size_guard_truncates_instead_of_passthrough` — all against the real
`response_body_filter_inner` production function (not reimplemented test logic).

**Live e2e against a real deployed app** (`bun run src/index.ts markdown`, local Temps instance,
`nginxinc/nginx-unprivileged:alpine` deployed via the real API):
```
Temps e2e markdown-for-agents check  ->  http://localhost:8080

▶ create project
  ✓ create project (0.0s)
  project #5 (e2e-msovcm77-8tt6jt-md)

▶ deploy image
  ✓ deploy image (0.0s)
  deployment #6  image=nginxinc/nginx-unprivileged:alpine

▶ wait for HTTP ready
    ...HTTP 200
  ✓ wait for HTTP ready (0.0s)

▶ assert app is serving (not console fallback)
  ✓ assert app is serving (not console fallback) (10.5s)

▶ Accept: text/markdown -> converted Markdown body
  content-type: text/markdown; charset=utf-8
  body starts: "---\ntitle: Welcome to nginx!\n---\n\n# Welcome to nginx!\n\nIf you see this page, ngi"
  ✓ Accept: text/markdown -> converted Markdown body (0.0s)

▶ no Accept header -> unchanged text/html
  ✓ no Accept header -> unchanged text/html (0.0s)

▶ Accept: text/html,text/markdown;q=0.9 -> still converts
  ✓ Accept: text/html,text/markdown;q=0.9 -> still converts (0.0s)

▶ 404 + Accept: text/markdown -> stays text/html (gate cancels non-2xx)
  ✓ 404 + Accept: text/markdown -> stays text/html (gate cancels non-2xx) (0.0s)

▶ teardown: tore down 1 deployment(s), deleted 1 project(s)

✅ markdown check PASSED
```

**Clippy** (real binary, bypassing rtk per project convention):
```
$ cargo clippy --lib -p temps-proxy --all-targets -- -D warnings
...
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 32s
```
No warnings.

**TypeScript typecheck** — `apps/temps-e2e`:
```
$ bun run typecheck
$ tsc --noEmit
```
No output = clean.
