### PR TITLE
fix(web): hide Git configuration for projects with no repository

### DIFF
--- a/web/src/components/project/settings/environments/EnvironmentConfigurationCard.tsx
+++ b/web/src/components/project/settings/environments/EnvironmentConfigurationCard.tsx
@@ -22,6 +22,7 @@ import {
   targetLabelsToPayload,
   targetNodesToPayload,
 } from '@/lib/environment-placement'
+import { projectHasGitRepo } from '@/lib/project-git'
 import {
   Select,
   SelectContent,
@@ -367,6 +368,8 @@ export function EnvironmentConfigurationCard({
     })
   }
 
+  const hasGitRepo = projectHasGitRepo(project)
+
   return (
     <Card>
       <CardHeader>
@@ -375,55 +378,63 @@ export function EnvironmentConfigurationCard({
           Configuration
         </CardTitle>
         <CardDescription>
-          Configure Git branch, compute resources, and scaling for this
-          environment
+          {hasGitRepo
+            ? 'Configure Git branch, compute resources, and scaling for this environment'
+            : 'Configure compute resources and scaling for this environment'}
         </CardDescription>
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit}>
           <div className="space-y-8">
-            {/* Git Configuration Section */}
-            <div className="border-b pb-6">
-              <h3 className="text-sm font-medium mb-4">Git Configuration</h3>
-              <div>
-                <Label>Branch Name</Label>
-                <div className="mt-2">
-                  <BranchSelector
-                    repoOwner={project.repo_owner || ''}
-                    repoName={project.repo_name || ''}
-                    connectionId={project.git_provider_connection_id || 0}
-                    defaultBranch={project.main_branch}
-                    value={formData.branch}
-                    onChange={(branch) =>
-                      setFormData((prev) => ({ ...prev, branch }))
+            {/* Git Configuration Section — only for projects that deploy from
+                Git. A static-files, uploaded-source or Docker-image project has
+                no branch to deploy from and no repository to push to, so both
+                controls here are inapplicable rather than unconfigured. */}
+            {hasGitRepo && (
+              <div className="border-b pb-6">
+                <h3 className="text-sm font-medium mb-4">Git Configuration</h3>
+                <div>
+                  <Label>Branch Name</Label>
+                  <div className="mt-2">
+                    <BranchSelector
+                      repoOwner={project.repo_owner || ''}
+                      repoName={project.repo_name || ''}
+                      connectionId={project.git_provider_connection_id || 0}
+                      defaultBranch={project.main_branch}
+                      value={formData.branch}
+                      onChange={(branch) =>
+                        setFormData((prev) => ({ ...prev, branch }))
+                      }
+                    />
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-2">
+                    Deployments will be triggered from this branch
+                  </p>
+                </div>
+
+                {/* Deploy on push toggle */}
+                <div className="flex items-start sm:items-center gap-3 p-3 border rounded-lg mt-4">
+                  <div className="flex-1 min-w-0">
+                    <Label className="text-sm font-medium">
+                      Deploy on push
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Automatically deploy when a commit is pushed to this
+                      branch. Disable to deploy on demand only.
+                    </p>
+                  </div>
+                  <Switch
+                    checked={formData.automatic_deploy}
+                    onCheckedChange={(checked) =>
+                      setFormData((prev) => ({
+                        ...prev,
+                        automatic_deploy: checked,
+                      }))
                     }
                   />
                 </div>
-                <p className="text-xs text-muted-foreground mt-2">
-                  Deployments will be triggered from this branch
-                </p>
               </div>
-
-              {/* Deploy on push toggle */}
-              <div className="flex items-start sm:items-center gap-3 p-3 border rounded-lg mt-4">
-                <div className="flex-1 min-w-0">
-                  <Label className="text-sm font-medium">Deploy on push</Label>
-                  <p className="text-xs text-muted-foreground">
-                    Automatically deploy when a commit is pushed to this branch.
-                    Disable to deploy on demand only.
-                  </p>
-                </div>
-                <Switch
-                  checked={formData.automatic_deploy}
-                  onCheckedChange={(checked) =>
-                    setFormData((prev) => ({
-                      ...prev,
-                      automatic_deploy: checked,
-                    }))
-                  }
-                />
-              </div>
-            </div>
+            )}
 
             {/* CPU Resources */}
             <div>

--- a/web/src/lib/project-git.test.ts
+++ b/web/src/lib/project-git.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test'
+import { projectHasGitRepo } from './project-git'
+
+describe('projectHasGitRepo', () => {
+  test('treats the "unknown" placeholder as no repository', () => {
+    // What project creation writes when no repo was supplied — the case that
+    // produced a 404 branch fetch against github.com/unknown/unknown.
+    expect(
+      projectHasGitRepo({ repo_owner: 'unknown', repo_name: 'unknown' })
+    ).toBe(false)
+  })
+
+  test('treats empty and whitespace-only fields as no repository', () => {
+    expect(projectHasGitRepo({ repo_owner: '', repo_name: '' })).toBe(false)
+    expect(projectHasGitRepo({ repo_owner: '  ', repo_name: '  ' })).toBe(false)
+    expect(projectHasGitRepo({})).toBe(false)
+    expect(projectHasGitRepo({ repo_owner: null, repo_name: null })).toBe(false)
+  })
+
+  test('requires both owner and name for a public repo', () => {
+    expect(projectHasGitRepo({ repo_owner: 'gotempsh', repo_name: '' })).toBe(
+      false
+    )
+    expect(
+      projectHasGitRepo({ repo_owner: 'unknown', repo_name: 'temps' })
+    ).toBe(false)
+    expect(
+      projectHasGitRepo({ repo_owner: 'gotempsh', repo_name: 'temps' })
+    ).toBe(true)
+  })
+
+  test('a provider connection counts even before a repo is picked', () => {
+    // Connected-but-not-yet-configured is an onboarding state; the section
+    // must stay visible so the user can finish setting it up.
+    expect(
+      projectHasGitRepo({
+        repo_owner: 'unknown',
+        repo_name: 'unknown',
+        git_provider_connection_id: 7,
+      })
+    ).toBe(true)
+  })
+
+  test('a connection id of 0 is not a connection', () => {
+    expect(
+      projectHasGitRepo({
+        repo_owner: 'unknown',
+        repo_name: 'unknown',
+        git_provider_connection_id: 0,
+      })
+    ).toBe(false)
+  })
+
+  test('an explicit git url counts on its own', () => {
+    expect(
+      projectHasGitRepo({
+        repo_owner: 'unknown',
+        repo_name: 'unknown',
+        git_url: 'https://git.example.com/team/app.git',
+      })
+    ).toBe(true)
+  })
+})

--- a/web/src/lib/project-git.ts
+++ b/web/src/lib/project-git.ts
@@ -1,0 +1,45 @@
+/** Whether a project actually deploys from a Git repository.
+ *
+ * `repo_owner`/`repo_name` are NOT NULL columns, and project creation fills
+ * them with the literal string `"unknown"` when no repository was supplied
+ * (`crates/temps-projects/src/services/project.rs`). So "has a repo" cannot be
+ * a truthiness check — a project created from static files, an uploaded
+ * archive or a Docker image carries `unknown/unknown` and looks configured.
+ *
+ * The backend already applies exactly this rule before allowing a switch to
+ * `source_type = git`; this mirrors it for the UI so both agree on what
+ * "connected to Git" means.
+ *
+ * Getting it wrong is visible: the environment settings page rendered a branch
+ * selector for such a project, which fetched
+ * `/api/git/public/github/unknown/unknown/branches`, got a 404, and showed
+ * "Error Loading Branches — Failed to load branches from repository" on a
+ * project that had no repository to load branches from in the first place.
+ */
+const PLACEHOLDER_REPO_FIELD = 'unknown'
+
+export interface ProjectGitFields {
+  repo_owner?: string | null
+  repo_name?: string | null
+  git_url?: string | null
+  git_provider_connection_id?: number | null
+}
+
+function isRealRepoField(value: string | null | undefined): boolean {
+  const trimmed = value?.trim() ?? ''
+  return trimmed !== '' && trimmed !== PLACEHOLDER_REPO_FIELD
+}
+
+export function projectHasGitRepo(project: ProjectGitFields): boolean {
+  // A provider connection or an explicit clone URL is decisive on its own: a
+  // connected project may legitimately not have picked a repository yet, and
+  // that is an onboarding state, not "this project isn't a Git project".
+  if (project.git_provider_connection_id) return true
+  if ((project.git_url?.trim() ?? '') !== '') return true
+
+  // Otherwise it's a public repo, identified only by owner + name — both must
+  // be real for the branch API to have anything to query.
+  return (
+    isRealRepoField(project.repo_owner) && isRealRepoField(project.repo_name)
+  )
+}


### PR DESCRIPTION
## The bug

The environment settings page rendered a **Git Configuration** section for every project. On a project with no repository it fetched `/api/git/public/github/unknown/unknown/branches`, got a 404, and rendered:

> ⚠️ **Error Loading Branches** — Failed to load branches from repository

…on a project that has no repository to load branches from. Reproduced on a VibeTemps-created project (`source_type = static_files`), confirmed in `proxy_logs`:

```
GET /api/git/public/github/unknown/unknown/branches → 404
```

## Root cause

`repo_owner`/`repo_name` are `NOT NULL` columns, and project creation fills them with the literal string `"unknown"` when no repository is supplied:

```rust
// crates/temps-projects/src/services/project.rs
active_project.repo_name  = Set(request.repo_name.unwrap_or_else(|| "unknown".to_string()));
active_project.repo_owner = Set(request.repo_owner.unwrap_or_else(|| "unknown".to_string()));
```

So a truthiness check reports a repository where there is none, and every static-files, uploaded-source or Docker-image project looks Git-configured. The offending row:

```
repo_owner=unknown  repo_name=unknown  git_url=(empty)
source_type=static_files  git_provider_connection_id=(null)
```

The backend already knows `"unknown"` means "no repo" — it applies exactly this rule before allowing a switch to `source_type = git` (`project.rs:1147-1150`) — but that rule was local to that one function and the UI had no equivalent.

## The fix

Add `projectHasGitRepo` (`web/src/lib/project-git.ts`) mirroring the backend rule, and gate the section on it.

A provider connection or an explicit `git_url` counts **on its own**, so a connected project that hasn't picked a repository yet keeps the section as an onboarding state rather than having it vanish — per the discoverability rule in `CLAUDE.md`. Only the "no Git source at all" case hides, where the controls are inapplicable rather than unconfigured.

"Deploy on push" moves with the section — it was rendered, and defaulted **on**, for projects with no repository to push to.

The card description drops its "Git branch" clause when the section is hidden.

## Verification

- `bun test src` — 358 pass, 0 fail (6 new tests covering the `"unknown"` placeholder, empty/whitespace fields, owner-without-name, `connection_id: 0`, and the connection/git_url overrides)
- `bunx tsc --noEmit` — 0 errors
- `eslint` on the changed files — clean (the pre-existing `setState`-in-effect error in `EnvironmentConfigurationCard.tsx:215` is untouched and present on `main`)

## Not in this PR

`web/src/lib/project-settings-view.ts` only special-cases `uploaded_source`, so the **Git Settings** page has the same class of bug for `static_files`. That page is where a provider gets connected, so hiding it outright would remove the only path to configuring one — it needs an onboarding empty state instead, which is a different change.

The `"unknown"` placeholder itself is also still written at creation. Storing `NULL` would remove the need for any placeholder-sniffing, but that's a schema + migration change and this PR keeps the two clients agreeing in the meantime.