### PR TITLE
feat(otel): count and alarm on rate-limited/quota-exceeded ingest requests

### DIFF
--- a/crates/temps-monitoring/src/alarm_service.rs
+++ b/crates/temps-monitoring/src/alarm_service.rs
@@ -43,6 +43,11 @@ pub enum AlarmType {
     DeploymentMetricThreshold,
     /// A node cpu/disk/memory metric crossed the configured threshold.
     NodeMetricThreshold,
+    /// OTLP ingest requests were rejected by the per-project rate limiter or
+    /// storage quota, and the count crossed the configured threshold. The
+    /// metric points are written as `otel.rate_limited_requests` /
+    /// `otel.quota_exceeded_requests` on `SourceKind::Node` (node_id 0).
+    OtelRateLimited,
 }
 
 impl AlarmType {
@@ -61,6 +66,7 @@ impl AlarmType {
             Self::ContainerMetricThreshold => "container_metric_threshold",
             Self::DeploymentMetricThreshold => "deployment_metric_threshold",
             Self::NodeMetricThreshold => "node_metric_threshold",
+            Self::OtelRateLimited => "otel_rate_limited",
         }
     }
 
@@ -79,6 +85,7 @@ impl AlarmType {
             "container_metric_threshold" => Some(Self::ContainerMetricThreshold),
             "deployment_metric_threshold" => Some(Self::DeploymentMetricThreshold),
             "node_metric_threshold" => Some(Self::NodeMetricThreshold),
+            "otel_rate_limited" => Some(Self::OtelRateLimited),
             _ => None,
         }
     }
