### PR TITLE
fix(deployments): clean up leaked /tmp/temps-deployments dirs on download failure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1068,6 +1068,12 @@ All use `TEMPS_` prefix:
 | `TEMPS_DATA_DIR` | `~/.temps` | No |
 | `TEMPS_LOG_LEVEL` | -- | No |
 
+Process-wide ops/debug toggles (not bootstrap config, not per-tenant -- see the admin-tuning-knob exception to the "no env vars" rule above):
+
+| Variable | Default | Required |
+|---|---|---|
+| `TEMPS_DEPLOYMENT_KEEP_TEMP_FILES` | unset (clean up) | No -- set to any value to keep `/tmp/temps-deployments/deployment-*` directories after a deployment finishes or fails, for inspecting a build/download issue. Restart the server to change. |
+
 ---
 
 ## Quick Reference Checklists

--- a/crates/temps-deployments/src/jobs/download_repo.rs
+++ b/crates/temps-deployments/src/jobs/download_repo.rs
@@ -16,8 +16,25 @@ use temps_logs::{LogLevel, LogService};
 /// operational debug knob (restart-to-change, not per-tenant config), not
 /// business configuration -- see `TEMPS_DEPLOYMENT_KEEP_TEMP_FILES` in the
 /// environment variable reference.
+///
+/// It disables cleanup on every path, including successful deployments, so
+/// leaving it set reintroduces the disk-space leak this file exists to fix.
+/// The first check emits a one-time warning so an operator who set it for a
+/// debug session and forgot to unset it sees it in the server logs, not only
+/// in a single deployment's log.
 fn keep_deployment_temp_files() -> bool {
-    std::env::var("TEMPS_DEPLOYMENT_KEEP_TEMP_FILES").is_ok()
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    let keep = std::env::var("TEMPS_DEPLOYMENT_KEEP_TEMP_FILES").is_ok();
+    if keep {
+        WARNED.call_once(|| {
+            tracing::warn!(
+                "TEMPS_DEPLOYMENT_KEEP_TEMP_FILES is set -- deployment temp directories under \
+                 /tmp/temps-deployments will NOT be cleaned up, including for successful \
+                 deployments. This must not remain set in production."
+            );
+        });
+    }
+    keep
 }
 
 /// Removes a deployment's temp directory on drop unless `disarm()` was
