### PR TITLE
fix(auth): don't treat transient DB errors as an expired session

### DIFF
--- a/crates/temps-auth/src/middleware.rs
+++ b/crates/temps-auth/src/middleware.rs
@@ -35,10 +35,20 @@ pub async fn auth_middleware(
             user = ctx.user.clone();
             Some(ctx)
         }
-        Err(_) => {
-            // For routes that don't require auth, continue without context
-            // The RequireAuth extractor will handle the error later
-            None
+        // Genuinely no/expired/invalid credentials: for routes that don't
+        // require auth, continue without context. The RequireAuth extractor
+        // will handle the error later with the correct 401.
+        Err(AuthError::Unauthorized(_)) => None,
+        // The auth backend itself failed to answer (DB error surfaced while
+        // validating a session/API key/token). Treating this as "no auth
+        // context" would let RequireAuth reject with a generic "Authentication
+        // Required" 401, which the frontend cannot distinguish from a real
+        // logout -- it force-redirects to the login screen. Surface the
+        // actual failure instead so a transient backend issue doesn't look
+        // like every session died at once.
+        Err(AuthError::InternalServerError(reason)) => {
+            warn!("Auth validation failed due to an internal error, refusing to treat the request as unauthenticated: {}", reason);
+            return Err(StatusCode::SERVICE_UNAVAILABLE);
         }
     };
 
@@ -225,7 +235,15 @@ async fn validate_session_cookie(
                     verified.session_id,
                 )));
             }
-            Err(_) => return Ok(None),
+            // A session row that genuinely doesn't exist (never created,
+            // expired, or the user was deleted) is the only case that means
+            // "not authenticated". Every other error here is the session
+            // store itself failing to answer (DB connection drop, pool
+            // exhaustion, timeout) -- that must NOT be reported as "no
+            // session", or a transient DB blip silently logs every active
+            // user out and bounces them to the login screen.
+            Err(crate::auth_service::AuthError::NotFound(_)) => return Ok(None),
+            Err(e) => return Err(e.into()),
         }
     }
 


### PR DESCRIPTION
## Summary
- Users reported the login screen sometimes flashing/reloading even while their session was valid.
- Root cause: `validate_session_cookie` and `auth_middleware` in `temps-auth` collapsed *every* error during session lookup — including transient DB connection failures, pool exhaustion, or timeouts — into "no valid session", identical to a genuinely expired/missing session.
- The frontend's global auth-error handler (`web/src/App.tsx`) treats any "Authentication Required"/"Unauthorized" response as "the session died" and force-redirects to the login screen. A momentary DB hiccup while validating a session cookie was therefore reported to the browser as a real logout.
- This fix distinguishes a genuinely missing/expired session (`AuthError::NotFound`) from any other failure to validate it — the latter now surfaces as `503 Service Unavailable` instead of a fake logout.
- Reviewed by `security-auditor`: no auth bypass (malformed/crafted cookies still resolve to "no session" via `extract_session_from_cookies`, never the new error path), no client-facing information leakage (503 has no body; server log may include a DB hostname but never credentials), and the 503 path isn't attacker-triggerable through session token content — it only fires when the DB itself is unhealthy.

## Test plan
- [x] `cargo check --lib` across the full workspace — 0 errors
- [x] Confirmed `middleware.rs` is the only caller of the two changed functions
- [x] Security review (auth bypass, info leakage, DoS surface) — no blocking findings
- [ ] Manual verification against a local instance with a simulated DB blip during session validation (not run in this environment)