### PR TITLE
fix(cli): api-query --filter is silently ignored

### DIFF
--- a/apps/temps-cli/src/commands/analytics/api-traffic.test.ts
+++ b/apps/temps-cli/src/commands/analytics/api-traffic.test.ts
@@ -6,6 +6,7 @@ import {
   parsePageSizeForTest,
   parseTrafficFilterForTest,
   parseTrafficMetricsForTest,
+  resolveApiQueryFiltersForTest,
   trafficOffsetPlanForTest,
 } from './api-traffic.js'
 
@@ -80,6 +81,16 @@ describe('traffic filters', () => {
     expect(() => parseTrafficFilterForTest('raw_sql:eq:anything')).toThrow(
       'Unknown filter dimension',
     )
+  })
+
+  test('reaches the request body from commander options.filter (regression: options.filters was always undefined)', () => {
+    expect(
+      resolveApiQueryFiltersForTest({ filter: ['path:eq:/pricing'] }),
+    ).toEqual([{ dimension: 'path', operator: 'eq', values: ['/pricing'] }])
+  })
+
+  test('defaults to no filters when none are passed', () => {
+    expect(resolveApiQueryFiltersForTest({})).toEqual([])
   })
 })
 

--- a/apps/temps-cli/src/commands/analytics/api-traffic.ts
+++ b/apps/temps-cli/src/commands/analytics/api-traffic.ts
@@ -40,7 +40,7 @@ interface ApiTrafficLimitOptions extends ApiTrafficOptions {
 export interface ApiTrafficQueryOptions extends ApiTrafficOptions {
   groupBy?: string
   metrics: string
-  filters?: string[]
+  filter?: string[]
   sortBy?: string
   order?: string
   page?: string
@@ -232,6 +232,7 @@ export const formatPercentForTest = formatPercent
 export const parseNonNegativeIntegerForTest = parseNonNegativeInteger
 export const parsePageSizeForTest = parsePageSize
 export const parseTrafficFilterForTest = parseFilter
+export const resolveApiQueryFiltersForTest = resolveApiQueryFilters
 export const parseTrafficMetricsForTest = (raw: string): TrafficMetric[] =>
   parseCsv(raw, TRAFFIC_METRICS, 'metric')
 
@@ -683,6 +684,12 @@ export async function apiPath(
   )
 }
 
+function resolveApiQueryFilters(
+  options: Pick<ApiTrafficQueryOptions, 'filter'>,
+): TrafficFilter[] {
+  return (options.filter ?? []).map(parseFilter)
+}
+
 export async function apiQuery(options: ApiTrafficQueryOptions): Promise<void> {
   const dimensions = parseCsv(
     options.groupBy ?? '',
@@ -709,7 +716,7 @@ export async function apiQuery(options: ApiTrafficQueryOptions): Promise<void> {
     options,
     dimensions,
     metrics,
-    (options.filters ?? []).map(parseFilter),
+    resolveApiQueryFilters(options),
     sortBy,
     options.order,
     'API traffic query:',


### PR DESCRIPTION
## Summary
- `temps analytics api-query --filter` was silently discarded: commander stores the flag as `options.filter` (singular), but the consumer read `options.filters` (plural), which was always `undefined`. The `?? []` fallback produced an unfiltered request with no error or warning.
- Renamed the `ApiTrafficQueryOptions.filter` field to match commander's actual output and read `options.filter` at the call site.
- Extracted the options-to-request-filters mapping into a small pure function (`resolveApiQueryFilters`) so it's testable without mocking the SDK.
- The `--filter` flag name itself is unchanged (still documented in help text/usage examples), so existing scripts keep working.

## Test plan
- [x] `bun test src/commands/analytics/api-traffic.test.ts` — added regression tests asserting `options.filter` reaches the request body, and that omitting it still defaults to `[]`
- [ ] Manual: `temps analytics api-query -p <project> --group-by path --metrics requests --filter path:eq:/pricing --period 7d` returns only matching rows