### PR TITLE
feat(cli): expose performance insights filters

### DIFF
--- a/apps/temps-cli/src/commands/analytics/index.ts
+++ b/apps/temps-cli/src/commands/analytics/index.ts
@@ -11,6 +11,7 @@ import {
   apiCallers,
   apiSummary,
 } from './api-traffic.js'
+import { performanceInsights } from './performance.js'
 
 export function registerAnalyticsCommands(program: Command): void {
   const analytics = program
@@ -57,6 +58,35 @@ export function registerAnalyticsCommands(program: Command): void {
     )
     .option('--json', 'Output in JSON format')
     .action(funnelsOverview)
+
+  analytics
+    .command('performance')
+    .alias('speed')
+    .description('Show real-user Web Vitals and optional dimension breakdowns')
+    .option('-p, --project <project>', 'Project slug or ID')
+    .option(
+      '--period <period>',
+      'Time period: today, <n>h, <n>d, <n>m (ignored with --start-date/--end-date)',
+      '7d'
+    )
+    .option('--start-date <date>', 'Explicit window start (RFC 3339; requires --end-date)')
+    .option('--end-date <date>', 'Explicit window end (RFC 3339; requires --start-date)')
+    .option('--environment-id <id>', 'Restrict samples to one environment ID')
+    .option('--deployment-id <id>', 'Restrict samples to one deployment ID')
+    .option('--device <device>', 'Device filter: desktop or mobile')
+    .option('--include-bots', 'Include crawler and datacenter bot samples')
+    .option(
+      '--group-by <dimension>',
+      'Break down by path, country, region, city, device_type, browser, or operating_system'
+    )
+    .option('--path <path>', 'Restrict samples to one page pathname')
+    .option('--country <country>', 'Restrict samples to one country')
+    .option('--region <region>', 'Restrict samples to one region')
+    .option('--city <city>', 'Restrict samples to one city')
+    .option('--browser <browser>', 'Restrict samples to one browser')
+    .option('--os <operating-system>', 'Restrict samples to one operating system')
+    .option('--json', 'Output in JSON format')
+    .action(performanceInsights)
 
   analytics
     .command('ai-agents')
@@ -196,6 +226,12 @@ Examples:
   $ temps analytics top referrers --period 1h
   $ temps analytics top browsers --period 48h --json
   $ temps analytics top countries --period 3m --limit 50
+
+  Performance Insights (real-user Web Vitals):
+  $ temps analytics performance -p my-app --period 7d --device desktop
+  $ temps analytics speed -p my-app --period 7d --device mobile
+  $ temps analytics performance -p my-app --group-by path --device mobile
+  $ temps analytics performance -p my-app --start-date 2026-08-01T00:00:00Z --end-date 2026-08-08T00:00:00Z --json
 
   AI agents (mirrors /analytics/ai-agents):
   $ temps analytics ai-agents -p my-app --period 24h

--- a/apps/temps-cli/src/commands/analytics/performance.test.ts
+++ b/apps/temps-cli/src/commands/analytics/performance.test.ts
@@ -38,6 +38,11 @@ describe('Performance Insights option validation', () => {
         /positive integer/
       )
     }
+    for (const tooLarge of ['2147483648', '9007199254740992']) {
+      expect(() => parsePositiveIntegerForTest(tooLarge, 'Environment ID')).toThrow(
+        /between 1 and 2147483647/
+      )
+    }
   })
 })
 

--- a/apps/temps-cli/src/commands/analytics/performance.test.ts
+++ b/apps/temps-cli/src/commands/analytics/performance.test.ts
@@ -89,6 +89,27 @@ describe('Performance Insights date windows', () => {
         })
       ).toThrow(/valid RFC 3339/)
     }
+    for (const invalidRfc3339 of [
+      '2026-02-29T00:00:00Z',
+      '2026-02-30T00:00:00Z',
+      '2026-08-01T24:00:00Z',
+      '2026-08-01T00:60:00Z',
+      '2026-08-01T00:00:60Z',
+      '2026-08-01T00:00:00+24:00',
+    ]) {
+      expect(() =>
+        resolvePerformanceWindow({
+          startDate: invalidRfc3339,
+          endDate: '2026-08-08T00:00:00Z',
+        })
+      ).toThrow(/valid RFC 3339/)
+    }
+    expect(() => resolvePerformanceWindow({ startDate: '', endDate: '' })).toThrow(
+      /valid RFC 3339/
+    )
+    expect(() =>
+      resolvePerformanceWindow({ startDate: '', endDate: '2026-08-08T00:00:00Z' })
+    ).toThrow(/valid RFC 3339/)
   })
 })
 

--- a/apps/temps-cli/src/commands/analytics/performance.test.ts
+++ b/apps/temps-cli/src/commands/analytics/performance.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildPerformanceQuery,
+  formatMetricForTest,
+  parseDeviceForTest,
+  parseGroupByForTest,
+  parsePositiveIntegerForTest,
+  resolvePerformanceWindow,
+} from './performance.js'
+
+describe('Performance Insights option validation', () => {
+  test('accepts supported devices and rejects unknown device values', () => {
+    expect(parseDeviceForTest('desktop')).toBe('desktop')
+    expect(parseDeviceForTest('mobile')).toBe('mobile')
+    expect(parseDeviceForTest(undefined)).toBeUndefined()
+    expect(() => parseDeviceForTest('tablet')).toThrow(/desktop, mobile/)
+  })
+
+  test('accepts every server-supported breakdown dimension', () => {
+    for (const dimension of [
+      'path',
+      'country',
+      'region',
+      'city',
+      'device_type',
+      'browser',
+      'operating_system',
+    ] as const) {
+      expect(parseGroupByForTest(dimension)).toBe(dimension)
+    }
+    expect(() => parseGroupByForTest('device')).toThrow(/device_type/)
+  })
+
+  test('requires positive environment and deployment IDs', () => {
+    expect(parsePositiveIntegerForTest('42', 'Environment ID')).toBe(42)
+    for (const invalid of ['0', '-1', '1.5', 'abc']) {
+      expect(() => parsePositiveIntegerForTest(invalid, 'Environment ID')).toThrow(
+        /positive integer/
+      )
+    }
+  })
+})
+
+describe('Performance Insights date windows', () => {
+  test('uses a period when no explicit dates are provided', () => {
+    const window = resolvePerformanceWindow({ period: '24h' })
+    expect(window.period).toBe('24h')
+    expect(Date.parse(window.endDate) - Date.parse(window.startDate)).toBeCloseTo(
+      24 * 60 * 60 * 1000,
+      -2
+    )
+  })
+
+  test('normalizes an explicit RFC 3339 range', () => {
+    const window = resolvePerformanceWindow({
+      startDate: '2026-08-01T00:00:00Z',
+      endDate: '2026-08-08T00:00:00Z',
+    })
+    expect(window.startDate).toBe('2026-08-01T00:00:00.000Z')
+    expect(window.endDate).toBe('2026-08-08T00:00:00.000Z')
+    expect(window.period).toBeUndefined()
+  })
+
+  test('rejects incomplete, invalid, and reversed explicit ranges', () => {
+    expect(() => resolvePerformanceWindow({ startDate: '2026-08-01T00:00:00Z' })).toThrow(
+      /provided together/
+    )
+    expect(() =>
+      resolvePerformanceWindow({ startDate: 'not-a-date', endDate: '2026-08-08T00:00:00Z' })
+    ).toThrow(/valid RFC 3339/)
+    expect(() =>
+      resolvePerformanceWindow({
+        startDate: '2026-08-08T00:00:00Z',
+        endDate: '2026-08-01T00:00:00Z',
+      })
+    ).toThrow(/earlier than end date/)
+  })
+})
+
+describe('Performance Insights API query', () => {
+  test('maps every CLI filter to the performance endpoint query', () => {
+    const window = {
+      startDate: '2026-08-01T00:00:00.000Z',
+      endDate: '2026-08-08T00:00:00.000Z',
+      label: 'test window',
+    }
+    expect(
+      buildPerformanceQuery(7, window, {
+        environmentId: '11',
+        deploymentId: '13',
+        device: 'mobile',
+        includeBots: true,
+        path: '/pricing',
+        country: 'Spain',
+        region: 'Madrid',
+        city: 'Madrid',
+        browser: 'Chrome',
+        os: 'Android',
+      })
+    ).toEqual({
+      project_id: 7,
+      start_date: window.startDate,
+      end_date: window.endDate,
+      environment_id: 11,
+      deployment_id: 13,
+      device_type: 'mobile',
+      include_bots: true,
+      filter_path: '/pricing',
+      filter_country: 'Spain',
+      filter_region: 'Madrid',
+      filter_city: 'Madrid',
+      filter_browser: 'Chrome',
+      filter_operating_system: 'Android',
+    })
+  })
+
+  test('defaults bot samples off and leaves optional filters unset', () => {
+    const window = resolvePerformanceWindow({ period: '7d' })
+    const query = buildPerformanceQuery(7, window, {})
+    expect(query.include_bots).toBe(false)
+    expect(query.device_type).toBeUndefined()
+    expect(query.environment_id).toBeUndefined()
+  })
+})
+
+describe('Performance Insights formatting', () => {
+  test('formats timing, CLS, missing, and zero values without conflating them', () => {
+    expect(formatMetricForTest(2499.6, 'ms')).toBe('2500ms')
+    expect(formatMetricForTest(0.08321, 'score')).toBe('0.083')
+    expect(formatMetricForTest(null, 'ms')).toBe('n/a')
+    expect(formatMetricForTest(0, 'ms')).toBe('0ms')
+  })
+})

