### PR TITLE
fix(console): show tooltips in collapsed sidebar

### DIFF
--- a/web/src/components/ui/sidebar-tooltip.ts
+++ b/web/src/components/ui/sidebar-tooltip.ts
@@ -1,0 +1,13 @@
+type SidebarTooltipState = {
+  isMinimal: boolean
+  isMobile: boolean
+  state: 'expanded' | 'collapsed'
+}
+
+export function isSidebarMenuTooltipVisible({
+  isMinimal,
+  isMobile,
+  state,
+}: SidebarTooltipState) {
+  return !isMobile && (isMinimal || state === 'collapsed')
+}

--- a/web/src/components/ui/sidebar.test.ts
+++ b/web/src/components/ui/sidebar.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test'
+
+import { isSidebarMenuTooltipVisible } from './sidebar-tooltip'
+
+describe('isSidebarMenuTooltipVisible', () => {
+  test('shows menu titles in the compact desktop sidebar', () => {
+    expect(
+      isSidebarMenuTooltipVisible({
+        isMinimal: true,
+        isMobile: false,
+        state: 'expanded',
+      })
+    ).toBe(true)
+  })
+
+  test('preserves tooltips for the legacy collapsed desktop state', () => {
+    expect(
+      isSidebarMenuTooltipVisible({
+        isMinimal: false,
+        isMobile: false,
+        state: 'collapsed',
+      })
+    ).toBe(true)
+  })
+
+  test('hides redundant tooltips in expanded and mobile sidebars', () => {
+    expect(
+      isSidebarMenuTooltipVisible({
+        isMinimal: false,
+        isMobile: false,
+        state: 'expanded',
+      })
+    ).toBe(false)
+    expect(
+      isSidebarMenuTooltipVisible({
+        isMinimal: true,
+        isMobile: true,
+        state: 'expanded',
+      })
+    ).toBe(false)
+  })
+})

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -15,6 +15,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { isSidebarMenuTooltipVisible } from '@/components/ui/sidebar-tooltip'
 import { cn } from '@/lib/utils'
 
 const SIDEBAR_COOKIE_NAME = 'sidebar:state'
@@ -581,7 +582,8 @@ const SidebarMenuButton = React.forwardRef<
     ref
   ) => {
     const Comp = asChild ? Slot : 'button'
-    const { isMobile, state } = useSidebar()
+    const { isMinimal, isMobile, state } = useSidebar()
+    const tooltipLabel = typeof tooltip === 'string' ? tooltip : undefined
 
     const button = (
       <Comp
@@ -589,6 +591,7 @@ const SidebarMenuButton = React.forwardRef<
         data-sidebar="menu-button"
         data-size={size}
         data-active={isActive}
+        aria-label={props['aria-label'] ?? tooltipLabel}
         className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
         {...props}
       />
@@ -610,7 +613,7 @@ const SidebarMenuButton = React.forwardRef<
         <TooltipContent
           side="right"
           align="center"
-          hidden={state !== 'collapsed' || isMobile}
+          hidden={!isSidebarMenuTooltipVisible({ isMinimal, isMobile, state })}
           {...tooltip}
         />
       </Tooltip>


### PR DESCRIPTION
## Summary

- show menu title tooltips when the desktop sidebar uses its compact icon rail
- preserve tooltip behavior for the legacy collapsed state while suppressing redundant mobile and expanded tooltips
- add accessible labels to icon-only menu items and regression coverage for every sidebar state

## Root cause

SidebarMenuButton only made tooltips visible when the legacy sidebar state was collapsed. The current desktop toggle changes isMinimal while leaving that state expanded, so every supplied menu tooltip remained rendered with the hidden attribute.

## Evidence

**Collapsed sidebar hover**: verified against the isolated local console at http://localhost:3014 after signing in and collapsing the sidebar.

    agent-browser --session sidebar-tooltip-pr hover @e47
    agent-browser --session sidebar-tooltip-pr eval DOM tooltip visibility

Browser result:

    [{"text":"Projects","hidden":false,"display":"block","visibility":"visible"}]

Screenshot captured from the rendered console showing the Projects tooltip beside the collapsed icon rail.

**Frontend tests**:

    cd web && bun test src

    398 pass
    0 fail
    672 expect() calls

**TypeScript**:

    cd web && bunx tsc --noEmit

Completed with exit code 0.

**Formatting**:

    cd web && bunx prettier --check src/components/ui/sidebar.tsx src/components/ui/sidebar-tooltip.ts src/components/ui/sidebar.test.ts

    All matched files use Prettier code style!

## DCO

The commit includes a Signed-off-by trailer.