### PR TITLE
fix(proxy): require Upgrade-Insecure-Requests for HTTP-origin page tracking

### DIFF
--- a/crates/temps-proxy/src/integration_test.rs
+++ b/crates/temps-proxy/src/integration_test.rs
@@ -180,6 +180,7 @@ mod integration_tests {
             "GET",
             browser_accept,
             document,
+            None,
         ));
         assert!(!LoadBalancer::should_track_page(
             "/api/_temps/health",
@@ -187,6 +188,7 @@ mod integration_tests {
             "GET",
             browser_accept,
             document,
+            None,
         ));
         assert!(!LoadBalancer::should_track_page(
             "/assets/style.css",
@@ -194,6 +196,7 @@ mod integration_tests {
             "GET",
             Some("text/css,*/*;q=0.1"),
             Some("style"),
+            None,
         ));
         assert!(LoadBalancer::should_track_page(
             "/some-page",
@@ -201,6 +204,7 @@ mod integration_tests {
             "GET",
             browser_accept,
             document,
+            None,
         ));
         assert!(!LoadBalancer::should_track_page(
             "/graphql",
@@ -208,6 +212,7 @@ mod integration_tests {
             "POST",
             Some("application/json"),
             Some("empty"),
+            None,
         ));
         assert!(!LoadBalancer::should_track_page(
             "/v1/users",
@@ -215,6 +220,7 @@ mod integration_tests {
             "GET",
             Some("application/json"),
             Some("empty"),
+            None,
         ));
         assert!(!LoadBalancer::should_track_page(
             "/missing-content-type",
@@ -222,6 +228,28 @@ mod integration_tests {
             "GET",
             browser_accept,
             document,
+            None,
+        ));
+
+        // HTTP-origin navigation: no Fetch Metadata, browser Accept, and
+        // Upgrade-Insecure-Requests: 1 → track.
+        assert!(LoadBalancer::should_track_page(
+            "/",
+            Some("text/html"),
+            "GET",
+            browser_accept,
+            None,
+            Some("1"),
+        ));
+        // HTTP-origin scraper: browser Accept, no Upgrade-Insecure-Requests
+        // → not tracked.
+        assert!(!LoadBalancer::should_track_page(
+            "/",
+            Some("text/html"),
+            "GET",
+            browser_accept,
+            None,
+            None,
         ));
         Ok(())
     }

--- a/crates/temps-proxy/src/proxy.rs
+++ b/crates/temps-proxy/src/proxy.rs
@@ -1203,6 +1203,7 @@ impl LoadBalancer {
         method: &str,
         accept: Option<&str>,
         fetch_destination: Option<&str>,
+        upgrade_insecure_requests: Option<&str>,
     ) -> bool {
         // API responses never represent a browser page, even when a framework
         // returns an HTML error document for an API-prefixed route.
@@ -1220,7 +1221,12 @@ impl LoadBalancer {
         // navigation with both an HTML Accept value and Fetch Metadata that
         // identifies a top-level document. Requiring both excludes generic
         // HTTP clients, framework data fetches, and embedded resources.
-        if !is_browser_document_request(method, accept, fetch_destination) {
+        if !is_browser_document_request(
+            method,
+            accept,
+            fetch_destination,
+            upgrade_insecure_requests,
+        ) {
             return false;
         }
 
@@ -1260,6 +1266,11 @@ impl LoadBalancer {
             .headers
             .get("sec-fetch-dest")
             .and_then(|value| value.to_str().ok());
+        let upgrade_insecure_requests = session
+            .req_header()
+            .headers
+            .get("upgrade-insecure-requests")
+            .and_then(|value| value.to_str().ok());
 
         if Self::should_track_page(
             &ctx.path,
@@ -1267,6 +1278,7 @@ impl LoadBalancer {
             &ctx.method,
             request_accept,
             fetch_destination,
+            upgrade_insecure_requests,
         ) {
             self.ensure_visitor_session(ctx).await;
         }
@@ -2734,6 +2746,7 @@ fn is_browser_document_request(
     method: &str,
     accept: Option<&str>,
     fetch_destination: Option<&str>,
+    upgrade_insecure_requests: Option<&str>,
 ) -> bool {
     if method != "GET" {
         return false;
@@ -2752,7 +2765,16 @@ fn is_browser_document_request(
 
     match fetch_destination {
         Some(destination) => destination.eq_ignore_ascii_case("document"),
-        None => true,
+        // Fetch Metadata is browser-sent only to potentially trustworthy
+        // origins (HTTPS, localhost), so it never arrives on a plain-HTTP
+        // deployment. On that path, Accept alone doesn't exclude non-browser
+        // clients (curl/wget/scrapers all send a browser-shaped Accept).
+        // Upgrade-Insecure-Requests is sent by browsers on top-level
+        // navigations to HTTP origins and essentially never by non-browser
+        // clients, so require it here. This still doesn't distinguish an
+        // <iframe> load from a top-level navigation — both send the header —
+        // which Fetch Metadata alone can't fix either.
+        None => upgrade_insecure_requests.is_some_and(|value| value.trim() == "1"),
     }
 }
 
@@ -5296,6 +5318,11 @@ impl ProxyHttp for LoadBalancer {
             .as_ref()
             .and_then(|headers| headers.get("sec-fetch-dest"))
             .map(String::as_str);
+        let upgrade_insecure_requests = ctx
+            .request_headers
+            .as_ref()
+            .and_then(|headers| headers.get("upgrade-insecure-requests"))
+            .map(String::as_str);
 
         // Check if we should track this page view
         let should_track = Self::should_track_page(
@@ -5304,6 +5331,7 @@ impl ProxyHttp for LoadBalancer {
             &ctx.method,
             request_accept,
             fetch_destination,
+            upgrade_insecure_requests,
         );
 
         // Only browser HTML documents create visitor/session state (skip SSE,

--- a/crates/temps-proxy/src/proxy_test.rs
+++ b/crates/temps-proxy/src/proxy_test.rs
@@ -491,6 +491,7 @@ pub mod proxy_tests {
 
         let browser_accept = Some("text/html,application/xhtml+xml");
         let document = Some("document");
+        let uir = Some("1");
 
         // Browser HTML navigation → track
         assert!(LoadBalancer::should_track_page(
@@ -499,6 +500,7 @@ pub mod proxy_tests {
             "GET",
             browser_accept,
             document,
+            None,
         ));
 
         // Internal API → do not track
@@ -508,6 +510,7 @@ pub mod proxy_tests {
             "GET",
             browser_accept,
             document,
+            None,
         ));
 
         // CSS static asset → do not track
@@ -517,6 +520,7 @@ pub mod proxy_tests {
             "GET",
             Some("text/css,*/*;q=0.1"),
             Some("style"),
+            None,
         ));
 
         // HTML error page (404) → track
@@ -526,6 +530,7 @@ pub mod proxy_tests {
             "GET",
             browser_accept,
             document,
+            None,
         ));
 
         // API-style errors outside /api must not create visitor sessions.
@@ -535,6 +540,7 @@ pub mod proxy_tests {
             "POST",
             Some("application/json"),
             Some("empty"),
+            None,
         ));
         assert!(!LoadBalancer::should_track_page(
             "/v1/users",
@@ -542,6 +548,7 @@ pub mod proxy_tests {
             "GET",
             Some("application/json"),
             Some("empty"),
+            None,
         ));
         assert!(!LoadBalancer::should_track_page(
             "/missing-content-type",
@@ -549,6 +556,7 @@ pub mod proxy_tests {
             "GET",
             browser_accept,
             document,
+            None,
         ));
 
         // API-prefixed routes are never browser pages, even if misconfigured
@@ -559,6 +567,7 @@ pub mod proxy_tests {
             "GET",
             browser_accept,
             document,
+            None,
         ));
 
         // A generic HTTP client receiving HTML is not a browser page view.
@@ -568,17 +577,42 @@ pub mod proxy_tests {
             "GET",
             Some("*/*"),
             None,
+            None,
         ));
 
-        // Absent Fetch Metadata falls back to Accept + an HTML response.
-        // Browsers omit Sec-Fetch-* on non-trustworthy (plain HTTP) origins,
-        // so requiring it would zero out analytics for every operator serving
-        // an app over HTTP. See is_browser_document_request.
+        // HTTP-origin navigation: no Fetch Metadata (plain-HTTP origins never
+        // get Sec-Fetch-*), browser Accept, and Upgrade-Insecure-Requests: 1
+        // (which browsers send on top-level navigations to HTTP origins) →
+        // track. See is_browser_document_request.
         assert!(LoadBalancer::should_track_page(
             "/docs",
             Some("text/html"),
             "GET",
             browser_accept,
+            None,
+            uir,
+        ));
+
+        // HTTP-origin scraper: browser-shaped Accept but no
+        // Upgrade-Insecure-Requests (curl/wget/scrapers don't send it) → not
+        // tracked, even though it evades the UA-based crawler detector.
+        assert!(!LoadBalancer::should_track_page(
+            "/docs",
+            Some("text/html"),
+            "GET",
+            browser_accept,
+            None,
+            None,
+        ));
+
+        // HTTPS behaviour unchanged: when Fetch Metadata is present,
+        // Sec-Fetch-Dest decides regardless of Upgrade-Insecure-Requests.
+        assert!(LoadBalancer::should_track_page(
+            "/docs",
+            Some("text/html"),
+            "GET",
+            browser_accept,
+            document,
             None,
         ));
 
@@ -590,6 +624,7 @@ pub mod proxy_tests {
             "GET",
             browser_accept,
             None,
+            uir,
         ));
 
         // A JS fetch() on an HTTP origin sends no Fetch Metadata either, but
@@ -600,6 +635,7 @@ pub mod proxy_tests {
             "GET",
             Some("*/*"),
             None,
+            uir,
         ));
 
         // The GET-only rule still holds on the no-Fetch-Metadata path: a form
@@ -611,6 +647,7 @@ pub mod proxy_tests {
             "POST",
             browser_accept,
             None,
+            uir,
         ));
 
         // Browser background fetches must not create sessions even if an
@@ -621,6 +658,7 @@ pub mod proxy_tests {
             "GET",
             browser_accept,
             Some("empty"),
+            None,
         ));
 
         // PNG image → do not track
@@ -630,6 +668,7 @@ pub mod proxy_tests {
             "GET",
             Some("image/avif,image/webp,*/*"),
             Some("image"),
+            None,
         ));
 
         Ok(())


### PR DESCRIPTION
## Summary
- On the no-Fetch-Metadata fallback path (plain-HTTP origins, added in #711), also require `Upgrade-Insecure-Requests: 1` before treating a request as a browser document navigation.
- Browsers send `Upgrade-Insecure-Requests: 1` on top-level navigations to HTTP origins; `curl`/`wget`/`python-requests`/Bun-Node `fetch` and scrapers that spoof a browser `Accept` header essentially never do.
- HTTPS behavior is unchanged — when `Sec-Fetch-Dest` is present, it alone decides.
- Documented non-goal (same as before): this doesn't separate an `<iframe>` load from a top-level navigation on HTTP origins, since browsers send the header for both.

Fixes #715

## Test plan
- [x] `cargo test --lib -p temps-proxy` — 566 passed, 4 ignored
- [x] `cargo clippy -p temps-proxy --lib --tests -- -D warnings` — clean
- [x] New/updated unit tests cover all three acceptance cases from #715:
  - HTTP-origin navigation (browser `Accept` + `Upgrade-Insecure-Requests: 1`) → tracked
  - HTTP-origin scraper (browser `Accept`, no `Upgrade-Insecure-Requests`) → not tracked
  - HTTPS behaviour unchanged (Fetch Metadata present → `Sec-Fetch-Dest` decides)