--- a/apps/temps-cli/src/commands/analytics/performance.test.ts
+++ b/apps/temps-cli/src/commands/analytics/performance.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 import {
   buildPerformanceQuery,
+  fetchPerformanceData,
+  formatGroupKeyForTest,
   formatMetricForTest,
   parseDeviceForTest,
   parseGroupByForTest,
@@ -79,6 +81,14 @@ describe('Performance Insights date windows', () => {
         endDate: '2026-08-01T00:00:00Z',
       })
     ).toThrow(/earlier than end date/)
+    for (const nonRfc3339 of ['08/01/2026', 'August 1, 2026', '2026-08-01 00:00:00']) {
+      expect(() =>
+        resolvePerformanceWindow({
+          startDate: nonRfc3339,
+          endDate: '2026-08-08T00:00:00Z',
+        })
+      ).toThrow(/valid RFC 3339/)
+    }
   })
 })
 
@@ -134,5 +144,90 @@ describe('Performance Insights formatting', () => {
     expect(formatMetricForTest(0.08321, 'score')).toBe('0.083')
     expect(formatMetricForTest(null, 'ms')).toBe('n/a')
     expect(formatMetricForTest(0, 'ms')).toBe('0ms')
+  })
+
+  test('sanitizes terminal controls in attacker-influenced breakdown keys', () => {
+    expect(formatGroupKeyForTest('/safe\x1b[2J\x1b]52;c;Zm9yZ2Vk\x07\nnext\u202E')).toBe(
+      '/safe next'
+    )
+  })
+})
+
+describe('Performance Insights endpoint orchestration', () => {
+  const query = {
+    project_id: 7,
+    start_date: '2026-08-01T00:00:00.000Z',
+    end_date: '2026-08-08T00:00:00.000Z',
+    device_type: 'mobile',
+    include_bots: false,
+  }
+  const timeline = {
+    timestamps: [],
+    lcp: [],
+    inp: [],
+    cls: [],
+    fcp: [],
+    ttfb: [],
+    fid: [],
+  }
+
+  test('fetches summary and timeline without requesting a breakdown by default', async () => {
+    const calls: string[] = []
+    const result = await fetchPerformanceData(query, undefined, {
+      getSummary: async (received) => {
+        calls.push(`summary:${received.device_type}`)
+        return { data: { lcp_p75: 1200 } }
+      },
+      getTimeline: async (received) => {
+        calls.push(`timeline:${received.device_type}`)
+        return { data: timeline }
+      },
+      getBreakdown: async () => {
+        calls.push('breakdown')
+        return { data: { grouped_by: 'path', groups: [], total_events: 0 } }
+      },
+    })
+
+    expect(calls).toEqual(['summary:mobile', 'timeline:mobile'])
+    expect(result.summary?.lcp_p75).toBe(1200)
+    expect(result.breakdown).toBeUndefined()
+  })
+
+  test('forwards the shared filters and selected grouping to the breakdown request', async () => {
+    let groupedQuery: Record<string, unknown> | undefined
+    const result = await fetchPerformanceData(query, 'path', {
+      getSummary: async () => ({ data: {} }),
+      getTimeline: async () => ({ data: timeline }),
+      getBreakdown: async (received) => {
+        groupedQuery = received
+        return {
+          data: { grouped_by: 'path', groups: [], total_events: 0 },
+        }
+      },
+    })
+
+    expect(groupedQuery).toEqual({ ...query, group_by: 'path' })
+    expect(result.breakdown?.grouped_by).toBe('path')
+  })
+
+  test('surfaces contextual errors from each performance endpoint', async () => {
+    for (const failing of ['summary', 'timeline', 'breakdown'] as const) {
+      const api = {
+        getSummary: async () =>
+          failing === 'summary' ? { error: { detail: 'summary unavailable' } } : { data: {} },
+        getTimeline: async () =>
+          failing === 'timeline'
+            ? { error: { detail: 'timeline unavailable' } }
+            : { data: timeline },
+        getBreakdown: async () =>
+          failing === 'breakdown'
+            ? { error: { detail: 'breakdown unavailable' } }
+            : { data: { grouped_by: 'path', groups: [], total_events: 0 } },
+      }
+
+      await expect(fetchPerformanceData(query, 'path', api)).rejects.toThrow(
+        `${failing} unavailable`
+      )
+    }
   })
 })

