### PR TITLE
fix(cli): close staged binary before self-update preflight

### DIFF
--- a/crates/temps-cli/src/commands/serve/self_update.rs
+++ b/crates/temps-cli/src/commands/serve/self_update.rs
@@ -40,7 +40,7 @@ use crate::commands::upgrade::{
     check_write_permission, create_upgrade_temp_file, current_version_tag, download_asset_text,
     download_asset_to_file, extract_binary_from_tarball_file, fetch_latest_release_in_channel,
     fetch_specific_release, finalize_staged_binary, is_newer_version, platform_target,
-    verify_computed_checksum, GitHubRelease, UpgradeChannel,
+    seal_staged_binary, verify_computed_checksum, GitHubRelease, UpgradeChannel,
 };
 
 /// Grace period between accepting the update and exiting the process. Long
@@ -928,15 +928,18 @@ impl UpdateJob {
             &staged_path,
         )?;
 
-        // Preflight against the staged file itself rather than writing a
-        // second full copy just to exec it.
-        preflight_staged_binary(&staged_path, staged_file.as_file())?;
+        // Finish and close the writable handle before preflight. Unix refuses
+        // to execute a file that is still open for writing (ETXTBSY on Linux;
+        // macOS may terminate it), which made every streamed self-update fail
+        // here before the live binary was swapped.
+        let staged_path = seal_staged_binary(staged_file)?;
+        preflight_staged_binary(staged_path.as_ref())?;
 
         self.set_phase(SelfUpdatePhase::Installing, None);
         // Keep the outgoing binary next to the new one so a release that boots
         // but misbehaves can be reverted with a single `mv`, without network.
         let backup_path = backup_current_binary(&self.binary_path)?;
-        finalize_staged_binary(&self.binary_path, staged_file)?;
+        finalize_staged_binary(&self.binary_path, staged_path)?;
 
         Ok((to_version, backup_path))
     }
