### PR TITLE
fix(auth): validate password character count instead of byte length

### DIFF
--- a/crates/temps-auth/src/auth_service.rs
+++ b/crates/temps-auth/src/auth_service.rs
@@ -1027,12 +1027,13 @@ impl AuthService {
 /// - Contains at least one digit
 /// - Contains at least one special character
 pub fn validate_password_complexity(password: &str) -> Result<(), UserAuthError> {
-    if password.len() < 8 {
+    let char_count = password.chars().count();
+    if char_count < 8 {
         return Err(UserAuthError::WeakPassword(
             "Password must be at least 8 characters long".to_string(),
         ));
     }
-    if password.len() > 128 {
+    if char_count > 128 {
         return Err(UserAuthError::WeakPassword(
             "Password must not exceed 128 characters".to_string(),
         ));
@@ -2443,6 +2444,20 @@ mod tests {
     fn test_password_empty() {
         let result = validate_password_complexity("");
         assert!(result.is_err());
+        assert!(
+            matches!(result.unwrap_err(), UserAuthError::WeakPassword(msg) if msg.contains("8 characters"))
+        );
+    }
+
+    #[test]
+    fn test_password_multibyte_characters_minimum_length() {
+        // "Aa1!🦀" is 5 characters (A, a, 1, !, 🦀) but 8 UTF-8 bytes.
+        // It must be rejected because it is under the 8 character minimum.
+        let result = validate_password_complexity("Aa1!🦀");
+        assert!(
+            result.is_err(),
+            "Password with 5 characters must be rejected even if 8 bytes"
+        );
         assert!(
             matches!(result.unwrap_err(), UserAuthError::WeakPassword(msg) if msg.contains("8 characters"))
         );


### PR DESCRIPTION
## Summary
Fixes password complexity validation in `temps-auth` to check Unicode character count (`chars().count()`) rather than raw byte length (`len()`). This prevents passwords containing multi-byte UTF-8 characters (e.g. emojis or non-Latin scripts) from bypassing the 8-character minimum policy.

## Root Cause & Fix
- **Root Cause:** `validate_password_complexity` used `password.len() < 8` and `password.len() > 128`. Because multi-byte characters occupy 2–4 bytes, a 5-character string like `"Aa1!🦀"` evaluates to 8 bytes, passing the length check despite violating the 8-character minimum.
- **Fix:** Switched length bounds checking in `crates/temps-auth/src/auth_service.rs` to count characters via `let char_count = password.chars().count();`. Added unit test `test_password_multibyte_characters_minimum_length` to prevent regressions.

## Test Logs

### BEFORE (Failing Test)
<img width="1001" height="758" alt="before" src="https://github.com/user-attachments/assets/fea76ccc-d124-4d39-9b47-4b7cbe280437" />


**AFTER (Passing Test)**

<img width="946" height="393" alt="after" src="https://github.com/user-attachments/assets/c0fd6ec9-a50d-40bf-ba3b-fe3e03d40389" />


**Testing Done**
```
cargo test -p temps-auth --lib test_password_multibyte_characters_minimum_length
cargo test -p temps-auth --lib
cargo fmt --check
cargo clippy -p temps-auth -- -D warnings
```