### PR TITLE
fix(ci): keep tag releases from writing Actions caches

### DIFF
--- a/.github/scripts/check-cache-save-guards.py
+++ b/.github/scripts/check-cache-save-guards.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""Fail if a pull_request-triggered workflow caches with Swatinem/rust-cache
-without a `save-if` guard.
+"""Fail when PR or tag-only workflows can write unusable cache entries.
 
 Why this exists: an unguarded Swatinem/rust-cache step in a workflow that
 runs on pull_request writes one copy of the cache per open PR ref. The
@@ -13,10 +12,9 @@ cargo-audit job, network-kernel-tests.yml's unit job) -- this check exists
 so a third occurrence fails CI instead of silently degrading every
 pipeline for days before someone notices.
 
-The fix is always the same: add `save-if: ${{ github.ref ==
-'refs/heads/main' }}` (or `save-if: false` for jobs that intentionally
-only ever read a cache another job writes, e.g. starters.yml's matrix
-jobs) to the step's `with:` block.
+The fix for PR workflows is to save only from main. The release workflow is
+tag-only, so it must be entirely read-only: tag-scoped entries cannot be read
+by main or by later tags.
 """
 
 import re
@@ -24,6 +22,7 @@ import sys
 from pathlib import Path
 
 WORKFLOWS_DIR = Path(__file__).resolve().parent.parent / "workflows"
+RELEASE_WORKFLOW = WORKFLOWS_DIR / "release.yml"
 
 
 def workflow_triggers_on_pull_request(text: str) -> bool:
@@ -74,6 +73,60 @@ def find_unguarded_cache_steps(text: str) -> list[int]:
     return violations
 
 
+def find_release_cache_writes(text: str) -> list[int]:
+    """Return lines that can write Actions caches from the tag-only release."""
+    lines = text.splitlines()
+    violations = []
+
+    for i, line in enumerate(lines):
+        # The combined action restores during the step and saves at job exit.
+        # Tag-only workflows must use actions/cache/restore instead.
+        if re.search(r"^\s*(?:-\s+)?uses:\s*actions/cache(?:/save)?@", line):
+            violations.append(i + 1)
+
+        # A BuildKit GHA export is also a tag-scoped Actions cache write.
+        cache_to = re.match(r"^(\s*)cache-to:\s*(.*)$", line)
+        if cache_to:
+            value = cache_to.group(2)
+            block_indent = len(cache_to.group(1))
+            for following in lines[i + 1 :]:
+                if not following.strip():
+                    continue
+                indent = len(following) - len(following.lstrip(" "))
+                if indent <= block_indent:
+                    break
+                value += "\n" + following
+            if "type=gha" in value:
+                violations.append(i + 1)
+
+        if not re.search(r"^\s*(?:-\s+)?uses:\s*Swatinem/rust-cache", line):
+            continue
+
+        step_indent = None
+        for k in range(i, -1, -1):
+            match = re.match(r"^(\s*)-\s", lines[k])
+            if match:
+                step_indent = len(match.group(1))
+                break
+        if step_indent is None:
+            step_indent = len(line) - len(line.lstrip(" "))
+
+        block_end = len(lines)
+        for j in range(i + 1, len(lines)):
+            if not lines[j].strip():
+                continue
+            indent = len(lines[j]) - len(lines[j].lstrip(" "))
+            if indent <= step_indent:
+                block_end = j
+                break
+
+        block = "\n".join(lines[i:block_end])
+        if not re.search(r"^\s*save-if:\s*(?:false|\$\{\{\s*false\s*\}\})\s*$", block, re.MULTILINE):
+            violations.append(i + 1)
+
+    return violations
+
+
 def main() -> int:
     failures = []
     for wf in sorted(WORKFLOWS_DIR.glob("*.yml")):
@@ -94,7 +147,20 @@ def main() -> int:
             print(f"  {f}", file=sys.stderr)
         return 1
 
-    print("OK: all pull_request-triggered Swatinem/rust-cache steps are save-if guarded.")
+    release_text = RELEASE_WORKFLOW.read_text()
+    release_failures = find_release_cache_writes(release_text)
+    if release_failures:
+        print(
+            "Cache write(s) in tag-only release workflow -- use "
+            "`actions/cache/restore`, set `Swatinem/rust-cache` to "
+            "`save-if: false`, and remove BuildKit `type=gha` exports:",
+            file=sys.stderr,
+        )
+        for line_no in release_failures:
+            print(f"  .github/workflows/release.yml:{line_no}", file=sys.stderr)
+        return 1
+
+    print("OK: PR caches are guarded and the tag-only release cache is read-only.")
     return 0
 
 

