### PR TITLE
chore: bump version to v0.1.0-beta.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,45 +5,846 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0-beta.56] - 2026-08-21
 
-### Security
-
-- **email:** Pin validated SMTP probe addresses and remove request-controlled proxy routing ([#305](https://github.com/gotempsh/temps/pull/305))
-### Fixed
-
-- **OTel ingest memory backpressure:** Bound concurrent OTLP request processing before body buffering (ceiling configurable via `TEMPS_OTEL_MAX_CONCURRENT_INGEST_REQUESTS`, default 64), single-flight repeated token authentication, coalesce token usage writes, remove duplicate metrics authentication, enforce the decompressed-size limit while streaming zstd payloads, and cap the compressed request body explicitly rather than relying on Axum's implicit default.
-- **command palette:** Show a left icon for every search result and rank matching projects ahead of common navigation pages.
-- **Cloud metadata egress isolation:** Block IPv4 and IPv6 metadata endpoints for routed app and Compose bridge traffic with an atomic, startup-reconciled nftables policy; reject Compose network drivers that bypass host filtering ([#431](https://github.com/gotempsh/temps/pull/431))
-- **Clone-error credential redaction:** Reject Git URLs with embedded userinfo and redact both usernames and passwords from libgit2 clone errors before deployment failures are persisted to project logs.
-- **Credential reveal boundaries:** Mask environment variables, container configuration, external-service parameters, notification providers, MCP servers, and legacy agent tool credentials by default; plaintext now requires an explicit, audited, non-cacheable reveal request
 ### Added
 
-- **providers:** Reset all accumulated `pg_stat_statements` statistics from the Query Performance page through a write-protected, audited API with explicit destructive-action confirmation.
-- **providers:** `pg_stat_statements`-based slow-query monitoring for user-provisioned Postgres services — a dedicated "Query Performance" page (sortable, paginated, with a per-query detail view) alongside a `GET /external-services/{id}/pg-stat-statements/slow-queries` endpoint and a `temps services slow-queries --id <id>` CLI command ([#460](https://github.com/gotempsh/temps/pull/460))
-- **providers:** self-service "Enable & Restart" action to load `pg_stat_statements` on standalone Postgres services that predate this feature — clustered/HA services are rejected with a clear error instead, since a blind single-container restart bypasses controlled failover ([#460](https://github.com/gotempsh/temps/pull/460))
-- **web:** date/time range picker (15m/1h/24h/7d + custom) on the service Logs screen, and a `temps services logs --id <id>` CLI command with `--from`/`--to` filtering ([#460](https://github.com/gotempsh/temps/pull/460))
+- **funnels:** Add time-range shortcuts and show exact completion seconds ([#750](https://github.com/gotempsh/temps/issues/750))
+- **projects:** Always show a health indicator on the project card ([#747](https://github.com/gotempsh/temps/issues/747))
+
+### Documentation
+
+- Require DCO sign-off on every commit, add Code of Conduct ([#752](https://github.com/gotempsh/temps/issues/752))
 
 ### Fixed
 
-- **Platform-admin code-execution boundary**: Remove container, sandbox creation/exec, and pipeline execution permissions from `PlatformAdmin` so the role cannot run caller-selected code inside customer workloads.
-- **PostgreSQL data-explorer query isolation**: Reject function calls and every PostgreSQL subquery form in user-supplied WHERE clauses, and parse PostgreSQL string and quoted-identifier boundaries safely, so expressions cannot read other tables through XML helpers or `IN (TABLE ...)` query expressions.
-- **compose security:** Require URL-safe PostgreSQL and Redis credentials, rotate existing PostgreSQL volumes to SCRAM before startup, keep credentials out of process arguments, bind internal ports to loopback, use authenticated readiness checks, and support unattended initial-admin creation from a mounted password secret.
-- **Webhook retry tenant isolation**: Scope `POST /projects/{project_id}/webhooks/{webhook_id}/deliveries/{delivery_id}/retry` lookups to the requested project and webhook so a writer cannot replay another tenant's delivery by guessing its ID.
-- **No-op visitor deduplication migration**: `m20260705_000001_add_visitor_unique_index` now skips bulk foreign-key rewrites when no duplicate `(visitor_id, project_id)` pairs exist, preventing TimescaleDB from eagerly decompressing unrelated hypertable chunks and exceeding `timescaledb.max_tuples_decompressed_per_dml_transaction` during upgrades.
-- **security:** Require the dedicated `secrets:read` permission before returning plaintext project or provider credentials, and mask container environment values for callers without it.
-- **providers:** `shared_preload_libraries` was unconditionally overwritten to just `pg_stat_statements` at container-creation time, silently dropping any image-required library (e.g. `timescaledb` for the `timescale/timescaledb-ha:pg18` image option) — the value is now merged, not overwritten ([#460](https://github.com/gotempsh/temps/pull/460))
-- **providers:** Postgres container restarts never picked up a corrected `shared_preload_libraries` value — the drift-reconciliation check only compared `archive_mode`; it now also detects `shared_preload_libraries` drift and recreates the container accordingly ([#460](https://github.com/gotempsh/temps/pull/460))
-- **web:** the service Logs tab crashed with a React error boundary (`Cannot read properties of undefined (reading 'next_cursor')`) when the logs API returned a non-2xx response ([#460](https://github.com/gotempsh/temps/pull/460))
-- **skills:** Scan changed agent skills in pull requests and all skills nightly, on demand, after relevant pushes to `main`, or when scanner controls change, using the hash-locked Cisco AI Defense Skill Scanner with behavioral analysis, a high-severity merge gate, and fail-closed symlink validation.
-- **temps-best-practices skill:** Add an application runtime contract covering `.temps.yaml` readiness paths, OpenTelemetry health-request suppression, port binding, graceful shutdown, replica-safe state, migrations, telemetry privacy, and browser credential boundaries so generated deployment guidance is safe and production-ready.
+- **projects:** Report the connected Git provider instead of guessing it ([#740](https://github.com/gotempsh/temps/issues/740))
+- **web:** Open the highlighted command palette row on Enter ([#751](https://github.com/gotempsh/temps/issues/751))
+- **proxy:** Scope the traffic aggregation window cap to unique counts ([#755](https://github.com/gotempsh/temps/issues/755))
+- **web:** Handle mutation and fetch errors in ErrorGroupDetail and ErrorEventDetail ([#746](https://github.com/gotempsh/temps/issues/746))
+
+### Testing
+
+- Fix flaky Postgres/Chrome tests and make MongoDB health timeouts diagnosable ([#754](https://github.com/gotempsh/temps/issues/754))
+
+## [0.1.0-nightly.20260821.cdad16f9] - 2026-08-20
+
+### Added
+
+- **flags:** Allow TEMPS_FLAGS_REFRESH_INTERVAL_MS to override the 30s poll ([#733](https://github.com/gotempsh/temps/issues/733))
+- **web:** Searchable, refreshable project select on the Proxy page ([#734](https://github.com/gotempsh/temps/issues/734))
 
 ### Fixed
 
-- **temps-cli skill:** Use an integrity-pinned, lifecycle-script-disabled CLI installation and the installed `temps` binary so agents no longer download mutable package code on every command; add explicit context, confirmation, secret-handling, credential-reveal, and untrusted-output boundaries.
-- **agent skills:** Make platform setup stop at human-controlled installation and secret boundaries, remove mutable package runners and credential-bearing examples, and pin React analytics/session-recording installation to a reviewed artifact while treating downloaded package content as untrusted.
+- **email:** Scope deployment delivery to authorized projects ([#685](https://github.com/gotempsh/temps/issues/685))
+- **web:** Handle fetch errors in BackupDetail and ScheduleDetail with actionable error state. ([#737](https://github.com/gotempsh/temps/issues/737))
+- **session-replay:** Stop duplicating and over-recording replay events ([#739](https://github.com/gotempsh/temps/issues/739))
 
-## [0.1.0-beta.55] - 2026-07-28
+## [0.1.0-nightly.20260820.bfa3b1e2] - 2026-08-19
+
+### Added
+
+- **projects:** Opt in to deploying a project from alternate sources ([#716](https://github.com/gotempsh/temps/issues/716))
+- **settings:** Bound project resource overrides with operator ceilings ([#713](https://github.com/gotempsh/temps/issues/713))
+- **otel:** Count and alarm on rate-limited/quota-exceeded ingest requests ([#730](https://github.com/gotempsh/temps/issues/730))
+- **ai-chat:** Expand read allowlist with ~130 safe GET endpoints ([#732](https://github.com/gotempsh/temps/issues/732))
+
+### CI
+
+- **rust-tests:** Verify temps-captcha-wasm pkg/ is a reproducible build ([#731](https://github.com/gotempsh/temps/issues/731))
+
+### Documentation
+
+- **installation:** Pin wasm-pack to required version 0.13.1 ([#706](https://github.com/gotempsh/temps/issues/706))
+
+### Fixed
+
+- **compose:** Make sandbox capability denials and override rejections actionable ([#723](https://github.com/gotempsh/temps/issues/723))
+- **security:** Close 14 open findings from the security review ([#709](https://github.com/gotempsh/temps/issues/709))
+- **web:** Support RFC3339 Sentry timestamps ([#727](https://github.com/gotempsh/temps/issues/727))
+- **cli:** Honor --data-dir when starting the proxy alongside the console ([#724](https://github.com/gotempsh/temps/issues/724))
+- **funnels:** Match CustomData filters against the props column ([#729](https://github.com/gotempsh/temps/issues/729))
+
+### Performance
+
+- **cli:** Build the serve runtime once, before the database pool ([#722](https://github.com/gotempsh/temps/issues/722))
+- **geo:** Load the GeoLite2 city database once per process ([#721](https://github.com/gotempsh/temps/issues/721))
+
+## [0.1.0-nightly.20260819.c2d15ad4] - 2026-08-18
+
+### Added
+
+- **monitoring:** Alert when file descriptors/sockets near exhaustion ([#712](https://github.com/gotempsh/temps/issues/712))
+- **web:** Deep-link into plugin routes from the console ([#720](https://github.com/gotempsh/temps/issues/720))
+
+### Fixed
+
+- **monitoring:** Normalise uncapped container CPU alerts against host cores ([#714](https://github.com/gotempsh/temps/issues/714))
+- **proxy:** Keep tracking page views when Fetch Metadata is absent ([#711](https://github.com/gotempsh/temps/issues/711))
+- **web:** Hide Git configuration for projects with no repository ([#717](https://github.com/gotempsh/temps/issues/717))
+- **proxy:** Honour the configured preview gateway host port ([#719](https://github.com/gotempsh/temps/issues/719))
+
+## [0.1.0-nightly.20260818.86db3048] - 2026-08-17
+
+### Added
+
+- **onboarding:** Surface the next setup step
+- **onboarding:** Add navigable copyable setup prompts
+- **email:** Generate DMARC recommendation, fix DNS TXT-record verification precision ([#304](https://github.com/gotempsh/temps/issues/304))
+- **analytics:** Select page timeframe from charts ([#696](https://github.com/gotempsh/temps/issues/696))
+- **deployments:** Per-project Docker image retention with nightly pruning ([#172](https://github.com/gotempsh/temps/issues/172))
+- **cli:** Deploy a drop archive into an existing project ([#703](https://github.com/gotempsh/temps/issues/703))
+
+### Documentation
+
+- **readme:** Fix star history chart across all locales ([#690](https://github.com/gotempsh/temps/issues/690))
+
+### Fixed
+
+- **projects:** Show traffic and deployment media
+- **ui:** Keep preset icons visible in dark mode
+- **monitoring:** Separate and widen alert rules
+- **onboarding:** Anchor checklist navigation controls
+- **projects:** Rollback failed domain reassignments
+- **ci:** Grant missing permissions for dependency-scan scheduled/manual runs ([#691](https://github.com/gotempsh/temps/issues/691))
+- **proxy:** Bucket projects-health summary hours without toUnixTimestamp64Milli ([#698](https://github.com/gotempsh/temps/issues/698))
+- **providers:** Allowlist pgvector images, and let operators extend the list ([#697](https://github.com/gotempsh/temps/issues/697))
+- **docker:** Bump Alpine base images off EOL 3.19/3.20 to 3.22 ([#692](https://github.com/gotempsh/temps/issues/692))
+- **session-replay:** Batch event inserts instead of one round-trip per event ([#701](https://github.com/gotempsh/temps/issues/701))
+- **dashboard:** Correct sessions and project navigation ([#700](https://github.com/gotempsh/temps/issues/700))
+- **migrate:** Show post-migration maintenance progress and cancel the right backend ([#707](https://github.com/gotempsh/temps/issues/707))
+- **proxy:** Redact credentials from persisted proxy logs ([#699](https://github.com/gotempsh/temps/issues/699))
+- **compose:** Deliver project secrets to Docker Compose stacks ([#702](https://github.com/gotempsh/temps/issues/702))
+- **skills:** Repin the temps skill to the published 0.1.34 integrity ([#710](https://github.com/gotempsh/temps/issues/710))
+
+### Miscellaneous
+
+- **cli:** Release @temps-sdk/cli v0.1.34 and repin skills ([#708](https://github.com/gotempsh/temps/issues/708))
+
+### Performance
+
+- **proxy:** Bound preview limiter flood work
+
+## [0.1.0-nightly.20260817.651f4a16] - 2026-08-16
+
+### Added
+
+- **web:** Redesign project navigation
+- **web:** Simplify platform sidebar
+- **web:** Restore monitoring workspace
+- **web:** Prioritize AI activation in onboarding
+- **web:** Verify AI harness activation
+- **platform:** Expose feature maturity labels
+- **web:** Streamline AI harness onboarding
+- **web:** Add platform tool section icons
+- **web:** Redesign project list
+
+### Documentation
+
+- **readme:** Tag temps.sh links with UTM parameters ([#688](https://github.com/gotempsh/temps/issues/688))
+- **cli:** Sync analytics command references
+
+### Fixed
+
+- **deps:** Patch event-listener RustSec finding ([#97](https://github.com/gotempsh/temps/issues/97))
+- **environments:** Allow clearing node placement
+- **deployments:** Treat an empty target_nodes list as unconstrained
+- **security:** Close final placement and preview gaps
+- **providers:** Restore redis database allocation isolation ([#683](https://github.com/gotempsh/temps/issues/683))
+- **ai-gateway:** Allow re-enabling a disabled provider model via add ([#687](https://github.com/gotempsh/temps/issues/687))
+- **ci:** Keep tag releases from writing Actions caches ([#686](https://github.com/gotempsh/temps/issues/686))
+- **web:** Widen service creation layout
+- **web:** Clarify platform tools group label
+- **platform:** Address navigation redesign review blockers
+- **security:** Scope redesign resource access
+
+### Refactor
+
+- **web:** Replace monitoring page with proxy
+- **web:** Group platform navigation by intent
+- **web:** Promote git providers in navigation
+- **web:** Open monitoring on alerts
+- **web:** Separate AI harness onboarding
+- **web:** Move AI harness out of sidebar
+
+### Testing
+
+- **e2e:** Focus multinode scenario on worker deployment
+
+## [0.1.0-nightly.20260816.3bf831a1] - 2026-08-16
+
+### Added
+
+- **analytics:** Add generic API traffic drilldowns ([#669](https://github.com/gotempsh/temps/issues/669))
+- **otel:** Span attribute facets for fast filtering at scale
+- **otel:** Production-harden facet backfill + add TimescaleDB parity
+- **otel,cli:** Regenerate API clients for facet status/retry, add CLI retry
+- **proxy:** Add scoped API traffic drilldowns ([#675](https://github.com/gotempsh/temps/issues/675))
+
+### Documentation
+
+- **providers:** Describe structured MariaDB filters
+- **e2e:** Describe HA probe callers
+
+### Fixed
+
+- **otel:** Harden claimed project slug diagnostics ([#666](https://github.com/gotempsh/temps/issues/666))
+- **presets:** Upgrade Autopack Python source builds ([#667](https://github.com/gotempsh/temps/issues/667))
+- **projects:** Stop mislabeling git connection errors as project-not-found ([#668](https://github.com/gotempsh/temps/issues/668))
+- **web:** Chart deploy-marker overlap and Cmd+K palette drift ([#671](https://github.com/gotempsh/temps/issues/671))
+- **projects:** Scope env detection and improve repository connections ([#665](https://github.com/gotempsh/temps/issues/665))
+- **projects:** Harden shared git settings follow-up ([#673](https://github.com/gotempsh/temps/issues/673))
+- **analytics:** Cast ClickHouse traffic percentiles ([#672](https://github.com/gotempsh/temps/issues/672))
+- **security:** Harden critical trust boundaries
+- **security:** Bundle high severity hardening
+- **security:** Address integration review findings
+- **security:** Close residual tenant identity races
+- **security:** Centralize tenant hostname claims
+- **security:** Canonicalize tenant identity claims
+- **security:** Isolate proxy inspection quotas
+- **ci:** Align tests with security hardening
+- **security:** Close upgrade and placement bypasses
+- **security:** Validate upgrade recovery paths
+- **security:** Fail closed on invalid placement
+- **security:** Enforce constrained scheduling
+- **tests:** Use supported postgres images in upgrade guard
+- **tests:** Use an allowlisted postgres image that actually exists
+- **tests:** Use allowlisted postgres image for image-update tests
+- **providers:** Probe walg.env from the volume when no live container exists
+- **proxy:** Scope production-HTTPS default to resolved project traffic
+- **e2e:** Enroll multinode workers over https
+- **e2e:** Emit portable probe images
+- **e2e:** Use valid control-plane probe placement
+- **otel:** Address review findings on facet backfill hardening
+- **auth:** Block admin MFA enrollment during password login ([#678](https://github.com/gotempsh/temps/issues/678))
+- **deployments:** Enforce project access on cron reads ([#679](https://github.com/gotempsh/temps/issues/679))
+- **providers:** Constrain legacy managed service sweep ([#680](https://github.com/gotempsh/temps/issues/680))
+
+### Miscellaneous
+
+- **cli,web:** Regenerate API clients against the merged backend
+- **cli,web:** Regenerate API clients after second main merge
+
+### Performance
+
+- **ci:** Inherit trusted nextest target cache ([#674](https://github.com/gotempsh/temps/issues/674))
+
+### Styling
+
+- **providers:** Satisfy rustfmt on wal-probe test helper call
+- **proxy:** Satisfy rustfmt on new production-https tests
+
+### Testing
+
+- **providers:** Use managed postgres images
+- **e2e:** Expect cross-project DNS isolation
+
+## [0.1.0-nightly.20260815.a23a4903] - 2026-08-14
+
+### Added
+
+- **web:** Redesign project deployment actions ([#660](https://github.com/gotempsh/temps/issues/660))
+- **analytics:** Add AI-powered API traffic insights ([#661](https://github.com/gotempsh/temps/issues/661))
+- **cli:** Expose performance insights filters ([#662](https://github.com/gotempsh/temps/issues/662))
+
+### Fixed
+
+- **web:** Show branch selector on Connect repository page ([#657](https://github.com/gotempsh/temps/issues/657))
+- **analytics:** Preserve events backfill progress output ([#658](https://github.com/gotempsh/temps/issues/658))
+- **proxy:** Add per-project/environment concurrent-connection cap ([#655](https://github.com/gotempsh/temps/issues/655))
+- **git:** Share live preset/env-example/compose fetches across users ([#659](https://github.com/gotempsh/temps/issues/659))
+- **web:** Simplify project header links ([#663](https://github.com/gotempsh/temps/issues/663))
+- **otel:** Include project slug in auth warnings ([#664](https://github.com/gotempsh/temps/issues/664))
+
+## [0.1.0-nightly.20260814.af018b31] - 2026-08-13
+
+### Added
+
+- **web:** Surface cluster DNS toggle in Worker Nodes settings ([#647](https://github.com/gotempsh/temps/issues/647))
+- **cli:** Add metrics command to query OTel project metrics ([#649](https://github.com/gotempsh/temps/issues/649))
+- **web:** Add copy URL on project deployment information ([#651](https://github.com/gotempsh/temps/issues/651))
+- **proxy:** Add per-project latency percentiles and custom time ranges ([#652](https://github.com/gotempsh/temps/issues/652))
+- **deployments:** Send redacted failure trace to Temps, or open a GitHub issue ([#653](https://github.com/gotempsh/temps/issues/653))
+
+### Build
+
+- **deps:** Bump axum-test from 18.7.0 to 21.0.0 ([#614](https://github.com/gotempsh/temps/issues/614))
+- **deps:** Bump schemars from 0.8.22 to 1.2.1 ([#615](https://github.com/gotempsh/temps/issues/615))
+- **deps:** Bump totp-rs from 5.7.2 to 6.0.0 ([#607](https://github.com/gotempsh/temps/issues/607))
+- **deps:** Bump jsonwebtoken from 10.4.0 to 11.0.0 ([#608](https://github.com/gotempsh/temps/issues/608))
+
+### Fixed
+
+- **proxy:** Keep RouteTableListener alive in split-mode proxy ([#644](https://github.com/gotempsh/temps/issues/644))
+- **cli:** Watch the newly triggered deployment, not the previous one ([#637](https://github.com/gotempsh/temps/issues/637))
+- **deployments:** Reclaim Docker build cache and old deployment images ([#645](https://github.com/gotempsh/temps/issues/645))
+- **web:** Re-measure AI composer height once the dock's open transition settles ([#654](https://github.com/gotempsh/temps/issues/654))
+- **database:** Replace testcontainers flat-sleep with real postgres readiness wait ([#648](https://github.com/gotempsh/temps/issues/648))
+- **git:** Make git connections shared across all users ([#656](https://github.com/gotempsh/temps/issues/656))
+
+### Miscellaneous
+
+- **cli:** Bump @temps-sdk/cli to 0.1.33 ([#650](https://github.com/gotempsh/temps/issues/650))
+
+## [0.1.0-nightly.20260813.e22f5ddf] - 2026-08-12
+
+### Added
+
+- **proxy:** Configurable request timeouts (global ceiling + per-project override, SSE/WebSocket-aware) ([#642](https://github.com/gotempsh/temps/issues/642))
+
+## [0.1.0-nightly.20260812.86c4c52e] - 2026-08-12
+
+### Added
+
+- **deployments:** Make public readiness check configurable per project/environment
+- **cli:** Add public readiness timeout/disable flags to projects config
+- **skills:** Add Temps workflow router
+- **sandbox:** Sandbox snapshots — take/restore for Docker backend (ADR-037) ([#622](https://github.com/gotempsh/temps/issues/622))
+- **skills:** Add start-temps dev skill for local server bootstrap ([#634](https://github.com/gotempsh/temps/issues/634))
+- **ai:** Add subscription-backed agent CLI provider foundation
+- **ai:** Add provider-aware interactive chat controls
+
+### CI
+
+- **skills:** Secure Temps router
+
+### Fixed
+
+- **cli:** Require target context in write examples
+- **deployer:** Require published ports reachable before compose readiness
+- **cli:** Pass detected composePath through on drop deploys
+- **deployments:** Guard TempDirGuard against removing paths outside safe temp roots ([#633](https://github.com/gotempsh/temps/issues/633))
+- **web:** Match new-project repo picker to compact project-settings design
+- **skills:** Harden Temps router generation
+- **skills:** Contain capability detector reads
+- **skills:** Ignore blocking special files ([#638](https://github.com/gotempsh/temps/issues/638))
+- **ci:** Fix three unrelated main CI failures ([#632](https://github.com/gotempsh/temps/issues/632))
+- **status-page:** Don't collapse degraded monitors into project-down status ([#640](https://github.com/gotempsh/temps/issues/640))
+- **deployments:** Remove the always-broken public-readiness rollback gate ([#641](https://github.com/gotempsh/temps/issues/641))
+- **ai:** Harden AgentCliAiService against security review findings
+- **web:** Restore global AI chat access
+- **ai:** Stabilize cli provider chat
+- **ai:** Refresh chat model capabilities
+- **ai:** Make harness controls and tools reliable
+- **ai:** Render API timestamps as dates in answers
+- **ai:** Isolate subscription chat tool runtime
+- **ai:** Enforce provider runtime boundaries
+
+### Performance
+
+- **otel:** Fix unbounded ClickHouse scans ([#639](https://github.com/gotempsh/temps/issues/639))
+
+### Refactor
+
+- **ai:** Unify provider capabilities and turn runtime
+
+### Testing
+
+- **database:** Derive latest migration in round-trip test
+- **ai:** Add infrastructure prompt catalog
+
+## [0.1.0-nightly.20260812.73dbd99e] - 2026-08-12
+
+### Added
+
+- **external-plugins:** Add caller-scoped platform API
+- **compose:** Make Git deployments usable end to end ([#592](https://github.com/gotempsh/temps/issues/592))
+- **error-tracking:** Add same-origin Sentry tunnel for browser SDKs
+- **self-update:** Apply pending migrations before restarting ([#629](https://github.com/gotempsh/temps/issues/629))
+
+### Build
+
+- **deps:** Bump docker/setup-buildx-action from 3 to 4 ([#604](https://github.com/gotempsh/temps/issues/604))
+- **deps:** Bump nanoid from 3.3.18 to 6.0.1 in /web ([#601](https://github.com/gotempsh/temps/issues/601))
+- **deps:** Bump tower from 0.4.13 to 0.5.3 ([#611](https://github.com/gotempsh/temps/issues/611))
+- **deps:** Bump the web-minor-patch group across 1 directory with 12 updates
+- **deps:** Bump tokio-tungstenite from 0.29.0 to 0.30.0
+- **deps:** Bump the cargo-minor-patch group across 1 directory with 8 updates
+- **deps:** Bump actions/checkout from 5 to 7
+- **deps:** Bump pem from 3.0.6 to 4.0.0 ([#612](https://github.com/gotempsh/temps/issues/612))
+- **deps:** Bump tower-http from 0.6.11 to 0.7.0 ([#613](https://github.com/gotempsh/temps/issues/613))
+- **deps:** Bump octocrab from 0.49.9 to 0.54.1 ([#610](https://github.com/gotempsh/temps/issues/610))
+- **deps:** Bump framer-motion from 12.43.0 to 13.0.0 in /web
+
+### Documentation
+
+- **cli:** Restructure skill references
+- **cli:** Use pinned zero-install commands
+
+### Fixed
+
+- **web:** Redirect to login on expired session instead of hanging on stale screen
+- **error-tracking:** Stop leaking DB error detail on tunnel path, fix wildcard route resolution
+- **proxy:** Canonicalize Google and Bing crawler names ([#625](https://github.com/gotempsh/temps/issues/625))
+- **proxy:** Stop leaking raw HTML under a text/markdown Content-Type ([#626](https://github.com/gotempsh/temps/issues/626))
+- **domains:** Persist request_challenge renewal failures, add attempt history
+- **deployments:** Clean up leaked /tmp/temps-deployments dirs on download failure ([#630](https://github.com/gotempsh/temps/issues/630))
+- **cli:** Generate complete Node-compatible command docs
+- **ci:** Pin readiness probes to local proxy
+- **deployments:** Probe HTTPS routes via local HTTP listener
+
+### Miscellaneous
+
+- **sdk:** Regenerate CLI and web SDKs after merging main
+- **cli:** Release v0.1.31
+- **web:** Remove framer-motion dependency
+
+### Testing
+
+- **e2e:** Verify internal application and database DNS ([#619](https://github.com/gotempsh/temps/issues/619))
+- Align GitHub and migration expectations
+- **e2e:** Wait for deployment completion
+
+## [0.1.0-nightly.20260811.7f6037c7] - 2026-08-10
+
+### Added
+
+- **ai-agents:** Classify plain Googlebot as Google/Mixed
+- **cli:** Add otel-forward commands for OTLP relay destinations ([#591](https://github.com/gotempsh/temps/issues/591))
+
+### Documentation
+
+- **security:** Design PostgreSQL datasource TLS trust ([#337](https://github.com/gotempsh/temps/issues/337))
+
+### Fixed
+
+- **ai-agents:** Add ClickHouse backfill counterpart, closes coverage gap
+- **cli:** Align apikeys create role vocabulary with backend Role enum ([#616](https://github.com/gotempsh/temps/issues/616))
+- **analytics:** Show real duration on bounce/exit pageviews instead of blank ([#618](https://github.com/gotempsh/temps/issues/618))
+
+### Testing
+
+- **e2e:** Close remaining scenario gaps (mariadb restore, env vars, api keys) ([#599](https://github.com/gotempsh/temps/issues/599))
+- **e2e:** Add multinode mTLS coverage and scenario CI ([#617](https://github.com/gotempsh/temps/issues/617))
+
+## [0.1.0-nightly.20260810.ccf9c612] - 2026-08-10
+
+### Added
+
+- **e2e:** Otel-quota-scenario + fix silently-inert OTel storage quota ([#586](https://github.com/gotempsh/temps/issues/586))
+- **providers:** MongoDB restore_in_place, restore_to_new_service, restore_capabilities ([#596](https://github.com/gotempsh/temps/issues/596))
+- **redis:** Implement restore_capabilities, restore_in_place, restore_to_new_service ([#597](https://github.com/gotempsh/temps/issues/597))
+- **restore:** S3/MinIO managed-service restore_in_place ([#595](https://github.com/gotempsh/temps/issues/595))
+
+### Fixed
+
+- Correct dual-license metadata and stale redirect status doc ([#598](https://github.com/gotempsh/temps/issues/598))
+
+### Testing
+
+- **e2e:** Add pitr-scenario for point-in-time postgres recovery ([#585](https://github.com/gotempsh/temps/issues/585))
+- **e2e:** Deploy-lifecycle-scenario (rollback/pause/resume/promote) + fix 3 real bugs ([#587](https://github.com/gotempsh/temps/issues/587))
+- **e2e:** Add db-ha-failover-scenario for Postgres HA/pg_auto_failover ([#588](https://github.com/gotempsh/temps/issues/588))
+- **e2e:** Add pg-upgrade-scenario for Postgres major-version upgrades ([#593](https://github.com/gotempsh/temps/issues/593))
+
+## [0.1.0-nightly.20260809.a6a711b9] - 2026-08-08
+
+### Added
+
+- **projects:** Mark environment variables as secrets at project creation
+- **otel:** Add OtelRelay extension point for telemetry forwarding plugins ([#583](https://github.com/gotempsh/temps/issues/583))
+- **teams:** Add ProjectAccessChecker::invalidate_permissions_cache ([#589](https://github.com/gotempsh/temps/issues/589))
+
+### Fixed
+
+- **security:** Harden postgres credential transport
+- **security:** Enforce private postgres consumers
+
+### Styling
+
+- **web:** Drop incidental prettier reformatting from the env-var change
+
+### Testing
+
+- **e2e:** DNS/TLS/email/CLI + observability/data-storage e2e coverage ([#582](https://github.com/gotempsh/temps/issues/582))
+
+## [0.1.0-nightly.20260808.e02f5881] - 2026-08-07
+
+### Added
+
+- **sandbox:** Add persistent workspace sandboxes with wake-on-access
+- **cli:** Resolve workspace source from project, repo, or local checkout
+- **sandbox:** Add interactive terminal and `sandbox shell`
+- **web:** Regenerate the SDK and surface workspaces in the console
+- **deployer:** Satisfy compose env_file references automatically
+
+### Build
+
+- **cli:** Add spec:update to refresh openapi.json canonically
+
+### CI
+
+- **cli:** Enforce canonical openapi.json in a hook and in CI
+- **sandbox:** Install protoc in the beta image prepare job
+
+### Documentation
+
+- **adr:** Add ADR-036 for persistent workspace sandboxes
+
+### Fixed
+
+- **settings:** Close the review findings on console updates
+- **auth:** Only require step-up from users who have enrolled MFA
+- **sandbox:** Restore terminal echo, work dir, and CLI response shapes
+- **sandbox:** Address review findings on the terminal and step-up policy
+- **sandbox:** Address review findings on workspaces and the terminal
+- **sandbox:** Normalise the PTY from the host so terminals echo on any image
+- **web:** Raise the js-yaml override past the advisory, and make detach honest
+- **sandbox:** Repair compound --cmd, bound agent writes, surface oversized input
+- **projects:** Normalize blank directory on settings and git updates
+- **web:** Detect presets and prefill the URL on the public-repo path
+- **auth:** Audit permission denials safely
+- **auth:** Bound permission denial audit storage
+- **security:** Bound query memory and audit data
+- **security:** Reject oversized rows before encoding
+- **security:** Redact audited data identifiers
+- **cli:** Sanitize untrusted terminal output
+- **cli:** Sanitize invalid filter errors
+- **security:** Resolve PR review findings
+- **security:** Enforce pre-wire Redis budgets
+- **redis:** Bound aggregate admission work
+- **security:** Close final review gaps
+- **security:** Bound metadata scan work
+- **redis:** Preserve bounded cursor paging
+- **review:** Close final compatibility gap
+
+### Miscellaneous
+
+- **cli:** Regenerate openapi spec and client
+- **sdk:** Release analytics-core v0.0.3, react-analytics v0.0.5, analytics-browser v0.0.3, svelte-analytics v0.0.2, vue-analytics v0.0.2 ([#575](https://github.com/gotempsh/temps/issues/575))
+- **cli:** Release v0.1.30, release node-sdk v0.0.7 ([#574](https://github.com/gotempsh/temps/issues/574))
+
+### Styling
+
+- **cli:** Canonicalize openapi.json key order and formatting
+
+### Testing
+
+- **e2e:** Make console/CLI e2e suite parallel-safe, add API-key coverage
+
+## [0.1.0-nightly.20260807.146be0c2] - 2026-08-06
+
+### Added
+
+- **analytics:** Crawler opt-in for breakdowns, and prune NULL keys early
+- **settings:** Apply releases and restart from the console
+- **settings:** Version page, release channels, and install without a restart
+- **providers:** Read-only GET rows endpoint and per-service AI data access opt-in
+- **cli:** Add 'temps data' for read-only browsing of service data
+- **query-postgres,web:** Show views, list-level stats, and per-engine labels
+- **web:** Independent tree scroll, column selection, and row detail panel
+- **web:** Container overview, sidebar sizes, per-tab scroll, and S3 fixes
+- **otel:** Rank operations by latency, volume, and variability
+- **cli:** Add `traces span-stats` for operation latency
+- **web:** Add an Operations view to Traces
+
+### Documentation
+
+- **analytics:** Declare include_crawlers on the timeline endpoint
+- Require features to be discoverable and onboard when unconfigured
+- **cli:** Document the data command group
+- **skills:** Document the data command group in the temps-cli skill
+
+### Fixed
+
+- **analytics:** Classify self-referrals as Direct, not Referral
+- **analytics:** Exclude crawler traffic from breakdowns and top pages
+- **cli:** Make analytics overview locations and sparkline respect --period
+- **analytics:** Populate visitor language instead of always "Unknown"
+- **analytics:** Send language from the shared browser SDK core too
+- **analytics:** Close review findings on attribution, language and CH parity
+- **cli:** Reject release tags that escape the temps repository
+- **web:** Restore deep paths on reload and compact the data browser
+- **providers:** Clamp row limit for every caller and cover the AI gate with tests
+- **web:** Drop a sort field the current table does not have
+- **query-postgres,web:** Count views in entity_count, inline the entity breadcrumb
+- **security:** Close connection-string injection, SQL denylist bypass, and markdown exfiltration
+- **security:** Share one SQL validator, close MariaDB bypasses and a remote panic
+- **security:** Close the nine findings from the data-browser audit
+- **security:** Close the review findings, and make the TLS ladder actually work
+- **security:** Close the re-audit findings, including a UNION injection I added
+- **web:** Give sole create actions an N shortcut and guard it behind overlays
+- **web:** Rank palette results by relevance, add Teams, resizable data-browser tree
+- **web:** Show unified-trace projects as a colour legend, not a slug per span
+- **web:** Make Back work on deep-linked pages
+- **web:** Address self-review findings on the shortcut hook and project dot
+- **web:** Order sibling spans correctly and show exact durations
+- **config,proxy:** Stop settings writes from wiping the admin gate
+- **proxy:** Close fail-open paths in the admin gate reload
+- **ci:** Unbreak the two checks that are red on every PR
+- **otel:** Bound span-stats project count and time window
+
+### Miscellaneous
+
+- Use neutral placeholder names in examples and comments
+- **scripts:** Seed OTel traces across projects and services
+- **scripts:** Replay a captured trace into a local instance
+
+### Performance
+
+- **query-postgres:** Use planner stats for row count, and report table size
+- **query:** Avoid full scans for MariaDB row counts, add MongoDB size
+
+### Revert
+
+- **web:** Drop the data-browser tree navigateTo routing
+
+## [0.1.0-nightly.20260806.c64e8f98] - 2026-08-06
+
+### Added
+
+- **console:** Improve user and project onboarding ([#552](https://github.com/gotempsh/temps/issues/552))
+- **flags:** Multi-language integration guide, and shiki-highlighted code blocks ([#556](https://github.com/gotempsh/temps/issues/556))
+- **env-vars:** Convert an existing variable to a write-only secret ([#555](https://github.com/gotempsh/temps/issues/555))
+- **dns:** Govern unattended provider automation ([#554](https://github.com/gotempsh/temps/issues/554))
+
+### Fixed
+
+- **git:** Stop invisible connections from blocking provider deletion ([#553](https://github.com/gotempsh/temps/issues/553))
+- **telemetry:** Report git-describe version, not static Cargo.toml version ([#558](https://github.com/gotempsh/temps/issues/558))
+- **sandbox:** Free volumes and work dirs when a sandbox is destroyed ([#523](https://github.com/gotempsh/temps/issues/523))
+
+## [0.1.0-nightly.20260805.c6bd08de] - 2026-08-04
+
+### Added
+
+- **presets:** Replace the nixpacks build engine with autopack ([#530](https://github.com/gotempsh/temps/issues/530))
+- **auth:** Add step-up verification for sensitive actions ([#547](https://github.com/gotempsh/temps/issues/547))
+- **flags:** Feature flags Phase 1 — backend, CLI, SDK and console UI ([#526](https://github.com/gotempsh/temps/issues/526))
+- **ai:** Let the assistant propose metric alert rules from a project's own telemetry ([#521](https://github.com/gotempsh/temps/issues/521))
+- **teams:** Teams and project-scoped RBAC in OSS ([#486](https://github.com/gotempsh/temps/issues/486))
+- **drop:** Deploy uploaded source archives ([#549](https://github.com/gotempsh/temps/issues/549))
+
+### Fixed
+
+- **proxy:** Keep backend latency for streaming sessions ([#545](https://github.com/gotempsh/temps/issues/545))
+- **web:** Advance traces time window on refresh and skip it for trace-id search ([#550](https://github.com/gotempsh/temps/issues/550))
+- **deps:** Patch aiohttp and cryptography Dependabot advisories ([#551](https://github.com/gotempsh/temps/issues/551))
+- **otel:** Bound ingest memory under exporter bursts ([#544](https://github.com/gotempsh/temps/issues/544))
+
+## [0.1.0-nightly.20260804.c51ac6c2] - 2026-08-03
+
+### Added
+
+- **providers:** Reset pg_stat_statements statistics ([#527](https://github.com/gotempsh/temps/issues/527))
+- **sandbox:** Mint shareable preview links with expiring session grants ([#525](https://github.com/gotempsh/temps/issues/525))
+- **telemetry:** Add deployment failure taxonomy and template context ([#546](https://github.com/gotempsh/temps/issues/546))
+
+### Fixed
+
+- **web:** Stop env var edit modal showing blank value after save ([#524](https://github.com/gotempsh/temps/issues/524))
+- **web:** Add icons and prioritize projects in command search
+- **deps:** Bump brace-expansion override to ^5.0.9 for GHSA-rgw5-rvv9-x895 ([#548](https://github.com/gotempsh/temps/issues/548))
+
+### Miscellaneous
+
+- **deps-dev:** Bump @types/react-dom in /web in the react group ([#528](https://github.com/gotempsh/temps/issues/528))
+
+### Refactor
+
+- **web:** Move project setup into project sidebar ([#541](https://github.com/gotempsh/temps/issues/541))
+
+## [0.1.0-nightly.20260803.ae960395] - 2026-08-02
+
+### Added
+
+- **providers:** Warn when a cluster has no node accepting writes
+- **audit:** Support events whose actor has no resolvable account ([#411](https://github.com/gotempsh/temps/issues/411))
+- **audit:** Record failed logins and rejected MFA codes ([#412](https://github.com/gotempsh/temps/issues/412))
+- **environments:** Per-environment HTTP→HTTPS redirect override, with an unconditional ACME bypass ([#522](https://github.com/gotempsh/temps/issues/522))
+- **security:** Block cloud-metadata egress from app containers
+
+### CI
+
+- Fix the cache-budget leak that makes Compose Security take 92 minutes ([#516](https://github.com/gotempsh/temps/issues/516))
+
+### Fixed
+
+- **providers:** Make cluster creation survive bad placement and stay retryable
+- **deployments:** Write the clone failure into the deploy log
+- **projects:** Reject repo changes that would strand the clone URL
+- **web:** Stop claiming a project deployed when its only run failed
+- **providers:** Treat unreachable cluster nodes as leaderless
+- **proxy:** Exclude streaming sessions from latency metrics ([#514](https://github.com/gotempsh/temps/issues/514))
+- **domains:** Validate custom-domain input and scope it to the caller's project ([#515](https://github.com/gotempsh/temps/issues/515))
+- **cli:** Repo lookup by search, nested group paths, and --secret for env vars ([#517](https://github.com/gotempsh/temps/issues/517))
+- **core:** Make Visit links reachable on sslip.io installs ([#488](https://github.com/gotempsh/temps/issues/488))
+- **web:** Show a back button in the collapsed sidebar's sub-navigation ([#520](https://github.com/gotempsh/temps/issues/520))
+- **git:** Keep clone credentials out of errors
+- **auth:** Remove code-execution permissions from PlatformAdmin
+- **auth:** Close platform admin sandbox creation gap
+- **web:** Make the AI chat page fill the content area exactly ([#518](https://github.com/gotempsh/temps/issues/518))
+- **providers:** Persist inferred parameters on the plugin init path
+- **providers:** Check loopback when picking host ports, and report real service health
+- **providers:** Route MariaDB port selection through the shared finder
+- **providers:** Persist cluster topology atomically
+- **email:** Close SSRF hole and DNS-rebinding gap in SMTP deliverability probe
+- **email:** Complete SMTP SSRF hardening
+- **email:** Keep validation configuration database-ready
+- **email:** Close remaining SMTP proxy SSRF gaps
+- **security:** Make metadata egress blocking atomic
+
+### Testing
+
+- **web:** Verify project deployment labels
+
+## [0.1.0-nightly.20260802.ba96c0f7] - 2026-08-02
+
+### Added
+
+- **deployer:** Attach app containers to required extra Docker networks ([#501](https://github.com/gotempsh/temps/issues/501))
+- **deployments:** Support worker nodes of a different architecture
+- **deployments:** Make cross-architecture builds opt-in
+- **deployments:** Report skipped nodes and refuse impossible replica counts
+- **projects:** Expose cross-architecture builds in the deployment config API
+
+### Documentation
+
+- **multi-node:** Document opt-in cross-builds and replica shortfall
+- **multi-node:** Correct the config key and regenerate the SDK
+
+### Fixed
+
+- **web:** Align react with react-dom at 19.2.8 and guard against future drift ([#505](https://github.com/gotempsh/temps/issues/505))
+- **deployments:** Reject cross-builds the legacy Docker builder mislabels
+- **deployments:** Never record a guessed node architecture
+- **deployments:** Close two paths that still trusted a guessed platform
+- **deployments:** Bound cross-build targets and record per-replica images
+- **deployments:** Act only on a confirmed control-plane platform
+- **deployments:** Discover the daemon platform on paths that never build
+- **deployer:** Keep the ARM variant through discovery and verification
+- **deployments:** Degrade instead of failing the cluster's builds
+- **deployments:** Check replica shortfall before the local-only fallback
+- **deployments:** Record the peer address on architecture-change audits
+- **deployments:** Clean up containers before owner deletion
+- **deployments:** Remove unsafe cross-instance orphan sweep
+- **providers:** Derive managed service container names in one place ([#503](https://github.com/gotempsh/temps/issues/503))
+
+### Testing
+
+- **web:** Add console end-to-end UI tests, and fix the post-login 404 they found ([#511](https://github.com/gotempsh/temps/issues/511))
+
+## [0.1.0-nightly.20260801.324ad120] - 2026-08-01
+
+### CI
+
+- Run temps-otel and four other crates' integration tests
+
+### Documentation
+
+- **contributing:** Specify temps binary for running server
+
+### Fixed
+
+- **auth:** Gate user administration on a dedicated users:manage permission
+- **auth:** Restrict audit:read to administration roles
+- **web:** Gate audit-log UI to roles with audit:read
+- **web:** Import Navigate from react-router, not react-router-dom
+- **otel:** Restore exact span dedup after dropping FINAL
+- **sdk:** Regenerate clients for the include_total contract
+- **imports:** Make repository link optional, add Portainer TLS skip
+- **cli:** Environments resources ignored -p, always resolving "Project not found"
+- **providers:** Enforce project scoping for session/API-key/CLI callers
+- **import:** Deploy docker-source imports for real instead of leaving them pending
+- **domains:** Reserve the console hostname from project domains
+- **kv,blob:** Confine data-plane access to the caller's projects
+- **auth:** Select jsonwebtoken crypto provider ([#497](https://github.com/gotempsh/temps/issues/497))
+
+### Performance
+
+- **otel:** Make trace-summaries scale with the query window
+
+### Styling
+
+- **kv,blob:** Apply rustfmt
+
+### Testing
+
+- **audit:** Add authorization tests for audit-log endpoints
+- **auth:** Relocate audit:read matrix test to avoid overlap with #350
+
+## [0.1.0-nightly.20260731.42fe6068] - 2026-07-30
+
+### Fixed
+
+- **ci:** Pin privileged workflow actions ([#473](https://github.com/gotempsh/temps/issues/473))
+- **auth:** Enforce privilege ceiling on key rotation ([#472](https://github.com/gotempsh/temps/issues/472))
+- **security:** Audit explicit credential reveals ([#459](https://github.com/gotempsh/temps/issues/459))
+- **providers:** Sort slow queries server-side instead of client-side ([#480](https://github.com/gotempsh/temps/issues/480))
+- **projects:** Resolve nixpacks variants to base nixpacks preset
+- **presets:** Generalize nixpacks provider selection
+- **web:** Align preset config request types
+- **deployments:** Persist terminal status for jobs that never run
+- **screenshots:** Redact credentials from remote provider health-check errors
+- **core:** Cancel jobs left pending when a workflow aborts mid-batch
+
+### Miscellaneous
+
+- **web:** Regenerate Nixpacks preset types
+
+### Testing
+
+- **presets:** Remove ineffective struct update
+
+## [0.1.0-nightly.20260730.e145a940] - 2026-07-30
+
+### Fixed
+
+- **release:** Install protoc for sandbox helpers ([#479](https://github.com/gotempsh/temps/issues/479))
+
+## [0.1.0-nightly.20260730.ed853d3a] - 2026-07-30
+
+### Fixed
+
+- **release:** Use git cli for dependencies ([#476](https://github.com/gotempsh/temps/issues/476))
+
+## [0.1.0-nightly.20260729.347ef444] - 2026-07-29
+
+### Fixed
+
+- **release:** Identify repository for nightly dispatch ([#475](https://github.com/gotempsh/temps/issues/475))
+
+## [0.1.0-nightly.20260729.bd382d68] - 2026-07-29
+
+### Added
+
+- **skills:** Add temps-best-practices skill ([#453](https://github.com/gotempsh/temps/issues/453))
+- **providers:** Pg_stat_statements slow-query monitoring + service log filtering ([#460](https://github.com/gotempsh/temps/issues/460))
+
+### Documentation
+
+- **skills:** Add runtime and telemetry guardrails ([#469](https://github.com/gotempsh/temps/issues/469))
+
+### Fixed
+
+- **otel:** Warn AI chat that only duration_ms is milliseconds, not raw attributes ([#461](https://github.com/gotempsh/temps/issues/461))
+- **skills:** Harden skill security and add full audit gate ([#462](https://github.com/gotempsh/temps/issues/462))
+- **web:** Duplicate day-label tooltip + cli: --connection flag for projects git ([#456](https://github.com/gotempsh/temps/issues/456))
+- **deployments:** Scope job metadata to projects ([#465](https://github.com/gotempsh/temps/issues/465))
+- **web:** Portal DropdownMenuSubContent to escape clipped parent ([#467](https://github.com/gotempsh/temps/issues/467))
+- **release:** Dispatch builds for nightly tags ([#470](https://github.com/gotempsh/temps/issues/470))
+- **release:** Recover failed nightly dispatches ([#471](https://github.com/gotempsh/temps/issues/471))
+
+### Performance
+
+- **build:** Isolate BuildKit cache mounts ([#463](https://github.com/gotempsh/temps/issues/463))
+
+## [0.1.0-nightly.20260729.419505e0] - 2026-07-28
+
+### Added
+
+- **monitoring:** Metric alerts as config-as-code in .temps.yaml ([#454](https://github.com/gotempsh/temps/issues/454))
+- **cli:** Add `temps projects secrets` subcommand ([#458](https://github.com/gotempsh/temps/issues/458))
+
+### Documentation
+
+- **readme:** Move why-statement above the fold, add stop-paying banner ([#457](https://github.com/gotempsh/temps/issues/457))
+
+### Fixed
+
+- **cli:** Add per-command --context flag to avoid silent wrong-server runs ([#455](https://github.com/gotempsh/temps/issues/455))
+
+## [0.1.0-nightly.20260727.32b7f235] - 2026-07-27
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10230,7 +10230,7 @@ dependencies = [
 
 [[package]]
 name = "temps-agent"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "axum",
@@ -10270,7 +10270,7 @@ dependencies = [
 
 [[package]]
 name = "temps-agents"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10317,7 +10317,7 @@ dependencies = [
 
 [[package]]
 name = "temps-agents-mcp-proxy"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "serde",
  "serde_json",
@@ -10325,7 +10325,7 @@ dependencies = [
 
 [[package]]
 name = "temps-ai"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "futures",
@@ -10340,7 +10340,7 @@ dependencies = [
 
 [[package]]
 name = "temps-ai-agent-cli"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "axum",
@@ -10357,7 +10357,7 @@ dependencies = [
 
 [[package]]
 name = "temps-ai-api-tools"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "axum",
@@ -10380,7 +10380,7 @@ dependencies = [
 
 [[package]]
 name = "temps-ai-chat"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10416,7 +10416,7 @@ dependencies = [
 
 [[package]]
 name = "temps-ai-gateway"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10454,7 +10454,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10487,7 +10487,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-backend"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10504,7 +10504,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-events"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10538,7 +10538,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-funnels"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10559,7 +10559,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-performance"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "axum",
@@ -10583,7 +10583,7 @@ dependencies = [
 
 [[package]]
 name = "temps-analytics-session-replay"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10609,7 +10609,7 @@ dependencies = [
 
 [[package]]
 name = "temps-audit"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "axum",
@@ -10631,7 +10631,7 @@ dependencies = [
 
 [[package]]
 name = "temps-auth"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "argon2",
@@ -10673,7 +10673,7 @@ dependencies = [
 
 [[package]]
 name = "temps-backup"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10720,7 +10720,7 @@ dependencies = [
 
 [[package]]
 name = "temps-backup-core"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10740,7 +10740,7 @@ dependencies = [
 
 [[package]]
 name = "temps-blob"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10789,7 +10789,7 @@ dependencies = [
 
 [[package]]
 name = "temps-cli"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "argon2",
@@ -10901,7 +10901,7 @@ dependencies = [
 
 [[package]]
 name = "temps-config"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "axum",
@@ -10933,7 +10933,7 @@ dependencies = [
 
 [[package]]
 name = "temps-core"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -10972,7 +10972,7 @@ dependencies = [
 
 [[package]]
 name = "temps-database"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "futures",
@@ -10991,7 +10991,7 @@ dependencies = [
 
 [[package]]
 name = "temps-deployer"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11031,7 +11031,7 @@ dependencies = [
 
 [[package]]
 name = "temps-deployments"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11103,7 +11103,7 @@ dependencies = [
 
 [[package]]
 name = "temps-dns"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11146,7 +11146,7 @@ dependencies = [
 
 [[package]]
 name = "temps-dns-resolver"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11167,7 +11167,7 @@ dependencies = [
 
 [[package]]
 name = "temps-domains"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11220,7 +11220,7 @@ dependencies = [
 
 [[package]]
 name = "temps-edge"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -11261,7 +11261,7 @@ dependencies = [
 
 [[package]]
 name = "temps-email"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11304,7 +11304,7 @@ dependencies = [
 
 [[package]]
 name = "temps-email-tracking"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "axum",
@@ -11341,7 +11341,7 @@ dependencies = [
 
 [[package]]
 name = "temps-embeddings"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -11352,7 +11352,7 @@ dependencies = [
 
 [[package]]
 name = "temps-entities"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "chrono",
  "sea-orm",
@@ -11366,7 +11366,7 @@ dependencies = [
 
 [[package]]
 name = "temps-environments"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "argon2",
@@ -11395,7 +11395,7 @@ dependencies = [
 
 [[package]]
 name = "temps-error-tracking"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11469,7 +11469,7 @@ dependencies = [
 
 [[package]]
 name = "temps-external-plugins"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "axum",
@@ -11498,7 +11498,7 @@ dependencies = [
 
 [[package]]
 name = "temps-file-store"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11514,7 +11514,7 @@ dependencies = [
 
 [[package]]
 name = "temps-flags"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11537,7 +11537,7 @@ dependencies = [
 
 [[package]]
 name = "temps-geo"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "axum",
@@ -11560,7 +11560,7 @@ dependencies = [
 
 [[package]]
 name = "temps-git"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11611,7 +11611,7 @@ dependencies = [
 
 [[package]]
 name = "temps-git-credential"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "chrono",
  "nix 0.31.3",
@@ -11651,7 +11651,7 @@ dependencies = [
 
 [[package]]
 name = "temps-import"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11691,7 +11691,7 @@ dependencies = [
 
 [[package]]
 name = "temps-import-caprover"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11712,7 +11712,7 @@ dependencies = [
 
 [[package]]
 name = "temps-import-coolify"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11733,7 +11733,7 @@ dependencies = [
 
 [[package]]
 name = "temps-import-docker"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "bollard",
@@ -11756,7 +11756,7 @@ dependencies = [
 
 [[package]]
 name = "temps-import-dokploy"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11778,7 +11778,7 @@ dependencies = [
 
 [[package]]
 name = "temps-import-kamal"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11799,7 +11799,7 @@ dependencies = [
 
 [[package]]
 name = "temps-import-kubernetes"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -11822,7 +11822,7 @@ dependencies = [
 
 [[package]]
 name = "temps-import-portainer"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11843,7 +11843,7 @@ dependencies = [
 
 [[package]]
 name = "temps-import-types"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11880,7 +11880,7 @@ dependencies = [
 
 [[package]]
 name = "temps-infra"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "axum",
@@ -11904,7 +11904,7 @@ dependencies = [
 
 [[package]]
 name = "temps-kv"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11957,7 +11957,7 @@ dependencies = [
 
 [[package]]
 name = "temps-log-aggregator"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -11992,7 +11992,7 @@ dependencies = [
 
 [[package]]
 name = "temps-logs"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-stream",
  "bollard",
@@ -12012,7 +12012,7 @@ dependencies = [
 
 [[package]]
 name = "temps-memory"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "thiserror 2.0.20",
@@ -12021,7 +12021,7 @@ dependencies = [
 
 [[package]]
 name = "temps-metrics"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -12051,7 +12051,7 @@ dependencies = [
 
 [[package]]
 name = "temps-migrations"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "sea-orm",
@@ -12065,7 +12065,7 @@ dependencies = [
 
 [[package]]
 name = "temps-monitoring"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12092,7 +12092,7 @@ dependencies = [
 
 [[package]]
 name = "temps-network"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "bollard",
@@ -12121,7 +12121,7 @@ dependencies = [
 
 [[package]]
 name = "temps-notifications"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12152,7 +12152,7 @@ dependencies = [
 
 [[package]]
 name = "temps-observability"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12184,7 +12184,7 @@ dependencies = [
 
 [[package]]
 name = "temps-otel"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -12232,7 +12232,7 @@ dependencies = [
 
 [[package]]
 name = "temps-plugin-sdk"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "axum",
  "clap",
@@ -12258,7 +12258,7 @@ dependencies = [
 
 [[package]]
 name = "temps-presets"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12280,7 +12280,7 @@ dependencies = [
 
 [[package]]
 name = "temps-preview-gateway"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "tokio",
@@ -12290,7 +12290,7 @@ dependencies = [
 
 [[package]]
 name = "temps-projects"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "axum",
@@ -12329,7 +12329,7 @@ dependencies = [
 
 [[package]]
 name = "temps-providers"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12387,7 +12387,7 @@ dependencies = [
 
 [[package]]
 name = "temps-proxy"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -12463,7 +12463,7 @@ dependencies = [
 
 [[package]]
 name = "temps-pty-agent"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "bytes",
  "clap",
@@ -12481,7 +12481,7 @@ dependencies = [
 
 [[package]]
 name = "temps-query"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "bytes",
@@ -12516,7 +12516,7 @@ dependencies = [
 
 [[package]]
 name = "temps-query-postgres"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "chrono",
@@ -12576,7 +12576,7 @@ dependencies = [
 
 [[package]]
 name = "temps-queue"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "log",
  "serde",
@@ -12589,7 +12589,7 @@ dependencies = [
 
 [[package]]
 name = "temps-revenue"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12623,7 +12623,7 @@ dependencies = [
 
 [[package]]
 name = "temps-routes"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12648,7 +12648,7 @@ dependencies = [
 
 [[package]]
 name = "temps-sandbox"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "argon2",
@@ -12685,7 +12685,7 @@ dependencies = [
 
 [[package]]
 name = "temps-screenshots"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12711,7 +12711,7 @@ dependencies = [
 
 [[package]]
 name = "temps-static-files"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "axum",
  "temps-auth",
@@ -12724,7 +12724,7 @@ dependencies = [
 
 [[package]]
 name = "temps-status-page"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12757,7 +12757,7 @@ dependencies = [
 
 [[package]]
 name = "temps-teams"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12778,7 +12778,7 @@ dependencies = [
 
 [[package]]
 name = "temps-telemetry"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "async-trait",
  "chrono",
@@ -12796,7 +12796,7 @@ dependencies = [
 
 [[package]]
 name = "temps-vm-agent"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "hex",
  "libc",
@@ -12806,7 +12806,7 @@ dependencies = [
 
 [[package]]
 name = "temps-vulnerability-scanner"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12838,7 +12838,7 @@ dependencies = [
 
 [[package]]
 name = "temps-webhooks"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12869,7 +12869,7 @@ dependencies = [
 
 [[package]]
 name = "temps-wireguard"
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 dependencies = [
  "base64 0.23.1",
  "defguard_wireguard_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0-beta.55"
+version = "0.1.0-beta.56"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Temps Contributors"]

--- a/_typos.toml
+++ b/_typos.toml
@@ -28,3 +28,6 @@ nin = "nin"
 # Hex string contains "ba" which the spell-checker mistakes for "by"/"be".
 "00f067aa0ba902b7" = "00f067aa0ba902b7"
 "deadbeef" = "deadbeef"
+# git-cliff nightly-tag changelog entry (CHANGELOG.md) — the short commit
+# hash "ba96c0f7" isolates to "ba", mistaken for "by"/"be".
+"ba96c0f7" = "ba96c0f7"


### PR DESCRIPTION
## Summary
- Bump workspace version to `0.1.0-beta.56`
- Regenerate `CHANGELOG.md` via git-cliff (8 conventional commits since beta.55)
- Add a `_typos.toml` identifier exception for a nightly-tag commit hash (`ba96c0f7`) that the spellchecker misread as "ba" → "by"/"be", following the existing precedent for hex fragments in that file

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --workspace` (266/267 passing; the one Docker DNS-fallback test needs real container network egress unavailable in this sandbox — confirmed passing on the last green CI run)
- [x] `Cargo.lock` version entries verified (0 stale `0.1.0-beta.55` entries, 84 `0.1.0-beta.56` entries)