### PR TITLE
fix(web): handle fetch errors in BackupDetail and ScheduleDetail with actionable error state.

### DIFF
--- a/web/src/pages/BackupDetail.tsx
+++ b/web/src/pages/BackupDetail.tsx
@@ -59,6 +59,7 @@ import {
   FileArchive,
   HardDrive,
   Loader2,
+  RotateCcw,
   Trash2,
   XCircle,
 } from 'lucide-react'
@@ -235,7 +236,7 @@ export function BackupDetail() {
   const navigate = useNavigate()
   const { setBreadcrumbs } = useBreadcrumbs()
 
-  const { data: backup, isLoading } = useQuery({
+  const { data: backup, isLoading, error, refetch } = useQuery({
     ...getBackupOptions({
       path: { id: backupId! },
     }),
@@ -337,6 +338,34 @@ export function BackupDetail() {
     return (
       <div className="flex items-center justify-center py-16">
         <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-16">
+        <AlertCircle className="h-8 w-8 text-destructive" />
+        <div className="text-center">
+          <h2 className="text-lg font-semibold">Failed to load backup</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {error instanceof Error
+              ? error.message
+              : 'An unexpected error occurred. Please try again.'}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => void refetch()}>
+            <RotateCcw className="mr-2 h-4 w-4" />
+            Retry
+          </Button>
+          <Button variant="ghost" asChild>
+            <Link to={`/backups/s3-sources/${id}`}>
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to S3 Source
+            </Link>
+          </Button>
+        </div>
       </div>
     )
   }

--- a/web/src/pages/BackupDetail.tsx
+++ b/web/src/pages/BackupDetail.tsx
@@ -342,7 +342,7 @@ export function BackupDetail() {
     )
   }
 
-  if (error) {
+  if (error && !backup) {
     return (
       <div className="flex flex-col items-center justify-center gap-4 py-16">
         <AlertCircle className="h-8 w-8 text-destructive" />

--- a/web/src/pages/ScheduleDetail.tsx
+++ b/web/src/pages/ScheduleDetail.tsx
@@ -553,7 +553,7 @@ export function ScheduleDetail() {
     )
   }
 
-  if (scheduleError) {
+  if (scheduleError && !schedule) {
     return (
       <div className="flex flex-col items-center justify-center gap-4 px-4 py-12 text-center">
         <AlertCircle className="h-8 w-8 text-destructive" />

--- a/web/src/pages/ScheduleDetail.tsx
+++ b/web/src/pages/ScheduleDetail.tsx
@@ -71,6 +71,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import {
+  AlertCircle,
   ArrowLeft,
   CalendarDays,
   ChevronLeft,
@@ -84,6 +85,7 @@ import {
   Pencil,
   Play,
   Plus,
+  RotateCcw,
   Trash2,
   X,
 } from 'lucide-react'
@@ -234,7 +236,12 @@ export function ScheduleDetail() {
 
   // ── Data fetching ──────────────────────────────────────────────────────────
 
-  const { data: schedule, isLoading: isLoadingSchedule } = useQuery({
+  const {
+    data: schedule,
+    isLoading: isLoadingSchedule,
+    error: scheduleError,
+    refetch: refetchSchedule,
+  } = useQuery({
     ...getBackupScheduleOptions({ path: { id: scheduleId! } }),
     enabled: !!scheduleId,
   })
@@ -542,6 +549,34 @@ export function ScheduleDetail() {
         <Skeleton className="h-8 w-48" />
         <Skeleton className="h-48 w-full" />
         <Skeleton className="h-96 w-full" />
+      </div>
+    )
+  }
+
+  if (scheduleError) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 px-4 py-12 text-center">
+        <AlertCircle className="h-8 w-8 text-destructive" />
+        <div>
+          <h2 className="text-lg font-semibold">Failed to load schedule</h2>
+          <p className="mt-1 text-base text-muted-foreground sm:text-sm">
+            {scheduleError instanceof Error
+              ? scheduleError.message
+              : 'An unexpected error occurred. Please try again.'}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => void refetchSchedule()}>
+            <RotateCcw className="mr-2 h-4 w-4" />
+            Retry
+          </Button>
+          <Button variant="ghost" asChild>
+            <Link to="/backups">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to Backups
+            </Link>
+          </Button>
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
Closes #736 
Closes #738 

## What changed

Both `BackupDetail` and `ScheduleDetail` showed a generic "not found" 
message when the API failed — masking real errors and giving operators 
no way to retry without a full page reload.

This PR adds a proper error state to both pages with the actual error 
message and a Retry button, consistent with the pattern already used 
in `DeploymentDetails`.

## Files changed
- `web/src/pages/BackupDetail.tsx`
- `web/src/pages/ScheduleDetail.tsx`

## How to test
1. `cd web && bun run dev`
2. DevTools → Request Blocking → block `*/api/backups/*`
3. Open a Backup Detail or Schedule Detail page
4. Should now show "Failed to load" with a Retry button
