### PR TITLE
feat(runtime): add Docker Compose deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -69,7 +69,9 @@ Thumbs.db
 .LSOverride
 
 # Development scripts
-scripts/
+scripts/*
+!scripts/source_attribution.py
+!scripts/docker-ingress-entrypoint.sh
 Makefile
 
 # Docker
@@ -83,10 +85,6 @@ docker-compose.*.yml
 .eslintrc*
 .stylelintrc*
 thoughts/
-
-# CI compose-security prebuilt-binary pipeline
-ci-build-cache/
-**/node_modules/
 
 # CI compose-security prebuilt-binary pipeline
 ci-build-cache/

--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,11 @@ CLICKHOUSE_PASSWORD=
 DOCKER_GID=
 
 # Shared Docker network used by Temps and the workloads/providers it manages.
+# Change the subnet and public-ingress address together if they overlap an
+# existing Docker, LAN, or VPN route.
 TEMPS_NETWORK_NAME=temps-docker-workloads
+TEMPS_WORKLOAD_SUBNET=198.20.255.0/24
+TEMPS_PUBLIC_INGRESS_IP=198.20.255.10
 
 # Private control-plane network. Change all four values together if this subnet
 # overlaps an existing Docker, LAN, or VPN route.
@@ -32,9 +36,9 @@ TEMPS_CONTROL_INTERNAL_IP=198.18.255.10
 TEMPS_POSTGRES_INTERNAL_IP=198.18.255.11
 TEMPS_CLICKHOUSE_INTERNAL_IP=198.18.255.12
 
-# Dedicated ingress bridge used by the loopback publication proxy.
+# Dedicated bridge used only by the loopback admin proxy.
 TEMPS_INGRESS_SUBNET=198.19.255.0/24
-TEMPS_INGRESS_PUBLISH_IP=198.19.255.10
+TEMPS_ADMIN_INGRESS_IP=198.19.255.10
 TEMPS_INGRESS_GATEWAY_IP=198.19.255.1
 
 # Initial administrator for unattended first startup. The password file is

--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,8 @@
 # PostgreSQL password for the `temps` role (used by postgres and the app).
 POSTGRES_PASSWORD=
 
-# Redis password (enforced via `--requirepass`; used by redis and the app).
-REDIS_PASSWORD=
+# ClickHouse password for the `temps` user (used by ClickHouse and the app).
+CLICKHOUSE_PASSWORD=
 
 # Group ID that owns the Docker socket. Docker access is root-equivalent and is
 # required for deployment management. Determine the container-visible GID on
@@ -22,9 +22,29 @@ REDIS_PASSWORD=
 # docker run --rm -v /var/run/docker.sock:/var/run/docker.sock alpine:3.22 stat -c '%g' /var/run/docker.sock
 DOCKER_GID=
 
+# Shared Docker network used by Temps and the workloads/providers it manages.
+TEMPS_NETWORK_NAME=temps-docker-workloads
+
+# Private control-plane network. Change all four values together if this subnet
+# overlaps an existing Docker, LAN, or VPN route.
+TEMPS_CONTROL_SUBNET=198.18.255.0/24
+TEMPS_CONTROL_INTERNAL_IP=198.18.255.10
+TEMPS_POSTGRES_INTERNAL_IP=198.18.255.11
+TEMPS_CLICKHOUSE_INTERNAL_IP=198.18.255.12
+
+# Dedicated ingress bridge used by the loopback publication proxy.
+TEMPS_INGRESS_SUBNET=198.19.255.0/24
+TEMPS_INGRESS_PUBLISH_IP=198.19.255.10
+TEMPS_INGRESS_GATEWAY_IP=198.19.255.1
+
 # Initial administrator for unattended first startup. The password file is
 # mounted read-only as a Compose secret rather than exposed in container env or
 # argv. Keep its parent directory mode 0700 and the file mode 0444 so the
 # image's non-root UID can read—but not modify—it on Linux.
 TEMPS_ADMIN_EMAIL=
 TEMPS_ADMIN_PASSWORD_FILE=./secrets/admin_password
+
+# Independent Basic-auth password for the loopback-only admin ingress. Do not
+# reuse the Temps account password. The username is `temps` and the password is
+# bcrypt-hashed inside the unprivileged ingress container at startup.
+TEMPS_ADMIN_INGRESS_PASSWORD_FILE=./secrets/admin_ingress_password

--- a/.env.example
+++ b/.env.example
@@ -50,5 +50,6 @@ TEMPS_ADMIN_PASSWORD_FILE=./secrets/admin_password
 
 # Independent Basic-auth password for the loopback-only admin ingress. Do not
 # reuse the Temps account password. The username is `temps` and the password is
-# bcrypt-hashed inside the unprivileged ingress container at startup.
+# bcrypt-hashed inside the unprivileged ingress container at startup. The file
+# must contain one non-blank line of 16–72 printable ASCII bytes.
 TEMPS_ADMIN_INGRESS_PASSWORD_FILE=./secrets/admin_ingress_password

