### PR TITLE
fix(proxy): scope the traffic aggregation window cap to unique counts

### DIFF
--- a/crates/temps-proxy/src/handler/proxy_logs.rs
+++ b/crates/temps-proxy/src/handler/proxy_logs.rs
@@ -47,6 +47,13 @@ impl From<ProxyLogServiceError> for Problem {
                     .with_title("Traffic Aggregation Timed Out")
                     .with_detail(error.to_string())
             }
+            // The caller can fix this by asking for less, so it is a 400 with
+            // the remedy spelled out — not a 500 the user can only stare at.
+            ProxyLogServiceError::TrafficAggregationTooManyGroups { .. } => {
+                problemdetails::new(StatusCode::BAD_REQUEST)
+                    .with_title("Traffic Aggregation Too Large")
+                    .with_detail(error.to_string())
+            }
             // The ClickHouse error's `reason` is the stringified client error,
             // which can embed the internal endpoint host or schema fragments —
             // don't reflect it to the caller. Log the full detail and surface

--- a/crates/temps-proxy/src/service/proxy_log_service.rs
+++ b/crates/temps-proxy/src/service/proxy_log_service.rs
@@ -26,6 +26,23 @@ pub enum ProxyLogServiceError {
     #[error("Traffic aggregation exceeded its {timeout_seconds}-second execution deadline")]
     TrafficAggregationTimeout { timeout_seconds: u64 },
 
+    /// The grouping produced more distinct groups than the storage backend will
+    /// aggregate (ClickHouse `max_rows_to_group_by` with
+    /// `group_by_overflow_mode = throw`).
+    ///
+    /// This is the ceiling that the old blanket 7-day cap on high-cardinality
+    /// dimensions was standing in for. Reporting it directly is strictly better:
+    /// it fires only for the projects that actually exceed the limit, and it can
+    /// say what to change. Grouping by raw `path` is the usual trigger, since
+    /// paths are not template-normalized and `/users/1` and `/users/2` count as
+    /// two groups.
+    #[error(
+        "Traffic aggregation grouped by {dimensions} produced more than {max_groups} \
+         distinct groups over this time range. Narrow the range, add a filter, or \
+         group by fewer dimensions."
+    )]
+    TrafficAggregationTooManyGroups { dimensions: String, max_groups: u64 },
+
     /// A ClickHouse operation failed. `operation` names the storage method
     /// (e.g. `list_with_filters`, `write_batch`) so logs/responses can identify
     /// exactly which read/write path hit the backend error. Not a `#[from]` of

--- a/crates/temps-proxy/src/storage/clickhouse.rs
+++ b/crates/temps-proxy/src/storage/clickhouse.rs
@@ -1026,7 +1026,7 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
             .client
             .clone()
             .with_setting("max_execution_time", "15")
-            .with_setting("max_rows_to_group_by", "100000")
+            .with_setting("max_rows_to_group_by", CH_MAX_ROWS_TO_GROUP_BY.to_string())
             .with_setting("group_by_overflow_mode", "throw")
             .with_setting("max_bytes_before_external_group_by", "67108864")
             // Four concurrent endpoint queries therefore reserve at most
@@ -1035,10 +1035,7 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
         let rows = apply_binds(query_client.query(&sql), binds)
             .fetch_all::<ChTrafficAggregationRow>()
             .await
