### PR TITLE
fix(proxy): harden static file serving and ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12456,7 +12456,6 @@ dependencies = [
  "clickhouse",
  "cookie",
  "dashmap",
- "flate2",
  "futures",
  "hex",
  "hmac 0.13.0",

--- a/crates/temps-core/src/lib.rs
+++ b/crates/temps-core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod retry;
 pub mod secrets_manager;
 pub mod self_update;
 pub mod sensitive_action;
+pub mod static_files;
 pub mod telemetry;
 pub mod time_window;
 pub mod tls;

--- a/crates/temps-core/src/static_files.rs
+++ b/crates/temps-core/src/static_files.rs
@@ -1,0 +1,458 @@
+//! Shared path policy for files published by static deployments.
+//!
+//! The same policy is applied when artifacts are ingested and immediately before
+//! the proxy resolves a request. This prevents an accidentally packaged secret
+//! from becoming public even when one of those boundaries is bypassed.
+
+use std::fmt;
+use std::path::{Component, Path, PathBuf};
+
+/// Maximum size of one publicly served immutable static asset.
+///
+/// Filesystem deployments stream larger ordinary files, but CAS fallback uses
+/// this limit at both persistence and serving boundaries.
+pub const MAX_PUBLIC_STATIC_ASSET_BYTES: u64 = 32 * 1024 * 1024;
+
+/// Maximum URL path retained or resolved by static-file infrastructure.
+pub const MAX_STATIC_ASSET_URL_PATH_BYTES: usize = 4 * 1024;
+
+/// Maximum number of components accepted in static artifact and deployment paths.
+///
+/// This is shared with archive extraction and recursive-copy boundaries so an
+/// image cannot manufacture path trees deep enough to exhaust the process stack.
+pub const MAX_STATIC_PATH_COMPONENTS: usize = 64;
+
+/// Why a path cannot be used by the static deployment subsystem.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StaticPathPolicyError {
+    Empty,
+    Absolute,
+    NotClean,
+    TooLong,
+    TooDeep,
+    NonUtf8,
+    Sensitive,
+}
+
+impl fmt::Display for StaticPathPolicyError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let reason = match self {
+            Self::Empty => "path is empty",
+            Self::Absolute => "path must be relative",
+            Self::NotClean => "path must contain only clean relative components",
+            Self::TooLong => "path exceeds the static asset URL length limit",
+            Self::TooDeep => "path exceeds the static path component limit",
+            Self::NonUtf8 => "path is not valid UTF-8",
+            Self::Sensitive => "path is reserved or may contain sensitive deployment data",
+        };
+        formatter.write_str(reason)
+    }
+}
+
+impl std::error::Error for StaticPathPolicyError {}
+
+/// Validate a relative file path before it enters a static deployment.
+pub fn validate_static_artifact_path(path: &Path) -> Result<(), StaticPathPolicyError> {
+    validate_clean_relative_path(path, false)?;
+    if is_sensitive_static_path(path) {
+        return Err(StaticPathPolicyError::Sensitive);
+    }
+    Ok(())
+}
+
+/// Validate and return a stored static deployment directory.
+///
+/// Stored locations are always relative to the operator-controlled static root.
+/// Normalizing absolute or parent-relative database values would turn corrupted
+/// state into an arbitrary filesystem lookup, so non-clean values are rejected.
+pub fn validate_static_dir(path: &str) -> Result<PathBuf, StaticPathPolicyError> {
+    if path.is_empty() {
+        return Err(StaticPathPolicyError::Empty);
+    }
+    if path.contains('\0') || path.contains('\\') {
+        return Err(StaticPathPolicyError::NotClean);
+    }
+    if path.len() > MAX_STATIC_ASSET_URL_PATH_BYTES {
+        return Err(StaticPathPolicyError::TooLong);
+    }
+    if path.as_bytes().get(1) == Some(&b':') {
+        return Err(StaticPathPolicyError::Absolute);
+    }
+    if path
+        .split('/')
+        .any(|component| component.is_empty() || component == ".")
+    {
+        return Err(StaticPathPolicyError::NotClean);
+    }
+
+    let path = PathBuf::from(path);
+    validate_clean_relative_path(&path, false)?;
+    Ok(path)
+}
+
+/// Decode and validate a URL path for static file resolution.
+///
+/// The returned path is decoded exactly once, matching filesystem lookup
+/// semantics. A second decoded view is validated only as a security check so
+/// callers are also protected when an HTTP stack has already decoded the path.
+/// The second view is never returned or used for lookup: this preserves literal
+/// percent filenames such as `100%25.svg`, and no filesystem layer decodes a
+/// third time. `/` returns an empty path so the caller can apply its index rule.
+pub fn normalize_static_request_path(raw_path: &str) -> Result<PathBuf, StaticPathPolicyError> {
+    if raw_path.len() > MAX_STATIC_ASSET_URL_PATH_BYTES {
+        return Err(StaticPathPolicyError::TooLong);
+    }
+    if raw_path.contains('\0') {
+        return Err(StaticPathPolicyError::NotClean);
+    }
+
+    let decoded = percent_decode_once(raw_path.as_bytes());
+    let second_view = percent_decode_once(&decoded);
+    validate_decoded_request_path(&second_view)?;
+    validate_decoded_request_path(&decoded)
+}
+
+fn validate_decoded_request_path(decoded: &[u8]) -> Result<PathBuf, StaticPathPolicyError> {
+    if decoded.contains(&0) {
+        return Err(StaticPathPolicyError::NotClean);
+    }
+    let decoded = std::str::from_utf8(decoded).map_err(|_| StaticPathPolicyError::NonUtf8)?;
+    let relative = decoded.strip_prefix('/').unwrap_or(decoded);
+    if relative.starts_with('/') || relative.contains('\\') {
+        return Err(StaticPathPolicyError::NotClean);
+    }
+    let relative = relative.strip_suffix('/').unwrap_or(relative);
+    if relative.is_empty() {
+        return Ok(PathBuf::new());
+    }
+    if relative
+        .split('/')
+        .any(|component| component.is_empty() || component == ".")
+    {
+        return Err(StaticPathPolicyError::NotClean);
+    }
+
+    let path = PathBuf::from(relative);
+    validate_static_artifact_path(&path)?;
+    Ok(path)
+}
+
+/// Return whether a deployment path is unsafe to publish.
+///
+/// Dot-prefixed components are private by default. The standardized top-level
+/// `.well-known` directory is the sole exception, allowing resources such as
+/// `security.txt` and ACME challenge files. Sensitive files remain denied inside
+/// that directory.
+pub fn is_sensitive_static_path(path: &Path) -> bool {
+    let mut components = path.components().enumerate();
+    components.any(|(index, component)| {
+        let Component::Normal(component) = component else {
+            return true;
+        };
+        let Some(name) = component.to_str() else {
+            return true;
+        };
+        let lower = name.to_ascii_lowercase();
+
+        if lower.starts_with('.') && !(index == 0 && lower == ".well-known") {
+            return true;
+        }
+
+        matches!(
+            lower.as_str(),
+            "id_rsa"
+                | "id_dsa"
+                | "id_ecdsa"
+                | "id_ed25519"
+                | "credentials"
+                | "credentials.json"
+                | "secrets.json"
+                | "kubeconfig"
+                | "client_secret.json"
+                | "client_secrets.json"
+                | "service-account.json"
+                | "service-account-key.json"
+                | "service_account.json"
+                | "service_account_key.json"
+                | "serviceaccountkey.json"
+        ) || [
+            ".env",
+            ".pem",
+            ".key",
+            ".ppk",
+            ".p12",
+            ".pfx",
+            ".jks",
+            ".keystore",
+            ".tfvars",
+            ".map",
+            ".sql",
+            ".sqlite",
+            ".sqlite3",
+            ".bak",
+            ".backup",
+            ".orig",
+            ".swp",
+        ]
+        .iter()
+        .any(|suffix| lower.ends_with(suffix))
+            || lower.ends_with(".tfstate")
+            || lower.contains(".tfstate.")
+            || lower.contains(".env.")
+    })
+}
+
+fn validate_clean_relative_path(
+    path: &Path,
+    allow_empty: bool,
+) -> Result<(), StaticPathPolicyError> {
+    if path.as_os_str().is_empty() {
+        return if allow_empty {
+            Ok(())
+        } else {
+            Err(StaticPathPolicyError::Empty)
+        };
+    }
+    if path.is_absolute() {
+        return Err(StaticPathPolicyError::Absolute);
+    }
+    let mut component_count = 0;
+    for component in path.components() {
+        match component {
+            Component::Normal(value) if value.to_str().is_some() => {
+                component_count += 1;
+                if component_count > MAX_STATIC_PATH_COMPONENTS {
+                    return Err(StaticPathPolicyError::TooDeep);
+                }
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(StaticPathPolicyError::Absolute);
+            }
+            Component::CurDir | Component::ParentDir | Component::Normal(_) => {
+                return Err(StaticPathPolicyError::NotClean);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn percent_decode_once(input: &[u8]) -> Vec<u8> {
+    let mut decoded = Vec::with_capacity(input.len());
+    let mut offset = 0;
+    while offset < input.len() {
+        if input[offset] != b'%' {
+            decoded.push(input[offset]);
+            offset += 1;
+            continue;
+        }
+        let Some((high, low)) = input
+            .get(offset + 1)
+            .and_then(|value| hex_value(*value))
+            .zip(input.get(offset + 2).and_then(|value| hex_value(*value)))
+        else {
+            decoded.push(input[offset]);
+            offset += 1;
+            continue;
+        };
+        decoded.push((high << 4) | low);
+        offset += 3;
+    }
+    decoded
+}
+
+const fn hex_value(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_normalization_accepts_ordinary_and_well_known_paths() {
+        assert_eq!(
+            normalize_static_request_path("/assets/app.js"),
+            Ok(PathBuf::from("assets/app.js"))
+        );
+        assert_eq!(
+            normalize_static_request_path("/.well-known/security.txt"),
+            Ok(PathBuf::from(".well-known/security.txt"))
+        );
+        assert_eq!(normalize_static_request_path("/"), Ok(PathBuf::new()));
+        assert_eq!(
+            normalize_static_request_path("/docs/"),
+            Ok(PathBuf::from("docs"))
+        );
+        assert_eq!(
+            normalize_static_request_path("/assets/100%25.svg"),
+            Ok(PathBuf::from("assets/100%.svg"))
+        );
+        assert_eq!(
+            normalize_static_request_path("/assets/100%.svg"),
+            Ok(PathBuf::from("assets/100%.svg"))
+        );
+    }
+
+    #[test]
+    fn request_normalization_rejects_raw_single_and_double_encoded_traversal() {
+        for path in [
+            "/../secret",
+            "/%2e%2e/secret",
+            "/%252e%252e/secret",
+            "/assets%2f..%2fsecret",
+            "/assets%252f..%252fsecret",
+            "/..%5csecret",
+            "/..%255csecret",
+            "/assets/%00app.js",
+        ] {
+            assert!(
+                normalize_static_request_path(path).is_err(),
+                "{path} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn request_normalization_rejects_oversized_paths_before_decoding() {
+        let oversized = format!("/{}", "a".repeat(MAX_STATIC_ASSET_URL_PATH_BYTES));
+        assert_eq!(
+            normalize_static_request_path(&oversized),
+            Err(StaticPathPolicyError::TooLong)
+        );
+    }
+
+    #[test]
+    fn sensitive_files_are_rejected_at_every_encoding_depth() {
+        for path in [
+            "/.git/config",
+            "/%2egit/config",
+            "/%252egit/config",
+            "/.env",
+            "/keys/server.pem",
+            "/assets/app.js.map",
+            "/.well-known/.env",
+            "/production.env",
+            "/terraform.tfstate",
+            "/terraform.tfstate.backup",
+            "/terraform.tfvars",
+            "/keys/deploy.ppk",
+            "/kubeconfig",
+            "/client_secret.json",
+            "/client_secrets.json",
+            "/serviceAccountKey.json",
+            "/service-account-key.json",
+            "/service_account_key.json",
+        ] {
+            assert_eq!(
+                normalize_static_request_path(path),
+                Err(StaticPathPolicyError::Sensitive),
+                "{path} must be rejected"
+            );
+        }
+
+        for path in [
+            "/client%5fsecret.json",
+            "/client%255fsecret.json",
+            "/terraform%2etfstate",
+            "/terraform%252etfstate",
+            "/production%2eenv",
+            "/production%252eenv",
+        ] {
+            assert_eq!(
+                normalize_static_request_path(path),
+                Err(StaticPathPolicyError::Sensitive),
+                "{path} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn stored_static_directory_must_be_a_clean_relative_path() {
+        assert_eq!(
+            validate_static_dir("projects/site/production/deploy-1"),
+            Ok(PathBuf::from("projects/site/production/deploy-1"))
+        );
+        for path in [
+            "",
+            "/tmp/site",
+            "../site",
+            "projects/../site",
+            "projects//site",
+            "projects/./site",
+            "projects/site/",
+            r"projects\site",
+            r"C:\site",
+        ] {
+            assert!(
+                validate_static_dir(path).is_err(),
+                "{path} must be rejected"
+            );
+        }
+
+        let oversized = "a".repeat(MAX_STATIC_ASSET_URL_PATH_BYTES + 1);
+        assert_eq!(
+            validate_static_dir(&oversized),
+            Err(StaticPathPolicyError::TooLong)
+        );
+    }
+
+    #[test]
+    fn clean_relative_paths_have_a_shared_component_depth_limit() {
+        let maximum = (0..MAX_STATIC_PATH_COMPONENTS)
+            .map(|_| "a")
+            .collect::<Vec<_>>()
+            .join("/");
+        let too_deep = format!("{maximum}/a");
+
+        assert!(validate_static_dir(&maximum).is_ok());
+        assert_eq!(
+            validate_static_dir(&too_deep),
+            Err(StaticPathPolicyError::TooDeep)
+        );
+        assert_eq!(
+            validate_static_artifact_path(Path::new(&too_deep)),
+            Err(StaticPathPolicyError::TooDeep)
+        );
+    }
+
+    #[test]
+    fn artifact_policy_rejects_sensitive_names_but_allows_well_known() {
+        assert!(validate_static_artifact_path(Path::new("index.html")).is_ok());
+        assert!(validate_static_artifact_path(Path::new(".well-known/security.txt")).is_ok());
+        assert_eq!(
+            validate_static_artifact_path(Path::new("nested/.env.production")),
+            Err(StaticPathPolicyError::Sensitive)
+        );
+        assert_eq!(
+            validate_static_artifact_path(Path::new("source/app.ts.map")),
+            Err(StaticPathPolicyError::Sensitive)
+        );
+        for path in [
+            "production.env",
+            "terraform.tfstate",
+            "terraform.tfstate.123",
+            "terraform.tfstate.backup",
+            "terraform.tfvars",
+            "keys/deploy.ppk",
+            "kubeconfig",
+            "client_secret.json",
+            "client_secrets.json",
+            "serviceAccountKey.json",
+            "service-account.json",
+            "service-account-key.json",
+            "service_account.json",
+            "service_account_key.json",
+        ] {
+            assert_eq!(
+                validate_static_artifact_path(Path::new(path)),
+                Err(StaticPathPolicyError::Sensitive),
+                "{path} must be rejected"
+            );
+        }
+    }
+}

--- a/crates/temps-deployer/src/docker.rs
+++ b/crates/temps-deployer/src/docker.rs
@@ -1,5 +1,6 @@
 //! Docker implementation of ImageBuilder and ContainerDeployer traits
 
+use crate::static_ingestion::{MAX_STATIC_ENTRIES, MAX_STATIC_ENTRY_BYTES, MAX_STATIC_TOTAL_BYTES};
 use crate::{
     BuildRequest, BuildResult, BuilderError, ContainerDeployer, ContainerInfo, ContainerRuntime,
     ContainerStatus, DeployRequest, DeployResult, DeployerError, ImageBuilder, PortMapping,
@@ -15,13 +16,392 @@ use bollard::{
 };
 use futures::{Stream, StreamExt, TryStreamExt};
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 use sysinfo::System;
 use tempfile::TempDir;
+use temps_core::static_files::MAX_STATIC_PATH_COMPONENTS;
 use tokio::io::AsyncWriteExt;
 use tracing::{debug, error, info, warn};
+
+const MAX_STATIC_ARCHIVE_STREAM_BYTES: u64 =
+    MAX_STATIC_TOTAL_BYTES + (MAX_STATIC_ENTRIES as u64 * 1024) + (1024 * 1024);
+
+struct DockerContainerCleanupGuard {
+    docker: Arc<Docker>,
+    container_id: String,
+    image_name: String,
+    source_path: String,
+    armed: bool,
+}
+
+impl DockerContainerCleanupGuard {
+    fn new(docker: Arc<Docker>, container_id: String, image_name: &str, source_path: &str) -> Self {
+        Self {
+            docker,
+            container_id,
+            image_name: image_name.to_string(),
+            source_path: source_path.to_string(),
+            armed: true,
+        }
+    }
+
+    async fn cleanup(&mut self) -> Result<(), String> {
+        self.docker
+            .remove_container(
+                &self.container_id,
+                Some(RemoveContainerOptions {
+                    force: true,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .map_err(|error| error.to_string())?;
+        self.armed = false;
+        Ok(())
+    }
+}
+
+impl Drop for DockerContainerCleanupGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        let docker = self.docker.clone();
+        let container_id = self.container_id.clone();
+        let image_name = self.image_name.clone();
+        let source_path = self.source_path.clone();
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            error!(
+                container_id,
+                image_name,
+                source_path,
+                "Could not schedule cancellation cleanup for Docker extraction container: no Tokio runtime"
+            );
+            return;
+        };
+        runtime.spawn(async move {
+            if let Err(error) = docker
+                .remove_container(
+                    &container_id,
+                    Some(RemoveContainerOptions {
+                        force: true,
+                        ..Default::default()
+                    }),
+                )
+                .await
+            {
+                error!(
+                    container_id,
+                    image_name,
+                    source_path,
+                    reason = %error,
+                    "Failed to remove Docker extraction container during cancellation cleanup"
+                );
+            }
+        });
+    }
+}
+
+fn combine_extraction_and_cleanup(
+    operation: Result<(), BuilderError>,
+    cleanup: Result<(), String>,
+    container_id: &str,
+    image_name: &str,
+    source_path: &str,
+) -> Result<(), BuilderError> {
+    match (operation, cleanup) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(operation_error), Ok(())) => Err(operation_error),
+        (Ok(()), Err(cleanup_error)) => Err(BuilderError::Other(format!(
+            "Static extraction completed for image '{image_name}' path '{source_path}', but failed to remove temporary Docker container '{container_id}': {cleanup_error}"
+        ))),
+        (Err(operation_error), Err(cleanup_error)) => Err(BuilderError::Other(format!(
+            "Static extraction failed for image '{image_name}' path '{source_path}': {operation_error}; additionally failed to remove temporary Docker container '{container_id}': {cleanup_error}"
+        ))),
+    }
+}
+
+fn checked_static_archive_entry_count(
+    current: u32,
+    image_name: &str,
+    source_path: &str,
+) -> Result<u32, BuilderError> {
+    let next = current.checked_add(1).ok_or_else(|| {
+        BuilderError::ResourceLimitExceeded(format!(
+            "Docker archive entry count overflowed for image '{image_name}' path '{source_path}'"
+        ))
+    })?;
+    if next > MAX_STATIC_ENTRIES {
+        return Err(BuilderError::ResourceLimitExceeded(format!(
+            "Docker archive for image '{image_name}' path '{source_path}' exceeds the {MAX_STATIC_ENTRIES} entry limit"
+        )));
+    }
+    Ok(next)
+}
+
+fn checked_static_archive_total(
+    current: u64,
+    entry_size: u64,
+    image_name: &str,
+    source_path: &str,
+) -> Result<u64, BuilderError> {
+    let next = current.checked_add(entry_size).ok_or_else(|| {
+        BuilderError::ResourceLimitExceeded(format!(
+            "Docker archive extracted byte count overflowed for image '{image_name}' path '{source_path}'"
+        ))
+    })?;
+    if next > MAX_STATIC_TOTAL_BYTES {
+        return Err(BuilderError::ResourceLimitExceeded(format!(
+            "Docker archive for image '{image_name}' path '{source_path}' exceeds the {MAX_STATIC_TOTAL_BYTES} byte extracted-size limit"
+        )));
+    }
+    Ok(next)
+}
+
+fn validate_static_archive_entry_path(
+    path: &Path,
+    image_name: &str,
+    source_path: &str,
+) -> Result<(), BuilderError> {
+    if path.as_os_str().is_empty() {
+        return Err(BuilderError::InvalidContext(format!(
+            "Docker archive for image '{image_name}' path '{source_path}' contains an empty entry path"
+        )));
+    }
+
+    for component in path.components() {
+        match component {
+            Component::Normal(_) => {}
+            Component::CurDir
+            | Component::ParentDir
+            | Component::RootDir
+            | Component::Prefix(_) => {
+                return Err(BuilderError::InvalidContext(format!(
+                    "Docker archive for image '{image_name}' path '{source_path}' contains unsafe entry '{}': path traversal and absolute paths are not allowed",
+                    path.display()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_static_archive_relative_depth(
+    path: &Path,
+    image_name: &str,
+    source_path: &str,
+) -> Result<(), BuilderError> {
+    let depth = path.components().count();
+    if depth > MAX_STATIC_PATH_COMPONENTS {
+        return Err(BuilderError::ResourceLimitExceeded(format!(
+            "Docker archive entry '{}' for image '{image_name}' path '{source_path}' has {depth} relative components, exceeding the {MAX_STATIC_PATH_COMPONENTS} component depth limit",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn process_bounded_static_archive(
+    archive_path: &Path,
+    destination: Option<&Path>,
+    image_name: &str,
+    source_path: &str,
+) -> Result<(), BuilderError> {
+    if let Some(destination) = destination {
+        std::fs::create_dir_all(destination).map_err(|error| {
+            BuilderError::IoError(std::io::Error::new(
+                error.kind(),
+                format!(
+                    "Failed to create Docker archive extraction directory {} for image '{image_name}' path '{source_path}': {error}",
+                    destination.display()
+                ),
+            ))
+        })?;
+    }
+    let file = std::fs::File::open(archive_path).map_err(|error| {
+        BuilderError::IoError(std::io::Error::new(
+            error.kind(),
+            format!(
+                "Failed to open downloaded Docker archive {} for image '{image_name}' path '{source_path}': {error}",
+                archive_path.display()
+            ),
+        ))
+    })?;
+    let mut archive = tar::Archive::new(file);
+    let entries = archive.entries().map_err(|error| {
+        BuilderError::InvalidContext(format!(
+            "Failed to read Docker archive entries for image '{image_name}' path '{source_path}': {error}"
+        ))
+    })?;
+    let mut entry_count = 0u32;
+    let mut extracted_bytes = 0u64;
+    let mut seen_paths = HashSet::new();
+    let archive_root = Path::new(source_path)
+        .file_name()
+        .filter(|component| !component.is_empty())
+        .ok_or_else(|| {
+            BuilderError::InvalidContext(format!(
+                "Docker extraction source path '{source_path}' for image '{image_name}' must name a file or directory"
+            ))
+        })?;
+
+    for entry in entries {
+        entry_count = checked_static_archive_entry_count(entry_count, image_name, source_path)?;
+
+        let mut entry = entry.map_err(|error| {
+            BuilderError::InvalidContext(format!(
+                "Failed to read Docker archive entry {entry_count} for image '{image_name}' path '{source_path}': {error}"
+            ))
+        })?;
+        let path = entry
+            .path()
+            .map_err(|error| {
+                BuilderError::InvalidContext(format!(
+                    "Failed to decode Docker archive entry {entry_count} path for image '{image_name}' path '{source_path}': {error}"
+                ))
+            })?
+            .into_owned();
+        validate_static_archive_entry_path(&path, image_name, source_path)?;
+        let relative_path = path.strip_prefix(archive_root).map_err(|_| {
+            BuilderError::InvalidContext(format!(
+                "Docker archive entry '{}' for image '{image_name}' is outside requested path root '{}'",
+                path.display(),
+                archive_root.to_string_lossy()
+            ))
+        })?;
+        validate_static_archive_relative_depth(relative_path, image_name, source_path)?;
+        if !seen_paths.insert(path.clone()) {
+            return Err(BuilderError::InvalidContext(format!(
+                "Docker archive for image '{image_name}' path '{source_path}' contains duplicate entry '{}'",
+                path.display()
+            )));
+        }
+
+        let destination_path = destination.map(|destination| destination.join(&path));
+        if let (Some(destination), Some(destination_path)) = (destination, &destination_path) {
+            if !destination_path.starts_with(destination) {
+                return Err(BuilderError::InvalidContext(format!(
+                    "Docker archive entry '{}' for image '{image_name}' path '{source_path}' escapes extraction directory {}",
+                    path.display(),
+                    destination.display()
+                )));
+            }
+        }
+
+        match entry.header().entry_type() {
+            tar::EntryType::Directory => {
+                if let Some(destination_path) = destination_path {
+                    std::fs::create_dir_all(&destination_path).map_err(|error| {
+                        BuilderError::IoError(std::io::Error::new(
+                            error.kind(),
+                            format!(
+                                "Failed to create Docker archive directory {} for image '{image_name}' path '{source_path}': {error}",
+                                destination_path.display()
+                            ),
+                        ))
+                    })?;
+                }
+            }
+            tar::EntryType::Regular => {
+                let declared_size = entry.header().size().map_err(|error| {
+                    BuilderError::InvalidContext(format!(
+                        "Failed to read declared size for Docker archive entry '{}' in image '{image_name}' path '{source_path}': {error}",
+                        path.display()
+                    ))
+                })?;
+                if declared_size > MAX_STATIC_ENTRY_BYTES {
+                    return Err(BuilderError::ResourceLimitExceeded(format!(
+                        "Docker archive entry '{}' for image '{image_name}' path '{source_path}' declares {declared_size} bytes, exceeding the {MAX_STATIC_ENTRY_BYTES} byte per-entry limit",
+                        path.display()
+                    )));
+                }
+                extracted_bytes = checked_static_archive_total(
+                    extracted_bytes,
+                    declared_size,
+                    image_name,
+                    source_path,
+                )?;
+
+                if let Some(destination_path) = destination_path {
+                    if let Some(parent) = destination_path.parent() {
+                        std::fs::create_dir_all(parent).map_err(|error| {
+                            BuilderError::IoError(std::io::Error::new(
+                                error.kind(),
+                                format!(
+                                    "Failed to create parent directory {} for Docker archive entry '{}' in image '{image_name}' path '{source_path}': {error}",
+                                    parent.display(),
+                                    path.display()
+                                ),
+                            ))
+                        })?;
+                    }
+                    let mut output = std::fs::OpenOptions::new()
+                        .write(true)
+                        .create_new(true)
+                        .open(&destination_path)
+                        .map_err(|error| {
+                            BuilderError::IoError(std::io::Error::new(
+                                error.kind(),
+                                format!(
+                                    "Failed to create extracted Docker archive file {} for image '{image_name}' path '{source_path}': {error}",
+                                    destination_path.display()
+                                ),
+                            ))
+                        })?;
+                    let copied = std::io::copy(&mut entry, &mut output).map_err(|error| {
+                        BuilderError::IoError(std::io::Error::new(
+                            error.kind(),
+                            format!(
+                                "Failed to extract Docker archive entry '{}' for image '{image_name}' path '{source_path}': {error}",
+                                path.display()
+                            ),
+                        ))
+                    })?;
+                    output.flush().map_err(|error| {
+                        BuilderError::IoError(std::io::Error::new(
+                            error.kind(),
+                            format!(
+                                "Failed to flush Docker archive entry '{}' for image '{image_name}' path '{source_path}': {error}",
+                                path.display()
+                            ),
+                        ))
+                    })?;
+                    if copied != declared_size {
+                        return Err(BuilderError::InvalidContext(format!(
+                            "Docker archive entry '{}' for image '{image_name}' path '{source_path}' declared {declared_size} bytes but yielded {copied} bytes",
+                            path.display()
+                        )));
+                    }
+                }
+            }
+            entry_type => {
+                return Err(BuilderError::InvalidContext(format!(
+                    "Docker archive entry '{}' for image '{image_name}' path '{source_path}' has disallowed type {entry_type:?}; only regular files and directories are accepted",
+                    path.display()
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn extract_bounded_static_archive(
+    archive_path: &Path,
+    destination: &Path,
+    image_name: &str,
+    source_path: &str,
+) -> Result<(), BuilderError> {
+    // First pass validates every header and drains every payload without
+    // creating filesystem entries. This guarantees an unsafe or malformed
+    // entry anywhere in the archive is rejected before extraction begins.
+    process_bounded_static_archive(archive_path, None, image_name, source_path)?;
+    process_bounded_static_archive(archive_path, Some(destination), image_name, source_path)
+}
 
 /// Extracts `nameserver` entries from resolv.conf-formatted text, excluding
 /// loopback addresses — meaningless inside a container's own network
@@ -1108,15 +1488,66 @@ impl DockerRuntime {
             .unwrap_or_else(crate::platform::native_platform)
     }
 
-    async fn concat_byte_stream<S>(s: S) -> Result<Vec<u8>, bollard::errors::Error>
+    async fn write_bounded_byte_stream<S>(
+        s: S,
+        output_path: &Path,
+        max_bytes: u64,
+        image_name: &str,
+        source_path: &str,
+    ) -> Result<u64, BuilderError>
     where
         S: Stream<Item = Result<bytes::Bytes, bollard::errors::Error>>,
     {
-        s.try_fold(Vec::new(), |mut acc, chunk| async move {
-            acc.extend_from_slice(&chunk[..]);
-            Ok(acc)
-        })
-        .await
+        let mut output = tokio::fs::File::create(output_path).await.map_err(|error| {
+            BuilderError::IoError(std::io::Error::new(
+                error.kind(),
+                format!(
+                    "Failed to create Docker archive download {} for image '{image_name}' path '{source_path}': {error}",
+                    output_path.display()
+                ),
+            ))
+        })?;
+        let mut stream = Box::pin(s);
+        let mut written = 0u64;
+
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|error| {
+                BuilderError::Other(format!(
+                    "Failed to download Docker archive for image '{image_name}' path '{source_path}': {error}"
+                ))
+            })?;
+            let next_size = written.checked_add(chunk.len() as u64).ok_or_else(|| {
+                BuilderError::ResourceLimitExceeded(format!(
+                    "Docker archive byte count overflowed for image '{image_name}' path '{source_path}'"
+                ))
+            })?;
+            if next_size > max_bytes {
+                return Err(BuilderError::ResourceLimitExceeded(format!(
+                    "Docker archive stream for image '{image_name}' path '{source_path}' exceeds the {max_bytes} byte download limit"
+                )));
+            }
+            output.write_all(&chunk).await.map_err(|error| {
+                BuilderError::IoError(std::io::Error::new(
+                    error.kind(),
+                    format!(
+                        "Failed to write Docker archive download {} for image '{image_name}' path '{source_path}': {error}",
+                        output_path.display()
+                    ),
+                ))
+            })?;
+            written = next_size;
+        }
+
+        output.flush().await.map_err(|error| {
+            BuilderError::IoError(std::io::Error::new(
+                error.kind(),
+                format!(
+                    "Failed to flush Docker archive download {} for image '{image_name}' path '{source_path}': {error}",
+                    output_path.display()
+                ),
+            ))
+        })?;
+        Ok(written)
     }
 
     fn map_container_status(status: &str) -> ContainerStatus {
@@ -1730,6 +2161,16 @@ impl ImageBuilder for DockerRuntime {
         source_path: &str,
         destination_path: &Path,
     ) -> Result<(), BuilderError> {
+        let archive_root = Path::new(source_path)
+            .file_name()
+            .filter(|component| !component.is_empty())
+            .ok_or_else(|| {
+                BuilderError::InvalidContext(format!(
+                    "Docker extraction source path '{source_path}' for image '{image_name}' must name a file or directory"
+                ))
+            })?
+            .to_os_string();
+
         // Skip pull for local images (temps-* are built locally, not from a registry)
         if !image_name.starts_with("temps-") {
             let _ = self
@@ -1764,24 +2205,36 @@ impl ImageBuilder for DockerRuntime {
             .map_err(|e| BuilderError::Other(format!("Failed to create container: {}", e)))?;
 
         let container_id = container.id.clone();
+        let mut cleanup_guard = DockerContainerCleanupGuard::new(
+            self.docker.clone(),
+            container_id.clone(),
+            image_name,
+            source_path,
+        );
 
-        // Cleanup function
-        let cleanup = || async {
-            let _ = self
-                .docker
-                .remove_container(
+        // Download from the container into a bounded temporary file. The archive
+        // and extraction directory are removed when this scope exits.
+        let temp_dir = match TempDir::new() {
+            Ok(temp_dir) => temp_dir,
+            Err(error) => {
+                let operation = Err(BuilderError::IoError(std::io::Error::new(
+                    error.kind(),
+                    format!(
+                        "Failed to create temporary Docker extraction directory for image '{image_name}' path '{source_path}': {error}"
+                    ),
+                )));
+                let cleanup = cleanup_guard.cleanup().await;
+                return combine_extraction_and_cleanup(
+                    operation,
+                    cleanup,
                     &container_id,
-                    Some(RemoveContainerOptions {
-                        force: true,
-                        ..Default::default()
-                    }),
-                )
-                .await;
+                    image_name,
+                    source_path,
+                );
+            }
         };
-
-        // Download from container
-        let temp_dir = TempDir::new().map_err(BuilderError::IoError)?;
-        let temp_path = temp_dir.path();
+        let archive_path = temp_dir.path().join("static-output.tar");
+        let extraction_path = temp_dir.path().join("extracted");
 
         let response_stream = self.docker.download_from_container(
             &container_id,
@@ -1790,43 +2243,83 @@ impl ImageBuilder for DockerRuntime {
             }),
         );
 
-        let bytes = match Self::concat_byte_stream(response_stream).await {
-            Ok(bytes) => bytes,
-            Err(e) => {
-                cleanup().await;
-                return Err(BuilderError::Other(format!(
-                    "Failed to download from container: {}",
-                    e
+        let operation = async {
+            Self::write_bounded_byte_stream(
+                response_stream,
+                &archive_path,
+                MAX_STATIC_ARCHIVE_STREAM_BYTES,
+                image_name,
+                source_path,
+            )
+            .await?;
+
+            let blocking_archive_path = archive_path.clone();
+            let blocking_extraction_path = extraction_path.clone();
+            let blocking_image_name = image_name.to_string();
+            let blocking_source_path = source_path.to_string();
+            tokio::task::spawn_blocking(move || {
+                extract_bounded_static_archive(
+                    &blocking_archive_path,
+                    &blocking_extraction_path,
+                    &blocking_image_name,
+                    &blocking_source_path,
+                )
+            })
+            .await
+            .map_err(|error| {
+                BuilderError::Other(format!(
+                    "Docker archive extraction task failed for image '{image_name}' path '{source_path}': {error}"
+                ))
+            })??;
+
+            let extracted_dir = extraction_path.join(&archive_root);
+            let canonical_extraction_path = tokio::fs::canonicalize(&extraction_path)
+                .await
+                .map_err(|error| {
+                    BuilderError::IoError(std::io::Error::new(
+                        error.kind(),
+                        format!(
+                            "Failed to resolve Docker extraction root {} for image '{image_name}' path '{source_path}': {error}",
+                            extraction_path.display()
+                        ),
+                    ))
+                })?;
+            let canonical_extracted_dir = tokio::fs::canonicalize(&extracted_dir)
+                .await
+                .map_err(|error| {
+                    BuilderError::IoError(std::io::Error::new(
+                        error.kind(),
+                        format!(
+                            "Docker archive for image '{image_name}' path '{source_path}' did not contain expected directory {}: {error}",
+                            extracted_dir.display()
+                        ),
+                    ))
+                })?;
+            if !canonical_extracted_dir.starts_with(&canonical_extraction_path)
+                || !canonical_extracted_dir.is_dir()
+            {
+                return Err(BuilderError::InvalidContext(format!(
+                    "Docker archive for image '{image_name}' path '{source_path}' did not resolve to a confined directory"
                 )));
             }
-        };
 
-        let mut archive_reader = tar::Archive::new(&bytes[..]);
-        if let Err(e) = archive_reader.unpack(temp_path) {
-            cleanup().await;
-            return Err(BuilderError::Other(format!(
-                "Failed to extract archive: {}",
-                e
-            )));
+            tokio::fs::rename(&canonical_extracted_dir, destination_path)
+                .await
+                .map_err(|error| {
+                    BuilderError::IoError(std::io::Error::new(
+                        error.kind(),
+                        format!(
+                            "Failed to move extracted Docker files for image '{image_name}' path '{source_path}' from {} to {}: {error}",
+                            canonical_extracted_dir.display(),
+                            destination_path.display()
+                        ),
+                    ))
+                })?;
+            Ok(())
         }
-
-        let last_path_component = std::path::Path::new(source_path)
-            .file_name()
-            .and_then(|os_str| os_str.to_str())
-            .unwrap_or("");
-
-        let extracted_dir = temp_path.join(last_path_component);
-
-        if let Err(e) = std::fs::rename(&extracted_dir, destination_path) {
-            cleanup().await;
-            return Err(BuilderError::Other(format!(
-                "Failed to move extracted files: {}",
-                e
-            )));
-        }
-
-        cleanup().await;
-        Ok(())
+        .await;
+        let cleanup = cleanup_guard.cleanup().await;
+        combine_extraction_and_cleanup(operation, cleanup, &container_id, image_name, source_path)
     }
 
     async fn list_images(&self) -> Result<Vec<String>, BuilderError> {
@@ -2922,6 +3415,35 @@ mod docker_tests {
     use tokio::fs;
     use tokio::time::{timeout, Duration};
 
+    #[test]
+    fn extraction_and_cleanup_errors_preserve_both_causes() {
+        let result = combine_extraction_and_cleanup(
+            Err(BuilderError::InvalidContext("unsafe archive".to_string())),
+            Err("daemon unavailable".to_string()),
+            "container-1",
+            "image-1",
+            "/app/dist",
+        )
+        .expect_err("operation and cleanup failures must be reported");
+        let message = result.to_string();
+        assert!(message.contains("unsafe archive"));
+        assert!(message.contains("daemon unavailable"));
+        assert!(message.contains("container-1"));
+    }
+
+    #[test]
+    fn cleanup_failure_turns_successful_extraction_into_error() {
+        let result = combine_extraction_and_cleanup(
+            Ok(()),
+            Err("permission denied".to_string()),
+            "container-2",
+            "image-2",
+            "/public",
+        );
+        assert!(matches!(result, Err(BuilderError::Other(message)) if
+            message.contains("permission denied") && message.contains("container-2")));
+    }
+
     async fn create_test_docker_runtime() -> Result<DockerRuntime, Box<dyn std::error::Error>> {
         let docker = Docker::connect_with_local_defaults()?;
 
@@ -2960,6 +3482,268 @@ mod docker_tests {
         let docker = Docker::connect_with_local_defaults()
             .expect("bollard client construction (no connection made)");
         DockerRuntime::new(Arc::new(docker), false, "test-network".to_string())
+    }
+
+    fn tar_with_files(files: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut builder = tar::Builder::new(Vec::new());
+        for (path, content) in files {
+            let mut header = tar::Header::new_gnu();
+            header.set_path(path).expect("test tar path");
+            header.set_entry_type(tar::EntryType::Regular);
+            header.set_mode(0o644);
+            header.set_size(content.len() as u64);
+            header.set_cksum();
+            builder
+                .append(&header, *content)
+                .expect("append test tar entry");
+        }
+        builder.into_inner().expect("finish test tar")
+    }
+
+    fn raw_tar_header(path: &[u8], entry_type: tar::EntryType, size: u64) -> Vec<u8> {
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(entry_type);
+        header.set_mode(0o644);
+        header.set_size(size);
+        header.as_mut_bytes()[..path.len()].copy_from_slice(path);
+        header.set_cksum();
+        let mut archive = header.as_bytes().to_vec();
+        archive.extend_from_slice(&[0; 1024]);
+        archive
+    }
+
+    #[test]
+    fn bounded_static_archive_extracts_ordinary_and_well_known_files() {
+        let temporary = TempDir::new().expect("temp dir");
+        let archive_path = temporary.path().join("site.tar");
+        let destination = temporary.path().join("extracted");
+        std::fs::write(
+            &archive_path,
+            tar_with_files(&[
+                ("dist/index.html", b"<h1>ok</h1>"),
+                ("dist/assets/app.js", b"console.log('ok')"),
+                (
+                    "dist/.well-known/security.txt",
+                    b"Contact: mailto:test@example.test",
+                ),
+            ]),
+        )
+        .expect("write archive");
+
+        extract_bounded_static_archive(&archive_path, &destination, "temps-test", "/app/dist")
+            .expect("safe archive extracts");
+
+        assert_eq!(
+            std::fs::read(destination.join("dist/index.html")).expect("read index"),
+            b"<h1>ok</h1>"
+        );
+        assert!(destination.join("dist/.well-known/security.txt").is_file());
+    }
+
+    #[test]
+    fn bounded_generic_archive_allows_private_source_maps() {
+        let temporary = TempDir::new().expect("temp dir");
+        let archive_path = temporary.path().join("site.tar");
+        let destination = temporary.path().join("extracted");
+        std::fs::write(
+            &archive_path,
+            tar_with_files(&[
+                ("dist/app.js", b"console.log('private source map')"),
+                ("dist/app.js.map", br#"{"version":3,"sources":[]}"#),
+            ]),
+        )
+        .expect("write archive");
+
+        extract_bounded_static_archive(&archive_path, &destination, "temps-test", "/app/dist")
+            .expect("generic extraction must preserve private source maps");
+
+        assert!(destination.join("dist/app.js.map").is_file());
+    }
+
+    #[test]
+    fn test_extract_bounded_static_archive_duplicate_path_rejected_before_output_created() {
+        // Arrange
+        let temporary = TempDir::new().expect("temp dir");
+        let archive_path = temporary.path().join("site.tar");
+        let destination = temporary.path().join("extracted");
+        std::fs::write(
+            &archive_path,
+            tar_with_files(&[
+                ("dist/index.html", b"first"),
+                ("dist/index.html", b"second"),
+            ]),
+        )
+        .expect("write archive");
+
+        // Act
+        let error =
+            extract_bounded_static_archive(&archive_path, &destination, "temps-test", "/app/dist")
+                .expect_err("duplicate archive path must fail");
+
+        // Assert
+        assert!(matches!(error, BuilderError::InvalidContext(_)));
+        assert!(error.to_string().contains("duplicate entry"));
+        assert!(
+            !destination.exists(),
+            "preflight must reject duplicate paths before creating extraction output"
+        );
+    }
+
+    #[test]
+    fn bounded_static_archive_rejects_traversal_entries() {
+        let temporary = TempDir::new().expect("temp dir");
+        let archive_path = temporary.path().join("site.tar");
+        std::fs::write(
+            &archive_path,
+            raw_tar_header(b"dist/../../outside", tar::EntryType::Regular, 0),
+        )
+        .expect("write archive");
+
+        let error = extract_bounded_static_archive(
+            &archive_path,
+            &temporary.path().join("extracted"),
+            "temps-test",
+            "/app/dist",
+        )
+        .expect_err("traversal entry must fail");
+
+        assert!(matches!(error, BuilderError::InvalidContext(_)));
+        assert!(!temporary.path().join("outside").exists());
+    }
+
+    #[test]
+    fn bounded_static_archive_rejects_links_and_special_entries() {
+        for entry_type in [
+            tar::EntryType::Symlink,
+            tar::EntryType::Link,
+            tar::EntryType::Fifo,
+        ] {
+            let temporary = TempDir::new().expect("temp dir");
+            let archive_path = temporary.path().join("site.tar");
+            std::fs::write(&archive_path, raw_tar_header(b"dist/unsafe", entry_type, 0))
+                .expect("write archive");
+
+            let error = extract_bounded_static_archive(
+                &archive_path,
+                &temporary.path().join("extracted"),
+                "temps-test",
+                "/app/dist",
+            )
+            .expect_err("non-regular entry must fail");
+
+            assert!(matches!(error, BuilderError::InvalidContext(_)));
+        }
+    }
+
+    #[test]
+    fn bounded_static_archive_rejects_oversized_declared_entry() {
+        let temporary = TempDir::new().expect("temp dir");
+        let archive_path = temporary.path().join("site.tar");
+        std::fs::write(
+            &archive_path,
+            raw_tar_header(
+                b"dist/large.bin",
+                tar::EntryType::Regular,
+                MAX_STATIC_ENTRY_BYTES + 1,
+            ),
+        )
+        .expect("write archive");
+
+        let error = extract_bounded_static_archive(
+            &archive_path,
+            &temporary.path().join("extracted"),
+            "temps-test",
+            "/app/dist",
+        )
+        .expect_err("oversized entry must fail before reading content");
+
+        assert!(matches!(error, BuilderError::ResourceLimitExceeded(_)));
+    }
+
+    #[test]
+    fn static_archive_limits_reject_entry_count_and_total_size_without_allocating() {
+        assert!(matches!(
+            checked_static_archive_entry_count(MAX_STATIC_ENTRIES, "temps-test", "/app/dist"),
+            Err(BuilderError::ResourceLimitExceeded(_))
+        ));
+        assert!(matches!(
+            checked_static_archive_total(MAX_STATIC_TOTAL_BYTES, 1, "temps-test", "/app/dist"),
+            Err(BuilderError::ResourceLimitExceeded(_))
+        ));
+    }
+
+    #[test]
+    fn static_archive_path_depth_accepts_exact_limit_and_rejects_next_component() {
+        let exact = (0..MAX_STATIC_PATH_COMPONENTS).fold(PathBuf::new(), |mut path, _| {
+            path.push("d");
+            path
+        });
+        let mut over = exact.clone();
+        over.push("asset.js");
+
+        assert!(validate_static_archive_relative_depth(&exact, "temps-test", "/app/dist").is_ok());
+        assert!(matches!(
+            validate_static_archive_relative_depth(&over, "temps-test", "/app/dist"),
+            Err(BuilderError::ResourceLimitExceeded(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn docker_archive_download_stream_stops_at_configured_limit() {
+        let temporary = TempDir::new().expect("temp dir");
+        let output_path = temporary.path().join("download.tar");
+        let stream = futures::stream::iter(vec![
+            Ok::<_, bollard::errors::Error>(bytes::Bytes::from_static(b"1234")),
+            Ok::<_, bollard::errors::Error>(bytes::Bytes::from_static(b"5")),
+        ]);
+
+        let error = DockerRuntime::write_bounded_byte_stream(
+            stream,
+            &output_path,
+            4,
+            "temps-test",
+            "/app/dist",
+        )
+        .await
+        .expect_err("stream above limit must fail");
+
+        assert!(matches!(error, BuilderError::ResourceLimitExceeded(_)));
+        assert!(
+            std::fs::metadata(output_path)
+                .expect("partial file metadata")
+                .len()
+                <= 4,
+            "download must never write the chunk that crosses the limit"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_write_bounded_byte_stream_exact_limit_writes_complete_stream() {
+        // Arrange
+        let temporary = TempDir::new().expect("temp dir");
+        let output_path = temporary.path().join("download.tar");
+        let stream = futures::stream::iter(vec![
+            Ok::<_, bollard::errors::Error>(bytes::Bytes::from_static(b"12")),
+            Ok::<_, bollard::errors::Error>(bytes::Bytes::from_static(b"34")),
+        ]);
+
+        // Act
+        let written = DockerRuntime::write_bounded_byte_stream(
+            stream,
+            &output_path,
+            4,
+            "temps-test",
+            "/app/dist",
+        )
+        .await
+        .expect("stream at exact limit should succeed");
+
+        // Assert
+        assert_eq!(written, 4);
+        assert_eq!(
+            std::fs::read(output_path).expect("download contents"),
+            b"1234"
+        );
     }
 
     #[test]

--- a/crates/temps-deployer/src/lib.rs
+++ b/crates/temps-deployer/src/lib.rs
@@ -27,6 +27,7 @@ pub mod plugin;
 pub mod readiness;
 pub mod remote;
 pub mod static_deployer;
+pub(crate) mod static_ingestion;
 
 pub use platform::{
     canonicalize_platform, is_buildable_platform, native_platform, normalize_arch,

--- a/crates/temps-deployer/src/static_deployer.rs
+++ b/crates/temps-deployer/src/static_deployer.rs
@@ -2,13 +2,20 @@
 //!
 //! Handles deployment of static files (Vite, React, etc.) to organized filesystem storage
 
+use crate::static_ingestion::{MAX_STATIC_ENTRIES, MAX_STATIC_ENTRY_BYTES, MAX_STATIC_TOTAL_BYTES};
 use async_trait::async_trait;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
+use temps_core::static_files::{
+    validate_static_artifact_path, validate_static_dir, MAX_STATIC_PATH_COMPONENTS,
+};
 use thiserror::Error;
 use tokio::fs;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::debug;
+
+const COPY_BUFFER_BYTES: usize = 64 * 1024;
 
 #[derive(Error, Debug)]
 pub enum StaticDeployError {
@@ -23,6 +30,9 @@ pub enum StaticDeployError {
 
     #[error("Invalid path: {0}")]
     InvalidPath(String),
+
+    #[error("Static deployment resource limit exceeded while processing '{path}': {reason}")]
+    ResourceLimitExceeded { path: String, reason: String },
 
     #[error("Other error: {0}")]
     Other(String),
@@ -109,9 +119,15 @@ pub struct FilesystemStaticDeployer {
 }
 
 // Type aliases to simplify complex async return types
-type CopyDirFuture<'a> = std::pin::Pin<
-    Box<dyn std::future::Future<Output = Result<(u32, u64), StaticDeployError>> + Send + 'a>,
->;
+type CopyDirFuture<'a> =
+    std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), StaticDeployError>> + Send + 'a>>;
+
+#[derive(Debug, Default)]
+struct CopyStats {
+    entry_count: u32,
+    file_count: u32,
+    total_size: u64,
+}
 
 type ListFilesFuture<'a> = std::pin::Pin<
     Box<dyn std::future::Future<Output = Result<Vec<FileInfo>, StaticDeployError>> + Send + 'a>,
@@ -140,12 +156,125 @@ impl FilesystemStaticDeployer {
             .join(&request.deployment_slug)
     }
 
-    /// Recursively copy directory contents
-    fn copy_dir_recursive<'a>(source: &'a PathBuf, dest: &'a PathBuf) -> CopyDirFuture<'a> {
-        Box::pin(async move {
-            let mut file_count = 0u32;
-            let mut total_size = 0u64;
+    fn validate_storage_component(name: &str, value: &str) -> Result<(), StaticDeployError> {
+        if value.is_empty() || value.contains(['/', '\\']) {
+            return Err(StaticDeployError::InvalidPath(format!(
+                "{name} must be a single non-empty relative path component, got '{value}'"
+            )));
+        }
 
+        let mut components = Path::new(value).components();
+        match (components.next(), components.next()) {
+            (Some(Component::Normal(component)), None) if component == value => Ok(()),
+            _ => Err(StaticDeployError::InvalidPath(format!(
+                "{name} must be a clean relative path component, got '{value}'"
+            ))),
+        }
+    }
+
+    fn validate_storage_identifiers(
+        project_slug: &str,
+        environment_slug: &str,
+        deployment_slug: &str,
+    ) -> Result<(), StaticDeployError> {
+        Self::validate_storage_component("project_slug", project_slug)?;
+        Self::validate_storage_component("environment_slug", environment_slug)?;
+        Self::validate_storage_component("deployment_slug", deployment_slug)
+    }
+
+    async fn copy_file_bounded(
+        source: &Path,
+        dest: &Path,
+        total_bytes_remaining: u64,
+    ) -> Result<u64, StaticDeployError> {
+        let mut input = fs::File::open(source).await.map_err(|error| {
+            StaticDeployError::IoError(std::io::Error::new(
+                error.kind(),
+                format!("Failed to open source file {}: {error}", source.display()),
+            ))
+        })?;
+        let mut output = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(dest)
+            .await
+            .map_err(|error| {
+                StaticDeployError::IoError(std::io::Error::new(
+                    error.kind(),
+                    format!(
+                        "Failed to create destination file {}: {error}",
+                        dest.display()
+                    ),
+                ))
+            })?;
+        let mut buffer = vec![0; COPY_BUFFER_BYTES];
+        let mut copied = 0u64;
+
+        loop {
+            let read = input.read(&mut buffer).await.map_err(|error| {
+                StaticDeployError::IoError(std::io::Error::new(
+                    error.kind(),
+                    format!("Failed to read source file {}: {error}", source.display()),
+                ))
+            })?;
+            if read == 0 {
+                break;
+            }
+            let next_size = copied.checked_add(read as u64).ok_or_else(|| {
+                StaticDeployError::ResourceLimitExceeded {
+                    path: source.display().to_string(),
+                    reason: "copied byte count overflowed".to_string(),
+                }
+            })?;
+            if next_size > MAX_STATIC_ENTRY_BYTES {
+                return Err(StaticDeployError::ResourceLimitExceeded {
+                    path: source.display().to_string(),
+                    reason: format!(
+                        "file exceeds the {MAX_STATIC_ENTRY_BYTES} byte per-file limit while streaming"
+                    ),
+                });
+            }
+            if next_size > total_bytes_remaining {
+                return Err(StaticDeployError::ResourceLimitExceeded {
+                    path: source.display().to_string(),
+                    reason: format!(
+                        "deployment exceeds the {MAX_STATIC_TOTAL_BYTES} byte aggregate limit while streaming"
+                    ),
+                });
+            }
+
+            output.write_all(&buffer[..read]).await.map_err(|error| {
+                StaticDeployError::IoError(std::io::Error::new(
+                    error.kind(),
+                    format!(
+                        "Failed to write destination file {}: {error}",
+                        dest.display()
+                    ),
+                ))
+            })?;
+            copied = next_size;
+        }
+
+        output.flush().await.map_err(|error| {
+            StaticDeployError::IoError(std::io::Error::new(
+                error.kind(),
+                format!(
+                    "Failed to flush destination file {}: {error}",
+                    dest.display()
+                ),
+            ))
+        })?;
+        Ok(copied)
+    }
+
+    /// Recursively copy directory contents
+    fn copy_dir_recursive<'a>(
+        source_root: &'a Path,
+        source: &'a PathBuf,
+        dest: &'a PathBuf,
+        stats: &'a mut CopyStats,
+    ) -> CopyDirFuture<'a> {
+        Box::pin(async move {
             // Ensure destination directory exists
             fs::create_dir_all(dest).await?;
 
@@ -157,47 +286,113 @@ impl FilesystemStaticDeployer {
             })?;
 
             while let Some(entry) = entries.next_entry().await? {
+                stats.entry_count = stats.entry_count.checked_add(1).ok_or_else(|| {
+                    StaticDeployError::ResourceLimitExceeded {
+                        path: source.display().to_string(),
+                        reason: "entry count overflowed".to_string(),
+                    }
+                })?;
+                if stats.entry_count > MAX_STATIC_ENTRIES {
+                    return Err(StaticDeployError::ResourceLimitExceeded {
+                        path: source_root.display().to_string(),
+                        reason: format!("deployment exceeds the {MAX_STATIC_ENTRIES} entry limit"),
+                    });
+                }
                 let source_path = entry.path();
                 let file_name = entry.file_name();
                 let dest_path = dest.join(&file_name);
+                let relative_path = source_path.strip_prefix(source_root).map_err(|error| {
+                    StaticDeployError::InvalidPath(format!(
+                        "Static deployment source entry {} is outside source root {}: {error}",
+                        source_path.display(),
+                        source_root.display()
+                    ))
+                })?;
+                let component_depth = relative_path.components().count();
+                if component_depth > MAX_STATIC_PATH_COMPONENTS {
+                    return Err(StaticDeployError::ResourceLimitExceeded {
+                        path: relative_path.display().to_string(),
+                        reason: format!(
+                            "path has {component_depth} components, exceeding the {MAX_STATIC_PATH_COMPONENTS} component depth limit"
+                        ),
+                    });
+                }
+                validate_static_artifact_path(relative_path).map_err(|error| {
+                    StaticDeployError::InvalidPath(format!(
+                        "Static deployment source entry '{}' is not publishable: {error}",
+                        relative_path.display()
+                    ))
+                })?;
 
-                let metadata = entry.metadata().await?;
+                let metadata = fs::symlink_metadata(&source_path).await?;
 
-                if metadata.is_dir() {
+                if metadata.file_type().is_symlink() {
+                    return Err(StaticDeployError::InvalidPath(format!(
+                        "Static deployment source contains a symbolic link: {}",
+                        source_path.display()
+                    )));
+                } else if metadata.is_dir() {
                     // Recurse into subdirectory
-                    let (sub_count, sub_size) =
-                        Self::copy_dir_recursive(&source_path, &dest_path).await?;
-                    file_count += sub_count;
-                    total_size += sub_size;
+                    Self::copy_dir_recursive(source_root, &source_path, &dest_path, stats).await?;
                 } else if metadata.is_file() {
-                    // Copy file using read + write for reliability
-                    let content = fs::read(&source_path).await.map_err(|e| {
-                        StaticDeployError::IoError(std::io::Error::new(
-                            e.kind(),
-                            format!("Failed to read file {}: {}", source_path.display(), e),
-                        ))
-                    })?;
+                    if metadata.len() > MAX_STATIC_ENTRY_BYTES {
+                        return Err(StaticDeployError::ResourceLimitExceeded {
+                            path: source_path.display().to_string(),
+                            reason: format!(
+                                "declared file size {} exceeds the {MAX_STATIC_ENTRY_BYTES} byte per-file limit",
+                                metadata.len()
+                            ),
+                        });
+                    }
+                    let declared_total =
+                        stats
+                            .total_size
+                            .checked_add(metadata.len())
+                            .ok_or_else(|| StaticDeployError::ResourceLimitExceeded {
+                                path: source_path.display().to_string(),
+                                reason: "aggregate byte count overflowed".to_string(),
+                            })?;
+                    if declared_total > MAX_STATIC_TOTAL_BYTES {
+                        return Err(StaticDeployError::ResourceLimitExceeded {
+                            path: source_path.display().to_string(),
+                            reason: format!(
+                                "declared deployment size exceeds the {MAX_STATIC_TOTAL_BYTES} byte aggregate limit"
+                            ),
+                        });
+                    }
 
-                    fs::write(&dest_path, content).await.map_err(|e| {
-                        StaticDeployError::IoError(std::io::Error::new(
-                            e.kind(),
-                            format!("Failed to write file {}: {}", dest_path.display(), e),
-                        ))
-                    })?;
+                    let remaining = MAX_STATIC_TOTAL_BYTES.saturating_sub(stats.total_size);
+                    let copied =
+                        Self::copy_file_bounded(&source_path, &dest_path, remaining).await?;
 
-                    file_count += 1;
-                    total_size += metadata.len();
+                    stats.file_count = stats.file_count.checked_add(1).ok_or_else(|| {
+                        StaticDeployError::ResourceLimitExceeded {
+                            path: source.display().to_string(),
+                            reason: "file count overflowed".to_string(),
+                        }
+                    })?;
+                    stats.total_size = stats.total_size.checked_add(copied).ok_or_else(|| {
+                        StaticDeployError::ResourceLimitExceeded {
+                            path: source.display().to_string(),
+                            reason: "aggregate byte count overflowed".to_string(),
+                        }
+                    })?;
 
                     debug!(
                         "Copied file: {} -> {} ({} bytes)",
                         source_path.display(),
                         dest_path.display(),
-                        metadata.len()
+                        copied
                     );
+                } else {
+                    return Err(StaticDeployError::InvalidPath(format!(
+                        "Static deployment source contains a non-regular filesystem entry: {}",
+                        source_path.display()
+                    )));
                 }
             }
 
-            Ok((file_count, total_size))
+            Ok(())
         })
     }
 
@@ -241,6 +436,12 @@ impl StaticDeployer for FilesystemStaticDeployer {
         &self,
         request: StaticDeployRequest,
     ) -> Result<StaticDeployResult, StaticDeployError> {
+        Self::validate_storage_identifiers(
+            &request.project_slug,
+            &request.environment_slug,
+            &request.deployment_slug,
+        )?;
+
         // Verify source directory exists
         if !request.source_dir.exists() {
             return Err(StaticDeployError::SourceNotFound(format!(
@@ -265,9 +466,48 @@ impl StaticDeployer for FilesystemStaticDeployer {
             storage_path.display()
         );
 
-        // Copy files recursively
-        let (file_count, total_size) =
-            Self::copy_dir_recursive(&request.source_dir, &storage_path).await?;
+        match fs::symlink_metadata(&storage_path).await {
+            Ok(_) => {
+                return Err(StaticDeployError::DeploymentFailed(format!(
+                    "Static deployment destination already exists: {}",
+                    storage_path.display()
+                )));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(StaticDeployError::IoError(std::io::Error::new(
+                    error.kind(),
+                    format!(
+                        "Failed to inspect static deployment destination {}: {error}",
+                        storage_path.display()
+                    ),
+                )));
+            }
+        }
+
+        // Copy files recursively and remove the unpublished partial deployment
+        // if any validation, limit, or I/O check fails.
+        let mut stats = CopyStats::default();
+        if let Err(error) = Self::copy_dir_recursive(
+            &request.source_dir,
+            &request.source_dir,
+            &storage_path,
+            &mut stats,
+        )
+        .await
+        {
+            if let Err(cleanup_error) = fs::remove_dir_all(&storage_path).await {
+                debug!(
+                    path = %storage_path.display(),
+                    error = %cleanup_error,
+                    "Failed to clean partial static deployment"
+                );
+            }
+            return Err(error);
+        }
+
+        let file_count = stats.file_count;
+        let total_size = stats.total_size;
 
         debug!(
             "Deployed {} files ({} bytes) to {}",
@@ -285,6 +525,18 @@ impl StaticDeployer for FilesystemStaticDeployer {
                 e
             ))
         })?;
+        let relative_storage_path = relative_storage_path.to_str().ok_or_else(|| {
+            StaticDeployError::InvalidPath(format!(
+                "Generated static storage path is not valid UTF-8: {}",
+                relative_storage_path.display()
+            ))
+        })?;
+        let relative_storage_path =
+            validate_static_dir(relative_storage_path).map_err(|error| {
+                StaticDeployError::InvalidPath(format!(
+                    "Generated static storage path '{relative_storage_path}' is invalid: {error}"
+                ))
+            })?;
 
         Ok(StaticDeployResult {
             storage_path: relative_storage_path.to_string_lossy().to_string(),
@@ -300,6 +552,8 @@ impl StaticDeployer for FilesystemStaticDeployer {
         environment_slug: &str,
         deployment_slug: &str,
     ) -> Result<StaticDeploymentInfo, StaticDeployError> {
+        Self::validate_storage_identifiers(project_slug, environment_slug, deployment_slug)?;
+
         // Search for deployment across all date partitions
         let project_env_path = self
             .base_dir
@@ -391,6 +645,7 @@ impl StaticDeployer for FilesystemStaticDeployer {
         environment_slug: &str,
         deployment_slug: &str,
     ) -> Result<Vec<FileInfo>, StaticDeployError> {
+        Self::validate_storage_identifiers(project_slug, environment_slug, deployment_slug)?;
         let deployment_info = self
             .get_deployment(project_slug, environment_slug, deployment_slug)
             .await?;
@@ -405,6 +660,7 @@ impl StaticDeployer for FilesystemStaticDeployer {
         environment_slug: &str,
         deployment_slug: &str,
     ) -> Result<(), StaticDeployError> {
+        Self::validate_storage_identifiers(project_slug, environment_slug, deployment_slug)?;
         let deployment_info = self
             .get_deployment(project_slug, environment_slug, deployment_slug)
             .await?;
@@ -591,5 +847,390 @@ mod tests {
 
         // Verify it's gone
         assert!(!full_storage_path.exists());
+    }
+
+    #[tokio::test]
+    async fn deploy_streams_large_ordinary_files_and_preserves_size() {
+        let temp_dir = TempDir::new().unwrap();
+        let base_dir = temp_dir.path().join("static");
+        let source_dir = temp_dir.path().join("source");
+        std_fs::create_dir_all(&source_dir).unwrap();
+        let content = vec![b'x'; COPY_BUFFER_BYTES * 3 + 17];
+        std_fs::write(source_dir.join("asset.bin"), &content).unwrap();
+
+        let deployer = FilesystemStaticDeployer::new(base_dir.clone());
+        let result = deployer
+            .deploy(StaticDeployRequest {
+                source_dir,
+                project_slug: "project".to_string(),
+                environment_slug: "production".to_string(),
+                deployment_slug: "deploy-stream".to_string(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.file_count, 1);
+        assert_eq!(result.total_size_bytes, content.len() as u64);
+        assert_eq!(
+            std_fs::read(base_dir.join(result.storage_path).join("asset.bin")).unwrap(),
+            content
+        );
+    }
+
+    #[tokio::test]
+    async fn deploy_rejects_sensitive_files_and_cleans_partial_destination() {
+        for sensitive_path in [".env", ".git/config", "assets/app.js.map"] {
+            let temp_dir = TempDir::new().unwrap();
+            let base_dir = temp_dir.path().join("static");
+            let source_dir = temp_dir.path().join("source");
+            let sensitive_file = source_dir.join(sensitive_path);
+            std_fs::create_dir_all(sensitive_file.parent().unwrap()).unwrap();
+            std_fs::write(&sensitive_file, b"must not publish").unwrap();
+            std_fs::write(source_dir.join("index.html"), b"ordinary").unwrap();
+
+            let deployer = FilesystemStaticDeployer::new(base_dir);
+            let request = StaticDeployRequest {
+                source_dir,
+                project_slug: "project".to_string(),
+                environment_slug: "production".to_string(),
+                deployment_slug: "deploy-sensitive".to_string(),
+            };
+            let destination = deployer.build_storage_path(&request);
+            let error = deployer.deploy(request).await.unwrap_err();
+
+            assert!(matches!(error, StaticDeployError::InvalidPath(_)));
+            assert!(
+                !destination.exists(),
+                "partial destination remained after rejecting {sensitive_path}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn deploy_allows_documented_well_known_content() {
+        let temp_dir = TempDir::new().unwrap();
+        let base_dir = temp_dir.path().join("static");
+        let source_dir = temp_dir.path().join("source");
+        std_fs::create_dir_all(source_dir.join(".well-known/acme-challenge")).unwrap();
+        std_fs::write(
+            source_dir.join(".well-known/security.txt"),
+            b"Contact: mailto:test@example.test",
+        )
+        .unwrap();
+        std_fs::write(
+            source_dir.join(".well-known/acme-challenge/token"),
+            b"challenge",
+        )
+        .unwrap();
+
+        let deployer = FilesystemStaticDeployer::new(base_dir.clone());
+        let result = deployer
+            .deploy(StaticDeployRequest {
+                source_dir,
+                project_slug: "project".to_string(),
+                environment_slug: "production".to_string(),
+                deployment_slug: "deploy-well-known".to_string(),
+            })
+            .await
+            .unwrap();
+        let destination = base_dir.join(result.storage_path);
+
+        assert!(destination.join(".well-known/security.txt").is_file());
+        assert!(destination
+            .join(".well-known/acme-challenge/token")
+            .is_file());
+    }
+
+    #[tokio::test]
+    async fn deploy_rejects_unclean_storage_identifiers_before_writing() {
+        let temp_dir = TempDir::new().unwrap();
+        let base_dir = temp_dir.path().join("static");
+        let source_dir = temp_dir.path().join("source");
+        std_fs::create_dir_all(&source_dir).unwrap();
+        std_fs::write(source_dir.join("index.html"), b"ordinary").unwrap();
+        let deployer = FilesystemStaticDeployer::new(base_dir.clone());
+
+        for invalid in ["", ".", "..", "../escape", "/absolute", r"nested\escape"] {
+            let error = deployer
+                .deploy(StaticDeployRequest {
+                    source_dir: source_dir.clone(),
+                    project_slug: invalid.to_string(),
+                    environment_slug: "production".to_string(),
+                    deployment_slug: "deploy".to_string(),
+                })
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(error, StaticDeployError::InvalidPath(_)),
+                "identifier {invalid:?} must be rejected"
+            );
+        }
+        assert!(!base_dir.exists());
+    }
+
+    #[test]
+    fn test_validate_storage_identifiers_unclean_value_in_any_position_returns_invalid_path() {
+        // Arrange
+        let invalid_values = ["", ".", "..", "../escape", "/absolute", r"nested\escape"];
+
+        // Act / Assert
+        for invalid in invalid_values {
+            for identifiers in [
+                (invalid, "production", "deploy"),
+                ("project", invalid, "deploy"),
+                ("project", "production", invalid),
+            ] {
+                let error = FilesystemStaticDeployer::validate_storage_identifiers(
+                    identifiers.0,
+                    identifiers.1,
+                    identifiers.2,
+                )
+                .expect_err("unclean storage identifier must fail");
+                assert!(
+                    matches!(error, StaticDeployError::InvalidPath(_)),
+                    "identifier tuple {identifiers:?} must be rejected"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_copy_file_bounded_aggregate_limit_crossed_does_not_write_crossing_chunk() {
+        // Arrange
+        let temp_dir = TempDir::new().unwrap();
+        let source = temp_dir.path().join("source.bin");
+        let destination = temp_dir.path().join("destination.bin");
+        std_fs::write(&source, b"two bytes").unwrap();
+
+        // Act
+        let error = FilesystemStaticDeployer::copy_file_bounded(&source, &destination, 1)
+            .await
+            .expect_err("aggregate limit crossing must fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            StaticDeployError::ResourceLimitExceeded { .. }
+        ));
+        assert_eq!(
+            std_fs::metadata(destination).unwrap().len(),
+            0,
+            "the chunk crossing the aggregate limit must not be written"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_copy_dir_recursive_entry_limit_crossed_rejects_small_fixture() {
+        // Arrange
+        let temp_dir = TempDir::new().unwrap();
+        let source = temp_dir.path().join("source");
+        let destination = temp_dir.path().join("destination");
+        std_fs::create_dir_all(&source).unwrap();
+        std_fs::write(source.join("asset.txt"), b"small").unwrap();
+        let mut stats = CopyStats {
+            entry_count: MAX_STATIC_ENTRIES,
+            ..CopyStats::default()
+        };
+
+        // Act
+        let error = FilesystemStaticDeployer::copy_dir_recursive(
+            &source,
+            &source,
+            &destination,
+            &mut stats,
+        )
+        .await
+        .expect_err("entry limit crossing must fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            StaticDeployError::ResourceLimitExceeded { .. }
+        ));
+        assert!(!destination.join("asset.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn test_copy_dir_recursive_total_limit_crossed_rejects_small_fixture() {
+        // Arrange
+        let temp_dir = TempDir::new().unwrap();
+        let source = temp_dir.path().join("source");
+        let destination = temp_dir.path().join("destination");
+        std_fs::create_dir_all(&source).unwrap();
+        std_fs::write(source.join("asset.txt"), b"small").unwrap();
+        let mut stats = CopyStats {
+            total_size: MAX_STATIC_TOTAL_BYTES,
+            ..CopyStats::default()
+        };
+
+        // Act
+        let error = FilesystemStaticDeployer::copy_dir_recursive(
+            &source,
+            &source,
+            &destination,
+            &mut stats,
+        )
+        .await
+        .expect_err("aggregate limit crossing must fail");
+
+        // Assert
+        assert!(matches!(
+            error,
+            StaticDeployError::ResourceLimitExceeded { .. }
+        ));
+        assert!(!destination.join("asset.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_deploy_special_file_rejected_and_partial_destination_removed() {
+        use std::os::unix::net::UnixListener;
+
+        // Arrange
+        let temp_dir = TempDir::new().unwrap();
+        let base_dir = temp_dir.path().join("static");
+        let source_dir = temp_dir.path().join("source");
+        std_fs::create_dir_all(&source_dir).unwrap();
+        std_fs::write(source_dir.join("index.html"), b"ordinary").unwrap();
+        let _socket = match UnixListener::bind(source_dir.join("server.sock")) {
+            Ok(socket) => socket,
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+                eprintln!("Skipping Unix socket fixture: {error}");
+                return;
+            }
+            Err(error) => panic!("failed to create Unix socket fixture: {error}"),
+        };
+        let deployer = FilesystemStaticDeployer::new(base_dir);
+        let request = StaticDeployRequest {
+            source_dir,
+            project_slug: "project".to_string(),
+            environment_slug: "production".to_string(),
+            deployment_slug: "deploy-special".to_string(),
+        };
+        let destination = deployer.build_storage_path(&request);
+
+        // Act
+        let error = deployer
+            .deploy(request)
+            .await
+            .expect_err("special filesystem entry must fail");
+
+        // Assert
+        assert!(matches!(error, StaticDeployError::InvalidPath(_)));
+        assert!(
+            !destination.exists(),
+            "partial deployment must be removed after special-file rejection"
+        );
+    }
+
+    #[tokio::test]
+    async fn deploy_rejects_oversized_declared_file_before_copying() {
+        let temp_dir = TempDir::new().unwrap();
+        let base_dir = temp_dir.path().join("static");
+        let source_dir = temp_dir.path().join("source");
+        std_fs::create_dir_all(&source_dir).unwrap();
+        std_fs::File::create(source_dir.join("large.bin"))
+            .unwrap()
+            .set_len(MAX_STATIC_ENTRY_BYTES + 1)
+            .unwrap();
+        let deployer = FilesystemStaticDeployer::new(base_dir);
+        let request = StaticDeployRequest {
+            source_dir,
+            project_slug: "project".to_string(),
+            environment_slug: "production".to_string(),
+            deployment_slug: "deploy-large".to_string(),
+        };
+        let destination = deployer.build_storage_path(&request);
+
+        let error = deployer.deploy(request).await.unwrap_err();
+        assert!(matches!(
+            error,
+            StaticDeployError::ResourceLimitExceeded { .. }
+        ));
+        assert!(!destination.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn deploy_rejects_symbolic_links() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = TempDir::new().unwrap();
+        let base_dir = temp_dir.path().join("static");
+        let source_dir = temp_dir.path().join("source");
+        std_fs::create_dir_all(&source_dir).unwrap();
+        let outside = temp_dir.path().join("outside.txt");
+        std_fs::write(&outside, b"secret").unwrap();
+        symlink(&outside, source_dir.join("linked.txt")).unwrap();
+        let deployer = FilesystemStaticDeployer::new(base_dir);
+        let request = StaticDeployRequest {
+            source_dir,
+            project_slug: "project".to_string(),
+            environment_slug: "production".to_string(),
+            deployment_slug: "deploy-link".to_string(),
+        };
+        let destination = deployer.build_storage_path(&request);
+
+        let error = deployer.deploy(request).await.unwrap_err();
+        assert!(matches!(error, StaticDeployError::InvalidPath(_)));
+        assert!(!destination.exists());
+    }
+
+    fn create_file_at_component_depth(root: &Path, component_depth: usize) {
+        assert!(component_depth > 0);
+        let mut file_path = root.to_path_buf();
+        for _ in 1..component_depth {
+            file_path.push("d");
+        }
+        std_fs::create_dir_all(&file_path).unwrap();
+        std_fs::write(file_path.join("asset.txt"), b"small").unwrap();
+    }
+
+    #[tokio::test]
+    async fn recursive_copy_accepts_path_at_exact_component_depth_limit() {
+        let temp_dir = TempDir::new().unwrap();
+        let base_dir = temp_dir.path().join("static");
+        let source_dir = temp_dir.path().join("source");
+        create_file_at_component_depth(&source_dir, MAX_STATIC_PATH_COMPONENTS);
+        let deployer = FilesystemStaticDeployer::new(base_dir);
+
+        let result = deployer
+            .deploy(StaticDeployRequest {
+                source_dir,
+                project_slug: "project".to_string(),
+                environment_slug: "production".to_string(),
+                deployment_slug: "deploy-depth-limit".to_string(),
+            })
+            .await
+            .expect("path at exact depth limit must deploy");
+
+        assert_eq!(result.file_count, 1);
+    }
+
+    #[tokio::test]
+    async fn recursive_copy_rejects_path_over_component_depth_and_cleans_output() {
+        let temp_dir = TempDir::new().unwrap();
+        let base_dir = temp_dir.path().join("static");
+        let source_dir = temp_dir.path().join("source");
+        create_file_at_component_depth(&source_dir, MAX_STATIC_PATH_COMPONENTS + 1);
+        let deployer = FilesystemStaticDeployer::new(base_dir);
+        let request = StaticDeployRequest {
+            source_dir,
+            project_slug: "project".to_string(),
+            environment_slug: "production".to_string(),
+            deployment_slug: "deploy-depth-over".to_string(),
+        };
+        let destination = deployer.build_storage_path(&request);
+
+        let error = deployer
+            .deploy(request)
+            .await
+            .expect_err("path over depth limit must fail");
+
+        assert!(matches!(
+            error,
+            StaticDeployError::ResourceLimitExceeded { .. }
+        ));
+        assert!(!destination.exists());
     }
 }

--- a/crates/temps-deployer/src/static_ingestion.rs
+++ b/crates/temps-deployer/src/static_ingestion.rs
@@ -1,0 +1,11 @@
+//! Shared resource limits for static artifact ingestion.
+//!
+//! These bounds cover both filesystem deployments and Docker archive
+//! extraction so neither path can silently accept a shape the other rejects.
+
+/// Maximum number of filesystem/archive entries in one static artifact.
+pub(crate) const MAX_STATIC_ENTRIES: u32 = 20_000;
+/// Maximum bytes in a single static artifact file.
+pub(crate) const MAX_STATIC_ENTRY_BYTES: u64 = 500 * 1024 * 1024;
+/// Maximum bytes across all files in one static artifact.
+pub(crate) const MAX_STATIC_TOTAL_BYTES: u64 = 2 * 1024 * 1024 * 1024;

--- a/crates/temps-deployments/src/jobs/capture_source_maps.rs
+++ b/crates/temps-deployments/src/jobs/capture_source_maps.rs
@@ -10,8 +10,10 @@ use std::path::Path;
 use std::sync::Arc;
 use temps_core::{JobResult, WorkflowContext, WorkflowError, WorkflowTask};
 use temps_deployer::ImageBuilder;
-use temps_error_tracking::services::SourceMapService;
+use temps_error_tracking::services::{SourceMapService, MAX_SOURCE_MAP_BYTES};
 use temps_logs::{LogLevel, LogService};
+use thiserror::Error;
+use tokio::io::AsyncReadExt;
 use tracing::{debug, info, warn};
 
 use crate::jobs::ImageOutput;
@@ -22,6 +24,68 @@ pub struct CaptureSourceMapsOutput {
     pub source_maps_captured: u32,
     pub total_size_bytes: u64,
     pub release: String,
+}
+
+#[derive(Debug, Error)]
+enum SourceMapFileReadError {
+    #[error("Failed to {operation} source map '{path}': {source}")]
+    Io {
+        path: String,
+        operation: &'static str,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Source map '{path}' is {size_bytes} bytes, exceeding the {limit_bytes} byte limit")]
+    TooLarge {
+        path: String,
+        size_bytes: u64,
+        limit_bytes: usize,
+    },
+}
+
+async fn read_source_map_bounded(path: &Path) -> Result<Vec<u8>, SourceMapFileReadError> {
+    let path_display = path.display().to_string();
+    let file = tokio::fs::File::open(path)
+        .await
+        .map_err(|source| SourceMapFileReadError::Io {
+            path: path_display.clone(),
+            operation: "open",
+            source,
+        })?;
+    let metadata = file
+        .metadata()
+        .await
+        .map_err(|source| SourceMapFileReadError::Io {
+            path: path_display.clone(),
+            operation: "inspect",
+            source,
+        })?;
+    if metadata.len() > MAX_SOURCE_MAP_BYTES as u64 {
+        return Err(SourceMapFileReadError::TooLarge {
+            path: path_display,
+            size_bytes: metadata.len(),
+            limit_bytes: MAX_SOURCE_MAP_BYTES,
+        });
+    }
+
+    let mut data = Vec::with_capacity(metadata.len() as usize);
+    let mut bounded_file = file.take(MAX_SOURCE_MAP_BYTES as u64 + 1);
+    bounded_file
+        .read_to_end(&mut data)
+        .await
+        .map_err(|source| SourceMapFileReadError::Io {
+            path: path.display().to_string(),
+            operation: "read",
+            source,
+        })?;
+    if data.len() > MAX_SOURCE_MAP_BYTES {
+        return Err(SourceMapFileReadError::TooLarge {
+            path: path.display().to_string(),
+            size_bytes: data.len() as u64,
+            limit_bytes: MAX_SOURCE_MAP_BYTES,
+        });
+    }
+    Ok(data)
 }
 
 /// Job that extracts source maps from the built image and stores them
@@ -218,19 +282,29 @@ impl WorkflowTask for CaptureSourceMapsJob {
                     search_path.trim_start_matches('/')
                 )
             };
-            // Create temporary directory for extraction
-            let temp_dir =
-                std::env::temp_dir().join(format!("temps-sourcemaps-{}", uuid::Uuid::new_v4()));
+            // Acquire first so reverse drop order removes the private
+            // directory before releasing capacity to another extraction.
+            let _extraction_permit = super::acquire_archive_extraction_permit().await?;
 
-            if let Err(e) = tokio::fs::create_dir_all(&temp_dir).await {
-                warn!(
-                    "Failed to create temp directory for source map extraction: {}",
-                    e
-                );
-                self.log(format!("⚠️ Failed to create temp directory: {}", e))
+            // Source maps are private artifacts. Keep their extraction in an
+            // owner-only RAII directory that is removed on every exit path.
+            let temp_dir = match tempfile::Builder::new()
+                .prefix("temps-sourcemaps-")
+                .tempdir()
+            {
+                Ok(temp_dir) => temp_dir,
+                Err(error) => {
+                    warn!(
+                        "Failed to create secure temp directory for source map extraction: {}",
+                        error
+                    );
+                    self.log(format!(
+                        "⚠️ Failed to create secure temp directory: {error}"
+                    ))
                     .await?;
-                continue;
-            }
+                    continue;
+                }
+            };
 
             // Extract files from the container image
             self.log(format!(
@@ -239,16 +313,16 @@ impl WorkflowTask for CaptureSourceMapsJob {
             ))
             .await?;
 
-            match self
+            let extraction_result = self
                 .image_builder
-                .extract_from_image(image_tag, &absolute_search_path, &temp_dir)
-                .await
-            {
+                .extract_from_image(image_tag, &absolute_search_path, temp_dir.path())
+                .await;
+            match extraction_result {
                 Ok(()) => {
                     debug!(
                         "Extracted files from {} to {}",
                         absolute_search_path,
-                        temp_dir.display()
+                        temp_dir.path().display()
                     );
                 }
                 Err(e) => {
@@ -262,15 +336,12 @@ impl WorkflowTask for CaptureSourceMapsJob {
                         absolute_search_path, e
                     ))
                     .await?;
-
-                    // Clean up temp dir
-                    let _ = tokio::fs::remove_dir_all(&temp_dir).await;
                     continue;
                 }
             }
 
             // Find all .map files
-            let map_files = self.find_source_maps(&temp_dir).await;
+            let map_files = self.find_source_maps(temp_dir.path()).await;
 
             if map_files.is_empty() {
                 self.log(format!(
@@ -278,7 +349,6 @@ impl WorkflowTask for CaptureSourceMapsJob {
                     absolute_search_path
                 ))
                 .await?;
-                let _ = tokio::fs::remove_dir_all(&temp_dir).await;
                 continue;
             }
 
@@ -292,7 +362,7 @@ impl WorkflowTask for CaptureSourceMapsJob {
             // Upload each source map
             for map_path in &map_files {
                 // Compute the file path relative to the search path
-                let relative_path = map_path.strip_prefix(&temp_dir).unwrap_or(map_path);
+                let relative_path = map_path.strip_prefix(temp_dir.path()).unwrap_or(map_path);
 
                 // Build the ~ prefixed path for storage
                 // search_path is relative (e.g., ".next/static") and gets path rewrites applied
@@ -320,7 +390,7 @@ impl WorkflowTask for CaptureSourceMapsJob {
                     .unwrap_or(&file_path)
                     .to_string();
 
-                let source_map_data = match tokio::fs::read(map_path).await {
+                let source_map_data = match read_source_map_bounded(map_path).await {
                     Ok(data) => data,
                     Err(e) => {
                         warn!(
@@ -360,11 +430,6 @@ impl WorkflowTask for CaptureSourceMapsJob {
                             .await?;
                     }
                 }
-            }
-
-            // Clean up temp directory
-            if let Err(e) = tokio::fs::remove_dir_all(&temp_dir).await {
-                warn!("Failed to clean up temp directory: {}", e);
             }
         }
 
@@ -424,6 +489,48 @@ impl WorkflowTask for CaptureSourceMapsJob {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn oversized_sparse_source_map_is_rejected_before_reading() {
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        let map_path = temp_dir.path().join("private.js.map");
+        let file = tokio::fs::File::create(&map_path)
+            .await
+            .expect("create sparse source map");
+        file.set_len(MAX_SOURCE_MAP_BYTES as u64 + 1)
+            .await
+            .expect("set sparse source map length");
+
+        let error = read_source_map_bounded(&map_path)
+            .await
+            .expect_err("oversized source map must be rejected from metadata");
+        assert!(matches!(
+            error,
+            SourceMapFileReadError::TooLarge {
+                size_bytes,
+                limit_bytes: MAX_SOURCE_MAP_BYTES,
+                ..
+            } if size_bytes == MAX_SOURCE_MAP_BYTES as u64 + 1
+        ));
+    }
+
+    #[test]
+    fn private_source_map_temp_directory_is_removed_on_scope_exit() {
+        let extraction_path;
+        {
+            let temp_dir = tempfile::Builder::new()
+                .prefix("temps-sourcemaps-test-")
+                .tempdir()
+                .expect("create private extraction directory");
+            extraction_path = temp_dir.path().to_path_buf();
+            std::fs::write(
+                temp_dir.path().join("private.js.map"),
+                b"private source map",
+            )
+            .expect("write private test artifact");
+        }
+        assert!(!extraction_path.exists());
+    }
 
     #[test]
     fn test_detect_log_level() {

--- a/crates/temps-deployments/src/jobs/deploy_static.rs
+++ b/crates/temps-deployments/src/jobs/deploy_static.rs
@@ -180,33 +180,40 @@ impl WorkflowTask for DeployStaticJob {
         )
         .await?;
 
-        // Create temporary directory to extract files
-        let temp_dir = std::env::temp_dir().join(format!("temps-static-{}", uuid::Uuid::new_v4()));
-        if let Err(e) = tokio::fs::create_dir_all(&temp_dir).await {
-            return Err(self
-                .log_and_fail(
-                    &context,
-                    format!("❌ Failed to create temp directory: {}", e),
-                )
-                .await);
-        }
+        // Acquire first so reverse drop order removes the extracted directory
+        // before releasing capacity to another extraction.
+        let _extraction_permit = super::acquire_archive_extraction_permit().await?;
+
+        // TempDir owns the extraction tree so every return path (including
+        // sensitive-file rejection and logging errors) removes it. tempfile
+        // also creates the directory with owner-only permissions on Unix.
+        let temp_dir = match tempfile::Builder::new().prefix("temps-static-").tempdir() {
+            Ok(temp_dir) => temp_dir,
+            Err(error) => {
+                return Err(self
+                    .log_and_fail(
+                        &context,
+                        format!("❌ Failed to create secure temp directory: {error}"),
+                    )
+                    .await);
+            }
+        };
 
         self.log(
             &context,
             format!(
                 "📂 Extracting from {} to {}",
                 self.static_output_dir,
-                temp_dir.display()
+                temp_dir.path().display()
             ),
         )
         .await?;
 
-        // Extract static files from the container image
-        if let Err(e) = self
+        let extraction_result = self
             .image_builder
-            .extract_from_image(&image_tag, &self.static_output_dir, &temp_dir)
-            .await
-        {
+            .extract_from_image(&image_tag, &self.static_output_dir, temp_dir.path())
+            .await;
+        if let Err(e) = extraction_result {
             return Err(self
                 .log_and_fail(
                     &context,
@@ -223,7 +230,7 @@ impl WorkflowTask for DeployStaticJob {
 
         // Create deploy request
         let request = StaticDeployRequest {
-            source_dir: temp_dir.clone(),
+            source_dir: temp_dir.path().to_path_buf(),
             project_slug: self.project_slug.clone(),
             environment_slug: self.environment_slug.clone(),
             deployment_slug: self.deployment_slug.clone(),
@@ -241,15 +248,6 @@ impl WorkflowTask for DeployStaticJob {
 
         self.log(&context, format!("📍 Deployed to: {}", result.storage_path))
             .await?;
-
-        // Clean up temporary directory
-        if let Err(e) = tokio::fs::remove_dir_all(&temp_dir).await {
-            self.log(
-                &context,
-                format!("⚠️  Warning: Failed to clean up temp directory: {}", e),
-            )
-            .await?;
-        }
 
         // Set outputs
         context.set_output(&self.job_id, "static_dir_location", &result.storage_path)?;
@@ -327,6 +325,7 @@ mod tests {
     // Mock ImageBuilder for tests
     struct MockImageBuilder {
         extract_dir: PathBuf,
+        extracted_destination: Option<Arc<std::sync::Mutex<Option<PathBuf>>>>,
     }
 
     #[async_trait]
@@ -352,6 +351,14 @@ mod tests {
             _source_path: &str,
             destination_path: &std::path::Path,
         ) -> Result<(), BuilderError> {
+            if let Some(extracted_destination) = &self.extracted_destination {
+                *extracted_destination.lock().map_err(|error| {
+                    BuilderError::Other(format!(
+                        "Failed to record mock extraction destination: {error}"
+                    ))
+                })? = Some(destination_path.to_path_buf());
+            }
+
             // Copy files from extract_dir to destination_path to simulate extraction
             std::fs::create_dir_all(destination_path)
                 .map_err(|e| BuilderError::Other(format!("Failed to create destination: {}", e)))?;
@@ -446,6 +453,7 @@ mod tests {
         let deployer = Arc::new(FilesystemStaticDeployer::new(base_dir.clone()));
         let image_builder = Arc::new(MockImageBuilder {
             extract_dir: built_files_dir,
+            extracted_destination: None,
         });
 
         let job = DeployStaticJob::new(
@@ -520,6 +528,7 @@ mod tests {
         let deployer = Arc::new(FilesystemStaticDeployer::new(base_dir));
         let image_builder = Arc::new(MockImageBuilder {
             extract_dir: temp_dir.path().to_path_buf(),
+            extracted_destination: None,
         });
 
         let job = DeployStaticJob::new(
@@ -556,6 +565,51 @@ mod tests {
             error_msg.contains("static_output_dir"),
             "Expected error about static_output_dir, got: {}",
             error_msg
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_sensitive_static_deploy_cleans_temporary_extraction() {
+        let temp_dir = TempDir::new().unwrap();
+        let base_dir = temp_dir.path().join("static");
+        let built_files_dir = temp_dir.path().join("built_files");
+        std_fs::create_dir_all(&built_files_dir).unwrap();
+        std_fs::write(built_files_dir.join("index.html"), b"ordinary").unwrap();
+        std_fs::write(built_files_dir.join("app.js.map"), b"private source map").unwrap();
+
+        let extracted_destination = Arc::new(std::sync::Mutex::new(None));
+        let deployer = Arc::new(FilesystemStaticDeployer::new(base_dir));
+        let image_builder = Arc::new(MockImageBuilder {
+            extract_dir: built_files_dir,
+            extracted_destination: Some(extracted_destination.clone()),
+        });
+        let job = DeployStaticJob::new(
+            "deploy_static".to_string(),
+            "build_image".to_string(),
+            "/app/dist".to_string(),
+            "my-project".to_string(),
+            "production".to_string(),
+            "deploy-sensitive".to_string(),
+            deployer,
+            image_builder,
+        );
+        let mut context = crate::test_utils::create_test_context("test".to_string(), 1, 1, 1);
+        context
+            .set_output("build_image", "image_tag", "myapp:latest")
+            .unwrap();
+
+        let result = job.execute(context).await;
+
+        assert!(result.is_err(), "source maps must not be published");
+        let extraction_path = extracted_destination
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("mock extraction destination was recorded");
+        assert!(
+            !extraction_path.exists(),
+            "failed deployment leaked temporary extraction directory {}",
+            extraction_path.display()
         );
     }
 }

--- a/crates/temps-deployments/src/jobs/persist_static_assets.rs
+++ b/crates/temps-deployments/src/jobs/persist_static_assets.rs
@@ -7,15 +7,17 @@
 //! The proxy looks up assets by URL path in the file store — no database table needed.
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use sea_orm::{ActiveModelTrait, Set};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use temps_core::static_files::{MAX_PUBLIC_STATIC_ASSET_BYTES, MAX_STATIC_PATH_COMPONENTS};
 use temps_core::{JobResult, WorkflowContext, WorkflowError, WorkflowTask};
 use temps_database::DbConnection;
 use temps_deployer::ImageBuilder;
 use temps_entities::static_asset_cache;
-use temps_file_store::FileStore;
+use temps_file_store::{FileStore, FileStoreError};
 use temps_logs::{LogLevel, LogService};
 use tracing::{debug, info, warn};
 
@@ -73,7 +75,79 @@ const STATIC_ASSET_EXTENSIONS: &[&str] = &[
     "ico", "json", "txt", "xml",
 ];
 
+#[derive(Debug, thiserror::Error)]
+enum PersistStaticAssetError {
+    #[error("Failed to inspect static asset '{path}': {source}")]
+    Metadata {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Failed to read static asset '{path}': {source}")]
+    Read {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Failed to store static asset '{path}' in CAS: {source}")]
+    Store {
+        path: String,
+        #[source]
+        source: FileStoreError,
+    },
+}
+
+struct PersistedStaticAsset {
+    content_hash: Option<String>,
+    size_bytes: u64,
+}
+
 impl PersistStaticAssetsJob {
+    async fn persist_asset_blob(
+        file_store: Option<&dyn FileStore>,
+        asset_path: &Path,
+    ) -> Result<Option<PersistedStaticAsset>, PersistStaticAssetError> {
+        let metadata = tokio::fs::metadata(asset_path).await.map_err(|source| {
+            PersistStaticAssetError::Metadata {
+                path: asset_path.display().to_string(),
+                source,
+            }
+        })?;
+        if !metadata.is_file() || metadata.len() > MAX_PUBLIC_STATIC_ASSET_BYTES {
+            return Ok(None);
+        }
+
+        let file_bytes =
+            tokio::fs::read(asset_path)
+                .await
+                .map_err(|source| PersistStaticAssetError::Read {
+                    path: asset_path.display().to_string(),
+                    source,
+                })?;
+        let size_bytes = file_bytes.len() as u64;
+        if size_bytes != metadata.len() || size_bytes > MAX_PUBLIC_STATIC_ASSET_BYTES {
+            return Ok(None);
+        }
+
+        let content_hash = if let Some(file_store) = file_store {
+            Some(
+                file_store
+                    .put_blob(Bytes::from(file_bytes))
+                    .await
+                    .map_err(|source| PersistStaticAssetError::Store {
+                        path: asset_path.display().to_string(),
+                        source,
+                    })?,
+            )
+        } else {
+            None
+        };
+        Ok(Some(PersistedStaticAsset {
+            content_hash,
+            size_bytes,
+        }))
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         job_id: String,
@@ -162,11 +236,14 @@ impl PersistStaticAssetsJob {
     /// Recursively find all static asset files in a directory, excluding .map files.
     fn find_static_assets(dir: &Path) -> Vec<PathBuf> {
         let mut assets = Vec::new();
-        Self::walk_dir_for_assets(dir, &mut assets);
+        Self::walk_dir_for_assets(dir, 0, &mut assets);
         assets
     }
 
-    fn walk_dir_for_assets(dir: &Path, assets: &mut Vec<PathBuf>) {
+    fn walk_dir_for_assets(dir: &Path, depth: usize, assets: &mut Vec<PathBuf>) {
+        if depth >= MAX_STATIC_PATH_COMPONENTS {
+            return;
+        }
         let entries = match std::fs::read_dir(dir) {
             Ok(e) => e,
             Err(_) => return,
@@ -174,9 +251,15 @@ impl PersistStaticAssetsJob {
 
         for entry in entries.flatten() {
             let path = entry.path();
-            if path.is_dir() {
-                Self::walk_dir_for_assets(&path, assets);
-            } else if Self::is_static_asset(&path) {
+            let Ok(metadata) = std::fs::symlink_metadata(&path) else {
+                continue;
+            };
+            if metadata.file_type().is_symlink() {
+                continue;
+            }
+            if metadata.is_dir() {
+                Self::walk_dir_for_assets(&path, depth + 1, assets);
+            } else if metadata.is_file() && Self::is_static_asset(&path) {
                 // Exclude source map files — handled by CaptureSourceMapsJob
                 if path.extension().and_then(|e| e.to_str()) != Some("map") {
                     assets.push(path);
@@ -300,16 +383,26 @@ impl WorkflowTask for PersistStaticAssetsJob {
                 )
             };
 
-            // Create temporary directory for extraction
-            let temp_dir =
-                std::env::temp_dir().join(format!("temps-persist-assets-{}", uuid::Uuid::new_v4()));
+            // Acquire first so reverse drop order removes the extracted
+            // directory before releasing capacity to another extraction.
+            let _extraction_permit = super::acquire_archive_extraction_permit().await?;
 
-            if let Err(e) = tokio::fs::create_dir_all(&temp_dir).await {
-                warn!("Failed to create temp directory: {}", e);
-                self.log(format!("⚠️ Failed to create temp directory: {}", e))
+            // RAII ownership guarantees cleanup on every continue/return path;
+            // tempfile creates owner-only directories on Unix.
+            let temp_dir = match tempfile::Builder::new()
+                .prefix("temps-persist-assets-")
+                .tempdir()
+            {
+                Ok(temp_dir) => temp_dir,
+                Err(error) => {
+                    warn!("Failed to create secure temp directory: {}", error);
+                    self.log(format!(
+                        "⚠️ Failed to create secure temp directory: {error}"
+                    ))
                     .await?;
-                continue;
-            }
+                    continue;
+                }
+            };
 
             // Extract files from the container image
             self.log(format!(
@@ -318,16 +411,16 @@ impl WorkflowTask for PersistStaticAssetsJob {
             ))
             .await?;
 
-            match self
+            let extraction_result = self
                 .image_builder
-                .extract_from_image(image_tag, &absolute_search_path, &temp_dir)
-                .await
-            {
+                .extract_from_image(image_tag, &absolute_search_path, temp_dir.path())
+                .await;
+            match extraction_result {
                 Ok(()) => {
                     debug!(
                         "Extracted files from {} to {}",
                         absolute_search_path,
-                        temp_dir.display()
+                        temp_dir.path().display()
                     );
                 }
                 Err(e) => {
@@ -340,13 +433,12 @@ impl WorkflowTask for PersistStaticAssetsJob {
                         absolute_search_path, e
                     ))
                     .await?;
-                    let _ = tokio::fs::remove_dir_all(&temp_dir).await;
                     continue;
                 }
             }
 
             // Find all static asset files (excluding .map files)
-            let asset_files = Self::find_static_assets(&temp_dir);
+            let asset_files = Self::find_static_assets(temp_dir.path());
 
             if asset_files.is_empty() {
                 self.log(format!(
@@ -354,7 +446,6 @@ impl WorkflowTask for PersistStaticAssetsJob {
                     absolute_search_path
                 ))
                 .await?;
-                let _ = tokio::fs::remove_dir_all(&temp_dir).await;
                 continue;
             }
 
@@ -367,7 +458,9 @@ impl WorkflowTask for PersistStaticAssetsJob {
 
             // Persist each asset: store blob in CAS + insert DB row for URL→hash mapping
             for asset_path in &asset_files {
-                let relative_path = asset_path.strip_prefix(&temp_dir).unwrap_or(asset_path);
+                let relative_path = asset_path
+                    .strip_prefix(temp_dir.path())
+                    .unwrap_or(asset_path);
 
                 let container_relative = format!(
                     "{}/{}",
@@ -376,40 +469,36 @@ impl WorkflowTask for PersistStaticAssetsJob {
                 );
                 let url_path = self.apply_rewrites(&container_relative);
 
-                let file_bytes = match tokio::fs::read(asset_path).await {
-                    Ok(b) => b,
-                    Err(e) => {
-                        warn!("Failed to read asset {}: {}", asset_path.display(), e);
+                let persisted = match Self::persist_asset_blob(
+                    self.file_store.as_deref(),
+                    asset_path,
+                )
+                .await
+                {
+                    Ok(Some(persisted)) => persisted,
+                    Ok(None) => {
+                        warn!(
+                            asset_path = %asset_path.display(),
+                            maximum_size_bytes = MAX_PUBLIC_STATIC_ASSET_BYTES,
+                            "Skipping static asset because it is oversized, not a file, or changed while reading"
+                        );
+                        continue;
+                    }
+                    Err(error) => {
+                        warn!(asset_path = %asset_path.display(), reason = %error, "Failed to persist static asset");
                         continue;
                     }
                 };
-                let file_size = file_bytes.len() as u64;
-
-                // Store blob in CAS (deduplicated by content hash)
-                let content_hash = if let Some(file_store) = &self.file_store {
-                    match file_store
-                        .put_blob(bytes::Bytes::from(file_bytes.clone()))
-                        .await
-                    {
-                        Ok(hash) => Some(hash),
-                        Err(e) => {
-                            warn!("Failed to store blob for {}: {}", url_path, e);
-                            None
-                        }
-                    }
-                } else {
-                    None
-                };
 
                 // Insert URL→hash mapping in database
-                if let (Some(hash), Some(db)) = (&content_hash, &self.db) {
+                if let (Some(hash), Some(db)) = (&persisted.content_hash, &self.db) {
                     let record = static_asset_cache::ActiveModel {
                         url_path: Set(url_path.clone()),
                         content_hash: Set(hash.clone()),
                         project_id: Set(self.project_id),
                         environment_id: Set(self.environment_id),
                         deployment_id: Set(self.deployment_id),
-                        size_bytes: Set(file_size as i64),
+                        size_bytes: Set(persisted.size_bytes as i64),
                         created_at: Set(chrono::Utc::now()),
                         ..Default::default()
                     };
@@ -422,12 +511,7 @@ impl WorkflowTask for PersistStaticAssetsJob {
                 }
 
                 total_assets += 1;
-                total_size += file_size;
-            }
-
-            // Clean up temp directory
-            if let Err(e) = tokio::fs::remove_dir_all(&temp_dir).await {
-                warn!("Failed to clean up temp directory: {}", e);
+                total_size += persisted.size_bytes;
             }
         }
 
@@ -475,6 +559,23 @@ impl WorkflowTask for PersistStaticAssetsJob {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use temps_file_store::OpenedBlob;
+
+    #[test]
+    fn extracted_static_asset_temp_directory_is_removed_on_scope_exit() {
+        let extraction_path;
+        {
+            let temp_dir = tempfile::Builder::new()
+                .prefix("temps-persist-assets-test-")
+                .tempdir()
+                .expect("create extraction directory");
+            extraction_path = temp_dir.path().to_path_buf();
+            std::fs::write(temp_dir.path().join("app.js"), b"temporary asset")
+                .expect("write temporary asset");
+        }
+        assert!(!extraction_path.exists());
+    }
 
     #[test]
     fn test_detect_log_level() {
@@ -770,6 +871,103 @@ mod tests {
         assert!(assets.iter().any(|p| p.ends_with("style.css")));
 
         let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn static_asset_walk_stops_at_shared_path_depth_limit() {
+        let temp_dir = tempfile::TempDir::new().expect("temporary extraction root");
+        let mut maximum_parent = temp_dir.path().to_path_buf();
+        for index in 0..(MAX_STATIC_PATH_COMPONENTS - 1) {
+            maximum_parent.push(format!("d{index}"));
+        }
+        std::fs::create_dir_all(&maximum_parent).expect("create maximum-depth directory");
+        let accepted = maximum_parent.join("accepted.js");
+        std::fs::write(&accepted, "accepted").expect("write maximum-depth asset");
+
+        let too_deep_parent = maximum_parent.join("too-deep");
+        std::fs::create_dir(&too_deep_parent).expect("create over-depth directory");
+        let rejected = too_deep_parent.join("rejected.js");
+        std::fs::write(&rejected, "rejected").expect("write over-depth asset");
+
+        let assets = PersistStaticAssetsJob::find_static_assets(temp_dir.path());
+
+        assert!(assets.contains(&accepted));
+        assert!(!assets.contains(&rejected));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn static_asset_walk_does_not_follow_directory_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = tempfile::TempDir::new().expect("temporary extraction root");
+        let outside = tempfile::TempDir::new().expect("outside directory");
+        std::fs::write(outside.path().join("private.js"), "private").expect("write outside asset");
+        symlink(outside.path(), temp_dir.path().join("linked")).expect("create directory symlink");
+
+        let assets = PersistStaticAssetsJob::find_static_assets(temp_dir.path());
+
+        assert!(assets.is_empty());
+    }
+
+    struct CountingFileStore {
+        put_blob_calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl FileStore for CountingFileStore {
+        async fn put_blob(&self, _data: Bytes) -> Result<String, FileStoreError> {
+            self.put_blob_calls.fetch_add(1, Ordering::Relaxed);
+            Ok("a".repeat(64))
+        }
+
+        async fn get_blob(&self, _hash: &str) -> Result<Bytes, FileStoreError> {
+            Err(FileStoreError::Backend("unused test operation".to_string()))
+        }
+
+        async fn open_blob(&self, _hash: &str) -> Result<OpenedBlob, FileStoreError> {
+            Err(FileStoreError::Backend("unused test operation".to_string()))
+        }
+
+        async fn blob_exists(&self, _hash: &str) -> Result<bool, FileStoreError> {
+            Err(FileStoreError::Backend("unused test operation".to_string()))
+        }
+
+        async fn delete_blob(&self, _hash: &str) -> Result<bool, FileStoreError> {
+            Err(FileStoreError::Backend("unused test operation".to_string()))
+        }
+
+        async fn put(&self, _path: &str, _data: Bytes) -> Result<u64, FileStoreError> {
+            Err(FileStoreError::Backend("unused test operation".to_string()))
+        }
+
+        async fn get(&self, _path: &str) -> Result<Bytes, FileStoreError> {
+            Err(FileStoreError::Backend("unused test operation".to_string()))
+        }
+
+        async fn exists(&self, _path: &str) -> Result<bool, FileStoreError> {
+            Err(FileStoreError::Backend("unused test operation".to_string()))
+        }
+    }
+
+    #[tokio::test]
+    async fn oversized_asset_is_rejected_before_put_blob() {
+        let temporary = tempfile::tempdir().expect("temporary asset directory");
+        let oversized = temporary.path().join("oversized.js");
+        let file = std::fs::File::create(&oversized).expect("create sparse oversized asset");
+        file.set_len(MAX_PUBLIC_STATIC_ASSET_BYTES + 1)
+            .expect("size sparse oversized asset");
+        drop(file);
+        let store = CountingFileStore {
+            put_blob_calls: AtomicUsize::new(0),
+        };
+
+        let result = PersistStaticAssetsJob::persist_asset_blob(Some(&store), &oversized)
+            .await
+            .expect("oversized assets are skipped without IO errors");
+
+        assert!(result.is_none());
+        assert_eq!(store.put_blob_calls.load(Ordering::Relaxed), 0);
     }
 
     // Minimal mock for tests that don't need real image extraction

--- a/crates/temps-deployments/src/services/docker_cleanup_service.rs
+++ b/crates/temps-deployments/src/services/docker_cleanup_service.rs
@@ -1090,7 +1090,8 @@ impl DockerCleanupService {
                     }
                     Ok(false) => {} // Already gone
                     Err(e) => {
-                        warn!("Failed to delete orphaned blob {}: {}", &hash[..8], e);
+                        let hash_prefix: String = hash.chars().take(8).collect();
+                        warn!("Failed to delete orphaned blob {}: {}", hash_prefix, e);
                     }
                 }
             }

--- a/crates/temps-error-tracking/src/handlers/sentry_compat_handlers.rs
+++ b/crates/temps-error-tracking/src/handlers/sentry_compat_handlers.rs
@@ -123,14 +123,15 @@ pub struct SentryChunkUploadResponse {
 /// rely on authentication alone to prevent abuse. The outer body limit rejects
 /// oversized uploads before they reach the multipart reader. A per-field inline
 /// check (`MAX_SOURCE_MAP_BYTES`) provides additional defense-in-depth.
-pub const SENTRY_UPLOAD_BODY_LIMIT: usize = 50 * 1024 * 1024;
+pub const SENTRY_UPLOAD_BODY_LIMIT: usize =
+    crate::services::source_map_service::MAX_SOURCE_MAP_BYTES;
 
 /// Maximum size for a single source map file field (50 MiB).
 ///
 /// Applied after the compressed body has been received. This is a second line
 /// of defense: the outer `DefaultBodyLimit` cap fires first, but if multiple
 /// small files add up the per-field check catches any single oversized field.
-const MAX_SOURCE_MAP_BYTES: usize = 50 * 1024 * 1024;
+use crate::services::source_map_service::MAX_SOURCE_MAP_BYTES;
 
 pub fn configure_sentry_compat_routes() -> Router<Arc<SentryCompatAppState>> {
     // Fix #4: the upload route gets its own sub-router with a 50 MiB body limit.

--- a/crates/temps-error-tracking/src/handlers/source_map_handlers.rs
+++ b/crates/temps-error-tracking/src/handlers/source_map_handlers.rs
@@ -18,7 +18,7 @@ use utoipa::{OpenApi, ToSchema};
 use crate::handlers::audit::{AuditContext, SourceFileUploadedAudit, SourceFilesDeletedAudit};
 
 use crate::services::source_map_service::{
-    SourceFileInfo, SourceMapError, SourceMapInfo, SourceMapService,
+    SourceFileInfo, SourceMapError, SourceMapInfo, SourceMapService, MAX_SOURCE_MAP_BYTES,
 };
 
 #[derive(OpenApi)]
@@ -59,7 +59,6 @@ pub fn configure_source_map_routes() -> Router<Arc<SourceMapAppState>> {
     // Body-size caps that fire at the transport layer, before the multipart
     // extractor buffers the request into memory. The per-field checks in the
     // handlers are defense-in-depth on top of these.
-    const SOURCE_MAP_UPLOAD_LIMIT: usize = 50 * 1024 * 1024;
     const SOURCE_FILE_UPLOAD_LIMIT: usize = 10 * 1024 * 1024;
 
     Router::new()
@@ -68,7 +67,7 @@ pub fn configure_source_map_routes() -> Router<Arc<SourceMapAppState>> {
             post(upload_source_map)
                 .get(list_source_maps)
                 .delete(delete_release_source_maps)
-                .layer(DefaultBodyLimit::max(SOURCE_MAP_UPLOAD_LIMIT)),
+                .layer(DefaultBodyLimit::max(MAX_SOURCE_MAP_BYTES)),
         )
         .route(
             "/projects/{project_id}/source-map-releases",
@@ -149,6 +148,11 @@ impl From<SourceMapError> for Problem {
             SourceMapError::Validation(msg) => problemdetails::new(StatusCode::BAD_REQUEST)
                 .with_title("Validation Error")
                 .with_detail(msg),
+            too_large @ SourceMapError::TooLarge { .. } => {
+                problemdetails::new(StatusCode::PAYLOAD_TOO_LARGE)
+                    .with_title("Source Map Too Large")
+                    .with_detail(too_large.to_string())
+            }
             SourceMapError::Database(e) => {
                 error!("Source map database error: {}", e);
                 problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
@@ -195,9 +199,6 @@ async fn upload_source_map(
     permission_guard!(auth, ErrorTrackingCreate);
     project_access_guard!(auth, project_id, state.project_access_checker);
 
-    // Maximum source map size: 50MB
-    const MAX_SOURCE_MAP_SIZE: usize = 50 * 1024 * 1024;
-
     let mut file_data: Option<Vec<u8>> = None;
     let mut file_path: Option<String> = None;
     let mut dist: Option<String> = None;
@@ -226,13 +227,13 @@ async fn upload_source_map(
                         .with_detail(e.to_string())
                 })?;
 
-                if data.len() > MAX_SOURCE_MAP_SIZE {
+                if data.len() > MAX_SOURCE_MAP_BYTES {
                     return Err(problemdetails::new(StatusCode::PAYLOAD_TOO_LARGE)
                         .with_title("Source Map Too Large")
                         .with_detail(format!(
                             "Source map size {} bytes exceeds maximum of {} bytes",
                             data.len(),
-                            MAX_SOURCE_MAP_SIZE
+                            MAX_SOURCE_MAP_BYTES
                         )));
                 }
 

--- a/crates/temps-error-tracking/src/services.rs
+++ b/crates/temps-error-tracking/src/services.rs
@@ -11,5 +11,5 @@ pub use error_analytics_service::{ErrorAnalyticsService, ErrorDashboardStats};
 pub use error_crud_service::ErrorCRUDService;
 pub use error_ingestion_service::ErrorIngestionService;
 pub use error_tracking_service::ErrorTrackingService;
-pub use source_map_service::SourceMapService;
+pub use source_map_service::{SourceMapService, MAX_SOURCE_MAP_BYTES};
 pub use types::*;

--- a/crates/temps-error-tracking/src/services/source_map_service.rs
+++ b/crates/temps-error-tracking/src/services/source_map_service.rs
@@ -11,6 +11,28 @@ use tracing::{debug, warn};
 
 use super::types::CreateErrorEventData;
 
+/// Maximum accepted size for one source map across HTTP uploads, deployment
+/// capture, parsing, and persistence.
+pub const MAX_SOURCE_MAP_BYTES: usize = 50 * 1024 * 1024;
+
+fn validate_source_map_size(
+    project_id: i32,
+    release: &str,
+    file_path: &str,
+    size_bytes: usize,
+) -> Result<(), SourceMapError> {
+    if size_bytes > MAX_SOURCE_MAP_BYTES {
+        return Err(SourceMapError::TooLarge {
+            project_id,
+            release: release.to_string(),
+            file_path: file_path.to_string(),
+            size_bytes,
+            limit_bytes: MAX_SOURCE_MAP_BYTES,
+        });
+    }
+    Ok(())
+}
+
 #[derive(Error, Debug)]
 pub enum SourceMapError {
     #[error("Database error: {0}")]
@@ -24,6 +46,17 @@ pub enum SourceMapError {
 
     #[error("Validation error: {0}")]
     Validation(String),
+
+    #[error(
+        "Source map for project {project_id}, release '{release}', file '{file_path}' is {size_bytes} bytes, exceeding the {limit_bytes} byte limit"
+    )]
+    TooLarge {
+        project_id: i32,
+        release: String,
+        file_path: String,
+        size_bytes: usize,
+        limit_bytes: usize,
+    },
 }
 
 /// Response type for listing source maps (without the binary data)
@@ -115,6 +148,7 @@ impl SourceMapService {
                 "Source map data cannot be empty".to_string(),
             ));
         }
+        validate_source_map_size(project_id, release, file_path, source_map_data.len())?;
 
         // Validate that the data is a valid source map
         sourcemap::SourceMap::from_slice(&source_map_data)
@@ -1414,6 +1448,23 @@ mod tests {
     use std::sync::Arc;
     use temps_database::test_utils::TestDatabase;
     use temps_entities::projects;
+
+    #[test]
+    fn source_map_size_limit_accepts_boundary_and_rejects_next_byte() {
+        assert!(validate_source_map_size(7, "v1", "~/app.js", MAX_SOURCE_MAP_BYTES).is_ok());
+
+        let error = validate_source_map_size(7, "v1", "~/app.js", MAX_SOURCE_MAP_BYTES + 1)
+            .expect_err("one byte over the limit must be rejected before parsing or storage");
+        assert!(matches!(
+            error,
+            SourceMapError::TooLarge {
+                project_id: 7,
+                size_bytes,
+                limit_bytes: MAX_SOURCE_MAP_BYTES,
+                ..
+            } if size_bytes == MAX_SOURCE_MAP_BYTES + 1
+        ));
+    }
 
     #[test]
     fn build_native_resolved_slices_context_around_line() {

--- a/crates/temps-file-store/src/fs_store.rs
+++ b/crates/temps-file-store/src/fs_store.rs
@@ -15,7 +15,7 @@ use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use tracing::debug;
 
-use crate::{FileStore, FileStoreError};
+use crate::{FileStore, FileStoreError, OpenedBlob};
 
 pub struct FsFileStore {
     root: PathBuf,
@@ -38,11 +38,14 @@ impl FsFileStore {
     }
 
     /// Git-style double-prefix sharding: `blobs/{hash[0..2]}/{hash[2..4]}/{hash}`
-    fn blob_path(&self, hash: &str) -> PathBuf {
-        let h = hash.trim();
-        let p1 = &h[..2.min(h.len())];
-        let p2 = if h.len() >= 4 { &h[2..4] } else { "00" };
-        self.root.join("blobs").join(p1).join(p2).join(h)
+    fn blob_path(&self, hash: &str) -> Result<PathBuf, FileStoreError> {
+        validate_content_hash(hash)?;
+        Ok(self
+            .root
+            .join("blobs")
+            .join(&hash[..2])
+            .join(&hash[2..4])
+            .join(hash))
     }
 
     /// Path-based cache: `cache/{sanitized_path}` (for edge caching, not CAS)
@@ -105,20 +108,28 @@ impl FsFileStore {
 impl FileStore for FsFileStore {
     async fn put_blob(&self, data: Bytes) -> Result<String, FileStoreError> {
         let hash = Self::content_hash(&data);
-        let blob = self.blob_path(&hash);
+        let blob = self.blob_path(&hash)?;
 
         if !blob.exists() {
             self.atomic_write(&blob, &data).await?;
-            debug!("CAS: stored blob {} ({} bytes)", &hash[..8], data.len());
+            debug!(
+                "CAS: stored blob {} ({} bytes)",
+                hash.get(..8).unwrap_or(hash.as_str()),
+                data.len()
+            );
         } else {
-            debug!("CAS: dedup hit {} ({} bytes saved)", &hash[..8], data.len());
+            debug!(
+                "CAS: dedup hit {} ({} bytes saved)",
+                hash.get(..8).unwrap_or(hash.as_str()),
+                data.len()
+            );
         }
 
         Ok(hash)
     }
 
     async fn get_blob(&self, hash: &str) -> Result<Bytes, FileStoreError> {
-        let blob = self.blob_path(hash);
+        let blob = self.blob_path(hash)?;
         let data = tokio::fs::read(&blob).await.map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
                 FileStoreError::NotFound {
@@ -134,12 +145,48 @@ impl FileStore for FsFileStore {
         Ok(Bytes::from(data))
     }
 
+    async fn open_blob(&self, hash: &str) -> Result<OpenedBlob, FileStoreError> {
+        let blob = self.blob_path(hash)?;
+        let file = tokio::fs::File::open(&blob).await.map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                FileStoreError::NotFound {
+                    path: hash.to_string(),
+                }
+            } else {
+                FileStoreError::Io {
+                    path: hash.to_string(),
+                    reason: format!("open blob: {error}"),
+                }
+            }
+        })?;
+        let metadata = file.metadata().await.map_err(|error| FileStoreError::Io {
+            path: hash.to_string(),
+            reason: format!("read opened blob metadata: {error}"),
+        })?;
+        if !metadata.is_file() {
+            return Err(FileStoreError::Io {
+                path: hash.to_string(),
+                reason: "opened blob is not a regular file".to_string(),
+            });
+        }
+        Ok(OpenedBlob {
+            reader: Box::new(file),
+            size_bytes: metadata.len(),
+        })
+    }
+
     async fn blob_exists(&self, hash: &str) -> Result<bool, FileStoreError> {
-        Ok(self.blob_path(hash).exists())
+        let blob = self.blob_path(hash)?;
+        tokio::fs::try_exists(&blob)
+            .await
+            .map_err(|error| FileStoreError::Io {
+                path: hash.to_string(),
+                reason: format!("check blob existence: {error}"),
+            })
     }
 
     async fn delete_blob(&self, hash: &str) -> Result<bool, FileStoreError> {
-        let blob = self.blob_path(hash);
+        let blob = self.blob_path(hash)?;
         match tokio::fs::remove_file(&blob).await {
             Ok(()) => Ok(true),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
@@ -181,9 +228,17 @@ impl FileStore for FsFileStore {
     }
 }
 
+fn validate_content_hash(hash: &str) -> Result<(), FileStoreError> {
+    if hash.len() == 64 && hash.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Ok(());
+    }
+    Err(FileStoreError::InvalidHash { length: hash.len() })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::AsyncReadExt;
 
     fn temp_store() -> (tempfile::TempDir, FsFileStore) {
         let dir = tempfile::tempdir().unwrap();
@@ -201,6 +256,12 @@ mod tests {
 
         let retrieved = store.get_blob(&hash).await.unwrap();
         assert_eq!(retrieved, data);
+
+        let mut opened = store.open_blob(&hash).await.unwrap();
+        assert_eq!(opened.size_bytes, data.len() as u64);
+        let mut streamed = Vec::new();
+        opened.reader.read_to_end(&mut streamed).await.unwrap();
+        assert_eq!(streamed, data);
     }
 
     #[tokio::test]
@@ -219,7 +280,7 @@ mod tests {
         let hash = store.put_blob(Bytes::from("test")).await.unwrap();
 
         assert!(store.blob_exists(&hash).await.unwrap());
-        assert!(!store.blob_exists("nonexistent").await.unwrap());
+        assert!(!store.blob_exists(&"0".repeat(64)).await.unwrap());
     }
 
     #[tokio::test]
@@ -235,8 +296,49 @@ mod tests {
     #[tokio::test]
     async fn test_get_not_found() {
         let (_dir, store) = temp_store();
-        let result = store.get_blob("nonexistent").await;
+        let result = store.get_blob(&"0".repeat(64)).await;
         assert!(matches!(result, Err(FileStoreError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn invalid_hashes_are_rejected_by_every_cas_blob_operation() {
+        let (_dir, store) = temp_store();
+        let invalid_hashes = [
+            "/absolute/path".to_string(),
+            format!("../{}", "a".repeat(61)),
+            "abcd".to_string(),
+            "z".repeat(64),
+            "secret".repeat(10_000),
+        ];
+
+        for hash in invalid_hashes {
+            assert!(matches!(
+                store.get_blob(&hash).await,
+                Err(FileStoreError::InvalidHash { .. })
+            ));
+            assert!(matches!(
+                store.open_blob(&hash).await,
+                Err(FileStoreError::InvalidHash { .. })
+            ));
+            assert!(matches!(
+                store.blob_exists(&hash).await,
+                Err(FileStoreError::InvalidHash { .. })
+            ));
+            assert!(matches!(
+                store.delete_blob(&hash).await,
+                Err(FileStoreError::InvalidHash { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn invalid_hash_errors_do_not_echo_untrusted_values() {
+        let untrusted = "private-value".repeat(1_000);
+        let error = validate_content_hash(&untrusted).expect_err("hash must be rejected");
+        let rendered = error.to_string();
+
+        assert!(rendered.contains(&untrusted.len().to_string()));
+        assert!(!rendered.contains("private-value"));
     }
 
     #[tokio::test]
@@ -245,7 +347,7 @@ mod tests {
         let hash = store.put_blob(Bytes::from("shard test")).await.unwrap();
 
         // Verify blob is at blobs/{hash[0..2]}/{hash[2..4]}/{hash}
-        let blob = store.blob_path(&hash);
+        let blob = store.blob_path(&hash).unwrap();
         let components: Vec<_> = blob.components().collect();
         let len = components.len();
         // .../{p1}/{p2}/{hash}

--- a/crates/temps-file-store/src/lib.rs
+++ b/crates/temps-file-store/src/lib.rs
@@ -11,9 +11,15 @@ pub mod fs_store;
 use async_trait::async_trait;
 use bytes::Bytes;
 use thiserror::Error;
+use tokio::io::AsyncRead;
 
 #[derive(Error, Debug)]
 pub enum FileStoreError {
+    #[error(
+        "Invalid CAS content hash ({length} bytes): expected exactly 64 ASCII hexadecimal characters"
+    )]
+    InvalidHash { length: usize },
+
     #[error("File not found: {path}")]
     NotFound { path: String },
 
@@ -22,6 +28,12 @@ pub enum FileStoreError {
 
     #[error("Backend error: {0}")]
     Backend(String),
+}
+
+/// An opened CAS blob whose body can be consumed with bounded async reads.
+pub struct OpenedBlob {
+    pub reader: Box<dyn AsyncRead + Send + Unpin>,
+    pub size_bytes: u64,
 }
 
 /// Content-addressable blob store.
@@ -35,6 +47,10 @@ pub trait FileStore: Send + Sync {
 
     /// Retrieve a blob by its content hash.
     async fn get_blob(&self, hash: &str) -> Result<Bytes, FileStoreError>;
+
+    /// Open a blob without buffering its body and return metadata from the
+    /// opened file/stream itself.
+    async fn open_blob(&self, hash: &str) -> Result<OpenedBlob, FileStoreError>;
 
     /// Check if a blob exists.
     async fn blob_exists(&self, hash: &str) -> Result<bool, FileStoreError>;

--- a/crates/temps-proxy/Cargo.toml
+++ b/crates/temps-proxy/Cargo.toml
@@ -28,7 +28,6 @@ bytes = { workspace = true }
 cookie = { workspace = true }
 sea-orm = { workspace = true }
 sea-orm-migration = { workspace = true }
-flate2 = { workspace = true }
 tracing = { workspace = true }
 memchr = "2.7"
 htmd = "0.5"

--- a/crates/temps-proxy/src/lib.rs
+++ b/crates/temps-proxy/src/lib.rs
@@ -25,6 +25,7 @@ pub mod redaction;
 pub mod server;
 pub mod service;
 pub mod services;
+mod static_file_serving;
 pub mod storage;
 pub mod tls_cert_loader;
 pub mod tls_fingerprint;

--- a/crates/temps-proxy/src/proxy.rs
+++ b/crates/temps-proxy/src/proxy.rs
@@ -39,14 +39,17 @@ use crate::service::proxy_log_batch_writer::{
     ProxyLogBatchHandle, TrackingBatchHandle, TrackingEvent,
 };
 use crate::service::proxy_log_service::CreateProxyLogRequest;
+use crate::static_file_serving::{
+    bounded_cas_etag, bounded_log_value, cap_static_chunk, if_none_match_matches, metadata_etag,
+    open_static_file, opened_cas_size_matches, read_static_chunk, static_not_found_contract,
+    unavailable_outcome, StaticFileServeOutcome, STATIC_NOT_FOUND_BODY,
+};
 use crate::tls_fingerprint;
 use crate::traits::*;
 use async_trait::async_trait;
 use axum::http::header;
 use bytes::Bytes;
 use cookie::Cookie;
-use flate2::write::GzEncoder;
-use flate2::Compression;
 use pingora::http::StatusCode;
 use pingora::Error;
 use pingora_core::{
@@ -57,9 +60,9 @@ use pingora_http::ResponseHeader;
 use pingora_proxy::{FailToProxy, ProxyHttp, Session as PingoraSession};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use std::collections::HashMap;
-use std::io::Write;
 use std::sync::Arc;
 use std::time::Instant;
+use temps_core::static_files::{normalize_static_request_path, MAX_PUBLIC_STATIC_ASSET_BYTES};
 use temps_database::DbConnection;
 use temps_entities::{deployments, domains, environments, projects};
 use tracing::{debug, error, info, warn};
@@ -2060,101 +2063,50 @@ impl LoadBalancer {
         builder.build().to_string()
     }
 
-    /// Serve a static file from the filesystem
-    /// Returns Ok(true) if file was served, Ok(false) if file not found, Err on error
+    /// Serve a static file from the filesystem using fixed-size response chunks.
+    ///
+    /// Filesystem/path failures are deliberately returned as a uniform not-found
+    /// outcome. Only response-protocol and mid-stream IO failures become Pingora
+    /// errors after a response has started.
     async fn serve_static_file(
         &self,
         session: &mut PingoraSession,
         ctx: &mut ProxyContext,
         static_dir: &str,
-    ) -> Result<bool> {
-        use std::path::PathBuf;
-        use tokio::fs;
-
-        let mut requested_path = ctx.path.trim_start_matches('/').to_owned();
-
-        // Handle root path -> index.html
-        if requested_path.is_empty() {
-            requested_path = "index.html".to_owned();
-        }
-
-        // Security: ALWAYS join with base static directory
-        // Never trust absolute paths from database - always enforce that static files
-        // must be within the configured static directory to prevent path traversal
-        let static_dir_path = PathBuf::from(static_dir);
-
-        // Strip leading slash if present (treat all paths as relative)
-        let relative_static_dir = static_dir_path
-            .strip_prefix("/")
-            .unwrap_or(&static_dir_path);
-
-        // Always join with base static directory from config
-        let absolute_static_dir = self.config_service.static_dir().join(relative_static_dir);
-
-        let file_path = absolute_static_dir.join(&requested_path);
-
-        // Security check: ensure the resolved path is still within static_dir
-        let canonical_static_dir = fs::canonicalize(&absolute_static_dir).await.map_err(|e| {
-            Error::because(
-                pingora::ErrorType::FileOpenError,
-                format!("Failed to canonicalize static dir: {}", e),
-                e,
-            )
-        })?;
-
-        // Try to canonicalize the file path, but handle the case where it doesn't exist
-        let canonical_file_path = match fs::canonicalize(&file_path).await {
-            Ok(path) => path,
-            Err(_) => {
-                // File doesn't exist - try with index.html for SPA routing
-                if !requested_path.contains('.') {
-                    // Likely a SPA route, serve index.html
-                    let index_path = absolute_static_dir.join("index.html");
-                    match fs::canonicalize(&index_path).await {
-                        Ok(path) => path,
-                        Err(_) => return Ok(false), // No index.html, file not found
-                    }
-                } else {
-                    return Ok(false); // File not found
-                }
+    ) -> Result<StaticFileServeOutcome> {
+        let mut opened = match open_static_file(
+            &self.config_service.static_dir(),
+            static_dir,
+            &ctx.path,
+        )
+        .await
+        {
+            Ok(opened) => opened,
+            Err(error) => {
+                debug!(
+                    request_path = %bounded_log_value(&ctx.path),
+                    stored_static_dir = %bounded_log_value(static_dir),
+                    failure = error.category(),
+                    "Static file request resolved to the uniform not-found response"
+                );
+                return Ok(unavailable_outcome(&error));
             }
         };
-
-        // Ensure the file is within the static directory (prevent path traversal)
-        if !canonical_file_path.starts_with(&canonical_static_dir) {
-            warn!(
-                "Path traversal attempt detected: {} -> {}",
-                requested_path,
-                canonical_file_path.display()
-            );
-            return Ok(false);
-        }
-
-        // Check if it's a directory -> serve index.html
-        let final_path = if canonical_file_path.is_dir() {
-            canonical_file_path.join("index.html")
-        } else {
-            canonical_file_path
-        };
-
-        // Read the file
-        let file_content = fs::read(&final_path).await.map_err(|e| {
-            Error::because(
-                pingora::ErrorType::FileOpenError,
-                format!("Failed to read file: {}", e),
-                e,
-            )
-        })?;
 
         // Resolve the actual response MIME before creating analytics state.
         // Static SPA fallbacks and extensionless paths otherwise look like
         // pages from the request path alone, including /api-style requests.
-        let content_type = Self::infer_content_type(final_path.to_str().unwrap_or("index.html"));
+        let content_type = opened
+            .canonical_path
+            .to_str()
+            .map(Self::infer_content_type)
+            .unwrap_or("application/octet-stream");
         self.ensure_static_visitor_session(session, ctx, content_type)
             .await;
 
-        // Generate ETag for cache validation
-        let etag = Self::generate_etag(&file_content);
+        // Metadata + immutable deployment identity produce the validator before
+        // body IO. Conditional requests therefore never read the file body.
+        let etag = metadata_etag(&opened.canonical_path, &opened.metadata);
 
         // Check If-None-Match header for 304 Not Modified response
         if let Some(if_none_match) = session
@@ -2163,14 +2115,14 @@ impl LoadBalancer {
             .get("if-none-match")
             .and_then(|v| v.to_str().ok())
         {
-            if if_none_match == etag {
+            if if_none_match_matches(if_none_match, &etag) {
                 debug!("ETag match - returning 304 Not Modified for: {}", ctx.path);
                 let mut resp = ResponseHeader::build(StatusCode::NOT_MODIFIED, None)?;
                 resp.insert_header("ETag", &etag)?;
                 resp.insert_header("X-Request-ID", &ctx.request_id)?;
 
                 // Add cache headers
-                if Self::is_cacheable_static_asset(&requested_path) {
+                if Self::is_cacheable_static_asset(&ctx.path) {
                     resp.insert_header(
                         header::CACHE_CONTROL,
                         "public, max-age=31536000, immutable",
@@ -2188,63 +2140,19 @@ impl LoadBalancer {
 
                 session.write_response_header(Box::new(resp), false).await?;
                 session.write_response_body(None, true).await?;
-                return Ok(true);
+                return Ok(StaticFileServeOutcome::Served);
             }
         }
-
-        // Check if we should compress the content
-        let client_accepts_gzip = Self::accepts_gzip(session);
-        let should_compress =
-            client_accepts_gzip && Self::should_compress_content(content_type, file_content.len());
-
-        // Compress content if appropriate
-        let (final_content, is_compressed) = if should_compress {
-            match Self::compress_gzip(&file_content) {
-                Ok(compressed) => {
-                    // Only use compression if it actually reduces size
-                    if compressed.len() < file_content.len() {
-                        debug!(
-                            "Compressed {} from {} to {} bytes ({:.1}% reduction)",
-                            ctx.path,
-                            file_content.len(),
-                            compressed.len(),
-                            (1.0 - (compressed.len() as f64 / file_content.len() as f64)) * 100.0
-                        );
-                        (compressed, true)
-                    } else {
-                        debug!(
-                            "Skipping compression for {} - compressed size ({}) >= original ({})",
-                            ctx.path,
-                            compressed.len(),
-                            file_content.len()
-                        );
-                        (file_content, false)
-                    }
-                }
-                Err(e) => {
-                    warn!("Failed to compress {}: {:?}", ctx.path, e);
-                    (file_content, false)
-                }
-            }
-        } else {
-            (file_content, false)
-        };
 
         // Build response
         let mut resp = ResponseHeader::build(200, None)?;
         resp.insert_header(header::CONTENT_TYPE, content_type)?;
-        resp.insert_header(header::CONTENT_LENGTH, final_content.len().to_string())?;
+        resp.insert_header(header::CONTENT_LENGTH, opened.metadata.len().to_string())?;
         resp.insert_header("X-Request-ID", &ctx.request_id)?;
         resp.insert_header("ETag", &etag)?;
 
-        // Add compression header if compressed
-        if is_compressed {
-            resp.insert_header("Content-Encoding", "gzip")?;
-            resp.insert_header("Vary", "Accept-Encoding")?;
-        }
-
         // Add cache headers for static assets
-        if Self::is_cacheable_static_asset(&requested_path) {
+        if Self::is_cacheable_static_asset(&ctx.path) {
             resp.insert_header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")?;
         } else {
             resp.insert_header(header::CACHE_CONTROL, "public, max-age=0, must-revalidate")?;
@@ -2253,13 +2161,46 @@ impl LoadBalancer {
         // Set visitor and session tracking cookies for static file responses
         self.set_tracking_cookies(session, &mut resp, ctx).await?;
 
-        // Write response
+        // HEAD has the same metadata as GET and intentionally never reads a body.
         session.write_response_header(Box::new(resp), false).await?;
-        session
-            .write_response_body(Some(Bytes::from(final_content)), true)
-            .await?;
+        if ctx.method == "HEAD" {
+            session.write_response_body(None, true).await?;
+            return Ok(StaticFileServeOutcome::Served);
+        }
 
-        Ok(true)
+        let mut remaining = opened.metadata.len();
+        while remaining > 0 {
+            let mut chunk = read_static_chunk(&mut opened.file).await.map_err(|error| {
+                Error::because(
+                    pingora::ErrorType::FileOpenError,
+                    format!(
+                        "Failed to stream static file '{}' for request '{}'",
+                        opened.canonical_path.display(),
+                        ctx.path
+                    ),
+                    error,
+                )
+            })?;
+            if chunk.is_empty() {
+                return Err(Error::because(
+                    pingora::ErrorType::FileOpenError,
+                    format!(
+                        "Static file '{}' ended before its opened length for request '{}'",
+                        opened.canonical_path.display(),
+                        bounded_log_value(&ctx.path)
+                    ),
+                    std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "static file shrank while streaming",
+                    ),
+                ));
+            }
+            remaining -= cap_static_chunk(&mut chunk, remaining);
+            session.write_response_body(Some(chunk), false).await?;
+        }
+        session.write_response_body(None, true).await?;
+
+        Ok(StaticFileServeOutcome::Served)
     }
 
     /// Serve embedded WASM files for CAPTCHA solver
@@ -2351,6 +2292,12 @@ impl LoadBalancer {
         ctx: &mut ProxyContext,
         url_path: &str,
     ) -> Result<bool> {
+        // Apply the static-file publication policy only to CAS serving. Invalid
+        // container routes still fall through to their upstream unchanged.
+        if normalize_static_request_path(url_path).is_err() {
+            return Ok(false);
+        }
+
         let file_store = match &self.file_store {
             Some(fs) => fs,
             None => return Ok(false),
@@ -2362,46 +2309,70 @@ impl LoadBalancer {
             }
             _ => return Ok(false),
         };
-        let content_hash = match self
+        let asset = match self
             .static_asset_lookup
-            .get_content_hash(scope.0, scope.1, scope.2, url_path)
+            .get_asset_metadata(scope.0, scope.1, scope.2, url_path)
             .await
         {
-            Some(hash) => hash,
+            Some(asset) => asset,
             None => return Ok(false),
         };
 
-        // Read blob from CAS by content hash
-        let data = match file_store.get_blob(&content_hash).await {
-            Ok(d) => d,
+        let Some(etag) = bounded_cas_etag(&asset.content_hash, asset.size_bytes) else {
+            warn!(
+                path = %url_path,
+                declared_size_bytes = asset.size_bytes,
+                maximum_size_bytes = MAX_PUBLIC_STATIC_ASSET_BYTES,
+                "CAS static asset has invalid or oversized metadata"
+            );
+            return Ok(false);
+        };
+
+        // Open first so 304/HEAD validate the actual blob size without reading
+        // body bytes or trusting stale/corrupt database metadata.
+        let mut opened = match file_store.open_blob(&asset.content_hash).await {
+            Ok(opened) => opened,
             Err(temps_file_store::FileStoreError::NotFound { .. }) => {
-                warn!(
-                    "CAS blob missing for hash {} (path: {})",
-                    &content_hash[..8],
-                    url_path
+                debug!(
+                    hash_prefix = asset.content_hash.get(..8).unwrap_or("<invalid>"),
+                    path = %bounded_log_value(url_path),
+                    "CAS blob is missing"
                 );
                 return Ok(false);
             }
-            Err(e) => {
-                debug!("CAS blob read failed for {}: {}", &content_hash[..8], e);
+            Err(error) => {
+                debug!(
+                    hash_prefix = asset.content_hash.get(..8).unwrap_or("<invalid>"),
+                    path = %bounded_log_value(url_path),
+                    reason = %error,
+                    "CAS blob open failed"
+                );
                 return Ok(false);
             }
         };
+        if !opened_cas_size_matches(asset.size_bytes, opened.size_bytes) {
+            warn!(
+                path = %bounded_log_value(url_path),
+                declared_size_bytes = asset.size_bytes,
+                actual_size_bytes = opened.size_bytes,
+                maximum_size_bytes = MAX_PUBLIC_STATIC_ASSET_BYTES,
+                "CAS static asset opened size violates bounded metadata"
+            );
+            return Ok(false);
+        }
 
         let content_type = Self::infer_content_type(url_path);
-
-        // ETag from content hash (fast, stable for immutable assets)
-        let etag = Self::generate_etag(&data);
         if let Some(if_none_match) = session
             .req_header()
             .headers
             .get("if-none-match")
-            .and_then(|v| v.to_str().ok())
+            .and_then(|value| value.to_str().ok())
         {
-            if if_none_match == etag {
+            if if_none_match_matches(if_none_match, &etag) {
                 let mut resp = ResponseHeader::build(StatusCode::NOT_MODIFIED, None)?;
                 resp.insert_header("ETag", &etag)?;
                 resp.insert_header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")?;
+                resp.insert_header("X-Request-ID", &ctx.request_id)?;
                 self.set_tracking_cookies(session, &mut resp, ctx).await?;
                 session.write_response_header(Box::new(resp), false).await?;
                 session.write_response_body(None, true).await?;
@@ -2409,36 +2380,60 @@ impl LoadBalancer {
             }
         }
 
-        // Check if we should compress
-        let client_accepts_gzip = Self::accepts_gzip(session);
-        let should_compress =
-            client_accepts_gzip && Self::should_compress_content(content_type, data.len());
-
-        let (final_content, is_compressed) = if should_compress {
-            match Self::compress_gzip(&data) {
-                Ok(compressed) if compressed.len() < data.len() => (compressed, true),
-                _ => (data.to_vec(), false),
-            }
-        } else {
-            (data.to_vec(), false)
-        };
+        // HEAD uses opened-file metadata but performs no body read.
+        if ctx.method == "HEAD" {
+            let mut resp = ResponseHeader::build(StatusCode::OK, None)?;
+            resp.insert_header(header::CONTENT_TYPE, content_type)?;
+            resp.insert_header(header::CONTENT_LENGTH, asset.size_bytes.to_string())?;
+            resp.insert_header("ETag", &etag)?;
+            resp.insert_header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")?;
+            resp.insert_header("X-Request-ID", &ctx.request_id)?;
+            self.set_tracking_cookies(session, &mut resp, ctx).await?;
+            session.write_response_header(Box::new(resp), false).await?;
+            session.write_response_body(None, true).await?;
+            return Ok(true);
+        }
 
         let mut resp = ResponseHeader::build(200, None)?;
         resp.insert_header(header::CONTENT_TYPE, content_type)?;
-        resp.insert_header(header::CONTENT_LENGTH, final_content.len().to_string())?;
+        resp.insert_header(header::CONTENT_LENGTH, opened.size_bytes.to_string())?;
         resp.insert_header("ETag", &etag)?;
         resp.insert_header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")?;
         resp.insert_header("X-Request-ID", &ctx.request_id)?;
-        if is_compressed {
-            resp.insert_header("Content-Encoding", "gzip")?;
-            resp.insert_header("Vary", "Accept-Encoding")?;
-        }
         self.set_tracking_cookies(session, &mut resp, ctx).await?;
 
         session.write_response_header(Box::new(resp), false).await?;
-        session
-            .write_response_body(Some(Bytes::from(final_content)), true)
-            .await?;
+        let mut remaining = opened.size_bytes;
+        while remaining > 0 {
+            let mut chunk = read_static_chunk(opened.reader.as_mut())
+                .await
+                .map_err(|error| {
+                    Error::because(
+                        pingora::ErrorType::FileOpenError,
+                        format!(
+                            "Failed to stream CAS static asset for request '{}'",
+                            bounded_log_value(url_path)
+                        ),
+                        error,
+                    )
+                })?;
+            if chunk.is_empty() {
+                return Err(Error::because(
+                    pingora::ErrorType::FileOpenError,
+                    format!(
+                        "CAS static asset ended before its opened length for request '{}'",
+                        bounded_log_value(url_path)
+                    ),
+                    std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "CAS static asset shrank while streaming",
+                    ),
+                ));
+            }
+            remaining -= cap_static_chunk(&mut chunk, remaining);
+            session.write_response_body(Some(chunk), false).await?;
+        }
+        session.write_response_body(None, true).await?;
 
         Ok(true)
     }
@@ -2456,65 +2451,6 @@ impl LoadBalancer {
         cacheable_patterns
             .iter()
             .any(|pattern| path.contains(pattern))
-    }
-
-    /// Generate ETag from file content using SHA-256 hash
-    fn generate_etag(content: &[u8]) -> String {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-
-        let mut hasher = DefaultHasher::new();
-        content.hash(&mut hasher);
-        let hash = hasher.finish();
-        format!("W/\"{:x}\"", hash)
-    }
-
-    /// Check if content should be compressed based on Content-Type
-    fn should_compress_content(content_type: &str, content_length: usize) -> bool {
-        // Don't compress if content is too small (overhead not worth it)
-        if content_length < 1024 {
-            return false;
-        }
-
-        // Compress text-based content types
-        let compressible_types = [
-            "text/html",
-            "text/css",
-            "text/javascript",
-            "text/plain",
-            "text/xml",
-            "application/javascript",
-            "application/json",
-            "application/xml",
-            "application/x-javascript",
-            "image/svg+xml",
-        ];
-
-        compressible_types
-            .iter()
-            .any(|ct| content_type.starts_with(ct))
-    }
-
-    /// Compress content using gzip
-    fn compress_gzip(content: &[u8]) -> Result<Vec<u8>> {
-        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-        encoder
-            .write_all(content)
-            .map_err(|_| Error::new_str("Failed to compress content"))?;
-        encoder
-            .finish()
-            .map_err(|_| Error::new_str("Failed to finish compression"))
-    }
-
-    /// Check if client accepts gzip encoding
-    fn accepts_gzip(session: &PingoraSession) -> bool {
-        session
-            .req_header()
-            .headers
-            .get("accept-encoding")
-            .and_then(|v| v.to_str().ok())
-            .map(|ae| ae.contains("gzip"))
-            .unwrap_or(false)
     }
 }
 
@@ -5004,119 +4940,54 @@ impl ProxyHttp for LoadBalancer {
             if !ctx.path.starts_with("/api/_temps/") {
                 // Serve static file
                 match self.serve_static_file(session, ctx, &static_dir).await {
-                    Ok(served) => {
-                        if served {
-                            debug!("Served static file: {}", ctx.path);
-                            ctx.routing_status = "static_file".to_string();
+                    Ok(StaticFileServeOutcome::Served) => {
+                        debug!("Served static file: {}", ctx.path);
+                        ctx.routing_status = "static_file".to_string();
+                        self.log_static_request(ctx, 200, "static_file", &static_dir, None, None);
+                        return Ok(true);
+                    }
+                    Ok(StaticFileServeOutcome::NotFound) => {
+                        debug!(
+                            request_path = %bounded_log_value(&ctx.path),
+                            stored_static_dir = %bounded_log_value(&static_dir),
+                            "Static file request returned the uniform not-found response"
+                        );
+                        let contract = static_not_found_contract(&ctx.method);
+                        let mut resp = ResponseHeader::build(contract.status, None)?;
+                        resp.insert_header(header::CONTENT_TYPE, contract.content_type)?;
+                        resp.insert_header(
+                            header::CONTENT_LENGTH,
+                            contract.content_length.to_string(),
+                        )?;
+                        resp.insert_header(header::CACHE_CONTROL, contract.cache_control)?;
+                        resp.insert_header("X-Request-ID", &ctx.request_id)?;
 
-                            // Log successful static file serving (HTML only)
-                            self.log_static_request(
-                                ctx,
-                                200,
-                                "static_file",
-                                &static_dir,
-                                None,
-                                None,
-                            );
-
-                            return Ok(true); // Request handled
-                        } else {
-                            // Static file not found in current deployment.
-                            // Try path-keyed file store (stale-chunk fallback, no DB).
-                            if Self::is_cacheable_static_asset(&ctx.path) {
-                                let url_path = ctx.path.trim_start_matches('/').to_string();
-                                if let Ok(true) =
-                                    self.serve_asset_from_store(session, ctx, &url_path).await
-                                {
-                                    ctx.routing_status = "stale_chunk_fallback".to_string();
-                                    return Ok(true);
-                                }
-                            }
-
-                            // Static file not found - return 404
-                            error!(
-                                "Static file not found: {} (static dir: {})",
-                                ctx.path, static_dir
-                            );
-                            let mut resp = ResponseHeader::build(StatusCode::NOT_FOUND, None)?;
-                            resp.insert_header(header::CONTENT_TYPE, "text/html")?;
-
-                            self.ensure_static_visitor_session(session, ctx, "text/html")
-                                .await;
-
-                            // Set tracking cookies for 404 response
-                            self.set_tracking_cookies(session, &mut resp, ctx).await?;
-
-                            session.write_response_header(Box::new(resp), false).await?;
+                        self.ensure_static_visitor_session(session, ctx, contract.content_type)
+                            .await;
+                        self.set_tracking_cookies(session, &mut resp, ctx).await?;
+                        session.write_response_header(Box::new(resp), false).await?;
+                        if contract.send_body {
                             session
                                 .write_response_body(
-                                    Some(bytes::Bytes::from(
-                                        b"<html><body><h1>404 - File Not Found</h1></body></html>"
-                                            .to_vec(),
-                                    )),
+                                    Some(Bytes::from_static(STATIC_NOT_FOUND_BODY)),
                                     true,
                                 )
                                 .await?;
-
-                            // Log 404 static file not found (HTML only)
-                            self.log_static_request(
-                                ctx,
-                                404,
-                                "static_file_not_found",
-                                &static_dir,
-                                Some("Static file not found".to_string()),
-                                Some(
-                                    b"<html><body><h1>404 - File Not Found</h1></body></html>".len()
-                                        as i64,
-                                ),
-                            );
-
-                            return Ok(true); // Request handled with 404
+                        } else {
+                            session.write_response_body(None, true).await?;
                         }
-                    }
-                    Err(e) => {
-                        // Static directory error (doesn't exist, permissions, etc.) - return 500
-                        error!(
-                            "Failed to serve static file {} from {}: {}",
-                            ctx.path, static_dir, e
-                        );
-                        let mut resp =
-                            ResponseHeader::build(StatusCode::INTERNAL_SERVER_ERROR, None)?;
-                        resp.insert_header(header::CONTENT_TYPE, "text/html")?;
 
-                        self.ensure_static_visitor_session(session, ctx, "text/html")
-                            .await;
-
-                        // Set tracking cookies for 500 response
-                        self.set_tracking_cookies(session, &mut resp, ctx).await?;
-
-                        session.write_response_header(Box::new(resp), false).await?;
-                        session
-                        .write_response_body(
-                            Some(bytes::Bytes::from(
-                                b"<html><body><h1>500 - Static Directory Error</h1><p>The static files directory could not be accessed.</p></body></html>"
-                                    .to_vec(),
-                            )),
-                            true,
-                        )
-                        .await?;
-
-                        // Log 500 static directory error (HTML only)
-                        let error_msg = format!("Static directory error: {}", e);
                         self.log_static_request(
-                        ctx,
-                        500,
-                        "static_directory_error",
-                        &static_dir,
-                        Some(error_msg),
-                        Some(
-                            b"<html><body><h1>500 - Static Directory Error</h1><p>The static files directory could not be accessed.</p></body></html>"
-                                .len() as i64,
-                        ),
-                    );
-
-                        return Ok(true); // Request handled with error response
+                            ctx,
+                            404,
+                            "static_file_not_found",
+                            &static_dir,
+                            Some("Static file not found".to_string()),
+                            Some(contract.content_length as i64),
+                        );
+                        return Ok(true);
                     }
+                    Err(error) => return Err(error),
                 }
             }
             // If we reach here and path starts with /api/_temps/,

--- a/crates/temps-proxy/src/service/static_asset_lookup.rs
+++ b/crates/temps-proxy/src/service/static_asset_lookup.rs
@@ -1,9 +1,12 @@
 use moka::future::Cache;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use std::time::Duration;
+use temps_core::static_files::MAX_STATIC_ASSET_URL_PATH_BYTES;
 use temps_database::DbConnection;
 use temps_entities::static_asset_cache;
+use tokio::sync::Semaphore;
 use tracing::debug;
 
 /// Cache TTL for static-asset-store lookups (both hits and misses).
@@ -18,10 +21,48 @@ const ASSET_STORE_CACHE_TTL: Duration = Duration::from_secs(60);
 
 /// Maximum number of entries held in the asset-store lookup cache.
 ///
-/// Each entry is an `(i32, String) → Option<String>` key–value pair (roughly
-/// 100 bytes). 50 000 entries ≈ 5 MiB — a reasonable ceiling for a production
-/// reverse proxy serving many projects.
+/// Each entry stores a fixed-size SHA-256 URL key plus a validated 64-byte
+/// content hash and declared size. 50 000 entries therefore remain a real,
+/// explicit memory ceiling independent of attacker-controlled URL length.
 const ASSET_STORE_CACHE_MAX_CAPACITY: u64 = 50_000;
+
+/// Maximum number of uncached CAS metadata queries admitted by this proxy.
+///
+/// Cache hits bypass this limit. Cache misses shed immediately when all slots
+/// are occupied so attacker-controlled unique paths cannot queue unbounded DB
+/// work or retain one waiting task per request.
+const MAX_CONCURRENT_ASSET_STORE_DB_LOOKUPS: usize = 32;
+
+#[derive(Debug)]
+struct AssetStoreLookupSaturated;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StaticAssetMetadata {
+    pub content_hash: String,
+    pub size_bytes: i64,
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+struct StaticAssetCacheKey {
+    project_id: i32,
+    environment_id: i32,
+    deployment_id: i32,
+    url_path_digest: [u8; 32],
+}
+
+impl StaticAssetCacheKey {
+    fn new(project_id: i32, environment_id: i32, deployment_id: i32, url_path: &str) -> Self {
+        let digest = Sha256::digest(url_path.as_bytes());
+        let mut url_path_digest = [0_u8; 32];
+        url_path_digest.copy_from_slice(&digest);
+        Self {
+            project_id,
+            environment_id,
+            deployment_id,
+            url_path_digest,
+        }
+    }
+}
 
 /// In-memory cache for `static_asset_cache` DB lookups on the proxy hot path.
 ///
@@ -33,12 +74,12 @@ const ASSET_STORE_CACHE_MAX_CAPACITY: u64 = 50_000;
 ///
 /// ## Cache strategy
 ///
-/// - **Key**: `(project_id, environment_id, deployment_id, url_path)` — binds
-///   the asset to the exact route context that requested it.
-/// - **Value**: `Option<String>` — `Some(content_hash)` when a matching row
-///   was found; `None` when no row exists. **Caching `None` (the miss case) is
-///   the critical path**: container deployments serve most assets upstream, so
-///   the vast majority of lookups find nothing.
+/// - **Key**: project/environment/deployment IDs plus a fixed SHA-256 URL digest
+///   — binds the asset to the exact route context without retaining raw URLs.
+/// - **Value**: optional content hash and declared size metadata when a matching
+///   row was found; `None` when no row exists. **Caching `None` (the miss case)
+///   is the critical path**: container deployments serve most assets upstream,
+///   so the vast majority of lookups find nothing.
 /// - **TTL**: 60 seconds for both hit and miss results. New deployments insert
 ///   rows with a higher `deployment_id`; the TTL bounds staleness to an
 ///   acceptable 60 s window that aligns with the stale-chunk fallback semantics.
@@ -52,8 +93,9 @@ const ASSET_STORE_CACHE_MAX_CAPACITY: u64 = 50_000;
 /// for this PR.
 pub struct StaticAssetLookup {
     db: Arc<DbConnection>,
-    /// `(project_id, environment_id, deployment_id, url_path) → Option<content_hash>`.
-    cache: Cache<(i32, i32, i32, String), Option<String>>,
+    /// `(project_id, environment_id, deployment_id, url_path) → asset metadata`.
+    cache: Cache<StaticAssetCacheKey, Option<StaticAssetMetadata>>,
+    db_lookup_slots: Arc<Semaphore>,
 }
 
 impl StaticAssetLookup {
@@ -65,62 +107,118 @@ impl StaticAssetLookup {
     /// Internal constructor that accepts an explicit TTL. Used in tests to
     /// shorten the TTL to observable durations without long `sleep` calls.
     fn new_with_ttl(db: Arc<DbConnection>, ttl: Duration) -> Self {
+        Self::new_with_ttl_and_limit(db, ttl, MAX_CONCURRENT_ASSET_STORE_DB_LOOKUPS)
+    }
+
+    fn new_with_ttl_and_limit(
+        db: Arc<DbConnection>,
+        ttl: Duration,
+        max_concurrent_db_lookups: usize,
+    ) -> Self {
         let cache = Cache::builder()
             .max_capacity(ASSET_STORE_CACHE_MAX_CAPACITY)
             .time_to_live(ttl)
             .build();
-        Self { db, cache }
+        Self {
+            db,
+            cache,
+            db_lookup_slots: Arc::new(Semaphore::new(max_concurrent_db_lookups)),
+        }
     }
 
-    /// Return the content hash for the exact routed deployment, or `None` when
-    /// no matching row exists in `static_asset_cache`.
+    /// Return bounded-serving metadata for the exact routed deployment, or
+    /// `None` when no matching row exists in `static_asset_cache`.
     ///
     /// Results are served from the in-memory cache when available. Both
-    /// `Some(hash)` and `None` are cached so the common miss case never
+    /// Hits and `None` are cached so the common miss case never
     /// amplifies into Postgres load.
-    pub async fn get_content_hash(
+    pub async fn get_asset_metadata(
+        &self,
+        project_id: i32,
+        environment_id: i32,
+        deployment_id: i32,
+        url_path: &str,
+    ) -> Option<StaticAssetMetadata> {
+        if url_path.len() > MAX_STATIC_ASSET_URL_PATH_BYTES {
+            return None;
+        }
+        let key = StaticAssetCacheKey::new(project_id, environment_id, deployment_id, url_path);
+
+        // Fast path: a previous lookup already resolved this key (hit or miss).
+        if let Some(cached) = self.cache.get(&key).await {
+            debug!(project_id, "static-asset cache hit (skipping DB)");
+            return cached;
+        }
+
+        let db = self.db.clone();
+        let db_lookup_slots = self.db_lookup_slots.clone();
+        let bounded_url_path = url_path.to_owned();
+        let loaded = self
+            .cache
+            .try_get_with(key, async move {
+                // Never await a permit: shedding is what bounds both queued work
+                // and memory when unique cache misses arrive concurrently.
+                let _permit = db_lookup_slots
+                    .try_acquire_owned()
+                    .map_err(|_| AssetStoreLookupSaturated)?;
+
+                let result = static_asset_cache::Entity::find()
+                    .filter(static_asset_cache::Column::ProjectId.eq(project_id))
+                    .filter(static_asset_cache::Column::EnvironmentId.eq(environment_id))
+                    .filter(static_asset_cache::Column::DeploymentId.eq(deployment_id))
+                    .filter(static_asset_cache::Column::UrlPath.eq(&bounded_url_path))
+                    .one(db.as_ref())
+                    .await
+                    .ok()
+                    .flatten()
+                    .and_then(|entry| {
+                        (entry.content_hash.len() == 64
+                            && entry
+                                .content_hash
+                                .bytes()
+                                .all(|byte| byte.is_ascii_hexdigit()))
+                        .then_some(StaticAssetMetadata {
+                            content_hash: entry.content_hash,
+                            size_bytes: entry.size_bytes,
+                        })
+                    });
+
+                Ok::<Option<StaticAssetMetadata>, AssetStoreLookupSaturated>(result)
+            })
+            .await;
+
+        match loaded {
+            Ok(result) => {
+                debug!(
+                    project_id,
+                    found = result.is_some(),
+                    "static-asset DB lookup complete; caching result (including None)"
+                );
+                result
+            }
+            Err(_) => {
+                // `try_get_with` never caches loader errors. A later request can
+                // retry once a slot is free instead of inheriting a negative TTL.
+                debug!(
+                    project_id,
+                    "static-asset DB lookup shed at concurrency limit"
+                );
+                None
+            }
+        }
+    }
+
+    #[cfg(test)]
+    async fn get_content_hash(
         &self,
         project_id: i32,
         environment_id: i32,
         deployment_id: i32,
         url_path: &str,
     ) -> Option<String> {
-        let key = (
-            project_id,
-            environment_id,
-            deployment_id,
-            url_path.to_string(),
-        );
-
-        // Fast path: a previous lookup already resolved this key (hit or miss).
-        if let Some(cached) = self.cache.get(&key).await {
-            debug!(project_id, url_path, "static-asset cache hit (skipping DB)");
-            return cached;
-        }
-
-        // Cache miss: query the DB (most recent deployment wins).
-        let result = static_asset_cache::Entity::find()
-            .filter(static_asset_cache::Column::ProjectId.eq(project_id))
-            .filter(static_asset_cache::Column::EnvironmentId.eq(environment_id))
-            .filter(static_asset_cache::Column::DeploymentId.eq(deployment_id))
-            .filter(static_asset_cache::Column::UrlPath.eq(url_path))
-            .one(self.db.as_ref())
+        self.get_asset_metadata(project_id, environment_id, deployment_id, url_path)
             .await
-            .ok()
-            .flatten()
-            .map(|entry| entry.content_hash);
-
-        debug!(
-            project_id,
-            url_path,
-            found = result.is_some(),
-            "static-asset DB lookup complete; caching result (including None)"
-        );
-
-        // Store the result — including None for the miss case so repeated
-        // lookups for absent assets do not re-hit Postgres within the TTL.
-        self.cache.insert(key, result.clone()).await;
-        result
+            .map(|asset| asset.content_hash)
     }
 }
 
@@ -129,6 +227,10 @@ mod tests {
     use super::*;
     use chrono::Utc;
     use sea_orm::{DatabaseBackend, MockDatabase};
+
+    fn valid_hash(character: char) -> String {
+        character.to_string().repeat(64)
+    }
 
     /// Build a minimal `static_asset_cache::Model` for use in MockDatabase results.
     fn asset_model(
@@ -180,6 +282,53 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn concurrent_same_key_misses_are_coalesced_into_one_db_query() {
+        let expected_hash = valid_hash('c');
+        let model = asset_model(42, "assets/coalesced.js", &expected_hash, 9);
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![model]])
+            .into_connection();
+        let lookup = StaticAssetLookup::new(Arc::new(db));
+
+        let (first, second) = tokio::join!(
+            lookup.get_content_hash(42, 1, 9, "assets/coalesced.js"),
+            lookup.get_content_hash(42, 1, 9, "assets/coalesced.js")
+        );
+
+        assert_eq!(first.as_deref(), Some(expected_hash.as_str()));
+        assert_eq!(second.as_deref(), Some(expected_hash.as_str()));
+    }
+
+    #[tokio::test]
+    async fn exhausted_lookup_slots_shed_without_querying_or_negative_caching() {
+        let expected_hash = valid_hash('d');
+        let model = asset_model(8, "assets/retry.js", &expected_hash, 13);
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![vec![model]])
+                .into_connection(),
+        );
+        let lookup =
+            StaticAssetLookup::new_with_ttl_and_limit(db.clone(), ASSET_STORE_CACHE_TTL, 1);
+        let permit = lookup
+            .db_lookup_slots
+            .clone()
+            .try_acquire_owned()
+            .expect("test reserves the sole DB lookup slot");
+
+        let shed = lookup.get_content_hash(8, 1, 13, "assets/retry.js").await;
+        assert!(shed.is_none());
+
+        drop(permit);
+        let retried = lookup.get_content_hash(8, 1, 13, "assets/retry.js").await;
+        assert_eq!(retried.as_deref(), Some(expected_hash.as_str()));
+
+        drop(lookup);
+        let db = Arc::try_unwrap(db).expect("lookup releases database");
+        assert_eq!(db.into_transaction_log().len(), 1);
+    }
+
     /// A hit result is cached — repeated lookups for the same key return the
     /// cached hash without a second DB query.
     ///
@@ -187,7 +336,7 @@ mod tests {
     /// would panic, proving the cache is serving the second request.
     #[tokio::test]
     async fn test_hit_path_returns_cached_hash_without_second_query() {
-        let expected_hash = "sha256:deadbeef1234567890abcdef".to_string();
+        let expected_hash = valid_hash('a');
         let model = asset_model(7, "_next/static/chunks/page-abc.js", &expected_hash, 99);
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
@@ -218,12 +367,29 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn asset_metadata_includes_declared_size_for_pre_read_bounding() {
+        let expected_hash = valid_hash('b');
+        let model = asset_model(7, "assets/app.js", &expected_hash, 99);
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![model]])
+            .into_connection();
+        let lookup = StaticAssetLookup::new(Arc::new(db));
+
+        let metadata = lookup
+            .get_asset_metadata(7, 1, 99, "assets/app.js")
+            .await
+            .expect("asset metadata");
+        assert_eq!(metadata.content_hash, expected_hash);
+        assert_eq!(metadata.size_bytes, 1024);
+    }
+
     /// Different `(project_id, url_path)` keys are independent: caching one
     /// key does not interfere with another. Each key goes to the DB exactly once.
     #[tokio::test]
     async fn test_different_keys_are_independent() {
-        let hash_a = "hash-for-project-1".to_string();
-        let hash_b = "hash-for-project-2".to_string();
+        let hash_a = valid_hash('a');
+        let hash_b = valid_hash('b');
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results(vec![
@@ -249,9 +415,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_same_project_path_isolated_by_environment_and_deployment() {
-        let mut env_a = asset_model(1, "assets/app.js", "hash-a", 10);
+        let hash_a = valid_hash('a');
+        let hash_b = valid_hash('b');
+        let mut env_a = asset_model(1, "assets/app.js", &hash_a, 10);
         env_a.environment_id = 11;
-        let mut env_b = asset_model(1, "assets/app.js", "hash-b", 20);
+        let mut env_b = asset_model(1, "assets/app.js", &hash_b, 20);
         env_b.environment_id = 22;
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
@@ -264,14 +432,14 @@ mod tests {
                 .get_content_hash(1, 11, 10, "assets/app.js")
                 .await
                 .as_deref(),
-            Some("hash-a")
+            Some(hash_a.as_str())
         );
         assert_eq!(
             lookup
                 .get_content_hash(1, 22, 20, "assets/app.js")
                 .await
                 .as_deref(),
-            Some("hash-b")
+            Some(hash_b.as_str())
         );
     }
 
@@ -298,5 +466,32 @@ mod tests {
         // Second call: entry expired → DB queried again (consumes the second queued result).
         let second = lookup.get_content_hash(5, 2, 8, "static/vendor.js").await;
         assert!(second.is_none());
+    }
+
+    #[tokio::test]
+    async fn oversized_url_path_never_queries_or_enters_the_cache() {
+        let db = Arc::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+        let lookup = StaticAssetLookup::new(db.clone());
+        let oversized = "a".repeat(MAX_STATIC_ASSET_URL_PATH_BYTES + 1);
+
+        assert!(lookup
+            .get_asset_metadata(1, 2, 3, &oversized)
+            .await
+            .is_none());
+        assert_eq!(lookup.cache.entry_count(), 0);
+
+        drop(lookup);
+        let db = Arc::try_unwrap(db).expect("lookup releases database");
+        assert!(db.into_transaction_log().is_empty());
+    }
+
+    #[test]
+    fn cache_key_has_fixed_size_independent_of_url_length() {
+        let short = StaticAssetCacheKey::new(1, 2, 3, "a.js");
+        let long = StaticAssetCacheKey::new(1, 2, 3, &"a".repeat(MAX_STATIC_ASSET_URL_PATH_BYTES));
+
+        assert_ne!(short.url_path_digest, long.url_path_digest);
+        assert!(std::mem::size_of::<StaticAssetCacheKey>() <= 48);
+        assert!(!std::mem::needs_drop::<StaticAssetCacheKey>());
     }
 }

--- a/crates/temps-proxy/src/static_file_serving.rs
+++ b/crates/temps-proxy/src/static_file_serving.rs
@@ -1,0 +1,894 @@
+use bytes::Bytes;
+use sha2::{Digest, Sha256};
+use std::fs::Metadata;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+use temps_core::static_files::{
+    normalize_static_request_path, validate_static_artifact_path, validate_static_dir,
+    StaticPathPolicyError, MAX_PUBLIC_STATIC_ASSET_BYTES,
+};
+use thiserror::Error;
+use tokio::fs::{self, File};
+use tokio::io::AsyncReadExt;
+
+/// Each filesystem read is bounded independently of the deployed file size.
+pub(crate) const STATIC_STREAM_CHUNK_BYTES: usize = 64 * 1024;
+pub(crate) const STATIC_NOT_FOUND_BODY: &[u8] =
+    b"<html><body><h1>404 - File Not Found</h1></body></html>";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct StaticNotFoundContract {
+    pub status: u16,
+    pub content_type: &'static str,
+    pub cache_control: &'static str,
+    pub content_length: usize,
+    pub send_body: bool,
+}
+
+pub(crate) fn static_not_found_contract(method: &str) -> StaticNotFoundContract {
+    StaticNotFoundContract {
+        status: 404,
+        content_type: "text/html",
+        cache_control: "no-store",
+        content_length: STATIC_NOT_FOUND_BODY.len(),
+        send_body: method != "HEAD",
+    }
+}
+
+pub(crate) fn bounded_cas_etag(content_hash: &str, size_bytes: i64) -> Option<String> {
+    if size_bytes < 0
+        || size_bytes as u64 > MAX_PUBLIC_STATIC_ASSET_BYTES
+        || content_hash.len() != 64
+        || !content_hash.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return None;
+    }
+    Some(format!("\"{}\"", content_hash.to_ascii_lowercase()))
+}
+
+pub(crate) fn opened_cas_size_matches(declared_size_bytes: i64, actual_size_bytes: u64) -> bool {
+    declared_size_bytes >= 0
+        && declared_size_bytes as u64 == actual_size_bytes
+        && actual_size_bytes <= MAX_PUBLIC_STATIC_ASSET_BYTES
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StaticFileServeOutcome {
+    Served,
+    NotFound,
+}
+
+#[derive(Debug)]
+pub(crate) struct OpenedStaticFile {
+    pub file: File,
+    pub canonical_path: PathBuf,
+    pub metadata: Metadata,
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum StaticFileUnavailable {
+    #[error("Static request path '{path}' was rejected: {reason}")]
+    RequestPath {
+        path: String,
+        reason: StaticPathPolicyError,
+    },
+    #[error("Stored static directory '{path}' was rejected: {reason}")]
+    StaticDirectory {
+        path: String,
+        reason: StaticPathPolicyError,
+    },
+    #[error("Stored static directory component '{path}' is a symbolic link")]
+    SymlinkedStaticDirectory { path: String },
+    #[error("Resolved static path '{path}' was rejected by the publication policy: {reason}")]
+    ResolvedPath {
+        path: String,
+        reason: StaticPathPolicyError,
+    },
+    #[error("Static path '{path}' was not found while attempting to {operation}: {reason}")]
+    NotFound {
+        path: String,
+        operation: &'static str,
+        reason: std::io::Error,
+    },
+    #[error("Static path '{path}' is unavailable while attempting to {operation}: {reason}")]
+    Unusable {
+        path: String,
+        operation: &'static str,
+        reason: std::io::Error,
+    },
+    #[error(
+        "Resolved static path '{path}' escapes deployment root '{deployment_root}' during {operation}"
+    )]
+    EscapesRoot {
+        path: String,
+        deployment_root: String,
+        operation: &'static str,
+    },
+    #[error("Resolved static path '{path}' is not a regular file")]
+    NotAFile { path: String },
+}
+
+impl StaticFileUnavailable {
+    pub(crate) fn category(&self) -> &'static str {
+        match self {
+            Self::RequestPath { .. } => "request_path_rejected",
+            Self::StaticDirectory { .. } => "static_directory_rejected",
+            Self::SymlinkedStaticDirectory { .. } => "static_directory_symlink",
+            Self::ResolvedPath { .. } => "resolved_path_rejected",
+            Self::NotFound { .. } => "not_found",
+            Self::Unusable { .. } => "unusable",
+            Self::EscapesRoot { .. } => "escapes_root",
+            Self::NotAFile { .. } => "not_a_file",
+        }
+    }
+}
+
+pub(crate) fn bounded_log_value(value: &str) -> &str {
+    const MAX_BYTES: usize = 256;
+    if value.len() <= MAX_BYTES {
+        return value;
+    }
+    let mut end = MAX_BYTES;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    &value[..end]
+}
+
+pub(crate) fn unavailable_outcome(_error: &StaticFileUnavailable) -> StaticFileServeOutcome {
+    StaticFileServeOutcome::NotFound
+}
+
+/// Resolve, contain, and open a request target without ever reading its body.
+pub(crate) async fn open_static_file(
+    configured_static_root: &Path,
+    stored_static_dir: &str,
+    raw_request_path: &str,
+) -> Result<OpenedStaticFile, StaticFileUnavailable> {
+    let relative_static_dir = validate_static_dir(stored_static_dir).map_err(|reason| {
+        StaticFileUnavailable::StaticDirectory {
+            path: bounded_log_value(stored_static_dir).to_owned(),
+            reason,
+        }
+    })?;
+    let relative_request_path =
+        normalize_static_request_path(raw_request_path).map_err(|reason| {
+            StaticFileUnavailable::RequestPath {
+                path: bounded_log_value(raw_request_path).to_owned(),
+                reason,
+            }
+        })?;
+
+    let canonical_configured_root =
+        canonicalize(configured_static_root, "canonicalize static root").await?;
+    reject_symlinked_static_directory(&canonical_configured_root, &relative_static_dir).await?;
+    let deployment_path = canonical_configured_root.join(relative_static_dir);
+    let canonical_deployment_root =
+        canonicalize(&deployment_path, "canonicalize deployment root").await?;
+    ensure_contained(
+        &canonical_deployment_root,
+        &canonical_configured_root,
+        &canonical_configured_root,
+        "validate deployment root",
+    )?;
+
+    let request_candidate = if relative_request_path.as_os_str().is_empty() {
+        canonical_deployment_root.join("index.html")
+    } else {
+        canonical_deployment_root.join(&relative_request_path)
+    };
+
+    let candidate = match fs::canonicalize(&request_candidate).await {
+        Ok(candidate) => candidate,
+        Err(reason)
+            if reason.kind() == std::io::ErrorKind::NotFound
+                && is_spa_route(&relative_request_path) =>
+        {
+            canonicalize(
+                &canonical_deployment_root.join("index.html"),
+                "resolve SPA fallback",
+            )
+            .await?
+        }
+        Err(reason) => {
+            return Err(io_error(
+                &request_candidate,
+                "resolve requested file",
+                reason,
+            ));
+        }
+    };
+
+    ensure_contained(
+        &candidate,
+        &canonical_deployment_root,
+        &canonical_deployment_root,
+        "validate requested path",
+    )?;
+    let candidate_metadata = fs::metadata(&candidate)
+        .await
+        .map_err(|reason| io_error(&candidate, "inspect requested path", reason))?;
+    let final_candidate = if candidate_metadata.is_dir() {
+        candidate.join("index.html")
+    } else {
+        candidate
+    };
+
+    // This is intentionally the last pathname operation before File::open.
+    // It catches directory-index symlinks as well as ordinary file symlinks.
+    let canonical_path = canonicalize(&final_candidate, "resolve final file").await?;
+    ensure_contained(
+        &canonical_path,
+        &canonical_deployment_root,
+        &canonical_deployment_root,
+        "validate final file",
+    )?;
+    let canonical_relative_path = canonical_path
+        .strip_prefix(&canonical_deployment_root)
+        .map_err(|_| StaticFileUnavailable::EscapesRoot {
+            path: canonical_path.display().to_string(),
+            deployment_root: canonical_deployment_root.display().to_string(),
+            operation: "validate canonical publication path",
+        })?;
+    validate_static_artifact_path(canonical_relative_path).map_err(|reason| {
+        StaticFileUnavailable::ResolvedPath {
+            path: canonical_relative_path.display().to_string(),
+            reason,
+        }
+    })?;
+    let file = File::open(&canonical_path)
+        .await
+        .map_err(|reason| io_error(&canonical_path, "open final file", reason))?;
+    let metadata = file
+        .metadata()
+        .await
+        .map_err(|reason| io_error(&canonical_path, "read opened file metadata", reason))?;
+    if !metadata.is_file() {
+        return Err(StaticFileUnavailable::NotAFile {
+            path: canonical_path.display().to_string(),
+        });
+    }
+
+    Ok(OpenedStaticFile {
+        file,
+        canonical_path,
+        metadata,
+    })
+}
+
+/// Reject every stored-directory symlink component before accepting its target.
+///
+/// The configured root itself may intentionally be a symlink, so the walk starts
+/// from its canonical target. Components below it come from stored deployment
+/// state and must preserve their deployment identity instead of aliasing another
+/// tenant or an in-root sensitive directory.
+async fn reject_symlinked_static_directory(
+    canonical_configured_root: &Path,
+    relative_static_dir: &Path,
+) -> Result<(), StaticFileUnavailable> {
+    let mut current = canonical_configured_root.to_path_buf();
+    for component in relative_static_dir.components() {
+        current.push(component.as_os_str());
+        let metadata = fs::symlink_metadata(&current)
+            .await
+            .map_err(|reason| io_error(&current, "inspect static directory component", reason))?;
+        if metadata.file_type().is_symlink() {
+            return Err(StaticFileUnavailable::SymlinkedStaticDirectory {
+                path: current.display().to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Build a weak validator from immutable deployment identity and file metadata.
+/// No content bytes are read, so conditional requests can complete before body IO.
+pub(crate) fn metadata_etag(path: &Path, metadata: &Metadata) -> String {
+    let modified = metadata
+        .modified()
+        .ok()
+        .and_then(|value| value.duration_since(UNIX_EPOCH).ok())
+        .unwrap_or_default();
+    let mut digest = Sha256::new();
+    digest.update(path.to_string_lossy().as_bytes());
+    digest.update(metadata.len().to_le_bytes());
+    digest.update(modified.as_secs().to_le_bytes());
+    digest.update(modified.subsec_nanos().to_le_bytes());
+    let encoded = hex::encode(digest.finalize());
+    format!("W/\"{}\"", &encoded[..32])
+}
+
+pub(crate) fn if_none_match_matches(value: &str, etag: &str) -> bool {
+    value
+        .split(',')
+        .map(str::trim)
+        .any(|candidate| candidate == "*" || candidate == etag)
+}
+
+/// Read one bounded response chunk. An empty result marks EOF.
+pub(crate) async fn read_static_chunk<R>(file: &mut R) -> std::io::Result<Bytes>
+where
+    R: tokio::io::AsyncRead + Unpin + ?Sized,
+{
+    let mut chunk = vec![0_u8; STATIC_STREAM_CHUNK_BYTES];
+    let bytes_read = file.read(&mut chunk).await?;
+    chunk.truncate(bytes_read);
+    Ok(Bytes::from(chunk))
+}
+
+/// Truncate a body chunk to the opened file length and return bytes consumed.
+/// This prevents a file that grows after metadata inspection from extending a
+/// response beyond its advertised and security-checked length.
+pub(crate) fn cap_static_chunk(chunk: &mut Bytes, remaining: u64) -> u64 {
+    if chunk.len() as u64 > remaining {
+        chunk.truncate(remaining as usize);
+    }
+    chunk.len() as u64
+}
+
+fn is_spa_route(relative_request_path: &Path) -> bool {
+    relative_request_path.as_os_str().is_empty() || relative_request_path.extension().is_none()
+}
+
+async fn canonicalize(
+    path: &Path,
+    operation: &'static str,
+) -> Result<PathBuf, StaticFileUnavailable> {
+    fs::canonicalize(path)
+        .await
+        .map_err(|reason| io_error(path, operation, reason))
+}
+
+fn io_error(path: &Path, operation: &'static str, reason: std::io::Error) -> StaticFileUnavailable {
+    if reason.kind() == std::io::ErrorKind::NotFound {
+        StaticFileUnavailable::NotFound {
+            path: path.display().to_string(),
+            operation,
+            reason,
+        }
+    } else {
+        StaticFileUnavailable::Unusable {
+            path: path.display().to_string(),
+            operation,
+            reason,
+        }
+    }
+}
+
+fn ensure_contained(
+    path: &Path,
+    root: &Path,
+    deployment_root: &Path,
+    operation: &'static str,
+) -> Result<(), StaticFileUnavailable> {
+    if path.starts_with(root) {
+        return Ok(());
+    }
+    Err(StaticFileUnavailable::EscapesRoot {
+        path: path.display().to_string(),
+        deployment_root: deployment_root.display().to_string(),
+        operation,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use temp_dir::TempDir;
+    use tokio::io::AsyncWriteExt;
+
+    async fn deployment() -> (TempDir, PathBuf) {
+        let root = TempDir::new().expect("temporary static root");
+        let deployment = root.path().join("projects/site/production/deploy-1");
+        fs::create_dir_all(deployment.join("docs"))
+            .await
+            .expect("create static deployment");
+        fs::write(deployment.join("index.html"), b"spa")
+            .await
+            .expect("write root index");
+        fs::write(deployment.join("docs/index.html"), b"docs")
+            .await
+            .expect("write directory index");
+        fs::write(deployment.join("app.js"), b"javascript")
+            .await
+            .expect("write asset");
+        (root, deployment)
+    }
+
+    const STORED_DIR: &str = "projects/site/production/deploy-1";
+
+    #[tokio::test]
+    async fn opens_assets_directories_and_legitimate_spa_fallbacks() {
+        let (root, _) = deployment().await;
+        for (request, suffix) in [
+            ("/app.js", "app.js"),
+            ("/docs/", "docs/index.html"),
+            ("/account/settings", "index.html"),
+            ("/user.name/settings", "index.html"),
+            ("/", "index.html"),
+        ] {
+            let opened = open_static_file(root.path(), STORED_DIR, request)
+                .await
+                .expect("valid static request");
+            assert!(opened.canonical_path.ends_with(suffix), "{request}");
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_raw_single_and_double_encoded_sensitive_or_traversal_paths() {
+        let (root, _) = deployment().await;
+        for request in [
+            "/../secret",
+            "/%2e%2e/secret",
+            "/%252e%252e/secret",
+            "/.git/config",
+            "/%2egit/config",
+            "/%252egit/config",
+        ] {
+            let error = open_static_file(root.path(), STORED_DIR, request)
+                .await
+                .expect_err("unsafe path must be rejected");
+            assert_eq!(
+                unavailable_outcome(&error),
+                StaticFileServeOutcome::NotFound,
+                "{request}: {error}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_open_static_file_well_known_path_opens_requested_file() {
+        // Arrange
+        let (root, deployment) = deployment().await;
+        let well_known = deployment.join(".well-known");
+        fs::create_dir_all(&well_known)
+            .await
+            .expect("create well-known directory");
+        fs::write(
+            well_known.join("security.txt"),
+            b"Contact: mailto:test@example.test",
+        )
+        .await
+        .expect("write security.txt");
+
+        // Act
+        let opened = open_static_file(root.path(), STORED_DIR, "/.well-known/security.txt")
+            .await
+            .expect("documented well-known file should be publishable");
+
+        // Assert
+        assert!(opened.canonical_path.ends_with(".well-known/security.txt"));
+    }
+
+    #[tokio::test]
+    async fn missing_invalid_sensitive_and_unusable_paths_share_the_not_found_contract() {
+        let (root, _) = deployment().await;
+        let failures = [
+            open_static_file(root.path(), STORED_DIR, "/missing.js")
+                .await
+                .expect_err("asset is absent"),
+            open_static_file(root.path(), "../escape", "/app.js")
+                .await
+                .expect_err("stored path is invalid"),
+            open_static_file(root.path(), STORED_DIR, "/.env")
+                .await
+                .expect_err("sensitive path is invalid"),
+        ];
+        let expected_contract = static_not_found_contract("GET");
+
+        for failure in failures {
+            assert_eq!(
+                unavailable_outcome(&failure),
+                StaticFileServeOutcome::NotFound,
+                "{failure}"
+            );
+            assert_eq!(static_not_found_contract("GET"), expected_contract);
+        }
+
+        let unusable_root = root.path().join("not-a-directory");
+        fs::write(&unusable_root, b"ordinary file")
+            .await
+            .expect("write unusable static root fixture");
+        let unusable = open_static_file(&unusable_root, STORED_DIR, "/app.js")
+            .await
+            .expect_err("non-directory static root is unusable");
+        assert!(matches!(unusable, StaticFileUnavailable::Unusable { .. }));
+        assert_eq!(
+            unavailable_outcome(&unusable),
+            StaticFileServeOutcome::NotFound
+        );
+        assert_eq!(static_not_found_contract("GET"), expected_contract);
+    }
+
+    #[tokio::test]
+    async fn oversized_paths_are_not_retained_in_resolution_errors() {
+        let oversized = "a".repeat(8 * 1024);
+        let stored_error = open_static_file(Path::new("unused"), &oversized, "/")
+            .await
+            .expect_err("oversized stored directory must fail before filesystem access");
+        let request_error = open_static_file(Path::new("unused"), STORED_DIR, &oversized)
+            .await
+            .expect_err("oversized request must fail before filesystem access");
+
+        assert!(matches!(
+            stored_error,
+            StaticFileUnavailable::StaticDirectory { path, .. } if path.len() <= 256
+        ));
+        assert!(matches!(
+            request_error,
+            StaticFileUnavailable::RequestPath { path, .. } if path.len() <= 256
+        ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn final_directory_index_symlink_cannot_escape_the_deployment() {
+        use std::os::unix::fs::symlink;
+
+        let (root, deployment) = deployment().await;
+        let outside = root.path().join("private.html");
+        fs::write(&outside, b"private")
+            .await
+            .expect("write outside file");
+        let linked_dir = deployment.join("linked");
+        fs::create_dir_all(&linked_dir)
+            .await
+            .expect("create linked directory");
+        symlink(&outside, linked_dir.join("index.html")).expect("create index symlink");
+
+        let error = open_static_file(root.path(), STORED_DIR, "/linked/")
+            .await
+            .expect_err("escaping index symlink must fail");
+        assert!(matches!(error, StaticFileUnavailable::EscapesRoot { .. }));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_open_static_file_file_symlink_escaping_root_returns_unavailable() {
+        use std::os::unix::fs::symlink;
+
+        // Arrange
+        let (root, deployment) = deployment().await;
+        let outside = root.path().join("private.txt");
+        fs::write(&outside, b"private")
+            .await
+            .expect("write outside file");
+        symlink(&outside, deployment.join("linked.txt")).expect("create file symlink");
+
+        // Act
+        let error = open_static_file(root.path(), STORED_DIR, "/linked.txt")
+            .await
+            .expect_err("escaping file symlink must fail");
+
+        // Assert
+        assert!(matches!(error, StaticFileUnavailable::EscapesRoot { .. }));
+        assert_eq!(
+            unavailable_outcome(&error),
+            StaticFileServeOutcome::NotFound
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn deployment_root_symlink_cannot_alias_in_root_sensitive_directory() {
+        use std::os::unix::fs::symlink;
+
+        let root = TempDir::new().expect("temporary static root");
+        let sensitive = root.path().join(".git");
+        fs::create_dir_all(&sensitive)
+            .await
+            .expect("create sensitive directory");
+        fs::write(sensitive.join("index.html"), b"private")
+            .await
+            .expect("write private index");
+        let deployment_parent = root.path().join("projects/site/production");
+        fs::create_dir_all(&deployment_parent)
+            .await
+            .expect("create deployment parent");
+        symlink(&sensitive, deployment_parent.join("deploy-1"))
+            .expect("create sensitive deployment alias");
+
+        let error = open_static_file(root.path(), STORED_DIR, "/")
+            .await
+            .expect_err("deployment root must not alias a sensitive directory");
+
+        assert!(matches!(
+            error,
+            StaticFileUnavailable::SymlinkedStaticDirectory { .. }
+        ));
+        assert_eq!(
+            unavailable_outcome(&error),
+            StaticFileServeOutcome::NotFound
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn deployment_root_symlink_cannot_alias_another_deployment() {
+        use std::os::unix::fs::symlink;
+
+        let root = TempDir::new().expect("temporary static root");
+        let other_deployment = root.path().join("projects/other/production/deploy-2");
+        fs::create_dir_all(&other_deployment)
+            .await
+            .expect("create other deployment");
+        fs::write(other_deployment.join("index.html"), b"other tenant")
+            .await
+            .expect("write other deployment index");
+        let deployment_parent = root.path().join("projects/site/production");
+        fs::create_dir_all(&deployment_parent)
+            .await
+            .expect("create deployment parent");
+        symlink(&other_deployment, deployment_parent.join("deploy-1"))
+            .expect("create cross-deployment alias");
+
+        let error = open_static_file(root.path(), STORED_DIR, "/")
+            .await
+            .expect_err("deployment root must not alias another deployment");
+
+        assert!(matches!(
+            error,
+            StaticFileUnavailable::SymlinkedStaticDirectory { .. }
+        ));
+        assert_eq!(
+            unavailable_outcome(&error),
+            StaticFileServeOutcome::NotFound
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn in_root_file_symlink_alias_cannot_publish_sensitive_target() {
+        use std::os::unix::fs::symlink;
+
+        let (root, deployment) = deployment().await;
+        let sensitive = deployment.join(".env");
+        fs::write(&sensitive, b"SECRET=test")
+            .await
+            .expect("write sensitive target");
+        symlink(&sensitive, deployment.join("public.txt")).expect("create public alias");
+
+        let error = open_static_file(root.path(), STORED_DIR, "/public.txt")
+            .await
+            .expect_err("canonical sensitive target must be rejected");
+
+        assert!(matches!(error, StaticFileUnavailable::ResolvedPath { .. }));
+        assert_eq!(
+            unavailable_outcome(&error),
+            StaticFileServeOutcome::NotFound
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn in_root_directory_symlink_alias_cannot_publish_sensitive_child() {
+        use std::os::unix::fs::symlink;
+
+        let (root, deployment) = deployment().await;
+        let sensitive_directory = deployment.join(".git");
+        fs::create_dir_all(&sensitive_directory)
+            .await
+            .expect("create sensitive directory");
+        fs::write(
+            sensitive_directory.join("config"),
+            b"private repository config",
+        )
+        .await
+        .expect("write sensitive child");
+        symlink(&sensitive_directory, deployment.join("public")).expect("create directory alias");
+
+        let error = open_static_file(root.path(), STORED_DIR, "/public/config")
+            .await
+            .expect_err("canonical sensitive child must be rejected");
+
+        assert!(matches!(error, StaticFileUnavailable::ResolvedPath { .. }));
+        assert_eq!(
+            unavailable_outcome(&error),
+            StaticFileServeOutcome::NotFound
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn directory_index_symlink_alias_cannot_publish_sensitive_target() {
+        use std::os::unix::fs::symlink;
+
+        let (root, deployment) = deployment().await;
+        let sensitive = deployment.join(".env");
+        fs::write(&sensitive, b"SECRET=test")
+            .await
+            .expect("write sensitive target");
+        let index = deployment.join("docs/index.html");
+        fs::remove_file(&index)
+            .await
+            .expect("remove ordinary directory index");
+        symlink(&sensitive, &index).expect("create directory index alias");
+
+        let error = open_static_file(root.path(), STORED_DIR, "/docs/")
+            .await
+            .expect_err("canonical sensitive index target must be rejected");
+
+        assert!(matches!(error, StaticFileUnavailable::ResolvedPath { .. }));
+        assert_eq!(
+            unavailable_outcome(&error),
+            StaticFileServeOutcome::NotFound
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_open_static_file_deployment_root_symlink_escaping_static_root_returns_unavailable(
+    ) {
+        use std::os::unix::fs::symlink;
+
+        // Arrange
+        let root = TempDir::new().expect("temporary static root");
+        let outside = TempDir::new().expect("outside deployment root");
+        fs::write(outside.path().join("index.html"), b"private")
+            .await
+            .expect("write outside index");
+        let deployment_parent = root.path().join("projects/site/production");
+        fs::create_dir_all(&deployment_parent)
+            .await
+            .expect("create deployment parent");
+        symlink(outside.path(), deployment_parent.join("deploy-1"))
+            .expect("create deployment root symlink");
+
+        // Act
+        let error = open_static_file(root.path(), STORED_DIR, "/")
+            .await
+            .expect_err("deployment root symlink must remain confined");
+
+        // Assert
+        assert!(matches!(
+            error,
+            StaticFileUnavailable::SymlinkedStaticDirectory { .. }
+        ));
+        assert_eq!(
+            unavailable_outcome(&error),
+            StaticFileServeOutcome::NotFound
+        );
+    }
+
+    #[tokio::test]
+    async fn etag_is_available_without_reading_and_is_stable_for_opened_metadata() {
+        let (root, _) = deployment().await;
+        let opened = open_static_file(root.path(), STORED_DIR, "/app.js")
+            .await
+            .expect("open asset");
+        let first = metadata_etag(&opened.canonical_path, &opened.metadata);
+        let second = metadata_etag(&opened.canonical_path, &opened.metadata);
+        let other_deployment = metadata_etag(Path::new("/other/deploy/app.js"), &opened.metadata);
+        assert_eq!(first, second);
+        assert_ne!(first, other_deployment);
+        assert!(first.starts_with("W/\""));
+    }
+
+    #[test]
+    fn if_none_match_supports_lists_and_wildcards() {
+        let etag = "W/\"abc\"";
+        assert!(if_none_match_matches(etag, etag));
+        assert!(if_none_match_matches("\"old\", W/\"abc\"", etag));
+        assert!(if_none_match_matches("*", etag));
+        assert!(!if_none_match_matches("\"old\"", etag));
+    }
+
+    #[test]
+    fn cas_policy_rejects_invalid_or_oversized_metadata_before_blob_io() {
+        let hash = "a".repeat(64);
+        assert!(bounded_cas_etag(&hash, 0).is_some());
+        assert!(bounded_cas_etag(&hash, MAX_PUBLIC_STATIC_ASSET_BYTES as i64).is_some());
+        assert!(bounded_cas_etag(&hash, -1).is_none());
+        assert!(bounded_cas_etag(&hash, MAX_PUBLIC_STATIC_ASSET_BYTES as i64 + 1).is_none());
+        assert!(bounded_cas_etag("short", 1).is_none());
+        assert!(bounded_cas_etag(&"z".repeat(64), 1).is_none());
+        assert!(opened_cas_size_matches(1024, 1024));
+        assert!(!opened_cas_size_matches(1024, 1025));
+        assert!(!opened_cas_size_matches(-1, 0));
+        assert!(!opened_cas_size_matches(
+            MAX_PUBLIC_STATIC_ASSET_BYTES as i64 + 1,
+            MAX_PUBLIC_STATIC_ASSET_BYTES + 1
+        ));
+    }
+
+    #[test]
+    fn all_static_resolution_failures_share_one_404_contract() {
+        let get = static_not_found_contract("GET");
+        let head = static_not_found_contract("HEAD");
+        assert_eq!(get.status, 404);
+        assert_eq!(get.content_type, "text/html");
+        assert_eq!(get.cache_control, "no-store");
+        assert_eq!(get.content_length, STATIC_NOT_FOUND_BODY.len());
+        assert!(get.send_body);
+        assert_eq!(head.status, get.status);
+        assert_eq!(head.content_type, get.content_type);
+        assert_eq!(head.cache_control, get.cache_control);
+        assert_eq!(head.content_length, get.content_length);
+        assert!(!head.send_body);
+    }
+
+    #[test]
+    fn attacker_controlled_log_values_are_utf8_safely_bounded() {
+        let ascii = "a".repeat(400);
+        assert_eq!(bounded_log_value(&ascii).len(), 256);
+
+        let unicode = "é".repeat(200);
+        let bounded = bounded_log_value(&unicode);
+        assert!(bounded.len() <= 256);
+        assert!(bounded.is_char_boundary(bounded.len()));
+    }
+
+    #[tokio::test]
+    async fn large_files_are_read_in_fixed_size_chunks() {
+        let (root, deployment) = deployment().await;
+        let large_path = deployment.join("large.bin");
+        let total_size = STATIC_STREAM_CHUNK_BYTES * 3 + 17;
+        let mut writer = File::create(&large_path).await.expect("create large file");
+        for _ in 0..3 {
+            writer
+                .write_all(&vec![7_u8; STATIC_STREAM_CHUNK_BYTES])
+                .await
+                .expect("write full chunk");
+        }
+        writer.write_all(&[9_u8; 17]).await.expect("write tail");
+        writer.flush().await.expect("flush large file");
+        drop(writer);
+
+        let mut opened = open_static_file(root.path(), STORED_DIR, "/large.bin")
+            .await
+            .expect("open large file");
+        let mut streamed = 0;
+        loop {
+            let chunk = read_static_chunk(&mut opened.file)
+                .await
+                .expect("read bounded chunk");
+            if chunk.is_empty() {
+                break;
+            }
+            assert!(chunk.len() <= STATIC_STREAM_CHUNK_BYTES);
+            streamed += chunk.len();
+        }
+        assert_eq!(streamed, total_size);
+    }
+
+    #[test]
+    fn opened_length_caps_chunks_from_a_growing_file() {
+        let mut chunk = Bytes::from_static(b"original-plus-growth");
+
+        let consumed = cap_static_chunk(&mut chunk, 8);
+
+        assert_eq!(consumed, 8);
+        assert_eq!(chunk, Bytes::from_static(b"original"));
+    }
+
+    #[tokio::test]
+    async fn cas_blob_get_path_uses_opened_size_and_fixed_chunks() {
+        use temps_file_store::fs_store::FsFileStore;
+        use temps_file_store::FileStore;
+
+        let root = TempDir::new().expect("temporary CAS root");
+        let store = FsFileStore::new(root.path().join("cas"));
+        let total_size = STATIC_STREAM_CHUNK_BYTES * 3 + 17;
+        let data = Bytes::from(vec![7_u8; total_size]);
+        let hash = store.put_blob(data).await.expect("persist CAS fixture");
+
+        let mut opened = store.open_blob(&hash).await.expect("open CAS fixture");
+        assert!(opened_cas_size_matches(
+            total_size as i64,
+            opened.size_bytes
+        ));
+
+        let mut streamed = 0;
+        loop {
+            let chunk = read_static_chunk(opened.reader.as_mut())
+                .await
+                .expect("read bounded CAS chunk");
+            if chunk.is_empty() {
+                break;
+            }
+            assert!(chunk.len() <= STATIC_STREAM_CHUNK_BYTES);
+            streamed += chunk.len();
+        }
+        assert_eq!(streamed, total_size);
+    }
+}


### PR DESCRIPTION
## Summary

- stream filesystem and CAS static responses through bounded buffers, compute ETags before serving, and remove per-request gzip work
- centralize the public-static policy so sensitive files, encoded traversal, invalid stored directories, and unsafe symlinks all fail with the same `404`, while documented `/.well-known/` files remain available
- bound Docker archive download/extraction, recursive copy, CAS reads/lookups, and source-map ingestion; clean partial deployment output on failure
- apply the same sensitive-file policy to drop-folder deployments: a `.env`, `.git/config`, source map, key, database, backup, or deployment-state file inside the selected public directory rejects the deployment

## Security behavior

- rejects raw, percent-encoded, and double-encoded sensitive/traversal paths
- canonicalizes and verifies the final filesystem target immediately before opening it
- rejects sensitive files during publication as well as at the proxy boundary
- validates configured static directories as clean relative paths
- returns a uniform cache-disabled `404` for invalid, sensitive, missing, unusable, and symlinked targets
- allows documented `/.well-known/` content such as `security.txt`
- limits archive entries, per-file bytes, total extracted bytes, nesting depth, concurrent extraction, recursive copy depth, and public CAS asset size

The security review approved the change with no critical, high, or medium findings. Two accepted low-risk follow-ups are tracked conceptually: use an OS-level beneath-only open primitive to close the same-host writer race completely, and move temporary extraction ownership into the blocking task so abrupt cancellation can clean partial work immediately.

## Verification

### Automated

- `cargo test --profile fast --lib -p temps-core` — 367 passed
- `cargo test --profile fast --lib -p temps-file-store` — 9 passed
- `cargo test --profile fast --lib -p temps-proxy` — 566 passed, 4 ignored (post-rebase)
- `cargo test --profile fast --lib -p temps-deployer` — 292 passed
- `cargo test --profile fast --lib -p temps-deployments` — 645 passed, 3 ignored
- `cargo test --profile fast --lib -p temps-error-tracking` — 130 passed
- `cargo check --lib` — 0 errors (existing warnings only)
- affected-crate `cargo clippy --lib ... -- -D warnings` runs — 0 errors
- `cargo fmt --all -- --check` — passed
- `git diff origin/main...HEAD --check` — passed

### Local end-to-end

Started Temps locally and exercised a synthetic static deployment through Pingora:

- root, SPA fallback, and `/.well-known/security.txt` returned `200`
- a 344,711-byte asset streamed with an exact SHA match
- `HEAD`, ETag, and conditional `304` behavior were correct
- `Accept-Encoding: gzip` did not trigger response-time compression
- missing files; raw/single/double-encoded `.env` and `.git` paths; sensitive extensions; traversal; and an in-root symlink alias returned the same `404` status, body, headers, and length
- invalid and unusable stored static directories returned that same uniform `404`

## Notes

The original compressed drop-folder bundle remains private for redeployment and is never served directly. Only the chosen public directory is published, and publication fails atomically if that directory contains a denied file.
