### PR TITLE
fix(web): handle fetch errors in ApiKeyDetail and ApiKeyEdit with retry state

### DIFF
--- a/web/src/pages/ApiKeyDetail.tsx
+++ b/web/src/pages/ApiKeyDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
@@ -30,13 +30,15 @@ import {
 import { useApiKeyPermissions } from '@/components/api-keys/useApiKeyPermissions'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import {
-  ArrowLeft,
-  Shield,
-  Key,
-  Calendar,
-  Activity,
+  AlertCircle,
   AlertTriangle,
+  ArrowLeft,
+  Calendar,
   Check,
+  Key,
+  RotateCcw,
+  Shield,
+  Activity,
   X,
 } from 'lucide-react'
 import { format } from 'date-fns'
@@ -88,7 +90,12 @@ export default function ApiKeyDetail() {
   const queryClient = useQueryClient()
   const [deleteModalOpen, setDeleteModalOpen] = useState(false)
 
-  const { data: apiKey, isLoading } = useQuery({
+  const {
+    data: apiKey,
+    isLoading,
+    error: apiKeyError,
+    refetch: refetchApiKey,
+  } = useQuery({
     queryKey: ['apiKey', id],
     queryFn: async () => {
       if (!id) throw new Error('API Key ID is required')
@@ -97,6 +104,14 @@ export default function ApiKeyDetail() {
     },
     enabled: !!id,
   })
+
+  useEffect(() => {
+    if (apiKey && apiKeyError) {
+      toast.error('Failed to refresh API key', {
+        action: { label: 'Retry', onClick: () => void refetchApiKey() },
+      })
+    }
+  }, [apiKey, apiKeyError, refetchApiKey])
 
   const { data: permissionsData } = useApiKeyPermissions()
 
@@ -139,6 +154,38 @@ export default function ApiKeyDetail() {
     return (
       <div className="container max-w-4xl mx-auto py-6">
         <div className="text-center py-8">Loading API key details...</div>
+      </div>
+    )
+  }
+
+  const isNotFound =
+    (apiKeyError as any)?.status === 404 ||
+    (apiKeyError as any)?.title === 'API Key Not Found'
+
+  if (!apiKey && apiKeyError && !isNotFound) {
+    return (
+      <div className="container max-w-4xl mx-auto py-6">
+        <div className="flex flex-col items-center justify-center gap-4 py-8 text-center">
+          <AlertCircle className="h-8 w-8 text-destructive" />
+          <div>
+            <h2 className="text-lg font-semibold">Failed to load API key</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {apiKeyError instanceof Error
+                ? apiKeyError.message
+                : 'An unexpected error occurred. Please try again.'}
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => void refetchApiKey()}>
+              <RotateCcw className="mr-2 h-4 w-4" />
+              Retry
+            </Button>
+            <Button variant="ghost" onClick={() => navigate('/settings/keys')}>
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to API Keys
+            </Button>
+          </div>
+        </div>
       </div>
     )
   }

--- a/web/src/pages/ApiKeyEdit.tsx
+++ b/web/src/pages/ApiKeyEdit.tsx
@@ -23,6 +23,7 @@ import {
   Clock,
   AlertCircle,
   Activity,
+  RotateCcw,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { format } from 'date-fns'
@@ -41,7 +42,12 @@ export default function ApiKeyEdit() {
     expires_at: '',
   })
 
-  const { data: apiKey, isLoading } = useQuery({
+  const {
+    data: apiKey,
+    isLoading,
+    error: apiKeyError,
+    refetch: refetchApiKey,
+  } = useQuery({
     queryKey: ['apiKey', id],
     queryFn: async () => {
       if (!id) throw new Error('No API key ID provided')
@@ -50,6 +56,14 @@ export default function ApiKeyEdit() {
     },
     enabled: !!id,
   })
+
+  useEffect(() => {
+    if (apiKey && apiKeyError) {
+      toast.error('Failed to refresh API key', {
+        action: { label: 'Retry', onClick: () => void refetchApiKey() },
+      })
+    }
+  }, [apiKey, apiKeyError, refetchApiKey])
 
   useEffect(() => {
     if (apiKey) {
@@ -108,6 +122,38 @@ export default function ApiKeyEdit() {
             <Skeleton className="h-10 w-full" />
             <Skeleton className="h-10 w-full" />
             <Skeleton className="h-20 w-full" />
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  const isNotFound =
+    (apiKeyError as any)?.status === 404 ||
+    (apiKeyError as any)?.title === 'API Key Not Found'
+
+  if (!apiKey && apiKeyError && !isNotFound) {
+    return (
+      <div className="container max-w-4xl mx-auto py-6">
+        <Card>
+          <CardContent className="py-12 text-center">
+            <AlertCircle className="h-12 w-12 text-destructive mx-auto mb-4" />
+            <h3 className="text-lg font-medium">Failed to load API key</h3>
+            <p className="text-muted-foreground mt-2">
+              {apiKeyError instanceof Error
+                ? apiKeyError.message
+                : 'An unexpected error occurred. Please try again.'}
+            </p>
+            <div className="flex justify-center gap-2 mt-4">
+              <Button variant="outline" onClick={() => void refetchApiKey()}>
+                <RotateCcw className="mr-2 h-4 w-4" />
+                Retry
+              </Button>
+              <Button variant="ghost" onClick={() => navigate('/settings/keys')}>
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Back to API Keys
+              </Button>
+            </div>
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
Closes #748 

## What changed

`ApiKeyDetail` and `ApiKeyEdit` previously showed a misleading "API key not found" message when data fetching failed due to transient server/network errors.

This PR:
- Extracts `error` and `refetch` from `useQuery` in both pages.
- Adds an error recovery state with an explicit **Retry** button.
- Preserves the dedicated "API key not found" state for genuine 404 responses.

## Files changed
- `web/src/pages/ApiKeyDetail.tsx`
- `web/src/pages/ApiKeyEdit.tsx`

## How to test
1. `cd web && bun run dev`
2. Open an API Key detail page (`/settings/keys/:id`) or edit page (`/settings/keys/:id/edit`).
3. DevTools → Request Blocking → block `*/api/api-keys/*`.
4. Refresh → verify "Failed to load API key" appears with a working **Retry** button.
5. Unblock → click **Retry** → verify data loads normally.
