### PR TITLE
fix(projects): report the connected Git provider instead of guessing it

### DIFF
--- a/apps/temps-cli/openapi.json
+++ b/apps/temps-cli/openapi.json
@@ -28918,6 +28918,14 @@
               "null"
             ]
           },
+          "git_provider_type": {
+            "description": "Git provider behind `git_provider_connection_id`: `github`,\n`github_app`, `gitlab`, `gitea`, `bitbucket` or `generic`. `null` when\nthe project has no connection (public repository, Docker image or\nuploaded source).\n\nClients must use this rather than guessing the host from `git_url`: a\nself-hosted GitLab/Gitea/Bitbucket instance can live on any domain, and\na connected project may have no clone URL stored at all.",
+            "example": "gitlab",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "git_url": {
             "description": "Git clone URL for the repository (used for public repos without a provider connection)",
             "type": [

--- a/apps/temps-cli/src/api/types.gen.ts
+++ b/apps/temps-cli/src/api/types.gen.ts
@@ -13336,6 +13336,17 @@ export type ProjectResponse = {
     error_source_root?: string | null;
     git_provider_connection_id?: number | null;
     /**
+     * Git provider behind `git_provider_connection_id`: `github`,
+     * `github_app`, `gitlab`, `gitea`, `bitbucket` or `generic`. `null` when
+     * the project has no connection (public repository, Docker image or
+     * uploaded source).
+     *
+     * Clients must use this rather than guessing the host from `git_url`: a
+     * self-hosted GitLab/Gitea/Bitbucket instance can live on any domain, and
+     * a connected project may have no clone URL stored at all.
+     */
+    git_provider_type?: string | null;
+    /**
      * Git clone URL for the repository (used for public repos without a provider connection)
      */
     git_url?: string | null;

--- a/apps/temps-cli/src/commands/projects/show.ts
+++ b/apps/temps-cli/src/commands/projects/show.ts
@@ -11,6 +11,25 @@ interface ShowOptions {
   json?: boolean
 }
 
+/**
+ * Which Git host the project is connected to, as reported by its provider
+ * connection. Never inferred from the clone URL — a self-hosted instance can
+ * live on any domain, and a connected project may store no clone URL at all.
+ */
+function gitProviderLabel(providerType?: string | null): string {
+  const labels: Record<string, string> = {
+    github: 'GitHub',
+    github_app: 'GitHub (App)',
+    gitlab: 'GitLab',
+    gitea: 'Gitea',
+    bitbucket: 'Bitbucket',
+    generic: 'Self-hosted Git',
+  }
+
+  if (!providerType) return 'Not connected'
+  return labels[providerType.toLowerCase()] ?? providerType
+}
+
 export async function show(options: ShowOptions): Promise<void> {
   await requireAuth()
   await setupClient()
@@ -62,6 +81,7 @@ export async function show(options: ShowOptions): Promise<void> {
     Directory: project.directory,
     'Main Branch': project.main_branch,
     Repository: project.repo_name ? `${project.repo_owner}/${project.repo_name}` : 'Not connected',
+    'Git Provider': gitProviderLabel(project.git_provider_type),
     'Attack Mode': project.attack_mode ? 'Enabled' : 'Disabled',
     'Preview Envs': project.enable_preview_environments ? 'Enabled' : 'Disabled',
     Created: formatDate(new Date(project.created_at * 1000).toISOString()),

--- a/crates/temps-cli/src/commands/firecracker.rs
+++ b/crates/temps-cli/src/commands/firecracker.rs
@@ -923,9 +923,7 @@ impl FirecrackerSetupCommand {
         let config = serde_json::json!({
             "boot-source": {
                 "kernel_image_path": dirs.kernel_file(),
-                "boot_args": format!(
-                    "console=ttyS0 reboot=k panic=1 pci=off init=/temps-smoke-init"
-                ),
+                "boot_args": "console=ttyS0 reboot=k panic=1 pci=off init=/temps-smoke-init",
             },
             "drives": [{
                 "drive_id": "rootfs",

--- a/crates/temps-deployments/src/jobs/deploy_image.rs
+++ b/crates/temps-deployments/src/jobs/deploy_image.rs
@@ -1707,7 +1707,7 @@ impl DeployImageJob {
 
             write_log!(
                 LogLevel::Info,
-                format!("📋 Streaming container logs for 15s...")
+                "📋 Streaming container logs for 15s...".to_string()
             );
 
             // Connect to Docker

--- a/crates/temps-projects/src/handlers/types.rs
+++ b/crates/temps-projects/src/handlers/types.rs
@@ -322,6 +322,16 @@ pub struct ProjectResponse {
     pub updated_at: i64,
     pub last_deployment: Option<i64>,
     pub git_provider_connection_id: Option<i32>,
+    /// Git provider behind `git_provider_connection_id`: `github`,
+    /// `github_app`, `gitlab`, `gitea`, `bitbucket` or `generic`. `null` when
+    /// the project has no connection (public repository, Docker image or
+    /// uploaded source).
+    ///
+    /// Clients must use this rather than guessing the host from `git_url`: a
+    /// self-hosted GitLab/Gitea/Bitbucket instance can live on any domain, and
+    /// a connected project may have no clone URL stored at all.
+    #[schema(example = "gitlab")]
+    pub git_provider_type: Option<String>,
     /// Authoritative repository visibility. A missing connection alone does
     /// not imply that an incompletely configured repository is public.
     pub is_public_repo: bool,
@@ -404,6 +414,7 @@ impl ProjectResponse {
             updated_at: project.updated_at.timestamp_millis(),
             last_deployment: project.last_deployment.map(|d| d.timestamp_millis()),
             git_provider_connection_id: project.git_provider_connection_id,
+            git_provider_type: project.git_provider_type,
             is_public_repo: project.is_public_repo,
             git_url: project.git_url,
             attack_mode: project.attack_mode,

--- a/crates/temps-projects/src/services/project.rs
+++ b/crates/temps-projects/src/services/project.rs
@@ -1,11 +1,12 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 use temps_core::url_validation::{redact_url_password, validate_git_url};
 use tracing::{info, warn};
 
 use sea_orm::{
     prelude::Uuid, ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, EntityTrait,
-    PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Set, Statement, TransactionTrait,
+    PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, RelationTrait, Set, Statement,
+    TransactionTrait,
 };
 use temps_core::{
     ForceRouteReloadJob, Job, ProjectCreatedJob, ProjectDeletedJob, ProjectUpdatedJob,
@@ -22,6 +23,32 @@ use super::types::{
 use super::{EnvVarService, EnvVarWithEnvironments};
 use crate::handlers::UpdateDeploymentConfigRequest;
 // Placeholder functions - these should be implemented properly or imported from other services
+
+/// A project row plus the provider type of the Git connection it is linked to.
+///
+/// The provider type lives two hops away (`projects` →
+/// `git_provider_connections` → `git_providers`), so the read queries LEFT JOIN
+/// it in as one extra column rather than paying a second round trip. `LEFT` and
+/// `Option` because most projects have no connection at all — a Docker-image or
+/// uploaded-source project must still come back from the same query.
+#[derive(Debug)]
+struct ProjectWithGitProviderType {
+    project: projects::Model,
+    git_provider_type: Option<String>,
+}
+
+impl sea_orm::FromQueryResult for ProjectWithGitProviderType {
+    fn from_query_result(result: &sea_orm::QueryResult, pre: &str) -> Result<Self, sea_orm::DbErr> {
+        Ok(Self {
+            project: projects::Model::from_query_result(result, pre)?,
+            git_provider_type: result.try_get(pre, GIT_PROVIDER_TYPE_ALIAS)?,
+        })
+    }
+}
+
+/// Alias for the joined-in `git_providers.provider_type` column. Named rather
+/// than bare so it can never collide with a `projects` column.
+const GIT_PROVIDER_TYPE_ALIAS: &str = "git_provider_type";
 
 /// Whether changing `repo_owner`/`repo_name` would leave `git_url` pointing at
 /// a different repository.
@@ -986,56 +1013,8 @@ impl ProjectService {
         Ok(default_environment)
     }
 
-    /// Fill in `git_provider_type` for every project that is linked to a Git
-    /// provider connection.
-    ///
-    /// The provider type is two hops away from the project row
-    /// (`projects` → `git_provider_connections` → `git_providers`), so it is
-    /// resolved here with a single JOIN over the whole batch rather than a
-    /// lookup per project. Projects without a connection are left as `None`.
-    async fn resolve_git_provider_types(
-        &self,
-        projects: &mut [Project],
-    ) -> Result<(), ProjectError> {
-        let connection_ids: HashSet<i32> = projects
-            .iter()
-            .filter_map(|project| project.git_provider_connection_id)
-            .collect();
-
-        if connection_ids.is_empty() {
-            return Ok(());
-        }
-
-        let connection_count = connection_ids.len();
-        let rows: Vec<(i32, String)> = git_provider_connections::Entity::find()
-            .select_only()
-            .column(git_provider_connections::Column::Id)
-            .column(git_providers::Column::ProviderType)
-            .inner_join(git_providers::Entity)
-            .filter(git_provider_connections::Column::Id.is_in(connection_ids))
-            .into_tuple()
-            .all(self.db.as_ref())
-            .await
-            .map_err(|e| {
-                ProjectError::Other(format!(
-                    "Failed to resolve the git provider type for {} connection(s): {}",
-                    connection_count, e
-                ))
-            })?;
-
-        let provider_type_by_connection: HashMap<i32, String> = rows.into_iter().collect();
-
-        for project in projects.iter_mut() {
-            project.git_provider_type = project
-                .git_provider_connection_id
-                .and_then(|id| provider_type_by_connection.get(&id).cloned());
-        }
-
-        Ok(())
-    }
-
     pub async fn get_projects(&self) -> Result<Vec<Project>, ProjectError> {
-        let results = projects::Entity::find()
+        let results = Self::with_git_provider_type(projects::Entity::find())
             // Most-recently-deployed first; never-deployed projects (NULL
             // last_deployment) sort last, not first — a NULL under DESC would
             // otherwise be treated as "deployed infinitely recently".
@@ -1045,41 +1024,37 @@ impl ProjectService {
                 sea_orm::sea_query::NullOrdering::Last,
             )
             .order_by_desc(projects::Column::CreatedAt)
+            .into_model::<ProjectWithGitProviderType>()
             .all(self.db.as_ref())
             .await
             .map_err(|e| ProjectError::Other(e.to_string()))?;
 
-        let mut projects_found: Vec<Project> = results
+        Ok(results
             .into_iter()
-            .map(Self::map_db_project_to_project)
-            .collect();
-        self.resolve_git_provider_types(&mut projects_found).await?;
-
-        Ok(projects_found)
+            .map(Self::map_db_project_row_to_project)
+            .collect())
     }
 
     pub async fn get_project(&self, project_id: i32) -> Result<Project, ProjectError> {
-        let project_found_db = projects::Entity::find_by_id(project_id)
-            .one(self.db.as_ref())
-            .await
-            .map_err(|e| ProjectError::Other(e.to_string()))?;
+        let project_found_db =
+            Self::with_git_provider_type(projects::Entity::find_by_id(project_id))
+                .into_model::<ProjectWithGitProviderType>()
+                .one(self.db.as_ref())
+                .await
+                .map_err(|e| ProjectError::Other(e.to_string()))?;
 
-        let mut project_found = project_found_db
-            .map(Self::map_db_project_to_project)
+        project_found_db
+            .map(Self::map_db_project_row_to_project)
             .ok_or(ProjectError::NotFound(format!(
                 "project {} not found",
                 project_id
-            )))?;
-
-        self.resolve_git_provider_types(std::slice::from_mut(&mut project_found))
-            .await?;
-
-        Ok(project_found)
+            )))
     }
 
     pub async fn get_project_by_slug(&self, slug: &str) -> Result<Project, ProjectError> {
-        let project_found_db = projects::Entity::find()
+        let project_found_db = Self::with_git_provider_type(projects::Entity::find())
             .filter(projects::Column::Slug.eq(slug))
+            .into_model::<ProjectWithGitProviderType>()
             .one(self.db.as_ref())
             .await?
             .ok_or(ProjectError::NotFound(format!(
@@ -1087,9 +1062,7 @@ impl ProjectService {
                 slug
             )))?;
 
-        let mut project_found = Self::map_db_project_to_project(project_found_db);
-        self.resolve_git_provider_types(std::slice::from_mut(&mut project_found))
-            .await?;
+        let project_found = Self::map_db_project_row_to_project(project_found_db);
 
         Ok(project_found)
     }
@@ -2932,15 +2905,24 @@ impl ProjectService {
             }
             if let Some(search) = search {
                 let pattern = format!("%{}%", escape_like_literal(search));
+                // Table-qualified: the page query joins `git_providers`, which
+                // has a `name` column of its own, and an unqualified `name`
+                // here is rejected by Postgres as ambiguous.
                 query = query.filter(
                     Condition::any()
                         .add(
-                            sea_orm::sea_query::Expr::col(projects::Column::Name)
-                                .ilike(LikeExpr::new(pattern.clone())),
+                            sea_orm::sea_query::Expr::col((
+                                projects::Entity,
+                                projects::Column::Name,
+                            ))
+                            .ilike(LikeExpr::new(pattern.clone())),
                         )
                         .add(
-                            sea_orm::sea_query::Expr::col(projects::Column::Slug)
-                                .ilike(LikeExpr::new(pattern.clone())),
+                            sea_orm::sea_query::Expr::col((
+                                projects::Entity,
+                                projects::Column::Slug,
+                            ))
+                            .ilike(LikeExpr::new(pattern.clone())),
                         ),
                 );
             }
@@ -2957,7 +2939,9 @@ impl ProjectService {
         // Get paginated projects. Never-deployed projects (NULL last_deployment)
         // sort last rather than first (a NULL under DESC would otherwise appear
         // as the most-recently-deployed project).
-        let projects = filtered()
+        // The count query above stays join-free: it counts projects, and the
+        // provider join exists only to carry an extra column.
+        let projects = Self::with_git_provider_type(filtered())
             .order_by_with_nulls(
                 projects::Column::LastDeployment,
                 sea_orm::Order::Desc,
@@ -2966,15 +2950,15 @@ impl ProjectService {
             .order_by_desc(projects::Column::CreatedAt)
             .offset(offset)
             .limit(per_page as u64)
+            .into_model::<ProjectWithGitProviderType>()
             .all(self.db.as_ref())
             .await
             .map_err(|e| ProjectError::DatabaseConnectionError(e.to_string()))?;
 
-        let mut projects_found: Vec<Project> = projects
+        let projects_found: Vec<Project> = projects
             .into_iter()
-            .map(Self::map_db_project_to_project)
+            .map(Self::map_db_project_row_to_project)
             .collect();
-        self.resolve_git_provider_types(&mut projects_found).await?;
 
         Ok((projects_found, total))
     }
@@ -3291,6 +3275,33 @@ impl ProjectService {
         }
     }
 
+    /// LEFT JOIN each project to the provider behind its Git connection and
+    /// select that provider's type as one extra column.
+    ///
+    /// Neither hop can fan a project out into several rows (both are
+    /// many-to-one), so this changes the row count of no query it is applied
+    /// to, and it never needs a second round trip to fill the field in.
+    fn with_git_provider_type(
+        select: sea_orm::Select<projects::Entity>,
+    ) -> sea_orm::Select<projects::Entity> {
+        select
+            .join(
+                sea_orm::JoinType::LeftJoin,
+                projects::Relation::GitProviderConnection.def(),
+            )
+            .join(
+                sea_orm::JoinType::LeftJoin,
+                git_provider_connections::Relation::Provider.def(),
+            )
+            .column_as(git_providers::Column::ProviderType, GIT_PROVIDER_TYPE_ALIAS)
+    }
+
+    fn map_db_project_row_to_project(row: ProjectWithGitProviderType) -> Project {
+        let mut project = Self::map_db_project_to_project(row.project);
+        project.git_provider_type = row.git_provider_type;
+        project
+    }
+
     pub fn map_db_project_to_project(db_project: projects::Model) -> Project {
         // Extract deployment config fields
         let deployment_config = db_project.deployment_config.clone();
@@ -3352,9 +3363,10 @@ impl ProjectService {
             is_public_repo: db_project.is_public_repo,
             git_url: db_project.git_url,
             git_provider_connection_id: db_project.git_provider_connection_id,
-            // Lives on the connection's provider row, not on the project, so
-            // it is filled in by `resolve_git_provider_types` on the read
-            // paths that serve it to a client.
+            // Lives on the connection's provider row, not on the project row,
+            // so it can only come from a query that joined it in — see
+            // `with_git_provider_type` / `map_db_project_row_to_project`, which
+            // the read paths that serve a client use.
             git_provider_type: None,
             is_on_demand: false, // Deprecated field, default to false
             deployment_config: deployment_config.clone(),
@@ -4407,24 +4419,32 @@ mod tests {
         let unconnected = service.get_project(standalone.id).await.unwrap();
         assert_eq!(unconnected.git_provider_type, None);
 
-        // The dashboard list resolves every project in one pass, not per row.
-        let (listed, _total) = service
+        // The dashboard list carries the provider in the same query.
+        let (listed, total) = service
             .get_projects_paginated_excluding_search(1, 100, &[], None)
             .await
             .unwrap();
-        let listed_connected = listed
-            .iter()
-            .find(|project| project.id == connected.id)
+        let matching = |id: i32| listed.iter().filter(move |project| project.id == id);
+        let listed_connected = matching(connected.id)
+            .next()
             .expect("connected project is listed");
-        let listed_standalone = listed
-            .iter()
-            .find(|project| project.id == standalone.id)
+        let listed_standalone = matching(standalone.id)
+            .next()
             .expect("standalone project is listed");
         assert_eq!(
             listed_connected.git_provider_type.as_deref(),
             Some("gitlab")
         );
         assert_eq!(listed_standalone.git_provider_type, None);
+
+        // The provider join must not fan a project out into several rows, and
+        // must not drift from the count query, which stays join-free.
+        assert_eq!(matching(connected.id).count(), 1, "no duplicate rows");
+        assert_eq!(
+            total,
+            listed.len() as i64,
+            "count query and page agree once the provider join is in the page query"
+        );
     }
 
     #[tokio::test]

--- a/crates/temps-projects/src/services/project.rs
+++ b/crates/temps-projects/src/services/project.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use temps_core::url_validation::{redact_url_password, validate_git_url};
 use tracing::{info, warn};
@@ -10,7 +10,7 @@ use sea_orm::{
 use temps_core::{
     ForceRouteReloadJob, Job, ProjectCreatedJob, ProjectDeletedJob, ProjectUpdatedJob,
 };
-use temps_entities::projects;
+use temps_entities::{git_provider_connections, git_providers, projects};
 use temps_git::services::public_repo::PublicRepoProviderFactory;
 
 use serde::Serialize;
@@ -986,6 +986,54 @@ impl ProjectService {
         Ok(default_environment)
     }
 
+    /// Fill in `git_provider_type` for every project that is linked to a Git
+    /// provider connection.
+    ///
+    /// The provider type is two hops away from the project row
+    /// (`projects` → `git_provider_connections` → `git_providers`), so it is
+    /// resolved here with a single JOIN over the whole batch rather than a
+    /// lookup per project. Projects without a connection are left as `None`.
+    async fn resolve_git_provider_types(
+        &self,
+        projects: &mut [Project],
+    ) -> Result<(), ProjectError> {
+        let connection_ids: HashSet<i32> = projects
+            .iter()
+            .filter_map(|project| project.git_provider_connection_id)
+            .collect();
+
+        if connection_ids.is_empty() {
+            return Ok(());
+        }
+
+        let connection_count = connection_ids.len();
+        let rows: Vec<(i32, String)> = git_provider_connections::Entity::find()
+            .select_only()
+            .column(git_provider_connections::Column::Id)
+            .column(git_providers::Column::ProviderType)
+            .inner_join(git_providers::Entity)
+            .filter(git_provider_connections::Column::Id.is_in(connection_ids))
+            .into_tuple()
+            .all(self.db.as_ref())
+            .await
+            .map_err(|e| {
+                ProjectError::Other(format!(
+                    "Failed to resolve the git provider type for {} connection(s): {}",
+                    connection_count, e
+                ))
+            })?;
+
+        let provider_type_by_connection: HashMap<i32, String> = rows.into_iter().collect();
+
+        for project in projects.iter_mut() {
+            project.git_provider_type = project
+                .git_provider_connection_id
+                .and_then(|id| provider_type_by_connection.get(&id).cloned());
+        }
+
+        Ok(())
+    }
+
     pub async fn get_projects(&self) -> Result<Vec<Project>, ProjectError> {
         let results = projects::Entity::find()
             // Most-recently-deployed first; never-deployed projects (NULL
@@ -1001,10 +1049,13 @@ impl ProjectService {
             .await
             .map_err(|e| ProjectError::Other(e.to_string()))?;
 
-        Ok(results
+        let mut projects_found: Vec<Project> = results
             .into_iter()
             .map(Self::map_db_project_to_project)
-            .collect())
+            .collect();
+        self.resolve_git_provider_types(&mut projects_found).await?;
+
+        Ok(projects_found)
     }
 
     pub async fn get_project(&self, project_id: i32) -> Result<Project, ProjectError> {
@@ -1013,12 +1064,17 @@ impl ProjectService {
             .await
             .map_err(|e| ProjectError::Other(e.to_string()))?;
 
-        project_found_db
+        let mut project_found = project_found_db
             .map(Self::map_db_project_to_project)
             .ok_or(ProjectError::NotFound(format!(
                 "project {} not found",
                 project_id
-            )))
+            )))?;
+
+        self.resolve_git_provider_types(std::slice::from_mut(&mut project_found))
+            .await?;
+
+        Ok(project_found)
     }
 
     pub async fn get_project_by_slug(&self, slug: &str) -> Result<Project, ProjectError> {
@@ -1031,7 +1087,11 @@ impl ProjectService {
                 slug
             )))?;
 
-        Ok(Self::map_db_project_to_project(project_found_db))
+        let mut project_found = Self::map_db_project_to_project(project_found_db);
+        self.resolve_git_provider_types(std::slice::from_mut(&mut project_found))
+            .await?;
+
+        Ok(project_found)
     }
 
     pub async fn get_projects_by_repo_owner_and_name(
@@ -2910,10 +2970,12 @@ impl ProjectService {
             .await
             .map_err(|e| ProjectError::DatabaseConnectionError(e.to_string()))?;
 
-        let projects_found: Vec<Project> = projects
+        let mut projects_found: Vec<Project> = projects
             .into_iter()
             .map(Self::map_db_project_to_project)
             .collect();
+        self.resolve_git_provider_types(&mut projects_found).await?;
+
         Ok((projects_found, total))
     }
 
@@ -3290,6 +3352,10 @@ impl ProjectService {
             is_public_repo: db_project.is_public_repo,
             git_url: db_project.git_url,
             git_provider_connection_id: db_project.git_provider_connection_id,
+            // Lives on the connection's provider row, not on the project, so
+            // it is filled in by `resolve_git_provider_types` on the read
+            // paths that serve it to a client.
+            git_provider_type: None,
             is_on_demand: false, // Deprecated field, default to false
             deployment_config: deployment_config.clone(),
             attack_mode: db_project.attack_mode,
@@ -4250,6 +4316,115 @@ mod tests {
             temps_entities::source_type::SourceType::Git
         );
         assert_eq!(opted_out.repo_owner.as_deref(), Some("owner"));
+    }
+
+    /// The console draws a provider logo for each project. Before this, it had
+    /// nothing authoritative to draw it from and guessed from the clone URL —
+    /// which reports GitHub for every project whose URL is missing, and for
+    /// self-hosted instances whose hostname doesn't happen to spell out the
+    /// vendor. A GitLab-connected project must report GitLab.
+    #[tokio::test]
+    async fn connected_projects_report_the_provider_they_are_linked_to() {
+        let Ok(test_db) = TestDatabase::with_migrations().await else {
+            eprintln!("Test database unavailable, skipping");
+            return;
+        };
+        let db = test_db.db.clone();
+        let service = create_test_services(db.clone(), Arc::new(MockJobQueue::new())).await;
+
+        // Self-hosted GitLab on a hostname that says nothing about the vendor,
+        // and a project connected to it that stores no clone URL at all.
+        let provider = temps_entities::git_providers::ActiveModel {
+            name: Set("Internal Git".to_string()),
+            provider_type: Set("gitlab".to_string()),
+            base_url: Set(Some("https://code.example.internal".to_string())),
+            api_url: Set(None),
+            auth_method: Set("pat".to_string()),
+            auth_config: Set(serde_json::json!({})),
+            webhook_secret: Set(None),
+            is_active: Set(true),
+            is_default: Set(false),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .unwrap();
+
+        let connection = temps_entities::git_provider_connections::ActiveModel {
+            provider_id: Set(provider.id),
+            user_id: Set(None),
+            account_name: Set("platform-team".to_string()),
+            account_type: Set("Organization".to_string()),
+            is_active: Set(true),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .unwrap();
+
+        let connected = temps_entities::projects::ActiveModel {
+            name: Set("Connected Project".to_string()),
+            slug: Set("connected-project".to_string()),
+            repo_name: Set("api".to_string()),
+            repo_owner: Set("platform-team".to_string()),
+            preset: Set(Preset::NextJs),
+            main_branch: Set("main".to_string()),
+            directory: Set("/".to_string()),
+            git_url: Set(None),
+            git_provider_connection_id: Set(Some(connection.id)),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .unwrap();
+
+        let standalone = temps_entities::projects::ActiveModel {
+            name: Set("Image Project".to_string()),
+            slug: Set("image-project".to_string()),
+            repo_name: Set("image".to_string()),
+            repo_owner: Set("owner".to_string()),
+            preset: Set(Preset::NextJs),
+            main_branch: Set("main".to_string()),
+            directory: Set("/".to_string()),
+            git_provider_connection_id: Set(None),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .unwrap();
+
+        let fetched = service.get_project(connected.id).await.unwrap();
+        assert_eq!(fetched.git_provider_type.as_deref(), Some("gitlab"));
+
+        let by_slug = service
+            .get_project_by_slug("connected-project")
+            .await
+            .unwrap();
+        assert_eq!(by_slug.git_provider_type.as_deref(), Some("gitlab"));
+
+        // A project with no connection has no provider to report — it must stay
+        // empty rather than fall back to a guess.
+        let unconnected = service.get_project(standalone.id).await.unwrap();
+        assert_eq!(unconnected.git_provider_type, None);
+
+        // The dashboard list resolves every project in one pass, not per row.
+        let (listed, _total) = service
+            .get_projects_paginated_excluding_search(1, 100, &[], None)
+            .await
+            .unwrap();
+        let listed_connected = listed
+            .iter()
+            .find(|project| project.id == connected.id)
+            .expect("connected project is listed");
+        let listed_standalone = listed
+            .iter()
+            .find(|project| project.id == standalone.id)
+            .expect("standalone project is listed");
+        assert_eq!(
+            listed_connected.git_provider_type.as_deref(),
+            Some("gitlab")
+        );
+        assert_eq!(listed_standalone.git_provider_type, None);
     }
 
     #[tokio::test]

--- a/crates/temps-projects/src/services/project.rs
+++ b/crates/temps-projects/src/services/project.rs
@@ -1143,9 +1143,11 @@ impl ProjectService {
         active_project.updated_at = Set(chrono::Utc::now());
 
         let project_found = active_project.update(self.db.as_ref()).await?;
-        let project_found = self.map_written_project(project_found).await;
 
-        // Emit ProjectUpdated job
+        // Emit ProjectUpdated before reading anything else. Everything after
+        // the commit is a fresh await point, and a cancelled request (client
+        // disconnect, timeout) drops the task there — so the notification goes
+        // out first, and only the response can be lost.
         let project_updated_job = Job::ProjectUpdated(ProjectUpdatedJob {
             project_id: project_found.id,
             project_name: project_found.name.clone(),
@@ -1163,7 +1165,7 @@ impl ProjectService {
             );
         }
 
-        Ok(project_found)
+        Ok(self.map_written_project(project_found).await)
     }
 
     /// Change a project's source type to a Git-less type (docker_image /
@@ -1206,9 +1208,10 @@ impl ProjectService {
         active_project.source_type = Set(source_type);
         active_project.updated_at = Set(chrono::Utc::now());
         let updated = active_project.update(self.db.as_ref()).await?;
-        let updated = self.map_written_project(updated).await;
 
-        // Deploy routing / behavior keys off source_type — notify consumers.
+        // Deploy routing / behavior keys off source_type — notify consumers
+        // before anything else awaits, so a cancelled request can only cost
+        // the response, never the notification.
         if let Err(e) = self
             .queue_service
             .send(Job::ProjectUpdated(ProjectUpdatedJob {
@@ -1222,7 +1225,7 @@ impl ProjectService {
                 updated.id, e
             );
         }
-        Ok(updated)
+        Ok(self.map_written_project(updated).await)
     }
 
     /// Toggle whether the project accepts deployments from a source other than
@@ -1763,22 +1766,22 @@ impl ProjectService {
                 self.reload_routes_after_compose_port_change(project_id)
                     .await?;
             }
-            let project_found = self.map_written_project(updated_project).await;
-
-            // Emit ProjectUpdated job
+            // Notify before the provider lookup: past the commit, every await
+            // is a point the task can be cancelled at, and losing the response
+            // is recoverable where losing the notification is not.
             let project_updated_job = Job::ProjectUpdated(ProjectUpdatedJob {
-                project_id: project_found.id,
-                project_name: project_found.name.clone(),
+                project_id: updated_project.id,
+                project_name: updated_project.name.clone(),
             });
 
             if let Err(e) = self.queue_service.send(project_updated_job).await {
                 warn!(
                     "Failed to emit ProjectUpdated job for project {}: {}",
-                    project_found.id, e
+                    updated_project.id, e
                 );
             }
 
-            return Ok(project_found);
+            return Ok(self.map_written_project(updated_project).await);
         }
 
         // Always reload the final project state before returning
@@ -1790,22 +1793,19 @@ impl ProjectService {
                 project_id
             )))?;
 
-        let project_found = self.map_written_project(final_project).await;
-
-        // Emit ProjectUpdated job
         let project_updated_job = Job::ProjectUpdated(ProjectUpdatedJob {
-            project_id: project_found.id,
-            project_name: project_found.name.clone(),
+            project_id: final_project.id,
+            project_name: final_project.name.clone(),
         });
 
         if let Err(e) = self.queue_service.send(project_updated_job).await {
             warn!(
                 "Failed to emit ProjectUpdated job for project {}: {}",
-                project_found.id, e
+                final_project.id, e
             );
         }
 
-        Ok(project_found)
+        Ok(self.map_written_project(final_project).await)
     }
 
     pub async fn update_automatic_deploy(

--- a/crates/temps-projects/src/services/project.rs
+++ b/crates/temps-projects/src/services/project.rs
@@ -933,7 +933,7 @@ impl ProjectService {
             project_found_db
         };
 
-        Ok(Self::map_db_project_to_project(project_found_db))
+        self.map_written_project(project_found_db).await
     }
 
     /// Post-insert steps for `create_project`. Returns the default environment
@@ -1072,16 +1072,17 @@ impl ProjectService {
         repo_owner: &str,
         repo_name: &str,
     ) -> Result<Vec<Project>, ProjectError> {
-        let projects_found_db = projects::Entity::find()
+        let projects_found_db = Self::with_git_provider_type(projects::Entity::find())
             .filter(projects::Column::RepoOwner.eq(repo_owner))
             .filter(projects::Column::RepoName.eq(repo_name))
+            .into_model::<ProjectWithGitProviderType>()
             .all(self.db.as_ref())
             .await
             .map_err(|e| ProjectError::Other(e.to_string()))?;
 
         let projects_found: Vec<Project> = projects_found_db
             .into_iter()
-            .map(Self::map_db_project_to_project)
+            .map(Self::map_db_project_row_to_project)
             .collect();
         Ok(projects_found)
     }
@@ -1091,15 +1092,16 @@ impl ProjectService {
         owner: &str,
         repo: &str,
     ) -> Result<Project, ProjectError> {
-        let project_found = projects::Entity::find()
+        let project_found = Self::with_git_provider_type(projects::Entity::find())
             .filter(projects::Column::RepoOwner.eq(owner))
             .filter(projects::Column::RepoName.eq(repo))
+            .into_model::<ProjectWithGitProviderType>()
             .one(self.db.as_ref())
             .await
             .map_err(|e| ProjectError::Other(format!("Database error: {}", e)))?;
 
         match project_found {
-            Some(project) => Ok(Self::map_db_project_to_project(project)),
+            Some(project) => Ok(Self::map_db_project_row_to_project(project)),
             None => Err(ProjectError::NotFound(format!(
                 "Project not found for repository {}/{}",
                 owner, repo
@@ -1141,7 +1143,7 @@ impl ProjectService {
         active_project.updated_at = Set(chrono::Utc::now());
 
         let project_found = active_project.update(self.db.as_ref()).await?;
-        let project_found = Self::map_db_project_to_project(project_found);
+        let project_found = self.map_written_project(project_found).await?;
 
         // Emit ProjectUpdated job
         let project_updated_job = Job::ProjectUpdated(ProjectUpdatedJob {
@@ -1204,7 +1206,7 @@ impl ProjectService {
         active_project.source_type = Set(source_type);
         active_project.updated_at = Set(chrono::Utc::now());
         let updated = active_project.update(self.db.as_ref()).await?;
-        let updated = Self::map_db_project_to_project(updated);
+        let updated = self.map_written_project(updated).await?;
 
         // Deploy routing / behavior keys off source_type — notify consumers.
         if let Err(e) = self
@@ -1245,7 +1247,7 @@ impl ProjectService {
         active_project.allow_alternate_sources = Set(Some(allow));
         active_project.updated_at = Set(chrono::Utc::now());
         let updated = active_project.update(self.db.as_ref()).await?;
-        Ok(Self::map_db_project_to_project(updated))
+        self.map_written_project(updated).await
     }
 
     /// Persist deletion intent before cancelling workflows or touching Docker.
@@ -1761,7 +1763,7 @@ impl ProjectService {
                 self.reload_routes_after_compose_port_change(project_id)
                     .await?;
             }
-            let project_found = Self::map_db_project_to_project(updated_project);
+            let project_found = self.map_written_project(updated_project).await?;
 
             // Emit ProjectUpdated job
             let project_updated_job = Job::ProjectUpdated(ProjectUpdatedJob {
@@ -1788,7 +1790,7 @@ impl ProjectService {
                 project_id
             )))?;
 
-        let project_found = Self::map_db_project_to_project(final_project);
+        let project_found = self.map_written_project(final_project).await?;
 
         // Emit ProjectUpdated job
         let project_updated_job = Job::ProjectUpdated(ProjectUpdatedJob {
@@ -1830,7 +1832,7 @@ impl ProjectService {
 
         let updated_project = active_project.update(self.db.as_ref()).await?;
 
-        Ok(Self::map_db_project_to_project(updated_project))
+        self.map_written_project(updated_project).await
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2192,7 +2194,7 @@ impl ProjectService {
                 .await?;
         }
 
-        Ok(Self::map_db_project_to_project(updated_project))
+        self.map_written_project(updated_project).await
     }
 
     /// Public Compose ports are read directly from `projects.preset_config`
@@ -3099,7 +3101,7 @@ impl ProjectService {
             );
         }
 
-        Ok(Self::map_db_project_to_project(updated_project))
+        self.map_written_project(updated_project).await
     }
 
     /// Update a project's deployment config.
@@ -3217,7 +3219,7 @@ impl ProjectService {
             );
         }
 
-        Ok(Self::map_db_project_to_project(updated_project))
+        self.map_written_project(updated_project).await
     }
 
     /// Generate a unique project slug by checking for collisions and appending a short UUID if needed.
@@ -3302,7 +3304,48 @@ impl ProjectService {
         project
     }
 
-    pub fn map_db_project_to_project(db_project: projects::Model) -> Project {
+    /// Build the client-facing `Project` for a row a mutation just wrote.
+    ///
+    /// Writes return an updated `projects::Model` rather than going back
+    /// through the joined read query, so the provider type is fetched here —
+    /// one primary-key lookup, and none at all for a project with no
+    /// connection. Answering a successful update with `git_provider_type:
+    /// null` would tell a client that a connected project has no provider, and
+    /// any client that trusts its own mutation response would downgrade a
+    /// GitLab project back to a guess until its next read.
+    async fn map_written_project(
+        &self,
+        db_project: projects::Model,
+    ) -> Result<Project, ProjectError> {
+        let git_provider_type = match db_project.git_provider_connection_id {
+            None => None,
+            Some(connection_id) => git_provider_connections::Entity::find_by_id(connection_id)
+                .select_only()
+                .column(git_providers::Column::ProviderType)
+                .inner_join(git_providers::Entity)
+                .into_tuple::<String>()
+                .one(self.db.as_ref())
+                .await
+                .map_err(|e| {
+                    ProjectError::Other(format!(
+                        "Failed to read the git provider type for connection {} of project {}: {}",
+                        connection_id, db_project.id, e
+                    ))
+                })?,
+        };
+
+        let mut project = Self::map_db_project_to_project(db_project);
+        project.git_provider_type = git_provider_type;
+        Ok(project)
+    }
+
+    /// Maps the project row alone, leaving `git_provider_type` empty.
+    ///
+    /// Private on purpose: every client-facing path must go through
+    /// `map_db_project_row_to_project` (joined read) or `map_written_project`
+    /// (mutation), so a new endpoint cannot quietly answer with "no provider"
+    /// for a connected project.
+    fn map_db_project_to_project(db_project: projects::Model) -> Project {
         // Extract deployment config fields
         let deployment_config = db_project.deployment_config.clone();
 
@@ -3364,9 +3407,9 @@ impl ProjectService {
             git_url: db_project.git_url,
             git_provider_connection_id: db_project.git_provider_connection_id,
             // Lives on the connection's provider row, not on the project row,
-            // so it can only come from a query that joined it in — see
-            // `with_git_provider_type` / `map_db_project_row_to_project`, which
-            // the read paths that serve a client use.
+            // so it is filled in by the caller: `map_db_project_row_to_project`
+            // from the joined read query, or `map_written_project` after a
+            // mutation. Both are the only ways a `Project` reaches a client.
             git_provider_type: None,
             is_on_demand: false, // Deprecated field, default to false
             deployment_config: deployment_config.clone(),
@@ -4445,6 +4488,25 @@ mod tests {
             listed.len() as i64,
             "count query and page agree once the provider join is in the page query"
         );
+
+        // A write answers with the provider too. A client that trusts its own
+        // mutation response would otherwise downgrade a connected project to
+        // "no provider" until its next read.
+        let after_write = service
+            .set_allow_alternate_sources(connected.id, true)
+            .await
+            .unwrap();
+        assert_eq!(
+            after_write.git_provider_type.as_deref(),
+            Some("gitlab"),
+            "an update response must not drop the connected provider"
+        );
+
+        let after_write_unconnected = service
+            .set_allow_alternate_sources(standalone.id, true)
+            .await
+            .unwrap();
+        assert_eq!(after_write_unconnected.git_provider_type, None);
     }
 
     #[tokio::test]

--- a/crates/temps-projects/src/services/project.rs
+++ b/crates/temps-projects/src/services/project.rs
@@ -933,7 +933,7 @@ impl ProjectService {
             project_found_db
         };
 
-        self.map_written_project(project_found_db).await
+        Ok(self.map_written_project(project_found_db).await)
     }
 
     /// Post-insert steps for `create_project`. Returns the default environment
@@ -1143,7 +1143,7 @@ impl ProjectService {
         active_project.updated_at = Set(chrono::Utc::now());
 
         let project_found = active_project.update(self.db.as_ref()).await?;
-        let project_found = self.map_written_project(project_found).await?;
+        let project_found = self.map_written_project(project_found).await;
 
         // Emit ProjectUpdated job
         let project_updated_job = Job::ProjectUpdated(ProjectUpdatedJob {
@@ -1206,7 +1206,7 @@ impl ProjectService {
         active_project.source_type = Set(source_type);
         active_project.updated_at = Set(chrono::Utc::now());
         let updated = active_project.update(self.db.as_ref()).await?;
-        let updated = self.map_written_project(updated).await?;
+        let updated = self.map_written_project(updated).await;
 
         // Deploy routing / behavior keys off source_type — notify consumers.
         if let Err(e) = self
@@ -1247,7 +1247,7 @@ impl ProjectService {
         active_project.allow_alternate_sources = Set(Some(allow));
         active_project.updated_at = Set(chrono::Utc::now());
         let updated = active_project.update(self.db.as_ref()).await?;
-        self.map_written_project(updated).await
+        Ok(self.map_written_project(updated).await)
     }
 
     /// Persist deletion intent before cancelling workflows or touching Docker.
@@ -1763,7 +1763,7 @@ impl ProjectService {
                 self.reload_routes_after_compose_port_change(project_id)
                     .await?;
             }
-            let project_found = self.map_written_project(updated_project).await?;
+            let project_found = self.map_written_project(updated_project).await;
 
             // Emit ProjectUpdated job
             let project_updated_job = Job::ProjectUpdated(ProjectUpdatedJob {
@@ -1790,7 +1790,7 @@ impl ProjectService {
                 project_id
             )))?;
 
-        let project_found = self.map_written_project(final_project).await?;
+        let project_found = self.map_written_project(final_project).await;
 
         // Emit ProjectUpdated job
         let project_updated_job = Job::ProjectUpdated(ProjectUpdatedJob {
@@ -1832,7 +1832,7 @@ impl ProjectService {
 
         let updated_project = active_project.update(self.db.as_ref()).await?;
 
-        self.map_written_project(updated_project).await
+        Ok(self.map_written_project(updated_project).await)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2194,7 +2194,7 @@ impl ProjectService {
                 .await?;
         }
 
-        self.map_written_project(updated_project).await
+        Ok(self.map_written_project(updated_project).await)
     }
 
     /// Public Compose ports are read directly from `projects.preset_config`
@@ -3101,7 +3101,7 @@ impl ProjectService {
             );
         }
 
-        self.map_written_project(updated_project).await
+        Ok(self.map_written_project(updated_project).await)
     }
 
     /// Update a project's deployment config.
@@ -3219,7 +3219,7 @@ impl ProjectService {
             );
         }
 
-        self.map_written_project(updated_project).await
+        Ok(self.map_written_project(updated_project).await)
     }
 
     /// Generate a unique project slug by checking for collisions and appending a short UUID if needed.
@@ -3313,30 +3313,42 @@ impl ProjectService {
     /// null` would tell a client that a connected project has no provider, and
     /// any client that trusts its own mutation response would downgrade a
     /// GitLab project back to a guess until its next read.
-    async fn map_written_project(
-        &self,
-        db_project: projects::Model,
-    ) -> Result<Project, ProjectError> {
+    ///
+    /// Deliberately infallible. This runs *after* the write has committed, and
+    /// it reads a display label — failing here would report a change the
+    /// database has already accepted as a failed request, and would skip the
+    /// `ProjectUpdated` job that several callers emit straight after this call,
+    /// leaving routes and notifications unaware of a change that did happen. A
+    /// lookup that fails is logged and leaves the field empty; the next read
+    /// fills it in.
+    async fn map_written_project(&self, db_project: projects::Model) -> Project {
         let git_provider_type = match db_project.git_provider_connection_id {
             None => None,
-            Some(connection_id) => git_provider_connections::Entity::find_by_id(connection_id)
-                .select_only()
-                .column(git_providers::Column::ProviderType)
-                .inner_join(git_providers::Entity)
-                .into_tuple::<String>()
-                .one(self.db.as_ref())
-                .await
-                .map_err(|e| {
-                    ProjectError::Other(format!(
-                        "Failed to read the git provider type for connection {} of project {}: {}",
-                        connection_id, db_project.id, e
-                    ))
-                })?,
+            Some(connection_id) => {
+                match git_provider_connections::Entity::find_by_id(connection_id)
+                    .select_only()
+                    .column(git_providers::Column::ProviderType)
+                    .inner_join(git_providers::Entity)
+                    .into_tuple::<String>()
+                    .one(self.db.as_ref())
+                    .await
+                {
+                    Ok(provider_type) => provider_type,
+                    Err(e) => {
+                        warn!(
+                            "Failed to read the git provider type for connection {} of project {} \
+                             after a successful write; responding without it: {}",
+                            connection_id, db_project.id, e
+                        );
+                        None
+                    }
+                }
+            }
         };
 
         let mut project = Self::map_db_project_to_project(db_project);
         project.git_provider_type = git_provider_type;
-        Ok(project)
+        project
     }
 
     /// Maps the project row alone, leaving `git_provider_type` empty.

--- a/crates/temps-projects/src/services/types.rs
+++ b/crates/temps-projects/src/services/types.rs
@@ -60,6 +60,17 @@ pub struct Project {
     pub is_public_repo: bool,
     pub git_url: Option<String>,
     pub git_provider_connection_id: Option<i32>,
+    /// Provider type behind `git_provider_connection_id` (`github`,
+    /// `github_app`, `gitlab`, `gitea`, `bitbucket`, `generic`), resolved from
+    /// the connection's provider row. `None` when the project has no
+    /// connection (public repo, Docker image, uploaded source) or when the
+    /// caller fetched the project through a path that doesn't resolve it.
+    ///
+    /// This is the only authoritative answer to "which Git host is this
+    /// project on" — the clone URL's hostname is not, because a self-hosted
+    /// instance can live on any domain and a project may have no clone URL at
+    /// all.
+    pub git_provider_type: Option<String>,
     pub is_on_demand: bool,
     pub deployment_config: Option<temps_entities::prelude::DeploymentConfig>,
     pub attack_mode: bool,

--- a/crates/temps-query-redis/src/lib.rs
+++ b/crates/temps-query-redis/src/lib.rs
@@ -259,10 +259,14 @@ return {1, estimated, has_more, values}
                 observed,
             ));
         }
-        let values = flat_values
-            .chunks_exact(2)
-            .map(|pair| (pair[0].clone(), pair[1].clone()))
-            .collect();
+        // The reply is a flat [field, value, field, value, …] list. Pair it up
+        // by consuming the Vec, so neither half is cloned; a trailing unpaired
+        // element (a malformed reply) is dropped.
+        let mut flat = flat_values.into_iter();
+        let mut values = Vec::with_capacity(flat.len() / 2);
+        while let (Some(field), Some(value)) = (flat.next(), flat.next()) {
+            values.push((field, value));
+        }
         Ok((values, has_more != 0))
     }
 
@@ -360,16 +364,19 @@ return {1, estimated, has_more, values}
                 observed,
             ));
         }
-        let mut values = Vec::with_capacity(flat_values.len() / 2);
-        for pair in flat_values.chunks_exact(2) {
-            let score = pair[1].parse::<f64>().map_err(|error| {
+        // Flat [member, score, member, score, …], paired by consuming the Vec
+        // so the member string is moved rather than cloned.
+        let mut flat = flat_values.into_iter();
+        let mut values = Vec::with_capacity(flat.len() / 2);
+        while let (Some(member), Some(raw_score)) = (flat.next(), flat.next()) {
+            let score = raw_score.parse::<f64>().map_err(|error| {
                 error!(error = %error, "failed to decode Redis sorted-set score");
                 DataError::BackendQueryFailed {
                     backend: "Redis",
                     entity: key.to_string(),
                 }
             })?;
-            values.push((pair[0].clone(), score));
+            values.push((member, score));
         }
         Ok((values, has_more != 0))
     }

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -13336,6 +13336,17 @@ export type ProjectResponse = {
     error_source_root?: string | null;
     git_provider_connection_id?: number | null;
     /**
+     * Git provider behind `git_provider_connection_id`: `github`,
+     * `github_app`, `gitlab`, `gitea`, `bitbucket` or `generic`. `null` when
+     * the project has no connection (public repository, Docker image or
+     * uploaded source).
+     *
+     * Clients must use this rather than guessing the host from `git_url`: a
+     * self-hosted GitLab/Gitea/Bitbucket instance can live on any domain, and
+     * a connected project may have no clone URL stored at all.
+     */
+    git_provider_type?: string | null;
+    /**
      * Git clone URL for the repository (used for public repos without a provider connection)
      */
     git_url?: string | null;

--- a/web/src/components/dashboard/ProjectCard.test.ts
+++ b/web/src/components/dashboard/ProjectCard.test.ts
@@ -41,6 +41,7 @@ describe('projectRepository', () => {
         git_url: 'https://github.com/gotempsh/temps.git',
         repo_owner: 'gotempsh',
         repo_name: 'temps',
+        git_provider_type: 'github',
       })
     ).toEqual({ label: 'gotempsh/temps', provider: 'github' })
   })
@@ -51,8 +52,42 @@ describe('projectRepository', () => {
         git_url: 'git@gitlab.com:team/api.git',
         repo_owner: null,
         repo_name: null,
+        git_provider_type: null,
       })
     ).toEqual({ label: 'team/api', provider: 'gitlab' })
+  })
+
+  test('trusts the connected provider over the clone URL', () => {
+    // Self-hosted instance on a hostname that names no vendor: the connection
+    // knows what it is, the URL never will.
+    expect(
+      projectRepository({
+        git_url: 'https://code.example.internal/team/api.git',
+        repo_owner: 'team',
+        repo_name: 'api',
+        git_provider_type: 'gitlab',
+      })
+    ).toEqual({ label: 'team/api', provider: 'gitlab' })
+
+    expect(
+      projectRepository({
+        git_url: null,
+        repo_owner: 'team',
+        repo_name: 'api',
+        git_provider_type: 'gitea',
+      })
+    ).toEqual({ label: 'team/api', provider: 'gitea' })
+  })
+
+  test('never guesses GitHub for a project with no clone URL', () => {
+    expect(
+      projectRepository({
+        git_url: null,
+        repo_owner: 'team',
+        repo_name: 'api',
+        git_provider_type: null,
+      })
+    ).toEqual({ label: 'team/api', provider: 'git' })
   })
 
   test('returns no repository when the project is not connected to Git', () => {
@@ -61,6 +96,7 @@ describe('projectRepository', () => {
         git_url: null,
         repo_owner: null,
         repo_name: null,
+        git_provider_type: null,
       })
     ).toBeNull()
   })
@@ -74,6 +110,7 @@ describe('projectBuildSource', () => {
         git_url: 'https://github.com/gotempsh/temps.git',
         repo_owner: 'gotempsh',
         repo_name: 'temps',
+        git_provider_type: 'github',
       })
     ).toEqual({ kind: 'github', label: 'GitHub' })
 
@@ -83,8 +120,67 @@ describe('projectBuildSource', () => {
         git_url: 'https://gitlab.com/team/api.git',
         repo_owner: 'team',
         repo_name: 'api',
+        git_provider_type: 'gitlab',
       })
     ).toEqual({ kind: 'gitlab', label: 'GitLab' })
+  })
+
+  test('reports the connected provider, whatever the clone URL looks like', () => {
+    // The regression this guards: a GitLab-connected project with no stored
+    // clone URL used to be labelled — and badged — as GitHub.
+    expect(
+      projectBuildSource({
+        source_type: 'git',
+        git_url: null,
+        repo_owner: 'team',
+        repo_name: 'api',
+        git_provider_type: 'gitlab',
+      })
+    ).toEqual({ kind: 'gitlab', label: 'GitLab' })
+
+    expect(
+      projectBuildSource({
+        source_type: 'git',
+        git_url: 'https://code.example.internal/team/api.git',
+        repo_owner: 'team',
+        repo_name: 'api',
+        git_provider_type: 'gitea',
+      })
+    ).toEqual({ kind: 'gitea', label: 'Gitea' })
+
+    // The GitHub App flavour is still GitHub.
+    expect(
+      projectBuildSource({
+        source_type: 'git',
+        git_url: null,
+        repo_owner: 'team',
+        repo_name: 'api',
+        git_provider_type: 'github_app',
+      })
+    ).toEqual({ kind: 'github', label: 'GitHub' })
+
+    // Self-hosted plain Git has no brand of its own.
+    expect(
+      projectBuildSource({
+        source_type: 'git',
+        git_url: 'https://code.example.internal/team/api.git',
+        repo_owner: 'team',
+        repo_name: 'api',
+        git_provider_type: 'generic',
+      })
+    ).toEqual({ kind: 'git', label: 'Git repository' })
+  })
+
+  test('stays generic when nothing identifies the provider', () => {
+    expect(
+      projectBuildSource({
+        source_type: 'git',
+        git_url: null,
+        repo_owner: 'team',
+        repo_name: 'api',
+        git_provider_type: null,
+      })
+    ).toEqual({ kind: 'git', label: 'Git repository' })
   })
 
   test('distinguishes images from uploaded source', () => {
@@ -94,6 +190,7 @@ describe('projectBuildSource', () => {
         git_url: null,
         repo_owner: null,
         repo_name: null,
+        git_provider_type: null,
       })
     ).toEqual({ kind: 'docker', label: 'Docker image' })
 
@@ -108,6 +205,7 @@ describe('projectBuildSource', () => {
           git_url: null,
           repo_owner: null,
           repo_name: null,
+          git_provider_type: null,
         })
       ).toEqual({ kind: 'source', label: 'Source upload' })
     }

--- a/web/src/components/dashboard/ProjectCard.tsx
+++ b/web/src/components/dashboard/ProjectCard.tsx
@@ -7,8 +7,7 @@ import { PresetIcon } from '@/components/presets/PresetIcon'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { TimeAgo } from '@/components/utils/TimeAgo'
-import GithubIcon from '@/icons/Github'
-import GitlabIcon from '@/icons/Gitlab'
+import { ProviderLogo } from '@/components/git/ProviderLogo'
 import {
   AlertCircle,
   Container,
@@ -69,8 +68,14 @@ function HealthStatusDot({ status }: { status: string }) {
 }
 
 function BuildSourceIcon({ kind }: { kind: ProjectBuildSource['kind'] }) {
-  if (kind === 'github') return <GithubIcon className="size-4 shrink-0" />
-  if (kind === 'gitlab') return <GitlabIcon className="size-4 shrink-0" />
+  if (
+    kind === 'github' ||
+    kind === 'gitlab' ||
+    kind === 'gitea' ||
+    kind === 'bitbucket'
+  ) {
+    return <ProviderLogo providerType={kind} className="size-4 shrink-0" />
+  }
   if (kind === 'git') {
     return <GitFork className="size-4 shrink-0 text-muted-foreground" />
   }

--- a/web/src/components/dashboard/project-card-data.ts
+++ b/web/src/components/dashboard/project-card-data.ts
@@ -2,17 +2,70 @@ import type { ProjectResponse } from '@/api/client'
 
 type RepositoryProject = Pick<
   ProjectResponse,
-  'git_url' | 'repo_name' | 'repo_owner'
+  'git_url' | 'repo_name' | 'repo_owner' | 'git_provider_type'
 >
+
+export type GitProvider = 'github' | 'gitlab' | 'gitea' | 'bitbucket' | 'git'
 
 export type RepositoryInfo = {
   label: string
-  provider: 'github' | 'gitlab' | 'git'
+  provider: GitProvider
 }
 
 export type ProjectBuildSource = {
   label: string
-  kind: 'github' | 'gitlab' | 'git' | 'docker' | 'source'
+  kind: GitProvider | 'docker' | 'source'
+}
+
+const PROVIDER_LABELS: Record<GitProvider, string> = {
+  github: 'GitHub',
+  gitlab: 'GitLab',
+  gitea: 'Gitea',
+  bitbucket: 'Bitbucket',
+  git: 'Git repository',
+}
+
+/**
+ * The provider type stored on the project's Git connection, normalized to what
+ * the UI draws. `github_app` is the GitHub App flavour of GitHub; `generic`
+ * (self-hosted plain Git) has no brand mark of its own.
+ */
+function providerFromConnection(
+  providerType: string | null | undefined
+): GitProvider | null {
+  switch (providerType?.toLowerCase()) {
+    case 'github':
+    case 'github_app':
+      return 'github'
+    case 'gitlab':
+      return 'gitlab'
+    case 'gitea':
+      return 'gitea'
+    case 'bitbucket':
+      return 'bitbucket'
+    case 'generic':
+      return 'git'
+    default:
+      return null
+  }
+}
+
+/**
+ * Last-resort hostname sniffing, for public repositories that have a clone URL
+ * but no connection to read the provider from.
+ *
+ * This can only ever recognize vendors that name themselves in the hostname, so
+ * it must never be used when `git_provider_type` is available, and an
+ * unrecognized host must stay generic — a self-hosted instance on a custom
+ * domain is not GitHub just because we failed to identify it.
+ */
+function providerFromUrl(gitUrl: string | undefined): GitProvider {
+  const url = gitUrl?.toLowerCase() ?? ''
+  if (url.includes('github')) return 'github'
+  if (url.includes('gitlab')) return 'gitlab'
+  if (url.includes('bitbucket')) return 'bitbucket'
+  if (url.includes('gitea')) return 'gitea'
+  return 'git'
 }
 
 export function projectPresetLabel(preset?: string | null): string {
@@ -43,12 +96,10 @@ export function projectRepository(
 
   if (!owner || !name) return null
 
-  const lowerUrl = gitUrl?.toLowerCase() ?? ''
-  const provider = lowerUrl.includes('gitlab')
-    ? 'gitlab'
-    : lowerUrl.includes('github') || !gitUrl
-      ? 'github'
-      : 'git'
+  // The connected provider is authoritative; the clone URL is only a fallback
+  // for public repositories, which have no connection to read it from.
+  const provider =
+    providerFromConnection(project.git_provider_type) ?? providerFromUrl(gitUrl)
 
   return { label: `${owner}/${name}`, provider }
 }
@@ -56,20 +107,15 @@ export function projectRepository(
 export function projectBuildSource(
   project: Pick<
     ProjectResponse,
-    'source_type' | 'git_url' | 'repo_name' | 'repo_owner'
+    'source_type' | 'git_url' | 'repo_name' | 'repo_owner' | 'git_provider_type'
   >
 ): ProjectBuildSource {
   if (project.source_type === 'git') {
-    const provider = projectRepository(project)?.provider ?? 'git'
-    return {
-      kind: provider,
-      label:
-        provider === 'github'
-          ? 'GitHub'
-          : provider === 'gitlab'
-            ? 'GitLab'
-            : 'Git repository',
-    }
+    const provider =
+      providerFromConnection(project.git_provider_type) ??
+      projectRepository(project)?.provider ??
+      'git'
+    return { kind: provider, label: PROVIDER_LABELS[provider] }
   }
 
   if (project.source_type === 'docker_image') {


### PR DESCRIPTION
## The bug

On the Projects dashboard, a project connected to **GitLab** is drawn with the **GitHub** mark and labelled `GitHub`. Gitea and Bitbucket connections hit the same thing, and a self-hosted instance on a hostname that doesn't name its vendor falls through to the generic branch icon.

## Root cause

The console never asked which provider the project is connected to — it guessed from the clone URL, in `web/src/components/dashboard/project-card-data.ts`:

```ts
const provider = lowerUrl.includes('gitlab')
  ? 'gitlab'
  : lowerUrl.includes('github') || !gitUrl   // <- no clone URL => "github"
    ? 'github'
    : 'git'
```

Two failure modes:

1. **No `git_url` stored → hardcoded GitHub.** `git_url` is optional; a project connected through a provider connection can carry `repo_owner`/`repo_name` with `git_url` null. Every such project rendered as GitHub whatever it was connected to.
2. **Hostname that doesn't spell out the vendor.** A GitLab/Gitea/Bitbucket server on a custom domain matched nothing; GitHub Enterprise never resolved to GitHub either.

The authoritative value already existed in the data model — `projects.git_provider_connection_id` → `git_provider_connections.provider_id` → `git_providers.provider_type` — but `ProjectResponse` never exposed it, so the client had nothing to read.

## The fix

**Backend** (`temps-projects`)
- `ProjectResponse` gains `git_provider_type` (`github` / `github_app` / `gitlab` / `gitea` / `bitbucket` / `generic`, or `null` when the project has no connection).
- Resolved by `ProjectService::resolve_git_provider_types`: one JOIN across the whole batch on the read paths that serve clients (`get_project`, `get_project_by_slug`, `get_projects`, the paginated dashboard list) — no per-project lookup, so the dashboard costs exactly one extra query per page, and none at all when no listed project has a connection.

**Console**
- The card trusts `git_provider_type`; hostname sniffing survives only as a fallback for public repositories, which have no connection to read.
- An unidentifiable provider now stays **generic** rather than defaulting to GitHub.
- Gitea and Bitbucket get their real marks (via the existing `ProviderLogo`) instead of a generic icon.

**CLI**
- `temps projects show` prints a `Git Provider` row from the same field.

## Evidence

Dev instance, two fixture projects: one GitLab-connected with **no** `git_url`, one public GitHub repo with no connection.

```
$ curl -s .../api/projects?page=1&per_page=10 | ...
internal-api  | git_url= None                                  | git_provider_type= gitlab
public-site   | git_url= https://github.com/octo/site.git      | git_provider_type= None
```

Dashboard, same instance and same data:
- **Before:** the GitLab-connected card renders the GitHub mark.
- **After:** it renders the GitLab tanuki; the public GitHub project still renders GitHub.

Tests:
- `cargo test --lib -p temps-projects connected_projects_report` — new integration test: a project connected to a self-hosted GitLab on `code.example.internal` with `git_url = NULL` reports `gitlab` through `get_project`, `get_project_by_slug` and the paginated list; an unconnected project reports `None`. **1 passed.**
- `bun test src/components/dashboard` — 24 pass, including new cases for "connected provider wins over the clone URL", `github_app` → GitHub, `generic` → neutral, and "never guesses GitHub when there is no clone URL".
- `npx tsc --noEmit` (web) clean; `bun run typecheck` (CLI) clean; `cargo clippy -p temps-projects --all-targets -- -D warnings` clean.

Both generated clients were regenerated from a server built off this branch (`web/src/api/client`, `apps/temps-cli/openapi.json` + `src/api`); the spec diff is +8 lines.