### PR TITLE
fix(routes): close lost-wakeup race in route sync long-poll

### DIFF
--- a/crates/temps-routes/src/route_sync.rs
+++ b/crates/temps-routes/src/route_sync.rs
@@ -116,6 +116,24 @@ pub async fn get_routes_snapshot(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     authenticate_node(&app_state.db, &headers, node_id).await?;
 
+    // Arm the notifier BEFORE checking the generation. `Notify::notified()`
+    // captures the current notify epoch at construction time, so a reload
+    // that races between our check and the wait is still observed instead
+    // of being silently missed — the same lost-wakeup hazard
+    // `CachedPeerTable::wait_until_loaded` already avoids the same way.
+    // Constructing the `Notified` future only *after* the fast-path check
+    // (the previous shape of this function) leaves a window where a
+    // `load_routes()` reload that lands in that window is invisible to
+    // this request: `notify_waiters()` only wakes waiters already armed
+    // when it's called, so we'd then wait out the full
+    // `LONG_POLL_TIMEOUT` (25s) instead of returning almost immediately.
+    // `mark_deployment_complete`'s worker-apply gate only allows 10s, so
+    // any occurrence of this race causes a spurious deployment revert even
+    // though the worker is perfectly healthy.
+    let notifier = app_state.peer_table.generation_notifier();
+    let armed = notifier.notified();
+    tokio::pin!(armed);
+
     // Fast path: generation already moved past `since` — return now.
     let mut current = app_state.peer_table.current_generation();
     if current > q.since {
@@ -127,17 +145,21 @@ pub async fn get_routes_snapshot(
     // intermediate proxies (and the agent's HTTP client) drop idle
     // connections after ~30 s, so we return a same-generation snapshot
     // before that point and let the agent reconnect cleanly.
-    let notifier = app_state.peer_table.generation_notifier();
     let _ = tokio::time::timeout(LONG_POLL_TIMEOUT, async {
+        // First wait uses the future armed above (before the fast-path
+        // check) so it can't miss a reload that raced the check.
+        armed.await;
         // Loop guards against spurious wakeups: keep waiting until the
-        // generation actually moves.
+        // generation actually moves. Subsequent iterations arm fresh —
+        // by this point we're already inside the wait, so a race here
+        // only costs another loop iteration, bounded by the outer timeout.
         loop {
-            let notified = notifier.notified();
-            tokio::pin!(notified);
-            notified.await;
             if app_state.peer_table.current_generation() > q.since {
                 break;
             }
+            let notified = notifier.notified();
+            tokio::pin!(notified);
+            notified.await;
         }
     })
     .await;


### PR DESCRIPTION
## Reported issue
A user deploying 2 replicas pinned to a worker node (control-plane + 1 worker cluster) saw the deploy pull and start containers successfully — the app was reachable — but the deployment was still reverted at completion with:

> Worker propagation incomplete after 10s (timed out waiting for 1 node(s) to ACK (target route_gen=24, dns_gen=12)) — reverting to the last usable deployment

## Root cause
`mark_deployment_complete` gates "completed" on every active node ACKing the new route/DNS generation within a 10s budget. Workers ACK via a long-poll (`get_routes_snapshot`) that's supposed to return almost instantly once a reload happens — but the handler checked the route generation *before* arming its `Notify` future. A route reload landing in that gap was silently missed (`notify_waiters()` only wakes already-armed waiters), forcing the request to wait out the full 25s `LONG_POLL_TIMEOUT` instead of returning near-instantly — blowing straight through the 10s budget and causing a spurious revert of an otherwise healthy deployment.

## Fix
Arm the `Notified` future before the fast-path generation check, mirroring the existing lost-wakeup-safe pattern already used elsewhere in this codebase (`CachedPeerTable::wait_until_loaded`).

## Test plan
- [x] `cargo check --lib -p temps-routes` — clean
- [x] `cargo check --lib -p temps-deployments` — clean
- [x] pre-commit hooks (fmt, clippy, conventional commit) — passed
- [x] Manual repro on a real 2-node cluster (control-plane + 1 worker, joined over mTLS): pinned an environment to the worker with `replicas: 2` and deployed. Both replicas landed on the worker's own Docker daemon and the deployment reached `completed` in ~6s — comfortably inside the 10s gate, matching the originally reported scenario.