### PR TITLE
fix(compose): make sandbox capability denials and override rejections actionable

### DIFF
--- a/crates/temps-deployer/src/compose.rs
+++ b/crates/temps-deployer/src/compose.rs
@@ -51,6 +51,57 @@ const CONTAINER_SECRETS_DIR: &str = "/run/secrets";
 /// Maximum diagnostic text persisted into a deployment error. Full container
 /// logs remain available through the authenticated logs endpoint.
 const MAX_COMPOSE_DIAGNOSTIC_BYTES: usize = 32 * 1024;
+
+/// Where the console exposes the per-service "Elevated permissions" toggle.
+/// Named once here because two places quote it — the pre-deploy advisory in
+/// `temps-deployments::jobs::deploy_compose` and the post-failure remediation
+/// in [`ComposeExecutor::capability_denial_remediation`]. A UI reshuffle that
+/// updated only one of them would send half of users to a page that no longer
+/// exists.
+pub const ELEVATED_PERMISSIONS_SETTINGS_PATH: &str = "Project Settings → Git → Compose services";
+
+/// Keys an inline override may not set because [`ComposeExecutor`]'s
+/// deploy-time security policy rejects them outright, wherever they appear.
+/// Telling someone to move one of these into the repository compose file would
+/// be sending them to do work that fails later, at deploy, with a different
+/// error. Mirrors `temps-presets::docker_compose::NEVER_ALLOWED_SERVICE_KEYS`,
+/// which guards the same override on the preview path.
+const NEVER_ALLOWED_OVERRIDE_KEYS: &[&str] = &[
+    "privileged",
+    "cgroup_parent",
+    "cap_add",
+    "devices",
+    "device_cgroup_rules",
+    "security_opt",
+    "sysctls",
+    "volumes_from",
+    "group_add",
+    "runtime",
+    "oom_kill_disable",
+    "tmpfs",
+    "ulimits",
+];
+
+/// Keys an inline override may not set, but which the repository compose file
+/// legitimately can — [`ComposeExecutor::validate_compose_security_policy`]
+/// admits them subject to its own checks (bind-mount path confinement for
+/// `volumes`, byte caps for `shm_size`, host-namespace rejection for
+/// `pid`/`ipc`/`network_mode` and friends). Kept separate from
+/// [`NEVER_ALLOWED_OVERRIDE_KEYS`] so the error can point somewhere that
+/// actually works instead of issuing the same blanket "move it to the
+/// repository" advice for every key.
+const REPO_ONLY_OVERRIDE_KEYS: &[&str] = &[
+    "network_mode",
+    "pid",
+    "ipc",
+    "uts",
+    "cgroup",
+    "userns_mode",
+    "cap_drop",
+    "volumes",
+    "shm_size",
+    "labels",
+];
 const SAFE_DOCKER_PATH: &str = "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin";
 const DOCKER_BINARY_CANDIDATES: &[&str] = &[
     "/usr/local/bin/docker",
@@ -213,6 +264,50 @@ fn render_env_file(vars: &HashMap<String, String>) -> Result<String, ComposeErro
         rendered.push('\n');
     }
     Ok(rendered)
