### PR TITLE
fix(web): support RFC3339 Sentry timestamps

### DIFF
--- a/web/src/components/error-tracking/SentryEventDetail.tsx
+++ b/web/src/components/error-tracking/SentryEventDetail.tsx
@@ -478,7 +478,7 @@ export function SentryEventDetail({
               <CardContent>
                 <ScrollArea className="h-[400px]">
                   <div className="space-y-3">
-                    {sentryData.spans.map((span, index) => {
+                    {sentryData.spans.map((span) => {
                       const spanStartMs = sentryTimestampToMillis(
                         span.start_timestamp
                       )
@@ -490,7 +490,7 @@ export function SentryEventDetail({
 
                       return (
                         <div
-                          key={index}
+                          key={span.span_id}
                           className="border rounded-lg p-3 hover:bg-muted/50 transition-colors"
                         >
                           <div className="space-y-2">
@@ -580,9 +580,9 @@ export function SentryEventDetail({
 
                         return b.originalIndex - a.originalIndex
                       })
-                      .map((breadcrumb, index) => (
+                      .map((breadcrumb) => (
                         <div
-                          key={index}
+                          key={breadcrumb.originalIndex}
                           className="flex items-start gap-3 p-2 hover:bg-muted/50 rounded transition-colors"
                         >
                           <div className="flex-shrink-0 mt-0.5">

--- a/web/src/components/error-tracking/SentryEventDetail.tsx
+++ b/web/src/components/error-tracking/SentryEventDetail.tsx
@@ -10,6 +10,7 @@ import {
 import { Label } from '@/components/ui/label'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Switch } from '@/components/ui/switch'
+import { sentryTimestampToMillis } from '@/lib/sentry-timestamp'
 import { cn } from '@/lib/utils'
 import { SentryEvent, SentryException } from '@/types/sentry'
 import { format, formatDistanceToNow } from 'date-fns'
@@ -76,6 +77,14 @@ export function SentryEventDetail({
   const mainException = exceptions[0]
   const breadcrumbs = sentryData.breadcrumbs?.values || []
   const contexts = sentryData.contexts || {}
+  const eventTimestampMs = sentryTimestampToMillis(sentryData.timestamp)
+  const eventStartTimestampMs = sentryTimestampToMillis(
+    sentryData.start_timestamp
+  )
+  const eventDurationMs =
+    eventTimestampMs !== null && eventStartTimestampMs !== null
+      ? eventTimestampMs - eventStartTimestampMs
+      : null
 
   // Helper function to convert Sentry stack frames to our StackTrace component format
   const convertStackFrames = (exception: SentryException) => {
@@ -113,7 +122,11 @@ export function SentryEventDetail({
             </h2>
           </div>
           <div className="flex items-center gap-4 text-sm text-muted-foreground">
-            <span>{format(new Date(sentryData.timestamp * 1000), 'PPpp')}</span>
+            <span>
+              {eventTimestampMs !== null
+                ? format(new Date(eventTimestampMs), 'PPpp')
+                : 'Unknown time'}
+            </span>
             <span>•</span>
             <span className="font-mono">ID: {sentryData.event_id}</span>
             {sentryData.transaction && (
@@ -465,61 +478,68 @@ export function SentryEventDetail({
               <CardContent>
                 <ScrollArea className="h-[400px]">
                   <div className="space-y-3">
-                    {sentryData.spans.map((span, index) => (
-                      <div
-                        key={index}
-                        className="border rounded-lg p-3 hover:bg-muted/50 transition-colors"
-                      >
-                        <div className="space-y-2">
-                          <div className="flex items-center justify-between">
-                            <div className="flex items-center gap-2">
-                              <Badge variant="outline" className="text-xs">
-                                {span.op || 'unknown'}
-                              </Badge>
-                              {span.status && (
-                                <Badge
-                                  variant={
-                                    span.status === 'ok'
-                                      ? 'outline'
-                                      : 'destructive'
-                                  }
-                                  className="text-xs"
-                                >
-                                  {span.status}
+                    {sentryData.spans.map((span, index) => {
+                      const spanStartMs = sentryTimestampToMillis(
+                        span.start_timestamp
+                      )
+                      const spanEndMs = sentryTimestampToMillis(span.timestamp)
+                      const spanDurationMs =
+                        spanStartMs !== null && spanEndMs !== null
+                          ? spanEndMs - spanStartMs
+                          : null
+
+                      return (
+                        <div
+                          key={index}
+                          className="border rounded-lg p-3 hover:bg-muted/50 transition-colors"
+                        >
+                          <div className="space-y-2">
+                            <div className="flex items-center justify-between">
+                              <div className="flex items-center gap-2">
+                                <Badge variant="outline" className="text-xs">
+                                  {span.op || 'unknown'}
                                 </Badge>
+                                {span.status && (
+                                  <Badge
+                                    variant={
+                                      span.status === 'ok'
+                                        ? 'outline'
+                                        : 'destructive'
+                                    }
+                                    className="text-xs"
+                                  >
+                                    {span.status}
+                                  </Badge>
+                                )}
+                              </div>
+                              {spanDurationMs !== null && (
+                                <span className="text-xs text-muted-foreground">
+                                  {spanDurationMs.toFixed(2)} ms
+                                </span>
                               )}
                             </div>
-                            {span.start_timestamp && span.timestamp && (
-                              <span className="text-xs text-muted-foreground">
-                                {(
-                                  (span.timestamp - span.start_timestamp) *
-                                  1000
-                                ).toFixed(2)}
-                                ms
+                            {span.description && (
+                              <p className="text-sm font-mono">
+                                {span.description}
+                              </p>
+                            )}
+                            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                              <span className="font-mono">
+                                Span: {span.span_id.slice(0, 8)}
                               </span>
-                            )}
-                          </div>
-                          {span.description && (
-                            <p className="text-sm font-mono">
-                              {span.description}
-                            </p>
-                          )}
-                          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                            <span className="font-mono">
-                              Span: {span.span_id.slice(0, 8)}
-                            </span>
-                            {span.parent_span_id && (
-                              <>
-                                <span>→</span>
-                                <span className="font-mono">
-                                  Parent: {span.parent_span_id.slice(0, 8)}
-                                </span>
-                              </>
-                            )}
+                              {span.parent_span_id && (
+                                <>
+                                  <span>→</span>
+                                  <span className="font-mono">
+                                    Parent: {span.parent_span_id.slice(0, 8)}
+                                  </span>
+                                </>
+                              )}
+                            </div>
                           </div>
                         </div>
-                      </div>
-                    ))}
+                      )
+                    })}
                   </div>
                 </ScrollArea>
               </CardContent>
@@ -542,12 +562,23 @@ export function SentryEventDetail({
                       .map((breadcrumb, originalIndex) => ({
                         ...breadcrumb,
                         originalIndex,
+                        timestampMs: sentryTimestampToMillis(
+                          breadcrumb.timestamp
+                        ),
                       }))
                       .sort((a, b) => {
-                        const timeDiff = (b.timestamp || 0) - (a.timestamp || 0)
-                        return timeDiff !== 0
-                          ? timeDiff
-                          : b.originalIndex - a.originalIndex
+                        if (a.timestampMs !== null && b.timestampMs !== null) {
+                          const timeDiff = b.timestampMs - a.timestampMs
+                          if (timeDiff !== 0) {
+                            return timeDiff
+                          }
+                        } else if (a.timestampMs !== null) {
+                          return -1
+                        } else if (b.timestampMs !== null) {
+                          return 1
+                        }
+
+                        return b.originalIndex - a.originalIndex
                       })
                       .map((breadcrumb, index) => (
                         <div
@@ -571,9 +602,9 @@ export function SentryEventDetail({
                                 </Badge>
                               )}
                               <span className="text-xs text-muted-foreground">
-                                {breadcrumb.timestamp
+                                {breadcrumb.timestampMs !== null
                                   ? formatDistanceToNow(
-                                      new Date(breadcrumb.timestamp * 1000),
+                                      new Date(breadcrumb.timestampMs),
                                       { addSuffix: true }
                                     )
                                   : 'Unknown time'}
@@ -758,17 +789,13 @@ export function SentryEventDetail({
                     </Badge>
                   </div>
                 )}
-                {sentryData.start_timestamp && (
+                {eventDurationMs !== null && (
                   <div className="text-sm">
                     <div className="text-muted-foreground text-xs">
                       Duration
                     </div>
                     <div className="font-mono">
-                      {(
-                        (sentryData.timestamp - sentryData.start_timestamp) *
-                        1000
-                      ).toFixed(2)}{' '}
-                      ms
+                      {eventDurationMs.toFixed(2)} ms
                     </div>
                   </div>
                 )}

--- a/web/src/components/error-tracking/SentryListItem.tsx
+++ b/web/src/components/error-tracking/SentryListItem.tsx
@@ -1,5 +1,6 @@
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
+import { sentryTimestampToMillis } from '@/lib/sentry-timestamp'
 import { SentryEvent } from '@/types/sentry'
 import { format } from 'date-fns'
 import { Clock, Code, Globe, Layers, Monitor } from 'lucide-react'
@@ -18,6 +19,7 @@ export function SentryListItem({
   const sentryData = event.sentry
   const mainException = sentryData.exception?.values?.[0]
   const contexts = sentryData.contexts || {}
+  const timestampMs = sentryTimestampToMillis(sentryData.timestamp)
 
   const getSeverityColor = (level: string) => {
     switch (level?.toLowerCase()) {
@@ -49,7 +51,9 @@ export function SentryListItem({
             <div className="flex items-center gap-2 mb-1">
               <Clock className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
               <span className="text-sm font-medium">
-                {format(new Date(sentryData.timestamp * 1000), 'PPpp')}
+                {timestampMs !== null
+                  ? format(new Date(timestampMs), 'PPpp')
+                  : 'Unknown time'}
               </span>
               {sentryData.level && (
                 <Badge variant={getSeverityColor(sentryData.level)}>

--- a/web/src/lib/sentry-timestamp.test.ts
+++ b/web/src/lib/sentry-timestamp.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  parseSentryTimestamp,
+  sentryTimestampToMillis,
+} from './sentry-timestamp'
+
+describe('parseSentryTimestamp', () => {
+  test('parses numeric Unix timestamps as seconds', () => {
+    const parsed = parseSentryTimestamp(1787071003.712074)
+
+    expect(parsed?.toISOString()).toBe('2026-08-18T16:36:43.712Z')
+  })
+
+  test('parses RFC3339 timestamps with offset and nanosecond precision', () => {
+    const parsed = parseSentryTimestamp(
+      '2026-08-19T00:36:43.712074786+08:00'
+    )
+
+    expect(parsed?.toISOString()).toBe('2026-08-18T16:36:43.712Z')
+  })
+
+  test('assumes UTC when an RFC3339 timestamp omits a timezone', () => {
+    const parsed = parseSentryTimestamp('2011-05-02T17:41:36.000')
+
+    expect(parsed?.toISOString()).toBe('2011-05-02T17:41:36.000Z')
+  })
+
+  test('returns null for invalid timestamps', () => {
+    expect(parseSentryTimestamp('not-a-timestamp')).toBeNull()
+    expect(parseSentryTimestamp(Number.NaN)).toBeNull()
+    expect(parseSentryTimestamp(Number.POSITIVE_INFINITY)).toBeNull()
+    expect(parseSentryTimestamp('')).toBeNull()
+  })
+
+  test('does not reinterpret numeric strings as protocol timestamps', () => {
+    expect(parseSentryTimestamp('1787071003.712074')).toBeNull()
+  })
+
+  test('returns milliseconds for timestamp comparisons and durations', () => {
+    expect(
+      sentryTimestampToMillis('2026-08-19T00:36:43.712074786+08:00')
+    ).toBe(1787071003712)
+  })
+})

--- a/web/src/lib/sentry-timestamp.ts
+++ b/web/src/lib/sentry-timestamp.ts
@@ -1,0 +1,45 @@
+import type { SentryTimestamp } from '@/types/sentry'
+import { isValid, parseISO } from 'date-fns'
+
+const RFC3339_TIMEZONE = /(?:Z|[+-]\d{2}:\d{2})$/i
+const NUMERIC_STRING = /^[+-]?\d+(?:\.\d+)?$/
+
+/**
+ * Parse a Sentry protocol timestamp.
+ *
+ * Sentry accepts RFC3339 strings or numeric Unix timestamps in seconds.
+ * When an RFC3339 string omits a timezone, Sentry treats it as UTC.
+ */
+export function parseSentryTimestamp(
+  value: SentryTimestamp | null | undefined
+): Date | null {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return null
+    }
+
+    const date = new Date(value * 1000)
+    return isValid(date) ? date : null
+  }
+
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const input = value.trim()
+  if (!input || NUMERIC_STRING.test(input)) {
+    return null
+  }
+
+  // Sentry assumes UTC when an RFC3339 timestamp omits the timezone.
+  const normalized = RFC3339_TIMEZONE.test(input) ? input : `${input}Z`
+  const date = parseISO(normalized)
+
+  return isValid(date) ? date : null
+}
+
+export function sentryTimestampToMillis(
+  value: SentryTimestamp | null | undefined
+): number | null {
+  return parseSentryTimestamp(value)?.getTime() ?? null
+}

--- a/web/src/types/sentry.ts
+++ b/web/src/types/sentry.ts
@@ -1,5 +1,7 @@
 // Sentry Event Types based on the Sentry protocol
 
+export type SentryTimestamp = string | number
+
 export interface SentrySDK {
   name: string
   version: string
@@ -132,7 +134,7 @@ export interface SentryException {
 }
 
 export interface SentryBreadcrumb {
-  timestamp?: number
+  timestamp?: SentryTimestamp
   category?: string
   level?: string
   message?: string
@@ -152,10 +154,10 @@ export interface SentrySpan {
   status?: string
   span_id: string
   trace_id: string
-  timestamp?: number
+  timestamp?: SentryTimestamp
   description?: string
   parent_span_id?: string
-  start_timestamp?: number
+  start_timestamp?: SentryTimestamp
   op?: string
   tags?: Record<string, any>
 }
@@ -189,14 +191,14 @@ export interface SentryEvent {
     exception?: {
       values: SentryException[]
     }
-    timestamp: number
+    timestamp: SentryTimestamp
     breadcrumbs?: {
       values: SentryBreadcrumb[]
     }
     environment?: string
     server_name?: string
     transaction?: string
-    start_timestamp?: number
+    start_timestamp?: SentryTimestamp
     transaction_info?: SentryTransactionInfo
     // Additional fields
     measurements?: Record<string, { value: number; unit?: string }>


### PR DESCRIPTION
## Summary

Fix Error Tracking rendering for Sentry protocol timestamps represented as RFC3339 strings, while retaining support for numeric Unix timestamps in seconds.

Sentry permits both representations, but the console types and rendering paths assumed numeric seconds and performed arithmetic directly on the raw values. A valid RFC3339 string therefore became `NaN` and could crash `date-fns` formatting with `RangeError: Invalid time value`.

## Changes

- add a shared `SentryTimestamp = string | number` protocol type
- add a shared parser for RFC3339 strings and numeric Unix seconds
- preserve Sentry's rule that timezone-less string timestamps are UTC
- render invalid event timestamps as `Unknown time` instead of throwing
- use parsed timestamps for breadcrumb sorting and relative time display
- use parsed timestamps for span and transaction duration calculations
- preserve the original raw event payload shown by the event detail UI

Numeric strings are intentionally not reinterpreted as Unix time, and there is no seconds-vs-milliseconds magnitude heuristic because the Sentry protocol defines numeric timestamps in seconds.

## Tests

Adds Bun unit coverage for:

- numeric Unix seconds
- RFC3339 with an explicit offset and nanosecond precision
- timezone-less RFC3339 timestamps (UTC semantics)
- invalid/non-finite values
- numeric strings remaining unsupported
- millisecond conversion used by sorting/duration calculations

CI will provide the repository-level test/typecheck validation.

Fixes #726