### PR TITLE
feat(self-update): apply pending migrations before restarting

### DIFF
--- a/crates/temps-cli/src/commands/migrate.rs
+++ b/crates/temps-cli/src/commands/migrate.rs
@@ -60,6 +60,25 @@ pub struct MigrateCommand {
     /// Log format: compact, full
     #[arg(long, env = "TEMPS_LOG_FORMAT", default_value = "compact")]
     pub log_format: String,
+
+    /// Progress output format.
+    ///
+    /// When set to `json`, one NDJSON line is written to stdout per migration
+    /// event instead of the human-readable text output. Designed for use by a
+    /// parent process (e.g. the "Update Now" orchestration worker) that spawns
+    /// `temps migrate --progress-format=json` as a child and parses its output
+    /// line-by-line to track progress. The human-readable format remains the
+    /// default for interactive use.
+    ///
+    /// JSON line shapes:
+    ///
+    /// ```json
+    /// {"event":"started","index":1,"total":5,"name":"m20260811_..."}
+    /// {"event":"finished","index":1,"total":5,"name":"...","success":true,"elapsed_ms":123}
+    /// {"event":"finished","index":1,"total":5,"name":"...","success":false,"elapsed_ms":123,"error":"..."}
+    /// ```
+    #[arg(long, value_name = "FORMAT")]
+    pub progress_format: Option<String>,
 }
 
 enum MaintenanceRace<T> {
@@ -149,6 +168,12 @@ impl MigrateCommand {
         // Local runtime — keep execute() synchronous (pingora compatibility).
         let rt = tokio::runtime::Runtime::new()?;
 
+        let use_json = self
+            .progress_format
+            .as_deref()
+            .map(|f| f.eq_ignore_ascii_case("json"))
+            .unwrap_or(false);
+
         rt.block_on(async {
             // Connect WITHOUT auto-migrating; we run migrations explicitly so
             // any error surfaces here rather than during a server boot. The
@@ -170,20 +195,35 @@ impl MigrateCommand {
                 .map_err(|e| anyhow::anyhow!("{}", e))?;
 
             if pending.is_empty() {
-                println!(
-                    "{}",
-                    "✓ Database already up to date — no migrations to apply.".green()
-                );
+                if use_json {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "event": "up_to_date",
+                            "message": "Database already up to date — no migrations to apply."
+                        })
+                    );
+                    let _ = std::io::stdout().flush();
+                } else {
+                    println!(
+                        "{}",
+                        "✓ Database already up to date — no migrations to apply.".green()
+                    );
+                }
                 if !self.dry_run {
                     // Non-transactional maintenance must remain retryable even
                     // after every schema migration is already recorded.
                     run_post_migration_maintenance(&db, &self.database_url, backend_pid).await?;
-                    println!("{}", "✓ Post-migration maintenance complete.".green());
+                    if !use_json {
+                        println!("{}", "✓ Post-migration maintenance complete.".green());
+                    }
                 }
                 return Ok(());
             }
 
-            print_pending_plan(&pending);
+            if !use_json {
+                print_pending_plan(&pending);
+            }
 
             // --dry-run: stop here, never touch the schema.
             if self.dry_run {
@@ -199,15 +239,22 @@ impl MigrateCommand {
                 return Ok(());
             }
 
-            // Confirmation gate. Skipped with --yes, or when stdin is not a TTY
-            // (piped/CI/systemd) so existing automation never hangs on a prompt.
-            if !self.yes && std::io::stdin().is_terminal() && !confirm_apply(pending.len())? {
+            // Confirmation gate. Skipped with --yes, in JSON mode (machine-driven),
+            // or when stdin is not a TTY (piped/CI/systemd) so existing automation
+            // never hangs on a prompt.
+            if !self.yes
+                && !use_json
+                && std::io::stdin().is_terminal()
+                && !confirm_apply(pending.len())?
+            {
                 println!("{}", "Migration cancelled. Nothing was changed.".dimmed());
                 return Ok(());
             }
 
-            println!();
-            println!("{}", "Applying…".bold());
+            if !use_json {
+                println!();
+                println!("{}", "Applying…".bold());
+            }
 
             // Stream progress so each migration is reported the moment it starts
             // and finishes — a slow index build shows as the in-flight line
@@ -218,22 +265,39 @@ impl MigrateCommand {
             // alone would leave Postgres running the DDL, so a re-run could put a
             // second backend on the same schema. The cancelled statement's
             // transaction rolls back, leaving the DB at the last applied step.
-            let report = tokio::select! {
-                res = temps_database::run_migrations_streaming(&db, print_progress) => {
-                    res.map_err(|e| anyhow::anyhow!("{}", e))?
+            let report = if use_json {
+                tokio::select! {
+                    res = temps_database::run_migrations_streaming(&db, print_progress_json) => {
+                        res.map_err(|e| anyhow::anyhow!("{}", e))?
+                    }
+                    _ = tokio::signal::ctrl_c() => {
+                        return Err(interrupted_maintenance_error(
+                            &self.database_url,
+                            backend_pid,
+                            "migration execution",
+                        ).await);
+                    }
                 }
-                _ = tokio::signal::ctrl_c() => {
-                    return Err(interrupted_maintenance_error(
-                        &self.database_url,
-                        backend_pid,
-                        "migration execution",
-                    ).await);
+            } else {
+                tokio::select! {
+                    res = temps_database::run_migrations_streaming(&db, print_progress) => {
+                        res.map_err(|e| anyhow::anyhow!("{}", e))?
+                    }
+                    _ = tokio::signal::ctrl_c() => {
+                        return Err(interrupted_maintenance_error(
+                            &self.database_url,
+                            backend_pid,
+                            "migration execution",
+                        ).await);
+                    }
                 }
             };
 
             // Surface anything planned but not attempted (everything after a
             // failure) so the operator knows the set is incomplete.
-            print_unattempted(&report);
+            if !use_json {
+                print_unattempted(&report);
+            }
 
             // Stop here if a migration failed — do not run the backfill or
             // claim success. Surface which migration failed and why.
@@ -256,15 +320,27 @@ impl MigrateCommand {
             run_post_migration_maintenance(&db, &self.database_url, backend_pid).await?;
 
             let total: std::time::Duration = report.results.iter().map(|r| r.elapsed).sum();
-            println!(
-                "{}",
-                format!(
-                    "✓ {} migration(s) applied in {}. Safe to restart the server.",
-                    report.results.len(),
-                    format_elapsed(total)
-                )
-                .green()
-            );
+            if use_json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "event": "complete",
+                        "migrations_applied": report.results.len(),
+                        "elapsed_ms": total.as_millis() as u64,
+                    })
+                );
+                let _ = std::io::stdout().flush();
+            } else {
+                println!(
+                    "{}",
+                    format!(
+                        "✓ {} migration(s) applied in {}. Safe to restart the server.",
+                        report.results.len(),
+                        format_elapsed(total)
+                    )
+                    .green()
+                );
+            }
             Ok::<(), anyhow::Error>(())
         })
     }
@@ -342,6 +418,56 @@ fn print_progress(progress: temps_database::MigrationProgress<'_>) {
             }
         }
     }
+}
+
+/// Machine-readable progress callback for `--progress-format=json`.
+///
+/// Emits one NDJSON line per event to stdout so a parent process can parse
+/// migration progress without screen-scraping human text. Each line is a
+/// self-contained JSON object terminated by `\n`.
+///
+/// Line shapes:
+/// ```json
+/// {"event":"started","index":1,"total":5,"name":"m20260811_..."}
+/// {"event":"finished","index":1,"total":5,"name":"...","success":true,"elapsed_ms":123}
+/// {"event":"finished","index":1,"total":5,"name":"...","success":false,"elapsed_ms":123,"error":"..."}
+/// ```
+fn print_progress_json(progress: temps_database::MigrationProgress<'_>) {
+    use temps_database::MigrationProgress;
+    match progress {
+        MigrationProgress::Started { index, total, name } => {
+            // Use serde_json::json! to avoid any escaping bugs in hand-rolled JSON.
+            let line = serde_json::json!({
+                "event": "started",
+                "index": index,
+                "total": total,
+                "name": name,
+            });
+            println!("{line}");
+        }
+        MigrationProgress::Finished {
+            index,
+            total,
+            result,
+        } => {
+            let elapsed_ms = result.elapsed.as_millis() as u64;
+            let mut obj = serde_json::json!({
+                "event": "finished",
+                "index": index,
+                "total": total,
+                "name": result.name,
+                "success": result.success,
+                "elapsed_ms": elapsed_ms,
+            });
+            if let Some(err) = &result.error {
+                obj["error"] = serde_json::Value::String(err.clone());
+            }
+            println!("{obj}");
+        }
+    }
+    // Flush so the parent sees the line immediately — unbuffered stdout is
+    // not guaranteed inside `tokio::spawn`, and the parent blocks on each line.
+    let _ = std::io::stdout().flush();
 }
 
 /// After a streaming apply, surface any planned migrations that were never

