### PR TITLE
test: fix flaky Postgres/Chrome tests and make MongoDB health timeouts diagnosable

### DIFF
--- a/crates/temps-analytics/src/testing/test_utils.rs
+++ b/crates/temps-analytics/src/testing/test_utils.rs
@@ -4,9 +4,33 @@ use std::sync::Arc;
 use temps_entities::upstream_config::UpstreamList;
 use temps_migrations::{Migrator, MigratorTrait};
 use testcontainers::{
-    core::ContainerPort, runners::AsyncRunner, ContainerAsync, GenericImage, ImageExt,
+    core::{ContainerPort, WaitFor},
+    runners::AsyncRunner,
+    ContainerAsync, GenericImage, ImageExt,
 };
 use uuid::Uuid;
+
+/// Attempts made by [`connect_with_retries`]; see its call site for why this is
+/// only a backstop rather than the primary readiness mechanism.
+const DB_CONNECT_ATTEMPTS: u32 = 15;
+const DB_CONNECT_RETRY_DELAY: tokio::time::Duration = tokio::time::Duration::from_secs(2);
+
+async fn connect_with_retries(database_url: &str) -> anyhow::Result<DatabaseConnection> {
+    let mut last_err = None;
+    for _ in 0..DB_CONNECT_ATTEMPTS {
+        match Database::connect(database_url).await {
+            Ok(db) => return Ok(db),
+            Err(e) => {
+                last_err = Some(e);
+                tokio::time::sleep(DB_CONNECT_RETRY_DELAY).await;
+            }
+        }
+    }
+    Err(anyhow::anyhow!(
+        "Failed to connect to database after {DB_CONNECT_ATTEMPTS} attempts: {}",
+        last_err.expect("at least one attempt was made")
+    ))
+}
 
 /// Test database setup with unique container per test
 pub struct TestDatabase {
@@ -27,11 +51,40 @@ impl TestDatabase {
         );
 
         let postgres_container = GenericImage::new("timescale/timescaledb-ha", "pg18")
+            // Without a readiness condition, `start()` returns as soon as the
+            // container is running — long before PostgreSQL accepts clients —
+            // and the fixed sleep that used to stand in for it lost the race on
+            // loaded CI runners, failing tests with `error communicating with
+            // database: Connection reset by peer (os error 104)`.
+            //
+            // The stream matters. The `timescaledb-ha` entrypoint boots a
+            // *temporary* server for initdb, stops it, then starts the real
+            // one, and each logs this line once. Verified against
+            // `timescale/timescaledb-ha:pg18`, the temporary server logs to
+            // **stdout** and the real server to **stderr**, so matching on
+            // stderr targets the real server. Do not "fix" this by matching
+            // stdout or by waiting for two occurrences — each stream only ever
+            // carries one.
+            .with_wait_for(WaitFor::message_on_stderr(
+                "database system is ready to accept connections",
+            ))
             .with_exposed_port(ContainerPort::Tcp(5432))
             .with_env_var("POSTGRES_DB", "test_db")
             .with_env_var("POSTGRES_USER", "test_user")
             .with_env_var("POSTGRES_PASSWORD", "test_password")
             .with_env_var("POSTGRES_HOST_AUTH_METHOD", "trust")
+            // The background-worker launcher polls independently of the test
+            // and is pure noise here (it floods the log with "out of background
+            // workers" and can compress chunks mid-test).
+            .with_cmd(vec![
+                "postgres",
+                "-c",
+                "timescaledb.max_background_workers=0",
+            ])
+            // testcontainers' default is 60s; this repository runs many
+            // Docker-backed tests concurrently, so give real headroom under
+            // contention instead of racing the default.
+            .with_startup_timeout(std::time::Duration::from_secs(120))
             .start()
             .await?;
 
@@ -42,26 +95,10 @@ impl TestDatabase {
             port
         );
 
-        // Wait for the database to be ready, then connect with retries
-        tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
-
-        let mut retries = 5;
-        let db = loop {
-            match Database::connect(&database_url).await {
-                Ok(db) => break db,
-                Err(e) if retries > 0 => {
-                    retries -= 1;
-                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-                    if retries == 0 {
-                        return Err(anyhow::anyhow!(
-                            "Failed to connect to database after retries: {}",
-                            e
-                        ));
-                    }
-                }
-                Err(e) => return Err(anyhow::anyhow!("Failed to connect to database: {}", e)),
-            }
-        };
+        // Backstop only — the wait condition above is what removes the race.
+        // This covers the brief window between the server logging readiness and
+        // the mapped port accepting connections.
+        let db = connect_with_retries(&database_url).await?;
 
         // Run migrations
         Migrator::up(&db, None).await?;

--- a/crates/temps-database/src/test_utils.rs
+++ b/crates/temps-database/src/test_utils.rs
@@ -62,12 +62,19 @@ use tokio::sync::{Mutex, OnceCell};
 /// The postgres/timescaledb entrypoint starts a temporary server to run
 /// initdb + init scripts, shuts it down, then starts the real server --
 /// "database system is ready to accept connections" is logged once for
-/// each. This waits for the first (temporary-server) occurrence -- same
-/// wait condition already proven reliable elsewhere in this workspace
+/// each.
+///
+/// The two go to DIFFERENT streams. Verified against
+/// `timescale/timescaledb-ha:pg18`, the temporary server logs to **stdout**
+/// (`[40] LOG: ...`) and the real server to **stderr** (`[1] LOG: ...`).
+/// Matching on stderr therefore already targets the real server -- this does
+/// not need a trailing buffer sleep to "clear the restart window", and it must
+/// not be changed to match stdout or to wait for two occurrences, because each
+/// stream only ever carries one.
+///
+/// Same wait condition already proven reliable elsewhere in this workspace
 /// (temps-providers/src/pg_stat_statements.rs,
-/// temps-metrics/tests/postgres_checkpoint_stats_integration.rs) -- and
-/// callers add a short buffer sleep afterward to clear the temp-server
-/// shutdown/real-server restart window before connecting.
+/// temps-metrics/tests/postgres_checkpoint_stats_integration.rs).
 fn postgres_ready_wait_for() -> WaitFor {
     WaitFor::message_on_stderr("database system is ready to accept connections")
 }
@@ -174,9 +181,10 @@ impl SharedContainer {
             username, password, port, db_name
         );
 
-        // The wait strategy fires on the temp-server's "ready" line, but
-        // postgres shuts that server down and restarts a second one right
-        // after -- a short buffer clears that window before we connect.
+        // The wait strategy above already fires on the REAL server's "ready"
+        // line (see `postgres_ready_wait_for`), so this is not closing a
+        // restart window -- it is just a small margin for the mapped port to
+        // start accepting. Callers retry on top of it.
         tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
 
         Ok(Self {
@@ -574,12 +582,13 @@ impl TestDatabase {
             username, password, port, db_name
         );
 
-        // The wait strategy fires on the temp-server's "ready" line, but
-        // postgres shuts that server down and restarts a second one right
-        // after -- a short buffer clears that window before we connect.
+        // The wait strategy above already fires on the REAL server's "ready"
+        // line (see `postgres_ready_wait_for`), so this is not closing a
+        // restart window -- it is just a small margin for the mapped port to
+        // start accepting.
         tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
 
-        // Connect with retries as a safety net on top of the buffer above.
+        // Connect with retries as a safety net on top of the margin above.
         let db = Self::connect_with_retry(&database_url, 10).await?;
 
         let test_db = TestDatabase {

--- a/crates/temps-dns/tests/dns_registry_test.rs
+++ b/crates/temps-dns/tests/dns_registry_test.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use temps_dns::services::{DnsRegistry, EndpointDraft, OwnerKind, RecordType};
 use temps_migrations::{Migrator, MigratorTrait};
-use testcontainers::{runners::AsyncRunner, GenericImage, ImageExt};
+use testcontainers::{core::WaitFor, runners::AsyncRunner, GenericImage, ImageExt};
 
 async fn boot_db() -> Option<Arc<DatabaseConnection>> {
     if std::env::var("TEMPS_TEST_DATABASE_URL").is_ok() {
@@ -21,10 +21,18 @@ async fn boot_db() -> Option<Arc<DatabaseConnection>> {
     }
 
     let container = match GenericImage::new("timescale/timescaledb-ha", "pg18")
+        // Without this, `start()` returns before PostgreSQL accepts clients
+        // and the test races the database ("Connection reset by peer").
+        // Must match on stderr: the temporary initdb server logs its "ready"
+        // line to stdout, the real server to stderr.
+        .with_wait_for(WaitFor::message_on_stderr(
+            "database system is ready to accept connections",
+        ))
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
         .with_env_var("POSTGRES_HOST_AUTH_METHOD", "trust")
+        .with_startup_timeout(std::time::Duration::from_secs(120))
         .start()
         .await
     {

--- a/crates/temps-migrations/tests/migration_tests.rs
+++ b/crates/temps-migrations/tests/migration_tests.rs
@@ -1,8 +1,34 @@
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection};
 use sea_orm_migration::MigratorTrait;
-use testcontainers::{runners::AsyncRunner, GenericImage, ImageExt};
+use testcontainers::{core::WaitFor, runners::AsyncRunner, GenericImage, ImageExt};
 
 use temps_migrations::Migrator;
+
+/// Wait until the *real* PostgreSQL server is accepting connections.
+///
+/// Without this, `start()` returns as soon as the container is running, which
+/// is long before PostgreSQL can serve clients — the tests then raced the
+/// database and failed intermittently in CI with
+/// `error communicating with database: Connection reset by peer (os error 104)`
+/// and `FATAL: the database system is starting up`.
+///
+/// The stream matters. The `timescaledb-ha` entrypoint boots a *temporary*
+/// server to run initdb, shuts it down, then starts the real one, and each
+/// logs "database system is ready to accept connections" once. Verified
+/// against `timescale/timescaledb-ha:pg18`, the temporary server logs to
+/// **stdout** (`[40] LOG: …`) and the real server to **stderr** (`[1] LOG: …`).
+/// Matching on stderr therefore targets the real server directly — do not
+/// "fix" this by matching stdout or by waiting for two occurrences, because
+/// each stream only ever carries one.
+fn postgres_ready_wait_for() -> WaitFor {
+    WaitFor::message_on_stderr("database system is ready to accept connections")
+}
+
+/// testcontainers' default startup timeout is 60s. This repository's
+/// convention is to run many Docker-backed integration tests concurrently, so
+/// a container can legitimately take longer than that to become ready under
+/// contention. Matches the budget used by `temps_database::test_utils`.
+const CONTAINER_STARTUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
 async fn env_var_preview_default(db: &DatabaseConnection) -> anyhow::Result<String> {
     let row = db
@@ -70,6 +96,7 @@ async fn test_preview_inclusion_default_migration_up_and_down() -> anyhow::Resul
     }
 
     let container = match GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_wait_for(postgres_ready_wait_for())
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -79,6 +106,7 @@ async fn test_preview_inclusion_default_migration_up_and_down() -> anyhow::Resul
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(CONTAINER_STARTUP_TIMEOUT)
         .start()
         .await
     {
@@ -92,7 +120,6 @@ async fn test_preview_inclusion_default_migration_up_and_down() -> anyhow::Resul
     };
     let port = container.get_host_port_ipv4(5432).await?;
     let db_url = format!("postgresql://postgres:postgres@localhost:{port}/postgres");
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
     let db = connect_with_retries(&db_url).await?;
 
     let target = "m20260815_000001_default_preview_inclusion_off";
@@ -175,6 +202,7 @@ async fn test_step_up_session_expiration_migration_up_and_down() -> anyhow::Resu
     }
 
     let container = match GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_wait_for(postgres_ready_wait_for())
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -184,6 +212,7 @@ async fn test_step_up_session_expiration_migration_up_and_down() -> anyhow::Resu
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(CONTAINER_STARTUP_TIMEOUT)
         .start()
         .await
     {
@@ -197,7 +226,6 @@ async fn test_step_up_session_expiration_migration_up_and_down() -> anyhow::Resu
     };
     let port = container.get_host_port_ipv4(5432).await?;
     let db_url = format!("postgresql://postgres:postgres@localhost:{port}/postgres");
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
     let db = connect_with_retries(&db_url).await?;
 
     let target = "m20260803_000002_add_step_up_expires_at_to_sessions";
@@ -248,6 +276,7 @@ async fn test_migration_up() -> anyhow::Result<()> {
 
     // Start TimescaleDB container
     let postgres_container = GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_wait_for(postgres_ready_wait_for())
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -264,6 +293,7 @@ async fn test_migration_up() -> anyhow::Result<()> {
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(CONTAINER_STARTUP_TIMEOUT)
         .start()
         .await
         .expect("Failed to start TimescaleDB container");
@@ -276,27 +306,7 @@ async fn test_migration_up() -> anyhow::Result<()> {
     // Create database connection string
     let db_url = format!("postgresql://postgres:postgres@localhost:{}/postgres", port);
 
-    // Wait a bit for the database to be ready, then connect with retries
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
-
-    let mut retries = 5;
-    let db = loop {
-        match Database::connect(&db_url).await {
-            Ok(db) => break db,
-            Err(e) if retries > 0 => {
-                retries -= 1;
-                println!(
-                    "Database connection failed, retrying in 2s... ({} retries left)",
-                    retries
-                );
-                tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-                if retries == 0 {
-                    panic!("Failed to connect to database after retries: {}", e);
-                }
-            }
-            Err(e) => panic!("Failed to connect to database: {}", e),
-        }
-    };
+    let db = connect_with_retries(&db_url).await?;
 
     // Run migrations
     let result = Migrator::up(&db, None).await;
@@ -325,6 +335,7 @@ async fn test_secure_sns_migration_upgrades_applied_global_suppression_schema() 
     }
 
     let container = match GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_wait_for(postgres_ready_wait_for())
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -341,6 +352,7 @@ async fn test_secure_sns_migration_upgrades_applied_global_suppression_schema() 
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(CONTAINER_STARTUP_TIMEOUT)
         .start()
         .await
     {
@@ -352,7 +364,6 @@ async fn test_secure_sns_migration_upgrades_applied_global_suppression_schema() 
     };
     let port = container.get_host_port_ipv4(5432).await?;
     let db_url = format!("postgresql://postgres:postgres@localhost:{port}/postgres");
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
     let db = connect_with_retries(&db_url).await?;
 
     let target = "m20260714_000001_secure_sns_email_events";
@@ -565,6 +576,7 @@ async fn test_migration_down() -> anyhow::Result<()> {
 
     // Start TimescaleDB container
     let postgres_container = GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_wait_for(postgres_ready_wait_for())
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -581,6 +593,7 @@ async fn test_migration_down() -> anyhow::Result<()> {
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(CONTAINER_STARTUP_TIMEOUT)
         .start()
         .await
         .expect("Failed to start TimescaleDB container");
@@ -593,27 +606,7 @@ async fn test_migration_down() -> anyhow::Result<()> {
     // Create database connection string
     let db_url = format!("postgresql://postgres:postgres@localhost:{}/postgres", port);
 
-    // Wait a bit for the database to be ready, then connect with retries
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
-
-    let mut retries = 5;
-    let db = loop {
-        match Database::connect(&db_url).await {
-            Ok(db) => break db,
-            Err(e) if retries > 0 => {
-                retries -= 1;
-                println!(
-                    "Database connection failed, retrying in 2s... ({} retries left)",
-                    retries
-                );
-                tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-                if retries == 0 {
-                    panic!("Failed to connect to database after retries: {}", e);
-                }
-            }
-            Err(e) => panic!("Failed to connect to database: {}", e),
-        }
-    };
+    let db = connect_with_retries(&db_url).await?;
 
     // First apply migrations
     Migrator::up(&db, None)
@@ -651,6 +644,7 @@ async fn test_migration_status() -> anyhow::Result<()> {
 
     // Start TimescaleDB container
     let postgres_container = GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_wait_for(postgres_ready_wait_for())
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -667,6 +661,7 @@ async fn test_migration_status() -> anyhow::Result<()> {
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(CONTAINER_STARTUP_TIMEOUT)
         .start()
         .await
         .expect("Failed to start TimescaleDB container");
@@ -679,27 +674,7 @@ async fn test_migration_status() -> anyhow::Result<()> {
     // Create database connection string
     let db_url = format!("postgresql://postgres:postgres@localhost:{}/postgres", port);
 
-    // Wait a bit for the database to be ready, then connect with retries
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
-
-    let mut retries = 5;
-    let db = loop {
-        match Database::connect(&db_url).await {
-            Ok(db) => break db,
-            Err(e) if retries > 0 => {
-                retries -= 1;
-                println!(
-                    "Database connection failed, retrying in 2s... ({} retries left)",
-                    retries
-                );
-                tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-                if retries == 0 {
-                    panic!("Failed to connect to database after retries: {}", e);
-                }
-            }
-            Err(e) => panic!("Failed to connect to database: {}", e),
-        }
-    };
+    let db = connect_with_retries(&db_url).await?;
 
     // Check status before migrations
     let status_before = Migrator::get_pending_migrations(&db).await?;
@@ -727,6 +702,7 @@ async fn test_migration_status() -> anyhow::Result<()> {
 async fn test_pgvector_extension() -> anyhow::Result<()> {
     // Start TimescaleDB container
     let postgres_container = GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_wait_for(postgres_ready_wait_for())
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -743,6 +719,7 @@ async fn test_pgvector_extension() -> anyhow::Result<()> {
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(CONTAINER_STARTUP_TIMEOUT)
         .start()
         .await
         .expect("Failed to start TimescaleDB container");
@@ -755,27 +732,7 @@ async fn test_pgvector_extension() -> anyhow::Result<()> {
     // Create database connection string
     let db_url = format!("postgresql://postgres:postgres@localhost:{}/postgres", port);
 
-    // Wait a bit for the database to be ready, then connect with retries
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
-
-    let mut retries = 5;
-    let db = loop {
-        match Database::connect(&db_url).await {
-            Ok(db) => break db,
-            Err(e) if retries > 0 => {
-                retries -= 1;
-                println!(
-                    "Database connection failed, retrying in 2s... ({} retries left)",
-                    retries
-                );
-                tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-                if retries == 0 {
-                    panic!("Failed to connect to database after retries: {}", e);
-                }
-            }
-            Err(e) => panic!("Failed to connect to database: {}", e),
-        }
-    };
+    let db = connect_with_retries(&db_url).await?;
 
     // Apply migrations (this should handle pgvector gracefully)
     Migrator::up(&db, None).await?;
@@ -849,6 +806,7 @@ async fn test_table_constraints() -> anyhow::Result<()> {
 
     // Start TimescaleDB container
     let postgres_container = GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_wait_for(postgres_ready_wait_for())
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -865,6 +823,7 @@ async fn test_table_constraints() -> anyhow::Result<()> {
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(CONTAINER_STARTUP_TIMEOUT)
         .start()
         .await
         .expect("Failed to start TimescaleDB container");
@@ -877,27 +836,7 @@ async fn test_table_constraints() -> anyhow::Result<()> {
     // Create database connection string
     let db_url = format!("postgresql://postgres:postgres@localhost:{}/postgres", port);
 
-    // Wait a bit for the database to be ready, then connect with retries
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
-
-    let mut retries = 5;
-    let db = loop {
-        match Database::connect(&db_url).await {
-            Ok(db) => break db,
-            Err(e) if retries > 0 => {
-                retries -= 1;
-                println!(
-                    "Database connection failed, retrying in 2s... ({} retries left)",
-                    retries
-                );
-                tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-                if retries == 0 {
-                    panic!("Failed to connect to database after retries: {}", e);
-                }
-            }
-            Err(e) => panic!("Failed to connect to database: {}", e),
-        }
-    };
+    let db = connect_with_retries(&db_url).await?;
 
     // Apply migrations
     Migrator::up(&db, None).await?;
@@ -1097,6 +1036,7 @@ async fn test_compute_network_migration() -> anyhow::Result<()> {
     }
 
     let container = GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_wait_for(postgres_ready_wait_for())
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -1113,13 +1053,13 @@ async fn test_compute_network_migration() -> anyhow::Result<()> {
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(CONTAINER_STARTUP_TIMEOUT)
         .start()
         .await
         .expect("Failed to start TimescaleDB container");
     let port = container.get_host_port_ipv4(5432).await?;
     let db_url = format!("postgresql://postgres:postgres@localhost:{}/postgres", port);
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
     let db = connect_with_retries(&db_url).await?;
     Migrator::up(&db, None).await?;
 
@@ -1241,6 +1181,7 @@ async fn test_dns_service_endpoints_migration() -> anyhow::Result<()> {
     }
 
     let container = GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_wait_for(postgres_ready_wait_for())
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -1257,13 +1198,13 @@ async fn test_dns_service_endpoints_migration() -> anyhow::Result<()> {
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(CONTAINER_STARTUP_TIMEOUT)
         .start()
         .await
         .expect("Failed to start TimescaleDB container");
     let port = container.get_host_port_ipv4(5432).await?;
     let db_url = format!("postgresql://postgres:postgres@localhost:{}/postgres", port);
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
     let db = connect_with_retries(&db_url).await?;
     Migrator::up(&db, None).await?;
 
@@ -1518,6 +1459,7 @@ async fn test_visitor_dedup_migration_repoints_session_replay_sessions() -> anyh
     }
 
     let container = GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_wait_for(postgres_ready_wait_for())
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -1534,13 +1476,13 @@ async fn test_visitor_dedup_migration_repoints_session_replay_sessions() -> anyh
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(CONTAINER_STARTUP_TIMEOUT)
         .start()
         .await
         .expect("Failed to start TimescaleDB container");
     let port = container.get_host_port_ipv4(5432).await?;
     let db_url = format!("postgresql://postgres:postgres@localhost:{}/postgres", port);
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
     let db = connect_with_retries(&db_url).await?;
 
     // ── 1. Apply every migration up to but not including the target. ──────
@@ -1768,21 +1710,36 @@ async fn test_visitor_dedup_migration_repoints_session_replay_sessions() -> anyh
     Ok(())
 }
 
+/// Number of connection attempts made by [`connect_with_retries`].
+///
+/// [`postgres_ready_wait_for`] is what actually removes the startup race; this
+/// retry is only a backstop for the brief window between the server logging
+/// "ready to accept connections" and the listener accepting on the mapped
+/// port. It is deliberately generous because the cost is paid only when the
+/// database is genuinely unreachable — the happy path returns on attempt 1.
+const DB_CONNECT_ATTEMPTS: u32 = 15;
+const DB_CONNECT_RETRY_DELAY: tokio::time::Duration = tokio::time::Duration::from_secs(2);
+
 async fn connect_with_retries(db_url: &str) -> anyhow::Result<DatabaseConnection> {
-    let mut retries = 5;
-    loop {
+    let mut last_err = None;
+    for attempt in 1..=DB_CONNECT_ATTEMPTS {
         match Database::connect(db_url).await {
             Ok(db) => return Ok(db),
-            Err(e) if retries > 0 => {
-                retries -= 1;
-                tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-                if retries == 0 {
-                    return Err(anyhow::Error::from(e));
-                }
+            Err(e) => {
+                println!(
+                    "Database connection attempt {attempt}/{DB_CONNECT_ATTEMPTS} failed ({e}), \
+                     retrying in {}s...",
+                    DB_CONNECT_RETRY_DELAY.as_secs()
+                );
+                last_err = Some(e);
+                tokio::time::sleep(DB_CONNECT_RETRY_DELAY).await;
             }
-            Err(e) => return Err(anyhow::Error::from(e)),
         }
     }
+    Err(anyhow::anyhow!(
+        "Failed to connect to database after {DB_CONNECT_ATTEMPTS} attempts: {}",
+        last_err.expect("at least one attempt was made")
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -1814,6 +1771,7 @@ async fn test_observe_correlation_migration_handles_compressed_proxy_logs() -> a
     }
 
     let container = GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_wait_for(postgres_ready_wait_for())
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -1830,12 +1788,12 @@ async fn test_observe_correlation_migration_handles_compressed_proxy_logs() -> a
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(CONTAINER_STARTUP_TIMEOUT)
         .start()
         .await
         .expect("Failed to start TimescaleDB container");
     let port = container.get_host_port_ipv4(5432).await?;
     let db_url = format!("postgresql://postgres:postgres@localhost:{}/postgres", port);
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
     let db = connect_with_retries(&db_url).await?;
 
     // ── 1. Apply every migration EXCEPT our target so we land on the same
@@ -2038,6 +1996,7 @@ async fn test_observe_correlation_migration_is_idempotent() -> anyhow::Result<()
     }
 
     let container = GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_wait_for(postgres_ready_wait_for())
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -2054,12 +2013,12 @@ async fn test_observe_correlation_migration_is_idempotent() -> anyhow::Result<()
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(CONTAINER_STARTUP_TIMEOUT)
         .start()
         .await
         .expect("Failed to start TimescaleDB container");
     let port = container.get_host_port_ipv4(5432).await?;
     let db_url = format!("postgresql://postgres:postgres@localhost:{}/postgres", port);
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
     let db = connect_with_retries(&db_url).await?;
 
     Migrator::up(&db, None).await?;
@@ -2104,6 +2063,7 @@ async fn test_observe_correlation_migration_survives_concurrent_retention() -> a
     }
 
     let container = GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_wait_for(postgres_ready_wait_for())
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -2120,12 +2080,12 @@ async fn test_observe_correlation_migration_survives_concurrent_retention() -> a
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(CONTAINER_STARTUP_TIMEOUT)
         .start()
         .await
         .expect("Failed to start TimescaleDB container");
     let port = container.get_host_port_ipv4(5432).await?;
     let db_url = format!("postgresql://postgres:postgres@localhost:{}/postgres", port);
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
     let db = connect_with_retries(&db_url).await?;
 
     // Bring schema up to but not including the target migration.
@@ -2286,6 +2246,7 @@ async fn test_mfa_pending_migration_revokes_ambiguous_sessions_and_defaults_clos
     }
 
     let container = match GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_wait_for(postgres_ready_wait_for())
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -2302,6 +2263,7 @@ async fn test_mfa_pending_migration_revokes_ambiguous_sessions_and_defaults_clos
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(CONTAINER_STARTUP_TIMEOUT)
         .start()
         .await
     {
@@ -2313,7 +2275,6 @@ async fn test_mfa_pending_migration_revokes_ambiguous_sessions_and_defaults_clos
     };
     let port = container.get_host_port_ipv4(5432).await?;
     let db_url = format!("postgresql://postgres:postgres@localhost:{port}/postgres");
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
     let db = connect_with_retries(&db_url).await?;
 
     let target = "m20260713_000001_add_mfa_pending_to_sessions";
@@ -2416,6 +2377,7 @@ async fn test_feature_flags_migration_is_reversible() -> anyhow::Result<()> {
     }
 
     let container = match GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_wait_for(postgres_ready_wait_for())
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -2425,6 +2387,7 @@ async fn test_feature_flags_migration_is_reversible() -> anyhow::Result<()> {
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(CONTAINER_STARTUP_TIMEOUT)
         .start()
         .await
     {
@@ -2437,7 +2400,6 @@ async fn test_feature_flags_migration_is_reversible() -> anyhow::Result<()> {
 
     let port = container.get_host_port_ipv4(5432).await?;
     let db_url = format!("postgresql://postgres:postgres@localhost:{port}/postgres");
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
     let db = connect_with_retries(&db_url).await?;
 
     Migrator::up(&db, None).await?;
@@ -2532,6 +2494,7 @@ async fn test_api_traffic_ai_and_model_catalog_migrations() -> anyhow::Result<()
     }
 
     let container = match GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_wait_for(postgres_ready_wait_for())
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -2541,6 +2504,7 @@ async fn test_api_traffic_ai_and_model_catalog_migrations() -> anyhow::Result<()
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(CONTAINER_STARTUP_TIMEOUT)
         .start()
         .await
     {
@@ -2553,7 +2517,6 @@ async fn test_api_traffic_ai_and_model_catalog_migrations() -> anyhow::Result<()
 
     let port = container.get_host_port_ipv4(5432).await?;
     let db_url = format!("postgresql://postgres:postgres@localhost:{port}/postgres");
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
     let db = connect_with_retries(&db_url).await?;
     Migrator::up(&db, None).await?;
 

--- a/crates/temps-migrations/tests/normalized_managed_domain_index_test.rs
+++ b/crates/temps-migrations/tests/normalized_managed_domain_index_test.rs
@@ -2,7 +2,7 @@ use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement, Transact
 use sea_orm_migration::{MigrationTrait, MigratorTrait, SchemaManager};
 use temps_migrations::Migrator;
 use temps_migrations::NormalizedManagedDomainIndexMigration;
-use testcontainers::{runners::AsyncRunner, GenericImage, ImageExt};
+use testcontainers::{core::WaitFor, runners::AsyncRunner, GenericImage, ImageExt};
 
 const INDEX_NAME: &str = "idx_dns_managed_domains_normalized_domain";
 
@@ -60,6 +60,13 @@ async fn test_normalized_managed_domain_index_migration_is_used_and_reversible(
     }
 
     let container = match GenericImage::new("timescale/timescaledb-ha", "pg18")
+        // Without this, `start()` returns before PostgreSQL accepts clients
+        // and the test races the database ("Connection reset by peer").
+        // Must match on stderr: the temporary initdb server logs its "ready"
+        // line to stdout, the real server to stderr.
+        .with_wait_for(WaitFor::message_on_stderr(
+            "database system is ready to accept connections",
+        ))
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -69,6 +76,7 @@ async fn test_normalized_managed_domain_index_migration_is_used_and_reversible(
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(std::time::Duration::from_secs(120))
         .start()
         .await
     {

--- a/crates/temps-migrations/tests/sandbox_workspace_lifecycle_test.rs
+++ b/crates/temps-migrations/tests/sandbox_workspace_lifecycle_test.rs
@@ -16,7 +16,7 @@
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement, TransactionTrait};
 use sea_orm_migration::{MigrationTrait, MigratorTrait, SchemaManager};
 use temps_migrations::{Migrator, SandboxWorkspaceLifecycleMigration};
-use testcontainers::{runners::AsyncRunner, GenericImage, ImageExt};
+use testcontainers::{core::WaitFor, runners::AsyncRunner, GenericImage, ImageExt};
 
 const LIFECYCLE_INDEX: &str = "idx_sandboxes_lifecycle";
 const PROJECT_INDEX: &str = "idx_sandboxes_project_id";
@@ -78,6 +78,13 @@ async fn test_sandbox_workspace_lifecycle_migration_defaults_indexes_and_reverse
     }
 
     let container = match GenericImage::new("timescale/timescaledb-ha", "pg18")
+        // Without this, `start()` returns before PostgreSQL accepts clients
+        // and the test races the database ("Connection reset by peer").
+        // Must match on stderr: the temporary initdb server logs its "ready"
+        // line to stdout, the real server to stderr.
+        .with_wait_for(WaitFor::message_on_stderr(
+            "database system is ready to accept connections",
+        ))
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
@@ -87,6 +94,7 @@ async fn test_sandbox_workspace_lifecycle_migration_defaults_indexes_and_reverse
             "-c",
             "timescaledb.max_background_workers=0",
         ])
+        .with_startup_timeout(std::time::Duration::from_secs(120))
         .start()
         .await
     {

--- a/crates/temps-network/tests/it_allocator.rs
+++ b/crates/temps-network/tests/it_allocator.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use temps_entities::nodes;
 use temps_migrations::Migrator;
 use temps_network::allocator::{AllocatorError, ComputeNetworkAllocator, PostgresAllocator};
-use testcontainers::{runners::AsyncRunner, GenericImage, ImageExt};
+use testcontainers::{core::WaitFor, runners::AsyncRunner, GenericImage, ImageExt};
 
 // ---------------------------------------------------------------------------
 // Fixture
@@ -37,10 +37,18 @@ async fn fixture() -> Option<Fixture> {
         return None;
     }
     let container = match GenericImage::new("timescale/timescaledb-ha", "pg18")
+        // Without this, `start()` returns before PostgreSQL accepts clients
+        // and the test races the database ("Connection reset by peer").
+        // Must match on stderr: the temporary initdb server logs its "ready"
+        // line to stdout, the real server to stderr.
+        .with_wait_for(WaitFor::message_on_stderr(
+            "database system is ready to accept connections",
+        ))
         .with_env_var("POSTGRES_DB", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_PASSWORD", "postgres")
         .with_env_var("POSTGRES_HOST_AUTH_METHOD", "trust")
+        .with_startup_timeout(std::time::Duration::from_secs(120))
         .start()
         .await
     {

--- a/crates/temps-providers/src/externalsvc/mongodb.rs
+++ b/crates/temps-providers/src/externalsvc/mongodb.rs
@@ -776,16 +776,72 @@ impl MongodbService {
         }
     }
 
+    /// Render a container's health state as a one-line, log-safe diagnostic.
+    ///
+    /// The MongoDB healthcheck embeds the root password in its command line, so
+    /// anything derived from it is treated as credential-bearing: only the
+    /// healthcheck's captured `output` is surfaced (never the command itself),
+    /// it is truncated, and newlines are flattened so a multi-line mongosh
+    /// stack trace cannot smear across the log.
+    fn describe_container_health(state: &bollard::models::ContainerState) -> String {
+        const MAX_OUTPUT: usize = 400;
+
+        let status = state
+            .health
+            .as_ref()
+            .and_then(|h| h.status.as_ref())
+            .map(|s| format!("{:?}", s))
+            .unwrap_or_else(|| "<no healthcheck reported>".to_string());
+
+        let streak = state
+            .health
+            .as_ref()
+            .and_then(|h| h.failing_streak)
+            .unwrap_or(0);
+
+        let last_output = state
+            .health
+            .as_ref()
+            .and_then(|h| h.log.as_ref())
+            .and_then(|log| log.last())
+            .and_then(|entry| entry.output.as_ref())
+            .map(|out| {
+                let flattened = out.split_whitespace().collect::<Vec<_>>().join(" ");
+                if flattened.chars().count() > MAX_OUTPUT {
+                    let truncated: String = flattened.chars().take(MAX_OUTPUT).collect();
+                    format!("{truncated}... (truncated)")
+                } else {
+                    flattened
+                }
+            })
+            .unwrap_or_else(|| "<no healthcheck output captured>".to_string());
+
+        format!(
+            "status={status}, container_status={:?}, failing_streak={streak}, last_probe_output=\"{last_output}\"",
+            state.status
+        )
+    }
+
     async fn wait_for_container_health(&self, docker: &Docker, container_id: &str) -> Result<()> {
         let mut delay = Duration::from_millis(500);
         let mut total_wait = Duration::from_secs(0);
         let max_wait = Duration::from_secs(90);
         let max_delay = Duration::from_secs(2);
+        // Captured on every poll so the timeout error below can explain WHY the
+        // container never became healthy. Without this the operator (and CI)
+        // only ever sees "health check timed out", which is unactionable —
+        // the healthcheck's own stderr is the one thing that identifies
+        // whether MongoDB is still initialising, rejecting the credentials, or
+        // missing `mongosh` entirely.
+        let mut last_health_diagnostic = String::from("no health status was ever reported");
 
         while total_wait < max_wait {
             let info = docker
                 .inspect_container(container_id, None::<InspectContainerOptions>)
                 .await?;
+            if let Some(ref state) = info.state {
+                last_health_diagnostic = Self::describe_container_health(state);
+            }
             if let Some(state) = info.state {
                 // Considered ready if it's running and either has a HEALTHY
                 // Docker healthcheck status or no healthcheck is defined at
@@ -817,7 +873,11 @@ impl MongodbService {
             delay = std::cmp::min(delay.mul_f32(1.5), max_delay);
         }
 
-        Err(anyhow::anyhow!("MongoDB container health check timed out"))
+        Err(anyhow::anyhow!(
+            "MongoDB container health check timed out after {}s. Last health status: {}",
+            max_wait.as_secs(),
+            last_health_diagnostic
+        ))
     }
 
     async fn get_mongo_client(&self) -> Result<MongoClient> {

--- a/crates/temps-screenshots/src/local_provider.rs
+++ b/crates/temps-screenshots/src/local_provider.rs
@@ -238,6 +238,30 @@ mod tests {
     // browser so only one Chrome instance starts up at a time.
     static CHROME_LAUNCH_LOCK: LazyLock<AsyncMutex<()>> = LazyLock::new(|| AsyncMutex::new(()));
 
+    /// Returns `false` (and prints why) when this machine cannot launch Chrome
+    /// at all, so a browser-dependent test can skip instead of failing.
+    ///
+    /// `headless_chrome`'s `fetch` feature downloads a Chrome build on first
+    /// use when no local Chrome is installed. On CI that download is an
+    /// unauthenticated request to a third-party host and intermittently comes
+    /// back `403`, which surfaced as
+    /// `Failed to launch browser: http status: 403` and failed the whole unit
+    /// test job. Chrome being unavailable is an environment fact, not a
+    /// regression in this crate — the same reason Docker-dependent tests in
+    /// this repository skip gracefully rather than being marked `#[ignore]`.
+    ///
+    /// This deliberately only tolerates *launch* failures. Once a browser
+    /// starts, every capture assertion below is still enforced.
+    async fn chrome_available(provider: &LocalScreenshotProvider) -> bool {
+        match provider.check_availability().await {
+            Ok(()) => true,
+            Err(e) => {
+                println!("Chrome browser not available, skipping test: {e}");
+                false
+            }
+        }
+    }
+
     #[tokio::test]
     async fn test_local_provider_creation() {
         let provider = LocalScreenshotProvider::new();
@@ -271,6 +295,9 @@ mod tests {
 
         let _guard = CHROME_LAUNCH_LOCK.lock().await;
         let provider = LocalScreenshotProvider::new();
+        if !chrome_available(&provider).await {
+            return;
+        }
         let result = provider.capture_screenshot("https://example.com").await;
 
         match result {
@@ -302,6 +329,9 @@ mod tests {
 
         let _guard = CHROME_LAUNCH_LOCK.lock().await;
         let provider = LocalScreenshotProvider::with_config(30, 1920, 1080);
+        if !chrome_available(&provider).await {
+            return;
+        }
         let result = provider.capture_screenshot("https://github.com").await;
 
         match result {
@@ -337,6 +367,9 @@ mod tests {
         let _guard = CHROME_LAUNCH_LOCK.lock().await;
         // Test with mobile viewport dimensions
         let provider = LocalScreenshotProvider::with_config(30, 375, 812); // iPhone X dimensions
+        if !chrome_available(&provider).await {
+            return;
+        }
         let result = provider.capture_screenshot("https://example.com").await;
 
         match result {


### PR DESCRIPTION
## Problem

Several CI jobs fail intermittently across open PRs. Triaging the actual logs (not the symptoms) turned up **one dominant root cause** plus two smaller ones.

Observed failures across recent runs:

| Job | Failing test | Error |
|---|---|---|
| Integration Tests (migrations) — PR #753 | `test_migration_up` | `Connection reset by peer (os error 104)` |
| Unit Tests (unit-b) — **main**, PR #751 | `test_empty_results_for_invalid_project` | `Connection reset by peer (os error 104)` |
| Integration Tests (docker-providers) — PR #749 | `docker_dump_restore_v16_to_v17` | `FATAL: the database system is starting up` |
| Unit Tests (unit-b) — PR #751 | `test_capture_screenshot_example_com` | `Failed to launch browser: http status: 403` |
| Scenario E2E (recovery) — PR #750, #562 | mongodb-restore-scenario | `MongoDB container health check timed out` |

## Root cause 1 — Postgres testcontainers had no readiness gate

Every flaky Postgres-backed test started its container with **no wait strategy at all**, then guessed at readiness with `sleep(3)` + five 2s connect retries. `start()` returns as soon as the container is *running*, which is long before PostgreSQL can serve clients — so on loaded runners the guess lost the race.

17 container starts in `migration_tests.rs`, zero wait strategies. Same in 4 other test files.

The fix is a real readiness condition. The subtlety is **which stream**: the `timescaledb-ha` entrypoint boots a temporary server for initdb, stops it, then starts the real one, and each logs `database system is ready to accept connections` once. I verified against `timescale/timescaledb-ha:pg18`:

- **stdout** → `[40] LOG:` (temporary initdb server)
- **stderr** → `[1] LOG:` (real server)

So `message_on_stderr` already targets the real server. This matters because the rationale previously recorded in `temps-database/src/test_utils.rs` claimed the opposite — that stderr matched the *temp* server and needed a trailing buffer sleep. That comment is what propagated the guess-and-sleep pattern; it is corrected here. It also rules out the tempting "wait for 2 occurrences" fix, which would hang forever.

The retained connect retry is now an explicit backstop, not the primary mechanism.

## Root cause 2 — Chrome download is a network dependency

`headless_chrome`'s `fetch` feature downloads Chrome on first use; on CI that unauthenticated request intermittently 403s. The three browser tests now skip via the provider's existing `check_availability()`, matching this repo's Docker-test convention (skip gracefully, never `#[ignore]`). Only *launch* failures are tolerated — every capture assertion still runs once a browser starts.

## Root cause 3 — MongoDB health timeout was undiagnosable

I could not fix this one honestly, so I made it fixable next time. `wait_for_container_health` polls for 90s and **discards the health state each iteration**, so the error is a bare "timed out" while `docker ps` shows `Up About a minute (unhealthy)`. The timeout now reports status, failing streak and last probe output.

**No timeout value was changed** — 90s is already the house norm across the Postgres/Redis/S3 providers, so raising it would be a guess.

The probe output is treated as credential-bearing (the healthcheck command embeds the root password): only captured output is surfaced, never the command; newlines flattened; truncated to 400 chars.

## What I checked and ruled out

The initial hypothesis was a connection/container leak. The evidence says otherwise:

- **No connection exhaustion** — zero `too many clients` / `remaining connection slots` in any failing run's Postgres log.
- **No container leak** — at the point of the MongoDB failure the runner held only the fixtures plus the one new container; the three preceding restore scenarios had torn down cleanly.
- The `out of background workers` warnings are TimescaleDB's job scheduler, not connections. Silenced in the analytics fixture by disabling the background-worker launcher (already done elsewhere in the workspace).

## Evidence

```
$ cargo test --test migration_tests
17 passed (1 suite, 16.84s)          # was ~75s in CI, and flaky

$ cargo test --lib -p temps-analytics test_empty_results_for_invalid_project
1 passed (3.05s)                     # previously red on main

$ cargo test --lib -p temps-screenshots
19 passed (12.86s)

$ cargo test --test normalized_managed_domain_index_test --test sandbox_workspace_lifecycle_test
2 passed (2 suites, 11.73s)

$ cargo clippy -p temps-providers -p temps-analytics -p temps-screenshots -p temps-database \
    --all-targets -- -D warnings
Finished — no warnings
```

Removing the 17 redundant `sleep(3)` calls also cuts ~51s of pure sleep from the migration suite.

## Not fixed (deliberately)

- **`Scenarios (edge)` — `Rate limit exceeded`** on the git-deploy scenario. Root cause found: the public-repo path uses unauthenticated GitHub API calls (by design — it must not borrow a credential and become a private-repo oracle), and GitHub-hosted runners share the anonymous 60 req/hour quota. The workflow sets `GITHUB_TOKEN` on the `setup` step, not on the `serve` step that actually makes the call — but even fixing that wouldn't help, since this path deliberately refuses stored credentials. This needs a design decision, not a retry, so I left it alone.
- **`dns_registry_test::unique_index_rejects_duplicate_fqdn_type_ip_across_owners`** fails on `origin/main` too (verified by stashing my changes and re-running). Pre-existing, unrelated to readiness, out of scope here.
- The `Check sign-off` failures on #741/#746/#747/#750 are missing DCO sign-offs, not flakes.