### PR TITLE
feat(web): surface cluster DNS toggle in Worker Nodes settings

### DIFF
--- a/web/src/api/platformSettings.ts
+++ b/web/src/api/platformSettings.ts
@@ -234,6 +234,9 @@ export async function updatePlatformSettings(
     // `#[serde(default)]`, so omitting this field would silently re-enable
     // console updates whenever any other settings page is saved.
     self_update: updated.self_update,
+    // Same reasoning: omitting this would silently reset cluster DNS back to
+    // disabled on every unrelated settings save.
+    cluster_dns: updated.cluster_dns,
   }
   const result = await updateSettings({ body })
   if (result.error) {

--- a/web/src/components/settings/ClusterDnsCard.tsx
+++ b/web/src/components/settings/ClusterDnsCard.tsx
@@ -1,0 +1,136 @@
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Switch } from '@/components/ui/switch'
+import { useSettings, useUpdateSettings } from '@/hooks/useSettings'
+import { AlertTriangle, Globe } from 'lucide-react'
+import { toast } from 'sonner'
+
+/**
+ * Cluster DNS (ADR-024, experimental beta) toggle.
+ *
+ * Off by default — a past incident showed the injected resolver adding
+ * 22-27s delays to outbound connections when it was slow to answer for
+ * non-`*.temps.local` hostnames (glibc cycled through all three configured
+ * nameservers at ~5s timeout x2 attempts each before falling through).
+ * Operators who need `*.temps.local` service-to-service resolution inside
+ * containers (e.g. reaching a managed Postgres cluster by hostname from a
+ * single control-plane node, where no worker agent is running its own
+ * resolver) must explicitly opt in here.
+ */
+export function ClusterDnsCard() {
+  const { data: settings, isLoading, error } = useSettings()
+  const updateSettings = useUpdateSettings()
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Globe className="h-5 w-5" />
+            Cluster DNS
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-16 w-full" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error || !settings) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Globe className="h-5 w-5" />
+            Cluster DNS
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>Failed to load settings</AlertTitle>
+            <AlertDescription>
+              The server returned an error. Check console logs or contact your
+              administrator.
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const enabled = settings.cluster_dns?.enabled ?? false
+
+  const onCheckedChange = (checked: boolean) => {
+    updateSettings.mutate(
+      { cluster_dns: { enabled: checked } },
+      {
+        onSuccess: () =>
+          toast.success(
+            checked ? 'Cluster DNS enabled' : 'Cluster DNS disabled'
+          ),
+      }
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Globe className="h-5 w-5" />
+          Cluster DNS
+          <span className="text-xs font-normal text-muted-foreground">
+            (experimental)
+          </span>
+        </CardTitle>
+        <CardDescription>
+          Lets deployed containers resolve <code>*.temps.local</code> hostnames
+          — required for service-to-service traffic such as reaching a managed
+          Postgres cluster by hostname (e.g.{' '}
+          <code>primary.pg-orders.temps.local</code>) from a single
+          control-plane node with no worker agent of its own.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Alert>
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>Known risk before enabling</AlertTitle>
+          <AlertDescription>
+            A past incident showed 22-27s outbound connection delays when the
+            injected resolver was slow to answer for hostnames outside{' '}
+            <code>*.temps.local</code> — glibc retried all three configured
+            nameservers at ~5s timeout x2 attempts each. Only enable this if you
+            need <code>*.temps.local</code> resolution inside containers.
+          </AlertDescription>
+        </Alert>
+
+        <div className="flex items-start justify-between rounded-lg border p-3">
+          <div className="space-y-0.5">
+            <Label htmlFor="cluster-dns-enabled" className="text-sm">
+              Enable cluster DNS
+            </Label>
+            <p className="text-xs text-muted-foreground max-w-prose">
+              Starts the control-plane Hickory resolver and injects it as the
+              first nameserver into every deployed container.
+            </p>
+          </div>
+          <Switch
+            id="cluster-dns-enabled"
+            checked={enabled}
+            disabled={updateSettings.isPending}
+            onCheckedChange={onCheckedChange}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/src/pages/settings/NodesPage.tsx
+++ b/web/src/pages/settings/NodesPage.tsx
@@ -6,6 +6,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { ClusterDnsCard } from '@/components/settings/ClusterDnsCard'
 import {
   Table,
   TableBody,
@@ -1317,6 +1318,8 @@ export function NodesPage() {
           )}
         </CardContent>
       </Card>
+
+      <ClusterDnsCard />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- `AppSettings.cluster_dns.enabled` (ADR-024) existed on the backend with no UI to set it and no CLI command for it — the only way to flip it was a raw `PATCH /api/settings` call.
- Fixes a silent-drop bug in the process: `updatePlatformSettings`'s PATCH body builder whitelists which fields get sent to the server, and `cluster_dns` was missing from that list — so even a hand-crafted client update would have been silently discarded on the next save from any other settings page (same failure mode the existing `self_update` field already has an explicit guard/comment against).
- Adds a "Cluster DNS" card to **Settings > Worker Nodes**, with an inline warning describing the known incident (glibc nameserver-timeout cascade adding 22-27s to outbound connections) that's the reason this defaults to off.

## Test plan
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx eslint` on all touched files — no errors (pre-existing warnings in `NodesPage.tsx` are unrelated, from lines this PR doesn't touch)
- [ ] Manual: toggle on/off in the running app, confirm `GET /api/settings` reflects the change after a save from an unrelated settings page (regression check for the whitelist bug)