### PR TITLE
feat(funnels): add time-range shortcuts and show exact completion seconds

### DIFF
--- a/web/src/components/funnel/FunnelDetail.tsx
+++ b/web/src/components/funnel/FunnelDetail.tsx
@@ -17,12 +17,18 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { getFunnelMetricsOptions } from '@/api/client/@tanstack/react-query.gen'
 import { cn } from '@/lib/utils'
 import { useQuery } from '@tanstack/react-query'
-import { format, subDays } from 'date-fns'
+import { format } from 'date-fns'
 import { ArrowLeft, Calendar as CalendarIcon } from 'lucide-react'
 import * as React from 'react'
 import { DateRange } from 'react-day-picker'
 import { useGoBack } from '@/hooks/useGoBack'
 import { FunnelVisualization } from './FunnelVisualization'
+import {
+  FUNNEL_DEFAULT_RANGE_KEY,
+  FUNNEL_QUICK_RANGES,
+  funnelQuickRange,
+  funnelQuickRangeBounds,
+} from './funnel-quick-ranges'
 
 interface FunnelDetailProps {
   project: ProjectResponse
@@ -31,10 +37,31 @@ interface FunnelDetailProps {
 
 export function FunnelDetail({ project, funnelId }: FunnelDetailProps) {
   const goBack = useGoBack(`/projects/${project.slug}/analytics/funnels`)
-  const [dateRange, setDateRange] = React.useState<DateRange | undefined>({
-    from: subDays(new Date(), 30),
-    to: new Date(),
-  })
+  // Which preset is highlighted, or null once the calendar is used. Tracked
+  // explicitly rather than inferred from the dates, so a custom range that
+  // happens to be 30 days long doesn't light up the "30d" button.
+  const [activeRangeKey, setActiveRangeKey] = React.useState<string | null>(
+    FUNNEL_DEFAULT_RANGE_KEY
+  )
+  const [dateRange, setDateRange] = React.useState<DateRange | undefined>(() =>
+    funnelQuickRangeBounds(FUNNEL_DEFAULT_RANGE_KEY)
+  )
+
+  const selectQuickRange = (key: string) => {
+    // Re-resolved against the current clock, so "24h" is still the last 24
+    // hours on a tab that has been open since yesterday.
+    setDateRange(funnelQuickRangeBounds(key))
+    setActiveRangeKey(key)
+  }
+
+  const selectCustomRange = (range: DateRange | undefined) => {
+    setDateRange(range)
+    setActiveRangeKey(null)
+  }
+
+  const activeRangeDescription = activeRangeKey
+    ? funnelQuickRange(activeRangeKey)?.description
+    : undefined
 
   const {
     data: metrics,
@@ -71,42 +98,78 @@ export function FunnelDetail({ project, funnelId }: FunnelDetailProps) {
             </p>
           </div>
         </div>
-        <Popover>
-          <PopoverTrigger asChild>
-            <Button
-              variant="outline"
-              className={cn(
-                'justify-start text-left font-normal',
-                !dateRange && 'text-muted-foreground'
-              )}
-            >
-              <CalendarIcon className="mr-2 h-4 w-4" />
-              {dateRange?.from ? (
-                dateRange.to ? (
-                  <>
-                    {format(dateRange.from, 'LLL dd, y')} -{' '}
-                    {format(dateRange.to, 'LLL dd, y')}
-                  </>
-                ) : (
-                  format(dateRange.from, 'LLL dd, y')
-                )
-              ) : (
-                <span>Pick a date range</span>
-              )}
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-auto p-0" align="end">
-            <Calendar
-              autoFocus
-              mode="range"
-              defaultMonth={dateRange?.from}
-              selected={dateRange}
-              onSelect={setDateRange}
-              numberOfMonths={2}
-              disabled={(date) => date > new Date()}
-            />
-          </PopoverContent>
-        </Popover>
+        <div className="flex flex-wrap items-center gap-2">
+          <div
+            className="flex items-center gap-0.5 rounded-md bg-muted p-0.5"
+            role="group"
+            aria-label="Funnel time range"
+          >
+            {FUNNEL_QUICK_RANGES.map((range) => {
+              const isActive = activeRangeKey === range.key
+              return (
+                <Button
+                  key={range.key}
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    'h-7 px-2.5 text-xs font-medium',
+                    isActive
+                      ? 'bg-background text-foreground shadow-sm hover:bg-background'
+                      : 'text-muted-foreground hover:text-foreground'
+                  )}
+                  aria-pressed={isActive}
+                  title={range.description}
+                  onClick={() => selectQuickRange(range.key)}
+                >
+                  {range.label}
+                  <span className="sr-only"> — {range.description}</span>
+                </Button>
+              )
+            })}
+          </div>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                variant={activeRangeKey ? 'ghost' : 'secondary'}
+                size="sm"
+                className={cn(
+                  'h-8 justify-start text-left font-normal',
+                  !dateRange && 'text-muted-foreground'
+                )}
+                title="Pick a custom date range"
+              >
+                <CalendarIcon className="mr-2 h-4 w-4" />
+                {/* While a preset is active its name is the honest label —
+                    "Last 24 hours" beats two identical-looking dates. */}
+                {activeRangeDescription ??
+                  (dateRange?.from ? (
+                    dateRange.to ? (
+                      <>
+                        {format(dateRange.from, 'LLL dd, y')} -{' '}
+                        {format(dateRange.to, 'LLL dd, y')}
+                      </>
+                    ) : (
+                      format(dateRange.from, 'LLL dd, y')
+                    )
+                  ) : (
+                    <span>Pick a date range</span>
+                  ))}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0" align="end">
+              <Calendar
+                autoFocus
+                mode="range"
+                defaultMonth={dateRange?.from}
+                selected={dateRange}
+                onSelect={selectCustomRange}
+                numberOfMonths={2}
+                disabled={(date) => date > new Date()}
+              />
+            </PopoverContent>
+          </Popover>
+        </div>
       </div>
 
       {isLoading ? (

--- a/web/src/components/funnel/FunnelVisualization.tsx
+++ b/web/src/components/funnel/FunnelVisualization.tsx
@@ -10,6 +10,7 @@ import {
   DollarSign,
 } from 'lucide-react'
 import * as React from 'react'
+import { formatFunnelDuration } from './funnel-duration'
 
 interface FunnelVisualizationProps {
   totalEntries: number
@@ -263,14 +264,15 @@ function FunnelView({
           </div>
           <div>
             <div className="text-sm text-muted-foreground mb-1">
-              Completion Time
+              Avg. Completion Time
             </div>
             <div className="text-xl font-bold">
-              {averageCompletionTime >= 3600
-                ? `${Math.round(averageCompletionTime / 3600)}h`
-                : averageCompletionTime >= 60
-                  ? `${Math.round(averageCompletionTime / 60)}m`
-                  : `${Math.round(averageCompletionTime)}s`}
+              {formatFunnelDuration(averageCompletionTime).primary}
+            </div>
+            {/* The exact figure, because "1h" alone hides half an hour of
+                difference between two funnels. */}
+            <div className="text-xs text-muted-foreground tabular-nums">
+              {formatFunnelDuration(averageCompletionTime).exact}
             </div>
           </div>
         </div>

--- a/web/src/components/funnel/funnel-duration.ts
+++ b/web/src/components/funnel/funnel-duration.ts
@@ -1,0 +1,52 @@
+/**
+ * Average completion time formatting.
+ *
+ * The old display collapsed the value to a single rounded unit — `Math.round(s
+ * / 3600)` + "h" — so 3,540s and 5,340s both read "1h" despite being half an
+ * hour apart, and the actual number the API returned was nowhere on screen.
+ * That is a lot of precision to throw away for a metric whose whole point is
+ * comparison between funnels.
+ *
+ * So: a readable compound value for scanning, plus the exact seconds beside it.
+ */
+
+export interface FunnelDuration {
+  /** Compound, human-scannable: `1h 29m`, `5m 12s`, `42s`. */
+  primary: string
+  /** The raw figure the API returned, e.g. `5,340 seconds`. */
+  exact: string
+}
+
+function round(seconds: number): number {
+  // Negative or non-finite input would render as garbage; treat it as no data.
+  if (!Number.isFinite(seconds) || seconds <= 0) return 0
+  return Math.round(seconds)
+}
+
+/**
+ * Two most-significant units only — `1h 29m`, never `1h 29m 3s`. Below a
+ * minute there is only one unit to show anyway.
+ */
+function compound(totalSeconds: number): string {
+  if (totalSeconds === 0) return '0s'
+
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`
+  }
+  if (minutes > 0) {
+    return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`
+  }
+  return `${seconds}s`
+}
+
+export function formatFunnelDuration(seconds: number): FunnelDuration {
+  const total = round(seconds)
+  return {
+    primary: compound(total),
+    exact: `${total.toLocaleString()} ${total === 1 ? 'second' : 'seconds'}`,
+  }
+}

--- a/web/src/components/funnel/funnel-quick-ranges.ts
+++ b/web/src/components/funnel/funnel-quick-ranges.ts
@@ -1,0 +1,51 @@
+/**
+ * Preset windows for the funnel view.
+ *
+ * The funnel only had a two-month calendar popover, so answering "how did this
+ * convert today" meant hand-picking two dates on every visit. These are the
+ * windows people actually ask for, one click each; the calendar stays for
+ * anything else.
+ *
+ * Bounds are exact instants rather than whole days — the metrics endpoint
+ * filters on `timestamp >= start AND timestamp <= end`, so "24h" means the
+ * trailing 24 hours, not "since midnight".
+ */
+
+export interface FunnelQuickRange {
+  key: string
+  /** Button text. */
+  label: string
+  /** Accessible name and tooltip, since the button text is an abbreviation. */
+  description: string
+  hours: number
+}
+
+export const FUNNEL_QUICK_RANGES: FunnelQuickRange[] = [
+  { key: '24h', label: '24h', description: 'Last 24 hours', hours: 24 },
+  { key: '7d', label: '7d', description: 'Last 7 days', hours: 24 * 7 },
+  { key: '30d', label: '30d', description: 'Last 30 days', hours: 24 * 30 },
+  { key: '90d', label: '90d', description: 'Last 90 days', hours: 24 * 90 },
+]
+
+/** The window the funnel opens on, matching the previous hard-coded default. */
+export const FUNNEL_DEFAULT_RANGE_KEY = '30d'
+
+export function funnelQuickRange(key: string): FunnelQuickRange | undefined {
+  return FUNNEL_QUICK_RANGES.find((range) => range.key === key)
+}
+
+/**
+ * Resolve a preset to a concrete range ending now. `now` is injected so this
+ * stays pure and testable.
+ */
+export function funnelQuickRangeBounds(
+  key: string,
+  now: Date = new Date()
+): { from: Date; to: Date } | undefined {
+  const range = funnelQuickRange(key)
+  if (!range) return undefined
+  return {
+    from: new Date(now.getTime() - range.hours * 60 * 60 * 1000),
+    to: now,
+  }
+}

--- a/web/src/components/funnel/funnel-time.test.ts
+++ b/web/src/components/funnel/funnel-time.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test'
+
+import { formatFunnelDuration } from './funnel-duration'
+import {
+  FUNNEL_DEFAULT_RANGE_KEY,
+  FUNNEL_QUICK_RANGES,
+  funnelQuickRange,
+  funnelQuickRangeBounds,
+} from './funnel-quick-ranges'
+
+describe('funnelQuickRangeBounds', () => {
+  const now = new Date('2026-08-21T14:30:00.000Z')
+
+  test('resolves the last 24 hours as a trailing window, not since midnight', () => {
+    const bounds = funnelQuickRangeBounds('24h', now)
+
+    expect(bounds?.to.toISOString()).toBe('2026-08-21T14:30:00.000Z')
+    expect(bounds?.from.toISOString()).toBe('2026-08-20T14:30:00.000Z')
+  })
+
+  test('resolves the longer presets', () => {
+    expect(funnelQuickRangeBounds('7d', now)?.from.toISOString()).toBe(
+      '2026-08-14T14:30:00.000Z'
+    )
+    expect(funnelQuickRangeBounds('30d', now)?.from.toISOString()).toBe(
+      '2026-07-22T14:30:00.000Z'
+    )
+    expect(funnelQuickRangeBounds('90d', now)?.from.toISOString()).toBe(
+      '2026-05-23T14:30:00.000Z'
+    )
+  })
+
+  test('returns nothing for an unknown preset', () => {
+    expect(funnelQuickRangeBounds('all-time', now)).toBeUndefined()
+    expect(funnelQuickRange('all-time')).toBeUndefined()
+  })
+
+  test('every preset is resolvable and the default is one of them', () => {
+    for (const range of FUNNEL_QUICK_RANGES) {
+      expect(funnelQuickRangeBounds(range.key, now)).toBeDefined()
+      expect(range.description).not.toBe('')
+    }
+    expect(funnelQuickRange(FUNNEL_DEFAULT_RANGE_KEY)).toBeDefined()
+  })
+
+  test('preserves the previous 30-day default window', () => {
+    // The funnel used to open on subDays(new Date(), 30); changing that
+    // silently would move everyone's numbers.
+    expect(funnelQuickRange(FUNNEL_DEFAULT_RANGE_KEY)?.hours).toBe(24 * 30)
+  })
+})
+
+describe('formatFunnelDuration', () => {
+  test('keeps precision the single-unit rounding used to destroy', () => {
+    // Both of these rendered as "1h" before.
+    expect(formatFunnelDuration(3540).primary).toBe('59m')
+    expect(formatFunnelDuration(5340).primary).toBe('1h 29m')
+  })
+
+  test('always reports the exact seconds alongside', () => {
+    expect(formatFunnelDuration(5340).exact).toBe('5,340 seconds')
+    expect(formatFunnelDuration(42).exact).toBe('42 seconds')
+    expect(formatFunnelDuration(1).exact).toBe('1 second')
+  })
+
+  test('drops empty trailing units', () => {
+    expect(formatFunnelDuration(7200).primary).toBe('2h')
+    expect(formatFunnelDuration(300).primary).toBe('5m')
+    expect(formatFunnelDuration(312).primary).toBe('5m 12s')
+    expect(formatFunnelDuration(42).primary).toBe('42s')
+  })
+
+  test('rounds fractional seconds', () => {
+    expect(formatFunnelDuration(41.6).primary).toBe('42s')
+    expect(formatFunnelDuration(41.6).exact).toBe('42 seconds')
+  })
+
+  test('treats missing or nonsensical values as zero rather than rendering NaN', () => {
+    for (const value of [0, -12, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(formatFunnelDuration(value)).toEqual({
+        primary: '0s',
+        exact: '0 seconds',
+      })
+    }
+  })
+})


### PR DESCRIPTION
## Time-range shortcuts

The funnel view's only time control was a two-month calendar popover hard-coded to `subDays(new Date(), 30)`. Answering "how did this convert today" meant hand-picking two dates, every visit.

Added a segmented control — **24h / 7d / 30d / 90d** — beside the existing calendar, which stays for anything else.

- Presets resolve against the clock **at click time**, so `24h` is still the trailing 24 hours on a tab that has been open since yesterday.
- Bounds are exact instants, not whole days: `24h` means the last 24 hours, not "since midnight". The metrics endpoint filters on `timestamp >= start AND timestamp <= end` (`service.rs:715`), so this needed **no backend change**.
- The trigger label shows the preset name (`Last 24 hours`) while one is active — more legible than two dates that look nearly identical.
- The active preset is tracked in state rather than inferred from the dates, so a custom range that happens to span 30 days doesn't light up the `30d` button.
- **The default window is unchanged at 30 days**, so nobody's numbers move.

## Exact completion seconds

`Completion Time` collapsed the value to one rounded unit:

```tsx
averageCompletionTime >= 3600 ? `${Math.round(averageCompletionTime / 3600)}h` : ...
```

So 3,540s and 5,340s **both rendered "1h"** despite being half an hour apart, and the number the API actually returned appeared nowhere on screen. For a metric whose entire purpose is comparison between funnels, that's a lot of precision to discard.

Now shows a compound value with the exact seconds beneath it, and renders `0s` for non-finite/negative input instead of `NaN`.

| `average_completion_time_seconds` | before | after |
|---|---|---|
| 3,540 | `1h` | **59m** · 3,540 seconds |
| 5,340 | `1h` | **1h 29m** · 5,340 seconds |
| 7,200 | `2h` | **2h** · 7,200 seconds |
| 312 | `5m` | **5m 12s** · 312 seconds |
| 42 | `42s` | **42s** · 42 seconds |

Also relabelled the tile `Completion Time` → `Avg. Completion Time`, since that is what it is.

## Evidence

Both behaviours are pure helpers (`funnel-quick-ranges.ts`, `funnel-duration.ts`) with `now` injected so range maths is deterministic:

```
$ cd web && bun test src/components/funnel
 10 pass
 0 fail
 32 expect() calls
$ bunx tsc --noEmit         # clean
$ bunx eslint src/components/funnel/   # clean for touched files
```

Tests cover the trailing-window semantics for every preset, that the default stays 30 days, the two values that used to both render "1h", trailing-unit suppression, fractional rounding, and NaN/Infinity/negative input.

**Rendered** through the real `FunnelDetail` and `FunnelVisualization` in a temporary fixture route, driven with Playwright, harness removed before commit (not in this diff):

- Default load → `30d` active, label `Last 30 days`.
- **Clicked `24h`** → active state moves to `24h`, label becomes `Last 24 hours`, query refetches with the new bounds. No page errors.
- Metrics tile with `averageCompletionTime={5340}` renders **`1h 29m`** over `5,340 seconds`.

The first pass used `variant="secondary"` for the active button and it was nearly indistinguishable from the inactive ones on a white card; switched to a `bg-muted` container with a `bg-background shadow-sm` active item (the segmented-control pattern) and re-shot to confirm.