### PR TITLE
fix(web): trim api key name on creation and prevent double-submit

### DIFF
--- a/web/src/pages/ApiKeyCreate.tsx
+++ b/web/src/pages/ApiKeyCreate.tsx
@@ -33,7 +33,7 @@ import {
   ChevronRight,
   Edit,
 } from 'lucide-react'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router'
 import { toast } from 'sonner'
 import { usePageTitle } from '@/hooks/usePageTitle'
@@ -64,6 +64,7 @@ export default function ApiKeyCreate() {
   const [copiedKey, setCopiedKey] = useState(false)
   const [openCategories, setOpenCategories] = useState<Set<string>>(new Set())
   const [createdKeyId, setCreatedKeyId] = useState<number | null>(null)
+  const isSubmittingRef = useRef(false)
 
   const { data: permissionsData, isLoading: isLoadingPermissions } =
     useApiKeyPermissions()
@@ -156,17 +157,30 @@ export default function ApiKeyCreate() {
   }
 
   const handleSubmit = () => {
+    const trimmedName = keyName.trim()
+    if (!trimmedName || isSubmittingRef.current || createMutation.isPending) {
+      return
+    }
+    isSubmittingRef.current = true
+
     const data: CreateApiKeyRequest = {
-      name: keyName,
+      name: trimmedName,
       role_type: useCustomPermissions ? 'custom' : selectedRole,
       permissions: useCustomPermissions
         ? Array.from(selectedPermissions)
         : undefined,
       expires_at: expiresAt ? new Date(expiresAt).toISOString() : undefined,
     }
-    createMutation.mutate({
-      body: data,
-    })
+    createMutation.mutate(
+      {
+        body: data,
+      },
+      {
+        onSettled: () => {
+          isSubmittingRef.current = false
+        },
+      }
+    )
   }
 
   const canProceed = () => {
@@ -239,7 +253,7 @@ export default function ApiKeyCreate() {
 
             <div className="space-y-4 p-4 bg-muted rounded-lg">
               <div className="text-sm">
-                <strong>Name:</strong> {keyName}
+                <strong>Name:</strong> {keyName.trim()}
               </div>
               <div className="text-sm">
                 <strong>Access Level:</strong>{' '}
@@ -631,7 +645,7 @@ export default function ApiKeyCreate() {
             <div className="space-y-4">
               <div>
                 <Label className="text-muted-foreground">Name</Label>
-                <p className="font-medium">{keyName}</p>
+                <p className="font-medium">{keyName.trim()}</p>
               </div>
 
               <Separator />


### PR DESCRIPTION
## Summary
Fixes an issue in `web/src/pages/ApiKeyCreate.tsx` where the API key creation form submitted untrimmed `keyName` strings with surrounding whitespace and lacked double-submit protection on the final creation mutation.

## Root Cause
1. `handleSubmit` forwarded raw `keyName` directly to `CreateApiKeyRequest`, persisting unwanted leading and trailing whitespace into the database.
2. The submit action lacked a synchronous re-entrancy lock, allowing rapid repeated clicks to fire concurrent `createMutation.mutate` calls before `isPending` state transitioned.
3. Steps 3 (Review) and 4 (Success Summary) displayed the raw untrimmed string.

## Changes Made
- **`web/src/pages/ApiKeyCreate.tsx`**:
  - Sanitized `keyName` with `keyName.trim()` before sending it in the mutation payload.
  - Added an `isSubmittingRef` synchronous lock with `onSettled` reset to prevent double-submit race conditions.
  - Updated Review (Step 3) and Success Summary (Step 4) cards to display `{keyName.trim()}`.


## Testing Done
- Verified in local browser (`agent-browser`) on `/settings/keys/new`.
- Tested entering padded whitespace names (`"  Production Server Key  "`) and confirmed payload is sanitized.
- Verified double-click resistance during mutation execution.
- Ran `bun run typecheck` in `web/` with zero errors.
