### PR TITLE
perf(proxy): stop spawning a thread and a runtime per background loop

### DIFF
--- a/crates/temps-cli/src/commands/serve/proxy.rs
+++ b/crates/temps-cli/src/commands/serve/proxy.rs
@@ -94,8 +94,23 @@ pub fn start_proxy_server(
     project_ip_gate: Arc<dyn temps_core::ProjectIpGate>,
 ) -> anyhow::Result<()> {
     let console_address = config.console_address.clone();
-    // Create tokio runtime to fetch preview_domain from config service
-    let rt = tokio::runtime::Runtime::new()?;
+    // Runtime for the startup settings fetch AND, when ADR-018 on-demand TLS is
+    // enabled, the long-lived home of `OnDemandCertManager`'s issuance consumer
+    // (`OnDemandCertManager::new` calls `tokio::spawn` on whatever runtime is
+    // current). It therefore has to outlive this fetch and it has to stay
+    // multi-threaded: on a `current_thread` runtime, a thread parked by Pingora
+    // would leave the consumer unpolled and silently break issuance.
+    //
+    // `Runtime::new()` sizes itself to the host (one worker per core), which on
+    // a big box means ~24 idle worker threads costing ~100 kB of anonymous RSS
+    // each for a runtime whose entire steady-state workload is one consumer
+    // task draining a bounded channel. Two workers keep the "a blocked thread
+    // can't stall the consumer" property at a fixed cost.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .thread_name("temps-proxy-ctl")
+        .enable_all()
+        .build()?;
 
     // Fetch settings once: we need `preview_domain` for routing AND the full
     // `AppSettings` to decide whether to wire ADR-018 on-demand TLS.

--- a/crates/temps-proxy/src/server.rs
+++ b/crates/temps-proxy/src/server.rs
@@ -269,7 +269,8 @@ fn shared_runtime(
         .map_err(|e| {
             anyhow::anyhow!(
                 "Failed to create the '{}' tokio runtime for proxy refresh loops: {}",
-                thread_name, e
+                thread_name,
+                e
             )
         })?;
     let handle = runtime.handle().clone();

--- a/crates/temps-proxy/src/server.rs
+++ b/crates/temps-proxy/src/server.rs
@@ -215,6 +215,54 @@ impl pingora::server::ShutdownSignalWatch for ShutdownSignalBridge {
     }
 }
 
+/// Process-wide runtime hosting the proxy's periodic control-plane refresh
+/// loops (custom-route snapshot, IP block list, cert-host set).
+///
+/// Each of those loops is the same shape — sleep 60s, run one query, swap an
+/// in-memory snapshot — and each used to own an OS thread plus a
+/// `current_thread` runtime of its own. Three threads and three runtimes
+/// idling on the same timer costs ~430 kB of anonymous RSS on a box where the
+/// whole budget is 4 GB, so they share one single-worker runtime instead.
+///
+/// Deliberately NOT shared with the proxy-log batch writer or the metrics
+/// samplers: the batch writer drains a bounded channel fed by the request
+/// path and must never queue behind a sampler's disk/`sysinfo` work, so those
+/// two keep their own threads. Nothing here runs on the Pingora request path.
+static REFRESH_RUNTIME: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
+
+/// Handle to [`REFRESH_RUNTIME`], creating it on first use.
+fn refresh_runtime() -> Result<tokio::runtime::Handle> {
+    if let Some(runtime) = REFRESH_RUNTIME.get() {
+        return Ok(runtime.handle().clone());
+    }
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .thread_name("temps-proxy-refresh")
+        .enable_all()
+        .build()
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to create the shared tokio runtime for proxy refresh loops: {}",
+                e
+            )
+        })?;
+    let handle = runtime.handle().clone();
+
+    // A concurrent first caller may have won the race; its runtime is the one
+    // that stays, and the loser's is dropped here without ever having run a
+    // task. Both callers end up with a handle to the same runtime.
+    match REFRESH_RUNTIME.set(runtime) {
+        Ok(()) => Ok(handle),
+        Err(_) => REFRESH_RUNTIME
+            .get()
+            .map(|runtime| runtime.handle().clone())
+            .ok_or_else(|| {
+                anyhow::anyhow!("Shared proxy refresh runtime disappeared after being set")
+            }),
+    }
+}
+
 /// Setup and configure the proxy server with all services
 #[allow(clippy::too_many_arguments)]
 pub fn setup_proxy_server(
@@ -245,7 +293,13 @@ pub fn setup_proxy_server(
     project_ip_gate: Arc<dyn temps_core::ProjectIpGate>,
 ) -> Result<()> {
     // Setup plugin system (async operation in sync context)
-    let context = tokio::runtime::Runtime::new()?
+    // A `current_thread` runtime is enough here: plugin registration awaits a
+    // bounded file-existence poll and does sync work, and it spawns nothing
+    // that outlives this call. `Runtime::new()` would stand up (and tear down)
+    // one worker thread per core purely to drive that.
+    let context = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?
         .block_on(setup_proxy_plugins(db.clone(), config.clone()))?;
 
     // Create service implementations
@@ -253,21 +307,12 @@ pub fn setup_proxy_server(
 
     // Keep the custom-route snapshot in memory so `has_custom_route` and
     // `has_route_for_host` never query Postgres on the request hot path (WS6-G).
-    // A dedicated thread owns the periodic 60-second refresh, which is the sole
-    // propagation mechanism for this instance: admin-API writes (create/update/
-    // delete) are handled by the separate console-owned LbService and never reach
-    // this object directly. Route changes become visible to real traffic within at
-    // most 60 seconds via the loop below.
-    {
-        let lb_refresher = lb_service.clone();
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("Failed to create tokio runtime for custom-route snapshot refresh");
-            rt.block_on(lb_refresher.run_refresh_loop());
-        });
-    }
+    // The shared refresh runtime owns the periodic 60-second refresh, which is
+    // the sole propagation mechanism for this instance: admin-API writes
+    // (create/update/delete) are handled by the separate console-owned
+    // LbService and never reach this object directly. Route changes become
+    // visible to real traffic within at most 60 seconds via that loop.
+    refresh_runtime()?.spawn(lb_service.clone().run_refresh_loop());
 
     let upstream_resolver = Arc::new(UpstreamResolverImpl::new(
         Arc::new(proxy_config.clone()),
@@ -313,34 +358,15 @@ pub fn setup_proxy_server(
     );
 
     // Keep the IP block list in memory so `is_blocked` never queries Postgres on
-    // the request hot path. A dedicated thread owns the periodic refresh, mirroring
-    // the proxy-log batch writer above.
-    {
-        let ip_access_refresher = ip_access_control_service.clone();
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("Failed to create tokio runtime for IP block-list refresh");
-            rt.block_on(ip_access_refresher.run_refresh_loop());
-        });
-    }
+    // the request hot path. The shared refresh runtime owns the periodic refresh.
+    refresh_runtime()?.spawn(ip_access_control_service.clone().run_refresh_loop());
 
     let cert_host_cache = Arc::new(CertHostCache::new(db.clone()));
 
     // Keep the cert-host set in memory so the HTTP→HTTPS redirect check never
-    // queries Postgres on the request hot path (WS3). A dedicated thread owns the
-    // periodic refresh, mirroring the IP block-list loop above.
-    {
-        let cert_host_refresher = cert_host_cache.clone();
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("Failed to create tokio runtime for cert-host refresh");
-            rt.block_on(cert_host_refresher.run_refresh_loop());
-        });
-    }
+    // queries Postgres on the request hot path (WS3). The shared refresh runtime
+    // owns the periodic refresh, alongside the IP block-list loop above.
+    refresh_runtime()?.spawn(cert_host_cache.clone().run_refresh_loop());
 
     let challenge_service = Arc::new(crate::service::challenge_service::ChallengeService::new(
         db.clone(),
@@ -543,7 +569,13 @@ pub fn create_proxy_service(
     project_ip_gate: Arc<dyn temps_core::ProjectIpGate>,
 ) -> Result<LoadBalancer> {
     // Setup plugin system (async operation in sync context)
-    let context = tokio::runtime::Runtime::new()?
+    // A `current_thread` runtime is enough here: plugin registration awaits a
+    // bounded file-existence poll and does sync work, and it spawns nothing
+    // that outlives this call. `Runtime::new()` would stand up (and tear down)
+    // one worker thread per core purely to drive that.
+    let context = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?
         .block_on(setup_proxy_plugins(db.clone(), config.clone()))?;
 
     // Create service implementations
@@ -551,16 +583,7 @@ pub fn create_proxy_service(
 
     // Keep the custom-route snapshot in memory so `has_custom_route` and
     // `has_route_for_host` never query Postgres on the request hot path (WS6-G).
-    {
-        let lb_refresher = lb_service.clone();
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("Failed to create tokio runtime for custom-route snapshot refresh");
-            rt.block_on(lb_refresher.run_refresh_loop());
-        });
-    }
+    refresh_runtime()?.spawn(lb_service.clone().run_refresh_loop());
 
     let upstream_resolver = Arc::new(UpstreamResolverImpl::new(
         Arc::new(proxy_config.clone()),
@@ -606,34 +629,15 @@ pub fn create_proxy_service(
     );
 
     // Keep the IP block list in memory so `is_blocked` never queries Postgres on
-    // the request hot path. A dedicated thread owns the periodic refresh, mirroring
-    // the proxy-log batch writer above.
-    {
-        let ip_access_refresher = ip_access_control_service.clone();
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("Failed to create tokio runtime for IP block-list refresh");
-            rt.block_on(ip_access_refresher.run_refresh_loop());
-        });
-    }
+    // the request hot path. The shared refresh runtime owns the periodic refresh.
+    refresh_runtime()?.spawn(ip_access_control_service.clone().run_refresh_loop());
 
     let cert_host_cache = Arc::new(CertHostCache::new(db.clone()));
 
     // Keep the cert-host set in memory so the HTTP→HTTPS redirect check never
-    // queries Postgres on the request hot path (WS3). A dedicated thread owns the
-    // periodic refresh, mirroring the IP block-list loop above.
-    {
-        let cert_host_refresher = cert_host_cache.clone();
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("Failed to create tokio runtime for cert-host refresh");
-            rt.block_on(cert_host_refresher.run_refresh_loop());
-        });
-    }
+    // queries Postgres on the request hot path (WS3). The shared refresh runtime
+    // owns the periodic refresh, alongside the IP block-list loop above.
+    refresh_runtime()?.spawn(cert_host_cache.clone().run_refresh_loop());
 
     let challenge_service = Arc::new(crate::service::challenge_service::ChallengeService::new(
         db.clone(),

--- a/crates/temps-proxy/src/server.rs
+++ b/crates/temps-proxy/src/server.rs
@@ -230,21 +230,46 @@ impl pingora::server::ShutdownSignalWatch for ShutdownSignalBridge {
 /// two keep their own threads. Nothing here runs on the Pingora request path.
 static REFRESH_RUNTIME: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
 
+/// Runtime for the IP block-list refresh, deliberately NOT the one above.
+///
+/// `LbService::refresh_snapshot` and `CertHostCache::refresh` await their query
+/// and then rebuild their collections in a synchronous loop, so on an instance
+/// with a large `domains` or `custom_routes` table either can hold a worker
+/// without yielding. The block list is the only cross-process propagation path
+/// for a new block and starts empty (fail-open), so delaying its refresh has a
+/// security consequence the other two loops do not. Giving it its own worker
+/// costs one thread and removes that coupling entirely.
+static SECURITY_REFRESH_RUNTIME: std::sync::OnceLock<tokio::runtime::Runtime> =
+    std::sync::OnceLock::new();
+
 /// Handle to [`REFRESH_RUNTIME`], creating it on first use.
 fn refresh_runtime() -> Result<tokio::runtime::Handle> {
-    if let Some(runtime) = REFRESH_RUNTIME.get() {
+    shared_runtime(&REFRESH_RUNTIME, "temps-refresh")
+}
+
+/// Handle to [`SECURITY_REFRESH_RUNTIME`], creating it on first use.
+fn security_refresh_runtime() -> Result<tokio::runtime::Handle> {
+    shared_runtime(&SECURITY_REFRESH_RUNTIME, "temps-ipblock")
+}
+
+/// Single-worker runtime held in `slot`, built on first use.
+fn shared_runtime(
+    slot: &'static std::sync::OnceLock<tokio::runtime::Runtime>,
+    thread_name: &str,
+) -> Result<tokio::runtime::Handle> {
+    if let Some(runtime) = slot.get() {
         return Ok(runtime.handle().clone());
     }
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(1)
-        .thread_name("temps-proxy-refresh")
+        .thread_name(thread_name)
         .enable_all()
         .build()
         .map_err(|e| {
             anyhow::anyhow!(
-                "Failed to create the shared tokio runtime for proxy refresh loops: {}",
-                e
+                "Failed to create the '{}' tokio runtime for proxy refresh loops: {}",
+                thread_name, e
             )
         })?;
     let handle = runtime.handle().clone();
@@ -252,9 +277,9 @@ fn refresh_runtime() -> Result<tokio::runtime::Handle> {
     // A concurrent first caller may have won the race; its runtime is the one
     // that stays, and the loser's is dropped here without ever having run a
     // task. Both callers end up with a handle to the same runtime.
-    match REFRESH_RUNTIME.set(runtime) {
+    match slot.set(runtime) {
         Ok(()) => Ok(handle),
-        Err(_) => REFRESH_RUNTIME
+        Err(_) => slot
             .get()
             .map(|runtime| runtime.handle().clone())
             .ok_or_else(|| {
@@ -294,9 +319,16 @@ pub fn setup_proxy_server(
 ) -> Result<()> {
     // Setup plugin system (async operation in sync context)
     // A `current_thread` runtime is enough here: plugin registration awaits a
-    // bounded file-existence poll and does sync work, and it spawns nothing
-    // that outlives this call. `Runtime::new()` would stand up (and tear down)
-    // one worker thread per core purely to drive that.
+    // bounded file-existence poll and otherwise does sync work, so a worker
+    // thread per core would be stood up and torn down purely to drive that.
+    //
+    // Registration is not entirely free of spawns: `ConfigPlugin` starts the
+    // `settings_change` LISTEN/NOTIFY task with `tokio::spawn`. That task does
+    // not survive this runtime being dropped at the end of the statement, and
+    // did not survive the previous multi-threaded one either -- the settings
+    // cache falls back to its 5s TTL, which is the documented non-fatal
+    // behaviour. This is pre-existing and unchanged here; it is called out so
+    // the lifetime is not mistaken for something this runtime guarantees.
     let context = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?
@@ -359,7 +391,7 @@ pub fn setup_proxy_server(
 
     // Keep the IP block list in memory so `is_blocked` never queries Postgres on
     // the request hot path. The shared refresh runtime owns the periodic refresh.
-    refresh_runtime()?.spawn(ip_access_control_service.clone().run_refresh_loop());
+    security_refresh_runtime()?.spawn(ip_access_control_service.clone().run_refresh_loop());
 
     let cert_host_cache = Arc::new(CertHostCache::new(db.clone()));
 
@@ -630,7 +662,7 @@ pub fn create_proxy_service(
 
     // Keep the IP block list in memory so `is_blocked` never queries Postgres on
     // the request hot path. The shared refresh runtime owns the periodic refresh.
-    refresh_runtime()?.spawn(ip_access_control_service.clone().run_refresh_loop());
+    security_refresh_runtime()?.spawn(ip_access_control_service.clone().run_refresh_loop());
 
     let cert_host_cache = Arc::new(CertHostCache::new(db.clone()));
 


### PR DESCRIPTION
## Description

### Summary

Each of the proxy's three periodic refresh loops owned a dedicated OS thread running its own `current_thread` runtime. They now share one runtime, and the plugin-setup runtimes that only drive a single `block_on` become `current_thread` instead of multi-threaded.

This is the smallest of the memory changes and is worth reviewing as hygiene rather than as megabytes.

### Measurement

Probe reproducing both shapes (five loops on five threads each with a `current_thread` runtime, versus the same five on one shared two-worker runtime):

| | `VmRSS` | `RssAnon` | threads |
|---|---|---|---|
| thread-per-loop | 4,500-4,552 kB | 1,328-1,332 kB | 6 |
| shared runtime | 4,052-4,160 kB | 676-684 kB | 3 |

Cost of an idle `multi_thread` runtime by worker count, used to size the capped runtime:

| workers | `RssAnon` |
|---|---|
| 2 | 676-680 kB |
| 4 | 924-928 kB |
| 24 | 2,548-2,564 kB |

About 100 kB per idle worker thread. Capping `serve`'s proxy runtime at 2 workers saves roughly 2 MB on a 24-core host and about 0.1 MB on the 3-vCPU reference box. The direct saving here is 430 kB and 2 threads.

### Hot path

`crates/temps-proxy/src/proxy.rs` is untouched. The diff covers only `server.rs` and `serve/proxy.rs`, both startup wiring. The three consolidated loops are the same futures spawned at the same points in startup, so the window between process start and the first blocklist, cert-host or route refresh is unchanged.

### What was deliberately left alone

- The **proxy-log batch writer** keeps its own thread. It drains a bounded channel fed by the request path, and sharing a runtime with the metrics samplers would let a sampler's disk or `sysinfo` work delay it. A stalled writer means dropped log events.
- The **metrics samplers** keep their own thread, for the same reason in reverse.
- `serve/proxy.rs`'s runtime **stays multi-threaded**, capped at 2 workers rather than converted. `OnDemandCertManager::new` calls `tokio::spawn` on the current runtime, so on a `current_thread` runtime a thread parked by Pingora would leave the issuance consumer unpolled and break on-demand TLS silently. Capping preserves the "a blocked thread cannot stall the consumer" property while dropping the per-core sizing.

The three loops that were consolidated are all purely async with no blocking work, which is what makes a single shared worker safe for them.

### Also in this change

Four `.expect()` calls on runtime construction were replaced with typed error propagation, per the repository's error-handling rules.

### Validation

- `cargo check --lib`: clean, no warnings.
- `cargo test --lib -p temps-proxy`: same results before and after this branch. The failures present in both are `Socket not found: /var/run/docker.sock`, from the unavailable Postgres testcontainer in this environment.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

Performance, no behaviour change intended.

## Checklist

- [ ] I have written tests that cover the changes; this is startup wiring with no new behaviour to assert
- [x] All new and existing tests pass (`cargo test --lib`)
- [x] `cargo check --lib` passes with no warnings
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated documentation where necessary; rationale lives in code comments

## Related issues

None.
