### PR TITLE
feat(proxy): add per-project latency percentiles and custom time ranges

### DIFF
--- a/crates/temps-core/src/time_window.rs
+++ b/crates/temps-core/src/time_window.rs
@@ -72,6 +72,31 @@ pub const MAX_WINDOW_DAYS: i64 = 7;
 /// for an existing menu option.
 pub const MAX_WINDOW_DAYS_SCOPED: i64 = 30;
 
+/// Hard cap on buckets/points a time-series chart query may return.
+///
+/// Window-width caps ([`MAX_WINDOW_DAYS`] / [`MAX_WINDOW_DAYS_SCOPED`]) bound
+/// how much raw data a scan considers. This bounds how many GROUP BY buckets
+/// (and gapfill placeholders) that scan is allowed to emit — `1 minute` over
+/// 7 days is 10_080 points, which is a large result and a large `time_bucket`
+/// / `toStartOfInterval` grouping on a small box.
+///
+/// Presets stay well under this: 7d at 1h = 168, 30d scoped at 1h = 720.
+/// Callers that pick their own step/interval must be rejected or coarsened
+/// when `span / step` would exceed this.
+pub const MAX_SERIES_POINTS: i64 = 1_000;
+
+/// Ceiling of `span_secs / step_secs` for positive durations.
+pub fn bucket_count(span_secs: i64, step_secs: i64) -> i64 {
+    let span = span_secs.max(1);
+    let step = step_secs.max(1);
+    span.saturating_add(step - 1) / step
+}
+
+/// Smallest step (seconds) that keeps [`bucket_count`] ≤ [`MAX_SERIES_POINTS`].
+pub fn min_step_secs(span_secs: i64) -> i64 {
+    bucket_count(span_secs, MAX_SERIES_POINTS)
+}
+
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum TimeWindowError {
     /// The requested span exceeds [`MAX_WINDOW_DAYS`].
@@ -355,5 +380,21 @@ mod tests {
         let err = resolve(Some(start), Some(end), Duration::hours(1))
             .expect_err("an explicit end one second over the cap has no tolerance to absorb it");
         assert!(matches!(err, TimeWindowError::TooWide { .. }));
+    }
+
+    #[test]
+    fn bucket_count_ceil_divides() {
+        assert_eq!(bucket_count(7 * 86_400, 60), 10_080);
+        assert_eq!(bucket_count(7 * 86_400, 3_600), 168);
+        assert_eq!(bucket_count(30 * 86_400, 3_600), 720);
+        assert_eq!(bucket_count(1, 60), 1);
+    }
+
+    #[test]
+    fn min_step_secs_keeps_7d_under_the_point_cap() {
+        let span = 7 * 86_400;
+        let step = min_step_secs(span);
+        assert!(bucket_count(span, step) <= MAX_SERIES_POINTS);
+        assert!(step > 60, "1-minute buckets over 7d must be coarsened");
     }
 }

--- a/crates/temps-metrics/src/lib.rs
+++ b/crates/temps-metrics/src/lib.rs
@@ -17,6 +17,5 @@ pub use store::clickhouse_migrations;
 pub use store::timescale::{validate_metric_name, TimescaleMetricsStore};
 pub use store::{
     duration_to_step, is_monotonic_counter, range_to_step, LabelledMetric, LatestByLabelQuery,
-    LatestQuery,
-    MetricKind, MetricPoint, MetricsStore, RangeQuery, SourceKind,
+    LatestQuery, MetricKind, MetricPoint, MetricsStore, RangeQuery, SourceKind,
 };

