### PR TITLE
fix(cli): read upgrade's --license-path from TEMPS_EE_LICENSE_PATH too

### DIFF
--- a/crates/temps-cli/src/commands/upgrade.rs
+++ b/crates/temps-cli/src/commands/upgrade.rs
@@ -171,7 +171,13 @@ pub struct UpgradeCommand {
     /// is also copied to `<data-dir>/data/license.jwt` and, if a systemd
     /// unit exists, the unit's `TEMPS_EE_LICENSE_PATH` env is updated so
     /// the binary finds its license on every restart.
-    #[arg(long)]
+    ///
+    /// Also readable from `TEMPS_EE_LICENSE_PATH` -- the same env var an
+    /// EE binary's own startup gate reads, so one value covers both "the
+    /// license this running binary starts with" and "the license to
+    /// install for this upgrade" when they're the same file, which they
+    /// almost always are.
+    #[arg(long, env = "TEMPS_EE_LICENSE_PATH")]
     pub license_path: Option<PathBuf>,
 
     /// Base URL of the Temps Cloud EE proxy (`--tier ee` only). Defaults to


### PR DESCRIPTION
## Summary
- \`UpgradeCommand::license_path\` now also reads \`TEMPS_EE_LICENSE_PATH\`, not just the \`--license-path\` flag.

## Why
Found while chasing a real bug on a live EE binary: EE's \`main.rs\` wrapper strips \`--license-path\` anywhere in argv for its own startup license gate, and that flag name collides with \`upgrade\`'s own \`--license-path\` (a different thing — the license to install for a \`--tier ee\` switch). The EE-side fix (separate PR on the private repo) teaches the wrapper to leave \`upgrade\`'s own flag alone, but that means the wrapper's env-var path (\`TEMPS_EE_LICENSE_PATH\`) no longer feeds \`upgrade\`'s flag at all unless this field can read the same env var directly.

One value now covers both "the license this running binary starts with" and "the license to install for this upgrade" — in practice these are almost always the same file.

## Test plan
- [x] \`cargo check -p temps-cli\`
- [x] Verified in isolation against the EE-side fix (private repo): \`upgrade --tier ee\` with only \`TEMPS_EE_LICENSE_PATH\` set (no \`--license-path\` flag) now resolves \`license_path\` correctly.