@@ -52,20 +69,24 @@ impl TempDirGuard {
 
 impl Drop for TempDirGuard {
     fn drop(&mut self) {
-        if !self.armed || self.keep || !self.path.exists() {
+        if !self.armed || self.keep {
             return;
         }
-        if let Err(e) = std::fs::remove_dir_all(&self.path) {
-            tracing::error!(
-                path = %self.path.display(),
-                error = %e,
-                "Failed to clean up deployment temp directory after download error"
-            );
-        } else {
-            tracing::warn!(
-                path = %self.path.display(),
-                "🧹 Cleaned up deployment temp directory after download error"
-            );
+        match std::fs::remove_dir_all(&self.path) {
+            Ok(()) => {
+                tracing::warn!(
+                    path = %self.path.display(),
+                    "🧹 Cleaned up deployment temp directory after download error"
+                );
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                tracing::error!(
+                    path = %self.path.display(),
+                    error = %e,
+                    "Failed to clean up deployment temp directory after download error"
+                );
+            }
         }
     }
 }

--- a/crates/temps-deployments/src/jobs/download_repo.rs
+++ b/crates/temps-deployments/src/jobs/download_repo.rs
@@ -10,6 +10,66 @@ use temps_core::{JobResult, WorkflowContext, WorkflowError, WorkflowTask};
 use temps_git::GitProviderManagerTrait;
 use temps_logs::{LogLevel, LogService};
 
+/// Process-wide debug toggle: when set, deployment temp directories under
+/// `/tmp/temps-deployments` are left on disk instead of being removed, so an
+/// operator can inspect a failed or successful download. This is an
+/// operational debug knob (restart-to-change, not per-tenant config), not
+/// business configuration -- see `TEMPS_DEPLOYMENT_KEEP_TEMP_FILES` in the
+/// environment variable reference.
+fn keep_deployment_temp_files() -> bool {
+    std::env::var("TEMPS_DEPLOYMENT_KEEP_TEMP_FILES").is_ok()
+}
+
+/// Removes a deployment's temp directory on drop unless `disarm()` was
+/// called first. Guarantees the directory created in `create_temp_dir()` is
+/// cleaned up on every error path inside `download_repository()` -- without
+/// this, a failure between directory creation and the final `Ok(repo_dir)`
+/// (network error, invalid archive, git clone failure, etc.) leaked the
+/// directory forever, since `context.work_dir` -- the only thing the
+/// existing `cleanup()` trait method looks at -- is never set until the job
+/// fully succeeds.
+struct TempDirGuard {
+    path: PathBuf,
+    keep: bool,
+    armed: bool,
+}
+
+impl TempDirGuard {
+    fn new(path: PathBuf, keep: bool) -> Self {
+        Self {
+            path,
+            keep,
+            armed: true,
+        }
+    }
+
+    /// Call on the success path: the directory is still needed by later
+    /// deployment jobs (build/deploy), so it must not be removed here.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        if !self.armed || self.keep || !self.path.exists() {
+            return;
+        }
+        if let Err(e) = std::fs::remove_dir_all(&self.path) {
+            tracing::error!(
+                path = %self.path.display(),
+                error = %e,
+                "Failed to clean up deployment temp directory after download error"
+            );
+        } else {
+            tracing::warn!(
+                path = %self.path.display(),
+                "🧹 Cleaned up deployment temp directory after download error"
+            );
+        }
+    }
+}
+
 /// Job for downloading repository source code
 pub struct DownloadRepoJob {
     job_id: String,
@@ -334,6 +394,18 @@ impl DownloadRepoJob {
 
         // Create temp directory
         let temp_dir = self.create_temp_dir(context)?;
+        let keep_temp_files = keep_deployment_temp_files();
+        let mut temp_dir_guard = TempDirGuard::new(temp_dir.clone(), keep_temp_files);
+        if keep_temp_files {
+            self.log(
+                context,
+                format!(
+                    "🐛 TEMPS_DEPLOYMENT_KEEP_TEMP_FILES is set — {} will not be cleaned up",
+                    temp_dir.display()
+                ),
+            )
+            .await?;
+        }
         let repo_dir = temp_dir.join("repository");
         std::fs::create_dir_all(&repo_dir).map_err(WorkflowError::IoError)?;
 
@@ -361,6 +433,7 @@ impl DownloadRepoJob {
                 }
                 self.clone_public_repository(context, git_url, &repo_dir)
                     .await?;
+                temp_dir_guard.disarm();
                 return Ok(repo_dir);
             } else {
                 return Err(WorkflowError::JobExecutionFailed(
@@ -522,6 +595,7 @@ impl DownloadRepoJob {
         self.log(context, "Repository validation passed".to_string())
             .await?;
 
+        temp_dir_guard.disarm();
         Ok(repo_dir)
     }
 }
@@ -620,6 +694,9 @@ impl WorkflowTask for DownloadRepoJob {
     }
 
     async fn cleanup(&self, context: &WorkflowContext) -> Result<(), WorkflowError> {
+        if keep_deployment_temp_files() {
+            return Ok(());
+        }
         // Clean up temporary directory if it exists
         if let Some(ref work_dir) = context.work_dir {
             if work_dir.exists() {
@@ -1042,5 +1119,163 @@ mod tests {
         // Cleanup
         let _ = std::fs::remove_dir_all(&dir_a);
         let _ = std::fs::remove_dir_all(&dir_b);
+    }
+
+    #[test]
+    fn test_temp_dir_guard_removes_directory_on_drop_by_default() {
+        let dir = std::env::temp_dir().join("temps-guard-test-drop");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        {
+            let _guard = TempDirGuard::new(dir.clone(), false);
+            // Guard stays armed and keep=false: dropping without calling
+            // `disarm()` must remove the directory, exactly what should
+            // happen when download_repository() bails out via `?` partway
+            // through.
+        }
+
+        assert!(
+            !dir.exists(),
+            "TempDirGuard must remove the directory on drop when not disarmed"
+        );
+    }
+
+    #[test]
+    fn test_temp_dir_guard_disarm_keeps_directory() {
+        let dir = std::env::temp_dir().join("temps-guard-test-disarm");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        {
+            let mut guard = TempDirGuard::new(dir.clone(), false);
+            guard.disarm();
+        }
+
+        assert!(
+            dir.exists(),
+            "A disarmed guard must not remove the directory"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_temp_dir_guard_keep_true_preserves_directory_even_on_error() {
+        let dir = std::env::temp_dir().join("temps-guard-test-keep");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        {
+            let _guard = TempDirGuard::new(dir.clone(), true);
+            // keep=true simulates TEMPS_DEPLOYMENT_KEEP_TEMP_FILES: even an
+            // armed guard on an error path must leave the directory in place.
+        }
+
+        assert!(
+            dir.exists(),
+            "keep=true must preserve the directory even without disarm()"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Regression test for the disk-space leak: a deployment temp directory
+    /// created before an error occurs during download (here, an SSRF/scheme
+    /// validation failure on the git URL) must not survive the failed job.
+    /// Before the `TempDirGuard`, `context.work_dir` was only ever set on
+    /// the success path, so `cleanup()`/`cleanup_terminal_resources` had
+    /// nothing to remove and `/tmp/temps-deployments/deployment-*` leaked
+    /// forever on every failed download.
+    #[tokio::test]
+    async fn test_download_repository_cleans_up_temp_dir_on_early_failure() {
+        let git_manager: Arc<dyn GitProviderManagerTrait> = Arc::new(MockGitProviderManager);
+
+        // A distinctive deployment ID keeps this test's glob isolated from
+        // any other directories that might exist under /tmp/temps-deployments.
+        let deployment_id = 918_273_645;
+        let job = DownloadRepoJob::new_public(
+            "test".to_string(),
+            "owner".to_string(),
+            "repo".to_string(),
+            // http (not https) fails validate_git_url before any temp files
+            // are written into the repo dir, isolating the guard's behavior.
+            "http://example.com/owner/repo.git".to_string(),
+            git_manager,
+        );
+
+        let context =
+            crate::test_utils::create_test_context("wf-leak-test".to_string(), deployment_id, 1, 1);
+
+        let result = job.download_repository(&context).await;
+        assert!(result.is_err(), "invalid scheme must fail validation");
+
+        let leaked: Vec<_> = std::fs::read_dir("/tmp/temps-deployments")
+            .into_iter()
+            .flatten()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(&format!("deployment-{}-", deployment_id))
+            })
+            .collect();
+
+        assert!(
+            leaked.is_empty(),
+            "temp dir for deployment {} must be cleaned up after a download failure, found: {:?}",
+            deployment_id,
+            leaked
+        );
+    }
+
+    #[tokio::test]
+    async fn test_download_repository_keeps_temp_dir_on_early_failure_when_debug_flag_set() {
+        let git_manager: Arc<dyn GitProviderManagerTrait> = Arc::new(MockGitProviderManager);
+
+        let deployment_id = 918_273_646;
+        let job = DownloadRepoJob::new_public(
+            "test".to_string(),
+            "owner".to_string(),
+            "repo".to_string(),
+            "http://example.com/owner/repo.git".to_string(),
+            git_manager,
+        );
+
+        let context = crate::test_utils::create_test_context(
+            "wf-leak-test-2".to_string(),
+            deployment_id,
+            1,
+            1,
+        );
+
+        // SAFETY: test-only; no other test in this process reads or asserts
+        // on the absence of this var, and it is always set to the same value.
+        unsafe {
+            std::env::set_var("TEMPS_DEPLOYMENT_KEEP_TEMP_FILES", "1");
+        }
+        let result = job.download_repository(&context).await;
+        // SAFETY: see above.
+        unsafe {
+            std::env::remove_var("TEMPS_DEPLOYMENT_KEEP_TEMP_FILES");
+        }
+        assert!(result.is_err(), "invalid scheme must fail validation");
+
+        let kept: Vec<_> = std::fs::read_dir("/tmp/temps-deployments")
+            .into_iter()
+            .flatten()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(&format!("deployment-{}-", deployment_id))
+            })
+            .collect();
+
+        assert!(
+            !kept.is_empty(),
+            "temp dir for deployment {} must be preserved when TEMPS_DEPLOYMENT_KEEP_TEMP_FILES is set",
+            deployment_id
+        );
+        for entry in kept {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
     }
 }


### PR DESCRIPTION
## Summary

Reported: on OVH VPS deployments, `/tmp` (a 3.8G tmpfs) fills up roughly every two weeks with directories under `/tmp/temps-deployments/*`, requiring manual `rm -rf`.

**Root cause**: `DownloadRepoJob::download_repository()` creates a temp dir (`create_temp_dir()`), but only records it into `context.work_dir` at the very end of `execute()`, right before returning success. Any error partway through download — network failure, SSRF/scheme validation rejection, git clone failure, archive extraction failure, etc. — propagates via `?` before `work_dir` is ever set. Since the existing cleanup mechanisms (`DownloadRepoJob::cleanup()` and the workflow-level `cleanup_terminal_resources` pass, both already correctly wired for the *successful*-download case since #549/`b4ce393b`) only ever look at `context.work_dir`, a failed download leaks its temp directory forever with nothing to clean it up.

**Fix**:
- `download_repository()` now wraps the temp dir in a `TempDirGuard` that removes it on drop unless explicitly disarmed. It's disarmed only on the two success paths (public-repo clone success, private-repo download/clone + validation success) — any early return via `?` lets the guard's `Drop` remove the directory.
- Added `TEMPS_DEPLOYMENT_KEEP_TEMP_FILES` — an opt-in, process-wide debug toggle so an operator debugging a deploy issue can keep a deployment's temp directory (success or failure) instead of having it cleaned up. Modeled as an env var rather than a DB column since it's a process-wide ops/debug switch (restart to change), not per-tenant configuration.
- `DownloadRepoJob::cleanup()` also respects the flag, so it's consistent whether the directory is removed early (guard, on download error) or late (end-of-workflow cleanup, on success).

## Test plan

- [x] `cargo test --lib -p temps-deployments download_repo` — all 10 tests pass, including two new regression tests added for this fix:
  - `test_download_repository_cleans_up_temp_dir_on_early_failure` — drives `download_repository()` with an invalid (non-https) git URL so it fails validation after the temp dir is created, and asserts the `/tmp/temps-deployments/deployment-<id>-*` directory does **not** survive.
  - `test_download_repository_keeps_temp_dir_on_early_failure_when_debug_flag_set` — same failure, but with `TEMPS_DEPLOYMENT_KEEP_TEMP_FILES` set, and asserts the directory **does** survive.
  - Plus three unit tests directly on `TempDirGuard` (default cleanup, disarm, keep=true).
- [x] `cargo check --lib -p temps-deployments`
- [x] `cargo clippy -p temps-deployments --lib -- -D warnings` (via the resolved `cargo` binary, not through rtk)