--- a/crates/temps-metrics/src/lib.rs
+++ b/crates/temps-metrics/src/lib.rs
@@ -16,6 +16,7 @@ pub use store::clickhouse::{ChMetricRow, ClickHouseMetricsConfig, ClickhouseMetr
 pub use store::clickhouse_migrations;
 pub use store::timescale::{validate_metric_name, TimescaleMetricsStore};
 pub use store::{
-    is_monotonic_counter, range_to_step, LabelledMetric, LatestByLabelQuery, LatestQuery,
+    duration_to_step, is_monotonic_counter, range_to_step, LabelledMetric, LatestByLabelQuery,
+    LatestQuery,
     MetricKind, MetricPoint, MetricsStore, RangeQuery, SourceKind,
 };

--- a/crates/temps-metrics/src/lib.rs
+++ b/crates/temps-metrics/src/lib.rs
@@ -16,6 +16,6 @@ pub use store::clickhouse::{ChMetricRow, ClickHouseMetricsConfig, ClickhouseMetr
 pub use store::clickhouse_migrations;
 pub use store::timescale::{validate_metric_name, TimescaleMetricsStore};
 pub use store::{
-    duration_to_step, is_monotonic_counter, range_to_step, LabelledMetric, LatestByLabelQuery,
-    LatestQuery, MetricKind, MetricPoint, MetricsStore, RangeQuery, SourceKind,
+    clamp_step, duration_to_step, is_monotonic_counter, range_to_step, LabelledMetric,
+    LatestByLabelQuery, LatestQuery, MetricKind, MetricPoint, MetricsStore, RangeQuery, SourceKind,
 };

--- a/crates/temps-metrics/src/store/clickhouse.rs
+++ b/crates/temps-metrics/src/store/clickhouse.rs
@@ -367,7 +367,8 @@ impl MetricsStore for ClickhouseMetricsStore {
     /// the CH backend has only the raw table and does query-time bucketing.
     /// The trait explicitly permits this. We still coerce very wide ranges to
     /// coarser buckets to cap the result point count:
-    /// - range ≤ 7 days  → honor `filter.step`
+    /// - always at least [`super::clamp_step`] (no 1-minute buckets over 7 days)
+    /// - range ≤ 7 days  → honor the (clamped) `filter.step`
     /// - range ≤ 90 days → at least 1-hour buckets
     /// - range > 90 days → at least 1-day buckets
     ///
@@ -392,8 +393,14 @@ impl MetricsStore for ClickhouseMetricsStore {
         let seven_days = chrono::Duration::days(7);
         let ninety_days = chrono::Duration::days(90);
 
-        // Coerce the bucket width for wide ranges to bound the point count.
-        let requested = filter.step.num_seconds().max(1);
+        // Coerce the bucket width to bound the point count:
+        // - always at least clamp_step (no 1m-over-7d)
+        // - range ≤ 7 days  → honor the (clamped) requested step
+        // - range ≤ 90 days → at least 1-hour buckets
+        // - range > 90 days → at least 1-day buckets
+        let requested = super::clamp_step(range_duration, filter.step)
+            .num_seconds()
+            .max(1);
         let step_secs = if range_duration <= seven_days {
             requested
         } else if range_duration <= ninety_days {

--- a/crates/temps-metrics/src/store/mod.rs
+++ b/crates/temps-metrics/src/store/mod.rs
@@ -24,10 +24,24 @@ pub fn is_monotonic_counter(metric_name: &str) -> bool {
         || metric_name.ends_with(".count")
 }
 
+/// Widen `requested` so `window / step` stays ≤ [`temps_core::time_window::MAX_SERIES_POINTS`].
+///
+/// A 7-day window at 1 minute is 10_080 points. Preset steps from
+/// [`duration_to_step`] already sit under the cap; this is the backstop when a
+/// caller passes a finer `RangeQuery::step` than the window can support.
+pub fn clamp_step(window: Duration, requested: Duration) -> Duration {
+    let window_secs = window.num_seconds().max(1);
+    let requested_secs = requested.num_seconds().max(1);
+    let min_step_secs = temps_core::time_window::min_step_secs(window_secs);
+    Duration::seconds(requested_secs.max(min_step_secs))
+}
+
 /// Bucket step for a metric range query, matching the node-metrics UI
 /// presets: 1m for ≤1h, 5m for ≤6h, 15m for ≤24h, 1h otherwise.
+/// Always passed through [`clamp_step`] so a wide window cannot emit 1-minute
+/// buckets.
 pub fn duration_to_step(window: Duration) -> Duration {
-    if window <= Duration::hours(1) {
+    let requested = if window <= Duration::hours(1) {
         Duration::minutes(1)
     } else if window <= Duration::hours(6) {
         Duration::minutes(5)
@@ -35,7 +49,8 @@ pub fn duration_to_step(window: Duration) -> Duration {
         Duration::minutes(15)
     } else {
         Duration::hours(1)
-    }
+    };
+    clamp_step(window, requested)
 }
 
 /// Convert a UI `range` string (`1h`, `6h`, `24h`, `7d`) to
@@ -283,6 +298,25 @@ mod tests {
         );
         assert_eq!(duration_to_step(Duration::hours(12)), Duration::minutes(15));
         assert_eq!(duration_to_step(Duration::hours(48)), Duration::hours(1));
+    }
+
+    #[test]
+    fn test_clamp_step_coarsens_1m_over_7d() {
+        let window = Duration::days(7);
+        let clamped = clamp_step(window, Duration::minutes(1));
+        let points =
+            temps_core::time_window::bucket_count(window.num_seconds(), clamped.num_seconds());
+        assert!(
+            points <= temps_core::time_window::MAX_SERIES_POINTS,
+            "7d at 1m must not emit {points} points"
+        );
+        assert!(clamped > Duration::minutes(1));
+    }
+
+    #[test]
+    fn test_clamp_step_preserves_preset_7d_hourly() {
+        let window = Duration::days(7);
+        assert_eq!(clamp_step(window, Duration::hours(1)), Duration::hours(1));
     }
 
     #[test]

--- a/crates/temps-metrics/src/store/mod.rs
+++ b/crates/temps-metrics/src/store/mod.rs
@@ -24,17 +24,32 @@ pub fn is_monotonic_counter(metric_name: &str) -> bool {
         || metric_name.ends_with(".count")
 }
 
+/// Bucket step for a metric range query, matching the node-metrics UI
+/// presets: 1m for ≤1h, 5m for ≤6h, 15m for ≤24h, 1h otherwise.
+pub fn duration_to_step(window: Duration) -> Duration {
+    if window <= Duration::hours(1) {
+        Duration::minutes(1)
+    } else if window <= Duration::hours(6) {
+        Duration::minutes(5)
+    } else if window <= Duration::hours(24) {
+        Duration::minutes(15)
+    } else {
+        Duration::hours(1)
+    }
+}
+
 /// Convert a UI `range` string (`1h`, `6h`, `24h`, `7d`) to
 /// `(window_duration, bucket_step)` for a [`RangeQuery`]. Unknown ranges
 /// fall back to the 1-hour window.
 pub fn range_to_step(range: &str) -> (Duration, Duration) {
-    match range {
-        "1h" => (Duration::hours(1), Duration::minutes(1)),
-        "6h" => (Duration::hours(6), Duration::minutes(5)),
-        "24h" => (Duration::hours(24), Duration::minutes(15)),
-        "7d" => (Duration::days(7), Duration::hours(1)),
-        _ => (Duration::hours(1), Duration::minutes(1)),
-    }
+    let window = match range {
+        "1h" => Duration::hours(1),
+        "6h" => Duration::hours(6),
+        "24h" => Duration::hours(24),
+        "7d" => Duration::days(7),
+        _ => Duration::hours(1),
+    };
+    (window, duration_to_step(window))
 }
 
 /// The kind of metric value being stored.
@@ -250,6 +265,24 @@ mod tests {
         let (window, step) = range_to_step("30d");
         assert_eq!(window, Duration::hours(1));
         assert_eq!(step, Duration::minutes(1));
+    }
+
+    #[test]
+    fn test_duration_to_step_matches_preset_windows() {
+        assert_eq!(duration_to_step(Duration::hours(1)), Duration::minutes(1));
+        assert_eq!(duration_to_step(Duration::hours(6)), Duration::minutes(5));
+        assert_eq!(duration_to_step(Duration::hours(24)), Duration::minutes(15));
+        assert_eq!(duration_to_step(Duration::days(7)), Duration::hours(1));
+    }
+
+    #[test]
+    fn test_duration_to_step_custom_windows() {
+        assert_eq!(
+            duration_to_step(Duration::minutes(90)),
+            Duration::minutes(5)
+        );
+        assert_eq!(duration_to_step(Duration::hours(12)), Duration::minutes(15));
+        assert_eq!(duration_to_step(Duration::hours(48)), Duration::hours(1));
     }
 
     #[test]

--- a/crates/temps-metrics/src/store/timescale.rs
+++ b/crates/temps-metrics/src/store/timescale.rs
@@ -402,8 +402,11 @@ impl MetricsStore for TimescaleMetricsStore {
         let raw_label_filter = raw_label_filter.as_str();
 
         let sql = if range_duration <= seven_days {
-            // Raw table — use time_bucket with the requested step.
-            let step_secs = filter.step.num_seconds().max(1);
+            // Raw table — use time_bucket with the requested step, coarsened
+            // so a 7-day window cannot emit 1-minute buckets.
+            let step_secs = super::clamp_step(range_duration, filter.step)
+                .num_seconds()
+                .max(1);
             let sk = escape_sql_string(filter.source_kind.as_str());
             let sid = filter.source_id;
             let nm = escape_sql_string(&filter.name);

--- a/crates/temps-providers/src/handlers/metrics_handlers.rs
+++ b/crates/temps-providers/src/handlers/metrics_handlers.rs
@@ -37,17 +37,19 @@ use axum::{
     routing::{get, patch, put},
     Json, Router,
 };
-use chrono::Utc;
+use chrono::{DateTime, Duration, Utc};
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
 use serde::{Deserialize, Serialize};
 use temps_auth::{permission_guard, RequireAuth};
 use temps_core::{
     error_builder::{bad_request, forbidden, internal_server_error, not_found, ErrorBuilder},
     problemdetails::Problem,
+    UtcDateTime,
 };
 use temps_entities::{external_services, monitoring_alert_rules};
 use temps_metrics::{
-    is_monotonic_counter, range_to_step, LatestByLabelQuery, LatestQuery, RangeQuery, SourceKind,
+    duration_to_step, is_monotonic_counter, range_to_step, LatestByLabelQuery, LatestQuery,
+    RangeQuery, SourceKind,
 };
 use tracing::error;
 use utoipa::{IntoParams, OpenApi, ToSchema};
@@ -110,15 +112,61 @@ pub struct MetricsRangeQuery {
     /// Metric name, e.g. `"pg.connections_active"`.
     pub metric: String,
     /// Time window: `"1h"` | `"6h"` | `"24h"` | `"7d"`.
+    /// Ignored when `start_time` and `end_time` are both set.
     #[serde(default = "default_range")]
     pub range: String,
     /// Optional histogram percentile (0–100).  When provided, the endpoint
     /// fetches histogram buckets and computes the requested quantile.
     pub percentile: Option<f64>,
+    /// Explicit window start (ISO 8601). Must be paired with `end_time`.
+    #[param(value_type = Option<String>, example = "2026-08-13T00:00:00Z")]
+    #[schema(value_type = Option<String>)]
+    pub start_time: Option<UtcDateTime>,
+    /// Explicit window end (ISO 8601). Must be paired with `start_time`.
+    #[param(value_type = Option<String>, example = "2026-08-13T12:00:00Z")]
+    #[schema(value_type = Option<String>)]
+    pub end_time: Option<UtcDateTime>,
 }
 
 fn default_range() -> String {
     "1h".to_string()
+}
+
+/// Resolve `(from, to, step)` from either an explicit `[start_time, end_time]`
+/// pair or a preset `range`. Explicit bounds win when both are present.
+fn resolve_range_window(
+    params: &MetricsRangeQuery,
+) -> Result<(DateTime<Utc>, DateTime<Utc>, Duration), Problem> {
+    match (params.start_time, params.end_time) {
+        (Some(start), Some(end)) => {
+            if start >= end {
+                return Err(bad_request()
+                    .detail("start_time must be before end_time")
+                    .build());
+            }
+            let span = end - start;
+            let max = Duration::days(temps_core::time_window::MAX_WINDOW_DAYS);
+            if span > max {
+                return Err(bad_request()
+                    .detail(format!(
+                        "Requested time range spans {} days, which exceeds the {}-day maximum for this endpoint. Older data is still available — request it {} days at a time by moving start_time/end_time back.",
+                        span.num_days().max(1),
+                        temps_core::time_window::MAX_WINDOW_DAYS,
+                        temps_core::time_window::MAX_WINDOW_DAYS
+                    ))
+                    .build());
+            }
+            Ok((start, end, duration_to_step(span)))
+        }
+        (None, None) => {
+            let (window, step) = range_to_step(&params.range);
+            let now = Utc::now();
+            Ok((now - window, now, step))
+        }
+        _ => Err(bad_request()
+            .detail("start_time and end_time must both be provided")
+            .build()),
+    }
 }
 
 /// A single `(timestamp, value)` data point in a metric series.
@@ -271,9 +319,7 @@ async fn get_service_metrics_range(
             .build()
     })?;
 
-    let (window, step) = range_to_step(&params.range);
-    let now = Utc::now();
-    let from = now - window;
+    let (from, to, step) = resolve_range_window(&params)?;
 
     let query = RangeQuery {
         source_kind: SourceKind::Database,
@@ -281,7 +327,7 @@ async fn get_service_metrics_range(
         monotonic: is_monotonic_counter(&params.metric),
         name: params.metric.clone(),
         from,
-        to: now,
+        to,
         step,
     };
 
@@ -1008,9 +1054,7 @@ async fn get_deployment_metrics_range(
             .build()
     })?;
 
-    let (window, step) = range_to_step(&params.range);
-    let now = Utc::now();
-    let from = now - window;
+    let (from, to, step) = resolve_range_window(&params)?;
 
     let query = RangeQuery {
         source_kind: SourceKind::Deployment,
@@ -1018,7 +1062,7 @@ async fn get_deployment_metrics_range(
         monotonic: is_monotonic_counter(&params.metric),
         name: params.metric.clone(),
         from,
-        to: now,
+        to,
         step,
     };
 
@@ -1179,9 +1223,7 @@ async fn get_node_metrics_range(
             .build()
     })?;
 
-    let (window, step) = range_to_step(&params.range);
-    let now = Utc::now();
-    let from = now - window;
+    let (from, to, step) = resolve_range_window(&params)?;
 
     let query = RangeQuery {
         source_kind: SourceKind::Node,
@@ -1189,7 +1231,7 @@ async fn get_node_metrics_range(
         monotonic: is_monotonic_counter(&params.metric),
         name: params.metric.clone(),
         from,
-        to: now,
+        to,
         step,
     };
 

--- a/crates/temps-providers/src/handlers/metrics_handlers.rs
+++ b/crates/temps-providers/src/handlers/metrics_handlers.rs
@@ -134,6 +134,9 @@ fn default_range() -> String {
 
 /// Resolve `(from, to, step)` from either an explicit `[start_time, end_time]`
 /// pair or a preset `range`. Explicit bounds win when both are present.
+///
+/// `step` is always server-derived via `duration_to_step` — callers cannot
+/// request 1-minute buckets over a 7-day window.
 fn resolve_range_window(
     params: &MetricsRangeQuery,
 ) -> Result<(DateTime<Utc>, DateTime<Utc>, Duration), Problem> {
@@ -1639,6 +1642,38 @@ mod tests {
     fn test_histogram_quantile_all_zero_counts_returns_nan() {
         let result = histogram_quantile(0.5, &[1.0, 2.0], &[0, 0]);
         assert!(result.is_nan());
+    }
+
+    fn range_query(start: DateTime<Utc>, end: DateTime<Utc>) -> MetricsRangeQuery {
+        MetricsRangeQuery {
+            metric: "node.cpu_percent".into(),
+            range: "1h".into(),
+            percentile: None,
+            start_time: Some(start),
+            end_time: Some(end),
+        }
+    }
+
+    #[test]
+    fn custom_seven_day_window_uses_hourly_step() {
+        let start = DateTime::parse_from_rfc3339("2026-08-06T00:00:00Z")
+            .expect("valid fixture")
+            .with_timezone(&Utc);
+        let end = start + Duration::days(7);
+        let (_, _, step) = resolve_range_window(&range_query(start, end)).expect("within cap");
+        assert_eq!(step, Duration::hours(1));
+        let points = (end - start).num_seconds() / step.num_seconds().max(1);
+        assert!(points <= temps_core::time_window::MAX_SERIES_POINTS);
+    }
+
+    #[test]
+    fn custom_one_hour_window_uses_minute_step() {
+        let start = DateTime::parse_from_rfc3339("2026-08-13T11:00:00Z")
+            .expect("valid fixture")
+            .with_timezone(&Utc);
+        let end = start + Duration::hours(1);
+        let (_, _, step) = resolve_range_window(&range_query(start, end)).expect("within cap");
+        assert_eq!(step, Duration::minutes(1));
     }
 
     #[test]

--- a/crates/temps-proxy/src/handler/proxy_logs.rs
+++ b/crates/temps-proxy/src/handler/proxy_logs.rs
@@ -369,7 +369,8 @@ pub struct TimeBucketStatsQuery {
     /// End time (ISO 8601 format)
     #[param(value_type = String, example = "2025-10-23T23:59:59Z")]
     pub end_time: UtcDateTime,
-    /// Bucket interval (e.g., "1 hour", "1 day", "5 minutes")
+    /// Bucket interval (e.g., "1 hour", "1 day", "5 minutes").
+    /// Must keep `span / interval` ≤ 1000 buckets (7 days at 1 minute is rejected).
     #[serde(default = "default_bucket_interval")]
     pub bucket_interval: String,
     /// Filter by HTTP method

--- a/crates/temps-proxy/src/service/proxy_log_service.rs
+++ b/crates/temps-proxy/src/service/proxy_log_service.rs
@@ -622,6 +622,65 @@ impl ProxyLogService {
         Self::resolve_window(Some(start_time), Some(end_time), project_scoped).map(|_| ())
     }
 
+    /// Reject a `bucket_interval` that would emit more than
+    /// [`temps_core::time_window::MAX_SERIES_POINTS`] buckets over `[start, end)`.
+    ///
+    /// Window-width caps alone are not enough: `1 minute` over 7 days is a
+    /// legal interval string and a legal window, but ~10k `time_bucket_gapfill`
+    /// buckets. The UI already coarsens with window size; this is the API
+    /// backstop for a crafted query.
+    fn enforce_bucket_count(
+        start_time: UtcDateTime,
+        end_time: UtcDateTime,
+        bucket_interval: &str,
+    ) -> Result<(), ProxyLogServiceError> {
+        if !Self::is_valid_interval(bucket_interval) {
+            return Err(ProxyLogServiceError::InvalidFilter(format!(
+                "Invalid bucket interval: {}",
+                bucket_interval
+            )));
+        }
+        let step_secs = Self::interval_to_seconds(bucket_interval).ok_or_else(|| {
+            ProxyLogServiceError::InvalidFilter(format!(
+                "Invalid bucket interval: {}",
+                bucket_interval
+            ))
+        })?;
+        let span_secs = (end_time - start_time).num_seconds().max(1);
+        let buckets = temps_core::time_window::bucket_count(span_secs, step_secs);
+        let max = temps_core::time_window::MAX_SERIES_POINTS;
+        if buckets > max {
+            let min_step_secs = temps_core::time_window::min_step_secs(span_secs);
+            return Err(ProxyLogServiceError::InvalidFilter(format!(
+                "bucket_interval '{bucket_interval}' would produce {buckets} buckets over this window, which exceeds the {max}-point maximum. Use an interval of at least {min_step_secs} seconds."
+            )));
+        }
+        Ok(())
+    }
+
+    /// Convert a validated `"N unit"` interval into seconds for the bucket-count
+    /// cap. Sub-second units collapse to 1-second buckets (same floor as the
+    /// ClickHouse path). Months/years are approximated; charts never request them.
+    pub(crate) fn interval_to_seconds(interval: &str) -> Option<i64> {
+        let parts: Vec<&str> = interval.split_whitespace().collect();
+        if parts.len() != 2 {
+            return None;
+        }
+        let n: i64 = parts[0].parse().ok()?;
+        let unit_secs: i64 = match parts[1] {
+            "microsecond" | "microseconds" | "millisecond" | "milliseconds" | "second"
+            | "seconds" => 1,
+            "minute" | "minutes" => 60,
+            "hour" | "hours" => 3_600,
+            "day" | "days" => 86_400,
+            "week" | "weeks" => 604_800,
+            "month" | "months" => 2_592_000,
+            "year" | "years" => 31_536_000,
+            _ => return None,
+        };
+        Some(n.saturating_mul(unit_secs).max(1))
+    }
+
     pub async fn list_with_filters(
         &self,
         start_date: Option<UtcDateTime>,
@@ -887,19 +946,14 @@ impl ProxyLogService {
     ) -> Result<Vec<TimeBucketStats>, ProxyLogServiceError> {
         let project_scoped = filters.as_ref().is_some_and(|f| f.project_id.is_some());
         Self::enforce_window_span(start_time, end_time, project_scoped)?;
+        Self::enforce_bucket_count(start_time, end_time, &bucket_interval)?;
 
         if let Some(storage) = &self.storage {
             return storage
                 .get_time_bucket_stats(start_time, end_time, bucket_interval, filters)
                 .await;
         }
-        // Validate bucket interval
-        if !Self::is_valid_interval(&bucket_interval) {
-            return Err(ProxyLogServiceError::InvalidFilter(format!(
-                "Invalid bucket interval: {}",
-                bucket_interval
-            )));
-        }
+        // Interval already checked by enforce_bucket_count.
 
         // Serve from the 1-minute continuous aggregate when it can answer
         // this query: every set filter is a grouping column of the aggregate
@@ -1954,6 +2008,7 @@ impl ProxyLogService {
         group_by: AiTimelineGroupBy,
     ) -> Result<Vec<AiAgentTimelineRow>, ProxyLogServiceError> {
         Self::enforce_window_span(start_time, end_time, project_id.is_some())?;
+        Self::enforce_bucket_count(start_time, end_time, &bucket_interval)?;
 
         if let Some(storage) = &self.storage {
             return storage
@@ -1966,12 +2021,6 @@ impl ProxyLogService {
                     group_by,
                 )
                 .await;
-        }
-        if !Self::is_valid_interval(&bucket_interval) {
-            return Err(ProxyLogServiceError::InvalidFilter(format!(
-                "Invalid bucket interval: {}",
-                bucket_interval
-            )));
         }
 
         let known: Vec<&str> = crate::ai_agent_detector::known_agents()
@@ -2544,6 +2593,60 @@ mod tests {
         // Invalid: special characters
         assert!(!ProxyLogService::is_valid_interval("1; DROP TABLE"));
         assert!(!ProxyLogService::is_valid_interval("1' OR '1'='1"));
+    }
+
+    fn fixture_range(start: &str, end: &str) -> (UtcDateTime, UtcDateTime) {
+        let start = chrono::DateTime::parse_from_rfc3339(start)
+            .expect("valid fixture timestamp")
+            .with_timezone(&chrono::Utc);
+        let end = chrono::DateTime::parse_from_rfc3339(end)
+            .expect("valid fixture timestamp")
+            .with_timezone(&chrono::Utc);
+        (start, end)
+    }
+
+    #[test]
+    fn enforce_bucket_count_rejects_1m_over_7d() {
+        let (start, end) = fixture_range("2026-08-06T00:00:00Z", "2026-08-13T00:00:00Z");
+        let err = ProxyLogService::enforce_bucket_count(start, end, "1 minute")
+            .expect_err("1m over 7d exceeds MAX_SERIES_POINTS");
+        let ProxyLogServiceError::InvalidFilter(msg) = err else {
+            panic!("expected InvalidFilter so the handler returns 400, got {err:?}");
+        };
+        assert!(
+            msg.contains(&format!(
+                "{}-point maximum",
+                temps_core::time_window::MAX_SERIES_POINTS
+            )),
+            "{msg}"
+        );
+        assert!(msg.contains("1 minute"), "{msg}");
+    }
+
+    #[test]
+    fn enforce_bucket_count_allows_1h_over_7d() {
+        let (start, end) = fixture_range("2026-08-06T00:00:00Z", "2026-08-13T00:00:00Z");
+        ProxyLogService::enforce_bucket_count(start, end, "1 hour")
+            .expect("7d at 1h is 168 buckets");
+    }
+
+    #[test]
+    fn enforce_bucket_count_allows_1h_over_30d_scoped() {
+        // Project-scoped windows may be 30d; the UI uses 1h buckets (720 points).
+        let (start, end) = fixture_range("2026-07-14T00:00:00Z", "2026-08-13T00:00:00Z");
+        ProxyLogService::enforce_bucket_count(start, end, "1 hour")
+            .expect("30d at 1h is 720 buckets");
+    }
+
+    #[test]
+    fn enforce_bucket_count_rejects_malformed_interval() {
+        let (start, end) = fixture_range("2026-08-13T00:00:00Z", "2026-08-13T01:00:00Z");
+        let err = ProxyLogService::enforce_bucket_count(start, end, "1 fortnight")
+            .expect_err("unknown unit");
+        let ProxyLogServiceError::InvalidFilter(msg) = err else {
+            panic!("expected InvalidFilter, got {err:?}");
+        };
+        assert!(msg.contains("Invalid bucket interval"), "{msg}");
     }
 
     #[test]

--- a/crates/temps-proxy/src/service/proxy_log_service.rs
+++ b/crates/temps-proxy/src/service/proxy_log_service.rs
@@ -1,6 +1,7 @@
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use sea_orm::*;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::sync::Arc;
 use temps_core::UtcDateTime;
 use temps_entities::proxy_logs;
@@ -909,9 +910,23 @@ impl ProxyLogService {
             && Self::is_minute_multiple_interval(&bucket_interval)
             && self.stats_cagg_exists().await
         {
-            return self
-                .get_time_bucket_stats_from_cagg(start_time, end_time, bucket_interval, filters)
-                .await;
+            let mut stats = self
+                .get_time_bucket_stats_from_cagg(
+                    start_time,
+                    end_time,
+                    bucket_interval.clone(),
+                    filters.clone(),
+                )
+                .await?;
+            self.attach_response_time_percentiles(
+                &mut stats,
+                start_time,
+                end_time,
+                &bucket_interval,
+                filters.as_ref(),
+            )
+            .await?;
+            return Ok(stats);
         }
 
         // Build the base WHERE clause for filters
@@ -969,13 +984,22 @@ impl ProxyLogService {
         }
 
         // Add bucket_interval as parameterized value
-        values.push(bucket_interval.into());
+        values.push(bucket_interval.clone().into());
 
         let stmt = sea_orm::Statement::from_sql_and_values(db_backend, &sql, values);
 
         let results = self.db.query_all(stmt).await?;
 
-        Ok(Self::rows_to_time_bucket_stats(&results, start_time))
+        let mut stats = Self::rows_to_time_bucket_stats(&results, start_time);
+        self.attach_response_time_percentiles(
+            &mut stats,
+            start_time,
+            end_time,
+            &bucket_interval,
+            filters.as_ref(),
+        )
+        .await?;
+        Ok(stats)
     }
 
     /// [`Self::get_time_bucket_stats`] served from the `proxy_logs_stats_1m`
@@ -1072,12 +1096,102 @@ impl ProxyLogService {
                     bucket: bucket.to_rfc3339(),
                     request_count,
                     avg_response_time_ms,
+                    p50_response_time_ms: 0.0,
+                    p95_response_time_ms: 0.0,
+                    p99_response_time_ms: 0.0,
                     error_count,
                     total_request_bytes,
                     total_response_bytes,
                 }
             })
             .collect()
+    }
+
+    /// Overlay p50/p95/p99 from the raw `proxy_logs` table onto already-bucketed
+    /// count/avg/byte stats.
+    ///
+    /// Counts come from the continuous aggregate when it can answer (sums roll
+    /// up losslessly). Percentiles cannot be reconstructed from those sums, so
+    /// this is a second, project-scoped scan of `response_time_ms` — the same
+    /// index the dashboard already uses, and only the timing column.
+    async fn attach_response_time_percentiles(
+        &self,
+        stats: &mut [TimeBucketStats],
+        start_time: UtcDateTime,
+        end_time: UtcDateTime,
+        bucket_interval: &str,
+        filters: Option<&StatsFilters>,
+    ) -> Result<(), ProxyLogServiceError> {
+        if stats.is_empty() {
+            return Ok(());
+        }
+
+        let mut where_clauses = vec!["timestamp >= $1".to_string(), "timestamp < $2".to_string()];
+        let mut param_index = 3;
+        if let Some(f) = filters {
+            Self::build_filter_sql(f, &mut param_index, &mut where_clauses);
+        }
+        let where_clause = format!("WHERE {}", where_clauses.join(" AND "));
+        let bucket_param_index = param_index;
+
+        let sql = format!(
+            r#"
+            SELECT
+                bucket::timestamptz as bucket,
+                COALESCE(p50, 0)::float8 as p50_response_time_ms,
+                COALESCE(p95, 0)::float8 as p95_response_time_ms,
+                COALESCE(p99, 0)::float8 as p99_response_time_ms
+            FROM (
+                SELECT
+                    time_bucket(${}::interval, timestamp) AS bucket,
+                    percentile_cont(0.50) WITHIN GROUP (ORDER BY response_time_ms) as p50,
+                    percentile_cont(0.95) WITHIN GROUP (ORDER BY response_time_ms) as p95,
+                    percentile_cont(0.99) WITHIN GROUP (ORDER BY response_time_ms) as p99
+                FROM proxy_logs
+                {}
+                GROUP BY bucket
+            ) sub
+            "#,
+            bucket_param_index, where_clause
+        );
+
+        let mut values: Vec<sea_orm::Value> = vec![start_time.into(), end_time.into()];
+        if let Some(f) = filters {
+            Self::add_filter_values(&mut values, f);
+        }
+        values.push(bucket_interval.to_string().into());
+
+        let stmt = sea_orm::Statement::from_sql_and_values(
+            sea_orm::DatabaseBackend::Postgres,
+            &sql,
+            values,
+        );
+        let rows = self.db.query_all(stmt).await?;
+
+        let mut by_epoch: HashMap<i64, (f64, f64, f64)> = HashMap::with_capacity(rows.len());
+        for row in rows {
+            let bucket: DateTime<Utc> = row.try_get("", "bucket").unwrap_or(start_time);
+            let p50: f64 = row.try_get("", "p50_response_time_ms").unwrap_or(0.0);
+            let p95: f64 = row.try_get("", "p95_response_time_ms").unwrap_or(0.0);
+            let p99: f64 = row.try_get("", "p99_response_time_ms").unwrap_or(0.0);
+            by_epoch.insert(bucket.timestamp(), (p50, p95, p99));
+        }
+
+        for bucket in stats.iter_mut() {
+            let Some(ts) = DateTime::parse_from_rfc3339(&bucket.bucket)
+                .ok()
+                .map(|d| d.timestamp())
+            else {
+                continue;
+            };
+            if let Some((p50, p95, p99)) = by_epoch.get(&ts) {
+                bucket.p50_response_time_ms = *p50;
+                bucket.p95_response_time_ms = *p95;
+                bucket.p99_response_time_ms = *p99;
+            }
+        }
+
+        Ok(())
     }
 
     /// Get health summaries for multiple projects in a single query
@@ -2170,6 +2284,12 @@ pub struct TimeBucketStats {
     pub request_count: i64,
     /// Average response time in milliseconds
     pub avg_response_time_ms: f64,
+    /// p50 response time in milliseconds (0 when the bucket has no timings)
+    pub p50_response_time_ms: f64,
+    /// p95 response time in milliseconds (0 when the bucket has no timings)
+    pub p95_response_time_ms: f64,
+    /// p99 response time in milliseconds (0 when the bucket has no timings)
+    pub p99_response_time_ms: f64,
     /// Number of errors (status >= 400)
     pub error_count: i64,
     /// Total request bytes
@@ -2869,6 +2989,15 @@ mod tests {
             .expect("populated raw bucket");
         assert!((cagg_busy.avg_response_time_ms - 50.0).abs() < 1e-9);
         assert!((cagg_busy.avg_response_time_ms - raw_busy.avg_response_time_ms).abs() < 1e-9);
+
+        // Percentiles are computed from raw response_time_ms on both paths
+        // ([20, 30, 50, 100] → p50=40, p95=92.5, p99=98.5 via percentile_cont).
+        assert!((cagg_busy.p50_response_time_ms - 40.0).abs() < 1e-9);
+        assert!((cagg_busy.p95_response_time_ms - 92.5).abs() < 1e-9);
+        assert!((cagg_busy.p99_response_time_ms - 98.5).abs() < 1e-9);
+        assert!((cagg_busy.p50_response_time_ms - raw_busy.p50_response_time_ms).abs() < 1e-9);
+        assert!((cagg_busy.p95_response_time_ms - raw_busy.p95_response_time_ms).abs() < 1e-9);
+        assert!((cagg_busy.p99_response_time_ms - raw_busy.p99_response_time_ms).abs() < 1e-9);
     }
 
     fn sample_proxy_log_model(request_id: &str) -> proxy_logs::Model {

--- a/crates/temps-proxy/src/storage/clickhouse.rs
+++ b/crates/temps-proxy/src/storage/clickhouse.rs
@@ -489,6 +489,9 @@ struct ChTimeBucketRow {
     bucket_ms: i64,
     request_count: u64,
     avg_response_time_ms: f64,
+    p50_response_time_ms: f64,
+    p95_response_time_ms: f64,
+    p99_response_time_ms: f64,
     error_count: u64,
     total_request_bytes: i64,
     total_response_bytes: i64,
@@ -1255,6 +1258,9 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
                 toInt64(toUnixTimestamp(toStartOfInterval(timestamp, INTERVAL {step} SECOND))) * 1000 AS bucket_ms, \
                 count() AS request_count, \
                 ifNull(avg(response_time_ms), 0) AS avg_response_time_ms, \
+                ifNull(quantile(0.50)(response_time_ms), 0) AS p50_response_time_ms, \
+                ifNull(quantile(0.95)(response_time_ms), 0) AS p95_response_time_ms, \
+                ifNull(quantile(0.99)(response_time_ms), 0) AS p99_response_time_ms, \
                 countIf(status_code >= 400) AS error_count, \
                 sum(ifNull(request_size_bytes, 0)) AS total_request_bytes, \
                 sum(ifNull(response_size_bytes, 0)) AS total_response_bytes \
@@ -1295,6 +1301,21 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
                     0.0
                 } else {
                     r.avg_response_time_ms
+                },
+                p50_response_time_ms: if r.p50_response_time_ms.is_nan() {
+                    0.0
+                } else {
+                    r.p50_response_time_ms
+                },
+                p95_response_time_ms: if r.p95_response_time_ms.is_nan() {
+                    0.0
+                } else {
+                    r.p95_response_time_ms
+                },
+                p99_response_time_ms: if r.p99_response_time_ms.is_nan() {
+                    0.0
+                } else {
+                    r.p99_response_time_ms
                 },
                 error_count: r.error_count as i64,
                 total_request_bytes: r.total_request_bytes,

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -10090,8 +10090,17 @@ export type MetricsRangeQuery = {
     percentile?: number | null;
     /**
      * Time window: `"1h"` | `"6h"` | `"24h"` | `"7d"`.
+     * Ignored when `start_time` and `end_time` are both set.
      */
     range?: string;
+    /**
+     * Explicit window start (ISO 8601). Must be paired with `end_time`.
+     */
+    start_time?: string | null;
+    /**
+     * Explicit window end (ISO 8601). Must be paired with `start_time`.
+     */
+    end_time?: string | null;
 };
 
 /**
@@ -17680,6 +17689,18 @@ export type TimeBucketStats = {
      * Number of errors (status >= 400)
      */
     error_count: number;
+    /**
+     * p50 response time in milliseconds (0 when the bucket has no timings)
+     */
+    p50_response_time_ms: number;
+    /**
+     * p95 response time in milliseconds (0 when the bucket has no timings)
+     */
+    p95_response_time_ms: number;
+    /**
+     * p99 response time in milliseconds (0 when the bucket has no timings)
+     */
+    p99_response_time_ms: number;
     /**
      * Total number of requests in this bucket
      */
@@ -25727,6 +25748,7 @@ export type DeploymentMetricsGetRangeData = {
         metric: string;
         /**
          * Time window: `"1h"` | `"6h"` | `"24h"` | `"7d"`.
+         * Ignored when `start_time` and `end_time` are both set.
          */
         range?: string;
         /**
@@ -25734,6 +25756,14 @@ export type DeploymentMetricsGetRangeData = {
          * fetches histogram buckets and computes the requested quantile.
          */
         percentile?: number | null;
+        /**
+         * Explicit window start (ISO 8601). Must be paired with `end_time`.
+         */
+        start_time?: string | null;
+        /**
+         * Explicit window end (ISO 8601). Must be paired with `start_time`.
+         */
+        end_time?: string | null;
     };
     url: '/deployments/{id}/metrics';
 };
@@ -28871,6 +28901,7 @@ export type ExternalServiceMetricsGetRangeData = {
         metric: string;
         /**
          * Time window: `"1h"` | `"6h"` | `"24h"` | `"7d"`.
+         * Ignored when `start_time` and `end_time` are both set.
          */
         range?: string;
         /**
@@ -28878,6 +28909,14 @@ export type ExternalServiceMetricsGetRangeData = {
          * fetches histogram buckets and computes the requested quantile.
          */
         percentile?: number | null;
+        /**
+         * Explicit window start (ISO 8601). Must be paired with `end_time`.
+         */
+        start_time?: string | null;
+        /**
+         * Explicit window end (ISO 8601). Must be paired with `start_time`.
+         */
+        end_time?: string | null;
     };
     url: '/external-services/{id}/metrics';
 };
@@ -34282,6 +34321,7 @@ export type NodeMetricsGetRangeData = {
         metric: string;
         /**
          * Time window: `"1h"` | `"6h"` | `"24h"` | `"7d"`.
+         * Ignored when `start_time` and `end_time` are both set.
          */
         range?: string;
         /**
@@ -34289,6 +34329,14 @@ export type NodeMetricsGetRangeData = {
          * fetches histogram buckets and computes the requested quantile.
          */
         percentile?: number | null;
+        /**
+         * Explicit window start (ISO 8601). Must be paired with `end_time`.
+         */
+        start_time?: string | null;
+        /**
+         * Explicit window end (ISO 8601). Must be paired with `start_time`.
+         */
+        end_time?: string | null;
     };
     url: '/nodes/{id}/metrics';
 };

--- a/web/src/lib/proxy-metrics-window.test.ts
+++ b/web/src/lib/proxy-metrics-window.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  pickProxyBucketInterval,
+  proxyWindowTooWide,
+  resolveProxyWindow,
+} from './proxy-metrics-window'
+
+const NOW = new Date('2026-08-13T12:00:00.000Z')
+
+describe('pickProxyBucketInterval', () => {
+  test('matches node-metric preset resolution', () => {
+    expect(pickProxyBucketInterval(3_600)).toBe('1 minute')
+    expect(pickProxyBucketInterval(21_600)).toBe('5 minutes')
+    expect(pickProxyBucketInterval(86_400)).toBe('15 minutes')
+    expect(pickProxyBucketInterval(604_800)).toBe('1 hour')
+  })
+})
+
+describe('resolveProxyWindow', () => {
+  test('preset 1h anchors to now and keeps the range param', () => {
+    const w = resolveProxyWindow('1h', undefined, NOW)
+    expect(w.rangeParam).toBe('1h')
+    expect(w.durationSeconds).toBe(3_600)
+    expect(w.bucketInterval).toBe('1 minute')
+    expect(w.endIso).toBe(NOW.toISOString())
+    expect(w.startIso).toBe(new Date(NOW.getTime() - 3_600_000).toISOString())
+    expect(w.showDate).toBe(false)
+  })
+
+  test('7d shows calendar dates on the axis', () => {
+    const w = resolveProxyWindow('7d', undefined, NOW)
+    expect(w.rangeParam).toBe('7d')
+    expect(w.showDate).toBe(true)
+    expect(w.bucketInterval).toBe('1 hour')
+  })
+
+  test('custom range omits rangeParam and sizes the bucket from span', () => {
+    const from = new Date('2026-08-13T08:00:00.000Z')
+    const to = new Date('2026-08-13T12:00:00.000Z')
+    const w = resolveProxyWindow('custom', { from, to }, NOW)
+    expect(w.rangeParam).toBeUndefined()
+    expect(w.durationSeconds).toBe(14_400)
+    expect(w.bucketInterval).toBe('5 minutes')
+    expect(w.startIso).toBe(from.toISOString())
+    expect(w.endIso).toBe(to.toISOString())
+    expect(w.showDate).toBe(false)
+  })
+
+  test('multi-day custom range shows dates', () => {
+    const from = new Date('2026-08-10T12:00:00.000Z')
+    const to = new Date('2026-08-13T12:00:00.000Z')
+    const w = resolveProxyWindow('custom', { from, to }, NOW)
+    expect(w.showDate).toBe(true)
+    expect(w.bucketInterval).toBe('1 hour')
+  })
+
+  test('incomplete custom range falls back to 24h', () => {
+    const w = resolveProxyWindow('custom', { from: NOW }, NOW)
+    expect(w.rangeParam).toBe('24h')
+    expect(w.durationSeconds).toBe(86_400)
+  })
+})
+
+describe('proxyWindowTooWide', () => {
+  test('unscoped cap is 7 days', () => {
+    const from = new Date('2026-08-01T12:00:00.000Z')
+    const to = new Date('2026-08-13T12:00:00.000Z')
+    const w = resolveProxyWindow('custom', { from, to }, NOW)
+    expect(proxyWindowTooWide(w, false)).toBe(true)
+    expect(proxyWindowTooWide(w, true)).toBe(false)
+  })
+
+  test('7d preset is inside the unscoped cap', () => {
+    const w = resolveProxyWindow('7d', undefined, NOW)
+    expect(proxyWindowTooWide(w, false)).toBe(false)
+  })
+})

--- a/web/src/lib/proxy-metrics-window.test.ts
+++ b/web/src/lib/proxy-metrics-window.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import {
   pickProxyBucketInterval,
+  PROXY_MAX_CHART_POINTS,
   proxyWindowTooWide,
   resolveProxyWindow,
 } from './proxy-metrics-window'
@@ -13,6 +14,21 @@ describe('pickProxyBucketInterval', () => {
     expect(pickProxyBucketInterval(21_600)).toBe('5 minutes')
     expect(pickProxyBucketInterval(86_400)).toBe('15 minutes')
     expect(pickProxyBucketInterval(604_800)).toBe('1 hour')
+  })
+
+  test('stays under PROXY_MAX_CHART_POINTS through 30d', () => {
+    const stepSeconds: Record<string, number> = {
+      '1 minute': 60,
+      '5 minutes': 300,
+      '15 minutes': 900,
+      '1 hour': 3_600,
+    }
+    for (const secs of [3_600, 21_600, 86_400, 604_800, 30 * 86_400]) {
+      const interval = pickProxyBucketInterval(secs)
+      const step = stepSeconds[interval]
+      expect(step).toBeDefined()
+      expect(Math.ceil(secs / step)).toBeLessThanOrEqual(PROXY_MAX_CHART_POINTS)
+    }
   })
 })
 

--- a/web/src/lib/proxy-metrics-window.ts
+++ b/web/src/lib/proxy-metrics-window.ts
@@ -1,0 +1,103 @@
+export type ProxyRangePreset = '1h' | '6h' | '24h' | '7d'
+export type ProxyRangeValue = ProxyRangePreset | 'custom'
+
+export const PROXY_RANGE_PRESETS: { value: ProxyRangePreset; label: string }[] =
+  [
+    { value: '1h', label: '1h' },
+    { value: '6h', label: '6h' },
+    { value: '24h', label: '24h' },
+    { value: '7d', label: '7d' },
+  ]
+
+/** Matches `temps_core::time_window::MAX_WINDOW_DAYS` (unscoped reads). */
+export const PROXY_MAX_WINDOW_DAYS = 7
+
+/** Matches `temps_core::time_window::MAX_WINDOW_DAYS_SCOPED`. */
+export const PROXY_MAX_WINDOW_DAYS_SCOPED = 30
+
+const PRESET_SECONDS: Record<ProxyRangePreset, number> = {
+  '1h': 3_600,
+  '6h': 21_600,
+  '24h': 86_400,
+  '7d': 604_800,
+}
+
+export type ResolvedProxyWindow = {
+  startIso: string
+  endIso: string
+  durationSeconds: number
+  /** Timescale/ClickHouse `bucket_interval` matching node-metric resolution. */
+  bucketInterval: string
+  /** Preset passed to `/nodes/{id}/metrics`. Undefined for a custom range. */
+  rangeParam: ProxyRangePreset | undefined
+  /** Include the calendar date on the chart x-axis. */
+  showDate: boolean
+}
+
+/** Bucket width matching the node-metrics endpoint's per-range resolution. */
+export function pickProxyBucketInterval(durationSeconds: number): string {
+  if (durationSeconds <= 3_600) return '1 minute'
+  if (durationSeconds <= 21_600) return '5 minutes'
+  if (durationSeconds <= 86_400) return '15 minutes'
+  return '1 hour'
+}
+
+export function formatProxyTimeLabel(iso: string, showDate: boolean): string {
+  const d = new Date(iso)
+  if (showDate) {
+    return d.toLocaleDateString([], { month: 'short', day: 'numeric' })
+  }
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+/**
+ * Resolve the proxy dashboard window.
+ *
+ * An incomplete custom range (Custom clicked, dates not yet picked) falls
+ * back to the 24h preset so charts keep a valid query rather than hanging
+ * empty.
+ */
+export function resolveProxyWindow(
+  range: ProxyRangeValue,
+  custom: { from?: Date; to?: Date } | undefined,
+  now: Date
+): ResolvedProxyWindow {
+  if (range === 'custom' && custom?.from && custom?.to) {
+    const start = custom.from
+    const end = custom.to.getTime() >= custom.from.getTime() ? custom.to : custom.from
+    const durationSeconds = Math.max(
+      1,
+      (end.getTime() - start.getTime()) / 1000
+    )
+    return {
+      startIso: start.toISOString(),
+      endIso: end.toISOString(),
+      durationSeconds,
+      bucketInterval: pickProxyBucketInterval(durationSeconds),
+      rangeParam: undefined,
+      showDate: durationSeconds > 86_400,
+    }
+  }
+
+  const preset: ProxyRangePreset = range === 'custom' ? '24h' : range
+  const durationSeconds = PRESET_SECONDS[preset]
+  const start = new Date(now.getTime() - durationSeconds * 1000)
+  return {
+    startIso: start.toISOString(),
+    endIso: now.toISOString(),
+    durationSeconds,
+    bucketInterval: pickProxyBucketInterval(durationSeconds),
+    rangeParam: preset,
+    showDate: preset === '7d',
+  }
+}
+
+export function proxyWindowTooWide(
+  window: ResolvedProxyWindow,
+  projectScoped: boolean
+): boolean {
+  const maxDays = projectScoped
+    ? PROXY_MAX_WINDOW_DAYS_SCOPED
+    : PROXY_MAX_WINDOW_DAYS
+  return window.durationSeconds > maxDays * 86_400
+}

--- a/web/src/lib/proxy-metrics-window.ts
+++ b/web/src/lib/proxy-metrics-window.ts
@@ -34,6 +34,9 @@ export type ResolvedProxyWindow = {
   showDate: boolean
 }
 
+/** Matches `temps_core::time_window::MAX_SERIES_POINTS`. */
+export const PROXY_MAX_CHART_POINTS = 1_000
+
 /** Bucket width matching the node-metrics endpoint's per-range resolution. */
 export function pickProxyBucketInterval(durationSeconds: number): string {
   if (durationSeconds <= 3_600) return '1 minute'

--- a/web/src/pages/ProxyMetrics.tsx
+++ b/web/src/pages/ProxyMetrics.tsx
@@ -7,9 +7,8 @@
  *   - "All projects" (default): process-wide proxy.* node metrics on the
  *     control-plane node (id 0). These have no project dimension by design.
  *   - Project/environment filtered: proxy-log-derived time buckets from
- *     GET /proxy-logs/stats/time-buckets (request/error counts, avg latency,
- *     bandwidth). Logs carry no percentiles, so the latency-percentile panel
- *     is replaced by a bandwidth panel in filtered mode.
+ *     GET /proxy-logs/stats/time-buckets (request/error counts, avg + p50/p95/p99
+ *     latency, bandwidth).
  *
  * All data comes from generated SDK bindings — never hand-rolled fetch.
  */
@@ -31,6 +30,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { DateRangePicker } from '@/components/ui/date-range-picker'
 import {
   Select,
   SelectContent,
@@ -50,8 +50,19 @@ import {
 import { useBreadcrumbs } from '@/contexts/BreadcrumbContext'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { TOOLTIP_CONTENT_STYLE, TOOLTIP_LABEL_STYLE } from '@/lib/chart-tooltip'
+import {
+  formatProxyTimeLabel,
+  PROXY_MAX_WINDOW_DAYS,
+  PROXY_MAX_WINDOW_DAYS_SCOPED,
+  PROXY_RANGE_PRESETS,
+  proxyWindowTooWide,
+  resolveProxyWindow,
+  type ProxyRangeValue,
+  type ResolvedProxyWindow,
+} from '@/lib/proxy-metrics-window'
 import { useQueries, useQuery } from '@tanstack/react-query'
 import { useEffect, useMemo, useRef, useState } from 'react'
+import type { DateRange } from 'react-day-picker'
 import {
   CartesianGrid,
   Line,
@@ -68,30 +79,6 @@ import {
 
 /** The control-plane node always has id 0. */
 const CONTROL_PLANE_NODE_ID = 0
-
-const RANGE_OPTIONS = [
-  { value: '1h', label: '1h' },
-  { value: '6h', label: '6h' },
-  { value: '24h', label: '24h' },
-  { value: '7d', label: '7d' },
-] as const
-
-type RangeValue = (typeof RANGE_OPTIONS)[number]['value']
-
-const RANGE_SECONDS: Record<RangeValue, number> = {
-  '1h': 3_600,
-  '6h': 21_600,
-  '24h': 86_400,
-  '7d': 604_800,
-}
-
-/** Bucket steps matching the node-metric endpoint's per-range resolution. */
-const RANGE_BUCKET_INTERVAL: Record<RangeValue, string> = {
-  '1h': '1 minute',
-  '6h': '5 minutes',
-  '24h': '15 minutes',
-  '7d': '1 hour',
-}
 
 /** One line in a chart panel: data key + display label + stroke color. */
 type SeriesDef = {
@@ -351,21 +338,18 @@ function isMetricsUnavailable(err: unknown): boolean {
   return msg.includes('not available') || msg.includes('unavailable')
 }
 
-/** Time-axis label — include the date on multi-day ranges. */
-function formatTimeLabel(iso: string, range: RangeValue): string {
-  const d = new Date(iso)
-  if (range === '7d') {
-    return d.toLocaleDateString([], { month: 'short', day: 'numeric' })
-  }
-  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-}
-
 /** Shared query options for one proxy metric series on the CP node. */
-function proxySeriesQuery(metric: string, range: RangeValue) {
+function proxySeriesQuery(metric: string, window: ResolvedProxyWindow) {
   return {
     ...nodeMetricsGetRangeOptions({
       path: { id: CONTROL_PLANE_NODE_ID },
-      query: { metric, range },
+      query: window.rangeParam
+        ? { metric, range: window.rangeParam }
+        : {
+            metric,
+            start_time: window.startIso,
+            end_time: window.endIso,
+          },
     }),
     staleTime: 15_000,
     refetchInterval: 30_000,
@@ -374,29 +358,27 @@ function proxySeriesQuery(metric: string, range: RangeValue) {
 }
 
 /** Memoized window bounds for the selected range (stable query keys). */
-function useWindowBounds(range: RangeValue) {
-  return useMemo(() => {
-    const end = new Date()
-    const start = new Date(end.getTime() - RANGE_SECONDS[range] * 1000)
-    return {
-      startIso: start.toISOString(),
-      endIso: end.toISOString(),
-    }
-  }, [range])
+function useResolvedWindow(
+  range: ProxyRangeValue,
+  custom: DateRange | undefined
+) {
+  return useMemo(
+    () => resolveProxyWindow(range, custom, new Date()),
+    [range, custom?.from?.getTime(), custom?.to?.getTime()]
+  )
 }
 
 /**
  * Proxy-log time buckets for the filtered view. Identical options across the
  * stat cards and every chart panel, so React Query dedupes to one request.
  */
-function useBucketStats(range: RangeValue, filter: ProxyFilter) {
-  const { startIso, endIso } = useWindowBounds(range)
+function useBucketStats(window: ResolvedProxyWindow, filter: ProxyFilter) {
   return useQuery({
     ...getTimeBucketStatsOptions({
       query: {
-        start_time: startIso,
-        end_time: endIso,
-        bucket_interval: RANGE_BUCKET_INTERVAL[range],
+        start_time: window.startIso,
+        end_time: window.endIso,
+        bucket_interval: window.bucketInterval,
         project_id: filter.projectId ?? undefined,
         environment_id: filter.environmentId ?? undefined,
       },
@@ -527,13 +509,13 @@ function ChartPanel({
 
 function NodeMetricPanel({
   panel,
-  range,
+  window,
 }: {
   panel: NodePanelDef
-  range: RangeValue
+  window: ResolvedProxyWindow
 }) {
   const results = useQueries({
-    queries: panel.series.map((s) => proxySeriesQuery(s.metric, range)),
+    queries: panel.series.map((s) => proxySeriesQuery(s.metric, window)),
   })
 
   const isPending = results.some((r) => r.isPending)
@@ -553,7 +535,7 @@ function NodeMetricPanel({
     for (const p of r.data ?? []) {
       const row = rows.get(p.time) ?? {
         time: p.time,
-        label: formatTimeLabel(p.time, range),
+        label: formatProxyTimeLabel(p.time, window.showDate),
       }
       row[key] = p.value
       rows.set(p.time, row)
@@ -581,30 +563,33 @@ function NodeMetricPanel({
 // Filtered charts (proxy-log time buckets)
 // ---------------------------------------------------------------------------
 
-function bucketChartRows(stats: TimeBucketStats[], range: RangeValue) {
+function bucketChartRows(stats: TimeBucketStats[], window: ResolvedProxyWindow) {
   return stats.map((b) => ({
     time: b.bucket,
-    label: formatTimeLabel(b.bucket, range),
+    label: formatProxyTimeLabel(b.bucket, window.showDate),
     request_count: b.request_count,
     error_count: b.error_count,
     error_rate:
       b.request_count > 0 ? (b.error_count / b.request_count) * 100 : 0,
     avg_response_time_ms: b.avg_response_time_ms,
+    p50_response_time_ms: b.p50_response_time_ms,
+    p95_response_time_ms: b.p95_response_time_ms,
+    p99_response_time_ms: b.p99_response_time_ms,
     total_request_bytes: b.total_request_bytes,
     total_response_bytes: b.total_response_bytes,
   }))
 }
 
 function FilteredCharts({
-  range,
+  window,
   filter,
 }: {
-  range: RangeValue
+  window: ResolvedProxyWindow
   filter: ProxyFilter
 }) {
-  const q = useBucketStats(range, filter)
+  const q = useBucketStats(window, filter)
   const stats = q.data?.stats ?? []
-  const data = bucketChartRows(stats, range)
+  const data = bucketChartRows(stats, window)
 
   const shared = {
     data,
@@ -614,8 +599,7 @@ function FilteredCharts({
   }
 
   return (
-    <div className="space-y-2">
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <ChartPanel
           title="Requests"
           description="Requests and errors (status ≥ 400) per interval, from proxy logs"
@@ -633,6 +617,29 @@ function FilteredCharts({
             { dataKey: 'error_rate', label: 'Error rate', color: '#dc2626' },
           ]}
           valueFormatter={formatPercent}
+          {...shared}
+        />
+        <ChartPanel
+          title="Latency percentiles"
+          description="Request duration p50 / p95 / p99, from proxy logs"
+          series={[
+            {
+              dataKey: 'p50_response_time_ms',
+              label: 'p50',
+              color: '#16a34a',
+            },
+            {
+              dataKey: 'p95_response_time_ms',
+              label: 'p95',
+              color: '#d97706',
+            },
+            {
+              dataKey: 'p99_response_time_ms',
+              label: 'p99',
+              color: '#dc2626',
+            },
+          ]}
+          valueFormatter={formatMs}
           {...shared}
         />
         <ChartPanel
@@ -666,10 +673,6 @@ function FilteredCharts({
           valueFormatter={formatBytesShort}
           {...shared}
         />
-      </div>
-      <p className="text-xs text-muted-foreground">
-        Percentile latency is only available for all traffic.
-      </p>
     </div>
   )
 }
@@ -713,19 +716,19 @@ function StatCard({ title, value, isPending, sub }: StatCardProps) {
 }
 
 /** Unfiltered stats — computed from the process-wide node metric series. */
-function NodeSummaryStats({ range }: { range: RangeValue }) {
+function NodeSummaryStats({ window }: { window: ResolvedProxyWindow }) {
   // Same query keys the chart panels use — React Query dedupes the fetches.
   const [requests, errors5xx, p95, destProject, destConsole, destOther] =
     useQueries({
       queries: [
-        proxySeriesQuery('proxy.requests', range),
-        proxySeriesQuery('proxy.requests_5xx', range),
-        proxySeriesQuery('proxy.request_duration_p95_ms', range),
+        proxySeriesQuery('proxy.requests', window),
+        proxySeriesQuery('proxy.requests_5xx', window),
+        proxySeriesQuery('proxy.request_duration_p95_ms', window),
         // Destination split — same options the "Requests by destination"
         // panel uses, so React Query dedupes the fetches.
-        proxySeriesQuery('proxy.requests_project', range),
-        proxySeriesQuery('proxy.requests_console', range),
-        proxySeriesQuery('proxy.requests_other', range),
+        proxySeriesQuery('proxy.requests_project', window),
+        proxySeriesQuery('proxy.requests_console', window),
+        proxySeriesQuery('proxy.requests_other', window),
       ],
     })
 
@@ -766,7 +769,7 @@ function NodeSummaryStats({ range }: { range: RangeValue }) {
         isPending={requests.isPending}
         value={
           hasRequests
-            ? `${(totalRequests / RANGE_SECONDS[range]).toFixed(2)}/s`
+            ? `${(totalRequests / window.durationSeconds).toFixed(2)}/s`
             : null
         }
       />
@@ -796,25 +799,20 @@ function NodeSummaryStats({ range }: { range: RangeValue }) {
 
 /** Filtered stats — computed from the proxy-log time buckets. */
 function FilteredSummaryStats({
-  range,
+  window,
   filter,
 }: {
-  range: RangeValue
+  window: ResolvedProxyWindow
   filter: ProxyFilter
 }) {
-  const q = useBucketStats(range, filter)
+  const q = useBucketStats(window, filter)
   const stats = q.data?.stats ?? []
 
   const totalRequests = stats.reduce((acc, b) => acc + b.request_count, 0)
   const totalErrors = stats.reduce((acc, b) => acc + b.error_count, 0)
-  // Weighted average of per-bucket means by request count.
-  const weightedAvg =
-    totalRequests > 0
-      ? stats.reduce(
-          (acc, b) => acc + b.avg_response_time_ms * b.request_count,
-          0
-        ) / totalRequests
-      : null
+  const latestP95 = [...stats]
+    .reverse()
+    .find((b) => b.request_count > 0)?.p95_response_time_ms
 
   const ok = !q.isPending && !q.isError
 
@@ -824,7 +822,9 @@ function FilteredSummaryStats({
         title="Requests/s"
         isPending={q.isPending}
         value={
-          ok ? `${(totalRequests / RANGE_SECONDS[range]).toFixed(2)}/s` : null
+          ok
+            ? `${(totalRequests / window.durationSeconds).toFixed(2)}/s`
+            : null
         }
       />
       <StatCard
@@ -842,9 +842,9 @@ function FilteredSummaryStats({
         }
       />
       <StatCard
-        title="Avg latency"
+        title="p95 latency"
         isPending={q.isPending}
-        value={ok && weightedAvg != null ? formatMs(weightedAvg) : null}
+        value={ok && latestP95 != null ? formatMs(latestP95) : null}
       />
     </div>
   )
@@ -996,16 +996,16 @@ function StatusBadge({ status }: { status: string }) {
 const TRAFFIC_PAGE_SIZE = 20
 
 function TrafficByProject({
-  range,
+  window,
   filter,
 }: {
-  range: RangeValue
+  window: ResolvedProxyWindow
   filter: ProxyFilter
 }) {
   const [sortKey, setSortKey] = useState<TrafficSortKey>('total_requests')
   const [sortDesc, setSortDesc] = useState(true)
   const [page, setPage] = useState(1)
-  const { startIso, endIso } = useWindowBounds(range)
+  const { startIso, endIso } = window
 
   // Defer fetching until the card is actually scrolled into view — on the
   // unfiltered view it sits below the node metrics panels, so a page load
@@ -1235,19 +1235,24 @@ function TrafficByProject({
 
 export default function ProxyMetrics() {
   const { setBreadcrumbs } = useBreadcrumbs()
-  const [range, setRange] = useState<RangeValue>('1h')
+  const [range, setRange] = useState<ProxyRangeValue>('1h')
+  const [customRange, setCustomRange] = useState<DateRange | undefined>()
   const [filter, setFilter] = useState<ProxyFilter>({
     projectId: null,
     environmentId: null,
   })
+  const resolved = useResolvedWindow(range, customRange)
+  const isFiltered = filter.projectId != null
+  const tooWide = proxyWindowTooWide(resolved, isFiltered)
+  const maxDays = isFiltered
+    ? PROXY_MAX_WINDOW_DAYS_SCOPED
+    : PROXY_MAX_WINDOW_DAYS
 
   useEffect(() => {
     setBreadcrumbs([{ label: 'Proxy' }])
   }, [setBreadcrumbs])
 
   usePageTitle('Proxy')
-
-  const isFiltered = filter.projectId != null
 
   // Full-width like Monitoring.tsx — the app layout wrapper supplies the
   // outer padding, so no container/max-w here.
@@ -1264,7 +1269,7 @@ export default function ProxyMetrics() {
           <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
             <FilterBar filter={filter} onChange={setFilter} />
             <div className="flex items-center gap-1">
-              {RANGE_OPTIONS.map((opt) => (
+              {PROXY_RANGE_PRESETS.map((opt) => (
                 <Button
                   key={opt.value}
                   variant={range === opt.value ? 'default' : 'outline'}
@@ -1274,31 +1279,52 @@ export default function ProxyMetrics() {
                   {opt.label}
                 </Button>
               ))}
+              <Button
+                variant={range === 'custom' ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setRange('custom')}
+              >
+                Custom
+              </Button>
             </div>
+            {range === 'custom' && (
+              <DateRangePicker
+                date={customRange}
+                onDateChange={setCustomRange}
+                showTime
+                className="w-full sm:w-[300px]"
+              />
+            )}
           </div>
         </div>
 
-        {isFiltered ? (
+        {tooWide ? (
+          <p className="rounded-md border border-dashed px-4 py-8 text-center text-sm text-muted-foreground">
+            Custom range exceeds the {maxDays}-day maximum
+            {isFiltered ? ' for a project' : ''}. Narrow the window, or request
+            older data {maxDays} days at a time.
+          </p>
+        ) : isFiltered ? (
           <>
-            <FilteredSummaryStats range={range} filter={filter} />
-            <FilteredCharts range={range} filter={filter} />
+            <FilteredSummaryStats window={resolved} filter={filter} />
+            <FilteredCharts window={resolved} filter={filter} />
           </>
         ) : (
           <>
-            <NodeSummaryStats range={range} />
+            <NodeSummaryStats window={resolved} />
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               {NODE_PANELS.map((panel) => (
                 <NodeMetricPanel
                   key={panel.title}
                   panel={panel}
-                  range={range}
+                  window={resolved}
                 />
               ))}
             </div>
           </>
         )}
 
-        <TrafficByProject range={range} filter={filter} />
+        {!tooWide && <TrafficByProject window={resolved} filter={filter} />}
       </div>
     </div>
   )


### PR DESCRIPTION
## Description
Selecting a project on the Proxy page dropped percentile latency — time-bucket stats only returned averages, and the UI treated p50/p95/p99 as all-traffic-only. The same page also only offered 1h/6h/24h/7d.
Fix:
- `TimeBucketStats` now includes p50/p95/p99. Timescale computes `percentile_cont` from raw `response_time_ms` (the 1-minute CAGG still serves counts/bytes; percentiles cannot roll up from sums). ClickHouse adds `quantile(0.50/0.95/0.99)` on the existing bucket query.
- The filtered Proxy view charts those percentiles and shows p95 on the summary card.
- Custom range (`DateRangePicker`, same pattern as Resource Monitoring) for the whole Proxy view. Node metrics accept optional `start_time`/`end_time` (7-day cap). Project-scoped log stats keep the 30-day scoped cap.
Window helpers live in `web/src/lib/proxy-metrics-window.ts` (`bun test src/lib/proxy-metrics-window.test.ts` — 8/8). `duration_to_step` tests in temps-metrics pass (5). CAGG vs raw percentiles: `cargo test --lib -p temps-proxy test_stats_served_from_cagg_match_raw_path` passes. `cargo check --lib` on temps-metrics, temps-providers, and temps-proxy is clean. Web SDK types in `web/src/api/client/types.gen.ts` were updated to match the new fields; CLI `openapi.json` was not regenerated (no CLI consumer of these params).
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
## Checklist
- [x] I have written tests that cover the changes
- [x] All new and existing tests pass (`cargo test --lib`)
- [x] `cargo check --lib` passes with no warnings
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have updated documentation where necessary
## Related issues
<!-- No linked issue. -->