### PR TITLE
docs: require DCO sign-off on every commit, add Code of Conduct

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,7 @@
 - [ ] All new and existing tests pass (`cargo test --lib`)
 - [ ] `cargo check --lib` passes with no warnings
 - [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
+- [ ] Every commit is signed off (`git commit -s`) per the [DCO](../DCO)
 - [ ] I have updated documentation where necessary
 
 ## Related issues

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,95 @@
+name: DCO
+
+# Every commit must carry a `Signed-off-by:` trailer certifying the Developer
+# Certificate of Origin (see the `DCO` file at the repository root). This is how
+# we get an on-the-record statement that a contributor has the right to submit
+# the code they are submitting — it is a provenance record, not a copyright
+# assignment, and it costs a contributor exactly one `-s` flag.
+#
+# Implemented as a workflow rather than the third-party DCO GitHub App so the
+# rule lives in this repository, is reviewable in a PR, and needs no org-level
+# app install to work on forks.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    name: Check sign-off
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Verify Signed-off-by on every commit
+        run: |
+          set -euo pipefail
+          git fetch origin "${{ github.base_ref }}" --quiet || true
+          base="$(git merge-base "origin/${{ github.base_ref }}" HEAD 2>/dev/null || echo '${{ github.event.pull_request.base.sha }}')"
+          echo "PR commit range: $base..HEAD"
+
+          fail=0
+          # --no-merges: a merge commit has no authored content to certify.
+          for sha in $(git log --no-merges --format='%H' "$base..HEAD"); do
+            subject="$(git log -1 --format='%s' "$sha")"
+            author_name="$(git log -1 --format='%an' "$sha")"
+            author_email="$(git log -1 --format='%ae' "$sha")"
+
+            # Bot-authored commits (dependabot, renovate) can't sign off and
+            # aren't contributions from a person whose rights need certifying.
+            case "$author_name$author_email" in
+              *'[bot]'*) echo "⏭️  ${sha:0:8} skipped (bot author: $author_name)"; continue ;;
+            esac
+
+            expected="Signed-off-by: $author_name <$author_email>"
+            if git log -1 --format='%B' "$sha" | grep -qixF "$expected"; then
+              echo "✅ ${sha:0:8} $subject"
+            else
+              echo "::error::Missing or mismatched sign-off on ${sha:0:8}: $subject"
+              echo "   expected trailer: $expected"
+              echo "   found:            $(git log -1 --format='%B' "$sha" | grep -i '^Signed-off-by:' || echo '(none)')"
+              fail=1
+            fi
+          done
+
+          if [ "$fail" -ne 0 ]; then
+            cat <<'EOF'
+
+          ─────────────────────────────────────────────────────────────
+          Every commit needs a Developer Certificate of Origin sign-off.
+
+          The trailer must match the commit author exactly:
+
+              Signed-off-by: Your Name <your@email.example>
+
+          Sign new commits automatically:
+
+              git commit -s -m "fix(scope): ..."
+              git config --global format.signOff true   # do it for every repo
+
+          Fix commits you already pushed — sign off the whole PR branch, then
+          force-push:
+
+              git rebase --signoff origin/main
+              git push --force-with-lease
+
+          The certification you are making is in the DCO file at the root of
+          this repository. See CONTRIBUTING.md for the full explanation.
+          ─────────────────────────────────────────────────────────────
+          EOF
+            exit 1
+          fi
+          echo "✅ All commits are signed off"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**david@temps.sh**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,6 +173,43 @@ docs: update installation instructions
 Use `!` after the type/scope for breaking changes (`feat(api)!: …`). Choose a
 meaningful **scope** — it becomes the bold prefix in the changelog.
 
+### Developer Certificate of Origin (sign-off required)
+
+Every commit must be signed off under the [Developer Certificate of Origin](DCO)
+(DCO 1.1, the same one the Linux kernel uses). Signing off means you are
+certifying that you wrote the code, or that you have the right to submit it
+under this project's licenses. It is **not** a copyright assignment — you keep
+the copyright to your contribution.
+
+In practice it is one flag:
+
+```bash
+git commit -s -m "feat(auth): add JWT token refresh"
+```
+
+which appends a trailer matching your git author identity:
+
+```
+Signed-off-by: Your Name <your@email.example>
+```
+
+Make it the default for every repository you work in:
+
+```bash
+git config --global format.signOff true
+```
+
+The **DCO** CI job checks every commit in the pull request and fails if any of
+them is missing the trailer or if the trailer does not match the commit author.
+If you forgot, sign off the whole branch retroactively and force-push:
+
+```bash
+git rebase --signoff origin/main
+git push --force-with-lease
+```
+
+Merge commits and bot-authored commits (Dependabot) are exempt.
+
 ### Changelog (generated — do not edit)
 
 `CHANGELOG.md` is a **generated artifact**, produced from Conventional Commits by
@@ -227,7 +264,7 @@ Docker-dependent tests run as part of the normal test suite and skip gracefully 
 2. **Name your branch** descriptively: `feat/add-webhook-support`, `fix/deployment-timeout`.
 3. **Write your code** following the coding standards above.
 4. **Add tests** for any new functionality.
