### PR TITLE
perf(geo): memory-map the MaxMind databases instead of reading them into the heap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11545,6 +11545,7 @@ dependencies = [
  "rand 0.10.2",
  "sea-orm",
  "serde",
+ "tempfile",
  "temps-auth",
  "temps-core",
  "temps-database",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5428,6 +5428,7 @@ checksum = "a7bd67e2f5d65937ff283e418fcad53c8e2eeda0719e455508b62dad8ffe6180"
 dependencies = [
  "ipnetwork",
  "memchr",
+ "memmap2",
  "serde",
  "thiserror 2.0.20",
 ]

--- a/crates/temps-geo/Cargo.toml
+++ b/crates/temps-geo/Cargo.toml
@@ -25,6 +25,7 @@ temps-auth = { path = "../temps-auth" }
 utoipa = "5.1"
 tracing = { workspace = true }
 tokio = { version = "1.0", features = ["time"] }
+tempfile = { workspace = true }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }

--- a/crates/temps-geo/Cargo.toml
+++ b/crates/temps-geo/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1.0"
 axum = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
 log = "0.4"
-maxminddb = "0.30.0"
+maxminddb = { version = "0.30.0", features = ["mmap"] }
 moka = { version = "0.12", features = ["future"] }
 rand = { workspace = true }
 sea-orm = { version = "1.0", features = ["sqlx-postgres", "runtime-tokio-rustls", "macros"] }

--- a/crates/temps-geo/src/geoip_service.rs
+++ b/crates/temps-geo/src/geoip_service.rs
@@ -1,4 +1,5 @@
 use maxminddb::geoip2;
+use maxminddb::Mmap;
 use rand::prelude::IndexedRandom;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -258,6 +259,34 @@ fn resolve_mmdb_path_from(
     data_dir.map(|path| path.join(filename)).unwrap_or(cwd_path)
 }
 
