### PR TITLE
fix(web): re-measure AI composer height once the dock's open transition settles

### DIFF
--- a/web/src/components/ai/DebugChatPanel.tsx
+++ b/web/src/components/ai/DebugChatPanel.tsx
@@ -1782,10 +1782,24 @@ export function DebugChatPanel({
     const textarea = composerRef.current
     if (!textarea) return
 
-    textarea.style.height = '0px'
-    const layout = resolveChatComposerLayout(textarea.scrollHeight)
-    textarea.style.height = `${layout.height}px`
-    textarea.style.overflowY = layout.overflowY
+    const resize = () => {
+      textarea.style.height = '0px'
+      const layout = resolveChatComposerLayout(textarea.scrollHeight)
+      textarea.style.height = `${layout.height}px`
+      textarea.style.overflowY = layout.overflowY
+    }
+    resize()
+
+    // The AI dock panel animates its width in on open (`transition-[width]`
+    // in AiAssistantDock), and this composer mounts immediately rather than
+    // after that transition finishes. So this effect's first run can measure
+    // scrollHeight while the panel is still narrow mid-animation, wrapping
+    // the placeholder onto extra lines and inflating the clamp to its max —
+    // stuck there until `input` next changes. Re-run once the composer's
+    // actual width settles instead of only reacting to typed input.
+    const observer = new ResizeObserver(resize)
+    observer.observe(textarea)
+    return () => observer.disconnect()
   }, [input])
 
   // Abort any in-flight stream if the panel unmounts mid-generation.


### PR DESCRIPTION
## Summary
- The AI assistant dock's `<aside>` animates its width in (`transition-[width] duration-300`) when it opens, but the composer inside mounts immediately, not after that transition finishes.
- When resuming an existing chat, the composer's height-clamping `useLayoutEffect` took its first `scrollHeight` measurement while the panel was still narrow mid-animation (confirmed via live measurement: textarea width ~24px), wrapping the placeholder onto extra lines and inflating the measured height past the 240px max clamp defined in `CHAT_COMPOSER_MAX_HEIGHT`.
- Because the effect's dependency array was only `[input]`, it never re-measured until the user typed — matching the reported symptom: composer opens oversized and empty, then visibly shrinks the moment you start typing.
- Fix: observe the textarea's own size with a `ResizeObserver` so the height is re-measured whenever its actual rendered width settles (e.g., once the panel's opening transition completes), not only when `input` changes.

## Test plan
- [x] `bunx tsc --noEmit` passes with no new errors
- [x] Reproduced live against a running dev instance: opened the AI dock immediately after click and captured the mid-transition state — textarea width ~24px, height inflated to the 240px clamp with `scrollHeight` measured at 416
- [x] Confirmed root cause matches the reported behavior (starts oversized, only corrects itself once the user types and `input` changes trigger a re-measure)
- [ ] Manual verification of the fully-settled post-fix state was inconclusive in this sandbox due to an unrelated, pre-existing dev-server quirk (the AI dock panel's width also gets stuck under certain conditions in this environment, independent of this change — reproduced identically on the unmodified `main` code before this fix was applied). The fix itself (`ResizeObserver`-driven re-measurement) is a standard, well-established pattern for this exact "measured before the container settled" class of bug, and correctly triggers whenever the textarea's rendered width changes.