### PR TITLE
fix(dashboard): correct sessions and project navigation

### DIFF
--- a/crates/temps-analytics-events/src/services/clickhouse_backend.rs
+++ b/crates/temps-analytics-events/src/services/clickhouse_backend.rs
@@ -917,6 +917,7 @@ impl AnalyticsEvents for ClickHouseEventsBackend {
                   AND timestamp >= fromUnixTimestamp64Milli(?)
                   AND timestamp <= fromUnixTimestamp64Milli(?)
                   AND visitor_id IS NOT NULL
+                  AND event_type = 'page_view'
                   AND is_crawler = 0
                   AND (? = 0 OR environment_id = ?)
                   AND (? = 0 OR deployment_id = ?)
@@ -926,6 +927,8 @@ impl AnalyticsEvents for ClickHouseEventsBackend {
                       WHERE project_id = ?
                         AND timestamp < fromUnixTimestamp64Milli(?)
                         AND visitor_id IS NOT NULL
+                        AND event_type = 'page_view'
+                        AND is_crawler = 0
                         AND (? = 0 OR environment_id = ?)
                         AND (? = 0 OR deployment_id = ?)
                   )
@@ -959,8 +962,10 @@ impl AnalyticsEvents for ClickHouseEventsBackend {
         // The Timescale impl validates the metric here; do the same so behavior
         // is identical.
         let count_expr = match q.metric.as_str() {
-            "sessions" => "uniq(session_id)",
-            "visitors" => "uniq(visitor_id)",
+            "sessions" => {
+                "uniqIf(if(startsWith(session_id, 'v2|'), splitByChar('|', session_id)[2], session_id), event_type = 'page_view' AND notEmpty(session_id))"
+            }
+            "visitors" => "uniqIf(visitor_id, event_type = 'page_view')",
             "page_views" => "countIf(event_type = 'page_view')",
             "paths" => "uniqIf(page_path, event_type = 'page_view')",
             other => {
@@ -1046,6 +1051,8 @@ impl AnalyticsEvents for ClickHouseEventsBackend {
             WHERE has(?, project_id)
               AND timestamp >= fromUnixTimestamp64Milli(?)
               AND timestamp <= fromUnixTimestamp64Milli(?)
+              AND event_type = 'page_view'
+              AND is_crawler = 0
             GROUP BY project_id
         "#;
 
@@ -1100,6 +1107,7 @@ impl AnalyticsEvents for ClickHouseEventsBackend {
               AND timestamp >= fromUnixTimestamp64Milli(?)
               AND timestamp <= fromUnixTimestamp64Milli(?)
               AND event_type = 'page_view'
+              AND is_crawler = 0
             GROUP BY project_id, bucket_ms
             ORDER BY project_id, bucket_ms
         "#;
@@ -1561,6 +1569,8 @@ mod tests {
         // Project 7, visitor 100: 1 visit before the reporting range, then
         // session A with 2 page_views + 1 signup inside it.
         // Project 7, session B, visitor 101: 1 page_view, 1 click.
+        // Project 7 also has one API-only session which must not count as a
+        // browser analytics session.
         // Project 8, session C, visitor 102: 1 page_view (different project — must
         // not leak into project 7 queries).
         let rows = [
@@ -1578,6 +1588,15 @@ mod tests {
             make_row(3, 7, "sess-a", Some(100), "signup", "signup", t(45)),
             make_row(4, 7, "sess-b", Some(101), "page_view", "page_view", t(30)),
             make_row(5, 7, "sess-b", Some(101), "click", "click", t(25)),
+            make_row(
+                11,
+                7,
+                "sess-api-only",
+                Some(199),
+                "api_request",
+                "api_request",
+                t(20),
+            ),
             make_row(6, 8, "sess-c", Some(102), "page_view", "page_view", t(20)),
             // Project 9 is dedicated to the include_crawlers gate so these
             // rows perturb none of the project 7/8 assertions above: one human
@@ -1689,8 +1708,8 @@ mod tests {
             .await
             .expect("query_events_count all");
         let total_events: i64 = counts_all.iter().map(|c| c.count).sum();
-        // 5 events on project 7. Project 8's row must not leak in.
-        assert_eq!(total_events, 5, "got {:?}", counts_all);
+        // 6 events on project 7. Project 8's row must not leak in.
+        assert_eq!(total_events, 6, "got {:?}", counts_all);
 
         // ---- query_event_type_breakdown ----
         let by_type = backend
@@ -1731,6 +1750,19 @@ mod tests {
             .expect("query_unique_counts visitors");
         // 2 distinct visitor_ids on project 7 (100, 101).
         assert_eq!(visitors.count, 2);
+
+        // ---- query_unique_counts: sessions ----
+        let sessions = backend
+            .query_unique_counts(UniqueCountsSpec {
+                range: full_range(),
+                scope: project_scope(7).with_deployment(None),
+                metric: "sessions".to_string(),
+            })
+            .await
+            .expect("query_unique_counts sessions");
+        // Only sessions with a page view are browser sessions. The API-only
+        // event must not inflate the analytics headline.
+        assert_eq!(sessions.count, 2);
 
         // ---- query_unique_counts: returning visitors ----
         let returning_visitors = backend
@@ -1834,11 +1866,11 @@ mod tests {
             })
             .await
             .expect("query_aggregated_buckets");
-        assert_eq!(aggr.total, 5);
+        assert_eq!(aggr.total, 6);
 
         // ---- query_property_breakdown ----
-        // Group by channel; all 5 project-7 events have channel="direct".
-        // events level = 5 raw events, all under one bucket.
+        // Group by channel; all 6 project-7 events have channel="direct".
+        // events level = 6 raw events, all under one bucket.
         let pb = backend
             .query_property_breakdown(PropertyBreakdownSpec::new(
                 full_range(),
@@ -1891,10 +1923,10 @@ mod tests {
         let on_total: i64 = bots_on.items.iter().map(|i| i.count).sum();
         assert_eq!(off_total, 1, "default must count only the human visitor");
         assert_eq!(on_total, 2, "opt-in must also count the crawler visitor");
-        assert_eq!(pb.total, 5);
+        assert_eq!(pb.total, 6);
         assert!(
-            pb.items.iter().any(|i| i.value == "direct" && i.count == 5),
-            "expected channel=direct count=5, got {:?}",
+            pb.items.iter().any(|i| i.value == "direct" && i.count == 6),
+            "expected channel=direct count=6, got {:?}",
             pb.items
         );
 
@@ -1932,7 +1964,7 @@ mod tests {
             .expect("query_property_timeline");
         assert_eq!(pt.property, "channel");
         let pt_total: i64 = pt.items.iter().map(|i| i.count).sum();
-        assert_eq!(pt_total, 5, "got {:?}", pt.items);
+        assert_eq!(pt_total, 6, "got {:?}", pt.items);
 
         // The timeline must honour include_crawlers exactly like the breakdown.
         // It previously accepted the flag and silently discarded it, so the

--- a/crates/temps-analytics-events/src/services/events_service.rs
+++ b/crates/temps-analytics-events/src/services/events_service.rs
@@ -1022,6 +1022,7 @@ WHERE project_id = $1
                       AND timestamp >= $2::timestamp
                       AND timestamp <= $3::timestamp
                       AND visitor_id IS NOT NULL
+                      AND event_type = 'page_view'
                       AND is_crawler = false
                       AND ($4::int IS NULL OR environment_id = $4)
                       AND ($5::int IS NULL OR deployment_id = $5)
@@ -1034,6 +1035,8 @@ WHERE project_id = $1
                     WHERE previous.project_id = $1
                       AND previous.visitor_id = cv.visitor_id
                       AND previous.timestamp < $2::timestamp
+                      AND previous.event_type = 'page_view'
+                      AND previous.is_crawler = false
                       AND ($4::int IS NULL OR previous.environment_id = $4)
                       AND ($5::int IS NULL OR previous.deployment_id = $5)
                 )
@@ -1066,12 +1069,17 @@ WHERE project_id = $1
 
         // Determine what to count based on metric
         let count_expr = match metric.as_str() {
-            "sessions" => {
-                "COUNT(DISTINCT session_id) FILTER (WHERE session_id IS NOT NULL)::bigint"
-            }
-            "visitors" => {
-                "COUNT(DISTINCT visitor_id) FILTER (WHERE visitor_id IS NOT NULL)::bigint"
-            }
+            "sessions" => r#"COUNT(DISTINCT CASE
+                    WHEN session_id LIKE 'v2|%' THEN split_part(session_id, '|', 2)
+                    ELSE session_id
+                END) FILTER (
+                    WHERE session_id IS NOT NULL
+                      AND event_type = 'page_view'
+                )::bigint"#,
+            "visitors" => "COUNT(DISTINCT visitor_id) FILTER (
+                    WHERE visitor_id IS NOT NULL
+                      AND event_type = 'page_view'
+                )::bigint",
             "page_views" => "COUNT(*) FILTER (WHERE event_type = 'page_view')::bigint",
             "paths" => {
                 "COUNT(DISTINCT page_path) FILTER (WHERE event_type = 'page_view')::bigint"
@@ -1191,6 +1199,8 @@ WHERE project_id = $1
             FROM events
             WHERE timestamp >= $1 AND timestamp <= $2
               AND project_id IN ({in_clause})
+              AND event_type = 'page_view'
+              AND is_crawler = false
             GROUP BY project_id
             "#,
         );
@@ -1224,6 +1234,8 @@ WHERE project_id = $1
             FROM events
             WHERE timestamp >= $1 AND timestamp <= $2
               AND project_id IN ({in_clause})
+              AND event_type = 'page_view'
+              AND is_crawler = false
             GROUP BY project_id
             "#,
         );
@@ -1271,6 +1283,7 @@ WHERE project_id = $1
                   AND timestamp <= $2
                   AND project_id IN ({in_clause})
                   AND event_type = 'page_view'
+                  AND is_crawler = false
                 GROUP BY project_id, date_trunc('hour', timestamp)
             ) d ON d.project_id = p.project_id AND d.bucket = h.bucket
             ORDER BY p.project_id, h.bucket ASC
@@ -4529,6 +4542,55 @@ mod tests {
             )
             .await
             .expect("Failed to record event");
+
+        // API/custom events may carry correlation session IDs, but they are
+        // not browser visits and must not inflate the analytics session count.
+        service
+            .record_event(
+                project.id,
+                Some(environment.id),
+                Some(deployment.id),
+                Some("api-only-session".to_string()),
+                None,
+                "api_request",
+                serde_json::json!({}),
+                "/v1/orders",
+                "",
+                Some("temps.example"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some("service-client/1.0".to_string()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("Failed to record API-only event");
+
+        let sessions = service
+            .get_unique_counts(
+                chrono::Utc::now() - chrono::Duration::hours(1),
+                chrono::Utc::now() + chrono::Duration::hours(1),
+                project.id,
+                None,
+                None,
+                "sessions".to_string(),
+            )
+            .await
+            .expect("Failed to count browser sessions");
+        assert_eq!(
+            sessions.count, 1,
+            "only the normalized human page-view session should count"
+        );
 
         let breakdown = service
             .get_property_breakdown(

--- a/crates/temps-analytics/src/analytics.rs
+++ b/crates/temps-analytics/src/analytics.rs
@@ -2957,12 +2957,26 @@ WHERE project_id = $1
                 unique_visitors AS (
                     SELECT COUNT(DISTINCT e.visitor_id) AS n
                     FROM events e
-                    WHERE e.timestamp >= $1 AND e.timestamp < $2
+                    WHERE e.event_type = 'page_view'
+                      AND e.is_crawler = false
+                      AND e.timestamp >= $1 AND e.timestamp < $2
                 ),
                 total_visits AS (
-                    SELECT COUNT(*) AS n
-                    FROM request_sessions rs
-                    WHERE rs.started_at >= $1 AND rs.started_at < $2
+                    -- Sessions shown in analytics must have a real browser
+                    -- page view. Proxy-only request sessions (for example API
+                    -- traffic created by older versions) are intentionally
+                    -- excluded so historical polluted rows cannot inflate the
+                    -- dashboard after the proxy-side fix is deployed.
+                    SELECT COUNT(DISTINCT CASE
+                        WHEN e.session_id LIKE 'v2|%'
+                            THEN split_part(e.session_id, '|', 2)
+                        ELSE e.session_id
+                    END) AS n
+                    FROM events e
+                    WHERE e.event_type = 'page_view'
+                      AND e.is_crawler = false
+                      AND e.session_id IS NOT NULL
+                      AND e.timestamp >= $1 AND e.timestamp < $2
                 ),
                 total_events AS (
                     SELECT COUNT(*) AS n
@@ -2973,6 +2987,7 @@ WHERE project_id = $1
                     SELECT COUNT(*) AS n
                     FROM events e
                     WHERE e.event_type = 'page_view'
+                      AND e.is_crawler = false
                       AND e.timestamp >= $1 AND e.timestamp < $2
                 ),
                 total_projects AS (
@@ -2987,17 +3002,31 @@ WHERE project_id = $1
                 -- column is never populated by the ingest path.
                 session_stats AS (
                     SELECT
-                        session_id,
-                        COUNT(*) FILTER (WHERE event_type = 'page_view') AS page_views,
+                        CASE
+                            WHEN session_id LIKE 'v2|%'
+                                THEN split_part(session_id, '|', 2)
+                            ELSE session_id
+                        END AS session_id,
+                        COUNT(*) FILTER (
+                            WHERE event_type = 'page_view' AND is_crawler = false
+                        ) AS page_views,
                         COUNT(*) FILTER (
                             WHERE event_type NOT IN ('page_view', 'page_leave')
                               AND event_type NOT LIKE '%\_viewed' ESCAPE '\'
+                              AND is_crawler = false
                         ) AS interaction_events,
                         EXTRACT(EPOCH FROM (MAX(timestamp) - MIN(timestamp))) AS duration_seconds
                     FROM events
                     WHERE timestamp >= $1 AND timestamp < $2
                       AND session_id IS NOT NULL
-                    GROUP BY session_id
+                    GROUP BY CASE
+                        WHEN session_id LIKE 'v2|%'
+                            THEN split_part(session_id, '|', 2)
+                        ELSE session_id
+                    END
+                    HAVING COUNT(*) FILTER (
+                        WHERE event_type = 'page_view' AND is_crawler = false
+                    ) > 0
                 ),
                 session_rates AS (
                     SELECT
@@ -5090,6 +5119,126 @@ mod tests {
 
         // If this test compiles, it proves our parameterized query pattern is correct
         // No assertion needed - compilation itself is the test
+    }
+
+    /// Regression test for proxy-created API sessions polluting the analytics
+    /// dashboard. A request session is not an analytics visit until a
+    /// non-crawler browser page-view event exists for it.
+    #[tokio::test]
+    async fn test_general_stats_excludes_sessions_without_human_page_views() -> anyhow::Result<()> {
+        use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+        use temps_entities::{
+            deployments, environments, events, projects, request_sessions, visitor,
+        };
+
+        let (service, db, _container) =
+            create_test_analytics_service!("test_general_stats_human_sessions");
+
+        let project = projects::Entity::find()
+            .filter(projects::Column::Slug.eq("test_project"))
+            .one(db.as_ref())
+            .await?
+            .expect("test project must exist from insert_test_data");
+        let environment = environments::Entity::find()
+            .filter(environments::Column::ProjectId.eq(project.id))
+            .one(db.as_ref())
+            .await?
+            .expect("test environment must exist from insert_test_data");
+        let deployment = deployments::Entity::find()
+            .filter(deployments::Column::ProjectId.eq(project.id))
+            .one(db.as_ref())
+            .await?
+            .expect("test deployment must exist from insert_test_data");
+
+        let now = chrono::Utc::now();
+        let human_visitor = visitor::ActiveModel {
+            visitor_id: Set("human-session-visitor".to_string()),
+            project_id: Set(project.id),
+            environment_id: Set(environment.id),
+            first_seen: Set(now),
+            last_seen: Set(now),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await?;
+
+        let human_session_id = "11111111-1111-4111-8111-111111111111";
+
+        // A mixed-version session can contain both bare and legacy cookie
+        // formats during a rolling upgrade. They still represent one visit.
+        events::ActiveModel {
+            project_id: Set(project.id),
+            environment_id: Set(Some(environment.id)),
+            deployment_id: Set(Some(deployment.id)),
+            visitor_id: Set(Some(human_visitor.id)),
+            session_id: Set(Some(format!("v2|{human_session_id}|1786982400"))),
+            event_type: Set("page_view".to_string()),
+            page_path: Set("/settings".to_string()),
+            hostname: Set("example.com".to_string()),
+            pathname: Set("/settings".to_string()),
+            href: Set("https://example.com/settings".to_string()),
+            timestamp: Set(now + chrono::Duration::seconds(1)),
+            is_crawler: Set(false),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await?;
+
+        request_sessions::ActiveModel {
+            session_id: Set(human_session_id.to_string()),
+            started_at: Set(now),
+            last_accessed_at: Set(now),
+            visitor_id: Set(Some(human_visitor.id)),
+            data: Set("{}".to_string()),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await?;
+
+        events::ActiveModel {
+            project_id: Set(project.id),
+            environment_id: Set(Some(environment.id)),
+            deployment_id: Set(Some(deployment.id)),
+            visitor_id: Set(Some(human_visitor.id)),
+            session_id: Set(Some(human_session_id.to_string())),
+            event_type: Set("page_view".to_string()),
+            page_path: Set("/dashboard".to_string()),
+            hostname: Set("example.com".to_string()),
+            pathname: Set("/dashboard".to_string()),
+            href: Set("https://example.com/dashboard".to_string()),
+            timestamp: Set(now),
+            is_crawler: Set(false),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await?;
+
+        // Simulates a row created by the old proxy behavior for an API call.
+        // It has no analytics page-view event and must never count as a visit.
+        request_sessions::ActiveModel {
+            session_id: Set("22222222-2222-4222-8222-222222222222".to_string()),
+            started_at: Set(now),
+            last_accessed_at: Set(now),
+            visitor_id: Set(None),
+            data: Set("{}".to_string()),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await?;
+
+        let stats = service
+            .get_general_stats(
+                now - chrono::Duration::minutes(1),
+                now + chrono::Duration::minutes(1),
+            )
+            .await?;
+
+        assert_eq!(stats.total_visits, 1);
+        assert_eq!(stats.total_unique_visitors, 1);
+        assert_eq!(stats.total_page_views, 2);
+
+        cleanup_test_analytics!(db);
+        Ok(())
     }
 
     /// Regression test: `get_session_details` must return correct

--- a/crates/temps-proxy/src/integration_test.rs
+++ b/crates/temps-proxy/src/integration_test.rs
@@ -165,21 +165,57 @@ mod integration_tests {
         // Visitor tracking decisions are now a pure static function — no DB needed.
         use crate::proxy::LoadBalancer;
 
-        assert!(LoadBalancer::should_track_page("/", Some("text/html"), 200));
+        let browser_accept = Some("text/html,application/xhtml+xml");
+        let document = Some("document");
+
+        assert!(LoadBalancer::should_track_page(
+            "/",
+            Some("text/html"),
+            "GET",
+            browser_accept,
+            document,
+        ));
         assert!(!LoadBalancer::should_track_page(
             "/api/_temps/health",
             Some("application/json"),
-            200
+            "GET",
+            browser_accept,
+            document,
         ));
         assert!(!LoadBalancer::should_track_page(
             "/assets/style.css",
             Some("text/css"),
-            200
+            "GET",
+            Some("text/css,*/*;q=0.1"),
+            Some("style"),
         ));
         assert!(LoadBalancer::should_track_page(
             "/some-page",
             Some("text/html"),
-            404
+            "GET",
+            browser_accept,
+            document,
+        ));
+        assert!(!LoadBalancer::should_track_page(
+            "/graphql",
+            Some("application/json"),
+            "POST",
+            Some("application/json"),
+            Some("empty"),
+        ));
+        assert!(!LoadBalancer::should_track_page(
+            "/v1/users",
+            Some("application/problem+json"),
+            "GET",
+            Some("application/json"),
+            Some("empty"),
+        ));
+        assert!(!LoadBalancer::should_track_page(
+            "/missing-content-type",
+            None,
+            "GET",
+            browser_accept,
+            document,
         ));
         Ok(())
     }

--- a/crates/temps-proxy/src/proxy.rs
+++ b/crates/temps-proxy/src/proxy.rs
@@ -1061,9 +1061,30 @@ impl LoadBalancer {
 
     /// Returns true when a page view should be tracked (visitor/session created).
     /// This replaces the old `VisitorManager::should_track_visitor` trait method.
-    pub fn should_track_page(path: &str, content_type: Option<&str>, status_code: u16) -> bool {
-        // Don't track internal API calls
-        if path.starts_with(ROUTE_PREFIX_TEMPS) {
+    pub fn should_track_page(
+        path: &str,
+        content_type: Option<&str>,
+        method: &str,
+        accept: Option<&str>,
+        fetch_destination: Option<&str>,
+    ) -> bool {
+        // API responses never represent a browser page, even when a framework
+        // returns an HTML error document for an API-prefixed route.
+        if path == "/api"
+            || path.starts_with("/api/")
+            || path == "/_temps"
+            || path.starts_with("/_temps/")
+            || path.starts_with(ROUTE_PREFIX_TEMPS)
+        {
+            return false;
+        }
+
+        // Visitor analytics describe browser navigations, not every HTTP
+        // client that happens to receive HTML. Browsers advertise document
+        // navigation with both an HTML Accept value and Fetch Metadata that
+        // identifies a top-level document. Requiring both excludes generic
+        // HTTP clients, framework data fetches, and embedded resources.
+        if !is_browser_document_request(method, accept, fetch_destination) {
             return false;
         }
 
@@ -1079,12 +1100,40 @@ impl LoadBalancer {
             return false;
         }
 
-        // Track HTML pages or error pages
-        let is_html = content_type
-            .map(|ct| ct.starts_with("text/html"))
-            .unwrap_or(false);
+        // A status code cannot distinguish a browser document from an API
+        // response. Only HTML documents create visitor/session state; this
+        // still includes genuine HTML 4xx/5xx error pages.
+        content_type
+            .and_then(|value| value.split(';').next())
+            .is_some_and(|mime| mime.trim().eq_ignore_ascii_case("text/html"))
+    }
 
-        is_html || status_code >= 400
+    async fn ensure_static_visitor_session(
+        &self,
+        session: &PingoraSession,
+        ctx: &mut ProxyContext,
+        content_type: &str,
+    ) {
+        let request_accept = session
+            .req_header()
+            .headers
+            .get("accept")
+            .and_then(|value| value.to_str().ok());
+        let fetch_destination = session
+            .req_header()
+            .headers
+            .get("sec-fetch-dest")
+            .and_then(|value| value.to_str().ok());
+
+        if Self::should_track_page(
+            &ctx.path,
+            Some(content_type),
+            &ctx.method,
+            request_accept,
+            fetch_destination,
+        ) {
+            self.ensure_visitor_session(ctx).await;
+        }
     }
 
     async fn finalize_response(
@@ -1892,11 +1941,11 @@ impl LoadBalancer {
         use std::path::PathBuf;
         use tokio::fs;
 
-        let mut requested_path = ctx.path.trim_start_matches('/');
+        let mut requested_path = ctx.path.trim_start_matches('/').to_owned();
 
         // Handle root path -> index.html
         if requested_path.is_empty() {
-            requested_path = "index.html";
+            requested_path = "index.html".to_owned();
         }
 
         // Security: ALWAYS join with base static directory
@@ -1912,7 +1961,7 @@ impl LoadBalancer {
         // Always join with base static directory from config
         let absolute_static_dir = self.config_service.static_dir().join(relative_static_dir);
 
-        let file_path = absolute_static_dir.join(requested_path);
+        let file_path = absolute_static_dir.join(&requested_path);
 
         // Security check: ensure the resolved path is still within static_dir
         let canonical_static_dir = fs::canonicalize(&absolute_static_dir).await.map_err(|e| {
@@ -1967,6 +2016,13 @@ impl LoadBalancer {
             )
         })?;
 
+        // Resolve the actual response MIME before creating analytics state.
+        // Static SPA fallbacks and extensionless paths otherwise look like
+        // pages from the request path alone, including /api-style requests.
+        let content_type = Self::infer_content_type(final_path.to_str().unwrap_or("index.html"));
+        self.ensure_static_visitor_session(session, ctx, content_type)
+            .await;
+
         // Generate ETag for cache validation
         let etag = Self::generate_etag(&file_content);
 
@@ -1984,7 +2040,7 @@ impl LoadBalancer {
                 resp.insert_header("X-Request-ID", &ctx.request_id)?;
 
                 // Add cache headers
-                if Self::is_cacheable_static_asset(requested_path) {
+                if Self::is_cacheable_static_asset(&requested_path) {
                     resp.insert_header(
                         header::CACHE_CONTROL,
                         "public, max-age=31536000, immutable",
@@ -2005,9 +2061,6 @@ impl LoadBalancer {
                 return Ok(true);
             }
         }
-
-        // Infer content type
-        let content_type = Self::infer_content_type(final_path.to_str().unwrap_or("index.html"));
 
         // Check if we should compress the content
         let client_accepts_gzip = Self::accepts_gzip(session);
@@ -2061,7 +2114,7 @@ impl LoadBalancer {
         }
 
         // Add cache headers for static assets
-        if Self::is_cacheable_static_asset(requested_path) {
+        if Self::is_cacheable_static_asset(&requested_path) {
             resp.insert_header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")?;
         } else {
             resp.insert_header(header::CACHE_CONTROL, "public, max-age=0, must-revalidate")?;
@@ -2553,6 +2606,22 @@ fn is_event_stream_content_type(value: &str) -> bool {
         .split(';')
         .next()
         .is_some_and(|essence| essence.trim().eq_ignore_ascii_case("text/event-stream"))
+}
+
+fn is_browser_document_request(
+    method: &str,
+    accept: Option<&str>,
+    fetch_destination: Option<&str>,
+) -> bool {
+    method == "GET"
+        && accept.is_some_and(|value| {
+            value.split(',').any(|part| {
+                part.split(';')
+                    .next()
+                    .is_some_and(|media_type| media_type.trim().eq_ignore_ascii_case("text/html"))
+            })
+        })
+        && fetch_destination.is_some_and(|destination| destination.eq_ignore_ascii_case("document"))
 }
 
 /// Console/control-plane traffic always gets a fixed timeout, regardless of
@@ -4651,34 +4720,6 @@ impl ProxyHttp for LoadBalancer {
             // IMPORTANT: Skip static file serving for /api/_temps/* paths
             // These must ALWAYS be proxied to the console address (admin API)
             if !ctx.path.starts_with("/api/_temps/") {
-                // Only create visitor/session for HTML page requests, not static assets.
-                // Without this guard, concurrent requests for JS/CSS/images on first visit
-                // (before the browser has received the Set-Cookie response) each create a
-                // separate visitor record, causing duplicate "live visitors".
-                let is_static_asset = ctx.path.contains('.')
-                    && (ctx.path.ends_with(".js")
-                        || ctx.path.ends_with(".css")
-                        || ctx.path.ends_with(".png")
-                        || ctx.path.ends_with(".jpg")
-                        || ctx.path.ends_with(".jpeg")
-                        || ctx.path.ends_with(".gif")
-                        || ctx.path.ends_with(".svg")
-                        || ctx.path.ends_with(".ico")
-                        || ctx.path.ends_with(".woff")
-                        || ctx.path.ends_with(".woff2")
-                        || ctx.path.ends_with(".ttf")
-                        || ctx.path.ends_with(".eot")
-                        || ctx.path.ends_with(".map")
-                        || ctx.path.ends_with(".webp")
-                        || ctx.path.ends_with(".avif")
-                        || ctx.path.ends_with(".json")
-                        || ctx.path.ends_with(".xml")
-                        || ctx.path.ends_with(".txt"));
-
-                if !is_static_asset {
-                    self.ensure_visitor_session(ctx).await;
-                }
-
                 // Serve static file
                 match self.serve_static_file(session, ctx, &static_dir).await {
                     Ok(served) => {
@@ -4717,6 +4758,9 @@ impl ProxyHttp for LoadBalancer {
                             );
                             let mut resp = ResponseHeader::build(StatusCode::NOT_FOUND, None)?;
                             resp.insert_header(header::CONTENT_TYPE, "text/html")?;
+
+                            self.ensure_static_visitor_session(session, ctx, "text/html")
+                                .await;
 
                             // Set tracking cookies for 404 response
                             self.set_tracking_cookies(session, &mut resp, ctx).await?;
@@ -4757,6 +4801,9 @@ impl ProxyHttp for LoadBalancer {
                         let mut resp =
                             ResponseHeader::build(StatusCode::INTERNAL_SERVER_ERROR, None)?;
                         resp.insert_header(header::CONTENT_TYPE, "text/html")?;
+
+                        self.ensure_static_visitor_session(session, ctx, "text/html")
+                            .await;
 
                         // Set tracking cookies for 500 response
                         self.set_tracking_cookies(session, &mut resp, ctx).await?;
@@ -5082,42 +5129,30 @@ impl ProxyHttp for LoadBalancer {
         }
 
         // Determine if this needs visitor tracking
-        let is_html_content = ctx
-            .content_type
-            .as_ref()
-            .map(|ct| ct.starts_with("text/html"))
-            .unwrap_or(false);
-
         let status_code = upstream_response.status.as_u16();
-        let is_error_page = status_code >= 400;
-
-        let is_static_asset = ctx.path.contains(".")
-            && (ctx.path.ends_with(".js")
-                || ctx.path.ends_with(".css")
-                || ctx.path.ends_with(".png")
-                || ctx.path.ends_with(".jpg")
-                || ctx.path.ends_with(".jpeg")
-                || ctx.path.ends_with(".gif")
-                || ctx.path.ends_with(".svg")
-                || ctx.path.ends_with(".ico")
-                || ctx.path.ends_with(".woff")
-                || ctx.path.ends_with(".woff2")
-                || ctx.path.ends_with(".ttf")
-                || ctx.path.ends_with(".eot"));
-
-        let is_api_endpoint = ctx.path.starts_with("/api/") || ctx.path.starts_with("/_temps/");
+        let request_accept = ctx
+            .request_headers
+            .as_ref()
+            .and_then(|headers| headers.get("accept"))
+            .map(String::as_str);
+        let fetch_destination = ctx
+            .request_headers
+            .as_ref()
+            .and_then(|headers| headers.get("sec-fetch-dest"))
+            .map(String::as_str);
 
         // Check if we should track this page view
-        let should_track =
-            Self::should_track_page(&ctx.path, ctx.content_type.as_deref(), status_code);
+        let should_track = Self::should_track_page(
+            &ctx.path,
+            ctx.content_type.as_deref(),
+            &ctx.method,
+            request_accept,
+            fetch_destination,
+        );
 
-        // Only create visitor/session for appropriate requests (skip for SSE)
-        if !ctx.skip_tracking
-            && should_track
-            && (is_html_content || is_error_page)
-            && !is_static_asset
-            && !is_api_endpoint
-        {
+        // Only browser HTML documents create visitor/session state (skip SSE,
+        // API responses, assets, and other non-document traffic).
+        if !ctx.skip_tracking && should_track {
             self.ensure_visitor_session(ctx).await;
         } else {
             debug!(

--- a/crates/temps-proxy/src/proxy_test.rs
+++ b/crates/temps-proxy/src/proxy_test.rs
@@ -485,35 +485,114 @@ pub mod proxy_tests {
     async fn test_proxy_visitor_tracking_decisions() -> Result<()> {
         use crate::proxy::LoadBalancer;
 
-        // HTML page → track
-        assert!(LoadBalancer::should_track_page("/", Some("text/html"), 200));
+        let browser_accept = Some("text/html,application/xhtml+xml");
+        let document = Some("document");
+
+        // Browser HTML navigation → track
+        assert!(LoadBalancer::should_track_page(
+            "/",
+            Some("text/html"),
+            "GET",
+            browser_accept,
+            document,
+        ));
 
         // Internal API → do not track
         assert!(!LoadBalancer::should_track_page(
             "/api/_temps/health",
             Some("application/json"),
-            200
+            "GET",
+            browser_accept,
+            document,
         ));
 
         // CSS static asset → do not track
         assert!(!LoadBalancer::should_track_page(
             "/assets/style.css",
             Some("text/css"),
-            200
+            "GET",
+            Some("text/css,*/*;q=0.1"),
+            Some("style"),
         ));
 
-        // Error page (404) → track regardless of extension
+        // HTML error page (404) → track
         assert!(LoadBalancer::should_track_page(
             "/some-page",
             Some("text/html"),
-            404
+            "GET",
+            browser_accept,
+            document,
+        ));
+
+        // API-style errors outside /api must not create visitor sessions.
+        assert!(!LoadBalancer::should_track_page(
+            "/graphql",
+            Some("application/json"),
+            "POST",
+            Some("application/json"),
+            Some("empty"),
+        ));
+        assert!(!LoadBalancer::should_track_page(
+            "/v1/users",
+            Some("application/problem+json"),
+            "GET",
+            Some("application/json"),
+            Some("empty"),
+        ));
+        assert!(!LoadBalancer::should_track_page(
+            "/missing-content-type",
+            None,
+            "GET",
+            browser_accept,
+            document,
+        ));
+
+        // API-prefixed routes are never browser pages, even if misconfigured
+        // to return HTML.
+        assert!(!LoadBalancer::should_track_page(
+            "/api/report",
+            Some("text/html; charset=utf-8"),
+            "GET",
+            browser_accept,
+            document,
+        ));
+
+        // A generic HTTP client receiving HTML is not a browser page view.
+        assert!(!LoadBalancer::should_track_page(
+            "/docs",
+            Some("text/html"),
+            "GET",
+            Some("*/*"),
+            None,
+        ));
+
+        // Accept alone is spoofable and does not prove a browser document
+        // navigation; Fetch Metadata must explicitly identify the document.
+        assert!(!LoadBalancer::should_track_page(
+            "/docs",
+            Some("text/html"),
+            "GET",
+            browser_accept,
+            None,
+        ));
+
+        // Browser background fetches must not create sessions even if an
+        // upstream mistakenly responds with HTML.
+        assert!(!LoadBalancer::should_track_page(
+            "/data",
+            Some("text/html"),
+            "GET",
+            browser_accept,
+            Some("empty"),
         ));
 
         // PNG image → do not track
         assert!(!LoadBalancer::should_track_page(
             "/images/logo.png",
             Some("image/png"),
-            200
+            "GET",
+            Some("image/avif,image/webp,*/*"),
+            Some("image"),
         ));
 
         Ok(())

--- a/crates/temps-proxy/src/service/proxy_log_service.rs
+++ b/crates/temps-proxy/src/service/proxy_log_service.rs
@@ -3645,10 +3645,14 @@ mod tests {
             })
         };
         let (cagg_reqs, cagg_errs, cagg_req_bytes, cagg_resp_bytes) = sum(&via_cagg);
-        assert_eq!(cagg_reqs, 4);
-        assert_eq!(cagg_errs, 2); // 404 + 500 (time-bucket errors are >= 400)
-        assert_eq!(cagg_req_bytes, 400);
-        assert_eq!(cagg_resp_bytes, 800);
+        // Generic time-bucket queries include system traffic unless callers
+        // explicitly request synthetic exclusion. This keeps the aggregate
+        // and raw backends equivalent; project health summaries above apply
+        // their own trusted-system exclusion.
+        assert_eq!(cagg_reqs, 5);
+        assert_eq!(cagg_errs, 3); // 404 + both 500s
+        assert_eq!(cagg_req_bytes, 500);
+        assert_eq!(cagg_resp_bytes, 1000);
         assert_eq!(
             sum(&via_raw),
             (cagg_reqs, cagg_errs, cagg_req_bytes, cagg_resp_bytes)
@@ -3663,14 +3667,14 @@ mod tests {
             .iter()
             .find(|b| b.request_count > 0)
             .expect("populated raw bucket");
-        assert!((cagg_busy.avg_response_time_ms - 50.0).abs() < 1e-9);
+        assert!((cagg_busy.avg_response_time_ms - 220.0).abs() < 1e-9);
         assert!((cagg_busy.avg_response_time_ms - raw_busy.avg_response_time_ms).abs() < 1e-9);
 
         // Percentiles are computed from raw response_time_ms on both paths
-        // ([20, 30, 50, 100] → p50=40, p95=92.5, p99=98.5 via percentile_cont).
-        assert!((cagg_busy.p50_response_time_ms - 40.0).abs() < 1e-9);
-        assert!((cagg_busy.p95_response_time_ms - 92.5).abs() < 1e-9);
-        assert!((cagg_busy.p99_response_time_ms - 98.5).abs() < 1e-9);
+        // ([20, 30, 50, 100, 900] → p50=50, p95=740, p99=868 via percentile_cont).
+        assert!((cagg_busy.p50_response_time_ms - 50.0).abs() < 1e-9);
+        assert!((cagg_busy.p95_response_time_ms - 740.0).abs() < 1e-9);
+        assert!((cagg_busy.p99_response_time_ms - 868.0).abs() < 1e-9);
         assert!((cagg_busy.p50_response_time_ms - raw_busy.p50_response_time_ms).abs() < 1e-9);
         assert!((cagg_busy.p95_response_time_ms - raw_busy.p95_response_time_ms).abs() < 1e-9);
         assert!((cagg_busy.p99_response_time_ms - raw_busy.p99_response_time_ms).abs() < 1e-9);

--- a/web/src/components/dashboard/Sidebar.tsx
+++ b/web/src/components/dashboard/Sidebar.tsx
@@ -1047,6 +1047,11 @@ const projectPrimaryGroups: ProjectNavGroup[] = [
     label: 'Configure',
     items: [
       { title: 'Environments', url: 'environments', icon: Layers },
+      {
+        title: 'Environment Variables',
+        url: 'environment-variables',
+        icon: KeyRound,
+      },
       { title: 'Domains', url: 'domains', icon: Globe },
       { title: 'Git', url: 'git', icon: GitFork },
       { title: 'Build & Deploy', url: 'build', icon: Settings2 },

--- a/web/src/components/project/ProjectToolsPage.tsx
+++ b/web/src/components/project/ProjectToolsPage.tsx
@@ -106,7 +106,7 @@ export function ProjectToolsPage({ project }: { project: ProjectResponse }) {
   }
 
   return (
-    <div className="mx-auto w-full max-w-7xl space-y-8 pb-12">
+    <div className="w-full space-y-8 pb-12">
       <div className="flex flex-col gap-5 border-b pb-6 lg:flex-row lg:items-end lg:justify-between">
         <div className="max-w-2xl">
           <h1 className="text-2xl font-semibold tracking-tight">

--- a/web/src/components/project/project-tools.ts
+++ b/web/src/components/project/project-tools.ts
@@ -130,11 +130,6 @@ export const projectToolGroups: ProjectToolGroup[] = [
     label: 'Configure',
     description: 'Connect runtime features and automate project workflows.',
     items: [
-      {
-        title: 'Environment Variables',
-        url: 'environment-variables',
-        icon: KeyRound,
-      },
       { title: 'Feature Flags', url: 'flags', icon: Flag },
       {
         title: 'AI Workflows',

--- a/web/src/lib/project-navigation.test.ts
+++ b/web/src/lib/project-navigation.test.ts
@@ -9,6 +9,9 @@ describe('project navigation route resolution', () => {
     expect(resolveProjectPrimaryRoute('errors/12')).toBe('errors')
     expect(resolveProjectPrimaryRoute('traces/trace-42')).toBe('traces')
     expect(resolveProjectPrimaryRoute('deployments/99')).toBe('deployments')
+    expect(resolveProjectPrimaryRoute('environment-variables')).toBe(
+      'environment-variables'
+    )
     expect(resolveProjectPrimaryRoute('domains/new')).toBe('domains')
     expect(resolveProjectPrimaryRoute('git/repository')).toBe('git')
     expect(resolveProjectPrimaryRoute('build/settings')).toBe('build')
@@ -37,6 +40,7 @@ describe('project navigation route resolution', () => {
 
   test('does not mark setup or primary routes as tools', () => {
     expect(isProjectToolsRoute('setup')).toBe(false)
+    expect(isProjectToolsRoute('environment-variables')).toBe(false)
     expect(isProjectToolsRoute('settings/security')).toBe(false)
     expect(isProjectToolsRoute('analytics')).toBe(false)
     expect(isProjectToolsRoute('traces/trace-1')).toBe(false)

--- a/web/src/lib/project-navigation.ts
+++ b/web/src/lib/project-navigation.ts
@@ -2,6 +2,7 @@ export const PROJECT_PRIMARY_ROUTES = [
   'project',
   'deployments',
   'environments',
+  'environment-variables',
   'domains',
   'git',
   'build',


### PR DESCRIPTION
## Summary

- count analytics visitors and sessions only from non-crawler browser page views, while keeping API requests in traffic analytics
- gate proxy visitor/session creation on real browser document responses and normalize legacy session IDs consistently in PostgreSQL and ClickHouse
- promote Environment Variables into the project sidebar and remove the duplicate secondary entry
- let All Project Tools use the full available content width

## Verification

- `cargo test --lib -p temps-analytics-events` — 60 passed, including the real ClickHouse query surface
- `cargo test --lib -p temps-analytics` — 45 passed
- `cargo test --lib -p temps-proxy` — 510 passed, 4 ignored
- `cargo check --lib`
- `bun test src/lib/project-navigation.test.ts`
- `bun run tsc --noEmit`
- scoped ESLint, `cargo fmt --all -- --check`, and `git diff --check`
- security review: approved; no blocking or major findings

## Visual evidence

Validated in the local Temps instance in light and dark mode. Evidence captures:

- `environment-variables-sidebar.png` — Environment Variables appears directly under Configure
- `project-tools-full-width.png` — All Project Tools fills the project content area

## Behavioral note

A visit now requires a GET document navigation with HTML request/response semantics. This intentionally avoids API false positives; clients that omit `Sec-Fetch-Dest: document` are not counted as visitors.