### PR TITLE
fix(web): restore dark-mode border/input contrast for toggles and buttons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,13 @@ check. `git revert` defaults to `Revert "original message"`, which is
 not conventional. Never use `git revert --no-edit` and leave it —
 either pass an explicit conventional `-m`, or amend right after.
 
+## DCO Sign-off
+
+Every commit must be signed off (`Signed-off-by: Name <email>` trailer).
+Always use `git commit -s` (and `-s` on `--amend`/`revert`). Like the
+Changelog check, the DCO check validates every commit in `base..HEAD`,
+not just the tip.
+
 ## Per-record config columns, not env vars
 
 When adding a new runtime knob, default to a column on the relevant

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -922,6 +922,15 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`
 
 `git revert` defaults to a non-conventional subject (`Revert "original message"`). Never accept that default — always pass an explicit conventional message, e.g. `git revert --no-edit` then `git commit --amend -m "test: drop temporary failing test"`, or better, pass `-m` directly on the revert itself.
 
+### DCO Sign-off
+
+**Every commit must be signed off** (`Signed-off-by: Name <email>` trailer) —
+this is the Developer Certificate of Origin required on this OSS repo. Always
+commit with `git commit -s` (or `-s` on `git commit --amend`/`git revert`).
+A PR with an unsigned commit fails the DCO check regardless of how many
+commits are on the branch — every commit in `base..HEAD` needs its own
+trailer, not just the final one.
+
 ---
 
 ## Workspace Structure

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -123,9 +123,12 @@
   --success-foreground: oklch(0.985 0 0);
   --warning: oklch(0.773 0.1776 69.61); /* amber */
   --warning-foreground: oklch(0.145 0 0);
-  /* gray-200 borders (#2e2e2e) */
-  --border: oklch(0.269 0 0);
-  --input: oklch(0.269 0 0);
+  /* gray-300 (#3a3a3a) — matches --accent; restores the pre-Geist-palette
+     border/input contrast against --card (0.205) that the Vercel rewrite
+     (6b4859637) collapsed from a 0.144 lightness delta down to 0.064,
+     washing out unchecked switches and outlined/disabled buttons */
+  --border: oklch(0.322 0 0);
+  --input: oklch(0.322 0 0);
   /* Vercel blue ring (#0070f3) */
   --ring: oklch(0.59 0.2032 256.82);
   /* Vercel signature accent colors for charts */


### PR DESCRIPTION
## Summary
- The unchecked toggle switch and Save button in dark mode were nearly invisible against their card background.
- Root cause: commit `6b4859637` ("style(web): apply Vercel Geist palette to light and dark themes") shrank the dark-mode lightness gap between `--card` (`oklch(0.205 0 0)`) and `--border`/`--input` (`oklch(0.269 0 0)`) from a 0.144 delta down to 0.064 — less than half the original contrast.
- Bumps `--border`/`--input` to `oklch(0.322 0 0)`, matching the existing `--accent` "gray-300" tier and restoring roughly the pre-rewrite contrast (`oklch(0.3211 0 0)`).

## Test plan
- [x] Started a local Temps instance (`/start-temps`, isolated worktree/slot) and logged into the console
- [x] Confirmed in dark mode that unchecked toggles (e.g. Settings → Platform → Screenshots → "Enable Screenshots") now render with a clearly visible track/border against the card, instead of blending in
- [x] Confirmed input fields also gained a visible border in dark mode
- [x] No other tokens touched — light mode and all other dark-mode surfaces unaffected