### PR TITLE
fix(providers): restore redis database allocation isolation

### DIFF
--- a/crates/temps-providers/src/externalsvc/redis.rs
+++ b/crates/temps-providers/src/externalsvc/redis.rs
@@ -595,6 +595,15 @@ impl RedisService {
     /// selected from DBs 1-15 and recorded in Redis before their connection
     /// details are returned, so two resources cannot silently receive the same
     /// logical DB. When all databases are in use, allocation fails closed.
+    ///
+    /// The "read mapping, then claim" sequence below isn't a single atomic
+    /// transaction, so a concurrent `drop_database` for the same resource
+    /// could in principle interleave between the mapping read and the
+    /// `SETNX` claim. This is an accepted race: a single Redis instance and
+    /// the short critical section make it low-risk in practice, and
+    /// allocate/drop for the same resource aren't expected to run
+    /// concurrently (provision and deprovision are serialized per resource
+    /// at the caller).
     async fn allocate_database(&self, resource_name: &str) -> Result<u8> {
         let mut conn = self.get_connection().await?;
         redis::cmd("SELECT")
@@ -3076,6 +3085,115 @@ mod tests {
         assert!(new_local_addr.contains("7544"), "New port should be 7544");
 
         // Cleanup
+        let _ = service.cleanup().await;
+    }
+
+    /// Regression coverage for the DB-collision bug this fix closes: two
+    /// distinct resources must never share a logical DB, re-allocating the
+    /// same resource must be idempotent, and `drop_database` must actually
+    /// free the slot for reuse rather than leaking it.
+    #[cfg(feature = "docker-tests")]
+    #[tokio::test]
+    async fn test_allocate_database_isolation_and_reuse() {
+        let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
+        let service = RedisService::new("test-db-alloc".to_string(), docker);
+
+        let config = super::ServiceConfig {
+            name: "test-db-alloc".to_string(),
+            service_type: super::ServiceType::Redis,
+            version: None,
+            parameters: serde_json::json!({
+                "host": "localhost",
+                "port": "7549",
+                "password": "allocpass123"
+            }),
+        };
+        service.init(config).await.expect("init should succeed");
+
+        // Two distinct resources must get distinct DBs.
+        let db_a = service
+            .allocate_database("project-a/prod")
+            .await
+            .expect("allocate resource A");
+        let db_b = service
+            .allocate_database("project-b/prod")
+            .await
+            .expect("allocate resource B");
+        assert_ne!(
+            db_a, db_b,
+            "distinct resources must not collide on the same DB"
+        );
+        assert!((1..=15).contains(&db_a), "allocated DB must be in 1-15");
+        assert!((1..=15).contains(&db_b), "allocated DB must be in 1-15");
+
+        // Re-allocating the same resource is idempotent.
+        let db_a_again = service
+            .allocate_database("project-a/prod")
+            .await
+            .expect("re-allocate resource A");
+        assert_eq!(
+            db_a, db_a_again,
+            "re-allocating the same resource must return the same DB"
+        );
+
+        // drop_database frees the slot for reuse by a different resource.
+        service
+            .drop_database("project-a/prod")
+            .await
+            .expect("drop resource A");
+        let db_c = service
+            .allocate_database("project-c/prod")
+            .await
+            .expect("allocate resource C after drop");
+        assert_eq!(
+            db_c, db_a,
+            "a freed DB must be reusable by a new resource"
+        );
+
+        // Cleanup
+        let _ = service.drop_database("project-b/prod").await;
+        let _ = service.drop_database("project-c/prod").await;
+        let _ = service.cleanup().await;
+    }
+
+    /// When all 15 workload DBs (1-15) are claimed, allocation for a new
+    /// resource must fail closed instead of silently colliding with an
+    /// existing resource's DB.
+    #[cfg(feature = "docker-tests")]
+    #[tokio::test]
+    async fn test_allocate_database_fails_closed_when_exhausted() {
+        let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
+        let service = RedisService::new("test-db-exhaust".to_string(), docker);
+
+        let config = super::ServiceConfig {
+            name: "test-db-exhaust".to_string(),
+            service_type: super::ServiceType::Redis,
+            version: None,
+            parameters: serde_json::json!({
+                "host": "localhost",
+                "port": "7550",
+                "password": "exhaustpass123"
+            }),
+        };
+        service.init(config).await.expect("init should succeed");
+
+        for i in 0..15 {
+            service
+                .allocate_database(&format!("resource-{i}"))
+                .await
+                .unwrap_or_else(|e| panic!("allocate resource-{i} should succeed: {e}"));
+        }
+
+        let result = service.allocate_database("resource-overflow").await;
+        assert!(
+            result.is_err(),
+            "allocation must fail closed once all 15 workload DBs are claimed"
+        );
+
+        // Cleanup
+        for i in 0..15 {
+            let _ = service.drop_database(&format!("resource-{i}")).await;
+        }
         let _ = service.cleanup().await;
     }
 

--- a/crates/temps-providers/src/externalsvc/redis.rs
+++ b/crates/temps-providers/src/externalsvc/redis.rs
@@ -3145,10 +3145,7 @@ mod tests {
             .allocate_database("project-c/prod")
             .await
             .expect("allocate resource C after drop");
-        assert_eq!(
-            db_c, db_a,
-            "a freed DB must be reusable by a new resource"
-        );
+        assert_eq!(db_c, db_a, "a freed DB must be reusable by a new resource");
 
         // Cleanup
         let _ = service.drop_database("project-b/prod").await;

--- a/crates/temps-providers/src/externalsvc/redis.rs
+++ b/crates/temps-providers/src/externalsvc/redis.rs
@@ -9,7 +9,7 @@ use bollard::query_parameters::{InspectContainerOptions, StopContainerOptions};
 use bollard::Docker;
 use flate2::read::GzDecoder;
 use futures::TryStreamExt;
-use redis::{aio::ConnectionManager, Client};
+use redis::{aio::ConnectionManager, AsyncCommands, Client};
 use schemars::JsonSchema;
 use sea_orm::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -581,18 +581,171 @@ impl RedisService {
         Err(anyhow::anyhow!("Redis container health check timed out"))
     }
 
-    /// Calculate a deterministic database number (0-15) from a resource name
-    /// This allows us to allocate databases without requiring a Redis connection
-    fn calculate_database_number(&self, resource_name: &str) -> u8 {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
+    fn resource_mapping_key(resource_name: &str) -> String {
+        format!("_temps:redis_db_mapping:{}", resource_name)
+    }
 
-        let mut hasher = DefaultHasher::new();
-        resource_name.hash(&mut hasher);
-        let hash = hasher.finish();
+    fn database_owner_key(db_number: u8) -> String {
+        format!("_temps:redis_db_owner:{}", db_number)
+    }
 
-        // Redis supports 16 databases (0-15), so we use modulo to get a valid number
-        (hash % 16) as u8
+    /// Allocate a Redis logical database for a project/environment resource.
+    ///
+    /// DB 0 is reserved for Temps allocation metadata. Workload databases are
+    /// selected from DBs 1-15 and recorded in Redis before their connection
+    /// details are returned, so two resources cannot silently receive the same
+    /// logical DB. When all databases are in use, allocation fails closed.
+    async fn allocate_database(&self, resource_name: &str) -> Result<u8> {
+        let mut conn = self.get_connection().await?;
+        redis::cmd("SELECT")
+            .arg(0)
+            .query_async::<()>(&mut conn)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to select Redis metadata DB 0: {}", e))?;
+
+        let mapping_key = Self::resource_mapping_key(resource_name);
+        let existing: Option<u8> = conn.get(&mapping_key).await.map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to read Redis DB mapping for resource '{}': {}",
+                resource_name,
+                e
+            )
+        })?;
+        if let Some(db_number) = existing {
+            return Ok(db_number);
+        }
+
+        for db_number in 1..=15 {
+            let owner_key = Self::database_owner_key(db_number);
+            let claimed: bool = conn.set_nx(&owner_key, resource_name).await.map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to claim Redis DB {} for resource '{}': {}",
+                    db_number,
+                    resource_name,
+                    e
+                )
+            })?;
+
+            if claimed {
+                conn.set::<_, _, ()>(&mapping_key, db_number)
+                    .await
+                    .map_err(|e| {
+                        anyhow::anyhow!(
+                            "Failed to store Redis DB {} mapping for resource '{}': {}",
+                            db_number,
+                            resource_name,
+                            e
+                        )
+                    })?;
+                return Ok(db_number);
+            }
+
+            let owner: Option<String> = conn.get(&owner_key).await.map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to read Redis DB {} owner while allocating resource '{}': {}",
+                    db_number,
+                    resource_name,
+                    e
+                )
+            })?;
+            if owner.as_deref() == Some(resource_name) {
+                conn.set::<_, _, ()>(&mapping_key, db_number)
+                    .await
+                    .map_err(|e| {
+                        anyhow::anyhow!(
+                            "Failed to restore Redis DB {} mapping for resource '{}': {}",
+                            db_number,
+                            resource_name,
+                            e
+                        )
+                    })?;
+                return Ok(db_number);
+            }
+        }
+
+        Err(anyhow::anyhow!(
+            "No Redis logical databases are available for resource '{}'; DB 0 is reserved for metadata and DBs 1-15 are already allocated",
+            resource_name
+        ))
+    }
+
+    async fn drop_database(&self, resource_name: &str) -> Result<()> {
+        let mut conn = self.get_connection().await?;
+        redis::cmd("SELECT")
+            .arg(0)
+            .query_async::<()>(&mut conn)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to select Redis metadata DB 0: {}", e))?;
+
+        let mapping_key = Self::resource_mapping_key(resource_name);
+        let db_number: Option<u8> = conn.get(&mapping_key).await.map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to read Redis DB mapping for resource '{}': {}",
+                resource_name,
+                e
+            )
+        })?;
+
+        let Some(db_number) = db_number else {
+            info!(
+                "No Redis database mapping found for resource '{}'; skipping deprovision",
+                resource_name
+            );
+            return Ok(());
+        };
+
+        redis::cmd("SELECT")
+            .arg(db_number)
+            .query_async::<()>(&mut conn)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to select Redis DB {} for resource '{}': {}",
+                    db_number,
+                    resource_name,
+                    e
+                )
+            })?;
+        redis::cmd("FLUSHDB")
+            .query_async::<()>(&mut conn)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to flush Redis DB {} for resource '{}': {}",
+                    db_number,
+                    resource_name,
+                    e
+                )
+            })?;
+
+        redis::cmd("SELECT")
+            .arg(0)
+            .query_async::<()>(&mut conn)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to reselect Redis metadata DB 0: {}", e))?;
+        conn.del::<_, ()>(&mapping_key).await.map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to delete Redis DB mapping for resource '{}': {}",
+                resource_name,
+                e
+            )
+        })?;
+        conn.del::<_, ()>(Self::database_owner_key(db_number))
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to delete Redis DB {} owner for resource '{}': {}",
+                    db_number,
+                    resource_name,
+                    e
+                )
+            })?;
+
+        info!(
+            "Flushed Redis DB {} and removed allocation for resource '{}'",
+            db_number, resource_name
+        );
+        Ok(())
     }
 
     fn get_redis_config(&self, service_config: ServiceConfig) -> Result<RedisConfig> {
@@ -1924,9 +2077,7 @@ impl ExternalService for RedisService {
     ) -> Result<HashMap<String, String>> {
         let resource_name = format!("{}_{}", project_id, environment);
 
-        // Calculate database number using a hash instead of requiring Redis connection
-        // This allows us to generate env vars before the service is started
-        let db_number = self.calculate_database_number(&resource_name);
+        let db_number = self.allocate_database(&resource_name).await?;
 
         let mut env_vars = HashMap::new();
 
@@ -2162,11 +2313,9 @@ impl ExternalService for RedisService {
         Ok(env_vars)
     }
 
-    async fn deprovision_resource(&self, _project_id: &str, _environment: &str) -> Result<()> {
-        // No database-level deprovisioning needed
-        // Each project/environment gets a calculated database number (0-15) based on hash
-        // Cleanup would happen at the application level (flushing keys with specific prefixes)
-        Ok(())
+    async fn deprovision_resource(&self, project_id: &str, environment: &str) -> Result<()> {
+        let resource_name = format!("{}_{}", project_id, environment);
+        self.drop_database(&resource_name).await
     }
 
     /// Backup Redis data to S3.


### PR DESCRIPTION
### Motivation
- The previous change used a deterministic `hash % 16` to pick a Redis DB and made `deprovision_resource` a no-op, which allowed DB collisions and stale data exposure between projects/environments.
- The intent is to restore strong per-resource isolation for Redis logical DBs and ensure deprovisioning cleans up allocated DBs.

### Description
- Replaced the hash-based allocator with an allocation-backed flow that stores mappings in Redis DB 0 via helper keys `'_temps:redis_db_mapping:{resource}'` and `'_temps:redis_db_owner:{db}'` and added helper functions `resource_mapping_key` and `database_owner_key` in `crates/temps-providers/src/externalsvc/redis.rs`.
- Implemented `allocate_database` which reserves DBs 1–15 using `SETNX` and records the mapping, and returns an error (fail-closed) when no DBs are available.
- Implemented `drop_database` which selects the allocated DB, runs `FLUSHDB`, and removes the allocation metadata; wired `deprovision_resource` to call `drop_database`.
- Updated runtime env generation in `get_runtime_env_vars` to call `allocate_database` and derive `REDIS_DATABASE`/`REDIS_URL` from the recorded allocation (instead of `calculate_database_number`).

### Testing
- `cargo fmt`
- `cargo check --lib -p temps-providers`
- Verified removal of the old `hash % 16` pattern and presence of `allocate_database`/`drop_database` and `REDIS_DATABASE` usage via grep.