### PR TITLE
fix(projects): harden shared git settings follow-up

### DIFF
--- a/crates/temps-projects/src/handlers/handlers.rs
+++ b/crates/temps-projects/src/handlers/handlers.rs
@@ -15,10 +15,10 @@ use axum::{
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use temps_auth::RequireAuth;
 use temps_auth::{
     permission_guard, project_access_guard, project_permission_guard, project_scope_guard,
 };
+use temps_auth::{AuthContext, RequireAuth};
 use temps_core::RequestMetadata;
 use tracing::{debug, error, info};
 
@@ -1214,6 +1214,7 @@ pub async fn update_git_settings(
     Json(settings): Json<UpdateGitSettingsRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsWrite);
+    require_git_settings_permissions(&auth)?;
     project_scope_guard!(auth, project_id);
     project_access_guard!(auth, project_id, state.project_access_checker);
 
@@ -1274,6 +1275,15 @@ pub async fn update_git_settings(
     }
 
     Ok(Json(ProjectResponse::map_from_project(updated_project)))
+}
+
+/// Updating connected-repository settings makes Temps use installation-wide
+/// provider credentials for branch validation and webhook lifecycle calls.
+/// Project write access alone must not grant that Git capability.
+fn require_git_settings_permissions(auth: &AuthContext) -> Result<(), Problem> {
+    permission_guard!(auth, GitConnectionsRead);
+    permission_guard!(auth, GitRepositoriesRead);
+    Ok(())
 }
 
 /// Reinstall the GitLab webhook for a project
@@ -2269,9 +2279,57 @@ pub async fn create_project_from_template(
 mod tests {
     use super::{
         compose_path_for_candidate, parse_owner_repo_from_git_url,
-        project_created_from_template_telemetry_event,
+        project_created_from_template_telemetry_event, require_git_settings_permissions,
     };
+    use chrono::Utc;
     use std::collections::BTreeMap;
+    use temps_auth::{AuthContext, Permission};
+    use temps_entities::users;
+
+    fn custom_api_key(permissions: Vec<Permission>) -> AuthContext {
+        let now = Utc::now();
+        let user = users::Model {
+            id: 42,
+            name: "Test User".to_string(),
+            email: "test@example.com".to_string(),
+            password_hash: None,
+            email_verified: true,
+            email_verification_token: None,
+            email_verification_expires: None,
+            password_reset_token: None,
+            password_reset_expires: None,
+            must_change_password: false,
+            deleted_at: None,
+            mfa_secret: None,
+            mfa_enabled: false,
+            mfa_recovery_codes: None,
+            oidc_subject: None,
+            oidc_provider_id: None,
+            created_at: now,
+            updated_at: now,
+        };
+
+        AuthContext::new_api_key(user, None, Some(permissions), "test-key".to_string(), 1)
+    }
+
+    #[test]
+    fn git_settings_require_connection_and_repository_permissions() {
+        let projects_only = custom_api_key(vec![Permission::ProjectsWrite]);
+        assert!(require_git_settings_permissions(&projects_only).is_err());
+
+        let missing_repository_read = custom_api_key(vec![
+            Permission::ProjectsWrite,
+            Permission::GitConnectionsRead,
+        ]);
+        assert!(require_git_settings_permissions(&missing_repository_read).is_err());
+
+        let authorized = custom_api_key(vec![
+            Permission::ProjectsWrite,
+            Permission::GitConnectionsRead,
+            Permission::GitRepositoriesRead,
+        ]);
+        assert!(require_git_settings_permissions(&authorized).is_ok());
+    }
 
     #[test]
     fn drop_compose_candidate_preserves_detected_modern_filename() {

--- a/crates/temps-projects/src/services/project.rs
+++ b/crates/temps-projects/src/services/project.rs
@@ -2670,21 +2670,9 @@ impl ProjectService {
             .encrypt_string(&token)
             .map_err(|e| format!("Failed to encrypt Generic webhook token: {e}"))?;
 
-        let external_url = self
-            .config_service
-            .get_settings()
-            .await
-            .ok()
-            .and_then(|s| s.external_url)
-            .unwrap_or_else(|| "http://localhost:8080".to_string());
-
         info!(
-            "Generated Generic webhook token for project {} (conn {}). \
-             Configure your git host to POST to: {}/api/webhook/git/generic/events/{}",
-            project_id,
-            connection_id,
-            external_url.trim_end_matches('/'),
-            token // plaintext token is only logged here; stored value is encrypted
+            "Generated and encrypted Generic webhook token for project {} (conn {})",
+            project_id, connection_id
         );
 
         Ok(Some(encrypted_token))

--- a/web/src/components/project/settings/EnvironmentVariablesSettings.tsx
+++ b/web/src/components/project/settings/EnvironmentVariablesSettings.tsx
@@ -1202,7 +1202,10 @@ export function EnvironmentVariablesSettings({
   const connectedEnvExample = useQuery({
     ...getRepositoryEnvExampleLiveOptions({
       path: { repository_id: repositoryData?.id ?? 0 },
-      query: { branch: project.main_branch },
+      query: {
+        branch: project.main_branch,
+        root_directory: project.directory || './',
+      },
     }),
     enabled: isDockerCompose && !!repositoryData?.id,
   })
@@ -1213,7 +1216,10 @@ export function EnvironmentVariablesSettings({
         owner: project.repo_owner ?? '',
         repo: project.repo_name ?? '',
       },
-      query: { branch: project.main_branch },
+      query: {
+        branch: project.main_branch,
+        root_directory: project.directory || './',
+      },
     }),
     enabled:
       isDockerCompose &&


### PR DESCRIPTION
## Summary

- preserve nested project env-example detection in the Environment Variables settings screen
- require Git connection and repository read permissions before project Git settings can use installation-wide credentials
- stop logging plaintext Generic webhook tokens and secret-bearing delivery URLs

## Why

PR #665 was merged after being refreshed from main. Its follow-up review found one nested-project regression and one authorization gap for custom API keys, so this patch is based directly on the resulting main commit.

## Evidence

**Custom API-key authorization regression**

    cargo test --lib -p temps-projects git_settings_require_connection_and_repository_permissions -- --nocapture

    cargo test: 1 passed, 107 filtered out

**temps-projects regression suite**

    cargo test --lib -p temps-projects

    cargo test: 108 passed (1 suite, 138.25s)

**Workspace compile**

    cargo check --lib

    cargo build: 0 errors, 5 warnings (918 crates)

**Nested env query and focused frontend regression**

    cd web
    bun test src/lib/public-repository.test.ts
    bunx tsc --noEmit

    9 pass, 0 fail
    TypeScript check passed in the dependency-installed PR #665 worktree containing the identical frontend patch.

## Security

The handler now requires ProjectsWrite, GitConnectionsRead, and GitRepositoriesRead before it can invoke shared provider credentials. Generic webhook tokens remain encrypted at rest and are no longer emitted to logs.