### PR TITLE
fix(install): paginate GitHub releases when resolving beta/nightly channel

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -183,13 +183,20 @@ if [[ ${#positional[@]} -eq 0 ]]; then
     #   release. This is GitHub's contract — it's exactly what we want.
     #   404 means there are zero stable releases yet; fall through to a
     #   helpful error.
-    # - beta: /releases/latest skips betas, so we walk the first page of
-    #   /releases (newest-first) and take the first `tag_name` that is NOT a
-    #   nightly build (mirrors `temps upgrade`'s `UpgradeChannel::Beta`,
-    #   which excludes `-nightly.` tags so a deliberate beta opt-in never
-    #   silently resolves to an automated nightly).
-    # - nightly: same page, but take the first `tag_name` that IS a nightly
-    #   build (contains `-nightly.`), minted by the "Nightly Release" workflow.
+    # - beta: /releases/latest skips betas, so we walk /releases
+    #   (newest-first) and take the first `tag_name` that is NOT a nightly
+    #   build (mirrors `temps upgrade`'s `UpgradeChannel::Beta`, which
+    #   excludes `-nightly.` tags so a deliberate beta opt-in never silently
+    #   resolves to an automated nightly).
+    # - nightly: same listing, but take the first `tag_name` that IS a
+    #   nightly build (contains `-nightly.`), minted by the "Nightly
+    #   Release" workflow.
+    #
+    # Pagination: nightlies are cut once a day from `main`, so a gap of more
+    # than one page's worth of days between beta releases (or, in principle,
+    # between nightly releases) means the desired tag isn't on page 1. Walk
+    # up to 5 pages of 100 releases (500 releases of headroom) and stop as
+    # soon as a match is found or the API runs out of releases.
     #
     # Why "first tag_name" (no draft check):
     #   We don't ship draft releases publicly — anything visible on the
@@ -205,21 +212,25 @@ if [[ ${#positional[@]} -eq 0 ]]; then
                     grep '"tag_name":' |
                     head -n 1 |
                     sed -E 's/.*"([^"]+)".*/\1/' 2>/dev/null)
-    elif [[ "$channel" = "nightly" ]]; then
-        # GitHub orders releases newest-first; take the first tag_name that
-        # contains the `-nightly.` marker.
-        temps_tag=$(curl --silent "https://api.github.com/repos/gotempsh/temps/releases?per_page=20" |
-                    grep -oE '"tag_name": *"[^"]*-nightly\.[^"]*"' |
-                    head -n 1 |
-                    sed -E 's/.*"([^"]+)"$/\1/' 2>/dev/null)
     else
-        # beta: GitHub orders releases newest-first; take the first
-        # tag_name that is NOT a nightly build.
-        temps_tag=$(curl --silent "https://api.github.com/repos/gotempsh/temps/releases?per_page=20" |
-                    grep '"tag_name":' |
-                    grep -v -- '-nightly\.' |
-                    head -n 1 |
-                    sed -E 's/.*"([^"]+)".*/\1/' 2>/dev/null)
+        temps_tag=""
+        page=1
+        while [[ -z "$temps_tag" && $page -le 5 ]]; do
+            page_tags=$(curl --silent "https://api.github.com/repos/gotempsh/temps/releases?per_page=100&page=$page" |
+                        grep -oE '"tag_name": *"[^"]*"' |
+                        sed -E 's/.*"([^"]+)"$/\1/')
+            [[ -z "$page_tags" ]] && break
+
+            if [[ "$channel" = "nightly" ]]; then
+                # First tag_name that IS a nightly build.
+                temps_tag=$(echo "$page_tags" | grep -- '-nightly\.' | head -n 1)
+            else
+                # beta: first tag_name that is NOT a nightly build.
+                temps_tag=$(echo "$page_tags" | grep -v -- '-nightly\.' | head -n 1)
+            fi
+
+            page=$((page + 1))
+        done
     fi
     set -e
 


### PR DESCRIPTION
## Summary
- `install.sh` (served as `https://temps.sh/deploy.sh`) resolved the beta/nightly channel by grepping only the first page of 20 releases from the GitHub API.
- Nightly builds are cut once a day from `main`. When 20+ nightlies accumulate without a beta release in between (currently the case — the last 24 releases are nightlies before the next beta), the beta filter matches nothing on that single page and the installer hard-fails with "No releases found on channel 'beta'".
- Fix: walk up to 5 pages of 100 releases (500 releases of headroom) for both the beta and nightly channels, stopping as soon as a matching tag is found or the API runs out of releases. `stable` is unaffected — it already uses GitHub's `/releases/latest` endpoint.

## Test plan
- [x] `bash -n scripts/install.sh` — syntax check passes
- [x] Extracted the new pagination loop and ran it against the live `api.github.com/repos/gotempsh/temps/releases` endpoint:
  - `channel=beta` → resolves `v0.1.0-beta.55` (previously would have failed — the first 24 releases are all `-nightly.` tags)
  - `channel=nightly` → resolves `v0.1.0-nightly.20260820.bfa3b1e2` (still correct)
  - `channel=stable` → resolves `v0.0.8` via `/releases/latest` (unchanged code path)

Fixes #742