### PR TITLE
fix(deployments): enforce project access on cron reads

### DIFF
--- a/crates/temps-deployments/src/handlers/crons.rs
+++ b/crates/temps-deployments/src/handlers/crons.rs
@@ -11,7 +11,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use temps_auth::{permission_guard, RequireAuth};
+use temps_auth::{permission_guard, project_access_guard, project_scope_guard, RequireAuth};
 use temps_core::error_builder::ErrorBuilder;
 use temps_core::problemdetails::Problem;
 use tracing::info;
@@ -147,6 +147,8 @@ async fn get_environment_crons(
     Path((project_id, env_id)): Path<(i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, CronsRead);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     info!(
         "Getting cron jobs for project {} environment {}",
@@ -198,6 +200,8 @@ async fn get_cron_by_id(
     Path((project_id, env_id, cron_id)): Path<(i32, i32, i32)>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, CronsRead);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     info!(
         "Getting cron job {} for project {} environment {}",
@@ -249,6 +253,8 @@ async fn get_cron_executions(
     Query(pagination): Query<PaginationParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, CronsRead);
+    project_scope_guard!(auth, project_id);
+    project_access_guard!(auth, project_id, app_state.project_access_checker);
 
     info!(
         "Getting executions for cron job {} (page {}, per_page {})",


### PR DESCRIPTION
### Motivation
- Project-scoped team RBAC was activated via the TeamsPlugin, but the cron read endpoints under `/projects/{project_id}/...` only validated the instance-wide `CronsRead` permission, allowing users with that global permission to read cron schedules and execution history for projects they don't belong to.

### Description
- Import `project_scope_guard` and `project_access_guard` and call them immediately after `permission_guard!(auth, CronsRead)` in `get_environment_crons`, `get_cron_by_id`, and `get_cron_executions` in `crates/temps-deployments/src/handlers/crons.rs`, enforcing deployment-token/project scoping and team-based project access before returning any cron data.

### Testing
- `cargo fmt --check`
- `cargo check -p temps-deployments --lib`
- `cargo test -p temps-auth every_project_scope_guard_has_access_guard_companion`