### PR TITLE
fix(monitoring): normalise uncapped container CPU alerts against host cores

### DIFF
--- a/crates/temps-deployer/src/docker.rs
+++ b/crates/temps-deployer/src/docker.rs
@@ -2495,6 +2495,15 @@ impl ContainerDeployer for DockerRuntime {
 
         let cpu_percent = cpu_percent_from_samples(&second, &first).unwrap_or(0.0);
 
+        // Host core count at sample time. For a container with no CPU limit
+        // this is its real ceiling — `cpu_utilization_percent()` needs it to
+        // avoid treating one saturated core on a multi-core host as 100%.
+        let online_cpus = second
+            .cpu_stats
+            .as_ref()
+            .and_then(|cpu| cpu.online_cpus)
+            .filter(|cpus| *cpus > 0);
+
         // Memory: subtract page cache (matches `docker stats` MEM USAGE).
         // cgroup v2 → `inactive_file`, cgroup v1 → `cache`. Both are
         // reclaimable file pages that the kernel counts as `usage` but
@@ -2530,6 +2539,7 @@ impl ContainerDeployer for DockerRuntime {
             container_name: container_info.container_name,
             cpu_percent,
             cpu_limit_cores: container_info.cpu_limit_cores,
+            online_cpus,
             memory_bytes,
             memory_limit_bytes,
             memory_percent,

--- a/crates/temps-deployer/src/lib.rs
+++ b/crates/temps-deployer/src/lib.rs
@@ -350,12 +350,20 @@ pub struct ContainerStats {
     /// Raw Docker CPU usage percentage, where **100% == one full core**.
     /// A container saturating 2 cores reads `200.0`, 4 cores `400.0`, etc.
     /// This is NOT bounded to 0-100 — to compare against a threshold you must
-    /// normalise against the CPU limit; use [`ContainerStats::cpu_utilization_percent`].
+    /// normalise against the CPU the container is allowed to use; use
+    /// [`ContainerStats::cpu_utilization_percent`].
     pub cpu_percent: f64,
     /// CPU limit applied to the container, in whole cores (e.g. `1.0`).
     /// None if no limit is set. Lets the UI render "0.5 / 1.0 cores".
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub cpu_limit_cores: Option<f64>,
+    /// Number of CPU cores Docker reported as online on the host at sample
+    /// time. This is the real ceiling for an *uncapped* container — without it
+    /// there is no way to tell "using 1 of 1 core" (saturated) from "using 1 of
+    /// 8 cores" (idle host). None when the counter is absent (e.g. stats from a
+    /// worker agent predating this field).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub online_cpus: Option<u32>,
     /// Memory usage in bytes
     pub memory_bytes: u64,
     /// Memory limit in bytes (if set)
@@ -386,6 +394,7 @@ impl Default for ContainerStats {
             container_name: String::new(),
             cpu_percent: 0.0,
             cpu_limit_cores: None,
+            online_cpus: None,
             memory_bytes: 0,
             memory_limit_bytes: None,
             memory_percent: None,
@@ -410,18 +419,29 @@ impl ContainerStats {
     /// limit) — well below saturation.
     ///
     /// When the container has an explicit limit (`cpu_limit_cores`), the ceiling
-    /// is `limit * 100` raw percent. With no limit set there is no fixed ceiling,
-    /// so we normalise per-core (ceiling = 100% raw = one core saturated); this
-    /// keeps the threshold meaningful for uncapped containers without firing the
-    /// instant a container exceeds a single core's worth of legitimate work —
-    /// callers that want host-relative behaviour should special-case `None`.
+    /// is `limit * 100` raw percent. When it has **no** limit the container may
+    /// legitimately use every core on the box, so the ceiling is the host's core
+    /// count (`online_cpus`) — using one core as the ceiling would report a
+    /// container quietly using 1 of 8 cores as "100% utilised" and fire a
+    /// high-CPU alarm on an idle host.
+    ///
+    /// Only when neither is known (no limit *and* no core count, e.g. stats from
+    /// an older worker agent) do we fall back to a one-core ceiling.
     pub fn cpu_utilization_percent(&self) -> f64 {
-        let ceiling_cores = match self.cpu_limit_cores {
+        self.cpu_percent / self.cpu_ceiling_cores()
+    }
+
+    /// Cores the container is allowed to use: its explicit limit, else every
+    /// core on the host, else one core when neither is known.
+    pub fn cpu_ceiling_cores(&self) -> f64 {
+        match self.cpu_limit_cores {
             Some(cores) if cores > 0.0 => cores,
-            // No (or invalid) limit: treat one core as the reference ceiling.
-            _ => 1.0,
-        };
-        self.cpu_percent / ceiling_cores
+            // Uncapped: the whole host is fair game.
+            _ => match self.online_cpus {
+                Some(cpus) if cpus > 0 => f64::from(cpus),
+                _ => 1.0,
+            },
+        }
     }
 }
 
@@ -747,6 +767,19 @@ mod tests {
         }
     }
 
+    fn stats_with_cpu_on_host(
+        cpu_percent: f64,
+        cpu_limit_cores: Option<f64>,
+        online_cpus: u32,
+    ) -> ContainerStats {
+        ContainerStats {
+            cpu_percent,
+            cpu_limit_cores,
+            online_cpus: Some(online_cpus),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn test_cpu_utilization_with_limit() {
         // 2-core limit, container using 1.8 cores (180% raw) -> 90% of its limit.
@@ -772,8 +805,34 @@ mod tests {
     }
 
     #[test]
-    fn test_cpu_utilization_no_limit_is_per_core() {
-        // No limit -> one core is the reference ceiling, so raw% == utilisation%.
+    fn test_cpu_utilization_no_limit_is_relative_to_host_cores() {
+        // The bug this guards: an uncapped container saturating one core on an
+        // 8-core host is at 12.5% of what it's allowed, NOT 100%. Normalising
+        // per-core fired a high-CPU alarm on an essentially idle host.
+        let stats = stats_with_cpu_on_host(100.0, None, 8);
+        assert!((stats.cpu_utilization_percent() - 12.5).abs() < 1e-9);
+
+        // Only when it saturates every core does it read 100%.
+        let stats = stats_with_cpu_on_host(800.0, None, 8);
+        assert!((stats.cpu_utilization_percent() - 100.0).abs() < 1e-9);
+
+        // Single-core host: uncapped and pinned really is 100%.
+        let stats = stats_with_cpu_on_host(100.0, None, 1);
+        assert!((stats.cpu_utilization_percent() - 100.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_cpu_utilization_explicit_limit_wins_over_host_cores() {
+        // A 0.5-core cap on an 8-core host: the cap is the ceiling, so half a
+        // core in use is full saturation.
+        let stats = stats_with_cpu_on_host(50.0, Some(0.5), 8);
+        assert!((stats.cpu_utilization_percent() - 100.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_cpu_utilization_unknown_host_cores_falls_back_to_one_core() {
+        // No limit and no core count (older worker agent) -> one-core ceiling,
+        // so raw% == utilisation%.
         let stats = stats_with_cpu(95.0, None);
         assert!((stats.cpu_utilization_percent() - 95.0).abs() < 1e-9);
 
@@ -782,14 +841,29 @@ mod tests {
     }
 
     #[test]
-    fn test_cpu_utilization_zero_or_invalid_limit_falls_back_to_one_core() {
-        // A zero/negative limit is treated as "no limit" (one-core ceiling)
+    fn test_cpu_utilization_zero_or_invalid_limit_falls_back_to_host_cores() {
+        // A zero/negative limit is treated as "no limit" (host-core ceiling)
         // rather than dividing by zero.
+        let stats = stats_with_cpu_on_host(120.0, Some(0.0), 4);
+        assert!((stats.cpu_utilization_percent() - 30.0).abs() < 1e-9);
+
+        let stats = stats_with_cpu_on_host(120.0, Some(-1.0), 4);
+        assert!((stats.cpu_utilization_percent() - 30.0).abs() < 1e-9);
+
+        // ...and to one core when the host core count is unknown too.
         let stats = stats_with_cpu(120.0, Some(0.0));
         assert!((stats.cpu_utilization_percent() - 120.0).abs() < 1e-9);
+    }
 
-        let stats = stats_with_cpu(120.0, Some(-1.0));
-        assert!((stats.cpu_utilization_percent() - 120.0).abs() < 1e-9);
+    #[test]
+    fn test_cpu_utilization_zero_online_cpus_is_not_a_divide_by_zero() {
+        let stats = ContainerStats {
+            cpu_percent: 50.0,
+            cpu_limit_cores: None,
+            online_cpus: Some(0),
+            ..Default::default()
+        };
+        assert!((stats.cpu_utilization_percent() - 50.0).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/temps-monitoring/src/container_health.rs
+++ b/crates/temps-monitoring/src/container_health.rs
@@ -508,15 +508,21 @@ impl ContainerHealthMonitor {
         // `stats.cpu_percent` is the raw Docker number where 100% == one core, so
         // a container *allowed* 2 cores can hit 200% while only being 100%
         // utilised. We must compare the threshold against utilisation relative to
-        // the container's CPU limit — otherwise a 2-core container fires at ~95%
-        // raw (≈47% of its limit), nowhere near saturation. `cpu_used_cores`
-        // (= raw% / 100) is surfaced alongside so the alarm is actionable.
+        // the CPU the container is allowed to use — its explicit limit when it
+        // has one (otherwise a 2-core container fires at ~95% raw, ≈47% of its
+        // limit), and the host's core count when it doesn't (otherwise an
+        // uncapped container using 1 of 8 cores fires at "100%" on an idle host).
+        // `cpu_used_cores` (= raw% / 100) is surfaced alongside so the alarm is
+        // actionable.
         let cpu_utilization = stats.cpu_utilization_percent();
         let cpu_used_cores = stats.cpu_percent / 100.0;
         if cpu_utilization > self.config.cpu_threshold_percent {
-            let limit_label = match stats.cpu_limit_cores {
-                Some(cores) if cores > 0.0 => format!("{cores:.2} core limit"),
-                _ => "no limit (per-core)".to_string(),
+            let capacity_label = match (stats.cpu_limit_cores, stats.online_cpus) {
+                (Some(cores), _) if cores > 0.0 => format!("its {cores:.2}-core limit"),
+                (_, Some(cpus)) if cpus > 0 => {
+                    format!("the {cpus} cores on this host (no CPU limit set)")
+                }
+                _ => "one core (no CPU limit set, host core count unknown)".to_string(),
             };
             self.handle_resource_threshold(
                 container,
@@ -524,25 +530,29 @@ impl ContainerHealthMonitor {
                 AlarmType::HighCpu,
                 AlarmSeverity::Warning,
                 format!(
-                    "Container '{}' CPU at {:.0}% of limit",
+                    "Container '{}' CPU at {:.0}% of available capacity",
                     container.container_name, cpu_utilization
                 ),
                 format!(
-                    "Container '{}' CPU usage is at {:.0}% of its {} ({:.2} cores in use), above the {:.0}% threshold.",
+                    "Container '{}' is using {:.2} cores — {:.0}% of {}, above the {:.0}% threshold.",
                     container.container_name,
-                    cpu_utilization,
-                    limit_label,
                     cpu_used_cores,
+                    cpu_utilization,
+                    capacity_label,
                     self.config.cpu_threshold_percent,
                 ),
                 serde_json::json!({
                     "container_name": container.container_name,
-                    // Utilisation relative to the CPU limit — what the threshold is compared against.
+                    // Utilisation relative to the CPU the container may use — what
+                    // the threshold is compared against.
                     "cpu_utilization_percent": cpu_utilization,
                     // Raw Docker percentage (100% == one core) and the cores it maps to.
                     "cpu_percent": stats.cpu_percent,
                     "cpu_used_cores": cpu_used_cores,
                     "cpu_limit_cores": stats.cpu_limit_cores,
+                    // Host cores — the ceiling used when no limit is configured.
+                    "online_cpus": stats.online_cpus,
+                    "cpu_ceiling_cores": stats.cpu_ceiling_cores(),
                     "threshold_percent": self.config.cpu_threshold_percent,
                 }),
             )
@@ -653,7 +663,8 @@ impl ContainerHealthMonitor {
                 stats.cpu_percent,
                 MetricKind::Gauge,
             ),
-            // CPU usage relative to the container's CPU limit (100% == limit
+            // CPU usage relative to the CPU the container may use — its limit
+            // when set, otherwise every core on the host (100% == that capacity
             // fully saturated). This is the metric alert rules should threshold
             // against — see `container_default_seeds()` in the evaluator.
             make_point(
@@ -885,6 +896,15 @@ mod tests {
 
         async fn set_cpu_percent(&self, percent: f64) {
             self.stats.lock().await.cpu_percent = percent;
+        }
+
+        /// Set the raw Docker CPU percentage together with the CPU the
+        /// container is allowed to use (limit if any, plus the host's cores).
+        async fn set_cpu(&self, percent: f64, limit_cores: Option<f64>, online_cpus: u32) {
+            let mut stats = self.stats.lock().await;
+            stats.cpu_percent = percent;
+            stats.cpu_limit_cores = limit_cores;
+            stats.online_cpus = Some(online_cpus);
         }
 
         async fn set_memory_percent(&self, percent: f64) {
@@ -1227,6 +1247,68 @@ mod tests {
     }
 
     // ── Resource threshold tests ──────────────────────────────────────
+
+    /// Build a monitor over a mock deployer, with no metrics store.
+    fn make_monitor(deployer: Arc<MockDeployer>) -> ContainerHealthMonitor {
+        let db = Arc::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+        let alarm_service = make_alarm_service(db.clone());
+        ContainerHealthMonitor::new(
+            db,
+            deployer,
+            alarm_service,
+            ContainerHealthConfig::default(),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_uncapped_container_does_not_breach_at_one_core_of_many() {
+        // Regression: with no CPU limit, one saturated core used to normalise to
+        // 100% and trip the 90% threshold — on a host with 7 idle cores.
+        let deployer = Arc::new(MockDeployer::new(0, ContainerStatus::Running));
+        deployer.set_cpu(100.0, None, 8).await;
+        let container = make_container_model(1);
+        let deployment = make_deployment_model();
+
+        let monitor = make_monitor(deployer);
+        monitor.check_resource_usage(&container, &deployment).await;
+
+        let counters = monitor.resource_counters.read().await;
+        assert!(
+            counters.get(&(1, "high_cpu")).is_none(),
+            "uncapped container using 1 of 8 cores must not count as a CPU breach"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_uncapped_container_breaches_when_it_saturates_the_host() {
+        // 7.8 of 8 cores == 97.5% of what it's allowed: a real breach.
+        let deployer = Arc::new(MockDeployer::new(0, ContainerStatus::Running));
+        deployer.set_cpu(780.0, None, 8).await;
+        let container = make_container_model(1);
+        let deployment = make_deployment_model();
+
+        let monitor = make_monitor(deployer);
+        monitor.check_resource_usage(&container, &deployment).await;
+
+        let counters = monitor.resource_counters.read().await;
+        assert_eq!(*counters.get(&(1, "high_cpu")).unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_capped_container_breaches_against_its_own_limit() {
+        // 0.48 cores against a 0.5-core cap == 96%, even though the 8-core host
+        // is almost entirely idle.
+        let deployer = Arc::new(MockDeployer::new(0, ContainerStatus::Running));
+        deployer.set_cpu(48.0, Some(0.5), 8).await;
+        let container = make_container_model(1);
+        let deployment = make_deployment_model();
+
+        let monitor = make_monitor(deployer);
+        monitor.check_resource_usage(&container, &deployment).await;
+
+        let counters = monitor.resource_counters.read().await;
+        assert_eq!(*counters.get(&(1, "high_cpu")).unwrap(), 1);
+    }
 
     #[tokio::test]
     async fn test_resource_counter_increments_before_alarm() {

--- a/crates/temps-monitoring/src/evaluator.rs
+++ b/crates/temps-monitoring/src/evaluator.rs
@@ -1124,10 +1124,12 @@ fn proxy_default_seeds() -> Vec<RuleSeed> {
 fn container_default_seeds() -> Vec<RuleSeed> {
     vec![
         RuleSeed {
-            // Threshold against utilisation relative to the container's CPU
-            // limit (100% == limit saturated), NOT raw `container.cpu_percent`
-            // where 100% == one core — a 2-core container would otherwise fire
-            // at ~95% raw (≈47% of its limit), nowhere near saturation.
+            // Threshold against utilisation relative to the CPU the container
+            // may use — its limit when set, else the host's core count (100% ==
+            // saturated) — NOT raw `container.cpu_percent` where 100% == one
+            // core. A 2-core container would otherwise fire at ~95% raw (≈47%
+            // of its limit), and an uncapped container would fire the moment it
+            // used a single core of a many-core host.
             name: "High CPU usage",
             metric_name: "container.cpu_utilization_percent",
             threshold: 90.0,


### PR DESCRIPTION
## Problem

With **no CPU limit set** on a service, the "High CPU usage" alarm fires as soon as the container uses **one core**, even on a host with plenty of idle cores.

`ContainerStats::cpu_utilization_percent()` — the value both alert paths threshold against — normalised Docker's raw `cpu_percent` (where 100% == one core) against the container's CPU limit. When there was no limit, it fell back to a hardcoded **1.0-core ceiling**:

```rust
let ceiling_cores = match self.cpu_limit_cores {
    Some(cores) if cores > 0.0 => cores,
    // No (or invalid) limit: treat one core as the reference ceiling.
    _ => 1.0,
};
```

So an uncapped container using 1 of 8 cores reported "100% utilised" and tripped the 90% threshold while the host was 87% idle.

## Fix

An uncapped container is allowed the whole machine, so the ceiling is the host's core count.

- `ContainerStats` gains `online_cpus: Option<u32>`, populated in `docker.rs` from `cpu_stats.online_cpus` — the same counter the percentage math already multiplies by. `#[serde(default)]`, so stats from a worker agent predating the field still deserialize.
- New `cpu_ceiling_cores()`: explicit limit → host core count → `1.0` only when neither is known.
- `cpu_utilization_percent()` divides by that.

Both alert paths go through that one function — the container health monitor (`AlarmType::HighCpu`) and the seeded `container.cpu_utilization_percent` rule — so **already-provisioned deployments are fixed without a migration or re-seed**.

The alarm text no longer reads "of its no limit (per-core)":

> Container 'api' is using 1.00 cores — 12% of the 8 cores on this host (no CPU limit set), above the 90% threshold.

and the metadata now carries `online_cpus` + `cpu_ceiling_cores` so the alarm is diagnosable after the fact.

## Evidence

**The new regression test fails against the old logic.** With `cpu_ceiling_cores()` temporarily reverted to `_ => 1.0`:

```
thread 'container_health::tests::test_uncapped_container_does_not_breach_at_one_core_of_many' panicked at
crates/temps-monitoring/src/container_health.rs:1276:9:
uncapped container using 1 of 8 cores must not count as a CPU breach

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 96 filtered out
```

**With the fix in place** — `check_resource_usage` end-to-end over a mock deployer:

```
$ cargo test --lib -p temps-monitoring -- container_health::tests::test_uncapped container_health::tests::test_capped
running 3 tests
test container_health::tests::test_capped_container_breaches_against_its_own_limit ... ok
test container_health::tests::test_uncapped_container_breaches_when_it_saturates_the_host ... ok
test container_health::tests::test_uncapped_container_does_not_breach_at_one_core_of_many ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 95 filtered out
```

Covering: uncapped at 1-of-8 cores does **not** breach; uncapped at 7.8-of-8 (97.5%) does; a 0.5-core cap still breaches at 0.48 cores on an idle 8-core host.

**Unit coverage of the ceiling math:**

```
$ cargo test --lib -p temps-deployer cpu_utilization
running 7 tests
test tests::test_cpu_utilization_unknown_host_cores_falls_back_to_one_core ... ok
test tests::test_cpu_utilization_with_limit ... ok
test tests::test_cpu_utilization_zero_or_invalid_limit_falls_back_to_host_cores ... ok
test tests::test_cpu_utilization_zero_online_cpus_is_not_a_divide_by_zero ... ok
test tests::test_cpu_utilization_no_limit_is_relative_to_host_cores ... ok
test tests::test_cpu_utilization_explicit_limit_wins_over_host_cores ... ok
test tests::test_cpu_utilization_fractional_limit ... ok

test result: ok. 7 passed
```

**Full suites for both crates:** `cargo test --lib -p temps-deployer -p temps-monitoring` → **352 passed**.
**Lint:** `cargo clippy -p temps-deployer -p temps-monitoring --all-targets -- -D warnings` → clean (workspace clippy also passed via the pre-commit hook).

## Notes / caveats

- **Worker nodes running an older agent** don't send `online_cpus`, so their uncapped containers keep the one-core ceiling until the agent is upgraded. Deliberate: over-alerting beats dividing by a guess.
- **No API/OpenAPI change.** `temps_deployer::ContainerStats` is internal; `ContainerMetricsResponse` is untouched, so no client regeneration is needed. Consequence: the UI still renders uncapped usage as a bare `0.85 cores` with no denominator. Surfacing `online_cpus` on the metrics response (→ `0.85 / 8 cores`) is a reasonable follow-up but needs a spec regen against a running server.