-5. **Commit** using Conventional Commits format.
+5. **Commit** using Conventional Commits format, and sign off each commit with `git commit -s` (see [Developer Certificate of Origin](#developer-certificate-of-origin-sign-off-required)).
 6. **Push** your branch and open a Pull Request targeting `main`.
 7. **Describe your changes** in the PR body: what changed, why, and how to test it.
 
@@ -239,6 +276,7 @@ Pre-commit hooks run automatically on each commit to check formatting (`cargo fm
 - [ ] Tests pass (`cargo test --lib`)
 - [ ] New functionality includes tests
 - [ ] Commit messages follow Conventional Commits (they generate the changelog — see below)
+- [ ] Every commit is signed off (`git commit -s`) per the [DCO](DCO)
 - [ ] PR description explains the change
 - [ ] Do **not** edit `CHANGELOG.md` — it is generated from your commit messages
 
@@ -252,4 +290,4 @@ This project follows a Code of Conduct to ensure a welcoming and inclusive commu
 
 ## License
 
-Temps is dual-licensed under the [MIT License](LICENSE-MIT) and [Apache License 2.0](LICENSE-APACHE). By contributing, you agree that your contributions will be licensed under the same terms.
+Temps is dual-licensed under the [MIT License](LICENSE-MIT) and [Apache License 2.0](LICENSE). By contributing, you agree that your contributions will be licensed under the same terms, and you certify their origin under the [Developer Certificate of Origin](DCO) by signing off each commit.

--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
## Description

Requires a [Developer Certificate of Origin](https://developercertificate.org/) sign-off on every commit, and enforces it in CI.

The DCO is a per-commit statement that the contributor wrote the code, or has the right to submit it under this project's licenses. It is a provenance record, not a copyright assignment — contributors keep the copyright to their work, and it costs them one `-s` flag. This is the same mechanism the Linux kernel, Kubernetes, Docker/Moby and most CNCF projects use.

What's here:

- **`DCO`** — the verbatim DCO 1.1 text at the repository root, so what a contributor is certifying is in the repo rather than behind a link.
- **`.github/workflows/dco.yml`** — a `DCO` check that runs on every PR to `main`, walks `merge-base..HEAD`, and fails if any commit lacks a `Signed-off-by:` trailer matching its author. Merge commits and bot-authored commits (Dependabot) are exempt. On failure it prints the exact remediation (`git rebase --signoff origin/main && git push --force-with-lease`) rather than just "check failed".
- **`CONTRIBUTING.md`** — a "Developer Certificate of Origin" section explaining what signing off means, `git commit -s`, `git config --global format.signOff true`, and how to fix commits already pushed. Added to the PR checklist and the PR process steps.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — checklist item.

Also fixes a broken link in `CONTRIBUTING.md`: the Apache 2.0 license file is `LICENSE`, not `LICENSE-APACHE`.

Implemented as a workflow rather than the third-party DCO GitHub App so the rule lives in this repository, is reviewable in a PR, and works without an org-level app install.

**After merge, this needs one manual step:** add `Check sign-off` to the required status checks in the `main` branch protection rules. Until then the check runs and reports but does not block merging.

---

## Also in this PR: Code of Conduct

`CONTRIBUTING.md` has always linked to `CODE_OF_CONDUCT.md`, but the file did not exist — the link 404'd. Added the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html) v2.1 verbatim, with **david@temps.sh** as the enforcement contact.

Using the standard text rather than a hand-written one is deliberate: it is the text GitHub's community-standards checker recognises, contributors already know what it says, and its enforcement ladder (correction → warning → temporary ban → permanent ban) is a decision framework you do not want to be inventing during an actual incident.

## Type of change

- [x] Documentation update
- [x] CI / contribution process

## Evidence

The workflow's `run` script was extracted from the YAML (verifying the block scalar de-indents correctly, so the heredoc terminator lands at column 0) and executed against real commits.

Against this branch — one signed commit:

```
$ bash /tmp/dco-run.sh
PR commit range: 25bc21279e7c74bfdbd0c1d04553ac84a9ed06e9..HEAD
✅ 4e9d84de docs(contributing): require DCO sign-off on every commit
✅ All commits are signed off
EXIT=0
```

Against a scratch repo containing an unsigned commit, a signed commit and a `dependabot[bot]`-authored commit:

```
$ bash /tmp/dco-run2.sh
PR commit range: ff95f2b004703af318da3cf2817add60c0c64395..HEAD
⏭️  321b76db skipped (bot author: dependabot[bot])
✅ 2a23a97b feat: signed commit
::error::Missing or mismatched sign-off on 6397ecbf: feat: unsigned commit
   expected trailer: Signed-off-by: Test Person <t@example.com>
   found:            (none)

─────────────────────────────────────────────────────────────
Every commit needs a Developer Certificate of Origin sign-off.

The trailer must match the commit author exactly:

    Signed-off-by: Your Name <your@email.example>
...
EXIT=1
```

So: unsigned fails with an actionable message, signed passes, bot-authored is skipped, and the `git fetch origin` fallback path (`|| true` → `merge-base` → `base.sha`) is exercised in the scratch run, which has no remote.

This PR's own commit is signed off, so the check gates itself once the workflow lands on `main`.
