### PR TITLE
fix(proxy): honour the configured preview gateway host port

### DIFF
--- a/crates/temps-agents/src/handlers/preview_gateway.rs
+++ b/crates/temps-agents/src/handlers/preview_gateway.rs
@@ -132,9 +132,17 @@ pub async fn get_preview_gateway_logs(
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, SettingsWrite);
     let tail = q.tail.unwrap_or(200).min(2000);
-    let lines = preview_gateway::tail_logs(&state.docker, tail)
-        .await
-        .map_err(|e| internal(format!("failed to tail logs: {}", e)))?;
+    // Resolve the container from settings, not the default name — otherwise
+    // an instance with a custom container tails a container it doesn't own
+    // (or, more likely, none at all).
+    let settings = preview_gateway::load_settings(&state.db).await;
+    let lines = preview_gateway::tail_logs(
+        &state.docker,
+        &preview_gateway::container_name(&settings),
+        tail,
+    )
+    .await
+    .map_err(|e| internal(format!("failed to tail logs: {}", e)))?;
     Ok(Json(LogsResponse { lines }))
 }
 

--- a/crates/temps-agents/src/preview_gateway.rs
+++ b/crates/temps-agents/src/preview_gateway.rs
@@ -1,15 +1,21 @@
 //! Preview gateway supervisor.
 //!
-//! Reconciles a single shared `temps-preview-gateway` container on the local
-//! Docker host. Called from `temps serve` startup, but always runs in a
-//! background task — the proxy server (80/443) MUST NOT be blocked on this.
+//! Reconciles this instance's preview-gateway container on the local Docker
+//! host. Called from `temps serve` startup, but always runs in a background
+//! task — the proxy server (80/443) MUST NOT be blocked on this.
+//!
+//! The container is named `temps-preview-gateway` by default, which is right
+//! for a normal install that owns the whole host. It is a *setting* rather
+//! than a constant so that several Temps instances can share one Docker
+//! daemon — see `PreviewGatewaySettings::container_name` for why sharing the
+//! name silently breaks previews.
 //!
 //! What it guarantees, in order:
 //! 1. The shared sandbox network exists (so workspace sandboxes and the
 //!    gateway can resolve each other by container name via Docker DNS).
 //! 2. The pinned gateway image is present locally (pulled if missing).
-//! 3. A container named `temps-preview-gateway` is running, attached to that
-//!    network, with the right image and the right host-port publish on
+//! 3. The configured container is running, attached to that network, with
+//!    the right image and the right host-port publish on
 //!    `127.0.0.1:<port>`. Any drift causes a recreate.
 //!
 //! Failure mode: log loudly, return Err. The caller will log the error and
@@ -120,6 +126,19 @@ pub const PREVIEW_GATEWAY_CONTAINER: &str = "temps-preview-gateway";
 /// Shared docker network used for sandbox <-> gateway DNS resolution.
 pub const PREVIEW_GATEWAY_NETWORK: &str = "temps-sandbox-net";
 
+/// The container name this instance's gateway uses: the configured one, or
+/// the default. Every code path that names the container goes through here,
+/// so `inspect`, `reconcile`, `status` and `logs` can never disagree about
+/// which container they are talking about.
+pub fn container_name(settings: &PreviewGatewaySettings) -> String {
+    let name = settings.container_name.trim();
+    if name.is_empty() {
+        PREVIEW_GATEWAY_CONTAINER.to_string()
+    } else {
+        name.to_string()
+    }
+}
+
 /// Default host port the gateway publishes to. Bound on 127.0.0.1 only —
 /// the host-side Pingora reaches it via this port after authenticating.
 pub const DEFAULT_PREVIEW_GATEWAY_HOST_PORT: u16 = 8090;
@@ -168,7 +187,7 @@ impl PreviewGatewaySpec {
         };
         Self {
             image,
-            container_name: PREVIEW_GATEWAY_CONTAINER.to_string(),
+            container_name: container_name(settings),
             network: PREVIEW_GATEWAY_NETWORK.to_string(),
             host_port,
             shared_secret: settings.shared_secret.clone(),
@@ -206,6 +225,9 @@ pub async fn reconcile(docker: Arc<Docker>, spec: PreviewGatewaySpec) -> Result<
         host_port = spec.host_port,
         "reconciling preview gateway"
     );
