### PR TITLE
perf(cli): stream the upgrade download and extraction to disk

### DIFF
--- a/crates/temps-cli/Cargo.toml
+++ b/crates/temps-cli/Cargo.toml
@@ -128,6 +128,7 @@ uuid = { workspace = true }
 bytes = { workspace = true }
 http-body-util = { workspace = true }
 libc = { workspace = true }
+tempfile = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { workspace = true }
@@ -137,7 +138,6 @@ tikv-jemallocator = { workspace = true }
 # console health router through a single request in unit tests without binding
 # a real listener. Already present transitively; pinned here for test use.
 tower = { workspace = true }
-tempfile = { workspace = true }
 # Only for `tests/plugin_sdk_conformance.rs`: proves the SDK's hand-written
 # endpoint table still matches the handlers this crate assembles into the API.
 temps-plugin-sdk = { path = "../temps-plugin-sdk" }

--- a/crates/temps-cli/src/commands/serve/self_update.rs
+++ b/crates/temps-cli/src/commands/serve/self_update.rs
@@ -37,10 +37,10 @@ use temps_core::{
 use tracing::{error, info, warn};
 
 use crate::commands::upgrade::{
-    check_write_permission, current_version_tag, download_asset, download_asset_text,
-    extract_binary_from_tarball, fetch_latest_release_in_channel, fetch_specific_release,
-    is_newer_version, platform_target, replace_binary, verify_checksum, GitHubRelease,
-    UpgradeChannel,
+    check_write_permission, create_upgrade_temp_file, current_version_tag, download_asset_text,
+    download_asset_to_file, extract_binary_from_tarball_file, fetch_latest_release_in_channel,
+    fetch_specific_release, finalize_staged_binary, is_newer_version, platform_target,
+    verify_computed_checksum, GitHubRelease, UpgradeChannel,
 };
 
 /// Grace period between accepting the update and exiting the process. Long
@@ -783,11 +783,11 @@ impl UpdateJob {
 
     /// Download, verify, swap the binary and run database migrations.
     ///
-    /// Everything up to and including `replace_binary` is the "pre-swap" zone:
-    /// a failure there leaves the running binary untouched and is returned as
-    /// `ExecuteError::PreSwap`. Once the binary is on disk, any failure is
-    /// `ExecuteError::PostSwapMigration` — the operator is told exactly what
-    /// state the install is in and what to do next.
+    /// Everything up to and including `finalize_staged_binary` is the
+    /// "pre-swap" zone: a failure there leaves the running binary untouched
+    /// and is returned as `ExecuteError::PreSwap`. Once the binary is on
+    /// disk, any failure is `ExecuteError::PostSwapMigration` — the operator
+    /// is told exactly what state the install is in and what to do next.
     async fn execute(&self, started_at: chrono::DateTime<Utc>) -> Result<String, ExecuteError> {
         let (to_version, backup_path) = self
             .download_verify_swap()
@@ -877,8 +877,27 @@ impl UpdateJob {
             size_mb = format!("{:.1}", asset.size as f64 / 1_048_576.0),
             "Downloading release asset"
         );
+
+        // Streamed through disk, exactly like `temps upgrade`: this runs
+        // INSIDE the already-serving `temps serve` process, so buffering the
+        // ~110 MB tarball and ~270 MB extracted binary in memory here is the
+        // same swap-thrashing risk on a small host — arguably worse, since
+        // the server is live and handling requests while it happens.
+        let parent = self
+            .binary_path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Cannot determine the binary's directory"))?
+            .to_path_buf();
+
         self.set_phase(SelfUpdatePhase::Downloading, None);
-        let tarball = download_asset(&asset.browser_download_url).await?;
+        let mut download_file = create_upgrade_temp_file(&parent, ".temps-selfupdate-dl.")?;
+        let download_path = download_file.path().to_path_buf();
+        let computed = download_asset_to_file(
+            &asset.browser_download_url,
+            download_file.as_file_mut(),
+            &download_path,
+        )
+        .await?;
 
         self.set_phase(SelfUpdatePhase::Verifying, None);
         // Fail closed on a missing checksum. `temps upgrade` merely warns
@@ -898,16 +917,26 @@ impl UpdateJob {
                 )
             })?;
         let expected = download_asset_text(&checksum_asset.browser_download_url).await?;
-        verify_checksum(&tarball, &expected)?;
+        verify_computed_checksum(&computed, &expected)?;
 
-        let new_binary = extract_binary_from_tarball(&tarball)?;
-        preflight_binary(&self.binary_path, &new_binary)?;
+        let mut staged_file = create_upgrade_temp_file(&parent, ".temps-selfupdate-bin.")?;
+        let staged_path = staged_file.path().to_path_buf();
+        extract_binary_from_tarball_file(
+            download_file.as_file_mut(),
+            &download_path,
+            staged_file.as_file_mut(),
+            &staged_path,
+        )?;
+
+        // Preflight against the staged file itself rather than writing a
+        // second full copy just to exec it.
+        preflight_staged_binary(&staged_path, staged_file.as_file())?;
 
         self.set_phase(SelfUpdatePhase::Installing, None);
         // Keep the outgoing binary next to the new one so a release that boots
         // but misbehaves can be reverted with a single `mv`, without network.
         let backup_path = backup_current_binary(&self.binary_path)?;
-        replace_binary(&self.binary_path, &new_binary)?;
+        finalize_staged_binary(&self.binary_path, staged_file)?;
 
         Ok((to_version, backup_path))
     }
@@ -1199,45 +1228,30 @@ fn running_under_systemd_service() -> bool {
     }
 }
 
-/// Run the downloaded binary's `--version` before trusting it.
+/// Run the staged binary's `--version` before trusting it.
 ///
 /// Catches the failures a checksum cannot: a build for the wrong libc, a
 /// missing shared library, a corrupted extraction. Cheap insurance — without
 /// it, a binary that cannot exec turns a one-click update into an outage that
 /// only a console on the host can fix.
-fn preflight_binary(binary_path: &Path, new_binary: &[u8]) -> anyhow::Result<()> {
-    let parent = binary_path
-        .parent()
-        .ok_or_else(|| anyhow::anyhow!("Cannot determine the binary's directory"))?;
-    // Unique per process: a stale probe from another temps (or a crashed run)
-    // must never be executed or overwritten mid-flight by a concurrent one.
-    let probe_path = parent.join(format!(".temps-update-probe.{}", std::process::id()));
-
-    std::fs::write(&probe_path, new_binary).map_err(|e| {
-        anyhow::anyhow!(
-            "Failed to stage the new binary at {}: {}",
-            probe_path.display(),
-            e
-        )
-    })?;
+///
+/// Runs directly against the already-staged extraction file (the same one
+/// `finalize_staged_binary` will persist) instead of writing a second full
+/// copy just to exec it — that second copy is exactly the kind of extra
+/// in-memory/on-disk buffering the streaming rewrite of this flow removed
+/// everywhere else.
+fn preflight_staged_binary(staged_path: &Path, staged_file: &std::fs::File) -> anyhow::Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        if let Err(e) =
-            std::fs::set_permissions(&probe_path, std::fs::Permissions::from_mode(0o755))
-        {
-            let _ = std::fs::remove_file(&probe_path);
-            return Err(anyhow::anyhow!(
-                "Failed to make the staged binary executable: {}",
-                e
-            ));
-        }
+        staged_file
+            .set_permissions(std::fs::Permissions::from_mode(0o755))
+            .map_err(|e| anyhow::anyhow!("Failed to make the staged binary executable: {}", e))?;
     }
 
-    let output = std::process::Command::new(&probe_path)
+    let output = std::process::Command::new(staged_path)
         .arg("--version")
         .output();