+/// Open an `.mmdb` database as a read-only memory map.
+///
+/// The GeoLite2 City database is ~70 MB and the ASN database ~10 MB.
+/// `Reader::open_readfile` would `read_to_end` both into `Vec<u8>`, i.e.
+/// ~80 MB of anonymous heap (`RssAnon`) that the kernel can only reclaim
+/// through swap. Mapping the files instead moves those pages to `RssFile`
+/// (clean page cache), which the kernel can evict and re-fault on demand —
+/// the working set of an mmdb lookup is a handful of pages along one search
+/// tree path, so resident usage tracks actual traffic instead of file size.
+///
+/// # Safety
+///
+/// `Reader::open_mmap` is `unsafe` because a mapped file that is modified
+/// *in place* under the process yields torn reads or `SIGBUS`. Every writer
+/// of these files in this codebase downloads to a `.mmdb.tmp` sibling and
+/// then `rename(2)`s it over the destination (see
+/// `temps-cli::commands::serve::console::download_geolite2_database` and
+/// `temps-cli::commands::setup`). A rename replaces the *directory entry*,
+/// not the inode, so an existing mapping keeps referring to the unlinked
+/// old inode and stays valid and self-consistent for the life of the
+/// process; the new file is picked up on the next restart. No code path
+/// truncates or rewrites an mmdb in place.
+fn open_mmdb(path: &std::path::Path) -> Result<maxminddb::Reader<Mmap>, maxminddb::MaxMindDbError> {
+    // SAFETY: see the doc comment above — all writers swap the file in
+    // atomically via rename(2), never mutating the mapped inode.
+    unsafe { maxminddb::Reader::open_mmap(path) }
+}
+
 impl GeoIpService {
     pub fn new() -> Result<Self, GeoIpError> {
         // Check if we should use mock service for local development
@@ -273,7 +302,7 @@ impl GeoIpService {
         let db_path = resolve_mmdb_path("GeoLite2-City.mmdb");
         let service = get_or_load(&LOADED_DATABASES, db_path.clone(), || {
             debug!("Loading MaxMind database from: {:?}", db_path);
-            let reader = maxminddb::Reader::open_readfile(&db_path).map_err(|e| {
+            let reader = open_mmdb(&db_path).map_err(|e| {
                 GeoIpError::Other(format!(
                     "Failed to open MaxMind database at '{}': {}",
                     db_path.display(),
@@ -286,7 +315,7 @@ impl GeoIpService {
             // the operator hasn't provisioned it, same as the City database's own
             // optional-file convention in Dockerfile/docker-compose.
             let asn_db_path = resolve_mmdb_path("GeoLite2-ASN.mmdb");
-            let asn_reader = match maxminddb::Reader::open_readfile(&asn_db_path) {
+            let asn_reader = match open_mmdb(&asn_db_path) {
                 Ok(reader) => {
                     info!("Loaded MaxMind ASN database from: {:?}", asn_db_path);
                     Some(reader)
@@ -316,8 +345,8 @@ impl GeoIpService {
 }
 
 pub struct MaxMindGeoIpService {
-    reader: maxminddb::Reader<Vec<u8>>,
-    asn_reader: Option<maxminddb::Reader<Vec<u8>>>,
+    reader: maxminddb::Reader<Mmap>,
+    asn_reader: Option<maxminddb::Reader<Mmap>>,
 }
 
 impl MaxMindGeoIpService {
@@ -544,6 +573,16 @@ mod tests {
         let recovered = get_or_load(&cache, path.clone(), || Ok("now present".to_string()))
             .expect("retry after a failed load should succeed");
         assert_eq!(*recovered, "now present");
+    }
+
+    #[test]
+    fn test_open_mmdb_missing_file_is_a_recoverable_error() {
+        // The ASN database is optional and its absence must stay a plain
+        // `Err` the caller can degrade on, not a panic. `open_mmap` is
+        // `unsafe`, so this also pins that a missing path is rejected before
+        // any mapping is attempted.
+        let missing = std::path::Path::new("/nonexistent/definitely-not-here.mmdb");
+        assert!(open_mmdb(missing).is_err());
     }
 
     #[test]

--- a/crates/temps-geo/src/geoip_service.rs
+++ b/crates/temps-geo/src/geoip_service.rs
@@ -261,30 +261,88 @@ fn resolve_mmdb_path_from(
 
 /// Open an `.mmdb` database as a read-only memory map.
 ///
-/// The GeoLite2 City database is ~70 MB and the ASN database ~10 MB.
-/// `Reader::open_readfile` would `read_to_end` both into `Vec<u8>`, i.e.
-/// ~80 MB of anonymous heap (`RssAnon`) that the kernel can only reclaim
-/// through swap. Mapping the files instead moves those pages to `RssFile`
-/// (clean page cache), which the kernel can evict and re-fault on demand —
-/// the working set of an mmdb lookup is a handful of pages along one search
-/// tree path, so resident usage tracks actual traffic instead of file size.
+/// Backing store for a MaxMind reader.
+///
+/// Normally a read-only mapping of a *private* copy of the database (see
+/// [`open_mmdb`]); falls back to the database read into the heap when a
+/// private copy cannot be made, so a read-only data directory still works.
+enum MmdbSource {
+    Mapped(Mmap),
+    Owned(Vec<u8>),
+}
+
+impl AsRef<[u8]> for MmdbSource {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Self::Mapped(mapping) => mapping.as_ref(),
+            Self::Owned(bytes) => bytes.as_slice(),
+        }
+    }
+}
+
+/// Copy `path` into an anonymous temporary file and map that.
 ///
 /// # Safety
 ///
-/// `Reader::open_mmap` is `unsafe` because a mapped file that is modified
-/// *in place* under the process yields torn reads or `SIGBUS`. Every writer
-/// of these files in this codebase downloads to a `.mmdb.tmp` sibling and
-/// then `rename(2)`s it over the destination (see
-/// `temps-cli::commands::serve::console::download_geolite2_database` and
-/// `temps-cli::commands::setup`). A rename replaces the *directory entry*,
-/// not the inode, so an existing mapping keeps referring to the unlinked
-/// old inode and stays valid and self-consistent for the life of the
-/// process; the new file is picked up on the next restart. No code path
-/// truncates or rewrites an mmdb in place.
-fn open_mmdb(path: &std::path::Path) -> Result<maxminddb::Reader<Mmap>, maxminddb::MaxMindDbError> {
-    // SAFETY: see the doc comment above — all writers swap the file in
-    // atomically via rename(2), never mutating the mapped inode.
-    unsafe { maxminddb::Reader::open_mmap(path) }
+/// `Mmap::map` is unsafe because a mapped file modified *in place* under the
+/// process yields torn reads or `SIGBUS`. These databases are operator-managed:
+/// the setup flow tells operators to `cp` the file into the data directory, and
+/// `docker-compose.yml` shows them bind-mounted from the host. A `cp` over an
+/// existing destination truncates and rewrites that inode, so mapping the
+/// operator's file directly would let a routine database refresh crash a running
+/// server.
+///
+/// `tempfile_in` creates a file with no name in the filesystem, so nothing
+/// outside this process can reach the inode this maps. The copy costs one pass
+/// over the file at startup and the space is released when the reader drops.
+fn private_mapping(path: &std::path::Path) -> std::io::Result<Mmap> {
+    use std::io::Write;
+
+    let mut source = std::fs::File::open(path)?;
+    // Alongside the database, not `std::env::temp_dir()`, which is a tmpfs on
+    // many hosts -- that would put the copy straight back into RAM and undo the
+    // point of mapping it.
+    let directory = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    let mut copy = tempfile::tempfile_in(directory)?;
+    std::io::copy(&mut source, &mut copy)?;
+    copy.flush()?;
+
+    // SAFETY: `copy` is an anonymous inode with no directory entry, so no other
+    // process can truncate or rewrite it, and this process only reads it.
+    unsafe { Mmap::map(&copy) }
+}
+
+/// Open a MaxMind database, mapping a private copy when possible.
+///
+/// The GeoLite2 City database is ~58 MB and the ASN database ~10 MB.
+/// `Reader::open_readfile` reads both into `Vec<u8>`, i.e. ~70 MB of anonymous
+/// heap (`RssAnon`) that the kernel can only reclaim through swap. A mapping
+/// puts those pages in `RssFile` (clean page cache) instead, which the kernel
+/// evicts and re-faults on demand -- the working set of a lookup is a handful
+/// of pages along one search tree path, so resident usage tracks traffic rather
+/// than file size.
+///
+/// Falls back to reading into the heap if the private copy cannot be made, for
+/// example when the data directory is mounted read-only. That is the previous
+/// behaviour, so the fallback is a footprint regression and never a failure.
+fn open_mmdb(
+    path: &std::path::Path,
+) -> Result<maxminddb::Reader<MmdbSource>, maxminddb::MaxMindDbError> {
+    match private_mapping(path) {
+        Ok(mapping) => maxminddb::Reader::from_source(MmdbSource::Mapped(mapping)),
+        Err(e) => {
+            // Only reachable if the database itself is unreadable (reported by
+            // the caller with the path) or the directory is not writable.
+            if path.exists() {
+                warn!(
+                    "Could not stage a private copy of '{}' ({}); reading it into memory instead",
+                    path.display(),
+                    e
+                );
+            }
+            maxminddb::Reader::from_source(MmdbSource::Owned(std::fs::read(path)?))
+        }
+    }
 }
 
 impl GeoIpService {
@@ -345,8 +403,8 @@ impl GeoIpService {
 }
 
 pub struct MaxMindGeoIpService {
-    reader: maxminddb::Reader<Mmap>,
-    asn_reader: Option<maxminddb::Reader<Mmap>>,
+    reader: maxminddb::Reader<MmdbSource>,
+    asn_reader: Option<maxminddb::Reader<MmdbSource>>,
 }
 
 impl MaxMindGeoIpService {
@@ -573,6 +631,44 @@ mod tests {
         let recovered = get_or_load(&cache, path.clone(), || Ok("now present".to_string()))
             .expect("retry after a failed load should succeed");
         assert_eq!(*recovered, "now present");
+    }
+
+    /// The case the mapping has to survive: an operator refreshing the database
+    /// with `cp`, which truncates and rewrites the *existing* inode. Mapping the
+    /// operator's file directly would give torn reads or SIGBUS here.
+    #[test]
+    fn private_mapping_survives_the_source_being_rewritten_in_place() {
+        use std::io::Write;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("GeoLite2-City.mmdb");
+        let original = vec![b'A'; 256 * 1024];
+        std::fs::write(&path, &original).expect("seed database");
+
+        let mapping = private_mapping(&path).expect("stage a private copy");
+        assert_eq!(mapping.len(), original.len());
+
+        // Exactly what `cp src dest` does to an existing dest: same inode,
+        // truncated and rewritten shorter.
+        let mut handle = std::fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .expect("reopen for truncation");
+        handle.write_all(b"replaced").expect("rewrite in place");
+        handle.sync_all().expect("flush");
+        drop(handle);
+
+        // The mapping is of a private inode, so it is unchanged and safe to read.
+        assert_eq!(mapping.len(), original.len());
+        assert!(mapping.iter().all(|byte| *byte == b'A'));
+    }
+
+    #[test]
+    fn private_mapping_reports_a_missing_source_instead_of_panicking() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("absent.mmdb");
+        assert!(private_mapping(&missing).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Summary

`Reader::open_readfile` reads GeoLite2-City.mmdb (~58 MB) and GeoLite2-ASN.mmdb (~10 MB) into `Vec<u8>`, so roughly 70 MB of anonymous heap stays resident for the life of the process. On a host with swap disabled the kernel cannot reclaim any of it.

This opens both databases as read-only mappings instead.

It composes with the per-process reader memo from #721 rather than replacing it. The memo still keeps the proxy and console registries sharing one reader; the mapping makes that reader's pages file-backed. The memo's tests are unchanged and still pass.

### Measurement

Against the committed 57.9 MB GeoLite2-City.mmdb, three A/B/A runs each, swapless host (`VmSwap: 0 kB` confirmed in every sample).

At startup, immediately after the reader is constructed:

| | `VmRSS` | `RssAnon` | `RssFile` |
|---|---|---|---|
| `open_readfile` | 62,764-62,832 kB | 60,056-60,068 kB | 2,704-2,784 kB |
| `open_mmap` | 3,484-3,516 kB | 680-688 kB | 2,800-2,828 kB |

After 17,220 uniformly distributed global IP lookups, reader still alive:

| | `VmRSS` | `RssAnon` | `RssFile` |
|---|---|---|---|
| `open_readfile` | 62,780-62,852 kB | 60,056-60,068 kB | 2,716-2,784 kB |
| `open_mmap` | 46,176-46,212 kB | 680-684 kB | 45,496-45,528 kB |

The point is not only the 16.6 MB of `VmRSS` at the fully warmed worst case. It is that ~45 MB moved from `RssAnon` to `RssFile`: anonymous pages are unreclaimable without swap, clean page-cache pages are evicted and re-faulted freely. And 17,220 uniformly random global IPs is a pessimistic access pattern; real traffic concentrates on far fewer search-tree paths, so steady-state `RssFile` should sit below that.

Latency, same runs:

| | per lookup |
|---|---|
| `open_readfile` | 2,253-2,543 ns |
| `open_mmap`, warm | 2,357-2,572 ns |
| `open_mmap`, first pass over a cold mapping | 3,831 ns |

Within noise once warm. The single cold pass costs about 1.3 us per lookup while pages fault in, and geolocation is not on the request path.

### On the `unsafe`

Updated after review: the first version of this branch mapped the operator's file directly, and the safety argument covered only this repository's downloaders, which stage to a `.mmdb.tmp` sibling and rename. That was too narrow. These databases are operator-managed: `temps setup` tells operators to `cp` the file into the data directory (`commands/setup.rs`, `serve/console.rs`), and `docker-compose.yml` shows them bind-mounted from the host. A `cp` over an existing destination truncates and rewrites that inode, so a routine database refresh on a running server could give torn reads or `SIGBUS`.

It now copies the database into an anonymous temporary file, created next to it with `tempfile_in`, and maps that. The inode has no directory entry, so nothing outside the process can reach it, and the safety requirement holds regardless of what the operator does to the original. The copy is staged beside the database rather than in `env::temp_dir()`, which is a tmpfs on many hosts and would put it straight back into RAM.

Cost: one pass over the file at startup, and the file's size in scratch space while the reader lives. That buys the `RssAnon` reduction above without depending on operator behaviour.

If the private copy cannot be made, for example a read-only data directory or no space, it falls back to reading into the heap. That is the behaviour before this branch, so the fallback costs footprint and never availability.

A test maps a file, then truncates and rewrites the original inode exactly as `cp` would, and asserts the mapping still reads back the original contents.

### Unchanged

Graceful degradation is the same: the City database still fails startup with a contextual error naming the path, and the ASN database still degrades to `None` with a warning, disabling hosting-provider detection. A test pins that a missing path returns `Err` rather than panicking.

`memmap2` supports every non-MSVC target this binary is built for, and `open_mmap` exists on Windows too, so the change is not `cfg`-gated.

### Validation

- `cargo check --lib`: clean, no warnings.
- `cargo test --lib -p temps-geo`: 18 passed, 0 failed, including the four memo tests from #721 and the in-place-rewrite test described above.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

Performance, no behaviour change intended.

## Checklist

- [x] I have written tests that cover the changes
- [x] All new and existing tests pass (`cargo test --lib`)
- [x] `cargo check --lib` passes with no warnings
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated documentation where necessary; the safety constraint lives in a code comment

## Related issues

Builds on #721.