@@ -1240,15 +1243,7 @@ fn running_under_systemd_service() -> bool {
 /// copy just to exec it — that second copy is exactly the kind of extra
 /// in-memory/on-disk buffering the streaming rewrite of this flow removed
 /// everywhere else.
-fn preflight_staged_binary(staged_path: &Path, staged_file: &std::fs::File) -> anyhow::Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        staged_file
-            .set_permissions(std::fs::Permissions::from_mode(0o755))
-            .map_err(|e| anyhow::anyhow!("Failed to make the staged binary executable: {}", e))?;
-    }
-
+fn preflight_staged_binary(staged_path: &Path) -> anyhow::Result<()> {
     let output = std::process::Command::new(staged_path)
         .arg("--version")
         .output();
@@ -1765,12 +1760,31 @@ mod tests {
         let dir = temp_dir("preflight");
         let staged_path = dir.join("staged");
         std::fs::write(&staged_path, b"definitely not an executable").unwrap();
-        let staged_file = std::fs::File::open(&staged_path).unwrap();
-
         // Not a valid executable — exec must fail, and the error must say the
         // running version is untouched.
-        let err = preflight_staged_binary(&staged_path, &staged_file).expect_err("must reject");
+        let err = preflight_staged_binary(&staged_path).expect_err("must reject");
         assert!(err.to_string().contains("left untouched"), "{err}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_preflight_accepts_valid_binary_after_staging_handle_is_closed() {
+        use std::io::Write;
+
+        let dir = temp_dir("preflight-valid");
+        let mut staged = create_upgrade_temp_file(&dir, ".temps-selfupdate-bin.")
+            .expect("create staged executable");
+        staged
+            .as_file_mut()
+            .write_all(b"#!/bin/sh\n[ \"$1\" = \"--version\" ] && exit 0\nexit 1\n")
+            .expect("write staged executable");
+
+        let staged_path = seal_staged_binary(staged).expect("seal staged executable");
+        preflight_staged_binary(staged_path.as_ref())
+            .expect("a valid staged binary must execute after its write handle is closed");
+
+        drop(staged_path);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/temps-cli/src/commands/upgrade.rs
+++ b/crates/temps-cli/src/commands/upgrade.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::io::{Seek, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tempfile::NamedTempFile;
+use tempfile::{NamedTempFile, TempPath};
 use tracing::{debug, info};
 
 const GITHUB_RELEASES_API: &str = "https://api.github.com/repos/gotempsh/temps/releases";
@@ -413,9 +413,14 @@ impl UpgradeCommand {
             &staged_path,
         )?;
 
+        // Close the writable staging handle before the file can ever be
+        // executed. This is also required by the in-process updater's
+        // preflight: Unix rejects an executable that is still open for write.
+        let staged_path = seal_staged_binary(staged_file)?;
+
         // Replace the binary atomically
         println!("  Replacing binary at {}...", binary_path.display());
-        finalize_staged_binary(&binary_path, staged_file)?;
+        finalize_staged_binary(&binary_path, staged_path)?;
 
         println!();
         println!(
@@ -579,8 +584,10 @@ impl UpgradeCommand {
             &staged_path,
         )?;
 
+        let staged_path = seal_staged_binary(staged_file)?;
+
         println!("  Replacing binary at {}...", binary_path.display());
-        finalize_staged_binary(&binary_path, staged_file)?;
+        finalize_staged_binary(&binary_path, staged_path)?;
 
         // Install the license into the data dir so the binary finds it.
         let data_dir = resolve_data_dir(&self.data_dir)?;
@@ -1461,11 +1468,13 @@ pub(crate) fn create_upgrade_temp_file(
         })
 }
 
-/// Atomically persist an owned staged binary over the target.
-pub(crate) fn finalize_staged_binary(
-    binary_path: &Path,
-    staged_file: NamedTempFile,
-) -> anyhow::Result<()> {
+/// Finish writing a staged executable, make it durable, and close its writable
+/// handle.
+///
+/// Closing the handle is part of the correctness contract: the in-process
+/// updater executes this path for its preflight, and Unix can reject (or kill)
+/// an executable while any process still has it open for writing.
+pub(crate) fn seal_staged_binary(staged_file: NamedTempFile) -> anyhow::Result<TempPath> {
     let staged_path = staged_file.path().to_path_buf();
 
     #[cfg(unix)]
@@ -1483,24 +1492,32 @@ pub(crate) fn finalize_staged_binary(
 
     staged_file.as_file().sync_all().map_err(|e| {
         anyhow::anyhow!(
-            "Failed to sync staged binary {} before replacing {}: {}",
+            "Failed to sync staged binary {} before closing its write handle: {}",
             staged_path.display(),
-            binary_path.display(),
             e
         )
     })?;
 
+    Ok(staged_file.into_temp_path())
+}
+
+/// Atomically persist a sealed staged binary over the target.
+pub(crate) fn finalize_staged_binary(
+    binary_path: &Path,
+    staged_path: TempPath,
+) -> anyhow::Result<()> {
+    let staged_path_for_error = staged_path.to_path_buf();
+
     // The destination normally exists, so overwrite-capable `persist` is the
     // correct atomic operation; `persist_noclobber` would reject an upgrade.
-    let installed_file = staged_file.persist(binary_path).map_err(|e| {
+    staged_path.persist(binary_path).map_err(|e| {
         anyhow::anyhow!(
             "Failed to atomically replace binary {} using staged file {}: {}",
             binary_path.display(),
-            staged_path.display(),
+            staged_path_for_error.display(),
             e.error
         )
     })?;
-    drop(installed_file);
 
     sync_binary_parent(binary_path)?;
     Ok(())
@@ -1600,7 +1617,8 @@ pub(crate) fn replace_binary(binary_path: &Path, new_binary: &[u8]) -> anyhow::R
             )
         })?;
 
-    finalize_staged_binary(binary_path, staged_file)
+    let staged_path = seal_staged_binary(staged_file)?;
+    finalize_staged_binary(binary_path, staged_path)
 }
 
 // ── EE proxy helpers ────────────────────────────────────────────────────────
@@ -2493,6 +2511,7 @@ mod tests {
         let staged_path = staged.path().to_path_buf();
         staged.as_file_mut().write_all(b"new").unwrap();
 
+        let staged = seal_staged_binary(staged).unwrap();
         finalize_staged_binary(&target, staged).unwrap();
 
         assert!(!staged_path.exists());


### PR DESCRIPTION
## Summary

- close and sync the streamed staging file before the in-process updater executes its preflight
- retain TempPath cleanup semantics until the sealed binary is atomically installed
- add a regression test covering successful preflight after the writable handle is closed

## Root cause

The streaming upgrade rewrite left NamedTempFile open for writing while Command executed the staged path with --version. Unix refuses to execute a file that is still writable: Linux reports ETXTBSY and macOS can terminate the process. The updater therefore failed during preflight before swapping the live binary.

A local kernel reproduction with a valid Bun executable returned 0 after its handle was closed and 137 while the same file remained open for writing.

## Verification

- cargo fmt --all -- --check
- cargo clippy --lib -p temps-cli -- -D warnings
- cargo check --lib
- cargo test --lib -p temps-cli test_preflight_accepts_valid_binary_after_staging_handle_is_closed -- --nocapture: 1 passed
- cargo test --lib -p temps-cli: 242 passed, 0 failed
- repository commit hooks passed, including all-target/all-feature clippy

## Live upgrade evidence

Started an isolated Temps instance in slot 3 from this branch, identified the source build as 0.1.0-beta.56-unknown, and applied v0.1.0-nightly.20260827.a78b7ec0 through POST /api/settings/update.

- request accepted with HTTP 202
- download and extraction completed
- staged binary preflight completed and the binary was swapped
- status reached installed_pending_restart with error: null and migrations 0/0
- the old process remained healthy before restart: /readyz returned 200
- after manual restart, current_version was v0.1.0-nightly.20260827.a78b7ec0, phase was idle, and last_attempt.status was succeeded with error: null
- restored slot 3 to a fresh build of this branch; API and dashboard both return 200
