### PR TITLE
fix(deployments): guard TempDirGuard against removing paths outside safe temp roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6593,7 +6593,7 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
 dependencies = [
- "base64 0.23.0",
+ "base64 0.23.1",
  "serde_core",
 ]
 

--- a/crates/temps-deployments/src/jobs/download_repo.rs
+++ b/crates/temps-deployments/src/jobs/download_repo.rs
@@ -49,10 +49,22 @@ const DEPLOYMENT_TEMP_ROOT: &str = "/tmp/temps-deployments";
 /// builds a `TempDirGuard` around the wrong path (a bad join, a variable
 /// mix-up, a copy-pasted call elsewhere in the codebase) can't turn into a
 /// silent `rm -rf` of something that isn't a scratch temp directory.
-/// `std::env::temp_dir()` is included alongside the hardcoded production
-/// root because tests intentionally create guards under the OS temp dir
-/// (which is `/tmp` on Linux CI but `$TMPDIR`, e.g. `/var/folders/...`, on
-/// macOS) rather than writing into the real `/tmp/temps-deployments`.
+///
+/// Production only allows `DEPLOYMENT_TEMP_ROOT` itself -- `std::env::temp_dir()`
+/// (`/tmp` on Linux) is NOT included there, since `/tmp/temps-deployments` is
+/// already a subdirectory of it: adding it would make the check accept any
+/// path under `/tmp`, silently defeating the whole point of scoping removal
+/// to the deployments tree. The broader OS-temp-dir root is added only under
+/// `#[cfg(test)]`, because tests intentionally build guards under
+/// `std::env::temp_dir()` (which is `/tmp` on Linux CI but `$TMPDIR`, e.g.
+/// `/var/folders/...`, on macOS) rather than writing into the real
+/// `/tmp/temps-deployments`.
+#[cfg(not(test))]
+fn safe_temp_roots() -> Vec<PathBuf> {
+    vec![PathBuf::from(DEPLOYMENT_TEMP_ROOT)]
+}
+
+#[cfg(test)]
 fn safe_temp_roots() -> Vec<PathBuf> {
     vec![PathBuf::from(DEPLOYMENT_TEMP_ROOT), std::env::temp_dir()]
 }