--- a/crates/temps-cli/src/commands/serve/mod.rs
+++ b/crates/temps-cli/src/commands/serve/mod.rs
@@ -388,6 +388,7 @@ impl ServeCommand {
             self.disable_self_update,
             self_update_caveat,
             update_status.clone(),
+            self.database_url.clone(),
         ));
 
         // Connect to Docker once and share the handle between:

--- a/crates/temps-cli/src/commands/serve/self_update.rs
+++ b/crates/temps-cli/src/commands/serve/self_update.rs
@@ -646,6 +646,13 @@ struct MigrateProgressLine {
     /// Present on `complete` events — total migrations applied in the run.
     #[serde(default)]
     migrations_applied: u32,
+    /// Present on `finished` events where `success == false` — the migration
+    /// runner's own error text (e.g. the underlying DB error). Without this,
+    /// a migrate failure is reported as only "migrate exited with code N",
+    /// leaving the operator to go hunting through logs for what actually
+    /// broke.
+    #[serde(default)]
+    error: Option<String>,
 }
 
 impl UpdateJob {
@@ -690,89 +697,85 @@ impl UpdateJob {
                     );
                 }
             },
-            Err(ExecuteError::PreSwap(e)) => {
+            Err(e) => {
+                // `Display` is the single source of truth for the operator
+                // -facing message in both variants — building it separately
+                // here would drift from `ExecuteError`'s own wording.
                 let message = e.to_string();
-                error!(
-                    from = %self.from_version,
-                    error = %message,
-                    "Self-update failed; the running binary was left untouched"
-                );
-                // Record the failure so it survives to the UI even if the
-                // operator's tab was closed when it happened.
-                let attempt = SelfUpdateAttempt {
-                    from_version: self.from_version.clone(),
-                    to_version: None,
-                    status: SelfUpdateStatus::Failed,
-                    started_at,
-                    finished_at: Some(Utc::now()),
-                    triggered_by_user_id: self.triggered_by_user_id,
-                    error: Some(message.clone()),
-                    previous_binary_path: None,
-                    migrations_applied: None,
-                    migrations_total: None,
-                };
-                if let Err(e) = write_journal(&self.journal_path, &attempt) {
-                    warn!("Could not persist failed self-update attempt: {}", e);
-                }
-                if let Ok(mut state) = self.state.write() {
-                    state.phase = SelfUpdatePhase::Failed;
-                    state.phase_error = Some(message);
-                    state.last_attempt = Some(attempt);
-                }
-            }
-            Err(ExecuteError::PostSwapMigration {
-                to_version,
-                backup_path,
-                error,
-                migrations_applied,
-                migrations_total,
-            }) => {
-                // The binary IS the new version on disk. This error message
-                // must never say "the running binary was left untouched" — it
-                // was replaced. The operator needs to know the exact state so
-                // they can decide whether to run `temps migrate` themselves
-                // before restarting.
-                let full_message = format!(
-                    "The binary was replaced with {to_version} but database migrations failed: \
-                     {error}. The schema may be partially migrated. {}Re-run `temps migrate` \
-                     against the database and then restart the server.",
-                    backup_path
-                        .as_ref()
-                        .map(|p| format!(
-                            "The previous binary was kept at {p} — restore it with \
-                             `mv {p} <binary_path>` if needed. "
-                        ))
-                        .unwrap_or_default()
-                );
-                error!(
-                    from = %self.from_version,
-                    to = %to_version,
-                    error = %error,
-                    "Binary swapped but migrations failed; schema may be partially migrated"
-                );
-                let attempt = SelfUpdateAttempt {
-                    from_version: self.from_version.clone(),
-                    to_version: Some(to_version),
-                    status: SelfUpdateStatus::Failed,
-                    started_at,
-                    finished_at: Some(Utc::now()),
-                    triggered_by_user_id: self.triggered_by_user_id,
-                    error: Some(full_message.clone()),
-                    previous_binary_path: backup_path,
-                    migrations_applied,
-                    migrations_total,
-                };
-                if let Err(e) = write_journal(&self.journal_path, &attempt) {
-                    warn!("Could not persist failed self-update attempt: {}", e);
-                }
-                if let Ok(mut state) = self.state.write() {
-                    // Clear live migration progress — it's now in the journal.
-                    state.migrations_applied = None;
-                    state.migrations_total = None;
-                    state.current_migration_name = None;
-                    state.phase = SelfUpdatePhase::Failed;
-                    state.phase_error = Some(full_message);
-                    state.last_attempt = Some(attempt);
+                match e {
+                    ExecuteError::PreSwap(_) => {
+                        error!(
+                            from = %self.from_version,
+                            error = %message,
+                            "Self-update failed; the running binary was left untouched"
+                        );
+                        // Record the failure so it survives to the UI even if
+                        // the operator's tab was closed when it happened.
+                        let attempt = SelfUpdateAttempt {
+                            from_version: self.from_version.clone(),
+                            to_version: None,
+                            status: SelfUpdateStatus::Failed,
+                            started_at,
+                            finished_at: Some(Utc::now()),
+                            triggered_by_user_id: self.triggered_by_user_id,
+                            error: Some(message.clone()),
+                            previous_binary_path: None,
+                            migrations_applied: None,
+                            migrations_total: None,
+                        };
+                        if let Err(e) = write_journal(&self.journal_path, &attempt) {
+                            warn!("Could not persist failed self-update attempt: {}", e);
+                        }
+                        if let Ok(mut state) = self.state.write() {
+                            state.phase = SelfUpdatePhase::Failed;
+                            state.phase_error = Some(message);
+                            state.last_attempt = Some(attempt);
+                        }
+                    }
+                    ExecuteError::PostSwapMigration {
+                        to_version,
+                        backup_path,
+                        migrations_applied,
+                        migrations_total,
+                        ..
+                    } => {
+                        // The binary IS the new version on disk. `message`
+                        // (built above from `Display`) never says "the
+                        // running binary was left untouched" for this variant
+                        // — it was replaced. The operator needs to know the
+                        // exact state so they can decide whether to run
+                        // `temps migrate` themselves before restarting.
+                        error!(
+                            from = %self.from_version,
+                            to = %to_version,
+                            error = %message,
+                            "Binary swapped but migrations failed; schema may be partially migrated"
+                        );
+                        let attempt = SelfUpdateAttempt {
+                            from_version: self.from_version.clone(),
+                            to_version: Some(to_version),
+                            status: SelfUpdateStatus::Failed,
+                            started_at,
+                            finished_at: Some(Utc::now()),
+                            triggered_by_user_id: self.triggered_by_user_id,
+                            error: Some(message.clone()),
+                            previous_binary_path: backup_path,
+                            migrations_applied,
+                            migrations_total,
+                        };
+                        if let Err(e) = write_journal(&self.journal_path, &attempt) {
+                            warn!("Could not persist failed self-update attempt: {}", e);
+                        }
+                        if let Ok(mut state) = self.state.write() {
+                            // Clear live migration progress — it's now in the journal.
+                            state.migrations_applied = None;
+                            state.migrations_total = None;
+                            state.current_migration_name = None;
+                            state.phase = SelfUpdatePhase::Failed;
+                            state.phase_error = Some(message);
+                            state.last_attempt = Some(attempt);
+                        }
+                    }
                 }
             }
         }
@@ -962,17 +965,26 @@ impl UpdateJob {
         // Drain stderr concurrently with stdout. If nothing reads it, a child
         // that writes more than the OS pipe buffer (64KB on Linux) to stderr
         // blocks on the write while we block reading stdout — a deadlock ends
-        // an update that would otherwise have succeeded. Logged via `warn!`
-        // rather than inherited: the child has `TEMPS_DATABASE_URL` in its
-        // environment, and a connection-failure message from sqlx/libpq can
-        // embed the full DSN (including the password) — piping and logging
-        // only the line text keeps that out of the parent's own log stream
-        // without silently discarding genuine error detail.
+        // an update that would otherwise have succeeded.
+        //
+        // Piped rather than inherited so this can be logged deliberately: the
+        // child has `TEMPS_DATABASE_URL` in its environment, and a
+        // connection-failure message from sqlx/libpq can embed the full DSN
+        // (including the password). Piping does NOT by itself keep the
+        // credential out of the parent's own log stream — `warn!` below IS
+        // the parent's log stream, same as `Stdio::inherit()` would have
+        // been, just structured instead of raw. `redact_dsn` is what
+        // actually prevents the leak, by stripping any `scheme://user:pass@`
+        // prefix before the line is logged.
         let stderr_task = tokio::spawn(async move {
             let mut lines = tokio::io::BufReader::new(stderr).lines();
             while let Ok(Some(line)) = lines.next_line().await {
                 if !line.trim().is_empty() {
-                    warn!(target: "temps_cli::self_update::migrate_stderr", "{line}");
+                    warn!(
+                        target: "temps_cli::self_update::migrate_stderr",
+                        "{}",
+                        redact_dsn(&line)
+                    );
                 }
             }
         });
@@ -980,6 +992,10 @@ impl UpdateJob {
         let mut lines = tokio::io::BufReader::new(stdout).lines();
         let mut applied: u32 = 0;
         let mut total: u32 = 0;
+        // The migration that failed and why, if any `finished` event reports
+        // `success: false` — carried into the final error so the operator
+        // sees the actual DB failure instead of just an exit code.
+        let mut last_failure: Option<(String, String)> = None;
 
         while let Ok(Some(line)) = lines.next_line().await {
             if let Ok(event) = serde_json::from_str::<MigrateProgressLine>(&line) {
@@ -1000,6 +1016,14 @@ impl UpdateJob {
                     "finished" => {
                         if event.success {
                             applied += 1;
+                        } else {
+                            last_failure = Some((
+                                event.name.clone(),
+                                event
+                                    .error
+                                    .clone()
+                                    .unwrap_or_else(|| "no error detail reported".to_string()),
+                            ));
                         }
                         if let Ok(mut state) = self.state.write() {
                             state.migrations_applied = Some(applied);
@@ -1010,6 +1034,7 @@ impl UpdateJob {
                             total = event.total,
                             name = %event.name,
                             success = event.success,
+                            error = event.error.as_deref().unwrap_or(""),
                             "Migration step finished"
                         );
                     }
@@ -1043,10 +1068,16 @@ impl UpdateJob {
 
         if !status.success() {
             let code = status.code().unwrap_or(-1);
+            let error = match &last_failure {
+                Some((name, detail)) => {
+                    format!("migration '{name}' failed: {detail} (migrate exited with code {code})")
+                }
+                None => format!("migrate exited with code {code}"),
+            };
             return Err(ExecuteError::PostSwapMigration {
                 to_version: to_version.to_string(),
                 backup_path: backup_path.clone(),
-                error: format!("migrate exited with code {code}"),
+                error,
                 migrations_applied: Some(applied),
                 migrations_total: Some(total),
             });
@@ -1068,6 +1099,47 @@ impl UpdateJob {
             Some(version) => fetch_specific_release(version).await,
             None => fetch_latest_release_in_channel(self.channel).await,
         }
+    }
+}
+
+/// Strip `scheme://user:pass@` credentials from a line before it is logged.
+///
+/// Defense in depth for the `migrate` child's stderr: that child has
+/// `TEMPS_DATABASE_URL` in its environment, and a connection-failure message
+/// from sqlx/libpq is not guaranteed never to embed the DSN (including the
+/// password) in its `Display` output. Piping stderr into `warn!` instead of
+/// inheriting it only changes WHERE the line goes, not whether it contains a
+/// credential — this is what actually keeps one out of the log.
+fn redact_dsn(line: &str) -> std::borrow::Cow<'_, str> {
+    if !line.contains("://") {
+        return std::borrow::Cow::Borrowed(line);
+    }
+    let mut result = String::with_capacity(line.len());
+    let mut rest = line;
+    let mut redacted_any = false;
+    while let Some(scheme_pos) = rest.find("://") {
+        let (before, after_marker) = rest.split_at(scheme_pos + 3);
+        result.push_str(before);
+        // The userinfo component, if present, ends at the next '/' or
+        // whitespace — scan only that span for a trailing '@'.
+        let boundary = after_marker
+            .find(|c: char| c.is_whitespace() || c == '/')
+            .unwrap_or(after_marker.len());
+        let candidate = &after_marker[..boundary];
+        if let Some(at_pos) = candidate.rfind('@') {
+            result.push_str("***@");
+            redacted_any = true;
+            rest = &after_marker[at_pos + 1..];
+        } else {
+            result.push_str(candidate);
+            rest = &after_marker[boundary..];
+        }
+    }
+    result.push_str(rest);
+    if redacted_any {
+        std::borrow::Cow::Owned(result)
+    } else {
+        std::borrow::Cow::Borrowed(line)
     }
 }
 
@@ -1239,6 +1311,39 @@ fn write_journal(path: &Path, attempt: &SelfUpdateAttempt) -> anyhow::Result<()>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_redact_dsn_strips_credentials() {
+        let line = "error connecting to postgresql://app:hunter2@db:5432/temps: connection refused";
+        let redacted = redact_dsn(line);
+        assert!(!redacted.contains("hunter2"), "{redacted}");
+        assert!(!redacted.contains("app:"), "{redacted}");
+        assert!(redacted.contains("***@db:5432/temps"), "{redacted}");
+    }
+
+    #[test]
+    fn test_redact_dsn_leaves_credential_free_lines_untouched() {
+        let line = "FATAL: password authentication failed for user \"app\"";
+        assert_eq!(redact_dsn(line), line);
+    }
+
+    #[test]
+    fn test_redact_dsn_leaves_url_without_userinfo_untouched() {
+        let line = "fetching https://example.com/releases/latest";
+        assert_eq!(redact_dsn(line), line);
+    }
+
+    #[test]
+    fn test_redact_dsn_handles_multiple_urls_in_one_line() {
+        let line = "postgres://a:b@host1/db and postgres://c:d@host2/db";
+        let redacted = redact_dsn(line);
+        assert!(!redacted.contains("a:b"), "{redacted}");
+        assert!(!redacted.contains("c:d"), "{redacted}");
+        assert_eq!(
+            redacted,
+            "postgres://***@host1/db and postgres://***@host2/db"
+        );
+    }
 
     fn updater(
         dir: &Path,

--- a/crates/temps-cli/src/commands/serve/self_update.rs
+++ b/crates/temps-cli/src/commands/serve/self_update.rs
@@ -62,6 +62,10 @@ struct UpdaterState {
     phase: SelfUpdatePhase,
     phase_error: Option<String>,
     last_attempt: Option<SelfUpdateAttempt>,
+    /// Live migration progress — populated while `phase == Migrating`.
+    migrations_applied: Option<u32>,
+    migrations_total: Option<u32>,
+    current_migration_name: Option<String>,
 }
 
 /// Replaces the on-disk binary and exits so the supervisor restarts it.
@@ -80,6 +84,9 @@ pub struct BinarySelfUpdater {
     /// check republishes it so the banner and the version page never disagree.
     update_status: Arc<UpdateStatusSlot>,
     state: Arc<RwLock<UpdaterState>>,
+    /// Database URL passed explicitly to the migrate child process so it works
+    /// even when the parent was started with `--database-url` (not the env var).
+    database_url: String,
 }
 
 impl BinarySelfUpdater {
@@ -87,11 +94,17 @@ impl BinarySelfUpdater {
     /// process. Never fails: a bad journal or an unresolvable binary path
     /// degrades to "self-update unavailable", which the capability endpoint
     /// reports with a reason.
+    ///
+    /// `database_url` is set explicitly on the migrate child process rather than
+    /// relying on environment inheritance, because the parent may have received
+    /// it as a `--database-url` flag (not in env) and a naively-spawned child
+    /// would then hard-fail clap's required-arg check.
     pub fn new(
         data_dir: PathBuf,
         disabled_by_flag: bool,
         topology_caveat: Option<String>,
         update_status: Arc<UpdateStatusSlot>,
+        database_url: String,
     ) -> Self {
         let binary_path = std::env::current_exe()
             .map(|p| std::fs::canonicalize(&p).unwrap_or(p))
@@ -116,6 +129,7 @@ impl BinarySelfUpdater {
             topology_caveat,
             update_status,
             state: Arc::new(RwLock::new(UpdaterState::default())),
+            database_url,
         };
 
         let last_attempt = updater.reconcile_journal();
@@ -368,11 +382,21 @@ impl SelfUpdater for BinarySelfUpdater {
         // The capability also backs the version page, so it reports the
         // effective channel even when no update is pending.
         let (channel, pinned) = resolve_channel(policy.channel.as_deref(), &current_version);
-        let (phase, phase_error, last_attempt) = match self.state.read() {
+        let (
+            phase,
+            phase_error,
+            last_attempt,
+            migrations_applied,
+            migrations_total,
+            current_migration_name,
+        ) = match self.state.read() {
             Ok(state) => (
                 state.phase,
                 state.phase_error.clone(),
                 state.last_attempt.clone(),
+                state.migrations_applied,
+                state.migrations_total,
+                state.current_migration_name.clone(),
             ),
             Err(poisoned) => {
                 let state = poisoned.into_inner();
@@ -380,6 +404,9 @@ impl SelfUpdater for BinarySelfUpdater {
                     state.phase,
                     state.phase_error.clone(),
                     state.last_attempt.clone(),
+                    state.migrations_applied,
+                    state.migrations_total,
+                    state.current_migration_name.clone(),
                 )
             }
         };
@@ -399,6 +426,9 @@ impl SelfUpdater for BinarySelfUpdater {
             phase,
             phase_error,
             last_attempt,
+            migrations_applied,
+            migrations_total,
+            current_migration_name,
         }
     }
 
@@ -452,6 +482,7 @@ impl SelfUpdater for BinarySelfUpdater {
             restart_mode,
             channel,
             state: self.state.clone(),
+            database_url: self.database_url.clone(),
         };
         tokio::spawn(job.run());
 
@@ -541,6 +572,80 @@ struct UpdateJob {
     /// Channel the "newest release" lookup uses when no version is pinned.
     channel: UpgradeChannel,
     state: Arc<RwLock<UpdaterState>>,
+    /// Passed explicitly to the `temps migrate` child so the DB URL is
+    /// guaranteed to be in its environment regardless of how the parent
+    /// received it (flag vs env var).
+    database_url: String,
+}
+
+/// Failure discriminator for `UpdateJob::execute`.
+///
+/// The two variants have completely different semantics: a pre-swap failure
+/// means the running binary was never touched, while a post-swap failure means
+/// the new binary is on disk and the DB may be partially migrated — the error
+/// message and journal entry must reflect that honestly.
+#[derive(Debug)]
+enum ExecuteError {
+    /// Failed before the binary was replaced. The running binary is untouched.
+    PreSwap(anyhow::Error),
+    /// Binary was replaced with `to_version`, but `temps migrate` exited
+    /// non-zero or could not be launched. The schema may be partially migrated.
+    PostSwapMigration {
+        to_version: String,
+        backup_path: Option<String>,
+        error: String,
+        /// How many migrations completed before the failure, if known.
+        migrations_applied: Option<u32>,
+        /// Total migrations that were planned, if known.
+        migrations_total: Option<u32>,
+    },
+}
+
+impl std::fmt::Display for ExecuteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PreSwap(e) => write!(f, "{e}"),
+            Self::PostSwapMigration {
+                to_version,
+                backup_path,
+                error,
+                ..
+            } => {
+                write!(
+                    f,
+                    "The binary was replaced with {to_version} but database migrations failed: \
+                     {error}. The schema may be partially migrated. {}Inspect the database and \
+                     re-run `temps migrate` to complete the upgrade before restarting.",
+                    backup_path
+                        .as_ref()
+                        .map(|p| format!(
+                            "The previous binary was kept at {p} — restore it with \
+                             `mv {p} <binary_path>` if needed. "
+                        ))
+                        .unwrap_or_default()
+                )
+            }
+        }
+    }
+}
+
+/// A single NDJSON progress line emitted by `temps migrate --progress-format=json`.
+///
+/// Field names must match what `print_progress_json` in `migrate.rs` emits exactly.
+#[derive(serde::Deserialize)]
+struct MigrateProgressLine {
+    event: String,
+    #[serde(default)]
+    index: u32,
+    #[serde(default)]
+    total: u32,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    success: bool,
+    /// Present on `complete` events — total migrations applied in the run.
+    #[serde(default)]
+    migrations_applied: u32,
 }
 
 impl UpdateJob {
@@ -556,34 +661,36 @@ impl UpdateJob {
         match self.execute(started_at).await {
             Ok(target) => match self.restart_mode {
                 SelfUpdateRestartMode::Automatic => {
-                    // The swap is done and the journal says `pending`. Exiting
-                    // is now the whole job: the supervisor brings us back on
-                    // the new binary and the next boot resolves the journal.
+                    // The swap is done, migrations applied, and the journal
+                    // says `pending`. Exiting is now the whole job: the
+                    // supervisor brings us back on the new binary and the next
+                    // boot resolves the journal.
                     self.set_phase(SelfUpdatePhase::Restarting, None);
                     warn!(
                         from = %self.from_version,
                         to = %target,
-                        "Binary replaced — exiting so the supervisor restarts temps on the new version"
+                        "Binary replaced and migrations applied — exiting so the supervisor \
+                         restarts temps on the new version"
                     );
                     tokio::time::sleep(RESTART_GRACE).await;
                     std::process::exit(0);
                 }
                 SelfUpdateRestartMode::Manual => {
-                    // Installed, but exiting here would take the server down
-                    // with nothing to bring it back. Keep serving the old
-                    // binary and make the outstanding restart obvious.
+                    // Installed and migrated, but exiting here would take the
+                    // server down with nothing to bring it back. Keep serving
+                    // the old binary and make the outstanding restart obvious.
                     self.set_phase(SelfUpdatePhase::PendingRestart, None);
                     warn!(
                         from = %self.from_version,
                         to = %target,
-                        "Binary replaced, but no supervisor was detected — temps is STILL RUNNING \
-                         {} and will pick up {} when you restart it",
+                        "Binary replaced and migrations applied, but no supervisor was detected \
+                         — temps is STILL RUNNING {} and will pick up {} when you restart it",
                         self.from_version,
                         target
                     );
                 }
             },
-            Err(e) => {
+            Err(ExecuteError::PreSwap(e)) => {
                 let message = e.to_string();
                 error!(
                     from = %self.from_version,
@@ -601,6 +708,8 @@ impl UpdateJob {
                     triggered_by_user_id: self.triggered_by_user_id,
                     error: Some(message.clone()),
                     previous_binary_path: None,
+                    migrations_applied: None,
+                    migrations_total: None,
                 };
                 if let Err(e) = write_journal(&self.journal_path, &attempt) {
                     warn!("Could not persist failed self-update attempt: {}", e);
@@ -611,15 +720,125 @@ impl UpdateJob {
                     state.last_attempt = Some(attempt);
                 }
             }
+            Err(ExecuteError::PostSwapMigration {
+                to_version,
+                backup_path,
+                error,
+                migrations_applied,
+                migrations_total,
+            }) => {
+                // The binary IS the new version on disk. This error message
+                // must never say "the running binary was left untouched" — it
+                // was replaced. The operator needs to know the exact state so
+                // they can decide whether to run `temps migrate` themselves
+                // before restarting.
+                let full_message = format!(
+                    "The binary was replaced with {to_version} but database migrations failed: \
+                     {error}. The schema may be partially migrated. {}Re-run `temps migrate` \
+                     against the database and then restart the server.",
+                    backup_path
+                        .as_ref()
+                        .map(|p| format!(
+                            "The previous binary was kept at {p} — restore it with \
+                             `mv {p} <binary_path>` if needed. "
+                        ))
+                        .unwrap_or_default()
+                );
+                error!(
+                    from = %self.from_version,
+                    to = %to_version,
+                    error = %error,
+                    "Binary swapped but migrations failed; schema may be partially migrated"
+                );
+                let attempt = SelfUpdateAttempt {
+                    from_version: self.from_version.clone(),
+                    to_version: Some(to_version),
+                    status: SelfUpdateStatus::Failed,
+                    started_at,
+                    finished_at: Some(Utc::now()),
+                    triggered_by_user_id: self.triggered_by_user_id,
+                    error: Some(full_message.clone()),
+                    previous_binary_path: backup_path,
+                    migrations_applied,
+                    migrations_total,
+                };
+                if let Err(e) = write_journal(&self.journal_path, &attempt) {
+                    warn!("Could not persist failed self-update attempt: {}", e);
+                }
+                if let Ok(mut state) = self.state.write() {
+                    // Clear live migration progress — it's now in the journal.
+                    state.migrations_applied = None;
+                    state.migrations_total = None;
+                    state.current_migration_name = None;
+                    state.phase = SelfUpdatePhase::Failed;
+                    state.phase_error = Some(full_message);
+                    state.last_attempt = Some(attempt);
+                }
+            }
         }
     }
 
-    /// Download, verify and install. Returns the version now on disk.
+    /// Download, verify, swap the binary and run database migrations.
     ///
-    /// Every failure here leaves the running binary untouched: the new bytes go
-    /// to a temp file and are only moved into place after the checksum matches
-    /// AND the new binary answers `--version`.
-    async fn execute(&self, started_at: chrono::DateTime<Utc>) -> anyhow::Result<String> {
+    /// Everything up to and including `replace_binary` is the "pre-swap" zone:
+    /// a failure there leaves the running binary untouched and is returned as
+    /// `ExecuteError::PreSwap`. Once the binary is on disk, any failure is
+    /// `ExecuteError::PostSwapMigration` — the operator is told exactly what
+    /// state the install is in and what to do next.
+    async fn execute(&self, started_at: chrono::DateTime<Utc>) -> Result<String, ExecuteError> {
+        let (to_version, backup_path) = self
+            .download_verify_swap()
+            .await
+            .map_err(ExecuteError::PreSwap)?;
+
+        let backup_str = backup_path.map(|p| p.display().to_string());
+
+        // Run the new binary's migrator so the schema is up to date before
+        // anything restarts. This MUST use the new binary (not in-process) so
+        // it applies migrations compiled into the new version, not the old one.
+        let (migrations_applied, migrations_total) =
+            self.run_migration_step(&to_version, &backup_str).await?;
+
+        // Written BEFORE the exit: once the process is gone there is no second
+        // chance to record what it was doing.
+        let attempt = SelfUpdateAttempt {
+            from_version: self.from_version.clone(),
+            to_version: Some(to_version.clone()),
+            // `Pending` means "we are about to exit, resolve this on the next
+            // boot". In manual mode nothing exits, so the attempt is already
+            // as finished as it can get until the operator restarts.
+            status: match self.restart_mode {
+                SelfUpdateRestartMode::Automatic => SelfUpdateStatus::Pending,
+                SelfUpdateRestartMode::Manual => SelfUpdateStatus::InstalledPendingRestart,
+            },
+            started_at,
+            finished_at: match self.restart_mode {
+                SelfUpdateRestartMode::Automatic => None,
+                SelfUpdateRestartMode::Manual => Some(Utc::now()),
+            },
+            triggered_by_user_id: self.triggered_by_user_id,
+            error: None,
+            previous_binary_path: backup_str,
+            migrations_applied: Some(migrations_applied),
+            migrations_total: Some(migrations_total),
+        };
+        write_journal(&self.journal_path, &attempt).map_err(ExecuteError::PreSwap)?;
+        if let Ok(mut state) = self.state.write() {
+            // Clear live migration progress now that it's recorded in the journal.
+            state.migrations_applied = None;
+            state.migrations_total = None;
+            state.current_migration_name = None;
+            state.last_attempt = Some(attempt);
+        }
+
+        Ok(to_version)
+    }
+
+    /// Everything from "resolve release" through "replace binary on disk".
+    ///
+    /// A failure at any point here leaves the running binary untouched and is
+    /// safe to propagate as `PreSwap`. Returns `(to_version, backup_path)`.
+    async fn download_verify_swap(&self) -> anyhow::Result<(String, Option<PathBuf>)> {
         let target = platform_target()?;
 
         let release = self.resolve_release().await?;
@@ -687,33 +906,158 @@ impl UpdateJob {
         let backup_path = backup_current_binary(&self.binary_path)?;
         replace_binary(&self.binary_path, &new_binary)?;
 
-        // Written BEFORE the exit: once the process is gone there is no second
-        // chance to record what it was doing.
-        let attempt = SelfUpdateAttempt {
-            from_version: self.from_version.clone(),
-            to_version: Some(to_version.clone()),
-            // `Pending` means "we are about to exit, resolve this on the next
-            // boot". In manual mode nothing exits, so the attempt is already
-            // as finished as it can get until the operator restarts.
-            status: match self.restart_mode {
-                SelfUpdateRestartMode::Automatic => SelfUpdateStatus::Pending,
-                SelfUpdateRestartMode::Manual => SelfUpdateStatus::InstalledPendingRestart,
-            },
-            started_at,
-            finished_at: match self.restart_mode {
-                SelfUpdateRestartMode::Automatic => None,
-                SelfUpdateRestartMode::Manual => Some(Utc::now()),
-            },
-            triggered_by_user_id: self.triggered_by_user_id,
-            error: None,
-            previous_binary_path: backup_path.map(|p| p.display().to_string()),
+        Ok((to_version, backup_path))
+    }
+
+    /// Spawn `<new_binary> migrate --yes --progress-format=json`, stream its
+    /// NDJSON stdout into the shared state for live polling, and return the
+    /// applied/total migration counts on success.
+    ///
+    /// On any failure (launch error, non-zero exit) this returns
+    /// `ExecuteError::PostSwapMigration` — the swap has already happened so the
+    /// caller must NOT describe the error as "the running binary was untouched".
+    async fn run_migration_step(
+        &self,
+        to_version: &str,
+        backup_path: &Option<String>,
+    ) -> Result<(u32, u32), ExecuteError> {
+        use tokio::io::AsyncBufReadExt;
+
+        self.set_phase(SelfUpdatePhase::Migrating, None);
+        info!(
+            to = %to_version,
+            binary = %self.binary_path.display(),
+            "Running database migrations with the new binary"
+        );
+
+        let post_swap_err = |error: String| ExecuteError::PostSwapMigration {
+            to_version: to_version.to_string(),
+            backup_path: backup_path.clone(),
+            error,
+            // Counts captured from state at the moment of failure.
+            migrations_applied: self.state.read().ok().and_then(|s| s.migrations_applied),
+            migrations_total: self.state.read().ok().and_then(|s| s.migrations_total),
         };
-        write_journal(&self.journal_path, &attempt)?;
-        if let Ok(mut state) = self.state.write() {
-            state.last_attempt = Some(attempt);
+
+        let mut child = tokio::process::Command::new(&self.binary_path)
+            .arg("migrate")
+            .arg("--yes")
+            .arg("--progress-format=json")
+            // Explicit env set: if the parent received the DB URL as a
+            // `--database-url` flag it is not in the environment, so a naive
+            // child spawn would fail clap's required-arg check.
+            .env("TEMPS_DATABASE_URL", &self.database_url)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| post_swap_err(format!("Failed to launch migrate subprocess: {e}")))?;
+
+        let stdout = child.stdout.take().ok_or_else(|| {
+            post_swap_err("migrate subprocess stdout was not captured".to_string())
+        })?;
+        let stderr = child.stderr.take().ok_or_else(|| {
+            post_swap_err("migrate subprocess stderr was not captured".to_string())
+        })?;
+
+        // Drain stderr concurrently with stdout. If nothing reads it, a child
+        // that writes more than the OS pipe buffer (64KB on Linux) to stderr
+        // blocks on the write while we block reading stdout — a deadlock ends
+        // an update that would otherwise have succeeded. Logged via `warn!`
+        // rather than inherited: the child has `TEMPS_DATABASE_URL` in its
+        // environment, and a connection-failure message from sqlx/libpq can
+        // embed the full DSN (including the password) — piping and logging
+        // only the line text keeps that out of the parent's own log stream
+        // without silently discarding genuine error detail.
+        let stderr_task = tokio::spawn(async move {
+            let mut lines = tokio::io::BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if !line.trim().is_empty() {
+                    warn!(target: "temps_cli::self_update::migrate_stderr", "{line}");
+                }
+            }
+        });
+
+        let mut lines = tokio::io::BufReader::new(stdout).lines();
+        let mut applied: u32 = 0;
+        let mut total: u32 = 0;
+
+        while let Ok(Some(line)) = lines.next_line().await {
+            if let Ok(event) = serde_json::from_str::<MigrateProgressLine>(&line) {
+                match event.event.as_str() {
+                    "started" => {
+                        total = event.total;
+                        if let Ok(mut state) = self.state.write() {
+                            state.migrations_total = Some(total);
+                            state.current_migration_name = Some(event.name.clone());
+                        }
+                        info!(
+                            index = event.index,
+                            total = event.total,
+                            name = %event.name,
+                            "Applying migration"
+                        );
+                    }
+                    "finished" => {
+                        if event.success {
+                            applied += 1;
+                        }
+                        if let Ok(mut state) = self.state.write() {
+                            state.migrations_applied = Some(applied);
+                            state.current_migration_name = None;
+                        }
+                        info!(
+                            index = event.index,
+                            total = event.total,
+                            name = %event.name,
+                            success = event.success,
+                            "Migration step finished"
+                        );
+                    }
+                    "complete" => {
+                        // Authoritative count from the child — use it if
+                        // higher than our per-event counter (defensive).
+                        if event.migrations_applied > applied {
+                            applied = event.migrations_applied;
+                            if let Ok(mut state) = self.state.write() {
+                                state.migrations_applied = Some(applied);
+                            }
+                        }
+                    }
+                    "up_to_date" => {
+                        // No migrations needed — counts stay at zero.
+                        info!("Database already up to date; no migrations to apply");
+                    }
+                    _ => {}
+                }
+            }
         }
 
-        Ok(to_version)
+        let status = child
+            .wait()
+            .await
+            .map_err(|e| post_swap_err(format!("Failed to wait for migrate subprocess: {e}")))?;
+        // Exiting closes the child's stderr, so this drains any remaining
+        // buffered lines and then returns; best-effort, a panicked drain task
+        // must not fail an otherwise-successful migration.
+        let _ = stderr_task.await;
+
+        if !status.success() {
+            let code = status.code().unwrap_or(-1);
+            return Err(ExecuteError::PostSwapMigration {
+                to_version: to_version.to_string(),
+                backup_path: backup_path.clone(),
+                error: format!("migrate exited with code {code}"),
+                migrations_applied: Some(applied),
+                migrations_total: Some(total),
+            });
+        }
+
+        info!(
+            applied = applied,
+            total = total,
+            "Database migrations completed successfully"
+        );
+        Ok((applied, total))
     }
 
     /// The release to install: an explicit pin, or the newest one on the channel
@@ -911,6 +1255,9 @@ mod tests {
             topology_caveat: None,
             update_status: Arc::new(UpdateStatusSlot::new()),
             state: Arc::new(RwLock::new(UpdaterState::default())),
+            // Tests don't exercise the migrate subprocess, so the URL value
+            // doesn't matter — it only needs to be present in the struct.
+            database_url: String::new(),
         }
     }
 
@@ -1149,6 +1496,8 @@ mod tests {
             triggered_by_user_id: Some(3),
             error: None,
             previous_binary_path: None,
+            migrations_applied: None,
+            migrations_total: None,
         };
         let path = dir.join(SELF_UPDATE_JOURNAL_FILE);
         write_journal(&path, &attempt).expect("write journal");
@@ -1177,6 +1526,8 @@ mod tests {
             triggered_by_user_id: None,
             error: None,
             previous_binary_path: Some("/usr/local/bin/temps.bak".to_string()),
+            migrations_applied: None,
+            migrations_total: None,
         };
         write_journal(&dir.join(SELF_UPDATE_JOURNAL_FILE), &attempt).expect("write journal");
 
@@ -1206,6 +1557,8 @@ mod tests {
             triggered_by_user_id: None,
             error: None,
             previous_binary_path: None,
+            migrations_applied: Some(2),
+            migrations_total: Some(2),
         };
         write_journal(&dir.join(SELF_UPDATE_JOURNAL_FILE), &attempt).expect("write journal");
         let resolved = updater(&dir, false, SupervisorKind::Systemd)
@@ -1231,6 +1584,8 @@ mod tests {
             triggered_by_user_id: Some(1),
             error: None,
             previous_binary_path: None,
+            migrations_applied: Some(0),
+            migrations_total: Some(0),
         };
         write_journal(&dir.join(SELF_UPDATE_JOURNAL_FILE), &attempt).expect("write journal");
 
@@ -1255,6 +1610,8 @@ mod tests {
             triggered_by_user_id: Some(1),
             error: None,
             previous_binary_path: None,
+            migrations_applied: Some(1),
+            migrations_total: Some(1),
         };
         write_journal(&dir.join(SELF_UPDATE_JOURNAL_FILE), &attempt).expect("write journal");
 
@@ -1311,6 +1668,75 @@ mod tests {
         assert_eq!(
             std::fs::read(&binary).unwrap(),
             std::fs::read(&backup).unwrap()
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_post_swap_migration_error_carries_to_version_and_backup_path() {
+        // This is the one failure mode that did not exist before migrations were
+        // added to the update flow: a failure AFTER the binary was replaced.
+        // The error must carry the `to_version` so the journal entry can record
+        // what binary is now on disk (not None, which would be wrong), and the
+        // `backup_path` so the operator knows how to recover.
+        let err = ExecuteError::PostSwapMigration {
+            to_version: "v0.2.0".to_string(),
+            backup_path: Some("/usr/local/bin/temps.bak".to_string()),
+            error: "migrate exited with code 1".to_string(),
+            migrations_applied: Some(2),
+            migrations_total: Some(5),
+        };
+
+        let msg = err.to_string();
+        // Must name the version that is now on disk.
+        assert!(msg.contains("v0.2.0"), "error message: {msg}");
+        // Must tell the operator where the old binary is.
+        assert!(msg.contains("temps.bak"), "error message: {msg}");
+        // Must NOT claim the running binary was untouched.
+        assert!(!msg.contains("left untouched"), "error message: {msg}");
+        // Must tell the operator to run migrate themselves.
+        assert!(
+            msg.contains("temps migrate") || msg.contains("migrate"),
+            "error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_migrating_phase_blocks_a_concurrent_trigger() {
+        // `Migrating` must be active (i.e. block a second trigger) so two
+        // concurrent updates can't race the migrate step against the same schema.
+        let dir = temp_dir("migrating-blocks");
+        let u = updater(&dir, false, SupervisorKind::Systemd);
+        u.set_phase(SelfUpdatePhase::Migrating, None);
+        let err = u
+            .start(None, Some(1), &policy(true))
+            .expect_err("must refuse while migrating");
+        assert!(matches!(err, SelfUpdateError::AlreadyRunning { .. }));
+        let cap = u.capability(&policy(true));
+        assert_eq!(cap.phase, SelfUpdatePhase::Migrating);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_capability_reports_migration_progress_from_state() {
+        // While migrating, the live progress fields should be visible in the
+        // capability so the frontend can show "2 of 5 migrations applied".
+        let dir = temp_dir("migration-progress");
+        let u = updater(&dir, false, SupervisorKind::Systemd);
+        {
+            let mut state = u.state.write().expect("write lock");
+            state.phase = SelfUpdatePhase::Migrating;
+            state.migrations_applied = Some(2);
+            state.migrations_total = Some(5);
+            state.current_migration_name = Some("m20260811_add_column".to_string());
+        }
+        let cap = u.capability(&policy(true));
+        assert_eq!(cap.phase, SelfUpdatePhase::Migrating);
+        assert_eq!(cap.migrations_applied, Some(2));
+        assert_eq!(cap.migrations_total, Some(5));
+        assert_eq!(
+            cap.current_migration_name.as_deref(),
+            Some("m20260811_add_column")
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/temps-config/src/handler.rs
+++ b/crates/temps-config/src/handler.rs
@@ -935,6 +935,14 @@ pub struct UpdateCapabilityResponse {
     /// Most recent attempt, including one resolved during this boot — this is
     /// how the console reports the outcome of an update that restarted it.
     pub last_attempt: Option<temps_core::SelfUpdateAttempt>,
+    /// Number of migrations applied so far. `Some` while `phase` is `migrating`.
+    pub migrations_applied: Option<u32>,
+    /// Total migrations to be applied. `Some` once the migrate child has
+    /// reported its first `started` event.
+    pub migrations_total: Option<u32>,
+    /// Name of the migration currently running. `Some` while `phase` is
+    /// `migrating` and a migration step is in flight.
+    pub current_migration_name: Option<String>,
 }
 
 /// Optional pin for the version to install.
@@ -1008,6 +1016,9 @@ fn updater_unavailable_response(allowed: bool) -> UpdateCapabilityResponse {
         phase: temps_core::SelfUpdatePhase::Idle,
         phase_error: None,
         last_attempt: None,
+        migrations_applied: None,
+        migrations_total: None,
+        current_migration_name: None,
     }
 }
 
@@ -1109,6 +1120,9 @@ async fn get_update_capability(
         phase: capability.phase,
         phase_error: capability.phase_error,
         last_attempt: capability.last_attempt,
+        migrations_applied: capability.migrations_applied,
+        migrations_total: capability.migrations_total,
+        current_migration_name: capability.current_migration_name,
     }))
 }
 

--- a/crates/temps-core/src/self_update.rs
+++ b/crates/temps-core/src/self_update.rs
@@ -126,12 +126,20 @@ pub enum SelfUpdatePhase {
     Verifying,
     /// Swapping the binary on disk (previous one kept as a `.bak` sibling).
     Installing,
-    /// Binary swapped; the process is shutting down so the supervisor restarts it.
+    /// Binary swapped; the new binary is running database migrations before
+    /// temps restarts on it. Progress is available in `migrations_applied`,
+    /// `migrations_total`, and `current_migration_name` on the capability.
+    Migrating,
+    /// Migrations done; the process is shutting down so the supervisor restarts it.
     Restarting,
-    /// Binary swapped, but nothing will restart temps automatically — it is
-    /// still serving the old version until the operator restarts it.
+    /// Binary swapped and migrations applied, but nothing will restart temps
+    /// automatically — it is still serving the old version until the operator
+    /// restarts it.
     PendingRestart,
-    /// The attempt failed. The running binary was left untouched.
+    /// The attempt failed. `Failed` before the swap means the running binary was
+    /// left untouched. `Failed` after the swap (during migrations) means the new
+    /// binary is on disk but the schema may be partially migrated — see `error`
+    /// for recovery instructions including the `.bak` path.
     Failed,
 }
 
@@ -140,7 +148,11 @@ impl SelfUpdatePhase {
     pub fn is_active(self) -> bool {
         matches!(
             self,
-            Self::Resolving | Self::Downloading | Self::Verifying | Self::Installing
+            Self::Resolving
+                | Self::Downloading
+                | Self::Verifying
+                | Self::Installing
+                | Self::Migrating
         )
     }
 
@@ -151,6 +163,7 @@ impl SelfUpdatePhase {
             Self::Downloading => "downloading",
             Self::Verifying => "verifying",
             Self::Installing => "installing",
+            Self::Migrating => "migrating",
             Self::Restarting => "restarting",
             Self::PendingRestart => "pending_restart",
             Self::Failed => "failed",
@@ -197,6 +210,15 @@ pub struct SelfUpdateAttempt {
     /// Where the replaced binary was kept, so a bad release can be reverted by
     /// hand (`mv <path> <binary>`). Set once the swap completes.
     pub previous_binary_path: Option<String>,
+    /// Number of database migrations that were successfully applied during
+    /// this attempt. Set at completion (success or migration failure). `None`
+    /// if migrations were never reached (pre-swap failure).
+    #[serde(default)]
+    pub migrations_applied: Option<u32>,
+    /// Total number of database migrations that were planned. Set at the same
+    /// time as `migrations_applied`. `None` if migrations were never reached.
+    #[serde(default)]
+    pub migrations_total: Option<u32>,
 }
 
 /// Everything the console needs to render the update control honestly: whether
@@ -240,6 +262,14 @@ pub struct SelfUpdateCapability {
     pub phase_error: Option<String>,
     /// The most recent attempt, including one resolved on this boot.
     pub last_attempt: Option<SelfUpdateAttempt>,
+    /// Number of migrations applied so far. `Some` while `phase == migrating`.
+    pub migrations_applied: Option<u32>,
+    /// Total migrations to be applied. `Some` once the migrate child has
+    /// reported its first `started` event.
+    pub migrations_total: Option<u32>,
+    /// Name of the migration currently running. `Some` while `phase == migrating`
+    /// and a migration step is in flight.
+    pub current_migration_name: Option<String>,
 }
 
 /// Accepted-update receipt returned by `start`.
@@ -387,6 +417,9 @@ mod tests {
             SelfUpdatePhase::Downloading,
             SelfUpdatePhase::Verifying,
             SelfUpdatePhase::Installing,
+            // Migrating is active: a second trigger while migrations are running
+            // would race the same binary and may corrupt the schema.
+            SelfUpdatePhase::Migrating,
         ] {
             assert!(phase.is_active(), "{phase:?} should occupy the updater");
         }
@@ -431,9 +464,30 @@ mod tests {
             triggered_by_user_id: Some(7),
             error: None,
             previous_binary_path: Some("/usr/local/bin/temps.bak".to_string()),
+            migrations_applied: Some(3),
+            migrations_total: Some(5),
         };
         let json = serde_json::to_string(&attempt).expect("serialize");
         let parsed: SelfUpdateAttempt = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(parsed, attempt);
+    }
+
+    #[test]
+    fn test_attempt_with_no_migration_fields_roundtrips_through_json() {
+        // Existing journals on disk written before the migration fields were
+        // added must still deserialize correctly (missing fields → None).
+        let json = r#"{
+            "from_version": "v0.1.0",
+            "to_version": "v0.2.0",
+            "status": "succeeded",
+            "started_at": "2026-08-11T10:00:00Z",
+            "finished_at": "2026-08-11T10:01:00Z",
+            "triggered_by_user_id": null,
+            "error": null,
+            "previous_binary_path": null
+        }"#;
+        let parsed: SelfUpdateAttempt = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(parsed.migrations_applied, None);
+        assert_eq!(parsed.migrations_total, None);
     }
 }

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -14632,6 +14632,16 @@ export type SelfUpdateAttempt = {
      */
     from_version: string;
     /**
+     * Number of database migrations that were successfully applied during
+     * this attempt. `None` if migrations were never reached (pre-swap failure).
+     */
+    migrations_applied?: number | null;
+    /**
+     * Total number of database migrations that were planned. `None` if
+     * migrations were never reached (pre-swap failure).
+     */
+    migrations_total?: number | null;
+    /**
      * Where the replaced binary was kept, so a bad release can be reverted by
      * hand (`mv <path> <binary>`). Set once the swap completes.
      */
@@ -14659,7 +14669,7 @@ export type SelfUpdateBlocker = 'disabled_by_flag' | 'disabled_by_setting' | 'no
  * Where an in-flight update has got to. Polled by the console so a long
  * download shows progress instead of an indefinite spinner.
  */
-export type SelfUpdatePhase = 'idle' | 'resolving' | 'downloading' | 'verifying' | 'installing' | 'restarting' | 'pending_restart' | 'failed';
+export type SelfUpdatePhase = 'idle' | 'resolving' | 'downloading' | 'verifying' | 'installing' | 'migrating' | 'restarting' | 'pending_restart' | 'failed';
 
 /**
  * What happens to the running process once the new binary is in place.
@@ -17577,6 +17587,20 @@ export type UpdateCapabilityResponse = {
      * The equivalent command to run by hand. Always present.
      */
     manual_command: string;
+    /**
+     * Name of the migration currently running. Set while `phase` is `migrating`
+     * and a migration step is in flight.
+     */
+    current_migration_name?: string | null;
+    /**
+     * Number of migrations applied so far. Set while `phase` is `migrating`.
+     */
+    migrations_applied?: number | null;
+    /**
+     * Total migrations to be applied. Set once the migrate child has reported
+     * its first `started` event.
+     */
+    migrations_total?: number | null;
     /**
      * Phase of an in-flight attempt: `idle` when none is running.
      */

--- a/web/src/components/alerts/UpdateNowDialog.tsx
+++ b/web/src/components/alerts/UpdateNowDialog.tsx
@@ -42,6 +42,7 @@ const PHASE_LABEL: Record<SelfUpdatePhase, string> = {
   downloading: 'Downloading…',
   verifying: 'Verifying checksum…',
   installing: 'Installing…',
+  migrating: 'Applying database migrations…',
   restarting: 'Restarting the server…',
   pending_restart: 'Installed — waiting for you to restart temps',
   failed: 'Failed',
@@ -187,6 +188,9 @@ export function UpdateNowDialog({
                   phase={phase}
                   waitedTooLong={waitedTooLong}
                   expectRestart={capability?.restart_mode !== 'manual'}
+                  migrationsApplied={capability?.migrations_applied ?? null}
+                  migrationsTotal={capability?.migrations_total ?? null}
+                  currentMigrationName={capability?.current_migration_name ?? null}
                 />
               ) : (
                 <ConfirmBody
@@ -330,10 +334,16 @@ function WatchingBody({
   phase,
   waitedTooLong,
   expectRestart,
+  migrationsApplied,
+  migrationsTotal,
+  currentMigrationName,
 }: {
   phase: SelfUpdatePhase
   waitedTooLong: boolean
   expectRestart: boolean
+  migrationsApplied: number | null
+  migrationsTotal: number | null
+  currentMigrationName: string | null
 }) {
   return (
     <>
@@ -341,6 +351,15 @@ function WatchingBody({
         <Loader2 className="h-4 w-4 animate-spin" />
         {PHASE_LABEL[phase] ?? 'Working…'}
       </p>
+
+      {phase === 'migrating' && (
+        <MigrationProgress
+          applied={migrationsApplied}
+          total={migrationsTotal}
+          currentName={currentMigrationName}
+        />
+      )}
+
       <p className="text-muted-foreground">
         {expectRestart
           ? 'The console loses contact with the server while it restarts — that is expected. This dialog reports the result as soon as it is back.'
@@ -360,6 +379,44 @@ function WatchingBody({
         </p>
       )}
     </>
+  )
+}
+
+function MigrationProgress({
+  applied,
+  total,
+  currentName,
+}: {
+  applied: number | null
+  total: number | null
+  currentName: string | null
+}) {
+  const hasCounts = applied !== null && total !== null && total > 0
+
+  return (
+    <div className="space-y-1 rounded border bg-muted/40 p-2 text-xs text-muted-foreground">
+      {hasCounts ? (
+        <>
+          <p className="font-medium text-foreground">
+            {applied} of {total} migration{total !== 1 ? 's' : ''} applied
+          </p>
+          {/* Progress bar */}
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full rounded-full bg-primary transition-all duration-300"
+              style={{ width: `${Math.round((applied / total) * 100)}%` }}
+            />
+          </div>
+        </>
+      ) : (
+        <p>Checking for pending migrations…</p>
+      )}
+      {currentName && (
+        <p className="truncate font-mono" title={currentName}>
+          {currentName}
+        </p>
+      )}
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary

Extends the existing self-update flow (`GET`/`POST /settings/update`, `PlatformUpdate`-gated) with a new `Migrating` phase between binary swap and restart, so long-running schema migrations run against the **new** binary before the process restarts — instead of the old in-process migrator blocking boot, or being skipped entirely.

- After `replace_binary` swaps the on-disk binary, spawn `<new_binary> migrate --yes --progress-format=json` as a child process (this must be the new binary's own migrator — the old, still-running process was compiled without whatever migrations ship in the new version).
- Stream NDJSON progress from the child into the existing `SelfUpdateCapability`/journal, so the console shows live "N of M migrations applied" and it survives across navigation/reload exactly like the rest of the update flow already does (polls the same `GET /settings/update`).
- On success: unchanged existing behavior — exit(0) for supervised installs (systemd/launchd relaunch on the new binary, already migrated, fast boot) or `PendingRestart` for unsupervised/containerized installs.
- On migration failure: a new `ExecuteError::PostSwapMigration` path reports accurately that the binary *was* replaced and the schema may be partially migrated (never the existing "left untouched" wording, which would be false at that point), including the actual DB failure text and the `.bak` recovery path.
- `migrate.rs` gets an additive `--progress-format=json` flag (human-text output unchanged/default) so this NDJSON contract exists independently of this feature.

## Design note — this is the second version of this PR

The first attempt built a fully separate `migration_runs` table + new HTTP endpoints + a hand-rolled frontend hook, duplicating a self-update system that already existed on `main` (`GET`/`POST /settings/update`, `PlatformUpdate` permission, journal-based restart, systemd/launchd/container-aware). That was caught in review before merge and reverted; this PR instead extends the existing system in place — smaller diff, no new endpoints, no new DB table, reuses the existing generated-SDK-backed frontend hooks.

## Review

Two full review passes were run (`review-pr` + `security-auditor`) against this diff:
- Round 1 (on the now-reverted duplicate-system version) caught the architectural duplication above, plus a wrong permission gate, credential exposure via inherited child stderr, and a fragile duplicate-detection pattern — all resolved by reverting to extend the existing system instead.
- Round 2 (on this version) found two real issues, both fixed in the second commit:
  - Migration failures were reported as only `"migrate exited with code N"`, discarding the actual DB error the child already emits — now captured from the NDJSON `finished` event and surfaced.
  - Piping (vs. inheriting) the migrate child's stderr only relocates where a DB-password-bearing connection error could land (the parent's own structured logs), it doesn't prevent it — added a `redact_dsn()` pass (with tests) before logging any stderr line.
- Also fixed independently: a genuine stdout/stderr pipe-buffer deadlock risk (stderr piped but never drained) via a concurrent tokio drain task.

## Test plan

- [x] `cargo check --lib` clean on `temps-core`, `temps-cli`, `temps-config`
- [x] `cargo clippy --lib -- -D warnings` clean on the same (via resolved `cargo` path, not `rtk`)
- [x] `cargo test --lib -p temps-core -p temps-cli`: 517 passed, including new tests for the `Migrating` phase, the post-swap-failure journal shape, and `redact_dsn`
- [x] `bunx tsc --noEmit` clean on `web/`
- [x] End-to-end verified manually against two distinct binary builds (one without the test migration, one with a simulated ~20s slow migration) confirming: the old running binary correctly triggers the new binary's migrator, live progress is real (NDJSON-driven, not scraped), progress persists across full page navigation/reload, the restart is a genuine same-PID process replacement, and a subsequent boot on the already-migrated binary is fast with no re-run — this was validated against the mechanism (subprocess-spawns-new-binary-to-migrate) before it was rewired into the existing self-update system in this PR's final form; the wiring change itself is covered by the unit tests above.