+}
+
+/// True when a container's log tail shows its entrypoint being denied a
+/// privileged startup operation — the signature of Temps' own `cap_drop: ALL`
+/// sandbox rather than a fault in the image or the user's configuration.
+///
+/// The official postgres/mysql/mariadb/mongo entrypoints (and others, e.g.
+/// Gitea) start as root, `chown`/`chmod` their data directory, then drop to a
+/// service user via `gosu`/`su-exec`. All three steps need capabilities the
+/// sandbox removes, so they fail with `EPERM` unless the service is listed in
+/// `relaxed_capability_services`.
+///
+/// Deliberately a two-factor match: "operation not permitted" on its own
+/// appears in plenty of ordinary application errors, and pointing those at a
+/// capability toggle that cannot help would be worse than saying nothing.
+/// Requiring a privileged-operation verb alongside it keeps the hint tied to
+/// the failure mode it actually explains.
+fn looks_like_capability_denial(logs: &str) -> bool {
+    const PRIVILEGED_OPERATIONS: [&str; 8] = [
+        "chmod",
+        "chown",
+        "setgroups",
+        "setuid",
+        "setgid",
+        "failed switching to",
+        "su-exec",
+        "gosu",
+    ];
+
+    let lower = logs.to_ascii_lowercase();
+    lower.contains("operation not permitted")
+        && PRIVILEGED_OPERATIONS
+            .iter()
+            .any(|operation| lower.contains(operation))
+}
+
+/// Render service names as a quoted, comma-separated list so a remediation
+/// message reads the same for one service as for several.
+fn quote_service_list(services: &[&String]) -> String {
+    services
+        .iter()
+        .map(|service| format!("'{service}'"))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Every literal value a Compose deployment knows to be sensitive, gathered
@@ -896,8 +991,14 @@ impl ComposeExecutor {
         // If a user-provided `container_name` conflicts with an existing
         // container, let Compose report the conflict instead of deleting
         // containers outside this Temps project boundary.
-        self.compose_up(&effective_dir, &project_name, compose_file, &redact_values)
-            .await?;
+        self.compose_up(
+            &effective_dir,
+            &project_name,
+            compose_file,
+            &redact_values,
+            &request.relaxed_capability_services,
+        )
+        .await?;
 
         // 3b. `up -d` returns as soon as containers are created/started, not
         // once they're actually ready. Wait for every service to reach
@@ -909,6 +1010,7 @@ impl ComposeExecutor {
             &project_name,
             compose_file,
             &redact_values,
+            &request.relaxed_capability_services,
             COMPOSE_READY_TIMEOUT,
         )
         .await?;
@@ -3257,38 +3359,26 @@ impl ComposeExecutor {
             });
         };
 
