### PR TITLE
fix(proxy): preserve original IP in admin gate updates

### DIFF
--- a/crates/temps-cli/src/commands/serve/admin_gate.rs
+++ b/crates/temps-cli/src/commands/serve/admin_gate.rs
@@ -19,7 +19,7 @@ use std::net::{IpAddr, SocketAddr};
 
 use axum::{
     extract::{ConnectInfo, Request, State},
-    http::{header, StatusCode},
+    http::{header, HeaderMap, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
 };
@@ -31,23 +31,43 @@ pub use temps_core::admin_gate::{
 
 /// Resolve the effective client IP for gating purposes. When
 /// `trust_forwarded_for` is true and the immediate peer is loopback, the
-/// leftmost address in `X-Forwarded-For` wins; otherwise the peer's address
-/// is used directly.
-fn effective_client_ip(req: &Request, peer: IpAddr, trust_forwarded_for: bool) -> IpAddr {
+/// rightmost address in `X-Forwarded-For` wins; otherwise the peer's address
+/// is used directly. Temps' trusted proxy replaces inbound XFF with that
+/// canonical address, so client-supplied entries cannot influence the gate.
+pub(crate) fn effective_client_ip(
+    headers: &HeaderMap,
+    peer: IpAddr,
+    trust_forwarded_for: bool,
+) -> Result<IpAddr, InvalidForwardedFor> {
     if !trust_forwarded_for || !peer.is_loopback() {
-        return peer;
+        return Ok(peer);
     }
-    let Some(value) = req.headers().get("x-forwarded-for") else {
-        return peer;
+    Ok(trusted_forwarded_client_ip(headers, peer)?.unwrap_or(peer))
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct InvalidForwardedFor;
+
+/// Return the client address supplied by a trusted loopback proxy. A present
+/// but invalid header is an error rather than a fallback to loopback: treating
+/// malformed proxy metadata as localhost would widen an allowlist on failure.
+pub(crate) fn trusted_forwarded_client_ip(
+    headers: &HeaderMap,
+    peer: IpAddr,
+) -> Result<Option<IpAddr>, InvalidForwardedFor> {
+    if !peer.is_loopback() {
+        return Ok(None);
+    }
+    let Some(value) = headers.get("x-forwarded-for") else {
+        return Ok(None);
     };
-    let Ok(value) = value.to_str() else {
-        return peer;
-    };
-    value
-        .split(',')
+    let value = value.to_str().map_err(|_| InvalidForwardedFor)?;
+    let ip = value
+        .rsplit(',')
         .next()
         .and_then(|s| s.trim().parse::<IpAddr>().ok())
-        .unwrap_or(peer)
+        .ok_or(InvalidForwardedFor)?;
+    Ok(Some(ip))
 }
 
 fn host_header(req: &Request) -> Option<String> {
@@ -70,7 +90,19 @@ pub async fn admin_gate(
         return next.run(req).await;
     }
 
-    let client_ip = effective_client_ip(&req, peer.ip(), config.trust_forwarded_for);
+    let client_ip = match effective_client_ip(req.headers(), peer.ip(), config.trust_forwarded_for)
+    {
+        Ok(client_ip) => client_ip,
+        Err(InvalidForwardedFor) => {
+            warn!(
+                peer = %peer,
+                host = host_header(&req).as_deref().unwrap_or(""),
+                path = %req.uri().path(),
+                "admin gate denied request with invalid trusted X-Forwarded-For header"
+            );
+            return StatusCode::NOT_FOUND.into_response();
+        }
+    };
     let host = host_header(&req);
 
     if !config.would_allow(client_ip, host.as_deref()) {
@@ -95,29 +127,61 @@ mod tests {
 
     #[test]
     fn forwarded_for_only_trusted_from_loopback() {
-        let req = Request::builder()
-            .uri("/")
-            .header("x-forwarded-for", "203.0.113.5")
-            .body(axum::body::Body::empty())
-            .unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-forwarded-for",
+            "198.51.100.99, 203.0.113.5".parse().unwrap(),
+        );
 
         let peer_loopback = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let peer_external = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1));
 
-        // Loopback + trust → use header
+        // Loopback + trust → use the rightmost proxy-appended address.
         assert_eq!(
-            effective_client_ip(&req, peer_loopback, true),
-            IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5))
+            effective_client_ip(&headers, peer_loopback, true),
+            Ok(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)))
         );
         // External + trust → ignore header (anti-spoofing)
         assert_eq!(
-            effective_client_ip(&req, peer_external, true),
-            peer_external
+            effective_client_ip(&headers, peer_external, true),
+            Ok(peer_external)
         );
         // Loopback + no trust → ignore header
         assert_eq!(
-            effective_client_ip(&req, peer_loopback, false),
-            peer_loopback
+            effective_client_ip(&headers, peer_loopback, false),
+            Ok(peer_loopback)
+        );
+    }
+
+    #[test]
+    fn malformed_forwarded_for_is_rejected() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "not-an-ip".parse().unwrap());
+        let peer = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+        assert_eq!(
+            effective_client_ip(&headers, peer, true),
+            Err(InvalidForwardedFor)
+        );
+    }
+
+    #[test]
+    fn missing_forwarded_for_falls_back_to_loopback_peer() {
+        let headers = HeaderMap::new();
+        let peer = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+        assert_eq!(effective_client_ip(&headers, peer, true), Ok(peer));
+    }
+
+    #[test]
+    fn ipv6_loopback_trusts_forwarded_ipv6_client() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "fd7a:115c:a1e0::123".parse().unwrap());
+        let peer = "::1".parse::<IpAddr>().unwrap();
+
+        assert_eq!(
+            effective_client_ip(&headers, peer, true),
+            Ok("fd7a:115c:a1e0::123".parse::<IpAddr>().unwrap())
         );
     }
 }

