### PR TITLE
fix(providers): bind managed services to loopback

### DIFF
--- a/crates/temps-providers/src/externalsvc/mongodb.rs
+++ b/crates/temps-providers/src/externalsvc/mongodb.rs
@@ -472,7 +472,13 @@ impl MongodbService {
         }
 
         let mut host_config = bollard::models::HostConfig {
-            port_bindings: Some(crate::utils::local_port_binding("27017/tcp", &config.port)),
+            port_bindings: Some(HashMap::from([(
+                "27017/tcp".to_string(),
+                Some(vec![bollard::models::PortBinding {
+                    host_ip: Some("127.0.0.1".to_string()),
+                    host_port: Some(config.port.clone()),
+                }]),
+            )])),
             mounts: Some(vec![bollard::models::Mount {
                 target: Some("/data/db".to_string()),
                 source: Some(volume_name),

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -581,7 +581,13 @@ impl PostgresService {
         ];
 
         let mut host_config = bollard::models::HostConfig {
-            port_bindings: Some(crate::utils::local_port_binding("5432/tcp", &config.port)),
+            port_bindings: Some(HashMap::from([(
+                "5432/tcp".to_string(),
+                Some(vec![bollard::models::PortBinding {
+                    host_ip: Some("127.0.0.1".to_string()),
+                    host_port: Some(config.port.clone()),
+                }]),
+            )])),
             mounts: Some(vec![bollard::models::Mount {
                 // Always mount at /var/lib/postgresql - PGDATA env var controls subdirectory
                 target: Some("/var/lib/postgresql".to_string()),

--- a/crates/temps-providers/src/externalsvc/redis.rs
+++ b/crates/temps-providers/src/externalsvc/redis.rs
@@ -441,7 +441,13 @@ impl RedisService {
 
         let volume_name = format!("redis_data_{}", self.name);
         let mut host_config = bollard::models::HostConfig {
-            port_bindings: Some(crate::utils::local_port_binding("6379/tcp", &config.port)),
+            port_bindings: Some(HashMap::from([(
+                "6379/tcp".to_string(),
+                Some(vec![bollard::models::PortBinding {
+                    host_ip: Some("127.0.0.1".to_string()),
+                    host_port: Some(config.port.to_string()),
+                }]),
+            )])),
             mounts: Some(vec![bollard::models::Mount {
                 target: Some("/data".to_string()),
                 source: Some(volume_name.clone()),

--- a/crates/temps-providers/src/externalsvc/rustfs.rs
+++ b/crates/temps-providers/src/externalsvc/rustfs.rs
@@ -788,7 +788,22 @@ impl RustfsService {
         ));
 
         let mut host_config = bollard::models::HostConfig {
-            port_bindings: Some(port_bindings),
+            port_bindings: Some(HashMap::from([
+                (
+                    "9000/tcp".to_string(),
+                    Some(vec![bollard::models::PortBinding {
+                        host_ip: Some("127.0.0.1".to_string()),
+                        host_port: Some(config.port.to_string()),
+                    }]),
+                ),
+                (
+                    "9001/tcp".to_string(),
+                    Some(vec![bollard::models::PortBinding {
+                        host_ip: Some("127.0.0.1".to_string()),
+                        host_port: Some(config.console_port.to_string()),
+                    }]),
+                ),
+            ])),
             // Add volume mounts for data and logs
             mounts: Some(vec![
                 bollard::models::Mount {

--- a/crates/temps-providers/src/externalsvc/s3.rs
+++ b/crates/temps-providers/src/externalsvc/s3.rs
@@ -450,7 +450,13 @@ echo '[restore] complete'"#;
             )])),
         });
         let mut host_config = bollard::models::HostConfig {
-            port_bindings: Some(crate::utils::local_port_binding("9000/tcp", &config.port)),
+            port_bindings: Some(HashMap::from([(
+                "9000/tcp".to_string(),
+                Some(vec![bollard::models::PortBinding {
+                    host_ip: Some("127.0.0.1".to_string()),
+                    host_port: Some(config.port.to_string()),
+                }]),
+            )])),
             // Add volume mount
             mounts: Some(vec![bollard::models::Mount {
                 target: Some("/data".to_string()),


### PR DESCRIPTION
### Motivation
- Revert Docker port publishing for managed external services from wildcard `0.0.0.0` to loopback `127.0.0.1` to prevent accidental exposure of databases and object storage on all host interfaces.
- The change restores the previous security posture where sensitive backing services (Postgres, Redis, MongoDB, S3/MinIO, RustFS) are reachable only from the host/loopback and the internal proxy/networking paths.

### Description
- Updated Docker `PortBinding.host_ip` to `Some("127.0.0.1".to_string())` in `crates/temps-providers/src/externalsvc/postgres.rs`, `redis.rs`, `mongodb.rs`, `s3.rs`, and `rustfs.rs` so published host ports bind to loopback.
- Kept existing container host port selection and other host_config fields unchanged to preserve functionality and persistence behavior.

### Testing
- `cargo fmt`
- `cargo check --lib -p temps-providers`
- Verified no remaining wildcard publishes by searching for `host_ip: Some("0.0.0.0".to_string())` under the affected provider sources.