### PR TITLE
feat(flags): allow TEMPS_FLAGS_REFRESH_INTERVAL_MS to override the 30s poll

### DIFF
--- a/sdks/node/packages/node-sdk/src/flags/client.test.ts
+++ b/sdks/node/packages/node-sdk/src/flags/client.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FlagsClient } from './client';
+import type { FlagSnapshotResponse } from './types';
+
+/**
+ * The refresh interval is the one setting an operator is likely to reach for
+ * without touching app code — via `TEMPS_FLAGS_REFRESH_INTERVAL_MS` on the
+ * deployment, not a `FlagsClient` constructor argument. These tests cover the
+ * env var path specifically: the constructor option path is exercised
+ * incidentally by every other test in this package that passes
+ * `refreshIntervalMs` directly.
+ */
+
+const SNAPSHOT: FlagSnapshotResponse = {
+  environment_id: 1,
+  flags: [{ key: 'checkout.v2', value_type: 'bool', default_value: false, enabled: true }],
+};
+
+function mockFetch() {
+  const fetchMock = vi.fn(async () => new Response(JSON.stringify(SNAPSHOT), { status: 200 }));
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('refresh interval from TEMPS_FLAGS_REFRESH_INTERVAL_MS', () => {
+  it('polls on the env-provided interval instead of the 30s default', async () => {
+    vi.useFakeTimers();
+    vi.stubEnv('TEMPS_FLAGS_REFRESH_INTERVAL_MS', '5000');
+    const fetchMock = mockFetch();
+
+    const client = new FlagsClient({ apiUrl: 'http://temps.test/api', apiToken: 'dt_test' });
+    await client.init();
+    expect(fetchMock).toHaveBeenCalledTimes(1); // initial load
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(fetchMock).toHaveBeenCalledTimes(2); // fired at 5s, not 30s
+
+    client.close();
+  });
+
+  it('an explicit refreshIntervalMs option wins over the env var', async () => {
+    vi.useFakeTimers();
+    vi.stubEnv('TEMPS_FLAGS_REFRESH_INTERVAL_MS', '5000');
+    const fetchMock = mockFetch();
+
+    const client = new FlagsClient({
+      apiUrl: 'http://temps.test/api',
+      apiToken: 'dt_test',
+      refreshIntervalMs: 1000,
+    });
+    await client.init();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fetchMock).toHaveBeenCalledTimes(2); // the option's 1s, not the env's 5s
+
+    client.close();
+  });
+
+  it('falls back to the 30s default and warns when the env value is not a valid number', async () => {
+    vi.useFakeTimers();
+    vi.stubEnv('TEMPS_FLAGS_REFRESH_INTERVAL_MS', 'not-a-number');
+    mockFetch();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const client = new FlagsClient({ apiUrl: 'http://temps.test/api', apiToken: 'dt_test' });
+    await client.init();
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('TEMPS_FLAGS_REFRESH_INTERVAL_MS'));
+
+    client.close();
+  });
+
+  it('falls back to the 30s default and warns when the env value is negative', async () => {
+    vi.useFakeTimers();
+    vi.stubEnv('TEMPS_FLAGS_REFRESH_INTERVAL_MS', '-1');
+    mockFetch();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const client = new FlagsClient({ apiUrl: 'http://temps.test/api', apiToken: 'dt_test' });
+    await client.init();
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('TEMPS_FLAGS_REFRESH_INTERVAL_MS'));
+
+    client.close();
+  });
+
+  it('an env value of 0 disables background polling, same as the option would', async () => {
+    vi.useFakeTimers();
+    vi.stubEnv('TEMPS_FLAGS_REFRESH_INTERVAL_MS', '0');
+    const fetchMock = mockFetch();
+
+    const client = new FlagsClient({ apiUrl: 'http://temps.test/api', apiToken: 'dt_test' });
+    await client.init();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no timer ever started
+
+    client.close();
+  });
+});

