### PR TITLE
fix(cli): honor --data-dir when starting the proxy alongside the console

### DIFF
--- a/crates/temps-cli/src/commands/serve/mod.rs
+++ b/crates/temps-cli/src/commands/serve/mod.rs
@@ -158,6 +158,17 @@ impl ServeCommand {
             std::env::set_var("TEMPS_CONSOLE_ADMIN_ADDRESS", admin);
         }
 
+        // Same bridge for the data directory. `ServerConfig::new` resolves it
+        // from TEMPS_DATA_DIR or falls back to ~/.temps, and never saw this
+        // flag — so `--data-dir /srv/temps` was silently ignored and the
+        // server wrote its encryption key, auth secret, logs and plugin data
+        // to the home directory instead. Two instances started with different
+        // `--data-dir` values would quietly share one directory.
+        if let Some(ref dir) = self.data_dir {
+            std::env::set_var("TEMPS_DATA_DIR", dir);
+            debug!("Data directory set to '{}' from CLI flag", dir.display());
+        }
+
         // In split (`--role=console`) mode the console must bind a STABLE,
         // known address: the sibling `temps proxy` forwards console/UI traffic
         // to it (proxy `ProxyConfig.console_address`). The default is a random


### PR DESCRIPTION
## Description

`ServerConfig::new` resolves the data directory from `TEMPS_DATA_DIR` (falling back to `~/.temps`) and never saw the `--data-dir` CLI flag, so passing that flag was silently ignored — the server wrote its encryption key, auth secret, logs and plugin data to the default location instead of the operator-specified directory.

Two consequences:

- Two instances started with different `--data-dir` values quietly share one directory, including its encryption key and auth secret.
- Pointing an existing install at a fresh data directory generates new keys, after which the server cannot decrypt rows encrypted under the old one.

`--console-admin-address` and `--screenshot-provider` already bridge their CLI flag into the matching env var for exactly this reason (`ServerConfig` only ever reads from the environment) — `--data-dir` was simply missing from that list. This adds the same bridge, directly above the existing ones.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I have written tests that cover the changes
- [x] All new and existing tests pass (`cargo test --lib`)
- [x] `cargo check --lib` passes with no warnings
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated documentation where necessary

Note on the two unchecked boxes: the change is a three-line flag-to-env bridge in `ServeCommand::execute`, matching the two bridges immediately above it. Covering it with an automated test would mean asserting on process-global `std::env` state from within the test harness, which is shared across parallel tests and would be flaky; it was verified manually instead (starting with `--data-dir <path>` and no `TEMPS_DATA_DIR` now writes `encryption_key`, `auth_secret`, logs and plugin data under that path rather than `~/.temps`). No user-facing docs describe the current broken behavior, so there is nothing to update.

## Related issues

<!-- none -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)