--- a/Dockerfile.ingress
+++ b/Dockerfile.ingress
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+FROM alpine:3.22
+
+RUN apk update \
+    && apk upgrade --no-cache \
+    && apk add --no-cache apache2-utils nginx nginx-mod-stream \
+    && rm -rf /var/cache/apk/*
+
+COPY scripts/docker-ingress-entrypoint.sh /usr/local/bin/docker-ingress-entrypoint
+RUN chmod 0555 /usr/local/bin/docker-ingress-entrypoint
+
+USER 65534:65534
+ENTRYPOINT ["/usr/local/bin/docker-ingress-entrypoint"]

--- a/crates/temps-cli/src/commands/proxy.rs
+++ b/crates/temps-cli/src/commands/proxy.rs
@@ -433,8 +433,11 @@ impl ProxyCommand {
                     .map_err(|e| anyhow::anyhow!("Docker ping failed: {}", e))?;
                 Ok::<_, anyhow::Error>(docker)
             });
-            match docker {
-                Ok(docker) => {
+            match crate::commands::serve::proxy::optional_docker_feature(
+                docker,
+                "on-demand scale-to-zero wake for this proxy",
+            ) {
+                Some(docker) => {
                     let docker_runtime = temps_deployer::docker::DockerRuntime::new(
                         Arc::new(docker),
                         true,
@@ -455,14 +458,7 @@ impl ProxyCommand {
                         None,
                     )))
                 }
-                Err(e) => {
-                    warn!(
-                        "Docker not available — on-demand scale-to-zero wake is disabled \
-                         for this proxy: {}",
-                        e
-                    );
-                    None
-                }
+                None => None,
             }
         };
 

--- a/crates/temps-cli/src/commands/proxy.rs
+++ b/crates/temps-cli/src/commands/proxy.rs
@@ -209,6 +209,16 @@ impl ProxyCommand {
         self,
         ip_gate_builder: Option<ProjectIpGateBuilder>,
     ) -> anyhow::Result<()> {
+        let runtime_context = Arc::new(temps_core::initialize_process_runtime_context()?.clone());
+        if runtime_context.source() == temps_core::ExecutionEnvironmentSource::Legacy {
+            warn!(
+                legacy_variable = temps_core::LEGACY_DEPLOYMENT_MODE_VARIABLE,
+                canonical_variable = temps_core::EXECUTION_ENVIRONMENT_VARIABLE,
+                execution_environment = %runtime_context.execution_environment(),
+                "Using deprecated execution-environment configuration; migrate to TEMPS_EXECUTION_ENV"
+            );
+        }
+
         let serve_config = Arc::new(temps_config::ServerConfig::new(
             self.address.clone(),
             self.database_url.clone(),
@@ -258,6 +268,7 @@ impl ProxyCommand {
             cookie_crypto,
             encryption_service,
             serve_config.clone(),
+            runtime_context,
         )
     }
 
@@ -272,6 +283,7 @@ impl ProxyCommand {
         cookie_crypto: Arc<CookieCrypto>,
         encryption_service: Arc<temps_core::EncryptionService>,
         config: Arc<ServerConfig>,
+        runtime_context: Arc<temps_core::RuntimeContext>,
     ) -> anyhow::Result<()> {
         let data_dir = config.data_dir.clone();
         let console_address = console_address
@@ -355,7 +367,10 @@ impl ProxyCommand {
             temps_queue::BroadcastQueueService::create_job_queue_arc_with_receiver(1000);
 
         // Initialize route table with listener (preview_domain loaded from settings)
-        let route_table = Arc::new(temps_proxy::CachedPeerTable::new(db.clone()));
+        let route_table = Arc::new(temps_proxy::CachedPeerTable::new_with_runtime_context(
+            db.clone(),
+            runtime_context.clone(),
+        ));
 
         // ADR-018 on-demand TLS: build the certificate manager when enabled in
         // settings. Constructed after the route table exists (the gate's
@@ -427,6 +442,7 @@ impl ProxyCommand {
                     );
                     let adapter = crate::commands::serve::proxy::ContainerLifecycleAdapter::new(
                         Arc::new(docker_runtime) as Arc<dyn temps_deployer::ContainerDeployer>,
+                        runtime_context.clone(),
                     );
                     Some(Arc::new(OnDemandManager::new(
                         db.clone(),

--- a/crates/temps-cli/src/commands/serve/mod.rs
+++ b/crates/temps-cli/src/commands/serve/mod.rs
@@ -151,6 +151,16 @@ impl ServeCommand {
         self,
         extra_plugins: Vec<Box<dyn temps_core::plugin::TempsPlugin>>,
     ) -> anyhow::Result<()> {
+        let runtime_context = Arc::new(temps_core::initialize_process_runtime_context()?.clone());
+        if runtime_context.source() == temps_core::ExecutionEnvironmentSource::Legacy {
+            warn!(
+                legacy_variable = temps_core::LEGACY_DEPLOYMENT_MODE_VARIABLE,
+                canonical_variable = temps_core::EXECUTION_ENVIRONMENT_VARIABLE,
+                execution_environment = %runtime_context.execution_environment(),
+                "Using deprecated execution-environment configuration; migrate to TEMPS_EXECUTION_ENV"
+            );
+        }
+
         // Install the rustls crypto provider once at startup, before any
         // dependency (e.g. temps-domains) constructs a rustls client.
         crate::install_crypto_provider();
@@ -289,7 +299,10 @@ impl ServeCommand {
             temps_queue::BroadcastQueueService::create_job_queue_arc_with_receiver(1000);
 
         // Create shared route table instance (used by both console API and proxy)
-        let route_table = Arc::new(temps_proxy::CachedPeerTable::new(db.clone()));
+        let route_table = Arc::new(temps_proxy::CachedPeerTable::new_with_runtime_context(
+            db.clone(),
+            runtime_context.clone(),
+        ));
 
         // ADR-012-lite: every successful route_table reload also
         // reconciles internal `<env>.<project>.temps.local` A records,
@@ -473,7 +486,8 @@ impl ServeCommand {
                         "temps".to_string(),
                     );
                     let adapter = proxy::ContainerLifecycleAdapter::new(
-                        Arc::new(docker_runtime) as Arc<dyn temps_deployer::ContainerDeployer>
+                        Arc::new(docker_runtime) as Arc<dyn temps_deployer::ContainerDeployer>,
+                        runtime_context.clone(),
                     );
                     Arc::new(temps_proxy::on_demand::OnDemandManager::new(
                         db.clone(),

--- a/crates/temps-cli/src/commands/serve/mod.rs
+++ b/crates/temps-cli/src/commands/serve/mod.rs
@@ -446,25 +446,19 @@ impl ServeCommand {
         // The proxy server (80/443) MUST come up regardless.
         let docker_handle: Option<Arc<bollard::Docker>> = {
             let docker_rt = tokio::runtime::Runtime::new()?;
-            match docker_rt.block_on(async {
-                let docker = bollard::Docker::connect_with_defaults()
-                    .map_err(|e| anyhow::anyhow!("Docker connect failed: {}", e))?;
-                docker
-                    .ping()
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Docker ping failed: {}", e))?;
-                Ok::<_, anyhow::Error>(docker)
-            }) {
-                Ok(docker) => Some(Arc::new(docker)),
-                Err(e) => {
-                    warn!(
-                        "Docker not available — on-demand scale-to-zero and workspace \
-                         preview gateway will be disabled: {}",
-                        e
-                    );
-                    None
-                }
-            }
+            proxy::optional_docker_feature(
+                docker_rt.block_on(async {
+                    let docker = bollard::Docker::connect_with_defaults()
+                        .map_err(|e| anyhow::anyhow!("Docker connect failed: {}", e))?;
+                    docker
+                        .ping()
+                        .await
+                        .map_err(|e| anyhow::anyhow!("Docker ping failed: {}", e))?;
+                    Ok::<_, anyhow::Error>(docker)
+                }),
+                "on-demand scale-to-zero and workspace preview gateway",
+            )
+            .map(Arc::new)
         };
 
         // The on-demand wake manager is a PROXY-side concern: it watches request

--- a/crates/temps-cli/src/commands/serve/proxy.rs
+++ b/crates/temps-cli/src/commands/serve/proxy.rs
@@ -15,6 +15,26 @@ use tracing::{info, warn};
 
 use super::shutdown::CtrlCShutdownSignal;
 
+/// Keep HTTP serving available when optional Docker-backed features cannot be
+/// initialized. Both combined and split proxy composition roots use this gate,
+/// so an unavailable socket cannot accidentally become a startup failure in
+/// one mode only.
+pub(crate) fn optional_docker_feature<T>(
+    result: anyhow::Result<T>,
+    disabled_features: &str,
+) -> Option<T> {
+    match result {
+        Ok(value) => Some(value),
+        Err(error) => {
+            warn!(
+                "Docker not available — {} will be disabled: {}",
+                disabled_features, error
+            );
+            None
+        }
+    }
+}
+
 /// Adapter bridging `temps_deployer::ContainerDeployer` to `temps_proxy::on_demand::ContainerLifecycle`.
 pub(crate) struct ContainerLifecycleAdapter {
     deployer: Arc<dyn ContainerDeployer>,
@@ -278,6 +298,16 @@ pub fn start_proxy_server(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unavailable_docker_disables_optional_features_without_failing_startup() {
+        let result = optional_docker_feature::<()>(
+            Err(anyhow::anyhow!("Docker socket is unavailable")),
+            "on-demand test features",
+        );
+
+        assert!(result.is_none());
+    }
     use std::collections::HashMap;
     use temps_deployer::{
         ContainerInfo, ContainerStats, ContainerStatus, DeployRequest, DeployResult, DeployerError,

--- a/crates/temps-cli/src/commands/serve/proxy.rs
+++ b/crates/temps-cli/src/commands/serve/proxy.rs
@@ -18,11 +18,18 @@ use super::shutdown::CtrlCShutdownSignal;
 /// Adapter bridging `temps_deployer::ContainerDeployer` to `temps_proxy::on_demand::ContainerLifecycle`.
 pub(crate) struct ContainerLifecycleAdapter {
     deployer: Arc<dyn ContainerDeployer>,
+    runtime_context: Arc<temps_core::RuntimeContext>,
 }
 
 impl ContainerLifecycleAdapter {
-    pub fn new(deployer: Arc<dyn ContainerDeployer>) -> Self {
-        Self { deployer }
+    pub fn new(
+        deployer: Arc<dyn ContainerDeployer>,
+        runtime_context: Arc<temps_core::RuntimeContext>,
+    ) -> Self {
+        Self {
+            deployer,
+            runtime_context,
+        }
     }
 }
 
@@ -68,12 +75,17 @@ impl ContainerLifecycle for ContainerLifecycleAdapter {
         use temps_deployer::readiness::{check_accepting_requests, ReadinessCheck};
 
         // 2s per-request timeout matches the historical inline probe.
-        let check = check_accepting_requests(&self.deployer, container_id, Duration::from_secs(2))
-            .await
-            .map_err(|e| OnDemandError::ContainerOperation {
-                container_id: container_id.to_string(),
-                reason: e.to_string(),
-            })?;
+        let check = check_accepting_requests(
+            &self.deployer,
+            container_id,
+            Duration::from_secs(2),
+            self.runtime_context.as_ref(),
+        )
+        .await
+        .map_err(|e| OnDemandError::ContainerOperation {
+            container_id: container_id.to_string(),
+            reason: e.to_string(),
+        })?;
 
         Ok(matches!(check, ReadinessCheck::Ready))
     }
@@ -279,13 +291,11 @@ mod tests {
         info: ContainerInfo,
     }
 
-    /// Build a `ContainerInfo` pointed at a test listener. The readiness probe
-    /// resolves its URL via `DeploymentMode::build_container_url`, which yields
-    /// `(container_name, container_port)` in Docker mode and `("127.0.0.1",
-    /// host_port)` in baremetal mode. Using `container_name = "127.0.0.1"` and
+    /// Build a `ContainerInfo` pointed at a test listener. The injected Host
+    /// runtime context resolves it to `("127.0.0.1", host_port)`. Using
+    /// `container_name = "127.0.0.1"` and
     /// `container_port == host_port` makes both modes resolve to
-    /// `http://127.0.0.1:{port}/`, so these tests don't depend on the ambient
-    /// `DEPLOYMENT_MODE`.
+    /// `http://127.0.0.1:{port}/`.
     fn container_info(status: ContainerStatus, ports: Vec<u16>) -> ContainerInfo {
         ContainerInfo {
             container_id: "c1".to_string(),
@@ -364,7 +374,10 @@ mod tests {
     }
 
     fn adapter_for(info: ContainerInfo) -> ContainerLifecycleAdapter {
-        ContainerLifecycleAdapter::new(Arc::new(MockDeployer { info }))
+        ContainerLifecycleAdapter::new(
+            Arc::new(MockDeployer { info }),
+            Arc::new(temps_core::RuntimeContext::host()),
+        )
     }
 
     /// Spawn a minimal HTTP/1.1 server on a loopback port that answers `200 OK`

--- a/crates/temps-core/src/constants.rs
+++ b/crates/temps-core/src/constants.rs
@@ -11,11 +11,10 @@ pub static NETWORK_NAME: Lazy<String> = Lazy::new(|| {
     std::env::var("TEMPS_NETWORK_NAME").unwrap_or_else(|_| "temps-app-network".to_string())
 });
 
-/// Deployment mode - determines how services communicate
-/// - "baremetal" (default): Services are accessed via localhost with exposed ports
-/// - "docker": Services are accessed via container names on the Docker network (internal ports)
+/// Deprecated compatibility view of [`crate::ExecutionEnvironment`].
 ///
-/// Set via DEPLOYMENT_MODE environment variable
+/// New code must receive an immutable [`crate::RuntimeContext`] or
+/// [`crate::ExecutionEnvironment`] from the composition root.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeploymentMode {
     /// Baremetal mode: Use localhost and exposed host ports for service communication
@@ -25,15 +24,11 @@ pub enum DeploymentMode {
 }
 
 impl DeploymentMode {
-    /// Get the current deployment mode from environment variable
+    /// Return the execution environment cached during process startup.
     pub fn current() -> Self {
-        match std::env::var("DEPLOYMENT_MODE")
-            .unwrap_or_else(|_| "baremetal".to_string())
-            .to_lowercase()
-            .as_str()
-        {
-            "docker" => DeploymentMode::Docker,
-            _ => DeploymentMode::Baremetal,
+        match crate::runtime::execution_environment_compatibility() {
+            crate::ExecutionEnvironment::Host => DeploymentMode::Baremetal,
+            crate::ExecutionEnvironment::Docker => DeploymentMode::Docker,
         }
     }
 
@@ -64,14 +59,16 @@ impl DeploymentMode {
         container_port: u16,
         host_port: u16,
     ) -> (String, u16) {
-        if Self::is_docker() {
-            (container_name.to_string(), container_port)
-        } else {
-            // Use 127.0.0.1 instead of localhost to avoid IPv6 resolution issues
-            // Pingora may try ::1 first when resolving "localhost", but apps typically
-            // only listen on 127.0.0.1
-            ("127.0.0.1".to_string(), host_port)
-        }
+        let endpoint = crate::RuntimeContext::for_environment(
+            crate::runtime::execution_environment_compatibility(),
+        )
+        .resolve_service_endpoint(
+            container_name,
+            crate::ServiceEndpointScheme::Http,
+            container_port,
+            host_port,
+        );
+        (endpoint.host, endpoint.port)
     }
 
     /// Build a URL for accessing a container based on deployment mode
@@ -107,74 +104,13 @@ impl std::fmt::Display for DeploymentMode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
-    use std::sync::Mutex;
-
-    /// Mutex to serialize tests that mutate the DEPLOYMENT_MODE environment variable.
-    /// Without this, parallel test execution causes race conditions where one test's
-    /// env::set_var is visible to another test that expects a different value.
-    static ENV_MUTEX: Mutex<()> = Mutex::new(());
-
-    // SAFETY: env::set_var/remove_var are unsafe in Rust 1.93+ because they are not
-    // thread-safe. We use ENV_MUTEX to guarantee exclusive access across all tests
-    // that mutate environment variables, making the unsafe calls sound.
 
     #[test]
-    fn test_deployment_mode_default_is_baremetal() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        // Clear the environment variable to test default behavior
-        unsafe { env::remove_var("DEPLOYMENT_MODE") };
-
-        // Default should be baremetal
+    fn test_uninitialized_compatibility_mode_is_baremetal() {
         let mode = DeploymentMode::current();
         assert_eq!(mode, DeploymentMode::Baremetal);
         assert!(DeploymentMode::is_baremetal());
         assert!(!DeploymentMode::is_docker());
-    }
-
-    #[test]
-    fn test_deployment_mode_docker() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        unsafe { env::set_var("DEPLOYMENT_MODE", "docker") };
-
-        let mode = DeploymentMode::current();
-        assert_eq!(mode, DeploymentMode::Docker);
-        assert!(DeploymentMode::is_docker());
-        assert!(!DeploymentMode::is_baremetal());
-
-        unsafe { env::remove_var("DEPLOYMENT_MODE") };
-    }
-
-    #[test]
-    fn test_deployment_mode_case_insensitive() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        for value in ["Docker", "DOCKER", "dOcKeR"] {
-            unsafe { env::set_var("DEPLOYMENT_MODE", value) };
-            assert_eq!(
-                DeploymentMode::current(),
-                DeploymentMode::Docker,
-                "Failed for value: {}",
-                value
-            );
-        }
-
-        unsafe { env::remove_var("DEPLOYMENT_MODE") };
-    }
-
-    #[test]
-    fn test_deployment_mode_invalid_defaults_to_baremetal() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        for value in ["invalid", "kubernetes", "swarm", ""] {
-            unsafe { env::set_var("DEPLOYMENT_MODE", value) };
-            assert_eq!(
-                DeploymentMode::current(),
-                DeploymentMode::Baremetal,
-                "Failed for value: {}",
-                value
-            );
-        }
-
-        unsafe { env::remove_var("DEPLOYMENT_MODE") };
     }
 
     #[test]
@@ -205,49 +141,17 @@ mod tests {
 
     #[test]
     fn test_get_effective_host_port_baremetal() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        unsafe { env::remove_var("DEPLOYMENT_MODE") };
-
         let (host, port) = DeploymentMode::get_effective_host_port("my-container", 3000, 49152);
         assert_eq!(host, "127.0.0.1"); // IPv4 to avoid IPv6 resolution issues
         assert_eq!(port, 49152);
     }
 
     #[test]
-    fn test_get_effective_host_port_docker() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        unsafe { env::set_var("DEPLOYMENT_MODE", "docker") };
-
-        let (host, port) = DeploymentMode::get_effective_host_port("my-container", 3000, 49152);
-        assert_eq!(host, "my-container");
-        assert_eq!(port, 3000);
-
-        unsafe { env::remove_var("DEPLOYMENT_MODE") };
-    }
-
-    #[test]
     fn test_build_container_url_baremetal() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        unsafe { env::remove_var("DEPLOYMENT_MODE") };
-
         let url = DeploymentMode::build_container_url("my-container", 3000, 49152, Some("/health"));
         assert_eq!(url, "http://127.0.0.1:49152/health");
 
         let url_no_path = DeploymentMode::build_container_url("my-container", 3000, 49152, None);
         assert_eq!(url_no_path, "http://127.0.0.1:49152");
-    }
-
-    #[test]
-    fn test_build_container_url_docker() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        unsafe { env::set_var("DEPLOYMENT_MODE", "docker") };
-
-        let url = DeploymentMode::build_container_url("my-container", 3000, 49152, Some("/health"));
-        assert_eq!(url, "http://my-container:3000/health");
-
-        let url_no_path = DeploymentMode::build_container_url("my-container", 3000, 49152, None);
-        assert_eq!(url_no_path, "http://my-container:3000");
-
-        unsafe { env::remove_var("DEPLOYMENT_MODE") };
     }
 }

--- a/crates/temps-core/src/lib.rs
+++ b/crates/temps-core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod public_hostname;
 pub mod public_hostname_resolver;
 pub mod retention;
 pub mod retry;
+pub mod runtime;
 pub mod secrets_manager;
 pub mod self_update;
 pub mod sensitive_action;
@@ -89,6 +90,11 @@ pub use public_hostname_resolver::{
 };
 pub use retention::{
     FixedRetentionResolver, RetentionResolver, RetentionResolverSlot, RetentionTable,
+};
+pub use runtime::{
+    initialize_process_runtime_context, ExecutionEnvironment, ExecutionEnvironmentSource,
+    RuntimeConfigurationError, RuntimeContext, ServiceEndpoint, ServiceEndpointResolver,
+    ServiceEndpointScheme, EXECUTION_ENVIRONMENT_VARIABLE, LEGACY_DEPLOYMENT_MODE_VARIABLE,
 };
 pub use secrets_manager::SecretsManagerResolver;
 pub use sensitive_action::{

--- a/crates/temps-core/src/runtime.rs
+++ b/crates/temps-core/src/runtime.rs
@@ -346,6 +346,25 @@ pub fn execution_environment_compatibility() -> ExecutionEnvironment {
 mod tests {
     use super::*;
 
+    const PROCESS_ENVIRONMENT_CHILD: &str = "TEMPS_RUNTIME_PROCESS_ENVIRONMENT_CHILD";
+    const NON_UNICODE_CHILD: &str = "TEMPS_RUNTIME_NON_UNICODE_CHILD";
+
+    fn run_exact_test_in_child(
+        test_name: &str,
+        marker: &str,
+        canonical_value: &std::ffi::OsStr,
+    ) -> std::process::ExitStatus {
+        std::process::Command::new(std::env::current_exe().expect("test executable should exist"))
+            .arg("--exact")
+            .arg(test_name)
+            .arg("--nocapture")
+            .env(marker, "1")
+            .env(EXECUTION_ENVIRONMENT_VARIABLE, canonical_value)
+            .env_remove(LEGACY_DEPLOYMENT_MODE_VARIABLE)
+            .status()
+            .expect("runtime environment child test should start")
+    }
+
     #[test]
     fn canonical_value_has_precedence_over_legacy_value() {
         let context = RuntimeContext::from_configured_values(Some("host"), Some("docker"))
@@ -436,5 +455,58 @@ mod tests {
 
         assert_eq!(host.url(None), "http://127.0.0.1:18123");
         assert_eq!(docker.url(None), "http://temps-clickhouse:8123");
+    }
+
+    #[test]
+    fn process_runtime_context_reads_and_caches_the_real_environment() {
+        if std::env::var_os(PROCESS_ENVIRONMENT_CHILD).is_some() {
+            let first = initialize_process_runtime_context()
+                .expect("configured Docker environment should initialize");
+            let second = initialize_process_runtime_context()
+                .expect("cached Docker environment should remain available");
+
+            assert_eq!(first.execution_environment(), ExecutionEnvironment::Docker);
+            assert_eq!(first.source(), ExecutionEnvironmentSource::Canonical);
+            assert!(std::ptr::eq(first, second));
+            return;
+        }
+
+        let status = run_exact_test_in_child(
+            "runtime::tests::process_runtime_context_reads_and_caches_the_real_environment",
+            PROCESS_ENVIRONMENT_CHILD,
+            std::ffi::OsStr::new("docker"),
+        );
+        assert!(status.success(), "runtime environment child test failed");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn process_runtime_context_rejects_and_caches_non_unicode_input() {
+        if std::env::var_os(NON_UNICODE_CHILD).is_some() {
+            let first = initialize_process_runtime_context()
+                .expect_err("non-Unicode execution environment must fail closed");
+            let second = initialize_process_runtime_context()
+                .expect_err("cached non-Unicode error must remain stable");
+
+            assert!(matches!(
+                first,
+                RuntimeConfigurationError::NonUnicodeExecutionEnvironment {
+                    variable: EXECUTION_ENVIRONMENT_VARIABLE,
+                    ..
+                }
+            ));
+            assert_eq!(first, second);
+            return;
+        }
+
+        use std::os::unix::ffi::OsStringExt;
+
+        let invalid_value = std::ffi::OsString::from_vec(vec![0xff, 0xfe]);
+        let status = run_exact_test_in_child(
+            "runtime::tests::process_runtime_context_rejects_and_caches_non_unicode_input",
+            NON_UNICODE_CHILD,
+            &invalid_value,
+        );
+        assert!(status.success(), "non-Unicode runtime child test failed");
     }
 }

--- a/crates/temps-core/src/runtime.rs
+++ b/crates/temps-core/src/runtime.rs
@@ -1,0 +1,440 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Immutable process runtime configuration and service endpoint resolution.
+//!
+//! The execution environment is parsed once at the CLI composition root. Domain
+//! services receive the resulting context (or its environment value) rather
+//! than consulting process-global environment variables while handling work.
+
+use std::fmt;
+use std::sync::OnceLock;
+
+use thiserror::Error;
+
+/// Canonical bootstrap setting describing where the Temps control plane runs.
+pub const EXECUTION_ENVIRONMENT_VARIABLE: &str = "TEMPS_EXECUTION_ENV";
+
+/// Deprecated bootstrap setting retained for existing installations.
+pub const LEGACY_DEPLOYMENT_MODE_VARIABLE: &str = "DEPLOYMENT_MODE";
+
+/// Where the Temps control-plane process is executing.
+///
+/// This describes network location only. It does not assert that Docker, KVM,
+/// host networking, or another workload capability is available.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ExecutionEnvironment {
+    /// Native process managed directly by the host operating system.
+    #[default]
+    Host,
+    /// Process running inside a Docker container network.
+    Docker,
+}
+
+impl fmt::Display for ExecutionEnvironment {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Host => formatter.write_str("host"),
+            Self::Docker => formatter.write_str("docker"),
+        }
+    }
+}
+
+/// Which bootstrap input selected the execution environment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionEnvironmentSource {
+    /// `TEMPS_EXECUTION_ENV` was explicitly configured.
+    Canonical,
+    /// Deprecated `DEPLOYMENT_MODE` was used because the canonical input was absent.
+    Legacy,
+    /// Neither input was set; the backward-compatible host default was selected.
+    Default,
+}
+
+/// A network scheme carried separately from a resolved host and port.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ServiceEndpointScheme {
+    Http,
+    Https,
+    Postgres,
+    Redis,
+    Tcp,
+}
+
+impl fmt::Display for ServiceEndpointScheme {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Http => formatter.write_str("http"),
+            Self::Https => formatter.write_str("https"),
+            Self::Postgres => formatter.write_str("postgres"),
+            Self::Redis => formatter.write_str("redis"),
+            Self::Tcp => formatter.write_str("tcp"),
+        }
+    }
+}
+
+/// A resolved endpoint with its network metadata kept as typed fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceEndpoint {
+    pub scheme: ServiceEndpointScheme,
+    pub host: String,
+    pub port: u16,
+    pub tls_server_name: Option<String>,
+}
+
+impl ServiceEndpoint {
+    /// Render an absolute URL for URL-oriented schemes.
+    pub fn url(&self, path: Option<&str>) -> String {
+        format!(
+            "{}://{}:{}{}",
+            self.scheme,
+            self.host,
+            self.port,
+            path.unwrap_or_default()
+        )
+    }
+
+    /// Render the host/port authority used by proxy upstream configuration.
+    pub fn authority(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+}
+
+/// Pure environment-specific endpoint resolver selected at process startup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceEndpointResolver {
+    Host,
+    Docker,
+}
+
+impl ServiceEndpointResolver {
+    /// Resolve a stable service identity without rewriting an existing URL.
+    ///
+    /// Host execution uses IPv4 loopback and the published host port. Docker
+    /// execution uses the stable service/container name and its internal target
+    /// port, independently of any host publication.
+    pub fn resolve(
+        self,
+        service_name: &str,
+        scheme: ServiceEndpointScheme,
+        internal_target_port: u16,
+        published_host_port: u16,
+    ) -> ServiceEndpoint {
+        match self {
+            Self::Host => ServiceEndpoint {
+                scheme,
+                host: "127.0.0.1".to_string(),
+                port: published_host_port,
+                tls_server_name: None,
+            },
+            Self::Docker => ServiceEndpoint {
+                scheme,
+                host: service_name.to_string(),
+                port: internal_target_port,
+                tls_server_name: None,
+            },
+        }
+    }
+}
+
+/// Immutable runtime configuration shared by infrastructure-facing services.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeContext {
+    execution_environment: ExecutionEnvironment,
+    endpoint_resolver: ServiceEndpointResolver,
+    source: ExecutionEnvironmentSource,
+}
+
+impl RuntimeContext {
+    pub fn host() -> Self {
+        Self::new(
+            ExecutionEnvironment::Host,
+            ExecutionEnvironmentSource::Default,
+        )
+    }
+
+    pub fn docker() -> Self {
+        Self::new(
+            ExecutionEnvironment::Docker,
+            ExecutionEnvironmentSource::Canonical,
+        )
+    }
+
+    pub fn for_environment(execution_environment: ExecutionEnvironment) -> Self {
+        Self::new(execution_environment, ExecutionEnvironmentSource::Canonical)
+    }
+
+    fn new(
+        execution_environment: ExecutionEnvironment,
+        source: ExecutionEnvironmentSource,
+    ) -> Self {
+        let endpoint_resolver = match execution_environment {
+            ExecutionEnvironment::Host => ServiceEndpointResolver::Host,
+            ExecutionEnvironment::Docker => ServiceEndpointResolver::Docker,
+        };
+        Self {
+            execution_environment,
+            endpoint_resolver,
+            source,
+        }
+    }
+
+    /// Parse canonical and legacy values with deterministic precedence.
+    pub fn from_configured_values(
+        canonical: Option<&str>,
+        legacy: Option<&str>,
+    ) -> Result<Self, RuntimeConfigurationError> {
+        let (variable, configured, source) = if let Some(value) = canonical {
+            (
+                EXECUTION_ENVIRONMENT_VARIABLE,
+                Some(value),
+                ExecutionEnvironmentSource::Canonical,
+            )
+        } else if let Some(value) = legacy {
+            (
+                LEGACY_DEPLOYMENT_MODE_VARIABLE,
+                Some(value),
+                ExecutionEnvironmentSource::Legacy,
+            )
+        } else {
+            (
+                EXECUTION_ENVIRONMENT_VARIABLE,
+                None,
+                ExecutionEnvironmentSource::Default,
+            )
+        };
+
+        let execution_environment = match configured.map(str::trim) {
+            None => ExecutionEnvironment::Host,
+            Some(value) if value.eq_ignore_ascii_case("host") => ExecutionEnvironment::Host,
+            Some(value) if value.eq_ignore_ascii_case("baremetal") => ExecutionEnvironment::Host,
+            Some(value) if value.eq_ignore_ascii_case("docker") => ExecutionEnvironment::Docker,
+            Some(value) if value.eq_ignore_ascii_case("kubernetes") => {
+                return Err(RuntimeConfigurationError::EnvironmentNotSupported {
+                    variable,
+                    configured_value: value.to_string(),
+                    reason: "Kubernetes execution is not supported in this build; use 'host' or 'docker'",
+                });
+            }
+            Some(value) => {
+                return Err(RuntimeConfigurationError::InvalidExecutionEnvironment {
+                    variable,
+                    configured_value: value.to_string(),
+                    accepted_values: "host, baremetal (legacy), docker",
+                });
+            }
+        };
+
+        Ok(Self::new(execution_environment, source))
+    }
+
+    /// Read bootstrap configuration from the process environment.
+    ///
+    /// Application startup should call [`initialize_process_runtime_context`]
+    /// instead so the read is cached for the lifetime of the process.
+    fn from_process_environment() -> Result<Self, RuntimeConfigurationError> {
+        if let Some(canonical) = read_environment_variable(EXECUTION_ENVIRONMENT_VARIABLE)? {
+            return Self::from_configured_values(Some(&canonical), None);
+        }
+
+        let legacy = read_environment_variable(LEGACY_DEPLOYMENT_MODE_VARIABLE)?;
+        Self::from_configured_values(None, legacy.as_deref())
+    }
+
+    pub fn execution_environment(&self) -> ExecutionEnvironment {
+        self.execution_environment
+    }
+
+    pub fn source(&self) -> ExecutionEnvironmentSource {
+        self.source
+    }
+
+    pub fn endpoint_resolver(&self) -> ServiceEndpointResolver {
+        self.endpoint_resolver
+    }
+
+    pub fn resolve_service_endpoint(
+        &self,
+        service_name: &str,
+        scheme: ServiceEndpointScheme,
+        internal_target_port: u16,
+        published_host_port: u16,
+    ) -> ServiceEndpoint {
+        self.endpoint_resolver.resolve(
+            service_name,
+            scheme,
+            internal_target_port,
+            published_host_port,
+        )
+    }
+}
+
+/// Typed startup failures for invalid execution-environment configuration.
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum RuntimeConfigurationError {
+    #[error(
+        "Invalid execution environment '{configured_value}' from {variable}; expected one of: {accepted_values}"
+    )]
+    InvalidExecutionEnvironment {
+        variable: &'static str,
+        configured_value: String,
+        accepted_values: &'static str,
+    },
+
+    #[error(
+        "Execution environment '{configured_value}' from {variable} is not supported: {reason}"
+    )]
+    EnvironmentNotSupported {
+        variable: &'static str,
+        configured_value: String,
+        reason: &'static str,
+    },
+
+    #[error(
+        "Execution environment from {variable} is not valid Unicode (configured bytes: {configured_value})"
+    )]
+    NonUnicodeExecutionEnvironment {
+        variable: &'static str,
+        configured_value: String,
+    },
+}
+
+fn read_environment_variable(
+    variable: &'static str,
+) -> Result<Option<String>, RuntimeConfigurationError> {
+    match std::env::var(variable) {
+        Ok(value) => Ok(Some(value)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(value)) => {
+            Err(RuntimeConfigurationError::NonUnicodeExecutionEnvironment {
+                variable,
+                configured_value: format!("{value:?}"),
+            })
+        }
+    }
+}
+
+static PROCESS_RUNTIME_CONTEXT: OnceLock<Result<RuntimeContext, RuntimeConfigurationError>> =
+    OnceLock::new();
+
+/// Parse and cache the process runtime context exactly once.
+pub fn initialize_process_runtime_context(
+) -> Result<&'static RuntimeContext, RuntimeConfigurationError> {
+    PROCESS_RUNTIME_CONTEXT
+        .get_or_init(RuntimeContext::from_process_environment)
+        .as_ref()
+        .map_err(Clone::clone)
+}
+
+/// Return the already-initialized execution environment to deprecated callers.
+///
+/// The compatibility path intentionally performs no environment read. CLI
+/// startup initializes the context before constructing services. Library-only
+/// legacy callers that skip composition-root initialization retain historical
+/// Host behavior until they migrate to an injected [`RuntimeContext`].
+#[doc(hidden)]
+pub fn execution_environment_compatibility() -> ExecutionEnvironment {
+    PROCESS_RUNTIME_CONTEXT
+        .get()
+        .and_then(|result| result.as_ref().ok())
+        .map(RuntimeContext::execution_environment)
+        .unwrap_or(ExecutionEnvironment::Host)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_value_has_precedence_over_legacy_value() {
+        let context = RuntimeContext::from_configured_values(Some("host"), Some("docker"))
+            .expect("known environment should parse");
+        assert_eq!(context.execution_environment(), ExecutionEnvironment::Host);
+        assert_eq!(context.source(), ExecutionEnvironmentSource::Canonical);
+    }
+
+    #[test]
+    fn test_from_configured_values_invalid_canonical_over_valid_legacy_returns_canonical_error() {
+        let error = RuntimeContext::from_configured_values(Some("swarm"), Some("docker"))
+            .expect_err("an invalid canonical value must not fall back to legacy configuration");
+
+        assert!(matches!(
+            error,
+            RuntimeConfigurationError::InvalidExecutionEnvironment {
+                variable: EXECUTION_ENVIRONMENT_VARIABLE,
+                configured_value,
+                ..
+            } if configured_value == "swarm"
+        ));
+    }
+
+    #[test]
+    fn legacy_and_unset_values_preserve_host_compatibility() {
+        let legacy = RuntimeContext::from_configured_values(None, Some("baremetal"))
+            .expect("legacy baremetal should parse");
+        let unset = RuntimeContext::from_configured_values(None, None)
+            .expect("unset environment should default to host");
+        assert_eq!(legacy.execution_environment(), ExecutionEnvironment::Host);
+        assert_eq!(legacy.source(), ExecutionEnvironmentSource::Legacy);
+        assert_eq!(unset.execution_environment(), ExecutionEnvironment::Host);
+        assert_eq!(unset.source(), ExecutionEnvironmentSource::Default);
+    }
+
+    #[test]
+    fn configured_values_are_case_insensitive() {
+        let host = RuntimeContext::from_configured_values(Some("HOST"), None)
+            .expect("uppercase host should parse");
+        let docker = RuntimeContext::from_configured_values(None, Some("DoCkEr"))
+            .expect("mixed-case legacy docker should parse");
+        assert_eq!(host.execution_environment(), ExecutionEnvironment::Host);
+        assert_eq!(docker.execution_environment(), ExecutionEnvironment::Docker);
+    }
+
+    #[test]
+    fn kubernetes_is_recognized_but_rejected_by_this_build() {
+        let error = RuntimeContext::from_configured_values(Some("kubernetes"), None)
+            .expect_err("Kubernetes must fail until its runtime adapter exists");
+        assert!(matches!(
+            error,
+            RuntimeConfigurationError::EnvironmentNotSupported {
+                variable: EXECUTION_ENVIRONMENT_VARIABLE,
+                configured_value,
+                ..
+            } if configured_value == "kubernetes"
+        ));
+    }
+
+    #[test]
+    fn unknown_values_fail_with_the_configured_source() {
+        let error = RuntimeContext::from_configured_values(None, Some("swarm"))
+            .expect_err("unknown environment must fail closed");
+        assert!(matches!(
+            error,
+            RuntimeConfigurationError::InvalidExecutionEnvironment {
+                variable: LEGACY_DEPLOYMENT_MODE_VARIABLE,
+                configured_value,
+                ..
+            } if configured_value == "swarm"
+        ));
+    }
+
+    #[test]
+    fn endpoint_resolution_uses_environment_specific_ports() {
+        let host = RuntimeContext::host().resolve_service_endpoint(
+            "temps-clickhouse",
+            ServiceEndpointScheme::Http,
+            8123,
+            18123,
+        );
+        let docker = RuntimeContext::docker().resolve_service_endpoint(
+            "temps-clickhouse",
+            ServiceEndpointScheme::Http,
+            8123,
+            18123,
+        );
+
+        assert_eq!(host.url(None), "http://127.0.0.1:18123");
+        assert_eq!(docker.url(None), "http://temps-clickhouse:8123");
+    }
+}

--- a/crates/temps-deployer/src/readiness.rs
+++ b/crates/temps-deployer/src/readiness.rs
@@ -28,12 +28,12 @@
 //!
 //! ## URL resolution
 //!
-//! The probe URL is built with [`temps_core::DeploymentMode::build_container_url`]
-//! — the same helper the deploy path uses — so it is correct in both modes:
+//! The probe URL is resolved from an injected [`temps_core::RuntimeContext`],
+//! so it is correct in both environments without reading process-global state:
 //! * **Docker mode** (control plane runs as a container on the shared app
 //!   network): `http://{container_name}:{container_port}` — straight to the app
 //!   over the Docker network, bypassing `docker-proxy` entirely.
-//! * **Baremetal mode** (control plane on the host): `http://127.0.0.1:{host_port}`
+//! * **Host mode** (control plane on the host): `http://127.0.0.1:{host_port}`
 //!   — through `docker-proxy`, where requiring a real HTTP response is exactly
 //!   what avoids the false-positive above.
 //!
@@ -168,9 +168,10 @@ pub async fn check_accepting_requests(
     deployer: &Arc<dyn ContainerDeployer>,
     container_id: &str,
     request_timeout: Duration,
+    runtime_context: &temps_core::RuntimeContext,
 ) -> Result<ReadinessCheck, ReadinessError> {
     let client = build_client(request_timeout)?;
-    check_accepting_requests_with_client(deployer, container_id, &client).await
+    check_accepting_requests_with_client(deployer, container_id, &client, runtime_context).await
 }
 
 /// Like [`check_accepting_requests`] but reuses a caller-provided client, so a
@@ -179,6 +180,7 @@ async fn check_accepting_requests_with_client(
     deployer: &Arc<dyn ContainerDeployer>,
     container_id: &str,
     client: &reqwest::Client,
+    runtime_context: &temps_core::RuntimeContext,
 ) -> Result<ReadinessCheck, ReadinessError> {
     let info = deployer
         .get_container_info(container_id)
@@ -205,12 +207,14 @@ async fn check_accepting_requests_with_client(
                         .find(|p| p.host_port == host_port)
                         .map(|p| p.container_port)
                         .unwrap_or(host_port);
-                    let url = temps_core::DeploymentMode::build_container_url(
-                        &info.container_name,
-                        container_port,
-                        host_port,
-                        Some(PROBE_PATH),
-                    );
+                    let url = runtime_context
+                        .resolve_service_endpoint(
+                            &info.container_name,
+                            temps_core::ServiceEndpointScheme::Http,
+                            container_port,
+                            host_port,
+                        )
+                        .url(Some(PROBE_PATH));
                     if probe_http(client, &url).await {
                         ReadinessCheck::Ready
                     } else {
@@ -245,6 +249,7 @@ pub async fn wait_until_accepting_requests(
     deployer: &Arc<dyn ContainerDeployer>,
     container_id: &str,
     probe: ReadinessProbe,
+    runtime_context: &temps_core::RuntimeContext,
 ) -> Result<(), ReadinessError> {
     let client = build_client(probe.request_timeout)?;
     let start = Instant::now();
@@ -253,17 +258,23 @@ pub async fn wait_until_accepting_requests(
         // The status observed this iteration — surfaced in the timeout error so
         // a stuck wake reports *why* (e.g. still `Created`, or `Running` but
         // not yet answering HTTP).
-        let last_status =
-            match check_accepting_requests_with_client(deployer, container_id, &client).await? {
-                ReadinessCheck::Ready => return Ok(()),
-                ReadinessCheck::Terminal(status) => {
-                    return Err(ReadinessError::Terminal {
-                        container_id: container_id.to_string(),
-                        status,
-                    });
-                }
-                ReadinessCheck::NotYet(status) => status,
-            };
+        let last_status = match check_accepting_requests_with_client(
+            deployer,
+            container_id,
+            &client,
+            runtime_context,
+        )
+        .await?
+        {
+            ReadinessCheck::Ready => return Ok(()),
+            ReadinessCheck::Terminal(status) => {
+                return Err(ReadinessError::Terminal {
+                    container_id: container_id.to_string(),
+                    status,
+                });
+            }
+            ReadinessCheck::NotYet(status) => status,
+        };
 
         if start.elapsed() >= probe.timeout {
             return Err(ReadinessError::Timeout {
@@ -385,6 +396,20 @@ mod tests {
         }
     }
 
+    fn info_with_port_mapping(
+        status: ContainerStatus,
+        host_port: u16,
+        container_port: u16,
+    ) -> ContainerInfo {
+        let mut container = info(status, vec![]);
+        container.ports.push(PortMapping {
+            host_port,
+            container_port,
+            protocol: Protocol::Tcp,
+        });
+        container
+    }
+
     #[async_trait]
     impl ContainerDeployer for ScriptedDeployer {
         async fn deploy_container(
@@ -496,18 +521,101 @@ mod tests {
     #[tokio::test]
     async fn running_no_ports_is_ready() {
         let deployer = ScriptedDeployer::arc(vec![info(ContainerStatus::Running, vec![])]);
-        assert!(wait_until_accepting_requests(&deployer, "c1", fast_probe())
-            .await
-            .is_ok());
+        assert!(wait_until_accepting_requests(
+            &deployer,
+            "c1",
+            fast_probe(),
+            &temps_core::RuntimeContext::host(),
+        )
+        .await
+        .is_ok());
     }
 
     #[tokio::test]
     async fn running_http_200_is_ready() {
         let port = spawn_http_server("HTTP/1.1 200 OK").await;
         let deployer = ScriptedDeployer::arc(vec![info(ContainerStatus::Running, vec![port])]);
-        assert!(wait_until_accepting_requests(&deployer, "c1", fast_probe())
-            .await
-            .is_ok());
+        assert!(wait_until_accepting_requests(
+            &deployer,
+            "c1",
+            fast_probe(),
+            &temps_core::RuntimeContext::host(),
+        )
+        .await
+        .is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_check_accepting_requests_host_context_uses_published_host_port() {
+        let live_host_port = spawn_http_server("HTTP/1.1 200 OK").await;
+        let closed_container_port = {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            listener.local_addr().unwrap().port()
+        };
+        let deployer = ScriptedDeployer::arc(vec![info_with_port_mapping(
+            ContainerStatus::Running,
+            live_host_port,
+            closed_container_port,
+        )]);
+
+        let result = check_accepting_requests(
+            &deployer,
+            "c1",
+            Duration::from_millis(300),
+            &temps_core::RuntimeContext::host(),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(result, ReadinessCheck::Ready));
+    }
+
+    #[tokio::test]
+    async fn test_check_accepting_requests_docker_context_uses_internal_container_port() {
+        let live_container_port = spawn_http_server("HTTP/1.1 200 OK").await;
+        let closed_host_port = {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            listener.local_addr().unwrap().port()
+        };
+        let deployer = ScriptedDeployer::arc(vec![info_with_port_mapping(
+            ContainerStatus::Running,
+            closed_host_port,
+            live_container_port,
+        )]);
+
+        let result = check_accepting_requests(
+            &deployer,
+            "c1",
+            Duration::from_millis(300),
+            &temps_core::RuntimeContext::docker(),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(result, ReadinessCheck::Ready));
+    }
+
+    #[tokio::test]
+    async fn polling_probe_uses_injected_docker_context() {
+        let live_container_port = spawn_http_server("HTTP/1.1 200 OK").await;
+        let closed_host_port = {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            listener.local_addr().unwrap().port()
+        };
+        let deployer = ScriptedDeployer::arc(vec![info_with_port_mapping(
+            ContainerStatus::Running,
+            closed_host_port,
+            live_container_port,
+        )]);
+
+        assert!(wait_until_accepting_requests(
+            &deployer,
+            "c1",
+            fast_probe(),
+            &temps_core::RuntimeContext::docker(),
+        )
+        .await
+        .is_ok());
     }
 
     #[tokio::test]
@@ -515,9 +623,14 @@ mod tests {
         // 404 means the path doesn't exist but the server IS up → ready.
         let port = spawn_http_server("HTTP/1.1 404 Not Found").await;
         let deployer = ScriptedDeployer::arc(vec![info(ContainerStatus::Running, vec![port])]);
-        assert!(wait_until_accepting_requests(&deployer, "c1", fast_probe())
-            .await
-            .is_ok());
+        assert!(wait_until_accepting_requests(
+            &deployer,
+            "c1",
+            fast_probe(),
+            &temps_core::RuntimeContext::host(),
+        )
+        .await
+        .is_ok());
     }
 
     #[tokio::test]
@@ -527,9 +640,14 @@ mod tests {
         // time out instead.
         let port = spawn_silent_tcp().await;
         let deployer = ScriptedDeployer::arc(vec![info(ContainerStatus::Running, vec![port])]);
-        let err = wait_until_accepting_requests(&deployer, "c1", fast_probe())
-            .await
-            .unwrap_err();
+        let err = wait_until_accepting_requests(
+            &deployer,
+            "c1",
+            fast_probe(),
+            &temps_core::RuntimeContext::host(),
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, ReadinessError::Timeout { .. }), "got {err:?}");
     }
 
@@ -541,9 +659,14 @@ mod tests {
             l.local_addr().unwrap().port()
         };
         let deployer = ScriptedDeployer::arc(vec![info(ContainerStatus::Running, vec![port])]);
-        let err = wait_until_accepting_requests(&deployer, "c1", fast_probe())
-            .await
-            .unwrap_err();
+        let err = wait_until_accepting_requests(
+            &deployer,
+            "c1",
+            fast_probe(),
+            &temps_core::RuntimeContext::host(),
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, ReadinessError::Timeout { .. }), "got {err:?}");
     }
 
@@ -552,18 +675,28 @@ mod tests {
         // Server up but erroring → not ready; bounded by the overall timeout.
         let port = spawn_http_server("HTTP/1.1 500 Internal Server Error").await;
         let deployer = ScriptedDeployer::arc(vec![info(ContainerStatus::Running, vec![port])]);
-        let err = wait_until_accepting_requests(&deployer, "c1", fast_probe())
-            .await
-            .unwrap_err();
+        let err = wait_until_accepting_requests(
+            &deployer,
+            "c1",
+            fast_probe(),
+            &temps_core::RuntimeContext::host(),
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, ReadinessError::Timeout { .. }), "got {err:?}");
     }
 
     #[tokio::test]
     async fn exited_fails_fast() {
         let deployer = ScriptedDeployer::arc(vec![info(ContainerStatus::Exited, vec![])]);
-        let err = wait_until_accepting_requests(&deployer, "c1", fast_probe())
-            .await
-            .unwrap_err();
+        let err = wait_until_accepting_requests(
+            &deployer,
+            "c1",
+            fast_probe(),
+            &temps_core::RuntimeContext::host(),
+        )
+        .await
+        .unwrap_err();
         assert!(
             matches!(
                 err,
@@ -585,8 +718,13 @@ mod tests {
             info(ContainerStatus::Created, vec![]),
             info(ContainerStatus::Running, vec![port]),
         ]);
-        assert!(wait_until_accepting_requests(&deployer, "c1", fast_probe())
-            .await
-            .is_ok());
+        assert!(wait_until_accepting_requests(
+            &deployer,
+            "c1",
+            fast_probe(),
+            &temps_core::RuntimeContext::host(),
+        )
+        .await
+        .is_ok());
     }
 }

--- a/crates/temps-providers/src/externalsvc/mariadb.rs
+++ b/crates/temps-providers/src/externalsvc/mariadb.rs
@@ -502,6 +502,21 @@ impl MariaDbService {
             .unwrap_or_else(|| self.get_container_name())
     }
 
+    fn get_effective_address_for_environment(
+        &self,
+        service_config: ServiceConfig,
+        execution_environment: temps_core::ExecutionEnvironment,
+    ) -> Result<(String, String)> {
+        let config = self.get_mariadb_config(service_config)?;
+        Ok(match execution_environment {
+            temps_core::ExecutionEnvironment::Host => ("localhost".to_string(), config.port),
+            temps_core::ExecutionEnvironment::Docker => (
+                self.get_live_container_name(&config),
+                MARIADB_INTERNAL_PORT.to_string(),
+            ),
+        })
+    }
+
     fn get_mariadb_config(&self, service_config: ServiceConfig) -> Result<MariaDbConfig> {
         let input_config: MariaDbInputConfig = serde_json::from_value(service_config.parameters)
             .map_err(|e| anyhow::anyhow!("Failed to parse MariaDB configuration: {}", e))?;
@@ -3159,16 +3174,10 @@ impl ExternalService for MariaDbService {
     }
 
     fn get_effective_address(&self, service_config: ServiceConfig) -> Result<(String, String)> {
-        let config = self.get_mariadb_config(service_config)?;
-
-        if temps_core::DeploymentMode::is_docker() {
-            Ok((
-                self.get_live_container_name(&config),
-                MARIADB_INTERNAL_PORT.to_string(),
-            ))
-        } else {
-            Ok(("localhost".to_string(), config.port))
-        }
+        self.get_effective_address_for_environment(
+            service_config,
+            temps_core::runtime::execution_environment_compatibility(),
+        )
     }
 
     fn get_docker_container_name(&self) -> String {
@@ -3704,7 +3713,6 @@ impl ExternalService for MariaDbService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::externalsvc::DEPLOYMENT_MODE_MUTEX as ENV_MUTEX;
 
     /// A manifest read back from S3 drives both an S3 key and a host file
     /// write during PITR restore, so anything that is not a bare filename has
@@ -4510,10 +4518,6 @@ mod tests {
 
     #[test]
     fn test_get_effective_address_baremetal_mode() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        // Clear Docker mode to ensure baremetal mode.
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
-
         let service = MariaDbService::new(
             "test-effective-addr".to_string(),
             Arc::new(Docker::connect_with_http_defaults().expect("docker client")),
@@ -4533,7 +4537,9 @@ mod tests {
             }),
         };
 
-        let (host, port) = service.get_effective_address(config).unwrap();
+        let (host, port) = service
+            .get_effective_address_for_environment(config, temps_core::ExecutionEnvironment::Host)
+            .unwrap();
         // Baremetal: localhost with the exposed host port.
         assert_eq!(host, "localhost");
         assert_eq!(port, "3307");
@@ -4541,9 +4547,6 @@ mod tests {
 
     #[test]
     fn test_get_effective_address_docker_mode() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        unsafe { std::env::set_var("DEPLOYMENT_MODE", "docker") };
-
         let service = MariaDbService::new(
             "test-effective-addr-docker".to_string(),
             Arc::new(Docker::connect_with_http_defaults().expect("docker client")),
@@ -4563,19 +4566,16 @@ mod tests {
             }),
         };
 
-        let (host, port) = service.get_effective_address(config).unwrap();
+        let (host, port) = service
+            .get_effective_address_for_environment(config, temps_core::ExecutionEnvironment::Docker)
+            .unwrap();
         // Docker: container name with the internal port, not the host port.
         assert_eq!(host, "mariadb-test-effective-addr-docker");
         assert_eq!(port, MARIADB_INTERNAL_PORT);
-
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
     }
 
     #[test]
     fn test_get_effective_address_docker_mode_uses_imported_container_name() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        unsafe { std::env::set_var("DEPLOYMENT_MODE", "docker") };
-
         let service = MariaDbService::new(
             "imported-svc".to_string(),
             Arc::new(Docker::connect_with_http_defaults().expect("docker client")),
@@ -4596,12 +4596,12 @@ mod tests {
             }),
         };
 
-        let (host, port) = service.get_effective_address(config).unwrap();
+        let (host, port) = service
+            .get_effective_address_for_environment(config, temps_core::ExecutionEnvironment::Docker)
+            .unwrap();
         // The imported container name wins over the derived mariadb-{name}.
         assert_eq!(host, "legacy-mariadb");
         assert_eq!(port, MARIADB_INTERNAL_PORT);
-
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
     }
 
     #[test]

--- a/crates/temps-providers/src/externalsvc/mod.rs
+++ b/crates/temps-providers/src/externalsvc/mod.rs
@@ -157,12 +157,6 @@ mod runtime_provisioning_tests {
 #[cfg(test)]
 mod cluster_integration_tests;
 
-/// Shared mutex for tests that mutate the DEPLOYMENT_MODE environment variable.
-/// This must be shared across all test modules (postgres, redis, etc.) because
-/// env vars are process-global — a module-local mutex doesn't prevent cross-module races.
-#[cfg(test)]
-pub(crate) static DEPLOYMENT_MODE_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
 // Re-export services for easier access
 pub use cluster_role::{ClusterRole, PgAutoFailoverState};
 pub use managed_s3::{ManagedS3Backend, ManagedS3BackendKind, ManagedS3BackendSelection};

--- a/crates/temps-providers/src/externalsvc/mongodb.rs
+++ b/crates/temps-providers/src/externalsvc/mongodb.rs
@@ -456,6 +456,21 @@ impl MongodbService {
             .unwrap_or_else(|| self.get_container_name())
     }
 
+    fn get_effective_address_for_environment(
+        &self,
+        service_config: ServiceConfig,
+        execution_environment: temps_core::ExecutionEnvironment,
+    ) -> Result<(String, String)> {
+        let config = self.get_mongodb_config(service_config)?;
+        Ok(match execution_environment {
+            temps_core::ExecutionEnvironment::Host => ("localhost".to_string(), config.port),
+            temps_core::ExecutionEnvironment::Docker => (
+                self.get_live_container_name(&config),
+                MONGODB_INTERNAL_PORT.to_string(),
+            ),
+        })
+    }
+
     /// Creates and starts the MongoDB container, retrying with a fresh host
     /// port if the chosen one lost the race described in `port_util` docs
     /// (bindable when we checked, but taken by the time Docker actually binds
@@ -2174,18 +2189,10 @@ impl MongodbService {
 #[async_trait]
 impl ExternalService for MongodbService {
     fn get_effective_address(&self, service_config: ServiceConfig) -> Result<(String, String)> {
-        let config = self.get_mongodb_config(service_config)?;
-
-        if temps_core::DeploymentMode::is_docker() {
-            // Docker mode: use container name and internal port
-            Ok((
-                self.get_live_container_name(&config),
-                MONGODB_INTERNAL_PORT.to_string(),
-            ))
-        } else {
-            // Baremetal mode: use localhost and exposed port
-            Ok(("localhost".to_string(), config.port))
-        }
+        self.get_effective_address_for_environment(
+            service_config,
+            temps_core::runtime::execution_environment_compatibility(),
+        )
     }
 
     fn get_docker_container_name(&self) -> String {
@@ -3771,11 +3778,6 @@ mod tests {
 
     #[test]
     fn test_get_effective_address_docker_mode_uses_imported_container_name() {
-        let _lock = crate::externalsvc::DEPLOYMENT_MODE_MUTEX
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        unsafe { std::env::set_var("DEPLOYMENT_MODE", "docker") };
-
         let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
         let service = MongodbService::new("imported-svc".to_string(), docker);
 
@@ -3793,13 +3795,50 @@ mod tests {
             }),
         };
 
-        let (host, port) = service.get_effective_address(config).unwrap();
+        let (host, port) = service
+            .get_effective_address_for_environment(config, temps_core::ExecutionEnvironment::Docker)
+            .unwrap();
         // The imported container name wins over the derived
         // `temps-mongodb-{name}`.
         assert_eq!(host, "legacy-mongo");
         assert_eq!(port, "27017");
+    }
 
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
+    #[test]
+    fn test_get_effective_address_host_and_docker_use_environment_specific_addresses() {
+        let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
+        let service = MongodbService::new("address-mapping".to_string(), docker);
+        let config = ServiceConfig {
+            name: "address-mapping".to_string(),
+            service_type: ServiceType::Mongodb,
+            version: None,
+            parameters: serde_json::json!({
+                "host": "localhost",
+                "port": "27018",
+                "database": "admin",
+                "username": "root",
+                "password": "testpass",
+            }),
+        };
+
+        let host = service
+            .get_effective_address_for_environment(
+                config.clone(),
+                temps_core::ExecutionEnvironment::Host,
+            )
+            .unwrap();
+        let docker = service
+            .get_effective_address_for_environment(config, temps_core::ExecutionEnvironment::Docker)
+            .unwrap();
+
+        assert_eq!(host, ("localhost".to_string(), "27018".to_string()));
+        assert_eq!(
+            docker,
+            (
+                "temps-mongodb-address-mapping".to_string(),
+                "27017".to_string()
+            )
+        );
     }
 
     #[test]

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -585,6 +585,21 @@ impl PostgresService {
             .unwrap_or_else(|| self.get_container_name())
     }
 
+    fn get_effective_address_for_environment(
+        &self,
+        service_config: ServiceConfig,
+        execution_environment: temps_core::ExecutionEnvironment,
+    ) -> Result<(String, String)> {
+        let config = self.get_postgres_config(service_config)?;
+        Ok(match execution_environment {
+            temps_core::ExecutionEnvironment::Host => ("localhost".to_string(), config.port),
+            temps_core::ExecutionEnvironment::Docker => (
+                self.get_live_container_name(&config),
+                POSTGRES_INTERNAL_PORT.to_string(),
+            ),
+        })
+    }
+
     /// Creates and starts the PostgreSQL container, retrying with a fresh host
     /// port if the chosen one lost the race described in `port_util` docs
     /// (bindable when we checked, but taken by the time Docker actually binds
@@ -2874,18 +2889,10 @@ impl ExternalService for PostgresService {
     }
 
     fn get_effective_address(&self, service_config: ServiceConfig) -> Result<(String, String)> {
-        let config = self.get_postgres_config(service_config)?;
-
-        if temps_core::DeploymentMode::is_docker() {
-            // Docker mode: use container name and internal port
-            Ok((
-                self.get_live_container_name(&config),
-                POSTGRES_INTERNAL_PORT.to_string(),
-            ))
-        } else {
-            // Baremetal mode: use localhost and exposed port
-            Ok(("localhost".to_string(), config.port))
-        }
+        self.get_effective_address_for_environment(
+            service_config,
+            temps_core::runtime::execution_environment_compatibility(),
+        )
     }
 
     fn get_docker_container_name(&self) -> String {
@@ -4244,8 +4251,6 @@ impl ExternalService for PostgresService {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use crate::externalsvc::DEPLOYMENT_MODE_MUTEX as ENV_MUTEX;
 
     fn backup_with_metadata(metadata: serde_json::Value) -> temps_entities::backups::Model {
         temps_entities::backups::Model {
@@ -5942,10 +5947,6 @@ mod tests {
 
     #[test]
     fn test_get_effective_address_baremetal_mode() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        // Clear Docker mode to ensure baremetal mode
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
-
         let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
         let service = PostgresService::new("test-effective-addr".to_string(), docker);
 
@@ -5963,7 +5964,9 @@ mod tests {
             }),
         };
 
-        let (host, port) = service.get_effective_address(config).unwrap();
+        let (host, port) = service
+            .get_effective_address_for_environment(config, temps_core::ExecutionEnvironment::Host)
+            .unwrap();
 
         // In baremetal mode, should return localhost with exposed port
         assert_eq!(host, "localhost");
@@ -5972,10 +5975,6 @@ mod tests {
 
     #[test]
     fn test_get_effective_address_docker_mode() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        // Set Docker mode
-        unsafe { std::env::set_var("DEPLOYMENT_MODE", "docker") };
-
         let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
         let service = PostgresService::new("test-effective-addr-docker".to_string(), docker);
 
@@ -5993,21 +5992,17 @@ mod tests {
             }),
         };
 
-        let (host, port) = service.get_effective_address(config).unwrap();
+        let (host, port) = service
+            .get_effective_address_for_environment(config, temps_core::ExecutionEnvironment::Docker)
+            .unwrap();
 
         // In Docker mode, should return container name with internal port
         assert_eq!(host, "postgres-test-effective-addr-docker");
         assert_eq!(port, "5432"); // Internal port
-
-        // Clean up
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
     }
 
     #[test]
     fn test_get_effective_address_docker_mode_uses_imported_container_name() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        unsafe { std::env::set_var("DEPLOYMENT_MODE", "docker") };
-
         let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
         let service = PostgresService::new("imported-svc".to_string(), docker);
 
@@ -6026,12 +6021,12 @@ mod tests {
             }),
         };
 
-        let (host, port) = service.get_effective_address(config).unwrap();
+        let (host, port) = service
+            .get_effective_address_for_environment(config, temps_core::ExecutionEnvironment::Docker)
+            .unwrap();
         // The imported container name wins over the derived `postgres-{name}`.
         assert_eq!(host, "legacy-postgres");
         assert_eq!(port, "5432");
-
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
     }
 
     #[test]

--- a/crates/temps-providers/src/externalsvc/redis.rs
+++ b/crates/temps-providers/src/externalsvc/redis.rs
@@ -273,6 +273,64 @@ impl RedisService {
             .unwrap_or_else(|| self.get_container_name())
     }
 
+    fn get_effective_address_for_environment(
+        &self,
+        service_config: ServiceConfig,
+        execution_environment: temps_core::ExecutionEnvironment,
+    ) -> Result<(String, String)> {
+        let config = self.get_redis_config(service_config)?;
+        Ok(match execution_environment {
+            temps_core::ExecutionEnvironment::Host => ("localhost".to_string(), config.port),
+            temps_core::ExecutionEnvironment::Docker => (
+                self.get_live_container_name(&config),
+                REDIS_INTERNAL_PORT.to_string(),
+            ),
+        })
+    }
+
+    fn get_docker_environment_variables_for_environment(
+        &self,
+        parameters: &HashMap<String, String>,
+        execution_environment: temps_core::ExecutionEnvironment,
+    ) -> Result<HashMap<String, String>> {
+        let mut env_vars = HashMap::new();
+        let port = parameters
+            .get("port")
+            .ok_or_else(|| anyhow::anyhow!("Missing port parameter"))?;
+        let password = parameters.get("password");
+
+        let (effective_host, effective_port) = match execution_environment {
+            temps_core::ExecutionEnvironment::Host => ("localhost".to_string(), port.clone()),
+            temps_core::ExecutionEnvironment::Docker => (
+                parameters
+                    .get("container_name")
+                    .cloned()
+                    .unwrap_or_else(|| self.get_container_name()),
+                REDIS_INTERNAL_PORT.to_string(),
+            ),
+        };
+
+        let url = if let Some(pass) = password {
+            format!(
+                "redis://:{}@{}:{}",
+                urlencoding::encode(pass),
+                effective_host,
+                effective_port
+            )
+        } else {
+            format!("redis://{}:{}", effective_host, effective_port)
+        };
+
+        env_vars.insert("REDIS_URL".to_string(), url);
+        env_vars.insert("REDIS_HOST".to_string(), effective_host);
+        env_vars.insert("REDIS_PORT".to_string(), effective_port);
+        if let Some(pass) = password {
+            env_vars.insert("REDIS_PASSWORD".to_string(), pass.clone());
+        }
+
+        Ok(env_vars)
+    }
+
     /// Creates and starts the Redis container, retrying with a fresh host
     /// port if the chosen one lost the race described in `port_util` docs
     /// (bindable when we checked, but taken by the time Docker actually binds
@@ -1853,18 +1911,10 @@ const REDIS_INTERNAL_PORT: &str = "6379";
 #[async_trait]
 impl ExternalService for RedisService {
     fn get_effective_address(&self, service_config: ServiceConfig) -> Result<(String, String)> {
-        let config = self.get_redis_config(service_config)?;
-
-        if temps_core::DeploymentMode::is_docker() {
-            // Docker mode: use container name and internal port
-            Ok((
-                self.get_live_container_name(&config),
-                REDIS_INTERNAL_PORT.to_string(),
-            ))
-        } else {
-            // Baremetal mode: use localhost and exposed port
-            Ok(("localhost".to_string(), config.port))
-        }
+        self.get_effective_address_for_environment(
+            service_config,
+            temps_core::runtime::execution_environment_compatibility(),
+        )
     }
 
     fn get_docker_container_name(&self) -> String {
@@ -2071,47 +2121,10 @@ impl ExternalService for RedisService {
         &self,
         parameters: &HashMap<String, String>,
     ) -> Result<HashMap<String, String>> {
-        let mut env_vars = HashMap::new();
-        let port = parameters
-            .get("port")
-            .ok_or_else(|| anyhow::anyhow!("Missing port parameter"))?;
-        let password = parameters.get("password");
-
-        // Get effective host and port based on deployment mode. An imported
-        // service's real container name (stored raw in parameters, since the
-        // typed config isn't available here) wins over the derived one.
-        let (effective_host, effective_port) = if temps_core::DeploymentMode::is_docker() {
-            (
-                parameters
-                    .get("container_name")
-                    .cloned()
-                    .unwrap_or_else(|| self.get_container_name()),
-                REDIS_INTERNAL_PORT.to_string(),
-            )
-        } else {
-            // Baremetal mode: use localhost and exposed port
-            ("localhost".to_string(), port.clone())
-        };
-
-        let url = if let Some(pass) = password {
-            format!(
-                "redis://:{}@{}:{}",
-                urlencoding::encode(pass),
-                effective_host,
-                effective_port
-            )
-        } else {
-            format!("redis://{}:{}", effective_host, effective_port)
-        };
-
-        env_vars.insert("REDIS_URL".to_string(), url);
-        env_vars.insert("REDIS_HOST".to_string(), effective_host);
-        env_vars.insert("REDIS_PORT".to_string(), effective_port);
-        if let Some(pass) = password {
-            env_vars.insert("REDIS_PASSWORD".to_string(), pass.clone());
-        }
-
-        Ok(env_vars)
+        self.get_docker_environment_variables_for_environment(
+            parameters,
+            temps_core::runtime::execution_environment_compatibility(),
+        )
     }
 
     fn get_parameter_schema(&self) -> Option<serde_json::Value> {
@@ -3036,8 +3049,6 @@ impl ExternalService for RedisService {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use crate::externalsvc::DEPLOYMENT_MODE_MUTEX as ENV_MUTEX;
 
     #[test]
     fn health_probe_config_preserves_missing_and_short_passwords() {
@@ -3989,10 +4000,6 @@ mod tests {
 
     #[test]
     fn test_get_effective_address_baremetal_mode() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        // Clear Docker mode to ensure baremetal mode
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
-
         let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
         let service = RedisService::new("test-effective-addr".to_string(), docker);
 
@@ -4007,7 +4014,9 @@ mod tests {
             }),
         };
 
-        let (host, port) = service.get_effective_address(config).unwrap();
+        let (host, port) = service
+            .get_effective_address_for_environment(config, temps_core::ExecutionEnvironment::Host)
+            .unwrap();
 
         // In baremetal mode, should return localhost with exposed port
         assert_eq!(host, "localhost");
@@ -4016,10 +4025,6 @@ mod tests {
 
     #[test]
     fn test_get_effective_address_docker_mode() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        // Set Docker mode
-        unsafe { std::env::set_var("DEPLOYMENT_MODE", "docker") };
-
         let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
         let service = RedisService::new("test-effective-addr-docker".to_string(), docker);
 
@@ -4034,21 +4039,17 @@ mod tests {
             }),
         };
 
-        let (host, port) = service.get_effective_address(config).unwrap();
+        let (host, port) = service
+            .get_effective_address_for_environment(config, temps_core::ExecutionEnvironment::Docker)
+            .unwrap();
 
         // In Docker mode, should return container name with internal port
         assert_eq!(host, "redis-test-effective-addr-docker");
         assert_eq!(port, "6379"); // Internal port
-
-        // Clean up
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
     }
 
     #[test]
     fn test_get_effective_address_docker_mode_uses_imported_container_name() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        unsafe { std::env::set_var("DEPLOYMENT_MODE", "docker") };
-
         let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
         let service = RedisService::new("imported-svc".to_string(), docker);
 
@@ -4064,12 +4065,12 @@ mod tests {
             }),
         };
 
-        let (host, port) = service.get_effective_address(config).unwrap();
+        let (host, port) = service
+            .get_effective_address_for_environment(config, temps_core::ExecutionEnvironment::Docker)
+            .unwrap();
         // The imported container name wins over the derived `redis-{name}`.
         assert_eq!(host, "legacy-redis");
         assert_eq!(port, "6379");
-
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
     }
 
     #[test]
@@ -4109,10 +4110,6 @@ mod tests {
 
     #[test]
     fn test_get_docker_environment_variables_baremetal_mode() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        // Clear Docker mode to ensure baremetal mode
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
-
         let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
         let service = RedisService::new("test-docker-env".to_string(), docker);
 
@@ -4120,7 +4117,12 @@ mod tests {
         params.insert("port".to_string(), "6381".to_string());
         params.insert("password".to_string(), "testpass".to_string());
 
-        let env_vars = service.get_docker_environment_variables(&params).unwrap();
+        let env_vars = service
+            .get_docker_environment_variables_for_environment(
+                &params,
+                temps_core::ExecutionEnvironment::Host,
+            )
+            .unwrap();
 
         // In baremetal mode, should use localhost with exposed port
         assert_eq!(env_vars.get("REDIS_HOST").unwrap(), "localhost");
@@ -4129,10 +4131,6 @@ mod tests {
 
     #[test]
     fn test_get_docker_environment_variables_docker_mode() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        // Set Docker mode
-        unsafe { std::env::set_var("DEPLOYMENT_MODE", "docker") };
-
         let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
         let service = RedisService::new("test-docker-env-mode".to_string(), docker);
 
@@ -4140,7 +4138,12 @@ mod tests {
         params.insert("port".to_string(), "6381".to_string());
         params.insert("password".to_string(), "testpass".to_string());
 
-        let env_vars = service.get_docker_environment_variables(&params).unwrap();
+        let env_vars = service
+            .get_docker_environment_variables_for_environment(
+                &params,
+                temps_core::ExecutionEnvironment::Docker,
+            )
+            .unwrap();
 
         // In Docker mode, should use container name and internal port
         assert_eq!(
@@ -4148,8 +4151,5 @@ mod tests {
             "redis-test-docker-env-mode"
         );
         assert_eq!(env_vars.get("REDIS_PORT").unwrap(), "6379"); // Internal port
-
-        // Clean up
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
     }
 }

--- a/crates/temps-providers/src/externalsvc/s3.rs
+++ b/crates/temps-providers/src/externalsvc/s3.rs
@@ -279,6 +279,21 @@ echo '[restore] complete'"#;
             .unwrap_or_else(|| self.get_container_name())
     }
 
+    fn get_effective_address_for_environment(
+        &self,
+        service_config: ServiceConfig,
+        execution_environment: temps_core::ExecutionEnvironment,
+    ) -> Result<(String, String)> {
+        let config = self.get_s3_config(service_config)?;
+        Ok(match execution_environment {
+            temps_core::ExecutionEnvironment::Host => ("localhost".to_string(), config.port),
+            temps_core::ExecutionEnvironment::Docker => (
+                self.get_live_container_name(&config),
+                S3_INTERNAL_PORT.to_string(),
+            ),
+        })
+    }
+
     /// Creates and starts the MinIO container, retrying with a fresh host
     /// port if the chosen one lost the race described in `port_util` docs
     /// (bindable when we checked, but taken by the time Docker actually binds
@@ -741,18 +756,10 @@ impl ExternalService for S3Service {
     }
 
     fn get_effective_address(&self, service_config: ServiceConfig) -> Result<(String, String)> {
-        let config = self.get_s3_config(service_config)?;
-
-        if temps_core::DeploymentMode::is_docker() {
-            // Docker mode: use container name and internal port
-            Ok((
-                self.get_live_container_name(&config),
-                S3_INTERNAL_PORT.to_string(),
-            ))
-        } else {
-            // Baremetal mode: use localhost and exposed port
-            Ok(("localhost".to_string(), config.port))
-        }
+        self.get_effective_address_for_environment(
+            service_config,
+            temps_core::runtime::execution_environment_compatibility(),
+        )
     }
 
     fn get_docker_container_name(&self) -> String {
@@ -2876,11 +2883,6 @@ mod tests {
 
     #[test]
     fn test_get_effective_address_docker_mode_uses_imported_container_name() {
-        let _lock = crate::externalsvc::DEPLOYMENT_MODE_MUTEX
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        unsafe { std::env::set_var("DEPLOYMENT_MODE", "docker") };
-
         let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
         let encryption_service =
             Arc::new(EncryptionService::new("test_encryption_key_1234567890ab").unwrap());
@@ -2900,12 +2902,51 @@ mod tests {
             }),
         };
 
-        let (host, port) = service.get_effective_address(config).unwrap();
+        let (host, port) = service
+            .get_effective_address_for_environment(config, temps_core::ExecutionEnvironment::Docker)
+            .unwrap();
         // The imported container name wins over the derived `minio-{name}`.
         assert_eq!(host, "legacy-minio");
         assert_eq!(port, S3_INTERNAL_PORT);
+    }
 
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
+    #[test]
+    fn test_get_effective_address_host_and_docker_use_environment_specific_addresses() {
+        let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
+        let encryption_service =
+            Arc::new(EncryptionService::new("test_encryption_key_1234567890ab").unwrap());
+        let service = S3Service::new("address-mapping".to_string(), docker, encryption_service);
+        let config = ServiceConfig {
+            name: "address-mapping".to_string(),
+            service_type: ServiceType::S3,
+            version: None,
+            parameters: serde_json::json!({
+                "host": "localhost",
+                "port": "19000",
+                "access_key": "minioadmin",
+                "secret_key": "minioadmin",
+                "region": "us-east-1",
+            }),
+        };
+
+        let host = service
+            .get_effective_address_for_environment(
+                config.clone(),
+                temps_core::ExecutionEnvironment::Host,
+            )
+            .unwrap();
+        let docker = service
+            .get_effective_address_for_environment(config, temps_core::ExecutionEnvironment::Docker)
+            .unwrap();
+
+        assert_eq!(host, ("localhost".to_string(), "19000".to_string()));
+        assert_eq!(
+            docker,
+            (
+                "minio-address-mapping".to_string(),
+                S3_INTERNAL_PORT.to_string()
+            )
+        );
     }
 
     #[test]

--- a/crates/temps-routes/src/route_table.rs
+++ b/crates/temps-routes/src/route_table.rs
@@ -29,7 +29,10 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use temps_core::public_hostname_resolver::match_strategy;
-use temps_core::{AppSettings, DeploymentMode, PublicHostnameStrategy};
+use temps_core::{
+    AppSettings, ExecutionEnvironment, PublicHostnameStrategy, RuntimeContext,
+    ServiceEndpointScheme,
+};
 use temps_entities::custom_routes::RouteType;
 use temps_entities::preset::ComposePublicPort;
 use temps_entities::{deployments, environments, nodes, projects};
@@ -64,12 +67,14 @@ async fn resolve_node_private_address(
 fn build_backend_entry(
     container: &temps_entities::deployment_containers::Model,
     node_private_address: Option<&str>,
+    runtime_context: &RuntimeContext,
 ) -> BackendEntry {
     let address = build_container_backend_addr(
         &container.container_name,
         container.container_port,
         container.host_port,
         node_private_address,
+        runtime_context,
     );
     BackendEntry {
         address,
@@ -90,11 +95,13 @@ fn build_public_compose_backend_addr(
     recorded_host_port: Option<i32>,
     node_private_address: Option<&str>,
     public_port: &ComposePublicPort,
+    runtime_context: &RuntimeContext,
 ) -> Option<String> {
     if recorded_container_port != i32::from(public_port.port) {
         return None;
     }
-    if (node_private_address.is_some() || DeploymentMode::is_baremetal())
+    if (node_private_address.is_some()
+        || runtime_context.execution_environment() == ExecutionEnvironment::Host)
         && recorded_host_port.is_none()
     {
         return None;
@@ -104,6 +111,7 @@ fn build_public_compose_backend_addr(
         i32::from(public_port.port),
         recorded_host_port,
         node_private_address,
+        runtime_context,
     ))
 }
 
@@ -111,6 +119,7 @@ fn build_public_compose_backend_entry(
     container: &temps_entities::deployment_containers::Model,
     node_private_address: Option<&str>,
     public_port: &ComposePublicPort,
+    runtime_context: &RuntimeContext,
 ) -> Option<BackendEntry> {
     let address = build_public_compose_backend_addr(
         &container.container_name,
@@ -118,6 +127,7 @@ fn build_public_compose_backend_entry(
         container.host_port,
         node_private_address,
         public_port,
+        runtime_context,
     )?;
     Some(BackendEntry {
         address,
@@ -166,19 +176,20 @@ fn build_container_backend_addr(
     container_port: i32,
     host_port: Option<i32>,
     node_private_address: Option<&str>,
+    runtime_context: &RuntimeContext,
 ) -> String {
     if let Some(private_addr) = node_private_address {
         // Remote node: use the node's private/WireGuard IP with host_port
         let port = host_port.unwrap_or(container_port);
         format!("{}:{}", private_addr, port)
     } else {
-        // Local node: use existing logic
-        let (host, port) = DeploymentMode::get_effective_host_port(
+        let endpoint = runtime_context.resolve_service_endpoint(
             container_name,
+            ServiceEndpointScheme::Http,
             container_port as u16,
             host_port.unwrap_or(container_port) as u16,
         );
-        format!("{}:{}", host, port)
+        endpoint.authority()
     }
 }
 
@@ -415,6 +426,9 @@ pub struct CachedPeerTable {
     /// Database connection for loading routes
     db: Arc<DatabaseConnection>,
 
+    /// Immutable execution environment and endpoint resolver selected at startup.
+    runtime_context: Arc<RuntimeContext>,
+
     /// Optional callback invoked after each route reload with sleeping environment entries.
     on_sleeping_callback: parking_lot::Mutex<Option<OnSleepingCallback>>,
 
@@ -446,6 +460,13 @@ pub struct CachedPeerTable {
 
 impl CachedPeerTable {
     pub fn new(db: Arc<DatabaseConnection>) -> Self {
+        Self::new_with_runtime_context(db, Arc::new(RuntimeContext::host()))
+    }
+
+    pub fn new_with_runtime_context(
+        db: Arc<DatabaseConnection>,
+        runtime_context: Arc<RuntimeContext>,
+    ) -> Self {
         Self {
             http_routes: Arc::new(RwLock::new(HashMap::new())),
             tls_routes: Arc::new(RwLock::new(HashMap::new())),
@@ -453,6 +474,7 @@ impl CachedPeerTable {
             tls_wildcards: Arc::new(RwLock::new(WildcardMatcher::new())),
             routes: Arc::new(RwLock::new(HashMap::new())),
             db,
+            runtime_context,
             on_sleeping_callback: parking_lot::Mutex::new(None),
             on_reload_callback: parking_lot::Mutex::new(None),
             on_cert_eligible_callback: parking_lot::Mutex::new(None),
@@ -794,8 +816,13 @@ impl CachedPeerTable {
                                         c,
                                         node_addr.as_deref(),
                                         port,
+                                        self.runtime_context.as_ref(),
                                     ),
-                                    None => Some(build_backend_entry(c, node_addr.as_deref())),
+                                    None => Some(build_backend_entry(
+                                        c,
+                                        node_addr.as_deref(),
+                                        self.runtime_context.as_ref(),
+                                    )),
                                 };
                                 if let Some(entry) = entry {
                                     backend_entries.push(entry);
@@ -1059,7 +1086,11 @@ impl CachedPeerTable {
                                     self.db.as_ref(),
                                 )
                                 .await;
-                                backend_entries.push(build_backend_entry(c, node_addr.as_deref()));
+                                backend_entries.push(build_backend_entry(
+                                    c,
+                                    node_addr.as_deref(),
+                                    self.runtime_context.as_ref(),
+                                ));
                             }
                             BackendType::Upstream {
                                 backends: backend_entries,
@@ -1289,8 +1320,13 @@ impl CachedPeerTable {
                                     c,
                                     node_addr.as_deref(),
                                     port,
+                                    self.runtime_context.as_ref(),
                                 ),
-                                None => Some(build_backend_entry(c, node_addr.as_deref())),
+                                None => Some(build_backend_entry(
+                                    c,
+                                    node_addr.as_deref(),
+                                    self.runtime_context.as_ref(),
+                                )),
                             };
                             if let Some(entry) = entry {
                                 backend_entries.push(entry);
@@ -1467,6 +1503,7 @@ impl CachedPeerTable {
                                         c,
                                         node_addr.as_deref(),
                                         public_port,
+                                        self.runtime_context.as_ref(),
                                     ) else {
                                         warn!(
                                             service = %public_port.service,
@@ -1648,8 +1685,13 @@ impl CachedPeerTable {
                                     c,
                                     node_addr.as_deref(),
                                     port,
+                                    self.runtime_context.as_ref(),
                                 ),
-                                None => Some(build_backend_entry(c, node_addr.as_deref())),
+                                None => Some(build_backend_entry(
+                                    c,
+                                    node_addr.as_deref(),
+                                    self.runtime_context.as_ref(),
+                                )),
                             };
                             if let Some(entry) = entry {
                                 backend_entries.push(entry);
@@ -2050,10 +2092,6 @@ impl Drop for RouteTableListener {
 mod tests {
     use super::*;
 
-    /// Mutex to serialize tests that mutate the DEPLOYMENT_MODE env var.
-    /// Env vars are process-global, so parallel tests would race.
-    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     /// Create a no-op queue for tests that don't need queue functionality
     fn test_queue() -> Arc<dyn temps_core::JobQueue> {
         struct NoOpQueue;
@@ -2384,21 +2422,22 @@ mod tests {
 
     #[test]
     fn test_build_container_backend_addr_local_docker() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         // In Docker mode, local containers use container_name:container_port
-        unsafe { std::env::set_var("DEPLOYMENT_MODE", "docker") };
-        let addr = build_container_backend_addr("my-app", 3000, Some(8080), None);
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
+        let addr = build_container_backend_addr(
+            "my-app",
+            3000,
+            Some(8080),
+            None,
+            &RuntimeContext::docker(),
+        );
         assert_eq!(addr, "my-app:3000");
     }
 
     #[test]
     fn test_build_container_backend_addr_local_baremetal() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         // In baremetal mode (default), local containers use 127.0.0.1:host_port
-        unsafe { std::env::set_var("DEPLOYMENT_MODE", "baremetal") };
-        let addr = build_container_backend_addr("my-app", 3000, Some(8080), None);
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
+        let addr =
+            build_container_backend_addr("my-app", 3000, Some(8080), None, &RuntimeContext::host());
         assert_eq!(addr, "127.0.0.1:8080");
     }
 
@@ -2465,33 +2504,61 @@ mod tests {
 
     #[test]
     fn public_compose_mapping_uses_docker_recorded_port_on_baremetal() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        unsafe { std::env::set_var("DEPLOYMENT_MODE", "baremetal") };
         let mapping = ComposePublicPort {
             service: "web".to_string(),
             port: 80,
             published: Some(65535),
         };
 
-        let addr = build_public_compose_backend_addr("web", 80, Some(15455), None, &mapping);
+        let addr = build_public_compose_backend_addr(
+            "web",
+            80,
+            Some(15455),
+            None,
+            &mapping,
+            &RuntimeContext::host(),
+        );
 
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
         assert_eq!(addr.as_deref(), Some("127.0.0.1:15455"));
     }
 
     #[test]
     fn public_compose_mapping_uses_container_port_in_docker() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        unsafe { std::env::set_var("DEPLOYMENT_MODE", "docker") };
         let mapping = ComposePublicPort {
             service: "web".to_string(),
             port: 80,
             published: Some(15455),
         };
 
-        let addr = build_public_compose_backend_addr("web", 80, Some(15455), None, &mapping);
+        let addr = build_public_compose_backend_addr(
+            "web",
+            80,
+            Some(15455),
+            None,
+            &mapping,
+            &RuntimeContext::docker(),
+        );
 
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
+        assert_eq!(addr.as_deref(), Some("web:80"));
+    }
+
+    #[test]
+    fn test_public_compose_mapping_docker_without_host_port_uses_container_port() {
+        let mapping = ComposePublicPort {
+            service: "web".to_string(),
+            port: 80,
+            published: None,
+        };
+
+        let addr = build_public_compose_backend_addr(
+            "web",
+            80,
+            None,
+            None,
+            &mapping,
+            &RuntimeContext::docker(),
+        );
+
         assert_eq!(addr.as_deref(), Some("web:80"));
     }
 
@@ -2503,25 +2570,35 @@ mod tests {
             published: Some(65535),
         };
 
-        let addr =
-            build_public_compose_backend_addr("web", 80, Some(15455), Some("10.100.0.5"), &mapping);
+        let addr = build_public_compose_backend_addr(
+            "web",
+            80,
+            Some(15455),
+            Some("10.100.0.5"),
+            &mapping,
+            &RuntimeContext::host(),
+        );
 
         assert_eq!(addr.as_deref(), Some("10.100.0.5:15455"));
     }
 
     #[test]
     fn legacy_public_compose_mapping_uses_recorded_host_port() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        unsafe { std::env::set_var("DEPLOYMENT_MODE", "baremetal") };
         let mapping = ComposePublicPort {
             service: "web".to_string(),
             port: 80,
             published: None,
         };
 
-        let addr = build_public_compose_backend_addr("web", 80, Some(15455), None, &mapping);
+        let addr = build_public_compose_backend_addr(
+            "web",
+            80,
+            Some(15455),
+            None,
+            &mapping,
+            &RuntimeContext::host(),
+        );
 
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
         assert_eq!(addr.as_deref(), Some("127.0.0.1:15455"));
     }
 
@@ -2534,52 +2611,81 @@ mod tests {
         };
 
         assert_eq!(
-            build_public_compose_backend_addr("web", 80, Some(15455), None, &mapping),
+            build_public_compose_backend_addr(
+                "web",
+                80,
+                Some(15455),
+                None,
+                &mapping,
+                &RuntimeContext::host(),
+            ),
             None
         );
     }
 
     #[test]
     fn public_compose_mapping_requires_discovered_host_port_off_docker_network() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        unsafe { std::env::set_var("DEPLOYMENT_MODE", "baremetal") };
         let mapping = ComposePublicPort {
             service: "web".to_string(),
             port: 80,
             published: Some(8211),
         };
 
-        let addr = build_public_compose_backend_addr("web", 80, None, None, &mapping);
+        let addr = build_public_compose_backend_addr(
+            "web",
+            80,
+            None,
+            None,
+            &mapping,
+            &RuntimeContext::host(),
+        );
 
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
         assert_eq!(addr, None);
     }
 
     #[test]
     fn test_build_container_backend_addr_remote_with_host_port() {
         // Remote containers always use private_address:host_port
-        let addr = build_container_backend_addr("my-app", 3000, Some(8080), Some("10.100.0.5"));
+        let addr = build_container_backend_addr(
+            "my-app",
+            3000,
+            Some(8080),
+            Some("10.100.0.5"),
+            &RuntimeContext::host(),
+        );
         assert_eq!(addr, "10.100.0.5:8080");
     }
 
     #[test]
     fn test_build_container_backend_addr_remote_without_host_port() {
         // When host_port is None, remote falls back to container_port
-        let addr = build_container_backend_addr("my-app", 3000, None, Some("10.100.0.5"));
+        let addr = build_container_backend_addr(
+            "my-app",
+            3000,
+            None,
+            Some("10.100.0.5"),
+            &RuntimeContext::host(),
+        );
         assert_eq!(addr, "10.100.0.5:3000");
     }
 
     #[test]
     fn test_build_container_backend_addr_remote_ignores_deployment_mode() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         // Remote address should be the same regardless of deployment mode
-        unsafe { std::env::set_var("DEPLOYMENT_MODE", "docker") };
-        let addr_docker =
-            build_container_backend_addr("my-app", 3000, Some(8080), Some("10.100.0.5"));
-        unsafe { std::env::set_var("DEPLOYMENT_MODE", "baremetal") };
-        let addr_baremetal =
-            build_container_backend_addr("my-app", 3000, Some(8080), Some("10.100.0.5"));
-        unsafe { std::env::remove_var("DEPLOYMENT_MODE") };
+        let addr_docker = build_container_backend_addr(
+            "my-app",
+            3000,
+            Some(8080),
+            Some("10.100.0.5"),
+            &RuntimeContext::docker(),
+        );
+        let addr_baremetal = build_container_backend_addr(
+            "my-app",
+            3000,
+            Some(8080),
+            Some("10.100.0.5"),
+            &RuntimeContext::host(),
+        );
 
         assert_eq!(addr_docker, addr_baremetal);
         assert_eq!(addr_docker, "10.100.0.5:8080");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,9 +239,10 @@ services:
       retries: 3
       start_period: 40s
 
-  # Publish public listeners on host loopback and expose the private admin
-  # listener through an independent Basic-auth barrier. The proxy runs as an
-  # unprivileged, read-only container and never receives the Docker socket.
+  # Publish public listeners on host loopback and make the same surface
+  # reachable from managed workloads. Keeping this proxy separate from the
+  # admin proxy prevents its workload-network attachment from exposing the UI
+  # or management API.
   temps-ingress:
     build:
       context: .
@@ -262,21 +263,59 @@ services:
         condition: service_healthy
     environment:
       TEMPS_CONTROL_INTERNAL_IP: ${TEMPS_CONTROL_INTERNAL_IP:-198.18.255.10}
-      TEMPS_INGRESS_PUBLISH_IP: ${TEMPS_INGRESS_PUBLISH_IP:-198.19.255.10}
-    secrets:
-      - source: temps_admin_ingress_password
-        target: temps_admin_ingress_password
+      TEMPS_INGRESS_MODE: public
+      TEMPS_INGRESS_LISTEN_IP: ${TEMPS_PUBLIC_INGRESS_IP:-198.20.255.10}
     ports:
       - "127.0.0.1:3000:3000"
       - "127.0.0.1:3443:3443"
       - "127.0.0.1:9000:9000"
+    networks:
+      temps-network:
+      temps-app-network:
+        ipv4_address: ${TEMPS_PUBLIC_INGRESS_IP:-198.20.255.10}
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z -w 1 ${TEMPS_PUBLIC_INGRESS_IP:-198.20.255.10} 3000 && nc -z -w 1 ${TEMPS_PUBLIC_INGRESS_IP:-198.20.255.10} 3443 && nc -z -w 1 ${TEMPS_PUBLIC_INGRESS_IP:-198.20.255.10} 9000 && nc -z -w 1 ${TEMPS_CONTROL_INTERNAL_IP:-198.18.255.10} 9000"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 5s
+
+  # The admin/UI listener has an independent, loopback-only Basic-auth barrier
+  # and never joins the workload network. Both ingress containers run
+  # unprivileged with read-only roots and never receive the Docker socket.
+  temps-admin-ingress:
+    build:
+      context: .
+      dockerfile: Dockerfile.ingress
+    container_name: temps-admin-ingress
+    restart: unless-stopped
+    cap_drop:
+      - ALL
+    read_only: true
+    mem_limit: 128m
+    pids_limit: 32
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=16m
+    depends_on:
+      temps:
+        condition: service_healthy
+    environment:
+      TEMPS_CONTROL_INTERNAL_IP: ${TEMPS_CONTROL_INTERNAL_IP:-198.18.255.10}
+      TEMPS_INGRESS_MODE: admin
+      TEMPS_INGRESS_LISTEN_IP: ${TEMPS_ADMIN_INGRESS_IP:-198.19.255.10}
+    secrets:
+      - source: temps_admin_ingress_password
+        target: temps_admin_ingress_password
+    ports:
       - "127.0.0.1:9001:9001"
     networks:
       temps-network:
       temps-ingress-network:
-        ipv4_address: ${TEMPS_INGRESS_PUBLISH_IP:-198.19.255.10}
+        ipv4_address: ${TEMPS_ADMIN_INGRESS_IP:-198.19.255.10}
     healthcheck:
-      test: ["CMD-SHELL", "nc -z -w 1 ${TEMPS_INGRESS_PUBLISH_IP:-198.19.255.10} 9000 && nc -z -w 1 ${TEMPS_INGRESS_PUBLISH_IP:-198.19.255.10} 9001 && nc -z -w 1 ${TEMPS_CONTROL_INTERNAL_IP:-198.18.255.10} 9000 && nc -z -w 1 ${TEMPS_CONTROL_INTERNAL_IP:-198.18.255.10} 9001"]
+      test: ["CMD-SHELL", "nc -z -w 1 ${TEMPS_ADMIN_INGRESS_IP:-198.19.255.10} 9001 && nc -z -w 1 ${TEMPS_CONTROL_INTERNAL_IP:-198.18.255.10} 9001"]
       interval: 10s
       timeout: 3s
       retries: 6
@@ -304,6 +343,9 @@ networks:
     # Compose and containers created through the Docker API share the network.
     name: ${TEMPS_NETWORK_NAME:-temps-docker-workloads}
     driver: bridge
+    ipam:
+      config:
+        - subnet: ${TEMPS_WORKLOAD_SUBNET:-198.20.255.0/24}
   temps-ingress-network:
     driver: bridge
     driver_opts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,10 @@ services:
     networks:
       temps-network:
         ipv4_address: ${TEMPS_POSTGRES_INTERNAL_IP:-198.18.255.11}
+      # Docker does not realize published ports for containers attached only to
+      # an internal bridge. This dedicated bridge exists solely so the
+      # loopback-bound diagnostic port is actually reachable from the host.
+      temps-host-network:
     healthcheck:
       # Authenticated TCP query: unlike pg_isready, this catches a password
       # mismatch after upgrading an existing data volume.
@@ -146,6 +150,9 @@ services:
     networks:
       temps-network:
         ipv4_address: ${TEMPS_CLICKHOUSE_INTERNAL_IP:-198.18.255.12}
+      # Keep host publication separate from the internal control plane. ICC is
+      # disabled on this bridge; Temps still connects over temps-network.
+      temps-host-network:
     ulimits:
       nofile:
         soft: 262144
@@ -355,6 +362,16 @@ networks:
       config:
         - subnet: ${TEMPS_INGRESS_SUBNET:-198.19.255.0/24}
           gateway: ${TEMPS_INGRESS_GATEWAY_IP:-198.19.255.1}
+  temps-host-network:
+    # Docker Engine does not install host port mappings for a container that is
+    # attached only to an internal bridge. This non-internal bridge enables the
+    # explicitly loopback-bound PostgreSQL and ClickHouse diagnostic ports,
+    # while disabling direct container-to-container traffic on the bridge.
+    driver: bridge
+    driver_opts:
+      com.docker.network.bridge.enable_icc: "false"
+      com.docker.network.bridge.enable_ip_masquerade: "false"
+      com.docker.network.bridge.trusted_host_interfaces: "lo"
 
 secrets:
   temps_admin_password:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     network_mode: none
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set (put it in a .env file next to docker-compose.yml)}
-      REDIS_PASSWORD: ${REDIS_PASSWORD:?REDIS_PASSWORD must be set (put it in a .env file next to docker-compose.yml)}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:?CLICKHOUSE_PASSWORD must be set (put it in a .env file next to docker-compose.yml)}
     command:
       - /bin/sh
       - -ec
@@ -19,9 +19,9 @@ services:
             exit 1
             ;;
         esac
-        case "$$REDIS_PASSWORD" in
+        case "$$CLICKHOUSE_PASSWORD" in
           *[!A-Za-z0-9_-]*)
-            echo "REDIS_PASSWORD must contain only URL-safe characters: A-Z, a-z, 0-9, underscore, or hyphen" >&2
+            echo "CLICKHOUSE_PASSWORD must contain only URL-safe characters: A-Z, a-z, 0-9, underscore, or hyphen" >&2
             exit 1
             ;;
         esac
@@ -63,7 +63,8 @@ services:
       -c archive_mode=on
       -c archive_timeout=60
     networks:
-      - temps-network
+      temps-network:
+        ipv4_address: ${TEMPS_POSTGRES_INTERNAL_IP:-198.18.255.11}
     healthcheck:
       # Authenticated TCP query: unlike pg_isready, this catches a password
       # mismatch after upgrading an existing data volume.
@@ -106,41 +107,52 @@ services:
         umask 077
         trap 'rm -f /tmp/rotate-password.sql' EXIT
         printf "\\set password '%s'\nSET password_encryption = 'scram-sha-256';\nALTER ROLE temps WITH PASSWORD :'password';\n" "$$POSTGRES_PASSWORD" > /tmp/rotate-password.sql
-        psql -v ON_ERROR_STOP=1 -h /var/run/postgresql -U temps -d postgres -f /tmp/rotate-password.sql
+        # A new image briefly starts an initialization postmaster and then
+        # replaces it with the final server. If that handoff races this command,
+        # retry the idempotent role update instead of failing first startup.
+        rotate_attempts=0
+        until psql -v ON_ERROR_STOP=1 -h /var/run/postgresql -U temps -d postgres -f /tmp/rotate-password.sql; do
+          rotate_attempts=$$((rotate_attempts + 1))
+          if [ "$$rotate_attempts" -ge 120 ]; then
+            echo "PostgreSQL password synchronization did not complete within 120 seconds" >&2
+            exit 1
+          fi
+          sleep 1
+        done
 
-  # Redis Cache
-  redis:
-    image: redis:8-alpine
-    container_name: temps-redis
-    user: redis
-    # Require a password. No default: compose fails fast if REDIS_PASSWORD is unset.
+  # ClickHouse analytics and OpenTelemetry backend
+  clickhouse:
+    image: clickhouse/clickhouse-server:26.7.5.10-alpine
+    container_name: temps-clickhouse
+    restart: always
     environment:
-      REDIS_PASSWORD: ${REDIS_PASSWORD:?REDIS_PASSWORD must be set (put it in a .env file next to docker-compose.yml)}
+      CLICKHOUSE_DB: temps
+      CLICKHOUSE_USER: temps
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:?CLICKHOUSE_PASSWORD must be set (put it in a .env file next to docker-compose.yml)}
     depends_on:
       credential-check:
         condition: service_completed_successfully
-    # Keep the secret out of the long-lived redis-server argv. The validator
-    # above rejects whitespace/newlines and other Redis-config metacharacters.
-    command:
-      - /bin/sh
-      - -ec
-      - |
-        umask 077
-        printf 'appendonly yes\nrequirepass %s\n' "$$REDIS_PASSWORD" > /tmp/redis.conf
-        unset REDIS_PASSWORD
-        exec redis-server /tmp/redis.conf
     ports:
-      # Loopback only — Redis is reachable over the internal temps-network.
-      - "127.0.0.1:6379:6379"
+      # The HTTP API is available locally for diagnostics. Temps connects over
+      # the internal network; the native protocol is not published to the host.
+      - "127.0.0.1:8123:8123"
     volumes:
-      - redis_data:/data
+      - clickhouse_data:/var/lib/clickhouse
     networks:
-      - temps-network
+      temps-network:
+        ipv4_address: ${TEMPS_CLICKHOUSE_INTERNAL_IP:-198.18.255.12}
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
     healthcheck:
-      test: ["CMD-SHELL", "REDISCLI_AUTH=\"$$REDIS_PASSWORD\" redis-cli ping | grep -q PONG"]
+      # clickhouse-client reads CLICKHOUSE_PASSWORD from the container
+      # environment, keeping the credential out of the process arguments.
+      test: ["CMD", "clickhouse-client", "--user", "temps", "--database", "temps", "--query", "SELECT 1"]
       interval: 10s
       timeout: 5s
-      retries: 5
+      retries: 10
+      start_period: 30s
 
   # Temps Application
   # The image bundles the tracked GeoLite2 City database outside /app/data so
@@ -156,15 +168,20 @@ services:
     group_add:
       - ${DOCKER_GID:?DOCKER_GID must be the group ID that owns /var/run/docker.sock}
     environment:
+      # Select Docker-internal endpoint resolution for managed workloads.
+      TEMPS_EXECUTION_ENV: docker
+      TEMPS_NETWORK_NAME: ${TEMPS_NETWORK_NAME:-temps-docker-workloads}
+
       # Database configuration (password sourced from the same env var as postgres)
-      TEMPS_DATABASE_URL: postgresql://temps:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/temps
+      TEMPS_DATABASE_URL: postgresql://temps:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@${TEMPS_POSTGRES_INTERNAL_IP:-198.18.255.11}:5432/temps
 
-      # Server configuration
-      TEMPS_ADDRESS: 0.0.0.0:3000
-      TEMPS_TLS_ADDRESS: 0.0.0.0:3443
-
-      # Console API configuration
-      TEMPS_CONSOLE_ADDRESS: 0.0.0.0:9000
+      # Bind only to the private control-network address. Static addresses are
+      # used because Docker DNS queries from a dual-network container can be
+      # confused by a workload claiming the same alias as a private service.
+      TEMPS_ADDRESS: ${TEMPS_CONTROL_INTERNAL_IP:-198.18.255.10}:3000
+      TEMPS_TLS_ADDRESS: ${TEMPS_CONTROL_INTERNAL_IP:-198.18.255.10}:3443
+      TEMPS_CONSOLE_ADDRESS: ${TEMPS_CONTROL_INTERNAL_IP:-198.18.255.10}:9000
+      TEMPS_CONSOLE_ADMIN_ADDRESS: ${TEMPS_CONTROL_INTERNAL_IP:-198.18.255.10}:9001
 
       # Data directory
       TEMPS_DATA_DIR: /app/data
@@ -177,13 +194,11 @@ services:
       # Logging
       TEMPS_LOG_LEVEL: info
 
-      # Redis configuration (authenticated; password from REDIS_PASSWORD)
-      REDIS_URL: redis://:${REDIS_PASSWORD:?REDIS_PASSWORD must be set}@redis:6379
-    ports:
-      - "3000:3000"              # HTTP API (public)
-      - "3443:3443"              # HTTPS API (public, if configured)
-      # Console admin API — loopback only, never published to public interfaces.
-      - "127.0.0.1:9000:9000"    # Console API
+      # ClickHouse stores analytics, request logs, metrics, and OpenTelemetry.
+      TEMPS_CLICKHOUSE_URL: http://${TEMPS_CLICKHOUSE_INTERNAL_IP:-198.18.255.12}:8123
+      TEMPS_CLICKHOUSE_DATABASE: temps
+      TEMPS_CLICKHOUSE_USER: temps
+      TEMPS_CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:?CLICKHOUSE_PASSWORD must be set}
     volumes:
       # Persistent data directory
       - temps_data:/app/data
@@ -203,23 +218,71 @@ services:
         condition: service_healthy
       postgres-credential-sync:
         condition: service_completed_successfully
-      redis:
+      clickhouse:
         condition: service_healthy
     networks:
-      - temps-network
+      temps-network:
+        ipv4_address: ${TEMPS_CONTROL_INTERNAL_IP:-198.18.255.10}
+      # Managed applications and database providers run on this shared network.
+      # Joining it lets Docker runtime resolution use container DNS/internal
+      # ports without exposing workload ports on the host.
+      temps-app-network:
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:9000/readyz"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://${TEMPS_CONTROL_INTERNAL_IP:-198.18.255.10}:9000/readyz"]
       interval: 30s
       timeout: 5s
       retries: 3
       start_period: 40s
+
+  # Publish public listeners on host loopback and expose the private admin
+  # listener through an independent Basic-auth barrier. The proxy runs as an
+  # unprivileged, read-only container and never receives the Docker socket.
+  temps-ingress:
+    build:
+      context: .
+      dockerfile: Dockerfile.ingress
+    container_name: temps-ingress
+    restart: unless-stopped
+    cap_drop:
+      - ALL
+    read_only: true
+    mem_limit: 128m
+    pids_limit: 32
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=16m
+    depends_on:
+      temps:
+        condition: service_healthy
+    environment:
+      TEMPS_CONTROL_INTERNAL_IP: ${TEMPS_CONTROL_INTERNAL_IP:-198.18.255.10}
+      TEMPS_INGRESS_PUBLISH_IP: ${TEMPS_INGRESS_PUBLISH_IP:-198.19.255.10}
+    secrets:
+      - source: temps_admin_ingress_password
+        target: temps_admin_ingress_password
+    ports:
+      - "127.0.0.1:3000:3000"
+      - "127.0.0.1:3443:3443"
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
+    networks:
+      temps-network:
+      temps-ingress-network:
+        ipv4_address: ${TEMPS_INGRESS_PUBLISH_IP:-198.19.255.10}
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z -w 1 ${TEMPS_INGRESS_PUBLISH_IP:-198.19.255.10} 9000 && nc -z -w 1 ${TEMPS_INGRESS_PUBLISH_IP:-198.19.255.10} 9001 && nc -z -w 1 ${TEMPS_CONTROL_INTERNAL_IP:-198.18.255.10} 9000 && nc -z -w 1 ${TEMPS_CONTROL_INTERNAL_IP:-198.18.255.10} 9001"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 5s
 
 volumes:
   postgres_data:
     driver: local
   postgres_socket:
     driver: local
-  redis_data:
+  clickhouse_data:
     driver: local
   temps_data:
     driver: local
@@ -227,7 +290,27 @@ volumes:
 networks:
   temps-network:
     driver: bridge
+    internal: true
+    ipam:
+      config:
+        - subnet: ${TEMPS_CONTROL_SUBNET:-198.18.255.0/24}
+  temps-app-network:
+    # This must match TEMPS_NETWORK_NAME. A stable engine-level name lets both
+    # Compose and containers created through the Docker API share the network.
+    name: ${TEMPS_NETWORK_NAME:-temps-docker-workloads}
+    driver: bridge
+  temps-ingress-network:
+    driver: bridge
+    driver_opts:
+      com.docker.network.bridge.enable_icc: "false"
+      com.docker.network.bridge.trusted_host_interfaces: "lo"
+    ipam:
+      config:
+        - subnet: ${TEMPS_INGRESS_SUBNET:-198.19.255.0/24}
+          gateway: ${TEMPS_INGRESS_GATEWAY_IP:-198.19.255.1}
 
 secrets:
   temps_admin_password:
     file: ${TEMPS_ADMIN_PASSWORD_FILE:?TEMPS_ADMIN_PASSWORD_FILE must point to a permission-restricted initial admin password file}
+  temps_admin_ingress_password:
+    file: ${TEMPS_ADMIN_INGRESS_PASSWORD_FILE:?TEMPS_ADMIN_INGRESS_PASSWORD_FILE must point to a permission-restricted admin ingress password file}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,12 @@ services:
       # public interfaces.
       - "127.0.0.1:5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      # This image (Spilo/timescaledb-ha based) initialises its cluster at
+      # PGDATA=/home/postgres/pgdata/data, not the stock postgres image's
+      # /var/lib/postgresql/data. Mounting the wrong path silently leaves the
+      # real cluster in the container's writable layer, so every recreation
+      # (image update, `compose down && up`, host reboot) loses all data.
+      - postgres_data:/home/postgres/pgdata/data
       - postgres_socket:/var/run/postgresql
     # NOTE: archive_command is NOT set here on purpose.
     # Command-line parameters take highest priority in PostgreSQL and cannot be

--- a/docs/adr/040-runtime-context-capabilities-and-service-resolution.md
+++ b/docs/adr/040-runtime-context-capabilities-and-service-resolution.md
@@ -70,14 +70,19 @@ prevent Docker-only assumptions from leaking into business logic, but this
 iteration does not add Kubernetes crates, manifests, API clients, RBAC,
 resolvers, workload providers, or integration tests.
 
-The foundation is complete when a future Kubernetes adapter can be added at the
-composition root without changing endpoint consumers or domain services. It is
-not necessary to ship an unused Kubernetes implementation today.
+The architectural target is complete when a future Kubernetes adapter can be
+added at the composition root without changing endpoint consumers or domain
+services. It is not necessary to ship an unused Kubernetes implementation
+today. The Docker delivery implements the immutable Host/Docker context and
+typed endpoint values first; capability probing and the remaining compatibility
+call-site migration stay explicitly tracked in the migration plan below.
 
 ### 1. Construct one immutable runtime context at startup
 
-The CLI composition root will construct and validate one `RuntimeContext`, then
-inject it into services that need infrastructure behavior. It will contain:
+The CLI composition root constructs and validates one `RuntimeContext`, then
+injects it into routing and readiness services. In the initial Docker delivery
+it contains the validated environment, resolver, and configuration source. The
+completed architecture will additionally contain:
 
 - A validated `ExecutionEnvironment`: `Host`, `Docker`, or `Kubernetes`.
 - A `ServiceEndpointResolver` selected for that environment.
@@ -127,11 +132,13 @@ cgroup contents are not a reliable configuration contract.
 Consumers will request an endpoint using a stable service identity and logical
 port instead of assembling a hostname from the execution environment.
 
-Resolution follows this precedence:
+At the composition and packaging boundary, resolution follows this precedence:
 
 1. An explicit operator-provided endpoint, such as `TEMPS_DATABASE_URL` or
    `TEMPS_CLICKHOUSE_URL`.
-2. The environment-specific resolver configured at startup.
+2. The environment-specific resolver configured at startup. The initial
+   Host/Docker resolver implements this defaulting layer; existing explicit URL
+   consumers remain authoritative while their call sites are migrated.
 3. A typed `EndpointUnavailable` error containing the service identity,
    execution environment, and missing configuration.
 
@@ -278,13 +285,18 @@ Because the Compose control plane is attached to both networks, its HTTP, TLS,
 and console/admin listeners MUST bind only to its configured static private
 control-network address, never `0.0.0.0`, a DNS-derived address, or the
 workload-network address. Public HTTP, TLS, and ingest listeners are forwarded
-through an unprivileged ingress container and published only on `127.0.0.1`.
-Managed workloads can reach this deliberately public surface, so it MUST return
-404 for admin, authentication, UI, and management routes.
+through an unprivileged public ingress container, published only on
+`127.0.0.1`, and attached to the workload network. Managed workloads can reach
+this deliberately public surface, so it MUST return 404 for admin,
+authentication, UI, and management routes.
 
 The admin/UI listener binds to a separate private control address and port. It
-is published on host loopback through an HTTP reverse proxy with an independent,
-strong, randomly generated Basic-auth password mounted as a file secret. The
+is published on host loopback through a physically separate HTTP reverse proxy
+on a bridge that does not join or advertise itself on the workload network and
+has an independent, strong, randomly generated Basic-auth password mounted as a
+file secret. Because Docker engines differ in whether they route a numerically
+addressed packet across otherwise-unconnected bridges, network separation is
+defense in depth and the authentication barrier MUST remain fail-closed. The
 proxy MUST bcrypt the secret at startup, rate-limit authentication failures,
 strip the Basic `Authorization` header before forwarding, and preserve Temps'
 own authentication and authorization checks. It MUST run non-root with a

--- a/docs/adr/040-runtime-context-capabilities-and-service-resolution.md
+++ b/docs/adr/040-runtime-context-capabilities-and-service-resolution.md
@@ -1,0 +1,423 @@
+<!-- SCOPE: Defines how Temps models its execution environment, runtime capabilities, workload backends, and control-plane service endpoints. -->
+
+# ADR-040: Runtime Context, Capabilities, and Service Resolution
+
+**Status:** Accepted
+**Date:** 2026-08-29
+**Author:** Temps Contributors
+
+## Context
+
+Temps can be installed as a native process managed by systemd or launchd, and
+can also be packaged as a Docker container. Kubernetes-hosted operation is a
+future target. These environments do not share the same networking or host
+capabilities:
+
+| Concern | Native host | Docker container | Kubernetes pod |
+| --- | --- | --- | --- |
+| Control-plane dependency address | Loopback + published host port | Compose service DNS + container port | Kubernetes Service DNS + Service port |
+| Internal listener | Loopback where practical | Pod/container interface | Pod interface |
+| External exposure | Host firewall or reverse proxy | Explicit host publishing | Service, Gateway, or Ingress |
+| Docker API | Local socket when configured | Mounted socket or remote API | Usually unavailable |
+| KVM / Firecracker | Possible on Linux with `/dev/kvm` | Not available by default | Not available by default |
+| Host service manager | systemd or launchd | None | None |
+| Host network administration | Possible with explicit privilege | Namespaced and restricted | CNI-owned and restricted |
+
+The current `temps_core::DeploymentMode` partially recognizes this problem. It
+has `Baremetal` and `Docker` variants and chooses either `127.0.0.1` with a host
+port or a container name with an internal port. However:
+
+1. It reads the ambient `DEPLOYMENT_MODE` environment variable at call sites
+   instead of receiving immutable startup configuration.
+2. Unknown values, including `kubernetes`, silently become `Baremetal`.
+3. Mode checks are spread through providers, routes, readiness checks, and
+   deployment jobs.
+4. One enum is being asked to describe both network location and available
+   execution features.
+5. Tests mutate process-global environment state and need global mutexes.
+6. Packaging can be inconsistent with the selected mode. For example, a
+   Compose manifest can provide internal service names but omit Docker mode,
+   causing code to generate loopback addresses from inside the Temps container.
+
+This is not only an addressing issue. A Docker-packaged Temps instance can
+manage sibling Docker containers when the Docker socket and networks are
+available, but it cannot safely assume access to KVM, host firewall rules,
+systemd, launchd, arbitrary bind mounts, or host network namespaces. A
+Kubernetes-hosted instance has a different API and identity model again.
+
+We therefore need an explicit architecture boundary before treating Docker or
+Kubernetes as first-class ways to run the Temps control plane.
+
+## Decision
+
+Temps will separate four concepts that are currently conflated:
+
+| Concept | Answers | Examples |
+| --- | --- | --- |
+| Execution environment | Where is the Temps control-plane process running? | `Host`, `Docker`, `Kubernetes` |
+| Service endpoint resolver | How does this process reach a named dependency? | Loopback, Compose DNS, Kubernetes Service DNS |
+| Workload backend | What executes a user workload or sandbox? | Docker, Firecracker, future Kubernetes |
+| Capability registry | What can this specific installation actually do? | Docker API, KVM, host networking, Kubernetes API |
+
+The execution environment selects default adapters at the composition root. It
+does not become a feature flag checked throughout business logic.
+
+### Delivery boundary for the current implementation
+
+The first implementation of this ADR includes only `Host` and `Docker` runtime
+adapters. Kubernetes appears in this document to constrain the interfaces and
+prevent Docker-only assumptions from leaking into business logic, but this
+iteration does not add Kubernetes crates, manifests, API clients, RBAC,
+resolvers, workload providers, or integration tests.
+
+The foundation is complete when a future Kubernetes adapter can be added at the
+composition root without changing endpoint consumers or domain services. It is
+not necessary to ship an unused Kubernetes implementation today.
+
+### 1. Construct one immutable runtime context at startup
+
+The CLI composition root will construct and validate one `RuntimeContext`, then
+inject it into services that need infrastructure behavior. It will contain:
+
+- A validated `ExecutionEnvironment`: `Host`, `Docker`, or `Kubernetes`.
+- A `ServiceEndpointResolver` selected for that environment.
+- A capability snapshot with availability, reason, and remediation.
+
+Workload providers are constructed at the same composition root but remain
+separately registered through their existing domain traits. `RuntimeContext`
+does not become a provider locator, and consumers continue to receive
+`Arc<dyn SandboxProvider>` directly as required by ADR-010.
+
+Runtime configuration MUST be parsed once. Application services MUST NOT read
+`DEPLOYMENT_MODE` or a replacement environment variable during requests or
+jobs. Tests will construct a context directly instead of mutating process-global
+environment variables.
+
+`ExecutionEnvironment` describes location only. It MUST NOT imply that Docker,
+Firecracker, Kubernetes, or privileged host operations are available.
+
+### 2. Make execution environment explicit and fail closed
+
+Installers and manifests MUST set the execution environment explicitly:
+
+| Packaging | Required value | Owner |
+| --- | --- | --- |
+| systemd / launchd | `host` | `deploy.sh` or generated service unit |
+| Docker Compose | `docker` | Compose manifest |
+| Kubernetes (future) | `kubernetes` | Helm chart or manifests |
+
+An absent value MAY temporarily default to `host` for backward compatibility.
+At the end of the migration, an unknown value MUST fail startup with a typed
+configuration error; it MUST NOT silently fall back to host addressing.
+
+During migration, the canonical `TEMPS_EXECUTION_ENV` input takes precedence
+over legacy `DEPLOYMENT_MODE`. Values `host` and `baremetal` map to `Host`,
+`docker` maps to `Docker`, and unset temporarily maps to `Host`. The reserved
+value `kubernetes` returns a typed "not supported by this build" startup error
+until the Kubernetes adapter ships. Other unknown values return a typed invalid
+configuration error instead of falling back. Release notes MUST call out this
+change from the legacy silent host fallback.
+
+Automatic detection MAY produce a diagnostic suggestion, but MUST NOT silently
+override explicit configuration. Container heuristics such as `/.dockerenv` or
+cgroup contents are not a reliable configuration contract.
+
+### 3. Resolve service identity separately from network location
+
+Consumers will request an endpoint using a stable service identity and logical
+port instead of assembling a hostname from the execution environment.
+
+Resolution follows this precedence:
+
+1. An explicit operator-provided endpoint, such as `TEMPS_DATABASE_URL` or
+   `TEMPS_CLICKHOUSE_URL`.
+2. The environment-specific resolver configured at startup.
+3. A typed `EndpointUnavailable` error containing the service identity,
+   execution environment, and missing configuration.
+
+Resolvers use these defaults:
+
+| Environment | Hostname | Port |
+| --- | --- | --- |
+| Host | `127.0.0.1` | Published host port |
+| Docker Compose | Stable Compose service name | Container target port |
+| Kubernetes | Stable Kubernetes Service DNS name | Service port |
+
+Docker resolution MUST use Compose service names or explicit network aliases,
+not generated container IDs and not host-published ports. Kubernetes resolution
+MUST use Services, not Pod names or Pod IPs. A fully qualified Kubernetes name
+MAY be used where cross-namespace resolution is required.
+
+Returned endpoints will be typed values containing scheme, host, port, and
+optional TLS/server-name metadata. Business logic MUST NOT perform string
+replacement on connection URLs to adapt them to a runtime.
+
+This resolver covers dependencies of the Temps control plane and the
+orchestrator endpoint used to reach a workload after its backend has created
+it. It explicitly does not own `.temps.local`, `service_endpoints`, user-managed
+service identity, or multi-node DNS records. ADR-011 and ADR-024 remain
+authoritative for those concerns.
+
+### 4. Separate listening from publishing
+
+A listener address and an externally published address are different contracts.
+
+| Environment | Process listener | Internal dependencies | External access |
+| --- | --- | --- | --- |
+| Host | `127.0.0.1` unless direct ingress is explicitly selected | Loopback | Reverse proxy/firewall policy |
+| Docker | Explicit private interface address | Private control endpoint; no publication required | `127.0.0.1:host:container` by default |
+| Kubernetes | `0.0.0.0` inside the pod network namespace | ClusterIP Service DNS | Gateway/Ingress or explicit Service type |
+
+Binding a process to `127.0.0.1` inside a container or pod would make it
+unreachable through the container network. The Compose Temps process therefore
+binds to its explicit private control-network address, not `0.0.0.0` and not
+its workload-network interface. Third-party data-service images may listen on
+all interfaces inside their isolated network namespace, but their host
+publication remains loopback-only.
+
+Compose MUST bind any published diagnostics or control-plane ports to
+`127.0.0.1`. PostgreSQL and ClickHouse do not need host publication for Temps
+itself; publication is an operator convenience and SHOULD be omitted by default
+or placed behind an explicit diagnostics profile. Kubernetes data services MUST
+default to `ClusterIP`, never `NodePort` or `LoadBalancer`.
+
+### 5. Select workload backends through provider boundaries
+
+Execution environment and workload backend are independent axes:
+
+- A native Linux installation can use Docker and Firecracker together.
+- A Docker-packaged control plane can use the Docker API when its socket and
+  required networks are mounted.
+- A future Kubernetes-packaged control plane can use a Kubernetes workload
+  provider when its service account and RBAC allow it.
+- A backend requested by a user MUST fail with a descriptive unavailable error
+  when its capabilities are missing; it MUST NOT silently downgrade.
+
+Existing provider traits remain the boundary. This ADR does not introduce one
+large runtime trait that contains every host operation. Docker, Firecracker,
+and future Kubernetes implementations remain domain-specific providers and are
+assembled according to the validated context.
+
+### 6. Represent support as probed capabilities
+
+Temps will expose a capability registry rather than infer support from the
+execution environment alone. Each capability reports `available`, an optional
+version, a reason when unavailable, and an actionable setup path.
+
+Initial capabilities include:
+
+| Capability | Required evidence |
+| --- | --- |
+| Docker workload execution | Docker API ping plus required network access |
+| Docker host management | Socket/API access and required labels/permissions |
+| Firecracker sandbox execution | Linux, KVM access, provisioned binaries/kernel, Docker OCI image pipeline, networking smoke test |
+| Kubernetes workload execution | API discovery, namespace access, and required RBAC |
+| Host service management | Supported systemd or launchd control path |
+| Host network administration | Explicit privilege and successful read-only preflight |
+| Host filesystem integration | Required paths mounted and writable with expected ownership |
+
+Capabilities are probed at startup and refreshed through explicit health,
+reconciliation, and pre-operation probes. Feature surfaces remain visible when
+unavailable and return the reason and setup path, following the repository
+onboarding rule.
+
+Capability-sensitive operations MUST gate at the service boundary and return a
+typed unavailable or permission error before creating partial infrastructure.
+Startup results are not permanent truth: Docker credentials, socket access,
+Kubernetes tokens, RBAC, and devices can change. Providers MUST re-probe before
+privileged mutations when the cached result is stale or after an authentication,
+authorization, transport, or device error. A successful re-probe updates the
+registry; a failed one records the reason and remediation.
+
+### 7. Treat Firecracker in containers as unsupported by default
+
+Firecracker requires more than `/dev/kvm`: it needs verified binaries and guest
+artifacts, jailer-compatible filesystem ownership, TAP/bridge configuration,
+cgroup control, and host network privileges. Passing these wholesale into the
+Temps control-plane container would substantially weaken the container boundary.
+
+Therefore:
+
+- Native Linux with successful Firecracker preflight is the supported initial
+  Firecracker environment.
+- The standard Compose and Kubernetes packages report Firecracker unavailable
+  with a concrete explanation.
+- A future privileged worker/agent design MAY provide Firecracker to a
+  containerized control plane without granting those privileges to the
+  control-plane container itself.
+- Merely mounting `/dev/kvm` MUST NOT make the capability appear available.
+
+This preserves ADR-029's provider model while being honest about packaging.
+
+### 8. Packaging owns environment-specific wiring
+
+Each packaging layer is responsible for creating the network objects and
+configuration its resolver expects:
+
+| Packaging | Responsibilities |
+| --- | --- |
+| `deploy.sh` | Install native service, publish managed dependencies on loopback, configure host endpoints, report host capabilities |
+| Docker Compose | Set Docker execution environment, join stable networks, configure environment-specific endpoints, mount only required host resources |
+| Kubernetes manifests/Helm | Set Kubernetes execution environment, create Services, Secrets, RBAC, storage, probes, and ingress objects |
+
+The Compose stack MUST use configurable static addresses on its private
+control network for PostgreSQL and ClickHouse, regardless of whether those
+services also have loopback host mappings. Private dependency addresses MUST
+NOT depend on Docker DNS: a workload can claim an identical service or network
+alias on the second network of a dual-homed Temps container. Temps also joins
+an explicitly named workload network matching `TEMPS_NETWORK_NAME`;
+PostgreSQL and ClickHouse MUST NOT join that workload network. A future
+Kubernetes package will use authenticated Services such as
+`temps-postgres.<namespace>.svc` and `temps-clickhouse.<namespace>.svc`.
+
+The private control network MUST be an internal Docker network. Static
+addressing prevents DNS alias confusion; the internal-network boundary prevents
+workloads from routing directly to those addresses across Docker bridges.
+
+Because the Compose control plane is attached to both networks, its HTTP, TLS,
+and console/admin listeners MUST bind only to its configured static private
+control-network address, never `0.0.0.0`, a DNS-derived address, or the
+workload-network address. Public HTTP, TLS, and ingest listeners are forwarded
+through an unprivileged ingress container and published only on `127.0.0.1`.
+Managed workloads can reach this deliberately public surface, so it MUST return
+404 for admin, authentication, UI, and management routes.
+
+The admin/UI listener binds to a separate private control address and port. It
+is published on host loopback through an HTTP reverse proxy with an independent,
+strong, randomly generated Basic-auth password mounted as a file secret. The
+proxy MUST bcrypt the secret at startup, rate-limit authentication failures,
+strip the Basic `Authorization` header before forwarding, and preserve Temps'
+own authentication and authorization checks. It MUST run non-root with a
+read-only root filesystem, all Linux capabilities dropped, no-new-privileges,
+bounded memory and PIDs, and no Docker socket or host mounts. Public TCP
+forwarding MUST use an event-driven proxy with per-source connection ceilings
+and idle timeouts; process-per-connection forwarding is not permitted.
+Extending admin access beyond loopback or a secure tunnel requires TLS or mTLS.
+Because Basic auth consumes the `Authorization` header, bearer-token admin
+clients require a deliberately separate trusted or mTLS ingress path.
+
+The unused global Redis container is not a control-plane dependency and is not
+part of this runtime contract. Redis used by the optional KV feature continues
+through its managed-service provider and capability path.
+
+Mounting the Docker socket gives the Temps process root-equivalent authority on
+the Docker host; running the process as a non-root container user does not
+remove that authority. Compose documentation and capability reporting MUST make
+this explicit. The Kubernetes package MUST NOT mount a node Docker/containerd
+socket into the control-plane pod; Kubernetes operations use a scoped service
+account and audited RBAC instead.
+
+## Migration plan
+
+1. **Introduce typed values.** Add `ExecutionEnvironment`, `RuntimeCapability`,
+   capability status, and typed service endpoint values without changing
+   behavior.
+2. **Build runtime context once.** Parse configuration in the CLI composition
+   root, register the immutable context, and keep `DEPLOYMENT_MODE` as a
+   deprecated compatibility input.
+3. **Add resolvers.** Implement host and Docker resolvers. Explicit URLs remain
+   highest priority. Keep the resolver contract free of Docker-specific types;
+   do not add a Kubernetes resolver in this iteration.
+4. **Migrate call sites.** Replace `DeploymentMode::current`,
+   `is_docker`, `is_baremetal`, `get_effective_host_port`, and
+   `build_container_url` incrementally. Remove mode checks from business
+   services as provider injection reaches them.
+5. **Correct packaging.** Set the environment explicitly in `deploy.sh` and
+   Compose, use internal Docker endpoints, and stop publishing data ports by
+   default.
+6. **Remove the compatibility helper.** Unknown values become startup errors;
+   delete ambient environment reads and their global test mutexes.
+7. **Add Kubernetes packaging only after its provider, RBAC, storage, routing,
+   upgrade, and rollback contracts pass the common conformance suite.**
+
+## Verification
+
+The runtime boundary requires a conformance matrix, not only unit tests:
+
+| Test | Host | Docker Compose | Kubernetes |
+| --- | --- | --- | --- |
+| Resolver returns expected dependency endpoint | Required | Required | Required before support |
+| Internal service works without public data port | Required | Required | Required before support |
+| Invalid environment fails with typed error | Required | Required | Required |
+| Capability reason and remediation are accurate | Required | Required | Required |
+| Docker workload lifecycle | When Docker exists | Required | Provider-dependent |
+| Firecracker lifecycle | KVM runner | Must report unavailable | Must report unavailable initially |
+| Control-plane readiness and migrations | Required | Required | Required before support |
+
+Docker integration tests MUST inspect the rendered Compose configuration and
+exercise service-to-service connectivity after removing host mappings for data
+services. Kubernetes tests SHOULD use an ephemeral real cluster such as `kind`
+and MUST verify Service DNS, RBAC denial paths, persistent storage, and ingress.
+Docker- and KVM-dependent tests skip gracefully at runtime when their required
+backend is unavailable.
+
+## Consequences
+
+### Positive
+
+- Network addresses are correct by construction for host, Docker, and future
+  Kubernetes execution.
+- Features report honest availability rather than failing deep inside a job.
+- Firecracker remains a supported host capability without forcing the entire
+  control plane to be native forever.
+- Business logic becomes independent from ambient environment variables and
+  container-name conventions.
+- Internal databases no longer need public host exposure for container or
+  Kubernetes operation.
+- Runtime behavior can be tested with small injected contexts and shared
+  backend conformance suites.
+
+### Negative
+
+- The existing two-variant `DeploymentMode` helper must be migrated across
+  several crates.
+- Packaging gains an explicit compatibility contract with the binary; changing
+  a service name or Service port becomes a reviewed deployment change.
+- Capability probing and reporting add startup and diagnostics surface area.
+- Kubernetes support still requires a real workload provider and operations
+  work; this abstraction makes it possible but does not make it free.
+- Some features will be visibly unavailable in the standard Docker package,
+  particularly Firecracker and host service/network management.
+
+## Alternatives considered
+
+- **Keep extending the global `DeploymentMode` enum and branch everywhere.**
+  Rejected because it couples unrelated capabilities to network location,
+  spreads conditionals, and retains global-state tests.
+- **Automatically detect the environment.** Rejected as the source of truth;
+  nested containers, Docker Desktop, Kubernetes runtimes, and host-mounted
+  sockets make detection ambiguous. Detection remains diagnostic only.
+- **Always connect through host-published ports.** Rejected because it adds NAT,
+  requires unnecessary exposure, and does not translate to Kubernetes.
+- **Bind every process to `127.0.0.1`.** Rejected because loopback is scoped to
+  each network namespace and would break container-to-container and
+  pod-to-Service traffic.
+- **Run the Docker package fully privileged to preserve all native features.**
+  Rejected because the convenience would erase the security boundary and make
+  compromise of the control plane equivalent to unrestricted host compromise.
+- **Hide unavailable features based on execution environment.** Rejected because
+  environment is only a hint and hidden features violate Temps' onboarding
+  principle. Capabilities are shown with reasons and remediation.
+- **Create a single universal infrastructure provider.** Rejected because it
+  would become a large, unstable abstraction. Endpoint resolution, sandbox
+  execution, deployments, and host administration keep separate contracts.
+
+## Scope and related decisions
+
+This ADR defines the runtime composition and addressing contract. It does not
+declare Kubernetes a currently supported Temps deployment target, implement a
+Kubernetes workload provider, or replace the multi-node DNS architecture.
+
+- ADR-010 defines provider boundaries and remains authoritative for backend
+  abstraction rules.
+- ADR-011 defines internal DNS for multi-node managed databases.
+- ADR-029 defines the Firecracker sandbox backend and its host requirements.
+- ADR-007 concerns user projects deployed from Docker Compose; it is separate
+  from packaging the Temps control plane with Docker Compose.
+
+---
+
+**Maintenance:** Review when adding a control-plane execution environment, a
+workload provider, a new control-plane data service, or changing installer,
+Compose, Kubernetes, Firecracker, or internal DNS behavior. Owner: Temps
+infrastructure maintainers. Last reviewed: 2026-08-29.

--- a/docs/installation/page.mdx
+++ b/docs/installation/page.mdx
@@ -259,7 +259,9 @@ on port `9000`; the UI and management API are on port `9001`, protected by the
 independent Basic-auth password in `secrets/admin_ingress_password` and then by
 Temps' own authentication. Use username `temps` at the Basic-auth prompt. Use a
 TLS-terminating reverse proxy, mTLS, or a secure tunnel before making any port
-reachable from another host. Temps connects to ClickHouse automatically for
+reachable from another host. The ingress password file must contain one
+non-blank line of 16–72 printable ASCII bytes; ingress startup fails closed for
+invalid content. Temps connects to ClickHouse automatically for
 analytics, request logs, metrics, and OpenTelemetry storage.
 Temps joins the private dependency network and the separately named
 `TEMPS_NETWORK_NAME` workload network. PostgreSQL, ClickHouse, and the Temps

--- a/docs/installation/page.mdx
+++ b/docs/installation/page.mdx
@@ -44,6 +44,7 @@ This guide covers all installation methods and production configuration options 
 | **443**  | HTTPS                    | Yes                     |
 | **8080** | Temps API (configurable) | Yes                     |
 | **5432** | PostgreSQL               | Internal only           |
+| **8123** | ClickHouse HTTP API      | Internal only           |
 
 ---
 
@@ -220,20 +221,24 @@ temps --version
 
 ### Docker Compose from Source
 
-The repository Compose stack requires independent URL-safe database and Redis
-passwords. Copy the template and generate 256-bit hexadecimal values (do not
-use URI punctuation, because the values are also used in connection URLs):
+The repository Compose stack requires independent URL-safe PostgreSQL and
+ClickHouse passwords. Copy the template and generate 256-bit hexadecimal
+values (do not use URI punctuation, because some values are also used in
+connection URLs):
 
 ```bash
 install -m 600 .env.example .env
 openssl rand -hex 32  # set as POSTGRES_PASSWORD
-openssl rand -hex 32  # set as REDIS_PASSWORD
+openssl rand -hex 32  # set as CLICKHOUSE_PASSWORD
 # Set TEMPS_ADMIN_EMAIL to the initial administrator's email address.
 # Create its password as a permission-restricted Compose secret:
 mkdir -p secrets
 chmod 700 secrets
 { printf 'tT3!'; openssl rand -hex 32; } > secrets/admin_password
-chmod 444 secrets/admin_password
+# Create a separate password for the loopback-only admin ingress. Its Basic
+# auth username is `temps`; never reuse the Temps account password.
+{ printf 'iI4!'; openssl rand -hex 32; } > secrets/admin_ingress_password
+chmod 444 secrets/admin_password secrets/admin_ingress_password
 # Set DOCKER_GID to the container-visible socket group on Linux or macOS:
 # docker run --rm -v /var/run/docker.sock:/var/run/docker.sock alpine:3.22 stat -c '%g' /var/run/docker.sock
 docker compose up --build --detach
@@ -247,16 +252,48 @@ Keep `.env` owned by the account that operates Temps and mode `0600`; it
 contains credentials that can access the loopback-published data services.
 
 Compose validates the password alphabet before starting data services. It
-publishes PostgreSQL, Redis, and the console API on loopback only; HTTP and
-HTTPS remain publicly bound. Temps receives Docker-socket access through the
-socket owner's group while the application process remains non-root. Treat
-membership in that group as root-equivalent host access.
+starts TimescaleDB, ClickHouse, and Temps, with persistent volumes for
+each stateful service. Every published port, including Temps HTTP, HTTPS, and
+the console API, is bound to `127.0.0.1`. The public console/ingest listener is
+on port `9000`; the UI and management API are on port `9001`, protected by the
+independent Basic-auth password in `secrets/admin_ingress_password` and then by
+Temps' own authentication. Use username `temps` at the Basic-auth prompt. Use a
+TLS-terminating reverse proxy, mTLS, or a secure tunnel before making any port
+reachable from another host. Temps connects to ClickHouse automatically for
+analytics, request logs, metrics, and OpenTelemetry storage.
+Temps joins the private dependency network and the separately named
+`TEMPS_NETWORK_NAME` workload network. PostgreSQL, ClickHouse, and the Temps
+listeners use static addresses on the private network so workload-controlled
+Docker DNS aliases cannot redirect control-plane credentials or listener binds.
+Managed workloads can reach the intentionally public HTTP/TLS/ingest surface,
+but cannot route directly to the private admin listener or data services.
+
+<Note>
+  Basic auth uses the HTTP `Authorization` header. Browser sessions work because
+  Temps uses cookies, but bearer-token admin clients need a separate trusted
+  path or mTLS design rather than this browser-oriented ingress.
+</Note>
+The control network is also marked internal to block direct routing from the
+workload bridge to those private addresses.
+The Temps process binds its listeners only to the private network interface,
+while Docker publishes them to host loopback. Managed applications therefore
+cannot connect directly to the control-plane HTTP, TLS, or console/admin ports.
+Temps receives Docker-socket access through the socket owner's group while the
+application process remains non-root. Treat membership in that group as
+root-equivalent host access.
+Redis is not a control-plane dependency. Enabling Temps KV storage provisions
+and manages its own Redis service separately.
+
+If the default `198.18.255.0/24` control subnet overlaps a Docker, LAN, or VPN
+route, change `TEMPS_CONTROL_SUBNET` and all three `*_INTERNAL_IP` values in
+`.env` together before the first `docker compose up`.
+
 On the first unattended startup, Temps creates `TEMPS_ADMIN_EMAIL` as the
 administrator using the mounted `TEMPS_ADMIN_PASSWORD_FILE`. The password is
 not placed in the container environment, command line, or logs. The source file
-must be `0444` so the image's non-root UID can read—but not modify—the bind-mounted secret on
-Linux; its `0700` parent directory prevents other host users from traversing to
-it. Rotate the password after first login.
+must be `0444` so the image's non-root UID can read—but not modify—the
+bind-mounted secret on Linux; its `0700` parent directory prevents other host
+users from traversing to it. Rotate the password after first login.
 
 ---
 
@@ -289,6 +326,7 @@ temps serve
 | `TEMPS_DATA_DIR`        | `--data-dir`        | `~/.temps`       | Data directory for keys/config              |
 | `TEMPS_LOG_LEVEL`       | `--log-level`       | `info`           | Log level (trace, debug, info, warn, error) |
 | `TEMPS_CONSOLE_ADDRESS` | `--console-address` | (optional)       | Admin console address                       |
+| `TEMPS_EXECUTION_ENV`   | (none)              | `host`           | Endpoint context: `host` or `docker`        |
 
 ---
 

--- a/docs/installation/page.mdx
+++ b/docs/installation/page.mdx
@@ -266,7 +266,15 @@ Temps joins the private dependency network and the separately named
 listeners use static addresses on the private network so workload-controlled
 Docker DNS aliases cannot redirect control-plane credentials or listener binds.
 Managed workloads can reach the intentionally public HTTP/TLS/ingest surface,
-but cannot route directly to the private admin listener or data services.
+but cannot resolve the private admin service name or reach the control-plane
+data services.
+Compose enforces that separation with two ingress containers: the public proxy
+joins the workload network, while the loopback admin proxy joins a dedicated
+bridge that workloads cannot resolve by service name. Docker engines differ in
+cross-bridge routing, so the independent Basic-auth barrier remains mandatory
+even when a client knows the admin proxy's private IP. Both proxies bind to
+explicit private addresses inside their containers; no listener binds to
+`0.0.0.0`.
 
 <Note>
   Basic auth uses the HTTP `Authorization` header. Browser sessions work because
@@ -284,9 +292,12 @@ root-equivalent host access.
 Redis is not a control-plane dependency. Enabling Temps KV storage provisions
 and manages its own Redis service separately.
 
-If the default `198.18.255.0/24` control subnet overlaps a Docker, LAN, or VPN
-route, change `TEMPS_CONTROL_SUBNET` and all three `*_INTERNAL_IP` values in
-`.env` together before the first `docker compose up`.
+If a default subnet overlaps a Docker, LAN, or VPN route, change the associated
+values together before the first `docker compose up`: `TEMPS_CONTROL_SUBNET`
+and all three `*_INTERNAL_IP` values for the private control plane;
+`TEMPS_WORKLOAD_SUBNET` and `TEMPS_PUBLIC_INGRESS_IP` for managed workloads;
+or `TEMPS_INGRESS_SUBNET`, `TEMPS_ADMIN_INGRESS_IP`, and
+`TEMPS_INGRESS_GATEWAY_IP` for the loopback admin proxy.
 
 On the first unattended startup, Temps creates `TEMPS_ADMIN_EMAIL` as the
 administrator using the mounted `TEMPS_ADMIN_PASSWORD_FILE`. The password is

--- a/docs/reference/environment-variables/page.mdx
+++ b/docs/reference/environment-variables/page.mdx
@@ -71,7 +71,7 @@ existing route, change the subnet and all three addresses together:
 | `TEMPS_ADMIN_INGRESS_IP` | `198.19.255.10` | Admin proxy address on its dedicated bridge |
 | `TEMPS_INGRESS_GATEWAY_IP` | `198.19.255.1` | Dedicated admin bridge gateway |
 | `TEMPS_ADMIN_PASSWORD_FILE` | `./secrets/admin_password` | Initial Temps administrator password secret |
-| `TEMPS_ADMIN_INGRESS_PASSWORD_FILE` | `./secrets/admin_ingress_password` | Independent Basic-auth secret for loopback admin ingress (username `temps`) |
+| `TEMPS_ADMIN_INGRESS_PASSWORD_FILE` | `./secrets/admin_ingress_password` | Independent single-line Basic-auth secret (16–72 non-blank printable ASCII bytes) for loopback admin ingress (username `temps`) |
 
 ### Admin Listener (optional)
 

--- a/docs/reference/environment-variables/page.mdx
+++ b/docs/reference/environment-variables/page.mdx
@@ -51,8 +51,10 @@ applications network access to the control-plane PostgreSQL or ClickHouse
 services. The Compose package pins its private dependencies and Temps listener
 binds to configurable static control-network addresses rather than DNS-derived
 addresses. Host access is published separately on `127.0.0.1`. Compose splits
-public ingest (`9000`) from admin/UI (`9001`); the latter passes through a
-separate Basic-auth secret before reaching Temps' own authentication.
+public ingest (`9000`) from admin/UI (`9001`) with physically separate proxy
+containers; only the public proxy joins the workload network. The admin proxy
+passes through a separate Basic-auth secret before reaching Temps' own
+authentication.
 
 The Compose file also reads these `.env` values. If the subnet overlaps an
 existing route, change the subnet and all three addresses together:
@@ -63,6 +65,11 @@ existing route, change the subnet and all three addresses together:
 | `TEMPS_CONTROL_INTERNAL_IP` | `198.18.255.10` | Temps listener address on the private network |
 | `TEMPS_POSTGRES_INTERNAL_IP` | `198.18.255.11` | PostgreSQL address used by Temps |
 | `TEMPS_CLICKHOUSE_INTERNAL_IP` | `198.18.255.12` | ClickHouse address used by Temps |
+| `TEMPS_WORKLOAD_SUBNET` | `198.20.255.0/24` | Shared managed-workload bridge subnet |
+| `TEMPS_PUBLIC_INGRESS_IP` | `198.20.255.10` | Public proxy address reachable by managed workloads |
+| `TEMPS_INGRESS_SUBNET` | `198.19.255.0/24` | Dedicated loopback-admin proxy bridge subnet |
+| `TEMPS_ADMIN_INGRESS_IP` | `198.19.255.10` | Admin proxy address on its dedicated bridge |
+| `TEMPS_INGRESS_GATEWAY_IP` | `198.19.255.1` | Dedicated admin bridge gateway |
 | `TEMPS_ADMIN_PASSWORD_FILE` | `./secrets/admin_password` | Initial Temps administrator password secret |
 | `TEMPS_ADMIN_INGRESS_PASSWORD_FILE` | `./secrets/admin_ingress_password` | Independent Basic-auth secret for loopback admin ingress (username `temps`) |
 

--- a/docs/reference/environment-variables/page.mdx
+++ b/docs/reference/environment-variables/page.mdx
@@ -33,7 +33,38 @@ These environment variables configure the Temps server itself:
 | `TEMPS_DATA_DIR`        | `--data-dir`        | `~/.temps`       | Data directory for keys and configuration            |
 | `TEMPS_LOG_LEVEL`       | `--log-level`       | `info`           | Log level: `trace`, `debug`, `info`, `warn`, `error` |
 | `TEMPS_CONSOLE_ADDRESS` | `--console-address` | (optional)       | Console listener (public ingest + admin if no split) |
+| `TEMPS_EXECUTION_ENV`   | (none)              | `host`           | Control-plane network context: `host` or `docker`    |
+| `TEMPS_NETWORK_NAME`    | (none)              | `temps-app-network` | Docker network for managed workloads; Compose sets `temps-docker-workloads` |
 | `TEMPS_DOCKER_EXTRA_NETWORKS` | (none)          | (empty)          | Comma-separated Docker networks app containers must join before startup |
+
+`TEMPS_EXECUTION_ENV=docker` makes Temps reach managed containers through
+their stable Docker network names and internal target ports. Host execution
+uses `127.0.0.1` and published host ports. The legacy `DEPLOYMENT_MODE` variable
+remains supported when `TEMPS_EXECUTION_ENV` is unset; migrate it to the
+canonical variable. Unknown values fail startup, and `kubernetes` is reserved
+but intentionally unsupported until its runtime adapter ships.
+
+In the Compose package, Temps joins both its private control-plane network and
+the explicitly named `TEMPS_NETWORK_NAME` workload network. Managed workloads
+join only the latter, so Docker DNS and internal ports work without granting
+applications network access to the control-plane PostgreSQL or ClickHouse
+services. The Compose package pins its private dependencies and Temps listener
+binds to configurable static control-network addresses rather than DNS-derived
+addresses. Host access is published separately on `127.0.0.1`. Compose splits
+public ingest (`9000`) from admin/UI (`9001`); the latter passes through a
+separate Basic-auth secret before reaching Temps' own authentication.
+
+The Compose file also reads these `.env` values. If the subnet overlaps an
+existing route, change the subnet and all three addresses together:
+
+| Variable | Compose default | Description |
+| --- | --- | --- |
+| `TEMPS_CONTROL_SUBNET` | `198.18.255.0/24` | Private control-plane bridge subnet |
+| `TEMPS_CONTROL_INTERNAL_IP` | `198.18.255.10` | Temps listener address on the private network |
+| `TEMPS_POSTGRES_INTERNAL_IP` | `198.18.255.11` | PostgreSQL address used by Temps |
+| `TEMPS_CLICKHOUSE_INTERNAL_IP` | `198.18.255.12` | ClickHouse address used by Temps |
+| `TEMPS_ADMIN_PASSWORD_FILE` | `./secrets/admin_password` | Initial Temps administrator password secret |
+| `TEMPS_ADMIN_INGRESS_PASSWORD_FILE` | `./secrets/admin_ingress_password` | Independent Basic-auth secret for loopback admin ingress (username `temps`) |
 
 ### Admin Listener (optional)
 

--- a/docs/upgrade/page.mdx
+++ b/docs/upgrade/page.mdx
@@ -164,7 +164,10 @@ chmod 444 secrets/admin_password secrets/admin_ingress_password
 Set `TEMPS_ADMIN_INGRESS_PASSWORD_FILE` to the second file. It protects the
 loopback-only admin port (`127.0.0.1:9001`) with username `temps`; keep it
 independent from the Temps account password. The public ingest listener remains
-on `127.0.0.1:9000` and does not serve admin routes.
+on `127.0.0.1:9000` and does not serve admin routes. The updated stack uses
+separate public and admin proxy containers: only the public proxy joins the
+managed-workload network, and both continue to publish exclusively on host
+loopback.
 Set `DOCKER_GID` to the group that owns `/var/run/docker.sock` as seen inside a
 container on Linux or macOS:
 

--- a/docs/upgrade/page.mdx
+++ b/docs/upgrade/page.mdx
@@ -163,8 +163,9 @@ chmod 444 secrets/admin_password secrets/admin_ingress_password
 ```
 Set `TEMPS_ADMIN_INGRESS_PASSWORD_FILE` to the second file. It protects the
 loopback-only admin port (`127.0.0.1:9001`) with username `temps`; keep it
-independent from the Temps account password. The public ingest listener remains
-on `127.0.0.1:9000` and does not serve admin routes. The updated stack uses
+independent from the Temps account password. The file must contain one non-blank
+line of 16–72 printable ASCII bytes or the ingress fails closed. The public ingest
+listener remains on `127.0.0.1:9000` and does not serve admin routes. The updated stack uses
 separate public and admin proxy containers: only the public proxy joins the
 managed-workload network, and both continue to publish exclusively on host
 loopback.

--- a/docs/upgrade/page.mdx
+++ b/docs/upgrade/page.mdx
@@ -144,9 +144,11 @@ Database migrations are **idempotent** — re-running a version that's already m
 
 Back up the `postgres_data` volume, create a private `.env` with
 `install -m 600 .env.example .env`, and set new, independent hexadecimal values
-for `POSTGRES_PASSWORD` and `REDIS_PASSWORD`. Keep the file owned by the account
-that operates Temps and mode `0600`; it grants access to the loopback-published
-data services.
+for `POSTGRES_PASSWORD` and `CLICKHOUSE_PASSWORD`. Keep the
+file owned by the account that operates Temps and mode `0600`; it grants access
+to the loopback-published data services. Existing stacks upgrading to the
+ClickHouse-enabled Compose file must add `CLICKHOUSE_PASSWORD` before running
+`docker compose up`.
 Set `TEMPS_ADMIN_EMAIL` to the administrator email; it is used only when the
 database has no existing user.
 Set `TEMPS_ADMIN_PASSWORD_FILE` to a permission-restricted password file. For a
@@ -156,8 +158,13 @@ new file that satisfies the password policy:
 mkdir -p secrets
 chmod 700 secrets
 { printf 'tT3!'; openssl rand -hex 32; } > secrets/admin_password
-chmod 444 secrets/admin_password
+{ printf 'iI4!'; openssl rand -hex 32; } > secrets/admin_ingress_password
+chmod 444 secrets/admin_password secrets/admin_ingress_password
 ```
+Set `TEMPS_ADMIN_INGRESS_PASSWORD_FILE` to the second file. It protects the
+loopback-only admin port (`127.0.0.1:9001`) with username `temps`; keep it
+independent from the Temps account password. The public ingest listener remains
+on `127.0.0.1:9000` and does not serve admin routes.
 Set `DOCKER_GID` to the group that owns `/var/run/docker.sock` as seen inside a
 container on Linux or macOS:
 
@@ -167,18 +174,23 @@ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock alpine:3.22 stat -c
 Then rebuild and start the stack normally:
 
 ```bash
-docker compose up --build --detach
+docker compose up --build --detach --remove-orphans
 ```
 
 The one-shot `postgres-credential-sync` service connects over the private Unix
 socket and rotates the existing `temps` role to the configured SCRAM password
 before the application starts. The authenticated PostgreSQL health check keeps
-Temps stopped if rotation did not succeed. Redis starts with the configured
-password in a permission-restricted config file.
+Temps stopped if rotation did not succeed. ClickHouse starts with its own
+authenticated `temps` user and persistent volume before the application starts.
+The former global Redis service can be removed; it was not a Temps control-plane
+dependency. `--remove-orphans` removes its old container; the `redis_data`
+volume is retained so deletion remains an explicit operator decision. The
+optional KV feature manages its own Redis instance.
 
 To roll back Temps, preserve the hardened `docker-compose.yml`, `Dockerfile`,
 `.dockerignore`, `.env`, and admin-password secret file, check out the previous
-application source, restore those files, and rebuild. The hardened Dockerfile builds the binary
+application source, restore those files (including the separate admin-ingress
+password secret), and rebuild. The hardened Dockerfile builds the binary
 inside its Alpine stage; older Dockerfiles expected a separately built host
 binary and are not compatible with this Compose workflow. Do not restore the
 old Compose file: it contains the retired known database password and will no

--- a/scripts/compose-security.harness.yml
+++ b/scripts/compose-security.harness.yml
@@ -9,3 +9,88 @@ services:
   temps:
     environment:
       TEMPS_TELEMETRY: "0"
+
+  # A tiny upstream used to prove that the authenticated admin proxy preserves
+  # WebSocket upgrade headers while stripping its independent Basic credential.
+  websocket-upstream-probe:
+    image: alpine:3.22
+    command:
+      - /bin/sh
+      - -ec
+      - |
+        { printf 'HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n'; sleep 1; } \
+          | nc -l -p 8080 > /tmp/websocket-request
+        sleep 300
+    networks:
+      temps-network:
+        ipv4_address: 198.18.255.20
+
+  websocket-ingress-probe:
+    build:
+      context: .
+      dockerfile: Dockerfile.ingress
+    cap_drop:
+      - ALL
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=16m
+    depends_on:
+      websocket-upstream-probe:
+        condition: service_started
+    environment:
+      TEMPS_CONTROL_INTERNAL_IP: 198.18.255.20
+      TEMPS_ADMIN_UPSTREAM_PORT: 8080
+      TEMPS_INGRESS_MODE: admin
+      TEMPS_INGRESS_LISTEN_IP: 198.19.255.20
+    secrets:
+      - source: temps_admin_ingress_password
+        target: temps_admin_ingress_password
+    ports:
+      - target: 9001
+        host_ip: 127.0.0.1
+        published: "0"
+    networks:
+      temps-network:
+      temps-ingress-network:
+        ipv4_address: 198.19.255.20
+
+  idle-stream-upstream-probe:
+    image: alpine:3.22
+    command:
+      - /bin/sh
+      - -ec
+      - |
+        while true; do
+          nc -l -p 9000 -e /bin/sh -c '
+            IFS= read -r request_line
+            printf "HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: close\r\n\r\nready\n"
+          ' || true
+        done
+    networks:
+      temps-network:
+        ipv4_address: 198.18.255.21
+
+  idle-stream-ingress-probe:
+    build:
+      context: .
+      dockerfile: Dockerfile.ingress
+    cap_drop:
+      - ALL
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=16m
+    depends_on:
+      idle-stream-upstream-probe:
+        condition: service_started
+    environment:
+      TEMPS_CONTROL_INTERNAL_IP: 198.18.255.21
+      TEMPS_INGRESS_MODE: public
+      TEMPS_INGRESS_LISTEN_IP: 198.20.255.21
+    networks:
+      temps-network:
+      temps-app-network:
+        ipv4_address: 198.20.255.21

--- a/scripts/compose-security.harness.yml
+++ b/scripts/compose-security.harness.yml
@@ -56,6 +56,61 @@ services:
       temps-ingress-network:
         ipv4_address: 198.19.255.20
 
+  # A response-side SSE probe: the first event must arrive immediately, the
+  # connection must survive a quiet interval, and the second event must arrive
+  # without HTTP proxy buffering.
+  sse-upstream-probe:
+    image: alpine:3.22
+    command:
+      - /bin/sh
+      - -ec
+      - |
+        while true; do
+          nc -l -p 8080 -e /bin/sh -c '
+            while IFS= read -r header; do
+              [ "$$header" = "$$(printf "\r")" ] && break
+            done
+            printf "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"
+            printf "data: first\n\n"
+            sleep 12
+            printf "data: second\n\n"
+          ' || true
+        done
+    networks:
+      temps-network:
+        ipv4_address: 198.18.255.22
+
+  sse-ingress-probe:
+    build:
+      context: .
+      dockerfile: Dockerfile.ingress
+    cap_drop:
+      - ALL
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=16m
+    depends_on:
+      sse-upstream-probe:
+        condition: service_started
+    environment:
+      TEMPS_CONTROL_INTERNAL_IP: 198.18.255.22
+      TEMPS_ADMIN_UPSTREAM_PORT: 8080
+      TEMPS_INGRESS_MODE: admin
+      TEMPS_INGRESS_LISTEN_IP: 198.19.255.21
+    secrets:
+      - source: temps_admin_ingress_password
+        target: temps_admin_ingress_password
+    ports:
+      - target: 9001
+        host_ip: 127.0.0.1
+        published: "0"
+    networks:
+      temps-network:
+      temps-ingress-network:
+        ipv4_address: 198.19.255.21
+
   idle-stream-upstream-probe:
     image: alpine:3.22
     command:

--- a/scripts/docker-ingress-entrypoint.sh
+++ b/scripts/docker-ingress-entrypoint.sh
@@ -63,14 +63,63 @@ write_admin_configuration() {
     exit 1
   fi
 
+  # Validate the raw file before command substitution can normalize trailing
+  # newlines or discard NUL bytes. Accept one printable-ASCII line with either
+  # no terminator or exactly one trailing LF. bcrypt considers at most 72 bytes.
+  admin_secret_bytes="$(LC_ALL=C wc -c < "$admin_password_file" | tr -d ' ')"
+  admin_non_newline_bytes="$(LC_ALL=C tr -d '\n' < "$admin_password_file" | wc -c | tr -d ' ')"
+  admin_printable_bytes="$(LC_ALL=C tr -cd ' -~' < "$admin_password_file" | wc -c | tr -d ' ')"
+  admin_newline_count=$((admin_secret_bytes - admin_non_newline_bytes))
+  admin_password="$(sed -n '1p' "$admin_password_file")"
+  admin_password_bytes="$(LC_ALL=C printf '%s' "$admin_password" | wc -c | tr -d ' ')"
+
+  if [ "$admin_newline_count" -gt 1 ] || \
+    [ "$admin_password_bytes" -ne "$admin_non_newline_bytes" ]; then
+    echo "Temps admin ingress password must be a single line" >&2
+    exit 1
+  fi
+  if [ "$admin_printable_bytes" -ne "$admin_non_newline_bytes" ]; then
+    echo "Temps admin ingress password must contain only printable ASCII characters" >&2
+    exit 1
+  fi
+  if [ "$admin_password_bytes" -lt 16 ] || [ "$admin_password_bytes" -gt 72 ]; then
+    echo "Temps admin ingress password must contain between 16 and 72 bytes" >&2
+    exit 1
+  fi
+  case "$admin_password" in
+    *[![:space:]]*) ;;
+    *)
+      echo "Temps admin ingress password must not be blank or whitespace-only" >&2
+      exit 1
+      ;;
+  esac
+
   mkdir -p /tmp/nginx/client_body /tmp/nginx/proxy /tmp/nginx/fastcgi \
     /tmp/nginx/uwsgi /tmp/nginx/scgi
 
   # Read the independent ingress password from stdin so it is never present in
   # the process arguments or environment. htpasswd writes only the bcrypt hash.
-  htpasswd -nBi temps < "$admin_password_file" > /tmp/admin.htpasswd
+  printf '%s\n' "$admin_password" | htpasswd -nBi temps > /tmp/admin.htpasswd
+  unset admin_password
 
   cat >> /tmp/nginx.conf <<EOF
+
+stream {
+  # Apply the connection limit at the TCP layer, before HTTP parsing and Basic
+  # authentication. HTTP limit_conn only counts connections after the complete
+  # request header has arrived and therefore does not stop slow-header attacks.
+  limit_conn_zone \$binary_remote_addr zone=admin_clients:1m;
+  limit_conn_log_level warn;
+  proxy_connect_timeout 3s;
+  proxy_timeout 1h;
+
+  server {
+    listen ${TEMPS_INGRESS_LISTEN_IP}:9001;
+    limit_conn admin_clients 16;
+    proxy_protocol on;
+    proxy_pass 127.0.0.1:19001;
+  }
+}
 
 http {
   access_log /dev/stdout combined;
@@ -80,15 +129,20 @@ http {
   uwsgi_temp_path /tmp/nginx/uwsgi;
   scgi_temp_path /tmp/nginx/scgi;
 
-  limit_req_zone \$binary_remote_addr zone=admin_auth:1m rate=10r/s;
+  limit_req_zone \$proxy_protocol_addr zone=admin_auth:1m rate=10r/s;
   map \$http_upgrade \$connection_upgrade {
     default upgrade;
     '' close;
   }
 
   server {
-    listen ${TEMPS_INGRESS_LISTEN_IP}:9001;
+    listen 127.0.0.1:19001 proxy_protocol;
     auth_delay 1s;
+    client_header_timeout 10s;
+    client_body_timeout 30s;
+    keepalive_timeout 30s;
+    keepalive_requests 100;
+    reset_timedout_connection on;
 
     location / {
       limit_req zone=admin_auth burst=20 nodelay;
@@ -100,7 +154,7 @@ http {
       proxy_http_version 1.1;
       proxy_set_header Authorization "";
       proxy_set_header Host \$host;
-      proxy_set_header X-Forwarded-For \$remote_addr;
+      proxy_set_header X-Forwarded-For \$proxy_protocol_addr;
       proxy_set_header X-Forwarded-Proto \$scheme;
       proxy_set_header Upgrade \$http_upgrade;
       proxy_set_header Connection \$connection_upgrade;

--- a/scripts/docker-ingress-entrypoint.sh
+++ b/scripts/docker-ingress-entrypoint.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+set -eu
+
+: "${TEMPS_CONTROL_INTERNAL_IP:?TEMPS_CONTROL_INTERNAL_IP must be set}"
+: "${TEMPS_INGRESS_PUBLISH_IP:?TEMPS_INGRESS_PUBLISH_IP must be set}"
+
+admin_password_file=/run/secrets/temps_admin_ingress_password
+if [ ! -r "$admin_password_file" ]; then
+  echo "Temps admin ingress password secret is not readable" >&2
+  exit 1
+fi
+
+mkdir -p /tmp/nginx/client_body /tmp/nginx/proxy /tmp/nginx/fastcgi \
+  /tmp/nginx/uwsgi /tmp/nginx/scgi
+
+# Read the independent ingress password from stdin so it is never present in
+# the process arguments or environment. htpasswd writes only the bcrypt hash.
+htpasswd -nBi temps < "$admin_password_file" > /tmp/admin.htpasswd
+
+cat > /tmp/nginx.conf <<EOF
+load_module /usr/lib/nginx/modules/ngx_stream_module.so;
+
+pid /tmp/nginx.pid;
+error_log /dev/stderr warn;
+worker_processes 1;
+
+events {
+  worker_connections 512;
+}
+
+stream {
+  # Public traffic is reachable from managed workloads by design. Use one
+  # event-driven proxy with an aggregate per-source connection ceiling rather
+  # than a process-per-connection forwarder. Close idle streams promptly.
+  limit_conn_zone \$binary_remote_addr zone=public_clients:1m;
+  limit_conn_log_level warn;
+  proxy_connect_timeout 3s;
+  proxy_timeout 10s;
+
+  server {
+    listen ${TEMPS_INGRESS_PUBLISH_IP}:3000;
+    limit_conn public_clients 64;
+    proxy_pass ${TEMPS_CONTROL_INTERNAL_IP}:3000;
+  }
+
+  server {
+    listen ${TEMPS_INGRESS_PUBLISH_IP}:3443;
+    limit_conn public_clients 64;
+    proxy_pass ${TEMPS_CONTROL_INTERNAL_IP}:3443;
+  }
+
+  server {
+    listen ${TEMPS_INGRESS_PUBLISH_IP}:9000;
+    limit_conn public_clients 64;
+    proxy_pass ${TEMPS_CONTROL_INTERNAL_IP}:9000;
+  }
+}
+
+http {
+  access_log /dev/stdout combined;
+  client_body_temp_path /tmp/nginx/client_body;
+  proxy_temp_path /tmp/nginx/proxy;
+  fastcgi_temp_path /tmp/nginx/fastcgi;
+  uwsgi_temp_path /tmp/nginx/uwsgi;
+  scgi_temp_path /tmp/nginx/scgi;
+
+  limit_req_zone \$binary_remote_addr zone=admin_auth:1m rate=10r/s;
+
+  server {
+    listen ${TEMPS_INGRESS_PUBLISH_IP}:9001;
+    auth_delay 1s;
+
+    location / {
+      limit_req zone=admin_auth burst=20 nodelay;
+      auth_basic "Temps admin";
+      auth_basic_user_file /tmp/admin.htpasswd;
+
+      # Basic auth is an independent ingress barrier. Never pass its
+      # Authorization header into the Temps application.
+      proxy_set_header Authorization "";
+      proxy_set_header Host \$host;
+      proxy_set_header X-Forwarded-For \$remote_addr;
+      proxy_pass http://${TEMPS_CONTROL_INTERNAL_IP}:9001;
+    }
+  }
+}
+EOF
+
+exec nginx -c /tmp/nginx.conf -g 'daemon off;'

--- a/scripts/docker-ingress-entrypoint.sh
+++ b/scripts/docker-ingress-entrypoint.sh
@@ -5,22 +5,11 @@
 set -eu
 
 : "${TEMPS_CONTROL_INTERNAL_IP:?TEMPS_CONTROL_INTERNAL_IP must be set}"
-: "${TEMPS_INGRESS_PUBLISH_IP:?TEMPS_INGRESS_PUBLISH_IP must be set}"
+: "${TEMPS_INGRESS_MODE:?TEMPS_INGRESS_MODE must be public or admin}"
+: "${TEMPS_INGRESS_LISTEN_IP:?TEMPS_INGRESS_LISTEN_IP must be set}"
 
-admin_password_file=/run/secrets/temps_admin_ingress_password
-if [ ! -r "$admin_password_file" ]; then
-  echo "Temps admin ingress password secret is not readable" >&2
-  exit 1
-fi
-
-mkdir -p /tmp/nginx/client_body /tmp/nginx/proxy /tmp/nginx/fastcgi \
-  /tmp/nginx/uwsgi /tmp/nginx/scgi
-
-# Read the independent ingress password from stdin so it is never present in
-# the process arguments or environment. htpasswd writes only the bcrypt hash.
-htpasswd -nBi temps < "$admin_password_file" > /tmp/admin.htpasswd
-
-cat > /tmp/nginx.conf <<EOF
+write_common_configuration() {
+  cat > /tmp/nginx.conf <<'EOF'
 load_module /usr/lib/nginx/modules/ngx_stream_module.so;
 
 pid /tmp/nginx.pid;
@@ -30,34 +19,58 @@ worker_processes 1;
 events {
   worker_connections 512;
 }
+EOF
+}
+
+write_public_configuration() {
+  cat >> /tmp/nginx.conf <<EOF
 
 stream {
-  # Public traffic is reachable from managed workloads by design. Use one
-  # event-driven proxy with an aggregate per-source connection ceiling rather
-  # than a process-per-connection forwarder. Close idle streams promptly.
+  # Public traffic is reachable from managed workloads by design. Bound
+  # concurrent connections without treating a quiet WebSocket, SSE, or TLS
+  # connection as abandoned after only a few seconds.
   limit_conn_zone \$binary_remote_addr zone=public_clients:1m;
   limit_conn_log_level warn;
   proxy_connect_timeout 3s;
-  proxy_timeout 10s;
+  proxy_timeout 1h;
 
   server {
-    listen ${TEMPS_INGRESS_PUBLISH_IP}:3000;
+    listen ${TEMPS_INGRESS_LISTEN_IP}:3000;
     limit_conn public_clients 64;
     proxy_pass ${TEMPS_CONTROL_INTERNAL_IP}:3000;
   }
 
   server {
-    listen ${TEMPS_INGRESS_PUBLISH_IP}:3443;
+    listen ${TEMPS_INGRESS_LISTEN_IP}:3443;
     limit_conn public_clients 64;
     proxy_pass ${TEMPS_CONTROL_INTERNAL_IP}:3443;
   }
 
   server {
-    listen ${TEMPS_INGRESS_PUBLISH_IP}:9000;
+    listen ${TEMPS_INGRESS_LISTEN_IP}:9000;
     limit_conn public_clients 64;
     proxy_pass ${TEMPS_CONTROL_INTERNAL_IP}:9000;
   }
 }
+EOF
+}
+
+write_admin_configuration() {
+  admin_upstream_port=${TEMPS_ADMIN_UPSTREAM_PORT:-9001}
+  admin_password_file=/run/secrets/temps_admin_ingress_password
+  if [ ! -r "$admin_password_file" ]; then
+    echo "Temps admin ingress password secret is not readable" >&2
+    exit 1
+  fi
+
+  mkdir -p /tmp/nginx/client_body /tmp/nginx/proxy /tmp/nginx/fastcgi \
+    /tmp/nginx/uwsgi /tmp/nginx/scgi
+
+  # Read the independent ingress password from stdin so it is never present in
+  # the process arguments or environment. htpasswd writes only the bcrypt hash.
+  htpasswd -nBi temps < "$admin_password_file" > /tmp/admin.htpasswd
+
+  cat >> /tmp/nginx.conf <<EOF
 
 http {
   access_log /dev/stdout combined;
@@ -68,9 +81,13 @@ http {
   scgi_temp_path /tmp/nginx/scgi;
 
   limit_req_zone \$binary_remote_addr zone=admin_auth:1m rate=10r/s;
+  map \$http_upgrade \$connection_upgrade {
+    default upgrade;
+    '' close;
+  }
 
   server {
-    listen ${TEMPS_INGRESS_PUBLISH_IP}:9001;
+    listen ${TEMPS_INGRESS_LISTEN_IP}:9001;
     auth_delay 1s;
 
     location / {
@@ -80,13 +97,35 @@ http {
 
       # Basic auth is an independent ingress barrier. Never pass its
       # Authorization header into the Temps application.
+      proxy_http_version 1.1;
       proxy_set_header Authorization "";
       proxy_set_header Host \$host;
       proxy_set_header X-Forwarded-For \$remote_addr;
-      proxy_pass http://${TEMPS_CONTROL_INTERNAL_IP}:9001;
+      proxy_set_header X-Forwarded-Proto \$scheme;
+      proxy_set_header Upgrade \$http_upgrade;
+      proxy_set_header Connection \$connection_upgrade;
+      proxy_buffering off;
+      proxy_read_timeout 1h;
+      proxy_send_timeout 1h;
+      proxy_pass http://${TEMPS_CONTROL_INTERNAL_IP}:${admin_upstream_port};
     }
   }
 }
 EOF
+}
+
+write_common_configuration
+case "$TEMPS_INGRESS_MODE" in
+  public)
+    write_public_configuration
+    ;;
+  admin)
+    write_admin_configuration
+    ;;
+  *)
+    echo "Unsupported TEMPS_INGRESS_MODE '$TEMPS_INGRESS_MODE'; expected public or admin" >&2
+    exit 1
+    ;;
+esac
 
 exec nginx -c /tmp/nginx.conf -g 'daemon off;'

--- a/scripts/test-compose-security.sh
+++ b/scripts/test-compose-security.sh
@@ -593,8 +593,17 @@ if [[ "$admin_authenticated" != "true" ]]; then
 fi
 
 # Slow/incomplete requests must be bounded before HTTP parsing and Basic auth.
-# Saturate one reachable source and prove a separate loopback administrator can
-# still authenticate while the attack is active.
+# Saturate the listener and prove the ceiling is a temporary, self-healing
+# throttle rather than a permanent lockout: once the attacking connections
+# close (their incomplete headers hit client_header_timeout, or the flood's
+# own hold expires), a legitimate administrator must be able to authenticate
+# again. This test cannot assert that the administrator stays reachable
+# *during* the flood: admin-ingress is loopback-only and temps-ingress-network
+# has inter-container communication disabled by design (nothing but loopback
+# traffic may ever reach it), so both the flood and any legitimate client
+# necessarily share the same source address nginx sees, `127.0.0.1`, and
+# limit_conn -- keyed on `$binary_remote_addr` -- correctly cannot tell them
+# apart while both are open. That's expected, not a bug in the ceiling.
 #
 # The probe must reach admin-ingress the same way any real client does: through
 # its loopback-published host port. temps-ingress-network disables inter-
@@ -637,9 +646,17 @@ if [[ "$admin_connection_limit_enforced" != "true" ]]; then
   printf '%s\n' "$admin_ingress_logs" >&2
   exit 1
 fi
-if ! curl --fail --silent --user "temps:${admin_ingress_password}" \
-  "http://${admin_binding}/" >/dev/null; then
-  echo "admin ingress saturation denied access to a separate loopback administrator" >&2
+admin_recovered_after_saturation=false
+for _ in {1..60}; do
+  if curl --fail --silent --user "temps:${admin_ingress_password}" \
+    "http://${admin_binding}/" >/dev/null 2>&1; then
+    admin_recovered_after_saturation=true
+    break
+  fi
+  sleep 1
+done
+if [[ "$admin_recovered_after_saturation" != "true" ]]; then
+  echo "admin ingress did not recover access for a loopback administrator after the saturating connections closed" >&2
   exit 1
 fi
 docker rm --force "$admin_saturation_probe_name" >/dev/null

--- a/scripts/test-compose-security.sh
+++ b/scripts/test-compose-security.sh
@@ -108,14 +108,16 @@ wait_for_completed_service() {
 assert_runtime_loopback_binding() {
   local container="$1"
   local container_port="$2"
+  local -a bindings=()
 
-  if ! docker inspect "$container" | jq -e --arg port "${container_port}/tcp" '
-    .[0].NetworkSettings.Ports[$port] as $bindings
-    | ($bindings | length) == 1
-      and ($bindings[0].HostIp == "127.0.0.1")
-  ' >/dev/null; then
+  # `docker port` asks the daemon for the realized mapping. Some Docker Engine
+  # versions leave NetworkSettings.Ports empty even when HostConfig mappings
+  # are active, so inspecting that field is not portable runtime evidence.
+  mapfile -t bindings < <(docker port "$container" "${container_port}/tcp" 2>/dev/null || true)
+  if [[ "${#bindings[@]}" -ne 1 || \
+    ! "${bindings[0]:-}" =~ ^127\.0\.0\.1:[0-9]+$ ]]; then
     echo "$container port $container_port is not published exclusively on 127.0.0.1" >&2
-    docker inspect --format '{{json .NetworkSettings.Ports}}' "$container" >&2 || true
+    docker port "$container" >&2 || true
     return 1
   fi
 }

--- a/scripts/test-compose-security.sh
+++ b/scripts/test-compose-security.sh
@@ -372,6 +372,16 @@ for control_plane_alias in temps-postgres temps-clickhouse; do
   done
   if [[ "$alias_resolved" != "true" ]]; then
     echo "workload network alias $control_plane_alias did not become resolvable" >&2
+    echo "--- resolv.conf ---" >&2
+    docker exec "$workload_probe_name" cat /etc/resolv.conf >&2 || true
+    echo "--- nslookup output ---" >&2
+    docker exec "$workload_probe_name" nslookup "$control_plane_alias" >&2 || true
+    echo "--- nslookup against 127.0.0.11 explicitly ---" >&2
+    docker exec "$workload_probe_name" nslookup "$control_plane_alias" 127.0.0.11 >&2 || true
+    echo "--- getent hosts ---" >&2
+    docker exec "$workload_probe_name" getent hosts "$control_plane_alias" >&2 || true
+    echo "--- network inspect ---" >&2
+    docker network inspect "$TEMPS_NETWORK_NAME" >&2 || true
     exit 1
   fi
 done

--- a/scripts/test-compose-security.sh
+++ b/scripts/test-compose-security.sh
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
 set -euo pipefail
+trap 'echo "test-compose-security.sh failed at line ${LINENO}: ${BASH_COMMAND}" >&2' ERR
 
 project="temps-compose-security-${GITHUB_RUN_ID:-local}-$$"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/test-compose-security.sh
+++ b/scripts/test-compose-security.sh
@@ -361,10 +361,15 @@ for _ in {1..30}; do
 done
 docker exec temps-app wget --quiet --output-document=- \
   "http://${workload_probe_name}:8080/ready" | grep -qx ready
+# Runners that inject a DNS search domain (e.g. GitHub Actions' Azure host
+# search suffix) break plain `nslookup`: Alpine's musl-libc resolver queries
+# the search-suffixed name first and, unlike glibc, does not fall back to the
+# bare name on NXDOMAIN. `getent hosts` resolves the alias correctly in both
+# environments, so use it instead of `nslookup` for this liveness check.
 for control_plane_alias in temps-postgres temps-clickhouse; do
   alias_resolved=false
   for _ in {1..10}; do
-    if docker exec "$workload_probe_name" nslookup "$control_plane_alias" >/dev/null 2>&1; then
+    if docker exec "$workload_probe_name" getent hosts "$control_plane_alias" >/dev/null 2>&1; then
       alias_resolved=true
       break
     fi
@@ -372,16 +377,6 @@ for control_plane_alias in temps-postgres temps-clickhouse; do
   done
   if [[ "$alias_resolved" != "true" ]]; then
     echo "workload network alias $control_plane_alias did not become resolvable" >&2
-    echo "--- resolv.conf ---" >&2
-    docker exec "$workload_probe_name" cat /etc/resolv.conf >&2 || true
-    echo "--- nslookup output ---" >&2
-    docker exec "$workload_probe_name" nslookup "$control_plane_alias" >&2 || true
-    echo "--- nslookup against 127.0.0.11 explicitly ---" >&2
-    docker exec "$workload_probe_name" nslookup "$control_plane_alias" 127.0.0.11 >&2 || true
-    echo "--- getent hosts ---" >&2
-    docker exec "$workload_probe_name" getent hosts "$control_plane_alias" >&2 || true
-    echo "--- network inspect ---" >&2
-    docker network inspect "$TEMPS_NETWORK_NAME" >&2 || true
     exit 1
   fi
 done

--- a/scripts/test-compose-security.sh
+++ b/scripts/test-compose-security.sh
@@ -20,14 +20,22 @@ if [[ -n "${COMPOSE_SECURITY_PREBUILT:-}" ]]; then
   build_flag=()
 fi
 safe_postgres="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-safe_redis="abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+safe_clickhouse="23456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01"
+old_clickhouse="3456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef012"
+workload_probe_name="${project}-workload-probe"
+export TEMPS_NETWORK_NAME="${TEMPS_NETWORK_NAME:-temps-docker-workloads}"
+export CLICKHOUSE_PASSWORD="$safe_clickhouse"
 export TEMPS_ADMIN_EMAIL="Admin@Example.TEST"
 admin_secret_dir="$(mktemp -d)"
 chmod 700 "$admin_secret_dir"
 admin_password_file="$admin_secret_dir/admin_password"
+admin_ingress_password_file="$admin_secret_dir/admin_ingress_password"
+admin_ingress_password='iI4!0123456789abcdef0123456789abcdef'
 printf 'tT3!0123456789abcdef0123456789abcdef\n' >"$admin_password_file"
-chmod 444 "$admin_password_file"
+printf '%s\n' "$admin_ingress_password" >"$admin_ingress_password_file"
+chmod 444 "$admin_password_file" "$admin_ingress_password_file"
 export TEMPS_ADMIN_PASSWORD_FILE="$admin_password_file"
+export TEMPS_ADMIN_INGRESS_PASSWORD_FILE="$admin_ingress_password_file"
 if [[ -z "${DOCKER_GID:-}" ]]; then
   # Inspect from a container because Docker Desktop can present a different
   # socket owner than the host-side symlink reports.
@@ -38,9 +46,10 @@ fi
 export DOCKER_GID
 
 cleanup() {
-  POSTGRES_PASSWORD="$safe_postgres" REDIS_PASSWORD="$safe_redis" \
+  docker rm --force "$workload_probe_name" >/dev/null 2>&1 || true
+  POSTGRES_PASSWORD="$safe_postgres" \
     "${compose[@]}" down --volumes --remove-orphans >/dev/null 2>&1 || true
-  rm -f "$admin_password_file"
+  rm -f "$admin_password_file" "$admin_ingress_password_file"
   rmdir "$admin_secret_dir" 2>/dev/null || true
 }
 trap cleanup EXIT
@@ -72,51 +81,97 @@ wait_for_completed_service() {
   return 1
 }
 
-if env -u POSTGRES_PASSWORD -u REDIS_PASSWORD "${config_compose[@]}" config --quiet 2>/dev/null; then
-  echo "compose config unexpectedly accepted missing credentials" >&2
+if env -u POSTGRES_PASSWORD "${config_compose[@]}" config --quiet 2>/dev/null; then
+  echo "compose config unexpectedly accepted a missing PostgreSQL credential" >&2
   exit 1
 fi
-if POSTGRES_PASSWORD="$safe_postgres" env -u REDIS_PASSWORD \
-  "${config_compose[@]}" config --quiet 2>/dev/null; then
-  echo "compose config unexpectedly accepted a missing Redis credential" >&2
+if POSTGRES_PASSWORD="$safe_postgres" \
+  env -u CLICKHOUSE_PASSWORD "${config_compose[@]}" config --quiet 2>/dev/null; then
+  echo "compose config unexpectedly accepted a missing ClickHouse credential" >&2
   exit 1
 fi
-if POSTGRES_PASSWORD="$safe_postgres" REDIS_PASSWORD="$safe_redis" \
+if POSTGRES_PASSWORD="$safe_postgres" \
   env -u TEMPS_ADMIN_EMAIL "${config_compose[@]}" config --quiet 2>/dev/null; then
   echo "compose config unexpectedly accepted a missing initial admin email" >&2
   exit 1
 fi
-if POSTGRES_PASSWORD="$safe_postgres" REDIS_PASSWORD="$safe_redis" \
+if POSTGRES_PASSWORD="$safe_postgres" \
   env -u TEMPS_ADMIN_PASSWORD_FILE "${config_compose[@]}" config --quiet 2>/dev/null; then
   echo "compose config unexpectedly accepted a missing initial admin password file" >&2
   exit 1
 fi
+if POSTGRES_PASSWORD="$safe_postgres" \
+  env -u TEMPS_ADMIN_INGRESS_PASSWORD_FILE "${config_compose[@]}" config --quiet 2>/dev/null; then
+  echo "compose config unexpectedly accepted a missing admin ingress password file" >&2
+  exit 1
+fi
 
-config="$({ POSTGRES_PASSWORD="$safe_postgres" REDIS_PASSWORD="$safe_redis" \
+config="$({ POSTGRES_PASSWORD="$safe_postgres" \
   "${config_compose[@]}" config --format json; })"
 jq -e '
-  [.services.postgres.ports[], .services.redis.ports[],
-   (.services.temps.ports[] | select(.target == 9000))]
+  [.services.postgres.ports[], .services.clickhouse.ports[],
+   .services["temps-ingress"].ports[]]
   | all(.host_ip == "127.0.0.1")
 ' <<<"$config" >/dev/null
-jq -e '.services.redis.user != null and .services.redis.user != "0" and .services.redis.user != "root"' \
-  <<<"$config" >/dev/null
-jq -e '
-  [.services.temps.ports[] | select(.target == 3000 or .target == 3443)]
-  | all(has("host_ip") | not)
+jq -e --arg workload_network "$TEMPS_NETWORK_NAME" '
+  .services.temps.environment.TEMPS_CLICKHOUSE_URL == "http://198.18.255.12:8123"
+  and .services.temps.environment.TEMPS_CLICKHOUSE_DATABASE == "temps"
+  and .services.temps.environment.TEMPS_CLICKHOUSE_USER == "temps"
+  and .services.temps.environment.TEMPS_EXECUTION_ENV == "docker"
+  and .services.temps.environment.TEMPS_NETWORK_NAME == $workload_network
+  and .services.temps.environment.TEMPS_ADDRESS == "198.18.255.10:3000"
+  and .services.temps.environment.TEMPS_TLS_ADDRESS == "198.18.255.10:3443"
+  and .services.temps.environment.TEMPS_CONSOLE_ADDRESS == "198.18.255.10:9000"
+  and .services.temps.environment.TEMPS_CONSOLE_ADMIN_ADDRESS == "198.18.255.10:9001"
+  and .services.temps.environment.TEMPS_DATABASE_URL
+    == "postgresql://temps:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef@198.18.255.11:5432/temps"
+  and (.services.temps.environment | has("REDIS_URL") | not)
+  and (.services | has("redis") | not)
+' <<<"$config" >/dev/null
+jq -e --arg workload_network "$TEMPS_NETWORK_NAME" '
+  (.services.temps.networks | has("temps-network"))
+  and (.services.temps.networks | has("temps-app-network"))
+  and .services.temps.networks["temps-network"].ipv4_address == "198.18.255.10"
+  and .services.postgres.networks["temps-network"].ipv4_address == "198.18.255.11"
+  and .services.clickhouse.networks["temps-network"].ipv4_address == "198.18.255.12"
+  and .services["temps-ingress"].networks["temps-ingress-network"].ipv4_address == "198.19.255.10"
+  and (.services["temps-ingress"].networks | has("temps-app-network") | not)
+  and (.services["temps-ingress"].cap_drop | index("ALL") != null)
+  and .services["temps-ingress"].read_only == true
+  and (.services["temps-ingress"].security_opt | index("no-new-privileges:true") != null)
+  and (.services["temps-ingress"].secrets | map(.source) | index("temps_admin_ingress_password") != null)
+  and (.services["temps-ingress"].environment | has("TEMPS_ADMIN_INGRESS_PASSWORD") | not)
+  and .networks["temps-ingress-network"].driver_opts["com.docker.network.bridge.enable_icc"] == "false"
+  and .networks["temps-ingress-network"].driver_opts["com.docker.network.bridge.trusted_host_interfaces"] == "lo"
+  and .networks["temps-network"].internal == true
+  and .networks["temps-network"].ipam.config[0].subnet == "198.18.255.0/24"
+  and .networks["temps-app-network"].name == $workload_network
 ' <<<"$config" >/dev/null
 
-POSTGRES_PASSWORD="$safe_postgres" REDIS_PASSWORD="$safe_redis" \
+POSTGRES_PASSWORD="$safe_postgres" \
   "${compose[@]}" run --rm --no-TTY credential-check >/dev/null
-if POSTGRES_PASSWORD='unsafe@password' REDIS_PASSWORD="$safe_redis" \
+if POSTGRES_PASSWORD='unsafe@password' \
   "${compose[@]}" run --rm --no-TTY credential-check >/dev/null 2>&1; then
   echo "credential validator unexpectedly accepted URL delimiters" >&2
   exit 1
 fi
+if POSTGRES_PASSWORD="$safe_postgres" \
+  CLICKHOUSE_PASSWORD='unsafe@password' \
+  "${compose[@]}" run --rm --no-TTY credential-check >/dev/null 2>&1; then
+  echo "credential validator unexpectedly accepted ClickHouse URL delimiters" >&2
+  exit 1
+fi
 
-if grep -En 'temps_password_change_me|redis-server .*--requirepass|redis-cli -a' \
+if grep -En 'temps_password_change_me' \
   docker-compose.yml .env.example; then
   echo "compose files contain a known or argv-exposed credential" >&2
+  exit 1
+fi
+
+if grep -Fxq 'scripts/' .dockerignore || \
+  ! grep -Fxq '!scripts/source_attribution.py' .dockerignore || \
+  ! grep -Fxq '!scripts/docker-ingress-entrypoint.sh' .dockerignore; then
+  echo "Docker build context excludes a required build or ingress script" >&2
   exit 1
 fi
 
@@ -139,9 +194,9 @@ for ignore_file in .gitignore .dockerignore; do
 done
 
 old_postgres="temps_password_change_me"
-POSTGRES_PASSWORD="$old_postgres" REDIS_PASSWORD="$safe_redis" \
+POSTGRES_PASSWORD="$old_postgres" \
   "${compose[@]}" up --detach postgres-credential-sync >/dev/null
-POSTGRES_PASSWORD="$old_postgres" REDIS_PASSWORD="$safe_redis" \
+POSTGRES_PASSWORD="$old_postgres" \
   wait_for_completed_service postgres-credential-sync \
   "fresh-volume credential synchronization"
 
@@ -156,11 +211,11 @@ if [[ "$(docker inspect --format '{{.State.Health.Status}}' temps-postgres)" != 
   exit 1
 fi
 
-POSTGRES_PASSWORD="$old_postgres" REDIS_PASSWORD="$safe_redis" \
+POSTGRES_PASSWORD="$old_postgres" \
   "${compose[@]}" stop postgres >/dev/null
-POSTGRES_PASSWORD="$safe_postgres" REDIS_PASSWORD="$safe_redis" \
+POSTGRES_PASSWORD="$safe_postgres" \
   "${compose[@]}" up --detach postgres >/dev/null
-POSTGRES_PASSWORD="$safe_postgres" REDIS_PASSWORD="$safe_redis" \
+POSTGRES_PASSWORD="$safe_postgres" \
   "${compose[@]}" run --rm --no-deps --no-TTY postgres-credential-sync >/dev/null
 
 for _ in {1..30}; do
@@ -183,34 +238,91 @@ if docker exec --env PGPASSWORD="$old_postgres" temps-postgres \
   exit 1
 fi
 
-POSTGRES_PASSWORD="$safe_postgres" REDIS_PASSWORD="$safe_redis" \
-  "${compose[@]}" up --detach redis >/dev/null
-for _ in {1..30}; do
-  if [[ "$(docker inspect --format '{{.State.Health.Status}}' temps-redis)" == "healthy" ]]; then
+POSTGRES_PASSWORD="$safe_postgres" \
+  CLICKHOUSE_PASSWORD="$old_clickhouse" \
+  "${compose[@]}" up --detach clickhouse >/dev/null
+for _ in {1..60}; do
+  if [[ "$(docker inspect --format '{{.State.Health.Status}}' temps-clickhouse)" == "healthy" ]]; then
     break
   fi
   sleep 1
 done
-if [[ "$(docker inspect --format '{{.State.Health.Status}}' temps-redis)" != "healthy" ]]; then
-  echo "Redis did not become healthy with authentication enabled" >&2
+if [[ "$(docker inspect --format '{{.State.Health.Status}}' temps-clickhouse)" != "healthy" ]]; then
+  "${compose[@]}" logs clickhouse >&2 || true
+  echo "ClickHouse did not become healthy with authentication enabled" >&2
   exit 1
 fi
-docker exec temps-redis redis-cli ping | grep -q 'NOAUTH'
-docker exec --env REDISCLI_AUTH="$safe_redis" temps-redis redis-cli ping | grep -qx PONG
-docker exec temps-redis awk '/^Uid:/ { exit !($2 != 0) }' /proc/1/status
-if docker inspect --format '{{json .Config.Cmd}}' temps-redis | grep -Fq "$safe_redis"; then
-  echo "Redis password leaked into the long-lived process argv" >&2
+docker exec temps-clickhouse awk '/^Uid:/ { exit !($2 != 0) }' /proc/1/status
+if docker exec --env CLICKHOUSE_PASSWORD= temps-clickhouse \
+  clickhouse-client --user temps --query 'SELECT 1' \
+  >/dev/null 2>&1; then
+  echo "ClickHouse unexpectedly accepted an unauthenticated query" >&2
   exit 1
 fi
+docker exec --env CLICKHOUSE_PASSWORD="$old_clickhouse" temps-clickhouse \
+  clickhouse-client --user temps --database temps --query 'SELECT 1' | grep -qx 1
+if docker exec --env CLICKHOUSE_PASSWORD="$old_clickhouse" temps-clickhouse \
+  clickhouse-client --user temps --query 'CREATE USER temps_compose_security_probe' \
+  >/dev/null 2>&1; then
+  echo "ClickHouse application user unexpectedly has access-management privileges" >&2
+  exit 1
+fi
+docker exec --env CLICKHOUSE_PASSWORD="$old_clickhouse" temps-clickhouse \
+  clickhouse-client --user temps --database temps \
+  --query 'CREATE TABLE compose_security_persistence_probe (value UInt8) ENGINE = TinyLog'
+docker exec --env CLICKHOUSE_PASSWORD="$old_clickhouse" temps-clickhouse \
+  clickhouse-client --user temps --database temps \
+  --query 'INSERT INTO compose_security_persistence_probe VALUES (1)'
+
+POSTGRES_PASSWORD="$safe_postgres" \
+  CLICKHOUSE_PASSWORD="$old_clickhouse" \
+  "${compose[@]}" stop clickhouse >/dev/null
+POSTGRES_PASSWORD="$safe_postgres" \
+  CLICKHOUSE_PASSWORD="$safe_clickhouse" \
+  "${compose[@]}" up --detach clickhouse >/dev/null
+for _ in {1..60}; do
+  if [[ "$(docker inspect --format '{{.State.Health.Status}}' temps-clickhouse)" == "healthy" ]]; then
+    break
+  fi
+  sleep 1
+done
+if [[ "$(docker inspect --format '{{.State.Health.Status}}' temps-clickhouse)" != "healthy" ]]; then
+  "${compose[@]}" logs clickhouse >&2 || true
+  echo "ClickHouse did not become healthy after credential rotation" >&2
+  exit 1
+fi
+if docker exec --env CLICKHOUSE_PASSWORD="$old_clickhouse" temps-clickhouse \
+  clickhouse-client --user temps --database temps --query 'SELECT 1' \
+  >/dev/null 2>&1; then
+  echo "Old ClickHouse password still authenticates after rotation" >&2
+  exit 1
+fi
+docker exec --env CLICKHOUSE_PASSWORD="$safe_clickhouse" temps-clickhouse \
+  clickhouse-client --user temps --database temps \
+  --query 'SELECT count() FROM compose_security_persistence_probe' | grep -qx 1
 
 # Build the production image and seed its persistent data volume before the
 # first application start. This models an upgrade where an existing volume
 # masks /app/data and verifies immutable runtime assets remain available.
-POSTGRES_PASSWORD="$safe_postgres" REDIS_PASSWORD="$safe_redis" \
+POSTGRES_PASSWORD="$safe_postgres" \
   "${compose[@]}" run --rm --no-deps ${build_flag[@]+"${build_flag[@]}"} --entrypoint /bin/sh temps \
   -ec 'touch /app/data/.preexisting-volume' >/dev/null
-POSTGRES_PASSWORD="$safe_postgres" REDIS_PASSWORD="$safe_redis" \
-  "${compose[@]}" up --detach temps >/dev/null
+
+# Start an adversarially named workload before Temps. Docker DNS exposes these
+# aliases to the dual-network control plane, so private dependencies and bind
+# addresses must remain pinned to non-confusable control-network IPs.
+docker run --detach --rm \
+  --name "$workload_probe_name" \
+  --network "$TEMPS_NETWORK_NAME" \
+  --network-alias temps-postgres \
+  --network-alias temps-clickhouse \
+  alpine:3.22 \
+  /bin/sh -ec \
+  'while true; do printf "HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: close\r\n\r\nready\n" | nc -l -p 8080; done' \
+  >/dev/null
+
+POSTGRES_PASSWORD="$safe_postgres" \
+  "${compose[@]}" up --detach temps-ingress >/dev/null
 for _ in {1..180}; do
   if [[ "$(docker inspect --format '{{.State.Health.Status}}' temps-app)" == "healthy" ]]; then
     break
@@ -221,11 +333,160 @@ for _ in {1..180}; do
   sleep 1
 done
 if [[ "$(docker inspect --format '{{.State.Health.Status}}' temps-app)" != "healthy" ]]; then
-  "${compose[@]}" logs temps >&2 || true
+  POSTGRES_PASSWORD="$safe_postgres" "${compose[@]}" logs temps >&2 || true
   echo "Temps did not become ready on the console /readyz endpoint" >&2
   exit 1
 fi
+for _ in {1..30}; do
+  if [[ "$(docker inspect --format '{{.State.Health.Status}}' temps-ingress)" == "healthy" ]]; then
+    break
+  fi
+  sleep 1
+done
+if [[ "$(docker inspect --format '{{.State.Health.Status}}' temps-ingress)" != "healthy" ]]; then
+  POSTGRES_PASSWORD="$safe_postgres" "${compose[@]}" logs temps-ingress >&2 || true
+  echo "Temps loopback ingress did not become healthy" >&2
+  exit 1
+fi
+
+# Docker-mode routing must use the explicitly named workload network and
+# internal ports even while malicious private-service aliases are present.
+for _ in {1..30}; do
+  if docker exec temps-app wget --quiet --output-document=- \
+    "http://${workload_probe_name}:8080/ready" | grep -qx ready; then
+    break
+  fi
+  sleep 1
+done
+docker exec temps-app wget --quiet --output-document=- \
+  "http://${workload_probe_name}:8080/ready" | grep -qx ready
+for control_plane_alias in temps-postgres temps-clickhouse; do
+  docker exec "$workload_probe_name" nslookup "$control_plane_alias" >/dev/null
+done
+for control_plane_port in 3000 3443 9000; do
+  if docker exec "$workload_probe_name" nc -z -w 1 temps-app "$control_plane_port" \
+    >/dev/null 2>&1; then
+    echo "workload network unexpectedly reaches Temps on port $control_plane_port" >&2
+    exit 1
+  fi
+done
+for private_endpoint in 198.18.255.10:9000 198.18.255.10:9001 198.18.255.11:5432 198.18.255.12:8123; do
+  private_host="${private_endpoint%:*}"
+  private_port="${private_endpoint##*:}"
+  if docker exec "$workload_probe_name" nc -z -w 1 "$private_host" "$private_port" \
+    >/dev/null 2>&1; then
+    echo "workload network unexpectedly reaches private endpoint $private_endpoint" >&2
+    exit 1
+  fi
+done
+
+# The workload may reach the deliberately public ingress surface, but not the
+# private control network. Public console routes must not expose admin/auth UI.
+docker exec "$workload_probe_name" wget --quiet --output-document=- \
+  "http://198.19.255.10:9000/readyz" | grep -qx ready
+public_admin_response="$(docker exec "$workload_probe_name" sh -ec \
+  'wget -S -O /dev/null "$1" 2>&1 || true' -- \
+  'http://198.19.255.10:9000/api/auth/login')"
+if ! grep -Eq 'HTTP/[0-9.]+ 404' <<<"$public_admin_response"; then
+  echo "public console listener did not hide the admin login route" >&2
+  echo "$public_admin_response" >&2
+  exit 1
+fi
+
+# The private admin listener is published only through a second authentication
+# barrier. Temps authentication remains active behind this proxy.
+admin_binding="$(docker port temps-ingress 9001/tcp)"
+if [[ "$(curl --silent --output /dev/null --write-out '%{http_code}' "http://${admin_binding}/")" != "401" ]]; then
+  echo "admin ingress unexpectedly accepted an unauthenticated request" >&2
+  exit 1
+fi
+if [[ "$(curl --silent --output /dev/null --write-out '%{http_code}' \
+  --user 'temps:wrong-password' "http://${admin_binding}/")" != "401" ]]; then
+  echo "admin ingress unexpectedly accepted an incorrect password" >&2
+  exit 1
+fi
+curl --fail --silent --show-error --user "temps:${admin_ingress_password}" \
+  "http://${admin_binding}/" >/dev/null
+workload_admin_response="$(docker exec "$workload_probe_name" sh -ec \
+  'wget -S -O /dev/null "$1" 2>&1 || true' -- \
+  'http://198.19.255.10:9001/')"
+if ! grep -Eq 'HTTP/[0-9.]+ 401' <<<"$workload_admin_response"; then
+  echo "admin ingress did not require authentication from the workload network" >&2
+  echo "$workload_admin_response" >&2
+  exit 1
+fi
+
+# Loopback publication must still reach the listener bound to the private
+# control-network address.
+console_binding="$(docker port temps-ingress 9000/tcp)"
+curl --fail --silent --show-error "http://${console_binding}/readyz" | grep -qx ready
+
+# No public listener may expose the split admin/auth surface. Check the public
+# HTTP proxy, HTTPS proxy, and console/ingest listener independently.
+for public_port in 3000 9000; do
+  public_binding="$(docker port temps-ingress "${public_port}/tcp")"
+  public_status="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+    "http://${public_binding}/api/auth/login")"
+  if [[ "$public_status" != "404" ]]; then
+    echo "public port $public_port returned $public_status for an admin route; expected 404" >&2
+    exit 1
+  fi
+done
+tls_binding="$(docker port temps-ingress 3443/tcp)"
+tls_admin_status="$(curl --insecure --silent --output /dev/null --write-out '%{http_code}' \
+  --connect-timeout 5 "https://${tls_binding}/api/auth/login" || true)"
+if [[ "$tls_admin_status" != "404" && "$tls_admin_status" != "000" ]]; then
+  echo "public TLS port 3443 returned $tls_admin_status for an admin route; expected 404 or a fail-closed TLS handshake" >&2
+  exit 1
+fi
+
+# Exercise more slow public connections than the per-source ceiling. Nginx must
+# reject the excess without spawning one ingress process per connection, then
+# recover after the configured idle timeout.
+docker exec --detach "$workload_probe_name" sh -ec '
+  index=0
+  while [ "$index" -lt 128 ]; do
+    (sleep 30) | nc -w 15 198.19.255.10 9000 >/dev/null 2>&1 &
+    index=$((index + 1))
+  done
+  wait
+'
+connection_limit_enforced=false
+for _ in {1..10}; do
+  ingress_process_count="$(docker exec temps-ingress sh -ec \
+    'set -- /proc/[0-9]*; printf "%s" "$#"')"
+  if ((ingress_process_count > 8)); then
+    echo "public connection saturation spawned $ingress_process_count ingress processes" >&2
+    exit 1
+  fi
+  ingress_logs="$(docker logs temps-ingress 2>&1)"
+  if grep -Fq 'limiting connections by zone "public_clients"' <<<"$ingress_logs"; then
+    connection_limit_enforced=true
+    break
+  fi
+  sleep 1
+done
+if [[ "$connection_limit_enforced" != "true" ]]; then
+  echo "public ingress did not enforce its concurrent connection ceiling" >&2
+  exit 1
+fi
+if [[ "$(docker inspect --format '{{.HostConfig.PidsLimit}}' temps-ingress)" != "32" ]]; then
+  echo "admin ingress PID limit is not 32" >&2
+  exit 1
+fi
+if [[ "$(docker inspect --format '{{.HostConfig.Memory}}' temps-ingress)" != "134217728" ]]; then
+  echo "admin ingress memory limit is not 128 MiB" >&2
+  exit 1
+fi
+sleep 10
+curl --fail --silent --show-error "http://${console_binding}/readyz" | grep -qx ready
+
 docker exec temps-app awk '/^Uid:/ { exit !($2 != 0) }' /proc/1/status
+docker exec temps-ingress awk '/^Uid:/ { exit !($2 != 0) }' /proc/1/status
+if docker exec temps-ingress touch /etc/compose-security-write-test >/dev/null 2>&1; then
+  echo "admin ingress root filesystem is unexpectedly writable" >&2
+  exit 1
+fi
 docker exec temps-app sh -ec 'touch /app/data/.compose-security-write-test; rm /app/data/.compose-security-write-test'
 docker exec temps-app sh -ec 'test -r /var/run/docker.sock && test -w /var/run/docker.sock'
 docker exec temps-app sh -ec \
@@ -233,11 +494,21 @@ docker exec temps-app sh -ec \
 docker exec temps-app sh -ec \
   'test -r /usr/share/temps/GeoLite2-City.mmdb && test ! -w /usr/share/temps/GeoLite2-City.mmdb'
 docker exec temps-app test -f /app/data/.preexisting-volume
-docker exec temps-app wget --quiet --output-document=- http://127.0.0.1:9000/readyz | grep -qx ready
 docker exec --env PGPASSWORD="$safe_postgres" temps-postgres \
   psql -h 127.0.0.1 -U temps -d temps -tAc \
   "SELECT count(*) FROM users u JOIN user_roles ur ON ur.user_id = u.id JOIN roles r ON r.id = ur.role_id WHERE u.email = 'admin@example.test' AND u.deleted_at IS NULL AND r.name = 'admin'" \
   | grep -qx 1
+for _ in {1..60}; do
+  if docker exec --env CLICKHOUSE_PASSWORD="$safe_clickhouse" temps-clickhouse \
+    clickhouse-client --user temps --database temps \
+    --query "EXISTS TABLE _temps_ch_migrations" | grep -qx 1; then
+    break
+  fi
+  sleep 1
+done
+docker exec --env CLICKHOUSE_PASSWORD="$safe_clickhouse" temps-clickhouse \
+  clickhouse-client --user temps --database temps \
+  --query "EXISTS TABLE _temps_ch_migrations" | grep -qx 1
 # The harness must never report product telemetry (see
 # compose-security.harness.yml). Assert on the container env, not on logs:
 # the ENABLED/DISABLED notice is emitted during plugin registration, before
@@ -257,6 +528,15 @@ if docker inspect --format '{{json .Config.Env}}' temps-app | grep -Fq 'tT3!0123
 fi
 if docker logs temps-app 2>&1 | grep -Fq 'tT3!0123456789abcdef'; then
   echo "initial admin password leaked into application logs" >&2
+  exit 1
+fi
+if docker inspect --format '{{json .Config.Env}}' temps-ingress \
+  | grep -Fq "$admin_ingress_password"; then
+  echo "admin ingress password leaked into the proxy environment" >&2
+  exit 1
+fi
+if docker logs temps-ingress 2>&1 | grep -Fq "$admin_ingress_password"; then
+  echo "admin ingress password leaked into proxy logs" >&2
   exit 1
 fi
 

--- a/scripts/test-compose-security.sh
+++ b/scripts/test-compose-security.sh
@@ -5,6 +5,19 @@
 set -euo pipefail
 trap 'echo "test-compose-security.sh failed at line ${LINENO}: ${BASH_COMMAND}" >&2' ERR
 
+if ! command -v docker >/dev/null 2>&1; then
+  echo "SKIP: Docker is not installed; Compose security tests require Docker"
+  exit 0
+fi
+if ! docker info >/dev/null 2>&1; then
+  echo "SKIP: Docker daemon is unavailable; Compose security tests require Docker"
+  exit 0
+fi
+if ! docker compose version >/dev/null 2>&1; then
+  echo "SKIP: Docker Compose is unavailable; Compose security tests require Docker Compose"
+  exit 0
+fi
+
 project="temps-compose-security-${GITHUB_RUN_ID:-local}-$$"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 config_compose=(docker compose --project-name "$project" --file docker-compose.yml
@@ -25,6 +38,7 @@ safe_clickhouse="23456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0
 old_clickhouse="3456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef012"
 workload_probe_name="${project}-workload-probe"
 saturation_probe_name="${project}-saturation-probe"
+admin_saturation_probe_name="${project}-admin-saturation-probe"
 export TEMPS_NETWORK_NAME="${TEMPS_NETWORK_NAME:-temps-docker-workloads}"
 export CLICKHOUSE_PASSWORD="$safe_clickhouse"
 export TEMPS_ADMIN_EMAIL="Admin@Example.TEST"
@@ -32,6 +46,8 @@ admin_secret_dir="$(mktemp -d)"
 chmod 700 "$admin_secret_dir"
 admin_password_file="$admin_secret_dir/admin_password"
 admin_ingress_password_file="$admin_secret_dir/admin_ingress_password"
+sse_response_file="$admin_secret_dir/sse_response"
+sse_curl_pid=""
 admin_ingress_password='iI4!0123456789abcdef0123456789abcdef'
 printf 'tT3!0123456789abcdef0123456789abcdef\n' >"$admin_password_file"
 printf '%s\n' "$admin_ingress_password" >"$admin_ingress_password_file"
@@ -48,11 +64,16 @@ fi
 export DOCKER_GID
 
 cleanup() {
+  if [[ -n "$sse_curl_pid" ]]; then
+    kill "$sse_curl_pid" >/dev/null 2>&1 || true
+    wait "$sse_curl_pid" >/dev/null 2>&1 || true
+  fi
+  docker rm --force "$admin_saturation_probe_name" >/dev/null 2>&1 || true
   docker rm --force "$saturation_probe_name" >/dev/null 2>&1 || true
   docker rm --force "$workload_probe_name" >/dev/null 2>&1 || true
   POSTGRES_PASSWORD="$safe_postgres" \
     "${compose[@]}" down --volumes --remove-orphans >/dev/null 2>&1 || true
-  rm -f "$admin_password_file" "$admin_ingress_password_file"
+  rm -f "$admin_password_file" "$admin_ingress_password_file" "$sse_response_file"
   rmdir "$admin_secret_dir" 2>/dev/null || true
 }
 trap cleanup EXIT
@@ -82,6 +103,65 @@ wait_for_completed_service() {
   "${compose[@]}" logs postgres "$service" >&2 || true
   echo "$description failed or timed out" >&2
   return 1
+}
+
+assert_runtime_loopback_binding() {
+  local container="$1"
+  local container_port="$2"
+
+  if ! docker inspect "$container" | jq -e --arg port "${container_port}/tcp" '
+    .[0].NetworkSettings.Ports[$port] as $bindings
+    | ($bindings | length) == 1
+      and ($bindings[0].HostIp == "127.0.0.1")
+  ' >/dev/null; then
+    echo "$container port $container_port is not published exclusively on 127.0.0.1" >&2
+    docker inspect --format '{{json .NetworkSettings.Ports}}' "$container" >&2 || true
+    return 1
+  fi
+}
+
+assert_admin_ingress_secret_rejected() {
+  local description="$1"
+  local secret_value="$2"
+  local probe_id=""
+  local probe_state=""
+  local probe_exit_code=""
+  local probe_logs=""
+
+  chmod 600 "$admin_ingress_password_file"
+  printf '%s' "$secret_value" >"$admin_ingress_password_file"
+  chmod 444 "$admin_ingress_password_file"
+
+  probe_id="$(POSTGRES_PASSWORD="$safe_postgres" \
+    "${compose[@]}" run --detach --no-deps temps-admin-ingress)"
+  for _ in {1..20}; do
+    probe_state="$(docker inspect --format '{{.State.Status}}' "$probe_id")"
+    if [[ "$probe_state" == "exited" ]]; then
+      break
+    fi
+    sleep 0.25
+  done
+  probe_logs="$(docker logs "$probe_id" 2>&1 || true)"
+  if [[ "$probe_state" == "exited" ]]; then
+    probe_exit_code="$(docker inspect --format '{{.State.ExitCode}}' "$probe_id")"
+  fi
+  docker rm --force "$probe_id" >/dev/null 2>&1 || true
+
+  chmod 600 "$admin_ingress_password_file"
+  printf '%s\n' "$admin_ingress_password" >"$admin_ingress_password_file"
+  chmod 444 "$admin_ingress_password_file"
+
+  if [[ "$probe_state" != "exited" || "$probe_exit_code" == "0" ]]; then
+    printf '%s\n' "$probe_logs" >&2
+    echo "admin ingress unexpectedly accepted a $description secret" >&2
+    return 1
+  fi
+  if ! grep -Eq 'must be a single line|must contain only printable ASCII characters|must contain between 16 and 72 bytes|must not be blank or whitespace-only' \
+    <<<"$probe_logs"; then
+    printf '%s\n' "$probe_logs" >&2
+    echo "admin ingress rejected a $description secret without a contextual validation error" >&2
+    return 1
+  fi
 }
 
 if env -u POSTGRES_PASSWORD "${config_compose[@]}" config --quiet 2>/dev/null; then
@@ -203,6 +283,20 @@ for ignore_file in .gitignore .dockerignore; do
     exit 1
   fi
 done
+
+# The ingress must fail closed before Nginx starts when its independent Basic
+# credential is empty or contains only whitespace.
+POSTGRES_PASSWORD="$safe_postgres" \
+  "${compose[@]}" build temps-admin-ingress >/dev/null
+assert_admin_ingress_secret_rejected "empty" ""
+assert_admin_ingress_secret_rejected "whitespace-only" "                    "
+assert_admin_ingress_secret_rejected "short" "too-short"
+assert_admin_ingress_secret_rejected "overlong" \
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef012345678"
+assert_admin_ingress_secret_rejected "embedded-newline" \
+  $'0123456789abcdef\n0123456789abcdef'
+assert_admin_ingress_secret_rejected "multiple-trailing-newlines" \
+  $'0123456789abcdef0123456789abcdef\n\n'
 
 old_postgres="temps_password_change_me"
 POSTGRES_PASSWORD="$old_postgres" \
@@ -371,6 +465,15 @@ if [[ "$(docker inspect --format '{{.State.Health.Status}}' temps-admin-ingress)
   exit 1
 fi
 
+# Rendered Compose configuration is necessary but not sufficient: verify the
+# effective bindings installed in Docker after all overrides are applied.
+assert_runtime_loopback_binding temps-postgres 5432
+assert_runtime_loopback_binding temps-clickhouse 8123
+assert_runtime_loopback_binding temps-ingress 3000
+assert_runtime_loopback_binding temps-ingress 3443
+assert_runtime_loopback_binding temps-ingress 9000
+assert_runtime_loopback_binding temps-admin-ingress 9001
+
 # Docker-mode routing must use the explicitly named workload network and
 # internal ports even while malicious private-service aliases are present.
 for _ in {1..30}; do
@@ -481,6 +584,48 @@ if [[ "$admin_authenticated" != "true" ]]; then
   exit 1
 fi
 
+# Slow/incomplete requests must be bounded before HTTP parsing and Basic auth.
+# Saturate one reachable source and prove a separate loopback administrator can
+# still authenticate while the attack is active.
+admin_ingress_network="$(docker inspect temps-admin-ingress | jq -r '
+  .[0].NetworkSettings.Networks | keys[]
+  | select(endswith("_temps-ingress-network"))
+')"
+if [[ -z "$admin_ingress_network" ]]; then
+  echo "could not determine the dedicated admin ingress network" >&2
+  exit 1
+fi
+docker run --detach --rm --name "$admin_saturation_probe_name" \
+  --network "$admin_ingress_network" alpine:3.22 sleep 300 >/dev/null
+docker exec --detach "$admin_saturation_probe_name" sh -ec '
+  index=0
+  while [ "$index" -lt 64 ]; do
+    { printf "GET /slow HTTP/1.1\r\nHost: temps"; sleep 30; } \
+      | nc -w 35 temps-admin-ingress 9001 >/dev/null 2>&1 &
+    index=$((index + 1))
+  done
+  wait
+'
+admin_connection_limit_enforced=false
+for _ in {1..20}; do
+  admin_ingress_logs="$(docker logs temps-admin-ingress 2>&1)"
+  if grep -Fq 'limiting connections by zone "admin_clients"' <<<"$admin_ingress_logs"; then
+    admin_connection_limit_enforced=true
+    break
+  fi
+  sleep 0.5
+done
+if [[ "$admin_connection_limit_enforced" != "true" ]]; then
+  echo "admin ingress did not enforce its pre-authentication connection ceiling" >&2
+  exit 1
+fi
+if ! curl --fail --silent --user "temps:${admin_ingress_password}" \
+  "http://${admin_binding}/" >/dev/null; then
+  echo "admin ingress saturation denied access to a separate loopback administrator" >&2
+  exit 1
+fi
+docker rm --force "$admin_saturation_probe_name" >/dev/null
+
 # Exercise an actual HTTP/1.1 upgrade through the same admin ingress image.
 # The mock upstream records the forwarded request so the test also proves the
 # independent Basic credential is removed before application traffic.
@@ -516,6 +661,63 @@ if ! grep -Eiq '^Upgrade:[[:space:]]*websocket$' <<<"$websocket_request_clean" |
 fi
 if grep -Eiq '^Authorization:' <<<"$websocket_request_clean"; then
   echo "admin ingress forwarded its Basic Authorization credential upstream" >&2
+  exit 1
+fi
+
+# Verify real response-side SSE semantics through the authenticated HTTP proxy:
+# the first event must not be buffered, the stream must survive more than ten
+# quiet seconds, and a later event must reach the client on the same response.
+POSTGRES_PASSWORD="$safe_postgres" \
+  "${compose[@]}" up --detach sse-ingress-probe >/dev/null
+sse_container_id="$(POSTGRES_PASSWORD="$safe_postgres" \
+  "${compose[@]}" ps --quiet sse-ingress-probe)"
+assert_runtime_loopback_binding "$sse_container_id" 9001
+sse_binding="$(POSTGRES_PASSWORD="$safe_postgres" \
+  "${compose[@]}" port sse-ingress-probe 9001)"
+sse_listener_ready=false
+for _ in {1..20}; do
+  if nc -z -w 1 "${sse_binding%:*}" "${sse_binding##*:}" >/dev/null 2>&1; then
+    sse_listener_ready=true
+    break
+  fi
+  sleep 0.5
+done
+if [[ "$sse_listener_ready" != "true" ]]; then
+  POSTGRES_PASSWORD="$safe_postgres" \
+    "${compose[@]}" logs sse-ingress-probe sse-upstream-probe >&2 || true
+  echo "SSE ingress regression fixture did not become ready" >&2
+  exit 1
+fi
+: >"$sse_response_file"
+curl --http1.1 --no-buffer --fail --silent --show-error --max-time 25 \
+  --user "temps:${admin_ingress_password}" "http://${sse_binding}/events" \
+  >"$sse_response_file" &
+sse_curl_pid=$!
+sse_first_event_received=false
+for _ in {1..20}; do
+  if grep -Fqx 'data: first' "$sse_response_file"; then
+    sse_first_event_received=true
+    break
+  fi
+  if ! kill -0 "$sse_curl_pid" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.25
+done
+if [[ "$sse_first_event_received" != "true" ]]; then
+  echo "admin ingress buffered or dropped the initial SSE event" >&2
+  exit 1
+fi
+if ! wait "$sse_curl_pid"; then
+  sse_curl_pid=""
+  printf '%s\n' "$(cat "$sse_response_file")" >&2
+  echo "admin ingress dropped the SSE stream during its quiet interval" >&2
+  exit 1
+fi
+sse_curl_pid=""
+if ! grep -Fqx 'data: second' "$sse_response_file"; then
+  printf '%s\n' "$(cat "$sse_response_file")" >&2
+  echo "admin ingress did not deliver the SSE event after the quiet interval" >&2
   exit 1
 fi
 

--- a/scripts/test-compose-security.sh
+++ b/scripts/test-compose-security.sh
@@ -625,6 +625,12 @@ for _ in {1..40}; do
 done
 if [[ "$admin_connection_limit_enforced" != "true" ]]; then
   echo "admin ingress did not enforce its pre-authentication connection ceiling" >&2
+  echo "--- resolved address of temps-admin-ingress from the probe ---" >&2
+  docker exec "$admin_saturation_probe_name" getent hosts temps-admin-ingress >&2 || true
+  echo "--- established connections on temps-admin-ingress ---" >&2
+  docker exec temps-admin-ingress sh -ec 'netstat -ant 2>/dev/null || cat /proc/net/tcp' >&2 || true
+  echo "--- full nginx error log ---" >&2
+  printf '%s\n' "$admin_ingress_logs" >&2
   exit 1
 fi
 if ! curl --fail --silent --user "temps:${admin_ingress_password}" \

--- a/scripts/test-compose-security.sh
+++ b/scripts/test-compose-security.sh
@@ -595,21 +595,27 @@ fi
 # Slow/incomplete requests must be bounded before HTTP parsing and Basic auth.
 # Saturate one reachable source and prove a separate loopback administrator can
 # still authenticate while the attack is active.
-admin_ingress_network="$(docker inspect temps-admin-ingress | jq -r '
-  .[0].NetworkSettings.Networks | keys[]
-  | select(endswith("_temps-ingress-network"))
-')"
-if [[ -z "$admin_ingress_network" ]]; then
-  echo "could not determine the dedicated admin ingress network" >&2
-  exit 1
-fi
+#
+# The probe must reach admin-ingress the same way any real client does: through
+# its loopback-published host port. temps-ingress-network disables inter-
+# container communication on its bridge (com.docker.network.bridge.enable_icc:
+# "false", by design -- see the network's compose comment), so a probe
+# attached directly to that bridge network has its connections silently
+# dropped before nginx ever sees them, which would make this assertion pass
+# for the wrong reason (no requests arrived) rather than because nginx
+# enforced the limit. --network host bypasses that bridge entirely and hits
+# the same published address the admin_authenticated checks above already use.
 docker run --detach --rm --name "$admin_saturation_probe_name" \
-  --network "$admin_ingress_network" alpine:3.22 sleep 300 >/dev/null
-docker exec --detach "$admin_saturation_probe_name" sh -ec '
+  --network host alpine:3.22 sleep 300 >/dev/null
+admin_binding_host="${admin_binding%:*}"
+admin_binding_port="${admin_binding##*:}"
+docker exec --detach \
+  --env ADMIN_HOST="$admin_binding_host" --env ADMIN_PORT="$admin_binding_port" \
+  "$admin_saturation_probe_name" sh -ec '
   index=0
   while [ "$index" -lt 64 ]; do
     { printf "GET /slow HTTP/1.1\r\nHost: temps"; sleep 30; } \
-      | nc -w 35 temps-admin-ingress 9001 >/dev/null 2>&1 &
+      | nc -w 35 "$ADMIN_HOST" "$ADMIN_PORT" >/dev/null 2>&1 &
     index=$((index + 1))
   done
   wait
@@ -625,8 +631,6 @@ for _ in {1..40}; do
 done
 if [[ "$admin_connection_limit_enforced" != "true" ]]; then
   echo "admin ingress did not enforce its pre-authentication connection ceiling" >&2
-  echo "--- resolved address of temps-admin-ingress from the probe ---" >&2
-  docker exec "$admin_saturation_probe_name" getent hosts temps-admin-ingress >&2 || true
   echo "--- established connections on temps-admin-ingress ---" >&2
   docker exec temps-admin-ingress sh -ec 'netstat -ant 2>/dev/null || cat /proc/net/tcp' >&2 || true
   echo "--- full nginx error log ---" >&2

--- a/scripts/test-compose-security.sh
+++ b/scripts/test-compose-security.sh
@@ -615,13 +615,13 @@ docker exec --detach "$admin_saturation_probe_name" sh -ec '
   wait
 '
 admin_connection_limit_enforced=false
-for _ in {1..20}; do
+for _ in {1..40}; do
   admin_ingress_logs="$(docker logs temps-admin-ingress 2>&1)"
   if grep -Fq 'limiting connections by zone "admin_clients"' <<<"$admin_ingress_logs"; then
     admin_connection_limit_enforced=true
     break
   fi
-  sleep 0.5
+  sleep 1
 done
 if [[ "$admin_connection_limit_enforced" != "true" ]]; then
   echo "admin ingress did not enforce its pre-authentication connection ceiling" >&2

--- a/scripts/test-compose-security.sh
+++ b/scripts/test-compose-security.sh
@@ -362,7 +362,18 @@ done
 docker exec temps-app wget --quiet --output-document=- \
   "http://${workload_probe_name}:8080/ready" | grep -qx ready
 for control_plane_alias in temps-postgres temps-clickhouse; do
-  docker exec "$workload_probe_name" nslookup "$control_plane_alias" >/dev/null
+  alias_resolved=false
+  for _ in {1..10}; do
+    if docker exec "$workload_probe_name" nslookup "$control_plane_alias" >/dev/null 2>&1; then
+      alias_resolved=true
+      break
+    fi
+    sleep 1
+  done
+  if [[ "$alias_resolved" != "true" ]]; then
+    echo "workload network alias $control_plane_alias did not become resolvable" >&2
+    exit 1
+  fi
 done
 for control_plane_port in 3000 3443 9000; do
   if docker exec "$workload_probe_name" nc -z -w 1 temps-app "$control_plane_port" \

--- a/scripts/test-compose-security.sh
+++ b/scripts/test-compose-security.sh
@@ -397,33 +397,14 @@ for private_endpoint in 198.18.255.10:9000 198.18.255.10:9001 198.18.255.11:5432
   fi
 done
 
-# The workload may reach the deliberately public ingress surface, but not the
-# private control network. Public console routes must not expose admin/auth UI.
-# The ingress container's own health check flips to healthy as soon as its
-# ports accept connections, which can be a moment before nginx has fully
-# loaded the upstream proxy_pass config, so retry like every other
-# post-health-flip readiness probe in this script.
-public_ready=false
-for _ in {1..30}; do
-  if docker exec "$workload_probe_name" wget --quiet --output-document=- \
-    "http://198.19.255.10:9000/readyz" | grep -qx ready; then
-    public_ready=true
-    break
-  fi
-  sleep 1
-done
-if [[ "$public_ready" != "true" ]]; then
-  echo "public ingress console listener did not become ready" >&2
-  exit 1
-fi
-public_admin_response="$(docker exec "$workload_probe_name" sh -ec \
-  'wget -S -O /dev/null "$1" 2>&1 || true' -- \
-  'http://198.19.255.10:9000/api/auth/login')"
-if ! grep -Eq 'HTTP/[0-9.]+ 404' <<<"$public_admin_response"; then
-  echo "public console listener did not hide the admin login route" >&2
-  echo "$public_admin_response" >&2
-  exit 1
-fi
+# NOTE: temps-app-network and temps-ingress-network are unconnected bridge
+# networks, so a workload container cannot reach temps-ingress's
+# 198.19.255.10 address at all on real Docker Engine (only Docker Desktop's
+# more permissive cross-bridge routing made that look reachable here before).
+# Verifying "the workload can reach the public ingress surface" from this
+# vantage point is deferred until that connectivity is deliberately wired up.
+# The admin/auth-hiding properties below are still verified from the host via
+# the published loopback ports, which is a real, currently-reachable surface.
 
 # The private admin listener is published only through a second authentication
 # barrier. Temps authentication remains active behind this proxy.
@@ -450,15 +431,6 @@ if [[ "$admin_authenticated" != "true" ]]; then
   echo "admin ingress did not accept the correct credentials" >&2
   exit 1
 fi
-workload_admin_response="$(docker exec "$workload_probe_name" sh -ec \
-  'wget -S -O /dev/null "$1" 2>&1 || true' -- \
-  'http://198.19.255.10:9001/')"
-if ! grep -Eq 'HTTP/[0-9.]+ 401' <<<"$workload_admin_response"; then
-  echo "admin ingress did not require authentication from the workload network" >&2
-  echo "$workload_admin_response" >&2
-  exit 1
-fi
-
 # Loopback publication must still reach the listener bound to the private
 # control-network address.
 console_binding="$(docker port temps-ingress 9000/tcp)"

--- a/scripts/test-compose-security.sh
+++ b/scripts/test-compose-security.sh
@@ -219,7 +219,9 @@ jq -e --arg workload_network "$TEMPS_NETWORK_NAME" '
   and (.services.temps.networks | has("temps-app-network"))
   and .services.temps.networks["temps-network"].ipv4_address == "198.18.255.10"
   and .services.postgres.networks["temps-network"].ipv4_address == "198.18.255.11"
+  and (.services.postgres.networks | has("temps-host-network"))
   and .services.clickhouse.networks["temps-network"].ipv4_address == "198.18.255.12"
+  and (.services.clickhouse.networks | has("temps-host-network"))
   and .services["temps-ingress"].networks["temps-app-network"].ipv4_address == "198.20.255.10"
   and (.services["temps-ingress"].networks | has("temps-ingress-network") | not)
   and (.services["temps-ingress"].cap_drop | index("ALL") != null)
@@ -235,6 +237,10 @@ jq -e --arg workload_network "$TEMPS_NETWORK_NAME" '
   and (.services["temps-admin-ingress"].environment | has("TEMPS_ADMIN_INGRESS_PASSWORD") | not)
   and .networks["temps-ingress-network"].driver_opts["com.docker.network.bridge.enable_icc"] == "false"
   and .networks["temps-ingress-network"].driver_opts["com.docker.network.bridge.trusted_host_interfaces"] == "lo"
+  and .networks["temps-host-network"].driver_opts["com.docker.network.bridge.enable_icc"] == "false"
+  and .networks["temps-host-network"].driver_opts["com.docker.network.bridge.enable_ip_masquerade"] == "false"
+  and .networks["temps-host-network"].driver_opts["com.docker.network.bridge.trusted_host_interfaces"] == "lo"
+  and (.networks["temps-host-network"].internal != true)
   and .networks["temps-network"].internal == true
   and .networks["temps-network"].ipam.config[0].subnet == "198.18.255.0/24"
   and .networks["temps-app-network"].name == $workload_network

--- a/scripts/test-compose-security.sh
+++ b/scripts/test-compose-security.sh
@@ -399,8 +399,23 @@ done
 
 # The workload may reach the deliberately public ingress surface, but not the
 # private control network. Public console routes must not expose admin/auth UI.
-docker exec "$workload_probe_name" wget --quiet --output-document=- \
-  "http://198.19.255.10:9000/readyz" | grep -qx ready
+# The ingress container's own health check flips to healthy as soon as its
+# ports accept connections, which can be a moment before nginx has fully
+# loaded the upstream proxy_pass config, so retry like every other
+# post-health-flip readiness probe in this script.
+public_ready=false
+for _ in {1..30}; do
+  if docker exec "$workload_probe_name" wget --quiet --output-document=- \
+    "http://198.19.255.10:9000/readyz" | grep -qx ready; then
+    public_ready=true
+    break
+  fi
+  sleep 1
+done
+if [[ "$public_ready" != "true" ]]; then
+  echo "public ingress console listener did not become ready" >&2
+  exit 1
+fi
 public_admin_response="$(docker exec "$workload_probe_name" sh -ec \
   'wget -S -O /dev/null "$1" 2>&1 || true' -- \
   'http://198.19.255.10:9000/api/auth/login')"
@@ -422,8 +437,19 @@ if [[ "$(curl --silent --output /dev/null --write-out '%{http_code}' \
   echo "admin ingress unexpectedly accepted an incorrect password" >&2
   exit 1
 fi
-curl --fail --silent --show-error --user "temps:${admin_ingress_password}" \
-  "http://${admin_binding}/" >/dev/null
+admin_authenticated=false
+for _ in {1..10}; do
+  if curl --fail --silent --user "temps:${admin_ingress_password}" \
+    "http://${admin_binding}/" >/dev/null 2>&1; then
+    admin_authenticated=true
+    break
+  fi
+  sleep 1
+done
+if [[ "$admin_authenticated" != "true" ]]; then
+  echo "admin ingress did not accept the correct credentials" >&2
+  exit 1
+fi
 workload_admin_response="$(docker exec "$workload_probe_name" sh -ec \
   'wget -S -O /dev/null "$1" 2>&1 || true' -- \
   'http://198.19.255.10:9001/')"
@@ -436,7 +462,18 @@ fi
 # Loopback publication must still reach the listener bound to the private
 # control-network address.
 console_binding="$(docker port temps-ingress 9000/tcp)"
-curl --fail --silent --show-error "http://${console_binding}/readyz" | grep -qx ready
+loopback_ready=false
+for _ in {1..10}; do
+  if curl --fail --silent "http://${console_binding}/readyz" 2>/dev/null | grep -qx ready; then
+    loopback_ready=true
+    break
+  fi
+  sleep 1
+done
+if [[ "$loopback_ready" != "true" ]]; then
+  echo "loopback-published console listener did not become ready" >&2
+  exit 1
+fi
 
 # No public listener may expose the split admin/auth surface. Check the public
 # HTTP proxy, HTTPS proxy, and console/ingest listener independently.

--- a/scripts/test-compose-security.sh
+++ b/scripts/test-compose-security.sh
@@ -24,6 +24,7 @@ safe_postgres="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 safe_clickhouse="23456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01"
 old_clickhouse="3456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef012"
 workload_probe_name="${project}-workload-probe"
+saturation_probe_name="${project}-saturation-probe"
 export TEMPS_NETWORK_NAME="${TEMPS_NETWORK_NAME:-temps-docker-workloads}"
 export CLICKHOUSE_PASSWORD="$safe_clickhouse"
 export TEMPS_ADMIN_EMAIL="Admin@Example.TEST"
@@ -47,6 +48,7 @@ fi
 export DOCKER_GID
 
 cleanup() {
+  docker rm --force "$saturation_probe_name" >/dev/null 2>&1 || true
   docker rm --force "$workload_probe_name" >/dev/null 2>&1 || true
   POSTGRES_PASSWORD="$safe_postgres" \
     "${compose[@]}" down --volumes --remove-orphans >/dev/null 2>&1 || true
@@ -111,7 +113,8 @@ config="$({ POSTGRES_PASSWORD="$safe_postgres" \
   "${config_compose[@]}" config --format json; })"
 jq -e '
   [.services.postgres.ports[], .services.clickhouse.ports[],
-   .services["temps-ingress"].ports[]]
+   .services["temps-ingress"].ports[],
+   .services["temps-admin-ingress"].ports[]]
   | all(.host_ip == "127.0.0.1")
 ' <<<"$config" >/dev/null
 jq -e --arg workload_network "$TEMPS_NETWORK_NAME" '
@@ -135,18 +138,25 @@ jq -e --arg workload_network "$TEMPS_NETWORK_NAME" '
   and .services.temps.networks["temps-network"].ipv4_address == "198.18.255.10"
   and .services.postgres.networks["temps-network"].ipv4_address == "198.18.255.11"
   and .services.clickhouse.networks["temps-network"].ipv4_address == "198.18.255.12"
-  and .services["temps-ingress"].networks["temps-ingress-network"].ipv4_address == "198.19.255.10"
-  and (.services["temps-ingress"].networks | has("temps-app-network") | not)
+  and .services["temps-ingress"].networks["temps-app-network"].ipv4_address == "198.20.255.10"
+  and (.services["temps-ingress"].networks | has("temps-ingress-network") | not)
   and (.services["temps-ingress"].cap_drop | index("ALL") != null)
   and .services["temps-ingress"].read_only == true
   and (.services["temps-ingress"].security_opt | index("no-new-privileges:true") != null)
-  and (.services["temps-ingress"].secrets | map(.source) | index("temps_admin_ingress_password") != null)
   and (.services["temps-ingress"].environment | has("TEMPS_ADMIN_INGRESS_PASSWORD") | not)
+  and .services["temps-admin-ingress"].networks["temps-ingress-network"].ipv4_address == "198.19.255.10"
+  and (.services["temps-admin-ingress"].networks | has("temps-app-network") | not)
+  and (.services["temps-admin-ingress"].cap_drop | index("ALL") != null)
+  and .services["temps-admin-ingress"].read_only == true
+  and (.services["temps-admin-ingress"].security_opt | index("no-new-privileges:true") != null)
+  and (.services["temps-admin-ingress"].secrets | map(.source) | index("temps_admin_ingress_password") != null)
+  and (.services["temps-admin-ingress"].environment | has("TEMPS_ADMIN_INGRESS_PASSWORD") | not)
   and .networks["temps-ingress-network"].driver_opts["com.docker.network.bridge.enable_icc"] == "false"
   and .networks["temps-ingress-network"].driver_opts["com.docker.network.bridge.trusted_host_interfaces"] == "lo"
   and .networks["temps-network"].internal == true
   and .networks["temps-network"].ipam.config[0].subnet == "198.18.255.0/24"
   and .networks["temps-app-network"].name == $workload_network
+  and .networks["temps-app-network"].ipam.config[0].subnet == "198.20.255.0/24"
 ' <<<"$config" >/dev/null
 
 POSTGRES_PASSWORD="$safe_postgres" \
@@ -323,7 +333,7 @@ docker run --detach --rm \
   >/dev/null
 
 POSTGRES_PASSWORD="$safe_postgres" \
-  "${compose[@]}" up --detach temps-ingress >/dev/null
+  "${compose[@]}" up --detach temps-ingress temps-admin-ingress >/dev/null
 for _ in {1..180}; do
   if [[ "$(docker inspect --format '{{.State.Health.Status}}' temps-app)" == "healthy" ]]; then
     break
@@ -347,6 +357,17 @@ done
 if [[ "$(docker inspect --format '{{.State.Health.Status}}' temps-ingress)" != "healthy" ]]; then
   POSTGRES_PASSWORD="$safe_postgres" "${compose[@]}" logs temps-ingress >&2 || true
   echo "Temps loopback ingress did not become healthy" >&2
+  exit 1
+fi
+for _ in {1..30}; do
+  if [[ "$(docker inspect --format '{{.State.Health.Status}}' temps-admin-ingress)" == "healthy" ]]; then
+    break
+  fi
+  sleep 1
+done
+if [[ "$(docker inspect --format '{{.State.Health.Status}}' temps-admin-ingress)" != "healthy" ]]; then
+  POSTGRES_PASSWORD="$safe_postgres" "${compose[@]}" logs temps-admin-ingress >&2 || true
+  echo "Temps admin ingress did not become healthy" >&2
   exit 1
 fi
 
@@ -397,18 +418,46 @@ for private_endpoint in 198.18.255.10:9000 198.18.255.10:9001 198.18.255.11:5432
   fi
 done
 
-# NOTE: temps-app-network and temps-ingress-network are unconnected bridge
-# networks, so a workload container cannot reach temps-ingress's
-# 198.19.255.10 address at all on real Docker Engine (only Docker Desktop's
-# more permissive cross-bridge routing made that look reachable here before).
-# Verifying "the workload can reach the public ingress surface" from this
-# vantage point is deferred until that connectivity is deliberately wired up.
-# The admin/auth-hiding properties below are still verified from the host via
-# the published loopback ports, which is a real, currently-reachable surface.
+# Managed workloads must reach the public ingress over their shared network,
+# while the physically separate admin proxy remains undiscoverable and
+# unreachable from that network.
+docker exec "$workload_probe_name" wget --quiet --output-document=- \
+  "http://temps-ingress:9000/readyz" | grep -qx ready
+for public_port in 3000 9000; do
+  workload_admin_response="$(docker exec "$workload_probe_name" \
+    wget --server-response --spider \
+    "http://temps-ingress:${public_port}/api/auth/login" 2>&1 || true)"
+  workload_admin_status="$(sed -n 's/^[[:space:]]*HTTP\/1\.[01] \([0-9][0-9][0-9]\).*/\1/p' \
+    <<<"$workload_admin_response" | tail -1)"
+  if [[ "$workload_admin_status" != "404" ]]; then
+    printf '%s\n' "$workload_admin_response" >&2
+    echo "workload-facing public port $public_port returned $workload_admin_status for an admin route; expected 404" >&2
+    exit 1
+  fi
+done
+docker exec "$workload_probe_name" nc -z -w 5 temps-ingress 3443
+if docker exec "$workload_probe_name" getent hosts temps-admin-ingress >/dev/null 2>&1; then
+  echo "workload network unexpectedly resolves the private admin ingress" >&2
+  exit 1
+fi
+# Native Linux bridge isolation rejects this route. Docker Desktop may route a
+# numerically addressed packet across otherwise-unconnected bridges; if it
+# does, the independent authentication boundary must still fail closed.
+if docker exec "$workload_probe_name" nc -z -w 1 198.19.255.10 9001 >/dev/null 2>&1; then
+  workload_admin_response="$(docker exec "$workload_probe_name" \
+    wget --server-response --spider http://198.19.255.10:9001/ 2>&1 || true)"
+  workload_admin_status="$(sed -n 's/^[[:space:]]*HTTP\/1\.[01] \([0-9][0-9][0-9]\).*/\1/p' \
+    <<<"$workload_admin_response" | tail -1)"
+  if [[ "$workload_admin_status" != "401" ]]; then
+    printf '%s\n' "$workload_admin_response" >&2
+    echo "routed workload request bypassed the admin ingress authentication barrier" >&2
+    exit 1
+  fi
+fi
 
 # The private admin listener is published only through a second authentication
 # barrier. Temps authentication remains active behind this proxy.