--- a/crates/temps-cli/src/commands/serve/admin_gate_handler.rs
+++ b/crates/temps-cli/src/commands/serve/admin_gate_handler.rs
@@ -23,8 +23,10 @@ use temps_auth::{permission_guard, RequireAuth};
 use temps_core::problemdetails::{self, Problem};
 use utoipa::ToSchema;
 
-use super::admin_gate::AdminGateSource;
-use super::admin_gate_service::{AdminGateService, AdminGateServiceError, AdminGateSettings};
+use super::admin_gate::{trusted_forwarded_client_ip, AdminGateSource, InvalidForwardedFor};
+use super::admin_gate_service::{
+    AdminGateCallerIps, AdminGateService, AdminGateServiceError, AdminGateSettings,
+};
 
 /// State carried by these handlers. Held behind an `Arc` so axum can clone
 /// it cheaply for every request.
@@ -54,6 +56,27 @@ pub struct UpdateAdminGateRequest {
     pub trust_forwarded_for: bool,
 }
 
+fn update_caller_ips(
+    headers: &axum::http::HeaderMap,
+    peer: SocketAddr,
+    trust_forwarded_for: bool,
+) -> Result<AdminGateCallerIps, AdminGateServiceError> {
+    let forwarded_ip =
+        trusted_forwarded_client_ip(headers, peer.ip()).map_err(|InvalidForwardedFor| {
+            AdminGateServiceError::InvalidCallerForwardedFor { peer_ip: peer.ip() }
+        })?;
+    let edge_client_ip = forwarded_ip.unwrap_or_else(|| peer.ip());
+    let console_client_ip = if trust_forwarded_for {
+        edge_client_ip
+    } else {
+        peer.ip()
+    };
+    Ok(AdminGateCallerIps {
+        edge_client_ip,
+        console_client_ip,
+    })
+}
+
 impl From<AdminGateServiceError> for Problem {
     fn from(err: AdminGateServiceError) -> Self {
         use AdminGateServiceError::*;
@@ -64,9 +87,11 @@ impl From<AdminGateServiceError> for Problem {
             EnvOverridden => problemdetails::new(StatusCode::CONFLICT)
                 .with_title("Admin Gate Read-Only")
                 .with_detail(err.to_string()),
-            WouldLockOut { .. } => problemdetails::new(StatusCode::CONFLICT)
-                .with_title("Lockout Prevented")
-                .with_detail(err.to_string()),
+            WouldLockOut { .. } | InvalidCallerForwardedFor { .. } => {
+                problemdetails::new(StatusCode::CONFLICT)
+                    .with_title("Lockout Prevented")
+                    .with_detail(err.to_string())
+            }
             Database(_) | Serde(_) => problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
                 .with_title("Internal Server Error")
                 .with_detail(err.to_string()),
@@ -128,6 +153,7 @@ async fn patch_admin_gate(
         .get(header::HOST)
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
+    let caller_ips = update_caller_ips(&headers, peer, request.trust_forwarded_for)?;
 
     let new_settings = AdminGateSettings {
         allowed_ips: request.allowed_ips,
@@ -137,7 +163,7 @@ async fn patch_admin_gate(
 
     let cfg = state
         .service
-        .update(new_settings, peer.ip(), caller_host.as_deref())
+        .update(new_settings, caller_ips, caller_host.as_deref())
         .await?;
 
     Ok(Json(AdminGateResponse {
@@ -165,4 +191,169 @@ pub fn configure_routes(state: Arc<AdminGateAppState>) -> Router {
             get(get_admin_gate).patch(patch_admin_gate),
         )
         .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::{DatabaseBackend, MockDatabase};
+    use std::net::IpAddr;
+    use temps_auth::{AuthContext, Role};
+    use temps_core::admin_gate::{AdminGateConfig, AdminGateSource};
+    use temps_entities::{settings, users};
+
+    fn settings_row(data: serde_json::Value) -> settings::Model {
+        settings::Model {
+            id: 1,
+            data,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    fn admin_auth() -> AuthContext {
+        let now = chrono::Utc::now();
+        let user = users::Model {
+            id: 1,
+            name: "Admin".to_string(),
+            email: "admin@example.com".to_string(),
+            password_hash: None,
+            email_verified: true,
+            email_verification_token: None,
+            email_verification_expires: None,
+            password_reset_token: None,
+            password_reset_expires: None,
+            must_change_password: false,
+            deleted_at: None,
+            mfa_secret: None,
+            mfa_enabled: false,
+            mfa_recovery_codes: None,
+            oidc_subject: None,
+            oidc_provider_id: None,
+            created_at: now,
+            updated_at: now,
+        };
+        AuthContext::new_session(user, Role::Admin)
+    }
+
+    fn request_headers(forwarded_for: &str) -> axum::http::HeaderMap {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(header::HOST, "admin.example.com".parse().unwrap());
+        headers.insert("x-forwarded-for", forwarded_for.parse().unwrap());
+        headers
+    }
+
+    #[test]
+    fn update_preflight_uses_original_ip_when_enabling_forwarded_for() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("x-forwarded-for", "100.100.1.2".parse().unwrap());
+        let peer = "127.0.0.1:43210".parse().unwrap();
+
+        let caller_ips = update_caller_ips(&headers, peer, true).unwrap();
+        let candidate = AdminGateConfig::from_parts(
+            &["100.64.0.0/10".to_string()],
+            &[],
+            true,
+            AdminGateSource::Db,
+        )
+        .unwrap();
+
+        assert_eq!(
+            caller_ips,
+            AdminGateCallerIps::direct("100.100.1.2".parse::<IpAddr>().unwrap())
+        );
+        assert!(candidate.would_allow(caller_ips.edge_client_ip, None));
+        assert!(candidate.would_allow(caller_ips.console_client_ip, None));
+    }
+
+    #[test]
+    fn update_preflight_ignores_forwarded_ip_when_candidate_disables_trust() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("x-forwarded-for", "100.100.1.2".parse().unwrap());
+        let peer = "127.0.0.1:43210".parse().unwrap();
+
+        let caller_ips = update_caller_ips(&headers, peer, false).unwrap();
+        assert_eq!(
+            caller_ips.edge_client_ip,
+            "100.100.1.2".parse::<IpAddr>().unwrap()
+        );
+        assert_eq!(
+            caller_ips.console_client_ip,
+            "127.0.0.1".parse::<IpAddr>().unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn patch_allows_forwarded_caller_inside_candidate_cidr() {
+        let bootstrap_row = settings_row(serde_json::json!({}));
+        let returned_row = settings_row(serde_json::json!({
+            "admin_gate": {
+                "allowed_ips": ["100.64.0.0/10"],
+                "allowed_hosts": ["admin.example.com"],
+                "trust_forwarded_for": true
+            }
+        }));
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![bootstrap_row.clone()]])
+            .append_query_results(vec![vec![bootstrap_row]])
+            .append_query_results(vec![vec![returned_row]])
+            .into_connection();
+        let (service, _handle) = AdminGateService::new(Arc::new(db), &[], &[], false)
+            .await
+            .unwrap();
+        let state = Arc::new(AdminGateAppState { service });
+
+        let response = patch_admin_gate(
+            RequireAuth(admin_auth()),
+            State(Arc::clone(&state)),
+            ConnectInfo("127.0.0.1:43210".parse().unwrap()),
+            request_headers("100.100.1.2"),
+            Json(UpdateAdminGateRequest {
+                allowed_ips: vec!["100.64.0.0/10".to_string()],
+                allowed_hosts: vec!["admin.example.com".to_string()],
+                trust_forwarded_for: true,
+            }),
+        )
+        .await
+        .unwrap()
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let config = state.service.snapshot();
+        assert!(config.would_allow(
+            "100.100.1.2".parse::<IpAddr>().unwrap(),
+            Some("admin.example.com")
+        ));
+    }
+
+    #[tokio::test]
+    async fn patch_rejects_loopback_only_candidate_that_denies_edge_caller() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![Vec::<settings::Model>::new()])
+            .into_connection();
+        let (service, _handle) = AdminGateService::new(Arc::new(db), &[], &[], false)
+            .await
+            .unwrap();
+        let state = Arc::new(AdminGateAppState { service });
+
+        let result = patch_admin_gate(
+            RequireAuth(admin_auth()),
+            State(Arc::clone(&state)),
+            ConnectInfo("127.0.0.1:43210".parse().unwrap()),
+            request_headers("100.100.1.2"),
+            Json(UpdateAdminGateRequest {
+                allowed_ips: vec!["127.0.0.1/32".to_string()],
+                allowed_hosts: vec!["admin.example.com".to_string()],
+                trust_forwarded_for: false,
+            }),
+        )
+        .await;
+        let problem = match result {
+            Ok(_) => panic!("loopback-only candidate unexpectedly passed lockout preflight"),
+            Err(problem) => problem,
+        };
+
+        assert_eq!(problem.status_code, StatusCode::CONFLICT);
+        assert!(state.service.snapshot().is_noop());
+    }
 }

--- a/crates/temps-cli/src/commands/serve/admin_gate_service.rs
+++ b/crates/temps-cli/src/commands/serve/admin_gate_service.rs
@@ -82,6 +82,11 @@ pub enum AdminGateServiceError {
         caller_host: Option<String>,
     },
 
+    #[error(
+        "Refusing to save: the trusted X-Forwarded-For header from loopback peer {peer_ip} does not contain a valid client IP"
+    )]
+    InvalidCallerForwardedFor { peer_ip: IpAddr },
+
     #[error("Database error: {0}")]
     Database(#[from] sea_orm::DbErr),
 
@@ -97,6 +102,24 @@ pub struct AdminGateService {
     /// True when env vars dictate the active config. Set once at construction
     /// time and never changes — the process must restart to flip modes.
     env_overridden: bool,
+}
+
+/// The caller identities seen by the two admin-gate enforcement points.
+/// Pingora evaluates the original edge client while the Axum listener may
+/// evaluate either that forwarded client or its loopback peer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AdminGateCallerIps {
+    pub edge_client_ip: IpAddr,
+    pub console_client_ip: IpAddr,
+}
+
+impl AdminGateCallerIps {
+    pub fn direct(client_ip: IpAddr) -> Self {
+        Self {
+            edge_client_ip: client_ip,
+            console_client_ip: client_ip,
+        }
+    }
 }
 
 impl AdminGateService {
@@ -189,12 +212,13 @@ impl AdminGateService {
 
     /// Persist a new config and swap the live handle.
     ///
-    /// `caller_ip` / `caller_host` are used for a lockout pre-flight: if the
-    /// new rules would deny the caller, the write is rejected.
+    /// `caller_ips` / `caller_host` are used for a lockout pre-flight. The
+    /// candidate must allow the identity seen by both Pingora and Axum or the
+    /// write is rejected.
     pub async fn update(
         &self,
         new_settings: AdminGateSettings,
-        caller_ip: IpAddr,
+        caller_ips: AdminGateCallerIps,
         caller_host: Option<&str>,
     ) -> Result<Arc<AdminGateConfig>, AdminGateServiceError> {
         if self.env_overridden {
@@ -211,11 +235,15 @@ impl AdminGateService {
 
         // Lockout pre-flight: only meaningful when the new config is *not*
         // a noop. A noop config allows everyone, so it can never lock out.
-        if !candidate.is_noop() && !candidate.would_allow(caller_ip, caller_host) {
-            return Err(AdminGateServiceError::WouldLockOut {
-                caller_ip,
-                caller_host: caller_host.map(|s| s.to_string()),
-            });
+        if !candidate.is_noop() {
+            for caller_ip in [caller_ips.edge_client_ip, caller_ips.console_client_ip] {
+                if !candidate.would_allow(caller_ip, caller_host) {
+                    return Err(AdminGateServiceError::WouldLockOut {
+                        caller_ip,
+                        caller_host: caller_host.map(|s| s.to_string()),
+                    });
+                }
+            }
         }
 
         persist_to_db(self.db.as_ref(), &new_settings).await?;
@@ -649,7 +677,7 @@ mod tests {
         let result = svc
             .update(
                 AdminGateSettings::default(),
-                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                AdminGateCallerIps::direct(IpAddr::V4(Ipv4Addr::LOCALHOST)),
                 None,
             )
             .await;
@@ -676,13 +704,61 @@ mod tests {
                     allowed_ips: vec!["10.0.0.0/8".to_string()],
                     ..Default::default()
                 },
-                IpAddr::V4(Ipv4Addr::new(192, 168, 1, 5)),
+                AdminGateCallerIps::direct(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 5))),
                 Some("anywhere"),
             )
             .await;
         assert!(matches!(
             result.unwrap_err(),
             AdminGateServiceError::WouldLockOut { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn update_refuses_when_either_enforcement_point_would_deny_caller() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![Vec::<temps_entities::settings::Model>::new()])
+            .into_connection();
+        let (svc, _handle) = AdminGateService::new(Arc::new(db), &[], &[], false)
+            .await
+            .unwrap();
+        let caller_ips = AdminGateCallerIps {
+            edge_client_ip: "100.100.1.2".parse().unwrap(),
+            console_client_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
+        };
+
+        let edge_denied = svc
+            .update(
+                AdminGateSettings {
+                    allowed_ips: vec!["127.0.0.1/32".to_string()],
+                    ..Default::default()
+                },
+                caller_ips,
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            edge_denied,
+            AdminGateServiceError::WouldLockOut { caller_ip, .. }
+                if caller_ip == caller_ips.edge_client_ip
+        ));
+
+        let console_denied = svc
+            .update(
+                AdminGateSettings {
+                    allowed_ips: vec!["100.64.0.0/10".to_string()],
+                    ..Default::default()
+                },
+                caller_ips,
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            console_denied,
+            AdminGateServiceError::WouldLockOut { caller_ip, .. }
+                if caller_ip == caller_ips.console_client_ip
         ));
     }
 
@@ -933,7 +1009,7 @@ mod tests {
                 allowed_hosts: vec!["admin.example.com".to_string()],
                 trust_forwarded_for: false,
             },
-            caller,
+            AdminGateCallerIps::direct(caller),
             Some("admin.example.com"),
         )
         .await


### PR DESCRIPTION
## Summary

- Resolve the admin caller IP from trusted loopback `X-Forwarded-For` metadata during gate updates.
- Validate both identities used by the two enforcement points: the original edge client seen by Pingora and the candidate-dependent client seen by Axum.
- Fail closed when a trusted forwarded header is present but malformed.
- Add handler, service, IPv4, IPv6, trust-boundary, and lockout regression coverage.

## Root cause

The PATCH lockout preflight passed the raw Axum socket peer directly to the service. Requests proxied internally by Pingora therefore appeared as `127.0.0.1`, even though Pingora had already canonicalized the original client address into `X-Forwarded-For`.

A single resolved identity was also insufficient: Pingora always evaluates the original edge client, while Axum evaluates either the forwarded address or its loopback peer depending on the candidate `trust_forwarded_for` value. The preflight now models and validates both enforcement points before persistence.

## Security

- Forwarded metadata is honored only from loopback peers.
- Temps Pingora replaces inbound XFF with its canonical client IP.
- Non-loopback peers cannot spoof XFF.
- Present but invalid trusted XFF is denied rather than treated as localhost.
- Independent `security-auditor` review: approved with no remaining findings.

## Evidence

**Exact reported regression: a proxied `100.100.1.2` caller can save `100.64.0.0/10`.**

```bash
cargo test --lib -p temps-cli patch_allows_forwarded_caller_inside_candidate_cidr -- --nocapture
```

```text
cargo test: 1 passed, 223 filtered out (1 suite, 0.00s)
```

**Lockout protection validates the edge identity even when Axum would use loopback.**

```bash
cargo test --lib -p temps-cli patch_rejects_loopback_only_candidate_that_denies_edge_caller -- --nocapture
```

```text
cargo test: 1 passed, 223 filtered out (1 suite, 0.00s)
```

**Focused admin-gate coverage.**

```bash
cargo test --lib -p temps-cli admin_gate -- --nocapture
```

```text
cargo test: 23 passed, 201 filtered out (1 suite, 0.01s)
```

**Full crate verification.**

```bash
cargo test --lib -p temps-cli
cargo check --lib -p temps-cli
cargo clippy --lib -p temps-cli -- -D warnings
```

```text
cargo test: 224 passed (1 suite, 2.14s)
cargo check: 0 errors
cargo clippy: 0 errors
```

No OpenAPI schema or generated-client changes are required.