### PR TITLE
fix(migrate): show post-migration maintenance progress and cancel the right backend

### DIFF
--- a/crates/temps-cli/src/commands/migrate.rs
+++ b/crates/temps-cli/src/commands/migrate.rs
@@ -122,9 +122,53 @@ async fn run_post_migration_maintenance(
     db: &Arc<temps_database::DbConnection>,
     database_url: &str,
     backend_pid: i32,
+    use_json: bool,
 ) -> anyhow::Result<()> {
+    // Announce the phase BEFORE any work starts. Concurrent index builds and
+    // continuous-aggregate refreshes routinely take minutes on a large install;
+    // without a header and per-step lines the operator stares at a terminal that
+    // looks hung after the last migration line and has no way to tell that
+    // anything is still running.
+    if !use_json {
+        println!();
+        println!("{}", "Post-migration maintenance…".bold());
+        println!(
+            "{}",
+            "  Non-transactional work that runs outside the migrations above. \
+             Ctrl+C cancels it safely; re-run `temps migrate` to resume."
+                .dimmed()
+        );
+    }
+
+    // In-place `\r` rewriting only reads correctly on a terminal. Piped into a
+    // log file or journald it concatenates every step onto one unreadable line,
+    // so non-TTY callers get one complete line per event instead.
+    let interactive = std::io::stdout().is_terminal();
+
+    // Track the backend each maintenance phase actually runs on. The index phase
+    // uses a disposable connection, so by the time the backfill starts, the
+    // connect-time `backend_pid` is a dead PID — cancelling it on Ctrl+C would
+    // report "PID N is not a PostgreSQL backend process" while the refresh it was
+    // meant to stop kept running. Phases announce their own PID; cancel that one.
+    let phase_pid = Arc::new(std::sync::atomic::AtomicI32::new(backend_pid));
+
+    let report_progress = {
+        let phase_pid = phase_pid.clone();
+        move |progress: temps_database::MaintenanceProgress<'_>| {
+            if let temps_database::MaintenanceProgress::PhaseBackend { pid } = &progress {
+                phase_pid.store(*pid, std::sync::atomic::Ordering::SeqCst);
+            }
+            if use_json {
+                print_maintenance_json(progress);
+            } else {
+                print_maintenance(progress, interactive);
+            }
+        }
+    };
+    let current_pid = || phase_pid.load(std::sync::atomic::Ordering::SeqCst);
+
     match race_maintenance(
-        temps_database::run_post_migration_indexes(db),
+        temps_database::run_post_migration_indexes_streaming(db, &report_progress),
         tokio::signal::ctrl_c(),
     )
     .await