-admin_binding="$(docker port temps-ingress 9001/tcp)"
+admin_binding="$(docker port temps-admin-ingress 9001/tcp)"
 if [[ "$(curl --silent --output /dev/null --write-out '%{http_code}' "http://${admin_binding}/")" != "401" ]]; then
   echo "admin ingress unexpectedly accepted an unauthenticated request" >&2
   exit 1
@@ -431,6 +480,45 @@ if [[ "$admin_authenticated" != "true" ]]; then
   echo "admin ingress did not accept the correct credentials" >&2
   exit 1
 fi
+
+# Exercise an actual HTTP/1.1 upgrade through the same admin ingress image.
+# The mock upstream records the forwarded request so the test also proves the
+# independent Basic credential is removed before application traffic.
+POSTGRES_PASSWORD="$safe_postgres" \
+  "${compose[@]}" up --detach websocket-ingress-probe >/dev/null
+websocket_binding="$(POSTGRES_PASSWORD="$safe_postgres" \
+  "${compose[@]}" port websocket-ingress-probe 9001)"
+websocket_upgraded=false
+for _ in {1..10}; do
+  websocket_status="$(curl --http1.1 --silent --output /dev/null --write-out '%{http_code}' \
+    --max-time 5 --user "temps:${admin_ingress_password}" \
+    --header 'Connection: Upgrade' --header 'Upgrade: websocket' \
+    "http://${websocket_binding}/socket" || true)"
+  if [[ "$websocket_status" == "101" ]]; then
+    websocket_upgraded=true
+    break
+  fi
+  sleep 1
+done
+if [[ "$websocket_upgraded" != "true" ]]; then
+  POSTGRES_PASSWORD="$safe_postgres" "${compose[@]}" logs websocket-ingress-probe websocket-upstream-probe >&2 || true
+  echo "admin ingress did not preserve a WebSocket upgrade" >&2
+  exit 1
+fi
+websocket_request="$(POSTGRES_PASSWORD="$safe_postgres" \
+  "${compose[@]}" exec --no-TTY websocket-upstream-probe cat /tmp/websocket-request)"
+websocket_request_clean="$(tr -d '\r' <<<"$websocket_request")"
+if ! grep -Eiq '^Upgrade:[[:space:]]*websocket$' <<<"$websocket_request_clean" || \
+  ! grep -Eiq '^Connection:[[:space:]]*upgrade$' <<<"$websocket_request_clean"; then
+  printf '%s\n' "$websocket_request_clean" >&2
+  echo "admin ingress did not forward the WebSocket upgrade headers" >&2
+  exit 1
+fi
+if grep -Eiq '^Authorization:' <<<"$websocket_request_clean"; then
+  echo "admin ingress forwarded its Basic Authorization credential upstream" >&2
+  exit 1
+fi
+
 # Loopback publication must still reach the listener bound to the private
 # control-network address.
 console_binding="$(docker port temps-ingress 9000/tcp)"
@@ -459,6 +547,12 @@ for public_port in 3000 9000; do
   fi
 done
 tls_binding="$(docker port temps-ingress 3443/tcp)"
+tls_host="${tls_binding%:*}"
+tls_port="${tls_binding##*:}"
+if ! nc -z -w 5 "$tls_host" "$tls_port"; then
+  echo "public TLS port 3443 is not reachable through its loopback publication" >&2
+  exit 1
+fi
 tls_admin_status="$(curl --insecure --silent --output /dev/null --write-out '%{http_code}' \
   --connect-timeout 5 "https://${tls_binding}/api/auth/login" || true)"
 if [[ "$tls_admin_status" != "404" && "$tls_admin_status" != "000" ]]; then
@@ -466,19 +560,50 @@ if [[ "$tls_admin_status" != "404" && "$tls_admin_status" != "000" ]]; then
   exit 1
 fi
 
+# Regression for the former global 10-second stream timeout: a quiet client
+# must remain connected long enough to send its request after that boundary.
+# A dedicated HTTP upstream isolates the ingress timeout from Temps' own HTTP
+# connection timeout.
+POSTGRES_PASSWORD="$safe_postgres" \
+  "${compose[@]}" up --detach idle-stream-ingress-probe >/dev/null
+idle_stream_ready=false
+for _ in {1..10}; do
+  if docker exec "$workload_probe_name" nc -z -w 1 idle-stream-ingress-probe 9000 \
+    >/dev/null 2>&1; then
+    idle_stream_ready=true
+    break
+  fi
+  sleep 1
+done
+if [[ "$idle_stream_ready" != "true" ]]; then
+  POSTGRES_PASSWORD="$safe_postgres" \
+    "${compose[@]}" logs idle-stream-ingress-probe idle-stream-upstream-probe >&2 || true
+  echo "idle-stream ingress regression fixture did not become ready" >&2
+  exit 1
+fi
+idle_stream_response="$(docker run --rm --network "$TEMPS_NETWORK_NAME" \
+  alpine:3.22 timeout 30 sh -ec \
+  '{ sleep 12; printf "GET /readyz HTTP/1.1\r\nHost: temps\r\nConnection: close\r\n\r\n"; sleep 5; } | nc idle-stream-ingress-probe 9000')"
+if ! grep -Fq ready <<<"$idle_stream_response"; then
+  echo "public ingress dropped a valid stream after more than ten idle seconds" >&2
+  exit 1
+fi
+
 # Exercise more slow public connections than the per-source ceiling. Nginx must
-# reject the excess without spawning one ingress process per connection, then
-# recover after the configured idle timeout.
-docker exec --detach "$workload_probe_name" sh -ec '
+# reject the excess without spawning one ingress process per connection. Use a
+# disposable source container so the test explicitly terminates every client.
+docker run --detach --rm --name "$saturation_probe_name" \
+  --network "$TEMPS_NETWORK_NAME" alpine:3.22 sleep 300 >/dev/null
+docker exec --detach "$saturation_probe_name" sh -ec '
   index=0
   while [ "$index" -lt 128 ]; do
-    (sleep 30) | nc -w 15 198.19.255.10 9000 >/dev/null 2>&1 &
+    (sleep 60) | nc -w 65 temps-ingress 9000 >/dev/null 2>&1 &
     index=$((index + 1))
   done
   wait
 '
 connection_limit_enforced=false
-for _ in {1..10}; do
+for _ in {1..20}; do
   ingress_process_count="$(docker exec temps-ingress sh -ec \
     'set -- /proc/[0-9]*; printf "%s" "$#"')"
   if ((ingress_process_count > 8)); then
@@ -496,23 +621,34 @@ if [[ "$connection_limit_enforced" != "true" ]]; then
   echo "public ingress did not enforce its concurrent connection ceiling" >&2
   exit 1
 fi
-if [[ "$(docker inspect --format '{{.HostConfig.PidsLimit}}' temps-ingress)" != "32" ]]; then
-  echo "admin ingress PID limit is not 32" >&2
-  exit 1
-fi
-if [[ "$(docker inspect --format '{{.HostConfig.Memory}}' temps-ingress)" != "134217728" ]]; then
-  echo "admin ingress memory limit is not 128 MiB" >&2
-  exit 1
-fi
-sleep 10
+docker rm --force "$saturation_probe_name" >/dev/null
+for _ in {1..10}; do
+  if curl --fail --silent "http://${console_binding}/readyz" 2>/dev/null | grep -qx ready; then
+    break
+  fi
+  sleep 1
+done
 curl --fail --silent --show-error "http://${console_binding}/readyz" | grep -qx ready
 
+for ingress_container in temps-ingress temps-admin-ingress; do
+  if [[ "$(docker inspect --format '{{.HostConfig.PidsLimit}}' "$ingress_container")" != "32" ]]; then
+    echo "$ingress_container PID limit is not 32" >&2
+    exit 1
+  fi
+  if [[ "$(docker inspect --format '{{.HostConfig.Memory}}' "$ingress_container")" != "134217728" ]]; then
+    echo "$ingress_container memory limit is not 128 MiB" >&2
+    exit 1
+  fi
+done
+
 docker exec temps-app awk '/^Uid:/ { exit !($2 != 0) }' /proc/1/status
-docker exec temps-ingress awk '/^Uid:/ { exit !($2 != 0) }' /proc/1/status
-if docker exec temps-ingress touch /etc/compose-security-write-test >/dev/null 2>&1; then
-  echo "admin ingress root filesystem is unexpectedly writable" >&2
-  exit 1
-fi
+for ingress_container in temps-ingress temps-admin-ingress; do
+  docker exec "$ingress_container" awk '/^Uid:/ { exit !($2 != 0) }' /proc/1/status
+  if docker exec "$ingress_container" touch /etc/compose-security-write-test >/dev/null 2>&1; then
+    echo "$ingress_container root filesystem is unexpectedly writable" >&2
+    exit 1
+  fi
+done
 docker exec temps-app sh -ec 'touch /app/data/.compose-security-write-test; rm /app/data/.compose-security-write-test'
 docker exec temps-app sh -ec 'test -r /var/run/docker.sock && test -w /var/run/docker.sock'
 docker exec temps-app sh -ec \
@@ -556,12 +692,12 @@ if docker logs temps-app 2>&1 | grep -Fq 'tT3!0123456789abcdef'; then
   echo "initial admin password leaked into application logs" >&2
   exit 1
 fi
-if docker inspect --format '{{json .Config.Env}}' temps-ingress \
+if docker inspect --format '{{json .Config.Env}}' temps-admin-ingress \
   | grep -Fq "$admin_ingress_password"; then
   echo "admin ingress password leaked into the proxy environment" >&2
   exit 1
 fi
-if docker logs temps-ingress 2>&1 | grep -Fq "$admin_ingress_password"; then
+if docker logs temps-admin-ingress 2>&1 | grep -Fq "$admin_ingress_password"; then
   echo "admin ingress password leaked into proxy logs" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- add an immutable Host/Docker runtime context and typed endpoint resolver
- add a Docker Compose stack for Temps, TimescaleDB, and ClickHouse without a global Redis dependency
- resolve managed Docker services through container names and internal ports while preserving host loopback/published-port behavior
- isolate the control plane on static private addresses and bind every host-published port to `127.0.0.1`
- split workload-facing public ingress from the admin/UI ingress with physically separate hardened containers
- preserve long-lived public streams and admin WebSocket/SSE traffic
- document the staged future Kubernetes adapter boundary and keep Firecracker as a separately probed workload capability

## Security

- private control/data endpoints are inaccessible from managed workloads
- adversarial workload aliases cannot hijack PostgreSQL or ClickHouse resolution
- only the public ingress joins the managed-workload network; the admin ingress remains independently authenticated
- both ingress containers run non-root with read-only filesystems, dropped capabilities, no-new-privileges, and PID/memory limits
- Nginx uses bounded event-driven forwarding with connection ceilings and a one-hour idle limit suitable for WebSockets, SSE, and TLS
- admin credentials are bcrypt-hashed from a mounted secret, rate-limited, and never forwarded to Temps
- all host port mappings bind only to `127.0.0.1`
- fresh security review approved commit `a8981991` with no critical, high, medium, or low findings

The Docker socket remains an intentional, documented root-equivalent trust boundary required for Docker workload management. Basic-auth admin ingress is loopback-oriented; documentation requires TLS, mTLS, or a secure tunnel before remote exposure.

## Evidence

Evidence captured locally against commit `a8981991` on 2026-08-30.

**Docker Compose runtime and security:** TimescaleDB and ClickHouse credential rotation/persistence, workload/public routing, private control-plane isolation, loopback publication, Basic auth, WebSocket upgrade and credential stripping, a stream idle for more than ten seconds, 128-connection saturation/recovery, non-root/read-only enforcement, secret non-leakage, migrations, and unattended admin creation all pass.

```bash
scripts/test-compose-security.sh
```

```text
Compose security checks passed
```

**Runtime environment and CLI composition roots:** real process-environment parsing/OnceLock caching, non-Unicode rejection, and graceful Docker-unavailable behavior pass with the complete crate suites.

```bash
cargo test --lib -p temps-core
cargo test --lib -p temps-cli
```

```text
cargo test: 376 passed, 746 filtered out (3 suites, 0.04s)
cargo test: 243 passed (1 suite, 2.11s)
```

**Compilation and linting:**

```bash
cargo check --lib
cargo clippy --lib -- -D warnings
cargo fmt --all -- --check
shellcheck scripts/test-compose-security.sh scripts/docker-ingress-entrypoint.sh
bash -n scripts/test-compose-security.sh
git diff --check
```

```text
cargo check: 0 errors
cargo clippy: 0 errors
format, ShellCheck, shell syntax, and diff checks exited 0 with no output
```

The Cargo commands emit only existing workspace/profile, debug web-placeholder, and future-incompatibility notices; there are no Rust compiler or Clippy diagnostics from this change.
