### PR TITLE
fix(skills): ignore blocking special files

### DIFF
--- a/skills/temps/scripts/detect_project_capabilities.py
+++ b/skills/temps/scripts/detect_project_capabilities.py
@@ -135,7 +135,14 @@ def candidate_files(root: Path):
 
 
 def read_candidate(path: Path) -> str | None:
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    # Opening a FIFO read-only blocks until a writer connects. Open candidates
+    # non-blocking first, then use fstat on the descriptor as the authoritative
+    # file-type check before reading any bytes.
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
     try:
         descriptor = os.open(path, flags)
     except OSError:

--- a/skills/temps/scripts/test_detect_project_capabilities.py
+++ b/skills/temps/scripts/test_detect_project_capabilities.py
@@ -3,9 +3,12 @@
 
 from __future__ import annotations
 
+import os
 import tempfile
+import threading
 import unittest
 from pathlib import Path
+from typing import Any, cast
 
 from detect_project_capabilities import detect
 
@@ -90,6 +93,28 @@ class CapabilityDetectorTests(unittest.TestCase):
             result = detect(root)
 
             self.assertEqual(result["capabilities"]["error_tracking"]["status"], "missing")
+
+    @unittest.skipUnless(hasattr(os, "mkfifo"), "FIFO files are not supported")
+    def test_named_pipe_is_ignored_without_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            os.mkfifo(root / "package.json")
+            outcome: dict[str, object] = {}
+
+            def run_detection() -> None:
+                outcome["result"] = detect(root)
+
+            detector = threading.Thread(target=run_detection, daemon=True)
+            detector.start()
+            detector.join(timeout=1)
+
+            self.assertFalse(detector.is_alive(), "capability detection blocked on a FIFO")
+            result = cast(dict[str, Any], outcome["result"])
+            self.assertIsInstance(result, dict)
+            self.assertEqual(
+                result["capabilities"]["error_tracking"]["status"],
+                "missing",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- prevent the Temps capability detector from blocking on eligible FIFO/special files
- open candidates non-blocking, then reject non-regular descriptors before reading
- add a bounded full-detector FIFO regression test

## Root cause

`read_candidate()` opened a path with blocking `O_RDONLY` before `fstat()` checked whether it was a regular file. A FIFO named `package.json` or with an eligible source suffix therefore waited indefinitely for a writer.

## Evidence

```bash
python3 -m unittest discover -s skills/temps/scripts -p 'test_*.py' -v
```

```text
test_named_pipe_is_ignored_without_blocking ... ok
...
Ran 13 tests in 0.012s
OK
```

```bash
python3 skills/temps/scripts/validate_skill.py
python3 /Users/davidviejo/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/temps
git diff --check origin/main...HEAD
```

```text
Temps skill validation passed (75 command groups).
Skill is valid!
# git diff --check exited 0
```

## Security

Independent security re-review of the exact fix: **PASS**. `O_NONBLOCK` makes the FIFO open return immediately, descriptor-backed `fstat()` rejects it before reading, and descriptor cleanup remains correct. No remaining high or medium findings.
