### PR TITLE
fix(build): install python3 in the musl toolchain image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,11 @@ ARG TEMPS_ARTIFACTS=artifacts-source
 # (compiling wasm-pack/wasm-bindgen-cli from source dominates a cold build).
 FROM rust:1.98-alpine AS toolchain
 
-# Install required build dependencies
+# Install required build dependencies.
+#
+# python3 is required by crates/temps-captcha-wasm's `build`/`build:dev` npm
+# scripts, which run scripts/source_attribution.py to annotate the generated
+# wasm-pack output — not by anything in this Dockerfile directly.
 RUN apk add --no-cache \
     bash \
     build-base \
@@ -34,7 +38,8 @@ RUN apk add --no-cache \
     curl \
     tar \
     gzip \
-    unzip
+    unzip \
+    python3
 
 # Install Node.js and npm (needed for wasm-pack and bun)
 RUN apk add --no-cache nodejs npm


### PR DESCRIPTION
## Summary
- PR #823 (and any other PR building off `main`) is failing the "Build temps Binary (musl)" job with `sh: python3: not found` (exit 127).
- Root cause: #820 (`chore(legal): preserve source attribution in distributions`) changed `crates/temps-captcha-wasm`'s `build`/`build:dev` npm scripts to run `python3 ../../scripts/source_attribution.py annotate ...` after `wasm-pack build`. The `toolchain` stage of the root `Dockerfile` — used both for the production image build and as the container CI compiles the musl binary in — never installed `python3`, so that step fails wherever `npm run build` runs for `temps-captcha-wasm`.
- Fix: add `python3` to the toolchain stage's `apk add` list, with a comment explaining why an Alpine build stage needs Python.

## Test plan
- [x] Verified `python3` installs cleanly via `apk add --no-cache python3` on the same `rust:1.98-alpine` base image used by the toolchain stage.
- [x] Reproduced the exact failing command (`cd crates/temps-captcha-wasm && python3 ../../scripts/source_attribution.py annotate crates/temps-captcha-wasm/pkg`) locally with python3 present — it now succeeds and correctly annotates the wasm-pack output instead of failing with "python3: not found".
- [ ] CI: the `Build temps Binary (musl)` job on this PR should go green (currently fails on `main` and every PR based on it, including #823).