### PR TITLE
feat(web): searchable, refreshable project select on the Proxy page

### DIFF
--- a/web/src/components/project/ProjectSelect.tsx
+++ b/web/src/components/project/ProjectSelect.tsx
@@ -1,0 +1,201 @@
+import * as React from 'react'
+import { getProjectsOptions } from '@/api/client/@tanstack/react-query.gen'
+import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { Skeleton } from '@/components/ui/skeleton'
+import { cn } from '@/lib/utils'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { Check, ChevronsUpDown, RefreshCw } from 'lucide-react'
+
+interface ProjectSelectProps {
+  /** Selected project id, or null for the "All projects" row. */
+  value: number | null
+  onValueChange: (projectId: number | null) => void
+  /** Show the "All projects" row. Off for pickers that require a project. */
+  allowAll?: boolean
+  placeholder?: string
+  disabled?: boolean
+  className?: string
+}
+
+/**
+ * Searchable, refreshable project picker. Filters against both project name
+ * and slug (cmdk matches the item's `value`, which we set to `"name slug"`),
+ * and exposes an explicit refresh action rather than relying solely on
+ * React Query's staleTime — a project created in another tab should be
+ * findable here without a timed wait.
+ */
+export function ProjectSelect({
+  value,
+  onValueChange,
+  allowAll = true,
+  placeholder = 'Select project…',
+  disabled,
+  className,
+}: ProjectSelectProps) {
+  const [open, setOpen] = React.useState(false)
+  const queryClient = useQueryClient()
+
+  const projectsQuery = useQuery({
+    ...getProjectsOptions({ query: { page: 1, per_page: 100 } }),
+    staleTime: 60_000,
+  })
+
+  const projects = React.useMemo(
+    () =>
+      (projectsQuery.data?.projects ?? [])
+        .slice()
+        .sort((a, b) =>
+          a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+        ),
+    [projectsQuery.data?.projects]
+  )
+
+  const selected = React.useMemo(
+    () => projects.find((p) => p.id === value) ?? null,
+    [projects, value]
+  )
+
+  const handleRefresh = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    queryClient.invalidateQueries({
+      queryKey: getProjectsOptions({ query: { page: 1, per_page: 100 } })
+        .queryKey,
+    })
+  }
+
+  const triggerLabel =
+    value == null ? 'All projects' : (selected?.name ?? placeholder)
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className={cn(
+            'h-10 w-full justify-between font-normal sm:w-[220px]',
+            value == null && !allowAll && 'text-muted-foreground',
+            className
+          )}
+        >
+          <span className="truncate">{triggerLabel}</span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[min(calc(100vw-2rem),300px)] min-w-[var(--radix-popover-trigger-width)] p-0"
+        align="start"
+      >
+        <Command>
+          <div className="flex items-center border-b">
+            <div className="flex-1">
+              <CommandInput
+                placeholder="Filter by name or slug…"
+                className="border-0"
+              />
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="mr-1 h-7 w-7 shrink-0"
+              onClick={handleRefresh}
+              disabled={projectsQuery.isFetching}
+              title="Refresh projects"
+            >
+              <RefreshCw
+                className={cn(
+                  'h-3.5 w-3.5',
+                  projectsQuery.isFetching && 'animate-spin'
+                )}
+              />
+            </Button>
+          </div>
+          <CommandList className="max-h-[320px]">
+            {projectsQuery.isPending ? (
+              <div className="space-y-1 p-1">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <Skeleton key={i} className="h-8 w-full" />
+                ))}
+              </div>
+            ) : projectsQuery.isError ? (
+              <div className="flex flex-col items-center gap-2 p-4 text-center text-sm text-muted-foreground">
+                Failed to load projects
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleRefresh}
+                >
+                  Retry
+                </Button>
+              </div>
+            ) : (
+              <>
+                <CommandEmpty>No projects found.</CommandEmpty>
+                {allowAll && (
+                  <CommandGroup>
+                    <CommandItem
+                      value="all-projects"
+                      onSelect={() => {
+                        onValueChange(null)
+                        setOpen(false)
+                      }}
+                    >
+                      <Check
+                        className={cn(
+                          'mr-2 h-4 w-4 shrink-0',
+                          value == null ? 'opacity-100' : 'opacity-0'
+                        )}
+                      />
+                      <span className="truncate">All projects</span>
+                    </CommandItem>
+                  </CommandGroup>
+                )}
+                <CommandGroup>
+                  {projects.map((p) => (
+                    <CommandItem
+                      key={p.id}
+                      value={`${p.name} ${p.slug}`}
+                      onSelect={() => {
+                        onValueChange(p.id)
+                        setOpen(false)
+                      }}
+                    >
+                      <Check
+                        className={cn(
+                          'mr-2 h-4 w-4 shrink-0',
+                          value === p.id ? 'opacity-100' : 'opacity-0'
+                        )}
+                      />
+                      <span className="min-w-0 flex-1 truncate">{p.name}</span>
+                      <span className="shrink-0 truncate text-xs text-muted-foreground">
+                        {p.slug}
+                      </span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/web/src/components/project/ProjectSelect.tsx
+++ b/web/src/components/project/ProjectSelect.tsx
@@ -77,7 +77,11 @@ export function ProjectSelect({
   }
 
   const triggerLabel =
-    value == null ? 'All projects' : (selected?.name ?? placeholder)
+    value == null
+      ? allowAll
+        ? 'All projects'
+        : placeholder
+      : (selected?.name ?? placeholder)
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/web/src/pages/ProxyMetrics.tsx
+++ b/web/src/pages/ProxyMetrics.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/api/client/@tanstack/react-query.gen'
 import type { TimeBucketStats } from '@/api/client/types.gen'
 import { Link } from 'react-router'
+import { ProjectSelect } from '@/components/project/ProjectSelect'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -922,10 +923,6 @@ function FilterBar({
   filter: ProxyFilter
   onChange: (f: ProxyFilter) => void
 }) {
-  const projectsQ = useQuery({
-    ...getProjectsOptions({ query: { page: 1, per_page: 100 } }),
-    staleTime: 60_000,
-  })
   const environmentsQ = useQuery({
     ...getEnvironmentsOptions({
       path: { project_id: filter.projectId ?? 0 },
@@ -934,34 +931,16 @@ function FilterBar({
     staleTime: 60_000,
   })
 
-  const projects = projectsQ.data?.projects ?? []
   const environments = environmentsQ.data ?? []
 
   return (
     <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
-      <Select
-        value={
-          filter.projectId != null ? String(filter.projectId) : ALL_SENTINEL
+      <ProjectSelect
+        value={filter.projectId}
+        onValueChange={(projectId) =>
+          onChange({ projectId, environmentId: null })
         }
-        onValueChange={(v) =>
-          onChange({
-            projectId: v === ALL_SENTINEL ? null : Number(v),
-            environmentId: null,
-          })
-        }
-      >
-        <SelectTrigger className="w-full sm:w-[200px]">
-          <SelectValue placeholder="All projects" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value={ALL_SENTINEL}>All projects</SelectItem>
-          {projects.map((p) => (
-            <SelectItem key={p.id} value={String(p.id)}>
-              {p.name}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      />
       {filter.projectId != null && (
         <Select
           value={


### PR DESCRIPTION
## Summary
- Adds `ProjectSelect`, a Popover + cmdk combobox that replaces the plain non-searchable `Select` used for the project filter on the Proxy metrics page (`ProxyMetrics.tsx`'s `FilterBar`).
- Filters as you type against both project **name and slug** (each row's match value is `"name slug"`).
- Adds an explicit **refresh button** that invalidates and re-fetches `/api/projects`, rather than relying only on `staleTime` — a project created in another tab/session is discoverable without waiting out the cache.
- Preserves the existing "All projects" sentinel and selection semantics (`projectId: number | null`), so `FilterBar` and the rest of the page are unaffected beyond the picker itself.

## Test plan
Verified live against a local dev instance (fresh worktree off `origin/main`, two test projects: `Marketing Site Beta` / `marketing-site-beta` and `Observability Starter` / `observability-starter`):
- [x] Opening the picker lists all projects with name + slug, "All projects" checked by default.
- [x] Typing a project's full slug (`marketing-site-beta`) narrows the list to exactly that project — confirms slug participates in filtering, not just name.
- [x] Selecting a project updates the trigger label, shows the checkmark on the correct row, and switches the page into the per-project filtered view (matches the existing environment-select pattern).
- [x] Refresh button fires a new `GET /api/projects?page=1&per_page=100` (confirmed via network log), independent of the 60s `staleTime`.
- [x] Selecting "All projects" again round-trips back to the unfiltered node-metrics view.
- [x] `tsc --noEmit` and `eslint` clean on both changed files.
- [x] Fixed a full-width layout bug found during manual testing: `CommandInput`'s internal wrapper div doesn't stretch when placed next to a sibling button in a flex row — wrapped it in `flex-1`.