### PR TITLE
fix(docker): apk upgrade base packages in runtime images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,8 +36,10 @@ bun.lockb
 docs/
 README.md
 CHANGELOG.md
-LICENSE
 *.md
+
+# NOTE: LICENSE is intentionally NOT excluded -- Dockerfile's runtime stage
+# COPYs LICENSE, LICENSE-MIT and NOTICE into the image for attribution.
 
 # Development files
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -138,6 +138,14 @@ FROM ${TEMPS_ARTIFACTS} AS artifacts
 # Stage 3: Runtime
 FROM alpine:3.22
 
+# `apk add` only installs the packages listed below -- it does not touch
+# packages already present in the base image (busybox, musl, ssl_client),
+# so those stay at whatever patch level was current the day this tag was
+# pulled. Upgrading them explicitly here means a base image security patch
+# (e.g. a musl or busybox CVE fix) lands on the next build, not only on the
+# next manual Alpine version bump.
+RUN apk update && apk upgrade --no-cache
+
 # Install runtime dependencies
 RUN apk add --no-cache \
     ca-certificates \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -3,6 +3,14 @@
 
 FROM alpine:3.22
 
+# `apk add` only installs the packages listed below -- it does not touch
+# packages already present in the base image (busybox, musl, ssl_client),
+# so those stay at whatever patch level was current the day this tag was
+# pulled. Upgrading them explicitly here means a base image security patch
+# (e.g. a musl or busybox CVE fix) lands on the next build, not only on the
+# next manual Alpine version bump.
+RUN apk update && apk upgrade --no-cache
+
 # Install runtime dependencies
 RUN apk add --no-cache \
     ca-certificates \


### PR DESCRIPTION
## Summary
- Closes the 10 open [code-scanning alerts](https://github.com/gotempsh/temps/security/code-scanning) (CVE-2026-40200, CVE-2026-6042, CVE-2024-58251, CVE-2025-46394 across `busybox`/`busybox-binsh`/`musl`/`musl-utils`/`ssl_client`) flagged by the weekly Trivy container scan against `ghcr.io/gotempsh/temps:latest`.
- Root cause: `apk add --no-cache <pkgs>` only installs the packages it's given -- it never upgrades packages already baked into the base image. `Dockerfile`/`Dockerfile.release` pin `alpine:3.22` but never run `apk upgrade`, so `busybox`/`musl`/`ssl_client` stay frozen at whatever patch level Alpine shipped the day the base tag was last bumped. #692 already moved both files off EOL `alpine:3.19`/`3.20` and that base already contains the fixed package versions -- but `:latest` still reflects `v0.0.8` (2026-03-31), the last stable release, which predates #692, so the currently-published image is still vulnerable.
- Fix: run `apk update && apk upgrade --no-cache` before installing runtime deps in both runtime Dockerfiles, so future Alpine security patches land on every rebuild automatically instead of requiring another manual base-image version bump each time.
- **Also fixes an unrelated CI break surfaced on this PR**: `.dockerignore` excluded `LICENSE` under "Docs and examples", but `Dockerfile`'s runtime stage (added in #820) `COPY`s `LICENSE LICENSE-MIT NOTICE` into the image for attribution. That mismatch broke every image build, including Compose Security CI, with `"/LICENSE": not found`. `.dockerignore` is updated to stop excluding `LICENSE`.

Note: since no stable release has shipped since #692, closing the code-scanning alerts for real also requires cutting a new stable release (or running `dependency-scan.yml` manually) so `:latest` is rebuilt from a fixed Dockerfile -- flagging this to maintainers separately.

## Test plan
- [x] Verified `apk upgrade --no-cache` on `alpine:3.19` brings `busybox`/`musl`/`ssl_client` to exactly the alert-referenced fixed versions (`busybox-1.36.1-r21`, `musl-1.2.4_git20230717-r6`, `ssl_client-1.36.1-r21`)
- [x] Verified `alpine:3.22` (current pin) already ships patched versions of all flagged packages
- [x] Confirmed `LICENSE` was the only license-related file matched by `.dockerignore`'s exclusion rules (`LICENSE-MIT`/`NOTICE` were never excluded)
- [ ] CI: `Dependency & Container Scan` / build / Compose Security workflows on this PR