--- a/.github/scripts/check-cache-save-guards.py
+++ b/.github/scripts/check-cache-save-guards.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail when PR or tag-only workflows can write unusable cache entries.
+"""Fail when PR or release workflows can write unusable cache entries.
 
 Why this exists: an unguarded Swatinem/rust-cache step in a workflow that
 runs on pull_request writes one copy of the cache per open PR ref. The
@@ -12,9 +12,9 @@ cargo-audit job, network-kernel-tests.yml's unit job) -- this check exists
 so a third occurrence fails CI instead of silently degrading every
 pipeline for days before someone notices.
 
-The fix for PR workflows is to save only from main. The release workflow is
-tag-only, so it must be entirely read-only: tag-scoped entries cannot be read
-by main or by later tags.
+The fix for PR workflows is to save only from main. Publishing release runs
+are tag-scoped, so the release workflow stays entirely read-only; manual dry
+runs follow the same policy to keep its behavior predictable.
 """
 
 import re
@@ -73,8 +73,30 @@ def find_unguarded_cache_steps(text: str) -> list[int]:
     return violations
 
 
+def step_block(lines: list[str], uses_line: int) -> str:
+    """Return one workflow step, starting at a zero-based `uses:` line."""
+    step_indent = None
+    for k in range(uses_line, -1, -1):
+        match = re.match(r"^(\s*)-\s", lines[k])
+        if match:
+            step_indent = len(match.group(1))
+            break
+    if step_indent is None:
+        step_indent = len(lines[uses_line]) - len(lines[uses_line].lstrip(" "))
+
+    block_end = len(lines)
+    for j in range(uses_line + 1, len(lines)):
+        if not lines[j].strip():
+            continue
+        indent = len(lines[j]) - len(lines[j].lstrip(" "))
+        if indent <= step_indent:
+            block_end = j
+            break
+    return "\n".join(lines[uses_line:block_end])
+
+
 def find_release_cache_writes(text: str) -> list[int]:
-    """Return lines that can write Actions caches from the tag-only release."""
+    """Return lines that can write Actions caches from the release workflow."""
     lines = text.splitlines()
     violations = []
 
@@ -99,30 +121,23 @@ def find_release_cache_writes(text: str) -> list[int]:
             if "type=gha" in value:
                 violations.append(i + 1)
 
-        if not re.search(r"^\s*(?:-\s+)?uses:\s*Swatinem/rust-cache", line):
-            continue
+        if re.search(r"^\s*(?:-\s+)?uses:\s*Swatinem/rust-cache", line):
+            block = step_block(lines, i)
+            if not re.search(r"^\s*save-if:\s*(?:false|\$\{\{\s*false\s*\}\})\s*$", block, re.MULTILINE):
+                violations.append(i + 1)
 
-        step_indent = None
-        for k in range(i, -1, -1):
-            match = re.match(r"^(\s*)-\s", lines[k])
-            if match:
-                step_indent = len(match.group(1))
-                break
-        if step_indent is None:
-            step_indent = len(line) - len(line.lstrip(" "))
-
-        block_end = len(lines)
-        for j in range(i + 1, len(lines)):
-            if not lines[j].strip():
+        # These Docker setup actions write small Actions cache entries unless
+        # their implicit caches are explicitly disabled.
+        implicit_cache_actions = {
+            "docker/setup-buildx-action": "cache-binary",
+            "docker/setup-qemu-action": "cache-image",
+        }
+        for action, opt_out in implicit_cache_actions.items():
+            if not re.search(rf"^\s*(?:-\s+)?uses:\s*{re.escape(action)}@", line):
                 continue
-            indent = len(lines[j]) - len(lines[j].lstrip(" "))
-            if indent <= step_indent:
-                block_end = j
-                break
-
-        block = "\n".join(lines[i:block_end])
-        if not re.search(r"^\s*save-if:\s*(?:false|\$\{\{\s*false\s*\}\})\s*$", block, re.MULTILINE):
-            violations.append(i + 1)
+            block = step_block(lines, i)
+            if not re.search(rf"^\s*{re.escape(opt_out)}:\s*false\s*$", block, re.MULTILINE):
+                violations.append(i + 1)
 
     return violations
 
@@ -151,16 +166,17 @@ def main() -> int:
     release_failures = find_release_cache_writes(release_text)
     if release_failures:
         print(
-            "Cache write(s) in tag-only release workflow -- use "
+            "Cache write(s) in release workflow -- use "
             "`actions/cache/restore`, set `Swatinem/rust-cache` to "
-            "`save-if: false`, and remove BuildKit `type=gha` exports:",
+            "`save-if: false`, disable Docker setup caches, and remove "
+            "BuildKit `type=gha` exports:",
             file=sys.stderr,
         )
         for line_no in release_failures:
             print(f"  .github/workflows/release.yml:{line_no}", file=sys.stderr)
         return 1
 
-    print("OK: PR caches are guarded and the tag-only release cache is read-only.")
+    print("OK: PR caches are guarded and the release workflow cache is read-only.")
     return 0
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,13 @@ name: Release
 # `actions/cache/restore`, and `Swatinem/rust-cache` with saving disabled).
 #
 # GitHub scopes Actions cache *writes* to the ref that produced them, and
-# scopes *reads* to the current ref plus the default branch. This workflow
-# only ever runs on a tag ref — either the `push: tags:` trigger below, or
+# scopes *reads* to the current ref plus the default branch. Publishing runs
+# execute on a tag ref — either the `push: tags:` trigger below, or
 # `workflow_dispatch --ref <tag>` from `nightly-release.yml`. A cache written
 # on a tag is therefore readable by exactly one thing: another run on that