@@ -1069,6 +1076,7 @@ mod tests {
             AlarmType::HighMemory,
             AlarmType::DeploymentFailed,
             AlarmType::HealthCheckFailed,
+            AlarmType::OtelRateLimited,
         ];
 
         for t in &types {

--- a/crates/temps-monitoring/src/evaluator.rs
+++ b/crates/temps-monitoring/src/evaluator.rs
@@ -140,6 +140,13 @@ impl AlertEvaluator {
             warn!("AlertEvaluator: failed to seed default proxy rules on startup: {e}");
         }
 
+        // Seed the default OTel rate-limit alarm rule for the control-plane
+        // node. Idempotent via the same ON CONFLICT DO NOTHING as the proxy
+        // rules above.
+        if let Err(e) = seed_default_otel_rate_limit_rules(self.db.as_ref()).await {
+            warn!("AlertEvaluator: failed to seed default OTel rate-limit rules on startup: {e}");
+        }
+
         // Seed default file-descriptor/socket exhaustion rules for the
         // control-plane node. `NodeMetricsSampler` (spawned alongside the
         // proxy metrics sampler) writes `node.*` points for node 0 whenever
@@ -668,7 +675,21 @@ fn compare(lhs: f64, rhs: f64, comparator: &str) -> bool {
 }
 
 /// Map a rule to the most appropriate [`AlarmType`].
+///
+/// OTel ingest rejection metrics (`otel.rate_limited_requests` /
+/// `otel.quota_exceeded_requests`) are written on the control-plane node
+/// (`SourceKind::Node`, node_id 0).  Because they share the same source
+/// kind/ID as other node metrics, we discriminate by metric name so the fired
+/// alarm carries the purpose-built `OtelRateLimited` type instead of the
+/// generic `NodeMetricThreshold`.
 fn alarm_type_for_rule(rule: &monitoring_alert_rules::Model) -> AlarmType {
+    // OTel ingest rejection metrics keyed on the control-plane node.
+    if matches!(
+        rule.metric_name.as_str(),
+        "otel.rate_limited_requests" | "otel.quota_exceeded_requests"
+    ) {
+        return AlarmType::OtelRateLimited;
+    }
     match (rule.service_id, rule.deployment_id, rule.node_id) {
         (Some(_), None, None) => AlarmType::DatabaseMetricThreshold,
         (None, Some(_), None) => AlarmType::DeploymentMetricThreshold,
@@ -807,6 +828,30 @@ const CONTROL_PLANE_NODE_ID: i32 = 0;
 /// `(node_id, metric_name)` so concurrent calls are safe.
 pub async fn seed_default_proxy_rules(db: &DatabaseConnection) -> Result<(), MetricsError> {
     seed_node_rules(db, "seed_default_proxy_rules", &proxy_default_seeds()).await
+}
+
+/// Insert a default alert rule that fires when OTLP ingest requests are being
+/// rate-limited at a sustained high rate, indicating either a noisy client or
+/// a quota that is too low for legitimate traffic.
+///
+/// The metric `otel.rate_limited_requests` is written to the metrics store by
+/// the OTel plugin's background pipeline-stats sampler (SourceKind::Node,
+/// node_id 0) every 60 seconds as a delta counter. The default threshold of
+/// 10 rejected requests per 60-second sample fires a warning if any project
+/// is being consistently turned away. Operators can tighten or loosen this by
+/// editing the seeded rule.
+///
+/// Uses `INSERT … ON CONFLICT DO NOTHING` against the unique index
+/// `(node_id, metric_name)` so concurrent calls are safe.
+pub async fn seed_default_otel_rate_limit_rules(
+    db: &DatabaseConnection,
+) -> Result<(), MetricsError> {
+    seed_node_rules(
+        db,
+        "seed_default_otel_rate_limit_rules",
+        &otel_rate_limit_default_seeds(),
+    )
+    .await
 }
 
 /// Insert default file-descriptor/socket exhaustion alert rules for the
@@ -1208,6 +1253,25 @@ fn node_fd_default_seeds() -> Vec<RuleSeed> {
             for_duration_secs: 30,
         },
     ]
+}
+
+/// Default alert rule for OTel ingest rate limiting.
+///
+/// Fires when the 60-second pipeline-stats sample reports more than 10 ingest
+/// requests rejected by the rate limiter.  A single noisy batch that briefly
+/// tips over the limit will not fire (it fires only when the threshold is
+/// crossed on a single sample, not sustained over time — `for_duration_secs`
+/// is 0 for immediacy).  Operators who want sustained-breach semantics can
+/// edit the rule and set `for_duration_secs`.
+fn otel_rate_limit_default_seeds() -> Vec<RuleSeed> {
+    vec![RuleSeed {
+        name: "OTel ingest rate-limited",
+        metric_name: "otel.rate_limited_requests",
+        threshold: 10.0,
+        comparator: ">",
+        severity: "warning",
+        for_duration_secs: 0,
+    }]
 }
 
 fn container_default_seeds() -> Vec<RuleSeed> {

--- a/crates/temps-monitoring/src/evaluator.rs
+++ b/crates/temps-monitoring/src/evaluator.rs
@@ -1453,6 +1453,36 @@ mod tests {
     }
 
     #[test]
+    fn alarm_type_otel_rate_limited_rule_is_otel_rate_limited() {
+        // Both rejection metrics the OTel pipeline-stats sampler writes must
+        // route to the same alarm type, regardless of (service/deployment/node)
+        // scope on the rule row — the metric name is authoritative here, not
+        // the scope columns matched by the fallback below it.
+        for metric in ["otel.rate_limited_requests", "otel.quota_exceeded_requests"] {
+            let mut rule = make_rule_with_node(None, None, Some(0));
+            rule.metric_name = metric.to_string();
+            assert_eq!(
+                alarm_type_for_rule(&rule).as_str(),
+                "otel_rate_limited",
+                "metric {metric} did not map to OtelRateLimited"
+            );
+        }
+    }
+
+    #[test]
+    fn otel_rate_limit_default_seeds_target_the_sampler_written_metric() {
+        let seeds = otel_rate_limit_default_seeds();
+        assert_eq!(seeds.len(), 1);
+        let seed = &seeds[0];
+        // Must match the metric name the plugin.rs pipeline-stats sampler
+        // actually writes, and the one `alarm_type_for_rule` recognizes above
+        // — a drift between these three would seed a rule that never fires.
+        assert_eq!(seed.metric_name, "otel.rate_limited_requests");
+        assert_eq!(seed.comparator, ">");
+        assert!(seed.threshold > 0.0);
+    }
+
+    #[test]
     fn proxy_default_seeds_are_rate_based_and_unique_per_metric() {
         let seeds = proxy_default_seeds();
         assert_eq!(seeds.len(), 2);

--- a/crates/temps-otel/src/plugin.rs
+++ b/crates/temps-otel/src/plugin.rs
@@ -815,6 +815,16 @@ impl TempsPlugin for OtelPlugin {
             // because the pipeline stats are process-internal counters rather than
             // externally-scraped ones; re-reading the config each cycle would add an
             // unnecessary DB round-trip on an ingest-hot path.
+            //
+            // Every cycle writes both points, even when the delta is zero. The
+            // AlertEvaluator's `query_latest` only looks back 15 minutes
+            // (`LATEST_WINDOW`), so if a burst of rejections is followed by
+            // silence, skipping the zero-delta write would leave that burst's
+            // non-zero point as the "latest" value for up to 15 minutes,
+            // keeping the alarm falsely active. Always writing — including
+            // zeros — lets the metric self-resolve on the next cycle, exactly
+            // like the proxy sampler's fixed-size point set does. The storage
+            // cost is two rows per minute regardless of ingest volume.
             {
                 const OTEL_STATS_SAMPLE_INTERVAL_SECS: u64 = 60;
                 /// Synthetic node ID of the control plane (mirrors proxy metrics sampler).
@@ -850,20 +860,9 @@ impl TempsPlugin for OtelPlugin {
                             .quota_exceeded_requests
                             .saturating_sub(prev_quota_exceeded);
 
-                        prev_rate_limited = snap.rate_limited_requests;
-                        prev_quota_exceeded = snap.quota_exceeded_requests;
-
-                        // Skip the write if both deltas are zero: no rejections happened,
-                        // no point in a noisy all-zero row in the metrics store.
-                        if delta_rate_limited == 0 && delta_quota_exceeded == 0 {
-                            continue;
-                        }
-
                         let now = Utc::now();
-                        let mut points = Vec::with_capacity(2);
-
-                        if delta_rate_limited > 0 {
-                            points.push(MetricPoint {
+                        let points = vec![
+                            MetricPoint {
                                 time: now,
                                 source_kind: SourceKind::Node,
                                 source_id: CONTROL_PLANE_NODE_ID,
@@ -874,11 +873,8 @@ impl TempsPlugin for OtelPlugin {
                                 environment: None,
                                 node_id: Some(CONTROL_PLANE_NODE_ID),
                                 labels: HashMap::new(),
-                            });
-                        }
-
-                        if delta_quota_exceeded > 0 {
-                            points.push(MetricPoint {
+                            },
+                            MetricPoint {
                                 time: now,
                                 source_kind: SourceKind::Node,
                                 source_id: CONTROL_PLANE_NODE_ID,
@@ -889,16 +885,25 @@ impl TempsPlugin for OtelPlugin {
                                 environment: None,
                                 node_id: Some(CONTROL_PLANE_NODE_ID),
                                 labels: HashMap::new(),
-                            });
-                        }
+                            },
+                        ];
 
+                        // Only advance the checkpoints once the write actually lands.
+                        // Advancing them unconditionally would discard this cycle's
+                        // deltas forever on a transient store failure; leaving them
+                        // in place means the next successful write's delta widens to
+                        // cover the missed cycle too, so no rejection is lost from
+                        // the series.
                         if let Err(e) = stats_metrics_store.write_batch(points).await {
                             warn!(
                                 error = %e,
                                 "OTel pipeline stats write failed (non-fatal); \
-                                 counters continue accumulating and will be included in the next sample"
+                                 checkpoints held back so the next successful write \
+                                 includes this cycle's deltas"
                             );
                         } else {
+                            prev_rate_limited = snap.rate_limited_requests;
+                            prev_quota_exceeded = snap.quota_exceeded_requests;
                             debug!(
                                 delta_rate_limited,
                                 delta_quota_exceeded, "OTel pipeline stats sampled and written"

--- a/crates/temps-otel/src/plugin.rs
+++ b/crates/temps-otel/src/plugin.rs
@@ -797,6 +797,117 @@ impl TempsPlugin for OtelPlugin {
                 });
             }
 
+            // 1c-stats. Background sampler: OTel pipeline rejection stats → MetricsStore.
+            //
+            // Reads `otel_service.pipeline_stats()` every 60 seconds, computes
+            // the delta since the previous sample, and writes two counter points
+            // to the unified MetricsStore (SourceKind::Node, node_id 0):
+            //
+            //   otel.rate_limited_requests  — ingest rejections from the rate limiter
+            //   otel.quota_exceeded_requests — ingest rejections from quota enforcement
+            //
+            // Using delta values (not cumulative) matches the proxy metrics sampler
+            // pattern: each store point represents "rejections in the last N seconds"
+            // so the AlertEvaluator threshold (e.g. "> 10") is intuitive to an
+            // operator ("more than 10 rejections this sample window").
+            //
+            // The 60-second interval is independent of `monitoring.scrape_interval_secs`
+            // because the pipeline stats are process-internal counters rather than
+            // externally-scraped ones; re-reading the config each cycle would add an
+            // unnecessary DB round-trip on an ingest-hot path.
+            {
+                const OTEL_STATS_SAMPLE_INTERVAL_SECS: u64 = 60;
+                /// Synthetic node ID of the control plane (mirrors proxy metrics sampler).
+                const CONTROL_PLANE_NODE_ID: i32 = 0;
+
+                let stats_otel_service = otel_service.clone();
+                let stats_metrics_store = metrics_store.clone();
+                tokio::spawn(async move {
+                    use chrono::Utc;
+                    use std::collections::HashMap;
+                    use temps_metrics::{MetricKind, MetricPoint, SourceKind};
+
+                    info!(
+                        "OTel pipeline stats sampler started (interval={}s)",
+                        OTEL_STATS_SAMPLE_INTERVAL_SECS
+                    );
+                    let mut interval =
+                        tokio::time::interval(Duration::from_secs(OTEL_STATS_SAMPLE_INTERVAL_SECS));
+                    interval.tick().await; // discard the immediate first tick
+
+                    let mut prev_rate_limited: u64 = 0;
+                    let mut prev_quota_exceeded: u64 = 0;
+
+                    loop {
+                        interval.tick().await;
+                        let snap = stats_otel_service.pipeline_stats();
+
+                        // Compute monotonic deltas; saturating_sub guards against a
+                        // counter reset (process restart resets all atomics to 0).
+                        let delta_rate_limited =
+                            snap.rate_limited_requests.saturating_sub(prev_rate_limited);
+                        let delta_quota_exceeded = snap
+                            .quota_exceeded_requests
+                            .saturating_sub(prev_quota_exceeded);
+
+                        prev_rate_limited = snap.rate_limited_requests;
+                        prev_quota_exceeded = snap.quota_exceeded_requests;
+
+                        // Skip the write if both deltas are zero: no rejections happened,
+                        // no point in a noisy all-zero row in the metrics store.
+                        if delta_rate_limited == 0 && delta_quota_exceeded == 0 {
+                            continue;
+                        }
+
+                        let now = Utc::now();
+                        let mut points = Vec::with_capacity(2);
+
+                        if delta_rate_limited > 0 {
+                            points.push(MetricPoint {
+                                time: now,
+                                source_kind: SourceKind::Node,
+                                source_id: CONTROL_PLANE_NODE_ID,
+                                name: "otel.rate_limited_requests".to_string(),
+                                value: delta_rate_limited as f64,
+                                kind: MetricKind::Counter,
+                                engine: Some("otel".to_string()),
+                                environment: None,
+                                node_id: Some(CONTROL_PLANE_NODE_ID),
+                                labels: HashMap::new(),
+                            });
+                        }
+
+                        if delta_quota_exceeded > 0 {
+                            points.push(MetricPoint {
+                                time: now,
+                                source_kind: SourceKind::Node,
+                                source_id: CONTROL_PLANE_NODE_ID,
+                                name: "otel.quota_exceeded_requests".to_string(),
+                                value: delta_quota_exceeded as f64,
+                                kind: MetricKind::Counter,
+                                engine: Some("otel".to_string()),
+                                environment: None,
+                                node_id: Some(CONTROL_PLANE_NODE_ID),
+                                labels: HashMap::new(),
+                            });
+                        }
+
+                        if let Err(e) = stats_metrics_store.write_batch(points).await {
+                            warn!(
+                                error = %e,
+                                "OTel pipeline stats write failed (non-fatal); \
+                                 counters continue accumulating and will be included in the next sample"
+                            );
+                        } else {
+                            debug!(
+                                delta_rate_limited,
+                                delta_quota_exceeded, "OTel pipeline stats sampled and written"
+                            );
+                        }
+                    }
+                });
+            }
+
             // 1d. ADR-027 Phase 0: daily prune of POSTGRES cross_project_trace_refs
             //     rows older than 90 days (matching the OTel span TTL on both
             //     backends). Runs unconditionally: on the TimescaleDB backend it

--- a/crates/temps-otel/src/services/otel_service.rs
+++ b/crates/temps-otel/src/services/otel_service.rs
@@ -854,6 +854,7 @@ mod tests {
 
         assert!(svc.check_rate_limit(1).is_ok());
         assert!(svc.check_rate_limit(1).is_ok());
+        assert_eq!(svc.pipeline_stats().rate_limited_requests, 0);
         let result = svc.check_rate_limit(1);
         // The error must report the limiter's actual configured limit (2),
         // not a hardcoded value.
@@ -861,6 +862,14 @@ mod tests {
             result,
             Err(OtelError::RateLimitExceeded { limit: 2, .. })
         ));
+        // The rejection counter the pipeline-stats sampler reads must move —
+        // this is what makes the rejection observable at all (dashboard,
+        // metrics store, alarm). A regression here silently blinds both.
+        assert_eq!(svc.pipeline_stats().rate_limited_requests, 1);
+
+        // A second rejection accumulates rather than resetting.
+        assert!(svc.check_rate_limit(1).is_err());
+        assert_eq!(svc.pipeline_stats().rate_limited_requests, 2);
     }
 
     // ── service (`si_`) ingest rate limit (SECURITY metrics-security-2) ────────
@@ -974,6 +983,7 @@ mod tests {
         });
         let (svc, _storage) = make_service(mock);
 
+        assert_eq!(svc.pipeline_stats().quota_exceeded_requests, 0);
         let result = svc.check_quota(42).await;
         assert!(matches!(
             result,
@@ -983,6 +993,11 @@ mod tests {
                 limit_bytes: 100,
             })
         ));
+        // Same counter contract as the rate-limit rejection path above: the
+        // pipeline-stats sampler and the settings-page UI both read this
+        // field, so a quota rejection that doesn't increment it is invisible
+        // to an operator even though requests are actually being dropped.
+        assert_eq!(svc.pipeline_stats().quota_exceeded_requests, 1);
     }
 
     #[tokio::test]

--- a/crates/temps-otel/src/services/otel_service.rs
+++ b/crates/temps-otel/src/services/otel_service.rs
@@ -75,6 +75,11 @@ struct PipelineStatsAtomic {
     logs_stored_s3: AtomicU64,
     logs_dropped: AtomicU64,
     ingest_errors: AtomicU64,
+    /// Ingest requests rejected by the per-project rate limiter (→ HTTP 429).
+    rate_limited_requests: AtomicU64,
+    /// Ingest requests rejected because the per-project storage quota was
+    /// exhausted (→ HTTP 413).
+    quota_exceeded_requests: AtomicU64,
 }
 
 impl Default for PipelineStatsAtomic {
@@ -91,6 +96,8 @@ impl Default for PipelineStatsAtomic {
             logs_stored_s3: AtomicU64::new(0),
             logs_dropped: AtomicU64::new(0),
             ingest_errors: AtomicU64::new(0),
+            rate_limited_requests: AtomicU64::new(0),
+            quota_exceeded_requests: AtomicU64::new(0),
         }
     }
 }
@@ -157,6 +164,9 @@ impl OtelService {
         if !self.rate_limiter.check_and_increment(project_id) {
             // Report the limiter's actual configured limit (set via
             // `TEMPS_OTEL_RATE_LIMIT`) so the error matches reality.
+            self.stats
+                .rate_limited_requests
+                .fetch_add(1, Ordering::Relaxed);
             return Err(OtelError::RateLimitExceeded {
                 project_id,
                 limit: self.rate_limiter.max_requests(),
@@ -196,6 +206,9 @@ impl OtelService {
         };
 
         if quota.usage_pct >= 100.0 {
+            self.stats
+                .quota_exceeded_requests
+                .fetch_add(1, Ordering::Relaxed);
             return Err(OtelError::QuotaExceeded {
                 project_id,
                 used_bytes: quota.total_bytes,
@@ -538,6 +551,8 @@ impl OtelService {
             logs_stored_s3: self.stats.logs_stored_s3.load(Ordering::Relaxed),
             logs_dropped: self.stats.logs_dropped.load(Ordering::Relaxed),
             ingest_errors: self.stats.ingest_errors.load(Ordering::Relaxed),
+            rate_limited_requests: self.stats.rate_limited_requests.load(Ordering::Relaxed),
+            quota_exceeded_requests: self.stats.quota_exceeded_requests.load(Ordering::Relaxed),
         }
     }
 

--- a/crates/temps-otel/src/types.rs
+++ b/crates/temps-otel/src/types.rs
@@ -617,6 +617,14 @@ pub struct PipelineStats {
     pub logs_stored_s3: u64,
     pub logs_dropped: u64,
     pub ingest_errors: u64,
+    /// Cumulative count of ingest requests rejected because the per-project
+    /// rate limit was exceeded (→ HTTP 429). Written to the metrics store as
+    /// `otel.rate_limited_requests` (SourceKind::Node, node_id 0) every 60s.
+    pub rate_limited_requests: u64,
+    /// Cumulative count of ingest requests rejected because the per-project
+    /// storage quota was exceeded (→ HTTP 413). Written to the metrics store
+    /// as `otel.quota_exceeded_requests` (SourceKind::Node, node_id 0) every 60s.
+    pub quota_exceeded_requests: u64,
 }
 
 // ── Query types ─────────────────────────────────────────────────────

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -414,6 +414,11 @@ const GlobalSkillDetailPage = lazy(() =>
     default: m.GlobalSkillDetail,
   }))
 )
+const OtelPipelineStatusPage = lazy(() =>
+  import('./pages/settings/OtelPipelineStatusPage').then((m) => ({
+    default: m.OtelPipelineStatusPage,
+  }))
+)
 const GlobalMcpServerDetailPage = lazy(() =>
   import('./pages/settings/GlobalMcpServerDetail').then((m) => ({
     default: m.GlobalMcpServerDetail,
@@ -675,6 +680,10 @@ const FullAppRoutes = () => {
                         element={<NodeDetailPage />}
                       />
                       <Route path="plugins" element={<PluginsPage />} />
+                      <Route
+                        path="otel-pipeline"
+                        element={<OtelPipelineStatusPage />}
+                      />
                     </Route>
                     {/* Top-level resources surfaced in the main sidebar */}
                     <Route path="/domains" element={<Domains />} />

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -12549,6 +12549,16 @@ export type PipelineStats = {
     metrics_dropped: number;
     metrics_received: number;
     metrics_stored: number;
+    /**
+     * Cumulative count of ingest requests rejected because the per-project
+     * rate limit was exceeded (HTTP 429). Sampled to otel.rate_limited_requests every 60s.
+     */
+    quota_exceeded_requests: number;
+    /**
+     * Cumulative count of ingest requests rejected because the per-project
+     * storage quota was exceeded (HTTP 413). Sampled to otel.quota_exceeded_requests every 60s.
+     */
+    rate_limited_requests: number;
     spans_dropped: number;
     spans_received: number;
     spans_stored: number;

--- a/web/src/components/dashboard/Sidebar.tsx
+++ b/web/src/components/dashboard/Sidebar.tsx
@@ -230,6 +230,11 @@ const settingsGroups: SettingsGroupDef[] = [
         url: '/settings/metrics-monitoring',
         icon: BarChart3,
       },
+      {
+        title: 'OTel Pipeline',
+        url: '/settings/otel-pipeline',
+        icon: Activity,
+      },
     ],
   },
 ]

--- a/web/src/pages/settings/OtelPipelineStatusPage.tsx
+++ b/web/src/pages/settings/OtelPipelineStatusPage.tsx
@@ -107,9 +107,13 @@ export function OtelPipelineStatusPage() {
 
   usePageTitle('OTel Pipeline Status')
 
-  const { data, isLoading, error } = useQuery(
-    getPipelineStatsOptions({ cache: 'no-store' })
-  )
+  const { data, isLoading, error } = useQuery({
+    ...getPipelineStatsOptions({ cache: 'no-store' }),
+    // Matches NodesPage's status-tile cadence: frequent enough that an
+    // operator watching this page after a rejection spike sees it clear
+    // without a manual refresh, cheap enough for a page that's rarely open.
+    refetchInterval: 30_000,
+  })
 
   const stats = data?.stats
 

--- a/web/src/pages/settings/OtelPipelineStatusPage.tsx
+++ b/web/src/pages/settings/OtelPipelineStatusPage.tsx
@@ -1,0 +1,264 @@
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { useBreadcrumbs } from '@/contexts/BreadcrumbContext'
+import { usePageTitle } from '@/hooks/usePageTitle'
+import { getPipelineStatsOptions } from '@/api/client/@tanstack/react-query.gen'
+import { useQuery } from '@tanstack/react-query'
+import { AlertCircle, AlertTriangle, ArrowRight, Activity } from 'lucide-react'
+import { useEffect } from 'react'
+import { Link } from 'react-router'
+
+function StatCard({
+  label,
+  value,
+  warn,
+  description,
+}: {
+  label: string
+  value: number | undefined
+  warn?: boolean
+  description?: string
+}) {
+  return (
+    <div
+      className={`rounded-lg border p-4 ${warn && value ? 'border-amber-400 bg-amber-50 dark:bg-amber-950/30' : 'bg-card'}`}
+    >
+      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        {label}
+      </p>
+      {value === undefined ? (
+        <Skeleton className="mt-2 h-7 w-20" />
+      ) : (
+        <p
+          className={`mt-1 text-2xl font-semibold tabular-nums ${warn && value > 0 ? 'text-amber-600 dark:text-amber-400' : ''}`}
+        >
+          {value.toLocaleString()}
+        </p>
+      )}
+      {description && (
+        <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+      )}
+    </div>
+  )
+}
+
+function SignalSection({
+  label,
+  received,
+  stored,
+  dropped,
+  isLoading,
+}: {
+  label: string
+  received: number | undefined
+  stored: number | undefined
+  dropped: number | undefined
+  isLoading: boolean
+}) {
+  const droppedCount = dropped ?? 0
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <h3 className="text-sm font-medium">{label}</h3>
+        {!isLoading && droppedCount > 0 && (
+          <Badge variant="destructive" className="text-xs">
+            {droppedCount.toLocaleString()} dropped
+          </Badge>
+        )}
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+        <StatCard
+          label="Received"
+          value={isLoading ? undefined : received}
+          description="Total ingest requests"
+        />
+        <StatCard
+          label="Stored"
+          value={isLoading ? undefined : stored}
+          description="Successfully persisted"
+        />
+        <StatCard
+          label="Dropped"
+          value={isLoading ? undefined : dropped}
+          description="Failed to store"
+        />
+      </div>
+    </div>
+  )
+}
+
+export function OtelPipelineStatusPage() {
+  const { setBreadcrumbs } = useBreadcrumbs()
+
+  useEffect(() => {
+    setBreadcrumbs([
+      { label: 'Settings', href: '/settings' },
+      { label: 'OTel Pipeline Status' },
+    ])
+  }, [setBreadcrumbs])
+
+  usePageTitle('OTel Pipeline Status')
+
+  const { data, isLoading, error } = useQuery(
+    getPipelineStatsOptions({ cache: 'no-store' })
+  )
+
+  const stats = data?.stats
+
+  const rateLimited = stats?.rate_limited_requests ?? 0
+  const quotaExceeded = stats?.quota_exceeded_requests ?? 0
+  const hasRejections = !isLoading && (rateLimited > 0 || quotaExceeded > 0)
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="h-4 w-4" />
+        <AlertTitle>Failed to load pipeline stats</AlertTitle>
+        <AlertDescription>
+          Could not fetch OTel pipeline statistics. The server may be
+          unavailable or you may not have permission.
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <Activity className="h-5 w-5 text-muted-foreground" />
+          <h1 className="text-xl font-semibold">OTel Pipeline Status</h1>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Cumulative counters since the last server restart. Rejection counters
+          are also written to the metrics store every 60&nbsp;s and can trigger
+          alarms.
+        </p>
+      </div>
+
+      {/* Rejection counters — always shown first since they're the point of this page */}
+      <Card className={hasRejections ? 'border-amber-400' : undefined}>
+        <CardHeader className="pb-3">
+          <div className="flex items-center gap-2">
+            <CardTitle className="text-base">Rejected requests</CardTitle>
+            {hasRejections && (
+              <AlertTriangle className="h-4 w-4 text-amber-500" />
+            )}
+          </div>
+          <CardDescription>
+            Ingest requests turned away since the server started. Non-zero
+            values mean projects are hitting their quotas or rate limits.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <StatCard
+              label="Rate limited (429)"
+              value={isLoading ? undefined : rateLimited}
+              warn
+              description="otel.rate_limited_requests"
+            />
+            <StatCard
+              label="Quota exceeded (413)"
+              value={isLoading ? undefined : quotaExceeded}
+              warn
+              description="otel.quota_exceeded_requests"
+            />
+          </div>
+
+          {hasRejections && (
+            <Alert className="mt-4" variant="default">
+              <AlertTriangle className="h-4 w-4 text-amber-500" />
+              <AlertTitle>Rejections detected</AlertTitle>
+              <AlertDescription className="flex items-center gap-2">
+                Projects are being rate-limited or have exceeded their storage
+                quota. Check the{' '}
+                <Link
+                  to="/monitoring/alarms"
+                  className="inline-flex items-center gap-1 font-medium underline underline-offset-2"
+                >
+                  Alarms page
+                  <ArrowRight className="h-3 w-3" />
+                </Link>{' '}
+                to see whether the OtelRateLimited alarm is firing.
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {!hasRejections && !isLoading && (
+            <p className="mt-3 text-xs text-muted-foreground">
+              No rejections recorded.{' '}
+              <Link
+                to="/monitoring/alarms"
+                className="inline-flex items-center gap-1 underline underline-offset-2"
+              >
+                View alarms
+                <ArrowRight className="h-3 w-3" />
+              </Link>
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Per-signal pipeline health */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Pipeline throughput</CardTitle>
+          <CardDescription>
+            Received vs. stored vs. dropped counts per signal type since the
+            last server restart.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <SignalSection
+            label="Traces (spans)"
+            received={stats?.spans_received}
+            stored={stats?.spans_stored}
+            dropped={stats?.spans_dropped}
+            isLoading={isLoading}
+          />
+          <SignalSection
+            label="Metrics"
+            received={stats?.metrics_received}
+            stored={stats?.metrics_stored}
+            dropped={stats?.metrics_dropped}
+            isLoading={isLoading}
+          />
+          <SignalSection
+            label="Logs"
+            received={stats?.logs_received}
+            stored={stats?.logs_stored_db}
+            dropped={stats?.logs_dropped}
+            isLoading={isLoading}
+          />
+
+          <div className="border-t pt-4">
+            <div className="flex items-center gap-2">
+              <h3 className="text-sm font-medium">Ingest errors</h3>
+              {!isLoading && (stats?.ingest_errors ?? 0) > 0 && (
+                <Badge variant="destructive" className="text-xs">
+                  {(stats?.ingest_errors ?? 0).toLocaleString()} errors
+                </Badge>
+              )}
+            </div>
+            <div className="mt-2 grid grid-cols-2 md:grid-cols-4 gap-3">
+              <StatCard
+                label="Ingest errors"
+                value={isLoading ? undefined : stats?.ingest_errors}
+                description="Parse/processing failures"
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- OTel ingest requests rejected by the per-project rate limiter (429) or storage quota (413) were previously invisible — nothing counted or surfaced them.
- Adds atomic rejection counters (`rate_limited_requests`, `quota_exceeded_requests`) on `PipelineStats`, incremented at the actual rejection points in `temps-otel`, and sampled every 60s into the shared metrics store as `otel.rate_limited_requests` / `otel.quota_exceeded_requests` — mirroring the existing proxy-stats sampler pattern (zero per-request overhead, atomics only, decoupled from span/event volume).
- Adds `AlarmType::OtelRateLimited` in `temps-monitoring`, with a default threshold rule (`otel.rate_limited_requests > 10`, warning) seeded at startup alongside the existing default proxy/node-resource rules.
- Adds a read-only "OTel Pipeline" settings page (`/settings/otel-pipeline`, linked from the Settings sidebar) showing rejection counts and per-signal (traces/metrics/logs) received/stored/dropped throughput, with a link out to the Alarms page.

## Test plan
- [x] `cargo check --lib` clean across touched crates (`temps-otel`, `temps-monitoring`)
- [x] `cargo test --lib -p temps-otel` (494 passed) and `cargo test --lib -p temps-monitoring` (99 passed)
- [x] `cargo fmt` / `cargo clippy -D warnings` clean (via pre-commit hooks on this commit)
- [x] `tsc --noEmit` clean on `web/`
- [x] End-to-end verified on a fresh local instance (slot 15, `start-temps`): logged in, navigated Settings → OTel Pipeline, confirmed the page renders live data from `GET /otel/pipeline-stats` (all zero on a fresh install, correctly matching an empty pipeline), confirmed "View alarms" links to `/monitoring/alarms`, and confirmed the seeded default alert rule exists in Postgres (`monitoring_alert_rules`: `otel.rate_limited_requests > 10`, `enabled = true`, node 0) — proving the startup seeding wire-up actually runs, not just compiles.
- [ ] Not exercised: an actual 429/413 rejection driving the counter to a nonzero value end-to-end (would require provisioning a project + OTel-enabled service + ingest token and waiting on the 60s sampler) — the increment path is covered by the crate's existing unit tests instead.