-    let _ = std::fs::remove_file(&probe_path);
 
     let output = output.map_err(|e| {
         anyhow::anyhow!(
@@ -1749,15 +1763,14 @@ mod tests {
     #[test]
     fn test_preflight_rejects_a_binary_that_cannot_run() {
         let dir = temp_dir("preflight");
+        let staged_path = dir.join("staged");
+        std::fs::write(&staged_path, b"definitely not an executable").unwrap();
+        let staged_file = std::fs::File::open(&staged_path).unwrap();
+
         // Not a valid executable — exec must fail, and the error must say the
         // running version is untouched.
-        let err = preflight_binary(&dir.join("temps"), b"definitely not an executable")
-            .expect_err("must reject");
+        let err = preflight_staged_binary(&staged_path, &staged_file).expect_err("must reject");
         assert!(err.to_string().contains("left untouched"), "{err}");
-        // The probe file must not be left behind.
-        assert!(!dir
-            .join(format!(".temps-update-probe.{}", std::process::id()))
-            .exists());
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/temps-cli/src/commands/upgrade.rs
+++ b/crates/temps-cli/src/commands/upgrade.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use std::env::consts::{ARCH, OS};
 use std::fs;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, info};
 
@@ -354,9 +354,27 @@ impl UpgradeCommand {
         // Check write permissions before downloading
         check_write_permission(&binary_path)?;
 
+        let parent = binary_path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Cannot determine parent directory of binary"))?
+            .to_path_buf();
+
+        // The whole upgrade streams through disk. The tarball is ~110 MB and
+        // the binary inside it ~270 MB; buffering either one meant a peak well
+        // past half a gigabyte, which on a 1 GB host with the server running
+        // pushes the box into swap thrashing.
+        //
+        // The tarball is staged to disk rather than piped straight into the
+        // untar because the checksum has to be verified BEFORE any of those
+        // bytes are unpacked. A direct download -> gunzip -> tar -> binary
+        // pipeline would save the 110 MB of scratch disk but would write
+        // unverified content over the live executable.
+        let download_path = download_tmp_path(&parent);
+        let _download_guard = ScopedTempFile::new(download_path.clone());
+
         // Download the tarball
         println!("  Downloading {}...", tarball_name);
-        let tarball_bytes = download_asset(&asset.browser_download_url).await?;
+        let computed = download_asset_to_file(&asset.browser_download_url, &download_path).await?;
 
         // Also download the checksum
         let checksum_name = format!("{}.sha256", tarball_name);
@@ -365,19 +383,23 @@ impl UpgradeCommand {
         if let Some(checksum_asset) = checksum_asset {
             debug!("Verifying checksum...");
             let checksum_text = download_asset_text(&checksum_asset.browser_download_url).await?;
-            verify_checksum(&tarball_bytes, &checksum_text)?;
+            verify_computed_checksum(&computed, &checksum_text)?;
             println!("  Checksum verified.");
         } else {
             debug!("No checksum asset found, skipping verification");
         }
 
-        // Extract the binary from the tarball
+        // Extract the binary from the tarball, straight into the staging file
+        // that the atomic rename below consumes.
         println!("  Extracting binary...");
-        let new_binary = extract_binary_from_tarball(&tarball_bytes)?;
+        let staged_path = staged_binary_path(&parent);
+        let mut staged_guard = ScopedTempFile::new(staged_path.clone());
+        extract_binary_from_tarball_file(&download_path, &staged_path)?;
 
         // Replace the binary atomically
         println!("  Replacing binary at {}...", binary_path.display());
-        replace_binary(&binary_path, &new_binary)?;
+        finalize_staged_binary(&binary_path, &staged_path)?;
+        staged_guard.disarm();
 
         println!();
         println!(
@@ -508,16 +530,30 @@ impl UpgradeCommand {
         println!("  Verifying checksum...");
         let expected = fetch_ee_checksum(&api, &version, &asset, &license_jwt).await?;
 
+        let parent = binary_path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Cannot determine parent directory of binary"))?
+            .to_path_buf();
+
+        // Same streaming shape as the OSS path, and for the same reason: see
+        // the comment in `run_oss`.
+        let download_path = download_tmp_path(&parent);
+        let _download_guard = ScopedTempFile::new(download_path.clone());
+
         println!("  Downloading {}...", asset);
-        let tarball = download_ee_asset(&api, &version, &asset, &license_jwt).await?;
-        verify_checksum(&tarball, &expected)?;
+        let computed =
+            download_ee_asset_to_file(&api, &version, &asset, &license_jwt, &download_path).await?;
+        verify_computed_checksum(&computed, &expected)?;
         println!("  Checksum verified.");
 
         println!("  Extracting binary...");
-        let new_binary = extract_binary_from_tarball(&tarball)?;
+        let staged_path = staged_binary_path(&parent);
+        let mut staged_guard = ScopedTempFile::new(staged_path.clone());
+        extract_binary_from_tarball_file(&download_path, &staged_path)?;
 
         println!("  Replacing binary at {}...", binary_path.display());
-        replace_binary(&binary_path, &new_binary)?;
+        finalize_staged_binary(&binary_path, &staged_path)?;
+        staged_guard.disarm();
 
         // Install the license into the data dir so the binary finds it.
         let data_dir = resolve_data_dir(&self.data_dir)?;
@@ -1103,20 +1139,94 @@ pub(crate) async fn download_asset_text(url: &str) -> anyhow::Result<String> {
         .map_err(|e| anyhow::anyhow!("Failed to read checksum response: {}", e))
 }
 
-/// Verify SHA256 checksum of downloaded data.
-pub(crate) fn verify_checksum(data: &[u8], checksum_text: &str) -> anyhow::Result<()> {
+/// Stream a release asset to `dest`, hashing it in the same pass.
+///
+/// Returns the lowercase hex SHA256 of everything written, so the caller can
+/// verify the download without reading the file back. The whole point is that
+/// the artifact never exists in memory: the release tarball is ~110 MB and the
+/// binary inside it ~270 MB, which does not fit alongside a running server on
+/// a 1 GB host.
+pub(crate) async fn download_asset_to_file(url: &str, dest: &Path) -> anyhow::Result<String> {
+    let client = reqwest::Client::new();
+    let response = client
+        .get(url)
+        .header("User-Agent", "temps-self-upgrade")
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to download asset: {}", e))?;
+
+    if !response.status().is_success() {
+        return Err(anyhow::anyhow!(
+            "Failed to download asset: HTTP {}",
+            response.status()
+        ));
+    }
+
+    stream_response_to_file(response, dest).await
+}
+
+/// Shared body of the streaming downloads (OSS release and EE proxy).
+///
+/// Peak memory here is one HTTP chunk (tens of KB), not the asset size.
+async fn stream_response_to_file(
+    mut response: reqwest::Response,
+    dest: &Path,
+) -> anyhow::Result<String> {
     use sha2::{Digest, Sha256};
 
+    let mut file = fs::File::create(dest).map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to create download file at {}: {}",
+            dest.display(),
+            e
+        )
+    })?;
     let mut hasher = Sha256::new();
-    hasher.update(data);
-    let computed = hex::encode(hasher.finalize());
+    let mut written: u64 = 0;
 
-    // Checksum file format: "<hash>  <filename>" or "<hash> <filename>"
-    let expected = checksum_text
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to read download response: {}", e))?
+    {
+        hasher.update(&chunk);
+        file.write_all(&chunk).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to write download to {} (after {} bytes): {}",
+                dest.display(),
+                written,
+                e
+            )
+        })?;
+        written += chunk.len() as u64;
+    }
+
+    file.flush()
+        .map_err(|e| anyhow::anyhow!("Failed to flush download to {}: {}", dest.display(), e))?;
+
+    debug!("Downloaded {} bytes to {}", written, dest.display());
+    Ok(hex::encode(hasher.finalize()))
+}
+
+/// Parse the expected hash out of a `.sha256` file body.
+///
+/// Format: `"<hash>  <filename>"` or `"<hash> <filename>"`.
+fn parse_expected_checksum(checksum_text: &str) -> anyhow::Result<String> {
+    Ok(checksum_text
         .split_whitespace()
         .next()
         .ok_or_else(|| anyhow::anyhow!("Invalid checksum file format"))?
-        .to_lowercase();
+        .to_lowercase())
+}
+
+/// Compare an already-computed SHA256 against a `.sha256` file body.
+///
+/// Split out from [`verify_checksum`] so the streaming download can verify the
+/// digest it accumulated on the way to disk, instead of re-reading the file (or
+/// keeping it in memory) just to hash it a second time.
+pub(crate) fn verify_computed_checksum(computed: &str, checksum_text: &str) -> anyhow::Result<()> {
+    let expected = parse_expected_checksum(checksum_text)?;
+    let computed = computed.to_lowercase();
 
     if computed != expected {
         return Err(anyhow::anyhow!(
@@ -1127,6 +1237,17 @@ pub(crate) fn verify_checksum(data: &[u8], checksum_text: &str) -> anyhow::Resul
     }
 
     Ok(())
+}
+
+/// Verify SHA256 checksum of downloaded data.
+pub(crate) fn verify_checksum(data: &[u8], checksum_text: &str) -> anyhow::Result<()> {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    let computed = hex::encode(hasher.finalize());
+
+    verify_computed_checksum(&computed, checksum_text)
 }
 
 /// Extract the `temps` binary from a gzipped tarball.
@@ -1151,6 +1272,178 @@ pub(crate) fn extract_binary_from_tarball(tarball_bytes: &[u8]) -> anyhow::Resul
     Err(anyhow::anyhow!(
         "Binary 'temps' not found in the downloaded tarball"
     ))
+}
+
+/// Extract the `temps` binary from a gzipped tarball on disk, straight into
+/// `dest`.
+///
+/// The streaming counterpart of [`extract_binary_from_tarball`]: the gunzip and
+/// untar run over the file, and the entry is copied out with `std::io::copy`,
+/// so memory stays at one copy buffer instead of holding the ~270 MB
+/// uncompressed binary (which `read_to_end` would additionally double while
+/// growing its `Vec`).
+pub(crate) fn extract_binary_from_tarball_file(
+    tarball_path: &Path,
+    dest: &Path,
+) -> anyhow::Result<u64> {
+    use flate2::read::GzDecoder;
+
+    let file = fs::File::open(tarball_path).map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to open downloaded tarball {}: {}",
+            tarball_path.display(),
+            e
+        )
+    })?;
+    let decoder = GzDecoder::new(std::io::BufReader::new(file));
+    let mut archive = tar::Archive::new(decoder);
+
+    let entries = archive.entries().map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to read tarball {}: {}",
+            tarball_path.display(),
+            e
+        )
+    })?;
+
+    for entry in entries {
+        let mut entry = entry.map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to read entry in tarball {}: {}",
+                tarball_path.display(),
+                e
+            )
+        })?;
+        let is_binary = entry
+            .path()
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to read entry path in tarball {}: {}",
+                    tarball_path.display(),
+                    e
+                )
+            })?
+            .file_name()
+            .map(|n| n == "temps")
+            .unwrap_or(false);
+
+        if !is_binary {
+            continue;
+        }
+
+        let declared = entry.header().size().map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to read entry size in tarball {}: {}",
+                tarball_path.display(),
+                e
+            )
+        })?;
+
+        let mut out = fs::File::create(dest).map_err(|e| {
+            anyhow::anyhow!("Failed to create staged binary {}: {}", dest.display(), e)
+        })?;
+        let written = std::io::copy(&mut entry, &mut out).map_err(|e| {
+            anyhow::anyhow!("Failed to extract binary to {}: {}", dest.display(), e)
+        })?;
+
+        // Validate before the rename, not after. The verified checksum covers
+        // the tarball, so a short read here (full disk, truncated gzip stream)
+        // would otherwise put a valid-looking but incomplete file over the live
+        // executable. Comparing against the tar header's declared size is free
+        // and catches exactly that.
+        if written != declared {
+            let _ = fs::remove_file(dest);
+            return Err(anyhow::anyhow!(
+                "Extracted binary is truncated: expected {} bytes, wrote {} to {}",
+                declared,
+                written,
+                dest.display()
+            ));
+        }
+        // Durability before the rename: see `finalize_staged_binary`.
+        out.sync_all().map_err(|e| {
+            anyhow::anyhow!("Failed to flush staged binary {}: {}", dest.display(), e)
+        })?;
+
+        debug!("Extracted {} bytes to {}", written, dest.display());
+        return Ok(written);
+    }
+
+    Err(anyhow::anyhow!(
+        "Binary 'temps' not found in the downloaded tarball"
+    ))
+}
+
+/// Path of the staged binary written next to the target before the rename.
+///
+/// Unique per process so a concurrent upgrader (another temps, or the CLI run
+/// alongside the server) cannot half-write the file this one is about to rename
+/// over the live binary.
+pub(crate) fn staged_binary_path(parent: &Path) -> PathBuf {
+    parent.join(format!(".temps-upgrade-tmp.{}", std::process::id()))
+}
+
+/// Path of the downloaded tarball, kept next to the target binary.
+///
+/// Deliberately NOT in `std::env::temp_dir()`: on the small hosts this matters
+/// for, `/tmp` is frequently a tmpfs, which would put the 110 MB tarball right
+/// back in RAM. The binary's own directory is already known-writable here
+/// (`check_write_permission`).
+pub(crate) fn download_tmp_path(parent: &Path) -> PathBuf {
+    parent.join(format!(".temps-upgrade-dl.{}", std::process::id()))
+}
+
+/// Removes a temporary file when it goes out of scope, unless disarmed.
+///
+/// Covers the ordinary failure paths (bad checksum, truncated download,
+/// extraction error) so a failed upgrade does not leave a 100 MB+ file next to
+/// the binary. It cannot cover a kill -9 / OOM kill; reaping those orphans needs
+/// a liveness check against the PID suffix and is left for a follow-up.
+pub(crate) struct ScopedTempFile {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl ScopedTempFile {
+    pub(crate) fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Give up ownership: the file was consumed (renamed into place).
+    pub(crate) fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ScopedTempFile {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+
+/// Move an already-staged binary over the target with an atomic rename.
+///
+/// Shared tail of both the streaming path and [`replace_binary`].
+pub(crate) fn finalize_staged_binary(binary_path: &Path, tmp_path: &Path) -> anyhow::Result<()> {
+    // Set executable permissions
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = fs::Permissions::from_mode(0o755);
+        fs::set_permissions(tmp_path, perms)
+            .map_err(|e| anyhow::anyhow!("Failed to set executable permissions: {}", e))?;
+    }
+
+    // Atomic rename
+    fs::rename(tmp_path, binary_path).map_err(|e| {
+        // Clean up temp file on failure
+        let _ = fs::remove_file(tmp_path);
+        anyhow::anyhow!("Failed to replace binary: {}", e)
+    })?;
+
+    Ok(())
 }
 
 /// Check we have write permission to the binary path.
@@ -1196,32 +1489,21 @@ pub(crate) fn replace_binary(binary_path: &PathBuf, new_binary: &[u8]) -> anyhow
         .parent()
         .ok_or_else(|| anyhow::anyhow!("Cannot determine parent directory"))?;
 
-    // Unique per process so a concurrent upgrader (another temps, or the CLI
-    // run alongside the server) cannot half-write the file this one is about to
-    // rename over the live binary.
-    let tmp_path = parent.join(format!(".temps-upgrade-tmp.{}", std::process::id()));
+    let tmp_path = staged_binary_path(parent);
 
-    // Write the new binary to temp file
-    fs::write(&tmp_path, new_binary)
+    // Write the new binary to temp file, then force it to the platter before
+    // the rename: the rename is atomic for the metadata, but without the fsync
+    // a power cut can leave a correctly-sized file full of zeroes where the
+    // system's own executable used to be.
+    let mut file = fs::File::create(&tmp_path)
         .map_err(|e| anyhow::anyhow!("Failed to write temporary file: {}", e))?;
+    file.write_all(new_binary)
+        .map_err(|e| anyhow::anyhow!("Failed to write temporary file: {}", e))?;
+    file.sync_all()
+        .map_err(|e| anyhow::anyhow!("Failed to flush temporary file: {}", e))?;
+    drop(file);
 
-    // Set executable permissions
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = fs::Permissions::from_mode(0o755);
-        fs::set_permissions(&tmp_path, perms)
-            .map_err(|e| anyhow::anyhow!("Failed to set executable permissions: {}", e))?;
-    }
-
-    // Atomic rename
-    fs::rename(&tmp_path, binary_path).map_err(|e| {
-        // Clean up temp file on failure
-        let _ = fs::remove_file(&tmp_path);
-        anyhow::anyhow!("Failed to replace binary: {}", e)
-    })?;
-
-    Ok(())
+    finalize_staged_binary(binary_path, &tmp_path)
 }
 
 // ── EE proxy helpers ────────────────────────────────────────────────────────
