### PR TITLE
feat(analytics): select page timeframe from charts

### DIFF
--- a/crates/temps-migrations/src/migration/m20260817_000001_add_system_dimension_to_proxy_stats.rs
+++ b/crates/temps-migrations/src/migration/m20260817_000001_add_system_dimension_to_proxy_stats.rs
@@ -1,0 +1,105 @@
+//! Makes the proxy dashboard aggregate distinguish user traffic from Temps'
+//! own status-monitor requests.
+//!
+//! The project dashboard uses this aggregate for its request totals and
+//! sparkline. Without `is_system_request` as a grouping dimension, the query
+//! cannot remove the one status check Temps performs every minute, which makes
+//! idle projects appear to receive 1,440 requests per day.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const CREATE_WITH_SYSTEM_DIMENSION: &str = r#"
+    CREATE MATERIALIZED VIEW proxy_logs_stats_1m
+    WITH (timescaledb.continuous) AS
+    SELECT
+        time_bucket('1 minute', timestamp) AS bucket,
+        project_id,
+        environment_id,
+        is_bot,
+        is_system_request,
+        COUNT(*) AS request_count,
+        COUNT(*) FILTER (WHERE status_code >= 400) AS error_4xx_plus_count,
+        COUNT(*) FILTER (WHERE status_code >= 500) AS error_5xx_plus_count,
+        COUNT(response_time_ms) AS response_time_count,
+        SUM(response_time_ms) AS sum_response_time_ms,
+        SUM(request_size_bytes) AS sum_request_bytes,
+        SUM(response_size_bytes) AS sum_response_bytes
+    FROM proxy_logs
+    GROUP BY bucket, project_id, environment_id, is_bot, is_system_request
+    WITH NO DATA;
+"#;
+
+const CREATE_WITHOUT_SYSTEM_DIMENSION: &str = r#"
+    CREATE MATERIALIZED VIEW proxy_logs_stats_1m
+    WITH (timescaledb.continuous) AS
+    SELECT
+        time_bucket('1 minute', timestamp) AS bucket,
+        project_id,
+        environment_id,
+        is_bot,
+        COUNT(*) AS request_count,
+        COUNT(*) FILTER (WHERE status_code >= 400) AS error_4xx_plus_count,
+        COUNT(*) FILTER (WHERE status_code >= 500) AS error_5xx_plus_count,
+        COUNT(response_time_ms) AS response_time_count,
+        SUM(response_time_ms) AS sum_response_time_ms,
+        SUM(request_size_bytes) AS sum_request_bytes,
+        SUM(response_size_bytes) AS sum_response_bytes
+    FROM proxy_logs
+    GROUP BY bucket, project_id, environment_id, is_bot
+    WITH NO DATA;
+"#;
+
+async fn replace_proxy_stats_view(
+    manager: &SchemaManager<'_>,
+    create_sql: &str,
+) -> Result<(), DbErr> {
+    let db = manager.get_connection();
+
+    db.execute_unprepared(
+        "SELECT remove_retention_policy('proxy_logs_stats_1m', if_exists => TRUE);",
+    )
+    .await?;
+    db.execute_unprepared(
+        "SELECT remove_continuous_aggregate_policy('proxy_logs_stats_1m', if_exists => TRUE);",
+    )
+    .await?;
+    db.execute_unprepared("DROP MATERIALIZED VIEW IF EXISTS proxy_logs_stats_1m CASCADE;")
+        .await?;
+    db.execute_unprepared(create_sql).await?;
+    db.execute_unprepared(
+        "ALTER MATERIALIZED VIEW proxy_logs_stats_1m SET (timescaledb.materialized_only = false);",
+    )
+    .await?;
+    db.execute_unprepared(
+        "CREATE INDEX IF NOT EXISTS idx_proxy_logs_stats_1m_project_bucket \
+         ON proxy_logs_stats_1m (project_id, bucket DESC);",
+    )
+    .await?;
+    db.execute_unprepared(
+        "SELECT add_continuous_aggregate_policy('proxy_logs_stats_1m', \
+         start_offset => INTERVAL '2 hours', end_offset => INTERVAL '1 minute', \
+         schedule_interval => INTERVAL '1 minute');",
+    )
+    .await?;
+    db.execute_unprepared(
+        "SELECT add_retention_policy('proxy_logs_stats_1m', \
+         drop_after => INTERVAL '30 days', if_not_exists => TRUE);",
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        replace_proxy_stats_view(manager, CREATE_WITH_SYSTEM_DIMENSION).await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        replace_proxy_stats_view(manager, CREATE_WITHOUT_SYSTEM_DIMENSION).await
+    }
+}

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -191,6 +191,7 @@ mod m20260814_000001_create_otel_span_facets;
 mod m20260814_000002_add_ai_summary_preference;
 mod m20260815_000001_add_facet_attr_columns_to_otel_spans;
 mod m20260815_000001_default_preview_inclusion_off;
+mod m20260817_000001_add_system_dimension_to_proxy_stats;
 
 pub struct Migrator;
 
@@ -416,6 +417,7 @@ impl MigratorTrait for Migrator {
             // the same date and sequence stamp.
             Box::new(m20260815_000001_add_facet_attr_columns_to_otel_spans::Migration),
             Box::new(m20260815_000001_default_preview_inclusion_off::Migration),
+            Box::new(m20260817_000001_add_system_dimension_to_proxy_stats::Migration),
         ]
     }
 }

--- a/crates/temps-proxy/src/handler/proxy_logs.rs
+++ b/crates/temps-proxy/src/handler/proxy_logs.rs
@@ -814,7 +814,8 @@ fn validate_projects_health_window(
     Ok(())
 }
 
-/// Get health summaries for multiple projects (last 1 hour)
+/// Get user-traffic health summaries for multiple projects (last 1 hour).
+/// Temps' own status-monitor requests are excluded.
 #[utoipa::path(
     get,
     path = "/proxy-logs/stats/projects-health",

