### PR TITLE
fix(presets): upgrade Autopack Python source builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,8 +462,8 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopack-core"
-version = "0.1.1"
-source = "git+https://github.com/gotempsh/autopack?rev=7de6ced1f2a3399f234fc444cec8361f4b5ac87f#7de6ced1f2a3399f234fc444cec8361f4b5ac87f"
+version = "0.1.2"
+source = "git+https://github.com/gotempsh/autopack?tag=v0.1.2#0c4a11cc79349aa28791121f95c4e837b224a899"
 dependencies = [
  "globset",
  "indexmap 2.14.0",
@@ -477,16 +477,16 @@ dependencies = [
 
 [[package]]
 name = "autopack-dockerfile"
-version = "0.1.1"
-source = "git+https://github.com/gotempsh/autopack?rev=7de6ced1f2a3399f234fc444cec8361f4b5ac87f#7de6ced1f2a3399f234fc444cec8361f4b5ac87f"
+version = "0.1.2"
+source = "git+https://github.com/gotempsh/autopack?tag=v0.1.2#0c4a11cc79349aa28791121f95c4e837b224a899"
 dependencies = [
  "autopack-core",
 ]
 
 [[package]]
 name = "autopack-providers"
-version = "0.1.1"
-source = "git+https://github.com/gotempsh/autopack?rev=7de6ced1f2a3399f234fc444cec8361f4b5ac87f#7de6ced1f2a3399f234fc444cec8361f4b5ac87f"
+version = "0.1.2"
+source = "git+https://github.com/gotempsh/autopack?tag=v0.1.2#0c4a11cc79349aa28791121f95c4e837b224a899"
 dependencies = [
  "autopack-core",
  "indexmap 2.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,8 +462,8 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopack-core"
-version = "0.1.2"
-source = "git+https://github.com/gotempsh/autopack?tag=v0.1.2#0c4a11cc79349aa28791121f95c4e837b224a899"
+version = "0.1.3"
+source = "git+https://github.com/gotempsh/autopack?tag=v0.1.3#57d768b70f4ccdfe9f2d57e9c27ffa65a3301564"
 dependencies = [
  "globset",
  "indexmap 2.14.0",
@@ -477,16 +477,16 @@ dependencies = [
 
 [[package]]
 name = "autopack-dockerfile"
-version = "0.1.2"
-source = "git+https://github.com/gotempsh/autopack?tag=v0.1.2#0c4a11cc79349aa28791121f95c4e837b224a899"
+version = "0.1.3"
+source = "git+https://github.com/gotempsh/autopack?tag=v0.1.3#57d768b70f4ccdfe9f2d57e9c27ffa65a3301564"
 dependencies = [
  "autopack-core",
 ]
 
 [[package]]
 name = "autopack-providers"
-version = "0.1.2"
-source = "git+https://github.com/gotempsh/autopack?tag=v0.1.2#0c4a11cc79349aa28791121f95c4e837b224a899"
+version = "0.1.3"
+source = "git+https://github.com/gotempsh/autopack?tag=v0.1.3#57d768b70f4ccdfe9f2d57e9c27ffa65a3301564"
 dependencies = [
  "autopack-core",
  "indexmap 2.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,38 +462,37 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopack-core"
-version = "0.1.0"
-source = "git+https://github.com/gotempsh/autopack?rev=f89c18515f203cdcd7e641ea594b7f62d54aed68#f89c18515f203cdcd7e641ea594b7f62d54aed68"
+version = "0.1.1"
+source = "git+https://github.com/gotempsh/autopack?rev=7de6ced1f2a3399f234fc444cec8361f4b5ac87f#7de6ced1f2a3399f234fc444cec8361f4b5ac87f"
 dependencies = [
  "globset",
  "indexmap 2.14.0",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "thiserror 2.0.20",
- "toml 0.8.23",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "walkdir",
 ]
 
 [[package]]
 name = "autopack-dockerfile"
-version = "0.1.0"
-source = "git+https://github.com/gotempsh/autopack?rev=f89c18515f203cdcd7e641ea594b7f62d54aed68#f89c18515f203cdcd7e641ea594b7f62d54aed68"
+version = "0.1.1"
+source = "git+https://github.com/gotempsh/autopack?rev=7de6ced1f2a3399f234fc444cec8361f4b5ac87f#7de6ced1f2a3399f234fc444cec8361f4b5ac87f"
 dependencies = [
  "autopack-core",
 ]
 
 [[package]]
 name = "autopack-providers"
-version = "0.1.0"
-source = "git+https://github.com/gotempsh/autopack?rev=f89c18515f203cdcd7e641ea594b7f62d54aed68#f89c18515f203cdcd7e641ea594b7f62d54aed68"
+version = "0.1.1"
+source = "git+https://github.com/gotempsh/autopack?rev=7de6ced1f2a3399f234fc444cec8361f4b5ac87f#7de6ced1f2a3399f234fc444cec8361f4b5ac87f"
 dependencies = [
  "autopack-core",
  "indexmap 2.14.0",
  "serde",
  "serde_json",
- "toml 0.8.23",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
 ]
 

--- a/crates/temps-presets/Cargo.toml
+++ b/crates/temps-presets/Cargo.toml
@@ -24,9 +24,9 @@ utoipa = { workspace = true, optional = true }
 # The build engine. Pinned to a commit rather than a branch: a build plan that
 # changes underneath a release would change what every project's image contains
 # without anything in this repository moving.
-autopack-core = { git = "https://github.com/gotempsh/autopack", tag = "v0.1.2" }
-autopack-providers = { git = "https://github.com/gotempsh/autopack", tag = "v0.1.2" }
-autopack-dockerfile = { git = "https://github.com/gotempsh/autopack", tag = "v0.1.2" }
+autopack-core = { git = "https://github.com/gotempsh/autopack", tag = "v0.1.3" }
+autopack-providers = { git = "https://github.com/gotempsh/autopack", tag = "v0.1.3" }
+autopack-dockerfile = { git = "https://github.com/gotempsh/autopack", tag = "v0.1.3" }
 
 [features]
 openapi = ["utoipa"]

--- a/crates/temps-presets/Cargo.toml
+++ b/crates/temps-presets/Cargo.toml
@@ -24,9 +24,9 @@ utoipa = { workspace = true, optional = true }
 # The build engine. Pinned to a commit rather than a branch: a build plan that
 # changes underneath a release would change what every project's image contains
 # without anything in this repository moving.
-autopack-core = { git = "https://github.com/gotempsh/autopack", rev = "7de6ced1f2a3399f234fc444cec8361f4b5ac87f" }
-autopack-providers = { git = "https://github.com/gotempsh/autopack", rev = "7de6ced1f2a3399f234fc444cec8361f4b5ac87f" }
-autopack-dockerfile = { git = "https://github.com/gotempsh/autopack", rev = "7de6ced1f2a3399f234fc444cec8361f4b5ac87f" }
+autopack-core = { git = "https://github.com/gotempsh/autopack", tag = "v0.1.2" }
+autopack-providers = { git = "https://github.com/gotempsh/autopack", tag = "v0.1.2" }
+autopack-dockerfile = { git = "https://github.com/gotempsh/autopack", tag = "v0.1.2" }
 
 [features]
 openapi = ["utoipa"]

--- a/crates/temps-presets/Cargo.toml
+++ b/crates/temps-presets/Cargo.toml
@@ -24,9 +24,9 @@ utoipa = { workspace = true, optional = true }
 # The build engine. Pinned to a commit rather than a branch: a build plan that
 # changes underneath a release would change what every project's image contains
 # without anything in this repository moving.
-autopack-core = { git = "https://github.com/gotempsh/autopack", rev = "f89c18515f203cdcd7e641ea594b7f62d54aed68" }
-autopack-providers = { git = "https://github.com/gotempsh/autopack", rev = "f89c18515f203cdcd7e641ea594b7f62d54aed68" }
-autopack-dockerfile = { git = "https://github.com/gotempsh/autopack", rev = "f89c18515f203cdcd7e641ea594b7f62d54aed68" }
+autopack-core = { git = "https://github.com/gotempsh/autopack", rev = "7de6ced1f2a3399f234fc444cec8361f4b5ac87f" }
+autopack-providers = { git = "https://github.com/gotempsh/autopack", rev = "7de6ced1f2a3399f234fc444cec8361f4b5ac87f" }
+autopack-dockerfile = { git = "https://github.com/gotempsh/autopack", rev = "7de6ced1f2a3399f234fc444cec8361f4b5ac87f" }
 
 [features]
 openapi = ["utoipa"]


### PR DESCRIPTION
## Summary

- upgrade `autopack-core`, `autopack-providers`, and `autopack-dockerfile` from the old commit pin to the immutable `v0.1.3` tag
- include the Python source-build toolchain fix from gotempsh/autopack#22
- include the resilient, signed mise installer fix from gotempsh/autopack#24
- allow Python starter builds to succeed when mise falls back from a missing precompiled Python release to a CPython source build

## Root cause

The Python presets request a minor version such as `3.12`. When mise resolved that to a newly published patch release without a precompiled artifact, it correctly fell back to compiling CPython. The generated build image did not include the compiler, CPython development headers, or matching runtime libraries, so the Django, FastAPI, and Flask starter builds failed during `mise install`.

Separately, generated builds downloaded the mise installer from `mise.run` once and piped it directly to `sh`. A transient connection reset failed the Playwright conformance build, and an uninitialized Bash report array then masked the original diagnostic.

Autopack v0.1.3 adds the Python build/runtime packages, retries bounded installer downloads, verifies the versioned installer signature against the pinned mise release-key fingerprint, and preserves the original conformance failure report.

Release: https://github.com/gotempsh/autopack/releases/tag/v0.1.3

## Upgrade scope

Temps now references the immutable Autopack `v0.1.3` release tag. The lockfile resolves all three crates to tagged main commit `57d768b70f4ccdfe9f2d57e9c27ffa65a3301564`; no branch or raw commit dependency is used.

The release also includes:

- pnpm 10/11 install support
- Playwright and Puppeteer runtime dependencies
- static, validated ELF runtime-library discovery and dynamic Chromium library resolution
- complete apt-expression validation and shell quoting before root package installation
- signed mise installer verification, bounded retries/timeouts, and safe temporary files
- shell-quoted tool resolution and consistent mise versions between locking and builds

## Verification evidence

### Temps presets

```text
$ cargo check --lib -p temps-presets
cargo build: 0 errors, 2 existing workspace/dependency warnings

$ cargo test --lib -p temps-presets
cargo test: 238 passed (1 suite, 0.54s)
```

### Autopack Playwright conformance

The exact upstream regression job passed on the v0.1.3 release commit:

```text
Conformance (playwright-app): SUCCESS
```

The packages-stage evidence verifies the signed installer and runtime installation:

```text
gpg: Good signature from "mise releases <release@mise.jdx.dev>" [unknown]
mise: installed successfully to /usr/local/bin/mise
mise node@22.23.2  ✓ installed
```

### Python starter images

The prior v0.1.2 verification remains applicable because v0.1.3 contains the same Python source-build patch:

```text
TEMPS_STARTERS_ONLY=python/django,python/fastapi,python/flask
cargo test: 1 passed, 3 filtered out (1 suite, 61.72s)
```

Each generated image was built, started, checked over HTTP, verified as non-root, and tested for graceful SIGTERM handling.