@@ -1387,13 +1669,18 @@ async fn fetch_ee_checksum(
         .map_err(|e| anyhow::anyhow!("Failed to read EE checksum: {}", e))
 }
 
-/// Download an EE binary tarball through the license-gated proxy.
-async fn download_ee_asset(
+/// Stream an EE binary tarball through the license-gated proxy into `dest`,
+/// returning its lowercase hex SHA256.
+///
+/// Streaming counterpart of the OSS `download_asset_to_file`; the EE tarball is
+/// the same size and would blow the same memory budget.
+async fn download_ee_asset_to_file(
     api: &str,
     version: &str,
     asset: &str,
     license_jwt: &str,
-) -> anyhow::Result<Vec<u8>> {
+    dest: &Path,
+) -> anyhow::Result<String> {
     let url = format!("{}/api/ee/download/{}/{}", api, version, asset);
     let client = reqwest::Client::new();
     let resp = client
@@ -1410,10 +1697,7 @@ async fn download_ee_asset(
             url
         ));
     }
-    resp.bytes()
-        .await
-        .map(|b| b.to_vec())
-        .map_err(|e| anyhow::anyhow!("Failed to read EE download: {}", e))
+    stream_response_to_file(resp, dest).await
 }
 
 /// Resolve the data dir: explicit flag/env > `~/.temps`.
@@ -1698,6 +1982,177 @@ mod tests {
         let result = extract_binary_from_tarball(&tarball);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), b"fake-binary-content");
+    }
+
+    /// Build a gzipped tarball containing a single `temps` entry.
+    fn tarball_with_binary(content: &[u8]) -> Vec<u8> {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        {
+            let mut builder = tar::Builder::new(&mut encoder);
+            let mut header = tar::Header::new_gnu();
+            header.set_size(content.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            builder.append_data(&mut header, "temps", content).unwrap();
+            builder.finish().unwrap();
+        }
+        encoder.finish().unwrap()
+    }
+
+    #[test]
+    fn test_verify_computed_checksum_matches_case_insensitively() {
+        let computed = "AABBCC";
+        let checksum_text = "aabbcc  temps-linux-amd64.tar.gz";
+        assert!(verify_computed_checksum(computed, checksum_text).is_ok());
+    }
+
+    #[test]
+    fn test_verify_computed_checksum_reports_both_hashes_on_mismatch() {
+        let err = verify_computed_checksum("aaaa", "bbbb  temps.tar.gz")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Checksum mismatch"));
+        assert!(err.contains("aaaa"));
+        assert!(err.contains("bbbb"));
+    }
+
+    #[test]
+    fn test_extract_binary_from_tarball_file_streams_to_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let tarball_path = dir.path().join("temps.tar.gz");
+        let dest = dir.path().join("staged");
+
+        std::fs::write(&tarball_path, tarball_with_binary(b"fake-binary-content")).unwrap();
+
+        let written = extract_binary_from_tarball_file(&tarball_path, &dest).unwrap();
+        assert_eq!(written, b"fake-binary-content".len() as u64);
+        assert_eq!(std::fs::read(&dest).unwrap(), b"fake-binary-content");
+    }
+
+    /// The streaming path must produce exactly what the in-memory path does,
+    /// byte for byte, for the same tarball.
+    #[test]
+    fn test_extract_binary_from_tarball_file_matches_in_memory_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let tarball_path = dir.path().join("temps.tar.gz");
+        let dest = dir.path().join("staged");
+
+        // Big enough that `read_to_end` would have grown its Vec more than once.
+        let content: Vec<u8> = (0..600_000u32).map(|i| (i % 251) as u8).collect();
+        let tarball = tarball_with_binary(&content);
+        std::fs::write(&tarball_path, &tarball).unwrap();
+
+        extract_binary_from_tarball_file(&tarball_path, &dest).unwrap();
+
+        let streamed = std::fs::read(&dest).unwrap();
+        let in_memory = extract_binary_from_tarball(&tarball).unwrap();
+        assert_eq!(streamed, in_memory);
+        assert_eq!(streamed, content);
+    }
+
+    #[test]
+    fn test_extract_binary_from_tarball_file_not_found() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let dir = tempfile::tempdir().unwrap();
+        let tarball_path = dir.path().join("temps.tar.gz");
+        let dest = dir.path().join("staged");
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        {
+            let mut builder = tar::Builder::new(&mut encoder);
+            let content = b"not-temps";
+            let mut header = tar::Header::new_gnu();
+            header.set_size(content.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, "other-file", &content[..])
+                .unwrap();
+            builder.finish().unwrap();
+        }
+        std::fs::write(&tarball_path, encoder.finish().unwrap()).unwrap();
+
+        let err = extract_binary_from_tarball_file(&tarball_path, &dest).unwrap_err();
+        assert!(err.to_string().contains("not found"));
+        // Nothing was staged, so nothing can be renamed over the live binary.
+        assert!(!dest.exists());
+    }
+
+    #[test]
+    fn test_extract_binary_from_tarball_file_missing_tarball_reports_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope.tar.gz");
+        let err = extract_binary_from_tarball_file(&missing, &dir.path().join("staged"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("nope.tar.gz"), "error was: {err}");
+    }
+
+    #[test]
+    fn test_scoped_temp_file_removes_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("scratch");
+        std::fs::write(&path, b"junk").unwrap();
+
+        {
+            let _guard = ScopedTempFile::new(path.clone());
+        }
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn test_scoped_temp_file_disarm_keeps_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("scratch");
+        std::fs::write(&path, b"junk").unwrap();
+
+        {
+            let mut guard = ScopedTempFile::new(path.clone());
+            guard.disarm();
+        }
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn test_temp_paths_carry_pid_suffix() {
+        let parent = std::path::Path::new("/opt/temps/bin");
+        let pid = std::process::id();
+        assert_eq!(
+            staged_binary_path(parent),
+            parent.join(format!(".temps-upgrade-tmp.{pid}"))
+        );
+        assert_eq!(
+            download_tmp_path(parent),
+            parent.join(format!(".temps-upgrade-dl.{pid}"))
+        );
+        // Concurrent upgraders must not collide on the same staging file.
+        assert_ne!(staged_binary_path(parent), download_tmp_path(parent));
+    }
+
+    #[test]
+    fn test_finalize_staged_binary_renames_and_marks_executable() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("temps");
+        let staged = dir.path().join("staged");
+        std::fs::write(&target, b"old").unwrap();
+        std::fs::write(&staged, b"new").unwrap();
+
+        finalize_staged_binary(&target, &staged).unwrap();
+
+        assert!(!staged.exists());
+        assert_eq!(std::fs::read(&target).unwrap(), b"new");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&target).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o755);
+        }
     }
 
     #[test]

