### PR TITLE
feat(web): redesign project deployment actions

### DIFF
--- a/web/src/components/deployment/DeploymentCompactRow.tsx
+++ b/web/src/components/deployment/DeploymentCompactRow.tsx
@@ -1,4 +1,4 @@
-import { DeploymentResponse } from '@/api/client'
+import { DeploymentResponse, type SourceType } from '@/api/client'
 import { getDeploymentOptions } from '@/api/client/@tanstack/react-query.gen'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
@@ -13,14 +13,18 @@ import { useQuery } from '@tanstack/react-query'
 import {
   ArrowUpRight,
   CheckCircle2,
+  Container,
+  FileArchive,
   GitBranch,
   GitCommit,
   MoreHorizontal,
+  Package,
   RefreshCw,
   RotateCcw,
   X,
 } from 'lucide-react'
 import { useCallback, useEffect, useMemo } from 'react'
+import { deploymentSourceSummary } from '@/lib/deployment-source-summary'
 import { TimeAgo } from '../utils/TimeAgo'
 import { DeploymentStatusBadge } from './DeploymentStatusBadge'
 
@@ -31,6 +35,7 @@ interface DeploymentCompactRowProps {
   onRollback?: () => void
   onPromote?: () => void
   onDeploymentUpdate?: (updatedDeployment: DeploymentResponse) => void
+  projectSourceType?: SourceType
 }
 
 export default function DeploymentCompactRow({
@@ -40,6 +45,7 @@ export default function DeploymentCompactRow({
   onRollback,
   onPromote,
   onDeploymentUpdate,
+  projectSourceType,
 }: DeploymentCompactRowProps) {
   const { refetch, data: refreshedDeployment } = useQuery({
     ...getDeploymentOptions({
@@ -57,8 +63,9 @@ export default function DeploymentCompactRow({
 
   const deployment = useMemo(
     () => refreshedDeployment ?? initialDeployment,
-    [refreshedDeployment, initialDeployment],
+    [refreshedDeployment, initialDeployment]
   )
+  const source = deploymentSourceSummary(deployment, projectSourceType)
 
   const pollDeployment = useCallback(async () => {
     const { data } = await refetch()
@@ -85,7 +92,10 @@ export default function DeploymentCompactRow({
       {/* Primary line: id + status + env + current */}
       <div className="flex min-w-0 items-center gap-2 sm:shrink-0">
         <span className="font-medium text-sm">#{deployment.id}</span>
-        <DeploymentStatusBadge deployment={deployment} className="text-[10px] px-1.5 py-0 h-5" />
+        <DeploymentStatusBadge
+          deployment={deployment}
+          className="text-[10px] px-1.5 py-0 h-5"
+        />
         <Badge variant="secondary" className="text-[10px] px-1.5 py-0 h-5">
           {deployment.environment.name}
         </Badge>
@@ -97,21 +107,48 @@ export default function DeploymentCompactRow({
         )}
       </div>
 
-      {/* Meta line: commit info — takes remaining space, truncates */}
+      {/* Meta line: source info — takes remaining space, truncates */}
       <div className="flex min-w-0 flex-1 items-center gap-3 text-xs text-muted-foreground">
-        <div className="flex items-center gap-1 shrink-0">
-          <GitBranch className="h-3 w-3" />
-          <span className="truncate max-w-[100px]">{deployment.branch}</span>
-        </div>
-        <div className="flex items-center gap-1 shrink-0">
-          <GitCommit className="h-3 w-3" />
-          <span className="font-mono">
-            {deployment.commit_hash?.slice(0, 7)}
-          </span>
-        </div>
-        <span className="truncate min-w-0">
-          {deployment.commit_message}
-        </span>
+        {source.kind === 'git' ? (
+          <>
+            {source.branch && (
+              <div className="flex shrink-0 items-center gap-1">
+                <GitBranch className="h-3 w-3" />
+                <span className="max-w-[100px] truncate">{source.branch}</span>
+              </div>
+            )}
+            {source.commit && (
+              <div className="flex shrink-0 items-center gap-1">
+                <GitCommit className="h-3 w-3" />
+                <span className="font-mono">{source.commit.slice(0, 7)}</span>
+              </div>
+            )}
+            {source.message && (
+              <span className="min-w-0 truncate">{source.message}</span>
+            )}
+          </>
+        ) : (
+          <div className="flex min-w-0 items-center gap-1.5">
+            {source.kind === 'docker_image' ? (
+              <Container className="h-3.5 w-3.5 shrink-0" />
+            ) : source.kind === 'manual' ? (
+              <Package className="h-3.5 w-3.5 shrink-0" />
+            ) : (
+              <FileArchive className="h-3.5 w-3.5 shrink-0" />
+            )}
+            <span className="shrink-0 font-medium text-foreground/80">
+              {source.label}
+            </span>
+            {source.detail && (
+              <span
+                className="min-w-0 truncate font-mono"
+                title={source.detail}
+              >
+                {source.detail}
+              </span>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Right cluster: author + time + menu */}

--- a/web/src/components/deployments/BranchSelector.tsx
+++ b/web/src/components/deployments/BranchSelector.tsx
@@ -48,7 +48,7 @@ function detectProviderFromUrl(gitUrl: string): 'github' | 'gitlab' | null {
 }
 
 /** Normalized branch shape the combobox renders, regardless of source. */
-interface ResolvedBranch {
+export interface ResolvedBranch {
   name: string
   commit_sha?: string
   protected?: boolean
@@ -67,6 +67,7 @@ interface BranchSelectorProps {
   onChange: (branch: string) => void
   onError?: (error: string | null) => void
   onBranchesLoaded?: (branches: string[]) => void
+  onBranchDetailsLoaded?: (branches: ResolvedBranch[]) => void
   disabled?: boolean
   /** Pre-loaded branches (for public repos or when already fetched) */
   branches?: Array<{ name: string; is_default?: boolean }>
@@ -83,6 +84,7 @@ export function BranchSelector({
   onChange,
   onError,
   onBranchesLoaded,
+  onBranchDetailsLoaded,
   disabled = false,
   branches: providedBranches,
   gitUrl,
@@ -259,9 +261,9 @@ export function BranchSelector({
 
   // Notify parent when branches are loaded
   useEffect(() => {
-    if (sortedBranches.length > 0 && onBranchesLoaded) {
-      onBranchesLoaded(sortedBranches.map((b) => b.name))
-    }
+    if (sortedBranches.length === 0) return
+    onBranchesLoaded?.(sortedBranches.map((b) => b.name))
+    onBranchDetailsLoaded?.(sortedBranches)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sortedBranches])
 
@@ -430,6 +432,9 @@ function BranchCombobox({
   const firstItemValue =
     (pinned[0] ?? rest[0])?.name ?? (showCustom ? customValue : '')
   useEffect(() => {
+    // cmdk keeps its own active-item state; synchronize it when our manually
+    // ranked result head changes so Enter follows the visible highlight.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setActiveValue(firstItemValue)
   }, [firstItemValue])
 

--- a/web/src/components/deployments/RedeploymentModal.tsx
+++ b/web/src/components/deployments/RedeploymentModal.tsx
@@ -31,16 +31,18 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { hashKey, useQuery } from '@tanstack/react-query'
 import { useMemo, useState, useEffect } from 'react'
 import { toast } from 'sonner'
+import { branchCommitSha } from '@/lib/project-header-actions'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
   AlertTriangle,
   CheckCircle2,
   GitCommitHorizontal,
+  GitBranch,
   Loader2,
   RefreshCw,
   Tag as TagIcon,
 } from 'lucide-react'
-import { BranchSelector } from './BranchSelector'
+import { BranchSelector, type ResolvedBranch } from './BranchSelector'
 
 const COMMIT_SHA_PATTERN = /^[0-9a-f]{7,40}$/i
 
@@ -62,10 +64,12 @@ function CommitDetailsCard({
   commit,
   label,
   reference,
+  referenceType = 'tag',
 }: {
   commit: CommitInfo
   label: string
   reference?: string
+  referenceType?: 'branch' | 'tag'
 }) {
   return (
     <div className="overflow-hidden rounded-md border bg-muted/20">
@@ -77,7 +81,11 @@ function CommitDetailsCard({
         <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
           {reference && (
             <span className="flex min-w-0 items-center gap-1 font-medium text-foreground">
-              <TagIcon className="h-3.5 w-3.5 shrink-0" />
+              {referenceType === 'branch' ? (
+                <GitBranch className="h-3.5 w-3.5 shrink-0" />
+              ) : (
+                <TagIcon className="h-3.5 w-3.5 shrink-0" />
+              )}
               <span className="max-w-40 truncate" title={reference}>
                 {reference}
               </span>
@@ -188,6 +196,9 @@ export function RedeploymentModal({
     'branch' | 'commit' | 'tag'
   >(defaultType || 'branch')
   const [availableBranches, setAvailableBranches] = useState<string[]>([])
+  const [availableBranchDetails, setAvailableBranchDetails] = useState<
+    ResolvedBranch[]
+  >([])
   const [commitToCheck, setCommitToCheck] = useState('')
   const [tagToCheck, setTagToCheck] = useState('')
 
@@ -224,6 +235,7 @@ export function RedeploymentModal({
       isOpen &&
       mode === 'new' &&
       (deploymentType === 'commit' ||
+        deploymentType === 'branch' ||
         (deploymentType === 'tag' && tagHasValue)) &&
       shouldLookUpGitReference,
   })
@@ -248,6 +260,25 @@ export function RedeploymentModal({
   const commitIsVerified = Boolean(
     checkedCurrentCommit && commitQuery.data?.exists && commitQuery.data.commit
   )
+
+  const selectedBranchCommitSha = branchCommitSha(
+    availableBranchDetails,
+    effectiveBranch
+  )
+  const branchCommitQuery = useQuery({
+    ...checkCommitExistsOptions({
+      path: {
+        repository_id: repositoryQuery.data?.id || 0,
+        commit_sha: selectedBranchCommitSha || '',
+      },
+    }),
+    enabled:
+      isOpen &&
+      deploymentType === 'branch' &&
+      !!repositoryQuery.data?.id &&
+      !!selectedBranchCommitSha,
+    retry: false,
+  })
 
   const tagsQueryOptions = getTagsByRepositoryIdOptions({
     path: { repository_id: repositoryQuery.data?.id || 0 },
@@ -677,9 +708,79 @@ export function RedeploymentModal({
                         onBranchesLoaded={(branches) =>
                           setAvailableBranches(branches)
                         }
+                        onBranchDetailsLoaded={setAvailableBranchDetails}
                         disabled={isLoading}
                       />
                     )}
+                    <div id="branch-lookup-status" aria-live="polite">
+                      {selectedBranchCommitSha && shouldLookUpGitReference && (
+                        <>
+                          {(repositoryQuery.isLoading ||
+                            branchCommitQuery.isLoading) &&
+                            !repositoryQuery.isError && (
+                              <div className="flex items-center gap-2 rounded-md border bg-muted/30 px-3 py-2.5 text-sm text-muted-foreground">
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                                Loading the branch head commit…
+                              </div>
+                            )}
+
+                          {(repositoryQuery.isError ||
+                            branchCommitQuery.isError) && (
+                            <Alert variant="destructive">
+                              <AlertTriangle className="h-4 w-4" />
+                              <AlertDescription className="flex items-center justify-between gap-3">
+                                <span>
+                                  Commit details could not be loaded. Check the
+                                  Git provider connection and try again.
+                                </span>
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  size="sm"
+                                  className="shrink-0"
+                                  onClick={() => {
+                                    if (repositoryQuery.isError) {
+                                      void repositoryQuery.refetch()
+                                    } else {
+                                      void branchCommitQuery.refetch()
+                                    }
+                                  }}
+                                >
+                                  <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+                                  Retry
+                                </Button>
+                              </AlertDescription>
+                            </Alert>
+                          )}
+
+                          {branchCommitQuery.data &&
+                            !branchCommitQuery.data.exists && (
+                              <Alert variant="destructive">
+                                <AlertTriangle className="h-4 w-4" />
+                                <AlertDescription>
+                                  The head commit for “{effectiveBranch}” was
+                                  not found in{' '}
+                                  <span className="font-medium">
+                                    {projectDetails.repo_owner}/
+                                    {projectDetails.repo_name}
+                                  </span>
+                                  . Refresh the branches and try again.
+                                </AlertDescription>
+                              </Alert>
+                            )}
+
+                          {branchCommitQuery.data?.exists &&
+                            branchCommitQuery.data.commit && (
+                              <CommitDetailsCard
+                                commit={branchCommitQuery.data.commit}
+                                label="Commit to deploy"
+                                reference={effectiveBranch}
+                                referenceType="branch"
+                              />
+                            )}
+                        </>
+                      )}
+                    </div>
                   </TabsContent>
                   <TabsContent value="commit" className="space-y-3">
                     <div className="space-y-1.5">

--- a/web/src/components/project/ProjectDeployments.tsx
+++ b/web/src/components/project/ProjectDeployments.tsx
@@ -263,6 +263,35 @@ export function ProjectDeployments({ project }: { project: ProjectResponse }) {
 
   const imageRef = resolveImageRef()
 
+  /* eslint-disable react-hooks/set-state-in-effect -- the query parameter is
+     an external navigation intent that must open the matching controlled dialog. */
+  useEffect(() => {
+    if (searchParams.get('deploy') !== 'true') return
+
+    const nextSearchParams = new URLSearchParams(searchParams)
+    nextSearchParams.delete('deploy')
+    setSearchParams(nextSearchParams, { replace: true })
+
+    if (project.source_type === 'static_files') {
+      setStaticDialogOpen(true)
+      return
+    }
+    if (project.source_type === 'docker_image') {
+      setImageRefInput(imageRef ?? '')
+      setImageDialogOpen(true)
+      return
+    }
+
+    handleOpenNewDeployment()
+  }, [
+    handleOpenNewDeployment,
+    imageRef,
+    project.source_type,
+    searchParams,
+    setSearchParams,
+  ])
+  /* eslint-enable react-hooks/set-state-in-effect */
+
   const handleRedeploy = async ({
     branch,
     commit,
@@ -750,7 +779,7 @@ export function ProjectDeployments({ project }: { project: ProjectResponse }) {
 
   return (
     <>
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
+      <div className="mb-4 flex items-center gap-2">
         <div className="flex items-center gap-2">
           <h2 className="text-lg font-semibold">Deployments</h2>
           <Button
@@ -767,45 +796,6 @@ export function ProjectDeployments({ project }: { project: ProjectResponse }) {
             )}
           </Button>
         </div>
-        {project.source_type === 'static_files' ? (
-          <Button
-            onClick={() => setStaticDialogOpen(true)}
-            className="w-full sm:w-auto"
-          >
-            <Upload className="h-4 w-4 mr-2" />
-            Deploy static files
-          </Button>
-        ) : project.source_type === 'uploaded_source' ? (
-          <Button asChild className="w-full sm:w-auto">
-            <Link to={`/projects/${project.slug}/drop`}>
-              <UploadCloud className="h-4 w-4 mr-2" />
-              Upload new source
-            </Link>
-          </Button>
-        ) : project.source_type === 'docker_image' ? (
-          <Button
-            onClick={() => {
-              setImageRefInput(imageRef ?? '')
-              setImageDialogOpen(true)
-            }}
-            className="w-full sm:w-auto"
-          >
-            <PlusIcon className="h-4 w-4 mr-2" />
-            New Deployment
-          </Button>
-        ) : (
-          <Button
-            onClick={handleOpenNewDeployment}
-            className="w-full sm:w-auto"
-          >
-            <PlusIcon className="h-4 w-4 mr-2" />
-            New Deployment
-            <KeyboardShortcut
-              shortcut="N"
-              onTrigger={handleOpenNewDeployment}
-            />
-          </Button>
-        )}
       </div>
 
       <Card>
@@ -818,6 +808,7 @@ export function ProjectDeployments({ project }: { project: ProjectResponse }) {
             >
               <DeploymentCompactRow
                 deployment={deployment}
+                projectSourceType={project.source_type}
                 onRedeploy={() => {
                   setSelectedDeployment(deployment.id)
                   setIsRedeployModalOpen(true)

--- a/web/src/components/project/ProjectDetailHeader.tsx
+++ b/web/src/components/project/ProjectDetailHeader.tsx
@@ -2,13 +2,20 @@ import { ProjectResponse } from '@/api/client'
 import { getLastDeploymentOptions } from '@/api/client/@tanstack/react-query.gen'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
-import { buttonVariants } from '@/components/ui/button'
+import { Button } from '@/components/ui/button'
 import { ReloadableImage } from '@/components/utils/ReloadableImage'
-import { cn } from '@/lib/utils'
 import { useDashboardHealth } from '@/hooks/useDashboardHealth'
+import {
+  gitProviderKind,
+  repositoryWebUrl,
+  type GitProviderKind,
+} from '@/lib/project-header-actions'
 import { useQuery } from '@tanstack/react-query'
-import { ExternalLink, Users } from 'lucide-react'
+import { GitFork, Globe2, Rocket, Users } from 'lucide-react'
+import BitbucketIcon from '@/icons/Bitbucket'
+import GiteaIcon from '@/icons/Gitea'
 import GithubIcon from '@/icons/Github'
+import GitlabIcon from '@/icons/Gitlab'
 import { Link, useNavigate } from 'react-router'
 
 const healthDotColors: Record<string, string> = {
@@ -27,16 +34,34 @@ interface ProjectDetailHeaderProps {
   project: ProjectResponse
   activeVisitorsCount?: { active_visitors: number }
   repositoryCloneUrl?: string | null
+  repositoryProviderType?: string | null
   lastDeploymentUrl?: string | null
   isLoadingLastDeployment?: boolean
+  onDeploy: () => void
+}
+
+function RepositoryProviderIcon({
+  provider,
+  className,
+}: {
+  provider: GitProviderKind | null
+  className?: string
+}) {
+  if (provider === 'github') return <GithubIcon className={className} />
+  if (provider === 'gitlab') return <GitlabIcon className={className} />
+  if (provider === 'bitbucket') return <BitbucketIcon className={className} />
+  if (provider === 'gitea') return <GiteaIcon className={className} />
+  return <GitFork className={className} />
 }
 
 export function ProjectDetailHeader({
   project,
   activeVisitorsCount,
   repositoryCloneUrl,
+  repositoryProviderType,
   lastDeploymentUrl,
   isLoadingLastDeployment = false,
+  onDeploy,
 }: ProjectDetailHeaderProps) {
   const navigate = useNavigate()
   const healthQuery = useDashboardHealth([project.id])
@@ -47,6 +72,12 @@ export function ProjectDetailHeader({
     refetchOnWindowFocus: true,
   })
   const screenshotLocation = lastDeployment?.screenshot_location
+  const repositoryUrl = repositoryCloneUrl
+    ? repositoryWebUrl(repositoryCloneUrl)
+    : null
+  const repositoryProvider = repositoryCloneUrl
+    ? gitProviderKind(repositoryProviderType, repositoryCloneUrl)
+    : null
 
   const handleVisitorsClick = () => {
     if ((activeVisitorsCount?.active_visitors ?? 0) > 0) {
@@ -77,14 +108,24 @@ export function ProjectDetailHeader({
             </Avatar>
           )}
           <div className="flex items-center gap-2 min-w-0">
-            <h1 className="text-base sm:text-lg font-semibold truncate">{project.slug}</h1>
-            <Badge variant={project.last_deployment ? 'default' : 'outline'} className="hidden sm:inline-flex shrink-0">
+            <h1 className="text-base sm:text-lg font-semibold truncate">
+              {project.slug}
+            </h1>
+            <Badge
+              variant={project.last_deployment ? 'default' : 'outline'}
+              className="hidden sm:inline-flex shrink-0"
+            >
               {project.last_deployment ? 'Deployed' : 'Not deployed'}
             </Badge>
             {health && health.status !== 'no_monitors' && (
               <Link to={`/projects/${project.slug}/monitors`}>
-                <Badge variant="outline" className="hidden sm:inline-flex shrink-0 gap-1.5">
-                  <span className={`inline-block h-2 w-2 rounded-full ${healthDotColors[health.status] || 'bg-zinc-400'}`} />
+                <Badge
+                  variant="outline"
+                  className="hidden sm:inline-flex shrink-0 gap-1.5"
+                >
+                  <span
+                    className={`inline-block h-2 w-2 rounded-full ${healthDotColors[health.status] || 'bg-zinc-400'}`}
+                  />
                   {healthLabels[health.status] || health.status}
                 </Badge>
               </Link>
@@ -118,63 +159,39 @@ export function ProjectDetailHeader({
               </span>
             </button>
           )}
-          {/* Mobile: Icon-only buttons */}
-          <div className="md:hidden flex items-center gap-1">
-            {repositoryCloneUrl && (
-              <Link
-                to={repositoryCloneUrl.replace('.git', '')}
+          {repositoryUrl && (
+            <Button variant="outline" size="sm" asChild>
+              <a
+                href={repositoryUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="p-2 hover:bg-accent rounded-md transition-colors"
-                title="View repository"
+                aria-label="Open repository in a new window"
               >
-                <GithubIcon className="h-4 w-4" />
-              </Link>
-            )}
-            {lastDeploymentUrl && !isLoadingLastDeployment && (
-              <Link
-                to={lastDeploymentUrl}
+                <RepositoryProviderIcon
+                  provider={repositoryProvider}
+                  className="size-4"
+                />
+                <span className="hidden md:inline">Repository</span>
+              </a>
+            </Button>
+          )}
+          {lastDeploymentUrl && !isLoadingLastDeployment && (
+            <Button variant="outline" size="icon" className="size-9" asChild>
+              <a
+                href={lastDeploymentUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="p-2 hover:bg-accent rounded-md transition-colors"
+                aria-label="Visit deployed site in a new window"
                 title="Visit deployed site"
               >
-                <ExternalLink className="h-4 w-4" />
-              </Link>
-            )}
-          </div>
-          {/* Desktop: Full buttons */}
-          <div className="hidden md:flex items-center gap-2">
-            {repositoryCloneUrl && (
-              <Link
-                to={repositoryCloneUrl.replace('.git', '')}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={cn(
-                  buttonVariants({
-                    variant: 'outline',
-                    size: 'sm',
-                  })
-                )}
-              >
-                Repository
-              </Link>
-            )}
-            {lastDeploymentUrl && !isLoadingLastDeployment && (
-              <Link
-                to={lastDeploymentUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={cn(
-                  buttonVariants({
-                    size: 'sm',
-                  })
-                )}
-              >
-                Visit
-              </Link>
-            )}
-          </div>
+                <Globe2 className="size-4" />
+              </a>
+            </Button>
+          )}
+          <Button size="sm" onClick={onDeploy}>
+            <Rocket className="size-4" />
+            <span className="hidden sm:inline">Deploy</span>
+          </Button>
         </div>
       </div>
     </header>

--- a/web/src/lib/deployment-source-summary.test.ts
+++ b/web/src/lib/deployment-source-summary.test.ts
@@ -71,7 +71,40 @@ describe('deploymentSourceSummary', () => {
     expect(deploymentSourceSummary(deployment(), 'static_files')).toEqual({
       kind: 'static_files',
       label: 'Static bundle',
-      detail: undefined,
+    })
+  })
+
+  test('keeps historical Git deployments Git-labelled after a source change', () => {
+    expect(
+      deploymentSourceSummary(
+        deployment({
+          branch: 'main',
+          commit_hash: 'abcdef1234567890',
+          commit_message: 'Initial deployment',
+        }),
+        'docker_image'
+      )
+    ).toEqual({
+      kind: 'git',
+      branch: 'main',
+      commit: 'abcdef1234567890',
+      message: 'Initial deployment',
+    })
+  })
+
+  test('does not expose internal static bundle paths', () => {
+    expect(
+      deploymentSourceSummary(
+        deployment({
+          metadata: {
+            deploymentSourceType: 'static_files',
+            staticBundlePath: 'internal/blobs/project-42/site.tar.gz',
+          },
+        })
+      )
+    ).toEqual({
+      kind: 'static_files',
+      label: 'Static bundle (tar.gz)',
     })
   })
 })

--- a/web/src/lib/deployment-source-summary.test.ts
+++ b/web/src/lib/deployment-source-summary.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test'
+import type { DeploymentResponse } from '@/api/client'
+import { deploymentSourceSummary } from './deployment-source-summary'
+
+function deployment(
+  overrides: Partial<DeploymentResponse> = {}
+): DeploymentResponse {
+  return {
+    created_at: 0,
+    environment: { domains: [], id: 1, name: 'production', slug: 'production' },
+    environment_id: 1,
+    id: 1,
+    is_current: false,
+    project_id: 1,
+    status: 'completed',
+    url: '',
+    ...overrides,
+  }
+}
+
+describe('deploymentSourceSummary', () => {
+  test('keeps only populated Git fields', () => {
+    expect(
+      deploymentSourceSummary(
+        deployment({ branch: 'main', commit_hash: null }),
+        'git'
+      )
+    ).toEqual({
+      kind: 'git',
+      branch: 'main',
+      commit: undefined,
+      message: undefined,
+    })
+  })
+
+  test('shows the image reference instead of empty Git metadata', () => {
+    expect(
+      deploymentSourceSummary(
+        deployment({
+          metadata: {
+            deploymentSourceType: 'docker_image',
+            externalImageRef: 'ghcr.io/example/service:latest',
+          },
+        }),
+        'git'
+      )
+    ).toEqual({
+      kind: 'docker_image',
+      label: 'Docker image',
+      detail: 'ghcr.io/example/service:latest',
+    })
+  })
+
+  test('describes uploaded ZIP source without Git placeholders', () => {
+    expect(
+      deploymentSourceSummary(
+        deployment({
+          metadata: {
+            deploymentSourceType: 'uploaded_source',
+            sourceBundleContentType: 'application/zip',
+          },
+        })
+      )
+    ).toEqual({
+      kind: 'uploaded_source',
+      label: 'Uploaded source (ZIP)',
+    })
+  })
+
+  test('falls back to the project source for older deployment metadata', () => {
+    expect(deploymentSourceSummary(deployment(), 'static_files')).toEqual({
+      kind: 'static_files',
+      label: 'Static bundle',
+      detail: undefined,
+    })
+  })
+})

--- a/web/src/lib/deployment-source-summary.ts
+++ b/web/src/lib/deployment-source-summary.ts
@@ -1,0 +1,84 @@
+import type { DeploymentResponse, SourceType } from '@/api/client'
+
+export type DeploymentSourceSummary =
+  | {
+      kind: 'git'
+      branch?: string
+      commit?: string
+      message?: string
+    }
+  | {
+      kind: 'docker_image' | 'static_files' | 'uploaded_source' | 'manual'
+      label: string
+      detail?: string
+    }
+
+function archiveLabel(
+  prefix: string,
+  contentType?: string | null,
+  path?: string | null
+): string {
+  const format = `${contentType ?? ''} ${path ?? ''}`.toLowerCase()
+  if (format.includes('zip')) return `${prefix} (ZIP)`
+  if (format.includes('gzip') || format.includes('.tgz')) {
+    return `${prefix} (tar.gz)`
+  }
+  return prefix
+}
+
+export function deploymentSourceSummary(
+  deployment: DeploymentResponse,
+  projectSourceType?: SourceType
+): DeploymentSourceSummary {
+  const metadata = deployment.metadata
+  const sourceType = metadata?.deploymentSourceType ?? projectSourceType
+  const hasGitData = Boolean(
+    deployment.branch || deployment.commit_hash || deployment.commit_message
+  )
+
+  if (sourceType === 'git' || (!sourceType && hasGitData)) {
+    return {
+      kind: 'git',
+      branch: deployment.branch || undefined,
+      commit: deployment.commit_hash || undefined,
+      message: deployment.commit_message || undefined,
+    }
+  }
+
+  if (sourceType === 'docker_image') {
+    return {
+      kind: 'docker_image',
+      label: 'Docker image',
+      detail:
+        metadata?.externalImageRef || metadata?.uploadedImageId || undefined,
+    }
+  }
+
+  if (sourceType === 'static_files') {
+    return {
+      kind: 'static_files',
+      label: archiveLabel(
+        'Static bundle',
+        metadata?.staticBundleContentType,
+        metadata?.staticBundlePath
+      ),
+      detail: metadata?.staticBundlePath || undefined,
+    }
+  }
+
+  if (sourceType === 'uploaded_source') {
+    return {
+      kind: 'uploaded_source',
+      label: archiveLabel(
+        'Uploaded source',
+        metadata?.sourceBundleContentType,
+        metadata?.sourceBundlePath
+      ),
+    }
+  }
+
+  return {
+    kind: 'manual',
+    label: sourceType === 'manual' ? 'Manual deployment' : 'Deployment source',
+  }
+}

--- a/web/src/lib/deployment-source-summary.ts
+++ b/web/src/lib/deployment-source-summary.ts
@@ -20,7 +20,11 @@ function archiveLabel(
 ): string {
   const format = `${contentType ?? ''} ${path ?? ''}`.toLowerCase()
   if (format.includes('zip')) return `${prefix} (ZIP)`
-  if (format.includes('gzip') || format.includes('.tgz')) {
+  if (
+    format.includes('gzip') ||
+    format.includes('.tgz') ||
+    format.includes('.tar.gz')
+  ) {
     return `${prefix} (tar.gz)`
   }
   return prefix
@@ -31,12 +35,13 @@ export function deploymentSourceSummary(
   projectSourceType?: SourceType
 ): DeploymentSourceSummary {
   const metadata = deployment.metadata
-  const sourceType = metadata?.deploymentSourceType ?? projectSourceType
   const hasGitData = Boolean(
     deployment.branch || deployment.commit_hash || deployment.commit_message
   )
+  const sourceType =
+    metadata?.deploymentSourceType ?? (hasGitData ? 'git' : projectSourceType)
 
-  if (sourceType === 'git' || (!sourceType && hasGitData)) {
+  if (sourceType === 'git') {
     return {
       kind: 'git',
       branch: deployment.branch || undefined,
@@ -62,7 +67,6 @@ export function deploymentSourceSummary(
         metadata?.staticBundleContentType,
         metadata?.staticBundlePath
       ),
-      detail: metadata?.staticBundlePath || undefined,
     }
   }
 

--- a/web/src/lib/project-header-actions.test.ts
+++ b/web/src/lib/project-header-actions.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  branchCommitSha,
+  gitProviderFromUrl,
+  gitProviderKind,
+  repositoryWebUrl,
+} from './project-header-actions'
+
+describe('repositoryWebUrl', () => {
+  test('removes only a trailing git clone suffix', () => {
+    expect(repositoryWebUrl('https://github.com/acme/widget.git')).toBe(
+      'https://github.com/acme/widget'
+    )
+    expect(repositoryWebUrl('https://git.example.com/acme.git/widget')).toBe(
+      'https://git.example.com/acme.git/widget'
+    )
+  })
+
+  test('rejects non-web schemes', () => {
+    expect(repositoryWebUrl('javascript:alert(1)')).toBeNull()
+    expect(repositoryWebUrl('file:///tmp/widget.git')).toBeNull()
+  })
+
+  test('turns SSH clone URLs into browser links', () => {
+    expect(repositoryWebUrl('git@github.com:acme/widget.git')).toBe(
+      'https://github.com/acme/widget'
+    )
+    expect(
+      repositoryWebUrl('ssh://git@gitlab.example.com/acme/widget.git')
+    ).toBe('https://gitlab.example.com/acme/widget')
+  })
+})
+
+describe('gitProviderFromUrl', () => {
+  test('recognizes supported provider hosts', () => {
+    expect(gitProviderFromUrl('https://github.com/acme/widget.git')).toBe(
+      'github'
+    )
+    expect(gitProviderFromUrl('https://gitlab.com/acme/widget.git')).toBe(
+      'gitlab'
+    )
+    expect(gitProviderFromUrl('https://bitbucket.org/acme/widget.git')).toBe(
+      'bitbucket'
+    )
+    expect(gitProviderFromUrl('https://gitea.example/acme/widget.git')).toBe(
+      'gitea'
+    )
+  })
+
+  test('returns null for an unknown self-hosted provider', () => {
+    expect(gitProviderFromUrl('https://git.example.com/acme/widget.git')).toBe(
+      null
+    )
+  })
+})
+
+describe('gitProviderKind', () => {
+  test('prefers the configured connection type for self-hosted providers', () => {
+    expect(
+      gitProviderKind('gitlab', 'https://source.example.com/acme/widget.git')
+    ).toBe('gitlab')
+  })
+
+  test('falls back to the repository host for public repositories', () => {
+    expect(
+      gitProviderKind(undefined, 'https://bitbucket.org/acme/widget.git')
+    ).toBe('bitbucket')
+  })
+})
+
+describe('branchCommitSha', () => {
+  test('returns the selected branch head', () => {
+    expect(
+      branchCommitSha(
+        [
+          { name: 'main', commit_sha: 'abc1234' },
+          { name: 'feature', commit_sha: 'def5678' },
+        ],
+        'feature'
+      )
+    ).toBe('def5678')
+  })
+
+  test('returns null for a custom branch without provider data', () => {
+    expect(
+      branchCommitSha([{ name: 'main', commit_sha: 'abc1234' }], 'new')
+    ).toBeNull()
+  })
+})

--- a/web/src/lib/project-header-actions.test.ts
+++ b/web/src/lib/project-header-actions.test.ts
@@ -29,6 +29,14 @@ describe('repositoryWebUrl', () => {
       repositoryWebUrl('ssh://git@gitlab.example.com/acme/widget.git')
     ).toBe('https://gitlab.example.com/acme/widget')
   })
+
+  test('removes credentials and token-bearing URL parts', () => {
+    expect(
+      repositoryWebUrl(
+        'https://deploy-user:secret@github.com/acme/widget.git?token=hidden#readme'
+      )
+    ).toBe('https://github.com/acme/widget')
+  })
 })
 
 describe('gitProviderFromUrl', () => {
@@ -42,15 +50,21 @@ describe('gitProviderFromUrl', () => {
     expect(gitProviderFromUrl('https://bitbucket.org/acme/widget.git')).toBe(
       'bitbucket'
     )
-    expect(gitProviderFromUrl('https://gitea.example/acme/widget.git')).toBe(
+    expect(gitProviderFromUrl('https://gitea.com/acme/widget.git')).toBe(
       'gitea'
     )
   })
 
-  test('returns null for an unknown self-hosted provider', () => {
+  test('does not trust provider names embedded in an arbitrary hostname', () => {
     expect(gitProviderFromUrl('https://git.example.com/acme/widget.git')).toBe(
       null
     )
+    expect(
+      gitProviderFromUrl('https://github.evil.example/acme/widget.git')
+    ).toBeNull()
+    expect(
+      gitProviderFromUrl('https://evilgithub.com/acme/widget.git')
+    ).toBeNull()
   })
 })
 

--- a/web/src/lib/project-header-actions.ts
+++ b/web/src/lib/project-header-actions.ts
@@ -17,6 +17,13 @@ export function repositoryWebUrl(url: string): string | null {
         : sourceUrl
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
 
+    // Clone URLs are link inputs, not credential transports. Legacy/provider
+    // records may still contain userinfo or token-like query parameters; never
+    // expose those in the DOM, browser history, referrers, or destination logs.
+    parsed.username = ''
+    parsed.password = ''
+    parsed.search = ''
+    parsed.hash = ''
     parsed.pathname = parsed.pathname.replace(/\.git\/?$/, '')
     return parsed.toString().replace(/\/$/, '')
   } catch {
@@ -29,10 +36,10 @@ export function gitProviderFromUrl(url: string): GitProviderKind | null {
   if (!repositoryUrl) return null
 
   const hostname = new URL(repositoryUrl).hostname.toLowerCase()
-  if (hostname.includes('github')) return 'github'
-  if (hostname.includes('gitlab')) return 'gitlab'
-  if (hostname.includes('bitbucket')) return 'bitbucket'
-  if (hostname.includes('gitea')) return 'gitea'
+  if (hostname === 'github.com') return 'github'
+  if (hostname === 'gitlab.com') return 'gitlab'
+  if (hostname === 'bitbucket.org') return 'bitbucket'
+  if (hostname === 'gitea.com') return 'gitea'
 
   return null
 }

--- a/web/src/lib/project-header-actions.ts
+++ b/web/src/lib/project-header-actions.ts
@@ -1,0 +1,60 @@
+export type GitProviderKind = 'github' | 'gitlab' | 'bitbucket' | 'gitea'
+
+export function repositoryWebUrl(url: string): string | null {
+  const trimmed = url.trim()
+  if (!trimmed) return null
+
+  try {
+    const scpStyle = trimmed.match(/^[^@\s]+@([^:/\s]+):(.+)$/)
+    const sourceUrl = scpStyle
+      ? new URL(`https://${scpStyle[1]}/${scpStyle[2]}`)
+      : new URL(trimmed)
+    const parsed =
+      sourceUrl.protocol === 'ssh:'
+        ? new URL(
+            `https://${sourceUrl.hostname}${sourceUrl.pathname}${sourceUrl.search}${sourceUrl.hash}`
+          )
+        : sourceUrl
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+
+    parsed.pathname = parsed.pathname.replace(/\.git\/?$/, '')
+    return parsed.toString().replace(/\/$/, '')
+  } catch {
+    return null
+  }
+}
+
+export function gitProviderFromUrl(url: string): GitProviderKind | null {
+  const repositoryUrl = repositoryWebUrl(url)
+  if (!repositoryUrl) return null
+
+  const hostname = new URL(repositoryUrl).hostname.toLowerCase()
+  if (hostname.includes('github')) return 'github'
+  if (hostname.includes('gitlab')) return 'gitlab'
+  if (hostname.includes('bitbucket')) return 'bitbucket'
+  if (hostname.includes('gitea')) return 'gitea'
+
+  return null
+}
+
+export function gitProviderKind(
+  providerType: string | null | undefined,
+  repositoryUrl: string
+): GitProviderKind | null {
+  const normalizedType = providerType?.toLowerCase()
+  if (normalizedType?.includes('github')) return 'github'
+  if (normalizedType?.includes('gitlab')) return 'gitlab'
+  if (normalizedType?.includes('bitbucket')) return 'bitbucket'
+  if (normalizedType?.includes('gitea')) return 'gitea'
+
+  return gitProviderFromUrl(repositoryUrl)
+}
+
+export function branchCommitSha(
+  branches: ReadonlyArray<{ name: string; commit_sha?: string }>,
+  branchName: string
+): string | null {
+  return (
+    branches.find((branch) => branch.name === branchName)?.commit_sha ?? null
+  )
+}

--- a/web/src/pages/ProjectDetail.tsx
+++ b/web/src/pages/ProjectDetail.tsx
@@ -3,6 +3,8 @@ import {
   getProjectBySlugOptions,
   getActiveVisitorsOptions,
   getRepositoryByNameOptions,
+  listConnectionsOptions,
+  listGitProvidersOptions,
   updateProjectSettingsMutation,
 } from '@/api/client/@tanstack/react-query.gen'
 import NotFound from '@/components/global/NotFound'
@@ -67,6 +69,7 @@ import {
   Navigate,
   Route,
   Routes,
+  useNavigate,
   useParams,
   useSearchParams,
 } from 'react-router'
@@ -78,6 +81,7 @@ import { toast } from 'sonner'
 
 export function ProjectDetail() {
   const { slug } = useParams()
+  const navigate = useNavigate()
   const { setBreadcrumbs } = useBreadcrumbs()
   const [searchParams, setSearchParams] = useSearchParams()
 
@@ -155,6 +159,21 @@ export function ProjectDetail() {
       !!project?.repo_name &&
       !!project?.git_provider_connection_id,
   })
+
+  const { data: connectionsData } = useQuery({
+    ...listConnectionsOptions({ query: { per_page: 100 } }),
+    enabled: !!project?.git_provider_connection_id,
+  })
+  const { data: gitProviders } = useQuery({
+    ...listGitProvidersOptions(),
+    enabled: !!project?.git_provider_connection_id,
+  })
+  const repositoryConnection = connectionsData?.connections.find(
+    (connection) => connection.id === project?.git_provider_connection_id
+  )
+  const repositoryProviderType = gitProviders?.find(
+    (provider) => provider.id === repositoryConnection?.provider_id
+  )?.provider_type
 
   // Mutation to disable attack mode
   const queryClient = useQueryClient()
@@ -314,15 +333,20 @@ export function ProjectDetail() {
           project={project}
           activeVisitorsCount={activeVisitorsCount}
           repositoryCloneUrl={
-            repository?.clone_url ||
-            (project?.repo_owner && project?.repo_name
-              ? `https://github.com/${project.repo_owner}/${project.repo_name}`
-              : undefined)
+            repository?.clone_url || project.git_url || undefined
           }
+          repositoryProviderType={repositoryProviderType}
           lastDeploymentUrl={
             lastDeployment ? resolveStableUrl(lastDeployment) : null
           }
           isLoadingLastDeployment={isLoadingLastDeployment}
+          onDeploy={() => {
+            if (project.source_type === 'uploaded_source') {
+              navigate(`/projects/${project.slug}/drop`)
+              return
+            }
+            navigate(`/projects/${project.slug}/deployments?deploy=true`)
+          }}
         />
         <div className="flex-1 overflow-y-auto overflow-x-hidden p-4">
           {/* Attack Mode Banner */}

--- a/web/src/pages/ProjectDetail.tsx
+++ b/web/src/pages/ProjectDetail.tsx
@@ -153,6 +153,9 @@ export function ProjectDetail() {
         owner: project?.repo_owner || '',
         name: project?.repo_name || '',
       },
+      query: {
+        connection_id: project?.git_provider_connection_id || 0,
+      },
     }),
     enabled:
       !!project?.repo_owner &&


### PR DESCRIPTION
## Summary

- redesign the project header with provider-aware repository links, an icon-only external visit action, and a primary Deploy action
- open the existing source-specific deployment modal from the header and show the selected branch head commit before deployment
- replace empty Git placeholders on non-Git deployments with Docker image, uploaded archive, static bundle, or manual source details
- strip credentials and token-bearing URL parts from repository links, scope connected repository lookup, and avoid exposing internal bundle paths

## Testing

```bash
cd web
bun test src
bun x tsc --noEmit
bun x eslint src/components/deployment/DeploymentCompactRow.tsx src/components/deployments/BranchSelector.tsx src/components/deployments/RedeploymentModal.tsx src/components/project/ProjectDeployments.tsx src/components/project/ProjectDetailHeader.tsx src/pages/ProjectDetail.tsx src/lib/deployment-source-summary.ts src/lib/deployment-source-summary.test.ts src/lib/project-header-actions.ts src/lib/project-header-actions.test.ts
bun run build
```

- `bun test src`: 258 passed, 0 failed, 400 assertions
- TypeScript: passed
- ESLint: passed (existing package module-type and baseline-data warnings only)
- Production build: passed (existing CSS import-order, package module-type, and `import.meta.hot` warnings only)

## Evidence

**Project detail UI**: exercised the changed page in Chromium against the feature-branch dev server on port 3031 with controlled authenticated API fixtures.

```bash
python3 /Users/davidviejo/projects/temps/.agents/skills/webapp-testing/scripts/with_server.py \
  --server "cd web && bun dev --port 3031" --port 3031 --timeout 60 \
  -- python3 web/e2e/project-header-pr-evidence.py
```

```text
PASS header repository action -> https://github.com/gotempsh/demo (target=_blank)
PASS visit action -> target=_blank
PASS Deploy opens Deploy Project dialog
PASS branch main resolves commit abcdef123456 and renders message/author/date
PASS non-Git deployment row renders Docker image source and image reference
PASS non-Git project hides repository action and empty Git metadata
SCREENSHOT /private/tmp/project-header-actions.png
```

The temporary evidence harness used route fixtures to make the Git and non-Git states deterministic and was removed after the run. The screenshot shows the GitHub repository action, external web action, header Deploy button, and the branch-resolved commit card in the open deployment modal.