-            .map_err(|error| ProxyLogServiceError::ClickHouse {
-                operation: "aggregate_traffic".to_string(),
-                reason: error.to_string(),
-            })?;
+            .map_err(|error| classify_traffic_query_error(&request, error))?;
         let empty_page_total = if rows.is_empty() {
             Some(
                 apply_binds(query_client.query(&count_sql), count_binds)
@@ -2182,6 +2179,44 @@ fn build_traffic_query(
         )
     };
     Ok((sql, binds, count_sql))
+}
+
+/// Group-count ceiling applied to every traffic aggregation. Kept next to the
+/// classifier so the number reported to the caller cannot drift from the number
+/// actually enforced in [`ClickHouseProxyLogStorage::aggregate_traffic`].
+const CH_MAX_ROWS_TO_GROUP_BY: u64 = 100_000;
+
+/// Turn a ClickHouse failure into the most specific error we can justify.
+///
+/// A `GROUP BY` overflow is the caller asking for too much, not the server
+/// breaking — the difference decides whether the user gets a 400 naming the
+/// dimensions to drop or a 500 saying "Storage error". ClickHouse signals it as
+/// `TOO_MANY_ROWS` (code 158) under `group_by_overflow_mode = throw`; match on
+/// the code and the name, since the client stringifies these differently across
+/// versions.
+fn classify_traffic_query_error(
+    request: &TrafficAggregationRequest,
+    error: clickhouse::error::Error,
+) -> ProxyLogServiceError {
+    let reason = error.to_string();
+    let overflowed = reason.contains("TOO_MANY_ROWS")
+        || reason.contains("Code: 158")
+        || reason.contains("max_rows_to_group_by");
+    if overflowed && !request.dimensions.is_empty() {
+        return ProxyLogServiceError::TrafficAggregationTooManyGroups {
+            dimensions: request
+                .dimensions
+                .iter()
+                .map(|dimension| dimension.api_name())
+                .collect::<Vec<_>>()
+                .join(" + "),
+            max_groups: CH_MAX_ROWS_TO_GROUP_BY,
+        };
+    }
+    ProxyLogServiceError::ClickHouse {
+        operation: "aggregate_traffic".to_string(),
+        reason,
+    }
 }
 
 fn ch_count(value: Option<u64>, metric: &str) -> Result<Option<i64>, ProxyLogServiceError> {

--- a/crates/temps-proxy/src/traffic_aggregation.rs
+++ b/crates/temps-proxy/src/traffic_aggregation.rs
@@ -10,6 +10,19 @@ use utoipa::ToSchema;
 
 use crate::service::proxy_log_service::ProxyLogServiceError;
 
+/// Widest window any traffic aggregation will serve. Matches
+/// [`temps_core::time_window::MAX_WINDOW_DAYS_SCOPED`] — every aggregation is
+/// project-scoped, so it earns the project-scoped cap.
+pub const MAX_TRAFFIC_WINDOW_DAYS: i64 = temps_core::time_window::MAX_WINDOW_DAYS_SCOPED;
+
+/// Widest window an aggregation requesting an exact distinct count will serve.
+///
+/// `unique_ips`/`unique_paths` compile to `uniqExact` on ClickHouse and
+/// `COUNT(DISTINCT …)` on TimescaleDB. Both materialize the distinct set per
+/// group, so their memory is a function of how many distinct values fall in the
+/// window — something neither pagination nor the group-count ceiling bounds.
+pub const MAX_UNIQUE_COUNT_WINDOW_DAYS: i64 = 7;
+
 pub const MAX_TRAFFIC_DIMENSIONS: usize = 4;
 pub const MAX_TRAFFIC_METRICS: usize = 14;
 pub const MAX_TRAFFIC_FILTERS: usize = 12;
@@ -219,28 +232,42 @@ impl TrafficAggregationRequest {
         if self.start_time >= self.end_time {
             return Err(invalid("start_time must be before end_time"));
         }
-        if self.end_time - self.start_time > chrono::Duration::days(30) {
-            return Err(invalid("traffic aggregation windows cannot exceed 30 days"));
-        }
         let span = self.end_time - self.start_time;
-        let has_high_cardinality_dimension = self.dimensions.iter().any(|dimension| {
-            matches!(
-                dimension,
-                TrafficDimension::ClientIp | TrafficDimension::Path | TrafficDimension::Host
-            )
-        });
-        let has_high_cardinality_metric = self.metrics.iter().any(|metric| {
-            matches!(
-                metric,
-                TrafficMetric::UniqueIps | TrafficMetric::UniquePaths
-            )
-        });
-        if (has_high_cardinality_dimension || has_high_cardinality_metric)
-            && span > chrono::Duration::days(7)
-        {
-            return Err(invalid(
-                "traffic aggregations using high-cardinality dimensions or unique counts cannot exceed 7 days",
-            ));
+        if span > chrono::Duration::days(MAX_TRAFFIC_WINDOW_DAYS) {
+            return Err(invalid(format!(
+                "traffic aggregation windows cannot exceed {MAX_TRAFFIC_WINDOW_DAYS} days"
+            )));
+        }
+        // Grouping by a high-cardinality dimension used to be capped at 7 days
+        // alongside the unique counts. It no longer is: every aggregation here
+        // is project-scoped, and `temps_core::time_window` already establishes
+        // 30 days as the sanctioned cap for a project-scoped read precisely
+        // because such a query is bounded by ONE project's volume rather than
+        // the deployment's. What the cap really protected against is GROUP BY
+        // cardinality, which the storage layer bounds directly (ClickHouse
+        // `max_rows_to_group_by`, Postgres `statement_timeout`) and reports as
+        // an actionable error — a far better fit than a blanket time rule that
+        // also rejected the small projects it was never meant to limit.
+        //
+        // The unique counts keep the tighter cap. `uniqExact`/`COUNT(DISTINCT)`
+        // build a real per-group set, so their cost scales with the DISTINCT
+        // count inside the window rather than with the number of groups
+        // returned, and pagination cannot bound it.
+        if span > chrono::Duration::days(MAX_UNIQUE_COUNT_WINDOW_DAYS) {
+            let unique_metric = self.metrics.iter().copied().find(|metric| {
+                matches!(
+                    metric,
+                    TrafficMetric::UniqueIps | TrafficMetric::UniquePaths
+                )
+            });
+            if let Some(metric) = unique_metric {
+                return Err(invalid(format!(
+                    "metric '{}' counts distinct values and cannot span more than \
+                     {MAX_UNIQUE_COUNT_WINDOW_DAYS} days. Narrow the time range, or \
+                     drop that metric to query up to {MAX_TRAFFIC_WINDOW_DAYS} days.",
+                    metric.api_name()
+                )));
+            }
         }
         if self.dimensions.len() >= 3 && span > chrono::Duration::days(1) {
             return Err(invalid(
@@ -439,24 +466,49 @@ mod tests {
     }
 
     #[test]
-    fn bounds_high_cardinality_windows_and_page_offsets() {
-        let mut high_cardinality = request();
-        high_cardinality.start_time = high_cardinality.end_time - chrono::Duration::days(8);
-        assert!(matches!(
-            high_cardinality.validate(),
-            Err(ProxyLogServiceError::InvalidFilter(message))
-                if message.contains("cannot exceed 7 days")
-        ));
+    fn allows_high_cardinality_dimensions_up_to_the_project_scoped_cap() {
+        // `path` + `client_ip` for a month is what the API Traffic tab asks for
+        // when the user picks "Last 30 Days". It is project-scoped, so it gets
+        // the project-scoped cap rather than the old 7-day one.
+        let mut month = request();
+        month.dimensions = vec![TrafficDimension::ClientIp, TrafficDimension::Path];
+        month.metrics = vec![TrafficMetric::Requests];
+        month.order_by = vec![TrafficOrderBy {
+            field: TrafficOrderField::Metric(TrafficMetric::Requests),
+            direction: TrafficSortDirection::Desc,
+        }];
+        month.start_time = month.end_time - chrono::Duration::days(30);
+        assert!(month.validate().is_ok());
 
+        let mut too_wide = month.clone();
+        too_wide.start_time = too_wide.end_time - chrono::Duration::days(31);
+        assert!(matches!(
+            too_wide.validate(),
+            Err(ProxyLogServiceError::InvalidFilter(message))
+                if message.contains("cannot exceed 30 days")
+        ));
+    }
+
+    #[test]
+    fn bounds_unique_count_windows_and_page_offsets() {
+        // The distinct counts keep the tighter cap regardless of grouping, and
+        // the message must name the offending metric so the client knows which
+        // one to drop.
         let mut unique_rollup = request();
         unique_rollup.dimensions.clear();
         unique_rollup.metrics = vec![TrafficMetric::UniqueIps];
-        unique_rollup.start_time = unique_rollup.end_time - chrono::Duration::days(30);
+        unique_rollup.order_by.clear();
+        unique_rollup.start_time = unique_rollup.end_time - chrono::Duration::days(8);
         assert!(matches!(
             unique_rollup.validate(),
             Err(ProxyLogServiceError::InvalidFilter(message))
-                if message.contains("cannot exceed 7 days")
+                if message.contains("unique_ips") && message.contains("more than 7 days")
         ));
+
+        // Same window, same grouping, minus the distinct count: allowed.
+        let mut without_unique = unique_rollup.clone();
+        without_unique.metrics = vec![TrafficMetric::Requests];
+        assert!(without_unique.validate().is_ok());
 
         let mut three_dimensions = request();
         three_dimensions.dimensions.push(TrafficDimension::Method);

--- a/web/src/components/analytics/ApiTraffic.tsx
+++ b/web/src/components/analytics/ApiTraffic.tsx
@@ -114,6 +114,44 @@ function trafficDimension(row: TrafficAggregationRow, name: string): string {
   return row.dimensions.find((item) => item.dimension === name)?.value ?? '—'
 }
 
+/// The aggregation endpoint rejects requests the client can legitimately build
+/// — a window wider than the cap for the requested dimensions/metrics is the
+/// common one — and answers with RFC 7807 Problem Details. `JSON.stringify`ing
+/// that into a bare `Error` threw away the one field that tells the user what
+/// to change, so the card could only say "refresh to try again" for a failure
+/// no refresh will ever fix. Keep the status and the server's own wording.
+class TrafficQueryError extends Error {
+  readonly status?: number
+  readonly title?: string
+  readonly detail?: string
+
+  constructor(args: { status?: number; title?: string; detail?: string }) {
+    super(args.detail ?? args.title ?? 'Traffic aggregation request failed')
+    this.name = 'TrafficQueryError'
+    this.status = args.status
+    this.title = args.title
+    this.detail = args.detail
+  }
+
+  /// 4xx means the request itself is wrong. Retrying re-sends the same body.
+  get isClientError(): boolean {
+    return this.status !== undefined && this.status >= 400 && this.status < 500
+  }
+}
+
+function toTrafficQueryError(error: unknown, status?: number) {
+  const problem = (error ?? {}) as {
+    status?: number
+    title?: string
+    detail?: string
+  }
+  return new TrafficQueryError({
+    status: problem.status ?? status,
+    title: problem.title,
+    detail: problem.detail,
+  })
+}
+
 async function queryTraffic(
   projectId: number,
   body: TrafficAggregationRequest
@@ -124,7 +162,7 @@ async function queryTraffic(
       body: requestBody,
     })
 
-  let { data, error } = await request(body)
+  let { data, error, response } = await request(body)
 
   // A console can be upgraded before its proxy/analytics process during a
   // rolling deployment. Older backends do not know the crawler metrics added
@@ -139,11 +177,18 @@ async function queryTraffic(
           metric !== 'bot_requests' && metric !== 'robots_txt_requests'
       ),
     }
-    ;({ data, error } = await request(compatibleBody))
+    ;({ data, error, response } = await request(compatibleBody))
   }
 
-  if (error || !data) throw new Error(JSON.stringify(error ?? 'No response'))
+  if (error || !data) throw toTrafficQueryError(error, response?.status)
   return data
+}
+
+/// React Query retries by default. A validation rejection is deterministic, so
+/// retrying only delays the message the user needs by several seconds.
+function retryUnlessClientError(failureCount: number, error: unknown): boolean {
+  if (error instanceof TrafficQueryError && error.isClientError) return false
+  return failureCount < 3
 }
 
 const API_TRAFFIC_SUMMARY_SCHEMA = {
@@ -353,7 +398,10 @@ export function ApiTrafficTab({ project }: ApiTrafficTabProps) {
           'latency_min',
           'latency_max',
           'latency_p95',
-          'unique_ips',
+          // No `unique_ips` here: nothing renders it and it cannot be a sort
+          // key, but asking for it capped this card at a 7-day window because
+          // exact distinct counts are the one aggregate whose cost pagination
+          // can't bound. Dropping it is what lets "Last 30 Days" work.
           'bot_requests',
           'robots_txt_requests',
           'last_seen',
@@ -370,6 +418,7 @@ export function ApiTrafficTab({ project }: ApiTrafficTabProps) {
         page_size: pageSize,
       }),
     enabled,
+    retry: retryUnlessClientError,
   })
 
   const callersQuery = useQuery({
@@ -398,7 +447,7 @@ export function ApiTrafficTab({ project }: ApiTrafficTabProps) {
           'latency_min',
           'latency_max',
           'latency_p95',
-          'unique_paths',
+          // Dropped for the same reason as `unique_ips` on the routes card.
           'bot_requests',
           'robots_txt_requests',
           'last_seen',
@@ -415,6 +464,7 @@ export function ApiTrafficTab({ project }: ApiTrafficTabProps) {
         page_size: pageSize,
       }),
     enabled,
+    retry: retryUnlessClientError,
   })
 
   const detailQuery = useQuery({
@@ -473,6 +523,7 @@ export function ApiTrafficTab({ project }: ApiTrafficTabProps) {
       })
     },
     enabled: enabled && detail !== null,
+    retry: retryUnlessClientError,
   })
 
   // Stable first-page context for the summary. These legacy response shapes
@@ -895,7 +946,10 @@ export function ApiTrafficTab({ project }: ApiTrafficTabProps) {
             {routesQuery.isPending ? (
               <Skeleton className="h-[240px] w-full" />
             ) : routesQuery.isError ? (
-              <QueryErrorState label="route data" />
+              <QueryErrorState
+                label="route data"
+                error={routesQuery.error}
+              />
             ) : (routesQuery.data?.rows.length ?? 0) === 0 ? (
               <p className="text-sm text-muted-foreground">
                 No API traffic for this period.
@@ -1010,7 +1064,10 @@ export function ApiTrafficTab({ project }: ApiTrafficTabProps) {
             {callersQuery.isPending ? (
               <Skeleton className="h-[240px] w-full" />
             ) : callersQuery.isError ? (
-              <QueryErrorState label="caller data" />
+              <QueryErrorState
+                label="caller data"
+                error={callersQuery.error}
+              />
             ) : (callersQuery.data?.rows.length ?? 0) === 0 ? (
               <p className="text-sm text-muted-foreground">
                 No API traffic for this period.
@@ -1096,6 +1153,7 @@ export function ApiTrafficTab({ project }: ApiTrafficTabProps) {
         data={detailQuery.data}
         isPending={detailQuery.isPending}
         isError={detailQuery.isError}
+        error={detailQuery.error}
         page={detailPage}
         pageSize={pageSize}
         sort={detailSort}
@@ -1160,6 +1218,7 @@ function TrafficDetailSheet({
   data,
   isPending,
   isError,
+  error,
   page,
   pageSize,
   sort,
@@ -1177,6 +1236,7 @@ function TrafficDetailSheet({
   data: TrafficAggregationResponse | undefined
   isPending: boolean
   isError: boolean
+  error?: unknown
   page: number
   pageSize: number
   sort: TrafficSort<TrafficMetric>
@@ -1208,7 +1268,7 @@ function TrafficDetailSheet({
           {isPending ? (
             <Skeleton className="h-[360px] w-full" />
           ) : isError ? (
-            <QueryErrorState label="traffic detail" />
+            <QueryErrorState label="traffic detail" error={error} />
           ) : (data?.rows.length ?? 0) === 0 ? (
             <>
               <p className="text-sm text-muted-foreground">
@@ -1515,10 +1575,30 @@ function StatTile({
   )
 }
 
-function QueryErrorState({ label }: { label: string }) {
+function QueryErrorState({
+  label,
+  error,
+}: {
+  label: string
+  error?: unknown
+}) {
+  const problem = error instanceof TrafficQueryError ? error : undefined
+  // A rejected request states its own reason far better than a generic
+  // fallback can — the server knows which cap was exceeded and by what.
+  const detail = problem?.detail
+  const isClientError = problem?.isClientError ?? false
+
   return (
-    <div className="rounded-md border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
-      Could not load {label}. Refresh to try again.
+    <div className="space-y-1 rounded-md border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+      <p className="font-medium">
+        {problem?.title ?? `Could not load ${label}.`}
+      </p>
+      {detail ? <p className="text-destructive/90">{detail}</p> : null}
+      <p className="text-destructive/80">
+        {isClientError
+          ? 'Adjust the time range or filters above — retrying the same request will fail again.'
+          : `Could not load ${label}. Refresh to try again.`}
+      </p>
     </div>
   )
 }


### PR DESCRIPTION
## Problem

Selecting **Last 30 Days** on a project's API Traffic tab makes the *Top routes* and *Top callers* cards fail:

```json
{
  "detail": "Invalid filter parameters: traffic aggregations using high-cardinality dimensions or unique counts cannot exceed 7 days",
  "title": "Invalid Filter Parameters"
}
```

Both cards group by a high-cardinality dimension (`path`, `client_ip`), which `TrafficAggregationRequest::validate` capped at 7 days regardless of scope — while the tab's date picker offers 30 days and arbitrary custom ranges. The UI offered a range the backend contract forbade, with no client-side awareness of the cap.

## Why the cap was wrong for dimensions

Every traffic aggregation is **project-scoped**, and `temps_core::time_window` already establishes 30 days (`MAX_WINDOW_DAYS_SCOPED`) as the sanctioned cap for a project-scoped read — precisely because such a query is bounded by one project's volume rather than the whole deployment's. The 7-day measurements that motivated the tighter cap are for *unscoped* reads.

What the rule actually protected against is **GROUP BY cardinality**, which the storage layer already bounds directly (ClickHouse `max_rows_to_group_by`, Postgres `statement_timeout`). Expressing that as a blanket time rule also rejected the small projects it was never meant to limit.

## Changes

- **Dimensions get the project-scoped 30-day cap.** New `MAX_TRAFFIC_WINDOW_DAYS`, aliased to `MAX_WINDOW_DAYS_SCOPED` so the two cannot drift.
- **Unique counts keep the 7-day cap** (`MAX_UNIQUE_COUNT_WINDOW_DAYS`). `uniqExact` / `COUNT(DISTINCT …)` materialize a real per-group set, so cost scales with the distinct count in the window — something neither pagination nor the group-count ceiling bounds. The rejection now **names the offending metric** and states that dropping it buys 30 days.
- **The real ceiling reports itself.** Removing the dimension rule without this would trade a clean 400 for an opaque 500, so ClickHouse `GROUP BY` overflow (`TOO_MANY_ROWS` / code 158) now maps to a new `TrafficAggregationTooManyGroups` → **400** naming the dimensions to drop. The `100000` limit is a shared const, so the number enforced and the number reported can't diverge.
- **Dropped `unique_ips`/`unique_paths` from the two card requests.** Nothing rendered them and they aren't in the `TrafficMetric` union, so they couldn't be sort keys either — pure dead weight that was single-handedly costing both cards their 30-day range.
- **Cards surface Problem Details.** The client stringified the error into a bare `Error`, so a validation failure could only say *"refresh to try again"* — advice that never works — after React Query silently retried the rejected body three times behind a skeleton. Now the card shows the server's title and detail, and 4xx no longer retries.

## Evidence

```
$ cargo test --lib -p temps-proxy
538 passed, 4 ignored

$ cargo clippy -p temps-proxy --all-targets -- -D warnings
Finished `dev` profile — clean

$ cd web && bun run tsc --noEmit -p tsconfig.json
(clean)

$ cd web && bun test src/components/analytics/ApiTraffic.test.ts
15 pass, 0 fail
```

New/updated unit tests in `traffic_aggregation.rs`:

- `allows_high_cardinality_dimensions_up_to_the_project_scoped_cap` — `client_ip + path` over **30 days** now validates; 31 days is rejected naming the 30-day cap.
- `bounds_unique_count_windows_and_page_offsets` — an 8-day window requesting `unique_ips` is rejected with a message containing `unique_ips`; the identical query without that metric passes.

**Not yet browser-verified.** The 30-day path is proven at the unit level only — I have not exercised the tab end-to-end against a running server. Worth a manual pass before merge.

## Follow-up (deliberately out of scope)

A very busy project grouping by raw `path` over 30 days can still hit the 100k group ceiling — it now says so clearly instead of 500ing. Raising that ceiling means **template-normalizing paths** before grouping (today `/users/1` and `/users/2` are two groups; the card's own description admits this). Swapping `uniqExact` → `uniq` (HLL) would similarly cheapen the distinct counts if the 7-day cap ever needs lifting.