### PR TITLE
fix(ai-gateway): allow re-enabling a disabled provider model via add

### DIFF
--- a/crates/temps-ai-gateway/src/services/provider_model_service.rs
+++ b/crates/temps-ai-gateway/src/services/provider_model_service.rs
@@ -182,6 +182,7 @@ impl ProviderModelService {
         display_name: Option<&str>,
     ) -> Result<ai_provider_models::Model, AiGatewayError> {
         let model_id = validate_model_id(model_id)?;
+        let display_name = display_name.map(validate_display_name).transpose()?;
         let _ = self.keys.get_by_id(provider_key_id).await?;
         let existing = ai_provider_models::Entity::find()
             .filter(ai_provider_models::Column::ProviderKeyId.eq(provider_key_id))
@@ -199,19 +200,23 @@ impl ProviderModelService {
             // Row already exists but was disabled/unavailable (e.g. left over
             // from a refresh, or manually disabled): re-enable it instead of
             // erroring, since the row is otherwise indistinguishable to the
-            // caller from "model not yet added".
+            // caller from "model not yet added". Mark it manual so the next
+            // refresh() doesn't zero out is_available again if the provider's
+            // discovery response happens to omit this model that time --
+            // that's the same reason the fresh-insert branch below is manual.
             let mut active: ai_provider_models::ActiveModel = model.into();
             active.is_enabled = Set(true);
             active.is_available = Set(true);
+            active.source = Set(MODEL_SOURCE_MANUAL.to_string());
             if let Some(name) = display_name {
-                active.display_name = Set(name.trim().to_string());
+                active.display_name = Set(name.to_string());
             }
             return Ok(active.update(self.db.as_ref()).await?);
         }
         Ok(ai_provider_models::ActiveModel {
             provider_key_id: Set(provider_key_id),
             model_id: Set(model_id.to_string()),
-            display_name: Set(display_name.unwrap_or(model_id).trim().to_string()),
+            display_name: Set(display_name.unwrap_or(model_id).to_string()),
             source: Set(MODEL_SOURCE_MANUAL.to_string()),
             is_available: Set(true),
             is_enabled: Set(true),
@@ -309,6 +314,19 @@ fn validate_model_id(model_id: &str) -> Result<&str, AiGatewayError> {
     Ok(model_id)
 }
 
+fn validate_display_name(display_name: &str) -> Result<&str, AiGatewayError> {
+    let display_name = display_name.trim();
+    if display_name.is_empty()
+        || display_name.len() > 255
+        || display_name.chars().any(char::is_control)
+    {
+        return Err(AiGatewayError::Validation {
+            message: "Display name must contain 1-255 non-control characters".to_string(),
+        });
+    }
+    Ok(display_name)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -381,11 +399,13 @@ mod tests {
 
     #[tokio::test]
     async fn add_manual_reenables_existing_disabled_row_instead_of_erroring() {
+        let mut reenabled = model("claude-haiku-4-5", true, true);
+        reenabled.source = MODEL_SOURCE_MANUAL.to_string();
         let db = Arc::new(
             MockDatabase::new(DatabaseBackend::Postgres)
                 .append_query_results([vec![provider_key(2)]])
                 .append_query_results([vec![model("claude-haiku-4-5", false, false)]])
-                .append_query_results([vec![model("claude-haiku-4-5", true, true)]])
+                .append_query_results([vec![reenabled]])
                 .into_connection(),
         );
         let encryption = Arc::new(
@@ -401,6 +421,25 @@ mod tests {
             .expect("re-adding a disabled model should re-enable it");
         assert!(result.is_enabled);
         assert!(result.is_available);
+        // Marked manual so the next refresh() doesn't re-disable it if that
+        // refresh's discovery response happens to omit this model again.
+        assert_eq!(result.source, MODEL_SOURCE_MANUAL);
+    }
+
+    #[test]
+    fn manual_display_name_is_trimmed_and_validated() {
+        assert_eq!(
+            validate_display_name("  Claude Haiku (fast)  ").unwrap(),
+            "Claude Haiku (fast)"
+        );
+        assert!(matches!(
+            validate_display_name("\n"),
+            Err(AiGatewayError::Validation { .. })
+        ));
+        assert!(matches!(
+            validate_display_name(&"x".repeat(256)),
+            Err(AiGatewayError::Validation { .. })
+        ));
     }
 
     #[tokio::test]

--- a/crates/temps-ai-gateway/src/services/provider_model_service.rs
+++ b/crates/temps-ai-gateway/src/services/provider_model_service.rs
@@ -183,17 +183,30 @@ impl ProviderModelService {
     ) -> Result<ai_provider_models::Model, AiGatewayError> {
         let model_id = validate_model_id(model_id)?;
         let _ = self.keys.get_by_id(provider_key_id).await?;
-        let duplicate = ai_provider_models::Entity::find()
+        let existing = ai_provider_models::Entity::find()
             .filter(ai_provider_models::Column::ProviderKeyId.eq(provider_key_id))
             .filter(ai_provider_models::Column::ModelId.eq(model_id))
             .one(self.db.as_ref())
             .await?;
-        if duplicate.is_some() {
-            return Err(AiGatewayError::Validation {
-                message: format!(
-                    "Model '{model_id}' already exists for provider key {provider_key_id}"
-                ),
-            });
+        if let Some(model) = existing {
+            if model.is_enabled && model.is_available {
+                return Err(AiGatewayError::Validation {
+                    message: format!(
+                        "Model '{model_id}' already exists for provider key {provider_key_id}"
+                    ),
+                });
+            }
+            // Row already exists but was disabled/unavailable (e.g. left over
+            // from a refresh, or manually disabled): re-enable it instead of
+            // erroring, since the row is otherwise indistinguishable to the
+            // caller from "model not yet added".
+            let mut active: ai_provider_models::ActiveModel = model.into();
+            active.is_enabled = Set(true);
+            active.is_available = Set(true);
+            if let Some(name) = display_name {
+                active.display_name = Set(name.trim().to_string());
+            }
+            return Ok(active.update(self.db.as_ref()).await?);
         }
         Ok(ai_provider_models::ActiveModel {
             provider_key_id: Set(provider_key_id),
@@ -335,6 +348,21 @@ mod tests {
         ProviderModelService::new(db, keys, gateway)
     }
 
+    fn provider_key(id: i32) -> ai_provider_keys::Model {
+        let now = chrono::Utc::now();
+        ai_provider_keys::Model {
+            id,
+            provider: "anthropic".to_string(),
+            display_name: "Anthropic".to_string(),
+            api_key_encrypted: "encrypted".to_string(),
+            base_url: None,
+            default_model: None,
+            is_active: true,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
     #[test]
     fn manual_model_id_is_trimmed_and_validated() {
         assert_eq!(
@@ -347,6 +375,51 @@ mod tests {
         ));
         assert!(matches!(
             validate_model_id(&"x".repeat(256)),
+            Err(AiGatewayError::Validation { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn add_manual_reenables_existing_disabled_row_instead_of_erroring() {
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![provider_key(2)]])
+                .append_query_results([vec![model("claude-haiku-4-5", false, false)]])
+                .append_query_results([vec![model("claude-haiku-4-5", true, true)]])
+                .into_connection(),
+        );
+        let encryption = Arc::new(
+            temps_core::EncryptionService::new("01234567890123456789012345678901").unwrap(),
+        );
+        let keys = Arc::new(ProviderKeyService::new(db.clone(), encryption));
+        let gateway = Arc::new(GatewayService::new(keys.clone()));
+        let service = ProviderModelService::new(db, keys, gateway);
+
+        let result = service
+            .add_manual(2, "claude-haiku-4-5", None)
+            .await
+            .expect("re-adding a disabled model should re-enable it");
+        assert!(result.is_enabled);
+        assert!(result.is_available);
+    }
+
+    #[tokio::test]
+    async fn add_manual_rejects_already_enabled_duplicate() {
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![provider_key(2)]])
+                .append_query_results([vec![model("claude-haiku-4-5", true, true)]])
+                .into_connection(),
+        );
+        let encryption = Arc::new(
+            temps_core::EncryptionService::new("01234567890123456789012345678901").unwrap(),
+        );
+        let keys = Arc::new(ProviderKeyService::new(db.clone(), encryption));
+        let gateway = Arc::new(GatewayService::new(keys.clone()));
+        let service = ProviderModelService::new(db, keys, gateway);
+
+        assert!(matches!(
+            service.add_manual(2, "claude-haiku-4-5", None).await,
             Err(AiGatewayError::Validation { .. })
         ));
     }

--- a/web/src/pages/AiGateway.tsx
+++ b/web/src/pages/AiGateway.tsx
@@ -148,6 +148,17 @@ import {
   compareAiModelIdsByRelevance,
   sortAiModelIdsByRelevance,
 } from '@/lib/ai-model-ranking'
+
+// Mutation errors here are thrown ProblemDetails response bodies, not Error
+// instances -- String(error) on an object stringifies to "[object Object]"
+// instead of the API's detail message.
+function providerModelErrorMessage(error: unknown): string {
+  if (error && typeof error === 'object' && 'detail' in error) {
+    const detail = (error as { detail?: unknown }).detail
+    if (typeof detail === 'string' && detail.length > 0) return detail
+  }
+  return String(error)
+}
 // ============================================================================
 // Usage Analytics types & fetchers
 // ============================================================================
@@ -420,7 +431,9 @@ function ProviderKeyModelDetail({
       toast.success(`${providerKey.display_name} models refreshed`)
     },
     onError: (error) =>
-      toast.error('Model refresh failed', { description: String(error) }),
+      toast.error('Model refresh failed', {
+        description: providerModelErrorMessage(error),
+      }),
   })
   const addMutation = useMutation({
     mutationFn: () =>
@@ -435,7 +448,9 @@ function ProviderKeyModelDetail({
       toast.success('Manual model added')
     },
     onError: (error) =>
-      toast.error('Could not add model', { description: String(error) }),
+      toast.error('Could not add model', {
+        description: providerModelErrorMessage(error),
+      }),
   })
   const updateMutation = useMutation({
     mutationFn: ({ id, enabled }: { id: number; enabled: boolean }) =>
@@ -446,7 +461,9 @@ function ProviderKeyModelDetail({
       }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey }),
     onError: (error) =>
-      toast.error('Could not update model', { description: String(error) }),
+      toast.error('Could not update model', {
+        description: providerModelErrorMessage(error),
+      }),
   })
   const defaultMutation = useMutation({
     mutationFn: (modelId: string) =>
@@ -461,7 +478,7 @@ function ProviderKeyModelDetail({
     },
     onError: (error) =>
       toast.error('Could not set default model', {
-        description: String(error),
+        description: providerModelErrorMessage(error),
       }),
   })
   const deleteMutation = useMutation({
@@ -472,7 +489,9 @@ function ProviderKeyModelDetail({
       }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey }),
     onError: (error) =>
-      toast.error('Could not delete model', { description: String(error) }),
+      toast.error('Could not delete model', {
+        description: providerModelErrorMessage(error),
+      }),
   })
 
   const models = useMemo(

--- a/web/src/pages/AiGateway.tsx
+++ b/web/src/pages/AiGateway.tsx
@@ -152,7 +152,7 @@ import {
 // Mutation errors here are thrown ProblemDetails response bodies, not Error
 // instances -- String(error) on an object stringifies to "[object Object]"
 // instead of the API's detail message.
-function providerModelErrorMessage(error: unknown): string {
+function apiErrorMessage(error: unknown): string {
   if (error && typeof error === 'object' && 'detail' in error) {
     const detail = (error as { detail?: unknown }).detail
     if (typeof detail === 'string' && detail.length > 0) return detail
@@ -303,7 +303,7 @@ function AiSummaryDefaultsCard({
     },
     onError: (error) =>
       toast.error('Could not save AI summary defaults', {
-        description: String(error),
+        description: apiErrorMessage(error),
       }),
   })
 
@@ -432,7 +432,7 @@ function ProviderKeyModelDetail({
     },
     onError: (error) =>
       toast.error('Model refresh failed', {
-        description: providerModelErrorMessage(error),
+        description: apiErrorMessage(error),
       }),
   })
   const addMutation = useMutation({
@@ -449,7 +449,7 @@ function ProviderKeyModelDetail({
     },
     onError: (error) =>
       toast.error('Could not add model', {
-        description: providerModelErrorMessage(error),
+        description: apiErrorMessage(error),
       }),
   })
   const updateMutation = useMutation({
@@ -462,7 +462,7 @@ function ProviderKeyModelDetail({
     onSuccess: () => queryClient.invalidateQueries({ queryKey }),
     onError: (error) =>
       toast.error('Could not update model', {
-        description: providerModelErrorMessage(error),
+        description: apiErrorMessage(error),
       }),
   })
   const defaultMutation = useMutation({
@@ -478,7 +478,7 @@ function ProviderKeyModelDetail({
     },
     onError: (error) =>
       toast.error('Could not set default model', {
-        description: providerModelErrorMessage(error),
+        description: apiErrorMessage(error),
       }),
   })
   const deleteMutation = useMutation({
@@ -490,7 +490,7 @@ function ProviderKeyModelDetail({
     onSuccess: () => queryClient.invalidateQueries({ queryKey }),
     onError: (error) =>
       toast.error('Could not delete model', {
-        description: providerModelErrorMessage(error),
+        description: apiErrorMessage(error),
       }),
   })
 
@@ -4191,7 +4191,7 @@ export function AiGatewayPage() {
     },
     onError: (error) =>
       toast.error('Some gateway model catalogs could not be refreshed', {
-        description: String(error),
+        description: apiErrorMessage(error),
       }),
   })
 
@@ -4328,7 +4328,9 @@ export function AiGatewayPage() {
       setTestingKeyId(null)
     },
     onError: (err) => {
-      toast.error('Failed to test provider key', { description: String(err) })
+      toast.error('Failed to test provider key', {
+        description: apiErrorMessage(err),
+      })
       setTestingKeyId(null)
     },
   })


### PR DESCRIPTION
## Summary
- `add_manual` on `ProviderModelService` previously errored with "already exists" whenever a provider-key model row already existed, even if it was disabled/unavailable — with no way to recover a model like `claude-haiku-4-5` once it ended up disabled, since the gateway also rejects requests for it via `ensure_model_selectable`. Now it re-enables the existing row instead, only rejecting when the row is already enabled and available. The re-enable path also marks the row `manual` (matching the fresh-insert branch) so a later `refresh()` can't silently flip it back to unavailable if that refresh's discovery response happens to omit the model again.
- Added `validate_display_name`, applied to both the insert and re-enable paths — `display_name` previously skipped the same control-character/length validation `model_id` gets.
- The AI Gateway mutations (provider-model refresh/add/update/set-default/delete, the bulk "refresh all" action, provider-key test, and AI summary defaults save) rendered `[object Object]` in error toasts instead of the real API error detail, because they called `String(error)` on a thrown `ProblemDetails` object instead of reading its `detail` field. Extracted a shared `apiErrorMessage` helper and applied it everywhere in this file with the same bug.

## Test plan
- [x] `cargo test --lib -p temps-ai-gateway` — 214 passed, including 3 new/extended tests covering re-enable-on-add (now asserting `source` becomes manual), reject-when-already-enabled, and display_name validation
- [x] `cargo check --lib -p temps-ai-gateway` — clean
- [x] `bunx tsc --noEmit` in `web/` — clean
- [x] Extracted `apiErrorMessage` and ran it directly against a realistic `ProblemDetails` shape: confirms `String(error)` on that shape produces `[object Object]` while the new helper produces the real `detail` string
- [ ] Manual verification in a running instance: add a disabled model back via the AI Gateway settings UI and confirm it stays selectable/usable across a subsequent refresh

## Review
Reviewed via `/review-pr` + `security-auditor`. Findings addressed in the second commit: `source` not marked manual on re-enable (functional — could get silently undone by the next refresh), missing `display_name` validation (low), and two more error-toast call sites with the same `String(error)` bug that weren't caught in the first pass. No blocking security findings; auth/permission guards unchanged.