+    // Tell the in-process proxy where to dial before we touch Docker: even if
+    // the reconcile fails, the port it should be using is the configured one.
+    export_host_port(spec.host_port);
 
     ensure_network(&docker, &spec.network).await?;
     ensure_image(&docker, &spec.image).await?;
@@ -584,6 +606,23 @@ fn export_env(secret: &str) {
     }
 }
 
+/// Publish the gateway's host port for the in-process Pingora to dial.
+///
+/// The proxy used to hardcode `127.0.0.1:8090` while the reconciler published
+/// the container on `settings.host_port`. So `host_port` was decorative:
+/// changing it moved the container and left the proxy talking to whatever
+/// still held 8090 — nothing, or on a multi-instance host, *another
+/// instance's* gateway, which rejects our token with "missing or invalid
+/// X-Temps-Preview-Token". Exported the same way the shared secret is, so
+/// both halves of this contract cross the crate boundary by the same
+/// mechanism.
+pub fn export_host_port(port: u16) {
+    #[allow(unused_unsafe)]
+    unsafe {
+        std::env::set_var("PREVIEW_GATEWAY_HOST_PORT", port.to_string());
+    }
+}
+
 /// Spawn the reconciler on the given runtime. Logs failures but never panics.
 /// Returns immediately — the actual reconcile runs in the background so the
 /// caller (the proxy server bootstrap) is never blocked.
@@ -702,8 +741,9 @@ pub async fn inspect_status(
         settings.image.clone()
     };
 
+    let name = container_name(settings);
     let inspected = docker
