### PR TITLE
fix(status-page): delay first health check to avoid proxy-startup race

### DIFF
--- a/crates/temps-status-page/src/services/health_check_service.rs
+++ b/crates/temps-status-page/src/services/health_check_service.rs
@@ -12,6 +12,21 @@ use tracing::{debug, error, info, warn};
 
 use super::types::{validate_check_path, StatusPageError};
 
+/// Grace period before the scheduler runs its first health check cycle.
+///
+/// In split mode (`temps proxy` + `temps serve --role=console`) these are
+/// independent OS processes with no startup handshake between them, and even
+/// in single-process mode the proxy's listener setup (route/project-change
+/// listeners, admin gate, DB connections) can still be in flight when the
+/// console's plugins finish registering. A check that fires the instant this
+/// scheduler starts races the proxy socket bind: `check_monitor` gets a
+/// connection-refused, which is treated as a definitive "container is down"
+/// and reported as `major_outage` with no retry (see the `is_connect()`
+/// branch below). This delay absorbs that boot window so the first cycle
+/// observes the platform in its normal running state; every cycle after the
+/// first runs on the regular interval.
+const STARTUP_GRACE_PERIOD: Duration = Duration::from_secs(20);
+
 /// Service for performing health checks on monitored environments
 pub struct HealthCheckService {
     db: Arc<DatabaseConnection>,
@@ -504,6 +519,13 @@ impl HealthCheckService {
     /// waiting for the next scheduled cycle.
     pub async fn start_scheduler(self: Arc<Self>, mut job_receiver: Box<dyn JobReceiver>) {
         debug!("Starting health check scheduler with realtime monitor creation handling");
+
+        // See STARTUP_GRACE_PERIOD: wait out the proxy's boot window before
+        // touching any monitor. This also delays `initialize_monitors` below,
+        // which prevents the MonitorCreated events it emits for newly-seen
+        // environments from triggering an immediate check during the same
+        // race window.
+        sleep(STARTUP_GRACE_PERIOD).await;
 
         // Initialize monitors for all environments first
         if let Err(e) = self.initialize_monitors().await {


### PR DESCRIPTION
## Summary
- On boot, the status-page health-check scheduler ran its first check cycle instantly (`tokio::time::interval`'s first tick fires immediately), before the proxy had bound its listener — most visible in split mode (`temps proxy` + `temps serve --role=console`), where the two run as independent processes with no readiness handshake.
- `check_monitor` treats a connection-refused response as a definitive outage with **no retry** (by design — see the comment at the call site), so this race reported every project as "down" right after a restart even though the platform came up fine seconds later.
- Adds a 20s startup grace period before the scheduler's first cycle, and before `initialize_monitors` (whose `MonitorCreated` events for newly-seen environments would otherwise trigger the same immediate-check race). Every cycle after the first still runs on the normal 60s interval, so steady-state monitoring is unaffected.

## Evidence

```
$ cargo check --lib -p temps-status-page
cargo build: 0 errors, 2 warnings (706 crates)

$ cargo check --lib   # full workspace
cargo build: 0 errors, 5 warnings (632 crates)
[exited with code 0]
```

Manual split-mode restart, `temps proxy` + `temps serve --role=console` launched
concurrently from a fresh DB, console log at `debug` level:

```
06:50:03.055Z  proxy: Starting Temps proxy on 0.0.0.0:8400 and 0.0.0.0:8763
06:50:03.141Z  proxy: Starting proxy server on 0.0.0.0:8400          <- proxy socket bound

06:50:02.609Z  console: Starting health check scheduler with realtime monitor creation handling
06:50:22.613Z  console: Initializing monitors for all existing environments
06:50:22.616Z  console: Starting health check cycle                  <- first cycle, now 20s later
06:50:22.618Z  console: Health check cycle completed
```

Before this change, the first cycle fired at scheduler-start time (~06:50:02.6Z)
— **before** the proxy bound its socket at 06:50:03.14Z, i.e. exactly the race
this PR fixes, reproduced with real timestamps from a live restart. With the
fix, the first cycle now runs at 06:50:22.6Z, ~19.5s after the proxy is already
listening.

Split-mode itself verified healthy:
```
console /healthz -> 200
console /readyz  -> 200
proxy / (fallback to console) -> 200
```