### PR TITLE
fix(providers): allowlist pgvector images, and let operators extend the list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1073,6 +1073,7 @@ Process-wide ops/debug toggles (not bootstrap config, not per-tenant -- see the 
 | Variable | Default | Required |
 |---|---|---|
 | `TEMPS_DEPLOYMENT_KEEP_TEMP_FILES` | unset (clean up) | No -- set to any value to keep `/tmp/temps-deployments/deployment-*` directories after a deployment finishes or fails, for inspecting a build/download issue. Restart the server to change. |
+| `TEMPS_ALLOWED_POSTGRES_DOCKER_IMAGES` | unset (built-in list only) | No -- comma-separated PostgreSQL images this instance may additionally pull and run, e.g. `postgis/postgis:18-3.5,registry.internal:5000/team/pg:18`. **Additive**: it extends the built-in allowlist in `crates/temps-providers/src/externalsvc/postgres.rs` and can never shrink it, so a typo cannot strand existing services. Matching is exact -- no globs or prefixes -- so each entry needs a `:tag` or `@sha256:` digest. Deliberately host-level rather than an API setting: which images this machine may execute is operator policy. Restart the server to change. |
 
 ---
 

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -339,11 +339,39 @@ fn default_docker_image() -> Option<String> {
     Some("gotempsh/postgres-walg:18-bookworm".to_string())
 }
 
+/// Every PostgreSQL-flavoured image the platform is allowed to pull and run.
+///
+/// This is an exact-match allowlist on purpose (never a substring/prefix test):
+/// a service's `docker_image` comes from client-deserializable parameters, and
+/// backup/restore helpers pull and execute it in sidecar containers, so a
+/// permissive match is remote code execution.
+///
+/// Because it is exact, it must list *every* image any other part of the
+/// product can put on a service, or that service becomes permanently
+/// un-initializable — `get_postgres_config` runs this check on every read of
+/// the config, so an unlisted image doesn't just block creation, it blocks
+/// deploys of every app linked to the service. Three sources feed it:
+///
+/// - images this repo builds (`images/*-walg/Dockerfile`),
+/// - images the console offers as upgrade targets
+///   (`web/src/components/storage/UpgradeServiceDialog.tsx`),
+/// - upstream images container discovery classifies as Postgres
+///   (`services.rs`, which matches `postgres` / `timescaledb` / `pgvector`).
+///
+/// Adding an image to any of those without adding it here is the bug this
+/// list keeps regressing into.
 const ALLOWED_POSTGRES_DOCKER_IMAGES: &[&str] = &[
     "gotempsh/postgres-walg:15-bookworm",
     "gotempsh/postgres-walg:16-bookworm",
     "gotempsh/postgres-walg:17-bookworm",
     "gotempsh/postgres-walg:18-bookworm",
+    "gotempsh/pgvector-walg:pg17",
+    "gotempsh/pgvector-walg:pg18",
+    "gotempsh/timescaledb-walg:pg18",
+    "pgvector/pgvector:pg15",
+    "pgvector/pgvector:pg16",
+    "pgvector/pgvector:pg17",
+    "pgvector/pgvector:pg18",
     "timescale/timescaledb-ha:pg17",
     "timescale/timescaledb-ha:pg18",
 ];
@@ -4235,6 +4263,96 @@ mod tests {
     fn managed_postgres_images_are_allowlisted() {
         assert!(validate_postgres_docker_image("gotempsh/postgres-walg:18-bookworm").is_ok());
         assert!(validate_postgres_docker_image("attacker/postgres:latest").is_err());
+    }
+
+    /// Every image the console offers as an upgrade target in
+    /// `web/src/components/storage/UpgradeServiceDialog.tsx` must validate.
+    /// These were offered in the UI while being rejected by the allowlist, so
+    /// picking one was a guaranteed failure.
+    #[test]
+    fn console_upgrade_target_images_are_allowlisted() {
+        for image in [
+            "gotempsh/postgres-walg:18-bookworm",
+            "gotempsh/postgres-walg:17-bookworm",
+            "gotempsh/pgvector-walg:pg18",
+            "gotempsh/pgvector-walg:pg17",
+            "gotempsh/timescaledb-walg:pg18",
+        ] {
+            assert!(
+                validate_postgres_docker_image(image).is_ok(),
+                "console offers {image} as an upgrade target but it is not allowlisted"
+            );
+        }
+    }
+
+    /// `services.rs` classifies any discovered container whose image contains
+    /// `pgvector` as a Postgres service, so importing one must not produce a
+    /// service that can never be initialized.
+    #[test]
+    fn discovered_pgvector_images_are_allowlisted() {
+        for image in [
+            "pgvector/pgvector:pg15",
+            "pgvector/pgvector:pg16",
+            "pgvector/pgvector:pg17",
+            "pgvector/pgvector:pg18",
+        ] {
+            assert!(
+                validate_postgres_docker_image(image).is_ok(),
+                "container discovery imports {image} as Postgres but it is not allowlisted"
+            );
+        }
+    }
+
+    /// The allowlist stays exact-match: a listed image must not make an
+    /// arbitrary image sharing its repository or tag prefix acceptable.
+    #[test]
+    fn allowlist_does_not_match_by_prefix_or_repository() {
+        for image in [
+            "pgvector/pgvector:latest",
+            "pgvector/pgvector",
+            "attacker/pgvector:pg18",
+            "gotempsh/pgvector-walg:pg18-evil",
+            "timescale/timescaledb-ha:pg18-attacker",
+        ] {
+            assert!(
+                validate_postgres_docker_image(image).is_err(),
+                "{image} must not be accepted by the exact-match allowlist"
+            );
+        }
+    }
+
+    /// pgvector needs no preload library, but the WAL-G TimescaleDB variant is
+    /// still a TimescaleDB image and must keep `timescaledb` preloaded —
+    /// dropping it silently disables hypertable background workers.
+    #[test]
+    fn shared_preload_libraries_cover_new_allowlisted_images() {
+        assert_eq!(
+            PostgresService::shared_preload_libraries_for_image("pgvector/pgvector:pg18"),
+            "pg_stat_statements"
+        );
+        assert_eq!(
+            PostgresService::shared_preload_libraries_for_image("gotempsh/pgvector-walg:pg18"),
+            "pg_stat_statements"
+        );
+        assert_eq!(
+            PostgresService::shared_preload_libraries_for_image("gotempsh/timescaledb-walg:pg18"),
+            "timescaledb,pg_stat_statements"
+        );
+    }
+
+    /// PGDATA is derived from the image tag, so every allowlisted image must
+    /// yield a parseable major version — otherwise the container is created
+    /// with a broken data directory path.
+    #[test]
+    fn every_allowlisted_image_yields_a_pgdata_path() {
+        for image in ALLOWED_POSTGRES_DOCKER_IMAGES {
+            let version = PostgresService::extract_postgres_version(image)
+                .unwrap_or_else(|e| panic!("no version for allowlisted image {image}: {e}"));
+            assert!(
+                (15..=18).contains(&version),
+                "unexpected major version {version} for {image}"
+            );
+        }
     }
 
     #[test]

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -360,6 +360,10 @@ fn default_docker_image() -> Option<String> {
 ///
 /// Adding an image to any of those without adding it here is the bug this
 /// list keeps regressing into.
+///
+/// Operators can extend (never shrink) this set via
+/// `TEMPS_ALLOWED_POSTGRES_DOCKER_IMAGES` — see
+/// [`extra_allowed_postgres_docker_images`].
 const ALLOWED_POSTGRES_DOCKER_IMAGES: &[&str] = &[
     "gotempsh/postgres-walg:15-bookworm",
     "gotempsh/postgres-walg:16-bookworm",
@@ -376,14 +380,117 @@ const ALLOWED_POSTGRES_DOCKER_IMAGES: &[&str] = &[
     "timescale/timescaledb-ha:pg18",
 ];
 
+/// Environment variable an operator sets to allow additional PostgreSQL images
+/// (comma-separated). This is deliberately host-level rather than an API
+/// setting: which images this machine may pull and execute is the operator's
+/// policy, and keeping it off the API avoids adding a write surface that can
+/// widen container execution.
+///
+/// Requires a restart to take effect, like the other process-wide operator
+/// knobs documented in `CLAUDE.md`.
+pub(crate) const EXTRA_POSTGRES_IMAGES_ENV: &str = "TEMPS_ALLOWED_POSTGRES_DOCKER_IMAGES";
+
+/// Parse the operator-provided image list.
+///
+/// Split on commas, trim, drop empties. Entries are kept verbatim otherwise —
+/// matching stays exact, so an entry without a `:tag` or `@sha256:` digest can
+/// never match a real service image. Those are returned separately as
+/// `suspicious` so startup can warn about them instead of silently ignoring
+/// them: a self-hosted operator who typo'd the variable gets told, rather than
+/// re-reading the same rejection error with no idea why their entry did
+/// nothing.
+fn parse_extra_allowed_images(raw: &str) -> (Vec<String>, Vec<String>) {
+    let mut images = Vec::new();
+    let mut suspicious = Vec::new();
+    for entry in raw.split(',') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        // A tag/digest separator must appear after the final `/`, otherwise the
+        // only `:` is a registry port (e.g. `registry.internal:5000/pg`).
+        let name_start = entry.rfind('/').map_or(0, |i| i + 1);
+        if !entry[name_start..].contains(':') && !entry.contains('@') {
+            suspicious.push(entry.to_string());
+        }
+        images.push(entry.to_string());
+    }
+    (images, suspicious)
+}
+
+/// Operator-supplied additions to [`ALLOWED_POSTGRES_DOCKER_IMAGES`], read once
+/// per process.
+///
+/// Additive by design: the built-in list stays the floor so a typo in this
+/// variable cannot strand every existing Postgres service. `get_postgres_config`
+/// validates on every read of a service's config, so shrinking the allowlist
+/// would not merely block new services — it would make existing ones
+/// permanently un-initializable and block deploys of every app linked to them.
+fn extra_allowed_postgres_docker_images() -> &'static [String] {
+    static EXTRA: std::sync::OnceLock<Vec<String>> = std::sync::OnceLock::new();
+    EXTRA.get_or_init(|| {
+        let Ok(raw) = std::env::var(EXTRA_POSTGRES_IMAGES_ENV) else {
+            return Vec::new();
+        };
+        let (images, suspicious) = parse_extra_allowed_images(&raw);
+        if !suspicious.is_empty() {
+            warn!(
+                "{} contains {} entr{} without a tag or digest ({}). Matching is exact, so \
+                 these can never match a service image — did you mean e.g. 'postgis/postgis:18-3.5'?",
+                EXTRA_POSTGRES_IMAGES_ENV,
+                suspicious.len(),
+                if suspicious.len() == 1 { "y" } else { "ies" },
+                suspicious.join(", ")
+            );
+        }
+        if !images.is_empty() {
+            info!(
+                "{} allows {} additional PostgreSQL image(s): {}",
+                EXTRA_POSTGRES_IMAGES_ENV,
+                images.len(),
+                images.join(", ")
+            );
+        }
+        images
+    })
+}
+
+/// Exact-match membership test over the built-in list plus the operator's
+/// additions.
+///
+/// Split out from [`validate_postgres_docker_image`] so the composition is
+/// testable without mutating process environment or racing the `OnceLock`.
+fn is_allowed_postgres_docker_image(docker_image: &str, extra: &[String]) -> bool {
+    ALLOWED_POSTGRES_DOCKER_IMAGES.contains(&docker_image)
+        || extra.iter().any(|allowed| allowed == docker_image)
+}
+
 pub(crate) fn validate_postgres_docker_image(docker_image: &str) -> Result<()> {
-    if ALLOWED_POSTGRES_DOCKER_IMAGES.contains(&docker_image) {
+    if is_allowed_postgres_docker_image(docker_image, extra_allowed_postgres_docker_images()) {
         Ok(())
     } else {
+        // Name the escape hatch. A self-hosted operator hitting this has no
+        // support channel; without this sentence the error is a dead end that
+        // reads as "temps cannot run your image" rather than "temps has not
+        // been told it may".
+        let extra = extra_allowed_postgres_docker_images();
         Err(anyhow::anyhow!(
-            "PostgreSQL Docker image '{}' is not supported. Allowed images: {}",
+            "PostgreSQL Docker image '{}' is not supported. Allowed images: {}{}. \
+             To allow additional images on this instance, set {} to a comma-separated \
+             list (e.g. {}=postgis/postgis:18-3.5) and restart temps.",
             docker_image,
-            ALLOWED_POSTGRES_DOCKER_IMAGES.join(", ")
+            ALLOWED_POSTGRES_DOCKER_IMAGES.join(", "),
+            if extra.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    " (plus {} from {})",
+                    extra.join(", "),
+                    EXTRA_POSTGRES_IMAGES_ENV
+                )
+            },
+            EXTRA_POSTGRES_IMAGES_ENV,
+            EXTRA_POSTGRES_IMAGES_ENV
         ))
     }
 }
@@ -4337,6 +4444,117 @@ mod tests {
         assert_eq!(
             PostgresService::shared_preload_libraries_for_image("gotempsh/timescaledb-walg:pg18"),
             "timescaledb,pg_stat_statements"
+        );
+    }
+
+    #[test]
+    fn extra_images_env_is_split_trimmed_and_compacted() {
+        let (images, suspicious) = parse_extra_allowed_images(
+            "  postgis/postgis:18-3.5 ,,registry.internal:5000/team/pg:18 , ",
+        );
+        assert_eq!(
+            images,
+            vec![
+                "postgis/postgis:18-3.5".to_string(),
+                "registry.internal:5000/team/pg:18".to_string(),
+            ]
+        );
+        // A registry port is not a tag separator, but both entries here are
+        // properly tagged, so neither should be flagged.
+        assert!(suspicious.is_empty(), "unexpected warnings: {suspicious:?}");
+    }
+
+    #[test]
+    fn extra_images_env_empty_or_blank_yields_nothing() {
+        assert_eq!(parse_extra_allowed_images("").0, Vec::<String>::new());
+        assert_eq!(
+            parse_extra_allowed_images("  , ,, ").0,
+            Vec::<String>::new()
+        );
+    }
+
+    /// An entry with no tag can never match, since comparison is exact. It is
+    /// still accepted verbatim, but the operator is warned rather than left to
+    /// wonder why their variable did nothing.
+    #[test]
+    fn extra_images_env_flags_entries_without_tag_or_digest() {
+        let (images, suspicious) =
+            parse_extra_allowed_images("postgis/postgis,registry.internal:5000/team/pg");
+        assert_eq!(images.len(), 2);
+        assert_eq!(
+            suspicious,
+            vec![
+                "postgis/postgis".to_string(),
+                // ':5000' is a registry port, not a tag -- must still be flagged.
+                "registry.internal:5000/team/pg".to_string(),
+            ]
+        );
+
+        let (_, ok) = parse_extra_allowed_images(
+            "postgis/postgis:18-3.5,gotempsh/postgres-walg@sha256:abc123",
+        );
+        assert!(
+            ok.is_empty(),
+            "tagged/digested entries must not warn: {ok:?}"
+        );
+    }
+
+    /// End-to-end over the parse + membership composition: a value the operator
+    /// puts in the env var makes an otherwise-rejected image acceptable, and
+    /// only that exact image.
+    #[test]
+    fn extra_images_env_admits_exactly_the_operator_listed_image() {
+        let (extra, _) = parse_extra_allowed_images("postgis/postgis:18-3.5");
+
+        assert!(
+            !is_allowed_postgres_docker_image("postgis/postgis:18-3.5", &[]),
+            "image must be rejected without the operator override"
+        );
+        assert!(
+            is_allowed_postgres_docker_image("postgis/postgis:18-3.5", &extra),
+            "operator-listed image must be accepted"
+        );
+
+        // Still exact-match: the override admits one image, not a repository.
+        for near_miss in [
+            "postgis/postgis:latest",
+            "postgis/postgis",
+            "postgis/postgis:18-3.5-evil",
+            "attacker/postgis:18-3.5",
+        ] {
+            assert!(
+                !is_allowed_postgres_docker_image(near_miss, &extra),
+                "{near_miss} must not be admitted by an exact-match override"
+            );
+        }
+    }
+
+    /// The operator knob extends the allowlist; it must never be able to shrink
+    /// it, or a typo would strand every existing Postgres service.
+    #[test]
+    fn extra_images_env_cannot_remove_builtin_images() {
+        // Built-ins are checked before the env list is even consulted.
+        for image in ALLOWED_POSTGRES_DOCKER_IMAGES {
+            assert!(
+                validate_postgres_docker_image(image).is_ok(),
+                "{image} must stay allowed regardless of {EXTRA_POSTGRES_IMAGES_ENV}"
+            );
+        }
+    }
+
+    /// The rejection message must name the env var -- a self-hosted operator
+    /// has no support channel, so a bare "not supported" is a dead end.
+    #[test]
+    fn rejection_message_points_at_the_operator_override() {
+        // Deliberately an image no operator would ever allowlist, so this test
+        // cannot flip if TEMPS_ALLOWED_POSTGRES_DOCKER_IMAGES happens to be set
+        // in the environment running the suite.
+        let err = validate_postgres_docker_image("temps-test/never-allowlisted:0")
+            .expect_err("unlisted image must be rejected")
+            .to_string();
+        assert!(
+            err.contains(EXTRA_POSTGRES_IMAGES_ENV),
+            "rejection message must mention {EXTRA_POSTGRES_IMAGES_ENV}, got: {err}"
         );
     }
 


### PR DESCRIPTION
Two commits: fix the immediate breakage, then remove the reason it recurs.

## 1. `fix(providers)`: allowlist pgvector and WAL-G variant images

Deploying an app linked to a pgvector Postgres service fails with:

```
Failed to gather environment variables from 1 external service(s). ...
 • Service ID 2: Internal error: Failed to initialize service: PostgreSQL Docker
   image 'pgvector/pgvector:pg18' is not supported.
```

`ALLOWED_POSTGRES_DOCKER_IMAGES` listed only `gotempsh/postgres-walg:*` and
`timescale/timescaledb-ha:pg17/pg18`. Three other parts of the product already put images outside
that list onto a Postgres service:

| Source | Image it sets | Allowlisted before |
|---|---|---|
| Container discovery — `services.rs` classifies any image containing `pgvector` as `ServiceType::Postgres` | `pgvector/pgvector:pgNN` | ❌ |
| Console upgrade dialog — `UpgradeServiceDialog.tsx` | `gotempsh/pgvector-walg:pg17`, `:pg18` | ❌ |
| Console upgrade dialog | `gotempsh/timescaledb-walg:pg18` | ❌ |

The last three are images **this repo builds** (`images/pgvector-walg/`, `images/timescaledb-walg/`).

Validation runs in `get_postgres_config`, which is called on **every read** of the service config —
not just on create. So an unlisted image doesn't merely block creation, it makes the service
permanently un-initializable and blocks deploys of every app linked to it. Picking a pgvector option
in the upgrade dialog was likewise a guaranteed failure.

Adds the seven missing images. No migration or backfill — this only changes what is accepted going
forward.

**Not affected:** `gotempsh/timescaledb-walg:pg18` still preloads `timescaledb` (existing substring
check), and PGDATA is derived from the parsed `pgNN` tag rather than the image default. Both covered
by tests.

## 2. `feat(providers)`: `TEMPS_ALLOWED_POSTGRES_DOCKER_IMAGES`

A hardcoded constant means any image we didn't ship — PostGIS, a custom-extension build, a mirrored
image in an air-gapped install, a digest-pinned tag — needs a new binary release. That is also how
the gap above arose in the first place.

Operators can now list additional images:

```
TEMPS_ALLOWED_POSTGRES_DOCKER_IMAGES=postgis/postgis:18-3.5,registry.internal:5000/team/pg:18
```

Design notes for review:

- **Host-level, not an API setting.** Which images a machine may pull and execute is operator policy;
  keeping it off the API avoids adding a write surface that widens container execution. Restart to
  change, like `TEMPS_DEPLOYMENT_KEEP_TEMP_FILES`. Documented in the ops-toggle table in `CLAUDE.md`.
- **Additive, never a replacement.** The built-in list stays the floor. Because validation runs on
  every config read, a shrinkable allowlist would strand existing services rather than just block new
  ones — the self-inflicted version of the bug in commit 1.
- **Exact-match preserved.** No globs, no prefixes. The variable admits specific images, not
  repositories or patterns, so the guard against executing an attacker-supplied image is unchanged.
- **Untagged entries warn at startup.** They can never match, so silently ignoring them would leave a
  typo'd operator re-reading the same rejection with no clue why. A registry port (`host:5000/pg`) is
  correctly not mistaken for a tag.
- **The rejection error now names the variable** — it was previously a dead end, reading as "temps
  cannot run your image" rather than "temps has not been told it may".

## Evidence

`cargo test --lib -p temps-providers -- externalsvc::postgres::tests` → **60 passed, 0 failed.**

**The allowlist regression tests bite.** With the seven new entries removed (tests kept):

```
test ...::discovered_pgvector_images_are_allowlisted ... FAILED
test ...::console_upgrade_target_images_are_allowlisted ... FAILED

panicked: container discovery imports pgvector/pgvector:pg15 as Postgres but it is not allowlisted
panicked: console offers gotempsh/pgvector-walg:pg18 as an upgrade target but it is not allowlisted

test result: FAILED. 4 passed; 2 failed
```

**The env var works end-to-end through the real environment**, verified with a temporary test
(not committed) calling the actual `validate_postgres_docker_image`:

```
--- WITHOUT env var (expect FAIL) ---
postgis should be allowed when the operator env var lists it
test result: FAILED. 0 passed; 1 failed

--- WITH TEMPS_ALLOWED_POSTGRES_DOCKER_IMAGES="postgis/postgis:18-3.5" (expect ok) ---
test ...::envproof_operator_image_validates_through_real_env ... ok
test result: ok. 1 passed; 0 failed
```

**Operator-facing rejection message** (actual output, unlisted `pgvector/pgvector:pg14`):

```
PostgreSQL Docker image 'pgvector/pgvector:pg14' is not supported. Allowed images:
gotempsh/postgres-walg:15-bookworm, ... timescale/timescaledb-ha:pg18. To allow additional
images on this instance, set TEMPS_ALLOWED_POSTGRES_DOCKER_IMAGES to a comma-separated list
(e.g. TEMPS_ALLOWED_POSTGRES_DOCKER_IMAGES=postgis/postgis:18-3.5) and restart temps.
```

**The list did not become permissive.** `allowlist_does_not_match_by_prefix_or_repository` and
`extra_images_env_admits_exactly_the_operator_listed_image` confirm that neither the built-in list
nor an operator override accepts `pgvector/pgvector:latest`, `pgvector/pgvector`,
`attacker/pgvector:pg18`, `gotempsh/pgvector-walg:pg18-evil`, `postgis/postgis:18-3.5-evil` or
`timescale/timescaledb-ha:pg18-attacker`.

`cargo clippy -p temps-providers --all-targets -- -D warnings`: clean.
`cargo fmt -p temps-providers -- --check`: clean.

## Scope

Backend + one doc table. No API surface change, so no CLI or SDK parity work.

## Security note for the reviewer

This touches an execution allowlist, so it likely wants `security-auditor` sign-off. Context that
informed the design: `SourceType::DockerImage` deployments (`remote_deployments.rs`, `DeployFromImageAudit
{ image_ref }`) already let any user with project deploy permission pull and run an **arbitrary image
from any registry** with no allowlist. Worth a separate look on its own merits — it is out of scope
here, but it means this change does not introduce a new class of container execution.
