### PR TITLE
fix(docker): bump Alpine base images off EOL 3.19/3.20 to 3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,7 +128,7 @@ COPY crates/temps-cli/GeoLite2-City.mmdb /GeoLite2-City.mmdb
 FROM ${TEMPS_ARTIFACTS} AS artifacts
 
 # Stage 3: Runtime
-FROM alpine:3.20
+FROM alpine:3.22
 
 # Install runtime dependencies
 RUN apk add --no-cache \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:3.22
 
 # Install runtime dependencies
 RUN apk add --no-cache \


### PR DESCRIPTION
## Summary
Follow-up to #691. Fixing the CI permissions bug in that PR let the `Container Image Scan (Trivy)` job actually run for the first time (it previously always failed on GHCR auth before reaching the scan step), and it surfaced a real finding:

- `Dockerfile.release` (what `release.yml` publishes to `ghcr.io/gotempsh/temps`) pinned `alpine:3.19` — EOL.
- `Dockerfile` (the documented `docker build -t temps:latest .` source-build path) pinned `alpine:3.20` in its runtime stage — also EOL as of 2026-04-01.
- Trivy flagged **HIGH** severity `CVE-2026-40200` (musl libc `qsort` stack-based memory corruption → arbitrary code execution/DoS), plus lower-severity musl (`CVE-2026-6042`) and BusyBox (`CVE-2024-58251`, `CVE-2025-46394`) findings, all attributable to the stale base — Trivy itself flags `alpine 3.19.9` as no longer supported by the distribution.

Bumped both to `alpine:3.22` — currently supported (EOL 2027-05-01) and matches the version already trusted elsewhere in this repo (`docker-compose.yml`'s `credential-check` helper).

This is a version-tag-only change: neither affected stage compiles anything (`Dockerfile.release`'s single stage and `Dockerfile`'s final runtime stage only run `apk add` + copy in a pre-built binary), all `apk` package names (`ca-certificates`, `tzdata`, `libgcc`, `libstdc++`, `libssl3`, `postgresql-client`) are unchanged across 3.19/3.20 → 3.22, and musl's 1.x series is ABI-backward-compatible so a binary built elsewhere against an older musl runs fine on the newer base.

**security-auditor sign-off** (required by CLAUDE.md for security-sensitive changes): reviewed and signed off, no blocking concerns. Noted as non-blocking: Alpine 3.24 (current latest stable, EOL 2028-06) would give more runway than 3.22 (EOL 2027-05) — fine to pick up on the next routine bump.

## Test plan
- [x] security-auditor review — signed off, no blockers
- [ ] CI on this PR (no `paths:` trigger currently covers Dockerfile changes in `dependency-scan.yml` — pre-existing gap, out of scope here)
- [ ] Takes effect on `ghcr.io/gotempsh/temps:latest` only once a new version tag is released — someone will need to cut a release for the published image itself to pick this up