### PR TITLE
fix(domains): disable Pebble nonce fault injection

### DIFF
--- a/crates/temps-domains/src/domain_service.rs
+++ b/crates/temps-domains/src/domain_service.rs
@@ -2651,6 +2651,13 @@ mod tests {
             .with_wait_for(WaitFor::message_on_stdout("ACME directory available at"))
             .with_env_var("PEBBLE_VA_ALWAYS_VALID", "0")
             .with_env_var("PEBBLE_VA_NOSLEEP", "1")
+            // Pebble deliberately rejects 5% of otherwise valid nonces by
+            // default. instant-acme retries badNonce responses internally,
+            // but three consecutive injected rejections exhaust its bounded
+            // retry budget and make this HTTP-01 integration test flaky. Nonce
+            // recovery is instant-acme's responsibility; keep this test focused
+            // on Temps' real challenge-serving and certificate-storage flow.
+            .with_env_var("PEBBLE_WFE_NONCEREJECT", "0")
             // Add host-gateway so Pebble's VA can reach the host's challenge
             // responder (the A-record points the hostname at the gateway IP).
             .with_host(


### PR DESCRIPTION
## Summary

- disable Pebble's deliberate valid-nonce rejection in the real HTTP-01 integration test
- keep real challenge validation enabled while avoiding exhaustion of instant-acme's bounded badNonce retry budget
- document why nonce recovery remains owned by instant-acme rather than adding a duplicate application retry

## Root cause

Pebble rejects 5% of otherwise valid anti-replay nonces by default to exercise ACME client recovery. instant-acme 0.8.5 already handles RFC 8555 badNonce responses internally, reusing the fresh Replay-Nonce header, but stops after three total attempts. Three consecutive injected rejections therefore surface the same terminal badNonce seen in CI. Temps uses a bare Hyper transport with no per-request timeout or header wrapper, so it does not discard the retry nonce or cut off the dependency retry.

This test covers Temps' real HTTP-01 challenge-serving and certificate-storage flow, not instant-acme's nonce implementation, so it now starts Pebble with PEBBLE_WFE_NONCEREJECT=0. PEBBLE_VA_ALWAYS_VALID remains 0, preserving genuine HTTP-01 validation.

## Evidence

- Forced PEBBLE_WFE_NONCEREJECT=100 before the fix: reproduced the terminal `urn:ietf:params:acme:error:badNonce` failure.
- Real Pebble HTTP-01 test repeated 10 times with fresh containers: **10/10 passed**, each issuing and chain-verifying a certificate.
- `cargo test --lib -p temps-domains`: **65 passed, 0 failed, 3 ignored**.
- `cargo check --workspace --all-targets`: passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: passed.
- `cargo fmt --all -- --check`: passed.

Surfaced by the docker-deployments integration job in CI run 32816616328.