### PR TITLE
docs(readme): tag temps.sh links with UTM parameters

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -16,7 +16,7 @@ Deployments, Analytics, Session Replay, Error Tracking, Uptime-Monitoring, Trans
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org/)
 [![GitHub Stars](https://img.shields.io/github/stars/gotempsh/temps?style=social)](https://github.com/gotempsh/temps)
 
-[Website](https://temps.sh) · [Dokumentation](https://temps.sh/docs) · [Schnellstart](https://temps.sh/docs/introduction) · [Diskussionen](https://github.com/gotempsh/temps/discussions) · [Contributing](CONTRIBUTING.md)
+[Website](https://temps.sh/?utm_source=github&utm_medium=repo&utm_content=header_de) · [Dokumentation](https://temps.sh/docs?utm_source=github&utm_medium=repo&utm_content=header_de) · [Schnellstart](https://temps.sh/docs/introduction?utm_source=github&utm_medium=repo&utm_content=header_de) · [Diskussionen](https://github.com/gotempsh/temps/discussions) · [Contributing](CONTRIBUTING.md)
 
 [English](README.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md) | [Français](README.fr.md) | Deutsch | [日本語](README.ja.md) | [Português](README.pt-BR.md)
 
@@ -253,7 +253,7 @@ curl -fsSL https://temps.sh/deploy.sh | bash
 
 **Getestet auf:** Ubuntu 24.04 / 22.04 &nbsp;|&nbsp; Läuft auch auf macOS
 
-Du willst keinen Server verwalten? [Temps Cloud](https://temps.sh/pricing) betreibt Temps für dich auf verwalteter Infrastruktur.
+Du willst keinen Server verwalten? [Temps Cloud](https://temps.sh/pricing?utm_source=github&utm_medium=repo&utm_content=cloud_cta_de) betreibt Temps für dich auf verwalteter Infrastruktur.
 
 ---
 
@@ -303,7 +303,7 @@ Du willst keinen Server verwalten? [Temps Cloud](https://temps.sh/pricing) betre
 
 **Wo die Alternativen punkten.** Coolify und Dokploy bieten One-Click-Template-Bibliotheken (280+ Apps bei Coolify), die Temps noch nicht hat, und beide haben deutlich größere Communities — allein Coolify zählt über 56k GitHub-Sterne, während Temps das jüngste Projekt auf dieser Liste ist. Kamal ist die einfachere Wahl, wenn du nur Zero-Downtime-Docker-Deploys per CLI willst. Vercel und die anderen Managed-Plattformen bieten dir ein globales Edge-Netzwerk, Edge Functions und DDoS-Absorption, mit denen ein einzelner VPS nicht mithalten kann — und sie betreiben die Infrastruktur für dich, was echten Mehrwert bedeutet, wenn du dich nie um einen Server kümmern willst.
 
-Ausführliche, regelmäßig aktualisierte Vergleiche: [temps.sh/compare](https://temps.sh/compare)
+Ausführliche, regelmäßig aktualisierte Vergleiche: [temps.sh/compare](https://temps.sh/compare?utm_source=github&utm_medium=repo&utm_content=compare_de)
 
 ---
 
@@ -416,6 +416,6 @@ Doppelt lizenziert unter [MIT](LICENSE-MIT) oder [Apache 2.0](LICENSE).
 
 <div align="center">
 
-[temps.sh](https://temps.sh) | [Dokumentation](https://temps.sh/docs) | [GitHub](https://github.com/gotempsh/temps)
+[temps.sh](https://temps.sh/?utm_source=github&utm_medium=repo&utm_content=footer_de) | [Dokumentation](https://temps.sh/docs?utm_source=github&utm_medium=repo&utm_content=footer_de) | [GitHub](https://github.com/gotempsh/temps)
 
 </div>

--- a/README.es.md
+++ b/README.es.md
@@ -16,7 +16,7 @@ Despliegues, analítica, session replay, error tracking, monitorización de disp
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org/)
 [![GitHub Stars](https://img.shields.io/github/stars/gotempsh/temps?style=social)](https://github.com/gotempsh/temps)
 
-[Sitio web](https://temps.sh) · [Documentación](https://temps.sh/docs) · [Inicio rápido](https://temps.sh/docs/introduction) · [Discusiones](https://github.com/gotempsh/temps/discussions) · [Contributing](CONTRIBUTING.md)
+[Sitio web](https://temps.sh/?utm_source=github&utm_medium=repo&utm_content=header_es) · [Documentación](https://temps.sh/docs?utm_source=github&utm_medium=repo&utm_content=header_es) · [Inicio rápido](https://temps.sh/docs/introduction?utm_source=github&utm_medium=repo&utm_content=header_es) · [Discusiones](https://github.com/gotempsh/temps/discussions) · [Contributing](CONTRIBUTING.md)
 
 [English](README.md) | [简体中文](README.zh-CN.md) | Español | [Français](README.fr.md) | [Deutsch](README.de.md) | [日本語](README.ja.md) | [Português](README.pt-BR.md)
 
@@ -253,7 +253,7 @@ curl -fsSL https://temps.sh/deploy.sh | bash
 
 **Probado en:** Ubuntu 24.04 / 22.04 &nbsp;|&nbsp; También funciona en macOS
 
-¿Prefieres no gestionar un servidor? [Temps Cloud](https://temps.sh/pricing) ejecuta Temps por ti en infraestructura gestionada.
+¿Prefieres no gestionar un servidor? [Temps Cloud](https://temps.sh/pricing?utm_source=github&utm_medium=repo&utm_content=cloud_cta_es) ejecuta Temps por ti en infraestructura gestionada.
 
 ---
 
@@ -303,7 +303,7 @@ curl -fsSL https://temps.sh/deploy.sh | bash
 
 **Dónde ganan las alternativas.** Coolify y Dokploy tienen bibliotecas de plantillas de un clic (más de 280 aplicaciones en Coolify) que Temps todavía no tiene, y ambos cuentan con comunidades mucho más grandes — solo Coolify supera las 56k estrellas en GitHub, mientras que Temps es el proyecto más nuevo de esta lista. Kamal es la opción más sencilla si lo único que quieres son despliegues Docker sin tiempo de inactividad gestionados desde una CLI. Vercel y el resto de plataformas gestionadas te dan una red edge global, funciones edge y absorción de DDoS que un único VPS no puede igualar — y además operan la infraestructura por ti, lo cual tiene un valor real si nunca quieres preocuparte por un servidor.
 
-Comparativas detalladas y actualizadas regularmente: [temps.sh/compare](https://temps.sh/compare)
+Comparativas detalladas y actualizadas regularmente: [temps.sh/compare](https://temps.sh/compare?utm_source=github&utm_medium=repo&utm_content=compare_es)
 
 ---
 
@@ -416,6 +416,6 @@ Con doble licencia [MIT](LICENSE-MIT) o [Apache 2.0](LICENSE).
 
 <div align="center">
 
-[temps.sh](https://temps.sh) | [Documentación](https://temps.sh/docs) | [GitHub](https://github.com/gotempsh/temps)
+[temps.sh](https://temps.sh/?utm_source=github&utm_medium=repo&utm_content=footer_es) | [Documentación](https://temps.sh/docs?utm_source=github&utm_medium=repo&utm_content=footer_es) | [GitHub](https://github.com/gotempsh/temps)
 
 </div>

--- a/README.fr.md
+++ b/README.fr.md
@@ -16,7 +16,7 @@ Déploiements, analytics, session replay, suivi d'erreurs, monitoring de disponi
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org/)
 [![GitHub Stars](https://img.shields.io/github/stars/gotempsh/temps?style=social)](https://github.com/gotempsh/temps)
 
-[Site web](https://temps.sh) · [Documentation](https://temps.sh/docs) · [Démarrage rapide](https://temps.sh/docs/introduction) · [Discussions](https://github.com/gotempsh/temps/discussions) · [Contributing](CONTRIBUTING.md)
+[Site web](https://temps.sh/?utm_source=github&utm_medium=repo&utm_content=header_fr) · [Documentation](https://temps.sh/docs?utm_source=github&utm_medium=repo&utm_content=header_fr) · [Démarrage rapide](https://temps.sh/docs/introduction?utm_source=github&utm_medium=repo&utm_content=header_fr) · [Discussions](https://github.com/gotempsh/temps/discussions) · [Contributing](CONTRIBUTING.md)
 
 [English](README.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md) | Français | [Deutsch](README.de.md) | [日本語](README.ja.md) | [Português](README.pt-BR.md)
 
@@ -253,7 +253,7 @@ curl -fsSL https://temps.sh/deploy.sh | bash
 
 **Testé sur :** Ubuntu 24.04 / 22.04 &nbsp;|&nbsp; Fonctionne aussi sur macOS
 
-Vous préférez ne pas gérer de serveur ? [Temps Cloud](https://temps.sh/pricing) fait tourner Temps pour vous sur une infrastructure managée.
+Vous préférez ne pas gérer de serveur ? [Temps Cloud](https://temps.sh/pricing?utm_source=github&utm_medium=repo&utm_content=cloud_cta_fr) fait tourner Temps pour vous sur une infrastructure managée.
 
 ---
 
@@ -303,7 +303,7 @@ Vous préférez ne pas gérer de serveur ? [Temps Cloud](https://temps.sh/pricin
 
 **Là où les alternatives gagnent.** Coolify et Dokploy offrent des bibliothèques de templates en un clic (280+ applications sur Coolify) que Temps n'a pas encore, et tous deux ont des communautés bien plus grandes — Coolify à lui seul dépasse les 56k étoiles GitHub, tandis que Temps est le projet le plus récent de cette liste. Kamal est le choix le plus simple si tout ce que vous voulez, ce sont des déploiements Docker sans interruption pilotés depuis une CLI. Vercel et les autres plateformes managées vous offrent un réseau edge mondial, des fonctions edge et une absorption des attaques DDoS qu'un simple VPS ne peut pas égaler — et elles gèrent l'infrastructure à votre place, ce qui est une vraie valeur ajoutée si vous ne voulez jamais avoir à penser à un serveur.
 
-Comparatifs détaillés et régulièrement mis à jour : [temps.sh/compare](https://temps.sh/compare)
+Comparatifs détaillés et régulièrement mis à jour : [temps.sh/compare](https://temps.sh/compare?utm_source=github&utm_medium=repo&utm_content=compare_fr)
 
 ---
 
@@ -416,6 +416,6 @@ Sous double licence [MIT](LICENSE-MIT) ou [Apache 2.0](LICENSE).
 
 <div align="center">
 
-[temps.sh](https://temps.sh) | [Documentation](https://temps.sh/docs) | [GitHub](https://github.com/gotempsh/temps)
+[temps.sh](https://temps.sh/?utm_source=github&utm_medium=repo&utm_content=footer_fr) | [Documentation](https://temps.sh/docs?utm_source=github&utm_medium=repo&utm_content=footer_fr) | [GitHub](https://github.com/gotempsh/temps)
 
 </div>

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,7 @@
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org/)
 [![GitHub Stars](https://img.shields.io/github/stars/gotempsh/temps?style=social)](https://github.com/gotempsh/temps)
 
-[ウェブサイト](https://temps.sh) · [ドキュメント](https://temps.sh/docs) · [クイックスタート](https://temps.sh/docs/introduction) · [ディスカッション](https://github.com/gotempsh/temps/discussions) · [Contributing](CONTRIBUTING.md)
+[ウェブサイト](https://temps.sh/?utm_source=github&utm_medium=repo&utm_content=header_ja) · [ドキュメント](https://temps.sh/docs?utm_source=github&utm_medium=repo&utm_content=header_ja) · [クイックスタート](https://temps.sh/docs/introduction?utm_source=github&utm_medium=repo&utm_content=header_ja) · [ディスカッション](https://github.com/gotempsh/temps/discussions) · [Contributing](CONTRIBUTING.md)
 
 [English](README.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | 日本語 | [Português](README.pt-BR.md)
 
@@ -253,7 +253,7 @@ curl -fsSL https://temps.sh/deploy.sh | bash
 
 **動作確認済み:** Ubuntu 24.04 / 22.04 &nbsp;|&nbsp; macOS でも動作します
 
-サーバーの管理はしたくない？ [Temps Cloud](https://temps.sh/pricing) なら、マネージドインフラ上で Temps をあなたの代わりに運用します。
+サーバーの管理はしたくない？ [Temps Cloud](https://temps.sh/pricing?utm_source=github&utm_medium=repo&utm_content=cloud_cta_ja) なら、マネージドインフラ上で Temps をあなたの代わりに運用します。
 
 ---
 
@@ -303,7 +303,7 @@ curl -fsSL https://temps.sh/deploy.sh | bash
 
 **代替ツールが勝る点。** Coolify と Dokploy には、Temps がまだ持っていないワンクリックテンプレートライブラリ（Coolify は280以上のアプリ）があり、コミュニティの規模もはるかに大きい —— Coolify だけで GitHub スター56k超を誇る一方、Temps はこのリストで最も新しいプロジェクトです。CLI からのゼロダウンタイム Docker デプロイだけが必要なら、Kamal のほうがシンプルな選択肢です。Vercel をはじめとするマネージドプラットフォームは、単一の VPS では太刀打ちできないグローバルエッジネットワーク、エッジ関数、DDoS 吸収能力を提供し、しかもインフラの運用まで代行してくれます —— サーバーのことを一切考えたくないなら、それは確かな価値です。
 
-詳細で定期的に更新される比較はこちら: [temps.sh/compare](https://temps.sh/compare)
+詳細で定期的に更新される比較はこちら: [temps.sh/compare](https://temps.sh/compare?utm_source=github&utm_medium=repo&utm_content=compare_ja)
 
 ---
 
@@ -416,6 +416,6 @@ cargo build --release
 
 <div align="center">
 
-[temps.sh](https://temps.sh) | [ドキュメント](https://temps.sh/docs) | [GitHub](https://github.com/gotempsh/temps)
+[temps.sh](https://temps.sh/?utm_source=github&utm_medium=repo&utm_content=footer_ja) | [ドキュメント](https://temps.sh/docs?utm_source=github&utm_medium=repo&utm_content=footer_ja) | [GitHub](https://github.com/gotempsh/temps)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img alt="Stop paying for 7 SaaS tools: Vercel, Sentry, PostHog, Pingdom, Resend, E2B and Datadog, replaced by one self-hosted Temps binary" src="assets/hero/stop-paying-light.svg" width="700">
 </picture>
 
-[Website](https://temps.sh) · [Docs](https://temps.sh/docs) · [Discussions](https://github.com/gotempsh/temps/discussions)
+[Website](https://temps.sh/?utm_source=github&utm_medium=repo&utm_content=header_en) · [Docs](https://temps.sh/docs?utm_source=github&utm_medium=repo&utm_content=header_en) · [Discussions](https://github.com/gotempsh/temps/discussions)
 
 </div>
 
@@ -237,7 +237,7 @@ curl -fsSL https://temps.sh/deploy.sh | bash
 
 **Tested on:** Ubuntu 24.04 / 22.04 &nbsp;|&nbsp; Also works on macOS
 
-Prefer not to manage a server? [Temps Cloud](https://temps.sh/pricing) runs Temps for you on managed infrastructure.
+Prefer not to manage a server? [Temps Cloud](https://temps.sh/pricing?utm_source=github&utm_medium=repo&utm_content=cloud_cta_en) runs Temps for you on managed infrastructure.
 
 ---
 
@@ -287,7 +287,7 @@ Prefer not to manage a server? [Temps Cloud](https://temps.sh/pricing) runs Temp
 
 **Where the alternatives win.** Coolify and Dokploy have one-click template libraries (280+ apps on Coolify) that Temps doesn't have yet, and both have far larger communities — Coolify alone has 56k+ GitHub stars, while Temps is the newest project on this list. Kamal is the simpler choice if all you want is zero-downtime Docker deploys driven from a CLI. Vercel and the other managed platforms give you a global edge network, edge functions, and DDoS absorption that a single VPS can't match — and they run the infrastructure for you, which is real value if you never want to think about a server.
 
-Detailed, regularly updated comparisons: [temps.sh/compare](https://temps.sh/compare)
+Detailed, regularly updated comparisons: [temps.sh/compare](https://temps.sh/compare?utm_source=github&utm_medium=repo&utm_content=compare_en)
 
 ---
 
@@ -405,7 +405,7 @@ Dual-licensed under [MIT](LICENSE-MIT) or [Apache 2.0](LICENSE).
 
 <div align="center">
 
-[temps.sh](https://temps.sh) | [Documentation](https://temps.sh/docs) | [GitHub](https://github.com/gotempsh/temps)
+[temps.sh](https://temps.sh/?utm_source=github&utm_medium=repo&utm_content=footer_en) | [Documentation](https://temps.sh/docs?utm_source=github&utm_medium=repo&utm_content=footer_en) | [GitHub](https://github.com/gotempsh/temps)
 
 English | [简体中文](README.zh-CN.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [日本語](README.ja.md) | [Português](README.pt-BR.md)
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -16,7 +16,7 @@ Deploys, analytics, session replay, error tracking, monitoramento de disponibili
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org/)
 [![GitHub Stars](https://img.shields.io/github/stars/gotempsh/temps?style=social)](https://github.com/gotempsh/temps)
 
-[Site](https://temps.sh) · [Documentação](https://temps.sh/docs) · [Guia Rápido](https://temps.sh/docs/introduction) · [Discussões](https://github.com/gotempsh/temps/discussions) · [Contributing](CONTRIBUTING.md)
+[Site](https://temps.sh/?utm_source=github&utm_medium=repo&utm_content=header_pt-BR) · [Documentação](https://temps.sh/docs?utm_source=github&utm_medium=repo&utm_content=header_pt-BR) · [Guia Rápido](https://temps.sh/docs/introduction?utm_source=github&utm_medium=repo&utm_content=header_pt-BR) · [Discussões](https://github.com/gotempsh/temps/discussions) · [Contributing](CONTRIBUTING.md)
 
 [English](README.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [日本語](README.ja.md) | Português
 
@@ -253,7 +253,7 @@ curl -fsSL https://temps.sh/deploy.sh | bash
 
 **Testado em:** Ubuntu 24.04 / 22.04 &nbsp;|&nbsp; Também funciona no macOS
 
-Prefere não gerenciar um servidor? O [Temps Cloud](https://temps.sh/pricing) roda o Temps para você em infraestrutura gerenciada.
+Prefere não gerenciar um servidor? O [Temps Cloud](https://temps.sh/pricing?utm_source=github&utm_medium=repo&utm_content=cloud_cta_pt-BR) roda o Temps para você em infraestrutura gerenciada.
 
 ---
 
@@ -303,7 +303,7 @@ Prefere não gerenciar um servidor? O [Temps Cloud](https://temps.sh/pricing) ro
 
 **Onde as alternativas ganham.** Coolify e Dokploy têm bibliotecas de templates one-click (280+ apps no Coolify) que o Temps ainda não tem, e ambos contam com comunidades muito maiores — só o Coolify tem mais de 56 mil estrelas no GitHub, enquanto o Temps é o projeto mais novo desta lista. O Kamal é a escolha mais simples se tudo o que você quer são deploys Docker sem downtime comandados pela CLI. A Vercel e as demais plataformas gerenciadas oferecem uma rede edge global, edge functions e absorção de DDoS que um único VPS não consegue igualar — e elas operam a infraestrutura por você, o que é um valor real se você nunca quiser se preocupar com um servidor.
 
-Comparações detalhadas e atualizadas regularmente: [temps.sh/compare](https://temps.sh/compare)
+Comparações detalhadas e atualizadas regularmente: [temps.sh/compare](https://temps.sh/compare?utm_source=github&utm_medium=repo&utm_content=compare_pt-BR)
 
 ---
 
@@ -416,6 +416,6 @@ Licenciado sob dupla licença: [MIT](LICENSE-MIT) ou [Apache 2.0](LICENSE).
 
 <div align="center">
 
-[temps.sh](https://temps.sh) | [Documentação](https://temps.sh/docs) | [GitHub](https://github.com/gotempsh/temps)
+[temps.sh](https://temps.sh/?utm_source=github&utm_medium=repo&utm_content=footer_pt-BR) | [Documentação](https://temps.sh/docs?utm_source=github&utm_medium=repo&utm_content=footer_pt-BR) | [GitHub](https://github.com/gotempsh/temps)
 
 </div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,7 +16,7 @@
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org/)
 [![GitHub Stars](https://img.shields.io/github/stars/gotempsh/temps?style=social)](https://github.com/gotempsh/temps)
 
-[官网](https://temps.sh) · [文档](https://temps.sh/docs) · [快速开始](https://temps.sh/docs/introduction) · [讨论区](https://github.com/gotempsh/temps/discussions) · [Contributing](CONTRIBUTING.md)
+[官网](https://temps.sh/?utm_source=github&utm_medium=repo&utm_content=header_zh) · [文档](https://temps.sh/docs?utm_source=github&utm_medium=repo&utm_content=header_zh) · [快速开始](https://temps.sh/docs/introduction?utm_source=github&utm_medium=repo&utm_content=header_zh) · [讨论区](https://github.com/gotempsh/temps/discussions) · [Contributing](CONTRIBUTING.md)
 
 [English](README.md) | 简体中文 | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [日本語](README.ja.md) | [Português](README.pt-BR.md)
 
@@ -253,7 +253,7 @@ curl -fsSL https://temps.sh/deploy.sh | bash
 
 **已测试系统：** Ubuntu 24.04 / 22.04 &nbsp;|&nbsp; macOS 也可运行
 
-不想自己维护服务器？[Temps Cloud](https://temps.sh/pricing) 可以在托管基础设施上为你运行 Temps。
+不想自己维护服务器？[Temps Cloud](https://temps.sh/pricing?utm_source=github&utm_medium=repo&utm_content=cloud_cta_zh) 可以在托管基础设施上为你运行 Temps。
 
 ---
 
@@ -303,7 +303,7 @@ curl -fsSL https://temps.sh/deploy.sh | bash
 
 **这些替代方案的优势所在。** Coolify 和 Dokploy 拥有一键模板库（Coolify 上有 280+ 应用），这些 Temps 目前还没有；而且两者的社区规模远大于 Temps —— 仅 Coolify 就有 56k+ GitHub star，Temps 则是这份列表中最年轻的项目。如果你只需要通过 CLI 驱动的零停机 Docker 部署，Kamal 是更简单的选择。Vercel 和其他托管平台提供全球边缘网络、边缘函数和 DDoS 吸收能力，这些是单台 VPS 无法企及的 —— 而且它们替你运维基础设施，如果你完全不想操心服务器，这是实实在在的价值。
 
-详细且持续更新的对比：[temps.sh/compare](https://temps.sh/compare)
+详细且持续更新的对比：[temps.sh/compare](https://temps.sh/compare?utm_source=github&utm_medium=repo&utm_content=compare_zh)
 
 ---
 
@@ -416,6 +416,6 @@ cargo build --release
 
 <div align="center">
 
-[temps.sh](https://temps.sh) | [文档](https://temps.sh/docs) | [GitHub](https://github.com/gotempsh/temps)
+[temps.sh](https://temps.sh/?utm_source=github&utm_medium=repo&utm_content=footer_zh) | [文档](https://temps.sh/docs?utm_source=github&utm_medium=repo&utm_content=footer_zh) | [GitHub](https://github.com/gotempsh/temps)
 
 </div>


### PR DESCRIPTION
## Why

GitHub is the single largest referrer to temps.sh — 308 views / 102 uniques in the last 14 days, ahead of Google. But every one of those clicks lands as an undifferentiated `github.com` referral, so there is currently no way to tell whether traffic came from the header nav, the Temps Cloud CTA, the comparisons link, or the footer — let alone which translated README drove it.

With v0.1.0 and a launch push coming, that attribution gap means we'd be able to measure how many people arrive but not what any part of the README actually converts.

## What changed

Tagged the `temps.sh` links across all seven READMEs with:

```
?utm_source=github&utm_medium=repo&utm_content=<location>_<locale>
```

Four locations per file — `header`, `cloud_cta`, `compare`, `footer` — across `en`, `zh`, `es`, `fr`, `de`, `ja`, `pt-BR`. 28 links total.

This gives two dimensions from one field: filter by prefix for placement (`cloud_cta_*`) or by suffix for locale (`*_ja`), which also tells us whether the translations are earning their maintenance cost.

## Deliberate exclusions

- **`curl -fsSL https://temps.sh/deploy.sh | bash` is left untagged.** A shell fetch never fires the analytics SDK, so the parameters would measure nothing — and tracking params inside a piped install command are a bad look for exactly the audience that reads those commands before running them. Install attribution is a server-side question on the `deploy.sh` request log, handled separately.
- **Links pointing at `github.com` are left alone.** GitHub reports referrers by domain only and never forwards query parameters, so tagging them measures nothing.
- **`utm_campaign` is intentionally unused**, so it stays free for time-boxed launch links (`utm_campaign=v010`) without colliding with these evergreen README tags.

## Evidence

No code change is required — the pipeline already handles these end to end:

- `sdks/node/packages/react-analytics/src/Provider.tsx:45` sends `request_query: window.location.search`
- `crates/temps-analytics-events/src/services/events_service.rs:1513` calls `temps_analytics::parse_utm_params(request_query)`
- Fields persist to `request_sessions`, `events`, and visitor first-touch (`first_utm_source`) via `m20260103_000002_add_utm_fields_to_sessions`
- `temps-landing/src/app/layout.tsx:103` already mounts `TempsAnalyticsProvider`

Diff verification:

```
7 files changed, 28 insertions(+), 28 deletions(-)
```

- `git diff -U0 | grep deploy.sh` returns empty, confirming the install one-liners are untouched
- Rendered link check on `README.es.md:19` — the extra `Inicio rápido` link present only in translations was picked up correctly:

```
[Sitio web](https://temps.sh/?utm_source=github&utm_medium=repo&utm_content=header_es) ·
[Documentación](https://temps.sh/docs?utm_source=github&utm_medium=repo&utm_content=header_es) ·
[Inicio rápido](https://temps.sh/docs/introduction?utm_source=github&utm_medium=repo&utm_content=header_es)
```

Pre-commit hooks passed (trailing whitespace, EOF, typos, conventional commit).

## Verifying after merge

Click a README link and confirm the session lands with the right attribution:

```bash
bunx @temps-sdk/cli analytics top -d utm_content --period 7d
```

## Follow-up (not in this PR)

Lead-magnet, contact, and Cloud signup endpoints under `temps-landing/src/app/api/` don't persist first-touch UTMs, so channel attribution stops at pageviews and doesn't reach conversions. Worth closing before the launch.