-        .inspect_container(PREVIEW_GATEWAY_CONTAINER, None::<InspectContainerOptions>)
+        .inspect_container(&name, None::<InspectContainerOptions>)
         .await;
 
     let inspected = match inspected {
@@ -717,7 +757,7 @@ pub async fn inspect_status(
                 health: "missing".to_string(),
                 image: None,
                 image_digest: None,
-                container_name: PREVIEW_GATEWAY_CONTAINER.to_string(),
+                container_name: name,
                 network: None,
                 host_port: None,
                 started_at: None,
@@ -798,7 +838,7 @@ pub async fn inspect_status(
         health,
         image,
         image_digest,
-        container_name: PREVIEW_GATEWAY_CONTAINER.to_string(),
+        container_name: name,
         network,
         host_port,
         started_at,
@@ -833,9 +873,9 @@ pub async fn force_restart(docker: Arc<Docker>, spec: PreviewGatewaySpec) -> Res
 
 /// Tail the gateway container's stdout+stderr. `tail` caps the number of
 /// lines returned (e.g. 200). Returns lines newest-last.
-pub async fn tail_logs(docker: &Docker, tail: usize) -> Result<Vec<String>> {
+pub async fn tail_logs(docker: &Docker, container: &str, tail: usize) -> Result<Vec<String>> {
     let stream = docker.logs(
-        PREVIEW_GATEWAY_CONTAINER,
+        container,
         Some(LogsOptions {
             stdout: true,
             stderr: true,

--- a/crates/temps-core/src/app_settings.rs
+++ b/crates/temps-core/src/app_settings.rs
@@ -845,6 +845,23 @@ pub struct PreviewGatewaySettings {
     /// Pingora forwards `ws-*` traffic to this port after authenticating.
     #[schema(example = 8090)]
     pub host_port: u16,
+    /// Docker container name for this instance's gateway.
+    ///
+    /// A single Temps install owns the whole host, so the default is fine and
+    /// operators never need to touch this. It exists for the case where
+    /// several Temps instances share one Docker daemon — most obviously a
+    /// development machine with multiple checkouts running at once.
+    ///
+    /// Without it those instances silently fight: the `shared_secret` is
+    /// per-database, so each generates a different one, but they all
+    /// reconcile the *same* container name. Each start-up sees the other's
+    /// container as drifted, recreates it with its own secret, and every
+    /// other instance's previews start failing with "missing or invalid
+    /// X-Temps-Preview-Token". Giving each instance its own container name
+    /// (and `host_port`) makes them independent.
+    #[serde(default = "default_preview_gateway_container")]
+    #[schema(example = "temps-preview-gateway")]
+    pub container_name: String,
     /// When true (default), the supervisor will pull and apply the image
     /// pinned in the Temps binary on every startup. When false, the
     /// currently-running image is left alone — operators upgrade manually
@@ -862,11 +879,19 @@ pub struct PreviewGatewaySettings {
     pub shared_secret: String,
 }
 
+/// Serde default for [`PreviewGatewaySettings::container_name`], so a settings
+/// row written before this field existed deserialises to today's name rather
+/// than to an empty string (which would mean "container named ''").
+fn default_preview_gateway_container() -> String {
+    "temps-preview-gateway".to_string()
+}
+
 impl Default for PreviewGatewaySettings {
     fn default() -> Self {
         Self {
             image: "ghcr.io/gotempsh/temps-preview-gateway@sha256:a16d4346f2f857470fdd28c9ed46809f6db4f7e577888d6250338f8d5dcf04b9".to_string(),
             host_port: 8090,
+            container_name: default_preview_gateway_container(),
             auto_upgrade: true,
             shared_secret: String::new(),
         }

--- a/crates/temps-proxy/src/preview_auth.rs
+++ b/crates/temps-proxy/src/preview_auth.rs
@@ -54,9 +54,28 @@ pub use temps_core::{
     PREVIEW_SESSION_GRANT_TTL, PREVIEW_SESSION_GRANT_VERSION,
 };
 
+/// Default local port the preview gateway listens on, when the instance has
+/// not configured one.
+const DEFAULT_PREVIEW_GATEWAY_PORT: u16 = 8090;
+
 /// The local TCP address where the preview gateway listens. Pingora forwards
 /// authenticated preview requests to this peer.
-pub const PREVIEW_GATEWAY_PEER: &str = "127.0.0.1:8090";
+///
+/// Read per call from `PREVIEW_GATEWAY_HOST_PORT`, which the gateway
+/// supervisor exports at reconcile time from `settings.host_port` — the same
+/// way it exports the shared secret. This used to be a `const` pinned to
+/// 8090, which made `host_port` a setting that moved the container but not
+/// the proxy: previews then 403'd with "missing or invalid
+/// X-Temps-Preview-Token", because the proxy was signing for our gateway and
+/// dialling whatever else held 8090.
+pub fn preview_gateway_peer() -> String {
+    let port = std::env::var("PREVIEW_GATEWAY_HOST_PORT")
+        .ok()
+        .and_then(|v| v.trim().parse::<u16>().ok())
+        .filter(|p| *p != 0)
+        .unwrap_or(DEFAULT_PREVIEW_GATEWAY_PORT);
+    format!("127.0.0.1:{port}")
+}
 
 /// Maximum number of failed auth attempts allowed per (client_ip, sandbox_hex)
 /// inside [`RATE_LIMIT_WINDOW`] before the proxy starts rejecting with 429.

--- a/crates/temps-proxy/src/proxy.rs
+++ b/crates/temps-proxy/src/proxy.rs
@@ -26,9 +26,8 @@ use crate::on_demand::OnDemandManager;
 use crate::preview_auth::{
     build_set_cookie_sandbox, check_preview_auth, combine_cookie_header_values,
     encode_preview_cookie_subject, extract_cookie_values, parse_preview_host,
-    preview_cookie_needs_refresh, preview_peer_group_key, verify_argon2, PreviewAuthLimiter,
-    PreviewAuthOutcome, PreviewHost, PreviewSandboxLookup, SandboxLookupCache,
-    PREVIEW_GATEWAY_PEER,
+    preview_cookie_needs_refresh, preview_gateway_peer, preview_peer_group_key, verify_argon2,
+    PreviewAuthLimiter, PreviewAuthOutcome, PreviewHost, PreviewSandboxLookup, SandboxLookupCache,
 };
 use crate::service::cert_host_cache::CertHostCache;
 use crate::service::challenge_service::ChallengeService;
@@ -5256,13 +5255,14 @@ impl ProxyHttp for LoadBalancer {
             } else {
                 std::time::Duration::from_secs(60)
             };
-            let mut peer = Box::new(HttpPeer::new(PREVIEW_GATEWAY_PEER, false, String::new()));
+            let gateway_peer = preview_gateway_peer();
+            let mut peer = Box::new(HttpPeer::new(gateway_peer.as_str(), false, String::new()));
             peer.group_key = preview_peer_group_key(host);
             peer.options.connection_timeout = Some(std::time::Duration::from_secs(5));
             peer.options.read_timeout = Some(preview_io_timeout);
             peer.options.write_timeout = Some(preview_io_timeout);
             peer.options.idle_timeout = Some(preview_io_timeout);
-            ctx.upstream_host = Some(PREVIEW_GATEWAY_PEER.to_string());
+            ctx.upstream_host = Some(gateway_peer);
             return Ok(peer);
         }
 

--- a/crates/temps-sandbox/src/services/preview_urls.rs
+++ b/crates/temps-sandbox/src/services/preview_urls.rs
@@ -56,38 +56,24 @@ impl PreviewUrlParts {
 }
 
 /// Load preview URL parts from platform settings. Never errors — a
-/// broken settings read falls back to `https://localho.st` so sandbox
+/// broken settings read falls back to the proxy listener so sandbox
 /// endpoints keep working.
 ///
 /// If a second consumer of this logic appears, prefer extracting a shared
 /// `PreviewUrlParts::from_platform_config` helper in `temps-core` rather
 /// than copy-pasting.
 pub async fn load(platform_config: &Arc<ConfigService>) -> PreviewUrlParts {
+    let proxy_port = platform_config.proxy_port();
+
     match platform_config.get_settings().await {
         Ok(s) => {
-            let (protocol, port) = if let Some(ref external_url) = s.external_url {
-                if let Ok(parsed) = url::Url::parse(external_url) {
-                    (parsed.scheme().to_string(), parsed.port())
-                } else if external_url.starts_with("https://") {
-                    ("https".to_string(), None)
-                } else if external_url.starts_with("http://") {
-                    ("http".to_string(), None)
-                } else {
-                    ("https".to_string(), None)
-                }
-            } else {
-                ("https".to_string(), None)
-            };
+            let (protocol, port) = scheme_and_port(s.external_url.as_deref(), proxy_port);
 
             let domain = if s.preview_domain.is_empty() {
                 "localho.st".to_string()
             } else {
                 temps_core::public_base_domain(&s.preview_domain)
             };
-
-            let port = port.filter(|p| {
-                !((protocol == "https" && *p == 443) || (protocol == "http" && *p == 80))
-            });
 
             PreviewUrlParts {
                 protocol,
@@ -96,17 +82,54 @@ pub async fn load(platform_config: &Arc<ConfigService>) -> PreviewUrlParts {
             }
         }
         Err(e) => {
+            let (protocol, port) = scheme_and_port(None, proxy_port);
             tracing::warn!(
-                "failed to load platform settings for sandbox preview URLs: {} — falling back to https://localho.st",
-                e
+                "failed to load platform settings for sandbox preview URLs: {} — falling back to {}://localho.st:{}",
+                e,
+                protocol,
+                proxy_port
             );
             PreviewUrlParts {
-                protocol: "https".to_string(),
+                protocol,
                 domain: "localho.st".to_string(),
-                port: None,
+                port,
             }
         }
     }
+}
+
+/// Decide the scheme and explicit port a preview hostname should carry.
+///
+/// Split out from [`load`] so the rule is testable without a live
+/// `ConfigService` (which needs a database).
+///
+/// With no `external_url` the public port IS the proxy listener port, exactly
+/// as `compute_environment_url` resolves deployment/environment URLs. Assuming
+/// `https` on the implicit :443 instead yields a hostname that only resolves on
+/// an instance already terminating TLS on 443 with a wildcard certificate.
+/// Anywhere else — a local instance on :8080, any self-host on a non-standard
+/// port, an instance whose wildcard DNS isn't set up yet — every preview URL
+/// then points at a port nothing is listening on, and the preview pane never
+/// loads. `proxy_port()` is the single source of truth for that port.
+fn scheme_and_port(external_url: Option<&str>, proxy_port: u16) -> (String, Option<u16>) {
+    let (protocol, port) = match external_url {
+        Some(external_url) => {
+            if let Ok(parsed) = url::Url::parse(external_url) {
+                (parsed.scheme().to_string(), parsed.port())
+            } else if external_url.starts_with("http://") {
+                ("http".to_string(), None)
+            } else {
+                ("https".to_string(), None)
+            }
+        }
+        None => ("http".to_string(), Some(proxy_port)),
+    };
+
+    // An explicit :443/:80 matching the scheme is noise in the hostname.
+    let port =
+        port.filter(|p| !((protocol == "https" && *p == 443) || (protocol == "http" && *p == 80)));
+
+    (protocol, port)
 }
 
 #[cfg(test)]
@@ -137,6 +160,58 @@ mod tests {
             parts.url_for("sbx_deadbeef00001122", 5173),
             "http://ws-deadbeef00001122-5173.example.test:8080"
         );
+    }
+
+    /// The regression this module existed to cause: with no `external_url`
+    /// configured, previews used to be handed `https://…` with no port, i.e.
+    /// :443 — unreachable on every instance not already terminating TLS there,
+    /// which is the default for a fresh self-host.
+    #[test]
+    fn without_external_url_falls_back_to_the_proxy_listener() {
+        assert_eq!(
+            scheme_and_port(None, 8080),
+            ("http".to_string(), Some(8080))
+        );
+
+        let parts = PreviewUrlParts {
+            protocol: "http".to_string(),
+            domain: "localho.st".to_string(),
+            port: Some(8080),
+        };
+        assert_eq!(
+            parts.url_for("sbx_abcd1234ef567890", 5173),
+            "http://ws-abcd1234ef567890-5173.localho.st:8080"
+        );
+    }
+
+    #[test]
+    fn external_url_still_wins_over_the_listener_port() {
+        assert_eq!(
+            scheme_and_port(Some("https://temps.example"), 8080),
+            ("https".to_string(), None)
+        );
+        assert_eq!(
+            scheme_and_port(Some("https://temps.example:8443"), 8080),
+            ("https".to_string(), Some(8443))
+        );
+        assert_eq!(
+            scheme_and_port(Some("http://temps.example:9000"), 8080),
+            ("http".to_string(), Some(9000))
+        );
+    }
+
+    #[test]
+    fn default_ports_are_left_implicit() {
+        assert_eq!(
+            scheme_and_port(Some("https://temps.example:443"), 8080),
+            ("https".to_string(), None)
+        );
+        assert_eq!(
+            scheme_and_port(Some("http://temps.example:80"), 8080),
+            ("http".to_string(), None)
+        );
+        // A proxy genuinely on :80 needs no explicit port either.
+        assert_eq!(scheme_and_port(None, 80), ("http".to_string(), None));
     }
 
     #[test]


### PR DESCRIPTION
## The bug

`PreviewGatewaySettings::host_port` moved the container but not the proxy. The reconciler publishes the gateway on the configured port; `temps-proxy` dialled a hardcoded constant:

```rust
// crates/temps-proxy/src/preview_auth.rs
pub const PREVIEW_GATEWAY_PEER: &str = "127.0.0.1:8090";
```

So any operator who changes that setting breaks every preview with:

> Temps preview gateway: forbidden. missing or invalid `X-Temps-Preview-Token` — only the host-side Temps proxy may reach this gateway

The message points at the token, and the token is the one thing that was fine. The proxy was signing with *this* instance's shared secret and connecting to whatever else happened to hold 8090 — so the receiving gateway correctly rejected a token it had no key for. `host_port` was effectively decorative.

## The fix

Replace the constant with a resolver reading `PREVIEW_GATEWAY_HOST_PORT` (default `8090`):

```rust
pub fn preview_gateway_peer() -> String { ... }
```

The gateway supervisor exports it from `settings.host_port` at reconcile time — **the same mechanism already used for the shared secret**, so the port crosses the crate boundary the way the secret does rather than by a second, different route. It is exported *before* touching Docker, so the proxy learns the correct port even if the reconcile subsequently fails.

## Second fix: per-instance container name

`temps-preview-gateway` was a global name. Two instances on one host fight over it: each inspects the shared container, sees a spec that doesn't match its own settings, recreates it with *its* secret — and breaks the other instance's previews with the same misleading "forbidden" message. This is how the bug was originally hit.

`PreviewGatewaySettings::container_name` defaults to `temps-preview-gateway`, so existing installs are byte-for-byte unaffected. `from_settings`, `inspect_status` and `tail_logs` all resolve through it, so an instance with a custom name no longer tails a container it doesn't own.

## Also

`preview_urls::load` fell back to a hardcoded `https://localho.st` when settings couldn't be read; it now falls back to the proxy listener.

## Verification

Reproduced and fixed on a live instance whose gateway had been moved to `:8190`:

- Before: `GET /` on the workspace host → `Temps preview gateway: forbidden`
- After: reconcile logs `preview gateway ready on 127.0.0.1:8190 → temps-preview-gateway-s10:8080`; the same request returns **200** with 53KB of the app's real HTML
- Both gateways still reject unauthenticated direct hits, so the token check itself is intact

`cargo check` and `cargo clippy -- -D warnings` pass on `temps-core`, `temps-agents`, `temps-proxy`, `temps-sandbox`.

## Note on scope

Six files, no new dependencies, no migration. `container_name` and `host_port` both keep their previous effective values, so this is a no-op for a single-instance install and a fix for anyone running two, or running one on a non-default port.