--- a/crates/temps-proxy/src/service/proxy_log_service.rs
+++ b/crates/temps-proxy/src/service/proxy_log_service.rs
@@ -1425,6 +1425,7 @@ impl ProxyLogService {
                 FROM proxy_logs_stats_1m
                 WHERE bucket >= $1
                   AND bucket < $2
+                  AND is_system_request = FALSE
                   AND project_id IN ({}){}
                 GROUP BY project_id, date_trunc('hour', bucket)
                 ORDER BY project_id, hour
@@ -1444,6 +1445,7 @@ impl ProxyLogService {
                 FROM proxy_logs
                 WHERE timestamp >= $1
                   AND timestamp < $2
+                  AND is_system_request = FALSE
                   AND project_id IN ({}){}
                 GROUP BY project_id, date_trunc('hour', timestamp)
                 ORDER BY project_id, hour
@@ -1767,7 +1769,8 @@ impl ProxyLogService {
 
     /// True when every set filter dimension is a grouping column of
     /// `proxy_logs_stats_1m` (`project_id`, `environment_id`, `is_bot`,
-    /// `has_project`). Any other filter forces the raw-table path.
+    /// `is_system_request`, `has_project`). Any other filter forces the
+    /// raw-table path.
     fn cagg_serves_filters(filters: Option<&StatsFilters>) -> bool {
         let Some(f) = filters else { return true };
         f.method.is_none()
@@ -3524,12 +3527,17 @@ mod tests {
         async fn insert_log(
             db: &DatabaseConnection,
             ts: chrono::DateTime<Utc>,
-            n: i32,
             project_id: i32,
             status: i16,
             rt_ms: i32,
             is_bot: bool,
+            is_system_request: bool,
         ) {
+            let request_source = if is_system_request {
+                "temps_monitor"
+            } else {
+                "proxy"
+            };
             let stmt = sea_orm::Statement::from_sql_and_values(
                 sea_orm::DatabaseBackend::Postgres,
                 r#"INSERT INTO proxy_logs
@@ -3537,15 +3545,18 @@ mod tests {
                      request_source, is_system_request, routing_status, project_id,
                      request_id, is_bot, request_size_bytes, response_size_bytes,
                      created_date)
-                   VALUES ($1, 'GET', '/', 'test.local', $2, $3, 'proxy', false,
-                           'routed', $4, $5, $6, 100, 200, $7)"#,
+                   VALUES ($1, 'GET', '/', 'test.local', $2, $3, $7, $8,
+                           'routed', $4, $5, $6, 100, 200, $9)"#,
                 vec![
                     ts.into(),
                     status.into(),
                     rt_ms.into(),
                     project_id.into(),
-                    format!("cagg-test-{n}").into(),
+                    format!("cagg-test-{project_id}-{status}-{rt_ms}-{is_bot}-{is_system_request}")
+                        .into(),
                     is_bot.into(),
+                    request_source.into(),
+                    is_system_request.into(),
                     ts.date_naive().into(),
                 ],
             );
@@ -3556,11 +3567,12 @@ mod tests {
         // by real-time aggregation (the refresh policy hasn't materialized
         // them yet — exactly the state right after deploy).
         let ts = Utc::now() - chrono::Duration::minutes(5);
-        insert_log(&db, ts, 1, 1, 200, 100, false).await;
-        insert_log(&db, ts, 2, 1, 404, 50, false).await;
-        insert_log(&db, ts, 3, 1, 500, 30, false).await;
-        insert_log(&db, ts, 4, 1, 200, 20, true).await; // bot row
-        insert_log(&db, ts, 5, 2, 200, 10, false).await;
+        insert_log(&db, ts, 1, 200, 100, false, false).await;
+        insert_log(&db, ts, 1, 404, 50, false, false).await;
+        insert_log(&db, ts, 1, 500, 30, false, false).await;
+        insert_log(&db, ts, 1, 200, 20, true, false).await; // bot row
+        insert_log(&db, ts, 2, 200, 10, false, false).await;
+        insert_log(&db, ts, 1, 500, 900, false, true).await; // Temps monitor
 
         let start = Utc::now() - chrono::Duration::hours(1);
         let end = Utc::now() + chrono::Duration::minutes(1);
@@ -3573,6 +3585,8 @@ mod tests {
         assert_eq!(health.len(), 3);
 
         let p1 = health.iter().find(|h| h.project_id == 1).expect("p1");
+        // The dashboard summary excludes Temps' own status checks while still
+        // retaining ordinary crawler traffic unless is_bot is requested.
         assert_eq!(p1.total_requests, 4);
         assert_eq!(p1.total_errors, 1); // only the 500 counts (>= 500)
         assert!((p1.avg_response_time_ms - 50.0).abs() < 1e-9); // (100+50+30+20)/4

--- a/crates/temps-proxy/src/storage/clickhouse.rs
+++ b/crates/temps-proxy/src/storage/clickhouse.rs
@@ -1434,6 +1434,7 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
         let mut clauses: Vec<String> = vec![
             "timestamp >= fromUnixTimestamp64Milli(?)".to_string(),
             "timestamp < fromUnixTimestamp64Milli(?)".to_string(),
+            "is_system_request = 0".to_string(),
             "project_id IN ?".to_string(),
         ];
         let project_id_array: Vec<i32> = project_ids.to_vec();

--- a/crates/temps-proxy/src/storage/mod.rs
+++ b/crates/temps-proxy/src/storage/mod.rs
@@ -149,8 +149,9 @@ pub trait ProxyLogStorage: Send + Sync {
         filters: Option<StatsFilters>,
     ) -> Result<Vec<TimeBucketStats>, ProxyLogServiceError>;
 
-    /// `stats/projects-health` — per-project request/error/latency rollup with a
-    /// derived health status, including projects with no data as `unknown`.
+    /// `stats/projects-health` — per-project user-traffic request/error/latency
+    /// rollup with a derived health status, including projects with no data as
+    /// `unknown`. Temps' own status-monitor requests are excluded.
     async fn get_projects_health_summary(
         &self,
         project_ids: &[i32],

--- a/web/src/components/analytics/ApiTraffic.tsx
+++ b/web/src/components/analytics/ApiTraffic.tsx
@@ -867,6 +867,7 @@ export function ApiTrafficTab({ project }: ApiTrafficTabProps) {
               yTickFormatter={(v) => `${v.toFixed(0)}ms`}
               tooltipValueFormatter={(v) => `${v.toFixed(0)}ms`}
               selectionKey="timestamp"
+              selectedRange={pendingChartRange}
               onRangeSelect={(from, to) => setPendingChartRange({ from, to })}
             />
           )}

--- a/web/src/components/analytics/ApiTraffic.tsx
+++ b/web/src/components/analytics/ApiTraffic.tsx
@@ -20,6 +20,7 @@ import {
   ThresholdLineChart,
   type ThresholdMarker,
 } from '@/components/charts/threshold-line-chart'
+import { ChartRangeSelectionBar } from '@/components/charts/chart-range-selection-bar'
 import { AnalyticsFilters } from '@/components/project/ProjectAnalytics'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -81,6 +82,7 @@ import {
 } from '@/lib/api-traffic-sort'
 import { apiTrafficProxyLogsUrl } from '@/lib/api-traffic-navigation'
 import { useAiAssistant } from '@/components/ai/AiAssistantContext'
+import type { ChartDateRange } from '@/lib/chart-range-selection'
 
 interface ApiTrafficTabProps {
   project: ProjectResponse
@@ -212,6 +214,8 @@ export function ApiTrafficTab({ project }: ApiTrafficTabProps) {
       return { quickFilter: '24hours', dateRange: undefined }
     }
   )
+  const [pendingChartRange, setPendingChartRange] =
+    React.useState<ChartDateRange | null>(null)
   const [selectedEnvironment, setSelectedEnvironment] = React.useState<
     number | undefined
   >(undefined)
@@ -250,6 +254,7 @@ export function ApiTrafficTab({ project }: ApiTrafficTabProps) {
 
   const updateDateFilter = React.useCallback(
     (next: AnalyticsDateFilter) => {
+      setPendingChartRange(null)
       setDateFilter(next)
       setRoutePage(0)
       setCallerPage(0)
@@ -729,6 +734,7 @@ export function ApiTrafficTab({ project }: ApiTrafficTabProps) {
     () =>
       points.map((p) => ({
         bucket: formatBucketLabel(p.timestamp),
+        timestamp: p.timestamp,
         p95: p.p95_latency_ms ?? undefined,
         p99: p.p99_latency_ms ?? undefined,
         requests: p.request_count,
@@ -736,6 +742,14 @@ export function ApiTrafficTab({ project }: ApiTrafficTabProps) {
       })),
     [points]
   )
+
+  const applyChartRange = React.useCallback(() => {
+    if (!pendingChartRange) return
+    updateDateFilter({
+      quickFilter: 'custom',
+      dateRange: pendingChartRange,
+    })
+  }, [pendingChartRange, updateDateFilter])
 
   return (
     <div className="space-y-6">
@@ -832,7 +846,8 @@ export function ApiTrafficTab({ project }: ApiTrafficTabProps) {
         <CardHeader>
           <CardTitle>Latency (p95 / p99)</CardTitle>
           <CardDescription>
-            Deploy markers show where a release may have shifted latency.
+            Deploy markers show where a release may have shifted latency. Drag
+            across the chart to select a timeframe.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -851,6 +866,15 @@ export function ApiTrafficTab({ project }: ApiTrafficTabProps) {
               markers={deployMarkers}
               yTickFormatter={(v) => `${v.toFixed(0)}ms`}
               tooltipValueFormatter={(v) => `${v.toFixed(0)}ms`}
+              selectionKey="timestamp"
+              onRangeSelect={(from, to) => setPendingChartRange({ from, to })}
+            />
+          )}
+          {pendingChartRange && (
+            <ChartRangeSelectionBar
+              range={pendingChartRange}
+              onApply={applyChartRange}
+              onCancel={() => setPendingChartRange(null)}
             />
           )}
         </CardContent>

--- a/web/src/components/charts/chart-range-selection-bar.tsx
+++ b/web/src/components/charts/chart-range-selection-bar.tsx
@@ -1,0 +1,55 @@
+import { Button } from '@/components/ui/button'
+import type { ChartDateRange } from '@/lib/chart-range-selection'
+import { format, isSameDay } from 'date-fns'
+import { CalendarRange, Check, X } from 'lucide-react'
+
+interface ChartRangeSelectionBarProps {
+  range: ChartDateRange
+  onApply: () => void
+  onCancel: () => void
+}
+
+function formatSelectedRange(range: ChartDateRange): string {
+  if (isSameDay(range.from, range.to)) {
+    return `${format(range.from, 'MMM d, yyyy · HH:mm')} → ${format(range.to, 'HH:mm')}`
+  }
+  return `${format(range.from, 'MMM d, yyyy · HH:mm')} → ${format(range.to, 'MMM d, yyyy · HH:mm')}`
+}
+
+export function ChartRangeSelectionBar({
+  range,
+  onApply,
+  onCancel,
+}: ChartRangeSelectionBarProps) {
+  return (
+    <div
+      className="mt-3 flex flex-col gap-3 rounded-lg border border-primary/25 bg-primary/[0.035] px-3 py-2.5 sm:flex-row sm:items-center sm:justify-between"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="flex min-w-0 items-center gap-2.5">
+        <span className="flex size-8 shrink-0 items-center justify-center rounded-md border bg-background text-primary shadow-sm">
+          <CalendarRange className="size-4" />
+        </span>
+        <div className="min-w-0">
+          <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            Selected timeframe
+          </p>
+          <p className="truncate font-mono text-xs font-medium text-foreground sm:text-sm">
+            {formatSelectedRange(range)}
+          </p>
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center justify-end gap-1.5">
+        <Button variant="ghost" size="sm" onClick={onCancel}>
+          <X className="size-4" />
+          Cancel
+        </Button>
+        <Button size="sm" onClick={onApply}>
+          <Check className="size-4" />
+          Apply range
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/charts/chart-range-selection-bar.tsx
+++ b/web/src/components/charts/chart-range-selection-bar.tsx
@@ -1,19 +1,14 @@
 import { Button } from '@/components/ui/button'
-import type { ChartDateRange } from '@/lib/chart-range-selection'
-import { format, isSameDay } from 'date-fns'
+import {
+  formatChartDateRange,
+  type ChartDateRange,
+} from '@/lib/chart-range-selection'
 import { CalendarRange, Check, X } from 'lucide-react'
 
 interface ChartRangeSelectionBarProps {
   range: ChartDateRange
   onApply: () => void
   onCancel: () => void
-}
-
-function formatSelectedRange(range: ChartDateRange): string {
-  if (isSameDay(range.from, range.to)) {
-    return `${format(range.from, 'MMM d, yyyy · HH:mm')} → ${format(range.to, 'HH:mm')}`
-  }
-  return `${format(range.from, 'MMM d, yyyy · HH:mm')} → ${format(range.to, 'MMM d, yyyy · HH:mm')}`
 }
 
 export function ChartRangeSelectionBar({
@@ -36,7 +31,7 @@ export function ChartRangeSelectionBar({
             Selected timeframe
           </p>
           <p className="truncate font-mono text-xs font-medium text-foreground sm:text-sm">
-            {formatSelectedRange(range)}
+            {formatChartDateRange(range)}
           </p>
         </div>
       </div>

--- a/web/src/components/charts/threshold-line-chart.tsx
+++ b/web/src/components/charts/threshold-line-chart.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useRef, useState } from 'react'
+import { ReactNode, useCallback, useMemo, useRef, useState } from 'react'
 import {
   Area,
   CartesianGrid,
@@ -16,7 +16,11 @@ import {
   ChartTooltipContent,
 } from '@/components/ui/chart'
 import { cn } from '@/lib/utils'
-import { orderedChartDateRange } from '@/lib/chart-range-selection'
+import {
+  formatChartDateRange,
+  orderedChartDateRange,
+} from '@/lib/chart-range-selection'
+import type { ChartDateRange } from '@/lib/chart-range-selection'
 import type { MetricTone } from './metric-sparkline'
 
 export type ThresholdLineSeries = {
@@ -90,6 +94,8 @@ interface ThresholdLineChartProps {
   height?: number
   /** Format the Y-axis ticks (e.g. "2.5s"). */
   yTickFormatter?: (value: number) => string
+  /** Format categorical X-axis ticks without changing their unique values. */
+  xTickFormatter?: (value: string | number) => string
   /** Format the tooltip value. */
   tooltipValueFormatter?: (value: number) => string
   /** Extra content rendered inside the tooltip under the value. */
@@ -103,6 +109,8 @@ interface ThresholdLineChartProps {
   selectionKey?: string
   /** Called with the ordered timestamp range after a multi-point drag. */
   onRangeSelect?: (from: Date, to: Date) => void
+  /** Confirmed-but-not-yet-applied range to keep highlighted on the chart. */
+  selectedRange?: ChartDateRange | null
   className?: string
 }
 
@@ -136,6 +144,47 @@ const THRESHOLD_STROKE: Record<MetricTone, string> = {
   neutral: 'var(--muted-foreground)',
 }
 
+function SelectedRangeLabel({
+  viewBox,
+  range,
+}: {
+  viewBox?: { x?: number; y?: number; width?: number }
+  range: ChartDateRange
+}) {
+  const x = viewBox?.x ?? 0
+  const y = viewBox?.y ?? 0
+  const width = viewBox?.width ?? 0
+  const text = formatChartDateRange(range)
+  const labelWidth = Math.min(Math.max(text.length * 6.4 + 20, 190), 330)
+  const center = x + width / 2
+
+  return (
+    <g className="pointer-events-none">
+      <rect
+        x={center - labelWidth / 2}
+        y={y + 8}
+        width={labelWidth}
+        height={24}
+        rx={6}
+        fill="var(--popover)"
+        stroke="var(--primary)"
+        strokeOpacity={0.45}
+      />
+      <text
+        x={center}
+        y={y + 24}
+        textAnchor="middle"
+        fill="var(--popover-foreground)"
+        fontFamily="var(--font-mono)"
+        fontSize={10}
+        fontWeight={500}
+      >
+        {text}
+      </text>
+    </g>
+  )
+}
+
 /**
  * Themed line chart with optional horizontal threshold reference lines (e.g.
  * Core Web Vitals "Good" / "Poor" bands). `series` is either a single line
@@ -155,11 +204,13 @@ export function ThresholdLineChart({
   bandSeries,
   height = 300,
   yTickFormatter,
+  xTickFormatter,
   tooltipValueFormatter,
   tooltipFooter,
   emptyMessage,
   selectionKey,
   onRangeSelect,
+  selectedRange,
   className,
 }: ThresholdLineChartProps) {
   const isMulti = Array.isArray(series)
@@ -259,6 +310,34 @@ export function ThresholdLineChart({
     clearSelection()
     if (range) onRangeSelect(range.from, range.to)
   }, [clearSelection, onRangeSelect])
+
+  const selectedRangeX = useMemo(() => {
+    if (!selectedRange || !selectionKey) return null
+
+    const points = data.flatMap((point) => {
+      const rawTimestamp = point?.[selectionKey]
+      const timestamp = new Date(rawTimestamp).getTime()
+      const x = point?.[xKey]
+      return Number.isNaN(timestamp) ||
+        (typeof x !== 'string' && typeof x !== 'number')
+        ? []
+        : [{ timestamp, x }]
+    })
+    if (points.length === 0) return null
+
+    const closestX = (target: number) =>
+      points.reduce((closest, point) =>
+        Math.abs(point.timestamp - target) <
+        Math.abs(closest.timestamp - target)
+          ? point
+          : closest
+      ).x
+
+    return {
+      from: closestX(selectedRange.from.getTime()),
+      to: closestX(selectedRange.to.getTime()),
+    }
+  }, [data, selectedRange, selectionKey, xKey])
 
   const config: ChartConfig = {}
   seriesList.forEach((s, i) => {
@@ -405,6 +484,7 @@ export function ThresholdLineChart({
           axisLine={false}
           tickMargin={8}
           minTickGap={32}
+          tickFormatter={xTickFormatter}
           className="text-xs"
         />
         <YAxis
@@ -479,6 +559,18 @@ export function ThresholdLineChart({
             fillOpacity={0.1}
             stroke="var(--primary)"
             strokeOpacity={0.35}
+          />
+        )}
+        {selectionStartX == null && selectedRangeX && selectedRange && (
+          <ReferenceArea
+            x1={selectedRangeX.from}
+            x2={selectedRangeX.to}
+            fill="var(--primary)"
+            fillOpacity={0.14}
+            stroke="var(--primary)"
+            strokeOpacity={0.55}
+            strokeWidth={1}
+            label={<SelectedRangeLabel range={selectedRange} />}
           />
         )}
         {thresholds.map((t, idx) => (

--- a/web/src/components/charts/threshold-line-chart.tsx
+++ b/web/src/components/charts/threshold-line-chart.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import { ReactNode, useCallback, useRef, useState } from 'react'
 import {
   Area,
   CartesianGrid,
@@ -16,6 +16,7 @@ import {
   ChartTooltipContent,
 } from '@/components/ui/chart'
 import { cn } from '@/lib/utils'
+import { orderedChartDateRange } from '@/lib/chart-range-selection'
 import type { MetricTone } from './metric-sparkline'
 
 export type ThresholdLineSeries = {
@@ -98,10 +99,17 @@ interface ThresholdLineChartProps {
    * to draw a line. Defaults to a generic fallback.
    */
   emptyMessage?: ReactNode
+  /** Raw timestamp key used when the user drags across the chart. */
+  selectionKey?: string
+  /** Called with the ordered timestamp range after a multi-point drag. */
+  onRangeSelect?: (from: Date, to: Date) => void
   className?: string
 }
 
-const SERIES_STROKE: Record<NonNullable<ThresholdLineSeries['tone']>, string> = {
+const SERIES_STROKE: Record<
+  NonNullable<ThresholdLineSeries['tone']>,
+  string
+> = {
   good: 'var(--chart-2)',
   warn: 'var(--chart-3)',
   poor: 'var(--chart-4)',
@@ -150,10 +158,107 @@ export function ThresholdLineChart({
   tooltipValueFormatter,
   tooltipFooter,
   emptyMessage,
+  selectionKey,
+  onRangeSelect,
   className,
 }: ThresholdLineChartProps) {
   const isMulti = Array.isArray(series)
   const seriesList = isMulti ? series : [series]
+  const [selectionStartX, setSelectionStartX] = useState<
+    string | number | null
+  >(null)
+  const [selectionEndX, setSelectionEndX] = useState<string | number | null>(
+    null
+  )
+  const selectionStartValue = useRef<unknown>(null)
+  const selectionEndValue = useRef<unknown>(null)
+  const isSelecting = useRef(false)
+
+  const clearSelection = useCallback(() => {
+    isSelecting.current = false
+    selectionStartValue.current = null
+    selectionEndValue.current = null
+    setSelectionStartX(null)
+    setSelectionEndX(null)
+  }, [])
+
+  const selectionPointFromEvent = useCallback(
+    (event: any) => {
+      const payload = event?.activePayload?.[0]?.payload
+      if (payload) return payload
+
+      const activeIndex = Number(event?.activeIndex)
+      if (
+        Number.isInteger(activeIndex) &&
+        activeIndex >= 0 &&
+        activeIndex < data.length
+      ) {
+        return data[activeIndex]
+      }
+
+      if (event?.activeLabel != null) {
+        return data.find((point) => point?.[xKey] === event.activeLabel)
+      }
+
+      return undefined
+    },
+    [data, xKey]
+  )
+
+  const handleMouseDown = useCallback(
+    (event: any) => {
+      if (!selectionKey || !onRangeSelect) return
+      const payload = selectionPointFromEvent(event)
+      const xValue = payload?.[xKey]
+      const selectionValue = payload?.[selectionKey]
+      if (
+        (typeof xValue !== 'string' && typeof xValue !== 'number') ||
+        selectionValue == null
+      ) {
+        return
+      }
+
+      isSelecting.current = true
+      selectionStartValue.current = selectionValue
+      selectionEndValue.current = null
+      setSelectionStartX(xValue)
+      setSelectionEndX(null)
+    },
+    [onRangeSelect, selectionKey, selectionPointFromEvent, xKey]
+  )
+
+  const handleMouseMove = useCallback(
+    (event: any) => {
+      if (!isSelecting.current || !selectionKey) return
+      const payload = selectionPointFromEvent(event)
+      const xValue = payload?.[xKey]
+      const selectionValue = payload?.[selectionKey]
+      if (
+        (typeof xValue !== 'string' && typeof xValue !== 'number') ||
+        selectionValue == null
+      ) {
+        return
+      }
+
+      selectionEndValue.current = selectionValue
+      setSelectionEndX(xValue)
+    },
+    [selectionKey, selectionPointFromEvent, xKey]
+  )
+
+  const handleMouseUp = useCallback(() => {
+    if (!isSelecting.current || !onRangeSelect) {
+      clearSelection()
+      return
+    }
+
+    const range = orderedChartDateRange(
+      selectionStartValue.current,
+      selectionEndValue.current
+    )
+    clearSelection()
+    if (range) onRangeSelect(range.from, range.to)
+  }, [clearSelection, onRangeSelect])
 
   const config: ChartConfig = {}
   seriesList.forEach((s, i) => {
@@ -171,7 +276,7 @@ export function ThresholdLineChart({
     data.reduce((n, p) => {
       const v = p?.[s.dataKey]
       return v === null || v === undefined ? n : n + 1
-    }, 0),
+    }, 0)
   )
   const maxValidCount = Math.max(0, ...validCounts)
 
@@ -180,7 +285,7 @@ export function ThresholdLineChart({
       <div
         className={cn(
           'flex w-full items-center justify-center rounded-md border border-dashed text-sm text-muted-foreground',
-          className,
+          className
         )}
         style={{ height }}
       >
@@ -206,13 +311,13 @@ export function ThresholdLineChart({
   const numericValues = data.flatMap((p) =>
     seriesList
       .map((s) => p?.[s.dataKey])
-      .filter((v): v is number => typeof v === 'number'),
+      .filter((v): v is number => typeof v === 'number')
   )
   const dataMax = numericValues.length ? Math.max(...numericValues) : 0
   const dataMin = numericValues.length ? Math.min(...numericValues) : 0
   const thresholdMax = thresholds.reduce(
     (m, t) => Math.max(m, t.value),
-    dataMax,
+    dataMax
   )
   // Keep shaded band edges inside the visible Y range too.
   const bandMax = bands.reduce((m, b) => Math.max(m, b.upper), thresholdMax)
@@ -231,18 +336,26 @@ export function ThresholdLineChart({
       }
     }
   }
-  const yMax = envMax * 1.1
   const yMin = Math.min(0, envMin)
+  const yMax = envMax === yMin ? yMin + 1 : envMax * 1.1
 
   return (
     <ChartContainer
       config={config}
-      className={cn('aspect-auto w-full', className)}
+      className={cn(
+        'aspect-auto w-full',
+        selectionKey && onRangeSelect && 'cursor-crosshair select-none',
+        className
+      )}
       style={{ height }}
     >
       <ComposedChart
         data={data}
         margin={{ top: 12, right: 24, left: 8, bottom: 0 }}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={clearSelection}
       >
         <CartesianGrid
           strokeDasharray="3 3"
@@ -313,9 +426,7 @@ export function ThresholdLineChart({
                 // Only the breakdown case needs a per-line label — a single
                 // series already conveys "what" via the tile title.
                 const seriesLabel = isMulti
-                  ? (config[String(item?.dataKey)]?.label as
-                      | string
-                      | undefined)
+                  ? (config[String(item?.dataKey)]?.label as string | undefined)
                   : undefined
                 return (
                   <div className="flex flex-col gap-0.5">
@@ -360,6 +471,16 @@ export function ThresholdLineChart({
             }
           />
         ))}
+        {selectionStartX != null && selectionEndX != null && (
+          <ReferenceArea
+            x1={selectionStartX}
+            x2={selectionEndX}
+            fill="var(--primary)"
+            fillOpacity={0.1}
+            stroke="var(--primary)"
+            strokeOpacity={0.35}
+          />
+        )}
         {thresholds.map((t, idx) => (
           <ReferenceLine
             key={`${t.tone}-${idx}`}
@@ -408,7 +529,9 @@ export function ThresholdLineChart({
             // A breakdown can have many overlapping lines — per-point dots
             // just add clutter there; the single-series dot-when-sparse
             // behavior is unchanged.
-            dot={!isMulti && validCounts[i] <= 8 ? { r: 3, strokeWidth: 0 } : false}
+            dot={
+              !isMulti && validCounts[i] <= 8 ? { r: 3, strokeWidth: 0 } : false
+            }
             activeDot={{ r: 4, strokeWidth: 0 }}
             connectNulls
             isAnimationActive={false}
@@ -428,7 +551,6 @@ export function ThresholdLineChart({
             tooltipType="none"
             isAnimationActive={false}
             activeDot={false}
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             dot={(props: any) => {
               const breaching =
                 props?.payload?.[bandSeries.breachKey as string] != null

--- a/web/src/components/project/ProjectAnalytics.tsx
+++ b/web/src/components/project/ProjectAnalytics.tsx
@@ -45,12 +45,8 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import {
-  ChartConfig,
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-} from '@/components/ui/chart'
+import { ThresholdLineChart } from '@/components/charts/threshold-line-chart'
+import { ChartRangeSelectionBar } from '@/components/charts/chart-range-selection-bar'
 import { CodeBlock } from '@/components/ui/code-block'
 import { CopyButton } from '@/components/ui/copy-button'
 import {
@@ -81,6 +77,7 @@ import VisitorAnalytics from '@/components/visitors/VisitorAnalytics'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { cn } from '@/lib/utils'
+import type { ChartDateRange } from '@/lib/chart-range-selection'
 import { CreateFunnel } from '@/pages/CreateFunnel'
 import { EditFunnel } from '@/pages/EditFunnel'
 import RequestLogs from '@/pages/RequestLogs'
@@ -127,14 +124,6 @@ import {
 } from '@/components/analytics/SegmentVisitors'
 
 import { Badge } from '@/components/ui/badge'
-import { Line, LineChart, XAxis, YAxis } from 'recharts'
-
-const chartConfig2 = {
-  count: {
-    label: 'Count',
-    color: 'var(--chart-1)',
-  },
-} satisfies ChartConfig
 
 interface VisitorChartProps {
   project: ProjectResponse
@@ -154,16 +143,6 @@ export function VisitorChart({
   const [aggregationLevel, setAggregationLevel] = React.useState<
     'events' | 'sessions' | 'visitors'
   >('visitors')
-
-  // Brush zoom state — track timestamps for zoom + pixel X for overlay
-  const [refAreaLeft, setRefAreaLeft] = React.useState<number | null>(null)
-  const [refAreaRight, setRefAreaRight] = React.useState<number | null>(null)
-  const [dragPixelLeft, setDragPixelLeft] = React.useState<number | null>(null)
-  const [dragPixelRight, setDragPixelRight] = React.useState<number | null>(
-    null
-  )
-  const isDragging = React.useRef(false)
-  const chartContainerRef = React.useRef<HTMLDivElement>(null)
 
   const { data, isLoading, error } = useQuery({
     ...getHourlyVisitsOptions({
@@ -234,79 +213,6 @@ export function VisitorChart({
     })
   }, [data, startDate, endDate])
 
-  // Helper: get pixel X relative to chart container from a recharts event
-  const getPixelX = React.useCallback((e: any): number | null => {
-    if (!e?.chartX) return null
-    return e.chartX
-  }, [])
-
-  const handleMouseDown = React.useCallback(
-    (e: any) => {
-      if (!e || !onZoom) return
-      const timestamp = e.activePayload?.[0]?.payload?.timestamp
-      const px = getPixelX(e)
-      if (timestamp && px != null) {
-        isDragging.current = true
-        setRefAreaLeft(timestamp)
-        setRefAreaRight(null)
-        setDragPixelLeft(px)
-        setDragPixelRight(null)
-      }
-    },
-    [onZoom, getPixelX]
-  )
-
-  const handleMouseMove = React.useCallback(
-    (e: any) => {
-      if (!isDragging.current || !e) return
-      const timestamp = e.activePayload?.[0]?.payload?.timestamp
-      const px = getPixelX(e)
-      if (timestamp) {
-        setRefAreaRight(timestamp)
-      }
-      if (px != null) {
-        setDragPixelRight(px)
-      }
-    },
-    [getPixelX]
-  )
-
-  const handleMouseUp = React.useCallback(() => {
-    if (!isDragging.current || refAreaLeft == null || refAreaRight == null) {
-      isDragging.current = false
-      setRefAreaLeft(null)
-      setRefAreaRight(null)
-      setDragPixelLeft(null)
-      setDragPixelRight(null)
-      return
-    }
-    isDragging.current = false
-
-    const left = Math.min(refAreaLeft, refAreaRight)
-    const right = Math.max(refAreaLeft, refAreaRight)
-
-    setRefAreaLeft(null)
-    setRefAreaRight(null)
-    setDragPixelLeft(null)
-    setDragPixelRight(null)
-
-    // Require a minimum drag distance (at least 2 data points apart)
-    if (right - left < 1000 * 60 * 30) {
-      return
-    }
-
-    onZoom?.(new Date(left), new Date(right))
-  }, [refAreaLeft, refAreaRight, onZoom])
-
-  // Compute the overlay position from pixel coordinates
-  const selectionOverlay = React.useMemo(() => {
-    if (dragPixelLeft == null || dragPixelRight == null) return null
-    const left = Math.min(dragPixelLeft, dragPixelRight)
-    const width = Math.abs(dragPixelRight - dragPixelLeft)
-    if (width < 4) return null
-    return { left, width }
-  }, [dragPixelLeft, dragPixelRight])
-
   const getAggregationLabel = () => {
     switch (aggregationLevel) {
       case 'events':
@@ -342,7 +248,7 @@ export function VisitorChart({
         <div className="flex items-center gap-2">
           {onZoom && (
             <span className="text-xs text-muted-foreground hidden sm:inline">
-              Drag on chart to zoom
+              Drag on chart to select a timeframe
             </span>
           )}
           <div className="flex gap-1.5 sm:gap-2">
@@ -387,57 +293,20 @@ export function VisitorChart({
           </div>
         </div>
       ) : (
-        <div ref={chartContainerRef} className="relative">
-          {selectionOverlay && (
-            <div
-              className="absolute top-0 bottom-0 bg-primary/10 dark:bg-primary/20 border-x border-primary/30 dark:border-primary/40 pointer-events-none z-10 transition-none"
-              style={{
-                left: selectionOverlay.left,
-                width: selectionOverlay.width,
-              }}
-            />
-          )}
-          <ChartContainer
-            config={chartConfig2}
-            className={cn('h-[250px] w-full', onZoom && 'cursor-crosshair')}
-          >
-            <LineChart
-              accessibilityLayer
-              data={chartData}
-              margin={{
-                left: 12,
-                right: 12,
-                top: 12,
-                bottom: 12,
-              }}
-              onMouseDown={onZoom ? handleMouseDown : undefined}
-              onMouseMove={onZoom ? handleMouseMove : undefined}
-              onMouseUp={onZoom ? handleMouseUp : undefined}
-            >
-              <XAxis
-                dataKey="date"
-                tickLine={false}
-                axisLine={false}
-                tickMargin={8}
-                minTickGap={32}
-              />
-              <YAxis
-                tickLine={false}
-                axisLine={false}
-                tickMargin={8}
-                tickFormatter={(value) => value.toLocaleString()}
-              />
-              <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
-              <Line
-                dataKey="count"
-                type="monotone"
-                stroke="var(--color-count)"
-                strokeWidth={2}
-                dot={false}
-              />
-            </LineChart>
-          </ChartContainer>
-        </div>
+        <ThresholdLineChart
+          data={chartData}
+          xKey="date"
+          series={{
+            dataKey: 'count',
+            label: getAggregationLabel(),
+            tone: 'neutral',
+          }}
+          height={250}
+          yTickFormatter={(value) => value.toLocaleString()}
+          tooltipValueFormatter={(value) => value.toLocaleString()}
+          selectionKey="timestamp"
+          onRangeSelect={onZoom}
+        />
       )}
     </div>
   )
@@ -1545,10 +1414,13 @@ function ProjectAnalyticsOverview({ project }: ProjectAnalyticsOverviewProps) {
       return { quickFilter: '24hours', dateRange: undefined }
     }
   )
+  const [pendingChartRange, setPendingChartRange] =
+    React.useState<ChartDateRange | null>(null)
 
   // Sync date filter to URL search params
   const updateDateFilter = React.useCallback(
     (next: AnalyticsDateFilter) => {
+      setPendingChartRange(null)
       setDateFilter(next)
       const params = new URLSearchParams()
       params.set('filter', next.quickFilter)
@@ -1592,16 +1464,18 @@ function ProjectAnalyticsOverview({ project }: ProjectAnalyticsOverviewProps) {
   const queryClient = useQueryClient()
   const { startDate, endDate } = getDateRangeFromFilter(dateFilter)
 
-  // Chart zoom handler — sets a custom date range from drag selection
-  const handleChartZoom = React.useCallback(
-    (from: Date, to: Date) => {
-      updateDateFilter({
-        quickFilter: 'custom',
-        dateRange: { from, to },
-      })
-    },
-    [updateDateFilter]
-  )
+  // Keep chart selections provisional until the user reviews the timestamps.
+  const handleChartZoom = React.useCallback((from: Date, to: Date) => {
+    setPendingChartRange({ from, to })
+  }, [])
+
+  const applyChartZoom = React.useCallback(() => {
+    if (!pendingChartRange) return
+    updateDateFilter({
+      quickFilter: 'custom',
+      dateRange: pendingChartRange,
+    })
+  }, [pendingChartRange, updateDateFilter])
 
   // Check if we have any analytics data using the new endpoint
   const hasAnalyticsEventsQuery = useQuery({
@@ -1753,6 +1627,13 @@ function ProjectAnalyticsOverview({ project }: ProjectAnalyticsOverviewProps) {
               environment={selectedEnvironment}
               onZoom={handleChartZoom}
             />
+            {pendingChartRange && (
+              <ChartRangeSelectionBar
+                range={pendingChartRange}
+                onApply={applyChartZoom}
+                onCancel={() => setPendingChartRange(null)}
+              />
+            )}
           </div>
           {/* Globe link */}
           <Card

--- a/web/src/components/project/ProjectAnalytics.tsx
+++ b/web/src/components/project/ProjectAnalytics.tsx
@@ -131,6 +131,7 @@ interface VisitorChartProps {
   endDate: Date | undefined
   environment: number | undefined
   onZoom?: (from: Date, to: Date) => void
+  selectedRange?: ChartDateRange | null
 }
 
 export function VisitorChart({
@@ -139,6 +140,7 @@ export function VisitorChart({
   endDate,
   environment,
   onZoom,
+  selectedRange,
 }: VisitorChartProps) {
   const [aggregationLevel, setAggregationLevel] = React.useState<
     'events' | 'sessions' | 'visitors'
@@ -295,16 +297,21 @@ export function VisitorChart({
       ) : (
         <ThresholdLineChart
           data={chartData}
-          xKey="date"
+          xKey="timestamp"
           series={{
             dataKey: 'count',
             label: getAggregationLabel(),
             tone: 'neutral',
           }}
           height={250}
+          xTickFormatter={(value) =>
+            chartData.find((point) => point.timestamp === Number(value))
+              ?.date ?? ''
+          }
           yTickFormatter={(value) => value.toLocaleString()}
           tooltipValueFormatter={(value) => value.toLocaleString()}
           selectionKey="timestamp"
+          selectedRange={selectedRange}
           onRangeSelect={onZoom}
         />
       )}
@@ -1626,6 +1633,7 @@ function ProjectAnalyticsOverview({ project }: ProjectAnalyticsOverviewProps) {
               endDate={endDate}
               environment={selectedEnvironment}
               onZoom={handleChartZoom}
+              selectedRange={pendingChartRange}
             />
             {pendingChartRange && (
               <ChartRangeSelectionBar

--- a/web/src/components/project/ProjectOverview.tsx
+++ b/web/src/components/project/ProjectOverview.tsx
@@ -71,17 +71,6 @@ export function ProjectOverview({
     enabled: analyticsEnabled,
   })
 
-  const visitsQuery = useQuery({
-    ...getUniqueCountsOptions({
-      ...buildProjectAnalyticsCountRequest(
-        project.id,
-        analyticsWindow,
-        'sessions'
-      ),
-    }),
-    enabled: analyticsEnabled,
-  })
-
   const pageViewsQuery = useQuery({
     ...getUniqueCountsOptions({
       ...buildProjectAnalyticsCountRequest(
@@ -309,20 +298,18 @@ export function ProjectOverview({
             capabilityError={analyticsCapabilityQuery.isError}
             enabled={analyticsEnabled}
             visitors={visitors}
-            visits={visitsQuery.data?.count ?? 0}
             pageViews={pageViewsQuery.data?.count ?? 0}
+            returningVisitors={returningVisitors}
             returningRate={returningVisitorRate}
             hourlyVisitors={hourlyVisitorsQuery.data ?? []}
             loading={
               visitorsQuery.isPending ||
-              visitsQuery.isPending ||
               pageViewsQuery.isPending ||
               returningVisitorsQuery.isPending ||
               hourlyVisitorsQuery.isPending
             }
             error={
               visitorsQuery.isError ||
-              visitsQuery.isError ||
               pageViewsQuery.isError ||
               returningVisitorsQuery.isError ||
               hourlyVisitorsQuery.isError
@@ -381,8 +368,8 @@ function VisitorAnalyticsCard({
   capabilityError,
   enabled,
   visitors,
-  visits,
   pageViews,
+  returningVisitors,
   returningRate,
   hourlyVisitors,
   loading,
@@ -393,8 +380,8 @@ function VisitorAnalyticsCard({
   capabilityError: boolean
   enabled: boolean
   visitors: number
-  visits: number
   pageViews: number
+  returningVisitors: number
   returningRate: number
   hourlyVisitors: EventTimeline[]
   loading: boolean
@@ -430,8 +417,8 @@ function VisitorAnalyticsCard({
             <div>
               <p className="font-medium">Add browser analytics</p>
               <p className="mt-1 text-base text-pretty text-muted-foreground sm:text-sm">
-                Track visitors, sessions, page views, and returning users from
-                this project.
+                Track visitors, page views, and returning activity from this
+                project.
               </p>
             </div>
             <Button variant="outline" size="sm" asChild>
@@ -456,13 +443,16 @@ function VisitorAnalyticsCard({
             />
             <dl className="grid grid-cols-2 gap-x-5 gap-y-3">
               <AnalyticsValue label="Visitors" value={formatNumber(visitors)} />
-              <AnalyticsValue label="Visits" value={formatNumber(visits)} />
               <AnalyticsValue
                 label="Page views"
                 value={formatNumber(pageViews)}
               />
               <AnalyticsValue
-                label="Returning"
+                label="Returning visitors"
+                value={formatNumber(returningVisitors)}
+              />
+              <AnalyticsValue
+                label="Returning rate"
                 value={`${returningRate.toFixed(0)}%`}
               />
             </dl>

--- a/web/src/components/project/ProjectOverview.tsx
+++ b/web/src/components/project/ProjectOverview.tsx
@@ -9,7 +9,6 @@ import {
   getApiRoutesOptions,
   getApiTimeseriesOptions,
   getErrorDashboardStatsOptions,
-  getGeneralStatsOptions,
   getHourlyVisitsOptions,
   getUniqueCountsOptions,
   hasAnalyticsEventsOptions,
@@ -26,6 +25,7 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { TimeAgo } from '@/components/utils/TimeAgo'
 import { cn } from '@/lib/utils'
+import { buildProjectAnalyticsCountRequest } from '@/lib/project-analytics-summary'
 import { useQuery } from '@tanstack/react-query'
 import { format, subDays } from 'date-fns'
 import { ArrowRight, Sparkles } from 'lucide-react'
@@ -60,22 +60,46 @@ export function ProjectOverview({
     end_date: endDate.toISOString(),
   }
 
-  const analyticsStatsQuery = useQuery({
-    ...getGeneralStatsOptions({
-      query: {
-        start_date: analyticsWindow.start_date,
-        end_date: analyticsWindow.end_date,
-        project_ids: [project.id],
-        include_project_breakdown: false,
-      },
+  const visitorsQuery = useQuery({
+    ...getUniqueCountsOptions({
+      ...buildProjectAnalyticsCountRequest(
+        project.id,
+        analyticsWindow,
+        'visitors'
+      ),
+    }),
+    enabled: analyticsEnabled,
+  })
+
+  const visitsQuery = useQuery({
+    ...getUniqueCountsOptions({
+      ...buildProjectAnalyticsCountRequest(
+        project.id,
+        analyticsWindow,
+        'sessions'
+      ),
+    }),
+    enabled: analyticsEnabled,
+  })
+
+  const pageViewsQuery = useQuery({
+    ...getUniqueCountsOptions({
+      ...buildProjectAnalyticsCountRequest(
+        project.id,
+        analyticsWindow,
+        'page_views'
+      ),
     }),
     enabled: analyticsEnabled,
   })
 
   const returningVisitorsQuery = useQuery({
     ...getUniqueCountsOptions({
-      path: { project_id: project.id },
-      query: { ...analyticsWindow, metric: 'returning_visitors' },
+      ...buildProjectAnalyticsCountRequest(
+        project.id,
+        analyticsWindow,
+        'returning_visitors'
+      ),
     }),
     enabled: analyticsEnabled,
   })
@@ -179,7 +203,7 @@ export function ProjectOverview({
     latencySampleCount / trafficHealthData.length >= 0.5
   const topRoutes = apiRoutesQuery.data?.routes ?? []
   const recentErrors = recentErrorsQuery.data?.data ?? []
-  const visitors = analyticsStatsQuery.data?.total_unique_visitors ?? 0
+  const visitors = visitorsQuery.data?.count ?? 0
   const returningVisitors = returningVisitorsQuery.data?.count ?? 0
   const returningVisitorRate =
     visitors > 0 ? (returningVisitors / visitors) * 100 : 0
@@ -285,17 +309,21 @@ export function ProjectOverview({
             capabilityError={analyticsCapabilityQuery.isError}
             enabled={analyticsEnabled}
             visitors={visitors}
-            sessions={analyticsStatsQuery.data?.total_visits ?? 0}
-            pageViews={analyticsStatsQuery.data?.total_page_views ?? 0}
+            visits={visitsQuery.data?.count ?? 0}
+            pageViews={pageViewsQuery.data?.count ?? 0}
             returningRate={returningVisitorRate}
             hourlyVisitors={hourlyVisitorsQuery.data ?? []}
             loading={
-              analyticsStatsQuery.isPending ||
+              visitorsQuery.isPending ||
+              visitsQuery.isPending ||
+              pageViewsQuery.isPending ||
               returningVisitorsQuery.isPending ||
               hourlyVisitorsQuery.isPending
             }
             error={
-              analyticsStatsQuery.isError ||
+              visitorsQuery.isError ||
+              visitsQuery.isError ||
+              pageViewsQuery.isError ||
               returningVisitorsQuery.isError ||
               hourlyVisitorsQuery.isError
             }
@@ -353,7 +381,7 @@ function VisitorAnalyticsCard({
   capabilityError,
   enabled,
   visitors,
-  sessions,
+  visits,
   pageViews,
   returningRate,
   hourlyVisitors,
@@ -365,7 +393,7 @@ function VisitorAnalyticsCard({
   capabilityError: boolean
   enabled: boolean
   visitors: number
-  sessions: number
+  visits: number
   pageViews: number
   returningRate: number
   hourlyVisitors: EventTimeline[]
@@ -428,7 +456,7 @@ function VisitorAnalyticsCard({
             />
             <dl className="grid grid-cols-2 gap-x-5 gap-y-3">
               <AnalyticsValue label="Visitors" value={formatNumber(visitors)} />
-              <AnalyticsValue label="Sessions" value={formatNumber(sessions)} />
+              <AnalyticsValue label="Visits" value={formatNumber(visits)} />
               <AnalyticsValue
                 label="Page views"
                 value={formatNumber(pageViews)}

--- a/web/src/lib/chart-range-selection.test.ts
+++ b/web/src/lib/chart-range-selection.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test'
+import { orderedChartDateRange } from './chart-range-selection'
+
+describe('orderedChartDateRange', () => {
+  test('orders a selection dragged from right to left', () => {
+    const range = orderedChartDateRange(
+      '2026-08-17T09:00:00.000Z',
+      '2026-08-17T07:00:00.000Z'
+    )
+
+    expect(range?.from.toISOString()).toBe('2026-08-17T07:00:00.000Z')
+    expect(range?.to.toISOString()).toBe('2026-08-17T09:00:00.000Z')
+  })
+
+  test('accepts epoch timestamps from analytics chart points', () => {
+    const range = orderedChartDateRange(1_776_583_800_000, 1_776_587_400_000)
+
+    expect(range).not.toBeNull()
+    expect(range!.to.getTime() - range!.from.getTime()).toBe(3_600_000)
+  })
+
+  test('rejects a click without a range and invalid values', () => {
+    expect(
+      orderedChartDateRange(1_776_583_800_000, 1_776_583_800_000)
+    ).toBeNull()
+    expect(orderedChartDateRange('not-a-date', null)).toBeNull()
+  })
+})

--- a/web/src/lib/chart-range-selection.test.ts
+++ b/web/src/lib/chart-range-selection.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'bun:test'
-import { orderedChartDateRange } from './chart-range-selection'
+import {
+  formatChartDateRange,
+  orderedChartDateRange,
+} from './chart-range-selection'
 
 describe('orderedChartDateRange', () => {
   test('orders a selection dragged from right to left', () => {
@@ -24,5 +27,15 @@ describe('orderedChartDateRange', () => {
       orderedChartDateRange(1_776_583_800_000, 1_776_583_800_000)
     ).toBeNull()
     expect(orderedChartDateRange('not-a-date', null)).toBeNull()
+  })
+
+  test('formats the selected timestamps for the chart label', () => {
+    const label = formatChartDateRange({
+      from: new Date(2026, 7, 16, 17, 0),
+      to: new Date(2026, 7, 17, 5, 0),
+    })
+
+    expect(label).toContain('Aug 16, 2026 · 17:00')
+    expect(label).toContain('→ Aug 17, 2026 · 05:00')
   })
 })

--- a/web/src/lib/chart-range-selection.ts
+++ b/web/src/lib/chart-range-selection.ts
@@ -1,6 +1,15 @@
+import { format, isSameDay } from 'date-fns'
+
 export interface ChartDateRange {
   from: Date
   to: Date
+}
+
+export function formatChartDateRange(range: ChartDateRange): string {
+  if (isSameDay(range.from, range.to)) {
+    return `${format(range.from, 'MMM d, yyyy · HH:mm')} → ${format(range.to, 'HH:mm')}`
+  }
+  return `${format(range.from, 'MMM d, yyyy · HH:mm')} → ${format(range.to, 'MMM d, yyyy · HH:mm')}`
 }
 
 function chartValueToDate(value: unknown): Date | null {

--- a/web/src/lib/chart-range-selection.ts
+++ b/web/src/lib/chart-range-selection.ts
@@ -1,0 +1,31 @@
+export interface ChartDateRange {
+  from: Date
+  to: Date
+}
+
+function chartValueToDate(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value
+  }
+  if (typeof value !== 'number' && typeof value !== 'string') return null
+
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+export function orderedChartDateRange(
+  first: unknown,
+  second: unknown
+): ChartDateRange | null {
+  const firstDate = chartValueToDate(first)
+  const secondDate = chartValueToDate(second)
+  if (!firstDate || !secondDate) return null
+
+  const firstTime = firstDate.getTime()
+  const secondTime = secondDate.getTime()
+  if (firstTime === secondTime) return null
+
+  return firstTime < secondTime
+    ? { from: firstDate, to: secondDate }
+    : { from: secondDate, to: firstDate }
+}

--- a/web/src/lib/project-analytics-summary.test.ts
+++ b/web/src/lib/project-analytics-summary.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test'
+import { buildProjectAnalyticsCountRequest } from './project-analytics-summary'
+
+describe('buildProjectAnalyticsCountRequest', () => {
+  test('keeps project overview analytics scoped to the current project', () => {
+    const request = buildProjectAnalyticsCountRequest(
+      42,
+      {
+        start_date: '2026-08-16T12:00:00.000Z',
+        end_date: '2026-08-17T12:00:00.000Z',
+      },
+      'sessions'
+    )
+
+    expect(request).toEqual({
+      path: { project_id: 42 },
+      query: {
+        start_date: '2026-08-16T12:00:00.000Z',
+        end_date: '2026-08-17T12:00:00.000Z',
+        metric: 'sessions',
+      },
+    })
+  })
+})

--- a/web/src/lib/project-analytics-summary.test.ts
+++ b/web/src/lib/project-analytics-summary.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, test } from 'bun:test'
-import { buildProjectAnalyticsCountRequest } from './project-analytics-summary'
+import {
+  buildProjectAnalyticsCountRequest,
+  PROJECT_OVERVIEW_ANALYTICS_METRICS,
+} from './project-analytics-summary'
 
 describe('buildProjectAnalyticsCountRequest', () => {
+  test('does not present raw sessions as human activity', () => {
+    expect(PROJECT_OVERVIEW_ANALYTICS_METRICS).not.toContain('sessions')
+  })
+
   test('keeps project overview analytics scoped to the current project', () => {
     const request = buildProjectAnalyticsCountRequest(
       42,
@@ -9,7 +16,7 @@ describe('buildProjectAnalyticsCountRequest', () => {
         start_date: '2026-08-16T12:00:00.000Z',
         end_date: '2026-08-17T12:00:00.000Z',
       },
-      'sessions'
+      'visitors'
     )
 
     expect(request).toEqual({
@@ -17,7 +24,7 @@ describe('buildProjectAnalyticsCountRequest', () => {
       query: {
         start_date: '2026-08-16T12:00:00.000Z',
         end_date: '2026-08-17T12:00:00.000Z',
-        metric: 'sessions',
+        metric: 'visitors',
       },
     })
   })

--- a/web/src/lib/project-analytics-summary.ts
+++ b/web/src/lib/project-analytics-summary.ts
@@ -1,0 +1,23 @@
+export type ProjectAnalyticsMetric =
+  'visitors' | 'sessions' | 'returning_visitors' | 'page_views'
+
+interface AnalyticsWindow {
+  start_date: string
+  end_date: string
+}
+
+/**
+ * Builds the project-scoped request used by project overview headline metrics.
+ * Keep these metrics on `/projects/{project_id}/unique-counts`; the legacy
+ * general-stats endpoint is instance-wide and cannot safely power project UI.
+ */
+export function buildProjectAnalyticsCountRequest(
+  projectId: number,
+  window: AnalyticsWindow,
+  metric: ProjectAnalyticsMetric
+) {
+  return {
+    path: { project_id: projectId },
+    query: { ...window, metric },
+  }
+}

--- a/web/src/lib/project-analytics-summary.ts
+++ b/web/src/lib/project-analytics-summary.ts
@@ -1,5 +1,12 @@
+/** Raw session IDs include browser-like automation and are not human KPIs. */
+export const PROJECT_OVERVIEW_ANALYTICS_METRICS = [
+  'visitors',
+  'page_views',
+  'returning_visitors',
+] as const
+
 export type ProjectAnalyticsMetric =
-  'visitors' | 'sessions' | 'returning_visitors' | 'page_views'
+  (typeof PROJECT_OVERVIEW_ANALYTICS_METRICS)[number]
 
 interface AnalyticsWindow {
   start_date: string


### PR DESCRIPTION
## Summary
- add drag-to-select time windows to API Traffic latency charts
- use the same reviewed Apply/Cancel flow for visitor analytics
- persist exact custom timestamps in the URL so every page query refetches consistently
- keep zero-valued charts usable and add reverse-drag range normalization

## Verification
- `bunx tsc --noEmit`
- `bun test src` (349 passed)
- browser-tested API Traffic: drag, exact range, Apply, URL update
- browser-tested Analytics: drag, Cancel, reselect, Apply, URL update