### PR TITLE
fix(web): match new-project repo picker to compact project-settings design

### DIFF
--- a/web/src/components/project/GitImportClone.tsx
+++ b/web/src/components/project/GitImportClone.tsx
@@ -884,7 +884,15 @@ export function GitImportClone({
                   showSelection={false}
                   itemsPerPage={15}
                   showHeader={true}
-                  compactMode={false}
+                  compactMode
+                  providerType={(() => {
+                    const selectedConn = connections?.connections?.find(
+                      (c) => c.id.toString() === selectedConnection
+                    )
+                    return selectedConn
+                      ? providerTypeForConnectionId(selectedConn.provider_id)
+                      : undefined
+                  })()}
                 />
               )}
             </CardContent>


### PR DESCRIPTION
## Summary
- The "connect repository" flow inside project settings (`GitSettings.tsx` → `RepositorySelector`) already renders repos with the compact card design (`RepositoryAvatar`, inline private/public + language, preset logos via `RepositoryPresetLogos`).
- The new-project wizard's repo browser (`GitImportClone.tsx`) hardcoded `compactMode={false}` on the same `RepositoryList` component, so it kept the older, taller rich-card layout — the two entry points for picking a GitHub repo looked inconsistent even though they share one component.
- Flips `GitImportClone.tsx` to `compactMode` and threads the selected connection's provider type through (same pattern `GitSettings.tsx` already uses), so provider-specific icons render correctly there too.

## Test plan
- [x] `bun x tsc --noEmit` passes in `web/`
- [x] pre-commit hooks (conventional commit, trailing whitespace, typos) pass
- [ ] Manually verify in browser: open the new-project wizard's "browse repositories" view and confirm it now matches the compact list style used in a project's git settings "connect repository" page