@@ -133,7 +177,7 @@ async fn run_post_migration_maintenance(
         MaintenanceRace::Interrupted => {
             return Err(interrupted_maintenance_error(
                 database_url,
-                backend_pid,
+                current_pid(),
                 "post-migration index creation",
             )
             .await)
@@ -141,7 +185,7 @@ async fn run_post_migration_maintenance(
     }
 
     match race_maintenance(
-        temps_database::run_post_migration_backfill(db),
+        temps_database::run_post_migration_backfill_streaming(db, &report_progress),
         tokio::signal::ctrl_c(),
     )
     .await
@@ -149,11 +193,19 @@ async fn run_post_migration_maintenance(
         MaintenanceRace::Completed(Ok(())) => {}
         MaintenanceRace::Completed(Err(error)) => {
             info!("Post-migration backfill skipped/failed (refresh policy will catch up): {error}");
+            if !use_json {
+                println!(
+                    "  {} {}",
+                    "!".yellow(),
+                    format!("Backfill skipped: {error} (the refresh policy will catch up)")
+                        .yellow()
+                );
+            }
         }
         MaintenanceRace::Interrupted => {
             return Err(interrupted_maintenance_error(
                 database_url,
-                backend_pid,
+                current_pid(),
                 "post-migration backfill",
             )
             .await)
@@ -213,7 +265,8 @@ impl MigrateCommand {
                 if !self.dry_run {
                     // Non-transactional maintenance must remain retryable even
                     // after every schema migration is already recorded.
-                    run_post_migration_maintenance(&db, &self.database_url, backend_pid).await?;
+                    run_post_migration_maintenance(&db, &self.database_url, backend_pid, use_json)
+                        .await?;
                     if !use_json {
                         println!("{}", "✓ Post-migration maintenance complete.".green());
                     }
@@ -317,7 +370,7 @@ impl MigrateCommand {
             // Tokio's process-wide signal handler remains installed after the
             // migration select above, so awaiting these phases directly would
             // swallow a later SIGINT and leave the operator unable to cancel.
-            run_post_migration_maintenance(&db, &self.database_url, backend_pid).await?;
+            run_post_migration_maintenance(&db, &self.database_url, backend_pid, use_json).await?;
 
             let total: std::time::Duration = report.results.iter().map(|r| r.elapsed).sum();
             if use_json {
@@ -470,6 +523,191 @@ fn print_progress_json(progress: temps_database::MigrationProgress<'_>) {
     let _ = std::io::stdout().flush();
 }
 
+/// Live progress callback for post-migration maintenance (human output).
+///
+/// On a terminal this uses the same in-place convention as [`print_progress`]:
+/// the in-flight line is written without a newline and rewritten via `\r` as
+/// work advances, so a 31-window backfill reports `[7/31]` as it goes instead
+/// of printing nothing for several minutes. Each rewritten line is at least as
+/// long as the one it replaces, so no characters are left behind.
+///
+/// When `interactive` is false (piped output, CI, systemd) every event gets its
+/// own complete line — `\r` rewriting is unreadable in a log file.
+fn print_maintenance(progress: temps_database::MaintenanceProgress<'_>, interactive: bool) {
+    use temps_database::MaintenanceProgress;
+    match progress {
+        // Bookkeeping for the interrupt path, not something to show an operator
+        // mid-run; the PID is surfaced in the interruption error if it matters.
+        MaintenanceProgress::PhaseBackend { .. } => {}
+        MaintenanceProgress::IndexStarted { name } => {
+            if interactive {
+                print!("  {} index {} …", "→".cyan(), name);
+                let _ = std::io::stdout().flush();
+            } else {
+                println!("  {} index {} …", "→".cyan(), name);
+            }
+        }
+        MaintenanceProgress::IndexFinished { name, elapsed } => {
+            println!(
+                "{}  {} index {} {}",
+                if interactive { "\r" } else { "" },
+                "✓".green(),
+                name,
+                format!("({})", format_elapsed(elapsed)).dimmed()
+            );
+        }
+        MaintenanceProgress::AggregateStarted { view, windows } => {
+            if interactive {
+                print!("  {} {} refresh [0/{}] …", "→".cyan(), view, windows);
+                let _ = std::io::stdout().flush();
+            } else {
+                println!(
+                    "  {} {} refresh: {} window(s) to process …",
+                    "→".cyan(),
+                    view,
+                    windows
+                );
+            }
+        }
+        MaintenanceProgress::AggregateWindow {
+            view,
+            index,
+            total,
+            elapsed,
+            error,
+        } => {
+            if let Some(error) = error {
+                // A failed window gets its own permanent line — the operator
+                // must be able to see WHICH window failed and why, even though
+                // the backfill deliberately continues.
+                println!(
+                    "{}  {} {} window {}/{} failed: {}",
+                    if interactive { "\r" } else { "" },
+                    "!".yellow(),
+                    view,
+                    index,
+                    total,
+                    error.yellow()
+                );
+            }
+            if interactive {
+                print!(
+                    "\r  {} {} refresh [{}/{}] … {}",
+                    "→".cyan(),
+                    view,
+                    index,
+                    total,
+                    format!("(last window {})", format_elapsed(elapsed)).dimmed()
+                );
+                let _ = std::io::stdout().flush();
+            } else {
+                println!(
+                    "  {} {} refresh [{}/{}] {}",
+                    "·".dimmed(),
+                    view,
+                    index,
+                    total,
+                    format!("({})", format_elapsed(elapsed)).dimmed()
+                );
+            }
+        }
+        MaintenanceProgress::AggregateFinished {
+            view,
+            windows,
+            failed,
+            elapsed,
+        } => {
+            let suffix = if failed == 0 {
+                format!("({})", format_elapsed(elapsed))
+                    .dimmed()
+                    .to_string()
+            } else {
+                format!("({}, {failed} window(s) failed)", format_elapsed(elapsed))
+                    .yellow()
+                    .to_string()
+            };
+            println!(
+                "{}  {} {} refresh [{}/{}] {}          ",
+                if interactive { "\r" } else { "" },
+                if failed == 0 {
+                    "✓".green()
+                } else {
+                    "!".yellow()
+                },
+                view,
+                windows,
+                windows,
+                suffix
+            );
+        }
+    }
+}
+
+/// Machine-readable maintenance progress for `--progress-format=json`.
+///
+/// Mirrors [`print_maintenance`] as NDJSON so the "Update Now" orchestration
+/// worker can show the same phase to the user instead of a stalled progress
+/// bar between the last migration and completion.
+fn print_maintenance_json(progress: temps_database::MaintenanceProgress<'_>) {
+    println!("{}", maintenance_json(progress));
+    let _ = std::io::stdout().flush();
+}
+
+/// The NDJSON line for one maintenance event. Split out from
+/// [`print_maintenance_json`] so the wire contract is unit-testable.
+fn maintenance_json(progress: temps_database::MaintenanceProgress<'_>) -> serde_json::Value {
+    use temps_database::MaintenanceProgress;
+    match progress {
+        // Emitted so a parent process can report/kill the exact backend if the
+        // child is terminated out from under it.
+        MaintenanceProgress::PhaseBackend { pid } => serde_json::json!({
+            "event": "maintenance_backend",
+            "pid": pid,
+        }),
+        MaintenanceProgress::IndexStarted { name } => serde_json::json!({
+            "event": "maintenance_index_started",
+            "name": name,
+        }),
+        MaintenanceProgress::IndexFinished { name, elapsed } => serde_json::json!({
+            "event": "maintenance_index_finished",
+            "name": name,
+            "elapsed_ms": elapsed.as_millis() as u64,
+        }),
+        MaintenanceProgress::AggregateStarted { view, windows } => serde_json::json!({
+            "event": "maintenance_backfill_started",
+            "view": view,
+            "windows": windows,
+        }),
+        MaintenanceProgress::AggregateWindow {
+            view,
+            index,
+            total,
+            elapsed,
+            error,
+        } => serde_json::json!({
+            "event": "maintenance_backfill_window",
+            "view": view,
+            "index": index,
+            "total": total,
+            "elapsed_ms": elapsed.as_millis() as u64,
+            "success": error.is_none(),
+            "error": error,
+        }),
+        MaintenanceProgress::AggregateFinished {
+            view,
+            windows,
+            failed,
+            elapsed,
+        } => serde_json::json!({
+            "event": "maintenance_backfill_finished",
+            "view": view,
+            "windows": windows,
+            "failed": failed,
+            "elapsed_ms": elapsed.as_millis() as u64,
+        }),
+    }
+}
+
 /// After a streaming apply, surface any planned migrations that were never
 /// attempted (everything after a failure) so the operator knows the set is
 /// incomplete. No-op on a fully successful run.
@@ -512,6 +750,52 @@ mod tests {
     async fn maintenance_race_observes_interrupts_after_migrations_finish() {
         let result = race_maintenance(std::future::pending::<()>(), std::future::ready(())).await;
         assert!(matches!(result, MaintenanceRace::Interrupted));
+    }
+
+    #[test]
+    fn maintenance_backfill_window_json_reports_progress_and_failure() {
+        use temps_database::MaintenanceProgress;
+
+        let ok = super::maintenance_json(MaintenanceProgress::AggregateWindow {
+            view: "proxy_logs_stats_1m",
+            index: 7,
+            total: 31,
+            elapsed: std::time::Duration::from_millis(1_200),
+            error: None,
+        });
+        assert_eq!(ok["event"], "maintenance_backfill_window");
+        assert_eq!(ok["view"], "proxy_logs_stats_1m");
+        assert_eq!(ok["index"], 7);
+        assert_eq!(ok["total"], 31);
+        assert_eq!(ok["elapsed_ms"], 1_200);
+        assert_eq!(ok["success"], true);
+        assert!(ok["error"].is_null());
+
+        let failed = super::maintenance_json(MaintenanceProgress::AggregateWindow {
+            view: "events_hourly",
+            index: 1,
+            total: 1,
+            elapsed: std::time::Duration::from_millis(5),
+            error: Some("lock timeout".to_string()),
+        });
+        assert_eq!(failed["success"], false);
+        assert_eq!(failed["error"], "lock timeout");
+    }
+
+    #[test]
+    fn maintenance_index_json_events_are_distinguishable() {
+        use temps_database::MaintenanceProgress;
+
+        let started = super::maintenance_json(MaintenanceProgress::IndexStarted { name: "idx_a" });
+        assert_eq!(started["event"], "maintenance_index_started");
+        assert_eq!(started["name"], "idx_a");
+
+        let finished = super::maintenance_json(MaintenanceProgress::IndexFinished {
+            name: "idx_a",
+            elapsed: std::time::Duration::from_secs(3),
+        });
+        assert_eq!(finished["event"], "maintenance_index_finished");
+        assert_eq!(finished["elapsed_ms"], 3_000);
     }
 
     #[tokio::test]

--- a/crates/temps-database/src/connection.rs
+++ b/crates/temps-database/src/connection.rs
@@ -284,6 +284,38 @@ pub async fn connect_for_migrate(database_url: &str) -> ServiceResult<(Arc<DbCon
     Ok((Arc::new(db), pid))
 }
 
+/// Whether `pid` is still a live backend executing a query.
+///
+/// A PID that has disconnected entirely is absent from `pg_stat_activity` and
+/// therefore reported as not active — the caller must be able to distinguish
+/// "gone" (safe) from "still running the DDL" (unsafe to re-run).
+async fn migration_backend_active(db: &DatabaseConnection, pid: i32) -> ServiceResult<bool> {
+    db.query_one(Statement::from_sql_and_values(
+        sea_orm::DatabaseBackend::Postgres,
+        "SELECT EXISTS (\
+             SELECT 1 FROM pg_stat_activity WHERE pid = $1 AND state = 'active'\
+         ) AS active",
+        [pid.into()],
+    ))
+    .await
+    .map_err(|error| {
+        ServiceError::Database(format!(
+            "Failed to verify cancellation of migration backend {pid}: {error}"
+        ))
+    })?
+    .ok_or_else(|| {
+        ServiceError::Database(format!(
+            "PostgreSQL returned no verification result for migration backend {pid}"
+        ))
+    })?
+    .try_get::<bool>("", "active")
+    .map_err(|error| {
+        ServiceError::Database(format!(
+            "Failed to decode cancellation verification for migration backend {pid}: {error}"
+        ))
+    })
+}
+
 /// Cancel an in-flight migration server-side — used when `temps migrate` is
 /// interrupted (Ctrl+C). Opens a FRESH connection (the migrating one is busy)
 /// and sends a query-cancel to the captured backend `pid`, exactly like pressing
@@ -323,6 +355,14 @@ pub async fn cancel_migration_backend(database_url: &str, pid: i32) -> ServiceRe
             ))
         })?;
     if !cancellation {
+        // `pg_cancel_backend` also returns false — with a
+        // "PID N is not a PostgreSQL backend process" warning — when the target
+        // is ALREADY GONE. That is the safe outcome, not a failure: there is no
+        // statement left to cancel and nothing for a re-run to race. Only treat
+        // it as a failure when the backend is still there running something.
+        if !migration_backend_active(&db, pid).await? {
+            return Ok(());
+        }
         return Err(ServiceError::Database(format!(
             "PostgreSQL did not confirm cancellation of migration backend {pid}"
         )));
@@ -333,31 +373,7 @@ pub async fn cancel_migration_backend(database_url: &str, pid: i32) -> ServiceRe
     // safe to rerun until the target is no longer executing an active query.
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
     loop {
-        let stopped = db
-            .query_one(Statement::from_sql_and_values(
-                sea_orm::DatabaseBackend::Postgres,
-                "SELECT NOT EXISTS (\
-                     SELECT 1 FROM pg_stat_activity WHERE pid = $1 AND state = 'active'\
-                 ) AS stopped",
-                [pid.into()],
-            ))
-            .await
-            .map_err(|error| {
-                ServiceError::Database(format!(
-                    "Failed to verify cancellation of migration backend {pid}: {error}"
-                ))
-            })?
-            .ok_or_else(|| {
-                ServiceError::Database(format!(
-                    "PostgreSQL returned no verification result for migration backend {pid}"
-                ))
-            })?
-            .try_get::<bool>("", "stopped")
-            .map_err(|error| {
-                ServiceError::Database(format!(
-                    "Failed to decode cancellation verification for migration backend {pid}: {error}"
-                ))
-            })?;
+        let stopped = !migration_backend_active(&db, pid).await?;
         if stopped {
             break;
         }
@@ -599,6 +615,51 @@ pub async fn get_pending_migration_names(db: &DbConnection) -> ServiceResult<Vec
 
 const PERMISSION_DENIED_RETENTION_INDEX: &str = "idx_audit_logs_permission_denied_retention";
 
+/// Live progress events from post-migration maintenance (concurrent index
+/// builds and continuous-aggregate backfill).
+///
+/// Both phases are non-transactional and can legitimately run for minutes on a
+/// large install — a concurrent index build scans the whole audit history, and
+/// the backfill issues one `refresh_continuous_aggregate()` transaction per
+/// window. Without these events an operator watching `temps migrate` sees a
+/// frozen terminal after the last migration line and cannot tell "still
+/// working" from "wedged on a lock". Callers turn them into per-step output.
+#[derive(Debug, Clone)]
+pub enum MaintenanceProgress<'a> {
+    /// The PostgreSQL backend PID that will execute the phase about to start.
+    ///
+    /// Emitted first by each phase. It is NOT necessarily the PID captured by
+    /// [`connect_for_migrate`]: the index phase deliberately disposes of its
+    /// connection (`close_on_drop`), so the backfill that follows runs on a
+    /// freshly-opened backend with a different PID. A caller that cancels
+    /// server-side on interrupt must target this PID, not the connect-time one,
+    /// or it will signal a backend that no longer exists while the real work
+    /// keeps running.
+    PhaseBackend { pid: i32 },
+    /// A concurrent index build is about to start.
+    IndexStarted { name: &'a str },
+    /// The concurrent index build finished successfully.
+    IndexFinished { name: &'a str, elapsed: Duration },
+    /// A continuous aggregate is about to be refreshed over `windows` windows.
+    AggregateStarted { view: &'a str, windows: usize },
+    /// One refresh window finished. `error` is set when that window failed —
+    /// windows are independent, so the backfill continues either way.
+    AggregateWindow {
+        view: &'a str,
+        index: usize,
+        total: usize,
+        elapsed: Duration,
+        error: Option<String>,
+    },
+    /// Every window for this aggregate has been attempted.
+    AggregateFinished {
+        view: &'a str,
+        windows: usize,
+        failed: usize,
+        elapsed: Duration,
+    },
+}
+
 /// Build large, non-correctness-critical indexes outside SeaORM's migration
 /// transaction. The caller runs this after the server has bound (or explicitly
 /// from `temps migrate`), so a busy audit table cannot block application boot.
@@ -607,6 +668,21 @@ const PERMISSION_DENIED_RETENTION_INDEX: &str = "idx_audit_logs_permission_denie
 /// the concurrent index build. `CREATE INDEX CONCURRENTLY` allows audit writes
 /// to continue while PostgreSQL scans the existing history.
 pub async fn run_post_migration_indexes(db: &DatabaseConnection) -> ServiceResult<()> {
+    run_post_migration_indexes_streaming(db, |_| {}).await
+}
+
+/// [`run_post_migration_indexes`] with live progress events.
+///
+/// `on_progress` is called immediately before the concurrent build starts and
+/// again when it completes, so an interactive caller can show which index is
+/// being built rather than an unexplained pause.
+pub async fn run_post_migration_indexes_streaming<F>(
+    db: &DatabaseConnection,
+    on_progress: F,
+) -> ServiceResult<()>
+where
+    F: Fn(MaintenanceProgress<'_>),
+{
     let pool = db.get_postgres_connection_pool();
     let mut connection = pool.acquire().await.map_err(|error| {
         ServiceError::Database(format!(
@@ -617,6 +693,17 @@ pub async fn run_post_migration_indexes(db: &DatabaseConnection) -> ServiceResul
     // is cancelled. Treat this as a disposable maintenance connection so no
     // cancellation or RESET failure can leak its settings back into the pool.
     connection.close_on_drop();
+
+    // Report the backend actually doing the work. Because this connection is
+    // disposable, it is the LAST phase to run on the connect-time PID — anything
+    // after it gets a new backend, and an interrupt aimed at the old PID would
+    // signal a process that no longer exists.
+    if let Ok(pid) = sqlx::query_scalar::<_, i32>("SELECT pg_backend_pid()")
+        .fetch_one(&mut *connection)
+        .await
+    {
+        on_progress(MaintenanceProgress::PhaseBackend { pid });
+    }
 
     sqlx::query("SET lock_timeout = '5s'")
         .execute(&mut *connection)
@@ -668,6 +755,11 @@ pub async fn run_post_migration_indexes(db: &DatabaseConnection) -> ServiceResul
             })?;
         }
 
+        on_progress(MaintenanceProgress::IndexStarted {
+            name: PERMISSION_DENIED_RETENTION_INDEX,
+        });
+        let started = std::time::Instant::now();
+
         sqlx::query(
             "CREATE INDEX CONCURRENTLY IF NOT EXISTS \
                  idx_audit_logs_permission_denied_retention \
@@ -682,6 +774,11 @@ pub async fn run_post_migration_indexes(db: &DatabaseConnection) -> ServiceResul
                  '{PERMISSION_DENIED_RETENTION_INDEX}': {error}"
             ))
         })?;
+
+        on_progress(MaintenanceProgress::IndexFinished {
+            name: PERMISSION_DENIED_RETENTION_INDEX,
+            elapsed: started.elapsed(),
+        });
 
         Ok(())
     }
@@ -726,6 +823,39 @@ pub async fn run_post_migration_indexes(db: &DatabaseConnection) -> ServiceResul
 type RefreshWindow = (Option<String>, String);
 
 pub async fn run_post_migration_backfill(db: &DatabaseConnection) -> ServiceResult<()> {
+    run_post_migration_backfill_streaming(db, |_| {}).await
+}
+
+/// [`run_post_migration_backfill`] with live progress events.
+///
+/// One [`MaintenanceProgress::AggregateWindow`] is emitted per refresh window,
+/// so an interactive caller can show "window 7/31" instead of nothing at all
+/// while a multi-minute backfill runs.
+pub async fn run_post_migration_backfill_streaming<F>(
+    db: &DatabaseConnection,
+    on_progress: F,
+) -> ServiceResult<()>
+where
+    F: Fn(MaintenanceProgress<'_>),
+{
+    // Report the backend that will run the refresh calls, so an interrupt can
+    // cancel THIS one. The migrate pool is capped at a single connection, so the
+    // PID read here is the PID every `refresh_continuous_aggregate()` below runs
+    // on — and it differs from the connect-time PID whenever a disposable
+    // maintenance connection (see `run_post_migration_indexes_streaming`) has
+    // already been retired.
+    if let Ok(Some(row)) = db
+        .query_one(Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT pg_backend_pid() AS pid".to_owned(),
+        ))
+        .await
+    {
+        if let Ok(pid) = row.try_get::<i32>("", "pid") {
+            on_progress(MaintenanceProgress::PhaseBackend { pid });
+        }
+    }
+
     // Refresh windows per aggregate, executed in order. `None` as a bound
     // means unbounded (NULL). Window ends mirror each aggregate's
     // refresh-policy end_offset so the backfill never overlaps the region
@@ -801,13 +931,20 @@ pub async fn run_post_migration_backfill(db: &DatabaseConnection) -> ServiceResu
         }
 
         debug!("Backfilling {view_name} continuous aggregate");
+        let total_windows = windows.len();
+        on_progress(MaintenanceProgress::AggregateStarted {
+            view: view_name,
+            windows: total_windows,
+        });
+        let aggregate_started = std::time::Instant::now();
         let mut failed = 0usize;
-        for (window_start, window_end) in &windows {
+        for (position, (window_start, window_end)) in windows.iter().enumerate() {
             let start_sql = window_start.as_deref().unwrap_or("NULL");
             let backfill_sql = format!(
                 "CALL refresh_continuous_aggregate('{view_name}', {start_sql}, {window_end})"
             );
-            if let Err(e) = db
+            let window_started = std::time::Instant::now();
+            let window_error = if let Err(e) = db
                 .execute(Statement::from_string(
                     sea_orm::DatabaseBackend::Postgres,
                     backfill_sql,
@@ -821,8 +958,24 @@ pub async fn run_post_migration_backfill(db: &DatabaseConnection) -> ServiceResu
                     "Failed to backfill {view_name} window [{start_sql}, {window_end}] \
                      (refresh policy will catch up): {e}"
                 );
-            }
+                Some(e.to_string())
+            } else {
+                None
+            };
+            on_progress(MaintenanceProgress::AggregateWindow {
+                view: view_name,
+                index: position + 1,
+                total: total_windows,
+                elapsed: window_started.elapsed(),
+                error: window_error,
+            });
         }
+        on_progress(MaintenanceProgress::AggregateFinished {
+            view: view_name,
+            windows: total_windows,
+            failed,
+            elapsed: aggregate_started.elapsed(),
+        });
         if failed == 0 {
             debug!("{view_name} continuous aggregate backfill complete");
         } else {
@@ -1003,6 +1156,75 @@ mod tests {
             other_result.is_ok(),
             "a separate temps_migrate backend must not be cancelled"
         );
+
+        Ok(())
+    }
+
+    /// Cancelling a backend that has already gone away must SUCCEED.
+    ///
+    /// `pg_cancel_backend()` returns false (with a "PID N is not a PostgreSQL
+    /// backend process" warning) for a PID that no longer exists. Treating that
+    /// as a failure told the operator "PostgreSQL did not confirm cancellation
+    /// … do not rerun migrations" when in fact nothing was left running — the
+    /// exact false alarm reported after interrupting post-migration maintenance,
+    /// whose backend differs from the connect-time one.
+    #[tokio::test]
+    async fn cancelling_an_already_gone_backend_succeeds() -> anyhow::Result<()> {
+        let container = match GenericImage::new("postgres", "18-alpine")
+            .with_exposed_port(testcontainers::core::ContainerPort::Tcp(5432))
+            .with_wait_for(WaitFor::message_on_stderr(
+                "database system is ready to accept connections",
+            ))
+            .with_env_var("POSTGRES_DB", "postgres")
+            .with_env_var("POSTGRES_USER", "postgres")
+            .with_env_var("POSTGRES_HOST_AUTH_METHOD", "trust")
+            .start()
+            .await
+        {
+            Ok(container) => container,
+            Err(error)
+                if crate::test_utils::is_container_runtime_unavailable(&error.to_string()) =>
+            {
+                eprintln!("Skipping Docker-dependent gone-backend cancellation test: {error}");
+                return Ok(());
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let host = container.get_host().await?.to_string();
+        let port = container.get_host_port_ipv4(5432).await?;
+        let database_url = format!("postgresql://postgres@{host}:{port}/postgres");
+
+        // Capture a real PID, then close its connection so the backend is gone.
+        let (db, pid) = connect_for_migrate(&database_url).await?;
+        db.get_postgres_connection_pool().close().await;
+        drop(db);
+
+        let observer = Database::connect(&database_url).await?;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let present = observer
+                .query_one(Statement::from_sql_and_values(
+                    sea_orm::DatabaseBackend::Postgres,
+                    "SELECT EXISTS (SELECT 1 FROM pg_stat_activity WHERE pid = $1) AS present",
+                    [pid.into()],
+                ))
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("activity query returned no row"))?
+                .try_get::<bool>("", "present")?;
+            if !present {
+                break;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                anyhow::bail!("closed migration backend never left pg_stat_activity");
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+
+        cancel_migration_backend(&database_url, pid)
+            .await
+            .map_err(|error| {
+                anyhow::anyhow!("cancelling an already-gone backend must succeed: {error}")
+            })?;
 
         Ok(())
     }

--- a/crates/temps-database/src/lib.rs
+++ b/crates/temps-database/src/lib.rs
@@ -8,8 +8,9 @@ pub use approx_count::{approximate_row_count, count_for_pagination, CountKind};
 pub use connection::{
     cancel_migration_backend, connect_for_migrate, connect_without_migrations,
     establish_connection, get_pending_migration_names, run_migrations, run_migrations_reported,
-    run_migrations_streaming, run_post_migration_backfill, run_post_migration_indexes,
-    DbConnection, MigrationProgress, MigrationRunReport, MigrationStepResult,
+    run_migrations_streaming, run_post_migration_backfill, run_post_migration_backfill_streaming,
+    run_post_migration_indexes, run_post_migration_indexes_streaming, DbConnection,
+    MaintenanceProgress, MigrationProgress, MigrationRunReport, MigrationStepResult,
 };
 
 // Export test utilities for use by other crates in their tests


### PR DESCRIPTION
## Problem

`temps migrate` looks hung after the last migration line. Two non-transactional phases run with **zero output**:

1. `CREATE INDEX CONCURRENTLY` on `audit_logs`
2. a continuous-aggregate backfill that issues **31 separate `refresh_continuous_aggregate()` calls** for `proxy_logs_stats_1m`

On a production-sized table that is minutes of dead terminal with no way to tell "still working" from "wedged on a lock".

Interrupting it then produced a **false alarm**:

```
Interrupted — cancelling post-migration backfill…
WARN PID 440394 is not a PostgreSQL backend process
Error: post-migration backfill was interrupted, but PostgreSQL did not confirm that backend 440394
stopped … Do not rerun migrations until that PID is no longer active
```

**Root cause:** the index phase acquires the migrate pool's single connection and marks it `close_on_drop`, so the connect-time PID is already dead by the time the backfill starts — the backfill runs on a brand-new backend. Measured on a live DB: index phase `pid 19524`, backfill `pid 19525`. Ctrl+C therefore signalled a PID that no longer existed **while the refresh it was meant to stop kept running server-side**, then told the operator not to re-run.

Separately, `pg_cancel_backend()` returns `false` for an already-gone PID. That is the *safe* outcome — nothing left to cancel — but it was reported as a hard failure.

## Changes

- New `MaintenanceProgress` event stream from `temps-database`; `run_post_migration_indexes_streaming` / `run_post_migration_backfill_streaming` emit per-index and per-window events. The existing non-streaming functions are thin wrappers, so `temps serve` is unchanged.
- CLI rendering: in-place `\r` line on a TTY, one complete line per event when piped (journald/CI, where `\r` is unreadable), NDJSON `maintenance_*` events for `--progress-format=json` so the "Update Now" worker can show the phase instead of a stalled bar.
- A failed refresh window now gets its own visible line instead of only a `warn!` the operator never sees.
- Each phase reports the backend PID it actually runs on; the CLI cancels *that* PID on Ctrl+C.
- `cancel_migration_backend` verifies against `pg_stat_activity` and returns `Ok` when the backend is already gone, failing only when it is genuinely still active.

## Evidence

Human output (TTY):

```
Post-migration maintenance…
  Non-transactional work that runs outside the migrations above. Ctrl+C cancels it safely; re-run `temps migrate` to resume.
  ✓ index idx_audit_logs_permission_denied_retention (1ms)
  ✓ events_hourly refresh [1/1] (3ms)
  → proxy_logs_stats_1m refresh [10/31] … (last window 343ms)
```

Piped output — one line per window, no `\r` mashing:

```
  · proxy_logs_stats_1m refresh [30/31] (317ms)
  · proxy_logs_stats_1m refresh [31/31] (3ms)
  ✓ proxy_logs_stats_1m refresh [31/31] (9.87s)
```

JSON mode:

```json
{"event":"maintenance_index_finished","name":"idx_audit_logs_permission_denied_retention","elapsed_ms":1}
{"event":"maintenance_backfill_started","view":"proxy_logs_stats_1m","windows":31}
{"event":"maintenance_backfill_window","view":"proxy_logs_stats_1m","index":31,"total":31,"elapsed_ms":1,"success":true,"error":null}
{"event":"maintenance_backfill_finished","view":"proxy_logs_stats_1m","windows":31,"failed":0,"elapsed_ms":54}
```

Two distinct backends, confirming the root cause:

```json
{"event":"maintenance_backend","pid":19524}
{"event":"maintenance_index_started","name":"idx_audit_logs_permission_denied_retention"}
{"event":"maintenance_backend","pid":19525}
{"event":"maintenance_backfill_started","view":"events_hourly","windows":1}
```

Live SIGINT mid-backfill against 7M seeded `proxy_logs` rows — correct backend cancelled, honest message:

```
  · proxy_logs_stats_1m refresh [10/31] (343ms)

Interrupted — cancelling post-migration backfill…
Error: post-migration backfill was interrupted and PostgreSQL confirmed the statement on backend 22486
is no longer active. Re-run `temps migrate` to repair any invalid concurrent index and continue.
```

Regression test `cancelling_an_already_gone_backend_succeeds` (testcontainers, skips gracefully without Docker) was verified to **fail** against the old behaviour:

```
Error: cancelling an already-gone backend must succeed: Database error: PostgreSQL did not confirm cancellation of mi...
```

Full run in a clean worktree off `origin/main`: `cargo check --lib`, `cargo test --lib -p temps-cli migrate` (4 passed), `cargo test --lib -p temps-database cancel` (2 passed), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` — all clean. Scratch databases dropped.

## Notes

No API surface change, so no `temps-cli` (TypeScript) parity work is needed — these are server lifecycle commands.