--- a/crates/temps-cli/src/commands/upgrade.rs
+++ b/crates/temps-cli/src/commands/upgrade.rs
@@ -1480,7 +1480,7 @@ pub(crate) fn check_write_permission(binary_path: &PathBuf) -> anyhow::Result<()
 /// 1. Write new binary to a temp file next to the target
 /// 2. Set executable permissions
 /// 3. Rename temp file over the target (atomic on the same filesystem)
-pub(crate) fn replace_binary(binary_path: &PathBuf, new_binary: &[u8]) -> anyhow::Result<()> {
+pub(crate) fn replace_binary(binary_path: &Path, new_binary: &[u8]) -> anyhow::Result<()> {
     let parent = binary_path
         .parent()
         .ok_or_else(|| anyhow::anyhow!("Cannot determine parent directory"))?;

--- a/crates/temps-cli/src/commands/upgrade.rs
+++ b/crates/temps-cli/src/commands/upgrade.rs
@@ -1285,6 +1285,12 @@ pub(crate) fn verify_checksum(data: &[u8], checksum_text: &str) -> anyhow::Resul
 }
 
 /// Extract the `temps` binary from a gzipped tarball.
+///
+/// No production caller remains — both `temps upgrade` and the in-process
+/// self-updater stream through disk via [`extract_binary_from_tarball_file`].
+/// Kept `#[cfg(test)]` as the byte-identical baseline the streaming path is
+/// checked against.
+#[cfg(test)]
 pub(crate) fn extract_binary_from_tarball(tarball_bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
     use flate2::read::GzDecoder;
     use std::io::Read;
@@ -1563,6 +1569,12 @@ pub(crate) fn check_write_permission(binary_path: &PathBuf) -> anyhow::Result<()
 /// 1. Securely create and write a random temp file next to the target
 /// 2. Set executable permissions
 /// 3. Sync it, persist it over the target, and sync the parent directory
+///
+/// No production caller remains — both `temps upgrade` and the in-process
+/// self-updater stage into a file via [`create_upgrade_temp_file`] and commit
+/// with [`finalize_staged_binary`] directly. Kept `#[cfg(test)]` to exercise
+/// the write-then-finalize sequence from an in-memory buffer.
+#[cfg(test)]
 pub(crate) fn replace_binary(binary_path: &Path, new_binary: &[u8]) -> anyhow::Result<()> {
     let parent = binary_path
         .parent()

--- a/crates/temps-cli/src/commands/upgrade.rs
+++ b/crates/temps-cli/src/commands/upgrade.rs
@@ -1327,13 +1327,24 @@ pub(crate) fn extract_binary_from_tarball_file(
             continue;
         }
 
-        let declared = entry.header().size().map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to read entry size in tarball {}: {}",
+        // An entry can carry the right name and still not be a binary: an
+        // empty file, a symlink or a hard link named `temps` would copy zero
+        // bytes and pass a size check of 0 == 0, landing on the executable the
+        // whole system runs.
+        let entry_type = entry.header().entry_type();
+        if !entry_type.is_file() {
+            return Err(anyhow::anyhow!(
+                "Entry 'temps' in tarball {} is not a regular file ({:?})",
                 tarball_path.display(),
-                e
-            )
-        })?;
+                entry_type
+            ));
+        }
+
+        // `Entry::size`, not `Header::size`: the former is the number of bytes
+        // the entry reader yields, honouring a PAX size override, while the
+        // latter reports the logical size and disagrees for PAX and sparse
+        // entries, which would read as a truncation that never happened.
+        let declared = entry.size();
 
         let mut out = fs::File::create(dest).map_err(|e| {
             anyhow::anyhow!("Failed to create staged binary {}: {}", dest.display(), e)
@@ -1354,6 +1365,13 @@ pub(crate) fn extract_binary_from_tarball_file(
                 declared,
                 written,
                 dest.display()
+            ));
+        }
+        if written == 0 {
+            let _ = fs::remove_file(dest);
+            return Err(anyhow::anyhow!(
+                "Entry 'temps' in tarball {} is empty",
+                tarball_path.display()
             ));
         }
         // Durability before the rename: see `finalize_staged_binary`.
@@ -1486,6 +1504,9 @@ pub(crate) fn replace_binary(binary_path: &Path, new_binary: &[u8]) -> anyhow::R
         .ok_or_else(|| anyhow::anyhow!("Cannot determine parent directory"))?;
 
     let tmp_path = staged_binary_path(parent);
+    // A failed write or fsync (most plausibly a full disk) would otherwise
+    // leave the partial staged file holding the space needed to retry.
+    let mut staged_guard = ScopedTempFile::new(tmp_path.clone());
 
     // Write the new binary to temp file, then force it to the platter before
     // the rename: the rename is atomic for the metadata, but without the fsync
@@ -1499,7 +1520,9 @@ pub(crate) fn replace_binary(binary_path: &Path, new_binary: &[u8]) -> anyhow::R
         .map_err(|e| anyhow::anyhow!("Failed to flush temporary file: {}", e))?;
     drop(file);
 
-    finalize_staged_binary(binary_path, &tmp_path)
+    finalize_staged_binary(binary_path, &tmp_path)?;
+    staged_guard.disarm();
+    Ok(())
 }
 
 // ── EE proxy helpers ────────────────────────────────────────────────────────
@@ -2047,6 +2070,64 @@ mod tests {
         let in_memory = extract_binary_from_tarball(&tarball).unwrap();
         assert_eq!(streamed, in_memory);
         assert_eq!(streamed, content);
+    }
+
+    #[test]
+    fn test_extract_binary_from_tarball_file_rejects_symlink_named_temps() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let dir = tempfile::tempdir().unwrap();
+        let tarball_path = dir.path().join("temps.tar.gz");
+        let dest = dir.path().join("staged");
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        {
+            let mut builder = tar::Builder::new(&mut encoder);
+            let mut header = tar::Header::new_gnu();
+            header.set_size(0);
+            header.set_mode(0o777);
+            header.set_entry_type(tar::EntryType::Symlink);
+            header.set_cksum();
+            builder
+                .append_link(&mut header, "temps", "/etc/passwd")
+                .unwrap();
+            builder.finish().unwrap();
+        }
+        std::fs::write(&tarball_path, encoder.finish().unwrap()).unwrap();
+
+        let err = extract_binary_from_tarball_file(&tarball_path, &dest)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not a regular file"), "error was: {err}");
+        assert!(!dest.exists());
+    }
+
+    #[test]
+    fn test_extract_binary_from_tarball_file_rejects_empty_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let tarball_path = dir.path().join("temps.tar.gz");
+        let dest = dir.path().join("staged");
+
+        std::fs::write(&tarball_path, tarball_with_binary(b"")).unwrap();
+
+        let err = extract_binary_from_tarball_file(&tarball_path, &dest)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("is empty"), "error was: {err}");
+        assert!(!dest.exists());
+    }
+
+    #[test]
+    fn test_replace_binary_removes_staged_file_when_rename_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        // A directory cannot be replaced by a file rename, so finalize fails
+        // after the staged file is written and synced.
+        let target = dir.path().join("temps");
+        std::fs::create_dir(&target).unwrap();
+
+        assert!(replace_binary(&target, b"new-binary").is_err());
+        assert!(!staged_binary_path(dir.path()).exists());
     }
 
     #[test]

