### PR TITLE
fix(security): harden critical trust boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **email:** Pin validated SMTP probe addresses and remove request-controlled proxy routing ([#305](https://github.com/gotempsh/temps/pull/305))
-- **critical hardening:** Close project-permission, Blob/KV tenant and token-scope bypasses; restrict managed PostgreSQL images; confine Compose build contexts and Docker secret paths; authenticate internal project routes; validate log WebSocket origins; fail closed on local-image tag drift; quote WAL-G environment values; replace raw data-browser SQL filters with safe filtering; and harden AI gateway and webhook egress against SSRF.
 ### Fixed
 
 - **OTel ingest memory backpressure:** Bound concurrent OTLP request processing before body buffering (ceiling configurable via `TEMPS_OTEL_MAX_CONCURRENT_INGEST_REQUESTS`, default 64), single-flight repeated token authentication, coalesce token usage writes, remove duplicate metrics authentication, enforce the decompressed-size limit while streaming zstd payloads, and cap the compressed request body explicitly rather than relying on Axum's implicit default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **email:** Pin validated SMTP probe addresses and remove request-controlled proxy routing ([#305](https://github.com/gotempsh/temps/pull/305))
+- **critical hardening:** Close project-permission, Blob/KV tenant and token-scope bypasses; restrict managed PostgreSQL images; confine Compose build contexts and Docker secret paths; authenticate internal project routes; validate log WebSocket origins; fail closed on local-image tag drift; quote WAL-G environment values; replace raw data-browser SQL filters with safe filtering; and harden AI gateway and webhook egress against SSRF.
 ### Fixed
 
 - **OTel ingest memory backpressure:** Bound concurrent OTLP request processing before body buffering (ceiling configurable via `TEMPS_OTEL_MAX_CONCURRENT_INGEST_REQUESTS`, default 64), single-flight repeated token authentication, coalesce token usage writes, remove duplicate metrics authentication, enforce the decompressed-size limit while streaming zstd payloads, and cap the compressed request body explicitly rather than relying on Axum's implicit default.

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,14 +30,30 @@ RUN apk add --no-cache \
     git \
     curl \
     tar \
-    gzip
+    gzip \
+    unzip
 
 # Install Node.js and npm (needed for wasm-pack and bun)
 RUN apk add --no-cache nodejs npm
 
-# Install bun using the official installer (faster and doesn't require nightly Rust)
-RUN curl -fsSL https://bun.sh/install | bash && \
-    ln -s $HOME/.bun/bin/bun /usr/local/bin/bun
+# Install a pinned Bun archive and verify it before execution. Avoid piping a
+# mutable remote installer into a shell inside the release build.
+ARG BUN_VERSION=1.3.14
+ARG BUN_LINUX_X64_MUSL_SHA256=14bd9aedeebf1dba67e8def9531c89bc989ecfdf1de42e5bfcaf1b8cd9294719
+ARG BUN_LINUX_AARCH64_MUSL_SHA256=b98e0ad3625c5c00d1d5b5ff55605c7adddbfae151861e68ade57b2d3b8703bb
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH:-amd64}" in \
+      amd64) bun_arch="x64"; bun_sha256="$BUN_LINUX_X64_MUSL_SHA256" ;; \
+      arm64) bun_arch="aarch64"; bun_sha256="$BUN_LINUX_AARCH64_MUSL_SHA256" ;; \
+      *) echo "Unsupported Bun architecture: ${TARGETARCH:-unknown}" >&2; exit 1 ;; \
+    esac; \
+    bun_zip="bun-linux-${bun_arch}-musl.zip"; \
+    curl -fsSLo "/tmp/${bun_zip}" "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/${bun_zip}"; \
+    echo "${bun_sha256}  /tmp/${bun_zip}" | sha256sum -c -; \
+    unzip -q "/tmp/${bun_zip}" -d /opt; \
+    ln -s "/opt/bun-linux-${bun_arch}-musl/bun" /usr/local/bin/bun; \
+    rm "/tmp/${bun_zip}"
 
 # Install the Rust-native WASM tooling. The npm wrapper tries to download a
 # prebuilt wasm-bindgen binary that does not exist for every Alpine architecture

--- a/apps/temps-cli/openapi.json
+++ b/apps/temps-cli/openapi.json
@@ -2931,7 +2931,7 @@
             "default": {
               "auto_upgrade": true,
               "host_port": 8090,
-              "image": "ghcr.io/gotempsh/temps-preview-gateway:latest"
+              "image": "ghcr.io/gotempsh/temps-preview-gateway:0.1.0"
             },
             "oneOf": [
               {
@@ -17148,7 +17148,7 @@
             ]
           },
           "image": {
-            "description": "Image reference the container was created with (e.g.\n`ghcr.io/gotempsh/temps-preview-gateway:latest`).",
+            "description": "Image reference the container was created with (e.g.\n`ghcr.io/gotempsh/temps-preview-gateway:0.1.0`).",
             "type": [
               "string",
               "null"
@@ -27900,9 +27900,9 @@
             "type": "integer"
           },
           "image": {
-            "default": "ghcr.io/gotempsh/temps-preview-gateway:latest",
+            "default": "ghcr.io/gotempsh/temps-preview-gateway:0.1.0",
             "description": "Docker image reference for the gateway. Pinned per Temps release.\nOperators can override this to test a custom build.",
-            "example": "ghcr.io/gotempsh/temps-preview-gateway:latest",
+            "example": "ghcr.io/gotempsh/temps-preview-gateway:0.1.0",
             "type": "string"
           },
           "shared_secret": {
@@ -43365,7 +43365,7 @@
       "UpgradeRequest": {
         "properties": {
           "image": {
-            "description": "Image reference to pull and run (e.g.\n`ghcr.io/gotempsh/temps-preview-gateway:latest`). Empty resets to default.",
+            "description": "Image reference to pull and run (e.g.\n`ghcr.io/gotempsh/temps-preview-gateway:0.1.0`). Empty resets to default.",
             "type": "string"
           }
         },

--- a/apps/temps-cli/src/api/types.gen.ts
+++ b/apps/temps-cli/src/api/types.gen.ts
@@ -8012,7 +8012,7 @@ export type GatewayStatus = {
     host_port?: number | null;
     /**
      * Image reference the container was created with (e.g.
-     * `ghcr.io/gotempsh/temps-preview-gateway:latest`).
+     * `ghcr.io/gotempsh/temps-preview-gateway:0.1.0`).
      */
     image?: string | null;
     /**
@@ -19745,7 +19745,7 @@ export type UpgradeExternalServiceRequest = {
 export type UpgradeRequest = {
     /**
      * Image reference to pull and run (e.g.
-     * `ghcr.io/gotempsh/temps-preview-gateway:latest`). Empty resets to default.
+     * `ghcr.io/gotempsh/temps-preview-gateway:0.1.0`). Empty resets to default.
      */
     image: string;
 };

--- a/apps/temps-e2e/README.md
+++ b/apps/temps-e2e/README.md
@@ -216,8 +216,8 @@ bun run src/index.ts backup-restore-scenario --registry localhost:5111
 # wait time so a WAL segment actually archives -- see the steps section below.
 bun run src/index.ts pitr-scenario --registry localhost:5111
 
-# pg-upgrade: Postgres major-version upgrade (16 → 17) -- provision a service
-# pinned to gotempsh/postgres-walg:16-bookworm, write 5 marker rows, trigger the upgrade
+# pg-upgrade: Postgres major-version upgrade (17 → 18) -- provision a service
+# pinned to timescale/timescaledb-ha:pg17, write 5 marker rows, trigger the upgrade
 # (pre_backup → snapshot → dump → new_container → restore → swap → analyze),
 # and prove via the read-only data-browser API that the marker rows survived
 # the pg_dumpall → psql restore cycle. Needs MinIO (docker-compose.e2e.yml).
@@ -891,13 +891,13 @@ reading the rows back after it finishes, not just watching a status field flip.
 1. build + push the db-probe Go app (`lib/probe-app.ts`) -- the same app
    `backup-restore-scenario` and `pitr-scenario` use. On every `/probe` hit
    it inserts a row into `e2e_probe` and returns the total count
-2. provision a real standalone Postgres service pinned to `gotempsh/postgres-walg:16-bookworm`
-   via `parameters.docker_image` at creation time. Platform-reviewed WAL-G
-   images are used; `extract_postgres_version("gotempsh/postgres-walg:16-bookworm")` returns
-   `"16"` and PGDATA is set to `/var/lib/postgresql/16/docker`. The explicit
+2. provision a real standalone Postgres service pinned to `timescale/timescaledb-ha:pg17`
+   via `parameters.docker_image` at creation time. Published, platform-reviewed
+   images are used; `extract_postgres_version("timescale/timescaledb-ha:pg17")` returns
+   `"17"`. The explicit
    pin is required because the upgrade API validates that `to_version > from_version`
    and both images are on the same OS family (Alpine ↔ Alpine, Debian ↔ Debian)
-   -- using the platform default 18-bookworm image would leave nowhere to
+   -- using the platform default PostgreSQL 18 image would leave nowhere to
    upgrade to in an e2e test
 3. create a **default** S3 source (`is_default: true`) pointed at the local
    MinIO. `phase_pre_backup` in the orchestrator calls
@@ -912,8 +912,8 @@ reading the rows back after it finishes, not just watching a status field flip.
    `normalize_database_name("{project_slug}_{env_slug}")` as computed by
    `normalizePostgresDatabaseName` in `flows.ts`
 6. `POST /external-services/{service_id}/upgrades` with
-   from_version="16" / to_version="17" / from_image="gotempsh/postgres-walg:16-bookworm" /
-   to_image="gotempsh/postgres-walg:17-bookworm". The orchestrator spawns a
+   from_version="17" / to_version="18" / from_image="timescale/timescaledb-ha:pg17" /
+   to_image="timescale/timescaledb-ha:pg18". The orchestrator spawns a
    tokio task and returns immediately with status="pending". It then runs
    seven real phases synchronously:
      - `pre_backup`: wal-g backup to the default MinIO S3 source (safety net)
@@ -922,7 +922,7 @@ reading the rows back after it finishes, not just watching a status field flip.
      - `dump`: boot throwaway old-version container with rollback volume
        mounted, run `pg_dumpall`, write dump to a separate volume
      - `new_container`: `lifecycle.create_and_start(service_id, to_image)` --
-       boots a fresh 17-bookworm container (empty data volume → initdb)
+       boots a fresh PostgreSQL 18 container (empty data volume → initdb)
      - `restore`: boot a psql container with the dump volume, run
        `psql < data.sql` against the new container
      - `swap`: persist `to_image` onto the service's `parameters.docker_image`
@@ -946,7 +946,7 @@ reading the rows back after it finishes, not just watching a status field flip.
    PITR does (WAL-logged `SEQ_LOG_VALS` advance), so we assert count and
    monotonicity, not the exact new id
 10. assert `GET /external-services/{id}`'s `current_parameters.docker_image`
-    now equals `gotempsh/postgres-walg:17-bookworm`. `phase_swap` calls
+    now equals `timescale/timescaledb-ha:pg18`. `phase_swap` calls
     `lifecycle.set_docker_image` which persists the new image into
     `external_services.parameters`; this checks the API-visible result
 11. teardown (deployment, project, service, S3 source)

--- a/apps/temps-e2e/README.md
+++ b/apps/temps-e2e/README.md
@@ -217,7 +217,7 @@ bun run src/index.ts backup-restore-scenario --registry localhost:5111
 bun run src/index.ts pitr-scenario --registry localhost:5111
 
 # pg-upgrade: Postgres major-version upgrade (16 → 17) -- provision a service
-# pinned to postgres:16-bookworm, write 5 marker rows, trigger the upgrade
+# pinned to gotempsh/postgres-walg:16-bookworm, write 5 marker rows, trigger the upgrade
 # (pre_backup → snapshot → dump → new_container → restore → swap → analyze),
 # and prove via the read-only data-browser API that the marker rows survived
 # the pg_dumpall → psql restore cycle. Needs MinIO (docker-compose.e2e.yml).
@@ -891,9 +891,9 @@ reading the rows back after it finishes, not just watching a status field flip.
 1. build + push the db-probe Go app (`lib/probe-app.ts`) -- the same app
    `backup-restore-scenario` and `pitr-scenario` use. On every `/probe` hit
    it inserts a row into `e2e_probe` and returns the total count
-2. provision a real standalone Postgres service pinned to `postgres:16-bookworm`
-   via `parameters.docker_image` at creation time. Standard official postgres
-   images are used; `extract_postgres_version("postgres:16-bookworm")` returns
+2. provision a real standalone Postgres service pinned to `gotempsh/postgres-walg:16-bookworm`
+   via `parameters.docker_image` at creation time. Platform-reviewed WAL-G
+   images are used; `extract_postgres_version("gotempsh/postgres-walg:16-bookworm")` returns
    `"16"` and PGDATA is set to `/var/lib/postgresql/16/docker`. The explicit
    pin is required because the upgrade API validates that `to_version > from_version`
    and both images are on the same OS family (Alpine ↔ Alpine, Debian ↔ Debian)
@@ -912,8 +912,8 @@ reading the rows back after it finishes, not just watching a status field flip.
    `normalize_database_name("{project_slug}_{env_slug}")` as computed by
    `normalizePostgresDatabaseName` in `flows.ts`
 6. `POST /external-services/{service_id}/upgrades` with
-   from_version="16" / to_version="17" / from_image="postgres:16-bookworm" /
-   to_image="postgres:17-bookworm". The orchestrator spawns a
+   from_version="16" / to_version="17" / from_image="gotempsh/postgres-walg:16-bookworm" /
+   to_image="gotempsh/postgres-walg:17-bookworm". The orchestrator spawns a
    tokio task and returns immediately with status="pending". It then runs
    seven real phases synchronously:
      - `pre_backup`: wal-g backup to the default MinIO S3 source (safety net)
@@ -946,7 +946,7 @@ reading the rows back after it finishes, not just watching a status field flip.
    PITR does (WAL-logged `SEQ_LOG_VALS` advance), so we assert count and
    monotonicity, not the exact new id
 10. assert `GET /external-services/{id}`'s `current_parameters.docker_image`
-    now equals `postgres:17-bookworm`. `phase_swap` calls
+    now equals `gotempsh/postgres-walg:17-bookworm`. `phase_swap` calls
     `lifecycle.set_docker_image` which persists the new image into
     `external_services.parameters`; this checks the API-visible result
 11. teardown (deployment, project, service, S3 source)

--- a/apps/temps-e2e/src/commands/pg-upgrade-scenario.ts
+++ b/apps/temps-e2e/src/commands/pg-upgrade-scenario.ts
@@ -5,10 +5,8 @@
  *
  *   1. provision a real standalone postgres service pinned explicitly to
  *      `gotempsh/postgres-walg:16-bookworm` (not the platform default which is 18).
- *      Standard official postgres images are used; the platform's
- *      extract_postgres_version() parses "16" from the tag correctly and
- *      sets PGDATA to /var/lib/postgresql/16/docker. The pre-upgrade backup
- *      falls back to the pg_dump sidecar since these images don't bundle wal-g.
+ *      Platform-reviewed WAL-G images are used; the platform extracts "16"
+ *      from the tag and sets PGDATA to /var/lib/postgresql/16/docker.
  *   2. create a **default** S3 source (`is_default: true`) pointed at the
  *      local MinIO. `phase_pre_backup` in the orchestrator resolves the
  *      default source via `BackupService::default_s3_source_id` (a simple

--- a/apps/temps-e2e/src/commands/pg-upgrade-scenario.ts
+++ b/apps/temps-e2e/src/commands/pg-upgrade-scenario.ts
@@ -4,7 +4,7 @@
  * backup (same infra as `backup-restore-scenario` and `pitr-scenario`):
  *
  *   1. provision a real standalone postgres service pinned explicitly to
- *      `postgres:16-bookworm` (not the platform default which is 18).
+ *      `gotempsh/postgres-walg:16-bookworm` (not the platform default which is 18).
  *      Standard official postgres images are used; the platform's
  *      extract_postgres_version() parses "16" from the tag correctly and
  *      sets PGDATA to /var/lib/postgresql/16/docker. The pre-upgrade backup
@@ -53,7 +53,7 @@
  *      the same reason PITR does (WAL-logged `SEQ_LOG_VALS` advance), so we
  *      assert the count and that the new row's id is > 5, not that it equals 6.
  *   9. assert the service's reported `docker_image` parameter now reflects
- *      the new image (`postgres:17-bookworm`). `phase_swap`
+ *      the new image (`gotempsh/postgres-walg:17-bookworm`). `phase_swap`
  *      calls `lifecycle.set_docker_image` which persists the new image into
  *      `external_services.parameters` -- `GET /external-services/{id}`'s
  *      `current_parameters.docker_image` is the API-visible proof.
@@ -94,12 +94,11 @@ import { buildProbeImage, PROBE_APP_HEALTH_PATH } from '../lib/probe-app.ts'
 // The from/to images MUST be on the same OS family (Alpine ↔ Alpine or
 // Debian ↔ Debian) -- `validate_os_family` in postgres_upgrade.rs enforces
 // this at start time. Both `-bookworm` means Debian; the versions differ.
-// Standard postgres:N-bookworm images are used here; the platform's
+// Temps' pinned WAL-G images are used here; the platform's
 // extract_postgres_version() parses the major version from the tag correctly,
-// and the pre-upgrade backup falls back to the pg_dump sidecar path since
-// these images don't bundle wal-g (same fallback as any unmanaged image).
-const FROM_IMAGE = 'postgres:16-bookworm'
-const TO_IMAGE = 'postgres:17-bookworm'
+// and the managed-service allowlist admits only platform-reviewed images.
+const FROM_IMAGE = 'gotempsh/postgres-walg:16-bookworm'
+const TO_IMAGE = 'gotempsh/postgres-walg:17-bookworm'
 const FROM_VERSION = '16'
 const TO_VERSION = '17'
 
@@ -212,13 +211,8 @@ export async function pgUpgradeScenarioCommand(opts: PgUpgradeScenarioOptions): 
 
     // Provision a postgres service explicitly pinned to the older major version.
     // The `docker_image` parameter overrides the platform default so the service
-    // actually runs Postgres 16. We use the standard `postgres:16-bookworm`
-    // (same OS family as `postgres:17-bookworm`) rather than a custom image
-    // because `validate_os_family` in postgres_upgrade.rs requires matching OS
-    // families, and the plain bookworm images are widely available without any
-    // registry auth. These images don't bundle wal-g, so the pre-upgrade backup
-    // falls back to the pg_dump sidecar path -- the same fallback documented at
-    // the top of this file and in the FROM_IMAGE/TO_IMAGE block above.
+    // actually runs Postgres 16. Both reviewed images use the same Debian
+    // family, as required by `validate_os_family` in postgres_upgrade.rs.
     const service = await step(`provision postgres service pinned to ${FROM_IMAGE}`, () =>
       createE2eService(client, {
         name: `${runId}-pg`,

--- a/apps/temps-e2e/src/commands/pg-upgrade-scenario.ts
+++ b/apps/temps-e2e/src/commands/pg-upgrade-scenario.ts
@@ -1,12 +1,12 @@
 /**
- * PostgreSQL major-version upgrade (16 → 17) against a live Temps instance,
+ * PostgreSQL major-version upgrade (17 → 18) against a live Temps instance,
  * using MinIO as the local S3-compatible target for the mandatory pre-upgrade
  * backup (same infra as `backup-restore-scenario` and `pitr-scenario`):
  *
  *   1. provision a real standalone postgres service pinned explicitly to
- *      `gotempsh/postgres-walg:16-bookworm` (not the platform default which is 18).
- *      Platform-reviewed WAL-G images are used; the platform extracts "16"
- *      from the tag and sets PGDATA to /var/lib/postgresql/16/docker.
+ *      `timescale/timescaledb-ha:pg17` (not the platform default which is 18).
+ *      Published platform-reviewed images are used; the platform extracts
+ *      "17" from the tag.
  *   2. create a **default** S3 source (`is_default: true`) pointed at the
  *      local MinIO. `phase_pre_backup` in the orchestrator resolves the
  *      default source via `BackupService::default_s3_source_id` (a simple
@@ -22,13 +22,13 @@
  *      `database` parameter -- see `PostgresService::get_runtime_env_vars` /
  *      `normalizePostgresDatabaseName`'s doc comment in flows.ts).
  *   5. start the upgrade: `POST /external-services/{id}/upgrades` with
- *      from_version="16", to_version="17", from_image and to_image matching
- *      the same OS family (`-bookworm`). The orchestrator runs phases
+ *      from_version="17", to_version="18", with reviewed Timescale images.
+ *      The orchestrator runs phases
  *      synchronously inside a spawned tokio task:
  *        pre_backup  → wal-g backup to MinIO (pre-upgrade safety net)
  *        snapshot    → stop old container, copy PGDATA volume to rollback vol
  *        dump        → pg_dumpall from old container into a dump volume
- *        new_container → create fresh 17-bookworm container (initdb on empty vol)
+ *        new_container → create fresh PostgreSQL 18 container (initdb on empty vol)
  *        restore     → psql restore from dump into new container
  *        swap        → persist to_image onto service config; restart container
  *        analyze     → ANALYZE for planner stats
@@ -51,7 +51,7 @@
  *      the same reason PITR does (WAL-logged `SEQ_LOG_VALS` advance), so we
  *      assert the count and that the new row's id is > 5, not that it equals 6.
  *   9. assert the service's reported `docker_image` parameter now reflects
- *      the new image (`gotempsh/postgres-walg:17-bookworm`). `phase_swap`
+ *      the new image (`timescale/timescaledb-ha:pg18`). `phase_swap`
  *      calls `lifecycle.set_docker_image` which persists the new image into
  *      `external_services.parameters` -- `GET /external-services/{id}`'s
  *      `current_parameters.docker_image` is the API-visible proof.
@@ -91,14 +91,13 @@ import { buildProbeImage, PROBE_APP_HEALTH_PATH } from '../lib/probe-app.ts'
 
 // The from/to images MUST be on the same OS family (Alpine ↔ Alpine or
 // Debian ↔ Debian) -- `validate_os_family` in postgres_upgrade.rs enforces
-// this at start time. Both `-bookworm` means Debian; the versions differ.
-// Temps' pinned WAL-G images are used here; the platform's
+// this at start time. Temps' reviewed Timescale images are used here; the platform's
 // extract_postgres_version() parses the major version from the tag correctly,
 // and the managed-service allowlist admits only platform-reviewed images.
-const FROM_IMAGE = 'gotempsh/postgres-walg:16-bookworm'
-const TO_IMAGE = 'gotempsh/postgres-walg:17-bookworm'
-const FROM_VERSION = '16'
-const TO_VERSION = '17'
+const FROM_IMAGE = 'timescale/timescaledb-ha:pg17'
+const TO_IMAGE = 'timescale/timescaledb-ha:pg18'
+const FROM_VERSION = '17'
+const TO_VERSION = '18'
 
 const PROBE_TABLE_ENTITY = 'e2e_probe'
 

--- a/apps/temps-e2e/src/index.ts
+++ b/apps/temps-e2e/src/index.ts
@@ -414,7 +414,7 @@ program
 program
   .command('pg-upgrade-scenario')
   .description(
-    'Real Postgres major-version upgrade (16 → 17): provision a service pinned to postgres:16-bookworm, deploy a db-probe app, write 5 marker rows, trigger the upgrade, poll through all phases to completed, and assert the marker rows survived via the read-only data-browser API (not /probe) -- proves the actual pg_dumpall → psql restore path, not just that the status field flipped',
+    'Real Postgres major-version upgrade (16 → 17): provision a service pinned to gotempsh/postgres-walg:16-bookworm, deploy a db-probe app, write 5 marker rows, trigger the upgrade, poll through all phases to completed, and assert the marker rows survived via the read-only data-browser API (not /probe) -- proves the actual pg_dumpall → psql restore path, not just that the status field flipped',
   )
   .option('--registry <host:port>', 'registry to push the db-probe image to (or $TEMPS_E2E_REGISTRY)')
   .option('--minio-endpoint <url>', 'MinIO S3 API endpoint, reachable from the target instance', 'http://localhost:9092')

--- a/apps/temps-e2e/src/index.ts
+++ b/apps/temps-e2e/src/index.ts
@@ -414,7 +414,7 @@ program
 program
   .command('pg-upgrade-scenario')
   .description(
-    'Real Postgres major-version upgrade (16 → 17): provision a service pinned to gotempsh/postgres-walg:16-bookworm, deploy a db-probe app, write 5 marker rows, trigger the upgrade, poll through all phases to completed, and assert the marker rows survived via the read-only data-browser API (not /probe) -- proves the actual pg_dumpall → psql restore path, not just that the status field flipped',
+    'Real Postgres major-version upgrade (17 → 18): provision a service pinned to timescale/timescaledb-ha:pg17, deploy a db-probe app, write 5 marker rows, trigger the upgrade, poll through all phases to completed, and assert the marker rows survived via the read-only data-browser API (not /probe) -- proves the actual pg_dumpall → psql restore path, not just that the status field flipped',
   )
   .option('--registry <host:port>', 'registry to push the db-probe image to (or $TEMPS_E2E_REGISTRY)')
   .option('--minio-endpoint <url>', 'MinIO S3 API endpoint, reachable from the target instance', 'http://localhost:9092')

--- a/crates/temps-agent/src/handlers.rs
+++ b/crates/temps-agent/src/handlers.rs
@@ -937,7 +937,12 @@ pub async fn get_container_info(
         .get_container_info(&container_id)
         .await
     {
-        Ok(info) => AgentResponse::ok(info).into_response(),
+        Ok(info) => match managed_container_detail(info) {
+            Some(info) => AgentResponse::ok(info).into_response(),
+            None => {
+                error_response(StatusCode::NOT_FOUND, "Container not found".into()).into_response()
+            }
+        },
         Err(e) => {
             tracing::error!(container_id = %container_id, "Failed to get info: {}", e);
             error_response(
@@ -954,6 +959,16 @@ fn is_temps_managed_container(container: &temps_deployer::ContainerInfo) -> bool
         .labels
         .get("sh.temps.managed")
         .is_some_and(|value| value == "true")
+}
+
+fn managed_container_detail(
+    mut container: temps_deployer::ContainerInfo,
+) -> Option<temps_deployer::ContainerInfo> {
+    if !is_temps_managed_container(&container) {
+        return None;
+    }
+    container.environment_vars.clear();
+    Some(container)
 }
 
 fn managed_container_inventory(
@@ -998,6 +1013,14 @@ mod inventory_tests {
         assert_eq!(inventory.len(), 1);
         assert_eq!(inventory[0].container_name, "managed");
         assert!(inventory[0].environment_vars.is_empty());
+    }
+
+    #[test]
+    fn detail_policy_rejects_unmanaged_and_redacts_managed_containers() {
+        assert!(managed_container_detail(container("unmanaged", None)).is_none());
+        let managed = managed_container_detail(container("managed", Some("true")))
+            .expect("managed container remains visible");
+        assert!(managed.environment_vars.is_empty());
     }
 }
 

--- a/crates/temps-agent/src/handlers.rs
+++ b/crates/temps-agent/src/handlers.rs
@@ -949,22 +949,76 @@ pub async fn get_container_info(
     }
 }
 
-/// List all containers on this worker node
+fn is_temps_managed_container(container: &temps_deployer::ContainerInfo) -> bool {
+    container
+        .labels
+        .get("sh.temps.managed")
+        .is_some_and(|value| value == "true")
+}
+
+fn managed_container_inventory(
+    containers: Vec<temps_deployer::ContainerInfo>,
+) -> Vec<temps_deployer::ContainerInfo> {
+    containers
+        .into_iter()
+        .filter(is_temps_managed_container)
+        .map(|mut container| {
+            container.environment_vars.clear();
+            container
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod inventory_tests {
+    use super::*;
+
+    fn container(name: &str, managed_label: Option<&str>) -> temps_deployer::ContainerInfo {
+        let mut info = temps_deployer::ContainerInfo {
+            container_name: name.to_string(),
+            ..Default::default()
+        };
+        if let Some(value) = managed_label {
+            info.labels
+                .insert("sh.temps.managed".to_string(), value.to_string());
+        }
+        info.environment_vars
+            .insert("DATABASE_URL".to_string(), "postgres://secret".to_string());
+        info
+    }
+
+    #[test]
+    fn inventory_only_returns_managed_containers_without_environment_secrets() {
+        let inventory = managed_container_inventory(vec![
+            container("unmanaged", None),
+            container("false-label", Some("false")),
+            container("managed", Some("true")),
+        ]);
+
+        assert_eq!(inventory.len(), 1);
+        assert_eq!(inventory[0].container_name, "managed");
+        assert!(inventory[0].environment_vars.is_empty());
+    }
+}
+
+/// List Temps-managed containers on this worker node without environment variables.
 #[utoipa::path(
     tag = "Containers",
     get,
     path = "/agent/containers",
     responses(
-        (status = 200, description = "List of containers", body = AgentResponse<Vec<temps_deployer::ContainerInfo>>),
+        (status = 200, description = "List of Temps-managed containers with environment variables redacted", body = AgentResponse<Vec<temps_deployer::ContainerInfo>>),
         (status = 401, description = "Unauthorized"),
         (status = 500, description = "Failed to list containers")
     ),
     security(("bearer_auth" = []))
 )]
 pub async fn list_containers(State(state): State<Arc<AgentState>>) -> impl IntoResponse {
-    tracing::debug!("Listing containers");
+    tracing::debug!("Listing Temps-managed containers");
     match state.container_deployer.list_containers().await {
-        Ok(containers) => AgentResponse::ok(containers).into_response(),
+        Ok(containers) => {
+            AgentResponse::ok(managed_container_inventory(containers)).into_response()
+        }
         Err(e) => {
             tracing::error!("Failed to list containers: {}", e);
             error_response(

--- a/crates/temps-agent/src/internal_proxy.rs
+++ b/crates/temps-agent/src/internal_proxy.rs
@@ -42,6 +42,7 @@
 //! via Docker. The only callers are processes inside the overlay
 //! network, which is precisely the trust boundary we want.
 
+use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
@@ -50,6 +51,7 @@ use axum::body::Body;
 use axum::extract::{ConnectInfo, Request, State};
 use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode, Uri};
 use axum::response::{IntoResponse, Response};
+use parking_lot::RwLock;
 use rand::prelude::SliceRandom;
 use tokio::net::TcpListener;
 use tokio::sync::Notify;
@@ -84,7 +86,7 @@ const MAX_RETRIES: usize = 3;
 struct ProxyState {
     client: reqwest::Client,
     store: SharedRouteStore,
-    docker: bollard::Docker,
+    caller_identities: Arc<RwLock<HashMap<IpAddr, String>>>,
 }
 
 /// Spawn the proxy on `<bridge_ip>:80`. Returns once the listener is
@@ -113,12 +115,30 @@ pub async fn spawn(
         .build()
         .map_err(|e| std::io::Error::other(e.to_string()))?;
 
+    let initial_identities = load_source_identities(&docker)
+        .await
+        .map_err(|error| std::io::Error::other(error.to_string()))?;
+    let caller_identities = Arc::new(RwLock::new(initial_identities));
     let state = Arc::new(ProxyState {
         client,
         store,
-        docker,
+        caller_identities: Arc::clone(&caller_identities),
     });
     let app = axum::Router::new().fallback(handle).with_state(state);
+
+    let identity_shutdown = Arc::clone(&shutdown);
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(2));
+        loop {
+            tokio::select! {
+                _ = identity_shutdown.notified() => break,
+                _ = interval.tick() => match load_source_identities(&docker).await {
+                    Ok(snapshot) => *caller_identities.write() = snapshot,
+                    Err(error) => warn!(%error, "failed to refresh internal proxy caller identities"),
+                }
+            }
+        }
+    });
 
     tokio::spawn(async move {
         let server = axum::serve(
@@ -206,7 +226,7 @@ async fn caller_may_access_route(
     let Some(peer) = extensions.get::<ConnectInfo<SocketAddr>>().map(|c| c.0) else {
         return false;
     };
-    let Some(container_id) = source_container_id(&state.docker, peer.ip()).await else {
+    let Some(container_id) = source_container_id(&state.caller_identities, peer.ip()) else {
         return false;
     };
     state
@@ -218,7 +238,16 @@ async fn caller_may_access_route(
 /// network attachment state is the authority for which container owns an IP;
 /// route destination addresses are not caller identity and may be hostnames or
 /// shared node addresses.
-async fn source_container_id(docker: &bollard::Docker, source_ip: IpAddr) -> Option<String> {
+fn source_container_id(
+    caller_identities: &RwLock<HashMap<IpAddr, String>>,
+    source_ip: IpAddr,
+) -> Option<String> {
+    caller_identities.read().get(&source_ip).cloned()
+}
+
+async fn load_source_identities(
+    docker: &bollard::Docker,
+) -> Result<HashMap<IpAddr, String>, bollard::errors::Error> {
     use bollard::query_parameters::ListContainersOptions;
 
     let containers = docker
@@ -226,34 +255,35 @@ async fn source_container_id(docker: &bollard::Docker, source_ip: IpAddr) -> Opt
             all: false,
             ..Default::default()
         }))
-        .await
-        .map_err(|error| {
-            warn!(%source_ip, %error, "failed to resolve internal proxy caller through Docker");
-            error
-        })
-        .ok()?;
+        .await?;
 
-    containers.into_iter().find_map(|container| {
-        let owns_source_ip = container
+    let mut identities = HashMap::new();
+    for container in containers {
+        let Some(container_id) = container.id else {
+            continue;
+        };
+        let Some(networks) = container
             .network_settings
             .as_ref()
             .and_then(|settings| settings.networks.as_ref())
-            .is_some_and(|networks| {
-                networks.values().any(|endpoint| {
-                    endpoint
-                        .ip_address
-                        .as_deref()
-                        .and_then(|value| value.parse::<IpAddr>().ok())
-                        .is_some_and(|ip| ip == source_ip)
-                        || endpoint
-                            .global_ipv6_address
-                            .as_deref()
-                            .and_then(|value| value.parse::<IpAddr>().ok())
-                            .is_some_and(|ip| ip == source_ip)
-                })
-            });
-        owns_source_ip.then_some(container.id).flatten()
-    })
+        else {
+            continue;
+        };
+        for endpoint in networks.values() {
+            for address in [
+                endpoint.ip_address.as_deref(),
+                endpoint.global_ipv6_address.as_deref(),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                if let Ok(ip) = address.parse::<IpAddr>() {
+                    identities.insert(ip, container_id.clone());
+                }
+            }
+        }
+    }
+    Ok(identities)
 }
 
 /// True if the client requested a protocol upgrade. We check both the
@@ -766,5 +796,19 @@ mod tests {
         store.apply_snapshot(1, vec![target.clone()]);
 
         assert!(!store.container_id_has_project("unknown", 42));
+    }
+
+    #[test]
+    fn caller_identity_lookup_is_memory_only_and_fails_closed() {
+        let identities = RwLock::new(HashMap::from([(
+            "172.20.1.10".parse().unwrap(),
+            "container-alpha".to_string(),
+        )]));
+
+        assert_eq!(
+            source_container_id(&identities, "172.20.1.10".parse().unwrap()).as_deref(),
+            Some("container-alpha")
+        );
+        assert!(source_container_id(&identities, "172.20.1.99".parse().unwrap()).is_none());
     }
 }

--- a/crates/temps-agent/src/internal_proxy.rs
+++ b/crates/temps-agent/src/internal_proxy.rs
@@ -84,6 +84,7 @@ const MAX_RETRIES: usize = 3;
 struct ProxyState {
     client: reqwest::Client,
     store: SharedRouteStore,
+    docker: bollard::Docker,
 }
 
 /// Spawn the proxy on `<bridge_ip>:80`. Returns once the listener is
@@ -96,6 +97,7 @@ pub async fn spawn(
     bridge_ip: IpAddr,
     port: u16,
     store: SharedRouteStore,
+    docker: bollard::Docker,
     shutdown: Arc<Notify>,
 ) -> std::io::Result<()> {
     let addr = SocketAddr::new(bridge_ip, port);
@@ -111,7 +113,11 @@ pub async fn spawn(
         .build()
         .map_err(|e| std::io::Error::other(e.to_string()))?;
 
-    let state = Arc::new(ProxyState { client, store });
+    let state = Arc::new(ProxyState {
+        client,
+        store,
+        docker,
+    });
     let app = axum::Router::new().fallback(handle).with_state(state);
 
     tokio::spawn(async move {
@@ -158,7 +164,7 @@ async fn handle(State(state): State<Arc<ProxyState>>, req: Request) -> Response 
         }
     };
 
-    if !caller_may_access_route(&state.store, req.extensions(), &entry) {
+    if !caller_may_access_route(&state, req.extensions(), &entry).await {
         warn!(%host, route_project_id = ?entry.project_id, "blocked cross-project internal proxy request");
         return error_body(
             StatusCode::FORBIDDEN,
@@ -187,8 +193,8 @@ async fn handle(State(state): State<Arc<ProxyState>>, req: Request) -> Response 
     proxy_with_retries(&state, &entry, req).await
 }
 
-fn caller_may_access_route(
-    store: &SharedRouteStore,
+async fn caller_may_access_route(
+    state: &ProxyState,
     extensions: &axum::http::Extensions,
     entry: &RouteEntry,
 ) -> bool {
@@ -200,7 +206,54 @@ fn caller_may_access_route(
     let Some(peer) = extensions.get::<ConnectInfo<SocketAddr>>().map(|c| c.0) else {
         return false;
     };
-    store.backend_ip_has_project(peer.ip(), route_project_id)
+    let Some(container_id) = source_container_id(&state.docker, peer.ip()).await else {
+        return false;
+    };
+    state
+        .store
+        .container_id_has_project(&container_id, route_project_id)
+}
+
+/// Resolve the peer address through the local Docker daemon. The daemon's
+/// network attachment state is the authority for which container owns an IP;
+/// route destination addresses are not caller identity and may be hostnames or
+/// shared node addresses.
+async fn source_container_id(docker: &bollard::Docker, source_ip: IpAddr) -> Option<String> {
+    use bollard::query_parameters::ListContainersOptions;
+
+    let containers = docker
+        .list_containers(Some(ListContainersOptions {
+            all: false,
+            ..Default::default()
+        }))
+        .await
+        .map_err(|error| {
+            warn!(%source_ip, %error, "failed to resolve internal proxy caller through Docker");
+            error
+        })
+        .ok()?;
+
+    containers.into_iter().find_map(|container| {
+        let owns_source_ip = container
+            .network_settings
+            .as_ref()
+            .and_then(|settings| settings.networks.as_ref())
+            .is_some_and(|networks| {
+                networks.values().any(|endpoint| {
+                    endpoint
+                        .ip_address
+                        .as_deref()
+                        .and_then(|value| value.parse::<IpAddr>().ok())
+                        .is_some_and(|ip| ip == source_ip)
+                        || endpoint
+                            .global_ipv6_address
+                            .as_deref()
+                            .and_then(|value| value.parse::<IpAddr>().ok())
+                            .is_some_and(|ip| ip == source_ip)
+                })
+            });
+        owns_source_ip.then_some(container.id).flatten()
+    })
 }
 
 /// True if the client requested a protocol upgrade. We check both the
@@ -673,12 +726,12 @@ mod tests {
     use crate::route_store::{RouteBackend, RouteEntry, RouteStore};
     use std::path::PathBuf;
 
-    fn route(host: &str, project_id: i32, backend: &str) -> RouteEntry {
+    fn route(host: &str, project_id: i32, container_id: &str) -> RouteEntry {
         RouteEntry {
             host: host.to_string(),
             backends: vec![RouteBackend {
-                address: backend.to_string(),
-                container_id: None,
+                address: format!("{container_id}:3000"),
+                container_id: Some(container_id.to_string()),
                 container_name: None,
             }],
             deployment_id: Some(project_id * 10),
@@ -687,49 +740,31 @@ mod tests {
         }
     }
 
-    fn extensions_for(peer: &str) -> axum::http::Extensions {
-        let mut extensions = axum::http::Extensions::new();
-        extensions.insert(ConnectInfo(peer.parse::<SocketAddr>().unwrap()));
-        extensions
-    }
-
     #[test]
-    fn caller_policy_allows_same_project_backend_ip() {
+    fn caller_policy_allows_same_project_container() {
         let store = Arc::new(RouteStore::new(PathBuf::from("/tmp/unused-routes.json")));
-        let target = route("prod.alpha.temps.local", 42, "172.20.1.10:3000");
+        let target = route("prod.alpha.temps.local", 42, "container-alpha");
         store.apply_snapshot(1, vec![target.clone()]);
 
-        assert!(caller_may_access_route(
-            &store,
-            &extensions_for("172.20.1.10:49152"),
-            &target
-        ));
+        assert!(store.container_id_has_project("container-alpha", 42));
     }
 
     #[test]
-    fn caller_policy_blocks_cross_project_backend_ip() {
+    fn caller_policy_blocks_cross_project_container() {
         let store = Arc::new(RouteStore::new(PathBuf::from("/tmp/unused-routes.json")));
-        let attacker = route("prod.attacker.temps.local", 7, "172.20.1.7:3000");
-        let victim = route("prod.victim.temps.local", 42, "172.20.1.42:3000");
+        let attacker = route("prod.attacker.temps.local", 7, "container-attacker");
+        let victim = route("prod.victim.temps.local", 42, "container-victim");
         store.apply_snapshot(1, vec![attacker, victim.clone()]);
 
-        assert!(!caller_may_access_route(
-            &store,
-            &extensions_for("172.20.1.7:49152"),
-            &victim
-        ));
+        assert!(!store.container_id_has_project("container-attacker", 42));
     }
 
     #[test]
-    fn caller_policy_blocks_unknown_source_ip() {
+    fn caller_policy_blocks_unknown_container() {
         let store = Arc::new(RouteStore::new(PathBuf::from("/tmp/unused-routes.json")));
-        let target = route("prod.alpha.temps.local", 42, "172.20.1.10:3000");
+        let target = route("prod.alpha.temps.local", 42, "container-alpha");
         store.apply_snapshot(1, vec![target.clone()]);
 
-        assert!(!caller_may_access_route(
-            &store,
-            &extensions_for("172.20.1.99:49152"),
-            &target
-        ));
+        assert!(!store.container_id_has_project("unknown", 42));
     }
 }

--- a/crates/temps-agent/src/internal_proxy.rs
+++ b/crates/temps-agent/src/internal_proxy.rs
@@ -51,6 +51,7 @@ use axum::body::Body;
 use axum::extract::{ConnectInfo, Request, State};
 use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode, Uri};
 use axum::response::{IntoResponse, Response};
+use futures::StreamExt;
 use parking_lot::RwLock;
 use rand::prelude::SliceRandom;
 use tokio::net::TcpListener;
@@ -110,7 +111,6 @@ impl CallerIdentitySnapshot {
 struct ProxyState {
     client: reqwest::Client,
     store: SharedRouteStore,
-    docker: bollard::Docker,
     caller_identities: Arc<RwLock<CallerIdentitySnapshot>>,
 }
 
@@ -147,29 +147,50 @@ pub async fn spawn(
     let state = Arc::new(ProxyState {
         client,
         store,
-        docker: docker.clone(),
         caller_identities: Arc::clone(&caller_identities),
     });
     let app = axum::Router::new().fallback(handle).with_state(state);
 
     let identity_shutdown = Arc::clone(&shutdown);
     tokio::spawn(async move {
-        let mut interval = tokio::time::interval(IDENTITY_REFRESH_INTERVAL);
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
-            tokio::select! {
-                _ = identity_shutdown.notified() => break,
-                _ = interval.tick() => match load_source_identities(&docker).await {
-                    Ok(snapshot) => {
-                        *caller_identities.write() = CallerIdentitySnapshot::new(snapshot);
+            let options = bollard::query_parameters::EventsOptionsBuilder::new().build();
+            let mut events = docker.events(Some(options));
+            let mut interval = tokio::time::interval(IDENTITY_REFRESH_INTERVAL);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+            let reconnect = loop {
+                tokio::select! {
+                    _ = identity_shutdown.notified() => return,
+                    _ = interval.tick() => {
+                        refresh_source_identities(&docker, &caller_identities).await;
                     }
-                    Err(error) => {
-                        // Docker is the identity authority. Retaining the old
-                        // IP map after an API failure could authorize a new
-                        // container that inherited a departed container's IP.
-                        caller_identities.write().clear();
-                        warn!(%error, "failed to refresh internal proxy caller identities; denying workload traffic");
+                    event = events.next() => match event {
+                        Some(Ok(event)) if identity_event_requires_refresh(&event) => {
+                            // Invalidate before reloading so an IP released by
+                            // this event cannot retain its old project identity.
+                            caller_identities.write().clear();
+                            refresh_source_identities(&docker, &caller_identities).await;
+                        }
+                        Some(Ok(_)) => {}
+                        Some(Err(error)) => {
+                            caller_identities.write().clear();
+                            warn!(%error, "Docker event stream failed; denying workload traffic until reconnect");
+                            break true;
+                        }
+                        None => {
+                            caller_identities.write().clear();
+                            warn!("Docker event stream ended; denying workload traffic until reconnect");
+                            break true;
+                        }
                     }
+                }
+            };
+
+            if reconnect {
+                tokio::select! {
+                    _ = identity_shutdown.notified() => return,
+                    _ = tokio::time::sleep(Duration::from_secs(1)) => {}
                 }
             }
         }
@@ -219,7 +240,7 @@ async fn handle(State(state): State<Arc<ProxyState>>, req: Request) -> Response 
         }
     };
 
-    if !caller_may_access_route(&state, req.extensions(), &entry).await {
+    if !caller_may_access_route(&state, req.extensions(), &entry) {
         warn!(%host, route_project_id = ?entry.project_id, "blocked cross-project internal proxy request");
         return error_body(
             StatusCode::FORBIDDEN,
@@ -248,7 +269,7 @@ async fn handle(State(state): State<Arc<ProxyState>>, req: Request) -> Response 
     proxy_with_retries(&state, &entry, req).await
 }
 
-async fn caller_may_access_route(
+fn caller_may_access_route(
     state: &ProxyState,
     extensions: &axum::http::Extensions,
     entry: &RouteEntry,
@@ -261,9 +282,7 @@ async fn caller_may_access_route(
     let Some(peer) = extensions.get::<ConnectInfo<SocketAddr>>().map(|c| c.0) else {
         return false;
     };
-    let Some(container_id) =
-        source_container_id(&state.docker, &state.caller_identities, peer.ip()).await
-    else {
+    let Some(container_id) = candidate_container_id(&state.caller_identities, peer.ip()) else {
         return false;
     };
     state
@@ -286,39 +305,33 @@ fn candidate_container_id(
     snapshot.identities.get(&source_ip).cloned()
 }
 
-/// Resolve a cached candidate and verify that Docker still reports the same
-/// running container as the owner of the peer IP. The point lookup prevents a
-/// recycled bridge IP from inheriting the previous container's authorization
-/// without putting a full container-list scan on every request.
-async fn source_container_id(
+fn identity_event_requires_refresh(event: &bollard::models::EventMessage) -> bool {
+    use bollard::models::EventMessageTypeEnum;
+
+    let identity_action = matches!(
+        event.action.as_deref(),
+        Some("start" | "stop" | "die" | "kill" | "destroy" | "connect" | "disconnect")
+    );
+    identity_action
+        && matches!(
+            event.typ,
+            Some(EventMessageTypeEnum::CONTAINER | EventMessageTypeEnum::NETWORK)
+        )
+}
+
+async fn refresh_source_identities(
     docker: &bollard::Docker,
     caller_identities: &RwLock<CallerIdentitySnapshot>,
-    source_ip: IpAddr,
-) -> Option<String> {
-    use bollard::query_parameters::InspectContainerOptions;
-
-    let container_id = candidate_container_id(caller_identities, source_ip)?;
-    let inspected = docker
-        .inspect_container(&container_id, None::<InspectContainerOptions>)
-        .await
-        .ok()?;
-    if inspected.state.and_then(|state| state.running) != Some(true) {
-        return None;
+) {
+    match load_source_identities(docker).await {
+        Ok(snapshot) => {
+            *caller_identities.write() = CallerIdentitySnapshot::new(snapshot);
+        }
+        Err(error) => {
+            caller_identities.write().clear();
+            warn!(%error, "failed to refresh internal proxy caller identities; denying workload traffic");
+        }
     }
-
-    let networks = inspected.network_settings?.networks?;
-    let owns_source_ip = networks.values().any(|endpoint| {
-        [
-            endpoint.ip_address.as_deref(),
-            endpoint.global_ipv6_address.as_deref(),
-        ]
-        .into_iter()
-        .flatten()
-        .filter_map(|address| address.parse::<IpAddr>().ok())
-        .any(|address| address == source_ip)
-    });
-
-    owns_source_ip.then_some(container_id)
 }
 
 async fn load_source_identities(
@@ -903,5 +916,24 @@ mod tests {
         snapshot.clear();
         drop(snapshot);
         assert!(candidate_container_id(&identities, source_ip).is_none());
+    }
+
+    #[test]
+    fn identity_events_refresh_only_for_network_ownership_changes() {
+        use bollard::models::EventMessageTypeEnum;
+
+        let mut event = bollard::models::EventMessage {
+            typ: Some(EventMessageTypeEnum::CONTAINER),
+            action: Some("start".to_string()),
+            ..Default::default()
+        };
+        assert!(identity_event_requires_refresh(&event));
+
+        event.action = Some("health_status: healthy".to_string());
+        assert!(!identity_event_requires_refresh(&event));
+
+        event.typ = Some(EventMessageTypeEnum::NETWORK);
+        event.action = Some("disconnect".to_string());
+        assert!(identity_event_requires_refresh(&event));
     }
 }

--- a/crates/temps-agent/src/internal_proxy.rs
+++ b/crates/temps-agent/src/internal_proxy.rs
@@ -88,9 +88,13 @@ const MAX_RETRIES: usize = 3;
 /// previous container's project identity.
 const IDENTITY_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
 const IDENTITY_MAX_AGE: Duration = Duration::from_secs(3);
-const IDENTITY_INSPECTION_BURST: usize = 64;
-const IDENTITY_INSPECTION_REFILL: usize = 32;
+const IDENTITY_INSPECTION_PROJECT_BURST: usize = 16;
+const IDENTITY_INSPECTION_PROJECT_REFILL: usize = 8;
 const IDENTITY_INSPECTION_REFILL_INTERVAL: Duration = Duration::from_millis(125);
+const IDENTITY_INSPECTION_PROJECT_CONCURRENCY: usize = 2;
+const IDENTITY_INSPECTION_GLOBAL_CONCURRENCY: usize = 32;
+const IDENTITY_INSPECTION_QUEUE_TIMEOUT: Duration = Duration::from_millis(100);
+const IDENTITY_INSPECTION_TIMEOUT: Duration = Duration::from_millis(500);
 
 struct CallerIdentitySnapshot {
     identities: HashMap<IpAddr, String>,
@@ -110,12 +114,27 @@ impl CallerIdentitySnapshot {
     }
 }
 
+struct InspectionQuota {
+    tokens: Arc<Semaphore>,
+    concurrency: Arc<Semaphore>,
+}
+
+impl InspectionQuota {
+    fn new() -> Self {
+        Self {
+            tokens: Arc::new(Semaphore::new(IDENTITY_INSPECTION_PROJECT_BURST)),
+            concurrency: Arc::new(Semaphore::new(IDENTITY_INSPECTION_PROJECT_CONCURRENCY)),
+        }
+    }
+}
+
 /// Shared HTTP client + route store for the proxy's request handler.
 struct ProxyState {
     client: reqwest::Client,
     store: SharedRouteStore,
     docker: bollard::Docker,
-    inspection_budget: Arc<Semaphore>,
+    inspection_quotas: Arc<RwLock<HashMap<i32, Arc<InspectionQuota>>>>,
+    inspection_concurrency: Arc<Semaphore>,
     caller_identities: Arc<RwLock<CallerIdentitySnapshot>>,
 }
 
@@ -149,12 +168,13 @@ pub async fn spawn(
         .await
         .map_err(|error| std::io::Error::other(error.to_string()))?;
     let caller_identities = Arc::new(RwLock::new(CallerIdentitySnapshot::new(initial_identities)));
-    let inspection_budget = Arc::new(Semaphore::new(IDENTITY_INSPECTION_BURST));
+    let inspection_quotas = Arc::new(RwLock::new(HashMap::new()));
     let state = Arc::new(ProxyState {
         client,
         store,
         docker: docker.clone(),
-        inspection_budget: Arc::clone(&inspection_budget),
+        inspection_quotas: Arc::clone(&inspection_quotas),
+        inspection_concurrency: Arc::new(Semaphore::new(IDENTITY_INSPECTION_GLOBAL_CONCURRENCY)),
         caller_identities: Arc::clone(&caller_identities),
     });
     let app = axum::Router::new().fallback(handle).with_state(state);
@@ -212,9 +232,14 @@ pub async fn spawn(
             tokio::select! {
                 _ = budget_shutdown.notified() => return,
                 _ = interval.tick() => {
-                    let missing = IDENTITY_INSPECTION_BURST
-                        .saturating_sub(inspection_budget.available_permits());
-                    inspection_budget.add_permits(missing.min(IDENTITY_INSPECTION_REFILL));
+                    let quotas = inspection_quotas.read().values().cloned().collect::<Vec<_>>();
+                    for quota in quotas {
+                        let missing = IDENTITY_INSPECTION_PROJECT_BURST
+                            .saturating_sub(quota.tokens.available_permits());
+                        quota.tokens.add_permits(
+                            missing.min(IDENTITY_INSPECTION_PROJECT_REFILL),
+                        );
+                    }
                 }
             }
         }
@@ -306,36 +331,74 @@ async fn caller_may_access_route(
     let Some(peer) = extensions.get::<ConnectInfo<SocketAddr>>().map(|c| c.0) else {
         return false;
     };
-    let Some(container_id) = source_container_id(state, peer.ip()).await else {
+    let Some(container_id) = candidate_container_id(&state.caller_identities, peer.ip()) else {
         return false;
     };
-    state
+    // Reject cross-project callers from memory before they can consume any
+    // Docker inspection capacity.
+    if !state
         .store
         .container_id_has_project(&container_id, route_project_id)
+    {
+        return false;
+    }
+    if !source_container_is_current(state, peer.ip(), &container_id, route_project_id).await {
+        return false;
+    }
+    true
 }
 
 /// Verify the cached candidate against Docker's current running-container and
 /// network state. A bounded token bucket prevents workload traffic from
 /// amplifying without limit into Docker-daemon API calls; exhausted requests
 /// fail closed.
-async fn source_container_id(state: &ProxyState, source_ip: IpAddr) -> Option<String> {
+async fn source_container_is_current(
+    state: &ProxyState,
+    source_ip: IpAddr,
+    container_id: &str,
+    project_id: i32,
+) -> bool {
     use bollard::query_parameters::InspectContainerOptions;
 
-    let container_id = candidate_container_id(&state.caller_identities, source_ip)?;
-    let permit = Arc::clone(&state.inspection_budget)
-        .try_acquire_owned()
-        .ok()?;
-    permit.forget();
+    let quota = inspection_quota(state, project_id);
+    let project_slot = Arc::clone(&quota.concurrency).try_acquire_owned().ok();
+    let Some(_project_slot) = project_slot else {
+        return false;
+    };
+    let token = Arc::clone(&quota.tokens).try_acquire_owned().ok();
+    let Some(token) = token else {
+        return false;
+    };
+    token.forget();
 
-    let inspected = state
-        .docker
-        .inspect_container(&container_id, None::<InspectContainerOptions>)
-        .await
-        .ok()?;
+    let global_slot = tokio::time::timeout(
+        IDENTITY_INSPECTION_QUEUE_TIMEOUT,
+        Arc::clone(&state.inspection_concurrency).acquire_owned(),
+    )
+    .await;
+    let Ok(Ok(_global_slot)) = global_slot else {
+        return false;
+    };
+
+    let inspected = tokio::time::timeout(
+        IDENTITY_INSPECTION_TIMEOUT,
+        state
+            .docker
+            .inspect_container(container_id, None::<InspectContainerOptions>),
+    )
+    .await;
+    let Ok(Ok(inspected)) = inspected else {
+        return false;
+    };
     if inspected.state.and_then(|container| container.running) != Some(true) {
-        return None;
+        return false;
     }
-    let networks = inspected.network_settings?.networks?;
+    let Some(networks) = inspected
+        .network_settings
+        .and_then(|settings| settings.networks)
+    else {
+        return false;
+    };
     let owns_source_ip = networks.values().any(|endpoint| {
         [
             endpoint.ip_address.as_deref(),
@@ -346,7 +409,19 @@ async fn source_container_id(state: &ProxyState, source_ip: IpAddr) -> Option<St
         .filter_map(|address| address.parse::<IpAddr>().ok())
         .any(|address| address == source_ip)
     });
-    owns_source_ip.then_some(container_id)
+    owns_source_ip
+}
+
+fn inspection_quota(state: &ProxyState, project_id: i32) -> Arc<InspectionQuota> {
+    if let Some(quota) = state.inspection_quotas.read().get(&project_id).cloned() {
+        return quota;
+    }
+    state
+        .inspection_quotas
+        .write()
+        .entry(project_id)
+        .or_insert_with(|| Arc::new(InspectionQuota::new()))
+        .clone()
 }
 
 /// Resolve the peer address through the local Docker daemon. The daemon's
@@ -994,5 +1069,23 @@ mod tests {
         event.typ = Some(EventMessageTypeEnum::NETWORK);
         event.action = Some("disconnect".to_string());
         assert!(identity_event_requires_refresh(&event));
+    }
+
+    #[test]
+    fn inspection_quotas_are_bounded_and_project_local() {
+        let project_a = InspectionQuota::new();
+        let project_b = InspectionQuota::new();
+
+        for _ in 0..IDENTITY_INSPECTION_PROJECT_BURST {
+            project_a.tokens.try_acquire().unwrap().forget();
+        }
+        assert!(project_a.tokens.try_acquire().is_err());
+        assert!(project_b.tokens.try_acquire().is_ok());
+
+        let first = project_a.concurrency.try_acquire().unwrap();
+        let second = project_a.concurrency.try_acquire().unwrap();
+        assert!(project_a.concurrency.try_acquire().is_err());
+        drop((first, second));
+        assert!(project_a.concurrency.try_acquire().is_ok());
     }
 }

--- a/crates/temps-agent/src/internal_proxy.rs
+++ b/crates/temps-agent/src/internal_proxy.rs
@@ -55,7 +55,7 @@ use futures::StreamExt;
 use parking_lot::RwLock;
 use rand::prelude::SliceRandom;
 use tokio::net::TcpListener;
-use tokio::sync::Notify;
+use tokio::sync::{Notify, Semaphore};
 use tracing::{debug, error, info, warn};
 
 use crate::route_store::{RouteEntry, SharedRouteStore};
@@ -88,6 +88,9 @@ const MAX_RETRIES: usize = 3;
 /// previous container's project identity.
 const IDENTITY_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
 const IDENTITY_MAX_AGE: Duration = Duration::from_secs(3);
+const IDENTITY_INSPECTION_BURST: usize = 64;
+const IDENTITY_INSPECTION_REFILL: usize = 32;
+const IDENTITY_INSPECTION_REFILL_INTERVAL: Duration = Duration::from_millis(125);
 
 struct CallerIdentitySnapshot {
     identities: HashMap<IpAddr, String>,
@@ -111,6 +114,8 @@ impl CallerIdentitySnapshot {
 struct ProxyState {
     client: reqwest::Client,
     store: SharedRouteStore,
+    docker: bollard::Docker,
+    inspection_budget: Arc<Semaphore>,
     caller_identities: Arc<RwLock<CallerIdentitySnapshot>>,
 }
 
@@ -144,9 +149,12 @@ pub async fn spawn(
         .await
         .map_err(|error| std::io::Error::other(error.to_string()))?;
     let caller_identities = Arc::new(RwLock::new(CallerIdentitySnapshot::new(initial_identities)));
+    let inspection_budget = Arc::new(Semaphore::new(IDENTITY_INSPECTION_BURST));
     let state = Arc::new(ProxyState {
         client,
         store,
+        docker: docker.clone(),
+        inspection_budget: Arc::clone(&inspection_budget),
         caller_identities: Arc::clone(&caller_identities),
     });
     let app = axum::Router::new().fallback(handle).with_state(state);
@@ -196,6 +204,22 @@ pub async fn spawn(
         }
     });
 
+    let budget_shutdown = Arc::clone(&shutdown);
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(IDENTITY_INSPECTION_REFILL_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tokio::select! {
+                _ = budget_shutdown.notified() => return,
+                _ = interval.tick() => {
+                    let missing = IDENTITY_INSPECTION_BURST
+                        .saturating_sub(inspection_budget.available_permits());
+                    inspection_budget.add_permits(missing.min(IDENTITY_INSPECTION_REFILL));
+                }
+            }
+        }
+    });
+
     tokio::spawn(async move {
         let server = axum::serve(
             listener,
@@ -240,7 +264,7 @@ async fn handle(State(state): State<Arc<ProxyState>>, req: Request) -> Response 
         }
     };
 
-    if !caller_may_access_route(&state, req.extensions(), &entry) {
+    if !caller_may_access_route(&state, req.extensions(), &entry).await {
         warn!(%host, route_project_id = ?entry.project_id, "blocked cross-project internal proxy request");
         return error_body(
             StatusCode::FORBIDDEN,
@@ -269,7 +293,7 @@ async fn handle(State(state): State<Arc<ProxyState>>, req: Request) -> Response 
     proxy_with_retries(&state, &entry, req).await
 }
 
-fn caller_may_access_route(
+async fn caller_may_access_route(
     state: &ProxyState,
     extensions: &axum::http::Extensions,
     entry: &RouteEntry,
@@ -282,12 +306,47 @@ fn caller_may_access_route(
     let Some(peer) = extensions.get::<ConnectInfo<SocketAddr>>().map(|c| c.0) else {
         return false;
     };
-    let Some(container_id) = candidate_container_id(&state.caller_identities, peer.ip()) else {
+    let Some(container_id) = source_container_id(state, peer.ip()).await else {
         return false;
     };
     state
         .store
         .container_id_has_project(&container_id, route_project_id)
+}
+
+/// Verify the cached candidate against Docker's current running-container and
+/// network state. A bounded token bucket prevents workload traffic from
+/// amplifying without limit into Docker-daemon API calls; exhausted requests
+/// fail closed.
+async fn source_container_id(state: &ProxyState, source_ip: IpAddr) -> Option<String> {
+    use bollard::query_parameters::InspectContainerOptions;
+
+    let container_id = candidate_container_id(&state.caller_identities, source_ip)?;
+    let permit = Arc::clone(&state.inspection_budget)
+        .try_acquire_owned()
+        .ok()?;
+    permit.forget();
+
+    let inspected = state
+        .docker
+        .inspect_container(&container_id, None::<InspectContainerOptions>)
+        .await
+        .ok()?;
+    if inspected.state.and_then(|container| container.running) != Some(true) {
+        return None;
+    }
+    let networks = inspected.network_settings?.networks?;
+    let owns_source_ip = networks.values().any(|endpoint| {
+        [
+            endpoint.ip_address.as_deref(),
+            endpoint.global_ipv6_address.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        .filter_map(|address| address.parse::<IpAddr>().ok())
+        .any(|address| address == source_ip)
+    });
+    owns_source_ip.then_some(container_id)
 }
 
 /// Resolve the peer address through the local Docker daemon. The daemon's

--- a/crates/temps-agent/src/internal_proxy.rs
+++ b/crates/temps-agent/src/internal_proxy.rs
@@ -47,7 +47,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::body::Body;
-use axum::extract::{Request, State};
+use axum::extract::{ConnectInfo, Request, State};
 use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode, Uri};
 use axum::response::{IntoResponse, Response};
 use rand::prelude::SliceRandom;
@@ -115,7 +115,11 @@ pub async fn spawn(
     let app = axum::Router::new().fallback(handle).with_state(state);
 
     tokio::spawn(async move {
-        let server = axum::serve(listener, app).with_graceful_shutdown(async move {
+        let server = axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .with_graceful_shutdown(async move {
             shutdown.notified().await;
             info!("internal edge proxy shutting down");
         });
@@ -154,6 +158,14 @@ async fn handle(State(state): State<Arc<ProxyState>>, req: Request) -> Response 
         }
     };
 
+    if !caller_may_access_route(&state.store, req.extensions(), &entry) {
+        warn!(%host, route_project_id = ?entry.project_id, "blocked cross-project internal proxy request");
+        return error_body(
+            StatusCode::FORBIDDEN,
+            "internal route is not accessible from this workload",
+        );
+    }
+
     if entry.backends.is_empty() {
         warn!(%host, "host has no backends");
         return error_body(StatusCode::SERVICE_UNAVAILABLE, "no live backends");
@@ -173,6 +185,22 @@ async fn handle(State(state): State<Arc<ProxyState>>, req: Request) -> Response 
     }
 
     proxy_with_retries(&state, &entry, req).await
+}
+
+fn caller_may_access_route(
+    store: &SharedRouteStore,
+    extensions: &axum::http::Extensions,
+    entry: &RouteEntry,
+) -> bool {
+    let Some(route_project_id) = entry.project_id else {
+        // Legacy or malformed snapshots without project metadata are not
+        // safe to expose through the workload-to-workload proxy.
+        return false;
+    };
+    let Some(peer) = extensions.get::<ConnectInfo<SocketAddr>>().map(|c| c.0) else {
+        return false;
+    };
+    store.backend_ip_has_project(peer.ip(), route_project_id)
 }
 
 /// True if the client requested a protocol upgrade. We check both the
@@ -637,4 +665,71 @@ fn error_body(status: StatusCode, message: &str) -> Response {
         HeaderValue::from_static("text/plain; charset=utf-8"),
     );
     resp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::route_store::{RouteBackend, RouteEntry, RouteStore};
+    use std::path::PathBuf;
+
+    fn route(host: &str, project_id: i32, backend: &str) -> RouteEntry {
+        RouteEntry {
+            host: host.to_string(),
+            backends: vec![RouteBackend {
+                address: backend.to_string(),
+                container_id: None,
+                container_name: None,
+            }],
+            deployment_id: Some(project_id * 10),
+            project_id: Some(project_id),
+            environment_id: Some(project_id * 100),
+        }
+    }
+
+    fn extensions_for(peer: &str) -> axum::http::Extensions {
+        let mut extensions = axum::http::Extensions::new();
+        extensions.insert(ConnectInfo(peer.parse::<SocketAddr>().unwrap()));
+        extensions
+    }
+
+    #[test]
+    fn caller_policy_allows_same_project_backend_ip() {
+        let store = Arc::new(RouteStore::new(PathBuf::from("/tmp/unused-routes.json")));
+        let target = route("prod.alpha.temps.local", 42, "172.20.1.10:3000");
+        store.apply_snapshot(1, vec![target.clone()]);
+
+        assert!(caller_may_access_route(
+            &store,
+            &extensions_for("172.20.1.10:49152"),
+            &target
+        ));
+    }
+
+    #[test]
+    fn caller_policy_blocks_cross_project_backend_ip() {
+        let store = Arc::new(RouteStore::new(PathBuf::from("/tmp/unused-routes.json")));
+        let attacker = route("prod.attacker.temps.local", 7, "172.20.1.7:3000");
+        let victim = route("prod.victim.temps.local", 42, "172.20.1.42:3000");
+        store.apply_snapshot(1, vec![attacker, victim.clone()]);
+
+        assert!(!caller_may_access_route(
+            &store,
+            &extensions_for("172.20.1.7:49152"),
+            &victim
+        ));
+    }
+
+    #[test]
+    fn caller_policy_blocks_unknown_source_ip() {
+        let store = Arc::new(RouteStore::new(PathBuf::from("/tmp/unused-routes.json")));
+        let target = route("prod.alpha.temps.local", 42, "172.20.1.10:3000");
+        store.apply_snapshot(1, vec![target.clone()]);
+
+        assert!(!caller_may_access_route(
+            &store,
+            &extensions_for("172.20.1.99:49152"),
+            &target
+        ));
+    }
 }

--- a/crates/temps-agent/src/internal_proxy.rs
+++ b/crates/temps-agent/src/internal_proxy.rs
@@ -45,7 +45,7 @@
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::body::Body;
 use axum::extract::{ConnectInfo, Request, State};
@@ -82,11 +82,36 @@ const UPSTREAM_TIMEOUT: Duration = Duration::from_secs(30);
 /// connect failure before returning 502.
 const MAX_RETRIES: usize = 3;
 
+/// Caller identity is derived from Docker's current network attachments. Keep
+/// the acceptance window short so a recycled bridge IP cannot retain the
+/// previous container's project identity.
+const IDENTITY_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
+const IDENTITY_MAX_AGE: Duration = Duration::from_secs(3);
+
+struct CallerIdentitySnapshot {
+    identities: HashMap<IpAddr, String>,
+    refreshed_at: Instant,
+}
+
+impl CallerIdentitySnapshot {
+    fn new(identities: HashMap<IpAddr, String>) -> Self {
+        Self {
+            identities,
+            refreshed_at: Instant::now(),
+        }
+    }
+
+    fn clear(&mut self) {
+        self.identities.clear();
+    }
+}
+
 /// Shared HTTP client + route store for the proxy's request handler.
 struct ProxyState {
     client: reqwest::Client,
     store: SharedRouteStore,
-    caller_identities: Arc<RwLock<HashMap<IpAddr, String>>>,
+    docker: bollard::Docker,
+    caller_identities: Arc<RwLock<CallerIdentitySnapshot>>,
 }
 
 /// Spawn the proxy on `<bridge_ip>:80`. Returns once the listener is
@@ -118,23 +143,33 @@ pub async fn spawn(
     let initial_identities = load_source_identities(&docker)
         .await
         .map_err(|error| std::io::Error::other(error.to_string()))?;
-    let caller_identities = Arc::new(RwLock::new(initial_identities));
+    let caller_identities = Arc::new(RwLock::new(CallerIdentitySnapshot::new(initial_identities)));
     let state = Arc::new(ProxyState {
         client,
         store,
+        docker: docker.clone(),
         caller_identities: Arc::clone(&caller_identities),
     });
     let app = axum::Router::new().fallback(handle).with_state(state);
 
     let identity_shutdown = Arc::clone(&shutdown);
     tokio::spawn(async move {
-        let mut interval = tokio::time::interval(Duration::from_secs(2));
+        let mut interval = tokio::time::interval(IDENTITY_REFRESH_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             tokio::select! {
                 _ = identity_shutdown.notified() => break,
                 _ = interval.tick() => match load_source_identities(&docker).await {
-                    Ok(snapshot) => *caller_identities.write() = snapshot,
-                    Err(error) => warn!(%error, "failed to refresh internal proxy caller identities"),
+                    Ok(snapshot) => {
+                        *caller_identities.write() = CallerIdentitySnapshot::new(snapshot);
+                    }
+                    Err(error) => {
+                        // Docker is the identity authority. Retaining the old
+                        // IP map after an API failure could authorize a new
+                        // container that inherited a departed container's IP.
+                        caller_identities.write().clear();
+                        warn!(%error, "failed to refresh internal proxy caller identities; denying workload traffic");
+                    }
                 }
             }
         }
@@ -226,7 +261,9 @@ async fn caller_may_access_route(
     let Some(peer) = extensions.get::<ConnectInfo<SocketAddr>>().map(|c| c.0) else {
         return false;
     };
-    let Some(container_id) = source_container_id(&state.caller_identities, peer.ip()) else {
+    let Some(container_id) =
+        source_container_id(&state.docker, &state.caller_identities, peer.ip()).await
+    else {
         return false;
     };
     state
@@ -238,11 +275,50 @@ async fn caller_may_access_route(
 /// network attachment state is the authority for which container owns an IP;
 /// route destination addresses are not caller identity and may be hostnames or
 /// shared node addresses.
-fn source_container_id(
-    caller_identities: &RwLock<HashMap<IpAddr, String>>,
+fn candidate_container_id(
+    caller_identities: &RwLock<CallerIdentitySnapshot>,
     source_ip: IpAddr,
 ) -> Option<String> {
-    caller_identities.read().get(&source_ip).cloned()
+    let snapshot = caller_identities.read();
+    if snapshot.refreshed_at.elapsed() > IDENTITY_MAX_AGE {
+        return None;
+    }
+    snapshot.identities.get(&source_ip).cloned()
+}
+
+/// Resolve a cached candidate and verify that Docker still reports the same
+/// running container as the owner of the peer IP. The point lookup prevents a
+/// recycled bridge IP from inheriting the previous container's authorization
+/// without putting a full container-list scan on every request.
+async fn source_container_id(
+    docker: &bollard::Docker,
+    caller_identities: &RwLock<CallerIdentitySnapshot>,
+    source_ip: IpAddr,
+) -> Option<String> {
+    use bollard::query_parameters::InspectContainerOptions;
+
+    let container_id = candidate_container_id(caller_identities, source_ip)?;
+    let inspected = docker
+        .inspect_container(&container_id, None::<InspectContainerOptions>)
+        .await
+        .ok()?;
+    if inspected.state.and_then(|state| state.running) != Some(true) {
+        return None;
+    }
+
+    let networks = inspected.network_settings?.networks?;
+    let owns_source_ip = networks.values().any(|endpoint| {
+        [
+            endpoint.ip_address.as_deref(),
+            endpoint.global_ipv6_address.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        .filter_map(|address| address.parse::<IpAddr>().ok())
+        .any(|address| address == source_ip)
+    });
+
+    owns_source_ip.then_some(container_id)
 }
 
 async fn load_source_identities(
@@ -800,15 +876,32 @@ mod tests {
 
     #[test]
     fn caller_identity_lookup_is_memory_only_and_fails_closed() {
-        let identities = RwLock::new(HashMap::from([(
+        let identities = RwLock::new(CallerIdentitySnapshot::new(HashMap::from([(
             "172.20.1.10".parse().unwrap(),
             "container-alpha".to_string(),
-        )]));
+        )])));
 
         assert_eq!(
-            source_container_id(&identities, "172.20.1.10".parse().unwrap()).as_deref(),
+            candidate_container_id(&identities, "172.20.1.10".parse().unwrap()).as_deref(),
             Some("container-alpha")
         );
-        assert!(source_container_id(&identities, "172.20.1.99".parse().unwrap()).is_none());
+        assert!(candidate_container_id(&identities, "172.20.1.99".parse().unwrap()).is_none());
+    }
+
+    #[test]
+    fn caller_identity_lookup_rejects_stale_or_cleared_snapshots() {
+        let source_ip = "172.20.1.10".parse().unwrap();
+        let identities = RwLock::new(CallerIdentitySnapshot {
+            identities: HashMap::from([(source_ip, "departed-container".to_string())]),
+            refreshed_at: Instant::now() - IDENTITY_MAX_AGE - Duration::from_millis(1),
+        });
+
+        assert!(candidate_container_id(&identities, source_ip).is_none());
+
+        let mut snapshot = identities.write();
+        snapshot.refreshed_at = Instant::now();
+        snapshot.clear();
+        drop(snapshot);
+        assert!(candidate_container_id(&identities, source_ip).is_none());
     }
 }

--- a/crates/temps-agent/src/route_store.rs
+++ b/crates/temps-agent/src/route_store.rs
@@ -24,7 +24,8 @@
 //! the store is empty and the proxy returns 503 until the first sync
 //! round finishes.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -65,6 +66,7 @@ struct DiskSnapshot {
 
 pub struct RouteStore {
     inner: RwLock<HashMap<String, RouteEntry>>,
+    backend_projects: RwLock<HashMap<IpAddr, HashSet<i32>>>,
     generation: RwLock<u64>,
     snapshot_path: PathBuf,
 }
@@ -73,6 +75,7 @@ impl RouteStore {
     pub fn new(snapshot_path: PathBuf) -> Self {
         Self {
             inner: RwLock::new(HashMap::new()),
+            backend_projects: RwLock::new(HashMap::new()),
             generation: RwLock::new(0),
             snapshot_path,
         }
@@ -82,10 +85,12 @@ impl RouteStore {
     /// to disk best-effort. Returns the new generation.
     pub fn apply_snapshot(&self, generation: u64, routes: Vec<RouteEntry>) -> u64 {
         let mut map = HashMap::with_capacity(routes.len());
+        let backend_projects = backend_project_index(&routes);
         for r in &routes {
             map.insert(r.host.to_ascii_lowercase(), r.clone());
         }
         *self.inner.write() = map;
+        *self.backend_projects.write() = backend_projects;
         *self.generation.write() = generation;
 
         // Best-effort disk persistence. We tolerate any error here —
@@ -112,6 +117,20 @@ impl RouteStore {
     pub fn lookup(&self, host: &str) -> Option<RouteEntry> {
         let key = host.to_ascii_lowercase();
         self.inner.read().get(&key).cloned()
+    }
+
+    /// Return the set of projects whose deployment backends include
+    /// `ip`. The internal proxy uses this as the request-side identity
+    /// signal: app containers reach the bridge proxy from their overlay
+    /// IP, and route snapshots already know which project owns each
+    /// deployment backend. Unknown source IPs intentionally map to an
+    /// empty set so they cannot use the proxy as a cross-project
+    /// forwarder.
+    pub fn backend_ip_has_project(&self, ip: IpAddr, project_id: i32) -> bool {
+        self.backend_projects
+            .read()
+            .get(&ip)
+            .is_some_and(|projects| projects.contains(&project_id))
     }
 
     pub fn current_generation(&self) -> u64 {
@@ -154,10 +173,12 @@ impl RouteStore {
             }
         };
         let mut map = HashMap::with_capacity(snap.routes.len());
+        let backend_projects = backend_project_index(&snap.routes);
         for r in &snap.routes {
             map.insert(r.host.to_ascii_lowercase(), r.clone());
         }
         *self.inner.write() = map;
+        *self.backend_projects.write() = backend_projects;
         *self.generation.write() = snap.generation;
         debug!(
             generation = snap.generation,
@@ -183,6 +204,27 @@ impl RouteStore {
     }
 }
 
+fn backend_ip(address: &str) -> Option<IpAddr> {
+    if let Ok(socket) = address.parse::<SocketAddr>() {
+        return Some(socket.ip());
+    }
+    address.parse::<IpAddr>().ok()
+}
+
+fn backend_project_index(routes: &[RouteEntry]) -> HashMap<IpAddr, HashSet<i32>> {
+    let mut index: HashMap<IpAddr, HashSet<i32>> = HashMap::new();
+    for route in routes {
+        if let Some(project_id) = route.project_id {
+            for backend in &route.backends {
+                if let Some(ip) = backend_ip(&backend.address) {
+                    index.entry(ip).or_default().insert(project_id);
+                }
+            }
+        }
+    }
+    index
+}
+
 pub type SharedRouteStore = Arc<RouteStore>;
 
 #[cfg(test)]
@@ -191,6 +233,10 @@ mod tests {
     use tempfile::TempDir;
 
     fn entry(host: &str, addr: &str) -> RouteEntry {
+        entry_with_project(host, addr, Some(1))
+    }
+
+    fn entry_with_project(host: &str, addr: &str, project_id: Option<i32>) -> RouteEntry {
         RouteEntry {
             host: host.into(),
             backends: vec![RouteBackend {
@@ -199,7 +245,7 @@ mod tests {
                 container_name: None,
             }],
             deployment_id: Some(1),
-            project_id: Some(1),
+            project_id,
             environment_id: Some(1),
         }
     }
@@ -228,6 +274,26 @@ mod tests {
         s2.load_from_disk();
         assert_eq!(s2.current_generation(), 7);
         assert!(s2.lookup("a.temps.local").is_some());
+    }
+
+    #[test]
+    fn project_ids_for_backend_ip_matches_socket_addresses() {
+        let dir = TempDir::new().unwrap();
+        let store = RouteStore::new(dir.path().join("routes.json"));
+        store.apply_snapshot(
+            1,
+            vec![
+                entry_with_project("prod.alpha.temps.local", "172.20.1.10:3000", Some(10)),
+                entry_with_project("prod.beta.temps.local", "172.20.1.10:8080", Some(20)),
+                entry_with_project("prod.gamma.temps.local", "172.20.1.11:8080", Some(30)),
+            ],
+        );
+
+        let shared_ip = "172.20.1.10".parse().unwrap();
+        assert!(store.backend_ip_has_project(shared_ip, 10));
+        assert!(store.backend_ip_has_project(shared_ip, 20));
+        assert!(!store.backend_ip_has_project(shared_ip, 30));
+        assert!(!store.backend_ip_has_project("172.20.1.99".parse().unwrap(), 10));
     }
 
     #[test]

--- a/crates/temps-agent/src/route_store.rs
+++ b/crates/temps-agent/src/route_store.rs
@@ -25,7 +25,6 @@
 //! round finishes.
 
 use std::collections::{HashMap, HashSet};
-use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -66,7 +65,7 @@ struct DiskSnapshot {
 
 pub struct RouteStore {
     inner: RwLock<HashMap<String, RouteEntry>>,
-    backend_projects: RwLock<HashMap<IpAddr, HashSet<i32>>>,
+    container_projects: RwLock<HashMap<String, HashSet<i32>>>,
     generation: RwLock<u64>,
     snapshot_path: PathBuf,
 }
@@ -75,7 +74,7 @@ impl RouteStore {
     pub fn new(snapshot_path: PathBuf) -> Self {
         Self {
             inner: RwLock::new(HashMap::new()),
-            backend_projects: RwLock::new(HashMap::new()),
+            container_projects: RwLock::new(HashMap::new()),
             generation: RwLock::new(0),
             snapshot_path,
         }
@@ -85,12 +84,12 @@ impl RouteStore {
     /// to disk best-effort. Returns the new generation.
     pub fn apply_snapshot(&self, generation: u64, routes: Vec<RouteEntry>) -> u64 {
         let mut map = HashMap::with_capacity(routes.len());
-        let backend_projects = backend_project_index(&routes);
+        let container_projects = container_project_index(&routes);
         for r in &routes {
             map.insert(r.host.to_ascii_lowercase(), r.clone());
         }
         *self.inner.write() = map;
-        *self.backend_projects.write() = backend_projects;
+        *self.container_projects.write() = container_projects;
         *self.generation.write() = generation;
 
         // Best-effort disk persistence. We tolerate any error here —
@@ -119,17 +118,14 @@ impl RouteStore {
         self.inner.read().get(&key).cloned()
     }
 
-    /// Return the set of projects whose deployment backends include
-    /// `ip`. The internal proxy uses this as the request-side identity
-    /// signal: app containers reach the bridge proxy from their overlay
-    /// IP, and route snapshots already know which project owns each
-    /// deployment backend. Unknown source IPs intentionally map to an
-    /// empty set so they cannot use the proxy as a cross-project
-    /// forwarder.
-    pub fn backend_ip_has_project(&self, ip: IpAddr, project_id: i32) -> bool {
-        self.backend_projects
+    /// Return whether a Docker container belongs to `project_id` according to
+    /// the control-plane route snapshot. Container IDs are trusted workload
+    /// identity; backend addresses are destinations and may be hostnames or
+    /// shared node IPs, so they must never be used as caller identity.
+    pub fn container_id_has_project(&self, container_id: &str, project_id: i32) -> bool {
+        self.container_projects
             .read()
-            .get(&ip)
+            .get(container_id)
             .is_some_and(|projects| projects.contains(&project_id))
     }
 
@@ -173,12 +169,12 @@ impl RouteStore {
             }
         };
         let mut map = HashMap::with_capacity(snap.routes.len());
-        let backend_projects = backend_project_index(&snap.routes);
+        let container_projects = container_project_index(&snap.routes);
         for r in &snap.routes {
             map.insert(r.host.to_ascii_lowercase(), r.clone());
         }
         *self.inner.write() = map;
-        *self.backend_projects.write() = backend_projects;
+        *self.container_projects.write() = container_projects;
         *self.generation.write() = snap.generation;
         debug!(
             generation = snap.generation,
@@ -204,20 +200,16 @@ impl RouteStore {
     }
 }
 
-fn backend_ip(address: &str) -> Option<IpAddr> {
-    if let Ok(socket) = address.parse::<SocketAddr>() {
-        return Some(socket.ip());
-    }
-    address.parse::<IpAddr>().ok()
-}
-
-fn backend_project_index(routes: &[RouteEntry]) -> HashMap<IpAddr, HashSet<i32>> {
-    let mut index: HashMap<IpAddr, HashSet<i32>> = HashMap::new();
+fn container_project_index(routes: &[RouteEntry]) -> HashMap<String, HashSet<i32>> {
+    let mut index: HashMap<String, HashSet<i32>> = HashMap::new();
     for route in routes {
         if let Some(project_id) = route.project_id {
             for backend in &route.backends {
-                if let Some(ip) = backend_ip(&backend.address) {
-                    index.entry(ip).or_default().insert(project_id);
+                if let Some(container_id) = backend.container_id.as_deref() {
+                    index
+                        .entry(container_id.to_string())
+                        .or_default()
+                        .insert(project_id);
                 }
             }
         }
@@ -277,23 +269,18 @@ mod tests {
     }
 
     #[test]
-    fn project_ids_for_backend_ip_matches_socket_addresses() {
+    fn project_ids_are_indexed_by_trusted_container_id() {
         let dir = TempDir::new().unwrap();
         let store = RouteStore::new(dir.path().join("routes.json"));
-        store.apply_snapshot(
-            1,
-            vec![
-                entry_with_project("prod.alpha.temps.local", "172.20.1.10:3000", Some(10)),
-                entry_with_project("prod.beta.temps.local", "172.20.1.10:8080", Some(20)),
-                entry_with_project("prod.gamma.temps.local", "172.20.1.11:8080", Some(30)),
-            ],
-        );
+        let mut alpha = entry_with_project("prod.alpha.temps.local", "alpha:3000", Some(10));
+        alpha.backends[0].container_id = Some("container-alpha".to_string());
+        let mut beta = entry_with_project("prod.beta.temps.local", "10.0.0.2:8080", Some(20));
+        beta.backends[0].container_id = Some("container-beta".to_string());
+        store.apply_snapshot(1, vec![alpha, beta]);
 
-        let shared_ip = "172.20.1.10".parse().unwrap();
-        assert!(store.backend_ip_has_project(shared_ip, 10));
-        assert!(store.backend_ip_has_project(shared_ip, 20));
-        assert!(!store.backend_ip_has_project(shared_ip, 30));
-        assert!(!store.backend_ip_has_project("172.20.1.99".parse().unwrap(), 10));
+        assert!(store.container_id_has_project("container-alpha", 10));
+        assert!(!store.container_id_has_project("container-alpha", 20));
+        assert!(!store.container_id_has_project("unknown", 10));
     }
 
     #[test]

--- a/crates/temps-agents/src/handlers/preview_gateway.rs
+++ b/crates/temps-agents/src/handlers/preview_gateway.rs
@@ -57,7 +57,8 @@ pub struct LogsResponse {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct UpgradeRequest {
     /// Image reference to pull and run (e.g.
-    /// `ghcr.io/gotempsh/temps-preview-gateway:0.1.0`). Empty resets to default.
+    /// an immutable `ghcr.io/gotempsh/temps-preview-gateway@sha256:…` reference).
+    /// Empty resets to default.
     pub image: String,
 }
 

--- a/crates/temps-agents/src/handlers/preview_gateway.rs
+++ b/crates/temps-agents/src/handlers/preview_gateway.rs
@@ -57,7 +57,7 @@ pub struct LogsResponse {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct UpgradeRequest {
     /// Image reference to pull and run (e.g.
-    /// `ghcr.io/gotempsh/temps-preview-gateway:latest`). Empty resets to default.
+    /// `ghcr.io/gotempsh/temps-preview-gateway:0.1.0`). Empty resets to default.
     pub image: String,
 }
 

--- a/crates/temps-agents/src/preview_gateway.rs
+++ b/crates/temps-agents/src/preview_gateway.rs
@@ -36,8 +36,8 @@ use std::sync::Arc;
 use temps_core::PreviewGatewaySettings;
 use tracing::{debug, info, warn};
 
-/// Pinned image reference. Bumped per release. Never `:latest`.
-pub const PREVIEW_GATEWAY_IMAGE: &str = "ghcr.io/gotempsh/temps-preview-gateway:0.1.0";
+/// Immutable multi-platform manifest reference. Bumped per release.
+pub const PREVIEW_GATEWAY_IMAGE: &str = "ghcr.io/gotempsh/temps-preview-gateway@sha256:a16d4346f2f857470fdd28c9ed46809f6db4f7e577888d6250338f8d5dcf04b9";
 
 /// Filename inside `TEMPS_DATA_DIR` that holds the gateway shared secret.
 /// The file is created with 0600 perms on first boot if missing; the same
@@ -663,8 +663,8 @@ pub struct GatewayStatus {
     /// Higher-level health label: "running" | "restarting" | "crash_looping"
     /// | "stopped" | "missing". UI should prefer this over `running`.
     pub health: String,
-    /// Image reference the container was created with (e.g.
-    /// `ghcr.io/gotempsh/temps-preview-gateway:0.1.0`).
+    /// Image reference the container was created with (e.g. an immutable
+    /// `ghcr.io/gotempsh/temps-preview-gateway@sha256:…` reference).
     pub image: Option<String>,
     /// Image digest if available (e.g. `sha256:…`).
     pub image_digest: Option<String>,
@@ -861,14 +861,12 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
-    fn default_gateway_image_is_release_pinned() {
+    fn default_gateway_image_is_immutable() {
         assert_eq!(
             PREVIEW_GATEWAY_IMAGE,
             PreviewGatewaySettings::default().image
         );
-        assert!(!PREVIEW_GATEWAY_IMAGE.ends_with(":latest"));
-        assert!(!PREVIEW_GATEWAY_IMAGE.ends_with(":beta"));
-        assert!(!PREVIEW_GATEWAY_IMAGE.ends_with(":stable"));
+        assert!(PREVIEW_GATEWAY_IMAGE.contains("@sha256:"));
     }
 
     #[test]

--- a/crates/temps-agents/src/preview_gateway.rs
+++ b/crates/temps-agents/src/preview_gateway.rs
@@ -37,7 +37,7 @@ use temps_core::PreviewGatewaySettings;
 use tracing::{debug, info, warn};
 
 /// Pinned image reference. Bumped per release. Never `:latest`.
-pub const PREVIEW_GATEWAY_IMAGE: &str = "ghcr.io/gotempsh/temps-preview-gateway:latest";
+pub const PREVIEW_GATEWAY_IMAGE: &str = "ghcr.io/gotempsh/temps-preview-gateway:0.1.0";
 
 /// Filename inside `TEMPS_DATA_DIR` that holds the gateway shared secret.
 /// The file is created with 0600 perms on first boot if missing; the same
@@ -664,7 +664,7 @@ pub struct GatewayStatus {
     /// | "stopped" | "missing". UI should prefer this over `running`.
     pub health: String,
     /// Image reference the container was created with (e.g.
-    /// `ghcr.io/gotempsh/temps-preview-gateway:latest`).
+    /// `ghcr.io/gotempsh/temps-preview-gateway:0.1.0`).
     pub image: Option<String>,
     /// Image digest if available (e.g. `sha256:…`).
     pub image_digest: Option<String>,
@@ -859,6 +859,17 @@ pub async fn tail_logs(docker: &Docker, tail: usize) -> Result<Vec<String>> {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn default_gateway_image_is_release_pinned() {
+        assert_eq!(
+            PREVIEW_GATEWAY_IMAGE,
+            PreviewGatewaySettings::default().image
+        );
+        assert!(!PREVIEW_GATEWAY_IMAGE.ends_with(":latest"));
+        assert!(!PREVIEW_GATEWAY_IMAGE.ends_with(":beta"));
+        assert!(!PREVIEW_GATEWAY_IMAGE.ends_with(":stable"));
+    }
 
     #[test]
     fn ensure_shared_secret_creates_file_on_first_call() {

--- a/crates/temps-ai-api-tools/src/caller.rs
+++ b/crates/temps-ai-api-tools/src/caller.rs
@@ -163,10 +163,9 @@ pub(crate) fn is_project_scope_param(op: &ApiOperation, param: &ParamSpec) -> bo
 ///   regardless of their (often-unreliable) `required` flag; the real router is
 ///   the source of truth and returns a real 4xx if needed.
 /// - **Enum check**: `ApiToolError::BadEnum` if a value is not in `param.enum_values`.
-/// - **Project scoping**: if a param is named `project_id` (exact match) and
-///   `allowed_project_ids` is non-empty, the value is validated ∈
-///   `allowed_project_ids`.  If the param is absent and `allowed_project_ids.len() == 1`,
-///   it is auto-filled with the single accessible project.
+/// - **Project scoping**: when `allowed_project_ids` is non-empty, the operation
+///   must expose a recognized project selector. The selector is validated
+///   against the allowed set and auto-filled when exactly one project is allowed.
 /// - **Limit injection**: if a param named `limit` exists in the operation:
 ///   - absent → `default_limit` is injected.
 ///   - present → clamped to `[1, max_limit]`.
@@ -274,6 +273,17 @@ pub fn build_request_parts(
     let mut path = op.path.clone();
     let mut query_parts: Vec<String> = Vec::new();
     let mut body_map = serde_json::Map::new();
+
+    if !allowed_project_ids.is_empty()
+        && !op
+            .params
+            .iter()
+            .any(|param| is_project_scope_param(op, param))
+    {
+        return Err(ApiToolError::UnscopedOperation {
+            operation_id: op.operation_id.clone(),
+        });
+    }
 
     for param in &op.params {
         // Special handling: auto-fill the project selector when the caller has
@@ -2305,16 +2315,29 @@ mod tests {
     }
 
     #[test]
-    fn non_project_id_path_param_stays_required() {
+    fn non_project_id_path_param_is_rejected_for_project_scoped_call() {
         // An `id` that is NOT the leading `/projects/{id}` segment (here a
-        // resource id) is a genuine required path param the model must supply —
-        // it must not be silently filled with the project id.
+        // resource id) cannot prove the replay stays inside the chat project.
         let op = make_op("get_thing", "/things/{id}", vec![path_param("id")]);
 
-        let err = build_request_parts(&op, &serde_json::json!({}), &[42], 20, 100)
-            .expect_err("non-project id must stay required");
+        let err = build_request_parts(&op, &serde_json::json!({ "id": 99 }), &[42], 20, 100)
+            .expect_err("resource-id-only operation must be rejected");
         assert!(
-            matches!(err, ApiToolError::MissingParam { ref name, .. } if name == "id"),
+            matches!(err, ApiToolError::UnscopedOperation { ref operation_id } if operation_id == "get_thing"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn global_operation_is_rejected_for_project_scoped_call() {
+        let mut limit = query_param("limit", false);
+        limit.ty = "integer".to_string();
+        let op = make_op("list_audit_logs", "/audit/logs", vec![limit]);
+
+        let err = build_request_parts(&op, &serde_json::json!({ "limit": 20 }), &[42], 20, 100)
+            .expect_err("global operation must be rejected in project scope");
+        assert!(
+            matches!(err, ApiToolError::UnscopedOperation { ref operation_id } if operation_id == "list_audit_logs"),
             "unexpected error: {err:?}"
         );
     }

--- a/crates/temps-ai-api-tools/src/error.rs
+++ b/crates/temps-ai-api-tools/src/error.rs
@@ -117,6 +117,16 @@ pub enum ApiToolError {
         operation_id: String,
     },
 
+    /// The operation cannot be safely constrained to the caller's project scope.
+    #[error(
+        "Operation '{operation_id}' is not available from a project-scoped AI chat \
+         because it does not expose a project selector."
+    )]
+    UnscopedOperation {
+        /// The operation that was called.
+        operation_id: String,
+    },
+
     /// The requested `operation_id` does not exist in the read-only index.
     #[error(
         "Operation '{operation_id}' was not found in the read-only API index. \

--- a/crates/temps-ai-chat/src/handlers.rs
+++ b/crates/temps-ai-chat/src/handlers.rs
@@ -590,13 +590,27 @@ fn ensure_context_read_permission(auth: &AuthContext, context_type: &str) -> Res
     if !can_read_context(auth, context_type) {
         return Err(problemdetails::new(axum::http::StatusCode::FORBIDDEN)
             .with_title("Insufficient Permissions")
-            .with_detail("The otel:read permission is required for alert suggestion chats."));
+            .with_detail(format!(
+                "The {} permission is required for this AI conversation context.",
+                required_context_permission(context_type)
+                    .map(|permission| permission.to_string())
+                    .unwrap_or_else(|| "corresponding read".to_string())
+            )));
     }
     Ok(())
 }
 
 fn can_read_context(auth: &AuthContext, context_type: &str) -> bool {
-    context_type != "alert_suggest" || auth.has_permission(&Permission::OtelRead)
+    required_context_permission(context_type)
+        .is_none_or(|permission| auth.has_permission(&permission))
+}
+
+fn required_context_permission(context_type: &str) -> Option<Permission> {
+    match context_type {
+        "alert" | "alert_suggest" => Some(Permission::OtelRead),
+        "deployment" => Some(Permission::DeploymentsRead),
+        _ => None,
+    }
 }
 
 fn ensure_conversation_read_permission(
@@ -1897,6 +1911,22 @@ mod tests {
             "test-key".to_string(),
             1,
         )
+    }
+
+    #[test]
+    fn seeded_contexts_require_their_domain_read_permissions() {
+        let project_writer = custom_auth(vec![Permission::ProjectsWrite]);
+        assert!(!can_read_context(&project_writer, "deployment"));
+        assert!(!can_read_context(&project_writer, "alert"));
+        assert!(!can_read_context(&project_writer, "alert_suggest"));
+
+        let deployment_reader = custom_auth(vec![Permission::DeploymentsRead]);
+        assert!(can_read_context(&deployment_reader, "deployment"));
+        assert!(!can_read_context(&deployment_reader, "alert"));
+
+        let telemetry_reader = custom_auth(vec![Permission::OtelRead]);
+        assert!(can_read_context(&telemetry_reader, "alert"));
+        assert!(can_read_context(&telemetry_reader, "alert_suggest"));
     }
 
     fn conversation_with_runtime(provider: &str, permission_mode: &str) -> ai_conversations::Model {

--- a/crates/temps-ai-chat/src/provider.rs
+++ b/crates/temps-ai-chat/src/provider.rs
@@ -104,6 +104,17 @@ pub trait ConversationContextProvider: Send + Sync {
         Vec::new()
     }
 
+    /// Return tools after applying caller-specific authorization. Providers
+    /// backed by a separately protected resource must override this method.
+    async fn tools_with_auth(
+        &self,
+        project_id: i32,
+        context_id: &str,
+        _auth: &AuthContext,
+    ) -> Vec<ChatTool> {
+        self.tools(project_id, context_id).await
+    }
+
     /// Execute a tool the model requested. `arguments` is the raw JSON string the
     /// model emitted. Returns a string fed back to the model — surface failures
     /// as readable text (e.g. "file not found"), never as an error, so the model

--- a/crates/temps-ai-chat/src/providers/repo_tools.rs
+++ b/crates/temps-ai-chat/src/providers/repo_tools.rs
@@ -23,6 +23,7 @@ use async_trait::async_trait;
 use sea_orm::{DatabaseConnection, EntityTrait};
 
 use temps_ai::ChatTool;
+use temps_auth::{context::AuthContext, permissions::Permission};
 use temps_entities::projects;
 use temps_git::GitProviderManager;
 
@@ -372,7 +373,16 @@ impl ConversationContextProvider for RepoToolsProvider {
         None
     }
 
-    async fn tools(&self, project_id: i32, _context_id: &str) -> Vec<ChatTool> {
+    async fn tools_with_auth(
+        &self,
+        project_id: i32,
+        _context_id: &str,
+        auth: &AuthContext,
+    ) -> Vec<ChatTool> {
+        if !auth.has_permission(&Permission::GitRepositoriesRead) {
+            return Vec::new();
+        }
+
         // No git manager → no tools.
         if self.git.is_none() {
             return Vec::new();
@@ -430,13 +440,18 @@ impl ConversationContextProvider for RepoToolsProvider {
         ]
     }
 
-    async fn execute_tool(
+    async fn execute_tool_with_auth(
         &self,
         project_id: i32,
         _context_id: &str,
         name: &str,
         arguments: &str,
+        auth: &AuthContext,
     ) -> String {
+        if !auth.has_permission(&Permission::GitRepositoriesRead) {
+            return "Repository tools require the git_repositories:read permission.".to_string();
+        }
+
         // Parse the JSON args. On failure return a readable message so the
         // model can self-correct rather than receiving a raw Rust error.
         let args: serde_json::Value = match serde_json::from_str(arguments) {
@@ -507,7 +522,7 @@ mod tests {
     async fn tools_empty_when_git_absent() {
         let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
         let provider = RepoToolsProvider::new(Arc::new(db), None);
-        let tools = provider.tools(1, "").await;
+        let tools = provider.tools_with_auth(1, "", &auth_with_git_read()).await;
         assert!(
             tools.is_empty(),
             "expected no tools when git manager is absent"
@@ -530,7 +545,9 @@ mod tests {
 
         // git = None → early return before DB query; result is still empty.
         let provider = RepoToolsProvider::new(Arc::new(db), None);
-        let tools = provider.tools(42, "").await;
+        let tools = provider
+            .tools_with_auth(42, "", &auth_with_git_read())
+            .await;
         assert!(tools.is_empty());
     }
 
@@ -624,7 +641,9 @@ mod tests {
     async fn execute_tool_unknown_name() {
         let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
         let provider = RepoToolsProvider::new(Arc::new(db), None);
-        let result = provider.execute_tool(1, "", "nonexistent_tool", "{}").await;
+        let result = provider
+            .execute_tool_with_auth(1, "", "nonexistent_tool", "{}", &auth_with_git_read())
+            .await;
         assert!(
             result.contains("Unknown repo tool"),
             "expected unknown-tool message, got: {result}"
@@ -637,7 +656,13 @@ mod tests {
         let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
         let provider = RepoToolsProvider::new(Arc::new(db), None);
         let result = provider
-            .execute_tool(1, "", "read_repo_file", "not json {{{")
+            .execute_tool_with_auth(
+                1,
+                "",
+                "read_repo_file",
+                "not json {{{",
+                &auth_with_git_read(),
+            )
             .await;
         assert!(
             result.contains("not valid JSON") || result.contains("Invalid"),
@@ -651,12 +676,65 @@ mod tests {
         let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
         let provider = RepoToolsProvider::new(Arc::new(db), None);
         // Arguments have no "path" key at all.
-        let result = provider.execute_tool(1, "", "read_repo_file", "{}").await;
+        let result = provider
+            .execute_tool_with_auth(1, "", "read_repo_file", "{}", &auth_with_git_read())
+            .await;
         // The missing-path guard fires before any git access.
         assert!(
             result.contains("path"),
             "expected path-required message, got: {result}"
         );
+    }
+
+    #[tokio::test]
+    async fn repo_tools_require_git_repository_read_permission() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+        let provider = RepoToolsProvider::new(Arc::new(db), None);
+        let auth = auth_without_git_read();
+
+        assert!(provider.tools_with_auth(1, "", &auth).await.is_empty());
+        let result = provider
+            .execute_tool_with_auth(1, "", "read_repo_file", r#"{"path":"README.md"}"#, &auth)
+            .await;
+        assert!(result.contains("git_repositories:read"), "{result}");
+    }
+
+    fn test_user() -> temps_entities::users::Model {
+        let now = chrono::Utc::now();
+        temps_entities::users::Model {
+            id: 1,
+            name: "Test User".to_string(),
+            email: "test@example.com".to_string(),
+            password_hash: None,
+            email_verified: true,
+            email_verification_token: None,
+            email_verification_expires: None,
+            password_reset_token: None,
+            password_reset_expires: None,
+            must_change_password: false,
+            deleted_at: None,
+            mfa_secret: None,
+            mfa_enabled: false,
+            mfa_recovery_codes: None,
+            oidc_subject: None,
+            oidc_provider_id: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn auth_with_git_read() -> AuthContext {
+        AuthContext::new_api_key(
+            test_user(),
+            None,
+            Some(vec![Permission::GitRepositoriesRead]),
+            "test".to_string(),
+            1,
+        )
+    }
+
+    fn auth_without_git_read() -> AuthContext {
+        AuthContext::new_api_key(test_user(), None, Some(Vec::new()), "test".to_string(), 1)
     }
 
     // ---------------------------------------------------------------------------

--- a/crates/temps-ai-chat/src/service.rs
+++ b/crates/temps-ai-chat/src/service.rs
@@ -185,6 +185,17 @@ fn format_permission_answer(decision: &PermissionDecision) -> String {
 /// Tool name for the write-proposal (confirm-gated) tool.
 const TEMPS_WRITE_TOOL_NAME: &str = "temps_write";
 
+/// Client-visible tool results must not contain raw data fetched through
+/// server-side credentials. The model keeps the full result for reasoning;
+/// the live stream and persisted transcript receive only this safe status.
+fn public_tool_result(name: &str, result: &str) -> String {
+    if name == TEMPS_WRITE_TOOL_NAME {
+        return redact_json_string(result);
+    }
+
+    "Tool completed; detailed result is withheld from the chat transcript.".to_string()
+}
+
 /// System prompt for the one-shot title generator. Kept terse so even small
 /// local models return a clean label rather than a sentence.
 const TITLE_SYSTEM_PROMPT: &str = "You write a short title for a chat based on the user's first message. \
@@ -1220,7 +1231,10 @@ impl ConversationService {
         let mut tools: Vec<ChatTool> = Vec::new();
         if chat_capable {
             if let Some(p) = &provider {
-                tools.extend(p.tools(conv.project_id, &conv.context_id).await);
+                tools.extend(
+                    p.tools_with_auth(conv.project_id, &conv.context_id, auth)
+                        .await,
+                );
             }
             // ADR-024: merge the generic API meta-tools from the sentinel provider.
             // This is done for EVERY conversation context so the model can always
@@ -1228,7 +1242,7 @@ impl ConversationService {
             if let Some(api_tools_provider) = self.providers.get("__api_tools__") {
                 tools.extend(
                     api_tools_provider
-                        .tools(conv.project_id, &conv.context_id)
+                        .tools_with_auth(conv.project_id, &conv.context_id, auth)
                         .await,
                 );
             }
@@ -1241,7 +1255,7 @@ impl ConversationService {
             if let Some(repo_tools_provider) = self.providers.get("__repo_tools__") {
                 tools.extend(
                     repo_tools_provider
-                        .tools(conv.project_id, &conv.context_id)
+                        .tools_with_auth(conv.project_id, &conv.context_id, auth)
                         .await,
                 );
             }
@@ -1836,7 +1850,7 @@ impl ConversationService {
                         .await
                     };
                     let display_arguments = redact_json_string(&tc.arguments);
-                    let display_result = redact_json_string(&result);
+                    let display_result = public_tool_result(&tc.name, &result);
                     // Surface the result right after — live.
                     if tx
                         .send(Ok(ChatStreamEvent::ToolResult {
@@ -2345,7 +2359,7 @@ async fn dispatch_conversation_tool(
     ) {
         if let Some(provider) = repo_tools {
             provider
-                .execute_tool(project_id, context_id, &call.name, &call.arguments)
+                .execute_tool_with_auth(project_id, context_id, &call.name, &call.arguments, auth)
                 .await
         } else {
             format!(
@@ -3226,6 +3240,18 @@ mod tests {
             .collect()
     }
 
+    #[test]
+    fn public_tool_results_hide_privileged_read_data() {
+        assert_eq!(
+            public_tool_result("read_repo_file", "SECRET_TOKEN=abc123"),
+            "Tool completed; detailed result is withheld from the chat transcript."
+        );
+        assert_eq!(
+            public_tool_result(TEMPS_WRITE_TOOL_NAME, r#"{"status":"proposed"}"#),
+            r#"{"status":"proposed"}"#
+        );
+    }
+
     // (a) a round calls a tool, the next round answers in prose -> the tool is
     // executed (ToolCall -> ToolResult, live) and the prose streams as the answer.
     #[tokio::test]
@@ -3270,7 +3296,9 @@ mod tests {
                 ChatStreamEvent::ToolResult {
                     id: "c1".to_string(),
                     name: "echo".to_string(),
-                    content: "tool result".to_string(),
+                    content:
+                        "Tool completed; detailed result is withheld from the chat transcript."
+                            .to_string(),
                 },
                 ChatStreamEvent::Token("final ".to_string()),
                 ChatStreamEvent::Token("answer".to_string()),

--- a/crates/temps-ai-gateway/src/handlers/gateway.rs
+++ b/crates/temps-ai-gateway/src/handlers/gateway.rs
@@ -75,6 +75,19 @@ fn credential_type_str(ct: CredentialType) -> &'static str {
     }
 }
 
+fn reject_deployment_token_base_url(
+    auth: &temps_auth::AuthContext,
+    byok: &ByokOverride,
+) -> Option<AiGatewayError> {
+    if auth.is_deployment_token() && byok.base_url.is_some() {
+        return Some(AiGatewayError::InvalidProviderUrl {
+            reason: "X-Provider-Base-URL is not allowed for deployment tokens".to_string(),
+        });
+    }
+
+    None
+}
+
 // ============================================================================
 // Streaming usage extraction
 // ============================================================================
@@ -401,6 +414,9 @@ async fn chat_completions(
     }
 
     let byok = extract_byok(&headers);
+    if let Some(error) = reject_deployment_token_base_url(&auth, &byok) {
+        return Ok(error_to_response(error).into_response());
+    }
     let ai_context = extract_ai_context(&headers);
     let start = Instant::now();
     let model = request.model.clone();
@@ -667,6 +683,9 @@ async fn embeddings(
     }
 
     let byok = extract_byok(&headers);
+    if let Some(error) = reject_deployment_token_base_url(&auth, &byok) {
+        return Ok(error_to_response(error).into_response());
+    }
     let ai_context = extract_ai_context(&headers);
     let start = Instant::now();
     let user_id = auth.user_id_opt();
@@ -1009,6 +1028,45 @@ mod tests {
     fn test_credential_type_str_values() {
         assert_eq!(credential_type_str(CredentialType::System), "system");
         assert_eq!(credential_type_str(CredentialType::Byok), "byok");
+    }
+    #[test]
+    fn test_deployment_token_rejects_custom_byok_base_url() {
+        let auth = temps_auth::AuthContext::new_deployment_token(
+            7,
+            None,
+            None,
+            1,
+            "deployment-token".to_string(),
+            vec![temps_entities::deployment_tokens::DeploymentTokenPermission::AiGatewayExecute],
+        );
+        let byok = ByokOverride {
+            api_key: Some("sk-user-key-123".to_string()),
+            base_url: Some("https://custom.openai.azure.com".to_string()),
+            system_key_id: None,
+        };
+
+        let error = reject_deployment_token_base_url(&auth, &byok)
+            .expect("deployment tokens must not set provider base URLs");
+        assert!(matches!(error, AiGatewayError::InvalidProviderUrl { .. }));
+    }
+
+    #[test]
+    fn test_deployment_token_allows_byok_without_custom_base_url() {
+        let auth = temps_auth::AuthContext::new_deployment_token(
+            7,
+            None,
+            None,
+            1,
+            "deployment-token".to_string(),
+            vec![temps_entities::deployment_tokens::DeploymentTokenPermission::AiGatewayExecute],
+        );
+        let byok = ByokOverride {
+            api_key: Some("sk-user-key-123".to_string()),
+            base_url: None,
+            system_key_id: None,
+        };
+
+        assert!(reject_deployment_token_base_url(&auth, &byok).is_none());
     }
 
     #[test]

--- a/crates/temps-analytics/src/handler.rs
+++ b/crates/temps-analytics/src/handler.rs
@@ -1871,13 +1871,11 @@ pub async fn get_recent_activity(
     project_scope_guard!(auth, query.project_id);
     project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
-    let environment_id = scoped_recent_activity_environment(&auth, query.environment_id)?;
-
     match app_state
         .analytics_service
         .get_recent_activity(
             query.project_id,
-            environment_id,
+            query.environment_id,
             query.since_id,
             query.limit,
         )
@@ -1888,71 +1886,6 @@ pub async fn get_recent_activity(
             error!("Analytics error: {:?}", e);
             Err(handle_analytics_error(e))
         }
-    }
-}
-
-fn scoped_recent_activity_environment(
-    auth: &temps_auth::AuthContext,
-    requested_environment_id: Option<i32>,
-) -> Result<Option<i32>, Problem> {
-    let Some(token_info) = auth.deployment_token_info() else {
-        return Ok(requested_environment_id);
-    };
-    let Some(scoped_environment_id) = token_info.environment_id else {
-        return Ok(requested_environment_id);
-    };
-
-    if requested_environment_id.is_some_and(|id| id != scoped_environment_id) {
-        return Err(temps_core::problemdetails::new(
-            axum::http::StatusCode::FORBIDDEN,
-        )
-            .with_title("Cross-Environment Access Denied")
-            .with_detail(
-                "This deployment token is scoped to a different environment and cannot access this resource",
-            ));
-    }
-
-    Ok(Some(scoped_environment_id))
-}
-
-#[cfg(test)]
-mod recent_activity_scope_tests {
-    use super::scoped_recent_activity_environment;
-    use temps_auth::AuthContext;
-    use temps_entities::deployment_tokens::DeploymentTokenPermission;
-
-    fn deployment_token(environment_id: Option<i32>) -> AuthContext {
-        AuthContext::new_deployment_token(
-            7,
-            environment_id,
-            Some(70),
-            1,
-            "test-token".to_string(),
-            vec![DeploymentTokenPermission::AnalyticsRead],
-        )
-    }
-
-    #[test]
-    fn environment_scoped_token_forces_its_environment() {
-        let auth = deployment_token(Some(42));
-        assert_eq!(
-            scoped_recent_activity_environment(&auth, None).unwrap(),
-            Some(42)
-        );
-        assert_eq!(
-            scoped_recent_activity_environment(&auth, Some(42)).unwrap(),
-            Some(42)
-        );
-        assert!(scoped_recent_activity_environment(&auth, Some(43)).is_err());
-    }
-
-    #[test]
-    fn project_scoped_token_preserves_environment_filter() {
-        let auth = deployment_token(None);
-        assert_eq!(
-            scoped_recent_activity_environment(&auth, Some(43)).unwrap(),
-            Some(43)
-        );
     }
 }
 

--- a/crates/temps-analytics/src/handler.rs
+++ b/crates/temps-analytics/src/handler.rs
@@ -1871,11 +1871,13 @@ pub async fn get_recent_activity(
     project_scope_guard!(auth, query.project_id);
     project_access_guard!(auth, query.project_id, app_state.project_access_checker);
 
+    let environment_id = scoped_recent_activity_environment(&auth, query.environment_id)?;
+
     match app_state
         .analytics_service
         .get_recent_activity(
             query.project_id,
-            query.environment_id,
+            environment_id,
             query.since_id,
             query.limit,
         )
@@ -1886,6 +1888,71 @@ pub async fn get_recent_activity(
             error!("Analytics error: {:?}", e);
             Err(handle_analytics_error(e))
         }
+    }
+}
+
+fn scoped_recent_activity_environment(
+    auth: &temps_auth::AuthContext,
+    requested_environment_id: Option<i32>,
+) -> Result<Option<i32>, Problem> {
+    let Some(token_info) = auth.deployment_token_info() else {
+        return Ok(requested_environment_id);
+    };
+    let Some(scoped_environment_id) = token_info.environment_id else {
+        return Ok(requested_environment_id);
+    };
+
+    if requested_environment_id.is_some_and(|id| id != scoped_environment_id) {
+        return Err(temps_core::problemdetails::new(
+            axum::http::StatusCode::FORBIDDEN,
+        )
+            .with_title("Cross-Environment Access Denied")
+            .with_detail(
+                "This deployment token is scoped to a different environment and cannot access this resource",
+            ));
+    }
+
+    Ok(Some(scoped_environment_id))
+}
+
+#[cfg(test)]
+mod recent_activity_scope_tests {
+    use super::scoped_recent_activity_environment;
+    use temps_auth::AuthContext;
+    use temps_entities::deployment_tokens::DeploymentTokenPermission;
+
+    fn deployment_token(environment_id: Option<i32>) -> AuthContext {
+        AuthContext::new_deployment_token(
+            7,
+            environment_id,
+            Some(70),
+            1,
+            "test-token".to_string(),
+            vec![DeploymentTokenPermission::AnalyticsRead],
+        )
+    }
+
+    #[test]
+    fn environment_scoped_token_forces_its_environment() {
+        let auth = deployment_token(Some(42));
+        assert_eq!(
+            scoped_recent_activity_environment(&auth, None).unwrap(),
+            Some(42)
+        );
+        assert_eq!(
+            scoped_recent_activity_environment(&auth, Some(42)).unwrap(),
+            Some(42)
+        );
+        assert!(scoped_recent_activity_environment(&auth, Some(43)).is_err());
+    }
+
+    #[test]
+    fn project_scoped_token_preserves_environment_filter() {
+        let auth = deployment_token(None);
+        assert_eq!(
+            scoped_recent_activity_environment(&auth, Some(43)).unwrap(),
+            Some(43)
+        );
     }
 }
 

--- a/crates/temps-auth/src/apikey_handler.rs
+++ b/crates/temps-auth/src/apikey_handler.rs
@@ -416,6 +416,7 @@ pub async fn rotate_api_key(
     Path(api_key_id): Path<i32>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ApiKeysWrite);
+    permission_guard!(auth, ApiKeysCreate);
 
     crate::require_sensitive_action(
         state.sensitive_action_authorizer.as_ref(),

--- a/crates/temps-auth/src/context.rs
+++ b/crates/temps-auth/src/context.rs
@@ -206,23 +206,15 @@ impl AuthContext {
             let required_dt_perm = match permission {
                 Permission::AnalyticsRead => DeploymentTokenPermission::AnalyticsRead,
                 Permission::AnalyticsWrite => DeploymentTokenPermission::VisitorsEnrich,
-                // Deployed apps inject their deployment token as TEMPS_API_TOKEN
-                // and use it to call POST /emails (guarded by EmailsSend). This
-                // is documented, project-scoped machine access, so map it to the
-                // matching deployment-token permission.
                 Permission::EmailsSend => DeploymentTokenPermission::EmailsSend,
-                // Deployed apps also use TEMPS_API_TOKEN to call the AI gateway
-                // (POST /ai/v1/chat/completions, guarded by AiGatewayExecute).
-                // Same documented machine-access pattern as EmailsSend.
                 Permission::AiGatewayExecute => DeploymentTokenPermission::AiGatewayExecute,
-                // Deployed apps read their own environment's feature-flag
-                // snapshot with TEMPS_API_TOKEN. Read-only: a machine
-                // credential baked into a container must never be able to
-                // flip a flag in production, so FlagsWrite/FlagsDelete are
-                // deliberately absent from this bridge.
                 Permission::FlagsRead => DeploymentTokenPermission::FlagsRead,
-                // No implicit bridge from deployment-token permissions to
-                // general control-plane permissions.
+                Permission::BlobRead => DeploymentTokenPermission::BlobRead,
+                Permission::BlobWrite => DeploymentTokenPermission::BlobWrite,
+                Permission::BlobDelete => DeploymentTokenPermission::BlobDelete,
+                Permission::KvRead => DeploymentTokenPermission::KvRead,
+                Permission::KvWrite => DeploymentTokenPermission::KvWrite,
+                Permission::KvDelete => DeploymentTokenPermission::KvDelete,
                 _ => return false,
             };
 
@@ -423,6 +415,17 @@ mod tests {
             "test-token".to_string(),
             permissions,
         )
+    }
+
+    #[test]
+    fn deployment_token_storage_permissions_map_to_standard_permissions() {
+        let blob_read = deployment_token_ctx(7, vec![DeploymentTokenPermission::BlobRead]);
+        assert!(blob_read.has_permission(&Permission::BlobRead));
+        assert!(!blob_read.has_permission(&Permission::BlobWrite));
+
+        let kv_write = deployment_token_ctx(7, vec![DeploymentTokenPermission::KvWrite]);
+        assert!(kv_write.has_permission(&Permission::KvWrite));
+        assert!(!kv_write.has_permission(&Permission::KvDelete));
     }
 
     #[test]

--- a/crates/temps-auth/src/permission_guard.rs
+++ b/crates/temps-auth/src/permission_guard.rs
@@ -282,9 +282,11 @@ macro_rules! project_access_guard {
 ///    out).
 /// 4. Otherwise, `checker.effective_project_permissions(user_id, project_id)`
 ///    is consulted:
-///    - `Ok(None)` → unrestricted from this checker's perspective (no plugin
-///      registered, or the project has no team grants) — the instance-wide
-///      result from step 1 stands.
+///    - `Ok(None)` → no permission-specific opinion, so the guard falls back
+///      to `checker.user_can_access_project(user_id, project_id)` to preserve
+///      the coarse team-membership check for existing checker implementations.
+///      If that coarse check allows, the instance-wide result from step 1
+///      stands; if it denies, this guard returns 403.
 ///    - `Ok(Some(perms))` → the permission must be present in `perms`, else
 ///      403. An empty `perms` denies every project-scoped permission.
 ///    - `Err(_)` → fail-closed, 500. Never a silent allow.
@@ -327,8 +329,49 @@ macro_rules! project_permission_guard {
                             .effective_project_permissions(__user_id, $project_id)
                             .await
                         {
-                            // No opinion from this checker — instance-wide result stands.
-                            Ok(None) => {}
+                            // No permission-specific opinion from this checker —
+                            // preserve the legacy coarse project-access check so
+                            // existing ProjectAccessChecker implementations that only
+                            // implement user_can_access_project() cannot be bypassed.
+                            Ok(None) => {
+                                match __checker
+                                    .user_can_access_project(__user_id, $project_id)
+                                    .await
+                                {
+                                    Ok(true) => {}
+                                    Ok(false) => {
+                                        return Err(temps_core::error_builder::ErrorBuilder::new(
+                                            ::axum::http::StatusCode::FORBIDDEN,
+                                        )
+                                        .type_("https://temps.sh/probs/project-access-denied")
+                                        .title("Project Access Denied")
+                                        .detail(
+                                            "Your team membership does not include access to \
+                                             this project",
+                                        )
+                                        .build());
+                                    }
+                                    Err(__e) => {
+                                        ::tracing::error!(
+                                            project_id = $project_id,
+                                            user_id = __user_id,
+                                            error = %__e,
+                                            "ProjectAccessChecker::user_can_access_project \
+                                             infrastructure failure after no \
+                                             permission-specific opinion — denying access"
+                                        );
+                                        return Err(temps_core::error_builder::ErrorBuilder::new(
+                                            ::axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                                        )
+                                        .type_("https://temps.sh/probs/project-access-check-failed")
+                                        .title("Project Access Check Failed")
+                                        .detail(
+                                            "Could not verify project access; please try again",
+                                        )
+                                        .build());
+                                    }
+                                }
+                            }
                             Ok(Some(__perms)) => {
                                 let __required =
                                     $crate::permissions::Permission::$permission.to_string();
@@ -440,7 +483,10 @@ macro_rules! permission_check {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
 
     use async_trait::async_trait;
     use axum::response::IntoResponse;
@@ -896,6 +942,48 @@ mod tests {
         assert!(
             result.is_ok(),
             "Ok(None) must fall through to the instance-wide result"
+        );
+    }
+
+    struct LegacyDenyChecker {
+        user_can_access_calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ProjectAccessChecker for LegacyDenyChecker {
+        async fn user_can_access_project(
+            &self,
+            _user_id: i32,
+            _project_id: i32,
+        ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+            self.user_can_access_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(false)
+        }
+    }
+
+    #[tokio::test]
+    async fn permission_guard_preserves_legacy_coarse_project_denial() {
+        // A checker compiled before effective_project_permissions() existed only
+        // implements user_can_access_project(). The default permission-specific
+        // response is Ok(None), but project_permission_guard! must still invoke
+        // the legacy coarse access check and deny if it denies.
+        let auth = user_auth(Role::User);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let checker: Arc<dyn ProjectAccessChecker> = Arc::new(LegacyDenyChecker {
+            user_can_access_calls: Arc::clone(&calls),
+        });
+
+        let result = run_permission_guard(&auth, 1, Some(checker)).await;
+        let err = result.expect_err("legacy coarse project denial must still deny");
+        assert_eq!(err.status_code, axum::http::StatusCode::FORBIDDEN);
+        assert_eq!(
+            err.body.get("type").and_then(|v| v.as_str()),
+            Some("https://temps.sh/probs/project-access-denied")
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "project_permission_guard! must fall back to user_can_access_project() on Ok(None)"
         );
     }
 

--- a/crates/temps-backup/src/engines/image_pull.rs
+++ b/crates/temps-backup/src/engines/image_pull.rs
@@ -22,12 +22,7 @@ use temps_backup_core::engine_v2::BackupError;
 /// `engine` is the engine key (e.g. `"control_plane"`, `"postgres_pgdump"`);
 /// errors carry it in logs so failures land on the right engine in the UI.
 pub async fn ensure_image_pulled_v2(image_tag: &str, engine: &str) -> Result<(), BackupError> {
-    let docker = Docker::connect_with_local_defaults().map_err(|e| BackupError::Failed {
-        reason: format!(
-            "ensure_image_pulled_v2 ({}): failed to connect to Docker: {}",
-            engine, e
-        ),
-    })?;
+    let docker = connect_to_docker("ensure_image_pulled_v2", engine)?;
 
     if docker.inspect_image(image_tag).await.is_ok() {
         return Ok(());
@@ -38,11 +33,40 @@ pub async fn ensure_image_pulled_v2(image_tag: &str, engine: &str) -> Result<(),
         engine, "ensure_image_pulled_v2: image not cached, pulling"
     );
 
+    pull_image(&docker, image_tag, engine).await
+}
+
+/// Refresh an image from its registry even if the same tag exists locally.
+///
+/// This is reserved for short-lived helpers that receive credentials. A local
+/// actor must not be able to pre-populate a trusted tag and have that image run
+/// with backup credentials.
+pub async fn force_pull_image_v2(image_tag: &str, engine: &str) -> Result<(), BackupError> {
+    let docker = connect_to_docker("force_pull_image_v2", engine)?;
+
+    info!(
+        image_tag,
+        engine, "force_pull_image_v2: refreshing image from registry"
+    );
+    pull_image(&docker, image_tag, engine).await
+}
+
+fn connect_to_docker(operation: &str, engine: &str) -> Result<Docker, BackupError> {
+    Docker::connect_with_local_defaults().map_err(|error| BackupError::Failed {
+        reason: format!("{operation} ({engine}): failed to connect to Docker: {error}"),
+    })
+}
+
+fn split_image_tag(image_tag: &str) -> (&str, &str) {
+    match image_tag.rsplit_once(':') {
+        Some((image, tag)) if !tag.contains('/') => (image, tag),
+        _ => (image_tag, "latest"),
+    }
+}
+
+async fn pull_image(docker: &Docker, image_tag: &str, engine: &str) -> Result<(), BackupError> {
     use bollard::query_parameters::CreateImageOptionsBuilder;
-    let (image, tag) = match image_tag.split_once(':') {
-        Some((i, t)) => (i, t),
-        None => (image_tag, "latest"),
-    };
+    let (image, tag) = split_image_tag(image_tag);
     let options = CreateImageOptionsBuilder::new()
         .from_image(image)
         .tag(tag)
@@ -64,6 +88,28 @@ pub async fn ensure_image_pulled_v2(image_tag: &str, engine: &str) -> Result<(),
         }
     }
 
-    info!(image_tag, engine, "ensure_image_pulled_v2: pull complete");
+    info!(image_tag, engine, "Docker pull complete");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split_image_tag;
+
+    #[test]
+    fn split_image_tag_handles_explicit_and_implicit_tags() {
+        assert_eq!(
+            split_image_tag("minio/mc:RELEASE.2025-08-13T08-35-41Z"),
+            ("minio/mc", "RELEASE.2025-08-13T08-35-41Z")
+        );
+        assert_eq!(split_image_tag("minio/mc"), ("minio/mc", "latest"));
+    }
+
+    #[test]
+    fn split_image_tag_does_not_treat_registry_port_as_tag() {
+        assert_eq!(
+            split_image_tag("registry.example.test:5000/minio/mc"),
+            ("registry.example.test:5000/minio/mc", "latest")
+        );
+    }
 }

--- a/crates/temps-backup/src/engines/image_pull.rs
+++ b/crates/temps-backup/src/engines/image_pull.rs
@@ -57,20 +57,25 @@ fn connect_to_docker(operation: &str, engine: &str) -> Result<Docker, BackupErro
     })
 }
 
-fn split_image_tag(image_tag: &str) -> (&str, &str) {
+fn split_image_tag(image_tag: &str) -> (&str, Option<&str>) {
+    if image_tag.contains("@sha256:") {
+        return (image_tag, None);
+    }
+
     match image_tag.rsplit_once(':') {
-        Some((image, tag)) if !tag.contains('/') => (image, tag),
-        _ => (image_tag, "latest"),
+        Some((image, tag)) if !tag.contains('/') => (image, Some(tag)),
+        _ => (image_tag, Some("latest")),
     }
 }
 
 async fn pull_image(docker: &Docker, image_tag: &str, engine: &str) -> Result<(), BackupError> {
     use bollard::query_parameters::CreateImageOptionsBuilder;
     let (image, tag) = split_image_tag(image_tag);
-    let options = CreateImageOptionsBuilder::new()
-        .from_image(image)
-        .tag(tag)
-        .build();
+    let mut options = CreateImageOptionsBuilder::new().from_image(image);
+    if let Some(tag) = tag {
+        options = options.tag(tag);
+    }
+    let options = options.build();
 
     let mut stream = docker.create_image(Some(options), None, None);
     while let Some(result) = FuturesStreamExt::next(&mut stream).await {
@@ -100,16 +105,22 @@ mod tests {
     fn split_image_tag_handles_explicit_and_implicit_tags() {
         assert_eq!(
             split_image_tag("minio/mc:RELEASE.2025-08-13T08-35-41Z"),
-            ("minio/mc", "RELEASE.2025-08-13T08-35-41Z")
+            ("minio/mc", Some("RELEASE.2025-08-13T08-35-41Z"))
         );
-        assert_eq!(split_image_tag("minio/mc"), ("minio/mc", "latest"));
+        assert_eq!(split_image_tag("minio/mc"), ("minio/mc", Some("latest")));
     }
 
     #[test]
     fn split_image_tag_does_not_treat_registry_port_as_tag() {
         assert_eq!(
             split_image_tag("registry.example.test:5000/minio/mc"),
-            ("registry.example.test:5000/minio/mc", "latest")
+            ("registry.example.test:5000/minio/mc", Some("latest"))
         );
+    }
+
+    #[test]
+    fn split_image_tag_preserves_digest_reference() {
+        let image = "minio/mc@sha256:0123456789abcdef";
+        assert_eq!(split_image_tag(image), (image, None));
     }
 }

--- a/crates/temps-backup/src/engines/s3_mirror.rs
+++ b/crates/temps-backup/src/engines/s3_mirror.rs
@@ -27,7 +27,7 @@ use super::v2_common;
 use temps_backup_core::engine_v2::{BackupContext, BackupEngine, BackupError, BackupOutcome};
 
 const ENGINE_KEY: &str = "s3_mirror";
-const MC_IMAGE: &str = "minio/mc:latest";
+const MC_IMAGE: &str = "minio/mc:RELEASE.2025-08-13T08-35-41Z";
 
 pub struct S3MirrorDeps {
     pub db: Arc<DatabaseConnection>,
@@ -162,7 +162,10 @@ impl BackupEngine for S3MirrorEngine {
         );
 
         // ── One-shot mc mirror container ─────────────────────────────────────
-        super::image_pull::ensure_image_pulled_v2(MC_IMAGE, ENGINE_KEY).await?;
+        // This helper receives both source and destination credentials. Refresh
+        // the registry tag before each run so a poisoned local cache entry
+        // cannot execute with those secrets.
+        super::image_pull::force_pull_image_v2(MC_IMAGE, ENGINE_KEY).await?;
 
         let env_vars = vec![
             format!(
@@ -308,4 +311,14 @@ async fn list_total_s3_size(
         }
     }
     Ok(total)
+}
+
+#[cfg(test)]
+mod image_tests {
+    use super::MC_IMAGE;
+
+    #[test]
+    fn credentialed_sidecar_uses_release_pinned_image() {
+        assert!(!MC_IMAGE.ends_with(":latest"));
+    }
 }

--- a/crates/temps-backup/src/engines/s3_mirror.rs
+++ b/crates/temps-backup/src/engines/s3_mirror.rs
@@ -27,7 +27,8 @@ use super::v2_common;
 use temps_backup_core::engine_v2::{BackupContext, BackupEngine, BackupError, BackupOutcome};
 
 const ENGINE_KEY: &str = "s3_mirror";
-const MC_IMAGE: &str = "minio/mc:RELEASE.2025-08-13T08-35-41Z";
+const MC_IMAGE: &str =
+    "minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727";
 
 pub struct S3MirrorDeps {
     pub db: Arc<DatabaseConnection>,
@@ -318,7 +319,7 @@ mod image_tests {
     use super::MC_IMAGE;
 
     #[test]
-    fn credentialed_sidecar_uses_release_pinned_image() {
-        assert!(!MC_IMAGE.ends_with(":latest"));
+    fn credentialed_sidecar_uses_immutable_image() {
+        assert!(MC_IMAGE.contains("@sha256:"));
     }
 }

--- a/crates/temps-backup/src/services/backup.rs
+++ b/crates/temps-backup/src/services/backup.rs
@@ -35,6 +35,18 @@ fn shell_escape(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
+fn shell_export_assignment(line: &str) -> Option<String> {
+    let (key, value) = line.split_once('=')?;
+    let valid_key = key
+        .chars()
+        .all(|character| character == '_' || character.is_ascii_alphanumeric())
+        && key
+            .chars()
+            .next()
+            .is_some_and(|character| character == '_' || character.is_ascii_alphabetic());
+    valid_key.then(|| format!("export {key}={}", shell_escape(value)))
+}
+
 /// Classify a backup location into one of the known storage formats.
 /// Returns `None` for non-postgres / unknown locations so the UI can show
 /// a neutral badge without guessing.
@@ -1730,7 +1742,8 @@ impl BackupService {
             "printf '%s\\n' {} > {} && chmod 600 {}",
             env_file_lines
                 .iter()
-                .map(|line| format!("'export {}'", line.replace('\'', "'\\''")))
+                .filter_map(|line| shell_export_assignment(line)
+                    .map(|assignment| shell_escape(&assignment)))
                 .collect::<Vec<_>>()
                 .join(" "),
             walg_env_path,
@@ -8179,6 +8192,15 @@ mod tests {
             classify_backup_format(loc, Some("postgres")),
             Some("pg_dump".to_string())
         );
+    }
+
+    #[test]
+    fn sourced_internal_walg_values_are_shell_quoted() {
+        assert_eq!(
+            shell_export_assignment("WALG_S3_PREFIX=s3://bucket/ok;touch${IFS}/tmp/pwn;#"),
+            Some("export WALG_S3_PREFIX='s3://bucket/ok;touch${IFS}/tmp/pwn;#'".to_string())
+        );
+        assert!(shell_export_assignment("BAD-KEY=value").is_none());
     }
 
     #[test]

--- a/crates/temps-blob/src/handlers/handler.rs
+++ b/crates/temps-blob/src/handlers/handler.rs
@@ -13,7 +13,7 @@ use axum::{
 use bytes::Bytes;
 use futures::TryStreamExt;
 use std::collections::HashMap;
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_scope_guard, RequireAuth};
 use temps_core::problemdetails::{Problem, ProblemDetails};
 use temps_core::RequestMetadata;
 use temps_providers::externalsvc::{ExternalService, ServiceType};
@@ -153,9 +153,12 @@ async fn blob_put(
     Query(query): Query<PutBlobQuery>,
     body: Bytes,
 ) -> Result<impl IntoResponse, Problem> {
+    permission_guard!(auth, BlobWrite);
+
     // Get project ID from query or auth context
     let project_id =
         extract_project_id(&auth, query.project_id, &state.project_access_checker).await?;
+    project_scope_guard!(auth, project_id);
 
     // Use pathname from query or default
     let pathname = query.pathname.as_deref().unwrap_or("upload");
@@ -190,8 +193,11 @@ async fn blob_delete(
     State(state): State<Arc<BlobAppState>>,
     Json(request): Json<DeleteBlobRequest>,
 ) -> Result<impl IntoResponse, Problem> {
+    permission_guard!(auth, BlobDelete);
+
     let project_id =
         extract_project_id(&auth, request.project_id, &state.project_access_checker).await?;
+    project_scope_guard!(auth, project_id);
 
     let deleted = state
         .blob_service
@@ -224,8 +230,11 @@ async fn blob_list(
     State(state): State<Arc<BlobAppState>>,
     Query(query): Query<ListBlobsQuery>,
 ) -> Result<impl IntoResponse, Problem> {
+    permission_guard!(auth, BlobRead);
+
     let project_id =
         extract_project_id(&auth, query.project_id, &state.project_access_checker).await?;
+    project_scope_guard!(auth, project_id);
 
     let options = ListOptions {
         limit: query.limit,
@@ -258,8 +267,12 @@ async fn blob_copy(
     State(state): State<Arc<BlobAppState>>,
     Json(request): Json<CopyBlobRequest>,
 ) -> Result<impl IntoResponse, Problem> {
+    permission_guard!(auth, BlobRead);
+    permission_guard!(auth, BlobWrite);
+
     let project_id =
         extract_project_id(&auth, request.project_id, &state.project_access_checker).await?;
+    project_scope_guard!(auth, project_id);
 
     // Extract pathname from URL (handles both full URLs and relative paths)
     let from_pathname = extract_pathname_from_url(&request.from_url);
@@ -336,22 +349,11 @@ async fn blob_head(
     State(state): State<Arc<BlobAppState>>,
     Path(params): Path<BlobPathParams>,
 ) -> Result<impl IntoResponse, Problem> {
-    // For deployment tokens, verify the token's project matches the path
-    // For API keys/sessions, use the project_id from the path (admins can access any project)
-    let project_id = if let Some(token_project_id) = auth.project_id() {
-        // Deployment token: must match path
-        if token_project_id != params.project_id {
-            return Err(temps_core::problemdetails::new(StatusCode::FORBIDDEN)
-                .with_title("Access Denied")
-                .with_detail("You do not have access to this project's blobs"));
-        }
-        token_project_id
-    } else {
-        // API key/session: use path parameter, then verify the caller may
-        // reach that project (no-op in OSS; enforced with a team-access plugin).
-        authorize_project_access(&auth, params.project_id, &state.project_access_checker).await?;
-        params.project_id
-    };
+    permission_guard!(auth, BlobRead);
+
+    let project_id = params.project_id;
+    project_scope_guard!(auth, project_id);
+    authorize_project_access(&auth, project_id, &state.project_access_checker).await?;
 
     let blob_info = state.blob_service.head(project_id, &params.path).await?;
 
@@ -392,22 +394,11 @@ async fn blob_download(
     State(state): State<Arc<BlobAppState>>,
     Path(params): Path<BlobPathParams>,
 ) -> Result<impl IntoResponse, Problem> {
-    // For deployment tokens, verify the token's project matches the path
-    // For API keys/sessions, use the project_id from the path (admins can access any project)
-    let project_id = if let Some(token_project_id) = auth.project_id() {
-        // Deployment token: must match path
-        if token_project_id != params.project_id {
-            return Err(temps_core::problemdetails::new(StatusCode::FORBIDDEN)
-                .with_title("Access Denied")
-                .with_detail("You do not have access to this project's blobs"));
-        }
-        token_project_id
-    } else {
-        // API key/session: use path parameter, then verify the caller may
-        // reach that project (no-op in OSS; enforced with a team-access plugin).
-        authorize_project_access(&auth, params.project_id, &state.project_access_checker).await?;
-        params.project_id
-    };
+    permission_guard!(auth, BlobRead);
+
+    let project_id = params.project_id;
+    project_scope_guard!(auth, project_id);
+    authorize_project_access(&auth, project_id, &state.project_access_checker).await?;
 
     let (stream, content_type, size) = state
         .blob_service

--- a/crates/temps-cli/src/commands/agent.rs
+++ b/crates/temps-cli/src/commands/agent.rs
@@ -175,6 +175,7 @@ impl AgentCommand {
             {
                 let bridge_slot = overlay_bridge_address.clone();
                 let store = route_store.clone();
+                let proxy_docker = docker.clone();
                 let proxy_shutdown = route_sync_shutdown.clone();
                 tokio::spawn(async move {
                     let bridge_ip = loop {
@@ -195,9 +196,14 @@ impl AgentCommand {
                         }
                         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                     };
-                    if let Err(e) =
-                        temps_agent::internal_proxy::spawn(bridge_ip, 80, store, proxy_shutdown)
-                            .await
+                    if let Err(e) = temps_agent::internal_proxy::spawn(
+                        bridge_ip,
+                        80,
+                        store,
+                        proxy_docker,
+                        proxy_shutdown,
+                    )
+                    .await
                     {
                         tracing::warn!(
                             error = %e,

--- a/crates/temps-cli/src/commands/setup.rs
+++ b/crates/temps-cli/src/commands/setup.rs
@@ -503,6 +503,7 @@ async fn create_git_provider(
     encryption_service: &EncryptionService,
     token: &str,
     github_username: &str,
+    admin_user_id: i32,
 ) -> anyhow::Result<GitProviderCreationResult> {
     // Check if GitHub provider already exists
     let existing = git_providers::Entity::find()
@@ -553,8 +554,19 @@ async fn create_git_provider(
         .await?;
 
     let connection = if let Some(connection) = existing_connection {
-        debug!("GitHub connection for '{}' already exists", github_username);
-        connection
+        if connection.user_id != Some(admin_user_id) {
+            let mut active: git_provider_connections::ActiveModel = connection.into();
+            active.user_id = Set(Some(admin_user_id));
+            let connection = active.update(conn).await?;
+            debug!(
+                "Assigned existing GitHub connection for '{}' to admin user {}",
+                github_username, admin_user_id
+            );
+            connection
+        } else {
+            debug!("GitHub connection for '{}' already exists", github_username);
+            connection
+        }
     } else {
         // Encrypt the PAT token for the connection
         let encrypted_token = encryption_service
@@ -564,7 +576,7 @@ async fn create_git_provider(
         // Create connection
         let new_connection = git_provider_connections::ActiveModel {
             provider_id: Set(provider.id),
-            user_id: Set(None), // No user in CLI setup
+            user_id: Set(Some(admin_user_id)),
             account_name: Set(github_username.to_string()),
             account_type: Set("User".to_string()),
             access_token: Set(Some(encrypted_token)),
@@ -1809,6 +1821,7 @@ impl SetupCommand {
                 &encryption_service,
                 github_token,
                 &github_user.username,
+                user.id,
             ))?;
             print_success("GitHub provider configured");
             print_success(&format!(

--- a/crates/temps-core/src/app_settings.rs
+++ b/crates/temps-core/src/app_settings.rs
@@ -787,9 +787,11 @@ impl Default for MultiNodeSettings {
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(default)]
 pub struct PreviewGatewaySettings {
-    /// Docker image reference for the gateway. Pinned per Temps release.
+    /// Docker image reference for the gateway. Pinned by digest per Temps release.
     /// Operators can override this to test a custom build.
-    #[schema(example = "ghcr.io/gotempsh/temps-preview-gateway:0.1.0")]
+    #[schema(
+        example = "ghcr.io/gotempsh/temps-preview-gateway@sha256:a16d4346f2f857470fdd28c9ed46809f6db4f7e577888d6250338f8d5dcf04b9"
+    )]
     pub image: String,
     /// Host port to publish the gateway on (always bound to 127.0.0.1).
     /// Pingora forwards `ws-*` traffic to this port after authenticating.
@@ -815,7 +817,7 @@ pub struct PreviewGatewaySettings {
 impl Default for PreviewGatewaySettings {
     fn default() -> Self {
         Self {
-            image: "ghcr.io/gotempsh/temps-preview-gateway:0.1.0".to_string(),
+            image: "ghcr.io/gotempsh/temps-preview-gateway@sha256:a16d4346f2f857470fdd28c9ed46809f6db4f7e577888d6250338f8d5dcf04b9".to_string(),
             host_port: 8090,
             auto_upgrade: true,
             shared_secret: String::new(),

--- a/crates/temps-core/src/app_settings.rs
+++ b/crates/temps-core/src/app_settings.rs
@@ -789,7 +789,7 @@ impl Default for MultiNodeSettings {
 pub struct PreviewGatewaySettings {
     /// Docker image reference for the gateway. Pinned per Temps release.
     /// Operators can override this to test a custom build.
-    #[schema(example = "ghcr.io/gotempsh/temps-preview-gateway:latest")]
+    #[schema(example = "ghcr.io/gotempsh/temps-preview-gateway:0.1.0")]
     pub image: String,
     /// Host port to publish the gateway on (always bound to 127.0.0.1).
     /// Pingora forwards `ws-*` traffic to this port after authenticating.
@@ -815,7 +815,7 @@ pub struct PreviewGatewaySettings {
 impl Default for PreviewGatewaySettings {
     fn default() -> Self {
         Self {
-            image: "ghcr.io/gotempsh/temps-preview-gateway:latest".to_string(),
+            image: "ghcr.io/gotempsh/temps-preview-gateway:0.1.0".to_string(),
             host_port: 8090,
             auto_upgrade: true,
             shared_secret: String::new(),

--- a/crates/temps-deployer/src/docker.rs
+++ b/crates/temps-deployer/src/docker.rs
@@ -394,8 +394,9 @@ impl DockerRuntime {
     /// rather than `/tmp` so the bind mount survives a host reboot —
     /// `/tmp` is tmpfs on most Linux distros and gets wiped, leaving
     /// containers with empty `/run/secrets` until the next redeploy.
-    fn secrets_host_dir(&self, container_name: &str) -> PathBuf {
-        self.secrets_root.join(container_name)
+    fn secrets_host_dir(&self, container_name: &str) -> std::io::Result<PathBuf> {
+        validate_secret_dir_name(container_name)?;
+        Ok(self.secrets_root.join(container_name))
     }
 
     /// Resolves the numeric (uid, gid) that the container will run as,
@@ -2029,7 +2030,12 @@ impl ContainerDeployer for DockerRuntime {
         let secrets_bind = if request.secrets.is_empty() {
             None
         } else {
-            let host_dir = self.secrets_host_dir(&request.container_name);
+            let host_dir = self
+                .secrets_host_dir(&request.container_name)
+                .map_err(|e| DeployerError::SecretMountFailed {
+                    container_name: request.container_name.clone(),
+                    reason: format!("derive host dir: {}", e),
+                })?;
             // Resolve the image's USER so we can chown the secret files to
             // the uid that the container will actually run as — otherwise
             // mode-0400 root-owned files are unreadable by nonroot images.
@@ -2307,15 +2313,22 @@ impl ContainerDeployer for DockerRuntime {
         );
         if should_cleanup_secrets {
             if let Some(name) = container_name {
-                let dir = self.secrets_host_dir(&name);
-                if dir.exists() {
-                    if let Err(e) = std::fs::remove_dir_all(&dir) {
-                        warn!(
-                            "Failed to clean up secrets host dir {}: {}",
-                            dir.display(),
-                            e
-                        );
+                match self.secrets_host_dir(&name) {
+                    Ok(dir) if dir.exists() => {
+                        if let Err(e) = std::fs::remove_dir_all(&dir) {
+                            warn!(
+                                "Failed to clean up secrets host dir {}: {}",
+                                dir.display(),
+                                e
+                            );
+                        }
                     }
+                    Ok(_) => {}
+                    Err(error) => warn!(
+                        container_name = %name,
+                        %error,
+                        "Skipping secrets host dir cleanup for invalid container name"
+                    ),
                 }
             }
         }
@@ -2648,6 +2661,26 @@ fn default_secrets_root() -> PathBuf {
                 .join(".temps")
         });
     base.join("secrets")
+}
+
+fn validate_secret_dir_name(name: &str) -> std::io::Result<()> {
+    if name.is_empty()
+        || name == "."
+        || name == ".."
+        || name.contains('/')
+        || name.contains('\\')
+        || name.contains('\0')
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "invalid container name '{}': must be a single path component",
+                name
+            ),
+        ));
+    }
+
+    Ok(())
 }
 
 /// Writes secrets as files into a per-container host directory for Docker
@@ -3270,6 +3303,24 @@ mod docker_tests {
         if let Some(v) = prev_data {
             std::env::set_var("TEMPS_DATA_DIR", v);
         }
+    }
+
+    #[test]
+    fn test_validate_secret_dir_name_rejects_path_traversal_components() {
+        for bad in [
+            "",
+            ".",
+            "..",
+            "../escaped/deployment-1",
+            "a/b",
+            "a\\b",
+            "with\0null",
+        ] {
+            let err = validate_secret_dir_name(bad).unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput, "name={}", bad);
+        }
+
+        validate_secret_dir_name("project-1").unwrap();
     }
 
     #[test]

--- a/crates/temps-deployments/src/handlers/deployment_tokens.rs
+++ b/crates/temps-deployments/src/handlers/deployment_tokens.rs
@@ -323,6 +323,7 @@ async fn rotate_deployment_token(
     Path((project_id, token_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentTokensWrite);
+    permission_guard!(auth, DeploymentTokensCreate);
     project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     let rotated = app_state

--- a/crates/temps-deployments/src/handlers/deployments.rs
+++ b/crates/temps-deployments/src/handlers/deployments.rs
@@ -12,7 +12,7 @@ use axum::{
         ws::{CloseFrame, Message, WebSocket, WebSocketUpgrade},
         Extension, Path, Query, State,
     },
-    http::{header, StatusCode},
+    http::{header, HeaderMap, StatusCode},
     response::IntoResponse,
     routing::{delete, get, post},
     Json,
@@ -180,6 +180,44 @@ fn public_compose_service_url(
     )
 )]
 pub struct DeploymentsApiDoc;
+
+fn validate_websocket_origin(headers: &HeaderMap) -> Result<(), Problem> {
+    let Some(origin) = headers.get(header::ORIGIN) else {
+        return Ok(());
+    };
+    let origin = origin.to_str().map_err(|_| {
+        problemdetails::new(StatusCode::FORBIDDEN)
+            .with_title("Forbidden")
+            .with_detail("WebSocket Origin header is invalid")
+    })?;
+    let origin = url::Url::parse(origin).map_err(|_| {
+        problemdetails::new(StatusCode::FORBIDDEN)
+            .with_title("Forbidden")
+            .with_detail("WebSocket Origin header is not allowed")
+    })?;
+    let host = headers
+        .get(header::HOST)
+        .and_then(|value| value.to_str().ok())
+        .ok_or_else(|| {
+            problemdetails::new(StatusCode::FORBIDDEN)
+                .with_title("Forbidden")
+                .with_detail("WebSocket Host header is required when Origin is present")
+        })?;
+    let origin_authority = origin.host_str().map(|name| match origin.port() {
+        Some(port) => format!("{name}:{port}"),
+        None => name.to_string(),
+    });
+    if origin_authority
+        .as_deref()
+        .is_some_and(|authority| authority.eq_ignore_ascii_case(host.trim()))
+    {
+        return Ok(());
+    }
+    warn!(origin = %origin, host = %host, "Rejected cross-origin WebSocket request");
+    Err(problemdetails::new(StatusCode::FORBIDDEN)
+        .with_title("Forbidden")
+        .with_detail("WebSocket Origin header is not allowed"))
+}
 
 pub fn configure_routes() -> Router<Arc<super::types::AppState>> {
     Router::new()
@@ -1005,10 +1043,12 @@ pub async fn get_container_logs_by_id(
     Path((project_id, environment_id, container_id)): Path<(i32, i32, String)>,
     Query(query): Query<ContainerLogsQuery>,
     RequireAuth(auth): RequireAuth,
+    headers: HeaderMap,
     ws: WebSocketUpgrade,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
     project_access_guard!(auth, project_id, state.project_access_checker);
+    validate_websocket_origin(&headers)?;
 
     debug!(
         "WebSocket request for container {} logs in environment {} of project: {}",
@@ -1199,10 +1239,12 @@ pub async fn get_container_logs(
     Path((project_id, environment_id)): Path<(i32, i32)>,
     Query(query): Query<ContainerLogsQuery>,
     RequireAuth(auth): RequireAuth,
+    headers: HeaderMap,
     ws: WebSocketUpgrade,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
     project_access_guard!(auth, project_id, state.project_access_checker);
+    validate_websocket_origin(&headers)?;
 
     debug!(
         "WebSocket request for container logs in environment {} of project: {}",
@@ -1538,10 +1580,12 @@ pub async fn tail_deployment_job_logs(
     RequireAuth(auth): RequireAuth,
     State(state): State<Arc<AppState>>,
     Path((project_id, deployment_id, job_id)): Path<(i32, i32, String)>,
+    headers: HeaderMap,
     ws: WebSocketUpgrade,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, DeploymentsRead);
     project_access_guard!(auth, project_id, state.project_access_checker);
+    validate_websocket_origin(&headers)?;
 
     debug!(
         "WebSocket request for tailing logs for job {} in deployment {}",
@@ -2379,6 +2423,37 @@ mod tests {
     use temps_logs::{DockerLogService, LogService};
     use tokio::time::{timeout, Duration};
     use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
+
+    fn websocket_origin_headers(origin: &str, host: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::ORIGIN, origin.parse().expect("valid test origin"));
+        headers.insert(header::HOST, host.parse().expect("valid test host"));
+        headers
+    }
+
+    #[test]
+    fn websocket_origin_requires_same_authority() {
+        assert!(validate_websocket_origin(&websocket_origin_headers(
+            "https://console.example.com",
+            "console.example.com"
+        ))
+        .is_ok());
+        assert!(validate_websocket_origin(&websocket_origin_headers(
+            "https://attacker.example.com",
+            "console.example.com"
+        ))
+        .is_err());
+        assert!(validate_websocket_origin(&websocket_origin_headers(
+            "http://localhost:4000",
+            "localhost:3000"
+        ))
+        .is_err());
+    }
+
+    #[test]
+    fn websocket_origin_allows_non_browser_clients_without_origin() {
+        assert!(validate_websocket_origin(&HeaderMap::new()).is_ok());
+    }
 
     #[test]
     fn compose_visit_urls_match_environment_url_for_primary_service() {

--- a/crates/temps-deployments/src/handlers/nodes.rs
+++ b/crates/temps-deployments/src/handlers/nodes.rs
@@ -2634,6 +2634,11 @@ impl From<NodeError> for Problem {
                     .with_title("Insufficient Compatible Nodes")
                     .with_detail(error.to_string())
             }
+            NodeError::PlacementConstraintsUnsatisfied { .. } => {
+                problemdetails::new(StatusCode::CONFLICT)
+                    .with_title("Placement Constraints Unsatisfied")
+                    .with_detail(error.to_string())
+            }
             NodeError::Database(ref e) => {
                 error!("Database error in node operation: {}", e);
                 problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)

--- a/crates/temps-deployments/src/jobs/deploy_image.rs
+++ b/crates/temps-deployments/src/jobs/deploy_image.rs
@@ -3475,10 +3475,10 @@ mod tests {
         }
     }
 
-    /// Test that target_nodes with no matching active nodes falls back to local
+    /// Explicit target constraints must never silently fall back to local.
     #[tokio::test]
-    async fn test_node_scheduling_target_nodes_no_match_falls_back_to_local() {
-        use crate::services::{NodeScheduler, NodeService};
+    async fn test_node_scheduling_target_nodes_no_match_fails_closed() {
+        use crate::services::{NodeError, NodeScheduler, NodeService};
         use sea_orm::{DatabaseBackend, MockDatabase};
         use temps_entities::nodes;
 
@@ -3512,16 +3512,20 @@ mod tests {
 
         // Target node 99 doesn't exist
         let target_ids = vec![99];
-        let assignments = scheduler
+        let error = scheduler
             .schedule_replicas(2, None, Some(&target_ids), false)
             .await
-            .unwrap();
-        assert_eq!(assignments.len(), 2);
-        for a in &assignments {
-            assert!(
-                a.is_local(),
-                "Should fall back to local when no target nodes match"
-            );
+            .expect_err("an unmatched explicit target must not run on the control plane");
+        match error {
+            NodeError::PlacementConstraintsUnsatisfied { excluded } => {
+                assert!(
+                    excluded.contains("no active node matched"),
+                    "unexpected placement diagnostic: {excluded}"
+                );
+            }
+            other => {
+                panic!("expected PlacementConstraintsUnsatisfied, got {other:?}");
+            }
         }
     }
 

--- a/crates/temps-deployments/src/jobs/deploy_image.rs
+++ b/crates/temps-deployments/src/jobs/deploy_image.rs
@@ -3458,7 +3458,7 @@ mod tests {
             .unwrap();
         assert_eq!(assignments.len(), 4);
 
-        // Pool is [Local, worker-a(1), worker-c(3)] → round-robin includes Local
+        // Explicit targets restrict the pool to worker-a(1) and worker-c(3).
         for a in &assignments {
             match a {
                 crate::services::NodeAssignment::Remote { node_id, .. } => {
@@ -3469,7 +3469,7 @@ mod tests {
                     );
                 }
                 crate::services::NodeAssignment::Local => {
-                    // Local (control plane) is always part of the pool
+                    panic!("explicit target nodes must exclude the control plane")
                 }
             }
         }

--- a/crates/temps-deployments/src/jobs/deploy_image.rs
+++ b/crates/temps-deployments/src/jobs/deploy_image.rs
@@ -1080,6 +1080,9 @@ impl DeployImageJob {
                     }
                     | crate::services::node_service::NodeError::PlacementConstraintsUnsatisfied {
                         ..
+                    }
+                    | crate::services::node_service::NodeError::Validation {
+                        ..
                     }),
                 ) => {
                     let msg = format!("Cannot schedule this deployment: {}", e);

--- a/crates/temps-deployments/src/jobs/deploy_image.rs
+++ b/crates/temps-deployments/src/jobs/deploy_image.rs
@@ -1075,9 +1075,12 @@ impl DeployImageJob {
                 // on one machine, which is the opposite of what was asked for,
                 // and reporting it as success would hide that.
                 Err(
-                    e @ crate::services::node_service::NodeError::InsufficientCompatibleNodes {
+                    e @ (crate::services::node_service::NodeError::InsufficientCompatibleNodes {
                         ..
-                    },
+                    }
+                    | crate::services::node_service::NodeError::PlacementConstraintsUnsatisfied {
+                        ..
+                    }),
                 ) => {
                     let msg = format!("Cannot schedule this deployment: {}", e);
                     self.log(context, format!("ERROR: {}", msg)).await?;

--- a/crates/temps-deployments/src/jobs/deploy_image.rs
+++ b/crates/temps-deployments/src/jobs/deploy_image.rs
@@ -274,6 +274,15 @@ pub struct DeploymentJobConfig {
     pub exclude_node_ids: Vec<i32>,
 }
 
+fn has_explicit_placement_constraints(
+    target_node_ids: Option<&[i32]>,
+    target_labels: Option<&serde_json::Value>,
+) -> bool {
+    target_node_ids.is_some()
+        || target_labels
+            .is_some_and(|labels| !labels.as_object().is_some_and(serde_json::Map::is_empty))
+}
+
 impl Default for DeploymentJobConfig {
     fn default() -> Self {
         Self {
@@ -1004,6 +1013,8 @@ impl DeployImageJob {
         let node_assignments = if let Some(ref scheduler) = self.node_scheduler {
             let target_ids = self.config.target_nodes.as_deref();
             let target_labels = self.config.target_labels.as_ref();
+            let has_explicit_constraints =
+                has_explicit_placement_constraints(target_ids, target_labels);
             // Which architectures do we actually have an image for? Nodes that
             // match none of them are excluded from the pool instead of being
             // handed a container that cannot start.
@@ -1089,6 +1100,14 @@ impl DeployImageJob {
                     self.log(context, format!("ERROR: {}", msg)).await?;
                     return Err(WorkflowError::JobExecutionFailed(msg));
                 }
+                Err(e) if has_explicit_constraints => {
+                    let msg = format!(
+                        "Cannot enforce this deployment's placement constraints: {}",
+                        e
+                    );
+                    self.log(context, format!("ERROR: {}", msg)).await?;
+                    return Err(WorkflowError::JobExecutionFailed(msg));
+                }
                 // Any other scheduling error (a transient database failure,
                 // say) historically degrades to a local deployment. That is
                 // still the right call — but only when the control plane can
@@ -1111,8 +1130,20 @@ impl DeployImageJob {
                 }
             }
         } else {
-            // No scheduler injected — pure single-node mode. Same guard: an
-            // image built for another architecture cannot run here either.
+            // A worker-only placement policy cannot be honoured without a
+            // scheduler. Failing closed also protects tests/custom embeddings
+            // that omit the scheduler even though production normally injects it.
+            if has_explicit_placement_constraints(
+                self.config.target_nodes.as_deref(),
+                self.config.target_labels.as_ref(),
+            ) {
+                let msg = "Cannot enforce placement constraints: no node scheduler is configured"
+                    .to_string();
+                self.log(context, format!("ERROR: {}", msg)).await?;
+                return Err(WorkflowError::JobExecutionFailed(msg));
+            }
+            // Pure single-node mode. Same architecture guard: an image built
+            // for another architecture cannot run here either.
             let image_platforms = self.available_image_platforms(image_output).await;
             self.ensure_local_can_run(&image_platforms, context, "no node scheduler is configured")
                 .await?;
@@ -3293,6 +3324,24 @@ mod tests {
     fn test_deployment_job_config_target_nodes_default() {
         let config = DeploymentJobConfig::default();
         assert_eq!(config.target_nodes, None);
+    }
+
+    #[test]
+    fn explicit_placement_constraints_are_fail_closed_for_every_scheduler_error() {
+        assert!(!has_explicit_placement_constraints(None, None));
+        assert!(!has_explicit_placement_constraints(
+            None,
+            Some(&serde_json::json!({}))
+        ));
+        assert!(has_explicit_placement_constraints(Some(&[]), None));
+        assert!(has_explicit_placement_constraints(
+            None,
+            Some(&serde_json::json!({"region": "eu"}))
+        ));
+        assert!(has_explicit_placement_constraints(
+            None,
+            Some(&serde_json::json!(["malformed"]))
+        ));
     }
 
     /// Test that node scheduling produces correct assignments when integrated with DeployImageJob.

--- a/crates/temps-deployments/src/jobs/mark_deployment_complete.rs
+++ b/crates/temps-deployments/src/jobs/mark_deployment_complete.rs
@@ -1819,11 +1819,13 @@ WHERE project.id = $2
     /// Teardown all running/pending deployments for the same environment.
     /// This ensures only one active deployment per environment.
     ///
-    /// After a deployment's containers are torn down, the deployment's state is
-    /// flipped to "stopped" so it is no longer re-scanned by subsequent
+    /// After a deployment's recorded containers are torn down, the deployment's
+    /// state is flipped to "stopped" so it is no longer re-scanned by subsequent
     /// teardown passes — bounding this work regardless of how much deployment
-    /// history accumulates. The route table already points at the new
-    /// deployment (via `environments.current_deployment_id`) before this runs.
+    /// history accumulates. Deployments without authoritative container records
+    /// remain active for a future safe retry. The route table already points at
+    /// the new deployment (via `environments.current_deployment_id`) before this
+    /// runs.
     async fn cancel_previous_deployments(
         &self,
         environment_id: i32,
@@ -2757,7 +2759,10 @@ mod teardown_tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(previous_after.state, "stopped");
+        assert_eq!(
+            previous_after.state, "completed",
+            "deployment must remain retryable when container ownership cannot be verified"
+        );
     }
 
     /// A slow older completion must never tear down a newer deployment that

--- a/crates/temps-deployments/src/jobs/mark_deployment_complete.rs
+++ b/crates/temps-deployments/src/jobs/mark_deployment_complete.rs
@@ -1926,27 +1926,16 @@ WHERE project.id = $2
             };
 
             if containers.is_empty() {
-                // Fallback: no deployment_containers records (pre-migration deployments).
-                // Try to stop the container by its slug name convention: {slug}
-                let slug = &deployment.slug;
+                // A slug is not proof of Docker-container ownership. Name
+                // collisions could otherwise stop or remove an unrelated
+                // container, so only recorded deployment containers are safe.
                 self.log(format!(
-                    "No container records for deployment {} — trying slug-based cleanup: {}",
-                    deployment_id, slug
+                    "No container records for deployment {} — skipping container teardown because ownership cannot be verified",
+                    deployment_id
                 ))
                 .await
                 .ok();
-
-                // Try stop + remove by container name (slug)
-                if let Err(e) = self.container_deployer.stop_container(slug).await {
-                    debug!("Could not stop container by slug {}: {}", slug, e);
-                }
-                if let Err(e) = self.container_deployer.remove_container(slug).await {
-                    debug!("Could not remove container by slug {}: {}", slug, e);
-                } else {
-                    self.log(format!("Removed orphaned container {}", slug))
-                        .await
-                        .ok();
-                }
+                continue;
             }
 
             // Tear down every container concurrently. Each container's
@@ -2738,6 +2727,37 @@ mod teardown_tests {
             "failed deployments must be left untouched"
         );
         assert!(deployer.stopped.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_teardown_without_container_records_never_uses_deployment_slug() {
+        let test_db = match TestDatabase::with_migrations().await {
+            Ok(db) => db,
+            Err(_) => {
+                println!("Postgres not available, skipping");
+                return;
+            }
+        };
+        let db = test_db.connection_arc();
+
+        let (project, env) = seed_project_env(&db).await;
+        let previous =
+            insert_deployment(&db, project.id, env.id, "collision-name", "completed").await;
+        let current = insert_deployment(&db, project.id, env.id, "current", "completed").await;
+
+        let deployer = Arc::new(RecordingDeployer::new());
+        let job = make_job(db.clone(), current.id, deployer.clone());
+        job.cancel_previous_deployments(env.id, current.created_at)
+            .await;
+
+        assert!(deployer.stopped.lock().unwrap().is_empty());
+        assert!(deployer.removed.lock().unwrap().is_empty());
+        let previous_after = deployments::Entity::find_by_id(previous.id)
+            .one(db.as_ref())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(previous_after.state, "stopped");
     }
 
     /// A slow older completion must never tear down a newer deployment that

--- a/crates/temps-deployments/src/jobs/pull_external_image.rs
+++ b/crates/temps-deployments/src/jobs/pull_external_image.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use temps_core::{JobResult, WorkflowContext, WorkflowError, WorkflowTask};
 use temps_logs::{LogLevel, LogService};
 use tracing::{debug, error, info};
+use url::Url;
 
 /// Output from PullExternalImageJob
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -115,6 +116,51 @@ impl PullExternalImageJob {
         self
     }
 
+    /// Extract the explicit registry host from an image reference.
+    pub(crate) fn registry_from_image_ref(image_ref: &str) -> Option<String> {
+        let image_name = Self::image_name_without_tag(image_ref);
+        let registry = image_name.split('/').next()?;
+
+        if registry.contains('.') || registry.contains(':') || registry == "localhost" {
+            Some(registry.to_ascii_lowercase())
+        } else {
+            None
+        }
+    }
+
+    /// Normalize a configured registry URL to the host[:port] Docker uses.
+    pub(crate) fn registry_host_from_url(registry_url: &str) -> Option<String> {
+        let registry_url = registry_url.trim();
+        if registry_url.is_empty() {
+            return None;
+        }
+
+        let parsed = if registry_url.contains("://") {
+            Url::parse(registry_url).ok()?
+        } else {
+            Url::parse(&format!("https://{registry_url}")).ok()?
+        };
+
+        let host = parsed.host_str()?.to_ascii_lowercase();
+        match parsed.port() {
+            Some(port) => Some(format!("{host}:{port}")),
+            None => Some(host),
+        }
+    }
+
+    fn image_name_without_tag(image_ref: &str) -> &str {
+        if let Some(idx) = image_ref.rfind(':') {
+            let potential_tag = &image_ref[idx + 1..];
+            if potential_tag.contains('/') {
+                image_ref
+            } else {
+                &image_ref[..idx]
+            }
+        } else {
+            image_ref
+        }
+    }
+
     /// Parse image reference to extract registry, image name, and tag
     fn parse_image_ref(&self) -> (Option<String>, String, String) {
         let image_ref = &self.image_ref;
@@ -133,13 +179,7 @@ impl PullExternalImageJob {
             (image_ref.as_str(), "latest")
         };
 
-        // Extract registry (before first '/')
-        let parts: Vec<&str> = image_name.split('/').collect();
-        let registry = if parts.len() > 1 && (parts[0].contains('.') || parts[0].contains(':')) {
-            Some(parts[0].to_string())
-        } else {
-            None // Default to Docker Hub
-        };
+        let registry = Self::registry_from_image_ref(image_ref);
 
         (registry, image_name.to_string(), tag.to_string())
     }
@@ -396,6 +436,39 @@ mod tests {
         assert_eq!(registry, Some("myregistry.io".to_string()));
         assert_eq!(image_name, "myregistry.io/app");
         assert_eq!(tag, "latest");
+    }
+
+    #[test]
+    fn registry_from_image_ref_normalizes_explicit_hosts() {
+        assert_eq!(
+            PullExternalImageJob::registry_from_image_ref("GHCR.IO/org/app:v1"),
+            Some("ghcr.io".to_string())
+        );
+        assert_eq!(
+            PullExternalImageJob::registry_from_image_ref("localhost:5000/myapp:v2"),
+            Some("localhost:5000".to_string())
+        );
+        assert_eq!(
+            PullExternalImageJob::registry_from_image_ref("nginx:latest"),
+            None
+        );
+    }
+
+    #[test]
+    fn registry_host_from_url_rejects_invalid_urls_and_normalizes_hosts() {
+        assert_eq!(
+            PullExternalImageJob::registry_host_from_url("https://REGISTRY.example.com/v2"),
+            Some("registry.example.com".to_string())
+        );
+        assert_eq!(
+            PullExternalImageJob::registry_host_from_url("registry.example.com:5000"),
+            Some("registry.example.com:5000".to_string())
+        );
+        assert_eq!(PullExternalImageJob::registry_host_from_url(""), None);
+        assert_eq!(
+            PullExternalImageJob::registry_host_from_url("https://"),
+            None
+        );
     }
 
     /// Even a bare tag already present locally must never satisfy a registry

--- a/crates/temps-deployments/src/jobs/verify_local_image.rs
+++ b/crates/temps-deployments/src/jobs/verify_local_image.rs
@@ -76,6 +76,24 @@ impl std::fmt::Debug for VerifyLocalImageJob {
     }
 }
 
+fn normalize_image_id(id: &str) -> String {
+    id.strip_prefix("sha256:").unwrap_or(id).to_lowercase()
+}
+
+fn image_ids_match(actual_id: &str, expected_id: &str) -> bool {
+    let actual_normalized = normalize_image_id(actual_id);
+    let expected_normalized = normalize_image_id(expected_id);
+
+    if actual_normalized.is_empty() || expected_normalized.is_empty() {
+        return false;
+    }
+    if expected_normalized.len() <= 12 {
+        actual_normalized.starts_with(&expected_normalized)
+    } else {
+        actual_normalized == expected_normalized
+    }
+}
+
 impl VerifyLocalImageJob {
     pub fn new(
         job_id: String,
@@ -172,20 +190,14 @@ impl WorkflowTask for VerifyLocalImageJob {
         let image_id = image_inspect.id.clone().unwrap_or_default();
         let size_bytes = image_inspect.size.unwrap_or(0) as u64;
 
-        // Optionally verify the image ID matches what we expect
+        // Verify the image ID still matches the image that was imported for this deployment.
+        // Docker tags are mutable and shared across the daemon, so a mismatch means deploying
+        // by this tag could run a different image with this deployment's configuration.
         if let Some(ref expected_id) = self.expected_image_id {
-            // Normalize both IDs for comparison (strip sha256: prefix if present)
-            let normalize_id =
-                |id: &str| -> String { id.strip_prefix("sha256:").unwrap_or(id).to_lowercase() };
-
-            let actual_normalized = normalize_id(&image_id);
-            let expected_normalized = normalize_id(expected_id);
-
-            if actual_normalized != expected_normalized {
+            if !image_ids_match(&image_id, expected_id) {
                 let error_msg = format!(
-                    "Image ID mismatch for '{}': expected '{}', found '{}'. Refusing to deploy a changed local image.",
-                    self.image_ref,
-                    expected_id, image_id
+                    "Image ID mismatch for local image '{}': expected '{}', found '{}'. Refusing to deploy mutable tag.",
+                    self.image_ref, expected_id, image_id
                 );
                 error!("{}", error_msg);
                 self.log(LogLevel::Error, &format!("❌ {}", error_msg))
@@ -238,6 +250,29 @@ impl WorkflowTask for VerifyLocalImageJob {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_image_ids_match_full_ids() {
+        assert!(image_ids_match(
+            "sha256:abcdef1234567890",
+            "sha256:abcdef1234567890"
+        ));
+    }
+
+    #[test]
+    fn test_image_ids_match_expected_short_id() {
+        assert!(image_ids_match("sha256:abcdef1234567890", "abcdef123456"));
+    }
+
+    #[test]
+    fn test_image_ids_match_detects_mismatch() {
+        assert!(!image_ids_match("sha256:abcdef1234567890", "123456abcdef"));
+        assert!(!image_ids_match(
+            "sha256:abcdef1234567890",
+            "sha256:abcdef1234560000"
+        ));
+        assert!(!image_ids_match("", ""));
+    }
 
     #[test]
     fn test_extract_tag_with_tag() {

--- a/crates/temps-deployments/src/jobs/verify_local_image.rs
+++ b/crates/temps-deployments/src/jobs/verify_local_image.rs
@@ -365,6 +365,7 @@ mod tests {
         assert!(result
             .message
             .as_deref()
-            .is_some_and(|message| message.contains("Refusing to deploy a changed local image")));
+            .is_some_and(|message| message.contains("Image ID mismatch")
+                && message.contains("Refusing to deploy mutable tag")));
     }
 }

--- a/crates/temps-deployments/src/jobs/verify_local_image.rs
+++ b/crates/temps-deployments/src/jobs/verify_local_image.rs
@@ -87,7 +87,11 @@ fn image_ids_match(actual_id: &str, expected_id: &str) -> bool {
     if actual_normalized.is_empty() || expected_normalized.is_empty() {
         return false;
     }
-    if expected_normalized.len() <= 12 {
+    if expected_normalized.len() == 12
+        && expected_normalized
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+    {
         actual_normalized.starts_with(&expected_normalized)
     } else {
         actual_normalized == expected_normalized
@@ -267,6 +271,8 @@ mod tests {
     #[test]
     fn test_image_ids_match_detects_mismatch() {
         assert!(!image_ids_match("sha256:abcdef1234567890", "123456abcdef"));
+        assert!(!image_ids_match("sha256:abcdef1234567890", "a"));
+        assert!(!image_ids_match("sha256:abcdef1234567890", "not-hex-id!!"));
         assert!(!image_ids_match(
             "sha256:abcdef1234567890",
             "sha256:abcdef1234560000"

--- a/crates/temps-deployments/src/services/deployment_token_service.rs
+++ b/crates/temps-deployments/src/services/deployment_token_service.rs
@@ -1314,7 +1314,14 @@ mod tests {
             DeploymentTokenPermission::AnalyticsRead,
             DeploymentTokenPermission::EventsWrite,
             DeploymentTokenPermission::ErrorsRead,
+            DeploymentTokenPermission::AiGatewayExecute,
             DeploymentTokenPermission::FlagsRead,
+            DeploymentTokenPermission::BlobRead,
+            DeploymentTokenPermission::BlobWrite,
+            DeploymentTokenPermission::BlobDelete,
+            DeploymentTokenPermission::KvRead,
+            DeploymentTokenPermission::KvWrite,
+            DeploymentTokenPermission::KvDelete,
             DeploymentTokenPermission::FullAccess,
         ];
 
@@ -1338,7 +1345,7 @@ mod tests {
     #[test]
     fn test_permission_all() {
         let all = DeploymentTokenPermission::all();
-        assert_eq!(all.len(), 8);
+        assert_eq!(all.len(), 14);
         assert!(all.contains(&DeploymentTokenPermission::VisitorsEnrich));
         assert!(all.contains(&DeploymentTokenPermission::EmailsSend));
         assert!(all.contains(&DeploymentTokenPermission::AnalyticsRead));
@@ -1346,6 +1353,12 @@ mod tests {
         assert!(all.contains(&DeploymentTokenPermission::ErrorsRead));
         assert!(all.contains(&DeploymentTokenPermission::AiGatewayExecute));
         assert!(all.contains(&DeploymentTokenPermission::FlagsRead));
+        assert!(all.contains(&DeploymentTokenPermission::BlobRead));
+        assert!(all.contains(&DeploymentTokenPermission::BlobWrite));
+        assert!(all.contains(&DeploymentTokenPermission::BlobDelete));
+        assert!(all.contains(&DeploymentTokenPermission::KvRead));
+        assert!(all.contains(&DeploymentTokenPermission::KvWrite));
+        assert!(all.contains(&DeploymentTokenPermission::KvDelete));
         assert!(all.contains(&DeploymentTokenPermission::FullAccess));
     }
 
@@ -1574,6 +1587,13 @@ mod tests {
             "events:write",
             "errors:read",
             "ai_gateway:execute",
+            "flags:read",
+            "blob:read",
+            "blob:write",
+            "blob:delete",
+            "kv:read",
+            "kv:write",
+            "kv:delete",
             "*",
         ];
 

--- a/crates/temps-deployments/src/services/job_processor.rs
+++ b/crates/temps-deployments/src/services/job_processor.rs
@@ -1193,6 +1193,10 @@ fn is_automatic_deploy_enabled(
     effective.unwrap_or(false)
 }
 
+fn should_skip_git_push_for_auto_deploy(auto_deploy_enabled: bool, manual_trigger: bool) -> bool {
+    !auto_deploy_enabled && !manual_trigger
+}
+
 // Extracted free function for testing
 async fn process_git_push_event(
     workflow_planner: Arc<WorkflowPlanner>,
@@ -1295,40 +1299,16 @@ async fn process_git_push_event(
         // the answer is false (opt-in, not opt-out). Manual triggers bypass this
         // gate entirely — the user clicked deploy, so they unambiguously want one.
         //
-        // Exception: the FIRST deployment for an environment always runs even when
-        // automatic_deploy=false, so a freshly-created opt-out env still boots.
         let auto_deploy_enabled = is_automatic_deploy_enabled(
             project.deployment_config.as_ref(),
             environment.deployment_config.as_ref(),
         );
-        if !auto_deploy_enabled && !job.manual_trigger {
-            let existing_count = match deployments::Entity::find()
-                .filter(deployments::Column::EnvironmentId.eq(environment.id))
-                .count(db.as_ref())
-                .await
-            {
-                Ok(n) => n,
-                Err(e) => {
-                    error!(
-                        "Failed to count existing deployments for environment {}: {}",
-                        environment.id, e
-                    );
-                    continue;
-                }
-            };
-
-            if existing_count > 0 {
-                info!(
-                    "Skipping push event for project {} environment {} ({}): automatic_deploy is disabled",
-                    project.id, environment.id, environment.name
-                );
-                continue;
-            }
-
+        if should_skip_git_push_for_auto_deploy(auto_deploy_enabled, job.manual_trigger) {
             info!(
-                "Allowing initial deployment for project {} environment {} ({}) despite automatic_deploy=false (no prior deployments)",
+                "Skipping push event for project {} environment {} ({}): automatic_deploy is disabled",
                 project.id, environment.id, environment.name
             );
+            continue;
         } else if job.manual_trigger && !auto_deploy_enabled {
             info!(
                 "Manual trigger for project {} environment {} ({}) — bypassing automatic_deploy=false",
@@ -2851,6 +2831,21 @@ mod tests {
             Some(&project_cfg),
             Some(&env_cfg)
         ));
+    }
+
+    #[test]
+    fn webhook_push_is_skipped_when_auto_deploy_disabled_even_for_first_deploy() {
+        assert!(should_skip_git_push_for_auto_deploy(false, false));
+    }
+
+    #[test]
+    fn manual_trigger_bypasses_auto_deploy_disabled() {
+        assert!(!should_skip_git_push_for_auto_deploy(false, true));
+    }
+
+    #[test]
+    fn auto_deploy_enabled_allows_webhook_push() {
+        assert!(!should_skip_git_push_for_auto_deploy(true, false));
     }
 
     #[test]

--- a/crates/temps-deployments/src/services/job_processor.rs
+++ b/crates/temps-deployments/src/services/job_processor.rs
@@ -2,7 +2,7 @@ use crate::services::workflow_execution_service::WorkflowExecutionService;
 use crate::services::workflow_planner::WorkflowPlanner;
 use sea_orm::{
     sea_query::{Expr, Query},
-    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set,
+    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set, TransactionTrait,
 };
 use serde_json;
 use std::collections::HashMap;
@@ -943,14 +943,30 @@ async fn find_environments_for_branch(
                 "Restoring soft-deleted preview environment {} for branch '{}'",
                 deleted_preview.id, branch_name
             );
+            let deleted_preview_id = deleted_preview.id;
+            let subdomain = deleted_preview.subdomain.clone();
+            let txn = db
+                .begin()
+                .await
+                .map_err(|error| format!("Failed to begin preview restore: {error}"))?;
+            if environments::claim_subdomain(&txn, &subdomain, &[deleted_preview_id])
+                .await
+                .map_err(|error| format!("Failed to claim preview subdomain: {error}"))?
+                .is_some()
+            {
+                return Err(format!("Preview subdomain '{subdomain}' is already in use"));
+            }
             let mut active_env: environments::ActiveModel = deleted_preview.into();
             active_env.deleted_at = Set(None);
             active_env.updated_at = Set(chrono::Utc::now());
             active_env.current_deployment_id = Set(None);
             let restored = active_env
-                .update(db.as_ref())
+                .update(&txn)
                 .await
                 .map_err(|e| format!("Failed to restore preview environment: {}", e))?;
+            txn.commit()
+                .await
+                .map_err(|error| format!("Failed to commit preview restore: {error}"))?;
             return Ok(vec![restored]);
         }
 
@@ -990,10 +1006,11 @@ async fn find_environments_for_branch(
     use chrono::Utc;
     use temps_entities::upstream_config::UpstreamList;
 
+    let subdomain = format!("{}-preview", project.slug);
     let preview_env = environments::ActiveModel {
         name: Set("preview".to_string()),
         slug: Set("preview".to_string()),
-        subdomain: Set(format!("{}-preview", project.slug)),
+        subdomain: Set(subdomain.clone()),
         host: Set(String::new()),
         branch: Set(None), // No specific branch - matches all unmatched branches
         project_id: Set(project.id),
@@ -1008,10 +1025,24 @@ async fn find_environments_for_branch(
         ..Default::default()
     };
 
+    let txn = db
+        .begin()
+        .await
+        .map_err(|error| format!("Failed to begin preview creation: {error}"))?;
+    if environments::claim_subdomain(&txn, &subdomain, &[])
+        .await
+        .map_err(|error| format!("Failed to claim preview subdomain: {error}"))?
+        .is_some()
+    {
+        return Err(format!("Preview subdomain '{subdomain}' is already in use"));
+    }
     let created_env = preview_env
-        .insert(db.as_ref())
+        .insert(&txn)
         .await
         .map_err(|e| format!("Failed to create preview environment: {}", e))?;
+    txn.commit()
+        .await
+        .map_err(|error| format!("Failed to commit preview creation: {error}"))?;
 
     info!(
         "Created generic preview environment '{}' for project {}",
@@ -1054,10 +1085,11 @@ async fn create_preview_environment(
         None
     };
 
+    let subdomain = format!("{}-{}", project.slug, slugified_branch);
     let preview_env = environments::ActiveModel {
         name: Set(slugified_branch.to_string()),
         slug: Set(slugified_branch.to_string()),
-        subdomain: Set(format!("{}-{}", project.slug, slugified_branch)),
+        subdomain: Set(subdomain.clone()),
         host: Set(String::new()),
         branch: Set(Some(branch_name.to_string())), // Link to specific branch (used for both deployment and tracking)
         project_id: Set(project.id),
@@ -1072,10 +1104,24 @@ async fn create_preview_environment(
         ..Default::default()
     };
 
+    let txn = db
+        .begin()
+        .await
+        .map_err(|error| format!("Failed to begin preview creation: {error}"))?;
+    if environments::claim_subdomain(&txn, &subdomain, &[])
+        .await
+        .map_err(|error| format!("Failed to claim preview subdomain: {error}"))?
+        .is_some()
+    {
+        return Err(format!("Preview subdomain '{subdomain}' is already in use"));
+    }
     let created_env = preview_env
-        .insert(db.as_ref())
+        .insert(&txn)
         .await
         .map_err(|e| format!("Failed to create preview environment: {}", e))?;
+    txn.commit()
+        .await
+        .map_err(|error| format!("Failed to commit preview creation: {error}"))?;
 
     info!(
         "Created preview environment '{}' (ID: {}) for branch '{}'",

--- a/crates/temps-deployments/src/services/job_processor.rs
+++ b/crates/temps-deployments/src/services/job_processor.rs
@@ -1006,7 +1006,7 @@ async fn find_environments_for_branch(
     use chrono::Utc;
     use temps_entities::upstream_config::UpstreamList;
 
-    let subdomain = format!("{}-preview", project.slug);
+    let subdomain = format!("{}-preview", project.slug).to_ascii_lowercase();
     let preview_env = environments::ActiveModel {
         name: Set("preview".to_string()),
         slug: Set("preview".to_string()),
@@ -1085,7 +1085,7 @@ async fn create_preview_environment(
         None
     };
 
-    let subdomain = format!("{}-{}", project.slug, slugified_branch);
+    let subdomain = format!("{}-{}", project.slug, slugified_branch).to_ascii_lowercase();
     let preview_env = environments::ActiveModel {
         name: Set(slugified_branch.to_string()),
         slug: Set(slugified_branch.to_string()),

--- a/crates/temps-deployments/src/services/node_scheduler.rs
+++ b/crates/temps-deployments/src/services/node_scheduler.rs
@@ -316,6 +316,14 @@ impl NodeScheduler {
             .list_active(self.heartbeat_threshold_secs)
             .await?;
 
+        let selector_map = labels
+            .map(|selector| {
+                selector.as_object().ok_or_else(|| NodeError::Validation {
+                    message: "target_labels must be a JSON object".to_string(),
+                })
+            })
+            .transpose()?;
+
         let mut platforms: Vec<String> = Vec::new();
         for node in active_nodes {
             if let Some(target_ids) = target_node_ids {
@@ -323,10 +331,8 @@ impl NodeScheduler {
                     continue;
                 }
             }
-            if let Some(selector) = labels {
-                if selector.as_object().map(|m| !m.is_empty()).unwrap_or(false)
-                    && !node_matches_labels(&node.labels, selector)
-                {
+            if let (Some(selector), Some(selector_map)) = (labels, selector_map) {
+                if !selector_map.is_empty() && !node_matches_labels(&node.labels, selector) {
                     continue;
                 }
             }
@@ -450,6 +456,14 @@ impl NodeScheduler {
             .list_active(self.heartbeat_threshold_secs)
             .await?;
 
+        let selector_map = labels
+            .map(|selector| {
+                selector.as_object().ok_or_else(|| NodeError::Validation {
+                    message: "target_labels must be a JSON object".to_string(),
+                })
+            })
+            .transpose()?;
+
         // Filter by target node IDs if specified
         let mut eligible_nodes: Vec<_> = if let Some(target_ids) = target_node_ids {
             active_nodes
@@ -461,11 +475,9 @@ impl NodeScheduler {
         };
 
         // Filter by label selectors if specified
-        if let Some(selector) = labels {
-            if let Some(selector_map) = selector.as_object() {
-                if !selector_map.is_empty() {
-                    eligible_nodes.retain(|node| node_matches_labels(&node.labels, selector));
-                }
+        if let (Some(selector), Some(selector_map)) = (labels, selector_map) {
+            if !selector_map.is_empty() {
+                eligible_nodes.retain(|node| node_matches_labels(&node.labels, selector));
             }
         }
 
@@ -551,9 +563,7 @@ impl NodeScheduler {
         let architecture_exclusions: Vec<&NodeExclusion> =
             exclusions.iter().filter(|e| e.excluded).collect();
         let has_node_constraints = target_node_ids.is_some()
-            || labels
-                .and_then(|selector| selector.as_object())
-                .is_some_and(|selector_map| !selector_map.is_empty());
+            || selector_map.is_some_and(|selector_map| !selector_map.is_empty());
         if has_node_constraints && eligible_nodes.is_empty() {
             let excluded = if architecture_exclusions.is_empty() {
                 "no active node matched the requested node IDs or labels".to_string()
@@ -913,7 +923,7 @@ fn schedule_anti_affinity_least_loaded(
 fn node_matches_labels(node_labels: &serde_json::Value, selector: &serde_json::Value) -> bool {
     let selector_map = match selector.as_object() {
         Some(m) => m,
-        None => return true, // Non-object selector matches everything
+        None => return false, // Public scheduling entry points reject malformed selectors.
     };
 
     let node_map = match node_labels.as_object() {
@@ -2207,6 +2217,22 @@ mod tests {
             error,
             NodeError::PlacementConstraintsUnsatisfied { .. }
         ));
+    }
+
+    #[tokio::test]
+    async fn test_malformed_label_selector_fails_closed() {
+        let node = make_node_with_labels(1, "worker", serde_json::json!({"region": "us"}));
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![node]])
+            .into_connection();
+        let scheduler = NodeScheduler::new(Arc::new(NodeService::new(Arc::new(db))));
+        let malformed = serde_json::json!(["region", "us"]);
+
+        let error = scheduler
+            .schedule_replicas(1, Some(&malformed), None, false)
+            .await
+            .expect_err("a malformed selector must never become unconstrained");
+        assert!(matches!(error, NodeError::Validation { .. }));
     }
 
     // --- Anti-affinity tests ---

--- a/crates/temps-deployments/src/services/node_scheduler.rs
+++ b/crates/temps-deployments/src/services/node_scheduler.rs
@@ -566,7 +566,11 @@ impl NodeScheduler {
             };
             return Err(NodeError::PlacementConstraintsUnsatisfied { excluded });
         }
-        let compatible_slots = usize::from(local_compatible) + eligible_nodes.len();
+        // The control plane has no node ID or worker labels, so it can never
+        // satisfy an explicit worker constraint. Include it only for
+        // unconstrained scheduling.
+        let include_local = local_compatible && !has_node_constraints;
+        let compatible_slots = usize::from(include_local) + eligible_nodes.len();
         if anti_affinity
             && !architecture_exclusions.is_empty()
             && (compatible_slots as u32) < replica_count
@@ -604,7 +608,7 @@ impl NodeScheduler {
         // The control plane joins the pool only when it can actually run the
         // image — on a heterogeneous cluster it is just another node with an
         // architecture.
-        let full_pool: Vec<PoolEntry> = local_compatible
+        let full_pool: Vec<PoolEntry> = include_local
             .then_some(PoolEntry {
                 assignment: NodeAssignment::Local,
                 load_score: None, // Local node has no capacity reporting
@@ -642,7 +646,7 @@ impl NodeScheduler {
                     self.max_load_threshold * 100.0
                 );
                 // Re-build full pool (moved above)
-                local_compatible
+                include_local
                     .then_some(PoolEntry {
                         assignment: NodeAssignment::Local,
                         load_score: None,
@@ -688,7 +692,7 @@ impl NodeScheduler {
                     "All nodes are excluded for anti-affinity, relaxing exclusion"
                 );
                 // Re-build: we can't use pool since it was moved, rebuild from eligible_nodes
-                local_compatible
+                include_local
                     .then_some(PoolEntry {
                         assignment: NodeAssignment::Local,
                         load_score: None,
@@ -1859,7 +1863,9 @@ mod tests {
                         node_id
                     );
                 }
-                NodeAssignment::Local => {}
+                NodeAssignment::Local => {
+                    panic!("explicit target IDs must never schedule on the control plane")
+                }
             }
         }
     }
@@ -2169,12 +2175,15 @@ mod tests {
         assert_eq!(assignments.len(), 4);
 
         for assignment in &assignments {
-            if let NodeAssignment::Remote { node_id, .. } = assignment {
-                assert!(
+            match assignment {
+                NodeAssignment::Remote { node_id, .. } => assert!(
                     *node_id == 1 || *node_id == 3,
                     "Expected node 1 (us) or 3 (asia), got {}",
                     node_id
-                );
+                ),
+                NodeAssignment::Local => {
+                    panic!("explicit labels must never schedule on the control plane")
+                }
             }
         }
     }

--- a/crates/temps-deployments/src/services/node_scheduler.rs
+++ b/crates/temps-deployments/src/services/node_scheduler.rs
@@ -554,15 +554,17 @@ impl NodeScheduler {
             || labels
                 .and_then(|selector| selector.as_object())
                 .is_some_and(|selector_map| !selector_map.is_empty());
-        if has_node_constraints && eligible_nodes.is_empty() && !architecture_exclusions.is_empty()
-        {
-            return Err(NodeError::PlacementConstraintsUnsatisfied {
-                excluded: architecture_exclusions
+        if has_node_constraints && eligible_nodes.is_empty() {
+            let excluded = if architecture_exclusions.is_empty() {
+                "no active node matched the requested node IDs or labels".to_string()
+            } else {
+                architecture_exclusions
                     .iter()
                     .map(|e| e.to_string())
                     .collect::<Vec<_>>()
-                    .join("; "),
-            });
+                    .join("; ")
+            };
+            return Err(NodeError::PlacementConstraintsUnsatisfied { excluded });
         }
         let compatible_slots = usize::from(local_compatible) + eligible_nodes.len();
         if anti_affinity
@@ -591,11 +593,6 @@ impl NodeScheduler {
                         .local_platform()
                         .unwrap_or_else(|| "unknown".to_string()),
                 });
-            }
-            if target_node_ids.is_some() {
-                tracing::warn!(
-                    "No active target nodes found for deployment, falling back to local deployment"
-                );
             }
             return Ok(SchedulingOutcome {
                 assignments: vec![NodeAssignment::Local; replica_count as usize],
@@ -1868,7 +1865,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_schedule_with_target_nodes_none_active_falls_back_to_local() {
+    async fn test_schedule_with_target_nodes_none_active_fails_closed() {
         let node_a = make_node(1, "worker-a");
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
@@ -1878,14 +1875,14 @@ mod tests {
         let scheduler = NodeScheduler::new(node_service);
 
         let target_ids = vec![99];
-        let assignments = scheduler
+        let error = scheduler
             .schedule_replicas(2, None, Some(&target_ids), false)
             .await
-            .unwrap();
-        assert_eq!(assignments.len(), 2);
-        for a in &assignments {
-            assert!(a.is_local());
-        }
+            .expect_err("explicit node constraints must never fall back to local");
+        assert!(matches!(
+            error,
+            NodeError::PlacementConstraintsUnsatisfied { .. }
+        ));
     }
 
     #[test]
@@ -2183,7 +2180,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_schedule_with_labels_no_match_falls_back_to_local() {
+    async fn test_schedule_with_labels_no_match_fails_closed() {
         let node_eu = make_node_with_labels(1, "eu-worker", serde_json::json!({"region": "eu"}));
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
@@ -2193,17 +2190,14 @@ mod tests {
         let scheduler = NodeScheduler::new(node_service);
 
         let labels = serde_json::json!({"region": "us"});
-        let assignments = scheduler
+        let error = scheduler
             .schedule_replicas(2, Some(&labels), None, false)
             .await
-            .unwrap();
-        assert_eq!(assignments.len(), 2);
-        for a in &assignments {
-            assert!(
-                a.is_local(),
-                "Should fall back to local when no labels match"
-            );
-        }
+            .expect_err("label constraints must never fall back to local");
+        assert!(matches!(
+            error,
+            NodeError::PlacementConstraintsUnsatisfied { .. }
+        ));
     }
 
     // --- Anti-affinity tests ---

--- a/crates/temps-deployments/src/services/node_scheduler.rs
+++ b/crates/temps-deployments/src/services/node_scheduler.rs
@@ -550,6 +550,20 @@ impl NodeScheduler {
         // permanent.
         let architecture_exclusions: Vec<&NodeExclusion> =
             exclusions.iter().filter(|e| e.excluded).collect();
+        let has_node_constraints = target_node_ids.is_some()
+            || labels
+                .and_then(|selector| selector.as_object())
+                .is_some_and(|selector_map| !selector_map.is_empty());
+        if has_node_constraints && eligible_nodes.is_empty() && !architecture_exclusions.is_empty()
+        {
+            return Err(NodeError::PlacementConstraintsUnsatisfied {
+                excluded: architecture_exclusions
+                    .iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<_>>()
+                    .join("; "),
+            });
+        }
         let compatible_slots = usize::from(local_compatible) + eligible_nodes.len();
         if anti_affinity
             && !architecture_exclusions.is_empty()
@@ -1150,6 +1164,60 @@ mod tests {
             }
             other => panic!("expected InsufficientCompatibleNodes, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_target_node_excluded_by_architecture_does_not_fallback_to_local() {
+        let scheduler = scheduler_with_nodes(
+            vec![make_node_with_arch(1, "worker-arm", "linux/arm64")],
+            "linux/amd64",
+        );
+
+        let err = scheduler
+            .schedule_replicas_excluding(
+                1,
+                None,
+                Some(&[1]),
+                false,
+                &[],
+                &["linux/amd64".to_string()],
+            )
+            .await
+            .unwrap_err();
+
+        match err {
+            NodeError::PlacementConstraintsUnsatisfied { ref excluded } => {
+                assert!(excluded.contains("worker-arm"), "got: {excluded}");
+                assert!(excluded.contains("linux/arm64"), "got: {excluded}");
+                assert!(excluded.contains("linux/amd64"), "got: {excluded}");
+            }
+            other => panic!("expected PlacementConstraintsUnsatisfied, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_target_label_excluded_by_architecture_does_not_fallback_to_local() {
+        let mut arm = make_node_with_arch(1, "worker-arm", "linux/arm64");
+        arm.labels = serde_json::json!({"tier": "isolated"});
+        let scheduler = scheduler_with_nodes(vec![arm], "linux/amd64");
+        let selector = serde_json::json!({"tier": "isolated"});
+
+        let err = scheduler
+            .schedule_replicas_excluding(
+                1,
+                Some(&selector),
+                None,
+                false,
+                &[],
+                &["linux/amd64".to_string()],
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            NodeError::PlacementConstraintsUnsatisfied { .. }
+        ));
     }
 
     /// A cluster that simply has fewer nodes than replicas keeps the

--- a/crates/temps-deployments/src/services/node_service.rs
+++ b/crates/temps-deployments/src/services/node_service.rs
@@ -52,6 +52,15 @@ pub enum NodeError {
         excluded: String,
     },
 
+    #[error(
+        "Placement constraints selected node(s) that cannot run this image ({excluded}); \
+         refusing to fall back to the control plane"
+    )]
+    PlacementConstraintsUnsatisfied {
+        /// Constrained nodes that were dropped from the pool and why.
+        excluded: String,
+    },
+
     #[error("Database error: {0}")]
     Database(#[from] sea_orm::DbErr),
 }

--- a/crates/temps-deployments/src/services/workflow_execution_service.rs
+++ b/crates/temps-deployments/src/services/workflow_execution_service.rs
@@ -2172,6 +2172,8 @@ impl WorkflowExecutionService {
                     .and_then(|v| v.as_i64())
                     .map(|id| id as i32);
 
+                let image_registry = PullExternalImageJob::registry_from_image_ref(&image_ref);
+
                 let mut job = PullExternalImageJob::new(
                     db_job.job_id.clone(),
                     image_ref,
@@ -2180,19 +2182,37 @@ impl WorkflowExecutionService {
                 )
                 .with_log_service(self.log_service.clone(), db_job.log_id.clone());
 
-                // Pass private registry credentials when configured
+                // Pass private registry credentials only to the configured registry.
                 if let Ok(settings) = self.config_service.get_settings().await {
                     let reg = &settings.docker_registry;
                     if reg.enabled {
-                        if let (Some(username), Some(password)) =
-                            (reg.username.clone(), reg.password.clone())
-                        {
-                            job = job.with_registry_credentials(bollard::auth::DockerCredentials {
-                                username: Some(username),
-                                password: Some(password),
-                                serveraddress: reg.registry_url.clone(),
-                                ..Default::default()
-                            });
+                        if let (Some(username), Some(password), Some(registry_url)) = (
+                            reg.username.clone(),
+                            reg.password.clone(),
+                            reg.registry_url.clone(),
+                        ) {
+                            let configured_registry =
+                                PullExternalImageJob::registry_host_from_url(&registry_url);
+                            if matches!(
+                                (&image_registry, &configured_registry),
+                                (Some(image_registry), Some(configured_registry))
+                                    if image_registry == configured_registry
+                            ) {
+                                job = job.with_registry_credentials(
+                                    bollard::auth::DockerCredentials {
+                                        username: Some(username),
+                                        password: Some(password),
+                                        serveraddress: Some(registry_url),
+                                        ..Default::default()
+                                    },
+                                );
+                            } else {
+                                warn!(
+                                    image_registry = ?image_registry,
+                                    configured_registry = ?configured_registry,
+                                    "Skipping Docker registry credentials because the image registry does not match"
+                                );
+                            }
                         }
                     }
                 }

--- a/crates/temps-deployments/src/services/workflow_execution_service.rs
+++ b/crates/temps-deployments/src/services/workflow_execution_service.rs
@@ -1281,6 +1281,9 @@ impl WorkflowExecutionService {
                             builder = builder.target_platforms(platforms);
                         }
                         Ok(_) => {}
+                        Err(crate::services::node_service::NodeError::Validation { message }) => {
+                            return Err(WorkflowExecutionError::InvalidJobConfig(message));
+                        }
                         // Not being able to enumerate nodes must not block a
                         // build: fall back to the native-only build and let the
                         // deploy path's architecture check catch a mismatch.

--- a/crates/temps-email/src/handlers/domains.rs
+++ b/crates/temps-email/src/handlers/domains.rs
@@ -576,14 +576,13 @@ pub async fn setup_dns(
     // authoritatively covers this email domain. The provider ID is caller
     // input and must not grant access to unrelated DNS credentials.
     let email_domain = &domain_with_dns.domain.domain;
-    let base_domain = extract_base_domain(email_domain);
     let verified_zone = dns_provider_service
-        .find_verified_zone_for_provider(request.dns_provider_id, &base_domain)
+        .find_verified_zone_for_provider(request.dns_provider_id, email_domain)
         .await
         .map_err(|error| {
             error!(
                 provider_id = request.dns_provider_id,
-                domain = %base_domain,
+                domain = %email_domain,
                 %error,
                 "Failed to verify DNS provider authorization"
             );
@@ -591,19 +590,25 @@ pub async fn setup_dns(
                 .detail("Failed to verify DNS provider authorization for this domain")
                 .build()
         })?;
-    if verified_zone.is_none() {
+    let Some(verified_zone) = verified_zone else {
         warn!(
             provider_id = request.dns_provider_id,
-            domain = %base_domain,
+            domain = %email_domain,
             "Rejected email DNS setup through an unrelated provider"
         );
         return Err(bad_request()
             .detail(format!(
                 "DNS provider {} is not authorized to manage {}",
-                request.dns_provider_id, base_domain
+                request.dns_provider_id, email_domain
             ))
             .build());
-    }
+    };
+    let base_domain = verified_zone
+        .domain
+        .trim()
+        .trim_end_matches('.')
+        .trim_start_matches("*.")
+        .to_ascii_lowercase();
 
     // The authorization query above also requires this provider to be active.
     let dns_provider = dns_provider_service
@@ -671,16 +676,6 @@ pub async fn setup_dns(
     };
 
     Ok(Json(response))
-}
-
-/// Extract the base domain from a full domain name
-fn extract_base_domain(domain: &str) -> String {
-    let parts: Vec<&str> = domain.split('.').collect();
-    if parts.len() >= 2 {
-        parts[parts.len() - 2..].join(".")
-    } else {
-        domain.to_string()
-    }
 }
 
 /// Create a single DNS record using the provider

--- a/crates/temps-email/src/handlers/domains.rs
+++ b/crates/temps-email/src/handlers/domains.rs
@@ -572,7 +572,40 @@ pub async fn setup_dns(
             not_found().detail("Email domain not found").build()
         })?;
 
-    // Get the DNS provider
+    // Bind use of the provider credentials to an active, verified zone that
+    // authoritatively covers this email domain. The provider ID is caller
+    // input and must not grant access to unrelated DNS credentials.
+    let email_domain = &domain_with_dns.domain.domain;
+    let base_domain = extract_base_domain(email_domain);
+    let verified_zone = dns_provider_service
+        .find_verified_zone_for_provider(request.dns_provider_id, &base_domain)
+        .await
+        .map_err(|error| {
+            error!(
+                provider_id = request.dns_provider_id,
+                domain = %base_domain,
+                %error,
+                "Failed to verify DNS provider authorization"
+            );
+            internal_server_error()
+                .detail("Failed to verify DNS provider authorization for this domain")
+                .build()
+        })?;
+    if verified_zone.is_none() {
+        warn!(
+            provider_id = request.dns_provider_id,
+            domain = %base_domain,
+            "Rejected email DNS setup through an unrelated provider"
+        );
+        return Err(bad_request()
+            .detail(format!(
+                "DNS provider {} is not authorized to manage {}",
+                request.dns_provider_id, base_domain
+            ))
+            .build());
+    }
+
+    // The authorization query above also requires this provider to be active.
     let dns_provider = dns_provider_service
         .get(request.dns_provider_id)
         .await
@@ -590,10 +623,6 @@ pub async fn setup_dns(
                 .detail(format!("Failed to initialize DNS provider: {}", e))
                 .build()
         })?;
-
-    // Extract the base domain (e.g., "example.com" from "mail.example.com")
-    let email_domain = &domain_with_dns.domain.domain;
-    let base_domain = extract_base_domain(email_domain);
 
     info!(
         "Setting up {} DNS records for {} using provider {}",

--- a/crates/temps-email/src/handlers/emails.rs
+++ b/crates/temps-email/src/handlers/emails.rs
@@ -9,7 +9,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{deny_deployment_token, permission_guard, RequireAuth};
 use temps_core::{
     error_builder::{bad_request, internal_server_error, not_found},
     problemdetails::Problem,
@@ -55,6 +55,7 @@ pub async fn send_email(
     Json(request): Json<SendEmailRequestBody>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, EmailsSend);
+    deny_deployment_token!(auth);
 
     // Validate request
     if request.to.is_empty() {

--- a/crates/temps-entities/src/deployment_tokens.rs
+++ b/crates/temps-entities/src/deployment_tokens.rs
@@ -138,6 +138,18 @@ pub enum DeploymentTokenPermission {
     AiGatewayExecute,
     /// Read feature-flag snapshots for the token's environment
     FlagsRead,
+    /// Read Blob storage data
+    BlobRead,
+    /// Write Blob storage data
+    BlobWrite,
+    /// Delete Blob storage data
+    BlobDelete,
+    /// Read KV store data
+    KvRead,
+    /// Write KV store data
+    KvWrite,
+    /// Delete KV store data
+    KvDelete,
     /// Full access (all permissions)
     FullAccess,
 }
@@ -153,6 +165,12 @@ impl DeploymentTokenPermission {
             DeploymentTokenPermission::ErrorsRead => "errors:read",
             DeploymentTokenPermission::AiGatewayExecute => "ai_gateway:execute",
             DeploymentTokenPermission::FlagsRead => "flags:read",
+            DeploymentTokenPermission::BlobRead => "blob:read",
+            DeploymentTokenPermission::BlobWrite => "blob:write",
+            DeploymentTokenPermission::BlobDelete => "blob:delete",
+            DeploymentTokenPermission::KvRead => "kv:read",
+            DeploymentTokenPermission::KvWrite => "kv:write",
+            DeploymentTokenPermission::KvDelete => "kv:delete",
             DeploymentTokenPermission::FullAccess => "*",
         }
     }
@@ -168,6 +186,12 @@ impl DeploymentTokenPermission {
             "errors:read" => Some(DeploymentTokenPermission::ErrorsRead),
             "ai_gateway:execute" => Some(DeploymentTokenPermission::AiGatewayExecute),
             "flags:read" => Some(DeploymentTokenPermission::FlagsRead),
+            "blob:read" => Some(DeploymentTokenPermission::BlobRead),
+            "blob:write" => Some(DeploymentTokenPermission::BlobWrite),
+            "blob:delete" => Some(DeploymentTokenPermission::BlobDelete),
+            "kv:read" => Some(DeploymentTokenPermission::KvRead),
+            "kv:write" => Some(DeploymentTokenPermission::KvWrite),
+            "kv:delete" => Some(DeploymentTokenPermission::KvDelete),
             "*" | "full_access" => Some(DeploymentTokenPermission::FullAccess),
             _ => None,
         }
@@ -183,6 +207,12 @@ impl DeploymentTokenPermission {
             DeploymentTokenPermission::ErrorsRead,
             DeploymentTokenPermission::AiGatewayExecute,
             DeploymentTokenPermission::FlagsRead,
+            DeploymentTokenPermission::BlobRead,
+            DeploymentTokenPermission::BlobWrite,
+            DeploymentTokenPermission::BlobDelete,
+            DeploymentTokenPermission::KvRead,
+            DeploymentTokenPermission::KvWrite,
+            DeploymentTokenPermission::KvDelete,
             DeploymentTokenPermission::FullAccess,
         ]
     }

--- a/crates/temps-entities/src/environments.rs
+++ b/crates/temps-entities/src/environments.rs
@@ -1,6 +1,9 @@
 use async_trait::async_trait;
 use sea_orm::entity::prelude::*;
-use sea_orm::{ActiveValue::Set, ConnectionTrait, DbErr};
+use sea_orm::{
+    ActiveValue::Set, ConnectionTrait, DatabaseBackend, DatabaseTransaction, DbErr, QueryFilter,
+    Statement,
+};
 use serde::{Deserialize, Serialize};
 use temps_core::DBDateTime;
 
@@ -55,6 +58,30 @@ pub struct Model {
     /// Last proxied request timestamp for on-demand environments.
     /// Persisted periodically by the idle sweep, not on every request.
     pub last_activity_at: Option<DBDateTime>,
+}
+
+/// Serialize a claim on the global preview-hostname namespace and return any
+/// active environment that already owns it. Callers must keep `txn` open until
+/// the corresponding create, restore, or rename is committed.
+pub async fn claim_subdomain(
+    txn: &DatabaseTransaction,
+    subdomain: &str,
+    excluded_environment_ids: &[i32],
+) -> Result<Option<Model>, DbErr> {
+    txn.execute(Statement::from_sql_and_values(
+        DatabaseBackend::Postgres,
+        "SELECT pg_advisory_xact_lock(hashtext($1))",
+        [subdomain.to_string().into()],
+    ))
+    .await?;
+
+    let mut conflict = Entity::find()
+        .filter(Column::Subdomain.eq(subdomain))
+        .filter(Column::DeletedAt.is_null());
+    if !excluded_environment_ids.is_empty() {
+        conflict = conflict.filter(Column::Id.is_not_in(excluded_environment_ids.iter().copied()));
+    }
+    conflict.one(txn).await
 }
 
 impl Model {

--- a/crates/temps-entities/src/environments.rs
+++ b/crates/temps-entities/src/environments.rs
@@ -68,15 +68,21 @@ pub async fn claim_subdomain(
     subdomain: &str,
     excluded_environment_ids: &[i32],
 ) -> Result<Option<Model>, DbErr> {
+    let canonical_subdomain = subdomain.trim().to_ascii_lowercase();
     txn.execute(Statement::from_sql_and_values(
         DatabaseBackend::Postgres,
         "SELECT pg_advisory_xact_lock(hashtext($1))",
-        [subdomain.to_string().into()],
+        [canonical_subdomain.clone().into()],
     ))
     .await?;
 
     let mut conflict = Entity::find()
-        .filter(Column::Subdomain.eq(subdomain))
+        // Include legacy mixed-case rows because DNS and the route store treat
+        // hostnames case-insensitively.
+        .filter(sea_orm::sea_query::Expr::cust_with_values(
+            "LOWER(BTRIM(\"subdomain\")) = $1",
+            [canonical_subdomain],
+        ))
         .filter(Column::DeletedAt.is_null());
     if !excluded_environment_ids.is_empty() {
         conflict = conflict.filter(Column::Id.is_not_in(excluded_environment_ids.iter().copied()));

--- a/crates/temps-environments/src/handlers/types.rs
+++ b/crates/temps-environments/src/handlers/types.rs
@@ -66,7 +66,7 @@ pub struct CreateEnvironmentVariableRequest {
     pub key: String,
     pub value: String,
     pub environment_ids: Vec<i32>,
-    /// Include this environment variable in preview environments (default: true)
+    /// Include this environment variable in preview environments (default: false)
     #[serde(default = "default_include_in_preview")]
     pub include_in_preview: bool,
     /// When true the variable is treated as write-only: never returned in
@@ -97,7 +97,7 @@ pub struct UpdateEnvironmentVariableRequest {
 }
 
 fn default_include_in_preview() -> bool {
-    true
+    false
 }
 
 #[derive(Serialize, Deserialize, ToSchema)]
@@ -518,7 +518,7 @@ pub struct CreateProjectSecretRequest {
     pub value: String,
     #[serde(default)]
     pub environment_ids: Vec<i32>,
-    /// Include this secret in preview environments.
+    /// Include this secret in preview environments (default: false).
     #[serde(default = "default_include_in_preview")]
     pub include_in_preview: bool,
 }
@@ -566,6 +566,35 @@ pub struct GetProjectSecretsQuery {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn env_var_preview_inclusion_requires_explicit_opt_in() {
+        let omitted: CreateEnvironmentVariableRequest = serde_json::from_str(
+            r#"{"key":"DATABASE_URL","value":"redacted","environment_ids":[1]}"#,
+        )
+        .unwrap();
+        let enabled: CreateEnvironmentVariableRequest = serde_json::from_str(
+            r#"{"key":"DATABASE_URL","value":"redacted","environment_ids":[1],"include_in_preview":true}"#,
+        )
+        .unwrap();
+
+        assert!(!omitted.include_in_preview);
+        assert!(enabled.include_in_preview);
+    }
+
+    #[test]
+    fn project_secret_preview_inclusion_requires_explicit_opt_in() {
+        let omitted: CreateProjectSecretRequest =
+            serde_json::from_str(r#"{"key":"API_TOKEN","value":"redacted","environment_ids":[1]}"#)
+                .unwrap();
+        let enabled: CreateProjectSecretRequest = serde_json::from_str(
+            r#"{"key":"API_TOKEN","value":"redacted","environment_ids":[1],"include_in_preview":true}"#,
+        )
+        .unwrap();
+
+        assert!(!omitted.include_in_preview);
+        assert!(enabled.include_in_preview);
+    }
 
     /// The four resource fields must distinguish three JSON states so the UI's
     /// "No limit" action (which sends `null`) actually clears the stored value

--- a/crates/temps-environments/src/services/environment_service.rs
+++ b/crates/temps-environments/src/services/environment_service.rs
@@ -1,6 +1,6 @@
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, ConnectionTrait, DbErr, EntityTrait, QueryFilter, QueryOrder,
-    Set, Statement, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseTransaction, DbErr, EntityTrait,
+    QueryFilter, QueryOrder, Set, Statement, TransactionTrait,
 };
 use serde::Serialize;
 use slug::slugify;
@@ -190,6 +190,39 @@ impl EnvironmentService {
         )
     }
 
+    /// Serialize every activation of a preview hostname and reject an active
+    /// owner. This must be called inside the transaction that creates,
+    /// restores, or renames the environment.
+    async fn claim_environment_subdomain(
+        &self,
+        txn: &DatabaseTransaction,
+        subdomain: &str,
+        excluding_environment_id: Option<i32>,
+    ) -> Result<(), EnvironmentError> {
+        txn.execute(Statement::from_sql_and_values(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT pg_advisory_xact_lock(hashtext($1))",
+            [subdomain.to_string().into()],
+        ))
+        .await
+        .map_err(|error| EnvironmentError::DatabaseConnectionError(error.to_string()))?;
+
+        let mut conflict = environments::Entity::find()
+            .filter(environments::Column::Subdomain.eq(subdomain))
+            .filter(environments::Column::DeletedAt.is_null());
+        if let Some(environment_id) = excluding_environment_id {
+            conflict = conflict.filter(environments::Column::Id.ne(environment_id));
+        }
+
+        if conflict.one(txn).await?.is_some() {
+            return Err(EnvironmentError::InvalidInput(format!(
+                "Subdomain '{}' is already in use",
+                subdomain
+            )));
+        }
+        Ok(())
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub async fn create_environment(
         &self,
@@ -219,11 +252,17 @@ impl EnvironmentService {
                 "Restoring soft-deleted environment {} for branch '{}' in project {}",
                 deleted_env.id, branch, project_id
             );
+            let deleted_env_id = deleted_env.id;
+            let subdomain = deleted_env.subdomain.clone();
+            let txn = self.db.begin().await?;
+            self.claim_environment_subdomain(&txn, &subdomain, Some(deleted_env_id))
+                .await?;
             let mut active_env: environments::ActiveModel = deleted_env.into();
             active_env.deleted_at = Set(None);
             active_env.updated_at = Set(chrono::Utc::now());
             active_env.current_deployment_id = Set(None);
-            let restored = active_env.update(self.db.as_ref()).await?;
+            let restored = active_env.update(&txn).await?;
+            txn.commit().await?;
             return Ok(restored);
         }
 
@@ -235,6 +274,8 @@ impl EnvironmentService {
 
         // Start a transaction for insert + domain creation
         let txn = self.db.begin().await?;
+        self.claim_environment_subdomain(&txn, &main_url, None)
+            .await?;
 
         // Create the new environment
         let new_environment = environments::ActiveModel {
@@ -432,13 +473,25 @@ impl EnvironmentService {
                 "Restoring soft-deleted environment {} for branch '{}'",
                 deleted_env.id, branch
             );
+            let deleted_env_id = deleted_env.id;
+            let subdomain = deleted_env.subdomain.clone();
+            let txn = self
+                .db
+                .begin()
+                .await
+                .map_err(|error| EnvironmentError::Other(error.to_string()))?;
+            self.claim_environment_subdomain(&txn, &subdomain, Some(deleted_env_id))
+                .await?;
             let mut active_env: environments::ActiveModel = deleted_env.into();
             active_env.deleted_at = Set(None);
             active_env.updated_at = Set(chrono::Utc::now());
             let restored = active_env
-                .update(self.db.as_ref())
+                .update(&txn)
                 .await
                 .map_err(|e| EnvironmentError::Other(e.to_string()))?;
+            txn.commit()
+                .await
+                .map_err(|error| EnvironmentError::Other(error.to_string()))?;
             return Ok(restored);
         }
 
@@ -506,6 +559,15 @@ impl EnvironmentService {
                 "Restoring soft-deleted environment {} ('{}') in project {}",
                 deleted_env.id, name, project_id
             );
+            let deleted_env_id = deleted_env.id;
+            let subdomain = deleted_env.subdomain.clone();
+            let txn = self
+                .db
+                .begin()
+                .await
+                .map_err(|error| EnvironmentError::Other(error.to_string()))?;
+            self.claim_environment_subdomain(&txn, &subdomain, Some(deleted_env_id))
+                .await?;
             let mut active_env: environments::ActiveModel = deleted_env.into();
             active_env.deleted_at = Set(None);
             active_env.branch = Set(Some(branch));
@@ -519,9 +581,12 @@ impl EnvironmentService {
                     }));
             }
             let restored = active_env
-                .update(self.db.as_ref())
+                .update(&txn)
                 .await
                 .map_err(|e| EnvironmentError::Other(e.to_string()))?;
+            txn.commit()
+                .await
+                .map_err(|error| EnvironmentError::Other(error.to_string()))?;
             return Ok(restored);
         }
 
@@ -558,6 +623,8 @@ impl EnvironmentService {
             .begin()
             .await
             .map_err(|e| EnvironmentError::Other(e.to_string()))?;
+        self.claim_environment_subdomain(&txn, &main_url, None)
+            .await?;
 
         // Insert the environment
         let environment = new_environment
@@ -825,32 +892,10 @@ impl EnvironmentService {
             .await
             .map_err(|e| EnvironmentError::DatabaseConnectionError(e.to_string()))?;
 
-        // Serialize claims for the same normalized hostname. A row-level lock
-        // cannot protect the "no conflict exists" case, and a new unique index
-        // would fail upgrades that already contain cross-project duplicates.
-        txn.execute(Statement::from_sql_and_values(
-            sea_orm::DatabaseBackend::Postgres,
-            "SELECT pg_advisory_xact_lock(hashtext($1))",
-            [normalized.clone().into()],
-        ))
-        .await
-        .map_err(|e| EnvironmentError::DatabaseConnectionError(e.to_string()))?;
-
-        // Preview hosts are `<subdomain>.<preview-domain>`, so the namespace is
-        // global rather than project-scoped. The advisory lock keeps this check
-        // and the update atomic with respect to competing claims for the name.
-        let conflict = environments::Entity::find()
-            .filter(environments::Column::Subdomain.eq(&normalized))
-            .filter(environments::Column::Id.ne(env_id))
-            .filter(environments::Column::DeletedAt.is_null())
-            .one(&txn)
+        // A row lock cannot protect the "no conflict exists" case, and a new
+        // unique index would fail upgrades that already contain duplicates.
+        self.claim_environment_subdomain(&txn, &normalized, Some(env_id))
             .await?;
-        if conflict.is_some() {
-            return Err(EnvironmentError::InvalidInput(format!(
-                "Subdomain '{}' is already in use",
-                normalized
-            )));
-        }
 
         let previous_subdomain = environment.subdomain.clone();
 

--- a/crates/temps-environments/src/services/environment_service.rs
+++ b/crates/temps-environments/src/services/environment_service.rs
@@ -790,8 +790,8 @@ impl EnvironmentService {
     /// the proxy reloads its route table.
     ///
     /// Returns `InvalidInput` if the slugified value is empty, exceeds the
-    /// DNS label length limit, or collides with another environment in the
-    /// same project.
+    /// DNS label length limit, or collides with another active environment
+    /// globally because preview hostnames are keyed by subdomain.
     pub async fn update_environment_subdomain(
         &self,
         project_id: i32,
@@ -819,18 +819,18 @@ impl EnvironmentService {
             return Ok(environment);
         }
 
-        // Reject collisions with any other environment in the same project.
+        // Preview hosts are `<subdomain>.<preview-domain>`, so the namespace is
+        // global rather than project-scoped.
         let conflict = environments::Entity::find()
-            .filter(environments::Column::ProjectId.eq(project_id))
             .filter(environments::Column::Subdomain.eq(&normalized))
             .filter(environments::Column::Id.ne(env_id))
             .filter(environments::Column::DeletedAt.is_null())
             .one(self.db.as_ref())
             .await?;
-        if let Some(other) = conflict {
+        if conflict.is_some() {
             return Err(EnvironmentError::InvalidInput(format!(
-                "Subdomain '{}' is already used by environment '{}' in this project",
-                normalized, other.name
+                "Subdomain '{}' is already in use",
+                normalized
             )));
         }
 
@@ -1686,6 +1686,38 @@ mod tests {
                 );
             }
             other => panic!("Expected InvalidInput, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_update_subdomain_rejects_conflict_across_projects() {
+        let env = make_env_model(false, false);
+        let conflict = environments::Model {
+            id: 2,
+            name: "victim-production".to_string(),
+            slug: "production".to_string(),
+            subdomain: "victim".to_string(),
+            project_id: 99,
+            ..make_env_model(false, false)
+        };
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![env]])
+            .append_query_results(vec![vec![conflict]])
+            .into_connection();
+        let svc = make_service(db);
+
+        let result = svc
+            .update_environment_subdomain(10, 1, "victim".to_string())
+            .await;
+
+        match result {
+            Err(EnvironmentError::InvalidInput(msg)) => {
+                assert!(msg.contains("already in use"), "got: {msg}");
+                assert!(!msg.contains("victim-production"), "got: {msg}");
+                assert!(!msg.contains("project 99"), "got: {msg}");
+            }
+            other => panic!("Expected InvalidInput, got {other:?}"),
         }
     }
 

--- a/crates/temps-environments/src/services/environment_service.rs
+++ b/crates/temps-environments/src/services/environment_service.rs
@@ -259,7 +259,7 @@ impl EnvironmentService {
         let env_slug = slugify(&name);
 
         // Create main_url using project_slug-env_slug format
-        let main_url = format!("{}-{}", project.slug, env_slug);
+        let main_url = format!("{}-{}", project.slug, env_slug).to_ascii_lowercase();
 
         // Start a transaction for insert + domain creation
         let txn = self.db.begin().await?;
@@ -584,7 +584,7 @@ impl EnvironmentService {
         let env_slug = slugify(&name);
 
         // Create main_url using project_slug-env_slug format
-        let main_url = format!("{}-{}", project.slug, env_slug);
+        let main_url = format!("{}-{}", project.slug, env_slug).to_ascii_lowercase();
 
         // Create the new environment
         let new_environment = environments::ActiveModel {

--- a/crates/temps-environments/src/services/environment_service.rs
+++ b/crates/temps-environments/src/services/environment_service.rs
@@ -819,13 +819,31 @@ impl EnvironmentService {
             return Ok(environment);
         }
 
+        let txn = self
+            .db
+            .begin()
+            .await
+            .map_err(|e| EnvironmentError::DatabaseConnectionError(e.to_string()))?;
+
+        // Serialize claims for the same normalized hostname. A row-level lock
+        // cannot protect the "no conflict exists" case, and a new unique index
+        // would fail upgrades that already contain cross-project duplicates.
+        txn.execute(Statement::from_sql_and_values(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT pg_advisory_xact_lock(hashtext($1))",
+            [normalized.clone().into()],
+        ))
+        .await
+        .map_err(|e| EnvironmentError::DatabaseConnectionError(e.to_string()))?;
+
         // Preview hosts are `<subdomain>.<preview-domain>`, so the namespace is
-        // global rather than project-scoped.
+        // global rather than project-scoped. The advisory lock keeps this check
+        // and the update atomic with respect to competing claims for the name.
         let conflict = environments::Entity::find()
             .filter(environments::Column::Subdomain.eq(&normalized))
             .filter(environments::Column::Id.ne(env_id))
             .filter(environments::Column::DeletedAt.is_null())
-            .one(self.db.as_ref())
+            .one(&txn)
             .await?;
         if conflict.is_some() {
             return Err(EnvironmentError::InvalidInput(format!(
@@ -835,12 +853,6 @@ impl EnvironmentService {
         }
 
         let previous_subdomain = environment.subdomain.clone();
-
-        let txn = self
-            .db
-            .begin()
-            .await
-            .map_err(|e| EnvironmentError::DatabaseConnectionError(e.to_string()))?;
 
         let mut active_model: environments::ActiveModel = environment.clone().into();
         active_model.subdomain = Set(normalized.clone());
@@ -1665,6 +1677,10 @@ mod tests {
             .append_query_results(vec![vec![env]])
             // 2. conflict check returns the sibling env
             .append_query_results(vec![vec![conflict]])
+            .append_exec_results(vec![MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
             .into_connection();
         let svc = make_service(db);
 
@@ -1675,13 +1691,13 @@ mod tests {
         match result {
             Err(EnvironmentError::InvalidInput(msg)) => {
                 assert!(
-                    msg.contains("already used"),
+                    msg.contains("already in use"),
                     "Error should describe conflict: {}",
                     msg
                 );
                 assert!(
-                    msg.contains("production"),
-                    "Error should name the conflicting env: {}",
+                    !msg.contains("production"),
+                    "Error must not disclose the conflicting environment: {}",
                     msg
                 );
             }
@@ -1704,6 +1720,10 @@ mod tests {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results(vec![vec![env]])
             .append_query_results(vec![vec![conflict]])
+            .append_exec_results(vec![MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
             .into_connection();
         let svc = make_service(db);
 

--- a/crates/temps-environments/src/services/environment_service.rs
+++ b/crates/temps-environments/src/services/environment_service.rs
@@ -199,22 +199,11 @@ impl EnvironmentService {
         subdomain: &str,
         excluding_environment_id: Option<i32>,
     ) -> Result<(), EnvironmentError> {
-        txn.execute(Statement::from_sql_and_values(
-            sea_orm::DatabaseBackend::Postgres,
-            "SELECT pg_advisory_xact_lock(hashtext($1))",
-            [subdomain.to_string().into()],
-        ))
-        .await
-        .map_err(|error| EnvironmentError::DatabaseConnectionError(error.to_string()))?;
-
-        let mut conflict = environments::Entity::find()
-            .filter(environments::Column::Subdomain.eq(subdomain))
-            .filter(environments::Column::DeletedAt.is_null());
-        if let Some(environment_id) = excluding_environment_id {
-            conflict = conflict.filter(environments::Column::Id.ne(environment_id));
-        }
-
-        if conflict.one(txn).await?.is_some() {
+        let excluded = excluding_environment_id.into_iter().collect::<Vec<_>>();
+        if environments::claim_subdomain(txn, subdomain, &excluded)
+            .await?
+            .is_some()
+        {
             return Err(EnvironmentError::InvalidInput(format!(
                 "Subdomain '{}' is already in use",
                 subdomain

--- a/crates/temps-git/src/services/git_provider_manager.rs
+++ b/crates/temps-git/src/services/git_provider_manager.rs
@@ -833,55 +833,10 @@ impl GitProviderManager {
                 .map_err(GitProviderManagerError::from);
         }
 
-        // Fallback: PAT or OAuth connection. There is no provider API
-        // to narrow these tokens to (repo, permission) at runtime, so
-        // we hand back the stored long-lived token. This trades the
-        // per-op blast-radius guarantee for the ability to use git at
-        // all — operators who need the strict guarantee should switch
-        // their project to a GitHub App connection. The trade-off is
-        // logged at WARN so audit reviews can see when it kicked in.
-        let provider = self.get_provider(connection.provider_id).await?;
-        let encrypted_token = connection.access_token.as_ref().ok_or_else(|| {
-            GitProviderManagerError::InvalidConfiguration(format!(
-                "Connection {} has no access_token; cannot mint credential",
-                connection_id
-            ))
-        })?;
-        let token = self.decrypt_string(encrypted_token).await?;
-
-        // Username conventions for HTTP Basic auth on git over HTTPS:
-        //   GitHub: `x-access-token` (works for both App tokens and PATs)
-        //   GitLab: `oauth2` (works for both PATs and OAuth tokens)
-        // Anything else: best-effort `x-access-token`. If we ever add
-        // Bitbucket etc. this needs updating.
-        let username = match provider.provider_type.as_str() {
-            "gitlab" => "oauth2",
-            "gitea" => "x-access-token",
-            "bitbucket" => "x-token-auth",
-            _ => "x-access-token",
-        }
-        .to_string();
-
-        tracing::warn!(
-            connection_id,
-            owner = %owner,
-            repo = %repo,
-            ?operation,
-            provider_type = %provider.provider_type,
-            "Minting non-scoped credential from PAT/OAuth connection — \
-             token is NOT narrowed per-op. Switch the project to a \
-             GitHub App connection if per-op scoping is required."
-        );
-
-        Ok(super::git_provider::ScopedTokenGrant {
-            username,
-            password: token,
-            // Stored tokens may have an expiry on the connection row,
-            // but the daemon doesn't depend on it (it re-mints on every
-            // operation anyway). Surface `None` so the helper protocol
-            // doesn't carry a misleading promise.
-            expires_at: connection.token_expires_at,
-        })
+        Err(GitProviderManagerError::InvalidConfiguration(format!(
+            "Connection {} is not backed by a GitHub App installation; PAT/OAuth connections cannot mint scoped per-op tokens",
+            connection_id
+        )))
     }
 
     /// Get decrypted webhook secret for a provider
@@ -1758,6 +1713,22 @@ impl GitProviderManager {
             })?;
 
         Ok(connection)
+    }
+
+    /// Resolve a connection only when it belongs to the authenticated user.
+    /// Returning not-found for both missing and foreign connections avoids an
+    /// ownership oracle at callers that use stored provider credentials.
+    pub async fn get_connection_for_user(
+        &self,
+        connection_id: i32,
+        user_id: i32,
+    ) -> Result<git_provider_connections::Model, GitProviderManagerError> {
+        git_provider_connections::Entity::find()
+            .filter(git_provider_connections::Column::Id.eq(connection_id))
+            .filter(git_provider_connections::Column::UserId.eq(user_id))
+            .one(self.db.as_ref())
+            .await?
+            .ok_or_else(|| GitProviderManagerError::ConnectionNotFound(connection_id.to_string()))
     }
 
     /// Set syncing status for a connection. When flipping to `true`, we also
@@ -5079,6 +5050,7 @@ impl GitProviderManager {
     pub async fn create_repository_and_push_template(
         &self,
         connection_id: i32,
+        user_id: i32,
         repo_name: &str,
         repo_owner: Option<&str>,
         description: Option<&str>,
@@ -5092,8 +5064,9 @@ impl GitProviderManager {
             repo_name, template_url, template_ref, template_subfolder
         );
 
-        // Get the connection and provider
-        let connection = self.get_connection(connection_id).await?;
+        // Repository creation is a credentialed mutation. Do not let a caller
+        // select another user's stored Git connection as a confused deputy.
+        let connection = self.get_connection_for_user(connection_id, user_id).await?;
         let provider_service = self.get_provider_service(connection.provider_id).await?;
         let access_token = self
             .validate_and_refresh_connection_token(connection_id)
@@ -5753,10 +5726,13 @@ impl GitProviderManagerTrait for GitProviderManager {
             }),
             Err(GitProviderManagerError::ProviderError(
                 super::git_provider::GitProviderError::InvalidConfiguration(reason),
-            )) => Err(TraitError::ScopedTokensUnsupported {
-                connection_id,
-                reason,
-            }),
+            ))
+            | Err(GitProviderManagerError::InvalidConfiguration(reason)) => {
+                Err(TraitError::ScopedTokensUnsupported {
+                    connection_id,
+                    reason,
+                })
+            }
             Err(GitProviderManagerError::ConnectionNotFound(_)) => {
                 Err(TraitError::ConnectionNotFound(connection_id))
             }
@@ -6515,6 +6491,76 @@ services:
             .unwrap(),
         );
         Arc::new(temps_config::ConfigService::new(server_config, db))
+    }
+
+    #[tokio::test]
+    async fn scoped_repo_tokens_refuse_pat_connections() {
+        use crate::services::git_provider::ScopedTokenOp;
+        use chrono::Utc;
+        use sea_orm::{DatabaseBackend, MockDatabase};
+
+        let raw_token = "ghp_RAW_LONG_LIVED_PAT_SCOPE_ALL_REPOS";
+        let now = Utc::now();
+        let connection = git_provider_connections::Model {
+            id: 42,
+            provider_id: 7,
+            user_id: Some(1),
+            account_name: "pat-account".to_string(),
+            account_type: "User".to_string(),
+            access_token: Some(raw_token.to_string()),
+            refresh_token: None,
+            token_expires_at: None,
+            refresh_token_expires_at: None,
+            installation_id: None,
+            metadata: None,
+            is_active: true,
+            is_expired: false,
+            syncing: false,
+            last_synced_at: None,
+            synced_repository_count: 0,
+            health_status: "unknown".to_string(),
+            health_message: None,
+            last_health_check_at: None,
+            consecutive_health_failures: 0,
+            created_at: now,
+            updated_at: now,
+        };
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![connection.clone()]])
+                .into_connection(),
+        );
+        let encryption_service = Arc::new(
+            temps_core::EncryptionService::new(
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            )
+            .unwrap(),
+        );
+        let manager = GitProviderManager::new(
+            db.clone(),
+            encryption_service,
+            Arc::new(MockJobQueue) as Arc<dyn JobQueue>,
+            create_test_config_service(db),
+        );
+
+        let error = manager
+            .mint_scoped_repo_token_for_connection(
+                connection.id,
+                "owner",
+                "repo",
+                ScopedTokenOp::Fetch,
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                error,
+                GitProviderManagerError::InvalidConfiguration(ref reason)
+                    if reason.contains("PAT/OAuth connections cannot mint scoped per-op tokens")
+            ),
+            "unexpected error: {error:?}"
+        );
+        assert!(!error.to_string().contains(raw_token));
     }
 
     #[tokio::test]

--- a/crates/temps-kv/src/handlers/handler.rs
+++ b/crates/temps-kv/src/handlers/handler.rs
@@ -10,7 +10,7 @@ use axum::{
     Json, Router,
 };
 use std::collections::HashMap;
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_scope_guard, RequireAuth};
 use temps_core::problemdetails::Problem;
 use temps_core::RequestMetadata;
 use temps_providers::externalsvc::{ExternalService, ServiceType};
@@ -108,8 +108,11 @@ pub async fn kv_get(
     State(state): State<Arc<KvAppState>>,
     Json(request): Json<GetRequest>,
 ) -> Result<impl IntoResponse, Problem> {
+    permission_guard!(auth, KvRead);
+
     let project_id =
         extract_project_id(&auth, request.project_id, &state.project_access_checker).await?;
+    project_scope_guard!(auth, project_id);
 
     let value = state.kv_service.get(project_id, &request.key).await?;
 
@@ -134,8 +137,11 @@ pub async fn kv_set(
     State(state): State<Arc<KvAppState>>,
     Json(request): Json<SetRequest>,
 ) -> Result<impl IntoResponse, Problem> {
+    permission_guard!(auth, KvWrite);
+
     let project_id =
         extract_project_id(&auth, request.project_id, &state.project_access_checker).await?;
+    project_scope_guard!(auth, project_id);
 
     info!(
         "KV SET request: key={}, project_id={}",
@@ -185,8 +191,11 @@ pub async fn kv_del(
     State(state): State<Arc<KvAppState>>,
     Json(request): Json<DelRequest>,
 ) -> Result<impl IntoResponse, Problem> {
+    permission_guard!(auth, KvDelete);
+
     let project_id =
         extract_project_id(&auth, request.project_id, &state.project_access_checker).await?;
+    project_scope_guard!(auth, project_id);
 
     let deleted = state.kv_service.del(project_id, request.keys).await?;
 
@@ -211,8 +220,11 @@ pub async fn kv_incr(
     State(state): State<Arc<KvAppState>>,
     Json(request): Json<IncrRequest>,
 ) -> Result<impl IntoResponse, Problem> {
+    permission_guard!(auth, KvWrite);
+
     let project_id =
         extract_project_id(&auth, request.project_id, &state.project_access_checker).await?;
+    project_scope_guard!(auth, project_id);
 
     let value = match request.amount {
         Some(amount) if amount != 1 => {
@@ -245,8 +257,11 @@ pub async fn kv_expire(
     State(state): State<Arc<KvAppState>>,
     Json(request): Json<ExpireRequest>,
 ) -> Result<impl IntoResponse, Problem> {
+    permission_guard!(auth, KvWrite);
+
     let project_id =
         extract_project_id(&auth, request.project_id, &state.project_access_checker).await?;
+    project_scope_guard!(auth, project_id);
 
     let success = state
         .kv_service
@@ -274,8 +289,11 @@ pub async fn kv_ttl(
     State(state): State<Arc<KvAppState>>,
     Json(request): Json<TtlRequest>,
 ) -> Result<impl IntoResponse, Problem> {
+    permission_guard!(auth, KvRead);
+
     let project_id =
         extract_project_id(&auth, request.project_id, &state.project_access_checker).await?;
+    project_scope_guard!(auth, project_id);
 
     let ttl = state.kv_service.ttl(project_id, &request.key).await?;
 
@@ -300,8 +318,11 @@ pub async fn kv_keys(
     State(state): State<Arc<KvAppState>>,
     Json(request): Json<KeysRequest>,
 ) -> Result<impl IntoResponse, Problem> {
+    permission_guard!(auth, KvRead);
+
     let project_id =
         extract_project_id(&auth, request.project_id, &state.project_access_checker).await?;
+    project_scope_guard!(auth, project_id);
 
     let keys = state.kv_service.keys(project_id, &request.pattern).await?;
 

--- a/crates/temps-migrations/src/migration/m20260815_000001_default_preview_inclusion_off.rs
+++ b/crates/temps-migrations/src/migration/m20260815_000001_default_preview_inclusion_off.rs
@@ -1,0 +1,29 @@
+//! Make preview-environment secret propagation opt-in for existing databases.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "ALTER TABLE env_vars ALTER COLUMN include_in_preview SET DEFAULT FALSE",
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "ALTER TABLE env_vars ALTER COLUMN include_in_preview SET DEFAULT TRUE",
+            )
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/temps-migrations/src/migration/m20260815_000001_default_preview_inclusion_off.rs
+++ b/crates/temps-migrations/src/migration/m20260815_000001_default_preview_inclusion_off.rs
@@ -8,6 +8,31 @@ pub struct Migration;
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Preserve the exact rows changed by this migration so `down()` can
+        // restore prior explicit/default-true behavior without changing rows
+        // that users opt into after the upgrade.
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "CREATE TABLE _temps_m20260815_preview_optout_backup (\
+                    env_var_id INTEGER PRIMARY KEY REFERENCES env_vars(id) ON DELETE CASCADE\
+                 )",
+            )
+            .await?;
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "INSERT INTO _temps_m20260815_preview_optout_backup (env_var_id) \
+                 SELECT id FROM env_vars WHERE include_in_preview = TRUE",
+            )
+            .await?;
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "UPDATE env_vars SET include_in_preview = FALSE \
+                 WHERE include_in_preview = TRUE",
+            )
+            .await?;
         manager
             .get_connection()
             .execute_unprepared(
@@ -23,6 +48,19 @@ impl MigrationTrait for Migration {
             .execute_unprepared(
                 "ALTER TABLE env_vars ALTER COLUMN include_in_preview SET DEFAULT TRUE",
             )
+            .await?;
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "UPDATE env_vars AS env \
+                 SET include_in_preview = TRUE \
+                 FROM _temps_m20260815_preview_optout_backup AS backup \
+                 WHERE env.id = backup.env_var_id",
+            )
+            .await?;
+        manager
+            .get_connection()
+            .execute_unprepared("DROP TABLE _temps_m20260815_preview_optout_backup")
             .await?;
         Ok(())
     }

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -188,6 +188,7 @@ mod m20260811_000001_create_renewal_attempts;
 mod m20260813_000001_add_ai_api_traffic_summary_enabled;
 mod m20260814_000001_create_ai_provider_models;
 mod m20260814_000002_add_ai_summary_preference;
+mod m20260815_000001_default_preview_inclusion_off;
 
 pub struct Migrator;
 
@@ -402,6 +403,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260813_000001_add_ai_api_traffic_summary_enabled::Migration),
             Box::new(m20260814_000001_create_ai_provider_models::Migration),
             Box::new(m20260814_000002_add_ai_summary_preference::Migration),
+            Box::new(m20260815_000001_default_preview_inclusion_off::Migration),
         ]
     }
 }

--- a/crates/temps-migrations/tests/migration_tests.rs
+++ b/crates/temps-migrations/tests/migration_tests.rs
@@ -4,6 +4,98 @@ use testcontainers::{runners::AsyncRunner, GenericImage, ImageExt};
 
 use temps_migrations::Migrator;
 
+async fn env_var_preview_default(db: &DatabaseConnection) -> anyhow::Result<String> {
+    let row = db
+        .query_one(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT column_default \
+             FROM information_schema.columns \
+             WHERE table_schema = 'public' \
+               AND table_name = 'env_vars' \
+               AND column_name = 'include_in_preview'"
+                .to_string(),
+        ))
+        .await?
+        .expect("env_vars.include_in_preview metadata exists");
+    Ok(row.try_get("", "column_default")?)
+}
+
+async fn env_var_preview_value(db: &DatabaseConnection, id: i32) -> anyhow::Result<bool> {
+    let row = db
+        .query_one(sea_orm::Statement::from_sql_and_values(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT include_in_preview FROM env_vars WHERE id = $1",
+            [id.into()],
+        ))
+        .await?
+        .expect("migration fixture env var exists");
+    Ok(row.try_get("", "include_in_preview")?)
+}
+
+#[tokio::test]
+async fn test_preview_inclusion_default_migration_up_and_down() -> anyhow::Result<()> {
+    if external_db_configured() {
+        println!(
+            "Skipping test_preview_inclusion_default_migration_up_and_down: external database configured"
+        );
+        return Ok(());
+    }
+
+    let container = match GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_env_var("POSTGRES_DB", "postgres")
+        .with_env_var("POSTGRES_USER", "postgres")
+        .with_env_var("POSTGRES_PASSWORD", "postgres")
+        .with_env_var("POSTGRES_HOST_AUTH_METHOD", "trust")
+        .with_cmd(vec![
+            "postgres",
+            "-c",
+            "timescaledb.max_background_workers=0",
+        ])
+        .start()
+        .await
+    {
+        Ok(container) => container,
+        Err(error) => {
+            eprintln!(
+                "Skipping test_preview_inclusion_default_migration_up_and_down: Docker unavailable: {error}"
+            );
+            return Ok(());
+        }
+    };
+    let port = container.get_host_port_ipv4(5432).await?;
+    let db_url = format!("postgresql://postgres:postgres@localhost:{port}/postgres");
+    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+    let db = connect_with_retries(&db_url).await?;
+
+    let target = "m20260815_000001_default_preview_inclusion_off";
+    let pre_target_count = Migrator::migrations()
+        .iter()
+        .position(|migration| migration.name() == target)
+        .unwrap_or_else(|| panic!("migration {target} not found in Migrator"));
+    Migrator::up(&db, Some(pre_target_count as u32)).await?;
+    assert_eq!(env_var_preview_default(&db).await?, "true");
+    db.execute_unprepared(
+        "SET session_replication_role = replica; \
+         INSERT INTO env_vars \
+             (id, project_id, key, value, created_at, updated_at) \
+         VALUES \
+             (987654, 987654, 'LEGACY_SECRET', 'encrypted', NOW(), NOW()); \
+         SET session_replication_role = origin;",
+    )
+    .await?;
+    assert!(env_var_preview_value(&db, 987654).await?);
+
+    Migrator::up(&db, Some(1)).await?;
+    assert_eq!(env_var_preview_default(&db).await?, "false");
+    assert!(!env_var_preview_value(&db, 987654).await?);
+
+    Migrator::down(&db, Some(1)).await?;
+    assert_eq!(env_var_preview_default(&db).await?, "true");
+    assert!(env_var_preview_value(&db, 987654).await?);
+
+    Ok(())
+}
+
 /// True when an external database is configured. CI can only *empty* an env
 /// var per matrix entry, not unset it, so empty counts as "not configured" —
 /// otherwise the skip-guards below would fire in the dedicated migrations

--- a/crates/temps-notifications/src/services.rs
+++ b/crates/temps-notifications/src/services.rs
@@ -17,7 +17,7 @@ use temps_core::notifications::{
     EmailMessage, NotificationData, NotificationError as CoreNotificationError,
     NotificationService as CoreNotificationService,
 };
-use temps_core::url_validation::{validate_domain_async, validate_external_url};
+use temps_core::url_validation::{resolve_and_validate_domain, validate_external_url};
 use temps_entities::types::RoleType;
 use temps_entities::{
     notification_preferences, notification_providers, notifications, roles, user_roles, users,
@@ -256,18 +256,37 @@ async fn validate_webhook_url(url: &str) -> Result<()> {
         .host_str()
         .filter(|host| host.parse::<std::net::IpAddr>().is_err())
     {
-        validate_domain_async(domain)
+        let port = parsed.port_or_known_default().ok_or_else(|| {
+            anyhow::anyhow!("Invalid webhook URL '{}': URL has no resolvable port", url)
+        })?;
+        resolve_and_validate_domain(domain, port)
             .await
             .map_err(|error| anyhow::anyhow!("Invalid webhook URL '{}': {}", url, error))?;
     }
     Ok(())
 }
 
-fn webhook_http_client(timeout_secs: u64) -> Result<reqwest::Client> {
-    Ok(reqwest::Client::builder()
+async fn webhook_http_client(url: &str, timeout_secs: u64) -> Result<reqwest::Client> {
+    let parsed = validate_external_url(url)
+        .map_err(|error| anyhow::anyhow!("Invalid webhook URL '{}': {}", url, error))?;
+    let mut builder = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(timeout_secs))
-        .redirect(reqwest::redirect::Policy::none())
-        .build()?)
+        .redirect(reqwest::redirect::Policy::none());
+
+    if let Some(domain) = parsed
+        .host_str()
+        .filter(|host| host.parse::<std::net::IpAddr>().is_err())
+    {
+        let port = parsed.port_or_known_default().ok_or_else(|| {
+            anyhow::anyhow!("Invalid webhook URL '{}': URL has no resolvable port", url)
+        })?;
+        let addrs = resolve_and_validate_domain(domain, port)
+            .await
+            .map_err(|error| anyhow::anyhow!("Invalid webhook URL '{}': {}", url, error))?;
+        builder = builder.resolve_to_addrs(domain, &addrs);
+    }
+
+    Ok(builder.build()?)
 }
 
 /// Cloudflare Email Sending provider.
@@ -1262,8 +1281,7 @@ impl NotificationProvider for WebhookProvider {
     }
 
     async fn send(&self, notification: &Notification) -> Result<()> {
-        validate_webhook_url(&self.url).await?;
-        let client = webhook_http_client(self.timeout_secs)?;
+        let client = webhook_http_client(&self.url, self.timeout_secs).await?;
 
         // Build the payload with all notification data. `_`-prefixed keys are
         // channel-specific payloads (e.g. the email's `_chart_svg`) — drop them
@@ -1317,8 +1335,7 @@ impl NotificationProvider for WebhookProvider {
     }
 
     async fn health_check(&self) -> Result<bool> {
-        validate_webhook_url(&self.url).await?;
-        let client = webhook_http_client(self.timeout_secs)?;
+        let client = webhook_http_client(&self.url, self.timeout_secs).await?;
 
         // Send a test payload
         let test_payload = serde_json::json!({

--- a/crates/temps-notifications/src/services.rs
+++ b/crates/temps-notifications/src/services.rs
@@ -17,6 +17,7 @@ use temps_core::notifications::{
     EmailMessage, NotificationData, NotificationError as CoreNotificationError,
     NotificationService as CoreNotificationService,
 };
+use temps_core::url_validation::{validate_domain_async, validate_external_url};
 use temps_entities::types::RoleType;
 use temps_entities::{
     notification_preferences, notification_providers, notifications, roles, user_roles, users,
@@ -246,6 +247,27 @@ pub struct WebhookProvider {
     /// Request timeout in seconds. Defaults to 30.
     #[serde(default = "default_timeout_secs")]
     pub timeout_secs: u64,
+}
+
+async fn validate_webhook_url(url: &str) -> Result<()> {
+    let parsed = validate_external_url(url)
+        .map_err(|error| anyhow::anyhow!("Invalid webhook URL '{}': {}", url, error))?;
+    if let Some(domain) = parsed
+        .host_str()
+        .filter(|host| host.parse::<std::net::IpAddr>().is_err())
+    {
+        validate_domain_async(domain)
+            .await
+            .map_err(|error| anyhow::anyhow!("Invalid webhook URL '{}': {}", url, error))?;
+    }
+    Ok(())
+}
+
+fn webhook_http_client(timeout_secs: u64) -> Result<reqwest::Client> {
+    Ok(reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(timeout_secs))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()?)
 }
 
 /// Cloudflare Email Sending provider.
@@ -1225,8 +1247,7 @@ impl NotificationProvider for WebhookProvider {
     async fn initialize(&mut self, _db: Arc<DatabaseConnection>) -> Result<()> {
         // Validate webhook URL with full SSRF protection (blocks private IPs,
         // loopback, cloud metadata, link-local, etc.)
-        temps_core::url_validation::validate_external_url(&self.url)
-            .map_err(|e| anyhow::anyhow!("Invalid webhook URL '{}': {}", self.url, e))?;
+        validate_webhook_url(&self.url).await?;
 
         // Validate HTTP method
         let method = self.method.to_uppercase();
@@ -1241,9 +1262,8 @@ impl NotificationProvider for WebhookProvider {
     }
 
     async fn send(&self, notification: &Notification) -> Result<()> {
-        let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(self.timeout_secs))
-            .build()?;
+        validate_webhook_url(&self.url).await?;
+        let client = webhook_http_client(self.timeout_secs)?;
 
         // Build the payload with all notification data. `_`-prefixed keys are
         // channel-specific payloads (e.g. the email's `_chart_svg`) — drop them
@@ -1297,9 +1317,8 @@ impl NotificationProvider for WebhookProvider {
     }
 
     async fn health_check(&self) -> Result<bool> {
-        let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(self.timeout_secs))
-            .build()?;
+        validate_webhook_url(&self.url).await?;
+        let client = webhook_http_client(self.timeout_secs)?;
 
         // Send a test payload
         let test_payload = serde_json::json!({
@@ -3194,7 +3213,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_webhook_ssrf_allows_public_https() {
-        let mut webhook = create_webhook("https://hooks.example.com/webhook");
+        // Use a public literal so this validation test stays deterministic in
+        // offline CI while domain-based targets exercise DNS validation.
+        let mut webhook = create_webhook("https://93.184.216.34/webhook");
         let db = Arc::new(MockDatabase::new(sea_orm::DatabaseBackend::Postgres).into_connection());
         let result = webhook.initialize(db).await;
         assert!(result.is_ok(), "Must allow public HTTPS URLs");

--- a/crates/temps-presets/src/nextjs.rs
+++ b/crates/temps-presets/src/nextjs.rs
@@ -246,21 +246,6 @@ RUN mkdir -p public
 # - ESLint configs
 # - Custom build tools
 
-# Assemble a minimal runtime tree while still in the build stage. Never copy
-# the complete checkout into the final image: it can contain authenticated Git
-# configuration, dotenv files, tests, and other build-only material.
-RUN set -eu; \
-    mkdir -p /runtime; \
-    for path in \
-        package.json package-lock.json npm-shrinkwrap.json \
-        bun.lock yarn.lock pnpm-lock.yaml \
-        node_modules .next public \
-        next.config.js next.config.mjs next.config.ts \
-        drizzle prisma locales messages mydata; \
-    do \
-        if [ -e "$path" ]; then cp -a "$path" /runtime/; fi; \
-    done
-
 # Stage 2: Production using hardened Alpine Node.js
 # Secure: non-root user, package manager removed, full CA certificates for HTTPS
 FROM {run_image} AS runner
@@ -275,13 +260,31 @@ WORKDIR /{project_slug}
             alpine_hardening = NODEJS_ALPINE_SECURITY_HARDENING,
         ));
 
-        // Alpine uses nodejs:nodejs user (uid 1001).
-        dockerfile.push_str(&format!(
-            r#"# Copy sanitized runtime artifacts only
-COPY --from=build --chown=nodejs:nodejs /runtime /{project_slug}
+        // Copy entire project from build stage
+        // This ensures all runtime files are available (drizzle, config, mydata, locales, etc.)
+        // Alpine uses nodejs:nodejs user (uid 1001)
+        match build_system.monorepo_tool {
+            MonorepoTool::None => {
+                dockerfile.push_str(&format!(
+                    r#"# Copy entire project directory to ensure all runtime files are available
+# This includes: node_modules, .next, public, and ANY custom directories (drizzle, mydata, etc.)
+COPY --from=build --chown=nodejs:nodejs /{project_slug} /{project_slug}
 "#,
-            project_slug = project_slug
-        ));
+                    project_slug = project_slug
+                ));
+            }
+            _ => {
+                // For monorepos, copy the subdirectory
+                dockerfile.push_str(&format!(
+                    r#"# Copy entire project directory to ensure all runtime files are available
+# This includes: node_modules, .next, public, and ANY custom directories (drizzle, mydata, etc.)
+COPY --from=build --chown=nodejs:nodejs /{project_slug}/{relative_path} /{project_slug}
+"#,
+                    project_slug = project_slug,
+                    relative_path = relative_path
+                ));
+            }
+        }
 
         // Set environment (already running as nodejs user via USER directive)
         dockerfile.push_str(
@@ -473,17 +476,13 @@ mod tests {
         assert!(result.content.contains("# Change to project subdirectory"));
         assert!(result.content.contains("WORKDIR /test_project/apps/web"));
 
-        // Verify the final image copies only the runtime allowlist assembled in
-        // the build stage, never the complete monorepo subdirectory.
-        assert!(result.content.contains("# Assemble a minimal runtime tree"));
-        assert!(result.content.contains("node_modules .next public"));
+        // Verify entire project directory is copied in production stage (not selective files)
         assert!(result
             .content
-            .contains("drizzle prisma locales messages mydata"));
-        assert!(result
-            .content
-            .contains("COPY --from=build --chown=nodejs:nodejs /runtime /test_project"));
-        assert!(!result.content.contains(
+            .contains("# Copy entire project directory to ensure all runtime files are available"));
+        assert!(result.content.contains("# This includes: node_modules, .next, public, and ANY custom directories (drizzle, mydata, etc.)"));
+        // Verify the copy is from the subdirectory path (apps/web) with nodejs user ownership
+        assert!(result.content.contains(
             "COPY --from=build --chown=nodejs:nodejs /test_project/apps/web /test_project"
         ));
 
@@ -525,12 +524,6 @@ mod tests {
 
         // Verify no subdirectory change
         assert!(!result.content.contains("# Change to project subdirectory"));
-        assert!(result
-            .content
-            .contains("COPY --from=build --chown=nodejs:nodejs /runtime /test_project"));
-        assert!(!result
-            .content
-            .contains("COPY --from=build --chown=nodejs:nodejs /test_project /test_project"));
 
         // Cleanup
         std::fs::remove_dir_all(&temp_dir).ok();

--- a/crates/temps-presets/src/nextjs.rs
+++ b/crates/temps-presets/src/nextjs.rs
@@ -246,6 +246,21 @@ RUN mkdir -p public
 # - ESLint configs
 # - Custom build tools
 
+# Assemble a minimal runtime tree while still in the build stage. Never copy
+# the complete checkout into the final image: it can contain authenticated Git
+# configuration, dotenv files, tests, and other build-only material.
+RUN set -eu; \
+    mkdir -p /runtime; \
+    for path in \
+        package.json package-lock.json npm-shrinkwrap.json \
+        bun.lock yarn.lock pnpm-lock.yaml \
+        node_modules .next public \
+        next.config.js next.config.mjs next.config.ts \
+        drizzle prisma locales messages mydata; \
+    do \
+        if [ -e "$path" ]; then cp -a "$path" /runtime/; fi; \
+    done
+
 # Stage 2: Production using hardened Alpine Node.js
 # Secure: non-root user, package manager removed, full CA certificates for HTTPS
 FROM {run_image} AS runner
@@ -260,31 +275,13 @@ WORKDIR /{project_slug}
             alpine_hardening = NODEJS_ALPINE_SECURITY_HARDENING,
         ));
 
-        // Copy entire project from build stage
-        // This ensures all runtime files are available (drizzle, config, mydata, locales, etc.)
-        // Alpine uses nodejs:nodejs user (uid 1001)
-        match build_system.monorepo_tool {
-            MonorepoTool::None => {
-                dockerfile.push_str(&format!(
-                    r#"# Copy entire project directory to ensure all runtime files are available
-# This includes: node_modules, .next, public, and ANY custom directories (drizzle, mydata, etc.)
-COPY --from=build --chown=nodejs:nodejs /{project_slug} /{project_slug}
+        // Alpine uses nodejs:nodejs user (uid 1001).
+        dockerfile.push_str(&format!(
+            r#"# Copy sanitized runtime artifacts only
+COPY --from=build --chown=nodejs:nodejs /runtime /{project_slug}
 "#,
-                    project_slug = project_slug
-                ));
-            }
-            _ => {
-                // For monorepos, copy the subdirectory
-                dockerfile.push_str(&format!(
-                    r#"# Copy entire project directory to ensure all runtime files are available
-# This includes: node_modules, .next, public, and ANY custom directories (drizzle, mydata, etc.)
-COPY --from=build --chown=nodejs:nodejs /{project_slug}/{relative_path} /{project_slug}
-"#,
-                    project_slug = project_slug,
-                    relative_path = relative_path
-                ));
-            }
-        }
+            project_slug = project_slug
+        ));
 
         // Set environment (already running as nodejs user via USER directive)
         dockerfile.push_str(
@@ -476,13 +473,17 @@ mod tests {
         assert!(result.content.contains("# Change to project subdirectory"));
         assert!(result.content.contains("WORKDIR /test_project/apps/web"));
 
-        // Verify entire project directory is copied in production stage (not selective files)
+        // Verify the final image copies only the runtime allowlist assembled in
+        // the build stage, never the complete monorepo subdirectory.
+        assert!(result.content.contains("# Assemble a minimal runtime tree"));
+        assert!(result.content.contains("node_modules .next public"));
         assert!(result
             .content
-            .contains("# Copy entire project directory to ensure all runtime files are available"));
-        assert!(result.content.contains("# This includes: node_modules, .next, public, and ANY custom directories (drizzle, mydata, etc.)"));
-        // Verify the copy is from the subdirectory path (apps/web) with nodejs user ownership
-        assert!(result.content.contains(
+            .contains("drizzle prisma locales messages mydata"));
+        assert!(result
+            .content
+            .contains("COPY --from=build --chown=nodejs:nodejs /runtime /test_project"));
+        assert!(!result.content.contains(
             "COPY --from=build --chown=nodejs:nodejs /test_project/apps/web /test_project"
         ));
 
@@ -524,6 +525,12 @@ mod tests {
 
         // Verify no subdirectory change
         assert!(!result.content.contains("# Change to project subdirectory"));
+        assert!(result
+            .content
+            .contains("COPY --from=build --chown=nodejs:nodejs /runtime /test_project"));
+        assert!(!result
+            .content
+            .contains("COPY --from=build --chown=nodejs:nodejs /test_project /test_project"));
 
         // Cleanup
         std::fs::remove_dir_all(&temp_dir).ok();

--- a/crates/temps-projects/src/handlers/handlers.rs
+++ b/crates/temps-projects/src/handlers/handlers.rs
@@ -2086,6 +2086,7 @@ pub async fn create_project_from_template(
                     .git_provider_manager
                     .create_repository_and_push_template(
                         connection_id,
+                        auth.user_id(),
                         repository_name,
                         request.repository_owner.as_deref(),
                         Some(&format!("Created from template: {}", template.name)),

--- a/crates/temps-projects/src/services/project.rs
+++ b/crates/temps-projects/src/services/project.rs
@@ -1,10 +1,11 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 use temps_core::url_validation::{redact_url_password, validate_git_url};
 use tracing::{info, warn};
 
 use sea_orm::{
     prelude::Uuid, ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, PaginatorTrait,
-    QueryFilter, QueryOrder, QuerySelect, Set, Statement,
+    QueryFilter, QueryOrder, QuerySelect, Set, Statement, TransactionTrait,
 };
 use temps_core::{
     ForceRouteReloadJob, Job, ProjectCreatedJob, ProjectDeletedJob, ProjectUpdatedJob,
@@ -1319,11 +1320,12 @@ impl ProjectService {
 
         // Update the slug if provided
         if let Some(slug_value) = new_slug {
+            let txn = self.db.begin().await?;
             // Check if the slug is already taken by another project
             let existing = projects::Entity::find()
                 .filter(projects::Column::Slug.eq(&slug_value))
                 .filter(projects::Column::Id.ne(project_id))
-                .one(self.db.as_ref())
+                .one(&txn)
                 .await?;
 
             if existing.is_some() {
@@ -1334,28 +1336,89 @@ impl ProjectService {
             }
 
             let old_slug = project.slug.clone();
-            project.slug = slug_value.clone();
-
-            // Update the project in the database
-            let mut active_project: projects::ActiveModel = project.into();
-            active_project.slug = Set(slug_value.clone());
-            project = active_project.update(self.db.as_ref()).await?;
-
-            // Update the environment_domain in the environment if the slug has changed
-            if old_slug != project.slug {
+            if old_slug != slug_value {
                 let envs = temps_entities::environments::Entity::find()
                     .filter(temps_entities::environments::Column::ProjectId.eq(project_id))
-                    .all(self.db.as_ref())
+                    .all(&txn)
                     .await?;
+                let project_environment_ids = envs.iter().map(|env| env.id).collect::<Vec<_>>();
+                let mut target_subdomains = HashSet::new();
+
+                // Acquire claims in deterministic order to avoid deadlocks when
+                // concurrent project renames touch multiple hostnames.
+                let mut active_claims = envs
+                    .iter()
+                    .filter(|env| env.deleted_at.is_none())
+                    .map(|env| (format!("{}-{}", slug_value, env.slug), env.id))
+                    .collect::<Vec<_>>();
+                active_claims.sort_unstable();
+                for (new_subdomain, _) in &active_claims {
+                    if !target_subdomains.insert(new_subdomain.clone()) {
+                        return Err(ProjectError::InvalidInput(format!(
+                            "Project slug '{}' would create duplicate environment subdomain '{}'",
+                            slug_value, new_subdomain
+                        )));
+                    }
+                    if temps_entities::environments::claim_subdomain(
+                        &txn,
+                        new_subdomain,
+                        &project_environment_ids,
+                    )
+                    .await?
+                    .is_some()
+                    {
+                        return Err(ProjectError::InvalidInput(format!(
+                            "Project slug '{}' would use an environment subdomain that is already in use",
+                            slug_value
+                        )));
+                    }
+                }
+
+                project.slug = slug_value.clone();
+                let mut active_project: projects::ActiveModel = project.clone().into();
+                active_project.slug = Set(slug_value.clone());
+                active_project.update(&txn).await?;
 
                 for env in envs {
-                    let new_subdomain = format!("{}-{}", slug_value.clone(), env.slug);
+                    let previous_subdomain = env.subdomain.clone();
+                    let new_subdomain = format!("{}-{}", slug_value, env.slug);
 
-                    // Update environment
+                    // Keep the environment and its auto-managed domain row in
+                    // the same transaction as the project rename.
                     let mut active_env: temps_entities::environments::ActiveModel = env.into();
                     active_env.subdomain = Set(new_subdomain.clone());
-                    active_env.update(self.db.as_ref()).await?;
+                    let updated_env = active_env.update(&txn).await?;
+
+                    let existing_domain = temps_entities::environment_domains::Entity::find()
+                        .filter(
+                            temps_entities::environment_domains::Column::EnvironmentId
+                                .eq(updated_env.id),
+                        )
+                        .filter(
+                            temps_entities::environment_domains::Column::Domain
+                                .eq(&previous_subdomain),
+                        )
+                        .one(&txn)
+                        .await?;
+                    if let Some(domain) = existing_domain {
+                        let mut active_domain: temps_entities::environment_domains::ActiveModel =
+                            domain.into();
+                        active_domain.domain = Set(new_subdomain);
+                        active_domain.update(&txn).await?;
+                    } else {
+                        let active_domain = temps_entities::environment_domains::ActiveModel {
+                            environment_id: Set(updated_env.id),
+                            domain: Set(new_subdomain),
+                            created_at: Set(chrono::Utc::now()),
+                            ..Default::default()
+                        };
+                        active_domain.insert(&txn).await?;
+                    }
                 }
+
+                txn.commit().await?;
+            } else {
+                txn.rollback().await?;
             }
         }
 

--- a/crates/temps-projects/src/services/project.rs
+++ b/crates/temps-projects/src/services/project.rs
@@ -1320,7 +1320,19 @@ impl ProjectService {
 
         // Update the slug if provided
         if let Some(slug_value) = new_slug {
+            let slug_value = slugify(&slug_value);
+            if slug_value.is_empty() || slug_value.len() > 63 {
+                return Err(ProjectError::InvalidInput(
+                    "Project slug must contain 1-63 lowercase DNS-safe characters".to_string(),
+                ));
+            }
             let txn = self.db.begin().await?;
+            txn.execute(Statement::from_sql_and_values(
+                sea_orm::DatabaseBackend::Postgres,
+                "SELECT pg_advisory_xact_lock(hashtext('project-slug:' || $1))",
+                [slug_value.clone().into()],
+            ))
+            .await?;
             // Check if the slug is already taken by another project
             let existing = projects::Entity::find()
                 .filter(projects::Column::Slug.eq(&slug_value))
@@ -1349,7 +1361,12 @@ impl ProjectService {
                 let mut active_claims = envs
                     .iter()
                     .filter(|env| env.deleted_at.is_none())
-                    .map(|env| (format!("{}-{}", slug_value, env.slug), env.id))
+                    .map(|env| {
+                        (
+                            format!("{}-{}", slug_value, env.slug).to_ascii_lowercase(),
+                            env.id,
+                        )
+                    })
                     .collect::<Vec<_>>();
                 active_claims.sort_unstable();
                 for (new_subdomain, _) in &active_claims {
@@ -1381,7 +1398,7 @@ impl ProjectService {
 
                 for env in envs {
                     let previous_subdomain = env.subdomain.clone();
-                    let new_subdomain = format!("{}-{}", slug_value, env.slug);
+                    let new_subdomain = format!("{}-{}", slug_value, env.slug).to_ascii_lowercase();
 
                     // Keep the environment and its auto-managed domain row in
                     // the same transaction as the project rename.

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -348,7 +348,7 @@ const ALLOWED_POSTGRES_DOCKER_IMAGES: &[&str] = &[
     "timescale/timescaledb-ha:pg18",
 ];
 
-fn validate_postgres_docker_image(docker_image: &str) -> Result<()> {
+pub(crate) fn validate_postgres_docker_image(docker_image: &str) -> Result<()> {
     if ALLOWED_POSTGRES_DOCKER_IMAGES.contains(&docker_image) {
         Ok(())
     } else {

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -40,6 +40,18 @@ pub(crate) fn shell_escape(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
+fn shell_export_assignment(line: &str) -> Option<String> {
+    let (key, value) = line.split_once('=')?;
+    let valid_key = key
+        .chars()
+        .all(|character| character == '_' || character.is_ascii_alphanumeric())
+        && key
+            .chars()
+            .next()
+            .is_some_and(|character| character == '_' || character.is_ascii_alphabetic());
+    valid_key.then(|| format!("export {key}={}", shell_escape(value)))
+}
+
 /// Rejections from same-version-only [`PostgresService::upgrade`]. The
 /// `ExternalService::upgrade` trait method returns `anyhow::Result<()>`
 /// across every provider, so this can't be a variant of a typed
@@ -327,6 +339,27 @@ fn default_docker_image() -> Option<String> {
     Some("gotempsh/postgres-walg:18-bookworm".to_string())
 }
 
+const ALLOWED_POSTGRES_DOCKER_IMAGES: &[&str] = &[
+    "gotempsh/postgres-walg:15-bookworm",
+    "gotempsh/postgres-walg:16-bookworm",
+    "gotempsh/postgres-walg:17-bookworm",
+    "gotempsh/postgres-walg:18-bookworm",
+    "timescale/timescaledb-ha:pg17",
+    "timescale/timescaledb-ha:pg18",
+];
+
+fn validate_postgres_docker_image(docker_image: &str) -> Result<()> {
+    if ALLOWED_POSTGRES_DOCKER_IMAGES.contains(&docker_image) {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "PostgreSQL Docker image '{}' is not supported. Allowed images: {}",
+            docker_image,
+            ALLOWED_POSTGRES_DOCKER_IMAGES.join(", ")
+        ))
+    }
+}
+
 // Schema example functions
 fn example_host() -> &'static str {
     "localhost"
@@ -389,8 +422,11 @@ impl PostgresService {
         let input_config: PostgresInputConfig =
             serde_json::from_value(service_config.parameters)
                 .map_err(|e| anyhow::anyhow!("Failed to parse PostgreSQL configuration: {}", e))?;
-        // Then convert to PostgresConfig which applies additional transformations
-        Ok(PostgresConfig::from(input_config))
+        let postgres_config = PostgresConfig::from(input_config);
+        if postgres_config.container_name.is_none() {
+            validate_postgres_docker_image(&postgres_config.docker_image)?;
+        }
+        Ok(postgres_config)
     }
     fn get_container_name(&self) -> String {
         format!("postgres-{}", self.name)
@@ -861,7 +897,8 @@ impl PostgresService {
             "printf '%s\\n' {} > {} && chmod 600 {}",
             env_file_lines
                 .iter()
-                .map(|line| format!("'export {}'", line.replace('\'', "'\\''")))
+                .filter_map(|line| shell_export_assignment(line)
+                    .map(|assignment| shell_escape(&assignment)))
                 .collect::<Vec<_>>()
                 .join(" "),
             walg_env_path,
@@ -4150,6 +4187,25 @@ mod tests {
     fn healthcheck_cmd_escapes_single_quotes_in_username_and_database() {
         let cmd = postgres_healthcheck_cmd("a'user", "a'db");
         assert_eq!(cmd, "pg_isready -U 'a'\\''user' -d 'a'\\''db'");
+    }
+
+    #[test]
+    fn sourced_walg_values_are_shell_quoted() {
+        assert_eq!(
+            shell_export_assignment("WALG_S3_PREFIX=s3://bucket/ok;touch${IFS}/tmp/pwn;#"),
+            Some("export WALG_S3_PREFIX='s3://bucket/ok;touch${IFS}/tmp/pwn;#'".to_string())
+        );
+        assert_eq!(
+            shell_export_assignment("AWS_SECRET_ACCESS_KEY=abc'def"),
+            Some("export AWS_SECRET_ACCESS_KEY='abc'\\''def'".to_string())
+        );
+        assert!(shell_export_assignment("BAD-KEY=value").is_none());
+    }
+
+    #[test]
+    fn managed_postgres_images_are_allowlisted() {
+        assert!(validate_postgres_docker_image("gotempsh/postgres-walg:18-bookworm").is_ok());
+        assert!(validate_postgres_docker_image("attacker/postgres:latest").is_err());
     }
 
     #[test]

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -423,9 +423,11 @@ impl PostgresService {
             serde_json::from_value(service_config.parameters)
                 .map_err(|e| anyhow::anyhow!("Failed to parse PostgreSQL configuration: {}", e))?;
         let postgres_config = PostgresConfig::from(input_config);
-        if postgres_config.container_name.is_none() {
-            validate_postgres_docker_image(&postgres_config.docker_image)?;
-        }
+        // Imported-service metadata is client-deserializable and therefore
+        // cannot be used as an authorization signal. Every image must remain
+        // allowlisted because backup/restore helpers may pull and execute it
+        // even when the primary database container already exists.
+        validate_postgres_docker_image(&postgres_config.docker_image)?;
         Ok(postgres_config)
     }
     fn get_container_name(&self) -> String {
@@ -1108,115 +1110,33 @@ impl PostgresService {
     /// the exact bug we're trying to avoid.
     async fn compute_desired_enable_archiving(&self) -> bool {
         let container_name = self.get_container_name();
-        let volume_name = format!("{}_data", container_name);
-        self.walg_env_exists_on_volume(&volume_name).await
+        self.walg_env_exists_in_container(&container_name).await
     }
 
-    /// Returns true iff `/var/lib/postgresql/walg.env` exists on the named
-    /// Docker volume. Runs a one-shot `busybox` container with the volume
-    /// mounted read-only. Any error (image pull, exec failure) returns
-    /// false — we err on the side of not enabling archiving.
-    async fn walg_env_exists_on_volume(&self, volume_name: &str) -> bool {
-        use bollard::query_parameters::{
-            CreateContainerOptions, CreateImageOptions, RemoveContainerOptions,
-            StartContainerOptions, WaitContainerOptions,
-        };
+    /// Returns true iff `/var/lib/postgresql/walg.env` exists in this service's
+    /// container filesystem. Docker's archive API can read a stopped
+    /// container's mounted volume without pulling or executing a mutable helper
+    /// image against database data.
+    async fn walg_env_exists_in_container(&self, container_name: &str) -> bool {
+        use bollard::query_parameters::DownloadFromContainerOptions;
         use futures::StreamExt;
 
-        // Pull busybox; cheap (~700 KB) and cached after first use.
-        let mut pull_stream = self.docker.create_image(
-            Some(CreateImageOptions {
-                from_image: Some("busybox".to_string()),
-                tag: Some("latest".to_string()),
-                ..Default::default()
+        let mut archive_stream = self.docker.download_from_container(
+            container_name,
+            Some(DownloadFromContainerOptions {
+                path: "/var/lib/postgresql/walg.env".to_string(),
             }),
-            None,
-            None,
         );
-        while let Some(result) = pull_stream.next().await {
-            if result.is_err() {
-                // Best-effort; treat unavailability as "no archiving".
-                return false;
+        let mut saw_archive_data = false;
+        while let Some(chunk) = archive_stream.next().await {
+            match chunk {
+                Ok(bytes) if !bytes.is_empty() => saw_archive_data = true,
+                Ok(_) => {}
+                Err(_) => return false,
             }
         }
 
-        let probe_name = format!("temps-walg-probe-{}", uuid::Uuid::new_v4());
-        let host_config = bollard::models::HostConfig {
-            mounts: Some(vec![bollard::models::Mount {
-                target: Some("/var/lib/postgresql".to_string()),
-                source: Some(volume_name.to_string()),
-                typ: Some(bollard::models::MountTypeEnum::VOLUME),
-                read_only: Some(true),
-                ..Default::default()
-            }]),
-            auto_remove: Some(false),
-            ..Default::default()
-        };
-
-        let create_result = self
-            .docker
-            .create_container(
-                Some(CreateContainerOptions {
-                    name: Some(probe_name.clone()),
-                    ..Default::default()
-                }),
-                bollard::models::ContainerCreateBody {
-                    image: Some("busybox:latest".to_string()),
-                    cmd: Some(vec![
-                        "sh".to_string(),
-                        "-c".to_string(),
-                        "test -f /var/lib/postgresql/walg.env".to_string(),
-                    ]),
-                    host_config: Some(host_config),
-                    ..Default::default()
-                },
-            )
-            .await;
-
-        if create_result.is_err() {
-            return false;
-        }
-
-        // Best effort cleanup: always try to remove the probe container.
-        let cleanup = |name: String| async move {
-            let _ = self
-                .docker
-                .remove_container(
-                    &name,
-                    Some(RemoveContainerOptions {
-                        force: true,
-                        ..Default::default()
-                    }),
-                )
-                .await;
-        };
-
-        if self
-            .docker
-            .start_container(&probe_name, None::<StartContainerOptions>)
-            .await
-            .is_err()
-        {
-            cleanup(probe_name).await;
-            return false;
-        }
-
-        let mut wait_stream = self
-            .docker
-            .wait_container(&probe_name, None::<WaitContainerOptions>);
-
-        let mut exit_code: Option<i64> = None;
-        while let Some(item) = wait_stream.next().await {
-            if let Ok(resp) = item {
-                exit_code = Some(resp.status_code);
-                break;
-            }
-        }
-
-        cleanup(probe_name).await;
-
-        // `test -f` exits 0 when the file is present.
-        matches!(exit_code, Some(0))
+        saw_archive_data
     }
 
     /// Returns true when the running container's CMD specifies an

--- a/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
@@ -77,6 +77,11 @@ pub trait PostgresContainerLifecycle: Send + Sync {
     /// `pg_dumpall` and `psql`.
     async fn connection_params(&self, service_id: i32) -> Result<PostgresConnection, String>;
 
+    /// Return the image currently persisted in the service configuration.
+    /// Upgrade requests must name this exact image as their source so callers
+    /// cannot use the upgrade API as an arbitrary image execution primitive.
+    async fn docker_image(&self, service_id: i32) -> Result<String, String>;
+
     /// Stop (best-effort) and remove any existing container for this
     /// service, preserving its named volume. Safe to call on a
     /// non-existent container.
@@ -117,6 +122,21 @@ pub enum PostgresUpgradeError {
         service_id: i32,
         service_type: String,
     },
+
+    #[error("PostgreSQL Docker image '{image}' is not supported for service {service_id}")]
+    UnsupportedImage { service_id: i32, image: String },
+
+    #[error(
+        "PostgreSQL image mismatch for service {service_id}: configured '{configured_image}', expected '{expected_image}'"
+    )]
+    SourceImageMismatch {
+        service_id: i32,
+        configured_image: String,
+        expected_image: String,
+    },
+
+    #[error("Could not validate PostgreSQL service {service_id} configuration: {reason}")]
+    ServiceConfiguration { service_id: i32, reason: String },
 
     #[error(
         "Cannot upgrade service {service_id} from {from_image} to {to_image}: OS family mismatch ({from_os} -> {to_os}). Cross-OS-family upgrades are unsupported."
@@ -373,6 +393,33 @@ pub fn validate_os_family(
     })
 }
 
+fn validate_phase_config_image(
+    service_id: i32,
+    current_phase: &str,
+    configured_image: &str,
+    from_image: &str,
+    to_image: &str,
+) -> Result<(), PostgresUpgradeError> {
+    let (matches_expected, expected_image) = match current_phase {
+        // `set_docker_image` and the phase update are separate durable
+        // operations. A retry at SWAP may therefore observe either value.
+        phase::SWAP => (
+            configured_image == from_image || configured_image == to_image,
+            format!("{} or {}", from_image, to_image),
+        ),
+        phase::ANALYZE | phase::COMPLETED => (configured_image == to_image, to_image.to_string()),
+        _ => (configured_image == from_image, from_image.to_string()),
+    };
+    if matches_expected {
+        return Ok(());
+    }
+    Err(PostgresUpgradeError::SourceImageMismatch {
+        service_id,
+        configured_image: configured_image.to_string(),
+        expected_image,
+    })
+}
+
 /// Strip the version prefix from a tag, keeping the OS portion.
 /// `postgres:17-alpine` -> `postgres:alpine`; `gotempsh/postgres-ha:17-bookworm` -> `gotempsh/postgres-ha:bookworm`.
 fn image_base(image: &str) -> String {
@@ -445,6 +492,27 @@ pub struct PostgresUpgradeOrchestrator {
 }
 
 impl PostgresUpgradeOrchestrator {
+    async fn validate_service_image(
+        &self,
+        row: &postgres_major_upgrades::Model,
+    ) -> Result<(), PostgresUpgradeError> {
+        let configured_image =
+            self.lifecycle
+                .docker_image(row.service_id)
+                .await
+                .map_err(|reason| PostgresUpgradeError::ServiceConfiguration {
+                    service_id: row.service_id,
+                    reason,
+                })?;
+        validate_phase_config_image(
+            row.service_id,
+            &row.phase,
+            &configured_image,
+            &row.from_image,
+            &row.to_image,
+        )
+    }
+
     pub fn new(
         db: Arc<DatabaseConnection>,
         docker: Arc<Docker>,
@@ -488,6 +556,18 @@ impl PostgresUpgradeOrchestrator {
     pub async fn run(&self, upgrade_id: i32) -> Result<(), PostgresUpgradeError> {
         let mut row = self.load_upgrade(upgrade_id).await?;
 
+        // Defense in depth for retries and boot-time resumption: never execute
+        // images from a legacy or manually inserted upgrade row.
+        for image in [&row.from_image, &row.to_image] {
+            super::postgres::validate_postgres_docker_image(image).map_err(|_| {
+                PostgresUpgradeError::UnsupportedImage {
+                    service_id: row.service_id,
+                    image: image.clone(),
+                }
+            })?;
+        }
+        self.validate_service_image(&row).await?;
+
         // Honour a cancel that arrived before we even started dispatching.
         if row.status == status::CANCELLED {
             self.log_info(&row.log_id, "orchestrator aborted: cancel requested")
@@ -514,6 +594,10 @@ impl PostgresUpgradeOrchestrator {
         // Between phases we re-read status so a cancel posted mid-run is
         // honoured without having to interrupt the currently-running phase.
         loop {
+            // Re-read the authoritative service image at every phase boundary.
+            // This catches an out-of-band reconfiguration before another image
+            // is pulled, started, restored, or persisted.
+            self.validate_service_image(&row).await?;
             match row.phase.as_str() {
                 phase::PRE_BACKUP => self.phase_pre_backup(&row).await?,
                 phase::SNAPSHOT => self.phase_snapshot(&row).await?,
@@ -2113,7 +2197,8 @@ impl From<PostgresUpgradeError> for temps_core::problemdetails::Problem {
 
             PostgresUpgradeError::WrongServiceType { .. }
             | PostgresUpgradeError::InvalidVersionTransition { .. }
-            | PostgresUpgradeError::OsFamilyMismatch { .. } => {
+            | PostgresUpgradeError::OsFamilyMismatch { .. }
+            | PostgresUpgradeError::UnsupportedImage { .. } => {
                 problemdetails::new(StatusCode::BAD_REQUEST)
                     .with_title("Invalid Upgrade Request")
                     .with_detail(error.to_string())
@@ -2128,6 +2213,12 @@ impl From<PostgresUpgradeError> for temps_core::problemdetails::Problem {
             PostgresUpgradeError::ConcurrentUpgrade { .. } => {
                 problemdetails::new(StatusCode::CONFLICT)
                     .with_title("Upgrade Already In Progress")
+                    .with_detail(error.to_string())
+            }
+
+            PostgresUpgradeError::SourceImageMismatch { .. } => {
+                problemdetails::new(StatusCode::CONFLICT)
+                    .with_title("PostgreSQL Service Changed")
                     .with_detail(error.to_string())
             }
 
@@ -2159,6 +2250,7 @@ impl From<PostgresUpgradeError> for temps_core::problemdetails::Problem {
             | PostgresUpgradeError::RollbackFailed { .. }
             | PostgresUpgradeError::Docker { .. }
             | PostgresUpgradeError::Log { .. }
+            | PostgresUpgradeError::ServiceConfiguration { .. }
             | PostgresUpgradeError::Database(_) => {
                 problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
                     .with_title("Internal Server Error")
@@ -2224,6 +2316,34 @@ mod tests {
             "gotempsh/postgres-ha:17-bookworm",
         )
         .expect("same custom repo with same base should pass");
+    }
+
+    #[test]
+    fn phase_image_validation_preserves_idempotent_swap_retries() {
+        let from = "gotempsh/postgres-walg:16-bookworm";
+        let to = "gotempsh/postgres-walg:17-bookworm";
+
+        validate_phase_config_image(1, phase::SWAP, from, from, to)
+            .expect("swap may resume before the image metadata write");
+        validate_phase_config_image(1, phase::SWAP, to, from, to)
+            .expect("swap may resume after the image metadata write");
+        assert!(matches!(
+            validate_phase_config_image(1, phase::SWAP, "postgres:latest", from, to),
+            Err(PostgresUpgradeError::SourceImageMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn phase_image_validation_requires_new_image_after_swap() {
+        let from = "gotempsh/postgres-walg:16-bookworm";
+        let to = "gotempsh/postgres-walg:17-bookworm";
+
+        assert!(matches!(
+            validate_phase_config_image(1, phase::ANALYZE, from, from, to),
+            Err(PostgresUpgradeError::SourceImageMismatch { .. })
+        ));
+        validate_phase_config_image(1, phase::ANALYZE, to, from, to)
+            .expect("analyze must use the persisted target image");
     }
 
     #[test]
@@ -3698,6 +3818,10 @@ mod tests {
             ) -> Result<PostgresConnection, String> {
                 self.record(LifecycleEventKind::ConnectionParams);
                 self.inner.connection_params(service_id).await
+            }
+
+            async fn docker_image(&self, service_id: i32) -> Result<String, String> {
+                self.inner.docker_image(service_id).await
             }
 
             async fn stop_and_remove(&self, service_id: i32) -> Result<(), String> {

--- a/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
@@ -1586,12 +1586,19 @@ impl PostgresUpgradeOrchestrator {
             .start_exec(&exec.id, None)
             .await
             .map_err(|e| format!("start_exec: {}", e))?;
+        const MAX_EXEC_DIAGNOSTIC_CHARS: usize = 2_000;
         let mut exec_output = String::new();
+        let mut exec_output_chars = 0usize;
         if let bollard::exec::StartExecResults::Attached { mut output, .. } = stream {
             while let Some(chunk) = output.next().await {
                 if let Ok(msg) = chunk {
                     let text = msg.to_string();
-                    exec_output.push_str(&text);
+                    let remaining = MAX_EXEC_DIAGNOSTIC_CHARS.saturating_sub(exec_output_chars);
+                    if remaining > 0 {
+                        let captured: String = text.chars().take(remaining).collect();
+                        exec_output_chars += captured.chars().count();
+                        exec_output.push_str(&captured);
+                    }
                     if !text.trim().is_empty() {
                         let _ = self
                             .log_service
@@ -1619,11 +1626,7 @@ impl PostgresUpgradeOrchestrator {
                                 return Err(if diagnostic.is_empty() {
                                     format!("exec exited with code {}", code)
                                 } else {
-                                    format!(
-                                        "exec exited with code {}: {}",
-                                        code,
-                                        diagnostic.chars().take(2_000).collect::<String>()
-                                    )
+                                    format!("exec exited with code {}: {}", code, diagnostic)
                                 });
                             }
                             None => return Err("exec finished with no exit code".to_string()),

--- a/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
@@ -393,6 +393,63 @@ pub fn validate_os_family(
     })
 }
 
+fn image_major_version(image: &str) -> Option<u32> {
+    image
+        .rsplit_once(':')
+        .map(|(_, tag)| tag)?
+        .trim_start_matches("pg")
+        .split(['-', '.'])
+        .next()?
+        .parse()
+        .ok()
+}
+
+/// Validate every image/version invariant needed before an upgrade row may
+/// execute. This is shared by request validation, retry/resumption, and
+/// rollback so legacy or manually modified rows cannot bypass the checks.
+pub fn validate_image_transition(
+    service_id: i32,
+    from_version: &str,
+    to_version: &str,
+    from_image: &str,
+    to_image: &str,
+) -> Result<(), PostgresUpgradeError> {
+    for image in [from_image, to_image] {
+        super::postgres::validate_postgres_docker_image(image).map_err(|_| {
+            PostgresUpgradeError::UnsupportedImage {
+                service_id,
+                image: image.to_string(),
+            }
+        })?;
+    }
+    validate_os_family(service_id, from_image, to_image)?;
+
+    let from_major = from_version.parse::<u32>().unwrap_or(0);
+    let to_major = to_version.parse::<u32>().unwrap_or(0);
+    if from_major == 0 || to_major == 0 || to_major <= from_major {
+        return Err(PostgresUpgradeError::InvalidVersionTransition {
+            service_id,
+            from_version: from_version.to_string(),
+            to_version: to_version.to_string(),
+            reason: "to_version must be a greater major version than from_version".into(),
+        });
+    }
+    for (image, declared_version) in [(from_image, from_major), (to_image, to_major)] {
+        if image_major_version(image) != Some(declared_version) {
+            return Err(PostgresUpgradeError::InvalidVersionTransition {
+                service_id,
+                from_version: from_version.to_string(),
+                to_version: to_version.to_string(),
+                reason: format!(
+                    "image '{}' does not match its declared major version {}",
+                    image, declared_version
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
 fn validate_phase_config_image(
     service_id: i32,
     current_phase: &str,
@@ -417,6 +474,28 @@ fn validate_phase_config_image(
         service_id,
         configured_image: configured_image.to_string(),
         expected_image,
+    })
+}
+
+fn validate_rollback_config_image(
+    service_id: i32,
+    rollback_status: &str,
+    configured_image: &str,
+    from_image: &str,
+    to_image: &str,
+) -> Result<(), PostgresUpgradeError> {
+    let retrying = rollback_status == status::ROLLING_BACK;
+    if configured_image == to_image || (retrying && configured_image == from_image) {
+        return Ok(());
+    }
+    Err(PostgresUpgradeError::SourceImageMismatch {
+        service_id,
+        configured_image: configured_image.to_string(),
+        expected_image: if retrying {
+            format!("{} or {}", to_image, from_image)
+        } else {
+            to_image.to_string()
+        },
     })
 }
 
@@ -556,16 +635,15 @@ impl PostgresUpgradeOrchestrator {
     pub async fn run(&self, upgrade_id: i32) -> Result<(), PostgresUpgradeError> {
         let mut row = self.load_upgrade(upgrade_id).await?;
 
-        // Defense in depth for retries and boot-time resumption: never execute
-        // images from a legacy or manually inserted upgrade row.
-        for image in [&row.from_image, &row.to_image] {
-            super::postgres::validate_postgres_docker_image(image).map_err(|_| {
-                PostgresUpgradeError::UnsupportedImage {
-                    service_id: row.service_id,
-                    image: image.clone(),
-                }
-            })?;
-        }
+        // Defense in depth for retries and boot-time resumption: legacy or
+        // manually modified rows must satisfy the same invariants as requests.
+        validate_image_transition(
+            row.service_id,
+            &row.from_version,
+            &row.to_version,
+            &row.from_image,
+            &row.to_image,
+        )?;
         self.validate_service_image(&row).await?;
 
         // Honour a cancel that arrived before we even started dispatching.
@@ -587,7 +665,13 @@ impl PostgresUpgradeOrchestrator {
 
         // Every phase transition re-validates OS family — cheap, and guards
         // against the service's Docker image being edited mid-upgrade.
-        validate_os_family(row.service_id, &row.from_image, &row.to_image)?;
+        validate_image_transition(
+            row.service_id,
+            &row.from_version,
+            &row.to_version,
+            &row.from_image,
+            &row.to_image,
+        )?;
 
         // Dispatch loop — each phase method advances `phase` on success.
         // On failure, the phase method itself writes status=failed + error_message.
@@ -942,6 +1026,11 @@ impl PostgresUpgradeOrchestrator {
                 &dump_container,
                 vec!["sh".to_string(), "-c".to_string(), dump_cmd],
                 Some(&conn.password),
+                // Some reviewed images run as a non-root UID whose primary
+                // group cannot write a freshly-created Docker volume. The
+                // dump client does not need to run as the database server
+                // user; root writes a world-readable SQL file for restore.
+                Some("0"),
             )
             .await;
 
@@ -1265,13 +1354,19 @@ impl PostgresUpgradeOrchestrator {
             "ANALYZE;".to_string(),
         ];
 
-        self.exec_and_wait(row, &container_name, analyze_cmd, Some(&conn.password))
-            .await
-            .map_err(|reason| PostgresUpgradeError::AnalyzeFailed {
-                upgrade_id: row.id,
-                service_id: row.service_id,
-                reason,
-            })?;
+        self.exec_and_wait(
+            row,
+            &container_name,
+            analyze_cmd,
+            Some(&conn.password),
+            None,
+        )
+        .await
+        .map_err(|reason| PostgresUpgradeError::AnalyzeFailed {
+            upgrade_id: row.id,
+            service_id: row.service_id,
+            reason,
+        })?;
 
         self.log_info(&row.log_id, "phase=analyze done").await?;
         self.advance_phase(row.id, phase::COMPLETED).await?;
@@ -1464,6 +1559,7 @@ impl PostgresUpgradeOrchestrator {
         container: &str,
         cmd: Vec<String>,
         pgpassword: Option<&str>,
+        user: Option<&str>,
     ) -> Result<(), String> {
         let env = pgpassword.map(|p| vec![format!("PGPASSWORD={}", p)]);
         let exec = self
@@ -1473,6 +1569,7 @@ impl PostgresUpgradeOrchestrator {
                 bollard::models::ExecConfig {
                     cmd: Some(cmd.clone()),
                     env,
+                    user: user.map(str::to_string),
                     attach_stdout: Some(true),
                     attach_stderr: Some(true),
                     ..Default::default()
@@ -1489,10 +1586,12 @@ impl PostgresUpgradeOrchestrator {
             .start_exec(&exec.id, None)
             .await
             .map_err(|e| format!("start_exec: {}", e))?;
+        let mut exec_output = String::new();
         if let bollard::exec::StartExecResults::Attached { mut output, .. } = stream {
             while let Some(chunk) = output.next().await {
                 if let Ok(msg) = chunk {
                     let text = msg.to_string();
+                    exec_output.push_str(&text);
                     if !text.trim().is_empty() {
                         let _ = self
                             .log_service
@@ -1515,7 +1614,18 @@ impl PostgresUpgradeOrchestrator {
                     if info.running == Some(false) {
                         match info.exit_code {
                             Some(0) => return Ok(()),
-                            Some(code) => return Err(format!("exec exited with code {}", code)),
+                            Some(code) => {
+                                let diagnostic = exec_output.trim();
+                                return Err(if diagnostic.is_empty() {
+                                    format!("exec exited with code {}", code)
+                                } else {
+                                    format!(
+                                        "exec exited with code {}: {}",
+                                        code,
+                                        diagnostic.chars().take(2_000).collect::<String>()
+                                    )
+                                });
+                            }
                             None => return Err("exec finished with no exit code".to_string()),
                         }
                     }
@@ -1966,6 +2076,14 @@ impl PostgresUpgradeOrchestrator {
     ) -> Result<postgres_major_upgrades::Model, PostgresUpgradeError> {
         let row = self.load_upgrade(upgrade_id).await?;
 
+        validate_image_transition(
+            row.service_id,
+            &row.from_version,
+            &row.to_version,
+            &row.from_image,
+            &row.to_image,
+        )?;
+
         // Preconditions. ROLLING_BACK is accepted alongside COMPLETED so a
         // rollback that failed partway (leaving the row stuck in
         // ROLLING_BACK) can be retried through this same entry point —
@@ -1979,6 +2097,21 @@ impl PostgresUpgradeOrchestrator {
                 ),
             });
         }
+        let configured_image =
+            self.lifecycle
+                .docker_image(row.service_id)
+                .await
+                .map_err(|reason| PostgresUpgradeError::ServiceConfiguration {
+                    service_id: row.service_id,
+                    reason,
+                })?;
+        validate_rollback_config_image(
+            row.service_id,
+            &row.status,
+            &configured_image,
+            &row.from_image,
+            &row.to_image,
+        )?;
         let rollback_volume = row.rollback_volume_name.clone().ok_or_else(|| {
             PostgresUpgradeError::NotRollbackable {
                 upgrade_id,
@@ -2344,6 +2477,40 @@ mod tests {
         ));
         validate_phase_config_image(1, phase::ANALYZE, to, from, to)
             .expect("analyze must use the persisted target image");
+    }
+
+    #[test]
+    fn resumed_rows_revalidate_image_versions_and_direction() {
+        let from = "gotempsh/postgres-walg:17-bookworm";
+        let to = "gotempsh/postgres-walg:16-bookworm";
+        assert!(matches!(
+            validate_image_transition(1, "17", "16", from, to),
+            Err(PostgresUpgradeError::InvalidVersionTransition { .. })
+        ));
+        assert!(matches!(
+            validate_image_transition(1, "16", "17", from, to),
+            Err(PostgresUpgradeError::InvalidVersionTransition { .. })
+        ));
+    }
+
+    #[test]
+    fn rollback_image_validation_is_phase_aware_and_fail_closed() {
+        let from = "gotempsh/postgres-walg:16-bookworm";
+        let to = "gotempsh/postgres-walg:17-bookworm";
+
+        validate_rollback_config_image(1, status::COMPLETED, to, from, to)
+            .expect("a fresh rollback starts from the target image");
+        assert!(validate_rollback_config_image(1, status::COMPLETED, from, from, to).is_err());
+        validate_rollback_config_image(1, status::ROLLING_BACK, from, from, to)
+            .expect("a rollback retry may resume after persisting the source image");
+        assert!(validate_rollback_config_image(
+            1,
+            status::ROLLING_BACK,
+            "postgres:latest",
+            from,
+            to
+        )
+        .is_err());
     }
 
     #[test]
@@ -3230,8 +3397,8 @@ mod tests {
     // * Cleanup is best-effort per-test via `Drop` plus an explicit
     //   `cleanup()` call. Tests that panic leak Docker resources; CI
     //   reaps them via a `temps_upgrade_test_*` label prune.
-    // * Images are `postgres:17-bookworm` → `postgres:18-bookworm` (official
-    //   images, not gotempsh). Cheaper to pull, no registry auth needed.
+    // * Images use the published, reviewed Timescale PostgreSQL 17/18 range
+    //   accepted by production.
     //
     // Run subset:
     //     cargo test -p temps-providers --features docker-tests \
@@ -3265,9 +3432,9 @@ mod tests {
 
         /// Images used by every integration test. Keep in sync with the
         /// stable range supported by the upgrade orchestrator.
-        pub const FROM_IMAGE: &str = "postgres:17-bookworm";
+        pub const FROM_IMAGE: &str = "timescale/timescaledb-ha:pg17";
         pub const FROM_VERSION: &str = "17";
-        pub const TO_IMAGE: &str = "postgres:18-bookworm";
+        pub const TO_IMAGE: &str = "timescale/timescaledb-ha:pg18";
         pub const TO_VERSION: &str = "18";
 
         /// Return `Some(docker)` if a Docker daemon responds; `None` if the
@@ -3323,7 +3490,7 @@ mod tests {
         }
 
         impl UpgradeTestCtx {
-            /// Spin up a fresh DB schema, a single `postgres:17-bookworm`
+            /// Spin up a fresh DB schema, a single reviewed Timescale PostgreSQL 17
             /// service row, and its container on the app network. Blocks
             /// until Postgres accepts connections.
             pub async fn new(test_name: &str) -> Self {
@@ -4583,47 +4750,26 @@ mod tests {
             ctx.psql_exec("CREATE TABLE dump_probe(id INT)").await?;
             ctx.psql_exec("INSERT INTO dump_probe VALUES (1),(2),(3)").await?;
 
-            // Drive phases PRE_BACKUP + SNAPSHOT via run() by inserting at
-            // PRE_BACKUP. We need the rollback volume in place for dump.
-            // But run() will go through ALL phases — we want to stop after
-            // dump. Simpler: execute snapshot manually by inserting at
-            // SNAPSHOT and running run() with a guard.
-            //
-            // Alternative: insert at DUMP after manually setting up the
-            // rollback volume. But that's brittle. We pick the first
-            // approach: run() until phase advances PAST dump, then reset
-            // phase to DUMP for a replay.
-
-            let upgrade_id = ctx.insert_upgrade_row(phase::PRE_BACKUP).await;
+            let upgrade_id = ctx.insert_upgrade_row(phase::SNAPSHOT).await;
             let rollback_vol =
                 format!("postgres-{}_data_rollback_{}", ctx.service_name, upgrade_id);
             let dump_vol =
                 format!("postgres-{}_pgdump_{}", ctx.service_name, upgrade_id);
             let orch = ctx.orchestrator(backup_provider, lifecycle);
 
-            // Run 1: run() goes through pre_backup → snapshot → dump
-            // → new_container → restore → swap → analyze → completed.
-            // That's the full upgrade. On completion, reset phase to DUMP
-            // and re-run — but that won't work cleanly because the service
-            // is now on v18 and the rollback volume has v17 PGDATA. We
-            // need a narrower test.
-            //
-            // Better: manually step to SNAPSHOT and stop there. We run
-            // run() with a status=cancelled injection after snapshot.
-            // Simplest: drive run() once, capture the TIME elapsed for
-            // dump. Then set phase=DUMP + status=running and re-run.
-            // The re-run will short-circuit dump (marker present) but
-            // then try to continue through new_container → restore →
-            // swap → analyze — all already done; those phases' idempotency
-            // is tested separately, we just assert dump is fast on retry.
-            //
-            // We instrument elapsed time of the `phase=dump` portion by
-            // timestamping DB row reads. Before first run, phase=PRE_BACKUP;
-            // once phase transitions away from DUMP, dump is done.
-
+            // Drive only the two phases needed for this test. Keeping the
+            // authoritative service image on FROM_IMAGE makes the simulated
+            // DUMP retry valid under the phase-aware security guard.
+            let snapshot_row = load_upgrade(ctx.test_db.db.as_ref(), upgrade_id).await;
+            orch.phase_snapshot(&snapshot_row)
+                .await
+                .map_err(|e| format!("snapshot: {}", e))?;
+            let first_dump_row = load_upgrade(ctx.test_db.db.as_ref(), upgrade_id).await;
             let run_start = std::time::Instant::now();
-            orch.run(upgrade_id).await.map_err(|e| format!("first run: {}", e))?;
-            let full_run_ms = run_start.elapsed().as_millis();
+            orch.phase_dump(&first_dump_row)
+                .await
+                .map_err(|e| format!("first dump: {}", e))?;
+            let first_dump_ms = run_start.elapsed().as_millis();
 
             // Marker must be present after a successful dump.
             // We re-check via dump_marker_present by calling the helper —
@@ -4633,26 +4779,21 @@ mod tests {
                 .await
                 .map_err(|e| format!("expected dump volume: {}", e))?;
 
-            // Reset phase to DUMP and status back to running, then re-run.
+            // Reset only the durable phase, simulating a crash after the
+            // marker write but before the phase transition committed.
             let row = load_upgrade(ctx.test_db.db.as_ref(), upgrade_id).await;
             let mut active: postgres_major_upgrades::ActiveModel = row.into();
             active.phase = Set(phase::DUMP.to_string());
             active.status = Set(status::RUNNING.to_string());
-            active.finished_at = Set(None);
             active.update(ctx.test_db.db.as_ref()).await.map_err(|e| e.to_string())?;
 
-            // Re-run. Because dump short-circuits on marker and the
-            // subsequent idempotent phases are no-ops on already-done
-            // state, the whole retry should complete FAST (< 60s typ).
+            // Re-run only DUMP. The marker makes this a fast no-op that
+            // advances back to NEW_CONTAINER.
             let retry_start = std::time::Instant::now();
-            let orch2 = ctx.orchestrator(
-                Arc::new(StubBackupProvider::new(ctx.test_db.db.clone())),
-                ctx.lifecycle_adapter.clone(),
-            );
-            orch2
-                .run(upgrade_id)
+            let retry_row = load_upgrade(ctx.test_db.db.as_ref(), upgrade_id).await;
+            orch.phase_dump(&retry_row)
                 .await
-                .map_err(|e| format!("retry run: {}", e))?;
+                .map_err(|e| format!("retry dump: {}", e))?;
             let retry_ms = retry_start.elapsed().as_millis();
 
             // A full first run includes real pg_dumpall + restore (slow).
@@ -4660,18 +4801,18 @@ mod tests {
             // writes plus at most a container restart, so must be
             // materially faster. We require retry < 0.5 * full_run to
             // give the assertion headroom for noisy CI runners.
-            if retry_ms >= full_run_ms {
+            if retry_ms >= first_dump_ms {
                 return Err(format!(
-                    "retry not materially faster: full={}ms retry={}ms — dump idempotency may be broken",
-                    full_run_ms, retry_ms
+                    "retry not materially faster: first_dump={}ms retry={}ms — dump idempotency may be broken",
+                    first_dump_ms, retry_ms
                 ));
             }
 
             let final_row = load_upgrade(ctx.test_db.db.as_ref(), upgrade_id).await;
-            if final_row.status != status::COMPLETED {
+            if final_row.phase != phase::NEW_CONTAINER {
                 return Err(format!(
-                    "retry left row in status={}, expected COMPLETED",
-                    final_row.status
+                    "retry left row in phase={}, expected NEW_CONTAINER",
+                    final_row.phase
                 ));
             }
 

--- a/crates/temps-providers/src/externalsvc/redis.rs
+++ b/crates/temps-providers/src/externalsvc/redis.rs
@@ -9,7 +9,7 @@ use bollard::query_parameters::{InspectContainerOptions, StopContainerOptions};
 use bollard::Docker;
 use flate2::read::GzDecoder;
 use futures::TryStreamExt;
-use redis::{aio::ConnectionManager, AsyncCommands, Client};
+use redis::{aio::ConnectionManager, Client};
 use schemars::JsonSchema;
 use sea_orm::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -581,181 +581,18 @@ impl RedisService {
         Err(anyhow::anyhow!("Redis container health check timed out"))
     }
 
-    fn resource_mapping_key(resource_name: &str) -> String {
-        format!("_temps:redis_db_mapping:{resource_name}")
-    }
+    /// Calculate a deterministic database number (0-15) from a resource name
+    /// This allows us to allocate databases without requiring a Redis connection
+    fn calculate_database_number(&self, resource_name: &str) -> u8 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
 
-    fn database_owner_key(db_number: u8) -> String {
-        format!("_temps:redis_db_owner:{db_number}")
-    }
+        let mut hasher = DefaultHasher::new();
+        resource_name.hash(&mut hasher);
+        let hash = hasher.finish();
 
-    /// Allocate one of Redis DBs 1-15. DB 0 is reserved for allocation
-    /// metadata, preventing hash collisions from silently sharing data.
-    async fn allocate_database(&self, resource_name: &str) -> Result<u8> {
-        let mut conn = self.get_connection().await?;
-        redis::cmd("SELECT")
-            .arg(0)
-            .query_async::<()>(&mut conn)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to select Redis metadata DB 0: {e}"))?;
-
-        let mapping_key = Self::resource_mapping_key(resource_name);
-        let existing: Option<u8> = conn.get(&mapping_key).await.map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to read Redis DB mapping for resource '{}': {}",
-                resource_name,
-                e
-            )
-        })?;
-        if let Some(db_number @ 1..=15) = existing {
-            let owner: Option<String> = conn
-                .get(Self::database_owner_key(db_number))
-                .await
-                .map_err(|e| {
-                    anyhow::anyhow!(
-                        "Failed to verify Redis DB {} mapping for resource '{}': {}",
-                        db_number,
-                        resource_name,
-                        e
-                    )
-                })?;
-            if owner.as_deref() == Some(resource_name) {
-                return Ok(db_number);
-            }
-            conn.del::<_, ()>(&mapping_key).await.map_err(|e| {
-                anyhow::anyhow!(
-                    "Failed to remove stale Redis DB mapping for resource '{}': {}",
-                    resource_name,
-                    e
-                )
-            })?;
-        }
-
-        for db_number in 1..=15 {
-            let owner_key = Self::database_owner_key(db_number);
-            let claimed: bool = conn.set_nx(&owner_key, resource_name).await.map_err(|e| {
-                anyhow::anyhow!(
-                    "Failed to claim Redis DB {} for resource '{}': {}",
-                    db_number,
-                    resource_name,
-                    e
-                )
-            })?;
-
-            if claimed {
-                if let Err(error) = conn.set::<_, _, ()>(&mapping_key, db_number).await {
-                    let _: redis::RedisResult<()> = conn.del(&owner_key).await;
-                    return Err(anyhow::anyhow!(
-                        "Failed to store Redis DB {} mapping for resource '{}': {}",
-                        db_number,
-                        resource_name,
-                        error
-                    ));
-                }
-                return Ok(db_number);
-            }
-
-            let owner: Option<String> = conn.get(&owner_key).await.map_err(|e| {
-                anyhow::anyhow!(
-                    "Failed to read Redis DB {} owner while allocating resource '{}': {}",
-                    db_number,
-                    resource_name,
-                    e
-                )
-            })?;
-            if owner.as_deref() == Some(resource_name) {
-                conn.set::<_, _, ()>(&mapping_key, db_number)
-                    .await
-                    .map_err(|e| {
-                        anyhow::anyhow!(
-                            "Failed to restore Redis DB {} mapping for resource '{}': {}",
-                            db_number,
-                            resource_name,
-                            e
-                        )
-                    })?;
-                return Ok(db_number);
-            }
-        }
-
-        Err(anyhow::anyhow!(
-            "No Redis logical databases are available for resource '{}'; DB 0 is reserved for metadata and DBs 1-15 are already allocated",
-            resource_name
-        ))
-    }
-
-    async fn drop_database(&self, resource_name: &str) -> Result<()> {
-        let mut conn = self.get_connection().await?;
-        redis::cmd("SELECT")
-            .arg(0)
-            .query_async::<()>(&mut conn)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to select Redis metadata DB 0: {e}"))?;
-
-        let mapping_key = Self::resource_mapping_key(resource_name);
-        let db_number: Option<u8> = conn.get(&mapping_key).await.map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to read Redis DB mapping for resource '{}': {}",
-                resource_name,
-                e
-            )
-        })?;
-        let Some(db_number @ 1..=15) = db_number else {
-            info!(
-                "No valid Redis database mapping found for resource '{}'; skipping deprovision",
-                resource_name
-            );
-            return Ok(());
-        };
-
-        let owner_key = Self::database_owner_key(db_number);
-        let owner: Option<String> = conn.get(&owner_key).await.map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to verify Redis DB {} owner for resource '{}': {}",
-                db_number,
-                resource_name,
-                e
-            )
-        })?;
-        if owner.as_deref() != Some(resource_name) {
-            return Err(anyhow::anyhow!(
-                "Redis DB {} ownership mismatch while deprovisioning resource '{}'",
-                db_number,
-                resource_name
-            ));
-        }
-
-        redis::cmd("SELECT")
-            .arg(db_number)
-            .query_async::<()>(&mut conn)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to select Redis DB {db_number}: {e}"))?;
-        redis::cmd("FLUSHDB")
-            .query_async::<()>(&mut conn)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to flush Redis DB {db_number}: {e}"))?;
-        redis::cmd("SELECT")
-            .arg(0)
-            .query_async::<()>(&mut conn)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to reselect Redis metadata DB 0: {e}"))?;
-
-        conn.del::<_, ()>(&mapping_key).await.map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to delete Redis DB mapping for resource '{}': {}",
-                resource_name,
-                e
-            )
-        })?;
-        conn.del::<_, ()>(&owner_key).await.map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to release Redis DB {} for resource '{}': {}",
-                db_number,
-                resource_name,
-                e
-            )
-        })?;
-        Ok(())
+        // Redis supports 16 databases (0-15), so we use modulo to get a valid number
+        (hash % 16) as u8
     }
 
     fn get_redis_config(&self, service_config: ServiceConfig) -> Result<RedisConfig> {
@@ -2087,7 +1924,9 @@ impl ExternalService for RedisService {
     ) -> Result<HashMap<String, String>> {
         let resource_name = format!("{}_{}", project_id, environment);
 
-        let db_number = self.allocate_database(&resource_name).await?;
+        // Calculate database number using a hash instead of requiring Redis connection
+        // This allows us to generate env vars before the service is started
+        let db_number = self.calculate_database_number(&resource_name);
 
         let mut env_vars = HashMap::new();
 
@@ -2323,9 +2162,11 @@ impl ExternalService for RedisService {
         Ok(env_vars)
     }
 
-    async fn deprovision_resource(&self, project_id: &str, environment: &str) -> Result<()> {
-        let resource_name = format!("{}_{}", project_id, environment);
-        self.drop_database(&resource_name).await
+    async fn deprovision_resource(&self, _project_id: &str, _environment: &str) -> Result<()> {
+        // No database-level deprovisioning needed
+        // Each project/environment gets a calculated database number (0-15) based on hash
+        // Cleanup would happen at the application level (flushing keys with specific prefixes)
+        Ok(())
     }
 
     /// Backup Redis data to S3.
@@ -2956,22 +2797,6 @@ impl ExternalService for RedisService {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn redis_database_allocation_metadata_is_namespaced_per_resource_and_database() {
-        assert_ne!(
-            RedisService::resource_mapping_key("project-a_prod"),
-            RedisService::resource_mapping_key("project-b_prod")
-        );
-        assert_eq!(
-            RedisService::database_owner_key(1),
-            "_temps:redis_db_owner:1"
-        );
-        assert_ne!(
-            RedisService::database_owner_key(1),
-            RedisService::database_owner_key(2)
-        );
-    }
 
     use crate::externalsvc::DEPLOYMENT_MODE_MUTEX as ENV_MUTEX;
 

--- a/crates/temps-providers/src/externalsvc/redis.rs
+++ b/crates/temps-providers/src/externalsvc/redis.rs
@@ -9,7 +9,7 @@ use bollard::query_parameters::{InspectContainerOptions, StopContainerOptions};
 use bollard::Docker;
 use flate2::read::GzDecoder;
 use futures::TryStreamExt;
-use redis::{aio::ConnectionManager, Client};
+use redis::{aio::ConnectionManager, AsyncCommands, Client};
 use schemars::JsonSchema;
 use sea_orm::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -581,18 +581,181 @@ impl RedisService {
         Err(anyhow::anyhow!("Redis container health check timed out"))
     }
 
-    /// Calculate a deterministic database number (0-15) from a resource name
-    /// This allows us to allocate databases without requiring a Redis connection
-    fn calculate_database_number(&self, resource_name: &str) -> u8 {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
+    fn resource_mapping_key(resource_name: &str) -> String {
+        format!("_temps:redis_db_mapping:{resource_name}")
+    }
 
-        let mut hasher = DefaultHasher::new();
-        resource_name.hash(&mut hasher);
-        let hash = hasher.finish();
+    fn database_owner_key(db_number: u8) -> String {
+        format!("_temps:redis_db_owner:{db_number}")
+    }
 
-        // Redis supports 16 databases (0-15), so we use modulo to get a valid number
-        (hash % 16) as u8
+    /// Allocate one of Redis DBs 1-15. DB 0 is reserved for allocation
+    /// metadata, preventing hash collisions from silently sharing data.
+    async fn allocate_database(&self, resource_name: &str) -> Result<u8> {
+        let mut conn = self.get_connection().await?;
+        redis::cmd("SELECT")
+            .arg(0)
+            .query_async::<()>(&mut conn)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to select Redis metadata DB 0: {e}"))?;
+
+        let mapping_key = Self::resource_mapping_key(resource_name);
+        let existing: Option<u8> = conn.get(&mapping_key).await.map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to read Redis DB mapping for resource '{}': {}",
+                resource_name,
+                e
+            )
+        })?;
+        if let Some(db_number @ 1..=15) = existing {
+            let owner: Option<String> = conn
+                .get(Self::database_owner_key(db_number))
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "Failed to verify Redis DB {} mapping for resource '{}': {}",
+                        db_number,
+                        resource_name,
+                        e
+                    )
+                })?;
+            if owner.as_deref() == Some(resource_name) {
+                return Ok(db_number);
+            }
+            conn.del::<_, ()>(&mapping_key).await.map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to remove stale Redis DB mapping for resource '{}': {}",
+                    resource_name,
+                    e
+                )
+            })?;
+        }
+
+        for db_number in 1..=15 {
+            let owner_key = Self::database_owner_key(db_number);
+            let claimed: bool = conn.set_nx(&owner_key, resource_name).await.map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to claim Redis DB {} for resource '{}': {}",
+                    db_number,
+                    resource_name,
+                    e
+                )
+            })?;
+
+            if claimed {
+                if let Err(error) = conn.set::<_, _, ()>(&mapping_key, db_number).await {
+                    let _: redis::RedisResult<()> = conn.del(&owner_key).await;
+                    return Err(anyhow::anyhow!(
+                        "Failed to store Redis DB {} mapping for resource '{}': {}",
+                        db_number,
+                        resource_name,
+                        error
+                    ));
+                }
+                return Ok(db_number);
+            }
+
+            let owner: Option<String> = conn.get(&owner_key).await.map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to read Redis DB {} owner while allocating resource '{}': {}",
+                    db_number,
+                    resource_name,
+                    e
+                )
+            })?;
+            if owner.as_deref() == Some(resource_name) {
+                conn.set::<_, _, ()>(&mapping_key, db_number)
+                    .await
+                    .map_err(|e| {
+                        anyhow::anyhow!(
+                            "Failed to restore Redis DB {} mapping for resource '{}': {}",
+                            db_number,
+                            resource_name,
+                            e
+                        )
+                    })?;
+                return Ok(db_number);
+            }
+        }
+
+        Err(anyhow::anyhow!(
+            "No Redis logical databases are available for resource '{}'; DB 0 is reserved for metadata and DBs 1-15 are already allocated",
+            resource_name
+        ))
+    }
+
+    async fn drop_database(&self, resource_name: &str) -> Result<()> {
+        let mut conn = self.get_connection().await?;
+        redis::cmd("SELECT")
+            .arg(0)
+            .query_async::<()>(&mut conn)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to select Redis metadata DB 0: {e}"))?;
+
+        let mapping_key = Self::resource_mapping_key(resource_name);
+        let db_number: Option<u8> = conn.get(&mapping_key).await.map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to read Redis DB mapping for resource '{}': {}",
+                resource_name,
+                e
+            )
+        })?;
+        let Some(db_number @ 1..=15) = db_number else {
+            info!(
+                "No valid Redis database mapping found for resource '{}'; skipping deprovision",
+                resource_name
+            );
+            return Ok(());
+        };
+
+        let owner_key = Self::database_owner_key(db_number);
+        let owner: Option<String> = conn.get(&owner_key).await.map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to verify Redis DB {} owner for resource '{}': {}",
+                db_number,
+                resource_name,
+                e
+            )
+        })?;
+        if owner.as_deref() != Some(resource_name) {
+            return Err(anyhow::anyhow!(
+                "Redis DB {} ownership mismatch while deprovisioning resource '{}'",
+                db_number,
+                resource_name
+            ));
+        }
+
+        redis::cmd("SELECT")
+            .arg(db_number)
+            .query_async::<()>(&mut conn)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to select Redis DB {db_number}: {e}"))?;
+        redis::cmd("FLUSHDB")
+            .query_async::<()>(&mut conn)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to flush Redis DB {db_number}: {e}"))?;
+        redis::cmd("SELECT")
+            .arg(0)
+            .query_async::<()>(&mut conn)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to reselect Redis metadata DB 0: {e}"))?;
+
+        conn.del::<_, ()>(&mapping_key).await.map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to delete Redis DB mapping for resource '{}': {}",
+                resource_name,
+                e
+            )
+        })?;
+        conn.del::<_, ()>(&owner_key).await.map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to release Redis DB {} for resource '{}': {}",
+                db_number,
+                resource_name,
+                e
+            )
+        })?;
+        Ok(())
     }
 
     fn get_redis_config(&self, service_config: ServiceConfig) -> Result<RedisConfig> {
@@ -1924,9 +2087,7 @@ impl ExternalService for RedisService {
     ) -> Result<HashMap<String, String>> {
         let resource_name = format!("{}_{}", project_id, environment);
 
-        // Calculate database number using a hash instead of requiring Redis connection
-        // This allows us to generate env vars before the service is started
-        let db_number = self.calculate_database_number(&resource_name);
+        let db_number = self.allocate_database(&resource_name).await?;
 
         let mut env_vars = HashMap::new();
 
@@ -2162,11 +2323,9 @@ impl ExternalService for RedisService {
         Ok(env_vars)
     }
 
-    async fn deprovision_resource(&self, _project_id: &str, _environment: &str) -> Result<()> {
-        // No database-level deprovisioning needed
-        // Each project/environment gets a calculated database number (0-15) based on hash
-        // Cleanup would happen at the application level (flushing keys with specific prefixes)
-        Ok(())
+    async fn deprovision_resource(&self, project_id: &str, environment: &str) -> Result<()> {
+        let resource_name = format!("{}_{}", project_id, environment);
+        self.drop_database(&resource_name).await
     }
 
     /// Backup Redis data to S3.
@@ -2797,6 +2956,22 @@ impl ExternalService for RedisService {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn redis_database_allocation_metadata_is_namespaced_per_resource_and_database() {
+        assert_ne!(
+            RedisService::resource_mapping_key("project-a_prod"),
+            RedisService::resource_mapping_key("project-b_prod")
+        );
+        assert_eq!(
+            RedisService::database_owner_key(1),
+            "_temps:redis_db_owner:1"
+        );
+        assert_ne!(
+            RedisService::database_owner_key(1),
+            RedisService::database_owner_key(2)
+        );
+    }
 
     use crate::externalsvc::DEPLOYMENT_MODE_MUTEX as ENV_MUTEX;
 

--- a/crates/temps-providers/src/mariadb_query.rs
+++ b/crates/temps-providers/src/mariadb_query.rs
@@ -580,8 +580,8 @@ impl Queryable for MariaDbSource {
         // The caller's tokio deadline frees the control-plane task, but dropping
         // the future does not stop the server: it keeps executing and keeps
         // holding its share of the operator's database. That matters here
-        // because this backend accepts a caller-supplied WHERE clause and a
-        // caller-supplied OFFSET, whose cost is O(offset) regardless of LIMIT.
+        // because this backend accepts structured caller-supplied filters and
+        // a caller-supplied OFFSET, whose cost is O(offset) regardless of LIMIT.
         //
         // See `apply_statement_timeout` for why both spellings are tried and
         // why this must share the query's connection.

--- a/crates/temps-providers/src/mariadb_query.rs
+++ b/crates/temps-providers/src/mariadb_query.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use futures::TryStreamExt;
-use sqlx::mysql::{MySqlPool, MySqlPoolOptions};
-use sqlx::Row;
-use std::collections::HashMap;
+use sqlx::mysql::{MySqlArguments, MySqlPool, MySqlPoolOptions};
+use sqlx::{MySql, Row};
+use std::collections::{HashMap, HashSet};
 use temps_query::{
     BoundedRows, Capability, ContainerCapabilities, ContainerInfo, ContainerPath, ContainerType,
     DataError, DataRow, DataSource, DatasetSchema, EntityCountHint, EntityInfo, FieldDef,
@@ -537,6 +537,7 @@ impl Queryable for MariaDbSource {
         validate_identifier("table", entity_name)?;
         let schema = self.get_schema(container_path, entity_name).await?;
         let columns = self.query_columns(database_name, entity_name).await?;
+        let allowed_fields = schema_field_names(&schema);
 
         let start = std::time::Instant::now();
         let mut sql = format!(
@@ -545,12 +546,10 @@ impl Queryable for MariaDbSource {
             quote_identifier(entity_name)
         );
 
-        if let Some(filter_json) = filters {
-            if let Some(where_clause) = filter_json.get("where").and_then(|v| v.as_str()) {
-                validate_where_clause(where_clause)?;
-                sql.push_str(" WHERE ");
-                sql.push_str(where_clause);
-            }
+        let filter = build_filter_clause(filters.as_ref(), &allowed_fields)?;
+        if let Some(filter) = &filter {
+            sql.push_str(" WHERE ");
+            sql.push_str(&filter.sql);
         }
 
         if let Some(sort_by) = &options.sort_by {
@@ -595,7 +594,11 @@ impl Queryable for MariaDbSource {
         })?;
         apply_statement_timeout(&mut conn, timeout_ms, database_name).await;
 
-        let mut stream = sqlx::query(&sql)
+        let mut query = sqlx::query(&sql);
+        if let Some(filter) = &filter {
+            query = bind_filter_params(query, &filter.params);
+        }
+        let mut stream = query
             .bind(limit as i64)
             .bind(offset as i64)
             .fetch(&mut *conn);
@@ -708,6 +711,8 @@ impl Queryable for MariaDbSource {
     ) -> Result<u64> {
         let database_name = database_from_path(container_path, &self.database_name)?;
         validate_identifier("table", entity_name)?;
+        let schema = self.get_schema(container_path, entity_name).await?;
+        let allowed_fields = schema_field_names(&schema);
 
         let mut sql = format!(
             "SELECT COUNT(*) AS row_count FROM {}.{}",
@@ -715,12 +720,10 @@ impl Queryable for MariaDbSource {
             quote_identifier(entity_name)
         );
 
-        if let Some(filter_json) = filters {
-            if let Some(where_clause) = filter_json.get("where").and_then(|v| v.as_str()) {
-                validate_where_clause(where_clause)?;
-                sql.push_str(" WHERE ");
-                sql.push_str(where_clause);
-            }
+        let filter = build_filter_clause(filters.as_ref(), &allowed_fields)?;
+        if let Some(filter) = &filter {
+            sql.push_str(" WHERE ");
+            sql.push_str(&filter.sql);
         }
 
         // SECURITY: bound this the way `query` is bounded.
@@ -742,7 +745,11 @@ impl Queryable for MariaDbSource {
         })?;
         apply_statement_timeout(&mut conn, COUNT_TIMEOUT_MS, database_name).await;
 
-        let row = sqlx::query(&sql)
+        let mut query = sqlx::query(&sql);
+        if let Some(filter) = &filter {
+            query = bind_filter_params(query, &filter.params);
+        }
+        let row = query
             .fetch_one(&mut *conn)
             .await
             .map_err(|e| DataError::QueryFailed(format!("Count query failed: {}", e)))?;
@@ -787,22 +794,35 @@ impl QuerySchemaProvider for MariaDbSource {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
             "title": "MariaDB Query Filters",
-            "description": "Filter data using SQL WHERE clause syntax",
+            "description": "Filter data with structured, parameterized conditions",
             "properties": {
-                "where": {
+                "logic": {
                     "type": "string",
-                    "title": "WHERE Clause",
-                    "description": "SQL WHERE clause (without 'WHERE' keyword). Example: status = 'active' AND created_at > '2025-01-01'",
-                    "examples": [
-                        "status = 'active'",
-                        "created_at > '2025-01-01'",
-                        "age >= 18 AND country = 'US'",
-                        "name LIKE '%test%'",
-                        "id IN (1, 2, 3)"
-                    ],
-                    "x-ui-widget": "textarea",
-                    "x-ui-placeholder": "status = 'active' AND created_at > NOW() - INTERVAL 7 DAY",
-                    "x-ui-rows": 3
+                    "title": "Condition Logic",
+                    "enum": ["and", "or"],
+                    "default": "and"
+                },
+                "conditions": {
+                    "type": "array",
+                    "title": "Conditions",
+                    "items": {
+                        "type": "object",
+                        "required": ["field", "op", "value"],
+                        "properties": {
+                            "field": { "type": "string", "title": "Column" },
+                            "op": {
+                                "type": "string",
+                                "title": "Operator",
+                                "enum": ["eq", "ne", "gt", "gte", "lt", "lte", "like", "in"],
+                                "default": "eq"
+                            },
+                            "value": {
+                                "title": "Value",
+                                "description": "Scalar value for comparisons, or an array when op is in"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
                 }
             },
             "additionalProperties": false
@@ -1024,6 +1044,193 @@ fn normalize_sort_field(sort_by: &str) -> Result<&str> {
     Ok(trimmed)
 }
 
+#[derive(Debug, Clone, PartialEq)]
+enum FilterParam {
+    Bool(bool),
+    F64(f64),
+    I64(i64),
+    String(String),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct FilterClause {
+    sql: String,
+    params: Vec<FilterParam>,
+}
+
+fn schema_field_names(schema: &DatasetSchema) -> HashSet<String> {
+    schema
+        .fields
+        .iter()
+        .map(|field| field.name.clone())
+        .collect()
+}
+
+fn build_filter_clause(
+    filters: Option<&serde_json::Value>,
+    allowed_fields: &HashSet<String>,
+) -> Result<Option<FilterClause>> {
+    let Some(filters) = filters else {
+        return Ok(None);
+    };
+    if filters.get("where").is_some() {
+        return Err(DataError::InvalidQuery(
+            "Raw SQL WHERE filters are not supported for MariaDB; use structured conditions"
+                .to_string(),
+        ));
+    }
+    let Some(conditions) = filters.get("conditions") else {
+        return if filters.as_object().is_some_and(|object| object.is_empty()) {
+            Ok(None)
+        } else {
+            Err(DataError::InvalidQuery(
+                "MariaDB filters require a 'conditions' array".to_string(),
+            ))
+        };
+    };
+    let conditions = conditions.as_array().ok_or_else(|| {
+        DataError::InvalidQuery("MariaDB filter 'conditions' must be an array".to_string())
+    })?;
+    if conditions.is_empty() {
+        return Ok(None);
+    }
+
+    let joiner = match filters
+        .get("logic")
+        .and_then(|value| value.as_str())
+        .unwrap_or("and")
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "and" => " AND ",
+        "or" => " OR ",
+        _ => {
+            return Err(DataError::InvalidQuery(
+                "MariaDB filter 'logic' must be 'and' or 'or'".to_string(),
+            ))
+        }
+    };
+
+    let mut sql_parts = Vec::with_capacity(conditions.len());
+    let mut params = Vec::new();
+    for condition in conditions {
+        let field = condition
+            .get("field")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| {
+                DataError::InvalidQuery(
+                    "MariaDB filter condition requires a string 'field'".to_string(),
+                )
+            })?;
+        validate_identifier("filter field", field)?;
+        if !allowed_fields.contains(field) {
+            return Err(DataError::InvalidQuery(format!(
+                "Filter field '{}' does not exist on the selected MariaDB table",
+                field
+            )));
+        }
+        let op = condition
+            .get("op")
+            .and_then(|value| value.as_str())
+            .unwrap_or("eq")
+            .to_ascii_lowercase();
+        let value = condition.get("value").ok_or_else(|| {
+            DataError::InvalidQuery("MariaDB filter condition requires a 'value'".to_string())
+        })?;
+        let ident = quote_identifier(field);
+        match op.as_str() {
+            "eq" | "ne" => {
+                if value.is_null() {
+                    let operator = if op == "eq" { "IS NULL" } else { "IS NOT NULL" };
+                    sql_parts.push(format!("{ident} {operator}"));
+                } else {
+                    let operator = if op == "eq" { "=" } else { "<>" };
+                    sql_parts.push(format!("{ident} {operator} ?"));
+                    params.push(filter_param(value)?);
+                }
+            }
+            "gt" | "gte" | "lt" | "lte" | "like" => {
+                if value.is_null() {
+                    return Err(DataError::InvalidQuery(format!(
+                        "MariaDB filter operator '{}' cannot compare against null",
+                        op
+                    )));
+                }
+                let operator = match op.as_str() {
+                    "gt" => ">",
+                    "gte" => ">=",
+                    "lt" => "<",
+                    "lte" => "<=",
+                    "like" => "LIKE",
+                    _ => unreachable!(),
+                };
+                sql_parts.push(format!("{ident} {operator} ?"));
+                params.push(filter_param(value)?);
+            }
+            "in" => {
+                let values = value.as_array().ok_or_else(|| {
+                    DataError::InvalidQuery(
+                        "MariaDB 'in' filter value must be an array".to_string(),
+                    )
+                })?;
+                if values.is_empty() || values.iter().any(serde_json::Value::is_null) {
+                    return Err(DataError::InvalidQuery(
+                        "MariaDB 'in' filter requires non-null values".to_string(),
+                    ));
+                }
+                sql_parts.push(format!(
+                    "{ident} IN ({})",
+                    vec!["?"; values.len()].join(", ")
+                ));
+                for value in values {
+                    params.push(filter_param(value)?)
+                }
+            }
+            _ => {
+                return Err(DataError::InvalidQuery(format!(
+                    "Unsupported MariaDB filter operator '{}'",
+                    op
+                )))
+            }
+        }
+    }
+    Ok(Some(FilterClause {
+        sql: sql_parts.join(joiner),
+        params,
+    }))
+}
+
+fn filter_param(value: &serde_json::Value) -> Result<FilterParam> {
+    if let Some(value) = value.as_bool() {
+        Ok(FilterParam::Bool(value))
+    } else if let Some(value) = value.as_i64() {
+        Ok(FilterParam::I64(value))
+    } else if let Some(value) = value.as_f64() {
+        Ok(FilterParam::F64(value))
+    } else if let Some(value) = value.as_str() {
+        Ok(FilterParam::String(value.to_string()))
+    } else {
+        Err(DataError::InvalidQuery(
+            "MariaDB filter values must be strings, numbers, or booleans".to_string(),
+        ))
+    }
+}
+
+fn bind_filter_params<'q>(
+    mut query: sqlx::query::Query<'q, MySql, MySqlArguments>,
+    params: &'q [FilterParam],
+) -> sqlx::query::Query<'q, MySql, MySqlArguments> {
+    for param in params {
+        query = match param {
+            FilterParam::Bool(value) => query.bind(*value),
+            FilterParam::F64(value) => query.bind(*value),
+            FilterParam::I64(value) => query.bind(*value),
+            FilterParam::String(value) => query.bind(value),
+        };
+    }
+    query
+}
+
 /// Server-side ceiling for `count`, which takes no `QueryOptions` and so has no
 /// caller-supplied deadline to honour. See the call site for why it needs one.
 const COUNT_TIMEOUT_MS: u64 = 10_000;
@@ -1066,6 +1273,7 @@ async fn apply_statement_timeout(
     }
 }
 
+#[cfg(test)]
 fn strip_sql_string_literals(sql: &str) -> Result<String> {
     let mut result = String::with_capacity(sql.len());
     let mut in_string = false;
@@ -1184,6 +1392,7 @@ fn strip_sql_string_literals(sql: &str) -> Result<String> {
     Ok(result)
 }
 
+#[cfg(test)]
 fn validate_where_clause(sql: &str) -> Result<()> {
     let sql_lower = sql.trim().to_ascii_lowercase();
 
@@ -1744,6 +1953,39 @@ mod tests {
         assert!(validate_where_clause("1=1; DROP TABLE users").is_err());
         assert!(validate_where_clause("id = 1 UNION SELECT password FROM users").is_err());
         assert!(validate_where_clause("name = 'x' -- comment").is_err());
+    }
+
+    #[test]
+    fn structured_filters_use_only_placeholders_and_known_fields() {
+        let fields = HashSet::from(["status".to_string(), "age".to_string(), "id".to_string()]);
+        let filters = serde_json::json!({
+            "logic": "and",
+            "conditions": [
+                {"field": "status", "op": "eq", "value": "active"},
+                {"field": "age", "op": "gte", "value": 18},
+                {"field": "id", "op": "in", "value": [1, 2, 3]}
+            ]
+        });
+        let clause = build_filter_clause(Some(&filters), &fields)
+            .expect("structured filter should validate")
+            .expect("structured filter should produce a clause");
+        assert_eq!(
+            clause.sql,
+            "`status` = ? AND `age` >= ? AND `id` IN (?, ?, ?)"
+        );
+        assert_eq!(clause.params.len(), 5);
+        assert!(!clause.sql.contains("active"));
+    }
+
+    #[test]
+    fn structured_filters_reject_raw_sql_and_unknown_fields() {
+        let fields = HashSet::from(["status".to_string()]);
+        let raw = serde_json::json!({"where": "EXISTS(SELECT 1 FROM mysql.user)"});
+        let unknown = serde_json::json!({
+            "conditions": [{"field": "password", "op": "eq", "value": "x"}]
+        });
+        assert!(build_filter_clause(Some(&raw), &fields).is_err());
+        assert!(build_filter_clause(Some(&unknown), &fields).is_err());
     }
 
     #[test]

--- a/crates/temps-providers/src/mariadb_query.rs
+++ b/crates/temps-providers/src/mariadb_query.rs
@@ -1724,7 +1724,9 @@ mod tests {
             .query(
                 &path,
                 "rows_budget",
-                Some(serde_json::json!({"where": "id = 1"})),
+                Some(serde_json::json!({
+                    "conditions": [{"field": "id", "op": "eq", "value": 1}]
+                })),
                 QueryOptions::default(),
             )
             .await?;
@@ -1734,7 +1736,9 @@ mod tests {
             .query(
                 &path,
                 "rows_budget",
-                Some(serde_json::json!({"where": "id = 2"})),
+                Some(serde_json::json!({
+                    "conditions": [{"field": "id", "op": "eq", "value": 2}]
+                })),
                 QueryOptions {
                     limit: Some(1),
                     budget: QueryBudget {

--- a/crates/temps-providers/src/parameter_strategies.rs
+++ b/crates/temps-providers/src/parameter_strategies.rs
@@ -879,19 +879,19 @@ impl ParameterStrategy for MinioParameterStrategy {
             );
         }
 
-        // Auto-generate access_key if not provided
+        // Never fall back to MinIO's well-known root credentials.
         if is_empty_value(params.get("access_key")) {
             params.insert(
                 "access_key".to_string(),
-                JsonValue::String("minioadmin".to_string()),
+                JsonValue::String(generate_access_key()),
             );
         }
 
-        // Auto-generate secret_key if not provided
+        // Generate an independent secret for every managed instance.
         if is_empty_value(params.get("secret_key")) {
             params.insert(
                 "secret_key".to_string(),
-                JsonValue::String("minioadmin".to_string()),
+                JsonValue::String(generate_secret_key()),
             );
         }
 
@@ -940,13 +940,13 @@ impl ParameterStrategy for MinioParameterStrategy {
             "properties": {
                 "access_key": {
                     "type": "string",
-                    "description": "Access key (read-only after creation)",
-                    "example": "minioadmin"
+                    "description": "Access key (read-only after creation, auto-generated)",
+                    "example": "AKIAIOSFODNN7EXAMPLE"
                 },
                 "secret_key": {
                     "type": "string",
-                    "description": "Secret key (read-only after creation)",
-                    "example": "minioadmin"
+                    "description": "Secret key (read-only after creation, auto-generated)",
+                    "example": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
                 },
                 "port": {
                     "type": "integer",
@@ -1772,6 +1772,43 @@ mod tests {
             err.contains("container_name"),
             "error should mention 'container_name', got: {err}"
         );
+    }
+
+    #[test]
+    fn minio_generates_unique_s3_style_credentials() {
+        let strategy = MinioParameterStrategy;
+        let mut first = HashMap::new();
+        let mut second = HashMap::new();
+
+        strategy
+            .auto_generate_missing(&mut first)
+            .expect("first MinIO credentials should generate");
+        strategy
+            .auto_generate_missing(&mut second)
+            .expect("second MinIO credentials should generate");
+
+        let first_access = first
+            .get("access_key")
+            .and_then(JsonValue::as_str)
+            .expect("access key should be generated");
+        let first_secret = first
+            .get("secret_key")
+            .and_then(JsonValue::as_str)
+            .expect("secret key should be generated");
+        assert_ne!(first_access, "minioadmin");
+        assert_ne!(first_secret, "minioadmin");
+        assert_eq!(first_access.len(), 20);
+        assert_eq!(first_secret.len(), 40);
+        assert!(first_access
+            .chars()
+            .all(|character| character.is_ascii_uppercase() || character.is_ascii_digit()));
+        assert!(first_secret
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric()
+                || character == '+'
+                || character == '/'));
+        assert_ne!(first.get("access_key"), second.get("access_key"));
+        assert_ne!(first.get("secret_key"), second.get("secret_key"));
     }
 
     #[test]

--- a/crates/temps-providers/src/postgres_lifecycle.rs
+++ b/crates/temps-providers/src/postgres_lifecycle.rs
@@ -360,6 +360,10 @@ impl PostgresContainerLifecycle for PostgresLifecycleAdapter {
         })
     }
 
+    async fn docker_image(&self, service_id: i32) -> Result<String, String> {
+        Ok(self.load_postgres_config(service_id).await?.docker_image)
+    }
+
     async fn stop_and_remove(&self, service_id: i32) -> Result<(), String> {
         let svc = self.load_service_row(service_id).await?;
         let container_name = format!("postgres-{}", svc.name);

--- a/crates/temps-providers/src/postgres_upgrade_service.rs
+++ b/crates/temps-providers/src/postgres_upgrade_service.rs
@@ -18,10 +18,36 @@ use temps_entities::{external_services, postgres_major_upgrades};
 use temps_logs::LogService;
 use uuid::Uuid;
 
+use crate::externalsvc::postgres::validate_postgres_docker_image;
 use crate::externalsvc::postgres_upgrade::{
     phase, status, validate_os_family, PostgresContainerLifecycle, PostgresUpgradeError,
     PostgresUpgradeOrchestrator, PreUpgradeBackupProvider,
 };
+
+fn image_major_version(image: &str) -> Option<u32> {
+    image
+        .rsplit_once(':')
+        .map(|(_, tag)| tag)?
+        .trim_start_matches("pg")
+        .split(['-', '.'])
+        .next()?
+        .parse()
+        .ok()
+}
+
+fn validate_configured_source_image(
+    req: &StartMajorUpgradeRequest,
+    configured_image: &str,
+) -> Result<(), PostgresUpgradeError> {
+    if req.from_image == configured_image {
+        return Ok(());
+    }
+    Err(PostgresUpgradeError::SourceImageMismatch {
+        service_id: req.service_id,
+        configured_image: configured_image.to_string(),
+        expected_image: req.from_image.clone(),
+    })
+}
 
 /// Pure pre-flight validation for a major upgrade request. Separated so
 /// unit tests can exercise the validation surface without a real Docker
@@ -38,6 +64,15 @@ pub fn validate_start_request(
         });
     }
 
+    for image in [&req.from_image, &req.to_image] {
+        validate_postgres_docker_image(image).map_err(|_| {
+            PostgresUpgradeError::UnsupportedImage {
+                service_id: req.service_id,
+                image: image.clone(),
+            }
+        })?;
+    }
+
     validate_os_family(req.service_id, &req.from_image, &req.to_image)?;
 
     let from_n: u32 = req.from_version.parse().unwrap_or(0);
@@ -49,6 +84,20 @@ pub fn validate_start_request(
             to_version: req.to_version.clone(),
             reason: "to_version must be a greater major version than from_version".into(),
         });
+    }
+
+    for (image, declared_version) in [(&req.from_image, from_n), (&req.to_image, to_n)] {
+        if image_major_version(image) != Some(declared_version) {
+            return Err(PostgresUpgradeError::InvalidVersionTransition {
+                service_id: req.service_id,
+                from_version: req.from_version.clone(),
+                to_version: req.to_version.clone(),
+                reason: format!(
+                    "image '{}' does not match its declared major version {}",
+                    image, declared_version
+                ),
+            });
+        }
     }
 
     Ok(())
@@ -122,6 +171,15 @@ impl PostgresUpgradeService {
                 upgrade_id: req.service_id,
             })?;
         validate_start_request(&req, &svc.service_type)?;
+        let configured_image =
+            self.lifecycle
+                .docker_image(req.service_id)
+                .await
+                .map_err(|reason| PostgresUpgradeError::ServiceConfiguration {
+                    service_id: req.service_id,
+                    reason,
+                })?;
+        validate_configured_source_image(&req, &configured_image)?;
 
         // 4. Defensive concurrency check. The partial-unique index is the
         //    real lock; this just turns the race into a typed 409.
@@ -503,8 +561,8 @@ mod tests {
             service_id: 1,
             from_version: "16".into(),
             to_version: "17".into(),
-            from_image: "postgres:16-bookworm".into(),
-            to_image: "postgres:17-bookworm".into(),
+            from_image: "gotempsh/postgres-walg:16-bookworm".into(),
+            to_image: "gotempsh/postgres-walg:17-bookworm".into(),
             created_by: 1,
         };
         assert_eq!(req.from_version, "16");
@@ -521,8 +579,8 @@ mod tests {
             service_id: 7,
             from_version: "16".into(),
             to_version: "17".into(),
-            from_image: "postgres:16-bookworm".into(),
-            to_image: "postgres:17-bookworm".into(),
+            from_image: "gotempsh/postgres-walg:16-bookworm".into(),
+            to_image: "gotempsh/postgres-walg:17-bookworm".into(),
             created_by: 1,
         }
     }
@@ -539,15 +597,14 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_cross_os_upgrade() {
+    fn validate_rejects_unreviewed_image() {
         let mut req = sample_request();
         req.from_image = "postgres:16-alpine".into();
-        // to_image stays bookworm
         let err = validate_start_request(&req, "postgres")
-            .expect_err("alpine -> bookworm must be rejected");
+            .expect_err("an unreviewed source image must be rejected");
         assert!(matches!(
             err,
-            PostgresUpgradeError::OsFamilyMismatch { service_id: 7, .. }
+            PostgresUpgradeError::UnsupportedImage { service_id: 7, .. }
         ));
     }
 
@@ -556,8 +613,8 @@ mod tests {
         let mut req = sample_request();
         req.from_version = "17".into();
         req.to_version = "16".into();
-        req.from_image = "postgres:17-bookworm".into();
-        req.to_image = "postgres:16-bookworm".into();
+        req.from_image = "gotempsh/postgres-walg:17-bookworm".into();
+        req.to_image = "gotempsh/postgres-walg:16-bookworm".into();
         let err = validate_start_request(&req, "postgres").expect_err("downgrade must be rejected");
         assert!(matches!(
             err,
@@ -569,7 +626,7 @@ mod tests {
     fn validate_rejects_same_version() {
         let mut req = sample_request();
         req.to_version = "16".into();
-        req.to_image = "postgres:16-bookworm".into();
+        req.to_image = "gotempsh/postgres-walg:16-bookworm".into();
         let err =
             validate_start_request(&req, "postgres").expect_err("same-version must be rejected");
         assert!(matches!(
@@ -587,10 +644,36 @@ mod tests {
     }
 
     #[test]
-    fn validate_accepts_custom_repo_upgrade() {
+    fn validate_rejects_unreviewed_repo_upgrade() {
         let mut req = sample_request();
         req.from_image = "gotempsh/postgres-ha:16-bookworm".into();
         req.to_image = "gotempsh/postgres-ha:17-bookworm".into();
-        validate_start_request(&req, "postgres").expect("custom repo 16->17 should pass");
+        assert!(matches!(
+            validate_start_request(&req, "postgres"),
+            Err(PostgresUpgradeError::UnsupportedImage { .. })
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_image_version_mismatch() {
+        let mut req = sample_request();
+        req.to_version = "18".into();
+        let err = validate_start_request(&req, "postgres")
+            .expect_err("declared version must agree with the reviewed image tag");
+        assert!(matches!(
+            err,
+            PostgresUpgradeError::InvalidVersionTransition { .. }
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_source_image_different_from_service_config() {
+        let req = sample_request();
+        let err = validate_configured_source_image(&req, "gotempsh/postgres-walg:15-bookworm")
+            .expect_err("upgrade source must match the current service image");
+        assert!(matches!(
+            err,
+            PostgresUpgradeError::SourceImageMismatch { service_id: 7, .. }
+        ));
     }
 }

--- a/crates/temps-providers/src/postgres_upgrade_service.rs
+++ b/crates/temps-providers/src/postgres_upgrade_service.rs
@@ -18,22 +18,10 @@ use temps_entities::{external_services, postgres_major_upgrades};
 use temps_logs::LogService;
 use uuid::Uuid;
 
-use crate::externalsvc::postgres::validate_postgres_docker_image;
 use crate::externalsvc::postgres_upgrade::{
-    phase, status, validate_os_family, PostgresContainerLifecycle, PostgresUpgradeError,
+    phase, status, validate_image_transition, PostgresContainerLifecycle, PostgresUpgradeError,
     PostgresUpgradeOrchestrator, PreUpgradeBackupProvider,
 };
-
-fn image_major_version(image: &str) -> Option<u32> {
-    image
-        .rsplit_once(':')
-        .map(|(_, tag)| tag)?
-        .trim_start_matches("pg")
-        .split(['-', '.'])
-        .next()?
-        .parse()
-        .ok()
-}
 
 fn validate_configured_source_image(
     req: &StartMajorUpgradeRequest,
@@ -64,43 +52,13 @@ pub fn validate_start_request(
         });
     }
 
-    for image in [&req.from_image, &req.to_image] {
-        validate_postgres_docker_image(image).map_err(|_| {
-            PostgresUpgradeError::UnsupportedImage {
-                service_id: req.service_id,
-                image: image.clone(),
-            }
-        })?;
-    }
-
-    validate_os_family(req.service_id, &req.from_image, &req.to_image)?;
-
-    let from_n: u32 = req.from_version.parse().unwrap_or(0);
-    let to_n: u32 = req.to_version.parse().unwrap_or(0);
-    if to_n == 0 || from_n == 0 || to_n <= from_n {
-        return Err(PostgresUpgradeError::InvalidVersionTransition {
-            service_id: req.service_id,
-            from_version: req.from_version.clone(),
-            to_version: req.to_version.clone(),
-            reason: "to_version must be a greater major version than from_version".into(),
-        });
-    }
-
-    for (image, declared_version) in [(&req.from_image, from_n), (&req.to_image, to_n)] {
-        if image_major_version(image) != Some(declared_version) {
-            return Err(PostgresUpgradeError::InvalidVersionTransition {
-                service_id: req.service_id,
-                from_version: req.from_version.clone(),
-                to_version: req.to_version.clone(),
-                reason: format!(
-                    "image '{}' does not match its declared major version {}",
-                    image, declared_version
-                ),
-            });
-        }
-    }
-
-    Ok(())
+    validate_image_transition(
+        req.service_id,
+        &req.from_version,
+        &req.to_version,
+        &req.from_image,
+        &req.to_image,
+    )
 }
 
 /// Request payload for starting a major-version upgrade.

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -11737,7 +11737,7 @@ mod tests {
         params.insert("port".to_string(), JsonValue::String(port.to_string()));
         params.insert(
             "docker_image".to_string(),
-            JsonValue::String("postgres:17-bookworm".to_string()),
+            JsonValue::String("timescale/timescaledb-ha:pg17".to_string()),
         );
         let svc = manager
             .create_service(CreateExternalServiceRequest {
@@ -11781,8 +11781,8 @@ mod tests {
                 service_id: Set(svc.id),
                 from_version: Set("17".to_string()),
                 to_version: Set("18".to_string()),
-                from_image: Set("postgres:17-bookworm".to_string()),
-                to_image: Set("postgres:18-bookworm".to_string()),
+                from_image: Set("timescale/timescaledb-ha:pg17".to_string()),
+                to_image: Set("timescale/timescaledb-ha:pg18".to_string()),
                 status: Set(status::PENDING.to_string()),
                 phase: Set(status::PENDING.to_string()),
                 pre_upgrade_backup_id: Set(None),

--- a/crates/temps-proxy/src/proxy.rs
+++ b/crates/temps-proxy/src/proxy.rs
@@ -430,6 +430,36 @@ fn should_redirect_to_https(
     env_force_https.unwrap_or_else(host_has_cert)
 }
 
+fn deployment_asset_path_matches(
+    current_deployment_slug: Option<&str>,
+    requested_deployment_slug: &str,
+) -> bool {
+    current_deployment_slug == Some(requested_deployment_slug)
+}
+
+fn inherited_https_policy(production_https: bool, host_has_cert: bool) -> bool {
+    production_https || host_has_cert
+}
+
+#[cfg(test)]
+mod deployment_asset_scope_tests {
+    use super::{deployment_asset_path_matches, inherited_https_policy};
+
+    #[test]
+    fn prefixed_asset_must_name_the_current_deployment() {
+        assert!(deployment_asset_path_matches(Some("deploy-a"), "deploy-a"));
+        assert!(!deployment_asset_path_matches(Some("deploy-a"), "deploy-b"));
+        assert!(!deployment_asset_path_matches(None, "deploy-a"));
+    }
+
+    #[test]
+    fn production_https_cannot_be_bypassed_with_an_unknown_host() {
+        assert!(inherited_https_policy(true, false));
+        assert!(!inherited_https_policy(false, false));
+        assert!(inherited_https_policy(false, true));
+    }
+}
+
 /// Proxy context for tracking request state
 pub struct ProxyContext {
     pub response_modified: bool,
@@ -547,7 +577,7 @@ pub struct LoadBalancer {
     route_table: Option<Arc<temps_routes::CachedPeerTable>>,
     file_store: Option<Arc<dyn temps_file_store::FileStore>>,
     /// In-memory moka cache for `static_asset_cache` DB lookups. Keyed on
-    /// `(project_id, url_path)`; values are `Option<content_hash>` so that
+    /// `(project_id, environment_id, deployment_id, url_path)`; values are `Option<content_hash>` so that
     /// **negative results (no row found) are cached too** — the miss case is
     /// the common path for container deployments where most assets are served
     /// by upstream, not the fallback store. TTL 60 s, max ~50 k entries. See
@@ -2057,8 +2087,8 @@ impl LoadBalancer {
 
     /// Serve a static asset from CAS via the in-memory lookup cache.
     ///
-    /// `static_asset_lookup` resolves `(project_id, url_path) → content_hash`
-    /// using a moka TTL cache (60 s) so the `static_asset_cache` table is not
+    /// `static_asset_lookup` resolves the exact routed project/environment/
+    /// deployment and URL path using a moka TTL cache (60 s), so the table is not
     /// queried on every cacheable-asset request. Both hits and misses are cached;
     /// the miss case (no fallback row — the common path for container deployments)
     /// is the most important one to protect. See WS4 / `static_asset_lookup.rs`.
@@ -2075,16 +2105,18 @@ impl LoadBalancer {
             None => return Ok(false),
         };
 
-        // Resolve project_id, then look up the content hash via cache (no DB on hit/cached-miss).
-        let content_hash = match ctx.project.as_ref().map(|p| p.id) {
-            Some(pid) => match self
-                .static_asset_lookup
-                .get_content_hash(pid, url_path)
-                .await
-            {
-                Some(hash) => hash,
-                None => return Ok(false),
-            },
+        let scope = match (&ctx.project, &ctx.environment, &ctx.deployment) {
+            (Some(project), Some(environment), Some(deployment)) => {
+                (project.id, environment.id, deployment.id)
+            }
+            _ => return Ok(false),
+        };
+        let content_hash = match self
+            .static_asset_lookup
+            .get_content_hash(scope.0, scope.1, scope.2, url_path)
+            .await
+        {
+            Some(hash) => hash,
             None => return Ok(false),
         };
 
@@ -4318,6 +4350,24 @@ impl ProxyHttp for LoadBalancer {
         // WS3: cert-host check is now a lock-free ArcSwap snapshot read; the
         // background `CertHostCache::run_refresh_loop` keeps it current (±30 s).
         let env_force_https = ctx.environment.as_ref().and_then(|env| env.force_https);
+        let production_https = if !self.disable_https_redirect
+            && !self.is_tls_connection(session)
+            && !ctx.path.starts_with(ACME_HTTP01_PREFIX)
+            && env_force_https.is_none()
+        {
+            match self.config_service.get_url_scheme().await {
+                Ok(scheme) => scheme != "http",
+                Err(error) => {
+                    warn!(
+                        error = %error,
+                        "Failed to read external URL scheme; enforcing HTTPS"
+                    );
+                    true
+                }
+            }
+        } else {
+            false
+        };
         let needs_redirect = should_redirect_to_https(
             self.disable_https_redirect,
             self.is_tls_connection(session),
@@ -4325,7 +4375,12 @@ impl ProxyHttp for LoadBalancer {
             env_force_https,
             // Lock-free ArcSwap snapshot read, and only reached when the
             // environment has no explicit override.
-            || self.cert_host_cache.has_cert_for_host(&ctx.host),
+            || {
+                inherited_https_policy(
+                    production_https,
+                    self.cert_host_cache.has_cert_for_host(&ctx.host),
+                )
+            },
         );
         if needs_redirect {
             // Build the HTTPS redirect URL preserving path and query string
@@ -4674,8 +4729,15 @@ impl ProxyHttp for LoadBalancer {
         if ctx.path.starts_with("/_temps/assets/") {
             let after_prefix = &ctx.path["/_temps/assets/".len()..];
             if let Some(slash_pos) = after_prefix.find('/') {
+                let deployment_slug = &after_prefix[..slash_pos];
                 let asset_path = after_prefix[slash_pos + 1..].to_string();
-                if Self::is_cacheable_static_asset(&asset_path) {
+                if deployment_asset_path_matches(
+                    ctx.deployment
+                        .as_ref()
+                        .map(|deployment| deployment.slug.as_str()),
+                    deployment_slug,
+                ) && Self::is_cacheable_static_asset(&asset_path)
+                {
                     if let Ok(true) = self.serve_asset_from_store(session, ctx, &asset_path).await {
                         ctx.routing_status = "prefixed_asset".to_string();
                         return Ok(true);

--- a/crates/temps-proxy/src/service/static_asset_lookup.rs
+++ b/crates/temps-proxy/src/service/static_asset_lookup.rs
@@ -1,5 +1,5 @@
 use moka::future::Cache;
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use std::sync::Arc;
 use std::time::Duration;
 use temps_database::DbConnection;
@@ -33,8 +33,8 @@ const ASSET_STORE_CACHE_MAX_CAPACITY: u64 = 50_000;
 ///
 /// ## Cache strategy
 ///
-/// - **Key**: `(project_id, url_path)` — identifies the asset within its
-///   project regardless of deployment.
+/// - **Key**: `(project_id, environment_id, deployment_id, url_path)` — binds
+///   the asset to the exact route context that requested it.
 /// - **Value**: `Option<String>` — `Some(content_hash)` when a matching row
 ///   was found; `None` when no row exists. **Caching `None` (the miss case) is
 ///   the critical path**: container deployments serve most assets upstream, so
@@ -52,8 +52,8 @@ const ASSET_STORE_CACHE_MAX_CAPACITY: u64 = 50_000;
 /// for this PR.
 pub struct StaticAssetLookup {
     db: Arc<DbConnection>,
-    /// `(project_id, url_path) → Option<content_hash>`. TTL 60 s, cap 50 k.
-    cache: Cache<(i32, String), Option<String>>,
+    /// `(project_id, environment_id, deployment_id, url_path) → Option<content_hash>`.
+    cache: Cache<(i32, i32, i32, String), Option<String>>,
 }
 
 impl StaticAssetLookup {
@@ -72,14 +72,25 @@ impl StaticAssetLookup {
         Self { db, cache }
     }
 
-    /// Return the content hash for `(project_id, url_path)`, or `None` when no
-    /// matching row exists in `static_asset_cache`.
+    /// Return the content hash for the exact routed deployment, or `None` when
+    /// no matching row exists in `static_asset_cache`.
     ///
     /// Results are served from the in-memory cache when available. Both
     /// `Some(hash)` and `None` are cached so the common miss case never
     /// amplifies into Postgres load.
-    pub async fn get_content_hash(&self, project_id: i32, url_path: &str) -> Option<String> {
-        let key = (project_id, url_path.to_string());
+    pub async fn get_content_hash(
+        &self,
+        project_id: i32,
+        environment_id: i32,
+        deployment_id: i32,
+        url_path: &str,
+    ) -> Option<String> {
+        let key = (
+            project_id,
+            environment_id,
+            deployment_id,
+            url_path.to_string(),
+        );
 
         // Fast path: a previous lookup already resolved this key (hit or miss).
         if let Some(cached) = self.cache.get(&key).await {
@@ -90,8 +101,9 @@ impl StaticAssetLookup {
         // Cache miss: query the DB (most recent deployment wins).
         let result = static_asset_cache::Entity::find()
             .filter(static_asset_cache::Column::ProjectId.eq(project_id))
+            .filter(static_asset_cache::Column::EnvironmentId.eq(environment_id))
+            .filter(static_asset_cache::Column::DeploymentId.eq(deployment_id))
             .filter(static_asset_cache::Column::UrlPath.eq(url_path))
-            .order_by_desc(static_asset_cache::Column::DeploymentId)
             .one(self.db.as_ref())
             .await
             .ok()
@@ -153,14 +165,14 @@ mod tests {
 
         // First call: cache miss → 1 DB query → None cached.
         let first = lookup
-            .get_content_hash(42, "_next/static/chunks/main-abc.js")
+            .get_content_hash(42, 4, 9, "_next/static/chunks/main-abc.js")
             .await;
         assert!(first.is_none(), "first call should return None (no row)");
 
         // Second call: negative cache hit → 0 DB queries.
         // If this makes a DB query, the MockDatabase empty queue panics.
         let second = lookup
-            .get_content_hash(42, "_next/static/chunks/main-abc.js")
+            .get_content_hash(42, 4, 9, "_next/static/chunks/main-abc.js")
             .await;
         assert!(
             second.is_none(),
@@ -187,7 +199,7 @@ mod tests {
 
         // First call: cache miss → 1 DB query → hash cached.
         let first = lookup
-            .get_content_hash(7, "_next/static/chunks/page-abc.js")
+            .get_content_hash(7, 3, 99, "_next/static/chunks/page-abc.js")
             .await;
         assert_eq!(
             first.as_deref(),
@@ -197,7 +209,7 @@ mod tests {
 
         // Second call: positive cache hit → 0 DB queries → same hash returned.
         let second = lookup
-            .get_content_hash(7, "_next/static/chunks/page-abc.js")
+            .get_content_hash(7, 3, 99, "_next/static/chunks/page-abc.js")
             .await;
         assert_eq!(
             second.as_deref(),
@@ -222,17 +234,45 @@ mod tests {
 
         let lookup = StaticAssetLookup::new(Arc::new(db));
 
-        let res_a = lookup.get_content_hash(1, "assets/app.js").await;
+        let res_a = lookup.get_content_hash(1, 1, 10, "assets/app.js").await;
         assert_eq!(res_a.as_deref(), Some(hash_a.as_str()));
 
-        let res_b = lookup.get_content_hash(2, "assets/app.js").await;
+        let res_b = lookup.get_content_hash(2, 1, 20, "assets/app.js").await;
         assert_eq!(res_b.as_deref(), Some(hash_b.as_str()));
 
         // Both keys cached — no more DB queries allowed.
-        let res_a2 = lookup.get_content_hash(1, "assets/app.js").await;
-        let res_b2 = lookup.get_content_hash(2, "assets/app.js").await;
+        let res_a2 = lookup.get_content_hash(1, 1, 10, "assets/app.js").await;
+        let res_b2 = lookup.get_content_hash(2, 1, 20, "assets/app.js").await;
         assert_eq!(res_a2.as_deref(), Some(hash_a.as_str()));
         assert_eq!(res_b2.as_deref(), Some(hash_b.as_str()));
+    }
+
+    #[tokio::test]
+    async fn test_same_project_path_isolated_by_environment_and_deployment() {
+        let mut env_a = asset_model(1, "assets/app.js", "hash-a", 10);
+        env_a.environment_id = 11;
+        let mut env_b = asset_model(1, "assets/app.js", "hash-b", 20);
+        env_b.environment_id = 22;
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![env_a], vec![env_b]])
+            .into_connection();
+        let lookup = StaticAssetLookup::new(Arc::new(db));
+
+        assert_eq!(
+            lookup
+                .get_content_hash(1, 11, 10, "assets/app.js")
+                .await
+                .as_deref(),
+            Some("hash-a")
+        );
+        assert_eq!(
+            lookup
+                .get_content_hash(1, 22, 20, "assets/app.js")
+                .await
+                .as_deref(),
+            Some("hash-b")
+        );
     }
 
     /// After a negative-cache entry expires, the loader retries the DB.
@@ -249,14 +289,14 @@ mod tests {
         // 1 ms TTL so we can expire it quickly in the test.
         let lookup = StaticAssetLookup::new_with_ttl(Arc::new(db), Duration::from_millis(1));
 
-        let first = lookup.get_content_hash(5, "static/vendor.js").await;
+        let first = lookup.get_content_hash(5, 2, 8, "static/vendor.js").await;
         assert!(first.is_none());
 
         // Wait for the negative cache entry to expire.
         tokio::time::sleep(Duration::from_millis(10)).await;
 
         // Second call: entry expired → DB queried again (consumes the second queued result).
-        let second = lookup.get_content_hash(5, "static/vendor.js").await;
+        let second = lookup.get_content_hash(5, 2, 8, "static/vendor.js").await;
         assert!(second.is_none());
     }
 }

--- a/crates/temps-proxy/src/services.rs
+++ b/crates/temps-proxy/src/services.rs
@@ -220,20 +220,38 @@ impl ProjectContextResolverImpl {
     pub fn new(route_table: Arc<CachedPeerTable>) -> Self {
         Self { route_table }
     }
-}
 
-#[async_trait]
-impl ProjectContextResolver for ProjectContextResolverImpl {
-    async fn resolve_context(&self, host: &str) -> Option<ProjectContext> {
-        // Get route info from O(1) route table lookup with cached models
+    fn project_context_from_route(&self, host: &str) -> Option<ProjectContext> {
         let route_info = self.route_table.get_route(host)?;
-
-        // Return cached models directly - no database queries!
         Some(ProjectContext {
             project: route_info.project?,
             environment: route_info.environment?,
             deployment: route_info.deployment?,
         })
+    }
+}
+
+#[async_trait]
+impl ProjectContextResolver for ProjectContextResolverImpl {
+    async fn resolve_context(&self, host: &str) -> Option<ProjectContext> {
+        if let Some(context) = self.project_context_from_route(host) {
+            return Some(context);
+        }
+
+        // Upstream selection waits for the first route load before retrying.
+        // Context resolution must do the same or request filters can observe no
+        // project and skip project-scoped protections for a route that becomes
+        // available moments later in the same request.
+        if !self.route_table.has_loaded() {
+            debug!(
+                "Route table not loaded yet; waiting up to {:?} before resolving project context (host: {})",
+                FIRST_LOAD_WAIT, host
+            );
+            self.route_table.wait_until_loaded(FIRST_LOAD_WAIT).await;
+            return self.project_context_from_route(host);
+        }
+
+        None
     }
 
     async fn is_static_deployment(&self, host: &str) -> bool {

--- a/crates/temps-query-postgres/src/lib.rs
+++ b/crates/temps-query-postgres/src/lib.rs
@@ -15,6 +15,7 @@ use tokio_postgres::{types::ToSql, Client, NoTls};
 use tokio_postgres_rustls::MakeRustlsConnect;
 use tracing::{debug, error, warn};
 
+#[cfg(test)]
 const FILTER_WHERE_PLACEHOLDER: &str = "status = 'active' AND created_at > '2025-01-01'";
 
 /// Server-side ceiling for the introspection paths that take no `QueryOptions`
@@ -26,6 +27,7 @@ const FILTER_WHERE_PLACEHOLDER: &str = "status = 'active' AND created_at > '2025
 /// scan. Ten seconds is far more than an honest count needs and short enough
 /// that a pile of them cannot hold the pool.
 const DEFAULT_COUNT_TIMEOUT_MS: u64 = 10_000;
+const MAX_QUERY_LIMIT: usize = 100;
 
 /// Escape a SQL identifier by doubling any internal double-quote characters.
 /// Prevents identifier injection when used inside `"..."` quoting.
@@ -252,6 +254,23 @@ fn starts_with_sql_keyword(input: &str, keyword: &str) -> bool {
 }
 
 impl PostgresSource {
+    /// Raw SQL fragments cannot be safely validated with a denylist because
+    /// PostgreSQL's parser remains the final authority. Accept only an absent
+    /// or empty filter object until the API has a typed, parameterized DSL.
+    fn validate_filters(filters: Option<&serde_json::Value>) -> Result<()> {
+        match filters {
+            None => Ok(()),
+            Some(value) if value.as_object().is_some_and(|object| object.is_empty()) => Ok(()),
+            Some(_) => Err(DataError::InvalidQuery(
+                "PostgreSQL data browsing does not accept raw SQL filters".to_string(),
+            )),
+        }
+    }
+
+    fn clamp_limit(limit: Option<usize>) -> usize {
+        limit.unwrap_or(MAX_QUERY_LIMIT).min(MAX_QUERY_LIMIT)
+    }
+
     /// Reject a database name that isn't a plausible PostgreSQL identifier.
     ///
     /// The typed `Config` above already makes injection impossible; this
@@ -1030,6 +1049,7 @@ impl PostgresSource {
     /// Return the byte length of a PostgreSQL dollar-quote delimiter at the
     /// start of `sql`. Tags follow unquoted identifier rules, except that `$`
     /// is not permitted inside the tag.
+    #[cfg(test)]
     fn dollar_quote_delimiter_len(sql: &str) -> Option<usize> {
         let after_dollar = sql.strip_prefix('$')?;
         if after_dollar.starts_with('$') {
@@ -1062,6 +1082,7 @@ impl PostgresSource {
     /// Ambiguous backslash-escaped quotes in ordinary strings are rejected so
     /// validation is independent of the server's `standard_conforming_strings`
     /// setting.
+    #[cfg(test)]
     fn strip_sql_string_literals(sql: &str) -> Result<String> {
         let mut result = String::with_capacity(sql.len());
         let mut position = 0;
@@ -1248,6 +1269,7 @@ impl PostgresSource {
     /// validation to prevent SQL injection. The denylist catches known attack
     /// patterns while structural checks block injection vectors like subqueries,
     /// UNION, and function calls that could bypass simple pattern matching.
+    #[cfg(test)]
     fn validate_sql(sql: &str) -> Result<()> {
         let sql_trimmed = sql.trim();
 
@@ -2093,6 +2115,8 @@ impl Queryable for PostgresSource {
         let columns = self.query_columns(schema_name, entity_name).await?;
 
         let start = std::time::Instant::now();
+        Self::validate_filters(filters.as_ref())?;
+        let schema = self.get_schema(container_path, entity_name).await?;
 
         // Build SQL query
         let mut sql = format!(
@@ -2100,16 +2124,6 @@ impl Queryable for PostgresSource {
             escape_ident(schema_name),
             escape_ident(entity_name)
         );
-
-        // Add WHERE clause if filters provided
-        if let Some(filter_json) = filters {
-            if let Some(where_clause) = filter_json.get("where").and_then(|v| v.as_str()) {
-                // Validate WHERE clause for dangerous operations
-                Self::validate_sql(where_clause)?;
-                sql.push_str(" WHERE ");
-                sql.push_str(where_clause);
-            }
-        }
 
         // Add ORDER BY
         if let Some(sort_by) = &options.sort_by {
@@ -2127,21 +2141,23 @@ impl Queryable for PostgresSource {
             // resting on that.
             let sort_by = sort_by.trim();
             Self::validate_sort_field(sort_by)?;
+            if !schema.fields.iter().any(|field| field.name == sort_by) {
+                return Err(DataError::InvalidQuery(format!(
+                    "Sort field '{}' is not present in table '{}.{}'",
+                    sort_by, schema_name, entity_name
+                )));
+            }
             let sort_order = match options.sort_order.as_deref() {
                 Some("desc") | Some("DESC") => "DESC",
                 _ => "ASC",
             };
             // Quote the column name to handle camelCase identifiers correctly
-            let quoted_sort = if sort_by.starts_with('"') && sort_by.ends_with('"') {
-                sort_by.to_string() // Already quoted
-            } else {
-                format!("\"{}\"", sort_by)
-            };
+            let quoted_sort = format!("\"{}\"", escape_ident(sort_by));
             sql.push_str(&format!(" ORDER BY {} {}", quoted_sort, sort_order));
         }
 
         // Add LIMIT and OFFSET
-        let limit = options.limit.unwrap_or(100);
+        let limit = Self::clamp_limit(options.limit);
         let offset = options.offset.unwrap_or(0);
         sql.push_str(&format!(" LIMIT {} OFFSET {}", limit, offset));
         let sql = with_wire_row_budget(&sql, &columns, options.budget)?;
@@ -2267,9 +2283,6 @@ impl Queryable for PostgresSource {
         }
         let (data_rows, truncated) = bounded.into_parts();
 
-        // Get schema from first row or from table schema
-        let schema = self.get_schema(container_path, entity_name).await?;
-
         let execution_ms = start.elapsed().as_millis() as u64;
         let row_count = data_rows.len();
 
@@ -2302,22 +2315,13 @@ impl Queryable for PostgresSource {
         }
 
         let schema_name = &container_path.segments[1];
+        Self::validate_filters(filters.as_ref())?;
 
-        let mut sql = format!(
+        let sql = format!(
             "SELECT COUNT(*) FROM \"{}\".\"{}\"",
             escape_ident(schema_name),
             escape_ident(entity_name)
         );
-
-        // Add WHERE clause if filters provided
-        if let Some(filter_json) = filters {
-            if let Some(where_clause) = filter_json.get("where").and_then(|v| v.as_str()) {
-                // Validate WHERE clause for dangerous operations
-                Self::validate_sql(where_clause)?;
-                sql.push_str(" WHERE ");
-                sql.push_str(where_clause);
-            }
-        }
 
         let client = &self.client;
         let _timeout_guard = self.query_timeout_lock.lock().await;
@@ -2489,25 +2493,8 @@ impl temps_query::QuerySchemaProvider for PostgresSource {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
             "title": "PostgreSQL Query Filters",
-            "description": "Filter data using SQL WHERE clause syntax",
-            "properties": {
-                "where": {
-                    "type": "string",
-                    "title": "WHERE Clause",
-                    "description": "SQL WHERE clause (without 'WHERE' keyword). Example: status = 'active' AND created_at > '2025-01-01'",
-                    "examples": [
-                        "status = 'active'",
-                        "created_at > '2025-01-01'",
-                        "age >= 18 AND country = 'US'",
-                        "name LIKE '%test%'",
-                        "id IN (1, 2, 3)"
-                    ],
-                    // UI hints embedded as custom properties
-                    "x-ui-widget": "textarea",
-                    "x-ui-placeholder": FILTER_WHERE_PLACEHOLDER,
-                    "x-ui-rows": 3
-                }
-            },
+            "description": "Raw SQL filters are disabled. Use sorting and pagination to browse data safely.",
+            "properties": {},
             "additionalProperties": false
         })
     }
@@ -3701,6 +3688,21 @@ mod tests {
         assert_sql_allowed("description = 'drop this item'");
         assert_sql_allowed("name = 'select the best option'");
         assert_sql_allowed("note = 'please delete me'");
+    }
+
+    #[test]
+    fn raw_filter_objects_are_rejected_before_query_construction() {
+        let filters = serde_json::json!({"where": "status = 'active'"});
+        assert!(PostgresSource::validate_filters(Some(&filters)).is_err());
+        assert!(PostgresSource::validate_filters(None).is_ok());
+        assert!(PostgresSource::validate_filters(Some(&serde_json::json!({}))).is_ok());
+    }
+
+    #[test]
+    fn query_limit_is_capped() {
+        assert_eq!(PostgresSource::clamp_limit(None), MAX_QUERY_LIMIT);
+        assert_eq!(PostgresSource::clamp_limit(Some(25)), 25);
+        assert_eq!(PostgresSource::clamp_limit(Some(10_000)), MAX_QUERY_LIMIT);
     }
 
     // ── Sort field validation tests ──────────────────────────────────

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -8012,7 +8012,7 @@ export type GatewayStatus = {
     host_port?: number | null;
     /**
      * Image reference the container was created with (e.g.
-     * `ghcr.io/gotempsh/temps-preview-gateway:latest`).
+     * `ghcr.io/gotempsh/temps-preview-gateway:0.1.0`).
      */
     image?: string | null;
     /**
@@ -19745,7 +19745,7 @@ export type UpgradeExternalServiceRequest = {
 export type UpgradeRequest = {
     /**
      * Image reference to pull and run (e.g.
-     * `ghcr.io/gotempsh/temps-preview-gateway:latest`). Empty resets to default.
+     * `ghcr.io/gotempsh/temps-preview-gateway:0.1.0`). Empty resets to default.
      */
     image: string;
 };

--- a/web/src/components/project/settings/EnvironmentVariablesSettings.tsx
+++ b/web/src/components/project/settings/EnvironmentVariablesSettings.tsx
@@ -1310,6 +1310,7 @@ export function EnvironmentVariablesSettings({
             key: variable.key,
             value: variable.value,
             environment_ids: variable.environments || [],
+            include_in_preview: false,
           },
         })
         successCount++


### PR DESCRIPTION
## Summary

Bundles the security-hardening work that can be safely applied to current `main` from 39 of bherila's security PRs. The branch was rebased onto current upstream and reviewed as one integrated change rather than merging the fork PRs independently.

### Critical fixes

- Parameterizes MariaDB data-browser filters and disables unsafe raw PostgreSQL filters.
- Restricts managed PostgreSQL images, applies the same allowlist and authoritative
  service-image checks to major upgrades and resumptions, and verifies local image
  identity fail-closed.
- Restores fail-closed project permission fallback and enforces Blob/KV project and token scope.
- Scopes internal proxy traffic to the caller's project using event-driven invalidation plus authoritative Docker ownership checks with per-project quotas, hard global concurrency, and fail-closed timeouts.
- Validates WebSocket origins, confines Docker secret paths, and safely quotes WAL-G environment values.
- Blocks unsafe webhook and custom AI endpoints with external-only resolution and redirects disabled.

### High-severity fixes

- Tightens credential rotation, AI tools, repository access, email sending, deployment-token, template, and setup-token authorization.
- Hardens node placement, registry credential forwarding, HTTPS host validation, preview subdomains, auto-deploy opt-out, CAS assets, teardown, and container inventory.
- Replaces predictable MinIO credentials, pins helper images by immutable manifest digest, removes credentialed helper build residue, binds DNS changes to verified provider zones, opts preview environments out of production secrets, and checksum-pins Bun installation.

### Source PR coverage

Critical: #48, #50, #53, #62, #70, #79, #82, #83, #85, #86, #92, #95, #96.

High: #47, #51, #52, #54, #55, #56, #57, #59, #60, #61, #63, #64, #65, #66, #67, #68, #69, #71, #72, #76, #84, #87, #88, #91, #93, #94.

#87 contributes only the owner-binding portion that is compatible with current main.

Not ported:

- #49 and #58 are superseded by #53 and #54.
- #73, #74, #75, #77, and #78 already have stronger equivalents on current main.
- #80 is incomplete when applied endpoint-by-endpoint; analytics token authorization needs a separate centralized fix.
- #81 is stale/unsafe against the current authorization model.
- #89 rejects valid Next.js runtime layouts and needs a compatibility-aware design.
- #90 can cross-wire existing Redis services without a durable allocation migration.

## Compatibility and migration notes

- PostgreSQL raw filter strings are rejected; callers must use structured filters.
- Existing environment variables marked for preview inclusion are backed up and set to opt-out during migration. The down migration restores exactly those prior rows.
- Preview gateway and MinIO client helper defaults now use immutable multi-platform manifest digests.

## Evidence

- `cargo fmt --all` — passed.
- `git diff --check` — passed.
- `cargo check --lib` — 0 errors across the workspace; only existing workspace/build-script/future-compatibility warnings.
- Repository commit hooks — passed, including formatting, generated API consistency, clippy, changelog policy, whitespace, EOF, and typo checks.
- `cargo test -p temps-agent --lib` — 48 passed.
- `cargo test -p temps-environments --lib` — 73 passed.
- `cargo test -p temps-projects --lib` — 108 passed.
- Deployment job-processor focused suite — 26 passed.
- `cargo test -p temps-email --lib` — 197 passed with local socket access.
- `cargo test -p temps-providers --lib` — 508 passed with local Docker/PostgreSQL access.
- PostgreSQL upgrade orchestrator Docker suite — 6 passed against published, allowlisted Timescale PostgreSQL 17/18 images, covering full upgrade, backup exec, snapshot ordering, dump retry, new-container startup, and rollback.
- `cargo test -p temps-deployments --lib` — 611 passed, 3 intentionally ignored, with local Docker/PostgreSQL access.
- `apps/temps-e2e: bun run typecheck` — passed.
- Scheduler explicit-target and label-mismatch fail-closed tests — 2 passed.
- Cross-project and sibling preview-subdomain conflict tests — 2 passed.
- Immutable preview-gateway and MinIO helper image tests — passed.
- Real PostgreSQL preview-inclusion migration up/down test — 1 passed; verifies existing-row backfill and restoration.
- Earlier focused suites on this branch passed for SQL query hardening, Blob/KV isolation, permission fallback, WebSocket origin validation, SSRF, image identity, WAL-G quoting, Docker secret paths, auto-deploy, MinIO credentials, DNS ownership, token scoping, and preview configuration.

## Review focus

- Authorization fallbacks and deployment-token scope mapping.
- Internal proxy identity behavior (event invalidation/expiry, per-project 64/s burst-16 quotas, per-project concurrency 2, global concurrency 32, and bounded queue/inspect timeouts).
- Canonical, case-insensitive hostname claims across manual updates, environment/job creation and restoration, and atomic project-slug renames.
- Preview-variable migration backup table and rollback semantics.
- Operational impact of rejecting PostgreSQL raw filters.
- Phase-aware PostgreSQL major-upgrade image validation and idempotent SWAP retries.