-# same tag, which never happens.
+# same tag, which normally never happens. Manual branch dry-runs follow the
+# same restore-only policy so this workflow cannot unexpectedly consume the
+# shared cache budget.
 #
 # So every byte `cache-to: type=gha,mode=max` wrote here was unreadable, and
 # it was not free: the repo cache is a single 10GB LRU pool. One nightly run
@@ -717,6 +719,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        with:
+          cache-binary: false
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
@@ -772,9 +776,9 @@ jobs:
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.title=Temps
             org.opencontainers.image.description=Open-source platform for deploying and managing applications
-          # Read-only on purpose — see the "GHA cache is read-only here" note
-          # at the top of this file. This workflow only ever runs on tag refs,
-          # whose cache scope nothing else can read.
+          # Read-only on purpose — see the "Actions cache is read-only here" note
+          # at the top of this file. Publishing runs use tag refs whose cache
+          # scope nothing else can read; manual dry-runs follow the same policy.
           cache-from: type=gha
 
   create-docker-manifest:
@@ -967,9 +971,13 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+        with:
+          cache-image: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        with:
+          cache-binary: false
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
@@ -1036,7 +1044,7 @@ jobs:
             org.opencontainers.image.title=temps-sandbox-${{ matrix.runtime }}
             org.opencontainers.image.description=Temps workspace sandbox image (${{ matrix.runtime }} runtime)
           # Read-only: `sandbox-images-beta.yml` populates this scope from
-          # `main`, where it is readable by every ref. See the "GHA cache is
+          # `main`, where it is readable by every ref. See the "Actions cache is
           # read-only here" note at the top of this file.
           cache-from: type=gha,scope=sandbox-${{ matrix.runtime }}
 
@@ -1055,9 +1063,13 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+        with:
+          cache-image: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        with:
+          cache-binary: false
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
-# GHA cache is read-only here (`cache-from` without `cache-to`).
+# Actions cache is read-only here (`cache-from` without `cache-to`, explicit
+# `actions/cache/restore`, and `Swatinem/rust-cache` with saving disabled).
 #
 # GitHub scopes Actions cache *writes* to the ref that produced them, and
 # scopes *reads* to the current ref plus the default branch. This workflow
@@ -90,8 +91,8 @@ jobs:
         with:
           bun-version: 1.3.14
 
-      - name: Cache Bun dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      - name: Restore Bun dependencies
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: web/node_modules
           key: ${{ runner.os }}-bun-${{ hashFiles('web/bun.lock') }}
@@ -149,6 +150,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: linux-amd64-release
+          save-if: false
 
       - name: Download web dist artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -217,6 +219,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: linux-arm64-release
+          save-if: false
 
       - name: Download web dist artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -292,6 +295,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: darwin-amd64-release
+          save-if: false
 
       - name: Install system dependencies
         run: brew install protobuf
@@ -367,6 +371,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: darwin-arm64-release
+          save-if: false
 
       - name: Build release binary
         run: cargo build --release --bin temps --target aarch64-apple-darwin
@@ -865,6 +870,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: sandbox-image-builder
+          save-if: false
 
       - name: Build helpers (print_dockerfile + print_bundle)
         # Single source of truth: same examples the runtime ships use of.


### PR DESCRIPTION
## Summary

- make the release workflow restore-only for Bun and Rust caches
- disable the implicit Buildx binary and QEMU binfmt caches
- prevent future BuildKit, actions/cache, rust-cache, and Docker setup cache writes from release.yml
- extend the existing cache contract check to enforce the complete release policy

This closes the remaining gap in #516: explicit BuildKit writes were removed, but five Swatinem/rust-cache steps, one actions/cache step, three Buildx setup steps, and two QEMU setup steps could still write caches during releases. The latest nightly left about 6.98 GB in its private ref scope.

## Evidence

**Regression reproduction**

Before the explicit-cache fix, the guard identified six writable steps. After those were fixed, expanding the guard to Docker setup defaults identified five more implicit writers:

```text
$ python3 .github/scripts/check-cache-save-guards.py
Cache write(s) in release workflow ...
  .github/workflows/release.yml:719
  .github/workflows/release.yml:969
  .github/workflows/release.yml:972
  .github/workflows/release.yml:1057
  .github/workflows/release.yml:1060
```

**Fixed cache contract**

```text
$ python3 .github/scripts/check-cache-save-guards.py
OK: PR caches are guarded and the release workflow cache is read-only.
```

**Release workflow contract suite**

```text
$ .github/scripts/test-nightly-release-workflows.sh
privileged workflow action pinning valid: 77 uses across 6 workflows
release permission allowlists and tool pins are valid
nightly release workflow wiring and publishing workflow security are valid
```

`python3 -m py_compile .github/scripts/check-cache-save-guards.py` and `git diff --check` also pass. No Rust source changed, so cargo check is not applicable.

## Security

Security review approved: actions remain SHA-pinned, permissions remain least-privilege, and removing cache-write capability reduces cache poisoning and eviction surface.