### PR TITLE
fix(providers): retry transient Docker image pull failures

### DIFF
--- a/crates/temps-core/src/retry.rs
+++ b/crates/temps-core/src/retry.rs
@@ -118,7 +118,13 @@ impl RetryConfig {
     }
 
     /// Compute the delay for the given attempt using exponential backoff.
-    fn compute_delay(&self, attempt: u32) -> Duration {
+    ///
+    /// `pub` (not just crate-internal) so callers that need early-exit
+    /// semantics `retry()` doesn't support — e.g. stopping immediately on a
+    /// terminal error instead of retrying it — can hand-roll their own loop
+    /// while still reusing this config's backoff math instead of duplicating
+    /// it.
+    pub fn compute_delay(&self, attempt: u32) -> Duration {
         let delay = self.base_delay.saturating_mul(1 << attempt);
         std::cmp::min(delay, self.max_delay)
     }

--- a/crates/temps-providers/src/externalsvc/mariadb.rs
+++ b/crates/temps-providers/src/externalsvc/mariadb.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use bollard::exec::CreateExecOptions;
 use bollard::query_parameters::{InspectContainerOptions, StopContainerOptions};
 use bollard::{body_full, Docker};
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -527,26 +527,11 @@ impl MariaDbService {
             );
         } else {
             info!("Pulling MariaDB image {}", config.docker_image);
-            let (image_name, tag) = if let Some((name, tag)) = config.docker_image.split_once(':') {
-                (name.to_string(), tag.to_string())
-            } else {
-                (config.docker_image.clone(), "latest".to_string())
-            };
 
-            tokio::time::timeout(MARIADB_IMAGE_PULL_TIMEOUT, async {
-                docker
-                    .create_image(
-                        Some(bollard::query_parameters::CreateImageOptions {
-                            from_image: Some(image_name),
-                            tag: Some(tag),
-                            ..Default::default()
-                        }),
-                        None,
-                        None,
-                    )
-                    .try_collect::<Vec<_>>()
-                    .await
-            })
+            tokio::time::timeout(
+                MARIADB_IMAGE_PULL_TIMEOUT,
+                crate::utils::pull_image_with_retry(docker, &config.docker_image, None),
+            )
             .await
             .map_err(|_| {
                 anyhow::anyhow!(

--- a/crates/temps-providers/src/externalsvc/mongodb.rs
+++ b/crates/temps-providers/src/externalsvc/mongodb.rs
@@ -6,7 +6,7 @@ use bollard::query_parameters::{
     StopContainerOptions, WaitContainerOptionsBuilder,
 };
 use bollard::{body_full, Docker};
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use mongodb::bson::doc;
 use mongodb::options::ClientOptions;
 use mongodb::Client as MongoClient;
@@ -478,18 +478,9 @@ impl MongodbService {
 
         // Pull the image first
         info!("Pulling MongoDB image: {}", image_tag);
-        let mut stream = docker.create_image(
-            Some(bollard::query_parameters::CreateImageOptions {
-                from_image: Some(image_tag.clone()),
-                ..Default::default()
-            }),
-            None,
-            None,
-        );
-
-        while let Some(result) = stream.next().await {
-            result.map_err(|e| anyhow::anyhow!("Failed to pull MongoDB image: {}", e))?;
-        }
+        crate::utils::pull_image_with_retry(docker, &image_tag, None)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to pull MongoDB image: {}", e))?;
 
         let mut host_config = bollard::models::HostConfig {
             port_bindings: Some(crate::utils::local_port_binding("27017/tcp", &config.port)),
@@ -951,32 +942,13 @@ impl MongodbService {
     /// Attempts to pull the image - fails if it doesn't exist or cannot be accessed
     #[allow(dead_code)]
     async fn verify_image_pullable(&self, image: &str) -> Result<()> {
-        // Parse image name and tag
-        let (image_name, tag) = if let Some((name, tag)) = image.split_once(':') {
-            (name.to_string(), tag.to_string())
-        } else {
-            (image.to_string(), "latest".to_string())
-        };
-
         info!("Attempting to pull Docker image: {}", image);
 
-        // Try to pull the image - this will fail if it doesn't exist
-        let result = self
-            .docker
-            .create_image(
-                Some(bollard::query_parameters::CreateImageOptions {
-                    from_image: Some(image_name.clone()),
-                    tag: Some(tag.clone()),
-                    ..Default::default()
-                }),
-                None,
-                None,
-            )
-            .try_collect::<Vec<_>>()
-            .await;
-
-        match result {
-            Ok(_) => {
+        // Try to pull the image - this will fail if it doesn't exist. Retries
+        // transient stream errors so a dropped connection isn't mistaken for
+        // the image genuinely being unavailable.
+        match crate::utils::pull_image_with_retry(&self.docker, image, None).await {
+            Ok(()) => {
                 info!("Docker image {} is available and pullable", image);
                 Ok(())
             }
@@ -1745,23 +1717,15 @@ impl MongodbService {
         password: &str,
     ) -> Result<()> {
         // Pull the sidecar image (no-op if already present).
-        let mut pull_stream = self.docker.create_image(
-            Some(bollard::query_parameters::CreateImageOptions {
-                from_image: Some(MONGO_SIDECAR_IMAGE.to_string()),
-                ..Default::default()
-            }),
-            None,
-            None,
-        );
-        while let Some(result) = pull_stream.next().await {
-            result.map_err(|e| {
+        crate::utils::pull_image_with_retry(&self.docker, MONGO_SIDECAR_IMAGE, None)
+            .await
+            .map_err(|e| {
                 anyhow::anyhow!(
                     "Failed to pull sidecar image {}: {}",
                     MONGO_SIDECAR_IMAGE,
                     e
                 )
             })?;
-        }
 
         let container_archive_path = format!("/backup/{}", archive_filename);
         let sidecar_name = format!(
@@ -4239,6 +4203,7 @@ mod tests {
         use super::super::test_utils::{
             create_mock_backup, create_mock_db, create_mock_external_service, MinioTestContainer,
         };
+        use futures::TryStreamExt;
 
         // Check if Docker is available
         let docker = match Docker::connect_with_local_defaults() {

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use bollard::query_parameters::{InspectContainerOptions, StopContainerOptions};
 use bollard::{body_full, Docker};
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use schemars::JsonSchema;
 use sea_orm::{prelude::*, *};
 use serde::{Deserialize, Serialize};
@@ -648,25 +648,9 @@ impl PostgresService {
         // Pull image first
         info!("Pulling PostgreSQL image {}", config.docker_image);
 
-        // Parse image name and tag
-        let (image_name, tag) = if let Some((name, tag)) = config.docker_image.split_once(':') {
-            (name.to_string(), tag.to_string())
-        } else {
-            (config.docker_image.clone(), "latest".to_string())
-        };
-
-        docker
-            .create_image(
-                Some(bollard::query_parameters::CreateImageOptions {
-                    from_image: Some(image_name),
-                    tag: Some(tag),
-                    ..Default::default()
-                }),
-                None,
-                None,
-            )
-            .try_collect::<Vec<_>>()
-            .await?;
+        crate::utils::pull_image_with_retry(docker, &config.docker_image, None)
+            .await
+            .map_err(|e| anyhow::anyhow!(e))?;
 
         let container_name = self.get_container_name();
         let volume_name = format!("{}_data", container_name);
@@ -1891,32 +1875,13 @@ impl PostgresService {
     /// Verify that a Docker image can be pulled without actually downloading the full image
     /// Attempts to pull the image - fails if it doesn't exist or cannot be accessed
     async fn verify_image_pullable(&self, image: &str) -> Result<()> {
-        // Parse image name and tag
-        let (image_name, tag) = if let Some((name, tag)) = image.split_once(':') {
-            (name.to_string(), tag.to_string())
-        } else {
-            (image.to_string(), "latest".to_string())
-        };
-
         info!("Attempting to pull Docker image: {}", image);
 
-        // Try to pull the image - this will fail if it doesn't exist
-        let result = self
-            .docker
-            .create_image(
-                Some(bollard::query_parameters::CreateImageOptions {
-                    from_image: Some(image_name.clone()),
-                    tag: Some(tag.clone()),
-                    ..Default::default()
-                }),
-                None,
-                None,
-            )
-            .try_collect::<Vec<_>>()
-            .await;
-
-        match result {
-            Ok(_) => {
+        // Try to pull the image - this will fail if it doesn't exist. Retries
+        // transient stream errors so a dropped connection isn't mistaken for
+        // the image genuinely being unavailable.
+        match crate::utils::pull_image_with_retry(&self.docker, image, None).await {
+            Ok(()) => {
                 info!("Docker image {} is available and pullable", image);
                 Ok(())
             }
@@ -2673,22 +2638,7 @@ impl PostgresService {
         let sidecar_image = postgres_config.docker_image.clone();
 
         info!("Pulling sidecar image {} for pg_dump", sidecar_image);
-        let (image_name, image_tag) = sidecar_image
-            .split_once(':')
-            .map(|(n, t)| (n.to_string(), t.to_string()))
-            .unwrap_or_else(|| (sidecar_image.clone(), "latest".to_string()));
-
-        self.docker
-            .create_image(
-                Some(bollard::query_parameters::CreateImageOptions {
-                    from_image: Some(image_name),
-                    tag: Some(image_tag),
-                    ..Default::default()
-                }),
-                None,
-                None,
-            )
-            .try_collect::<Vec<_>>()
+        crate::utils::pull_image_with_retry(&self.docker, &sidecar_image, None)
             .await
             .map_err(|e| {
                 anyhow::anyhow!(

--- a/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
@@ -1396,28 +1396,12 @@ impl PostgresUpgradeOrchestrator {
         row: &postgres_major_upgrades::Model,
         image: &str,
     ) -> Result<(), PostgresUpgradeError> {
-        use futures::TryStreamExt;
-        let (image_name, tag) = match image.split_once(':') {
-            Some((n, t)) => (n.to_string(), t.to_string()),
-            None => (image.to_string(), "latest".to_string()),
-        };
-        self.docker
-            .create_image(
-                Some(bollard::query_parameters::CreateImageOptions {
-                    from_image: Some(image_name),
-                    tag: Some(tag),
-                    ..Default::default()
-                }),
-                None,
-                None,
-            )
-            .try_collect::<Vec<_>>()
+        crate::utils::pull_image_with_retry(&self.docker, image, None)
             .await
             .map_err(|e| PostgresUpgradeError::Docker {
                 upgrade_id: row.id,
-                reason: format!("pull image '{}' failed: {}", image, e),
-            })?;
-        Ok(())
+                reason: e,
+            })
     }
 
     /// Check whether the dump volume already contains the `/dump/.done`
@@ -1668,24 +1652,12 @@ impl PostgresUpgradeOrchestrator {
         &self,
         row: &postgres_major_upgrades::Model,
     ) -> Result<(), PostgresUpgradeError> {
-        use futures::TryStreamExt;
-        self.docker
-            .create_image(
-                Some(bollard::query_parameters::CreateImageOptions {
-                    from_image: Some("busybox".to_string()),
-                    tag: Some("latest".to_string()),
-                    ..Default::default()
-                }),
-                None,
-                None,
-            )
-            .try_collect::<Vec<_>>()
+        crate::utils::pull_image_with_retry(&self.docker, "busybox:latest", None)
             .await
             .map_err(|e| PostgresUpgradeError::Docker {
                 upgrade_id: row.id,
-                reason: format!("failed to pull busybox: {}", e),
-            })?;
-        Ok(())
+                reason: e,
+            })
     }
 
     /// Create a named Docker volume. Ignores "already exists" — we treat

--- a/crates/temps-providers/src/externalsvc/redis.rs
+++ b/crates/temps-providers/src/externalsvc/redis.rs
@@ -8,7 +8,6 @@ use async_trait::async_trait;
 use bollard::query_parameters::{InspectContainerOptions, StopContainerOptions};
 use bollard::Docker;
 use flate2::read::GzDecoder;
-use futures::TryStreamExt;
 use redis::{aio::ConnectionManager, AsyncCommands, Client};
 use schemars::JsonSchema;
 use sea_orm::prelude::*;
@@ -339,24 +338,7 @@ impl RedisService {
         // Use the docker_image from config
         info!("Pulling Redis image {}", config.docker_image);
 
-        // Parse image name and tag
-        let (image_name, tag) = if let Some((name, tag)) = config.docker_image.split_once(':') {
-            (name.to_string(), tag.to_string())
-        } else {
-            (config.docker_image.to_string(), "latest".to_string())
-        };
-
-        docker
-            .create_image(
-                Some(bollard::query_parameters::CreateImageOptions {
-                    from_image: Some(image_name),
-                    tag: Some(tag),
-                    ..Default::default()
-                }),
-                None,
-                None,
-            )
-            .try_collect::<Vec<_>>()
+        crate::utils::pull_image_with_retry(docker, &config.docker_image, None)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to pull Redis image: {}", e))?;
 
@@ -875,32 +857,13 @@ impl RedisService {
     /// Attempts to pull the image - fails if it doesn't exist or cannot be accessed
     #[allow(dead_code)]
     async fn verify_image_pullable(&self, image: &str) -> Result<()> {
-        // Parse image name and tag
-        let (image_name, tag) = if let Some((name, tag)) = image.split_once(':') {
-            (name.to_string(), tag.to_string())
-        } else {
-            (image.to_string(), "latest".to_string())
-        };
-
         info!("Attempting to pull Docker image: {}", image);
 
-        // Try to pull the image - this will fail if it doesn't exist
-        let result = self
-            .docker
-            .create_image(
-                Some(bollard::query_parameters::CreateImageOptions {
-                    from_image: Some(image_name.clone()),
-                    tag: Some(tag.clone()),
-                    ..Default::default()
-                }),
-                None,
-                None,
-            )
-            .try_collect::<Vec<_>>()
-            .await;
-
-        match result {
-            Ok(_) => {
+        // Try to pull the image - this will fail if it doesn't exist. Retries
+        // transient stream errors so a dropped connection isn't mistaken for
+        // the image genuinely being unavailable.
+        match crate::utils::pull_image_with_retry(&self.docker, image, None).await {
+            Ok(()) => {
                 info!("Docker image {} is available and pullable", image);
                 Ok(())
             }

--- a/crates/temps-providers/src/externalsvc/rustfs.rs
+++ b/crates/temps-providers/src/externalsvc/rustfs.rs
@@ -493,24 +493,9 @@ impl RustfsService {
     async fn pull_mc_image(&self, docker: &Docker) -> Result<()> {
         info!("Pulling MinIO Client image {}", Self::MC_IMAGE);
 
-        let (image_name, tag) = if let Some((name, tag)) = Self::MC_IMAGE.split_once(':') {
-            (name.to_string(), tag.to_string())
-        } else {
-            (Self::MC_IMAGE.to_string(), "latest".to_string())
-        };
-
-        docker
-            .create_image(
-                Some(bollard::query_parameters::CreateImageOptions {
-                    from_image: Some(image_name),
-                    tag: Some(tag),
-                    ..Default::default()
-                }),
-                None,
-                None,
-            )
-            .try_collect::<Vec<_>>()
-            .await?;
+        crate::utils::pull_image_with_retry(docker, Self::MC_IMAGE, None)
+            .await
+            .map_err(|e| anyhow::anyhow!(e))?;
         Ok(())
     }
 
@@ -575,25 +560,9 @@ impl RustfsService {
         // Pull the image first
         info!("Pulling RustFS image {}", config.docker_image);
 
-        // Parse image name and tag
-        let (image_name, tag) = if let Some((name, tag)) = config.docker_image.split_once(':') {
-            (name.to_string(), tag.to_string())
-        } else {
-            (config.docker_image.to_string(), "latest".to_string())
-        };
-
-        docker
-            .create_image(
-                Some(bollard::query_parameters::CreateImageOptions {
-                    from_image: Some(image_name),
-                    tag: Some(tag),
-                    ..Default::default()
-                }),
-                None,
-                None,
-            )
-            .try_collect::<Vec<_>>()
-            .await?;
+        crate::utils::pull_image_with_retry(docker, &config.docker_image, None)
+            .await
+            .map_err(|e| anyhow::anyhow!(e))?;
 
         let container_name = self.get_container_name();
         // Add volume names for data and logs

--- a/crates/temps-providers/src/externalsvc/s3.rs
+++ b/crates/temps-providers/src/externalsvc/s3.rs
@@ -340,25 +340,9 @@ echo '[restore] complete'"#;
         // Pull the image first
         info!("Pulling MinIO image {}", config.docker_image);
 
-        // Parse image name and tag
-        let (image_name, tag) = if let Some((name, tag)) = config.docker_image.split_once(':') {
-            (name.to_string(), tag.to_string())
-        } else {
-            (config.docker_image.to_string(), "latest".to_string())
-        };
-
-        docker
-            .create_image(
-                Some(bollard::query_parameters::CreateImageOptions {
-                    from_image: Some(image_name),
-                    tag: Some(tag),
-                    ..Default::default()
-                }),
-                None,
-                None,
-            )
-            .try_collect::<Vec<_>>()
-            .await?;
+        crate::utils::pull_image_with_retry(docker, &config.docker_image, None)
+            .await
+            .map_err(|e| anyhow::anyhow!(e))?;
 
         let container_name = self.get_container_name();
         // Add volume name construction
@@ -527,25 +511,9 @@ echo '[restore] complete'"#;
     async fn pull_mc_image(&self, docker: &Docker) -> Result<()> {
         info!("Pulling MinIO Client image {}", Self::MC_IMAGE);
 
-        // Parse image name and tag
-        let (image_name, tag) = if let Some((name, tag)) = Self::MC_IMAGE.split_once(':') {
-            (name.to_string(), tag.to_string())
-        } else {
-            (Self::MC_IMAGE.to_string(), "latest".to_string())
-        };
-
-        docker
-            .create_image(
-                Some(bollard::query_parameters::CreateImageOptions {
-                    from_image: Some(image_name),
-                    tag: Some(tag),
-                    ..Default::default()
-                }),
-                None,
-                None,
-            )
-            .try_collect::<Vec<_>>()
-            .await?;
+        crate::utils::pull_image_with_retry(docker, Self::MC_IMAGE, None)
+            .await
+            .map_err(|e| anyhow::anyhow!(e))?;
         Ok(())
     }
 
@@ -685,32 +653,13 @@ echo '[restore] complete'"#;
     /// Attempts to pull the image - fails if it doesn't exist or cannot be accessed
     #[allow(dead_code)]
     async fn verify_image_pullable(&self, image: &str) -> Result<()> {
-        // Parse image name and tag
-        let (image_name, tag) = if let Some((name, tag)) = image.split_once(':') {
-            (name.to_string(), tag.to_string())
-        } else {
-            (image.to_string(), "latest".to_string())
-        };
-
         info!("Attempting to pull Docker image: {}", image);
 
-        // Try to pull the image - this will fail if it doesn't exist
-        let result = self
-            .docker
-            .create_image(
-                Some(bollard::query_parameters::CreateImageOptions {
-                    from_image: Some(image_name.clone()),
-                    tag: Some(tag.clone()),
-                    ..Default::default()
-                }),
-                None,
-                None,
-            )
-            .try_collect::<Vec<_>>()
-            .await;
-
-        match result {
-            Ok(_) => {
+        // Try to pull the image - this will fail if it doesn't exist. Retries
+        // transient stream errors so a dropped connection isn't mistaken for
+        // the image genuinely being unavailable.
+        match crate::utils::pull_image_with_retry(&self.docker, image, None).await {
+            Ok(()) => {
                 info!("Docker image {} is available and pullable", image);
                 Ok(())
             }

--- a/crates/temps-providers/src/postgres_lifecycle.rs
+++ b/crates/temps-providers/src/postgres_lifecycle.rs
@@ -409,23 +409,7 @@ impl PostgresContainerLifecycle for PostgresLifecycleAdapter {
         let pgdata_path = Self::pgdata_path_for(image)?;
 
         // Pull image first for clear fail-fast errors.
-        let (image_name, tag) = match image.split_once(':') {
-            Some((n, t)) => (n.to_string(), t.to_string()),
-            None => (image.to_string(), "latest".to_string()),
-        };
-        self.docker
-            .create_image(
-                Some(bollard::query_parameters::CreateImageOptions {
-                    from_image: Some(image_name),
-                    tag: Some(tag),
-                    ..Default::default()
-                }),
-                None,
-                None,
-            )
-            .try_collect::<Vec<_>>()
-            .await
-            .map_err(|e| format!("pull image '{}' failed: {}", image, e))?;
+        crate::utils::pull_image_with_retry(&self.docker, image, None).await?;
 
         // Create volume if missing — idempotent.
         self.docker

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -7421,7 +7421,6 @@ echo "[restore] Pre-seed complete"
     ) -> Result<(String, Option<i32>, Option<String>), ExternalServiceError> {
         use bollard::models::*;
         use bollard::query_parameters::*;
-        use futures::TryStreamExt;
 
         // Ensure network exists
         crate::utils::ensure_network_exists(&self.docker)
@@ -7432,21 +7431,9 @@ echo "[restore] Pre-seed complete"
             })?;
 
         // Pull image
-        self.docker
-            .create_image(
-                Some(CreateImageOptions {
-                    from_image: Some(params.image.clone()),
-                    ..Default::default()
-                }),
-                None,
-                None,
-            )
-            .try_collect::<Vec<_>>()
+        crate::utils::pull_image_with_retry(&self.docker, &params.image, None)
             .await
-            .map_err(|e| ExternalServiceError::DockerError {
-                id: 0,
-                reason: format!("Failed to pull image {}: {}", params.image, e),
-            })?;
+            .map_err(|e| ExternalServiceError::DockerError { id: 0, reason: e })?;
 
         // Create volume
         let volume_name = format!("{}_data", container_name);

--- a/crates/temps-providers/src/utils.rs
+++ b/crates/temps-providers/src/utils.rs
@@ -1,6 +1,11 @@
+use bollard::auth::DockerCredentials;
+use bollard::query_parameters::CreateImageOptions;
 use bollard::{models::NetworkCreateRequest, query_parameters::ListNetworksOptions, Docker};
+use futures::StreamExt;
 use std::collections::HashMap;
-use tracing::{error, info};
+use std::time::Duration;
+use temps_core::retry::RetryConfig;
+use tracing::{error, info, warn};
 
 pub(crate) async fn ensure_network_exists(
     docker: &Docker,
@@ -80,9 +85,137 @@ pub(crate) fn local_port_binding(
     )])
 }
 
+/// True for a definitive "this image cannot be pulled, ever" response from
+/// the registry (image doesn't exist, access denied, bad reference) — a 4xx
+/// `DockerResponseServerError`. Everything else (a mid-stream drop like
+/// "bytes remaining on stream", a hyper/IO error, a request timeout, or a
+/// 5xx from the registry) is presumed transient. Matches this project's own
+/// resilience rule: retry transient failures, not not-found/auth errors.
+fn is_terminal_pull_error(e: &bollard::errors::Error) -> bool {
+    matches!(
+        e,
+        bollard::errors::Error::DockerResponseServerError { status_code, .. }
+            if (400..500).contains(status_code)
+    )
+}
+
+/// Pull a Docker image, retrying transient stream failures (e.g. "bytes
+/// remaining on stream" from a connection dropped mid-transfer) instead of
+/// failing the whole provisioning attempt on the first hiccup. Does NOT
+/// retry a terminal failure (image not found, access denied) — see
+/// `is_terminal_pull_error` — so a typo'd image name fails fast instead of
+/// burning ~20s on backoff for something that will never succeed.
+///
+/// `image` is the full reference including tag (e.g. `"mongo:8"`), matching
+/// how every call site already builds it. Docker's daemon caches layers by
+/// digest, so a retried pull only re-fetches whatever didn't finish, not the
+/// whole image — cheap even for large images like MongoDB's. This is why a
+/// bare retry (no attempt to resume mid-stream) is the right fix here rather
+/// than something more elaborate.
+///
+/// Returns `Err(String)` with the image name and last error already folded
+/// in, so callers can pass it straight to their existing error type/message
+/// via `.map_err(...)` without needing to know the retry happened.
+pub(crate) async fn pull_image_with_retry(
+    docker: &Docker,
+    image: &str,
+    registry_credentials: Option<DockerCredentials>,
+) -> Result<(), String> {
+    let retry = RetryConfig::new(3)
+        .with_base_delay(Duration::from_secs(2))
+        .with_max_delay(Duration::from_secs(15));
+
+    for attempt in 0..retry.max_attempts {
+        let mut stream = docker.create_image(
+            Some(CreateImageOptions {
+                from_image: Some(image.to_string()),
+                ..Default::default()
+            }),
+            None,
+            registry_credentials.clone(),
+        );
+
+        let mut pull_err = None;
+        while let Some(item) = stream.next().await {
+            if let Err(e) = item {
+                pull_err = Some(e);
+                break;
+            }
+        }
+
+        let Some(e) = pull_err else {
+            return Ok(());
+        };
+
+        let is_last_attempt = attempt + 1 >= retry.max_attempts;
+        if is_terminal_pull_error(&e) || is_last_attempt {
+            warn!("Failed to pull image '{}': {}", image, e);
+            return Err(format!("failed to pull image '{}': {}", image, e));
+        }
+
+        let delay = retry.compute_delay(attempt);
+        warn!(
+            "Pull attempt {}/{} for image '{}' failed, retrying in {:?}: {}",
+            attempt + 1,
+            retry.max_attempts,
+            image,
+            delay,
+            e
+        );
+        tokio::time::sleep(delay).await;
+    }
+
+    unreachable!("loop always returns Ok or Err before exhausting max_attempts")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn test_pull_image_with_retry_pulls_a_real_image() {
+        let docker = match Docker::connect_with_local_defaults() {
+            Ok(d) => d,
+            Err(e) => {
+                println!("Docker unavailable, skipping: {e}");
+                return;
+            }
+        };
+        if docker.ping().await.is_err() {
+            println!("Docker daemon not responding, skipping");
+            return;
+        }
+
+        let result = pull_image_with_retry(&docker, "busybox:latest", None).await;
+        assert!(result.is_ok(), "expected pull to succeed: {result:?}");
+    }
+
+    #[tokio::test]
+    async fn test_pull_image_with_retry_reports_the_image_name_on_failure() {
+        let docker = match Docker::connect_with_local_defaults() {
+            Ok(d) => d,
+            Err(e) => {
+                println!("Docker unavailable, skipping: {e}");
+                return;
+            }
+        };
+        if docker.ping().await.is_err() {
+            println!("Docker daemon not responding, skipping");
+            return;
+        }
+
+        let result = pull_image_with_retry(
+            &docker,
+            "temps-nonexistent-image-fixture:does-not-exist",
+            None,
+        )
+        .await;
+        let err = result.expect_err("pulling a nonexistent image must fail");
+        assert!(
+            err.contains("temps-nonexistent-image-fixture:does-not-exist"),
+            "error should name the image that failed to pull: {err}"
+        );
+    }
 
     #[test]
     fn test_local_port_binding_binds_to_loopback_only() {


### PR DESCRIPTION
## Summary
- Every managed-service provisioner (MongoDB, Postgres, Redis, MariaDB, S3, RustFS) pulled its Docker image with a single-shot stream drain and no retry, so a transient connection drop mid-pull ("bytes remaining on stream" et al.) failed the whole provisioning attempt on the first hiccup. Large images (`mongo:8` in particular) spend longer in the pull loop and so hit this far more often, though the gap applied to every provider.
- Adds `pull_image_with_retry` in `temps-providers::utils`, reused across all `externalsvc` pull sites plus `postgres_lifecycle.rs` and `services.rs`.
- Only retries the transient category (`DockerStreamError`, hyper/IO errors, request timeouts, 5xx from the registry) and fails fast on terminal ones (a 4xx `DockerResponseServerError` — image genuinely doesn't exist or isn't accessible), matching this project's own "don't retry not-found errors" resilience rule.
- `RetryConfig::compute_delay` is exposed as `pub` in `temps-core` so this can reuse its backoff math without duplicating it — `RetryConfig::retry()` itself retries every error unconditionally and has no early-exit hook for terminal errors, which this use case needs.
- Net diff is negative (201 insertions / 338 deletions) despite adding a whole new capability, since ~15 near-identical inline pull-and-drain blocks collapse into one shared call.

## Left out of scope
- Pull sites inside `#[cfg(test)]` fixtures (`exec_util.rs`, `postgres_upgrade.rs` tests) — they pull stable, trivially-available images (`busybox`) for test setup, not user-facing provisioning.
- Other crates with their own `create_image` call sites (`temps-backup`, `temps-deployments`, `temps-import`, `temps-agents`, `temps-domains`) — different subsystems with more custom progress-reporting logic around their pulls, deserving individual attention rather than a blanket change bundled into this PR.

## Test plan
- [x] `cargo check --lib` across the full workspace — 0 errors
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (the exact pre-commit/CI invocation) — passes clean
- [x] `cargo test --lib -p temps-providers` — all 541 tests pass, no regressions
- [x] `cargo test --lib -p temps-core retry::` — existing `RetryConfig` tests unaffected by the `compute_delay` visibility change
- [x] Added two Docker-gated integration tests for `pull_image_with_retry` (skip gracefully if Docker unavailable, matching this repo's convention): pulling a real image succeeds, and pulling a nonexistent image fails fast (not after 3 retries) with the image name in the error
- [x] Ran both new tests against a real local Docker daemon — pass in 1.62s total, confirming the fail-fast path doesn't burn the ~20s retry budget on a terminal error