### PR TITLE
fix(skills): repin the temps skill to the published 0.1.34 integrity

### DIFF
--- a/.github/workflows/skill-security.yml
+++ b/.github/workflows/skill-security.yml
@@ -65,6 +65,7 @@ jobs:
               "apps/temps-cli/package.json",
               "apps/temps-cli/src/commands/docs.ts",
               "apps/temps-cli/src/commands/docs.test.ts",
+              "skills/temps-cli/SKILL.md",
               "skills/temps-cli/references/COMMANDS.md",
           }
           name_pattern = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
@@ -139,9 +140,11 @@ jobs:
                       selected.add(validated)
 
               # The /temps command references are generated from the CLI
-              # catalog. Changes to that catalog or its generator must scan
-              # and validate both the source skill and routed skill even when
-              # only one skill directory appears in the diff.
+              # catalog, and both skills pin the same package integrity in
+              # their preflight guard. Changes to that catalog, its generator,
+              # or the guard must scan and validate both the source skill and
+              # routed skill even when only one skill directory appears in the
+              # diff.
               if temps_dependency_files.intersection(changed):
                   for dependent_skill in ("temps", "temps-cli"):
                       validated = validate_skill(skills_root / dependent_skill)

--- a/skills/temps/references/cli-runtime.md
+++ b/skills/temps/references/cli-runtime.md
@@ -9,7 +9,7 @@ has a global `temps` command and never use an unpinned package runner.
 ```bash
 command -v bunx || command -v npx
 
-expected_temps_cli_integrity='sha512-fpObk7bMdEodFbv/lNyTPIoVG+st8mDlb2v/JQ63LXl43GHLm6onDfyursQUYBHcu5wFOY8EX0a7LM/PEcBNKA=='
+expected_temps_cli_integrity='sha512-y8k0npyL16Ue1C6OExexSI6o4sCjR9VOtUy+PWelSIZPEAOMg6a2C2RSYk1m48DS4ZyjkZsFRcd+hNQKv5zYag=='
 actual_temps_cli_integrity="$(npm view @temps-sdk/cli@0.1.34 dist.integrity)"
 test "$actual_temps_cli_integrity" = "$expected_temps_cli_integrity" || {
   echo 'Refusing to run: @temps-sdk/cli@0.1.34 integrity mismatch' >&2

--- a/skills/temps/scripts/test_validate_skill.py
+++ b/skills/temps/scripts/test_validate_skill.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Regression tests for the Temps skill validator."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from validate_skill import GUARDED_SKILLS, check_integrity_pins
+
+
+GUARD = """```bash
+expected_temps_cli_integrity='{pin}'
+actual_temps_cli_integrity="$(npm view @temps-sdk/cli@9.9.9 dist.integrity)"
+```
+"""
+
+
+def write_skills(root: Path, pins: dict[str, str]) -> None:
+    for skill, pin in pins.items():
+        skill_root = root / skill
+        skill_root.mkdir(parents=True)
+        (skill_root / "SKILL.md").write_text(GUARD.format(pin=pin), encoding="utf-8")
+
+
+class IntegrityPinTests(unittest.TestCase):
+    def test_accepts_skills_pinning_the_published_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_skills(root, {skill: "sha512-current" for skill in GUARDED_SKILLS})
+
+            self.assertEqual(check_integrity_pins(root, "sha512-current"), [])
+
+    def test_rejects_a_pin_left_behind_by_a_version_bump(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_skills(
+                root,
+                {
+                    "temps": "sha512-previous",
+                    "temps-cli": "sha512-current",
+                },
+            )
+
+            errors = check_integrity_pins(root, "sha512-current")
+
+            self.assertEqual(len(errors), 1)
+            self.assertIn("temps/SKILL.md", errors[0])
+            self.assertIn("sha512-previous", errors[0])
+
+    def test_rejects_a_skill_with_no_guard_at_all(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for skill in GUARDED_SKILLS:
+                (root / skill).mkdir(parents=True)
+                (root / skill / "SKILL.md").write_text("no guard", encoding="utf-8")
+
+            errors = check_integrity_pins(root, "sha512-current")
+
+            self.assertEqual(len(errors), 1)
+            self.assertIn("no expected_temps_cli_integrity guard", errors[0])
+
+    def test_reports_a_missing_guarded_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_skills(root, {GUARDED_SKILLS[0]: "sha512-current"})
+
+            errors = check_integrity_pins(root, "sha512-current")
+
+            self.assertEqual(len(errors), 1)
+            self.assertIn(f"skills/{GUARDED_SKILLS[1]}", errors[0])
+
+    def test_the_checked_in_skills_pin_the_published_artifact(self) -> None:
+        skills_root = Path(__file__).resolve().parents[2]
+
+        self.assertEqual(check_integrity_pins(skills_root), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/temps/scripts/validate_skill.py
+++ b/skills/temps/scripts/validate_skill.py
@@ -10,11 +10,49 @@ from pathlib import Path
 
 LINK = re.compile(r"\[[^]]*\]\(([^)]+)\)")
 PINNED_CLI = "@temps-sdk/cli@0.1.34"
+# sha512 of the published tarball for PINNED_CLI, as reported by
+# `npm view @temps-sdk/cli@<version> dist.integrity`. Refresh it in the same
+# commit that bumps PINNED_CLI, once the release is actually on npm — the value
+# has no version substring, so a find-and-replace bump silently leaves it stale
+# and every preflight guard below fails closed against the new release.
+PINNED_CLI_INTEGRITY = "sha512-y8k0npyL16Ue1C6OExexSI6o4sCjR9VOtUy+PWelSIZPEAOMg6a2C2RSYk1m48DS4ZyjkZsFRcd+hNQKv5zYag=="
+INTEGRITY_PIN = re.compile(r"expected_temps_cli_integrity='([^']*)'")
+# Skills whose preflight guard installs the pinned CLI. They embed the same
+# hash independently, so they are validated together.
+GUARDED_SKILLS = ("temps", "temps-cli")
+
+
+def check_integrity_pins(
+    skills_root: Path, expected: str = PINNED_CLI_INTEGRITY
+) -> list[str]:
+    """Every CLI preflight guard must pin the same, current package integrity."""
+    errors: list[str] = []
+    pins = 0
+    for skill in GUARDED_SKILLS:
+        skill_root = skills_root / skill
+        if not skill_root.is_dir():
+            errors.append(f"guarded skill is missing: skills/{skill}")
+            continue
+        for markdown in sorted(skill_root.rglob("*.md")):
+            text = markdown.read_text(encoding="utf-8")
+            for pin in INTEGRITY_PIN.findall(text):
+                pins += 1
+                if pin != expected:
+                    errors.append(
+                        f"{markdown.relative_to(skills_root)}: integrity pin {pin} "
+                        f"does not match the published {PINNED_CLI} artifact"
+                    )
+    if not pins:
+        errors.append(
+            "no expected_temps_cli_integrity guard found in "
+            f"{', '.join(f'skills/{skill}' for skill in GUARDED_SKILLS)}"
+        )
+    return errors
 
 
 def main() -> int:
     root = Path(__file__).resolve().parents[1]
-    errors: list[str] = []
+    errors: list[str] = check_integrity_pins(root.parent)
     skill = root / "SKILL.md"
     if len(skill.read_text(encoding="utf-8").splitlines()) > 500:
         errors.append("SKILL.md exceeds 500 lines")


### PR DESCRIPTION
## Problem

The `/temps` skill fails before it can run a single command:

```
Expected sha512-fpObk7bMdEodFbv/lNyTPIoVG+st8mDlb2v/JQ63LXl43GHLm6onDfyursQUYBHcu5wFOY8EX0a7LM/PEcBNKA==
npm has  sha512-y8k0npyL16Ue1C6OExexSI6o4sCjR9VOtUy+PWelSIZPEAOMg6a2C2RSYk1m48DS4ZyjkZsFRcd+hNQKv5zYag==
```

`skills/temps/references/cli-runtime.md` still pinned the **0.1.33** tarball hash while every version string around it said 0.1.34. The guard fails closed, so the agent stops and asks the user whether to run an unverified package — which is the wrong question to put in front of anyone.

## Root cause

Both skills embed the same preflight guard independently:

| file | pin on `main` |
|---|---|
| `skills/temps-cli/SKILL.md` | `y8k0npy…` (0.1.34, correct) |
| `skills/temps/references/cli-runtime.md` | `fpObk7…` (0.1.33, stale) |

The 0.1.34 release (#708) refreshed the first and missed the second. Two things let it through:

1. **The sha512 is the only pinned value with no version substring in it.** Bumping `0.1.33` → `0.1.34` across the skills is a find-and-replace; the hash line is untouched by construction. The same thing happened at 0.1.33 — #650 shipped with the 0.1.32 hash and needed a follow-up commit.
2. **Nothing validated it.** `validate_skill.py` checks `@temps-sdk/cli@<version>` references only. And #708's follow-up repin touched *only* `skills/temps-cli/SKILL.md`, which selects just `skills/temps-cli` in the CI matrix — the temps validator never ran on it.

## Fix

- **Repin** `cli-runtime.md` to 0.1.34's integrity. Verified independently rather than copied from registry metadata: the tarball was downloaded and its sha512/sha1 computed locally, both match npm's `dist.integrity` and `dist.shasum` (`eac65db0…`), and the tarball's own `package.json` says `0.1.34`.
- **`validate_skill.py`** gains `PINNED_CLI_INTEGRITY` next to `PINNED_CLI` and asserts every `expected_temps_cli_integrity` guard across `skills/temps` and `skills/temps-cli` matches it — and that a guard exists at all. Bumping the CLI now means updating two adjacent constants, and forgetting either is a CI failure instead of a broken skill.
- **`skill-security.yml`** adds `skills/temps-cli/SKILL.md` to the dependency bridge, so editing that copy of the guard selects both skills and actually runs the cross-check. Without this the new validation would have missed #708's follow-up commit too.
- **`test_validate_skill.py`** covers the drift case, the missing-guard case, and pins the checked-in skills against the real constant.

## Evidence

The guard from `cli-runtime.md`, run verbatim:

```console
$ expected_temps_cli_integrity='sha512-y8k0npyL16Ue1C6OExexSI6o4sCjR9VOtUy+PWelSIZPEAOMg6a2C2RSYk1m48DS4ZyjkZsFRcd+hNQKv5zYag=='
$ actual_temps_cli_integrity="$(npm view @temps-sdk/cli@0.1.34 dist.integrity)"
$ test "$actual_temps_cli_integrity" = "$expected_temps_cli_integrity" && echo "PREFLIGHT OK"
PREFLIGHT OK
$ bunx @temps-sdk/cli@0.1.34 --version
0.1.34
```

Independent hash verification:

```console
$ curl -sSfL -o cli-0.1.34.tgz https://registry.npmjs.org/@temps-sdk/cli/-/cli-0.1.34.tgz
$ echo "sha512-$(openssl dgst -sha512 -binary cli-0.1.34.tgz | openssl base64 -A)"
sha512-y8k0npyL16Ue1C6OExexSI6o4sCjR9VOtUy+PWelSIZPEAOMg6a2C2RSYk1m48DS4ZyjkZsFRcd+hNQKv5zYag==
$ shasum -a 1 cli-0.1.34.tgz
eac65db0f86a07ada57323166df39b6fcfd5cc53  cli-0.1.34.tgz
$ tar -xzOf cli-0.1.34.tgz package/package.json | grep '"version"'
  "version": "0.1.34",
```

The new check reproduces the shipped bug — restoring the 0.1.33 hash:

```console
$ python3 skills/temps/scripts/validate_skill.py
Temps skill validation failed:
- temps/references/cli-runtime.md: integrity pin sha512-fpObk7bMdEodFbv/... does not match the published @temps-sdk/cli@0.1.34 artifact
$ echo $?
1
```

And passes on this branch:

```console
$ python3 skills/temps/scripts/validate_skill.py
Temps skill validation passed (77 command groups).
$ python3 -m unittest discover -s skills/temps/scripts -p 'test_*.py'
Ran 18 tests in 0.035s

OK
```