### PR TITLE
fix(web): handle fetch errors in EmailProviderDetail with retry state

### DIFF
--- a/web/src/pages/EmailProviderDetail.tsx
+++ b/web/src/pages/EmailProviderDetail.tsx
@@ -42,7 +42,7 @@ import { TimeAgo } from '@/components/utils/TimeAgo'
 import { useBreadcrumbs } from '@/contexts/BreadcrumbContext'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { AlertCircle, ArrowLeft, Globe, Plus, Send, Trash2 } from 'lucide-react'
+import { AlertCircle, ArrowLeft, Globe, Plus, RotateCcw, Send, Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router'
 import { toast } from 'sonner'
@@ -50,9 +50,14 @@ import { toast } from 'sonner'
 async function fetchProvider(id: number): Promise<EmailProviderResponse> {
   const response = await getEmailProvider({ path: { id } })
   if (response.error || !response.data) {
-    throw new Error(
+    const error = new Error(
       problemMessage(response.error, 'Failed to fetch email provider')
-    )
+    ) as Error & { status?: number; title?: string }
+    if (response.error) {
+      error.status = (response.error as any).status
+      error.title = (response.error as any).title
+    }
+    throw error
   }
   return response.data
 }
@@ -98,11 +103,20 @@ export function EmailProviderDetail() {
     data: provider,
     isLoading,
     error: fetchError,
+    refetch: refetchProvider,
   } = useQuery({
     queryKey: ['email-provider', id],
     queryFn: () => fetchProvider(id!),
     enabled: !!id,
   })
+
+  useEffect(() => {
+    if (provider && fetchError) {
+      toast.error('Failed to refresh email provider', {
+        action: { label: 'Retry', onClick: () => void refetchProvider() },
+      })
+    }
+  }, [provider, fetchError, refetchProvider])
 
   const {
     data: domains,
@@ -189,7 +203,40 @@ export function EmailProviderDetail() {
     )
   }
 
-  if (fetchError || !provider) {
+  const isNotFound =
+    (fetchError as any)?.status === 404 ||
+    (fetchError as any)?.title === 'Not Found' ||
+    (fetchError as any)?.title === 'Provider Not Found'
+
+  if (!provider && fetchError && !isNotFound) {
+    return (
+      <div className="flex-1 overflow-auto">
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <AlertCircle className="size-8 text-destructive" />
+          <h2 className="mt-3 text-lg font-semibold">Failed to load email provider</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {fetchError instanceof Error
+              ? fetchError.message
+              : 'An unexpected error occurred. Please try again.'}
+          </p>
+          <div className="mt-4 flex gap-2">
+            <Button variant="outline" onClick={() => void refetchProvider()}>
+              <RotateCcw className="mr-2 size-4" />
+              Retry
+            </Button>
+            <Button variant="ghost" asChild>
+              <Link to="/email?tab=providers">
+                <ArrowLeft className="mr-2 size-4" />
+                Back to providers
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!provider) {
     return (
       <div className="flex-1 overflow-auto">
         <div className="flex flex-col items-center justify-center py-16 text-center">


### PR DESCRIPTION
 
 Closes  #757 
## Summary

Fixes error handling in `EmailProviderDetail.tsx` so that transient network and API fetch failures display a recovery screen with an actionable **Retry** button instead of falsely reporting that the resource does not exist.

---

### Problem
Previously, any non-2xx response (such as a transient 500 error, gateway timeout, or connection drop) caused the page to unconditionally render:
> *"Provider not found — The requested email provider could not be found."*

This false 404 provided no way for the user to retry the operation without navigating away from the page.

---

### Proposed Changes
1. **Separated Error Classification:** Differentiated genuine 404 responses (`status: 404` / `title: 'Not Found'`) from transient network and server errors.
2. **Actionable Retry State:** Added a dedicated *"Failed to load email provider"* recovery screen featuring an `AlertCircle` icon, the error description, and a working **Retry** button.
3. **Background Refresh Error Handling:** Added a toast alert with an inline **Retry** action when background query refetches fail while viewing existing data.

---

## Visual Evidence

Before snapshot

<img width="1262" height="568" alt="email-provider-detail-before" src="https://github.com/user-attachments/assets/d930fd81-9ae0-4c28-b66d-683b1bb2be42" />

After snapshot

<img width="1262" height="568" alt="email-provider-detail-after" src="https://github.com/user-attachments/assets/8ac1ad83-6930-4437-ad0d-f60d42e7e982" />


## How to Test
1. Start the web dev server (`cd web && bun run dev`).
2. Navigate to an email provider detail route (`/email/providers/1`).
3. Simulate a backend 500/network error:
   - **Verify:** The new *"Failed to load email provider"* card appears with the **Retry** button.
   - **Verify:** Clicking **Retry** triggers a refetch attempt.
4. Verify that genuine 404 responses continue to preserve the dedicated *"Provider not found"* screen.
