### PR TITLE
feat(web): deep-link into plugin routes from the console

### DIFF
--- a/web/e2e/authenticated/plugin-deep-link.spec.ts
+++ b/web/e2e/authenticated/plugin-deep-link.spec.ts
@@ -1,0 +1,231 @@
+import { expect, test } from '../fixtures'
+
+/**
+ * An external plugin's own route must survive a copy/paste of the address bar.
+ *
+ * Before this, every plugin URL collapsed to `/plugins/<name>`: the iframe
+ * `src` was fixed, nothing mirrored the plugin's route outward, and the splat
+ * in `<Route path="/plugins/:pluginName/*">` was declared but unread. Sharing
+ * "look at this app" meant sharing a screenshot and directions.
+ *
+ * These specs test the console's half of the contract, not any one plugin's
+ * router. They drive the iframe's `location.hash` directly rather than
+ * clicking plugin UI, so they stay meaningful when the installed plugin
+ * changes — and they skip cleanly on an instance with no plugins at all,
+ * which is the default and must not read as a failure.
+ */
+
+interface PluginManifest {
+  name: string
+  nav: { section: string }[]
+}
+
+/** The first plugin with a platform-section nav entry, or null. */
+async function platformPlugin(
+  request: import('@playwright/test').APIRequestContext
+): Promise<string | null> {
+  const response = await request.get('/api/x/plugins')
+  if (!response.ok()) return null
+  const plugins = (await response.json()) as PluginManifest[]
+  const found = plugins.find((plugin) =>
+    plugin.nav?.some((entry) => entry.section === 'platform')
+  )
+  return found?.name ?? null
+}
+
+/**
+ * The plugin's iframe, once it has actually loaded a document.
+ *
+ * `contentWindow` exists from the moment the element is parsed, pointing at
+ * `about:blank`, so waiting on the element alone races the load and reads a
+ * hash that is always empty.
+ */
+async function pluginFrame(
+  page: import('@playwright/test').Page,
+  name: string
+) {
+  const iframe = page.locator('iframe')
+  await expect(iframe).toHaveCount(1)
+  const frame = await page
+    .frameLocator('iframe')
+    .locator('body')
+    .waitFor({ state: 'attached', timeout: 30_000 })
+    .then(() =>
+      page
+        .frames()
+        .find((candidate) => candidate.url().includes(`/api/x/${name}/`))
+    )
+  expect(frame, `the ${name} plugin iframe should have loaded`).toBeTruthy()
+  return frame!
+}
+
+test.describe('external plugin deep linking', () => {
+  test('a plugin sub-route is restored from a pasted console URL', async ({
+    page,
+    request,
+  }) => {
+    const name = await platformPlugin(request)
+    test.skip(
+      !name,
+      'no external plugin with a platform nav entry is installed'
+    )
+
+    // A route the plugin need not recognise: what is under test is that the
+    // console hands it over, not what the plugin renders for it.
+    await page.goto(`/plugins/${name}/deep/link/probe`)
+
+    const iframe = page.locator('iframe')
+    await expect(iframe).toHaveCount(1)
+
+    // The `src` is built once, at mount, and is the deterministic evidence:
+    // it carries the pasted sub-route into the plugin. Asserting the frame's
+    // live hash instead would race the plugin's own boot-time redirects.
+    await expect(iframe).toHaveAttribute(
+      'src',
+      `/api/x/${name}/ui/#/deep/link/probe`
+    )
+  })
+
+  test("the plugin's own route is mirrored into the console URL", async ({
+    page,
+    request,
+  }) => {
+    const name = await platformPlugin(request)
+    test.skip(
+      !name,
+      'no external plugin with a platform nav entry is installed'
+    )
+
+    await page.goto(`/plugins/${name}`)
+    const frame = await pluginFrame(page, name!)
+
+    await frame.evaluate(() => {
+      window.location.hash = '#/mirrored/route'
+    })
+
+    // The invariant is that the two agree — polled against whatever hash the
+    // plugin settles on, since a plugin is entitled to redirect on arrival and
+    // pinning the literal route would flake on that.
+    await expect
+      .poll(
+        async () => {
+          const hash = await frame.evaluate(() => window.location.hash)
+          const subPath = hash.replace(/^#\/?/, '')
+          return `${new URL(page.url()).pathname}|${subPath}`
+        },
+        {
+          timeout: 15_000,
+          message: 'the console URL should mirror the plugin route',
+        }
+      )
+      .toMatch(new RegExp(`^/plugins/${name}/(.+)\\|\\1$`))
+
+    // ...and it must have actually moved off the bare plugin route, or the
+    // regex above would be satisfied by nothing having happened.
+    expect(new URL(page.url()).pathname).not.toBe(`/plugins/${name}`)
+  })
+
+  test('mirroring a route never reloads the plugin', async ({
+    page,
+    request,
+  }) => {
+    const name = await platformPlugin(request)
+    test.skip(
+      !name,
+      'no external plugin with a platform nav entry is installed'
+    )
+
+    await page.goto(`/plugins/${name}`)
+    const frame = await pluginFrame(page, name!)
+
+    // Anything on the plugin's `window` is lost if the document reloads. This
+    // stands in for what a user would lose: an in-flight chat, a half-filled
+    // form, a running build.
+    await frame.evaluate(() => {
+      ;(window as unknown as Record<string, unknown>).__e2eSurvives = 'yes'
+    })
+
+    for (const route of ['#/one', '#/two', '#/three']) {
+      await frame.evaluate((target) => {
+        window.location.hash = target
+      }, route)
+      await page.waitForTimeout(250)
+    }
+
+    const survived = await frame.evaluate(
+      () => (window as unknown as Record<string, unknown>).__e2eSurvives
+    )
+    expect(
+      survived,
+      'the iframe was reloaded — mirroring must write location.hash, never src'
+    ).toBe('yes')
+
+    // The same guarantee stated structurally: `src` is written once.
+    await expect(page.locator('iframe')).toHaveAttribute(
+      'src',
+      `/api/x/${name}/ui/`
+    )
+  })
+
+  test('a plugin can drive the console URL over postMessage', async ({
+    page,
+    request,
+  }) => {
+    const name = await platformPlugin(request)
+    test.skip(
+      !name,
+      'no external plugin with a platform nav entry is installed'
+    )
+
+    await page.goto(`/plugins/${name}`)
+    const frame = await pluginFrame(page, name!)
+
+    // The escape hatch for plugins that route without a hash.
+    await frame.evaluate(() => {
+      window.parent.postMessage(
+        { type: 'temps:route', path: 'posted/route' },
+        window.location.origin
+      )
+    })
+
+    await page.waitForURL(
+      new RegExp(`/plugins/${name}/posted/route(?:[?#]|$)`),
+      { timeout: 15_000 }
+    )
+
+    // ...and it has to *stay*. A plugin routing by message leaves its hash
+    // permanently empty, and the hash listener re-snapshots that empty value
+    // whenever it re-attaches — which silently reset the URL to the bare
+    // plugin route a beat after the message landed. Caught only because this
+    // spec ran alongside others; alone, the re-attach never happened.
+    await page.waitForTimeout(2_000)
+    expect(new URL(page.url()).pathname).toBe(`/plugins/${name}/posted/route`)
+  })
+
+  test('a message that is not the route contract is ignored', async ({
+    page,
+    request,
+  }) => {
+    const name = await platformPlugin(request)
+    test.skip(
+      !name,
+      'no external plugin with a platform nav entry is installed'
+    )
+
+    await page.goto(`/plugins/${name}`)
+    const frame = await pluginFrame(page, name!)
+    const before = page.url()
+
+    // Shapes the console must not act on: an unrelated message type, and a
+    // well-formed one carrying a non-string path. The address bar is a
+    // capability — anything that can write it needs to be exactly our contract.
+    await frame.evaluate(() => {
+      window.parent.postMessage({ type: 'something:else', path: 'nope' }, '*')
+      window.parent.postMessage({ type: 'temps:route', path: 42 }, '*')
+      window.parent.postMessage('temps:route', '*')
+    })
+
+    await page.waitForTimeout(1_000)
+    expect(page.url()).toBe(before)
+  })
+})

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -525,7 +525,14 @@ const FullAppRoutes = () => {
                   )
                 }}
               >
