### PR TITLE
fix(deployments): reclaim Docker build cache and old deployment images

### DIFF
--- a/crates/temps-cli/src/commands/agent.rs
+++ b/crates/temps-cli/src/commands/agent.rs
@@ -108,6 +108,22 @@ impl AgentCommand {
 
             tracing::info!("Starting temps agent (node_id={})...", config.node_id);
 
+            // Nightly Docker image + build-cache prune. Worker nodes build
+            // and pull images locally but never run the console's plugin
+            // system (where `DockerCleanupService` normally lives), so
+            // without this they accumulate build cache/images forever.
+            // See `DockerOnlyCleanupScheduler` for why this is split out
+            // from the console's DB-backed cleanup service.
+            tokio::spawn({
+                let cleanup_scheduler =
+                    temps_deployments::services::DockerOnlyCleanupScheduler::new(Arc::new(
+                        temps_deployments::services::DefaultDockerClient,
+                    ));
+                async move {
+                    cleanup_scheduler.start_cleanup_scheduler().await;
+                }
+            });
+
             // Internal-zone route store (Option 1 sync). Hydrated from
             // disk so the agent serves correctly across restarts even
             // when the CP is briefly unreachable. The sync client below

--- a/crates/temps-deployments/src/services/docker_cleanup_service.rs
+++ b/crates/temps-deployments/src/services/docker_cleanup_service.rs
@@ -92,6 +92,14 @@ impl DockerClient for DefaultDockerClient {
         filters.insert("until".to_string(), vec![duration]);
 
         let options = PruneBuildOptionsBuilder::default()
+            // Without `all`, the Build/prune API only removes cache marked
+            // "dangling" (not shared by any remaining build lineage) --
+            // the same distinction as `docker image prune` vs `-a`. Most
+            // build cache (e.g. per-build COPY/RUN layers with unique
+            // content) is never dangling, so leaving this unset meant the
+            // nightly cleanup reclaimed almost none of it regardless of
+            // the `until` age filter, letting the cache grow unbounded.
+            .all(true)
             .filters(&filters)
             .build();
 

--- a/crates/temps-deployments/src/services/docker_cleanup_service.rs
+++ b/crates/temps-deployments/src/services/docker_cleanup_service.rs
@@ -306,6 +306,11 @@ pub struct DockerCleanupService {
     /// removal, even if it falls outside `keep_recent_deployment_images`
     /// (default: 7)
     max_deployment_image_age_days: i64,
+    /// Maximum number of stale deployment images to remove in a single
+    /// nightly run (default: 500). Bounds memory and Docker API calls on
+    /// installs with very large deployment histories; any remainder is
+    /// picked up on the following night's run.
+    max_deployment_images_per_run: u64,
 }
 
 impl DockerCleanupService {
@@ -325,6 +330,7 @@ impl DockerCleanupService {
             max_asset_cache_age_days: 7,
             keep_recent_deployment_images: 5,
             max_deployment_image_age_days: 7,
+            max_deployment_images_per_run: 500,
         }
     }
 
@@ -355,6 +361,11 @@ impl DockerCleanupService {
 
     pub fn with_max_deployment_image_age_days(mut self, days: i64) -> Self {
         self.max_deployment_image_age_days = days;
+        self
+    }
+
+    pub fn with_max_deployment_images_per_run(mut self, count: u64) -> Self {
+        self.max_deployment_images_per_run = count;
         self
     }
 
@@ -433,11 +444,14 @@ impl DockerCleanupService {
     /// Keeps, per project+environment: the environment's currently-live
     /// deployment, the `keep_recent_deployment_images` most recent
     /// deployments, and anything younger than
-    /// `max_deployment_image_age_days`. Everything else is removed.
-    /// Removal is best-effort and never forced (see `DockerClient::
-    /// remove_image`), so Docker itself refuses if a container still
-    /// references the image — the safety net against this query being
-    /// wrong.
+    /// `max_deployment_image_age_days`. Everything else is removed, oldest
+    /// first, capped at `max_deployment_images_per_run` per call so a very
+    /// large deployment history can't load an unbounded result set or
+    /// serialize an unbounded run of Docker API calls in one pass — any
+    /// remainder is picked up on the next nightly run. Removal is
+    /// best-effort and never forced (see `DockerClient::remove_image`), so
+    /// Docker itself refuses if a container still references the image —
+    /// the safety net against this query being wrong.
     async fn cleanup_stale_deployment_images(&self) {
         use sea_orm::{DatabaseBackend, FromQueryResult, Statement};
 
@@ -466,10 +480,13 @@ WHERE rn > $1
       SELECT current_deployment_id FROM environments
       WHERE current_deployment_id IS NOT NULL
   )
+ORDER BY created_at ASC
+LIMIT $3
 "#,
                 [
                     (self.keep_recent_deployment_images as i64).into(),
                     cutoff.into(),
+                    (self.max_deployment_images_per_run as i64).into(),
                 ],
             ))
             .all(self.db.as_ref())
@@ -915,6 +932,7 @@ mod tests {
 
         assert_eq!(service.keep_recent_deployment_images, 5);
         assert_eq!(service.max_deployment_image_age_days, 7);
+        assert_eq!(service.max_deployment_images_per_run, 500);
     }
 
     #[test]
@@ -922,9 +940,11 @@ mod tests {
         let service =
             DockerCleanupService::new(Arc::new(DefaultDockerClient), mock_db(), mock_file_store())
                 .with_keep_recent_deployment_images(10)
-                .with_max_deployment_image_age_days(30);
+                .with_max_deployment_image_age_days(30)
+                .with_max_deployment_images_per_run(50);
 
         assert_eq!(service.keep_recent_deployment_images, 10);
         assert_eq!(service.max_deployment_image_age_days, 30);
+        assert_eq!(service.max_deployment_images_per_run, 50);
     }
 }

--- a/crates/temps-deployments/src/services/docker_cleanup_service.rs
+++ b/crates/temps-deployments/src/services/docker_cleanup_service.rs
@@ -17,6 +17,12 @@ pub trait DockerClient: Send + Sync {
 
     /// Remove unused Docker build cache
     async fn prune_builder_cache(&self, max_unused_days: i64) -> Result<String, String>;
+
+    /// Remove a single named image. Must NOT force-remove: Docker refuses
+    /// removal while any container still references the image, which is
+    /// the safety net against deleting an image a retention-policy query
+    /// incorrectly judged unneeded.
+    async fn remove_image(&self, image_name: &str) -> Result<(), String>;
 }
 
 /// Statistics from Docker prune operations
@@ -24,6 +30,13 @@ pub trait DockerClient: Send + Sync {
 pub struct PruneStats {
     pub images_deleted: u64,
     pub space_reclaimed_mb: u64,
+}
+
+/// Row shape for the deployment-image retention query in
+/// `DockerCleanupService::cleanup_stale_deployment_images`.
+#[derive(Debug, sea_orm::FromQueryResult)]
+struct DeploymentImageCandidate {
+    image_name: String,
 }
 
 /// Default Docker client implementation using the Docker daemon
@@ -97,6 +110,22 @@ impl DockerClient for DefaultDockerClient {
                 }
             }
             Err(e) => Err(format!("Failed to prune build cache: {}", e)),
+        }
+    }
+
+    async fn remove_image(&self, image_name: &str) -> Result<(), String> {
+        use bollard::query_parameters::RemoveImageOptionsBuilder;
+        use bollard::Docker;
+
+        let docker = Docker::connect_with_unix_defaults()
+            .map_err(|e| format!("Failed to connect to Docker daemon: {}", e))?;
+
+        // No `force`: see the safety note on the trait method.
+        let options = RemoveImageOptionsBuilder::default().build();
+
+        match docker.remove_image(image_name, Some(options), None).await {
+            Ok(_) => Ok(()),
+            Err(e) => Err(format!("Failed to remove image '{}': {}", image_name, e)),
         }
     }
 }