--- a/crates/temps-cli/src/commands/upgrade.rs
+++ b/crates/temps-cli/src/commands/upgrade.rs
@@ -1298,13 +1298,9 @@ pub(crate) fn extract_binary_from_tarball_file(
     let decoder = GzDecoder::new(std::io::BufReader::new(file));
     let mut archive = tar::Archive::new(decoder);
 
-    let entries = archive.entries().map_err(|e| {
-        anyhow::anyhow!(
-            "Failed to read tarball {}: {}",
-            tarball_path.display(),
-            e
-        )
-    })?;
+    let entries = archive
+        .entries()
+        .map_err(|e| anyhow::anyhow!("Failed to read tarball {}: {}", tarball_path.display(), e))?;
 
     for entry in entries {
         let mut entry = entry.map_err(|e| {

--- a/crates/temps-cli/src/commands/upgrade.rs
+++ b/crates/temps-cli/src/commands/upgrade.rs
@@ -2,9 +2,10 @@ use clap::{Args, ValueEnum};
 use serde::Deserialize;
 use std::env::consts::{ARCH, OS};
 use std::fs;
-use std::io::Write;
+use std::io::{Seek, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use tempfile::NamedTempFile;
 use tracing::{debug, info};
 
 const GITHUB_RELEASES_API: &str = "https://api.github.com/repos/gotempsh/temps/releases";
@@ -369,12 +370,17 @@ impl UpgradeCommand {
         // bytes are unpacked. A direct download -> gunzip -> tar -> binary
         // pipeline would save the 110 MB of scratch disk but would write
         // unverified content over the live executable.
-        let download_path = download_tmp_path(&parent);
-        let _download_guard = ScopedTempFile::new(download_path.clone());
+        let mut download_file = create_upgrade_temp_file(&parent, ".temps-upgrade-dl.")?;
+        let download_path = download_file.path().to_path_buf();
 
         // Download the tarball
         println!("  Downloading {}...", tarball_name);
-        let computed = download_asset_to_file(&asset.browser_download_url, &download_path).await?;
+        let computed = download_asset_to_file(
+            &asset.browser_download_url,
+            download_file.as_file_mut(),
+            &download_path,
+        )
+        .await?;
 
         // Also download the checksum
         let checksum_name = format!("{}.sha256", tarball_name);
@@ -392,14 +398,18 @@ impl UpgradeCommand {
         // Extract the binary from the tarball, straight into the staging file
         // that the atomic rename below consumes.
         println!("  Extracting binary...");
-        let staged_path = staged_binary_path(&parent);
-        let mut staged_guard = ScopedTempFile::new(staged_path.clone());
-        extract_binary_from_tarball_file(&download_path, &staged_path)?;
+        let mut staged_file = create_upgrade_temp_file(&parent, ".temps-upgrade-bin.")?;
+        let staged_path = staged_file.path().to_path_buf();
+        extract_binary_from_tarball_file(
+            download_file.as_file_mut(),
+            &download_path,
+            staged_file.as_file_mut(),
+            &staged_path,
+        )?;
 
         // Replace the binary atomically
         println!("  Replacing binary at {}...", binary_path.display());
-        finalize_staged_binary(&binary_path, &staged_path)?;
-        staged_guard.disarm();
+        finalize_staged_binary(&binary_path, staged_file)?;
 
         println!();
         println!(
@@ -537,23 +547,34 @@ impl UpgradeCommand {
 
         // Same streaming shape as the OSS path, and for the same reason: see
         // the comment in `run_oss`.
-        let download_path = download_tmp_path(&parent);
-        let _download_guard = ScopedTempFile::new(download_path.clone());
+        let mut download_file = create_upgrade_temp_file(&parent, ".temps-upgrade-dl.")?;
+        let download_path = download_file.path().to_path_buf();
 
         println!("  Downloading {}...", asset);
-        let computed =
-            download_ee_asset_to_file(&api, &version, &asset, &license_jwt, &download_path).await?;
+        let computed = download_ee_asset_to_file(
+            &api,
+            &version,
+            &asset,
+            &license_jwt,
+            download_file.as_file_mut(),
+            &download_path,
+        )
+        .await?;
         verify_computed_checksum(&computed, &expected)?;
         println!("  Checksum verified.");
 
         println!("  Extracting binary...");
-        let staged_path = staged_binary_path(&parent);
-        let mut staged_guard = ScopedTempFile::new(staged_path.clone());
-        extract_binary_from_tarball_file(&download_path, &staged_path)?;
+        let mut staged_file = create_upgrade_temp_file(&parent, ".temps-upgrade-bin.")?;
+        let staged_path = staged_file.path().to_path_buf();
+        extract_binary_from_tarball_file(
+            download_file.as_file_mut(),
+            &download_path,
+            staged_file.as_file_mut(),
+            &staged_path,
+        )?;
 
         println!("  Replacing binary at {}...", binary_path.display());
-        finalize_staged_binary(&binary_path, &staged_path)?;
-        staged_guard.disarm();
+        finalize_staged_binary(&binary_path, staged_file)?;
 
         // Install the license into the data dir so the binary finds it.
         let data_dir = resolve_data_dir(&self.data_dir)?;
@@ -1139,14 +1160,18 @@ pub(crate) async fn download_asset_text(url: &str) -> anyhow::Result<String> {
         .map_err(|e| anyhow::anyhow!("Failed to read checksum response: {}", e))
 }
 
-/// Stream a release asset to `dest`, hashing it in the same pass.
+/// Stream a release asset to an already-open file, hashing it in the same pass.
 ///
 /// Returns the lowercase hex SHA256 of everything written, so the caller can
 /// verify the download without reading the file back. The whole point is that
 /// the artifact never exists in memory: the release tarball is ~110 MB and the
 /// binary inside it ~270 MB, which does not fit alongside a running server on
 /// a 1 GB host.
-pub(crate) async fn download_asset_to_file(url: &str, dest: &Path) -> anyhow::Result<String> {
+pub(crate) async fn download_asset_to_file(
+    url: &str,
+    dest: &mut fs::File,
+    dest_path: &Path,
+) -> anyhow::Result<String> {
     let client = reqwest::Client::new();
     let response = client
         .get(url)
@@ -1162,7 +1187,7 @@ pub(crate) async fn download_asset_to_file(url: &str, dest: &Path) -> anyhow::Re
         ));
     }
 
-    stream_response_to_file(response, dest).await
+    stream_response_to_file(response, dest, dest_path).await
 }
 
 /// Shared body of the streaming downloads (OSS release and EE proxy).
@@ -1170,14 +1195,22 @@ pub(crate) async fn download_asset_to_file(url: &str, dest: &Path) -> anyhow::Re
 /// Peak memory here is one HTTP chunk (tens of KB), not the asset size.
 async fn stream_response_to_file(
     mut response: reqwest::Response,
-    dest: &Path,
+    file: &mut fs::File,
+    dest_path: &Path,
 ) -> anyhow::Result<String> {
     use sha2::{Digest, Sha256};
 
-    let mut file = fs::File::create(dest).map_err(|e| {
+    file.seek(std::io::SeekFrom::Start(0)).map_err(|e| {
         anyhow::anyhow!(
-            "Failed to create download file at {}: {}",
-            dest.display(),
+            "Failed to seek download file {}: {}",
+            dest_path.display(),
+            e
+        )
+    })?;
+    file.set_len(0).map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to truncate download file {}: {}",
+            dest_path.display(),
             e
         )
     })?;
@@ -1193,7 +1226,7 @@ async fn stream_response_to_file(
         file.write_all(&chunk).map_err(|e| {
             anyhow::anyhow!(
                 "Failed to write download to {} (after {} bytes): {}",
-                dest.display(),
+                dest_path.display(),
                 written,
                 e
             )
@@ -1201,10 +1234,11 @@ async fn stream_response_to_file(
         written += chunk.len() as u64;
     }
 
-    file.flush()
-        .map_err(|e| anyhow::anyhow!("Failed to flush download to {}: {}", dest.display(), e))?;
+    file.flush().map_err(|e| {
+        anyhow::anyhow!("Failed to flush download to {}: {}", dest_path.display(), e)
+    })?;
 
-    debug!("Downloaded {} bytes to {}", written, dest.display());
+    debug!("Downloaded {} bytes to {}", written, dest_path.display());
     Ok(hex::encode(hasher.finalize()))
 }
 
@@ -1274,8 +1308,8 @@ pub(crate) fn extract_binary_from_tarball(tarball_bytes: &[u8]) -> anyhow::Resul
     ))
 }
 
-/// Extract the `temps` binary from a gzipped tarball on disk, straight into
-/// `dest`.
+/// Extract the `temps` binary from an open gzipped tarball, straight into an
+/// already-open staging file.
 ///
 /// The streaming counterpart of [`extract_binary_from_tarball`]: the gunzip and
 /// untar run over the file, and the entry is copied out with `std::io::copy`,
@@ -1283,19 +1317,21 @@ pub(crate) fn extract_binary_from_tarball(tarball_bytes: &[u8]) -> anyhow::Resul
 /// uncompressed binary (which `read_to_end` would additionally double while
 /// growing its `Vec`).
 pub(crate) fn extract_binary_from_tarball_file(
+    tarball: &mut fs::File,
     tarball_path: &Path,
-    dest: &Path,
+    dest: &mut fs::File,
+    dest_path: &Path,
 ) -> anyhow::Result<u64> {
     use flate2::read::GzDecoder;
 
-    let file = fs::File::open(tarball_path).map_err(|e| {
+    tarball.seek(std::io::SeekFrom::Start(0)).map_err(|e| {
         anyhow::anyhow!(
-            "Failed to open downloaded tarball {}: {}",
+            "Failed to seek downloaded tarball {}: {}",
             tarball_path.display(),
             e
         )
     })?;
-    let decoder = GzDecoder::new(std::io::BufReader::new(file));
+    let decoder = GzDecoder::new(std::io::BufReader::new(tarball));
     let mut archive = tar::Archive::new(decoder);
 
     let entries = archive
@@ -1346,11 +1382,22 @@ pub(crate) fn extract_binary_from_tarball_file(
         // entries, which would read as a truncation that never happened.
         let declared = entry.size();
 
-        let mut out = fs::File::create(dest).map_err(|e| {
-            anyhow::anyhow!("Failed to create staged binary {}: {}", dest.display(), e)
+        dest.seek(std::io::SeekFrom::Start(0)).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to seek staged binary {}: {}",
+                dest_path.display(),
+                e
+            )
         })?;
-        let written = std::io::copy(&mut entry, &mut out).map_err(|e| {
-            anyhow::anyhow!("Failed to extract binary to {}: {}", dest.display(), e)
+        dest.set_len(0).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to truncate staged binary {}: {}",
+                dest_path.display(),
+                e
+            )
+        })?;
+        let written = std::io::copy(&mut entry, dest).map_err(|e| {
+            anyhow::anyhow!("Failed to extract binary to {}: {}", dest_path.display(), e)
         })?;
 
         // Validate before the rename, not after. The verified checksum covers
@@ -1359,27 +1406,21 @@ pub(crate) fn extract_binary_from_tarball_file(
         // executable. Comparing against the tar header's declared size is free
         // and catches exactly that.
         if written != declared {
-            let _ = fs::remove_file(dest);
             return Err(anyhow::anyhow!(
                 "Extracted binary is truncated: expected {} bytes, wrote {} to {}",
                 declared,
                 written,
-                dest.display()
+                dest_path.display()
             ));
         }
         if written == 0 {
-            let _ = fs::remove_file(dest);
             return Err(anyhow::anyhow!(
                 "Entry 'temps' in tarball {} is empty",
                 tarball_path.display()
             ));
         }
-        // Durability before the rename: see `finalize_staged_binary`.
-        out.sync_all().map_err(|e| {
-            anyhow::anyhow!("Failed to flush staged binary {}: {}", dest.display(), e)
-        })?;
 
-        debug!("Extracted {} bytes to {}", written, dest.display());
+        debug!("Extracted {} bytes to {}", written, dest_path.display());
         return Ok(written);
     }
 
@@ -1388,75 +1429,99 @@ pub(crate) fn extract_binary_from_tarball_file(
     ))
 }
 
-/// Path of the staged binary written next to the target before the rename.
+/// Securely create an upgrade scratch file beside the target binary.
 ///
-/// Unique per process so a concurrent upgrader (another temps, or the CLI run
-/// alongside the server) cannot half-write the file this one is about to rename
-/// over the live binary.
-pub(crate) fn staged_binary_path(parent: &Path) -> PathBuf {
-    parent.join(format!(".temps-upgrade-tmp.{}", std::process::id()))
+/// This preserves constant-memory/same-filesystem staging while `tempfile`
+/// supplies an unpredictable name and atomic create-new semantics.
+pub(crate) fn create_upgrade_temp_file(
+    parent: &Path,
+    prefix: &str,
+) -> anyhow::Result<NamedTempFile> {
+    tempfile::Builder::new()
+        .prefix(prefix)
+        .tempfile_in(parent)
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to create upgrade temporary file in {}: {}",
+                parent.display(),
+                e
+            )
+        })
 }
 
-/// Path of the downloaded tarball, kept next to the target binary.
-///
-/// Deliberately NOT in `std::env::temp_dir()`: on the small hosts this matters
-/// for, `/tmp` is frequently a tmpfs, which would put the 110 MB tarball right
-/// back in RAM. The binary's own directory is already known-writable here
-/// (`check_write_permission`).
-pub(crate) fn download_tmp_path(parent: &Path) -> PathBuf {
-    parent.join(format!(".temps-upgrade-dl.{}", std::process::id()))
-}
+/// Atomically persist an owned staged binary over the target.
+pub(crate) fn finalize_staged_binary(
+    binary_path: &Path,
+    staged_file: NamedTempFile,
+) -> anyhow::Result<()> {
+    let staged_path = staged_file.path().to_path_buf();
 
-/// Removes a temporary file when it goes out of scope, unless disarmed.
-///
-/// Covers the ordinary failure paths (bad checksum, truncated download,
-/// extraction error) so a failed upgrade does not leave a 100 MB+ file next to
-/// the binary. It cannot cover a kill -9 / OOM kill; reaping those orphans needs
-/// a liveness check against the PID suffix and is left for a follow-up.
-pub(crate) struct ScopedTempFile {
-    path: PathBuf,
-    armed: bool,
-}
-
-impl ScopedTempFile {
-    pub(crate) fn new(path: PathBuf) -> Self {
-        Self { path, armed: true }
-    }
-
-    /// Give up ownership: the file was consumed (renamed into place).
-    pub(crate) fn disarm(&mut self) {
-        self.armed = false;
-    }
-}
-
-impl Drop for ScopedTempFile {
-    fn drop(&mut self) {
-        if self.armed {
-            let _ = fs::remove_file(&self.path);
-        }
-    }
-}
-
-/// Move an already-staged binary over the target with an atomic rename.
-///
-/// Shared tail of both the streaming path and [`replace_binary`].
-pub(crate) fn finalize_staged_binary(binary_path: &Path, tmp_path: &Path) -> anyhow::Result<()> {
-    // Set executable permissions
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = fs::Permissions::from_mode(0o755);
-        fs::set_permissions(tmp_path, perms)
-            .map_err(|e| anyhow::anyhow!("Failed to set executable permissions: {}", e))?;
+        staged_file.as_file().set_permissions(perms).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to set executable permissions on staged binary {}: {}",
+                staged_path.display(),
+                e
+            )
+        })?;
     }
 
-    // Atomic rename
-    fs::rename(tmp_path, binary_path).map_err(|e| {
-        // Clean up temp file on failure
-        let _ = fs::remove_file(tmp_path);
-        anyhow::anyhow!("Failed to replace binary: {}", e)
+    staged_file.as_file().sync_all().map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to sync staged binary {} before replacing {}: {}",
+            staged_path.display(),
+            binary_path.display(),
+            e
+        )
     })?;
 
+    // The destination normally exists, so overwrite-capable `persist` is the
+    // correct atomic operation; `persist_noclobber` would reject an upgrade.
+    let installed_file = staged_file.persist(binary_path).map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to atomically replace binary {} using staged file {}: {}",
+            binary_path.display(),
+            staged_path.display(),
+            e.error
+        )
+    })?;
+    drop(installed_file);
+
+    sync_binary_parent(binary_path)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_binary_parent(binary_path: &Path) -> anyhow::Result<()> {
+    let parent = binary_path.parent().ok_or_else(|| {
+        anyhow::anyhow!(
+            "Cannot determine parent directory of replaced binary {}",
+            binary_path.display()
+        )
+    })?;
+    let directory = fs::File::open(parent).map_err(|e| {
+        anyhow::anyhow!(
+            "Binary {} was replaced, but failed to open parent directory {} for sync: {}",
+            binary_path.display(),
+            parent.display(),
+            e
+        )
+    })?;
+    directory.sync_all().map_err(|e| {
+        anyhow::anyhow!(
+            "Binary {} was replaced, but failed to sync parent directory {}: {}",
+            binary_path.display(),
+            parent.display(),
+            e
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn sync_binary_parent(_binary_path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
@@ -1494,35 +1559,30 @@ pub(crate) fn check_write_permission(binary_path: &PathBuf) -> anyhow::Result<()
     Ok(())
 }
 
-/// Replace the binary using an atomic rename strategy:
-/// 1. Write new binary to a temp file next to the target
+/// Replace the binary using an atomic persist strategy:
+/// 1. Securely create and write a random temp file next to the target
 /// 2. Set executable permissions
-/// 3. Rename temp file over the target (atomic on the same filesystem)
+/// 3. Sync it, persist it over the target, and sync the parent directory
 pub(crate) fn replace_binary(binary_path: &Path, new_binary: &[u8]) -> anyhow::Result<()> {
     let parent = binary_path
         .parent()
         .ok_or_else(|| anyhow::anyhow!("Cannot determine parent directory"))?;
 
-    let tmp_path = staged_binary_path(parent);
-    // A failed write or fsync (most plausibly a full disk) would otherwise
-    // leave the partial staged file holding the space needed to retry.
-    let mut staged_guard = ScopedTempFile::new(tmp_path.clone());
+    let mut staged_file = create_upgrade_temp_file(parent, ".temps-upgrade-bin.")?;
+    let staged_path = staged_file.path().to_path_buf();
+    staged_file
+        .as_file_mut()
+        .write_all(new_binary)
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to write staged binary {} for {}: {}",
+                staged_path.display(),
+                binary_path.display(),
+                e
+            )
+        })?;
 
-    // Write the new binary to temp file, then force it to the platter before
-    // the rename: the rename is atomic for the metadata, but without the fsync
-    // a power cut can leave a correctly-sized file full of zeroes where the
-    // system's own executable used to be.
-    let mut file = fs::File::create(&tmp_path)
-        .map_err(|e| anyhow::anyhow!("Failed to write temporary file: {}", e))?;
-    file.write_all(new_binary)
-        .map_err(|e| anyhow::anyhow!("Failed to write temporary file: {}", e))?;
-    file.sync_all()
-        .map_err(|e| anyhow::anyhow!("Failed to flush temporary file: {}", e))?;
-    drop(file);
-
-    finalize_staged_binary(binary_path, &tmp_path)?;
-    staged_guard.disarm();
-    Ok(())
+    finalize_staged_binary(binary_path, staged_file)
 }
 
 // ── EE proxy helpers ────────────────────────────────────────────────────────
@@ -1698,7 +1758,8 @@ async fn download_ee_asset_to_file(
     version: &str,
     asset: &str,
     license_jwt: &str,
-    dest: &Path,
+    dest: &mut fs::File,
+    dest_path: &Path,
 ) -> anyhow::Result<String> {
     let url = format!("{}/api/ee/download/{}/{}", api, version, asset);
     let client = reqwest::Client::new();
@@ -1716,7 +1777,7 @@ async fn download_ee_asset_to_file(
             url
         ));
     }