-        const FORBIDDEN_SERVICE_KEYS: &[&str] = &[
-            "privileged",
-            "network_mode",
-            "pid",
-            "ipc",
-            "uts",
-            "cgroup",
-            "cgroup_parent",
-            "cap_add",
-            "cap_drop",
-            "devices",
-            "device_cgroup_rules",
-            "security_opt",
-            "sysctls",
-            "userns_mode",
-            "volumes",
-            "volumes_from",
-            "group_add",
-            "runtime",
-            "oom_kill_disable",
-            "shm_size",
-            "tmpfs",
-            "ulimits",
-            "labels",
-        ];
-
         for key in service.keys().filter_map(Self::yaml_key) {
-            if FORBIDDEN_SERVICE_KEYS.contains(&key.as_str()) {
+            if NEVER_ALLOWED_OVERRIDE_KEYS.contains(&key.as_str()) {
                 return Err(ComposeError::InvalidOverride {
                     project: project_name.to_string(),
                     reason: format!(
-                        "service '{service_name}' uses forbidden inline override key '{key}'; put host-affecting Compose settings in the repository compose file for review"
+                        "service '{service_name}' uses forbidden key '{key}', which Compose \
+                         deployments do not permit anywhere — the deploy-time security policy \
+                         rejects it in the repository compose file too, so moving it there \
+                         will not help"
+                    ),
+                });
+            }
+            if REPO_ONLY_OVERRIDE_KEYS.contains(&key.as_str()) {
+                return Err(ComposeError::InvalidOverride {
+                    project: project_name.to_string(),
+                    reason: format!(
+                        "service '{service_name}' cannot set '{key}' as an inline override; \
+                         declare it in the repository compose file instead, where it is \
+                         checked against the deployment security policy (host paths, host \
+                         namespaces and resource limits are still rejected there)"
                     ),
                 });
             }
@@ -3433,6 +3523,7 @@ impl ComposeExecutor {
         project_name: &str,
         compose_file: &str,
         redact_values: &[String],
+        relaxed_capability_services: &[String],
     ) -> Result<(), ComposeError> {
         let mut cmd = isolated_docker_command();
         cmd.args(["compose", "-p", project_name]);
@@ -3472,6 +3563,7 @@ impl ComposeExecutor {
                     project_name,
                     compose_file,
                     redact_values,
+                    relaxed_capability_services,
                 )
                 .await;
             let diagnostic = sanitize_compose_diagnostic(
@@ -3556,6 +3648,7 @@ impl ComposeExecutor {
         project_name: &str,
         compose_file: &str,
         redact_values: &[String],
+        relaxed_capability_services: &[String],
     ) -> String {
         let entries = match self
             .compose_ps(project_dir, project_name, compose_file)
@@ -3571,6 +3664,7 @@ impl ComposeExecutor {
         };
 
         let mut sections = Vec::new();
+        let mut capability_denied = Vec::new();
         for entry in &entries {
             let is_unhealthy = !entry.health.is_empty() && entry.health != "healthy";
             let is_not_running = entry.state != "running";
@@ -3582,6 +3676,9 @@ impl ComposeExecutor {
                 &self.container_log_tail(&entry.id).await,
                 redact_values,
             );
+            if looks_like_capability_denial(&logs) {
+                capability_denied.push(entry.service.clone());
+            }
             let health = if entry.health.is_empty() {
                 "n/a"
             } else {
@@ -3598,13 +3695,62 @@ impl ComposeExecutor {
         }
 
         if sections.is_empty() {
-            String::new()
-        } else {
-            format!(
-                "\n\nContainer logs for unhealthy/stopped services:\n\n{}",
-                sections.join("\n\n")
-            )
+            return String::new();
         }
+
+        format!(
+            "\n\nContainer logs for unhealthy/stopped services:\n\n{}{}",
+            sections.join("\n\n"),
+            Self::capability_denial_remediation(&capability_denied, relaxed_capability_services)
+        )
+    }
+
+    /// Turn a detected capability denial into the one instruction that fixes
+    /// it. Appended to the failure text rather than only logged, because the
+    /// advisory `deploy_compose` emits before the deploy is easy to miss under
+    /// hundreds of lines of image-pull progress — whereas the error is the one
+    /// thing the operator cannot avoid reading.
+    ///
+    /// A service that is *already* relaxed and still denied gets the opposite
+    /// message: the toggle is not the answer, so say so instead of sending the
+    /// operator to flip a switch that is on.
+    fn capability_denial_remediation(
+        denied_services: &[String],
+        relaxed_capability_services: &[String],
+    ) -> String {
+        if denied_services.is_empty() {
+            return String::new();
+        }
+
+        let (already_relaxed, needs_relaxing): (Vec<_>, Vec<_>) = denied_services
+            .iter()
+            .partition(|service| relaxed_capability_services.contains(service));
+
+        let mut hints = Vec::new();
+        if !needs_relaxing.is_empty() {
+            hints.push(format!(
+                "Service(s) {} failed with \"Operation not permitted\". Temps runs every \
+                 Compose service with all Linux capabilities dropped, and image entrypoints \
+                 that prepare a data directory and then drop from root to a service user \
+                 need {} to start. Enable \"Elevated permissions\" for them in {}, then \
+                 redeploy.",
+                quote_service_list(&needs_relaxing),
+                Self::RELAXED_CAPABILITIES.join(", "),
+                ELEVATED_PERMISSIONS_SETTINGS_PATH,
+            ));
+        }
+        if !already_relaxed.is_empty() {
+            hints.push(format!(
+                "Service(s) {} already have \"Elevated permissions\" enabled, so this denial \
+                 is not the Temps sandbox's capability drop — check whether the image needs a \
+                 capability outside the granted set ({}), or runs as a user that cannot write \
+                 its mounted data directory.",
+                quote_service_list(&already_relaxed),
+                Self::RELAXED_CAPABILITIES.join(", "),
+            ));
+        }
+
+        format!("\n\n{}", hints.join("\n\n"))
     }
 
     /// Fetches the last [`Self::FAILED_CONTAINER_LOG_TAIL`] lines (stdout +
@@ -3645,6 +3791,7 @@ impl ComposeExecutor {
         project_name: &str,
         compose_file: &str,
         redact_values: &[String],
+        relaxed_capability_services: &[String],
         timeout: std::time::Duration,
     ) -> Result<(), ComposeError> {
         let start = std::time::Instant::now();
@@ -3677,6 +3824,7 @@ impl ComposeExecutor {
                                 project_name,
                                 compose_file,
                                 redact_values,
+                                relaxed_capability_services,
                             )
                             .await;
                         return Err(ComposeError::ServicesNotReady {
@@ -3694,6 +3842,7 @@ impl ComposeExecutor {
                             project_name,
                             compose_file,
                             redact_values,
+                            relaxed_capability_services,
                         )
                         .await;
                     return Err(ComposeError::ServicesNotReady {
@@ -3710,6 +3859,7 @@ impl ComposeExecutor {
                                 project_name,
                                 compose_file,
                                 redact_values,
+                                relaxed_capability_services,
                             )
                             .await;
                         return Err(ComposeError::ServicesNotReady {
@@ -5062,11 +5212,154 @@ services:
                 &override_content,
             )
             .unwrap_err();
+            let key = dangerous_override.split(':').next().unwrap();
             assert!(
-                error.to_string().contains("forbidden inline override key"),
-                "expected {dangerous_override} to be rejected, got {error}"
+                matches!(error, ComposeError::InvalidOverride { .. }),
+                "expected {dangerous_override} to be rejected as an invalid override, got {error}"
+            );
+            assert!(
+                error.to_string().contains(key),
+                "expected the rejection of {dangerous_override} to name the key '{key}', got {error}"
             );
         }
+    }
+
+    /// The log tail an official postgres image leaves when the Temps sandbox
+    /// denies its entrypoint the capabilities it needs. Shape preserved from a
+    /// real failure; no identifying detail.
+    const POSTGRES_CAPABILITY_DENIAL_LOG: &str =
+        "chmod: /var/lib/postgresql/data: Operation not permitted\n\
+         chmod: /var/run/postgresql: Operation not permitted\n\
+         error: failed switching to 'postgres': operation not permitted\n";
+
+    #[test]
+    fn test_looks_like_capability_denial_detects_entrypoint_privilege_drop() {
+        assert!(looks_like_capability_denial(POSTGRES_CAPABILITY_DENIAL_LOG));
+        assert!(looks_like_capability_denial(
+            "su-exec: setgroups: Operation not permitted"
+        ));
+        assert!(looks_like_capability_denial(
+            "chown: changing ownership of '/data': Operation not permitted"
+        ));
+    }
+
+    /// The hint must not fire on ordinary application errors — sending someone
+    /// to a capability toggle that cannot fix their problem is worse than
+    /// leaving the raw logs to speak for themselves.
+    #[test]
+    fn test_looks_like_capability_denial_ignores_unrelated_failures() {
+        // "operation not permitted" with no privileged operation alongside it.
+        assert!(!looks_like_capability_denial(
+            "FATAL: password authentication failed for user 'app'"
+        ));
+        assert!(!looks_like_capability_denial(
+            "Error: connect ECONNREFUSED 127.0.0.1:5432"
+        ));
+        assert!(!looks_like_capability_denial(
+            "socket bind: Operation not permitted"
+        ));
+        // A privileged verb with no denial is just normal startup chatter.
+        assert!(!looks_like_capability_denial(
+            "chown: adjusting ownership of /var/lib/postgresql/data"
+        ));
+    }
+
+    #[test]
+    fn test_capability_denial_remediation_names_the_service_and_the_toggle() {
+        let remediation =
+            ComposeExecutor::capability_denial_remediation(&["postgres".to_string()], &[]);
+
+        assert!(remediation.contains("'postgres'"), "{remediation}");
+        assert!(
+            remediation.contains(ELEVATED_PERMISSIONS_SETTINGS_PATH),
+            "{remediation}"
+        );
+        assert!(remediation.contains("SETUID"), "{remediation}");
+    }
+
+    /// A service that is already relaxed and *still* denied needs the opposite
+    /// advice: the toggle is on, so it is not the answer.
+    #[test]
+    fn test_capability_denial_remediation_does_not_resend_already_relaxed_services() {
+        let remediation = ComposeExecutor::capability_denial_remediation(
+            &["postgres".to_string()],
+            &["postgres".to_string()],
+        );
+
+        assert!(
+            remediation.contains("already have \"Elevated permissions\" enabled"),
+            "{remediation}"
+        );
+        assert!(
+            !remediation.contains(ELEVATED_PERMISSIONS_SETTINGS_PATH),
+            "should not send the operator to a toggle that is already on: {remediation}"
+        );
+    }
+
+    #[test]
+    fn test_capability_denial_remediation_is_empty_without_a_denial() {
+        assert!(
+            ComposeExecutor::capability_denial_remediation(&[], &["postgres".to_string()])
+                .is_empty()
+        );
+    }
+
+    /// The two denylists must stay disjoint: a key in both would make the
+    /// "never allowed" message win by ordering alone, and silently reintroduce
+    /// the misleading advice the split exists to remove.
+    #[test]
+    fn test_override_key_denylists_are_disjoint() {
+        for key in NEVER_ALLOWED_OVERRIDE_KEYS {
+            assert!(
+                !REPO_ONLY_OVERRIDE_KEYS.contains(key),
+                "'{key}' is classified both as never-allowed and as repo-only"
+            );
+        }
+    }
+
+    /// A key the deploy-time policy rejects everywhere must not tell the user
+    /// to move it into the repository compose file — that advice costs them a
+    /// round trip and then fails with a different error.
+    #[test]
+    fn test_never_allowed_override_key_does_not_advise_moving_to_repository() {
+        let compose = "services:\n  web:\n    image: nginx\n";
+        let error = ComposeExecutor::validate_compose_override(
+            "temps-test",
+            compose,
+            "services:\n  web:\n    privileged: true\n",
+        )
+        .unwrap_err();
+        let message = error.to_string();
+        assert!(
+            message.contains("do not permit anywhere"),
+            "expected an anywhere-forbidden message, got {message}"
+        );
+        assert!(
+            message.contains("will not help"),
+            "expected the message to rule out moving it to the repository, got {message}"
+        );
+    }
+
+    /// A key the repository compose file legitimately accepts must point there,
+    /// since that is the route that actually works.
+    #[test]
+    fn test_repo_only_override_key_points_at_the_repository_compose_file() {
+        let compose = "services:\n  web:\n    image: nginx\n";
+        let error = ComposeExecutor::validate_compose_override(
+            "temps-test",
+            compose,
+            "services:\n  web:\n    volumes: ['data:/var/lib/data']\n",
+        )
+        .unwrap_err();
+        let message = error.to_string();
+        assert!(
+            message.contains("declare it in the repository compose file"),
+            "expected the message to point at the repository compose file, got {message}"
+        );
+        assert!(
+            !message.contains("do not permit anywhere"),
+            "'volumes' is accepted in the repository compose file, got {message}"
+        );
     }
 
     #[test]
@@ -7393,9 +7686,7 @@ services:
         let error =
             ComposeExecutor::validate_compose_override("temps-test", compose, override_content)
                 .unwrap_err();
-        assert!(error
-            .to_string()
-            .contains("forbidden inline override key 'runtime'"));
+        assert!(error.to_string().contains("forbidden key 'runtime'"));
     }
 
     #[test]

--- a/crates/temps-deployments/src/jobs/deploy_compose.rs
+++ b/crates/temps-deployments/src/jobs/deploy_compose.rs
@@ -464,12 +464,12 @@ impl WorkflowTask for DeployComposeJob {
                     type_param
                 );
                 if needs_relaxed_capabilities {
-                    message.push_str(
+                    message.push_str(&format!(
                         " It also runs with all Linux capabilities dropped by default; if \
                          it fails to start with \"Operation not permitted\" errors, enable \
-                         \"Elevated permissions\" for it in Project Settings → Git → \
-                         Compose services, then redeploy.",
-                    );
+                         \"Elevated permissions\" for it in {}, then redeploy.",
+                        temps_deployer::compose::ELEVATED_PERMISSIONS_SETTINGS_PATH,
+                    ));
                 }
                 let _ = self.log_service.log_info(log_id, &message).await;
             }

--- a/crates/temps-presets/src/docker_compose.rs
+++ b/crates/temps-presets/src/docker_compose.rs
@@ -364,6 +364,47 @@ fn strip_excluded_services_value(root: &mut serde_yaml::Value, excluded: &[Strin
     }
 }
 
+/// Keys an inline override may not set because the deploy-time security
+/// policy (`temps-deployer::compose::validate_compose_security_policy`)
+/// rejects them outright, wherever they appear. Telling someone to move one of
+/// these into the repository Compose file would be sending them to do work
+/// that fails later, at deploy, with a different error.
+const NEVER_ALLOWED_SERVICE_KEYS: &[&str] = &[
+    "privileged",
+    "cgroup_parent",
+    "cap_add",
+    "devices",
+    "device_cgroup_rules",
+    "security_opt",
+    "sysctls",
+    "volumes_from",
+    "group_add",
+    "runtime",
+    "oom_kill_disable",
+    "tmpfs",
+    "ulimits",
+];
+
+/// Keys an inline override may not set, but which the repository Compose file
+/// legitimately can — the deploy-time policy admits them subject to its own
+/// checks (bind-mount path confinement for `volumes`, byte caps for
+/// `shm_size`, host-namespace rejection for `pid`/`ipc`/`network_mode` and
+/// friends). Kept separate from [`NEVER_ALLOWED_SERVICE_KEYS`] so the error
+/// can point somewhere that actually works instead of issuing the same
+/// blanket "move it to the repository" advice for every key.
+const REPO_ONLY_SERVICE_KEYS: &[&str] = &[
+    "network_mode",
+    "pid",
+    "ipc",
+    "uts",
+    "cgroup",
+    "userns_mode",
+    "cap_drop",
+    "volumes",
+    "shm_size",
+    "labels",
+];
+
 fn validate_preview_override(
     base: &serde_yaml::Value,
     override_document: &serde_yaml::Value,
@@ -407,39 +448,30 @@ fn validate_preview_override(
                 reason: format!("service '{name}' override must be a mapping"),
             });
         };
-        const FORBIDDEN_SERVICE_KEYS: &[&str] = &[
-            "privileged",
-            "network_mode",
-            "pid",
-            "ipc",
-            "uts",
-            "cgroup",
-            "cgroup_parent",
-            "cap_add",
-            "cap_drop",
-            "devices",
-            "device_cgroup_rules",
-            "security_opt",
-            "sysctls",
-            "userns_mode",
-            "volumes",
-            "volumes_from",
-            "group_add",
-            "runtime",
-            "oom_kill_disable",
-            "shm_size",
-            "tmpfs",
-            "ulimits",
-            "labels",
-        ];
         if let Some(key) = service
             .keys()
             .filter_map(serde_yaml::Value::as_str)
-            .find(|key| FORBIDDEN_SERVICE_KEYS.contains(key))
+            .find(|key| NEVER_ALLOWED_SERVICE_KEYS.contains(key))
         {
             return Err(ComposeParseError::InvalidOverride {
                 reason: format!(
-                    "service '{name}' uses forbidden inline override key '{key}'; put host-affecting Compose settings in the repository Compose file for review"
+                    "service '{name}' uses forbidden key '{key}', which Compose deployments \
+                     do not permit anywhere — the deploy-time security policy rejects it in \
+                     the repository Compose file too, so moving it there will not help"
+                ),
+            });
+        }
+        if let Some(key) = service
+            .keys()
+            .filter_map(serde_yaml::Value::as_str)
+            .find(|key| REPO_ONLY_SERVICE_KEYS.contains(key))
+        {
+            return Err(ComposeParseError::InvalidOverride {
+                reason: format!(
+                    "service '{name}' cannot set '{key}' as an inline override; declare it in \
+                     the repository Compose file instead, where it is checked against the \
+                     deployment security policy (host paths, host namespaces and resource \
+                     limits are still rejected there)"
                 ),
             });
         }
@@ -1142,9 +1174,54 @@ secrets:
 
         let error = render_effective_compose_preview(base, Some(override_yaml), &[]).unwrap_err();
 
-        assert!(error
-            .to_string()
-            .contains("forbidden inline override key 'privileged'"));
+        assert!(error.to_string().contains("forbidden key 'privileged'"));
+    }
+
+    /// `privileged` is rejected by the deploy-time policy as well, so the
+    /// preview must not send the user off to move it into the repository
+    /// Compose file — that trip ends in a second, different failure.
+    #[test]
+    fn effective_preview_does_not_advise_moving_never_allowed_keys_to_the_repository() {
+        let base = "services:\n  web:\n    image: nginx\n";
+        let override_yaml = "services:\n  web:\n    privileged: true\n";
+
+        let error = render_effective_compose_preview(base, Some(override_yaml), &[]).unwrap_err();
+
+        let message = error.to_string();
+        assert!(
+            message.contains("do not permit anywhere") && message.contains("will not help"),
+            "expected the message to rule out the repository Compose file, got {message}"
+        );
+    }
+
+    /// `volumes` *is* accepted in the repository Compose file (subject to
+    /// bind-path confinement), so the preview should point there.
+    #[test]
+    fn effective_preview_points_repo_only_keys_at_the_repository_compose_file() {
+        let base = "services:\n  web:\n    image: nginx\n";
+        let override_yaml = "services:\n  web:\n    volumes: ['data:/var/lib/data']\n";
+
+        let error = render_effective_compose_preview(base, Some(override_yaml), &[]).unwrap_err();
+
+        let message = error.to_string();
+        assert!(
+            message.contains("declare it in the repository Compose file"),
+            "expected the message to point at the repository Compose file, got {message}"
+        );
+        assert!(
+            !message.contains("do not permit anywhere"),
+            "'volumes' is not forbidden everywhere, got {message}"
+        );
+    }
+
+    #[test]
+    fn override_key_denylists_are_disjoint() {
+        for key in NEVER_ALLOWED_SERVICE_KEYS {
+            assert!(
+                !REPO_ONLY_SERVICE_KEYS.contains(key),
+                "'{key}' is classified both as never-allowed and as repo-only"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Two Compose failure paths pointed operators somewhere that could not help them.

**1. The sandbox breaks database images, and the error never says so.**

Temps hardens every Compose service with `cap_drop: ALL` + `no-new-privileges`. Image entrypoints that prepare a data directory and then drop from root to a service user — the official postgres/mysql/mariadb/mongo images, and others such as Gitea — need `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETUID` and `SETGID` to do that, so they crash-loop:

```
chmod: /var/lib/postgresql/data: Operation not permitted
error: failed switching to 'postgres': operation not permitted
```

The per-service opt-out already exists (`relaxed_capability_services`, surfaced as **Elevated permissions**), and `deploy_compose` already logs an advisory naming it. But that advisory is emitted *before* the deploy, where it lands under hundreds of lines of image-pull progress — while the thing the operator cannot avoid reading is a `container is unhealthy` error plus an EPERM log tail that never mentions the toggle. The result is a five-minute readiness timeout and no route to the fix.

**2. The inline-override rejection gave advice that fails 20 times out of 23.**

All 23 denylisted service keys produced one message:

> put host-affecting Compose settings in the repository Compose file for review

That is wrong twice over. The deploy-time security policy rejects `privileged`, `cap_add`, `security_opt` and 10 others in the repository file too, so following the advice costs a round trip and ends in a *different* error. And it describes a review step that does not exist — the repository file is not trusted, it goes through the same `validate_compose_security_policy`.

## Changes

**Self-explaining capability denials.** `describe_unhealthy_containers` already captures a log tail per failed container; it now scans that tail and appends the remediation to the error itself, naming the service and the setting. `relaxed_capability_services` is threaded from `deploy()` through `compose_up`/`wait_for_services_ready` so all four failure paths know which services are already exempt.

The detection is deliberately two-factor — `"operation not permitted"` alongside a privileged-operation verb (`chmod`, `chown`, `setgroups`, `setuid`, `setgid`, `failed switching to`, `su-exec`, `gosu`). The phrase alone appears in plenty of ordinary application errors, and pointing those at a capability toggle that cannot fix them would be worse than staying quiet. A service that is *already* relaxed and still denied gets the opposite message, so nobody is sent to flip a switch that is on.

**Honest override rejections.** The denylist is split in two:

- `NEVER_ALLOWED_*` (13 keys) — rejected by the deploy-time policy everywhere: *"…which Compose deployments do not permit anywhere … so moving it there will not help"*
- `REPO_ONLY_*` (10 keys) — the repository file legitimately accepts these subject to its own checks (bind-path confinement for `volumes`, byte caps for `shm_size`, host-namespace rejection for `pid`/`ipc`/`network_mode`): *"…declare it in the repository Compose file instead, where it is checked against the deployment security policy"*

The union is unchanged, so nothing is newly permitted — only the message differs. Both copies of the denylist are updated: `temps-deployer` guards the deploy, `temps-presets` guards the preview.

**One source of truth for the console path.** The advisory and the remediation both quote where the toggle lives; that string is now the shared `ELEVATED_PERMISSIONS_SETTINGS_PATH` constant, so a settings reshuffle cannot leave one of them pointing at a page that no longer exists.

## Testing

12 new unit tests: detection positives/negatives, remediation content, already-relaxed inversion, denylist disjointness, and the two distinct rejection messages on both the deploy and preview paths. `cargo clippy --all-targets -- -D warnings` clean across the three crates.

One unrelated pre-existing failure in this crate, verified by stashing the changes and re-running on the unmodified tree: `docker::docker_tests::test_dns_fallback_survives_unreachable_primary_resolver`. Environment-dependent, untouched here.

## Not in scope

Two follow-ups this deliberately leaves alone:

- The warning still only reaches the deploy log. A banner on the Compose services settings card, next to the toggle, would catch it before a deploy is spent.
- The default remains "all capabilities dropped", so `app + postgres` — the most common Compose stack there is — still fails on first deploy until the operator flips the toggle. Pre-selecting Elevated permissions for detected database services would fix that, but it widens default capabilities and wants a security review rather than a drive-by change.