@@ -248,6 +277,13 @@ pub struct DockerCleanupService {
     max_chunk_age_hours: u64,
     /// Maximum age of static asset cache entries in days (default: 7)
     max_asset_cache_age_days: i64,
+    /// Number of most-recent deployment images to always keep per
+    /// project+environment, regardless of age (default: 5)
+    keep_recent_deployment_images: u64,
+    /// Minimum age in days before a deployment's image becomes eligible for
+    /// removal, even if it falls outside `keep_recent_deployment_images`
+    /// (default: 7)
+    max_deployment_image_age_days: i64,
 }
 
 impl DockerCleanupService {
@@ -265,6 +301,8 @@ impl DockerCleanupService {
             static_dir: None,
             max_chunk_age_hours: 24,
             max_asset_cache_age_days: 7,
+            keep_recent_deployment_images: 5,
+            max_deployment_image_age_days: 7,
         }
     }
 
@@ -285,6 +323,16 @@ impl DockerCleanupService {
 
     pub fn with_max_asset_cache_age_days(mut self, days: i64) -> Self {
         self.max_asset_cache_age_days = days;
+        self
+    }
+
+    pub fn with_keep_recent_deployment_images(mut self, count: u64) -> Self {
+        self.keep_recent_deployment_images = count;
+        self
+    }
+
+    pub fn with_max_deployment_image_age_days(mut self, days: i64) -> Self {
+        self.max_deployment_image_age_days = days;
         self
     }
 
@@ -326,6 +374,10 @@ impl DockerCleanupService {
 
         perform_docker_prune(&self.docker_client, self.max_cache_age_days).await;
 
+        // Cleanup old deployment images that generic image pruning can
+        // never reach (see cleanup_stale_deployment_images)
+        self.cleanup_stale_deployment_images().await;
+
         // Cleanup old persisted static asset chunks
         if let Some(ref static_dir) = self.static_dir {
             let chunks_base = static_dir.join("chunks");
@@ -348,6 +400,94 @@ impl DockerCleanupService {
         self.cleanup_stale_asset_cache().await;
 
         info!("Nightly cleanup completed");
+    }
+
+    /// Remove Docker images for deployments that are no longer needed for
+    /// rollback. Every deployment builds a uniquely-tagged image
+    /// (`temps-{project}:{deployment_id}`), so unlike ordinary build output
+    /// these never become "dangling" and `perform_docker_prune` above can
+    /// never reclaim them — left unchecked they accumulate forever.
+    ///
+    /// Keeps, per project+environment: the environment's currently-live
+    /// deployment, the `keep_recent_deployment_images` most recent
+    /// deployments, and anything younger than
+    /// `max_deployment_image_age_days`. Everything else is removed.
+    /// Removal is best-effort and never forced (see `DockerClient::
+    /// remove_image`), so Docker itself refuses if a container still
+    /// references the image — the safety net against this query being
+    /// wrong.
+    async fn cleanup_stale_deployment_images(&self) {
+        use sea_orm::{DatabaseBackend, FromQueryResult, Statement};
+
+        let cutoff =
+            chrono::Utc::now() - chrono::Duration::days(self.max_deployment_image_age_days);
+
+        let candidates =
+            match DeploymentImageCandidate::find_by_statement(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"
+SELECT image_name FROM (
+    SELECT
+        id,
+        image_name,
+        created_at,
+        ROW_NUMBER() OVER (
+            PARTITION BY project_id, environment_id
+            ORDER BY created_at DESC
+        ) AS rn
+    FROM deployments
+    WHERE image_name IS NOT NULL
+) ranked
+WHERE rn > $1
+  AND created_at < $2
+  AND id NOT IN (
+      SELECT current_deployment_id FROM environments
+      WHERE current_deployment_id IS NOT NULL
+  )
+"#,
+                [
+                    (self.keep_recent_deployment_images as i64).into(),
+                    cutoff.into(),
+                ],
+            ))
+            .all(self.db.as_ref())
+            .await
+            {
+                Ok(rows) => rows,
+                Err(e) => {
+                    error!("Failed to query stale deployment images: {}", e);
+                    return;
+                }
+            };
+
+        if candidates.is_empty() {
+            debug!("No stale deployment images to remove");
+            return;
+        }
+
+        let mut removed = 0u64;
+        for candidate in &candidates {
+            match self.docker_client.remove_image(&candidate.image_name).await {
+                Ok(()) => removed += 1,
+                Err(e) => {
+                    // Expected and harmless: the image was already removed,
+                    // was never local (multi-node builds run on a different
+                    // node's daemon), or is still referenced by a running
+                    // container — Docker's own refusal covers that last case.
+                    debug!(
+                        "Skipped removing deployment image '{}': {}",
+                        candidate.image_name, e
+                    );
+                }
+            }
+        }
+
+        if removed > 0 {
+            info!(
+                "🧹 Removed {} stale deployment image(s) (older than {} days, beyond the last {})",
+                removed, self.max_deployment_image_age_days, self.keep_recent_deployment_images
+            );
+        }
     }
 
     /// Delete static_asset_cache rows older than `max_asset_cache_age_days`
@@ -565,6 +705,10 @@ mod tests {
         async fn prune_builder_cache(&self, _max_unused_days: i64) -> Result<String, String> {
             self.prune_cache_result.clone()
         }
+
+        async fn remove_image(&self, _image_name: &str) -> Result<(), String> {
+            Ok(())
+        }
     }
 
     fn mock_db() -> Arc<sea_orm::DatabaseConnection> {
@@ -657,5 +801,100 @@ mod tests {
         // are logged and cleanup continues (e.g. images prune failing must
         // not skip the build-cache prune).
         perform_docker_prune(&client, 7).await;
+    }
+
+    #[derive(Clone, Default)]
+    struct RecordingDockerClient {
+        removed: Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl DockerClient for RecordingDockerClient {
+        async fn prune_images(&self, _force: bool) -> Result<PruneStats, String> {
+            Ok(PruneStats {
+                images_deleted: 0,
+                space_reclaimed_mb: 0,
+            })
+        }
+
+        async fn prune_builder_cache(&self, _max_unused_days: i64) -> Result<String, String> {
+            Ok(String::new())
+        }
+
+        async fn remove_image(&self, image_name: &str) -> Result<(), String> {
+            self.removed.lock().unwrap().push(image_name.to_string());
+            Ok(())
+        }
+    }
+
+    fn image_candidate_row(image_name: &str) -> std::collections::BTreeMap<String, sea_orm::Value> {
+        std::collections::BTreeMap::from([(
+            "image_name".to_string(),
+            sea_orm::Value::String(Some(Box::new(image_name.to_string()))),
+        )])
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_stale_deployment_images_removes_candidates() {
+        let db = Arc::new(
+            sea_orm::MockDatabase::new(sea_orm::DatabaseBackend::Postgres)
+                .append_query_results([[
+                    image_candidate_row("temps-blog:12"),
+                    image_candidate_row("temps-blog:13"),
+                ]])
+                .into_connection(),
+        );
+        let removed = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let docker_client: Arc<dyn DockerClient> = Arc::new(RecordingDockerClient {
+            removed: removed.clone(),
+        });
+
+        let service = DockerCleanupService::new(docker_client, db, mock_file_store());
+        service.cleanup_stale_deployment_images().await;
+
+        let removed = removed.lock().unwrap();
+        assert_eq!(removed.len(), 2);
+        assert!(removed.contains(&"temps-blog:12".to_string()));
+        assert!(removed.contains(&"temps-blog:13".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_stale_deployment_images_noop_when_none_stale() {
+        let db = Arc::new(
+            sea_orm::MockDatabase::new(sea_orm::DatabaseBackend::Postgres)
+                .append_query_results([
+                    Vec::<std::collections::BTreeMap<String, sea_orm::Value>>::new(),
+                ])
+                .into_connection(),
+        );
+        let removed = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let docker_client: Arc<dyn DockerClient> = Arc::new(RecordingDockerClient {
+            removed: removed.clone(),
+        });
+
+        let service = DockerCleanupService::new(docker_client, db, mock_file_store());
+        service.cleanup_stale_deployment_images().await;
+
+        assert!(removed.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_default_deployment_image_retention() {
+        let service =
+            DockerCleanupService::new(Arc::new(DefaultDockerClient), mock_db(), mock_file_store());
+
+        assert_eq!(service.keep_recent_deployment_images, 5);
+        assert_eq!(service.max_deployment_image_age_days, 7);
+    }
+
+    #[test]
+    fn test_custom_deployment_image_retention() {
+        let service =
+            DockerCleanupService::new(Arc::new(DefaultDockerClient), mock_db(), mock_file_store())
+                .with_keep_recent_deployment_images(10)
+                .with_max_deployment_image_age_days(30);
+
+        assert_eq!(service.keep_recent_deployment_images, 10);
+        assert_eq!(service.max_deployment_image_age_days, 30);
     }
 }

--- a/crates/temps-deployments/src/services/docker_cleanup_service.rs
+++ b/crates/temps-deployments/src/services/docker_cleanup_service.rs
@@ -101,6 +101,138 @@ impl DockerClient for DefaultDockerClient {
     }
 }
 
+/// Calculate seconds until the next occurrence of `cleanup_hour` (UTC).
+/// Shared by `DockerCleanupService` (console) and `DockerOnlyCleanupScheduler`
+/// (worker agents) so both run on the same nightly cadence.
+fn seconds_until_next_cleanup(cleanup_hour: u32) -> u64 {
+    let now = chrono::Utc::now();
+
+    // Calculate target time (today at cleanup_hour)
+    let target_time = now
+        .with_hour(cleanup_hour)
+        .and_then(|t| t.with_minute(0))
+        .and_then(|t| t.with_second(0))
+        .expect("Failed to calculate target cleanup time");
+
+    let next_cleanup = if target_time > now {
+        // Cleanup time hasn't passed today
+        target_time
+    } else {
+        // Cleanup time already passed today, schedule for tomorrow
+        target_time + chrono::Duration::days(1)
+    };
+
+    let duration = next_cleanup - now;
+    duration.num_seconds().max(0) as u64
+}
+
+/// Prune unused Docker images and stale build cache via `docker_client`.
+/// Shared by `DockerCleanupService` (console, which also cleans up the
+/// DB-backed static asset cache) and `DockerOnlyCleanupScheduler` (worker
+/// agents, which have no database connection).
+async fn perform_docker_prune(docker_client: &Arc<dyn DockerClient>, max_cache_age_days: i64) {
+    // Cleanup unused images
+    match docker_client.prune_images(true).await {
+        Ok(stats) => {
+            if stats.images_deleted > 0 {
+                info!(
+                    "✅ Removed {} unused Docker images, freed {} MB",
+                    stats.images_deleted, stats.space_reclaimed_mb
+                );
+            } else {
+                info!("✅ No unused Docker images to remove");
+            }
+        }
+        Err(e) => {
+            error!("❌ Failed to prune Docker images: {}", e);
+        }
+    }
+
+    // Cleanup old build cache
+    match docker_client.prune_builder_cache(max_cache_age_days).await {
+        Ok(output) => {
+            // Parse output for statistics
+            if output.contains("freed") || output.contains("removed") {
+                info!("✅ Docker build cache cleanup completed: {}", output.trim());
+            } else if output.is_empty() {
+                info!("✅ No old Docker build cache to remove");
+            } else {
+                debug!("Docker build cache cleanup output: {}", output);
+            }
+        }
+        Err(e) => {
+            // Builder prune might not be available in all Docker versions
+            warn!(
+                "⚠️ Failed to prune Docker builder cache (may not be available): {}",
+                e
+            );
+        }
+    }
+}
+
+/// Lightweight Docker-only cleanup scheduler for hosts without a database
+/// connection — namely worker agent nodes (`temps agent`), which are a
+/// separate process from the console and never register the plugin system
+/// that wires up `DockerCleanupService`. Worker nodes still build images
+/// and accumulate build cache locally, so they need the same nightly
+/// image + build-cache prune; they just skip the DB-backed static asset
+/// cache and chunk cleanup steps, which are console-only concerns.
+pub struct DockerOnlyCleanupScheduler {
+    docker_client: Arc<dyn DockerClient>,
+    /// Hour of day (UTC) to run cleanup (default: 2 AM)
+    cleanup_hour: u32,
+    /// Maximum number of days build cache can be unused before deletion (default: 7)
+    max_cache_age_days: i64,
+}
+
+impl DockerOnlyCleanupScheduler {
+    pub fn new(docker_client: Arc<dyn DockerClient>) -> Self {
+        Self {
+            docker_client,
+            cleanup_hour: 2, // 2 AM UTC
+            max_cache_age_days: 7,
+        }
+    }
+
+    pub fn with_cleanup_hour(mut self, hour: u32) -> Self {
+        self.cleanup_hour = hour % 24;
+        self
+    }
+
+    pub fn with_max_cache_age_days(mut self, days: i64) -> Self {
+        self.max_cache_age_days = days;
+        self
+    }
+
+    /// Start the cleanup scheduler (blocking, should be spawned in a tokio task).
+    pub async fn start_cleanup_scheduler(&self) {
+        info!(
+            "Docker cleanup scheduler started (agent node, cleanup hour: {}:00 UTC)",
+            self.cleanup_hour
+        );
+
+        loop {
+            let seconds_until_cleanup = seconds_until_next_cleanup(self.cleanup_hour);
+            let hours = seconds_until_cleanup / 3600;
+            let minutes = (seconds_until_cleanup % 3600) / 60;
+
+            debug!(
+                "Next Docker cleanup scheduled in {} hours {} minutes",
+                hours, minutes
+            );
+
+            sleep(Duration::from_secs(seconds_until_cleanup)).await;
+
+            info!("🧹 Starting nightly Docker cleanup (agent node)");
+            perform_docker_prune(&self.docker_client, self.max_cache_age_days).await;
+            info!("Nightly Docker cleanup completed (agent node)");
+
+            // Sleep for 1 minute to avoid running cleanup multiple times in the same minute
+            sleep(Duration::from_secs(60)).await;
+        }
+    }
+}
+
 /// Docker cleanup service that runs nightly
 pub struct DockerCleanupService {
     docker_client: Arc<dyn DockerClient>,
@@ -158,25 +290,7 @@ impl DockerCleanupService {
 
     /// Calculate seconds until the next scheduled cleanup
     fn seconds_until_next_cleanup(&self) -> u64 {
-        let now = chrono::Utc::now();
-
-        // Calculate target time (today at cleanup_hour)
-        let target_time = now
-            .with_hour(self.cleanup_hour)
-            .and_then(|t| t.with_minute(0))
-            .and_then(|t| t.with_second(0))
-            .expect("Failed to calculate target cleanup time");
-
-        let next_cleanup = if target_time > now {
-            // Cleanup time hasn't passed today
-            target_time
-        } else {
-            // Cleanup time already passed today, schedule for tomorrow
-            target_time + chrono::Duration::days(1)
-        };
-
-        let duration = next_cleanup - now;
-        duration.num_seconds().max(0) as u64
+        seconds_until_next_cleanup(self.cleanup_hour)
     }
 
     /// Start the cleanup scheduler (blocking, should be spawned in tokio task)
@@ -210,47 +324,7 @@ impl DockerCleanupService {
     async fn perform_cleanup(&self) {
         info!("🧹 Starting nightly Docker cleanup");
 
-        // Cleanup unused images
-        match self.docker_client.prune_images(true).await {
-            Ok(stats) => {
-                if stats.images_deleted > 0 {
-                    info!(
-                        "✅ Removed {} unused Docker images, freed {} MB",
-                        stats.images_deleted, stats.space_reclaimed_mb
-                    );
-                } else {
-                    info!("✅ No unused Docker images to remove");
-                }
-            }
-            Err(e) => {
-                error!("❌ Failed to prune Docker images: {}", e);
-            }
-        }
-
-        // Cleanup old build cache
-        match self
-            .docker_client
-            .prune_builder_cache(self.max_cache_age_days)
-            .await
-        {
-            Ok(output) => {
-                // Parse output for statistics
-                if output.contains("freed") || output.contains("removed") {
-                    info!("✅ Docker build cache cleanup completed: {}", output.trim());
-                } else if output.is_empty() {
-                    info!("✅ No old Docker build cache to remove");
-                } else {
-                    debug!("Docker build cache cleanup output: {}", output);
-                }
-            }
-            Err(e) => {
-                // Builder prune might not be available in all Docker versions
-                warn!(
-                    "⚠️ Failed to prune Docker builder cache (may not be available): {}",
-                    e
-                );
-            }
-        }
+        perform_docker_prune(&self.docker_client, self.max_cache_age_days).await;
 
         // Cleanup old persisted static asset chunks
         if let Some(ref static_dir) = self.static_dir {
@@ -530,5 +604,58 @@ mod tests {
                 .with_max_cache_age_days(14);
 
         assert_eq!(service.max_cache_age_days, 14);
+    }
+
+    #[test]
+    fn test_docker_only_scheduler_defaults() {
+        let scheduler = DockerOnlyCleanupScheduler::new(Arc::new(DefaultDockerClient));
+
+        assert_eq!(scheduler.cleanup_hour, 2);
+        assert_eq!(scheduler.max_cache_age_days, 7);
+    }
+
+    #[test]
+    fn test_docker_only_scheduler_custom_cleanup_hour() {
+        let scheduler =
+            DockerOnlyCleanupScheduler::new(Arc::new(DefaultDockerClient)).with_cleanup_hour(3);
+
+        assert_eq!(scheduler.cleanup_hour, 3);
+    }
+
+    #[test]
+    fn test_docker_only_scheduler_custom_cache_age() {
+        let scheduler = DockerOnlyCleanupScheduler::new(Arc::new(DefaultDockerClient))
+            .with_max_cache_age_days(14);
+
+        assert_eq!(scheduler.max_cache_age_days, 14);
+    }
+
+    #[tokio::test]
+    async fn test_perform_docker_prune_reports_success() {
+        let client: Arc<dyn DockerClient> = Arc::new(MockDockerClient {
+            prune_images_result: Ok(PruneStats {
+                images_deleted: 2,
+                space_reclaimed_mb: 128,
+            }),
+            prune_cache_result: Ok("removed 1 build cache entries, freed 64 MB".to_string()),
+        });
+
+        // Exercises the shared free function directly — success is "did
+        // not panic and produced no error path" since prune_images/
+        // prune_builder_cache results are only logged, not returned.
+        perform_docker_prune(&client, 7).await;
+    }
+
+    #[tokio::test]
+    async fn test_perform_docker_prune_handles_errors_gracefully() {
+        let client: Arc<dyn DockerClient> = Arc::new(MockDockerClient {
+            prune_images_result: Err("daemon unreachable".to_string()),
+            prune_cache_result: Err("builder prune not supported".to_string()),
+        });
+
+        // Both prune calls fail; the shared helper must not panic — errors
+        // are logged and cleanup continues (e.g. images prune failing must
+        // not skip the build-cache prune).
+        perform_docker_prune(&client, 7).await;
     }
 }

--- a/crates/temps-deployments/src/services/docker_cleanup_service.rs
+++ b/crates/temps-deployments/src/services/docker_cleanup_service.rs
@@ -144,12 +144,26 @@ impl DockerClient for DefaultDockerClient {
 fn seconds_until_next_cleanup(cleanup_hour: u32) -> u64 {
     let now = chrono::Utc::now();
 
-    // Calculate target time (today at cleanup_hour)
-    let target_time = now
+    // Calculate target time (today at cleanup_hour). `with_hour` etc. only
+    // return None for an out-of-range component; every caller already
+    // constrains `cleanup_hour` to 0..24 via `% 24`, but this runs on every
+    // scheduler tick for the life of the process (console and every worker
+    // agent), so a future caller skipping that guard must not crash the
+    // spawned task -- retry in 24h instead of panicking.
+    let target_time = match now
         .with_hour(cleanup_hour)
         .and_then(|t| t.with_minute(0))
         .and_then(|t| t.with_second(0))
-        .expect("Failed to calculate target cleanup time");
+    {
+        Some(t) => t,
+        None => {
+            error!(
+                cleanup_hour,
+                "Invalid cleanup hour; docker cleanup scheduler will retry in 24h"
+            );
+            return 24 * 3600;
+        }
+    };
 
     let next_cleanup = if target_time > now {
         // Cleanup time hasn't passed today
@@ -738,6 +752,14 @@ mod tests {
         // Should be positive and less than 24 hours
         assert!(seconds > 0);
         assert!(seconds <= 24 * 3600);
+    }
+
+    #[test]
+    fn test_seconds_until_next_cleanup_invalid_hour_retries_instead_of_panicking() {
+        // 25 is out of chrono's 0..24 range for `with_hour`; every real
+        // caller guards with `% 24`, but this must degrade to a 24h retry
+        // rather than panic if that guard is ever skipped.
+        assert_eq!(seconds_until_next_cleanup(25), 24 * 3600);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Root cause of the reported 350GB build cache growth:** `bollard::query_parameters::PruneBuildOptions` has an `all: Option<bool>` field that the nightly cleanup never set. Without it, `POST /build/prune` only removes cache marked *dangling* (not part of any remaining build lineage) — the exact same dangling-vs-all distinction as `docker image prune` vs `docker image prune -a`. Almost all real build cache (every build's COPY/RUN layers, unique per build) is never dangling, so despite running nightly with a 7-day age filter, the job was reclaiming almost none of the accumulated cache regardless of age. Fixed by setting `.all(true)`, matching what `docker builder prune --all --filter until=168h` does manually.

**Also found and fixed while investigating, on the control plane:**
- Every deployment builds a uniquely-tagged image `temps-{project.slug}:{deployment.id}`, so it never becomes dangling and the existing `prune_images(dangling=true)` could never reclaim it — every deployment ever made left a permanent image on disk. Rollback reads the exact old image by tag from the deployment row, so naively pruning "all unused images" would have silently broken rollback. Added `cleanup_stale_deployment_images`: keeps the environment's currently-live deployment, the 5 most recent, and anything younger than 7 days per project+environment; removes the rest via a new `DockerClient::remove_image` that never force-removes, so Docker itself refuses if a container still references the image.

**Also found and fixed, on worker nodes:**
- `temps agent` (worker nodes, started by `worker.sh`) never ran any Docker cleanup at all — separate process from the console, never registers the plugin system that wires up `DockerCleanupService`. Extracted the Docker-only prune logic into a shared function and a new `DockerOnlyCleanupScheduler`, spawned from `temps agent` at startup.

## Test plan
- [x] `cargo check --lib -p temps-deployments` / `-p temps-cli` — 0 warnings
- [x] `cargo test --lib -p temps-deployments docker_cleanup` — 12/12 passed
- [x] `cargo clippy --lib -p temps-deployments -p temps-cli -- -D warnings` — clean
- [ ] Manual verification on a running console: confirm `docker builder prune --all --filter until=168h` (what the fix now does under the hood) reclaims the accumulated cache, and that `cleanup_stale_deployment_images` removes old deployment images while leaving the live one + last 5 intact and rollback still works