### PR TITLE
fix(release): pin Linux release builds to ubuntu-22.04 for glibc compat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,10 @@ jobs:
   build-linux-amd64:
     name: Build Linux AMD64
     needs: build-web-assets
-    runs-on: ubuntu-latest
+    # Pinned to 22.04 (glibc 2.35) so the released binary runs on Ubuntu 22.04+/Debian 12+.
+    # ubuntu-latest currently resolves to 24.04 (glibc 2.39), which broke the binary on
+    # older-but-still-common distros with a "GLIBC_2.38/2.39 not found" error.
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
     steps:
@@ -202,7 +205,8 @@ jobs:
   build-linux-arm64:
     name: Build Linux ARM64
     needs: build-web-assets
-    runs-on: ubuntu-24.04-arm
+    # See build-linux-amd64: pinned to 22.04 (glibc 2.35) for the same broad-compatibility reason.
+    runs-on: ubuntu-22.04-arm
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary
- `build-linux-amd64` ran on `ubuntu-latest`, which now resolves to Ubuntu 24.04 (glibc 2.39). The published `temps-linux-amd64` binary was linked against glibc 2.38/2.39 symbols, so it failed to run on the still-common Ubuntu 22.04 (glibc 2.35) with `libc.so.6: version 'GLIBC_2.38' not found`.
- `install.sh` only falls back to a musl build when `/etc/alpine-release` exists, so it has no way to detect this and always ships the glibc-linked binary on non-Alpine Linux.
- Pins both `build-linux-amd64` (`ubuntu-22.04`) and `build-linux-arm64` (`ubuntu-22.04-arm`, confirmed GA runner label) so released binaries target glibc 2.35, which is forward-compatible with all newer distros.

## Test plan
- [x] Confirmed `ubuntu-22.04-arm` is a GA GitHub-hosted runner label (arm64 standard runners, generally available for public/private repos).
- [ ] CI release workflow builds successfully on the new runners (verify on merge / next tag).
- [ ] Manually verify `ldd --version` / binary `file` output on the next tagged release matches glibc 2.35 baseline.