--- a/apps/temps-cli/src/commands/analytics/performance.ts
+++ b/apps/temps-cli/src/commands/analytics/performance.ts
@@ -11,15 +11,19 @@ import {
 import type {
   GetPerformanceMetricsData,
   GroupedPageMetric,
+  GroupedPageMetricsResponse,
   MetricsOverTimeResponse,
   PerformanceMetricsResponse,
 } from '../../api/types.gen.js'
 import { withSpinner } from '../../ui/spinner.js'
 import { colors, info, json as jsonOut, newline } from '../../ui/output.js'
+import { sanitizeTerminalText } from '../../ui/terminal.js'
 import { parsePeriod } from './period.js'
 
 const DEVICES = ['desktop', 'mobile'] as const
 const MAX_BACKEND_ID = 2_147_483_647
+const RFC3339_DATE_TIME =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/
 const GROUP_BY_DIMENSIONS = [
   'path',
   'country',
@@ -66,6 +70,19 @@ interface MetricDefinition {
   unit: 'ms' | 'score'
 }
 
+interface PerformanceRequestResult<T> {
+  data?: T
+  error?: unknown
+}
+
+export interface PerformanceApi {
+  getSummary(query: PerformanceQuery): Promise<PerformanceRequestResult<PerformanceMetricsResponse>>
+  getTimeline(query: PerformanceQuery): Promise<PerformanceRequestResult<MetricsOverTimeResponse>>
+  getBreakdown(
+    query: PerformanceQuery & { group_by: GroupByDimension }
+  ): Promise<PerformanceRequestResult<GroupedPageMetricsResponse>>
+}
+
 const METRICS: MetricDefinition[] = [
   { key: 'lcp', label: 'LCP', unit: 'ms' },
   { key: 'inp', label: 'INP', unit: 'ms' },
@@ -104,11 +121,46 @@ function parseGroupBy(value: string | undefined): GroupByDimension | undefined {
 }
 
 function parseDate(value: string, label: string): string {
+  if (!RFC3339_DATE_TIME.test(value)) {
+    throw new Error(`${label} must be a valid RFC 3339 date`)
+  }
   const timestamp = Date.parse(value)
   if (Number.isNaN(timestamp)) {
     throw new Error(`${label} must be a valid RFC 3339 date`)
   }
   return new Date(timestamp).toISOString()
+}
+
+const defaultPerformanceApi: PerformanceApi = {
+  getSummary: (query) => getPerformanceMetrics({ client, query }),
+  getTimeline: (query) => getMetricsOverTime({ client, query }),
+  getBreakdown: (query) => getGroupedPageMetrics({ client, query }),
+}
+
+export async function fetchPerformanceData(
+  query: PerformanceQuery,
+  groupBy?: GroupByDimension,
+  api: PerformanceApi = defaultPerformanceApi
+): Promise<{
+  summary?: PerformanceMetricsResponse
+  timeline?: MetricsOverTimeResponse
+  breakdown?: GroupedPageMetricsResponse
+}> {
+  const [summaryResult, timelineResult, breakdownResult] = await Promise.all([
+    api.getSummary(query),
+    api.getTimeline(query),
+    groupBy ? api.getBreakdown({ ...query, group_by: groupBy }) : Promise.resolve(undefined),
+  ])
+
+  if (summaryResult.error) throw new Error(getErrorMessage(summaryResult.error))
+  if (timelineResult.error) throw new Error(getErrorMessage(timelineResult.error))
+  if (breakdownResult?.error) throw new Error(getErrorMessage(breakdownResult.error))
+
+  return {
+    summary: summaryResult.data,
+    timeline: timelineResult.data,
+    breakdown: breakdownResult?.data,
+  }
 }
 
 export function resolvePerformanceWindow(options: PerformanceOptions): ResolvedWindow {
@@ -193,7 +245,8 @@ function renderSummary(data: PerformanceMetricsResponse): void {
 }
 
 function formatGroupKey(value: string): string {
-  return value.length > 34 ? `${value.slice(0, 31)}...` : value
+  const safeValue = sanitizeTerminalText(value)
+  return safeValue.length > 34 ? `${safeValue.slice(0, 31)}...` : safeValue
 }
 
 function renderBreakdown(groups: GroupedPageMetric[], groupedBy: string, totalEvents: number): void {
@@ -219,9 +272,10 @@ export async function performanceInsights(options: PerformanceOptions): Promise<
   const window = resolvePerformanceWindow(options)
   const groupBy = parseGroupBy(options.groupBy)
   const resolved = await requireProjectSlug(options.project)
+  const safeProjectSlug = sanitizeTerminalText(resolved.slug)
 
   if (resolved.source !== 'flag') {
-    info(`Using project ${colors.bold(resolved.slug)} (from ${resolved.source})`)
+    info(`Using project ${colors.bold(safeProjectSlug)} (from ${resolved.source})`)
   }
 
   const { data: project, error: projectError } = await getProjectBySlug({
@@ -232,29 +286,13 @@ export async function performanceInsights(options: PerformanceOptions): Promise<
     throw new Error(getErrorMessage(projectError))
   }
   if (!project) {
-    throw new Error(`Project "${resolved.slug}" not found`)
+    throw new Error(`Project "${safeProjectSlug}" not found`)
   }
 
   const query = buildPerformanceQuery(project.id, window, options)
-  const result = await withSpinner('Fetching Performance Insights...', async () => {
-    const [summaryResult, timelineResult, breakdownResult] = await Promise.all([
-      getPerformanceMetrics({ client, query }),
-      getMetricsOverTime({ client, query }),
-      groupBy
-        ? getGroupedPageMetrics({ client, query: { ...query, group_by: groupBy } })
-        : Promise.resolve(undefined),
-    ])
-
-    if (summaryResult.error) throw new Error(getErrorMessage(summaryResult.error))
-    if (timelineResult.error) throw new Error(getErrorMessage(timelineResult.error))
-    if (breakdownResult?.error) throw new Error(getErrorMessage(breakdownResult.error))
-
-    return {
-      summary: summaryResult.data,
-      timeline: timelineResult.data,
-      breakdown: breakdownResult?.data,
-    }
-  })
+  const result = await withSpinner('Fetching Performance Insights...', () =>
+    fetchPerformanceData(query, groupBy)
+  )
 
   if (options.json) {
     jsonOut({
@@ -286,7 +324,7 @@ export async function performanceInsights(options: PerformanceOptions): Promise<
   newline()
   console.log(line)
   console.log(
-    `   ${chalk.bold.white('Performance Insights:')} ${chalk.bold.cyan(resolved.slug)} ${chalk.gray(`(${window.label}${deviceLabel})`)}`
+    `   ${chalk.bold.white('Performance Insights:')} ${chalk.bold.cyan(safeProjectSlug)} ${chalk.gray(`(${window.label}${deviceLabel})`)}`
   )
   console.log(line)
   newline()
@@ -320,3 +358,4 @@ export const parseDeviceForTest = parseDevice
 export const parseGroupByForTest = parseGroupBy
 export const parsePositiveIntegerForTest = parsePositiveInteger
 export const formatMetricForTest = formatMetric
+export const formatGroupKeyForTest = formatGroupKey

--- a/apps/temps-cli/src/commands/analytics/performance.ts
+++ b/apps/temps-cli/src/commands/analytics/performance.ts
@@ -23,7 +23,7 @@ import { parsePeriod } from './period.js'
 const DEVICES = ['desktop', 'mobile'] as const
 const MAX_BACKEND_ID = 2_147_483_647
 const RFC3339_DATE_TIME =
-  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-](\d{2}):(\d{2}))$/
 const GROUP_BY_DIMENSIONS = [
   'path',
   'country',
@@ -121,9 +121,37 @@ function parseGroupBy(value: string | undefined): GroupByDimension | undefined {
 }
 
 function parseDate(value: string, label: string): string {
-  if (!RFC3339_DATE_TIME.test(value)) {
+  const match = RFC3339_DATE_TIME.exec(value)
+  if (!match) {
     throw new Error(`${label} must be a valid RFC 3339 date`)
   }
+
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText, offsetHourText, offsetMinuteText] =
+    match
+  const year = Number(yearText)
+  const month = Number(monthText)
+  const day = Number(dayText)
+  const hour = Number(hourText)
+  const minute = Number(minuteText)
+  const second = Number(secondText)
+  const offsetHour = offsetHourText === undefined ? 0 : Number(offsetHourText)
+  const offsetMinute = offsetMinuteText === undefined ? 0 : Number(offsetMinuteText)
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0)
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+  const validComponents =
+    month >= 1 &&
+    month <= 12 &&
+    day >= 1 &&
+    day <= (daysInMonth[month - 1] ?? 0) &&
+    hour <= 23 &&
+    minute <= 59 &&
+    second <= 59 &&
+    offsetHour <= 23 &&
+    offsetMinute <= 59
+  if (!validComponents) {
+    throw new Error(`${label} must be a valid RFC 3339 date`)
+  }
+
   const timestamp = Date.parse(value)
   if (Number.isNaN(timestamp)) {
     throw new Error(`${label} must be a valid RFC 3339 date`)
@@ -177,9 +205,11 @@ export function resolvePerformanceWindow(options: PerformanceOptions): ResolvedW
     throw new Error('--start-date and --end-date must be provided together')
   }
 
-  if (options.startDate && options.endDate) {
-    const startDate = parseDate(options.startDate, 'Start date')
-    const endDate = parseDate(options.endDate, 'End date')
+  if (hasStart && hasEnd) {
+    const startValue = options.startDate ?? ''
+    const endValue = options.endDate ?? ''
+    const startDate = parseDate(startValue, 'Start date')
+    const endDate = parseDate(endValue, 'End date')
     if (Date.parse(startDate) >= Date.parse(endDate)) {
       throw new Error('Start date must be earlier than end date')
     }

--- a/apps/temps-cli/src/commands/analytics/performance.ts
+++ b/apps/temps-cli/src/commands/analytics/performance.ts
@@ -152,9 +152,15 @@ export async function fetchPerformanceData(
     groupBy ? api.getBreakdown({ ...query, group_by: groupBy }) : Promise.resolve(undefined),
   ])
 
-  if (summaryResult.error) throw new Error(getErrorMessage(summaryResult.error))
-  if (timelineResult.error) throw new Error(getErrorMessage(timelineResult.error))
-  if (breakdownResult?.error) throw new Error(getErrorMessage(breakdownResult.error))
+  if (summaryResult.error) {
+    throw new Error(sanitizeTerminalText(getErrorMessage(summaryResult.error)))
+  }
+  if (timelineResult.error) {
+    throw new Error(sanitizeTerminalText(getErrorMessage(timelineResult.error)))
+  }
+  if (breakdownResult?.error) {
+    throw new Error(sanitizeTerminalText(getErrorMessage(breakdownResult.error)))
+  }
 
   return {
     summary: summaryResult.data,
@@ -251,7 +257,7 @@ function formatGroupKey(value: string): string {
 
 function renderBreakdown(groups: GroupedPageMetric[], groupedBy: string, totalEvents: number): void {
   newline()
-  console.log(`  ${chalk.bold.white(`Breakdown by ${groupedBy}`)}`)
+  console.log(`  ${chalk.bold.white(`Breakdown by ${sanitizeTerminalText(groupedBy)}`)}`)
   console.log(
     `  ${chalk.gray('Value'.padEnd(36))}${chalk.gray('Samples'.padStart(10))}${chalk.gray('LCP'.padStart(10))}${chalk.gray('INP'.padStart(10))}${chalk.gray('CLS'.padStart(10))}${chalk.gray('FCP'.padStart(10))}${chalk.gray('TTFB'.padStart(10))}`
   )
@@ -283,7 +289,7 @@ export async function performanceInsights(options: PerformanceOptions): Promise<
     path: { slug: resolved.slug },
   })
   if (projectError) {
-    throw new Error(getErrorMessage(projectError))
+    throw new Error(sanitizeTerminalText(getErrorMessage(projectError)))
   }
   if (!project) {
     throw new Error(`Project "${safeProjectSlug}" not found`)

--- a/apps/temps-cli/src/commands/analytics/performance.ts
+++ b/apps/temps-cli/src/commands/analytics/performance.ts
@@ -1,0 +1,314 @@
+import chalk from 'chalk'
+import { requireAuth } from '../../config/store.js'
+import { requireProjectSlug } from '../../config/resolve-project.js'
+import { client, getErrorMessage, setupClient } from '../../lib/api-client.js'
+import {
+  getGroupedPageMetrics,
+  getMetricsOverTime,
+  getPerformanceMetrics,
+  getProjectBySlug,
+} from '../../api/sdk.gen.js'
+import type {
+  GetPerformanceMetricsData,
+  GroupedPageMetric,
+  MetricsOverTimeResponse,
+  PerformanceMetricsResponse,
+} from '../../api/types.gen.js'
+import { withSpinner } from '../../ui/spinner.js'
+import { colors, info, json as jsonOut, newline } from '../../ui/output.js'
+import { parsePeriod } from './period.js'
+
+const DEVICES = ['desktop', 'mobile'] as const
+const GROUP_BY_DIMENSIONS = [
+  'path',
+  'country',
+  'region',
+  'city',
+  'device_type',
+  'browser',
+  'operating_system',
+] as const
+
+type Device = (typeof DEVICES)[number]
+type GroupByDimension = (typeof GROUP_BY_DIMENSIONS)[number]
+type PerformanceQuery = GetPerformanceMetricsData['query']
+
+export interface PerformanceOptions {
+  project?: string
+  period?: string
+  startDate?: string
+  endDate?: string
+  environmentId?: string
+  deploymentId?: string
+  device?: string
+  includeBots?: boolean
+  groupBy?: string
+  path?: string
+  country?: string
+  region?: string
+  city?: string
+  browser?: string
+  os?: string
+  json?: boolean
+}
+
+interface ResolvedWindow {
+  startDate: string
+  endDate: string
+  label: string
+  period?: string
+}
+
+interface MetricDefinition {
+  key: 'lcp' | 'inp' | 'cls' | 'fcp' | 'ttfb' | 'fid'
+  label: string
+  unit: 'ms' | 'score'
+}
+
+const METRICS: MetricDefinition[] = [
+  { key: 'lcp', label: 'LCP', unit: 'ms' },
+  { key: 'inp', label: 'INP', unit: 'ms' },
+  { key: 'cls', label: 'CLS', unit: 'score' },
+  { key: 'fcp', label: 'FCP', unit: 'ms' },
+  { key: 'ttfb', label: 'TTFB', unit: 'ms' },
+  { key: 'fid', label: 'FID', unit: 'ms' },
+]
+
+function parsePositiveInteger(value: string | undefined, label: string): number | undefined {
+  if (value === undefined) return undefined
+  if (!/^[1-9]\d*$/.test(value)) {
+    throw new Error(`${label} must be a positive integer`)
+  }
+  return Number.parseInt(value, 10)
+}
+
+function parseDevice(value: string | undefined): Device | undefined {
+  if (value === undefined) return undefined
+  if (!DEVICES.includes(value as Device)) {
+    throw new Error(`Device must be one of: ${DEVICES.join(', ')}`)
+  }
+  return value as Device
+}
+
+function parseGroupBy(value: string | undefined): GroupByDimension | undefined {
+  if (value === undefined) return undefined
+  if (!GROUP_BY_DIMENSIONS.includes(value as GroupByDimension)) {
+    throw new Error(`Group by must be one of: ${GROUP_BY_DIMENSIONS.join(', ')}`)
+  }
+  return value as GroupByDimension
+}
+
+function parseDate(value: string, label: string): string {
+  const timestamp = Date.parse(value)
+  if (Number.isNaN(timestamp)) {
+    throw new Error(`${label} must be a valid RFC 3339 date`)
+  }
+  return new Date(timestamp).toISOString()
+}
+
+export function resolvePerformanceWindow(options: PerformanceOptions): ResolvedWindow {
+  const hasStart = options.startDate !== undefined
+  const hasEnd = options.endDate !== undefined
+
+  if (hasStart !== hasEnd) {
+    throw new Error('--start-date and --end-date must be provided together')
+  }
+
+  if (options.startDate && options.endDate) {
+    const startDate = parseDate(options.startDate, 'Start date')
+    const endDate = parseDate(options.endDate, 'End date')
+    if (Date.parse(startDate) >= Date.parse(endDate)) {
+      throw new Error('Start date must be earlier than end date')
+    }
+    return { startDate, endDate, label: `${startDate} to ${endDate}` }
+  }
+
+  const period = options.period ?? '7d'
+  const window = parsePeriod(period)
+  return { ...window, period }
+}
+
+export function buildPerformanceQuery(
+  projectId: number,
+  window: ResolvedWindow,
+  options: PerformanceOptions
+): PerformanceQuery {
+  return {
+    project_id: projectId,
+    start_date: window.startDate,
+    end_date: window.endDate,
+    environment_id: parsePositiveInteger(options.environmentId, 'Environment ID'),
+    deployment_id: parsePositiveInteger(options.deploymentId, 'Deployment ID'),
+    device_type: parseDevice(options.device),
+    include_bots: options.includeBots ?? false,
+    filter_path: options.path,
+    filter_country: options.country,
+    filter_region: options.region,
+    filter_city: options.city,
+    filter_browser: options.browser,
+    filter_operating_system: options.os,
+  }
+}
+
+function formatMetric(value: number | null | undefined, unit: MetricDefinition['unit']): string {
+  if (value === null || value === undefined) return 'n/a'
+  return unit === 'score' ? value.toFixed(3) : `${Math.round(value)}ms`
+}
+
+function metricValue(
+  data: PerformanceMetricsResponse,
+  metric: MetricDefinition['key'],
+  percentile?: 'p75' | 'p90' | 'p95' | 'p99'
+): number | null | undefined {
+  const key = percentile ? `${metric}_${percentile}` : metric
+  return data[key as keyof PerformanceMetricsResponse] as number | null | undefined
+}
+
+function hasMetricData(data: PerformanceMetricsResponse | undefined): boolean {
+  if (!data) return false
+  return METRICS.some((metric) => metricValue(data, metric.key) != null)
+}
+
+function renderSummary(data: PerformanceMetricsResponse): void {
+  console.log(
+    `  ${chalk.gray('Metric'.padEnd(10))}${chalk.gray('Average'.padStart(12))}${chalk.gray('p75'.padStart(12))}${chalk.gray('p90'.padStart(12))}${chalk.gray('p95'.padStart(12))}${chalk.gray('p99'.padStart(12))}`
+  )
+  console.log(`  ${chalk.gray('─'.repeat(70))}`)
+
+  for (const metric of METRICS) {
+    const average = formatMetric(metricValue(data, metric.key), metric.unit)
+    const p75 = formatMetric(metricValue(data, metric.key, 'p75'), metric.unit)
+    const p90 = formatMetric(metricValue(data, metric.key, 'p90'), metric.unit)
+    const p95 = formatMetric(metricValue(data, metric.key, 'p95'), metric.unit)
+    const p99 = formatMetric(metricValue(data, metric.key, 'p99'), metric.unit)
+    console.log(
+      `  ${chalk.white(metric.label.padEnd(10))}${average.padStart(12)}${p75.padStart(12)}${p90.padStart(12)}${p95.padStart(12)}${p99.padStart(12)}`
+    )
+  }
+}
+
+function formatGroupKey(value: string): string {
+  return value.length > 34 ? `${value.slice(0, 31)}...` : value
+}
+
+function renderBreakdown(groups: GroupedPageMetric[], groupedBy: string, totalEvents: number): void {
+  newline()
+  console.log(`  ${chalk.bold.white(`Breakdown by ${groupedBy}`)}`)
+  console.log(
+    `  ${chalk.gray('Value'.padEnd(36))}${chalk.gray('Samples'.padStart(10))}${chalk.gray('LCP'.padStart(10))}${chalk.gray('INP'.padStart(10))}${chalk.gray('CLS'.padStart(10))}${chalk.gray('FCP'.padStart(10))}${chalk.gray('TTFB'.padStart(10))}`
+  )
+  console.log(`  ${chalk.gray('─'.repeat(96))}`)
+
+  for (const group of groups) {
+    console.log(
+      `  ${chalk.white(formatGroupKey(group.group_key).padEnd(36))}${group.events.toLocaleString('en-US').padStart(10)}${formatMetric(group.lcp, 'ms').padStart(10)}${formatMetric(group.inp, 'ms').padStart(10)}${formatMetric(group.cls, 'score').padStart(10)}${formatMetric(group.fcp, 'ms').padStart(10)}${formatMetric(group.ttfb, 'ms').padStart(10)}`
+    )
+  }
+  console.log(`  ${chalk.gray(`Total samples: ${totalEvents.toLocaleString('en-US')}`)}`)
+}
+
+export async function performanceInsights(options: PerformanceOptions): Promise<void> {
+  await requireAuth()
+  await setupClient()
+
+  const window = resolvePerformanceWindow(options)
+  const groupBy = parseGroupBy(options.groupBy)
+  const resolved = await requireProjectSlug(options.project)
+
+  if (resolved.source !== 'flag') {
+    info(`Using project ${colors.bold(resolved.slug)} (from ${resolved.source})`)
+  }
+
+  const { data: project, error: projectError } = await getProjectBySlug({
+    client,
+    path: { slug: resolved.slug },
+  })
+  if (projectError || !project) {
+    throw new Error(`Project "${resolved.slug}" not found`)
+  }
+
+  const query = buildPerformanceQuery(project.id, window, options)
+  const result = await withSpinner('Fetching Performance Insights...', async () => {
+    const [summaryResult, timelineResult, breakdownResult] = await Promise.all([
+      getPerformanceMetrics({ client, query }),
+      getMetricsOverTime({ client, query }),
+      groupBy
+        ? getGroupedPageMetrics({ client, query: { ...query, group_by: groupBy } })
+        : Promise.resolve(undefined),
+    ])
+
+    if (summaryResult.error) throw new Error(getErrorMessage(summaryResult.error))
+    if (timelineResult.error) throw new Error(getErrorMessage(timelineResult.error))
+    if (breakdownResult?.error) throw new Error(getErrorMessage(breakdownResult.error))
+
+    return {
+      summary: summaryResult.data,
+      timeline: timelineResult.data,
+      breakdown: breakdownResult?.data,
+    }
+  })
+
+  if (options.json) {
+    jsonOut({
+      project: resolved.slug,
+      period: window.period,
+      start_date: window.startDate,
+      end_date: window.endDate,
+      filters: {
+        environment_id: query.environment_id,
+        deployment_id: query.deployment_id,
+        device_type: query.device_type,
+        include_bots: query.include_bots,
+        path: query.filter_path,
+        country: query.filter_country,
+        region: query.filter_region,
+        city: query.filter_city,
+        browser: query.filter_browser,
+        operating_system: query.filter_operating_system,
+      },
+      summary: result.summary,
+      timeline: result.timeline,
+      breakdown: result.breakdown,
+    })
+    return
+  }
+
+  const line = chalk.cyan('━'.repeat(72))
+  const deviceLabel = query.device_type ? ` · ${query.device_type}` : ' · all devices'
+  newline()
+  console.log(line)
+  console.log(
+    `   ${chalk.bold.white('Performance Insights:')} ${chalk.bold.cyan(resolved.slug)} ${chalk.gray(`(${window.label}${deviceLabel})`)}`
+  )
+  console.log(line)
+  newline()
+
+  if (!hasMetricData(result.summary)) {
+    console.log(`  ${chalk.yellow('No Web Vitals samples were recorded for these filters.')}`)
+  } else {
+    renderSummary(result.summary as PerformanceMetricsResponse)
+  }
+
+  const timeline = result.timeline as MetricsOverTimeResponse | undefined
+  if (timeline?.timestamps.length) {
+    newline()
+    console.log(`  ${chalk.gray(`Timeline buckets: ${timeline.timestamps.length}`)}`)
+  }
+
+  if (result.breakdown) {
+    renderBreakdown(
+      result.breakdown.groups,
+      result.breakdown.grouped_by,
+      result.breakdown.total_events
+    )
+  }
+
+  newline()
+  console.log(line)
+  newline()
+}
+
+export const parseDeviceForTest = parseDevice
+export const parseGroupByForTest = parseGroupBy
+export const parsePositiveIntegerForTest = parsePositiveInteger
+export const formatMetricForTest = formatMetric

--- a/apps/temps-cli/src/commands/analytics/performance.ts
+++ b/apps/temps-cli/src/commands/analytics/performance.ts
@@ -19,6 +19,7 @@ import { colors, info, json as jsonOut, newline } from '../../ui/output.js'
 import { parsePeriod } from './period.js'
 
 const DEVICES = ['desktop', 'mobile'] as const
+const MAX_BACKEND_ID = 2_147_483_647
 const GROUP_BY_DIMENSIONS = [
   'path',
   'country',
@@ -79,7 +80,11 @@ function parsePositiveInteger(value: string | undefined, label: string): number 
   if (!/^[1-9]\d*$/.test(value)) {
     throw new Error(`${label} must be a positive integer`)
   }
-  return Number.parseInt(value, 10)
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isSafeInteger(parsed) || parsed > MAX_BACKEND_ID) {
+    throw new Error(`${label} must be between 1 and ${MAX_BACKEND_ID}`)
+  }
+  return parsed
 }
 
 function parseDevice(value: string | undefined): Device | undefined {
@@ -223,7 +228,10 @@ export async function performanceInsights(options: PerformanceOptions): Promise<
     client,
     path: { slug: resolved.slug },
   })
-  if (projectError || !project) {
+  if (projectError) {
+    throw new Error(getErrorMessage(projectError))
+  }
+  if (!project) {
     throw new Error(`Project "${resolved.slug}" not found`)
   }
 

--- a/skills/temps-cli/SKILL.md
+++ b/skills/temps-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: temps-cli
-description: Operate Temps through the pinned `@temps-sdk/cli` package with bunx or npx. Use when the user mentions Temps CLI, `@temps-sdk/cli`, a CLI command, or asks to deploy, configure, inspect, automate, or administer Temps from a terminal. Covers contexts, projects, deployments, environments, services, domains, monitoring, backups, telemetry, Cloud, platform administration, and read-only managed-data browsing. Apply the target-context, secret-handling, confirmation, and verification rules for every agentic CLI operation.
+description: Operate Temps through the pinned `@temps-sdk/cli` package with bunx or npx. Use when the user mentions Temps CLI, `@temps-sdk/cli`, a CLI command, or asks to deploy, configure, inspect, automate, or administer Temps from a terminal. Covers contexts, projects, deployments, environments, services, domains, monitoring, backups, telemetry, browser Performance Insights/Core Web Vitals, Cloud, platform administration, and read-only managed-data browsing. Apply the target-context, secret-handling, confirmation, and verification rules for every agentic CLI operation.
 ---
 
 # Temps CLI
@@ -78,6 +78,10 @@ npx @temps-sdk/cli@0.1.33 --version
 Never use unpinned `bunx @temps-sdk/cli`, `npx @temps-sdk/cli`, a globally
 installed mutable version, or a downloaded script.
 
+For Performance Insights, confirm `analytics performance --help` exists in the
+reviewed runtime. If it does not, report the version gap instead of silently
+substituting OTel `metrics` or the traffic-only `analytics top devices` query.
+
 ## Discover commands efficiently
 
 The generated catalog contains every command, subcommand, alias, and option for
@@ -100,7 +104,7 @@ Use these routing hints:
 | Manage databases and storage | `services`, `backups`, `data`, `kv`, `blob` |
 | Configure traffic and TLS | `domains`, `custom-domains`, `dns`, `dns-provider` |
 | Inspect runtime behavior | `containers`, `runtime-logs`, `proxy-logs`, `services` |
-| Operate observability | `analytics`, `errors`, `traces`, `session-replay`, `monitors`, `incidents` |
+| Operate observability or review desktop/mobile Web Vitals | `analytics`, `errors`, `traces`, `session-replay`, `monitors`, `incidents` |
 | Configure telemetry forwarding | `otel-forward` |
 | Manage Cloud integration | `cloud` |
 | Manage agent capabilities | `sandbox`, `skills`, `mcp-servers`, `secrets`, `workflow`, `ai` |

--- a/skills/temps-cli/references/COMMANDS.md
+++ b/skills/temps-cli/references/COMMANDS.md
@@ -5382,9 +5382,14 @@ View project analytics
 - `overview` (`o`) - Show analytics dashboard overview
 - `top` - Show breakdown by dimension: pages, referrers, browsers, os, devices, countries, regions, cities, channels, events, languages, utm_source, utm_medium, utm_campaign
 - `funnels` - Show funnel conversion metrics for all funnels
+- `performance` (`speed`) - Show real-user Web Vitals and optional dimension breakdowns
 - `ai-agents` - Show AI crawler / provider breakdown (web /analytics/ai-agents)
 - `ai-pages` - Show pages crawled by AI agents, with distinct-agent counts
 - `ai-page` - Show which agents/providers crawled a single page (e.g. /docs)
+- `api-overview` - Show API traffic timeseries (requests, errors, latency) from /api-analytics/timeseries
+- `api-routes` - Show top API routes by request count from /api-analytics/routes
+- `api-callers` - Show top API callers by client IP from /api-analytics/callers
+- `api-summary` - Show an AI-generated summary of API traffic from /api-analytics/summary (requires AI Assistance to be configured and enabled on the project)
 
 ### `analytics overview` (alias: `o`)
 
@@ -5421,6 +5426,31 @@ Show funnel conversion metrics for all funnels
 |------|-------------|---------|----------|
 | `-p, --project <project>` | Project slug or ID | - | No |
 | `--period <period>` | Time period: today, <n>h, <n>d, <n>m (e.g. 1h, 6h, 48h, 7d, 30d, 3m) | `7d` | No |
+| `--json` | Output in JSON format | - | No |
+
+### `analytics performance` (alias: `speed`)
+
+Show real-user Web Vitals and optional dimension breakdowns
+
+**Options:**
+
+| Flag | Description | Default | Required |
+|------|-------------|---------|----------|
+| `-p, --project <project>` | Project slug or ID | - | No |
+| `--period <period>` | Time period: today, <n>h, <n>d, <n>m (ignored with --start-date/--end-date) | `7d` | No |
+| `--start-date <date>` | Explicit window start (RFC 3339; requires --end-date) | - | No |
+| `--end-date <date>` | Explicit window end (RFC 3339; requires --start-date) | - | No |
+| `--environment-id <id>` | Restrict samples to one environment ID | - | No |
+| `--deployment-id <id>` | Restrict samples to one deployment ID | - | No |
+| `--device <device>` | Device filter: desktop or mobile | - | No |
+| `--include-bots` | Include crawler and datacenter bot samples | - | No |
+| `--group-by <dimension>` | Break down by path, country, region, city, device_type, browser, or operating_system | - | No |
+| `--path <path>` | Restrict samples to one page pathname | - | No |
+| `--country <country>` | Restrict samples to one country | - | No |
+| `--region <region>` | Restrict samples to one region | - | No |
+| `--city <city>` | Restrict samples to one city | - | No |
+| `--browser <browser>` | Restrict samples to one browser | - | No |
+| `--os <operating-system>` | Restrict samples to one operating system | - | No |
 | `--json` | Output in JSON format | - | No |
 
 ### `analytics ai-agents`
@@ -5465,6 +5495,62 @@ Show which agents/providers crawled a single page (e.g. /docs)
 | `--period <period>` | Time period: today, <n>h, <n>d, <n>m (e.g. 24h, 7d, 30d) | `24h` | No |
 | `--limit <n>` | Number of rows to fetch (default: 50, max: 100) | - | No |
 | `--group-by <mode>` | Group rows by "agent" (default) or "provider" | `agent` | No |
+| `--json` | Output in JSON format | - | No |
+
+### `analytics api-overview`
+
+Show API traffic timeseries (requests, errors, latency) from /api-analytics/timeseries
+
+**Options:**
+
+| Flag | Description | Default | Required |
+|------|-------------|---------|----------|
+| `-p, --project <project>` | Project slug or ID | - | No |
+| `--environment-id <id>` | Restrict traffic to one environment ID | - | No |
+| `--period <period>` | Time period: today, <n>h, <n>d, <n>m (e.g. 1h, 6h, 48h, 7d, 30d, 3m) | `24h` | No |
+| `--json` | Output in JSON format | - | No |
+
+### `analytics api-routes`
+
+Show top API routes by request count from /api-analytics/routes
+
+**Options:**
+
+| Flag | Description | Default | Required |
+|------|-------------|---------|----------|
+| `-p, --project <project>` | Project slug or ID | - | No |
+| `--environment-id <id>` | Restrict traffic to one environment ID | - | No |
+| `--period <period>` | Time period: today, <n>h, <n>d, <n>m (e.g. 1h, 6h, 48h, 7d, 30d, 3m) | `24h` | No |
+| `--limit <n>` | Number of routes to return (default: 20, max: 100) | - | No |
+| `--offset <n>` | Number of ranked routes to skip (default: 0) | - | No |
+| `--json` | Output in JSON format | - | No |
+
+### `analytics api-callers`
+
+Show top API callers by client IP from /api-analytics/callers
+
+**Options:**
+
+| Flag | Description | Default | Required |
+|------|-------------|---------|----------|
+| `-p, --project <project>` | Project slug or ID | - | No |
+| `--environment-id <id>` | Restrict traffic to one environment ID | - | No |
+| `--period <period>` | Time period: today, <n>h, <n>d, <n>m (e.g. 1h, 6h, 48h, 7d, 30d, 3m) | `24h` | No |
+| `--limit <n>` | Number of callers to return (default: 20, max: 100) | - | No |
+| `--offset <n>` | Number of ranked callers to skip (default: 0) | - | No |
+| `--json` | Output in JSON format | - | No |
+
+### `analytics api-summary`
+
+Show an AI-generated summary of API traffic from /api-analytics/summary (requires AI Assistance to be configured and enabled on the project)
+
+**Options:**
+
+| Flag | Description | Default | Required |
+|------|-------------|---------|----------|
+| `-p, --project <project>` | Project slug or ID | - | No |
+| `--environment-id <id>` | Restrict traffic to one environment ID | - | No |
+| `--period <period>` | Time period: today, <n>h, <n>d, <n>m (e.g. 1h, 6h, 48h, 7d, 30d, 3m) | `24h` | No |
 | `--json` | Output in JSON format | - | No |
 
 ## `funnels` (alias: `funnel`)

--- a/skills/temps/SKILL.md
+++ b/skills/temps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: temps
-description: Manage, deploy, operate, and instrument applications with Temps. Use this skill whenever the user mentions Temps, `@temps-sdk/cli@0.1.33`, deploying or migrating an app to Temps, projects, environments, services, domains, backups, logs, monitoring, analytics, observability, error tracking, OpenTelemetry, tracing, session replay, or Temps Cloud. Also use it when preparing an application for production on Temps even if the user does not explicitly ask for the CLI. Route to focused references, proactively detect missing observability during create/link/deploy journeys, and use pinned `bunx` or `npx` CLI invocations with explicit target contexts.
+description: Manage, deploy, operate, and instrument applications with Temps. Use this skill whenever the user mentions Temps, `@temps-sdk/cli@0.1.33`, deploying or migrating an app to Temps, projects, environments, services, domains, backups, logs, monitoring, analytics, browser Performance Insights/Core Web Vitals, observability, error tracking, OpenTelemetry, tracing, session replay, or Temps Cloud. Also use it when preparing an application for production on Temps even if the user does not explicitly ask for the CLI. Route to focused references, proactively detect missing observability during create/link/deploy journeys, and use pinned `bunx` or `npx` CLI invocations with explicit target contexts.
 ---
 
 # Temps
@@ -76,6 +76,7 @@ When the user opts in:
 | Automate Temps from CI | [howtos/ci-automation.md](howtos/ci-automation.md) |
 | Add or review observability end to end | [howtos/observability-onboarding.md](howtos/observability-onboarding.md), then one framework guide |
 | Add browser/product analytics | [references/observability/analytics.md](references/observability/analytics.md) |
+| Review Performance Insights, Core Web Vitals, or desktop/mobile speed | [references/commands/analytics.md](references/commands/analytics.md), then [references/observability/analytics.md](references/observability/analytics.md) only when capture/setup also needs review |
 | Add exception capture | [references/observability/error-tracking.md](references/observability/error-tracking.md) |
 | Add distributed traces | [references/observability/tracing.md](references/observability/tracing.md) |
 | Add metrics or structured logs | [references/observability/metrics.md](references/observability/metrics.md) or [references/observability/logs.md](references/observability/logs.md) |
@@ -97,6 +98,11 @@ bunx @temps-sdk/cli@0.1.33 <group> <command> --help
 
 Use `npx @temps-sdk/cli@0.1.33` only when Bun is unavailable. Never omit the
 reviewed version and never assume a global `temps` binary exists.
+
+For Performance Insights, confirm `analytics performance --help` exists in the
+reviewed runtime before querying. If the current reviewed version predates that
+command, report the version gap instead of silently substituting OTel `metrics`
+or a traffic-only `analytics top devices` query.
 
 ## Verification standards
 

--- a/skills/temps/references/commands/analytics.md
+++ b/skills/temps/references/commands/analytics.md
@@ -13,9 +13,14 @@ View project analytics
 - `overview` (`o`) - Show analytics dashboard overview
 - `top` - Show breakdown by dimension: pages, referrers, browsers, os, devices, countries, regions, cities, channels, events, languages, utm_source, utm_medium, utm_campaign
 - `funnels` - Show funnel conversion metrics for all funnels
+- `performance` (`speed`) - Show real-user Web Vitals and optional dimension breakdowns
 - `ai-agents` - Show AI crawler / provider breakdown (web /analytics/ai-agents)
 - `ai-pages` - Show pages crawled by AI agents, with distinct-agent counts
 - `ai-page` - Show which agents/providers crawled a single page (e.g. /docs)
+- `api-overview` - Show API traffic timeseries (requests, errors, latency) from /api-analytics/timeseries
+- `api-routes` - Show top API routes by request count from /api-analytics/routes
+- `api-callers` - Show top API callers by client IP from /api-analytics/callers
+- `api-summary` - Show an AI-generated summary of API traffic from /api-analytics/summary (requires AI Assistance to be configured and enabled on the project)
 
 ### `analytics overview` (alias: `o`)
 
@@ -52,6 +57,31 @@ Show funnel conversion metrics for all funnels
 |------|-------------|---------|----------|
 | `-p, --project <project>` | Project slug or ID | - | No |
 | `--period <period>` | Time period: today, <n>h, <n>d, <n>m (e.g. 1h, 6h, 48h, 7d, 30d, 3m) | `7d` | No |
+| `--json` | Output in JSON format | - | No |
+
+### `analytics performance` (alias: `speed`)
+
+Show real-user Web Vitals and optional dimension breakdowns
+
+**Options:**
+
+| Flag | Description | Default | Required |
+|------|-------------|---------|----------|
+| `-p, --project <project>` | Project slug or ID | - | No |
+| `--period <period>` | Time period: today, <n>h, <n>d, <n>m (ignored with --start-date/--end-date) | `7d` | No |
+| `--start-date <date>` | Explicit window start (RFC 3339; requires --end-date) | - | No |
+| `--end-date <date>` | Explicit window end (RFC 3339; requires --start-date) | - | No |
+| `--environment-id <id>` | Restrict samples to one environment ID | - | No |
+| `--deployment-id <id>` | Restrict samples to one deployment ID | - | No |
+| `--device <device>` | Device filter: desktop or mobile | - | No |
+| `--include-bots` | Include crawler and datacenter bot samples | - | No |
+| `--group-by <dimension>` | Break down by path, country, region, city, device_type, browser, or operating_system | - | No |
+| `--path <path>` | Restrict samples to one page pathname | - | No |
+| `--country <country>` | Restrict samples to one country | - | No |
+| `--region <region>` | Restrict samples to one region | - | No |
+| `--city <city>` | Restrict samples to one city | - | No |
+| `--browser <browser>` | Restrict samples to one browser | - | No |
+| `--os <operating-system>` | Restrict samples to one operating system | - | No |
 | `--json` | Output in JSON format | - | No |
 
 ### `analytics ai-agents`
@@ -96,4 +126,60 @@ Show which agents/providers crawled a single page (e.g. /docs)
 | `--period <period>` | Time period: today, <n>h, <n>d, <n>m (e.g. 24h, 7d, 30d) | `24h` | No |
 | `--limit <n>` | Number of rows to fetch (default: 50, max: 100) | - | No |
 | `--group-by <mode>` | Group rows by "agent" (default) or "provider" | `agent` | No |
+| `--json` | Output in JSON format | - | No |
+
+### `analytics api-overview`
+
+Show API traffic timeseries (requests, errors, latency) from /api-analytics/timeseries
+
+**Options:**
+
+| Flag | Description | Default | Required |
+|------|-------------|---------|----------|
+| `-p, --project <project>` | Project slug or ID | - | No |
+| `--environment-id <id>` | Restrict traffic to one environment ID | - | No |
+| `--period <period>` | Time period: today, <n>h, <n>d, <n>m (e.g. 1h, 6h, 48h, 7d, 30d, 3m) | `24h` | No |
+| `--json` | Output in JSON format | - | No |
+
+### `analytics api-routes`
+
+Show top API routes by request count from /api-analytics/routes
+
+**Options:**
+
+| Flag | Description | Default | Required |
+|------|-------------|---------|----------|
+| `-p, --project <project>` | Project slug or ID | - | No |
+| `--environment-id <id>` | Restrict traffic to one environment ID | - | No |
+| `--period <period>` | Time period: today, <n>h, <n>d, <n>m (e.g. 1h, 6h, 48h, 7d, 30d, 3m) | `24h` | No |
+| `--limit <n>` | Number of routes to return (default: 20, max: 100) | - | No |
+| `--offset <n>` | Number of ranked routes to skip (default: 0) | - | No |
+| `--json` | Output in JSON format | - | No |
+
+### `analytics api-callers`
+
+Show top API callers by client IP from /api-analytics/callers
+
+**Options:**
+
+| Flag | Description | Default | Required |
+|------|-------------|---------|----------|
+| `-p, --project <project>` | Project slug or ID | - | No |
+| `--environment-id <id>` | Restrict traffic to one environment ID | - | No |
+| `--period <period>` | Time period: today, <n>h, <n>d, <n>m (e.g. 1h, 6h, 48h, 7d, 30d, 3m) | `24h` | No |
+| `--limit <n>` | Number of callers to return (default: 20, max: 100) | - | No |
+| `--offset <n>` | Number of ranked callers to skip (default: 0) | - | No |
+| `--json` | Output in JSON format | - | No |
+
+### `analytics api-summary`
+
+Show an AI-generated summary of API traffic from /api-analytics/summary (requires AI Assistance to be configured and enabled on the project)
+
+**Options:**
+
+| Flag | Description | Default | Required |
+|------|-------------|---------|----------|
+| `-p, --project <project>` | Project slug or ID | - | No |
+| `--environment-id <id>` | Restrict traffic to one environment ID | - | No |
+| `--period <period>` | Time period: today, <n>h, <n>d, <n>m (e.g. 1h, 6h, 48h, 7d, 30d, 3m) | `24h` | No |
 | `--json` | Output in JSON format | - | No |

--- a/skills/temps/references/observability/analytics.md
+++ b/skills/temps/references/observability/analytics.md
@@ -101,12 +101,10 @@ Use `analytics performance` (alias `speed`) to query the same real-user Web
 Vitals surface as the project's Performance Insights page. Compare desktop and
 mobile with identical windows and segment filters:
 
-```bash
-temps --target-context production \
-  analytics performance -p my-app --period 7d --device desktop
-temps --target-context production \
-  analytics performance -p my-app --period 7d --device mobile
-```
+After runtime help confirms support, append either
+`analytics performance -p my-app --period 7d --device desktop` or
+`analytics performance -p my-app --period 7d --device mobile` to the verified,
+pinned invocation from [../cli-runtime.md](../cli-runtime.md).
 
 Add `--group-by path` to locate slow pages, or group by `country`, `region`,
 `city`, `device_type`, `browser`, or `operating_system`. Narrow the same query
@@ -118,10 +116,8 @@ the aggregate percentiles, time series, and optional breakdown payload.
 
 Do not confuse this with `metrics query`, which reads OpenTelemetry application
 metrics, or `analytics top devices`, which reports traffic counts rather than
-browser performance. Runtime `--help` is authoritative; replace
-`temps` with the verified pinned invocation from
-[../cli-runtime.md](../cli-runtime.md) only after that runtime's help lists the
-command.
+browser performance. Runtime `--help` is authoritative; do not substitute an
+ambient executable while the reviewed pinned version predates the command.
 
 ## What belongs here vs. other pillars
 

--- a/skills/temps/references/observability/analytics.md
+++ b/skills/temps/references/observability/analytics.md
@@ -95,6 +95,34 @@ For browser-side tracking in a non-React frontend (vanilla JS, Vue, Svelte, a mo
 
 Do not place secrets, emails, raw identifiers, payment data, or sensitive URL query values in `event_data`, `request_query`, URLs, or referrers. The endpoint stores application-provided event data; see [hygiene.md](hygiene.md).
 
+## Review Performance Insights from the CLI
+
+Use `analytics performance` (alias `speed`) to query the same real-user Web
+Vitals surface as the project's Performance Insights page. Compare desktop and
+mobile with identical windows and segment filters:
+
+```bash
+temps --target-context production \
+  analytics performance -p my-app --period 7d --device desktop
+temps --target-context production \
+  analytics performance -p my-app --period 7d --device mobile
+```
+
+Add `--group-by path` to locate slow pages, or group by `country`, `region`,
+`city`, `device_type`, `browser`, or `operating_system`. Narrow the same query
+with `--environment-id`, `--deployment-id`, `--path`, `--country`, `--region`,
+`--city`, `--browser`, or `--os`. Use paired RFC 3339 `--start-date` and
+`--end-date` values for an exact comparison window. Bot samples are excluded by
+default; include them only deliberately with `--include-bots`. Use `--json` for
+the aggregate percentiles, time series, and optional breakdown payload.
+
+Do not confuse this with `metrics query`, which reads OpenTelemetry application
+metrics, or `analytics top devices`, which reports traffic counts rather than
+browser performance. Runtime `--help` is authoritative; replace
+`temps` with the verified pinned invocation from
+[../cli-runtime.md](../cli-runtime.md) only after that runtime's help lists the
+command.
+
 ## What belongs here vs. other pillars
 
 - Page views, custom product events ("signed up", "clicked upgrade"), scroll/engagement/Web Vitals — all analytics.


### PR DESCRIPTION
## Summary

- add `analytics performance` (alias `speed`) for real-user Web Vitals
- expose desktop/mobile, time-window, environment/deployment, bot, segment, and grouping parameters
- return aggregate percentiles, timeline data, and optional grouped breakdowns in human-readable or JSON output
- regenerate the `temps-cli` command catalog and update both `temps-cli` and `temps` skills

## Evidence

**CLI runtime:** the built CLI exposes the new command and all filters.

```bash
cd apps/temps-cli
node dist/index.js analytics performance --help
```

```text
Usage: temps analytics performance|speed [options]
...
--device <device>        Device filter: desktop or mobile
--group-by <dimension>   Break down by path, country, region, city,
                         device_type, browser, or operating_system
--json                   Output in JSON format
```

**Focused behavior:** option validation, exact date windows, complete API query mapping, bot defaults, and metric formatting execute successfully.

```bash
cd apps/temps-cli
bun test src/commands/analytics/performance.test.ts
```

```text
13 pass
0 fail
55 expect() calls
```

## Verification

- `bun test`: 876 pass, 0 fail
- `bun run typecheck`
- `bun run build`
- `bun run spec:check`: canonical OpenAPI snapshot, 702 paths
- `python3 skills/temps/scripts/validate_skill.py`
- `python3 skills/temps/scripts/test_generate_command_references.py`: 6 pass
- `python3 skills/temps/scripts/test_detect_project_capabilities.py`: 7 pass
- both skill packages pass `quick_validate.py` and package successfully
- `git diff --check`

No Rust code or migrations changed, so Rust checks are not applicable.