-                <div className="h-full overflow-y-auto py-2 px-0 sm:p-4">
+                {/* `flex-1 min-h-0`, not `h-full`. `SidebarInset` is a
+                    fixed-height (`h-dvh`) flex column holding the banners,
+                    the header and this; `h-full` resolved to the whole
+                    viewport height rather than what is left after them, so
+                    with a banner showing this box hung past the bottom of
+                    the screen. Anything sized to 100% of it — a plugin
+                    iframe, say — lost its last rows off-screen. */}
+                <div className="flex-1 min-h-0 overflow-y-auto py-2 px-0 sm:p-4">
                   <Routes>
                     {extraRoutes?.map((r) => (
                       <Route key={r.path} path={r.path} element={r.element} />

--- a/web/src/components/command/CommandPalette.tsx
+++ b/web/src/components/command/CommandPalette.tsx
@@ -974,7 +974,8 @@ export function CommandPalette() {
   const [search, setSearch] = useState('')
   const navigate = useNavigate()
   const location = useLocation()
-  const { plugins, projectNavEntries } = usePluginsContext()
+  const { platformNavEntries, settingsNavEntries, projectNavEntries } =
+    usePluginsContext()
   const showFullBrowseCatalog =
     localStorage.getItem('temps:show-full-command-catalog') === 'true'
 
@@ -1135,20 +1136,21 @@ export function CommandPalette() {
     runCommand(command)
   }
 
-  // Build plugin navigation items for the command palette
+  // Build plugin navigation items for the command palette.
+  //
+  // These come from the context's *resolved* entries, not from
+  // `plugins[].nav` — a manifest's own path (`/vibe`) matches no console
+  // route, so mapping the manifests here sent every plugin command to a 404
+  // while the sidebar, which uses the resolved entries, worked.
   const pluginNavItems: NavigationItem[] = useMemo(
     () =>
-      plugins.flatMap((p) =>
-        p.nav
-          .filter((e) => e.section !== 'project')
-          .map((entry) => ({
-            title: entry.label,
-            url: entry.path,
-            icon: resolvePluginIcon(entry.icon),
-            keywords: ['plugin', p.name, entry.label.toLowerCase()],
-          }))
-      ),
-    [plugins]
+      [...platformNavEntries, ...settingsNavEntries].map((entry) => ({
+        title: entry.label,
+        url: entry.path,
+        icon: resolvePluginIcon(entry.icon),
+        keywords: ['plugin', entry.pluginName, entry.label.toLowerCase()],
+      })),
+    [platformNavEntries, settingsNavEntries]
   )
 
   // Project-scoped plugin nav entries (relative URLs, prefixed at render time)

--- a/web/src/components/command/CommandPalette.tsx
+++ b/web/src/components/command/CommandPalette.tsx
@@ -1139,7 +1139,7 @@ export function CommandPalette() {
   // Build plugin navigation items for the command palette.
   //
   // These come from the context's *resolved* entries, not from
-  // `plugins[].nav` — a manifest's own path (`/vibe`) matches no console
+  // `plugins[].nav` — a manifest's own path (`/builder`) matches no console
   // route, so mapping the manifests here sent every plugin command to a 404
   // while the sidebar, which uses the resolved entries, worked.
   const pluginNavItems: NavigationItem[] = useMemo(

--- a/web/src/contexts/PluginsContext.tsx
+++ b/web/src/contexts/PluginsContext.tsx
@@ -1,18 +1,24 @@
 import { createContext, useContext, useMemo, type ReactNode } from 'react'
 import { usePlugins } from '@/hooks/usePlugins'
-import type { PluginManifest, NavEntry } from '@/types/plugins'
+import type { PluginManifest, ResolvedNavEntry } from '@/types/plugins'
 
 interface PluginsContextType {
-  /** All loaded external plugin manifests */
+  /**
+   * All loaded external plugin manifests.
+   *
+   * For navigation use the `*NavEntries` below instead: a manifest's own
+   * `nav[].path` is the plugin's internal route and does not match the
+   * console's router.
+   */
   plugins: PluginManifest[]
   /** Whether the initial fetch is still loading */
   isLoading: boolean
   /** Nav entries for the platform sidebar section, sorted by order */
-  platformNavEntries: NavEntry[]
+  platformNavEntries: ResolvedNavEntry[]
   /** Nav entries for the settings sidebar section, sorted by order */
-  settingsNavEntries: NavEntry[]
+  settingsNavEntries: ResolvedNavEntry[]
   /** Nav entries for the project detail sidebar, sorted by order */
-  projectNavEntries: NavEntry[]
+  projectNavEntries: ResolvedNavEntry[]
   /** Get a plugin manifest by name */
   getPlugin: (name: string) => PluginManifest | undefined
 }
@@ -24,11 +30,12 @@ export function PluginsProvider({ children }: { children: ReactNode }) {
 
   // Build nav entries with resolved paths: /plugins/{pluginName} for
   // platform/settings sections so they match the <Route path="/plugins/:pluginName/*"> in App.tsx
-  const resolvedEntries = useMemo(
+  const resolvedEntries = useMemo<ResolvedNavEntry[]>(
     () =>
       plugins.flatMap((p) =>
         p.nav.map((entry) => ({
           ...entry,
+          pluginName: p.name,
           path:
             entry.section === 'project'
               ? entry.path // Project entries stay relative

--- a/web/src/pages/plugins/PluginPage.tsx
+++ b/web/src/pages/plugins/PluginPage.tsx
@@ -46,20 +46,28 @@ export function PluginPage() {
   const iframeSrc = `/api/x/${plugin.name}/ui/`
 
   return (
-    <div className="flex flex-col h-[calc(100vh-4rem)]">
-      {/* Compact header */}
-      <div className="flex items-center gap-2 px-4 py-2 border-b bg-background shrink-0">
-        <div className="flex h-7 w-7 items-center justify-center rounded-md bg-muted">
-          <Icon className="h-4 w-4" />
+    // `h-full`, not `h-[calc(100vh-4rem)]`. The old value assumed exactly
+    // one 4rem strip of console chrome above; the disk-space and
+    // update-available banners are dismissible and stack, so whenever one
+    // showed, the frame ran past the bottom of the window and the plugin
+    // lost its last rows — for a chat UI, that is the composer.
+    <div className="flex flex-col h-full min-h-0">
+      {/* Header, unless the plugin renders its own — see
+          `PluginManifest::hide_header`. */}
+      {!plugin.hide_header && (
+        <div className="flex items-center gap-2 px-4 py-2 border-b bg-background shrink-0">
+          <div className="flex h-7 w-7 items-center justify-center rounded-md bg-muted">
+            <Icon className="h-4 w-4" />
+          </div>
+          <h1 className="text-sm font-medium">{displayName}</h1>
+          <span className="text-xs text-muted-foreground font-mono">
+            v{plugin.version}
+          </span>
+          {isLoading && (
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground ml-auto" />
+          )}
         </div>
-        <h1 className="text-sm font-medium">{displayName}</h1>
-        <span className="text-xs text-muted-foreground font-mono">
-          v{plugin.version}
-        </span>
-        {isLoading && (
-          <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground ml-auto" />
-        )}
-      </div>
+      )}
 
       {/* iframe container */}
       {hasError ? (
@@ -79,10 +87,19 @@ export function PluginPage() {
           ref={iframeRef}
           src={iframeSrc}
           title={`${displayName} plugin`}
-          className="flex-1 w-full border-0"
+          className="flex-1 min-h-0 w-full border-0"
           onLoad={handleLoad}
           onError={handleError}
-          sandbox="allow-scripts allow-forms allow-same-origin allow-popups"
+          // `allow-top-navigation-by-user-activation` lets a plugin link the
+          // user back into the console — a plugin whose feature depends on
+          // operator configuration has to be able to say "set it up here"
+          // and have the link work. Without it such links silently do
+          // nothing, which reads as a broken button.
+          //
+          // The `-by-user-activation` form, not the blanket one: navigation
+          // is only permitted as the direct result of a click, so a plugin
+          // cannot redirect the console on its own.
+          sandbox="allow-scripts allow-forms allow-same-origin allow-popups allow-top-navigation-by-user-activation"
         />
       )}
     </div>

--- a/web/src/pages/plugins/PluginPage.tsx
+++ b/web/src/pages/plugins/PluginPage.tsx
@@ -1,29 +1,210 @@
 import { usePluginsContext } from '@/contexts/PluginsContext'
 import { resolvePluginIcon } from '@/lib/pluginIcons'
 import { Loader2 } from 'lucide-react'
-import { useCallback, useRef, useState } from 'react'
-import { useParams } from 'react-router'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useLocation, useNavigate, useParams } from 'react-router'
 
 /**
  * Renders an external plugin's UI inside an iframe.
  *
  * The plugin serves its own HTML/JS/CSS at `/api/x/{pluginName}/ui/`.
- * This component wraps it in a full-height iframe that communicates
- * via postMessage for theme and navigation events.
+ *
+ * ## Deep linking
+ *
+ * A plugin's own route is mirrored into the console's address bar, so
+ * `/plugins/vibetemps/app/21` is a real, copyable link that reopens the
+ * plugin exactly where it was. Without this every plugin URL collapsed to
+ * `/plugins/vibetemps`, and sharing "look at this app" meant sharing a
+ * screenshot and a sentence of directions.
+ *
+ * Two mechanisms, because plugins route in two different ways:
+ *
+ * 1. **Hash routers, zero configuration.** The iframe is same-origin (it is
+ *    served from `/api/x/...` on this origin), so the console can read and
+ *    write `contentWindow.location.hash` directly and listen for
+ *    `hashchange`. A plugin using a hash router — the common choice for
+ *    something mounted under an arbitrary prefix — gets deep linking without
+ *    knowing this exists.
+ *
+ * 2. **`postMessage`, for everything else.** A plugin using history routing
+ *    (or one that simply wants control) posts
+ *    `{ type: 'temps:route', path: 'app/21' }` and receives
+ *    `{ type: 'temps:navigate', path }` when the user goes back or forward.
+ *
+ * Both are guarded against feedback loops by `syncedPathRef`: whichever side
+ * moved last records the path, and the opposite direction ignores it.
  */
 export function PluginPage() {
-  const { pluginName } = useParams<{ pluginName: string }>()
+  const { pluginName, '*': pluginPath } = useParams<{
+    pluginName: string
+    '*': string
+  }>()
   const { getPlugin } = usePluginsContext()
+  const navigate = useNavigate()
+  const location = useLocation()
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [hasError, setHasError] = useState(false)
 
   const plugin = pluginName ? getPlugin(pluginName) : undefined
 
-  const handleLoad = useCallback(() => {
-    setIsLoading(false)
-  }, [])
+  /**
+   * The path last propagated in either direction.
+   *
+   * Both syncs write it before acting, so the change they cause arrives back
+   * as a no-op instead of bouncing forever between the console's router and
+   * the plugin's.
+   */
+  const syncedPathRef = useRef<string | undefined>(pluginPath)
 
+  /**
+   * Whether this plugin has declared its route over `postMessage`.
+   *
+   * Latches on the first `temps:route` and never clears: a plugin does not
+   * switch routing strategy mid-session, and treating it as a one-way door is
+   * what keeps the hash listener from clobbering an explicitly-sent path.
+   */
+  const routesByMessageRef = useRef(false)
+
+  /**
+   * The sub-route this page was opened at, frozen at mount.
+   *
+   * The iframe `src` is derived from it and must never be recomputed as the
+   * route changes: assigning `src` reloads the document, so mirroring a
+   * navigation back into it would restart the plugin — losing an in-flight
+   * chat, a half-filled form, a running build — on every click. Later
+   * navigation goes through `location.hash` or `postMessage`, neither of
+   * which reloads.
+   *
+   * State rather than a ref because the manifest list is still loading on the
+   * first render, so the value has to survive until `plugin` resolves, and
+   * reading a ref during render is what actually renders the `src`.
+   */
+  const [initialPath] = useState(() => pluginPath ?? '')
+
+  /** The console URL for a path inside this plugin. */
+  const consoleUrlFor = useCallback(
+    (path: string) =>
+      path ? `/plugins/${pluginName}/${path}` : `/plugins/${pluginName}`,
+    [pluginName]
+  )
+
+  /**
+   * Plugin → console. Mirror the plugin's route into the address bar.
+   *
+   * `replace`, not `push`: an iframe navigation already contributes to the
+   * joint session history, so pushing here would make the browser's back
+   * button need two presses for one step inside the plugin.
+   */
+  const adoptPluginPath = useCallback(
+    (path: string) => {
+      if (path === syncedPathRef.current) return
+      syncedPathRef.current = path
+      navigate(consoleUrlFor(path), { replace: true })
+    },
+    [consoleUrlFor, navigate]
+  )
+
+  // ---- 1. Hash routers: read the iframe's own location -------------------
+  useEffect(() => {
+    const win = iframeRef.current?.contentWindow
+    if (!win) return
+
+    const readHash = () => {
+      try {
+        return win.location.hash.replace(/^#\/?/, '')
+      } catch {
+        // Cross-origin: a plugin served from somewhere other than this
+        // origin. Not an error — it simply has to use `postMessage`.
+        return undefined
+      }
+    }
+
+    const onHashChange = () => {
+      // A plugin that has spoken `temps:route` owns its routing; its hash is
+      // not where its route lives, and reading it would fight the messages.
+      if (routesByMessageRef.current) return
+      const path = readHash()
+      if (path !== undefined) adoptPluginPath(path)
+    }
+
+    // Snapshot on attach, because the plugin may have redirected during boot
+    // (a bare `/ui/` landing on `#/apps`) and that destination is what belongs
+    // in the address bar.
+    //
+    // Only a non-empty hash, though. This effect re-runs whenever it is
+    // re-attached, and an empty hash carries no routing information — so
+    // snapshotting one would reset the URL to the bare plugin route every
+    // time, silently undoing a path that arrived over `postMessage`. A
+    // *hashchange event* to empty is different: that is a hash router
+    // genuinely navigating to its root, and `onHashChange` still honours it.
+    const settled = readHash()
+    if (!routesByMessageRef.current && settled) adoptPluginPath(settled)
+
+    win.addEventListener('hashchange', onHashChange)
+    return () => win.removeEventListener('hashchange', onHashChange)
+    // Re-attached after every load: navigating the iframe replaces its
+    // window, and listeners do not survive that.
+  }, [adoptPluginPath, isLoading])
+
+  // ---- 2. postMessage: for plugins that route without a hash -------------
+  useEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      // Same-origin only. The iframe is served from this origin, so anything
+      // from elsewhere is not our plugin and must not be able to steer the
+      // console's address bar.
+      if (event.origin !== window.location.origin) return
+      if (event.source !== iframeRef.current?.contentWindow) return
+
+      const data = event.data as { type?: string; path?: string } | null
+      if (data?.type !== 'temps:route' || typeof data.path !== 'string') return
+
+      // From here on this plugin routes explicitly, so the hash listener
+      // stands down. The two channels are alternatives, not a fallback chain:
+      // a history-router plugin leaves its hash permanently empty, and letting
+      // that empty value keep mirroring would erase every route it sends.
+      routesByMessageRef.current = true
+      adoptPluginPath(data.path.replace(/^\/+/, ''))
+    }
+
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [adoptPluginPath])
+
+  // ---- 3. Console → plugin: back, forward, and pasted links --------------
+  useEffect(() => {
+    const path = pluginPath ?? ''
+    if (path === (syncedPathRef.current ?? '')) return
+    syncedPathRef.current = path
+
+    const win = iframeRef.current?.contentWindow
+    if (!win) return
+
+    // Tell a postMessage-based plugin either way; it is a no-op for one that
+    // does not listen, and the fragment navigation below is a no-op for one
+    // that does not use hashes.
+    win.postMessage({ type: 'temps:navigate', path }, window.location.origin)
+    try {
+      // `location.replace` rather than assigning `location.hash`. A URL that
+      // differs only in its fragment is a same-document navigation either
+      // way — no reload — but `replace` overwrites the iframe's current
+      // history entry instead of pushing a new one. That matches the
+      // `replace: true` used on the console side, so one user-visible move
+      // stays one press of the back button rather than two.
+      const target = new URL(win.location.href)
+      target.hash = path ? `#/${path}` : ''
+      if (target.href !== win.location.href) win.location.replace(target.href)
+    } catch {
+      // Cross-origin plugin: the postMessage above was the only channel.
+    }
+  }, [pluginPath, location.key])
+
+  // Declared here, not inline in the JSX below: everything after this point is
+  // past the `if (!plugin)` early return, and a hook called there runs only on
+  // the renders where a plugin happens to be resolved. React counts hooks
+  // positionally, so the first render that finds one blows up the whole tree —
+  // which shows up as a blank page, not an error boundary.
+  const handleLoad = useCallback(() => setIsLoading(false), [])
   const handleError = useCallback(() => {
     setIsLoading(false)
     setHasError(true)
@@ -39,11 +220,8 @@ export function PluginPage() {
 
   const Icon = resolvePluginIcon(plugin.nav[0]?.icon ?? 'puzzle')
   const displayName = plugin.display_name ?? plugin.name
-
-  // The plugin UI is served by the plugin itself, proxied through the standard
-  // API proxy at /api/x/{name}/. This works in both dev (rsbuild proxies /api)
-  // and production (SPA fallback skips /api/ paths).
-  const iframeSrc = `/api/x/${plugin.name}/ui/`
+  const base = `/api/x/${plugin.name}/ui/`
+  const iframeSrc = initialPath ? `${base}#/${initialPath}` : base
 
   return (
     // `h-full`, not `h-[calc(100vh-4rem)]`. The old value assumed exactly

--- a/web/src/pages/plugins/PluginPage.tsx
+++ b/web/src/pages/plugins/PluginPage.tsx
@@ -12,9 +12,9 @@ import { useLocation, useNavigate, useParams } from 'react-router'
  * ## Deep linking
  *
  * A plugin's own route is mirrored into the console's address bar, so
- * `/plugins/vibetemps/app/21` is a real, copyable link that reopens the
+ * `/plugins/builder/app/21` is a real, copyable link that reopens the
  * plugin exactly where it was. Without this every plugin URL collapsed to
- * `/plugins/vibetemps`, and sharing "look at this app" meant sharing a
+ * `/plugins/builder`, and sharing "look at this app" meant sharing a
  * screenshot and a sentence of directions.
  *
  * Two mechanisms, because plugins route in two different ways:

--- a/web/src/pages/settings/PluginsPage.tsx
+++ b/web/src/pages/settings/PluginsPage.tsx
@@ -19,6 +19,7 @@ import {
   RefreshCw,
 } from 'lucide-react'
 import { useEffect } from 'react'
+import { Link } from 'react-router'
 import { toast } from 'sonner'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 
@@ -144,6 +145,22 @@ export function PluginsPage() {
                     >
                       Running
                     </Badge>
+                    {/* A plugin listed here with no way to reach it sends the
+                        user hunting through the sidebar.
+
+                        Gated on the nav entry, not on `plugin.ui`: that field
+                        describes a *declared* bundle, and a plugin can serve
+                        its UI from `/ui/` without one (vibetemps does, and
+                        reports `ui: null`). What actually makes a plugin
+                        reachable is a platform/settings nav entry — those are
+                        what `/plugins/:pluginName` routes to. Project-scoped
+                        entries live under a project and have no address from
+                        here. */}
+                    {plugin.nav.some((e) => e.section !== 'project') && (
+                      <Button asChild variant="outline" size="sm">
+                        <Link to={`/plugins/${plugin.name}`}>Open</Link>
+                      </Button>
+                    )}
                   </div>
                 </div>
               ))}

--- a/web/src/pages/settings/PluginsPage.tsx
+++ b/web/src/pages/settings/PluginsPage.tsx
@@ -150,7 +150,7 @@ export function PluginsPage() {
 
                         Gated on the nav entry, not on `plugin.ui`: that field
                         describes a *declared* bundle, and a plugin can serve
-                        its UI from `/ui/` without one (vibetemps does, and
+                        its UI from `/ui/` without one (some plugins do, and
                         reports `ui: null`). What actually makes a plugin
                         reachable is a platform/settings nav entry — those are
                         what `/plugins/:pluginName` routes to. Project-scoped

--- a/web/src/types/plugins.ts
+++ b/web/src/types/plugins.ts
@@ -20,6 +20,22 @@ export interface NavEntry {
   order: number
 }
 
+/**
+ * A nav entry whose `path` has been rewritten to a route the console can
+ * actually navigate to.
+ *
+ * A manifest's `path` is the plugin's *own* route (`/vibe`), which matches
+ * nothing in the console's router — platform and settings entries are served
+ * by `/plugins/:pluginName`. Consumers must use these, never `PluginManifest.nav`
+ * directly, or they send the user to a 404. `pluginName` is carried along so a
+ * consumer that needs the owning plugin (search keywords, icons) doesn't have
+ * to re-join against the manifest list to get it.
+ */
+export interface ResolvedNavEntry extends NavEntry {
+  /** `name` of the plugin that contributed this entry. */
+  pluginName: string
+}
+
 /** A client-side route provided by the plugin UI. */
 export interface UiRoute {
   /** Route path pattern (e.g., "/my-plugin/:id") */
@@ -56,4 +72,10 @@ export interface PluginManifest {
   requires_db: boolean
   /** Health check endpoint path (relative to plugin root) */
   health_path: string
+  /**
+   * Suppress the console's header strip above this plugin's UI, for plugins
+   * that render their own. Optional: a plugin built against an older SDK
+   * omits it entirely, and `undefined` means "show the header".
+   */
+  hide_header?: boolean
 }

--- a/web/src/types/plugins.ts
+++ b/web/src/types/plugins.ts
@@ -24,7 +24,7 @@ export interface NavEntry {
  * A nav entry whose `path` has been rewritten to a route the console can
  * actually navigate to.
  *
- * A manifest's `path` is the plugin's *own* route (`/vibe`), which matches
+ * A manifest's `path` is the plugin's *own* route (`/builder`), which matches
  * nothing in the console's router — platform and settings entries are served
  * by `/plugins/:pluginName`. Consumers must use these, never `PluginManifest.nav`
  * directly, or they send the user to a 404. `pluginName` is carried along so a


### PR DESCRIPTION
## What's missing today

An installed plugin is reachable, but its *internal* state isn't. The console mounts a plugin at `/plugins/{name}` and stops there:

- Navigating inside the plugin doesn't change the console URL, so **there is no copyable link to anything a plugin shows**. Sharing "look at this" meant sharing the plugin's front door and a description of how to get back.
- A browser reload drops you at the plugin root, losing wherever you were.
- Command-palette entries built from `plugins[].nav` used the *manifest's* own path (e.g. `/builder`), which matches no console route — so selecting one navigated nowhere useful.
- The settings list showed installed plugins with no way to open one.
- Routed pages overflowed the viewport when a banner was shown, cutting off the bottom rows — which for a plugin rendering a chat UI is the composer.

## What this does

Four commits, all in `web/`:

- **`fix(web)`** — stop routed pages overflowing when banners are shown.
- **`feat(web)`** — open an installed plugin from the settings list.
- **`fix(web)`** — send command-palette plugin entries to the *mounted* console route rather than the manifest's own path.
- **`feat(web)`** — restore a plugin's own route from the console URL, so `/plugins/{name}/app/21` is a real, copyable, reload-safe link.

Plus a comments-only commit replacing a specific first-party plugin's name in the illustrative examples with a generic one — a reader of this repo has no reason to know that plugin, and the behaviour described is the same for any of them.

## Tests

Includes `web/e2e/authenticated/plugin-deep-link.spec.ts` (231 lines) covering the round trip: deep link in → plugin restores its route → console URL tracks navigation → reload lands in the same place.

## Verification

- `bunx tsc --noEmit` — **0 errors**
- `bun test src` — **358 pass, 0 fail**
- `eslint` on every touched file — clean apart from one pre-existing error, `Cannot create components during render` in `PluginPage.tsx`. I confirmed it is **not introduced here**: the same `const Icon = resolvePluginIcon(...)` → `<Icon />` pattern is on `main` today and fails identically (`main` at `53:12`, here at `238:14` after the rewrite moved it). Left alone rather than folded into an unrelated PR.

## Note

These commits already existed on a long-running local branch and had simply never been upstreamed. Cherry-picked onto current `main` rather than merged, so the PR contains only this work — no unrelated in-flight changes came along.