@@ -760,10 +772,21 @@ impl WorkflowTask for DownloadRepoJob {
         if keep_deployment_temp_files() {
             return Ok(());
         }
-        // Clean up temporary directory if it exists
+        // Clean up temporary directory if it exists. Same safety check as
+        // `TempDirGuard::drop()`: `work_dir` is only ever set to a path this
+        // job created under `DEPLOYMENT_TEMP_ROOT`, but this stays defensive
+        // rather than trusting that invariant holds forever.
         if let Some(ref work_dir) = context.work_dir {
             if work_dir.exists() {
-                std::fs::remove_dir_all(work_dir).map_err(WorkflowError::IoError)?;
+                if is_within_safe_temp_root(work_dir) {
+                    std::fs::remove_dir_all(work_dir).map_err(WorkflowError::IoError)?;
+                } else {
+                    tracing::error!(
+                        path = %work_dir.display(),
+                        "Refusing to clean up deployment work dir: path is outside the \
+                         expected temp roots."
+                    );
+                }
             }
         }
         Ok(())

--- a/crates/temps-deployments/src/jobs/download_repo.rs
+++ b/crates/temps-deployments/src/jobs/download_repo.rs
@@ -37,6 +37,39 @@ fn keep_deployment_temp_files() -> bool {
     keep
 }
 
+/// The only directory tree `create_temp_dir()` ever hands to a
+/// `TempDirGuard`. Kept as a named constant so the guard's own safety check
+/// (below) and the path construction can't silently drift apart.
+const DEPLOYMENT_TEMP_ROOT: &str = "/tmp/temps-deployments";
+
+/// Returns the directory roots a `TempDirGuard` is allowed to
+/// `remove_dir_all()`. Anything outside these is refused, regardless of how
+/// the guard was constructed -- this is deliberately checked in `Drop`
+/// itself rather than trusted at each call site, so a future caller that
+/// builds a `TempDirGuard` around the wrong path (a bad join, a variable
+/// mix-up, a copy-pasted call elsewhere in the codebase) can't turn into a
+/// silent `rm -rf` of something that isn't a scratch temp directory.
+/// `std::env::temp_dir()` is included alongside the hardcoded production
+/// root because tests intentionally create guards under the OS temp dir
+/// (which is `/tmp` on Linux CI but `$TMPDIR`, e.g. `/var/folders/...`, on
+/// macOS) rather than writing into the real `/tmp/temps-deployments`.
+fn safe_temp_roots() -> Vec<PathBuf> {
+    vec![PathBuf::from(DEPLOYMENT_TEMP_ROOT), std::env::temp_dir()]
+}
+
+/// True if `path` resolves inside one of `safe_temp_roots()`. Canonicalizes
+/// both sides when possible so a symlinked tmp dir (e.g. macOS's
+/// `/tmp` -> `/private/tmp`) doesn't produce a false negative; falls back to
+/// a plain prefix comparison if canonicalization fails (path already
+/// removed, or a root that doesn't exist on this platform).
+fn is_within_safe_temp_root(path: &std::path::Path) -> bool {
+    let candidate = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    safe_temp_roots().iter().any(|root| {
+        let root = root.canonicalize().unwrap_or_else(|_| root.clone());
+        candidate.starts_with(&root)
+    })
+}
+
 /// Removes a deployment's temp directory on drop unless `disarm()` was
 /// called first. Guarantees the directory created in `create_temp_dir()` is
 /// cleaned up on every error path inside `download_repository()` -- without
@@ -70,6 +103,15 @@ impl TempDirGuard {
 impl Drop for TempDirGuard {
     fn drop(&mut self) {
         if !self.armed || self.keep {
+            return;
+        }
+        if !is_within_safe_temp_root(&self.path) {
+            tracing::error!(
+                path = %self.path.display(),
+                "Refusing to remove deployment temp directory: path is outside the \
+                 expected temp roots. This should never happen -- treat it as a bug in \
+                 whatever constructed this TempDirGuard, not as a directory to delete."
+            );
             return;
         }
         match std::fs::remove_dir_all(&self.path) {
@@ -287,7 +329,7 @@ impl DownloadRepoJob {
             .map_err(|e| WorkflowError::Other(format!("Failed to get unix timestamp: {}", e)))?
             .as_secs();
 
-        let temp_dir = std::path::PathBuf::from("/tmp/temps-deployments").join(format!(
+        let temp_dir = std::path::PathBuf::from(DEPLOYMENT_TEMP_ROOT).join(format!(
             "deployment-{}-{}",
             context.deployment_id, unix_epoch
         ));
@@ -1159,6 +1201,28 @@ mod tests {
             !dir.exists(),
             "TempDirGuard must remove the directory on drop when not disarmed"
         );
+    }
+
+    #[test]
+    fn test_temp_dir_guard_refuses_to_remove_path_outside_safe_temp_roots() {
+        // A directory that is neither under `/tmp/temps-deployments` nor
+        // under `std::env::temp_dir()` -- e.g. a call site that built the
+        // guard around the wrong path. This must never be deleted, no
+        // matter how the guard was constructed.
+        let dir = std::env::current_dir()
+            .unwrap()
+            .join("temps-guard-unsafe-test-dir");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        {
+            let _guard = TempDirGuard::new(dir.clone(), false);
+        }
+
+        assert!(
+            dir.exists(),
+            "TempDirGuard must refuse to remove a directory outside the safe temp roots"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #630. `TempDirGuard::drop()` trusted whatever `PathBuf` it was constructed with and called `remove_dir_all()` on it unconditionally. Today that path always comes from `create_temp_dir()` (`/tmp/temps-deployments/deployment-<id>-<epoch>`), so there's no live bug — but nothing enforced that invariant *at the point of deletion*. A future caller that builds a guard around the wrong path (a bad `.join()`, a variable mix-up, a copy-pasted call elsewhere in the codebase) would silently `rm -rf` whatever that path pointed to.

**Fix**: added `is_within_safe_temp_root()`, checked inside `TempDirGuard::drop()` itself (not at today's call site) so it protects every current *and future* caller, not just `download_repository()`. It refuses removal unless the path resolves under `/tmp/temps-deployments`. On refusal it logs an error and leaves the directory in place rather than panicking.

Also extracted the previously-duplicated `"/tmp/temps-deployments"` literal into a `DEPLOYMENT_TEMP_ROOT` constant shared by `create_temp_dir()` and the safety check, so the two can't drift apart. `DownloadRepoJob::cleanup()`'s own `remove_dir_all(work_dir)` now goes through the same check, so both removal paths in this file are consistently guarded.

**Fixed during review**: the first version of this PR also accepted `std::env::temp_dir()` as a safe root unconditionally, to accommodate unit tests that build guards under the OS temp dir. Since `/tmp/temps-deployments` is a subdirectory of `/tmp`, that made the check accept *any* path under `/tmp` on Linux production — silently defeating the scoping this PR exists to add. The OS-temp-dir root is now gated behind `#[cfg(test)]`; production only ever accepts `DEPLOYMENT_TEMP_ROOT`.

## Test plan

- [x] New regression test: `test_temp_dir_guard_refuses_to_remove_path_outside_safe_temp_roots` — constructs a guard around a directory outside both safe roots and asserts it survives drop.
- [x] `cargo test --lib -p temps-deployments download_repo` — 11/11 pass (10 existing + 1 new). Output: `cargo test: 11 passed, 566 filtered out (1 suite, 0.01s)`.
- [x] `cargo clippy -p temps-deployments --lib -- -D warnings` (via the resolved `cargo` binary, not through rtk) — clean, both before and after the `#[cfg(test)]` fix.
- [x] CI green (see checks).