### PR TITLE
fix(proxy): keep RouteTableListener alive in split-mode proxy

### DIFF
--- a/crates/temps-cli/src/commands/proxy.rs
+++ b/crates/temps-cli/src/commands/proxy.rs
@@ -423,8 +423,16 @@ impl ProxyCommand {
         }
 
         // Start route table listener
+        // Keep `listener` itself alive on the stack — only pass a clone into
+        // start_listening(). RouteTableListener's Drop aborts its background
+        // recv task, so consuming the only Arc reference here would abort the
+        // task the instant this block_on call returns: the "Started listening"
+        // log would fire, but the loop would never actually process a single
+        // NOTIFY. Mirrors the pattern already used for `project_listener` below
+        // and for `route_table_listener` in `serve/mod.rs`.
         info!("Starting route table listener...");
-        rt.block_on(async { listener.start_listening().await })?;
+        let listener_clone = listener.clone();
+        rt.block_on(async move { listener_clone.start_listening().await })?;
 
         // Start project change listener
         // Keep the listener alive on the stack so its Drop doesn't abort the background task


### PR DESCRIPTION
## Summary
- In the standalone `temps proxy` command (ADR-017 split topology), the only `Arc<RouteTableListener>` reference was moved directly into `start_listening()` and never retained anywhere else.
- `RouteTableListener` implements `Drop` to `abort()` its background NOTIFY-recv task, so that `Arc` dropped to zero references the instant `start_listening()` returned — aborting the recv task before it ever processed a single notification on the `route_table_changes` channel. The "Started listening..." log line still fired, since that happens before the abort, which made the listener look healthy while being silently dead.
- This broke live propagation, in split mode, for every route change that only travels over `route_table_changes`: environment domains, custom routes, project custom domains, environment backend URLs, and the `preview_domain` setting. Deploys were unaffected because they propagate over the sibling `project_route_change` channel via `ProjectChangeListener`, which this same file already keeps alive correctly via a retained local variable (with a comment flagging the exact hazard a few lines below the bug).
- Fix: clone the `Arc` before calling `start_listening()`, keeping the original alive on the stack for the process's lifetime — the same pattern already used for `project_listener` in this file and for `route_table_listener` in `serve/mod.rs`.

## Test plan
- [x] `cargo check --lib -p temps-cli` passes clean (0 errors)
- [x] Reproduced pre-fix in a live split-mode instance (`temps proxy` + `temps serve --role=console`): created a custom domain via the console API, confirmed the proxy's route table never reloaded and `RouteTableListener` never logged receiving a single notification, even after 10+ minutes and multiple domain creations
- [x] Rebuilt with the fix and reran the same reproduction: `RouteTableListener` now logs `Received route table change notification` and completes a reload (`RouteTableUpdated` job) within ~150ms of the domain being created