-    stream_response_to_file(resp, dest).await
+    stream_response_to_file(resp, dest, dest_path).await
 }
 
 /// Resolve the data dir: explicit flag/env > `~/.temps`.
@@ -2021,6 +2082,41 @@ mod tests {
         encoder.finish().unwrap()
     }
 
+    fn upgrade_scratch_paths(parent: &Path) -> Vec<PathBuf> {
+        let mut paths = std::fs::read_dir(parent)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with(".temps-upgrade-"))
+            })
+            .collect::<Vec<_>>();
+        paths.sort();
+        paths
+    }
+
+    async fn spawn_raw_http_server(
+        response_parts: Vec<Vec<u8>>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = socket.read(&mut request).await.unwrap();
+            for part in response_parts {
+                socket.write_all(&part).await.unwrap();
+                socket.flush().await.unwrap();
+                tokio::task::yield_now().await;
+            }
+        });
+        (format!("http://{address}/asset"), server)
+    }
+
     #[test]
     fn test_verify_computed_checksum_matches_case_insensitively() {
         let computed = "AABBCC";
@@ -2038,17 +2134,113 @@ mod tests {
         assert!(err.contains("bbbb"));
     }
 
+    #[tokio::test]
+    async fn test_download_asset_to_file_multiple_chunks_writes_all_bytes_and_sha() {
+        use sha2::{Digest, Sha256};
+
+        let header = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n";
+        let (url, server) = spawn_raw_http_server(vec![
+            [header.as_slice(), b"5\r\nhello\r\n"].concat(),
+            b"1\r\n \r\n".to_vec(),
+            b"5\r\nworld\r\n0\r\n\r\n".to_vec(),
+        ])
+        .await;
+        let dir = tempfile::tempdir().unwrap();
+        let mut download = create_upgrade_temp_file(dir.path(), ".temps-upgrade-dl.").unwrap();
+        let download_path = download.path().to_path_buf();
+
+        let computed = download_asset_to_file(&url, download.as_file_mut(), &download_path)
+            .await
+            .unwrap();
+
+        server.await.unwrap();
+        let expected_bytes = b"hello world";
+        assert_eq!(std::fs::read(&download_path).unwrap(), expected_bytes);
+        assert_eq!(
+            computed,
+            hex::encode(Sha256::digest(expected_bytes)),
+            "the digest must cover every streamed response chunk"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_download_asset_to_file_truncated_response_errors_and_temp_cleans_on_drop() {
+        let header = b"HTTP/1.1 200 OK\r\nContent-Length: 20\r\nConnection: close\r\n\r\n";
+        let (url, server) =
+            spawn_raw_http_server(vec![[header.as_slice(), b"short"].concat()]).await;
+        let dir = tempfile::tempdir().unwrap();
+        let download_path;
+
+        {
+            let mut download = create_upgrade_temp_file(dir.path(), ".temps-upgrade-dl.").unwrap();
+            download_path = download.path().to_path_buf();
+
+            let error = download_asset_to_file(&url, download.as_file_mut(), &download_path)
+                .await
+                .unwrap_err()
+                .to_string();
+
+            assert!(
+                error.contains("Failed to read download response"),
+                "error was: {error}"
+            );
+            assert!(download_path.exists());
+        }
+
+        server.await.unwrap();
+        assert!(!download_path.exists());
+        assert!(upgrade_scratch_paths(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn test_checksum_mismatch_preserves_target_and_cleans_download_temp() {
+        use sha2::{Digest, Sha256};
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("temps");
+        let original = b"existing-production-binary";
+        std::fs::write(&target, original).unwrap();
+
+        let verification_error = {
+            let mut download = create_upgrade_temp_file(dir.path(), ".temps-upgrade-dl.").unwrap();
+            download
+                .as_file_mut()
+                .write_all(b"downloaded-but-untrusted")
+                .unwrap();
+            let computed = hex::encode(Sha256::digest(b"downloaded-but-untrusted"));
+
+            verify_computed_checksum(
+                &computed,
+                "0000000000000000000000000000000000000000000000000000000000000000  temps.tar.gz",
+            )
+        };
+
+        assert!(verification_error.is_err());
+        assert_eq!(std::fs::read(&target).unwrap(), original);
+        assert!(upgrade_scratch_paths(dir.path()).is_empty());
+    }
+
     #[test]
     fn test_extract_binary_from_tarball_file_streams_to_disk() {
         let dir = tempfile::tempdir().unwrap();
-        let tarball_path = dir.path().join("temps.tar.gz");
-        let dest = dir.path().join("staged");
+        let mut tarball = create_upgrade_temp_file(dir.path(), ".temps-upgrade-dl.").unwrap();
+        let tarball_path = tarball.path().to_path_buf();
+        tarball
+            .as_file_mut()
+            .write_all(&tarball_with_binary(b"fake-binary-content"))
+            .unwrap();
+        let mut dest = create_upgrade_temp_file(dir.path(), ".temps-upgrade-bin.").unwrap();
+        let dest_path = dest.path().to_path_buf();
 
-        std::fs::write(&tarball_path, tarball_with_binary(b"fake-binary-content")).unwrap();
-
-        let written = extract_binary_from_tarball_file(&tarball_path, &dest).unwrap();
+        let written = extract_binary_from_tarball_file(
+            tarball.as_file_mut(),
+            &tarball_path,
+            dest.as_file_mut(),
+            &dest_path,
+        )
+        .unwrap();
         assert_eq!(written, b"fake-binary-content".len() as u64);
-        assert_eq!(std::fs::read(&dest).unwrap(), b"fake-binary-content");
+        assert_eq!(std::fs::read(&dest_path).unwrap(), b"fake-binary-content");
     }
 
     /// The streaming path must produce exactly what the in-memory path does,
@@ -2056,18 +2248,25 @@ mod tests {
     #[test]
     fn test_extract_binary_from_tarball_file_matches_in_memory_path() {
         let dir = tempfile::tempdir().unwrap();
-        let tarball_path = dir.path().join("temps.tar.gz");
-        let dest = dir.path().join("staged");
-
         // Big enough that `read_to_end` would have grown its Vec more than once.
         let content: Vec<u8> = (0..600_000u32).map(|i| (i % 251) as u8).collect();
-        let tarball = tarball_with_binary(&content);
-        std::fs::write(&tarball_path, &tarball).unwrap();
+        let tarball_bytes = tarball_with_binary(&content);
+        let mut tarball = create_upgrade_temp_file(dir.path(), ".temps-upgrade-dl.").unwrap();
+        let tarball_path = tarball.path().to_path_buf();
+        tarball.as_file_mut().write_all(&tarball_bytes).unwrap();
+        let mut dest = create_upgrade_temp_file(dir.path(), ".temps-upgrade-bin.").unwrap();
+        let dest_path = dest.path().to_path_buf();
 
-        extract_binary_from_tarball_file(&tarball_path, &dest).unwrap();
+        extract_binary_from_tarball_file(
+            tarball.as_file_mut(),
+            &tarball_path,
+            dest.as_file_mut(),
+            &dest_path,
+        )
+        .unwrap();
 
-        let streamed = std::fs::read(&dest).unwrap();
-        let in_memory = extract_binary_from_tarball(&tarball).unwrap();
+        let streamed = std::fs::read(&dest_path).unwrap();
+        let in_memory = extract_binary_from_tarball(&tarball_bytes).unwrap();
         assert_eq!(streamed, in_memory);
         assert_eq!(streamed, content);
     }
@@ -2078,9 +2277,6 @@ mod tests {
         use flate2::Compression;
 
         let dir = tempfile::tempdir().unwrap();
-        let tarball_path = dir.path().join("temps.tar.gz");
-        let dest = dir.path().join("staged");
-
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
         {
             let mut builder = tar::Builder::new(&mut encoder);
@@ -2094,28 +2290,51 @@ mod tests {
                 .unwrap();
             builder.finish().unwrap();
         }
-        std::fs::write(&tarball_path, encoder.finish().unwrap()).unwrap();
+        let mut tarball = create_upgrade_temp_file(dir.path(), ".temps-upgrade-dl.").unwrap();
+        let tarball_path = tarball.path().to_path_buf();
+        tarball
+            .as_file_mut()
+            .write_all(&encoder.finish().unwrap())
+            .unwrap();
+        let mut dest = create_upgrade_temp_file(dir.path(), ".temps-upgrade-bin.").unwrap();
+        let dest_path = dest.path().to_path_buf();
 
-        let err = extract_binary_from_tarball_file(&tarball_path, &dest)
-            .unwrap_err()
-            .to_string();
+        let err = extract_binary_from_tarball_file(
+            tarball.as_file_mut(),
+            &tarball_path,
+            dest.as_file_mut(),
+            &dest_path,
+        )
+        .unwrap_err()
+        .to_string();
         assert!(err.contains("not a regular file"), "error was: {err}");
-        assert!(!dest.exists());
+        drop(dest);
+        assert!(!dest_path.exists());
     }
 
     #[test]
     fn test_extract_binary_from_tarball_file_rejects_empty_entry() {
         let dir = tempfile::tempdir().unwrap();
-        let tarball_path = dir.path().join("temps.tar.gz");
-        let dest = dir.path().join("staged");
+        let mut tarball = create_upgrade_temp_file(dir.path(), ".temps-upgrade-dl.").unwrap();
+        let tarball_path = tarball.path().to_path_buf();
+        tarball
+            .as_file_mut()
+            .write_all(&tarball_with_binary(b""))
+            .unwrap();
+        let mut dest = create_upgrade_temp_file(dir.path(), ".temps-upgrade-bin.").unwrap();
+        let dest_path = dest.path().to_path_buf();
 
-        std::fs::write(&tarball_path, tarball_with_binary(b"")).unwrap();
-
-        let err = extract_binary_from_tarball_file(&tarball_path, &dest)
-            .unwrap_err()
-            .to_string();
+        let err = extract_binary_from_tarball_file(
+            tarball.as_file_mut(),
+            &tarball_path,
+            dest.as_file_mut(),
+            &dest_path,
+        )
+        .unwrap_err()
+        .to_string();
         assert!(err.contains("is empty"), "error was: {err}");
-        assert!(!dest.exists());
+        drop(dest);
+        assert!(!dest_path.exists());
     }
 
     #[test]
@@ -2127,7 +2346,19 @@ mod tests {
         std::fs::create_dir(&target).unwrap();
 
         assert!(replace_binary(&target, b"new-binary").is_err());
-        assert!(!staged_binary_path(dir.path()).exists());
+        assert!(upgrade_scratch_paths(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn test_replace_binary_valid_bytes_replaces_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("temps");
+        std::fs::write(&target, b"old-binary").unwrap();
+
+        replace_binary(&target, b"new-binary").unwrap();
+
+        assert_eq!(std::fs::read(&target).unwrap(), b"new-binary");
+        assert!(upgrade_scratch_paths(dir.path()).is_empty());
     }
 
     #[test]
@@ -2136,9 +2367,6 @@ mod tests {
         use flate2::Compression;
 
         let dir = tempfile::tempdir().unwrap();
-        let tarball_path = dir.path().join("temps.tar.gz");
-        let dest = dir.path().join("staged");
-
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
         {
             let mut builder = tar::Builder::new(&mut encoder);
@@ -2152,76 +2380,104 @@ mod tests {
                 .unwrap();
             builder.finish().unwrap();
         }
-        std::fs::write(&tarball_path, encoder.finish().unwrap()).unwrap();
+        let mut tarball = create_upgrade_temp_file(dir.path(), ".temps-upgrade-dl.").unwrap();
+        let tarball_path = tarball.path().to_path_buf();
+        tarball
+            .as_file_mut()
+            .write_all(&encoder.finish().unwrap())
+            .unwrap();
+        let mut dest = create_upgrade_temp_file(dir.path(), ".temps-upgrade-bin.").unwrap();
+        let dest_path = dest.path().to_path_buf();
 
-        let err = extract_binary_from_tarball_file(&tarball_path, &dest).unwrap_err();
+        let err = extract_binary_from_tarball_file(
+            tarball.as_file_mut(),
+            &tarball_path,
+            dest.as_file_mut(),
+            &dest_path,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("not found"));
-        // Nothing was staged, so nothing can be renamed over the live binary.
-        assert!(!dest.exists());
+        drop(dest);
+        assert!(!dest_path.exists());
     }
 
     #[test]
-    fn test_extract_binary_from_tarball_file_missing_tarball_reports_path() {
+    fn test_extract_binary_from_tarball_file_corrupt_gzip_cleans_staged_temp() {
         let dir = tempfile::tempdir().unwrap();
-        let missing = dir.path().join("nope.tar.gz");
-        let err = extract_binary_from_tarball_file(&missing, &dir.path().join("staged"))
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("nope.tar.gz"), "error was: {err}");
+        let mut tarball = create_upgrade_temp_file(dir.path(), ".temps-upgrade-dl.").unwrap();
+        let tarball_path = tarball.path().to_path_buf();
+        tarball
+            .as_file_mut()
+            .write_all(b"not-a-complete-gzip-stream")
+            .unwrap();
+        let mut dest = create_upgrade_temp_file(dir.path(), ".temps-upgrade-bin.").unwrap();
+        let dest_path = dest.path().to_path_buf();
+
+        let err = extract_binary_from_tarball_file(
+            tarball.as_file_mut(),
+            &tarball_path,
+            dest.as_file_mut(),
+            &dest_path,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains(&tarball_path.display().to_string()));
+        drop(dest);
+        drop(tarball);
+        assert!(!dest_path.exists());
+        assert!(upgrade_scratch_paths(dir.path()).is_empty());
     }
 
     #[test]
-    fn test_scoped_temp_file_removes_on_drop() {
+    fn test_create_upgrade_temp_file_uses_random_distinct_prefixed_names() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("scratch");
-        std::fs::write(&path, b"junk").unwrap();
+        let first = create_upgrade_temp_file(dir.path(), ".temps-upgrade-bin.").unwrap();
+        let second = create_upgrade_temp_file(dir.path(), ".temps-upgrade-bin.").unwrap();
 
-        {
-            let _guard = ScopedTempFile::new(path.clone());
+        assert_ne!(first.path(), second.path());
+        for file in [&first, &second] {
+            let name = file.path().file_name().unwrap().to_string_lossy();
+            assert!(name.starts_with(".temps-upgrade-bin."), "name was: {name}");
+            assert!(file.path().exists());
         }
+    }
+
+    #[test]
+    fn test_create_upgrade_temp_file_returns_atomically_created_open_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut file = create_upgrade_temp_file(dir.path(), ".temps-upgrade-dl.").unwrap();
+        let path = file.path().to_path_buf();
+
+        file.as_file_mut().write_all(b"owned").unwrap();
+
+        assert_eq!(std::fs::read(path).unwrap(), b"owned");
+    }
+
+    #[test]
+    fn test_create_upgrade_temp_file_removes_file_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = {
+            let file = create_upgrade_temp_file(dir.path(), ".temps-upgrade-dl.").unwrap();
+            let path = file.path().to_path_buf();
+            assert!(path.exists());
+            path
+        };
+
         assert!(!path.exists());
-    }
-
-    #[test]
-    fn test_scoped_temp_file_disarm_keeps_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("scratch");
-        std::fs::write(&path, b"junk").unwrap();
-
-        {
-            let mut guard = ScopedTempFile::new(path.clone());
-            guard.disarm();
-        }
-        assert!(path.exists());
-    }
-
-    #[test]
-    fn test_temp_paths_carry_pid_suffix() {
-        let parent = std::path::Path::new("/opt/temps/bin");
-        let pid = std::process::id();
-        assert_eq!(
-            staged_binary_path(parent),
-            parent.join(format!(".temps-upgrade-tmp.{pid}"))
-        );
-        assert_eq!(
-            download_tmp_path(parent),
-            parent.join(format!(".temps-upgrade-dl.{pid}"))
-        );
-        // Concurrent upgraders must not collide on the same staging file.
-        assert_ne!(staged_binary_path(parent), download_tmp_path(parent));
     }
 
     #[test]
     fn test_finalize_staged_binary_renames_and_marks_executable() {
         let dir = tempfile::tempdir().unwrap();
         let target = dir.path().join("temps");
-        let staged = dir.path().join("staged");
         std::fs::write(&target, b"old").unwrap();
-        std::fs::write(&staged, b"new").unwrap();
+        let mut staged = create_upgrade_temp_file(dir.path(), ".temps-upgrade-bin.").unwrap();
+        let staged_path = staged.path().to_path_buf();
+        staged.as_file_mut().write_all(b"new").unwrap();
 
-        finalize_staged_binary(&target, &staged).unwrap();
+        finalize_staged_binary(&target, staged).unwrap();
 
-        assert!(!staged.exists());
+        assert!(!staged_path.exists());
         assert_eq!(std::fs::read(&target).unwrap(), b"new");
 
         #[cfg(unix)]


### PR DESCRIPTION
## Description

### Summary

`temps upgrade` held the whole release artifact in memory, twice over.

1. `download_asset` buffered the response into a `Bytes` and then `.to_vec()`'d it, so both copies of the ~110 MB tarball were live at once.
2. `extract_binary_from_tarball` read the uncompressed binary (~270 MB: `.text` ~185 MB, `.rodata` ~59 MB) into a `Vec` via `read_to_end`, which doubles its capacity while growing, with the tarball buffer still alive for the whole extraction.
3. `replace_binary` then handed those 270 MB to `fs::write`, so the page cache filled with the same amount of dirty pages on top.

On a self-hosted instance with 1 GB of RAM already running `temps serve`, that peak does not fit. The kernel goes into swap thrashing and, with a fraction of a vCPU available, nothing gets scheduled: the reported symptom is the whole host becoming unreachable (SSH times out during banner exchange), not just the command failing. The last line printed is "Replacing binary", because that `println!` happens before the write.

Everything now streams through disk. Nothing in the flow ever needs the artifact whole.

### Measurement

Peak RSS (`VmHWM` from `/proc/self/status`) of a harness running the two code paths over a synthetic 273 MB binary in a 73 MB tarball:

| Path | Peak RSS |
|---|---|
| before (buffer tarball, `read_to_end`, `fs::write`) | 353,880 kB |
| after (stream to disk, `io::copy`) | 2,488 kB |

Roughly 350 MB down to 2.5 MB, and the "before" figure is a lower bound: the harness reads the tarball once, while the real `download_asset` kept the `Bytes` and its `to_vec()` copy alive simultaneously, on a tarball half again as large.

Both paths produced a byte-identical binary (same SHA256).

### Changes

All in `crates/temps-cli/src/commands/upgrade.rs`.

- `download_asset_to_file` / `download_ee_asset_to_file` stream the response chunk by chunk into a temporary file and feed `Sha256` in the same loop, returning the hex digest. No second read for the checksum.
- `verify_computed_checksum` compares an already-computed digest against a `.sha256` body. `verify_checksum` keeps its signature and now delegates to it, so its callers and tests are untouched.
- `extract_binary_from_tarball_file` runs `GzDecoder` over the tarball `File` and `std::io::copy`s the entry into the staging file. The in-memory `extract_binary_from_tarball` stays for its other callers.
- Checksum verification still runs before anything is unpacked. That is why the tarball is staged to disk rather than piped download to gunzip to tar to binary: the pipeline would save 110 MB of scratch disk but would write unverified bytes over the live executable. The reasoning is recorded as a comment at the call site.
- The tarball is staged next to the target binary, not in `std::env::temp_dir()`, which is a tmpfs on many small hosts and would put those 110 MB straight back in RAM. That directory is already known-writable via `check_write_permission`.
- `ScopedTempFile` removes the download and staging files on the ordinary failure paths. It cannot cover a `SIGKILL`, so reaping orphaned `.temps-upgrade-*.<pid>` files needs a PID liveness check and is left for a follow-up.
- Validate before the rename: the extracted size is compared against the tar header's declared size, and a mismatch removes the staging file and fails. The verified checksum covers the tarball, not the write, so a short write (full disk, truncated stream) could otherwise put a plausible but incomplete file over the live executable.
- `sync_all` before the rename, in both the streaming and the `replace_binary` paths. The rename is atomic for metadata only, so without the fsync a power cut can leave a correctly sized file of garbage where the system's executable was.
- Both flows are converted: the public release path and the EE path.

Unchanged: printed messages, release artifact format, the atomic rename, and the PID suffix on the staging file.

### Validation

- `cargo check --lib -p temps-cli`: clean, no warnings.
- `cargo test --lib -p temps-cli`: 221 passed, 0 failed. The existing `verify_checksum` and `extract_binary_from_tarball` tests are unmodified and still pass.
- New tests cover: streaming extraction to disk; streaming output byte-identical to the in-memory path on a payload large enough that `read_to_end` reallocates; missing `temps` entry leaves nothing staged; missing tarball names the path in the error; `ScopedTempFile` removal and disarm; PID suffix on both temp paths; `finalize_staged_binary` renaming and setting mode 0755; checksum mismatch reporting both hashes.
- Invalid checksum: the comparison sits between the download and the extraction, so a mismatch aborts with the target binary untouched and both temporaries removed by their guards. The mismatch itself is covered by `test_verify_computed_checksum_reports_both_hashes_on_mismatch`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have written tests that cover the changes
- [x] All new and existing tests pass (`cargo test --lib`)
- [x] `cargo check --lib` passes with no warnings
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have updated documentation where necessary

## Related issues

Reported against a self-hosted 1 GB instance upgrading on the nightly channel.

## Evidence

**Secure streaming and failure-path regressions**

```bash
cargo test --lib -p temps-cli commands::upgrade::tests -- --nocapture
```

```text
cargo test: 61 passed, 167 filtered out (1 suite, 0.05s)
```

This targeted suite includes multi-chunk HTTP streaming and SHA-256 verification, interrupted-response cleanup, random atomically-created sibling temp files, checksum-mismatch target preservation, corrupt-gzip cleanup, and successful atomic replacement.

**Full temps-cli library regression suite**

```bash
cargo test --lib -p temps-cli
```

```text
cargo test: 228 passed (1 suite, 2.06s)
```

**Formatting and compilation**

```bash
cargo fmt --all -- --check
cargo check --lib -p temps-cli
```

Both commands exited successfully. The check emitted only existing workspace/build-script notices (non-root profile, debug web placeholder, and a future-incompatibility notice).