### PR TITLE
fix(providers): keep MongoDB credentials off mongosh's command line

### DIFF
--- a/crates/temps-providers/src/externalsvc/mongodb.rs
+++ b/crates/temps-providers/src/externalsvc/mongodb.rs
@@ -120,6 +120,82 @@ fn default_docker_image() -> String {
 /// [`crate::externalsvc::restore_image`] for why the override is constrained.
 const RESTORE_IMAGE_REPOSITORIES: &[&str] = &["mongo", "gotempsh/mongodb-walg"];
 
+/// Environment variable holding the root username, consumed by the official
+/// MongoDB entrypoint at first boot. Every container this provider creates is
+/// given it (see [`MongodbService::create_container_once`]), which is what
+/// lets in-container probes read the credential back out of their own
+/// environment instead of putting it on `mongosh`'s command line.
+const MONGO_ROOT_USER_ENV: &str = "MONGO_INITDB_ROOT_USERNAME";
+
+/// Environment variable holding the root password. See [`MONGO_ROOT_USER_ENV`].
+const MONGO_ROOT_PASSWORD_ENV: &str = "MONGO_INITDB_ROOT_PASSWORD";
+
+/// `CMD-SHELL` script used as the Docker healthcheck for MongoDB containers.
+///
+/// **The credentials are deliberately absent from `mongosh`'s argv.** They are
+/// read inside the `--eval` script from `process.env`, which mongosh exposes to
+/// evaluated JavaScript. This is not a style preference:
+///
+/// `mongosh` is a Node CLI whose argument parser treats *any* token beginning
+/// with `-` as a new flag, including in the value position of a space-separated
+/// `-u`, `-p` or `--password`. Because [`generate_secure_password`] draws from a
+/// charset containing `-`, roughly one in seventy-three auto-generated MongoDB
+/// passwords starts with one. Such a password was quoted perfectly by the shell
+/// and still reached mongosh as a clean argv token that its own parser rejected:
+///
+/// ```text
+/// MongoshUnimplementedError: [COMMON-10001] Error parsing command line: unrecognized option: -<password>
+/// ```
+///
+/// Every probe then failed and service creation stalled for the full 90-second
+/// health-check budget in [`MongodbService::wait_for_container_health`].
+///
+/// Neither shape that keeps the other providers safe helps here, both verified
+/// against a real `gotempsh/mongodb-walg:8.0` container:
+///
+/// * the glued `-p<value>` form that makes `mariadb-admin` immune is **not**
+///   accepted by mongosh — it ignores the glued value, prompts `Enter password:`
+///   on stdin and then fails authentication, which is a worse failure than the
+///   parse error because it looks like a credential problem;
+/// * `--password=<value>` does work, but protects only the password and leaves
+///   `-u <username>` open to the identical parse error.
+///
+/// Keeping both values off argv entirely is the only form immune to *every*
+/// username and password shape, including ones an operator sets by hand through
+/// the API rather than ones this crate generated.
+///
+/// Note the probe must authenticate to be meaningful: `ping` is answerable on an
+/// unauthenticated connection, so a bare `db.adminCommand({ping: 1})` reports
+/// healthy regardless of the credentials. `db.auth()` throwing on rejection is
+/// what makes this check fail closed.
+const HEALTHCHECK_COMMAND: &str = concat!(
+    "mongosh --norc --quiet --eval ",
+    "'db.getSiblingDB(\"admin\").auth(process.env.MONGO_INITDB_ROOT_USERNAME, ",
+    "process.env.MONGO_INITDB_ROOT_PASSWORD); db.adminCommand({ping: 1})'",
+    " || exit 1",
+);
+
+/// Build a `mongodb://` connection URI for an in-container `mongosh` probe
+/// against localhost, percent-encoding both credentials.
+///
+/// In-container probes hand this to `mongosh` as a positional connection
+/// string rather than as `-u <user> -p <pass>`. The reason is the same one
+/// documented on [`HEALTHCHECK_COMMAND`]: mongosh's parser reads any argv token
+/// starting with `-` as a flag, so a username or password beginning with `-`
+/// makes a space-separated `-u`/`-p` value fail with
+/// `unrecognized option: -...` no matter how carefully the shell quoted it. A
+/// URI is always a single token starting with `mongodb://`, so it can never be
+/// mistaken for a flag whatever the credentials look like, and percent-encoding
+/// keeps `:`, `@`, `/` and `?` inside the credentials from reshaping the URI.
+fn local_probe_uri(username: &str, password: &str) -> String {
+    format!(
+        "mongodb://{}:{}@127.0.0.1:{}/admin?authSource=admin",
+        urlencoding::encode(username),
+        urlencoding::encode(password),
+        MONGODB_INTERNAL_PORT
+    )
+}
+
 /// Environment variable an operator sets to allow additional MongoDB
 /// repositories as a restore-time `docker_image` override (comma-separated).
 /// Additive — it can only widen [`RESTORE_IMAGE_REPOSITORIES`], never shrink
@@ -453,9 +529,12 @@ impl MongodbService {
 
         info!("Created MongoDB volume: {}", volume_name);
 
+        // The root credentials are supplied only as environment variables. The
+        // healthcheck below reads them back from here rather than embedding
+        // them in its command line — see [`HEALTHCHECK_COMMAND`].
         let mut env_vars: Vec<String> = vec![
-            format!("MONGO_INITDB_ROOT_USERNAME={}", config.username),
-            format!("MONGO_INITDB_ROOT_PASSWORD={}", config.password),
+            format!("{}={}", MONGO_ROOT_USER_ENV, config.username),
+            format!("{}={}", MONGO_ROOT_PASSWORD_ENV, config.password),
             format!("MONGO_INITDB_DATABASE={}", config.database),
         ];
 
@@ -553,16 +632,14 @@ impl MongodbService {
             }),
             networking_config,
             healthcheck: Some(bollard::models::HealthConfig {
-                test: Some(vec!["CMD-SHELL".to_string(), {
-                    // Properly escape credentials for shell execution by wrapping in single quotes
-                    // and escaping any single quotes within the values
-                    let escaped_username = config.username.replace("'", "'\"'\"'");
-                    let escaped_password = config.password.replace("'", "'\"'\"'");
-                    format!(
-                            "mongosh --norc --eval \"db.adminCommand('ping')\" -u '{}' -p '{}' --authenticationDatabase admin || exit 1",
-                            escaped_username, escaped_password
-                        )
-                }]),
+                // Credential-free command line: the probe reads the root
+                // credentials from the container's own environment (set above)
+                // rather than taking them as `mongosh` arguments. See
+                // [`HEALTHCHECK_COMMAND`] for why argv is not usable here.
+                test: Some(vec![
+                    "CMD-SHELL".to_string(),
+                    HEALTHCHECK_COMMAND.to_string(),
+                ]),
                 interval: Some(2000000000), // 2 seconds
                 timeout: Some(10000000000), // 10 seconds
                 retries: Some(5),
@@ -622,18 +699,20 @@ impl MongodbService {
     ) -> Result<()> {
         use bollard::exec::{StartExecOptions, StartExecResults};
 
-        // Pass credentials via env to avoid quoting hazards in the shell
-        // command. The replica-set name is also injected as an env var so it
-        // can't break out of the JSON literal.
+        // Credentials travel as a percent-encoded connection URI in an env var,
+        // never as `-u`/`-p` arguments — see [`local_probe_uri`]. The
+        // replica-set name is also injected as an env var so it can't break out
+        // of the JSON literal.
         let env = [
-            format!("INIT_USER={}", config.username),
-            format!("INIT_PASS={}", config.password),
+            format!(
+                "INIT_URI={}",
+                local_probe_uri(&config.username, &config.password)
+            ),
             format!("INIT_RS={}", rs_name),
         ];
         let env_refs: Vec<&str> = env.iter().map(String::as_str).collect();
 
-        let script = "mongosh --quiet --norc \
-             -u \"$INIT_USER\" -p \"$INIT_PASS\" --authenticationDatabase admin \
+        let script = "mongosh --quiet --norc \"$INIT_URI\" \
              --eval 'try { rs.initiate({_id: process.env.INIT_RS, members: [{_id: 0, host: \"127.0.0.1:27017\"}]}); } catch (e) { if (e.codeName !== \"AlreadyInitialized\" && !String(e).includes(\"already initialized\")) { throw e; } print(\"replica set already initialized\"); }' 2>&1";
 
         let exec = docker
@@ -714,13 +793,14 @@ impl MongodbService {
     ) -> Result<()> {
         use bollard::exec::{StartExecOptions, StartExecResults};
 
-        let env = [
-            format!("INIT_USER={}", config.username),
-            format!("INIT_PASS={}", config.password),
-        ];
+        // Credentials travel as a percent-encoded connection URI, not as
+        // `-u`/`-p` arguments — see [`local_probe_uri`].
+        let env = [format!(
+            "INIT_URI={}",
+            local_probe_uri(&config.username, &config.password)
+        )];
         let env_refs: Vec<&str> = env.iter().map(String::as_str).collect();
-        let probe_script = "mongosh --quiet --norc \
-             -u \"$INIT_USER\" -p \"$INIT_PASS\" --authenticationDatabase admin \
+        let probe_script = "mongosh --quiet --norc \"$INIT_URI\" \
              --eval 'const r = db.hello(); if (!r.isWritablePrimary) { quit(2); }' 2>&1";
 
         let max_wait = Duration::from_secs(30);
@@ -769,11 +849,12 @@ impl MongodbService {
 
     /// Render a container's health state as a one-line, log-safe diagnostic.
     ///
-    /// The MongoDB healthcheck embeds the root password in its command line, so
-    /// anything derived from it is treated as credential-bearing: only the
-    /// healthcheck's captured `output` is surfaced (never the command itself),
-    /// it is truncated, and newlines are flattened so a multi-line mongosh
-    /// stack trace cannot smear across the log.
+    /// The healthcheck itself no longer carries the root credentials (see
+    /// [`HEALTHCHECK_COMMAND`]), but anything derived from a probe against a
+    /// credentialed service is still treated as potentially credential-bearing:
+    /// only the healthcheck's captured `output` is surfaced (never the command
+    /// itself), it is truncated, and newlines are flattened so a multi-line
+    /// mongosh stack trace cannot smear across the log.
     fn describe_container_health(state: &bollard::models::ContainerState) -> String {
         const MAX_OUTPUT: usize = 400;
 
@@ -1443,18 +1524,17 @@ impl MongodbService {
         use bollard::exec::{CreateExecOptions, StartExecOptions, StartExecResults};
         use futures::StreamExt;
 
-        // Probe via env var so special chars can't break the shell. mongosh
-        // reads `--password "$P"` literally.
+        // Probe via env var so special chars can't break the shell, and as a
+        // percent-encoded connection URI rather than `-u`/`--password`
+        // arguments so a credential starting with `-` can't be mistaken for a
+        // flag by mongosh's parser — see [`local_probe_uri`].
         let probe_cmd = vec![
             "sh",
             "-c",
-            "mongosh --quiet -u \"$PROBE_USER\" --authenticationDatabase admin --password \"$PROBE_PASS\" --eval 'db.runCommand({ping:1})' mongodb://127.0.0.1:27017/admin 2>&1",
+            "mongosh --quiet --norc \"$PROBE_URI\" --eval 'db.runCommand({ping:1})' 2>&1",
         ];
 
-        let env = [
-            format!("PROBE_USER={}", username),
-            format!("PROBE_PASS={}", password),
-        ];
+        let env = [format!("PROBE_URI={}", local_probe_uri(username, password))];
         let env_refs: Vec<&str> = env.iter().map(|s| s.as_str()).collect();
 
         let exec = self
@@ -3469,6 +3549,172 @@ mod tests {
             default_docker_image(),
             "gotempsh/mongodb-walg:8.0".to_string()
         );
+    }
+
+    // ── Regression: credentials that mongosh's parser mistakes for flags ────
+
+    /// A root password with the shape that broke MongoDB service creation:
+    /// 32 characters drawn from `generate_secure_password()`'s charset, the
+    /// first of which is `-`. Roughly 1 in 73 generated passwords looks like
+    /// this. Synthesised here rather than copied from the incident, but the
+    /// shape (leading `-`, plus `!&=^@*#%+` in the tail) is preserved because
+    /// that shape is the whole point of the test.
+    const DASH_LEADING_PASSWORD: &str = "-Xq!7&Zt=3^w_9@Mr*4#Pv2%Kd+Ln8*Q";
+
+    /// A username with the same hazard. `-u <value>` is exposed to the exact
+    /// same parse error as `-p <value>`, so fixing only the password would
+    /// leave half the bug in place.
+    const DASH_LEADING_USERNAME: &str = "-temps-probe-admin";
+
+    /// Cheap drift guard: the probe must not carry any credential on
+    /// `mongosh`'s command line, and must reference the env vars the container
+    /// is actually created with.
+    ///
+    /// This is deliberately *not* the regression test. The original bug lived
+    /// entirely in how mongosh parses the string, not in the string itself, so
+    /// an assertion on the constructed command would have passed happily while
+    /// production timed out. Its only job is to fail loudly if a later edit
+    /// puts credentials back on argv, without needing Docker to do so.
+    #[test]
+    fn test_healthcheck_command_carries_no_credentials_on_argv() {
+        assert!(
+            !HEALTHCHECK_COMMAND.contains(" -u "),
+            "healthcheck must not pass the username as an argument: {HEALTHCHECK_COMMAND}"
+        );
+        assert!(
+            !HEALTHCHECK_COMMAND.contains(" -p "),
+            "healthcheck must not pass the password as an argument: {HEALTHCHECK_COMMAND}"
+        );
+        assert!(
+            !HEALTHCHECK_COMMAND.contains("--password"),
+            "healthcheck must not pass the password as an argument: {HEALTHCHECK_COMMAND}"
+        );
+        assert!(
+            HEALTHCHECK_COMMAND.contains(MONGO_ROOT_USER_ENV)
+                && HEALTHCHECK_COMMAND.contains(MONGO_ROOT_PASSWORD_ENV),
+            "healthcheck must read both credentials from the env vars the container is created with: {HEALTHCHECK_COMMAND}"
+        );
+    }
+
+    /// The in-container exec probes hand credentials to mongosh as a
+    /// connection URI, which is a single token always starting with
+    /// `mongodb://` and therefore never mistakable for a flag.
+    #[test]
+    fn test_local_probe_uri_is_never_flag_shaped() {
+        let uri = local_probe_uri(DASH_LEADING_USERNAME, DASH_LEADING_PASSWORD);
+        assert!(
+            uri.starts_with("mongodb://"),
+            "probe URI must be a positional connection string, got: {uri}"
+        );
+        // Characters that would otherwise re-shape the URI must be encoded.
+        assert!(uri.contains("%40"), "`@` must be percent-encoded: {uri}");
+        assert!(uri.contains("%21"), "`!` must be percent-encoded: {uri}");
+        assert!(uri.contains("%3D"), "`=` must be percent-encoded: {uri}");
+        assert!(uri.contains("%26"), "`&` must be percent-encoded: {uri}");
+        assert!(
+            uri.ends_with("/admin?authSource=admin"),
+            "probe URI must authenticate against admin: {uri}"
+        );
+    }
+
+    /// Regression test for the 90-second health-check timeout that made every
+    /// MongoDB service with a `-`-leading root password fail to create.
+    ///
+    /// **This has to run against a real container.** The bug was never in the
+    /// string temps built — the shell quoted it correctly and handed `mongosh`
+    /// two clean argv tokens — it was in how mongosh's own Node-based parser
+    /// reads a token beginning with `-` in a value position. So this boots the
+    /// real image, goes through the same `create_container` path the provider
+    /// uses in production (same env vars, same `HealthConfig`), and lets Docker
+    /// execute the health probe for real. `create_container` only returns `Ok`
+    /// once Docker reports the container HEALTHY; before the fix it returned
+    /// `Err("MongoDB container health check timed out after 90s...")`.
+    ///
+    /// Both the username and the password start with `-`, since `-u` was
+    /// exposed to the identical parse error as `-p`.
+    ///
+    /// Skips (does not fail) when Docker is unavailable — Docker tests in this
+    /// repo must never be `#[ignore]`d.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_container_becomes_healthy_with_dash_leading_credentials() {
+        // Bounded so a wedged daemon or an unreachable registry fails with a
+        // diagnostic instead of stalling CI. The health probe itself is already
+        // capped at 90s inside `wait_for_container_health`.
+        const TEST_TIMEOUT: Duration = Duration::from_secs(300);
+
+        let docker = match Docker::connect_with_local_defaults() {
+            Ok(d) => Arc::new(d),
+            Err(e) => {
+                println!("Docker not available, skipping test: {e}");
+                return;
+            }
+        };
+        if docker.ping().await.is_err() {
+            println!("Docker daemon not responding, skipping test");
+            return;
+        }
+
+        let service_name = format!("test-dash-pw-{}", chrono::Utc::now().timestamp_millis());
+        let port = match find_available_port(27200) {
+            Some(p) => p,
+            None => {
+                println!("No available port for MongoDB, skipping test");
+                return;
+            }
+        };
+
+        let service = MongodbService::new(service_name.clone(), docker.clone());
+        let mut config = MongodbRuntimeConfig {
+            host: "localhost".to_string(),
+            port: port.to_string(),
+            database: "testdb".to_string(),
+            username: DASH_LEADING_USERNAME.to_string(),
+            password: DASH_LEADING_PASSWORD.to_string(),
+            docker_image: default_docker_image(),
+            replica_set: None,
+            keyfile_content: None,
+            container_name: None,
+        };
+
+        let result = tokio::time::timeout(
+            TEST_TIMEOUT,
+            service.create_container(&docker, &mut config, &ServiceResourceLimits::default()),
+        )
+        .await;
+
+        // Tear down before asserting so a failure never leaks a container or
+        // volume onto the developer's machine or the CI runner.
+        let container_name = service.get_container_name();
+        let _ = docker
+            .remove_container(
+                &container_name,
+                Some(bollard::query_parameters::RemoveContainerOptions {
+                    force: true,
+                    v: true,
+                    ..Default::default()
+                }),
+            )
+            .await;
+        let _ = docker
+            .remove_volume(
+                &format!("temps-mongodb-{}-data", service_name),
+                None::<bollard::query_parameters::RemoveVolumeOptions>,
+            )
+            .await;
+
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => panic!(
+                "MongoDB container with a '-'-leading username and password never became healthy. \
+                 This is the regression: mongosh rejects such a value in a space-separated \
+                 -u/-p/--password position with `unrecognized option`, so every probe fails \
+                 and creation times out. Underlying error: {e}"
+            ),
+            Err(_) => panic!(
+                "create_container exceeded {}s — the daemon or the image pull is wedged",
+                TEST_TIMEOUT.as_secs()
+            ),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Creating a MongoDB service could fail with a 90-second health-check timeout whenever the auto-generated root password happened to start with `-`:

```
MongoshUnimplementedError: [COMMON-10001] Error parsing command line: unrecognized option: -<password>
```

The shell quoting of the healthcheck command was already correct — `mongosh` received two clean argv tokens. The fault is in **mongosh's own argument parser**, which treats any token beginning with `-` as a new flag, including in the value position of a space-separated `-u`, `-p`, or `--password`. `generate_secure_password()`'s charset includes `-` with no leading-character constraint, so roughly 1 in 73 generated MongoDB root passwords was unprovisionable.

Two shapes that keep the other providers (Postgres, MariaDB) safe from this class of bug do **not** transfer to mongosh, both verified against a real `gotempsh/mongodb-walg:8.0` container:
- The glued `-p<value>` form that makes `mariadb-admin` immune is **not** accepted by mongosh — it silently ignores the glued value, prompts for a password on stdin, and fails auth. That's a worse failure mode than the parse error, since it looks like a credential problem rather than a parsing one.
- `--password=<value>` works, but only covers the password — `-u <username>` is exposed to the identical parse error.

**Fix**: keep both credentials off `mongosh`'s argv entirely.
- The Docker health check reads `MONGO_INITDB_ROOT_USERNAME`/`MONGO_INITDB_ROOT_PASSWORD` from the container's own environment inside a `--eval` script (`process.env`), rather than passing them as CLI flags.
- Three in-container exec probes with the same latent bug (replica-set initiation, primary-wait, and the WAL-G backup auth probe) now pass a percent-encoded `mongodb://` connection URI instead of `-u`/`-p`/`--password` — a URI is always a single token starting with `mongodb://`, so it can never be misread as a flag regardless of what the credentials contain.

This is immune to *any* credential shape, including passwords an operator sets by hand through the API rather than ones this crate generated — the underlying issue isn't specific to the password generator, so the generator itself is intentionally left unchanged (it's shared with Postgres/MariaDB, and constraining its charset would only patch the symptom for auto-generated passwords while leaving manually-set ones just as exposed).

## Test plan

- [x] `cargo check --lib -p temps-providers` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (verified independently via resolved `cargo` path)
- [x] `cargo test -p temps-providers` (all targets) — 572 + 3 + 5 + 1 passed, 0 failed
- [x] New regression test boots a **real** MongoDB container through the same `create_container` path production uses, with a `-`-leading username *and* password, and asserts it reaches Docker-reported `healthy`. This has to run for real — the bug was in how `mongosh` parses the string, not in the string itself, so a pure string assertion would pass while production still times out. Confirmed as a true regression test: hand-reverting only the health-check hunk makes it fail in ~92s reproducing the exact original error; the fix passes in ~8s. Skips gracefully (not `#[ignore]`) when Docker is unavailable.
- [x] Cheap non-Docker drift guard also added: asserts the health-check command string never contains `-u`/`-p`/`--password` and does reference both env var names, so a future edit can't silently reintroduce this without Docker.
- [x] Verified no incident-specific secret strings leaked into the diff (test uses a synthesized password of the same shape, not the one from the original report).