### PR TITLE
fix(web): handle mutation and fetch errors in ErrorGroupDetail and ErrorEventDetail

### DIFF
--- a/web/src/pages/ErrorEventDetail.tsx
+++ b/web/src/pages/ErrorEventDetail.tsx
@@ -19,7 +19,7 @@ import { cn } from '@/lib/utils'
 import { extractSentryEvent } from '@/lib/sentry-utils'
 import { useQuery } from '@tanstack/react-query'
 import { format } from 'date-fns'
-import { AlertTriangle, ArrowLeft, Clock } from 'lucide-react'
+import { AlertCircle, AlertTriangle, ArrowLeft, Clock, RotateCcw } from 'lucide-react'
 import { useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router'
 
@@ -33,7 +33,12 @@ export function ErrorEventDetail({ project }: { project: ProjectResponse }) {
   const { setBreadcrumbs } = useBreadcrumbs()
 
   // Fetch event details
-  const { data: event, isLoading } = useQuery({
+  const {
+    data: event,
+    isLoading,
+    error: eventError,
+    refetch: refetchEvent,
+  } = useQuery({
     ...getErrorEventOptions({
       path: {
         event_id: parseInt(eventId!),
@@ -98,6 +103,39 @@ export function ErrorEventDetail({ project }: { project: ProjectResponse }) {
             </div>
           </CardContent>
         </Card>
+      </div>
+    )
+  }
+
+  const isNotFound =
+    (eventError as any)?.status === 404 ||
+    (eventError as any)?.title === 'Not Found'
+
+  if (!event && eventError && !isNotFound) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 min-h-[400px]">
+        <AlertCircle className="h-8 w-8 text-destructive" />
+        <div className="text-center">
+          <h2 className="text-lg font-semibold">Failed to load error event</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {eventError instanceof Error
+              ? eventError.message
+              : 'An unexpected error occurred. Please try again.'}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => void refetchEvent()}>
+            <RotateCcw className="mr-2 h-4 w-4" />
+            Retry
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={() => navigate(`/projects/${project.slug}/errors/${errorGroupId}`)}
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Error Group
+          </Button>
+        </div>
       </div>
     )
   }

--- a/web/src/pages/ErrorGroupDetail.tsx
+++ b/web/src/pages/ErrorGroupDetail.tsx
@@ -46,6 +46,7 @@ import { extractSentryEvent } from '@/lib/sentry-utils'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import {
+  AlertCircle,
   AlertTriangle,
   ArrowLeft,
   Check,
@@ -68,7 +69,12 @@ export function ErrorGroupDetail({ project }: { project: ProjectResponse }) {
   const [selectedTab, setSelectedTab] = useState('overview')
 
   // Fetch error group details
-  const { data: errorGroup, isLoading: isLoadingGroup } = useQuery({
+  const {
+    data: errorGroup,
+    isLoading: isLoadingGroup,
+    error: errorGroupError,
+    refetch: refetchErrorGroup,
+  } = useQuery({
     ...getErrorGroupOptions({
       path: { group_id: parseInt(errorGroupId!), project_id: project.id },
     }),
@@ -89,6 +95,7 @@ export function ErrorGroupDetail({ project }: { project: ProjectResponse }) {
 
   const statusMutation = useMutation({
     ...updateErrorGroupMutation(),
+    meta: { errorTitle: 'Failed to update error status' },
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: getErrorGroupOptions({
@@ -162,12 +169,12 @@ export function ErrorGroupDetail({ project }: { project: ProjectResponse }) {
   // Tell the assistant which error the user is looking at.
   const assistantContext = errorGroup
     ? [
-        'The user is viewing an error group (error tracking) in the Temps console.',
-        `Project: "${project.name}" (slug: ${project.slug}, id: ${project.id}).`,
-        `Error group #${errorGroupId}: "${errorGroup.title}" (type: ${errorGroup.error_type ?? 'unknown'}).`,
-        `Seen ${errorGroup.total_count} time(s); first ${errorGroup.first_seen}, last ${errorGroup.last_seen}.`,
-        'Fetch details via the temps CLI: `error-tracking get_error_group --group_id` and `list_error_events --group_id`.',
-      ].join('\n')
+      'The user is viewing an error group (error tracking) in the Temps console.',
+      `Project: "${project.name}" (slug: ${project.slug}, id: ${project.id}).`,
+      `Error group #${errorGroupId}: "${errorGroup.title}" (type: ${errorGroup.error_type ?? 'unknown'}).`,
+      `Seen ${errorGroup.total_count} time(s); first ${errorGroup.first_seen}, last ${errorGroup.last_seen}.`,
+      'Fetch details via the temps CLI: `error-tracking get_error_group --group_id` and `list_error_events --group_id`.',
+    ].join('\n')
     : null
   useAssistantPageContext(assistantContext, 'this error')
 
@@ -208,6 +215,36 @@ export function ErrorGroupDetail({ project }: { project: ProjectResponse }) {
             </div>
           </CardContent>
         </Card>
+      </div>
+    )
+  }
+
+  const isNotFound =
+    (errorGroupError as any)?.status === 404 ||
+    (errorGroupError as any)?.title === 'Not Found'
+
+  if (!errorGroup && errorGroupError && !isNotFound) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 min-h-[400px]">
+        <AlertCircle className="h-8 w-8 text-destructive" />
+        <div className="text-center">
+          <h2 className="text-lg font-semibold">Failed to load error group</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {errorGroupError instanceof Error
+              ? errorGroupError.message
+              : 'An unexpected error occurred. Please try again.'}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => void refetchErrorGroup()}>
+            <RotateCcw className="mr-2 h-4 w-4" />
+            Retry
+          </Button>
+          <Button variant="ghost" onClick={() => navigate(`/projects/${project.slug}/errors`)}>
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Error Tracking
+          </Button>
+        </div>
       </div>
     )
   }
@@ -321,16 +358,16 @@ export function ErrorGroupDetail({ project }: { project: ProjectResponse }) {
               )}
             {((errorGroup as any).status === 'resolved' ||
               (errorGroup as any).status === 'ignored') && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => updateStatus('unresolved')}
-                disabled={statusMutation.isPending}
-              >
-                <RotateCcw className="h-4 w-4 mr-1.5" />
-                Unresolve
-              </Button>
-            )}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => updateStatus('unresolved')}
+                  disabled={statusMutation.isPending}
+                >
+                  <RotateCcw className="h-4 w-4 mr-1.5" />
+                  Unresolve
+                </Button>
+              )}
           </div>
 
           {/* Mobile: actions collapsed behind a kebab menu */}
@@ -362,11 +399,11 @@ export function ErrorGroupDetail({ project }: { project: ProjectResponse }) {
                   )}
                 {((errorGroup as any).status === 'resolved' ||
                   (errorGroup as any).status === 'ignored') && (
-                  <DropdownMenuItem onClick={() => updateStatus('unresolved')}>
-                    <RotateCcw className="mr-2 h-4 w-4" />
-                    Unresolve
-                  </DropdownMenuItem>
-                )}
+                    <DropdownMenuItem onClick={() => updateStatus('unresolved')}>
+                      <RotateCcw className="mr-2 h-4 w-4" />
+                      Unresolve
+                    </DropdownMenuItem>
+                  )}
               </DropdownMenuContent>
             </DropdownMenu>
           </div>


### PR DESCRIPTION
Closes #745 

## What changed

Hardens error handling across the Error Tracking detail views:

1. **`ErrorGroupDetail.tsx`**:
   - Added `meta.errorTitle` to `statusMutation` so Resolve / Ignore / Unresolve API failures surface toast feedback instead of failing silently.
   - Extracted `error` + `refetch` from `useQuery`.
   - Added an error guard that catches non-404 API/network errors with an actionable retry button while letting genuine 404s render "Error group not found".

2. **`ErrorEventDetail.tsx`**:
   - Extracted `error` + `refetch` from `useQuery`.
   - Added an error guard with 404 passthrough to display an error recovery state with a retry button instead of a false "Event not found" message.

## Files changed
- `web/src/pages/ErrorGroupDetail.tsx`
- `web/src/pages/ErrorEventDetail.tsx`

## How to test
1. `cd web && bun run dev`
2. Open any error group detail page.
3. DevTools → Request Blocking → block `*/errors/*`.
4. Refresh → verify "Failed to load error group" with Retry appears.
5. Unblock → open an individual event → block `*/errors/*` → refresh → verify "Failed to load error event" with Retry appears.
