### PR TITLE
fix(git): make git connections shared across all users

### DIFF
--- a/crates/temps-git/src/handlers/base.rs
+++ b/crates/temps-git/src/handlers/base.rs
@@ -810,7 +810,7 @@ pub async fn list_connections(
 
     let (connections, total_count) = state
         .git_provider_manager
-        .get_user_connections_paginated(auth.user_id(), page, per_page, sort, direction)
+        .get_user_connections_paginated(page, per_page, sort, direction)
         .await?;
 
     let response_connections: Vec<ConnectionResponse> = connections
@@ -859,17 +859,9 @@ pub async fn sync_repositories(
 ) -> Result<impl IntoResponse, Problem> {
     permission_check!(auth, Permission::GitRepositoriesSync);
 
-    // Ownership check, mirroring list_repositories_by_connection below:
-    // without this, any authenticated user could trigger a background sync
-    // (including an OAuth token refresh) on another user's git connection by
-    // guessing/enumerating an integer connection_id.
-    let connection = state
-        .git_provider_manager
-        .get_connection(connection_id)
-        .await?;
-    if connection.user_id != Some(auth.user_id()) {
-        return Err(GitProviderManagerError::ConnectionNotFound(connection_id.to_string()).into());
-    }
+    // Connections are shared across all authenticated users (single-tenant:
+    // "the team is the app" for now), so any user with GitRepositoriesSync
+    // may sync any connection -- no per-owner ownership check here.
 
     // Fire and forget: the manager spawns a detached task owning a drop
     // guard that resets `syncing=false` on every exit path. We can
@@ -927,13 +919,13 @@ pub async fn list_repositories_by_connection(
 ) -> Result<impl IntoResponse, Problem> {
     permission_check!(auth, Permission::GitRepositoriesRead);
 
-    let connection = state
+    // 404s if the connection doesn't exist. Connections are shared across all
+    // authenticated users (single-tenant: "the team is the app" for now), so
+    // no per-owner ownership check here.
+    state
         .git_provider_manager
         .get_connection(connection_id)
         .await?;
-    if connection.user_id != Some(auth.user_id()) {
-        return Err(GitProviderManagerError::ConnectionNotFound(connection_id.to_string()).into());
-    }
 
     let page = query.page.unwrap_or(1).max(1);
     let per_page = query.per_page.unwrap_or(30).min(100);
@@ -1090,13 +1082,12 @@ pub async fn list_repositories_by_provider(
 
     // provider_id identifies a shared, platform-level OAuth app/PAT config --
     // many users can each have their own git_provider_connections row against
-    // the same provider, so this must stay scoped to the caller's own user_id
-    // or it leaks every other user's repositories (names, clone/SSH URLs,
-    // private flag).
-    let user_id = auth.user_id();
+    // the same provider. Connections (and their repositories) are shared
+    // across all authenticated users (single-tenant: "the team is the app"
+    // for now), so this is intentionally not scoped to the caller's user_id.
     let filter = RepositoryFilter {
         provider_id: Some(provider_id),
-        user_id: Some(user_id),
+        user_id: None,
         search: query.search.clone(),
         owner: query.owner.clone(),
         language: query.language.clone(),
@@ -1112,7 +1103,7 @@ pub async fn list_repositories_by_provider(
     // For total count, make a separate call without pagination.
     let count_filter = RepositoryFilter {
         provider_id: Some(provider_id),
-        user_id: Some(user_id),
+        user_id: None,
         search: query.search.clone(),
         owner: query.owner.clone(),
         language: query.language.clone(),

--- a/crates/temps-git/src/services/git_provider_manager.rs
+++ b/crates/temps-git/src/services/git_provider_manager.rs
@@ -1634,10 +1634,13 @@ impl GitProviderManager {
         Ok(connections)
     }
 
-    /// Get connections for a user with pagination and sorting
+    /// Get all connections with pagination and sorting.
+    ///
+    /// Connections are visible to every authenticated user (single-tenant:
+    /// "the team is the app" for now) rather than scoped to their creator,
+    /// so teammates can share and reuse each other's git connections.
     pub async fn get_user_connections_paginated(
         &self,
-        caller_user_id: i32,
         page: u64,
         per_page: u64,
         sort: &str,
@@ -1646,8 +1649,7 @@ impl GitProviderManager {
         use sea_orm::QueryOrder;
 
         let mut query = git_provider_connections::Entity::find()
-            .filter(git_provider_connections::Column::IsActive.eq(true))
-            .filter(git_provider_connections::Column::UserId.eq(Some(caller_user_id)));
+            .filter(git_provider_connections::Column::IsActive.eq(true));
 
         // Apply sorting - default to created_at desc
         query = match (sort, direction) {

--- a/crates/temps-git/src/services/repository.rs
+++ b/crates/temps-git/src/services/repository.rs
@@ -42,13 +42,17 @@ pub struct RepositoryModel {
 pub struct RepositoryFilter {
     pub git_provider_connection_id: Option<i32>,
     pub provider_id: Option<i32>,
-    /// Scopes `provider_id` lookups to a single caller's own
+    /// Optionally scopes `provider_id` lookups to a single caller's own
     /// `git_provider_connections` row(s) — `provider_id` identifies a
     /// shared, platform-level OAuth app/PAT config that many users can each
-    /// have their own connection to, so a `provider_id`-only filter would
-    /// return every user's repositories. Ignored when `provider_id` is
-    /// unset (`git_provider_connection_id`-scoped lookups already resolve
-    /// to a single connection).
+    /// have their own connection to, so a `provider_id`-only filter can
+    /// span connections across users. Callers currently pass `None` here
+    /// (connections are shared across all users for now — see
+    /// `list_repositories_by_provider`), but the field is kept so a future
+    /// per-user or per-org scope can opt back in without a signature
+    /// change. Ignored when `provider_id` is unset
+    /// (`git_provider_connection_id`-scoped lookups already resolve to a
+    /// single connection).
     pub user_id: Option<i32>,
     pub search: Option<String>,
     pub owner: Option<String>,


### PR DESCRIPTION
## Summary
- Removes the per-user (`user_id`) scoping added in #456 on the **read/sync** paths for git connections — `list_connections`, `sync_repositories`, `list_repositories_by_connection`, and `list_repositories_by_provider` — so any authenticated user with the relevant permission can see and use a connection a teammate set up.
- Connection **creation** still records the creating `user_id` for audit/attribution; only visibility and use are unscoped.
- Existing permission checks (`GitConnectionsRead`, `GitRepositoriesRead`, `GitRepositoriesSync`) are unchanged and still enforced.
- Fixes a stale doc comment on `RepositoryFilter::user_id` (`crates/temps-git/src/services/repository.rs`) that no longer matched behavior after this change.

## Why
Temps is currently single-tenant per instance (the app instance *is* the team), so per-user connection ownership was blocking legitimate collaboration — a teammate who didn't personally connect a GitHub App/PAT couldn't see or use it at all. This is an intentional, deliberate rollback of the ownership check introduced in #456 as an IDOR fix; that tradeoff was discussed and explicitly accepted for the current single-tenant model. A follow-up (project/org-scoped permission gating) is expected before this becomes multi-tenant.

## Review
- `/review-pr`-style pass run via context-scout (blast radius) + security-auditor (security gate), both scoped to exclude the accepted ownership-check rollback:
  - **context-scout**: verified no other call sites assume per-user connection scoping (CLI, web frontend, rate-limiting are all unaffected); found and fixed one stale doc comment (`repository.rs`); no dead code/unused imports from the removed blocks.
  - **security-auditor**: PASS — no new secret/credential exposure in `ConnectionResponse`, all `RequireAuth` + `permission_check!` guards intact and unchanged, no injection surface, no unauthenticated path introduced, no audit-logging regression.

## Test plan
- [x] `cargo check --lib -p temps-git`
- [x] `cargo check --lib` (full workspace)
- [x] `cargo test --lib -p temps-git` — 319 passed
- [x] `/review-pr` (context-scout + security-auditor)