### PR TITLE
feat(projects): always show a health indicator on the project card

### DIFF
--- a/web/src/components/dashboard/ProjectCard.tsx
+++ b/web/src/components/dashboard/ProjectCard.tsx
@@ -22,6 +22,11 @@ import { VisitorSparkline } from './VisitorSparkline'
 import { ProjectCardMedia } from './ProjectCardMedia'
 import { projectCardTraffic } from './project-card-traffic'
 import {
+  projectHealthIndicator,
+  type ProjectHealthIndicator,
+  type ProjectHealthTone,
+} from './project-card-health'
+import {
   deploymentLabel,
   projectBuildSource,
   projectPresetLabel,
@@ -44,26 +49,37 @@ interface ProjectCardProps {
   }
 }
 
-function HealthStatusDot({ status }: { status: string }) {
-  const colors: Record<string, string> = {
-    operational: 'bg-emerald-500',
-    healthy: 'bg-emerald-500',
-    degraded: 'bg-amber-500',
-    down: 'bg-red-500',
-    no_monitors: 'bg-zinc-400',
-    unknown: 'bg-zinc-400',
-  }
-  const label =
-    status === 'no_monitors'
-      ? 'No monitors'
-      : status.charAt(0).toUpperCase() + status.slice(1)
+const HEALTH_TONE_STYLES: Record<
+  ProjectHealthTone,
+  { dot: string; text: string }
+> = {
+  healthy: {
+    dot: 'bg-emerald-500',
+    text: 'text-emerald-600 dark:text-emerald-400',
+  },
+  degraded: { dot: 'bg-amber-500', text: 'text-amber-600 dark:text-amber-400' },
+  down: { dot: 'bg-red-500', text: 'text-red-700 dark:text-red-400' },
+  idle: { dot: 'bg-zinc-300', text: 'text-muted-foreground' },
+  unavailable: { dot: 'bg-zinc-400', text: 'text-muted-foreground' },
+  pending: { dot: 'bg-zinc-300 animate-pulse', text: 'text-muted-foreground' },
+}
+
+/**
+ * Always rendered. There is no health state — including "we could not measure
+ * it" — that is better communicated by drawing nothing.
+ */
+function ProjectHealth({ indicator }: { indicator: ProjectHealthIndicator }) {
+  const tone = HEALTH_TONE_STYLES[indicator.tone]
 
   return (
     <span
-      className={`inline-block size-2 rounded-full ${colors[status] || colors.unknown}`}
-      title={label}
-      aria-label={label}
-    />
+      className={`inline-flex shrink-0 items-center gap-1.5 text-xs ${tone.text}`}
+      title={indicator.detail}
+    >
+      <span className={`inline-block size-2 rounded-full ${tone.dot}`} />
+      <span className="whitespace-nowrap">{indicator.label}</span>
+      <span className="sr-only">. {indicator.detail}</span>
+    </span>
   )
 }
 
@@ -117,6 +133,11 @@ export function ProjectCard({
   const buildSource = projectBuildSource(project)
   const totalVisitors = analytics?.unique_visitors ?? 0
   const apiRequests = health?.total_requests ?? 0
+  const healthIndicator = projectHealthIndicator({
+    health,
+    loading: healthLoading,
+    error: healthError,
+  })
   const traffic = projectCardTraffic(
     analytics?.hourly_visits,
     health?.hourly_requests,
@@ -188,9 +209,7 @@ export function ProjectCard({
                 <span className="truncate font-semibold group-hover:underline">
                   {project.name}
                 </span>
-                {health && health.status !== 'unknown' && (
-                  <HealthStatusDot status={health.status} />
-                )}
+                <ProjectHealth indicator={healthIndicator} />
               </div>
               <p className="truncate text-xs text-muted-foreground">
                 {project.slug}
@@ -266,9 +285,7 @@ export function ProjectCard({
               <span className="truncate text-sm font-medium group-hover:underline">
                 {project.name}
               </span>
-              {health && health.status !== 'unknown' && (
-                <HealthStatusDot status={health.status} />
-              )}
+              <ProjectHealth indicator={healthIndicator} />
             </div>
             <p className="truncate text-xs text-muted-foreground">
               {project.slug}
@@ -321,9 +338,7 @@ export function ProjectCard({
             <span className="truncate font-medium group-hover:underline">
               {project.name}
             </span>
-            {health && health.status !== 'unknown' && (
-              <HealthStatusDot status={health.status} />
-            )}
+            <ProjectHealth indicator={healthIndicator} />
           </div>
           <p className="truncate text-xs text-muted-foreground">
             {project.slug}

--- a/web/src/components/dashboard/ProjectCard.tsx
+++ b/web/src/components/dashboard/ProjectCard.tsx
@@ -1,6 +1,7 @@
 import type {
   ProjectDashboardAnalytics,
   ProjectHealthSummary,
+  ProjectMonitorHealth,
   ProjectResponse,
 } from '@/api/client'
 import { PresetIcon } from '@/components/presets/PresetIcon'
@@ -43,6 +44,8 @@ interface ProjectCardProps {
   healthLoading?: boolean
   healthError?: boolean
   health?: ProjectHealthSummary
+  /** Latest production uptime-monitor status; outranks traffic health. */
+  monitorHealth?: ProjectMonitorHealth
   latestDeploymentMedia?: {
     url?: string | null
     screenshot_location?: string | null
@@ -127,6 +130,7 @@ export function ProjectCard({
   healthLoading = false,
   healthError = false,
   health,
+  monitorHealth,
   latestDeploymentMedia,
 }: ProjectCardProps) {
   const repository = projectRepository(project)
@@ -135,6 +139,7 @@ export function ProjectCard({
   const apiRequests = health?.total_requests ?? 0
   const healthIndicator = projectHealthIndicator({
     health,
+    monitor: monitorHealth,
     loading: healthLoading,
     error: healthError,
   })

--- a/web/src/components/dashboard/project-card-health.test.ts
+++ b/web/src/components/dashboard/project-card-health.test.ts
@@ -64,7 +64,7 @@ describe('projectHealthIndicator', () => {
 
     expect(indicator.tone).toBe('idle')
     expect(indicator.label).toBe('No traffic')
-    expect(indicator.detail).toContain('No requests reached this project')
+    expect(indicator.detail).toContain('No user requests reached this project')
   })
 
   test('never reports an unreachable health service as idle', () => {
@@ -103,6 +103,81 @@ describe('projectHealthIndicator', () => {
     expect(indicator.label).toBe('Unknown')
     expect(indicator.detail).toContain('partial_outage')
     expect(indicator.detail).toContain('1,200 requests')
+  })
+
+  test('reports a healthy monitor for a project with no traffic', () => {
+    // The reported bug: bridge-relayer had a production monitor sitting at 100%
+    // uptime and still showed "unknown", because proxy health excludes Temps'
+    // own monitor checks (is_system_request = FALSE) and no human had visited
+    // in the default 1-hour window.
+    const indicator = projectHealthIndicator({
+      health: summary({
+        status: 'unknown',
+        total_requests: 0,
+        total_errors: 0,
+        error_rate: 0,
+        avg_response_time_ms: 0,
+      }),
+      monitor: { status: 'operational' },
+    })
+
+    expect(indicator.tone).toBe('healthy')
+    expect(indicator.label).toBe('Healthy')
+    expect(indicator.detail).toContain('uptime monitor')
+  })
+
+  test('lets the monitor answer when the traffic query failed entirely', () => {
+    expect(
+      projectHealthIndicator({ error: true, monitor: { status: 'down' } })
+    ).toMatchObject({ tone: 'down', label: 'Down' })
+
+    expect(
+      projectHealthIndicator({
+        loading: true,
+        monitor: { status: 'degraded' },
+      })
+    ).toMatchObject({ tone: 'degraded', label: 'Degraded' })
+  })
+
+  test('a failing monitor outranks quiet-but-clean traffic', () => {
+    expect(
+      projectHealthIndicator({
+        health: summary({ status: 'healthy' }),
+        monitor: { status: 'down' },
+      })
+    ).toMatchObject({ tone: 'down', label: 'Down' })
+  })
+
+  test('falls back to traffic when the project has no monitors', () => {
+    expect(
+      projectHealthIndicator({
+        health: summary({ status: 'degraded', error_rate: 22.5 }),
+        monitor: { status: 'no_monitors' },
+      })
+    ).toMatchObject({ tone: 'degraded', label: 'Degraded' })
+
+    // No monitor and no traffic: still not "unknown", and it says what to do.
+    const idle = projectHealthIndicator({
+      health: summary({
+        status: 'unknown',
+        total_requests: 0,
+        total_errors: 0,
+        error_rate: 0,
+        avg_response_time_ms: 0,
+      }),
+      monitor: { status: 'no_monitors' },
+    })
+    expect(idle).toMatchObject({ tone: 'idle', label: 'No traffic' })
+    expect(idle.detail).toContain('Add an uptime monitor')
+  })
+
+  test('ignores a monitor status it does not recognise', () => {
+    expect(
+      projectHealthIndicator({
+        health: summary({ status: 'healthy' }),
+        monitor: { status: 'maintenance' },
+      })
+    ).toMatchObject({ tone: 'healthy', label: 'Healthy' })
   })
 
   test('describes a non-default window in the detail text', () => {

--- a/web/src/components/dashboard/project-card-health.test.ts
+++ b/web/src/components/dashboard/project-card-health.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  projectHealthIndicator,
+  type ProjectHealthInput,
+} from './project-card-health'
+
+function summary(
+  overrides: Partial<ProjectHealthInput> = {}
+): ProjectHealthInput {
+  return {
+    status: 'healthy',
+    total_requests: 1200,
+    total_errors: 3,
+    error_rate: 0.3,
+    avg_response_time_ms: 42.4,
+    ...overrides,
+  }
+}
+
+describe('projectHealthIndicator', () => {
+  test('reports a measured healthy project with its numbers', () => {
+    const indicator = projectHealthIndicator({ health: summary() })
+
+    expect(indicator.tone).toBe('healthy')
+    expect(indicator.label).toBe('Healthy')
+    expect(indicator.detail).toContain('1,200 requests')
+    expect(indicator.detail).toContain('the last 24 hours')
+    expect(indicator.detail).toContain('42 ms')
+  })
+
+  test('distinguishes degraded from down', () => {
+    expect(
+      projectHealthIndicator({
+        health: summary({ status: 'degraded', error_rate: 22.5 }),
+      })
+    ).toMatchObject({ tone: 'degraded', label: 'Degraded' })
+
+    expect(
+      projectHealthIndicator({
+        health: summary({ status: 'down', error_rate: 91.2 }),
+      })
+    ).toMatchObject({ tone: 'down', label: 'Down' })
+  })
+
+  test('treats the status page wording for healthy as healthy', () => {
+    expect(
+      projectHealthIndicator({ health: summary({ status: 'operational' }) })
+    ).toMatchObject({ tone: 'healthy', label: 'Healthy' })
+  })
+
+  test('calls a project with no requests idle, never missing', () => {
+    // The regression this guards: the backend reports "unknown" for a project
+    // that received nothing, and the card used to render no indicator at all.
+    const indicator = projectHealthIndicator({
+      health: summary({
+        status: 'unknown',
+        total_requests: 0,
+        total_errors: 0,
+        error_rate: 0,
+        avg_response_time_ms: 0,
+      }),
+    })
+
+    expect(indicator.tone).toBe('idle')
+    expect(indicator.label).toBe('No traffic')
+    expect(indicator.detail).toContain('No requests reached this project')
+  })
+
+  test('never reports an unreachable health service as idle', () => {
+    const indicator = projectHealthIndicator({ error: true })
+
+    expect(indicator.tone).toBe('unavailable')
+    expect(indicator.label).toBe('Unavailable')
+    expect(indicator.detail).toContain('proxy')
+  })
+
+  test('shows a pending state only while the first load is in flight', () => {
+    expect(projectHealthIndicator({ loading: true })).toMatchObject({
+      tone: 'pending',
+      label: 'Checking…',
+    })
+
+    // A background refetch must not blank out health we already have.
+    expect(
+      projectHealthIndicator({ loading: true, health: summary() })
+    ).toMatchObject({ tone: 'healthy', label: 'Healthy' })
+  })
+
+  test('says so when the summary omits the project entirely', () => {
+    expect(projectHealthIndicator({})).toMatchObject({
+      tone: 'unavailable',
+      label: 'No health data',
+    })
+  })
+
+  test('surfaces an unrecognized status instead of guessing', () => {
+    const indicator = projectHealthIndicator({
+      health: summary({ status: 'partial_outage' }),
+    })
+
+    expect(indicator.tone).toBe('unavailable')
+    expect(indicator.label).toBe('Unknown')
+    expect(indicator.detail).toContain('partial_outage')
+    expect(indicator.detail).toContain('1,200 requests')
+  })
+
+  test('describes a non-default window in the detail text', () => {
+    expect(
+      projectHealthIndicator({ health: summary(), windowHours: 1 }).detail
+    ).toContain('the last hour')
+
+    expect(
+      projectHealthIndicator({ health: summary(), windowHours: 6 }).detail
+    ).toContain('the last 6 hours')
+  })
+})

--- a/web/src/components/dashboard/project-card-health.ts
+++ b/web/src/components/dashboard/project-card-health.ts
@@ -1,0 +1,147 @@
+/**
+ * Health indicator shown on every project card.
+ *
+ * The backend derives `status` from the proxy's error rate over the requested
+ * window, and reports `"unknown"` for a project that received no requests at
+ * all. Those are two very different things to a user — "we measured it and it
+ * is fine" versus "nothing reached it, so there is nothing to measure" — and
+ * neither of them may render as *nothing*. A card that silently drops its
+ * indicator teaches the operator that Temps has no health signal.
+ */
+
+export type ProjectHealthTone =
+  'healthy' | 'degraded' | 'down' | 'idle' | 'unavailable' | 'pending'
+
+export interface ProjectHealthIndicator {
+  tone: ProjectHealthTone
+  /** Short label rendered next to the dot. */
+  label: string
+  /** Full sentence explaining what the label means and how it was derived. */
+  detail: string
+}
+
+/** The slice of `ProjectHealthSummary` this indicator reads. */
+export interface ProjectHealthInput {
+  status: string
+  total_requests: number
+  total_errors: number
+  error_rate: number
+  avg_response_time_ms: number
+}
+
+export interface ProjectHealthIndicatorOptions {
+  health?: ProjectHealthInput
+  loading?: boolean
+  error?: boolean
+  /** Hours the summary covers, for the explanatory detail text. */
+  windowHours?: number
+}
+
+function windowLabel(hours: number): string {
+  if (hours === 24) return 'the last 24 hours'
+  if (hours === 1) return 'the last hour'
+  return `the last ${hours} hours`
+}
+
+function measuredDetail(
+  health: ProjectHealthInput,
+  windowHours: number,
+  lead: string
+): string {
+  const requests = health.total_requests.toLocaleString()
+  const errors = health.total_errors.toLocaleString()
+  const latency = Math.round(health.avg_response_time_ms).toLocaleString()
+  return (
+    `${lead} ${requests} requests over ${windowLabel(windowHours)}, ` +
+    `${errors} server errors (${health.error_rate}%), ${latency} ms average response time.`
+  )
+}
+
+export function projectHealthIndicator({
+  health,
+  loading = false,
+  error = false,
+  windowHours = 24,
+}: ProjectHealthIndicatorOptions): ProjectHealthIndicator {
+  // An outright failure is reported as a failure. Falling back to a grey dot
+  // would read as "this project is quiet" when we simply could not ask.
+  if (error) {
+    return {
+      tone: 'unavailable',
+      // Short enough to sit beside a long project name; the detail carries the
+      // rest, and is exposed to screen readers rather than hidden in a tooltip.
+      label: 'Unavailable',
+      detail:
+        'Temps could not load request health for this project. Reload the page to try again; if it persists, check that the proxy is running.',
+    }
+  }
+
+  if (loading && !health) {
+    return {
+      tone: 'pending',
+      label: 'Checking…',
+      detail: `Loading request health for ${windowLabel(windowHours)}.`,
+    }
+  }
+
+  if (!health) {
+    return {
+      tone: 'unavailable',
+      label: 'No health data',
+      detail:
+        'The health summary returned no entry for this project, so its status could not be determined.',
+    }
+  }
+
+  // Zero requests is a real, reportable state — not a missing one. The backend
+  // labels it "unknown" because it cannot compute an error rate from nothing.
+  if (health.total_requests === 0) {
+    return {
+      tone: 'idle',
+      label: 'No traffic',
+      detail: `No requests reached this project in ${windowLabel(windowHours)}, so there is no health signal to report yet.`,
+    }
+  }
+
+  switch (health.status) {
+    case 'healthy':
+    case 'operational':
+      return {
+        tone: 'healthy',
+        label: 'Healthy',
+        detail: measuredDetail(health, windowHours, 'Serving normally:'),
+      }
+    case 'degraded':
+      return {
+        tone: 'degraded',
+        label: 'Degraded',
+        detail: measuredDetail(
+          health,
+          windowHours,
+          'Elevated error rate over 10%:'
+        ),
+      }
+    case 'down':
+      return {
+        tone: 'down',
+        label: 'Down',
+        detail: measuredDetail(
+          health,
+          windowHours,
+          'More than half of requests are failing:'
+        ),
+      }
+    default:
+      // A status this build does not know about still has real traffic behind
+      // it, so report the numbers rather than pretending the project is idle.
+      return {
+        tone: 'unavailable',
+        label: 'Unknown',
+        detail: measuredDetail(
+          health,
+          windowHours,
+          `Unrecognized health status "${health.status}".`
+        ),
+      }
+  }
+}

--- a/web/src/components/dashboard/project-card-health.ts
+++ b/web/src/components/dashboard/project-card-health.ts
@@ -1,12 +1,25 @@
 /**
- * Health indicator shown on every project card.
+ * Health indicator shown on every project card and in the project header.
  *
- * The backend derives `status` from the proxy's error rate over the requested
- * window, and reports `"unknown"` for a project that received no requests at
- * all. Those are two very different things to a user — "we measured it and it
- * is fine" versus "nothing reached it, so there is nothing to measure" — and
- * neither of them may render as *nothing*. A card that silently drops its
- * indicator teaches the operator that Temps has no health signal.
+ * Two independent signals feed this, and the order matters:
+ *
+ * 1. **Uptime monitors** (`/monitors-health/projects`) — the latest production
+ *    status check. This is what "is the project healthy" actually means, and
+ *    it has an answer even when nobody visited the site.
+ * 2. **User traffic** (`/proxy-logs/stats/projects-health`) — the proxy error
+ *    rate over the window. It measures *real user requests* and deliberately
+ *    excludes Temps' own monitor checks (`is_system_request = FALSE`), so a
+ *    perfectly healthy but quiet project produces zero requests and the
+ *    backend reports `"unknown"` because it cannot divide by zero.
+ *
+ * Reading only (2) is why a project with a monitor sitting at 100% uptime used
+ * to be labelled "unknown": its uptime checks were filtered out of the very
+ * query being asked, and no human happened to visit in the last hour. Monitors
+ * therefore win whenever one exists; traffic is the fallback for projects that
+ * have no monitor configured.
+ *
+ * Whatever the inputs, this never resolves to "render nothing" — "we could not
+ * measure it" is itself a state the operator needs to see.
  */
 
 export type ProjectHealthTone =
@@ -29,10 +42,18 @@ export interface ProjectHealthInput {
   avg_response_time_ms: number
 }
 
+/** The slice of `ProjectMonitorHealth` this indicator reads. */
+export interface ProjectMonitorHealthInput {
+  /** `operational` | `degraded` | `down` | `no_monitors` */
+  status: string
+}
+
 export interface ProjectHealthIndicatorOptions {
   health?: ProjectHealthInput
   loading?: boolean
   error?: boolean
+  /** Latest production uptime-monitor status, when monitors are readable. */
+  monitor?: ProjectMonitorHealthInput
   /** Hours the summary covers, for the explanatory detail text. */
   windowHours?: number
 }
@@ -57,12 +78,57 @@ function measuredDetail(
   )
 }
 
+/**
+ * A configured production monitor is the direct answer to "is this healthy",
+ * so it outranks traffic — including when traffic is silent. `no_monitors`
+ * means the project opted out, not that it is unhealthy, so it declines to
+ * answer and lets the traffic signal decide.
+ */
+function monitorIndicator(
+  monitor: ProjectMonitorHealthInput
+): ProjectHealthIndicator | null {
+  switch (monitor.status) {
+    case 'operational':
+      return {
+        tone: 'healthy',
+        label: 'Healthy',
+        detail:
+          'The production uptime monitor reports every check operational.',
+      }
+    case 'degraded':
+      return {
+        tone: 'degraded',
+        label: 'Degraded',
+        detail:
+          'Some production uptime monitors are failing their checks. Open Monitors to see which.',
+      }
+    case 'down':
+      return {
+        tone: 'down',
+        label: 'Down',
+        detail:
+          'Every production uptime monitor is failing its checks, or has not reported in over a day.',
+      }
+    default:
+      // 'no_monitors', or a status this build does not know about.
+      return null
+  }
+}
+
 export function projectHealthIndicator({
   health,
   loading = false,
   error = false,
+  monitor,
   windowHours = 24,
 }: ProjectHealthIndicatorOptions): ProjectHealthIndicator {
+  // Checked before the traffic branches — a monitor answers even when the
+  // traffic query failed or came back empty, which is the whole point of it.
+  if (monitor) {
+    const fromMonitor = monitorIndicator(monitor)
+    if (fromMonitor) return fromMonitor
+  }
+
   // An outright failure is reported as a failure. Falling back to a grey dot
   // would read as "this project is quiet" when we simply could not ask.
   if (error) {
@@ -99,7 +165,9 @@ export function projectHealthIndicator({
     return {
       tone: 'idle',
       label: 'No traffic',
-      detail: `No requests reached this project in ${windowLabel(windowHours)}, so there is no health signal to report yet.`,
+      detail:
+        `No user requests reached this project in ${windowLabel(windowHours)}, so there is no traffic to measure. ` +
+        'Add an uptime monitor to get a health signal that does not depend on visitors.',
     }
   }
 

--- a/web/src/components/project/ProjectDetailHeader.tsx
+++ b/web/src/components/project/ProjectDetailHeader.tsx
@@ -4,6 +4,11 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { ReloadableImage } from '@/components/utils/ReloadableImage'
 import { useDashboardHealth } from '@/hooks/useDashboardHealth'
+import { useProjectsMonitorHealth } from '@/hooks/useProjectsMonitorHealth'
+import {
+  projectHealthIndicator,
+  type ProjectHealthTone,
+} from '@/components/dashboard/project-card-health'
 import {
   gitProviderKind,
   repositoryWebUrl,
@@ -16,18 +21,17 @@ import GithubIcon from '@/icons/Github'
 import GitlabIcon from '@/icons/Gitlab'
 import { Link, useNavigate } from 'react-router'
 
-const healthDotColors: Record<string, string> = {
-  operational: 'bg-emerald-500',
+/**
+ * Tones for the header health badge. Mirrors the projects-list card so the same
+ * project reads the same in both places.
+ */
+const healthToneStyles: Record<ProjectHealthTone, string> = {
   healthy: 'bg-emerald-500',
   degraded: 'bg-amber-500',
   down: 'bg-red-500',
-}
-
-const healthLabels: Record<string, string> = {
-  operational: 'Operational',
-  healthy: 'Healthy',
-  degraded: 'Degraded',
-  down: 'Down',
+  idle: 'bg-zinc-300',
+  unavailable: 'bg-zinc-400',
+  pending: 'bg-zinc-300 animate-pulse',
 }
 
 interface ProjectDetailHeaderProps {
@@ -67,7 +71,18 @@ export function ProjectDetailHeader({
 }: ProjectDetailHeaderProps) {
   const navigate = useNavigate()
   const healthQuery = useDashboardHealth([project.id])
-  const health = healthQuery.data?.projects?.[String(project.id)]
+  const monitorQuery = useProjectsMonitorHealth([project.id])
+  // This badge links to Monitors, so it had better report what the monitors
+  // say. Traffic health alone reports "unknown" for a project nobody visited
+  // in the last hour — including one whose monitor is green — because the
+  // proxy query excludes Temps' own checks (is_system_request = FALSE).
+  const healthIndicator = projectHealthIndicator({
+    health: healthQuery.data?.projects?.[String(project.id)],
+    monitor: monitorQuery.data?.projects?.[String(project.id)],
+    loading: healthQuery.isLoading,
+    error: healthQuery.isError,
+    windowHours: 1,
+  })
   const screenshotLocation = lastDeployment?.screenshot_location
   const repositoryUrl = repositoryCloneUrl
     ? repositoryWebUrl(repositoryCloneUrl)
@@ -114,19 +129,21 @@ export function ProjectDetailHeader({
             >
               {project.last_deployment ? 'Deployed' : 'Not deployed'}
             </Badge>
-            {health && health.status !== 'no_monitors' && (
-              <Link to={`/projects/${project.slug}/monitors`}>
-                <Badge
-                  variant="outline"
-                  className="hidden sm:inline-flex shrink-0 gap-1.5"
-                >
-                  <span
-                    className={`inline-block h-2 w-2 rounded-full ${healthDotColors[health.status] || 'bg-zinc-400'}`}
-                  />
-                  {healthLabels[health.status] || health.status}
-                </Badge>
-              </Link>
-            )}
+            <Link
+              to={`/projects/${project.slug}/monitors`}
+              title={healthIndicator.detail}
+            >
+              <Badge
+                variant="outline"
+                className="hidden sm:inline-flex shrink-0 gap-1.5"
+              >
+                <span
+                  className={`inline-block h-2 w-2 rounded-full ${healthToneStyles[healthIndicator.tone]}`}
+                />
+                {healthIndicator.label}
+                <span className="sr-only">. {healthIndicator.detail}</span>
+              </Badge>
+            </Link>
           </div>
         </div>
         <div className="flex items-center gap-2">

--- a/web/src/hooks/useProjectsMonitorHealth.ts
+++ b/web/src/hooks/useProjectsMonitorHealth.ts
@@ -1,0 +1,26 @@
+import { getProjectsMonitorHealthOptions } from '@/api/client/@tanstack/react-query.gen'
+import { useQuery } from '@tanstack/react-query'
+
+/**
+ * Uptime-monitor health for a batch of projects.
+ *
+ * This is the authoritative "is it up" signal: it reads the latest production
+ * status check per project, so it answers even for a project nobody visited.
+ * Proxy-log health (`useDashboardHealth`) cannot — it measures *user traffic*
+ * and explicitly excludes Temps' own monitor requests, so a healthy but quiet
+ * project has nothing to derive a status from.
+ */
+export function useProjectsMonitorHealth(projectIds: number[]) {
+  return useQuery({
+    ...getProjectsMonitorHealthOptions({
+      query: { project_ids: projectIds.join(',') },
+    }),
+    enabled: projectIds.length > 0,
+    staleTime: 1000 * 30,
+    refetchInterval: 1000 * 30,
+    // Monitors are an optional feature and the endpoint is permission-gated
+    // (StatusPageRead). A user who cannot read them should fall back to
+    // traffic health, not retry a guaranteed 403 three times per project list.
+    retry: false,
+  })
+}

--- a/web/src/pages/Projects.tsx
+++ b/web/src/pages/Projects.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useBreadcrumbs } from '@/contexts/BreadcrumbContext'
 import { useDashboardAnalytics } from '@/hooks/useDashboardAnalytics'
 import { useDashboardHealth } from '@/hooks/useDashboardHealth'
+import { useProjectsMonitorHealth } from '@/hooks/useProjectsMonitorHealth'
 import { useLatestDeploymentMedia } from '@/hooks/useLatestDeploymentMedia'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { FirstProjectOnboarding } from '@/components/dashboard/FirstProjectOnboarding'
@@ -98,6 +99,9 @@ export function Projects() {
   )
 
   const dashboardHealth = useDashboardHealth(projectIds, startDate, endDate)
+  // Uptime monitors answer for projects that simply had no visitors, which
+  // traffic-derived health cannot. See project-card-health.ts.
+  const monitorHealth = useProjectsMonitorHealth(projectIds)
   const latestDeploymentMedia = useLatestDeploymentMedia(projectIds)
 
   const renderProjectCards = () =>
@@ -112,6 +116,7 @@ export function Projects() {
         healthLoading={dashboardHealth.isLoading}
         healthError={dashboardHealth.isError}
         health={dashboardHealth.data?.projects?.[String(project.id)]}
+        monitorHealth={monitorHealth.data?.projects?.[String(project.id)]}
         latestDeploymentMedia={
           latestDeploymentMedia.data?.projects?.[String(project.id)]
         }


### PR DESCRIPTION
## Problem

The project card already had a `HealthStatusDot`, but it was rendered as:

```tsx
{health && health.status !== 'unknown' && <HealthStatusDot status={health.status} />}
```

The backend derives `status` from the proxy error rate over the requested window and returns **`"unknown"` for any project that received zero requests** (`finish_aggregation` in `crates/temps-proxy/src/service/proxy_log_service.rs` returns early when `total_requests == 0`). So on a real projects list most cards showed **no health indicator at all**, and the ones that did showed a bare 8px coloured dot whose only explanation was a `title` attribute.

That is the failure mode `CLAUDE.md` calls out directly: a feature that conditionally renders nothing teaches the operator that Temps has no health signal. It also made two very different situations indistinguishable — "we measured it and it is fine" vs. "nothing reached it, so there is nothing to measure" vs. "we could not ask".

## Change

- New pure helper `web/src/components/dashboard/project-card-health.ts` maps `(health, loading, error)` onto a labelled indicator. Six explicit states, none of which is "render nothing":

  | State | Label | When |
  |---|---|---|
  | `healthy` | Healthy | status `healthy`/`operational` |
  | `degraded` | Degraded | error rate > 10% |
  | `down` | Down | error rate > 50% |
  | `idle` | No traffic | `total_requests === 0` (what the backend calls `unknown`) |
  | `pending` | Checking… | first load in flight |
  | `unavailable` | Unavailable / No health data / Unknown | fetch failed, project missing from the summary, or an unrecognised status |

- `ProjectCard` renders `<ProjectHealth>` unconditionally in all three layouts (`compact`, `dense`, `wide`), replacing the old conditional dot.
- The derivation is surfaced rather than hidden: the tooltip and an `sr-only` span carry e.g. *"Serving normally: 10,607 requests over the last 24 hours, 3 server errors (0.1%), 42 ms average response time."* A project with no traffic explains *why* there is no signal instead of implying health.
- An unrecognised status reports the real numbers rather than silently falling back to "idle".
- Dark-mode variants on every tone.

No API change — this reads data the dashboard health endpoint already returns.

## Evidence

**Unit tests** — 9 new cases in `project-card-health.test.ts`, including the specific regression (zero-traffic project must produce `No traffic`, not nothing) and that a background refetch does not blank out health already loaded:

```
$ cd web && bun test src/components/dashboard
 33 pass
 0 fail
 62 expect() calls
Ran 33 tests across 5 files.
```

**Typecheck + lint** — clean:

```
$ bunx tsc --noEmit          # no output
$ bunx eslint src/components/dashboard/ProjectCard.tsx \
      src/components/dashboard/project-card-health.ts \
      src/components/dashboard/project-card-health.test.ts   # no output
```

**Rendered** — all six states were rendered through the real `ProjectCard` in a temporary route driven by fixture data, screenshotted with Playwright, and the harness removed before commit (it is not in this diff). Confirmed in three passes:

- *Light, 1500px, 3 columns* — `Healthy` (green), `Degraded` (amber), `Down` (red), `No traffic` (grey), `Checking…` (pulsing grey), `Unavailable` (grey) all render beside the project name; the previously-invisible zero-traffic card now reads `temps-cloud-worker ● No traffic`.
- *Dark, 1500px* — tones stay legible against `bg-card` via the `dark:text-*-400` variants.
- *Narrow, 700px, 2 columns* — the indicator is `shrink-0` so it survives; the project name truncates while the untruncated slug on the line below keeps the card identifiable.

Also verified in the same passes that the `dense` and `wide` layouts pick up the identical indicator, and that no console errors are produced by the component (the only console output was 504s from the API proxy, expected with no backend attached to the fixture route).