--- a/sdks/node/packages/node-sdk/src/flags/client.ts
+++ b/sdks/node/packages/node-sdk/src/flags/client.ts
@@ -41,6 +41,29 @@ function envVar(name: string): string | undefined {
   return global.process?.env?.[name];
 }
 
+/**
+ * Parse `TEMPS_FLAGS_REFRESH_INTERVAL_MS`, falling back to `fallback` for an
+ * unset, non-numeric, or negative value.
+ *
+ * A malformed value is surfaced via `console.warn` rather than silently
+ * ignored — an operator who set this and sees no effect needs to know the
+ * value they set was rejected, not that the feature doesn't exist.
+ */
+function refreshIntervalFromEnv(fallback: number): number {
+  const raw = envVar('TEMPS_FLAGS_REFRESH_INTERVAL_MS');
+  if (raw === undefined) return fallback;
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    console.warn(
+      `[temps-flags] TEMPS_FLAGS_REFRESH_INTERVAL_MS=${JSON.stringify(raw)} is not a valid non-negative number. Using the default of ${fallback}ms instead.`,
+    );
+    return fallback;
+  }
+
+  return parsed;
+}
+
 export class FlagsClient {
   private readonly apiUrl: string;
   private readonly apiToken: string;
@@ -75,7 +98,8 @@ export class FlagsClient {
     this.apiUrl = (options.apiUrl ?? envVar('TEMPS_API_URL') ?? '').replace(/\/+$/, '');
     this.apiToken = options.apiToken ?? envVar('TEMPS_API_TOKEN') ?? '';
     this.environmentId = options.environmentId;
-    this.refreshIntervalMs = options.refreshIntervalMs ?? DEFAULT_REFRESH_INTERVAL_MS;
+    this.refreshIntervalMs =
+      options.refreshIntervalMs ?? refreshIntervalFromEnv(DEFAULT_REFRESH_INTERVAL_MS);
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.reportExposure = options.reportExposure ?? true;
     this.onError =

--- a/sdks/node/packages/node-sdk/src/flags/types.ts
+++ b/sdks/node/packages/node-sdk/src/flags/types.ts
@@ -78,6 +78,10 @@ export interface FlagsClientOptions {
   /**
    * Background refresh interval in milliseconds. Default 30s. Unchanged flags
    * cost a 304, not a payload.
+   *
+   * Falls back to `TEMPS_FLAGS_REFRESH_INTERVAL_MS` when unset, so a
+   * deployment can tighten (or loosen) polling without a code change or
+   * redeploy of the SDK itself — just the env var.
    */
   refreshIntervalMs?: number;
   /** Per-request timeout in milliseconds. Default 5s. */


### PR DESCRIPTION
## Summary
- `FlagsClient` caches the whole environment's flag snapshot in memory and refreshes it via a background poll every 30s by default — reads are synchronous and cost no I/O, but a flag flipped in the console can take up to 30s to reach an already-running process.
- Adds an env var fallback, `TEMPS_FLAGS_REFRESH_INTERVAL_MS`, so a deployment can tighten or loosen that window without an app code change or SDK redeploy — same `envVar()`-fallback shape already used for `TEMPS_API_URL`/`TEMPS_API_TOKEN`. An explicit `refreshIntervalMs` constructor option still takes precedence.
- A non-numeric or negative value is rejected (falls back to the 30s default) and logged via `console.warn` rather than silently accepted, consistent with this client's existing "surface it, don't swallow it" error handling.
- Setting it to `0` disables the background poll entirely, same behavior as passing `refreshIntervalMs: 0` today.
- Docs for this live in `temps-landing` (separate PR), not here.

## Test plan
- [x] New `client.test.ts` covers: polling on the env-provided interval, an explicit `refreshIntervalMs` option winning over the env var, a non-numeric env value warning and falling back to 30s, a negative env value warning and falling back to 30s, and `0` disabling the timer entirely.
- [x] `bunx vitest run src/flags/` — 24/24 tests pass (3 files, including the 2 pre-existing flag test files, no regressions).
- [x] `bunx tsc --noEmit` — clean.