### PR TITLE
perf(cli): build the serve runtime once, before the database pool

### DIFF
--- a/crates/temps-cli/src/commands/serve/mod.rs
+++ b/crates/temps-cli/src/commands/serve/mod.rs
@@ -189,7 +189,20 @@ impl ServeCommand {
         let cookie_crypto = Arc::new(temps_core::CookieCrypto::new(&serve_config.auth_secret)?);
 
         debug!("Initializing database connection...");
-        // Create tokio runtime for database connection since we need async for this
+        // THE long-lived runtime for this process. It runs the startup
+        // `block_on`s just below, and later the index build, the backfill, the
+        // listeners and the console (`rt.spawn` further down). It is never
+        // dropped -- the process ends while pingora holds this thread.
+        //
+        // It is deliberately built HERE, *before* the pool, rather than as a
+        // second runtime after startup: the pool has to be created on the
+        // runtime that will keep driving it. sqlx spawns a pool-maintenance
+        // task when the pool is constructed, and every socket the pool opens
+        // (`min_connections`, plus the connection migrations run on) registers
+        // with the creating runtime's IO driver. A startup-only runtime would
+        // leave both stranded -- the maintenance task unpolled and the pooled
+        // sockets bound to a driver nothing runs -- and the first query issued
+        // from the main runtime would hang forever.
         let rt = tokio::runtime::Runtime::new()?;
         let db = rt.block_on(temps_database::establish_connection(&self.database_url))?;
 
@@ -306,8 +319,6 @@ impl ServeCommand {
         // worker nodes that don't share this queue.) Keep it alive on the stack.
         let route_reload_subscriber =
             temps_routes::RouteReloadSubscriber::new(route_table.clone(), queue.clone());
-
-        let rt = tokio::runtime::Runtime::new()?;
 
         // Run non-transactional indexes and the TimescaleDB backfill on this
         // long-lived runtime, detached. Index creation retries with capped

--- a/crates/temps-cli/src/commands/serve/mod.rs
+++ b/crates/temps-cli/src/commands/serve/mod.rs
@@ -191,8 +191,10 @@ impl ServeCommand {
         debug!("Initializing database connection...");
         // THE long-lived runtime for this process. It runs the startup
         // `block_on`s just below, and later the index build, the backfill, the
-        // listeners and the console (`rt.spawn` further down). It is never
-        // dropped -- the process ends while pingora holds this thread.
+        // listeners and the console (`rt.spawn` further down). It stays alive
+        // until `serve` returns: under `--role=all` that is when pingora stops
+        // blocking this thread, and under `--role=console` when the console
+        // future it is blocking on finishes.
         //
         // It is deliberately built HERE, *before* the pool, rather than as a
         // second runtime after startup: the pool has to be created on the


### PR DESCRIPTION
## Description

### Summary

`temps serve` built two multi-threaded tokio runtimes. The first (`serve/mod.rs:193`) ran the three startup `block_on`s (database connection, private-address setting, console version) and was then never used again. The second, created ~120 lines later, is the long-lived one that drives the index build, the backfill, the listeners and the console.

The first was never dropped. Shadowing a binding does not drop the shadowed value: it stays alive, unreachable, until the end of scope, and drops run in reverse declaration order. Since the function only returns when serving ends, that runtime's worker threads (one per CPU, via `available_parallelism()`) lived for essentially the whole process doing nothing.

This builds the long-lived runtime up front and uses it for the startup work too, deleting the second runtime.

### Why it is safe

The runtime has to stay multi-threaded, and it has to be created before the pool rather than after. Shrinking the startup runtime to `new_current_thread()`, the obvious-looking alternative, silently breaks the server:

- `sqlx` spawns a pool-maintenance task when the pool is constructed (`sqlx-core-0.8.6` `pool/inner.rs:70` -> `spawn_maintenance_tasks` -> `rt::spawn`). `establish_connection` sets `.idle_timeout(600s)`, so it takes the long-lived looping branch.
- Every socket the pool opens registers with the creating runtime's IO driver. `.min_connections(5)` means five sockets, plus the connection migrations run on, are bound to that runtime.

If the creating runtime stops being driven, both are stranded and the first query issued from the main runtime hangs forever. Reproduced with the real sea-orm pool, the real pool options and a real PostgreSQL, A/B/A/B:

```
[multi]   query from runtime B: OK               => WORKS
[current] query from runtime B: TIMED OUT (10s)  => BROKEN
[multi]   query from runtime B: OK               => WORKS
[current] query from runtime B: TIMED OUT (10s)  => BROKEN
```

Creating the pool on the runtime that will keep driving it avoids the whole class of problem, which is why this moves the runtime up rather than shrinking it.

The similar-looking startup runtime in `serve/proxy.rs` is deliberately left alone. It builds the on-demand TLS cert manager, whose `spawn_consumer` calls `tokio::spawn`, and pingora then blocks the thread. Converting it would leave the TLS callback's `try_enqueue` jobs unprocessed, a silent failure that only appears when on-demand TLS is configured. Same hazard, different mechanism, out of scope here.

Nothing else in the moved runtime's scope needs to outlive its `block_on`, and all later `rt.spawn` calls land on the same runtime they always did.

### Cost

Local PostgreSQL 16 with TimescaleDB and pgvector, `serve --role=all`, sampled from `/proc/<pid>/status` 8s after `✅ Console API is ready`. No swap on the box, so RSS cannot be hidden. Runs interleaved A/B.

4-CPU machine, 4 runs each:

| | threads | tokio workers | VmRSS | RssAnon | ready |
|---|---|---|---|---|---|
| before | 29.8 | 17.8 | 408.1 MB | 204.8 MB | 2.00 s |
| after | 25.2 | 13.2 | 408.2 MB | 204.2 MB | 2.00 s |

With `TOKIO_WORKER_THREADS=24`, to show how it scales on a bigger box, 3 runs each:

| | threads | tokio workers | VmRSS | RssAnon | ready |
|---|---|---|---|---|---|
| before | 89.0 | 77.0 | 412.3 MB | 209.1 MB | 2.32 s |
| after | 65.7 | 53.7 | 410.8 MB | 207.6 MB | 2.21 s |

The thread saving is exactly one runtime's worth and is deterministic: -4 workers natively, -24 at `TOKIO_WORKER_THREADS=24` (77 -> 53 in every run).

**The memory saving is not measurable, and this PR should not be sold as one.** Even with 24 threads removed the VmRSS delta is -1.4 MB against a 3.6 MB spread between runs, which is noise. Startup time is unchanged.

The case here is hygiene: an entire multi-threaded runtime was held for the life of the process to do nothing, and its cost grows linearly with CPU count with no ceiling. On the documented minimum (2 cores) it saves 2 threads; on a 24-core box, 24.

### Validation

- `cargo check --lib`: clean, no code warnings.
- `cargo fmt --check`: clean.
- `temps serve` brought fully up against a real PostgreSQL + TimescaleDB and driven to `✅ Console API is ready` on both binaries, 7 runs each, exercising migrations, index build, backfill, listeners, proxy bind and console on the consolidated runtime.
- CI green: unit tests, every integration shard, MariaDB PITR E2E, E2E deployment tests, all seven scenario E2E suites, clippy, formatting and the musl build. The E2E and scenario suites boot the real server.

Note for a follow-up, not addressed here: `serve/mod.rs` still builds a third multi-threaded runtime for the Docker capability probe, and `serve/proxy.rs` its own.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I have written tests that cover the changes. No new tests: this removes a redundant runtime without changing any API or behaviour, and thread count over process lifetime is not unit-testable. Validated by direct measurement instead.
- [x] All new and existing tests pass (`cargo test --lib`)
- [x] `cargo check --lib` passes with no warnings
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have updated documentation where necessary; the reasoning is captured in a comment at the runtime's construction site

## Related issues

None.
