### PR TITLE
fix(proxy): allow IPv6 addresses in IP Access Control rules

### DIFF
--- a/apps/temps-cli/src/commands/ip-access/index.ts
+++ b/apps/temps-cli/src/commands/ip-access/index.ts
@@ -80,7 +80,7 @@ export function registerIpAccessCommands(program: Command): void {
     .command('create')
     .alias('add')
     .description('Create a new IP access control rule')
-    .option('--ip <ip_or_cidr>', 'IP address or CIDR range (e.g., "192.168.1.1" or "10.0.0.0/24")')
+    .option('--ip <ip_or_cidr>', 'IPv4 or IPv6 address or CIDR range (e.g., "192.168.1.1", "10.0.0.0/24", or "2001:db8::/32")')
     .option('--action <action>', 'Action to take: "allow" or "deny"')
     .option('--description <desc>', 'Optional description/reason for the rule')
     .option('-y, --yes', 'Skip confirmation prompts (for automation)')

--- a/crates/temps-entities/src/ip_access_control.rs
+++ b/crates/temps-entities/src/ip_access_control.rs
@@ -9,8 +9,9 @@ use temps_core::DBDateTime;
 pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,
-    /// IP address in CIDR notation (e.g., "192.168.1.1" or "10.0.0.0/24")
-    /// Stored as PostgreSQL inet type
+    /// IPv4 or IPv6 address, in CIDR notation for ranges (e.g., "192.168.1.1",
+    /// "10.0.0.0/24", "2001:db8::1", or "2001:db8::/32")
+    /// Stored as PostgreSQL inet type (dual-stack)
     pub ip_address: String,
     /// Action to take: "block" or "allow"
     pub action: String,

--- a/crates/temps-proxy/src/service/ip_access_control_service.rs
+++ b/crates/temps-proxy/src/service/ip_access_control_service.rs
@@ -65,7 +65,8 @@ impl From<ip_access_control::Model> for IpAccessControlResponse {
 /// Request to create an IP access control rule
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct CreateIpAccessControlRequest {
-    /// IP address in CIDR notation (e.g., "192.168.1.1" or "10.0.0.0/24")
+    /// IPv4 or IPv6 address, in CIDR notation for ranges (e.g., "192.168.1.1",
+    /// "10.0.0.0/24", "2001:db8::1", or "2001:db8::/32")
     #[schema(example = "192.168.1.100")]
     pub ip_address: String,
     /// Action to take: "block" or "allow"
@@ -423,45 +424,12 @@ impl IpAccessControlService {
         Ok(())
     }
 
-    /// Basic IP/CIDR validation (can be improved with proper IP parsing library)
+    /// Validates an IP address or CIDR range for either IPv4 or IPv6, using the
+    /// same `IpNetwork` parser `refresh_blocklist`/`is_blocked` rely on — so
+    /// nothing accepted here is later silently skipped as unparsable when the
+    /// hot-path snapshot is built.
     fn is_valid_ip_or_cidr(ip: &str) -> bool {
-        // Allow IPv4 addresses and CIDR notation
-        // This is a simple validation - PostgreSQL inet type will do final validation
-        if ip.contains('/') {
-            // CIDR notation
-            let parts: Vec<&str> = ip.split('/').collect();
-            if parts.len() != 2 {
-                return false;
-            }
-            // Check if prefix length is valid
-            if let Ok(prefix) = parts[1].parse::<u8>() {
-                if prefix > 32 {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-            // Validate the IP part
-            Self::is_valid_ipv4(parts[0])
-        } else {
-            // Single IP address
-            Self::is_valid_ipv4(ip)
-        }
-    }
-
-    /// Basic IPv4 validation
-    fn is_valid_ipv4(ip: &str) -> bool {
-        let parts: Vec<&str> = ip.split('.').collect();
-        if parts.len() != 4 {
-            return false;
-        }
-        for part in parts {
-            // parse::<u8>() already validates 0-255 range
-            if part.parse::<u8>().is_err() {
-                return false;
-            }
-        }
-        true
+        ip.parse::<IpNetwork>().is_ok()
     }
 }
 
@@ -472,16 +440,6 @@ mod tests {
     // NOTE: Database tests are disabled because MockDatabase doesn't support
     // PostgreSQL-specific inet operators (::inet casting and <<= operator).
     // These require integration tests with a real PostgreSQL database.
-
-    #[test]
-    fn test_is_valid_ipv4() {
-        assert!(IpAccessControlService::is_valid_ipv4("192.168.1.1"));
-        assert!(IpAccessControlService::is_valid_ipv4("10.0.0.1"));
-        assert!(IpAccessControlService::is_valid_ipv4("255.255.255.255"));
-        assert!(!IpAccessControlService::is_valid_ipv4("256.1.1.1"));
-        assert!(!IpAccessControlService::is_valid_ipv4("192.168.1"));
-        assert!(!IpAccessControlService::is_valid_ipv4("invalid"));
-    }
 
     #[tokio::test]
     async fn test_is_blocked_matches_in_memory_snapshot() {
@@ -522,6 +480,14 @@ mod tests {
         assert!(!IpAccessControlService::is_valid_ip_or_cidr("10.0.0.0/33"));
         assert!(!IpAccessControlService::is_valid_ip_or_cidr("256.1.1.1/24"));
         assert!(!IpAccessControlService::is_valid_ip_or_cidr("invalid"));
+
+        // IPv6: bare address, CIDR range, and out-of-range prefix
+        assert!(IpAccessControlService::is_valid_ip_or_cidr("2001:db8::1"));
+        assert!(IpAccessControlService::is_valid_ip_or_cidr("2001:db8::/32"));
+        assert!(IpAccessControlService::is_valid_ip_or_cidr("::1"));
+        assert!(!IpAccessControlService::is_valid_ip_or_cidr(
+            "2001:db8::1/129"
+        ));
     }
 
     // Database tests are commented out because MockDatabase doesn't support PostgreSQL-specific features

--- a/web/src/components/settings/IpAccessControl.tsx
+++ b/web/src/components/settings/IpAccessControl.tsx
@@ -50,20 +50,11 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 
 const ipAccessControlSchema = z.object({
-  ip_address: z
-    .string()
-    .min(1, 'IP address is required')
-    .refine(
-      (val) => {
-        // Basic IPv4 validation (including CIDR)
-        const ipv4Regex = /^(\d{1,3}\.){3}\d{1,3}(\/\d{1,2})?$/
-        return ipv4Regex.test(val)
-      },
-      {
-        message:
-          'Invalid IP address format. Use format: 192.168.1.1 or 10.0.0.0/24',
-      }
-    ),
+  // IPv4/IPv6 + CIDR format is validated server-side (temps_proxy's
+  // IpAccessControlService parses via ipnetwork::IpNetwork); a client-side
+  // regex here would either reject valid IPv6 forms or need to reimplement
+  // that parser, so invalid input surfaces via the mutation's error toast.
+  ip_address: z.string().min(1, 'IP address is required'),
   action: z.enum(['block', 'allow'], {
     message: 'Action is required',
   }),
@@ -383,7 +374,7 @@ export function IpAccessControl() {
                   <Label htmlFor="create-ip">IP Address</Label>
                   <Input
                     id="create-ip"
-                    placeholder="192.168.1.1 or 10.0.0.0/24"
+                    placeholder="192.168.1.1, 10.0.0.0/24, or 2001:db8::/32"
                     {...registerCreate('ip_address')}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') {
@@ -399,7 +390,7 @@ export function IpAccessControl() {
                     </p>
                   )}
                   <p className="text-xs text-muted-foreground">
-                    Supports IPv4 addresses and CIDR notation
+                    Supports IPv4 and IPv6 addresses, and CIDR notation
                   </p>
                 </div>
 
@@ -481,7 +472,7 @@ export function IpAccessControl() {
                   <Label htmlFor="edit-ip">IP Address</Label>
                   <Input
                     id="edit-ip"
-                    placeholder="192.168.1.1 or 10.0.0.0/24"
+                    placeholder="192.168.1.1, 10.0.0.0/24, or 2001:db8::/32"
                     {...registerEdit('ip_address')}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') {


### PR DESCRIPTION
## Summary
- `IpAccessControlService::is_valid_ip_or_cidr` rejected every IPv6 address/CIDR at create/update time (hand-rolled dotted-decimal octet splitter), even though the `inet` storage column and the hot-path blocklist snapshot (`refresh_blocklist`/`is_blocked`) were already fully dual-stack via `ipnetwork::IpNetwork`/`std::net::IpAddr`. Replaced the validator with the same `IpNetwork` parser those two already use.
- Mirrored the fix on the frontend: `IpAccessControl.tsx`'s zod validator had an equivalent IPv4-only regex. Dropped it in favor of the existing `AdminGateCard` pattern already used elsewhere in this codebase (rely on the backend's real validation, surface errors via the existing mutation error toast) rather than reimplementing IP parsing in JS.
- Updated the now-inaccurate "IPv4 only" doc comments/UI copy: entity doc comment, request schema doc comment, CLI `--ip` help text, and the form's placeholders/help text.

Found via a sweep for other IPv4-only assumptions after fixing IPv6 discoverability gaps in a separate EE plugin's Network Access UI. This is the only genuine *logic* bug the sweep turned up (splitting a string on `.` will reject any address containing `:`); the rest were text-only discoverability gaps in unrelated files, tracked separately.

Not folded into #725 — unrelated feature, unrelated files.

## Test plan
- [x] `cargo check --lib -p temps-proxy -p temps-entities`
- [x] `cargo test --lib -p temps-proxy ip_access_control` — 3/3 pass, including new IPv6 assertions (`2001:db8::1`, `2001:db8::/32`, `::1`, and out-of-range `/129` rejection)
- [x] `cargo fmt --check` / `cargo clippy -D warnings` on both changed crates
- [x] `tsc --noEmit` on `web/` and `apps/temps-cli/` — no new errors introduced by this diff
- [x] Manual UI verification (create/edit an IPv6 rule end-to-end against a running server) — see comment below
