### PR TITLE
fix(otel): harden claimed project slug diagnostics

### DIFF
--- a/crates/temps-auth/src/permission_guard.rs
+++ b/crates/temps-auth/src/permission_guard.rs
@@ -1070,6 +1070,7 @@ mod tests {
         let expected_crates: &[&str] = &[
             "temps-agents",
             "temps-ai-chat",
+            "temps-ai-gateway",
             "temps-analytics",
             "temps-analytics-events",
             "temps-analytics-funnels",

--- a/crates/temps-deployments/src/services/env_resolver.rs
+++ b/crates/temps-deployments/src/services/env_resolver.rs
@@ -24,14 +24,30 @@ use super::workflow_planner::{public_sentry_dsn_var, public_sentry_tunnel_var};
 /// Build the OpenTelemetry SDK header-list value for a deployed project.
 ///
 /// Header values in `OTEL_EXPORTER_OTLP_HEADERS` use URL encoding, so the
-/// space in the Bearer scheme must be encoded. The slug is diagnostic context
-/// only; ingest authentication continues to rely exclusively on the token.
-pub(super) fn otel_exporter_headers(token: Option<&str>, project_slug: &str) -> String {
+/// space in the Bearer scheme must be encoded. The diagnostic slug uses an
+/// explicit hex transport header so Unicode and delimiter characters cannot
+/// corrupt the header-list grammar. Authentication still relies only on the
+/// token.
+pub(super) fn otel_exporter_headers(
+    token: Option<&str>,
+    existing_headers: Option<&str>,
+    project_slug: &str,
+) -> String {
+    let slug_header = format!(
+        "X-Temps-Project-Slug-Hex={}",
+        hex::encode(project_slug.as_bytes())
+    );
     match token {
-        Some(token) => {
-            format!("Authorization=Bearer%20{token},X-Temps-Project-Slug={project_slug}")
-        }
-        None => format!("X-Temps-Project-Slug={project_slug}"),
+        Some(token) => format!(
+            "Authorization=Bearer%20{},{slug_header}",
+            urlencoding::encode(token),
+        ),
+        None => existing_headers
+            .map(str::trim)
+            .map(|headers| headers.trim_end_matches(',').trim_end())
+            .filter(|headers| !headers.is_empty())
+            .map(|headers| format!("{headers},{slug_header}"))
+            .unwrap_or(slug_header),
     }
 }
 
@@ -344,10 +360,11 @@ impl DeploymentEnvResolver {
             // project context. Authorization is added when token provisioning
             // succeeded (the token is already in TEMPS_API_TOKEN).
             let token = env_vars_map.get("TEMPS_API_TOKEN").map(String::as_str);
-            env_vars_map.insert(
-                "OTEL_EXPORTER_OTLP_HEADERS".to_string(),
-                otel_exporter_headers(token, &project.slug),
-            );
+            let existing_headers = env_vars_map
+                .get("OTEL_EXPORTER_OTLP_HEADERS")
+                .map(String::as_str);
+            let otel_headers = otel_exporter_headers(token, existing_headers, &project.slug);
+            env_vars_map.insert("OTEL_EXPORTER_OTLP_HEADERS".to_string(), otel_headers);
 
             env_vars_map.insert("OTEL_SERVICE_NAME".to_string(), project.name.clone());
 
@@ -378,16 +395,36 @@ mod tests {
     #[test]
     fn otel_headers_include_encoded_token_and_project_slug() {
         assert_eq!(
-            otel_exporter_headers(Some("dt_example"), "example-project"),
-            "Authorization=Bearer%20dt_example,X-Temps-Project-Slug=example-project"
+            otel_exporter_headers(Some("dt_example"), None, "example-project"),
+            "Authorization=Bearer%20dt_example,X-Temps-Project-Slug-Hex=6578616d706c652d70726f6a656374"
         );
     }
 
     #[test]
     fn otel_headers_preserve_project_slug_without_token() {
         assert_eq!(
-            otel_exporter_headers(None, "example-project"),
-            "X-Temps-Project-Slug=example-project"
+            otel_exporter_headers(None, None, "example-project"),
+            "X-Temps-Project-Slug-Hex=6578616d706c652d70726f6a656374"
+        );
+    }
+
+    #[test]
+    fn otel_headers_hex_encode_unicode_and_delimiters_in_project_slug() {
+        assert_eq!(
+            otel_exporter_headers(None, None, "café,slug=value"),
+            "X-Temps-Project-Slug-Hex=636166c3a92c736c75673d76616c7565"
+        );
+    }
+
+    #[test]
+    fn otel_headers_preserve_manual_auth_when_platform_token_is_missing() {
+        assert_eq!(
+            otel_exporter_headers(
+                None,
+                Some("Authorization=Bearer%20manual-token"),
+                "example-project"
+            ),
+            "Authorization=Bearer%20manual-token,X-Temps-Project-Slug-Hex=6578616d706c652d70726f6a656374"
         );
     }
 }

--- a/crates/temps-deployments/src/services/workflow_planner.rs
+++ b/crates/temps-deployments/src/services/workflow_planner.rs
@@ -553,10 +553,12 @@ impl WorkflowPlanner {
             // project context. Authorization is added when token provisioning
             // succeeded (the token is already in TEMPS_API_TOKEN).
             let token = env_vars_map.get("TEMPS_API_TOKEN").map(String::as_str);
-            env_vars_map.insert(
-                "OTEL_EXPORTER_OTLP_HEADERS".to_string(),
-                super::env_resolver::otel_exporter_headers(token, &project.slug),
-            );
+            let existing_headers = env_vars_map
+                .get("OTEL_EXPORTER_OTLP_HEADERS")
+                .map(String::as_str);
+            let otel_headers =
+                super::env_resolver::otel_exporter_headers(token, existing_headers, &project.slug);
+            env_vars_map.insert("OTEL_EXPORTER_OTLP_HEADERS".to_string(), otel_headers);
 
             env_vars_map.insert("OTEL_SERVICE_NAME".to_string(), project.name.clone());
 

--- a/crates/temps-otel/src/error.rs
+++ b/crates/temps-otel/src/error.rs
@@ -7,9 +7,9 @@ pub enum OtelError {
     AuthFailed { reason: String },
 
     #[error(
-        "Authentication failed for project '{project_slug}': Missing token in Authorization or X-Temps-Api-Key header"
+        "Authentication failed for claimed project '{claimed_project_slug}': Missing token in Authorization or X-Temps-Api-Key header"
     )]
-    MissingAuthToken { project_slug: String },
+    MissingAuthToken { claimed_project_slug: String },
 
     #[error("Invalid API key format")]
     InvalidApiKey,
@@ -90,11 +90,11 @@ mod tests {
     #[test]
     fn test_display_missing_auth_token_includes_project_slug() {
         let err = OtelError::MissingAuthToken {
-            project_slug: "example-project".into(),
+            claimed_project_slug: "example-project".into(),
         };
         assert_eq!(
             err.to_string(),
-            "Authentication failed for project 'example-project': Missing token in Authorization or X-Temps-Api-Key header"
+            "Authentication failed for claimed project 'example-project': Missing token in Authorization or X-Temps-Api-Key header"
         );
     }
 

--- a/crates/temps-otel/src/handlers/ingest_handler.rs
+++ b/crates/temps-otel/src/handlers/ingest_handler.rs
@@ -31,8 +31,11 @@ use temps_metrics::{
 impl From<OtelError> for Problem {
     fn from(error: OtelError) -> Self {
         match error {
-            OtelError::MissingAuthToken { ref project_slug } => {
-                warn!(project_slug = %project_slug, error = %error, "OTel ingest auth failed");
+            OtelError::MissingAuthToken { .. } => {
+                // The slug is carried in the error message for diagnostics but
+                // deliberately not emitted as a structured project dimension:
+                // authentication has not established that the caller owns it.
+                warn!(error = %error, "OTel ingest auth failed");
                 problemdetails::new(StatusCode::UNAUTHORIZED)
                     .with_title("Authentication Failed")
                     .with_detail(error.to_string())
@@ -153,30 +156,44 @@ fn extract_project_id_header(headers: &HeaderMap) -> Option<i32> {
         .and_then(|s| s.parse::<i32>().ok())
 }
 
-/// Extract a diagnostic project slug from `X-Temps-Project-Slug`.
+/// Extract a caller-claimed diagnostic project slug.
 ///
 /// This header is not trusted for authentication. It only preserves project
 /// context when authentication cannot run because the credential is missing.
-/// Restricting it to the persisted slug character set prevents arbitrary
-/// attacker-controlled data from entering structured logs.
-fn extract_project_slug_header(headers: &HeaderMap) -> Option<&str> {
+/// Generated deployments use a hex transport header so persisted Unicode
+/// slugs remain valid HTTP metadata. The plain header remains accepted for
+/// manually configured exporters with canonical ASCII slugs.
+fn extract_claimed_project_slug(headers: &HeaderMap) -> Option<String> {
+    let is_valid_slug = |slug: &str| {
+        !slug.is_empty()
+            && slug.len() <= 64
+            && slug
+                .chars()
+                .all(|character| character.is_alphanumeric() || character == '-')
+    };
+
+    if let Some(encoded_slug) = headers
+        .get("x-temps-project-slug-hex")
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| value.len() <= 128)
+    {
+        let slug = hex::decode(encoded_slug)
+            .ok()
+            .and_then(|bytes| String::from_utf8(bytes).ok())?;
+        return is_valid_slug(&slug).then_some(slug);
+    }
+
     headers
         .get("x-temps-project-slug")
         .and_then(|value| value.to_str().ok())
-        .filter(|slug| {
-            !slug.is_empty()
-                && slug.len() <= 64
-                && slug
-                    .bytes()
-                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
-        })
+        .filter(|slug| is_valid_slug(slug))
+        .map(str::to_string)
 }
 
 fn missing_auth_token_error(headers: &HeaderMap) -> OtelError {
     OtelError::MissingAuthToken {
-        project_slug: extract_project_slug_header(headers)
-            .unwrap_or("unknown")
-            .to_string(),
+        claimed_project_slug: extract_claimed_project_slug(headers)
+            .unwrap_or_else(|| "unknown".to_string()),
     }
 }
 
@@ -1122,13 +1139,29 @@ mod tests {
     #[test]
     fn test_missing_auth_token_error_includes_valid_project_slug() {
         let mut headers = HeaderMap::new();
-        headers.insert("x-temps-project-slug", "example-project".parse().unwrap());
+        headers.insert(
+            "x-temps-project-slug-hex",
+            "6578616d706c652d70726f6a656374".parse().unwrap(),
+        );
 
         let error = missing_auth_token_error(&headers);
 
         assert!(matches!(
             error,
-            OtelError::MissingAuthToken { project_slug } if project_slug == "example-project"
+            OtelError::MissingAuthToken { claimed_project_slug } if claimed_project_slug == "example-project"
+        ));
+    }
+
+    #[test]
+    fn test_missing_auth_token_error_decodes_unicode_project_slug() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-temps-project-slug-hex", "636166c3a9".parse().unwrap());
+
+        let error = missing_auth_token_error(&headers);
+
+        assert!(matches!(
+            error,
+            OtelError::MissingAuthToken { claimed_project_slug } if claimed_project_slug == "café"
         ));
     }
 
@@ -1141,7 +1174,7 @@ mod tests {
 
         assert!(matches!(
             error,
-            OtelError::MissingAuthToken { project_slug } if project_slug == "unknown"
+            OtelError::MissingAuthToken { claimed_project_slug } if claimed_project_slug == "unknown"
         ));
     }
 
@@ -1174,7 +1207,7 @@ mod tests {
     #[test]
     fn test_error_missing_auth_token_maps_to_401() {
         let err = OtelError::MissingAuthToken {
-            project_slug: "example-project".into(),
+            claimed_project_slug: "example-project".into(),
         };
         let problem: Problem = err.into();
         assert_eq!(problem.status_code, StatusCode::UNAUTHORIZED);

--- a/crates/temps-otel/src/handlers/ingest_handler.rs
+++ b/crates/temps-otel/src/handlers/ingest_handler.rs
@@ -128,18 +128,27 @@ fn extract_token(headers: &HeaderMap) -> Option<String> {
                 "OTLP extract_token"
             );
             if let Some(key) = value.strip_prefix("Bearer ") {
-                return Some(key.trim().to_string());
+                let key = key.trim();
+                if !key.is_empty() {
+                    return Some(key.to_string());
+                }
             }
             // Some OTLP exporters send the literal string "Bearer%20<token>"
             if let Some(key) = value.strip_prefix("Bearer%20") {
-                return Some(key.trim().to_string());
+                let key = key.trim();
+                if !key.is_empty() {
+                    return Some(key.to_string());
+                }
             }
         }
     }
 
     if let Some(key) = headers.get("x-temps-api-key") {
         if let Ok(value) = key.to_str() {
-            return Some(value.trim().to_string());
+            let key = value.trim();
+            if !key.is_empty() {
+                return Some(key.to_string());
+            }
         }
     }
 
@@ -1092,6 +1101,19 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_token_treats_empty_credentials_as_missing() {
+        for (header, value) in [
+            ("authorization", "Bearer "),
+            ("authorization", "Bearer%20"),
+            ("x-temps-api-key", ""),
+        ] {
+            let mut headers = HeaderMap::new();
+            headers.insert(header, value.parse().unwrap());
+            assert_eq!(extract_token(&headers), None, "header: {header}");
+        }
+    }
+
+    #[test]
     fn test_extract_token_bearer_takes_priority() {
         let mut headers = HeaderMap::new();
         headers.insert("authorization", "Bearer tk_first".parse().unwrap());
@@ -1176,6 +1198,22 @@ mod tests {
             error,
             OtelError::MissingAuthToken { claimed_project_slug } if claimed_project_slug == "unknown"
         ));
+    }
+
+    #[test]
+    fn test_missing_auth_token_error_rejects_malformed_hex_slug() {
+        let oversized_slug = "61".repeat(65);
+        for encoded_slug in ["not-hex", "ff", oversized_slug.as_str()] {
+            let mut headers = HeaderMap::new();
+            headers.insert("x-temps-project-slug-hex", encoded_slug.parse().unwrap());
+
+            let error = missing_auth_token_error(&headers);
+
+            assert!(matches!(
+                error,
+                OtelError::MissingAuthToken { claimed_project_slug } if claimed_project_slug == "unknown"
+            ));
+        }
     }
 
     // ── content_encoding tests ─────────────────────────────────────

--- a/crates/temps-otel/src/handlers/ingest_handler.rs
+++ b/crates/temps-otel/src/handlers/ingest_handler.rs
@@ -117,13 +117,21 @@ impl From<OtelError> for Problem {
 /// Checks `Authorization: Bearer <token>` and `X-Temps-Api-Key: <token>`.
 /// Works for `tk_`, `dt_`, and `si_` token prefixes. Handles both plain
 /// `Bearer <token>` and percent-encoded `Bearer%20<token>` from OTLP SDKs.
+fn authorization_scheme(value: &str) -> &'static str {
+    if value.starts_with("Bearer ") || value.starts_with("Bearer%20") {
+        "Bearer"
+    } else {
+        "other"
+    }
+}
+
 fn extract_token(headers: &HeaderMap) -> Option<String> {
     if let Some(auth) = headers.get("authorization") {
         if let Ok(value) = auth.to_str() {
             // SECURITY: never log the raw header — it carries a live, mostly
             // non-expiring credential (Bearer dt_/tk_/si_). Log only its shape.
             tracing::debug!(
-                scheme = value.split_whitespace().next().unwrap_or(""),
+                scheme = authorization_scheme(value),
                 len = value.len(),
                 "OTLP extract_token"
             );
@@ -1092,6 +1100,24 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("x-temps-api-key", "tk_xyz789".parse().unwrap());
         assert_eq!(extract_token(&headers), Some("tk_xyz789".to_string()));
+    }
+
+    #[test]
+    fn test_authorization_scheme_never_contains_token_material() {
+        let token = "dt_live_credential_must_not_be_logged";
+
+        for value in [
+            format!("Bearer {token}"),
+            format!("Bearer%20{token}"),
+            format!("Custom {token}"),
+        ] {
+            let scheme = authorization_scheme(&value);
+            assert!(!scheme.contains(token));
+        }
+
+        assert_eq!(authorization_scheme(&format!("Bearer {token}")), "Bearer");
+        assert_eq!(authorization_scheme(&format!("Bearer%20{token}")), "Bearer");
+        assert_eq!(authorization_scheme(&format!("Custom {token}")), "other");
     }
 
     #[test]

--- a/crates/temps-otel/src/ingest/auth.rs
+++ b/crates/temps-otel/src/ingest/auth.rs
@@ -73,8 +73,10 @@ impl From<OtelError> for CachedAuthError {
         match error {
             OtelError::InvalidApiKey => Self::InvalidApiKey,
             OtelError::AuthFailed { reason } => Self::AuthFailed(reason),
-            OtelError::MissingAuthToken { project_slug } => Self::AuthFailed(format!(
-                "Missing token in Authorization or X-Temps-Api-Key header for project '{project_slug}'"
+            OtelError::MissingAuthToken {
+                claimed_project_slug,
+            } => Self::AuthFailed(format!(
+                "Missing token in Authorization or X-Temps-Api-Key header for claimed project '{claimed_project_slug}'"
             )),
             OtelError::Storage { message } => Self::Storage(message),
             other => Self::Storage(other.to_string()),


### PR DESCRIPTION
## Summary

Follow-up to #664, which auto-merged before its required review completed. This PR carries the review and security remediations only.

- treat unauthenticated slug context explicitly as caller-claimed and keep it out of trusted structured project dimensions
- transport generated slug hints as bounded hex so Unicode and delimiters cannot corrupt the OTel header-list grammar
- preserve manually configured OTel Authorization headers when platform token provisioning fails
- classify empty credentials as missing so warnings retain claimed-project context
- prevent literal Bearer%20 credentials from leaking through the debug scheme field

## Security

The claimed slug is diagnostic only and never participates in authentication or authorization. Input is bounded, UTF-8 checked, and restricted to persisted slug characters before entering the error text. Malformed values fail closed to unknown. Bearer schemes are logged through a fixed-value classifier; token material is never used as the logged scheme.

Final security review approved PR #666 at HEAD 4797f77bc with no remaining CRITICAL, HIGH, MEDIUM, or LOW findings. The review also identified the pre-existing Bearer%20 debug leak, which is fixed here.

## Evidence

**OTel authentication and diagnostic handling**

```bash
cargo test --lib -p temps-otel
```

```text
cargo test: 464 passed (1 suite, 0.05s)
```

**Generated deployment header behavior**

```bash
cargo test --lib -p temps-deployments otel_headers_ -- --nocapture
```

```text
cargo test: 4 passed, 596 filtered out (1 suite, 0.00s)
```

**Full deployment suite and compile verification**

```bash
cargo test --lib -p temps-deployments
cargo check --lib -p temps-otel -p temps-deployments
```

```text
temps-deployments: 597 passed, 3 ignored
cargo check: 0 errors
```

Repository commit hooks passed cargo fmt, cargo clippy, typo checks, canonical-file checks, and Conventional Commit validation.

## Operational note

Existing deployments receive the diagnostic slug header after their next redeployment.
