### PR TITLE
fix(web): trim whitespace inputs and guard against double-submission in CreateS3Source

### DIFF
--- a/web/src/pages/CreateS3Source.tsx
+++ b/web/src/pages/CreateS3Source.tsx
@@ -61,24 +61,26 @@ export function CreateS3Source() {
   })
 
   const handleTestConnection = () => {
-    if (
-      !formData.name ||
-      !formData.bucket_name ||
-      !formData.region ||
-      !formData.access_key_id ||
-      !formData.secret_key
-    ) {
+    if (testConnectionMutation.isPending || createMutation.isPending) return
+
+    const name = formData.name?.trim()
+    const bucket_name = formData.bucket_name?.trim()
+    const region = formData.region?.trim()
+    const access_key_id = formData.access_key_id?.trim()
+    const secret_key = formData.secret_key?.trim()
+
+    if (!name || !bucket_name || !region || !access_key_id || !secret_key) {
       toast.error('Fill all required fields to test the connection')
       return
     }
     testConnectionMutation.mutate({
-      name: formData.name,
-      bucket_name: formData.bucket_name,
+      name,
+      bucket_name,
       bucket_path: '/',
-      region: formData.region,
-      access_key_id: formData.access_key_id,
-      secret_key: formData.secret_key,
-      endpoint: formData.endpoint || undefined,
+      region,
+      access_key_id,
+      secret_key,
+      endpoint: formData.endpoint?.trim() || undefined,
       force_path_style: formData.force_path_style ?? undefined,
     })
   }
@@ -86,13 +88,15 @@ export function CreateS3Source() {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
 
-    if (
-      !formData.name ||
-      !formData.bucket_name ||
-      !formData.region ||
-      !formData.access_key_id ||
-      !formData.secret_key
-    ) {
+    if (createMutation.isPending || testConnectionMutation.isPending) return
+
+    const name = formData.name?.trim()
+    const bucket_name = formData.bucket_name?.trim()
+    const region = formData.region?.trim()
+    const access_key_id = formData.access_key_id?.trim()
+    const secret_key = formData.secret_key?.trim()
+
+    if (!name || !bucket_name || !region || !access_key_id || !secret_key) {
       toast.error('Please fill in all required fields')
       return
     }
@@ -100,17 +104,23 @@ export function CreateS3Source() {
     createMutation.mutate({
       body: {
         ...(formData as NewS3Source),
+        name,
+        bucket_name,
+        region,
+        access_key_id,
+        secret_key,
+        endpoint: formData.endpoint?.trim() || undefined,
         bucket_path: '/',
       },
     })
   }
 
   const isFormValid =
-    formData.name &&
-    formData.bucket_name &&
-    formData.region &&
-    formData.access_key_id &&
-    formData.secret_key
+    Boolean(formData.name?.trim()) &&
+    Boolean(formData.bucket_name?.trim()) &&
+    Boolean(formData.region?.trim()) &&
+    Boolean(formData.access_key_id?.trim()) &&
+    Boolean(formData.secret_key?.trim())
 
   return (
     <div className="container mx-auto max-w-2xl py-6">
@@ -188,13 +198,13 @@ export function CreateS3Source() {
                   className="flex items-baseline justify-between"
                 >
                   <span>Endpoint URL</span>
-                   <span className="text-xs text-muted-foreground">
+                  <span className="text-xs text-muted-foreground">
                     (Optional, for RustFS/MinIO)
                   </span>
                 </Label>
                 <Input
                   id="endpoint"
-                   placeholder="http://rustfs.example.com:9000"
+                  placeholder="http://rustfs.example.com:9000"
                   value={formData.endpoint || ''}
                   onChange={(e) =>
                     setFormData({ ...formData, endpoint: e.target.value })
@@ -262,6 +272,9 @@ export function CreateS3Source() {
                 type="button"
                 variant="outline"
                 onClick={() => navigate('/backups')}
+                disabled={
+                  createMutation.isPending || testConnectionMutation.isPending
+                }
               >
                 Cancel
               </Button>
@@ -287,7 +300,11 @@ export function CreateS3Source() {
                 </Button>
                 <Button
                   type="submit"
-                  disabled={createMutation.isPending || !isFormValid}
+                  disabled={
+                    createMutation.isPending ||
+                    testConnectionMutation.isPending ||
+                    !isFormValid
+                  }
                 >
                   {createMutation.isPending
                     ? 'Creating...'


### PR DESCRIPTION
Closes #759 

## Summary

Enhances client-side form validation, prevents double-submissions, and sanitizes payload values in `CreateS3Source.tsx`.

---

### Problem
1. **Whitespace Validation Bypass:** The `isFormValid` check evaluated raw string truthiness (`formData.name && ...`) without trimming. Entering whitespace-only strings (`"   "`) caused the client to treat the form as complete, enabling the **"Create S3 Source"** and **"Test connection"** buttons.
2. **Double-Submission Risk:** The `handleSubmit` function did not check `isPending` state, allowing rapid `Enter` key presses to fire duplicate creation requests to the backend.

---

### Changes
- **Trimmed Validation:** Updated `isFormValid` to verify non-empty trimmed strings (`Boolean(formData.name?.trim())`) across all required fields (`name`, `bucket_name`, `region`, `access_key_id`, `secret_key`).
- **Double-Submission Lock:** Added `isPending` guards in `handleSubmit` and `handleTestConnection` to block concurrent requests while in-flight.
- **Payload Sanitization:** Applied `.trim()` to all text fields before dispatching mutation requests.

---

## Visual Evidence

**Before Evidence** 
 
<img width="1280" height="900" alt="create-s3-source-before" src="https://github.com/user-attachments/assets/7e2fa7f9-b21d-4149-ba86-cb4778256ac2" />
 
 **After Evidence** 
 
<img width="1280" height="900" alt="create-s3-source-after" src="https://github.com/user-attachments/assets/240d341c-6ad6-4e49-b7a5-f7662309f9a7" />




## How to Test
1. Run the web dev server (`cd web && bun run dev`).
2. Navigate to `/backups/s3-sources/new`.
3. Type only spaces `"   "` into the required fields:
   - **Verify:** The "Create S3 Source" and "Test connection" buttons remain disabled and cannot be submitted.
4. Enter valid credentials and press `Enter` rapidly:
   - **Verify:** Only a single creation request is sent.
