### PR TITLE
fix(web): stop login form from resetting while the user is typing

### DIFF
--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/api/client/@tanstack/react-query.gen'
 import { UserResponse } from '@/api/client/types.gen'
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { createContext, useContext, useState, ReactNode } from 'react'
+import { createContext, useContext, ReactNode } from 'react'
 
 interface AuthContextType {
   user: UserResponse | null
@@ -24,6 +24,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     data: user,
     isLoading: userLoading,
     error: userError,
+    dataUpdatedAt,
+    errorUpdatedAt,
     refetch: refetchUser,
   } = useQuery({
     ...getCurrentUserOptions({}),
@@ -56,19 +58,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // -- wiping any in-progress email/password input. Only the very FIRST
   // resolution (success or error) should count as "loading"; every
   // subsequent refetch should be invisible to consumers already showing the
-  // login screen. `hasResolvedOnce` latches true the first time the query
-  // leaves its loading state and never resets — set during render (React's
-  // documented "adjusting state during rendering" pattern) rather than in an
-  // effect, so the latch applies to the very render that needs it instead of
-  // one tick later.
-  const [prevUserLoading, setPrevUserLoading] = useState(userLoading)
-  const [hasResolvedOnce, setHasResolvedOnce] = useState(false)
-  if (userLoading !== prevUserLoading) {
-    setPrevUserLoading(userLoading)
-    if (!userLoading) {
-      setHasResolvedOnce(true)
-    }
-  }
+  // login screen. `dataUpdatedAt`/`errorUpdatedAt` are timestamps TanStack
+  // Query itself maintains on the query (0 until it has settled once), so
+  // this is a plain derivation of query state every render rather than a
+  // second state machine that has to be kept in sync with it.
+  const hasResolvedOnce = dataUpdatedAt > 0 || errorUpdatedAt > 0
 
   const { mutateAsync: logout } = useMutation({
     ...logoutMutation({}),

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/api/client/@tanstack/react-query.gen'
 import { UserResponse } from '@/api/client/types.gen'
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { createContext, useContext, ReactNode } from 'react'
+import { createContext, useContext, useState, ReactNode } from 'react'
 
 interface AuthContextType {
   user: UserResponse | null
@@ -47,6 +47,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     gcTime: 1000 * 60 * 10, // Keep in cache for 10 minutes
   })
 
+  // `getCurrentUser` never holds data while logged out, so TanStack Query
+  // resets its status to 'pending' (userLoading -> true) on every refetch,
+  // not just the first one -- including refetches an unrelated query
+  // triggers by invalidating this query's key after a 401 of its own (see
+  // App.tsx's QueryCache.onError). ProtectedLayout renders a full-screen
+  // spinner while `isLoading` is true, which unmounts and remounts <Login />
+  // -- wiping any in-progress email/password input. Only the very FIRST
+  // resolution (success or error) should count as "loading"; every
+  // subsequent refetch should be invisible to consumers already showing the
+  // login screen. `hasResolvedOnce` latches true the first time the query
+  // leaves its loading state and never resets — set during render (React's
+  // documented "adjusting state during rendering" pattern) rather than in an
+  // effect, so the latch applies to the very render that needs it instead of
+  // one tick later.
+  const [prevUserLoading, setPrevUserLoading] = useState(userLoading)
+  const [hasResolvedOnce, setHasResolvedOnce] = useState(false)
+  if (userLoading !== prevUserLoading) {
+    setPrevUserLoading(userLoading)
+    if (!userLoading) {
+      setHasResolvedOnce(true)
+    }
+  }
+
   const { mutateAsync: logout } = useMutation({
     ...logoutMutation({}),
     meta: {
@@ -59,7 +82,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const value = {
     user: user || null,
-    isLoading: userLoading,
+    isLoading: userLoading && !hasResolvedOnce,
     error: userError as Error | null,
     logout: async () => {
       await logout({})

--- a/web/src/contexts/PresetContext.tsx
+++ b/web/src/contexts/PresetContext.tsx
@@ -3,7 +3,7 @@
 
 import { createContext, useContext, ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { listPresetsOptions } from '@/api/client/@tanstack/react-query.gen'
+import { listPresets } from '@/api/client'
 import type { PresetResponse } from '@/api/client'
 import { useAuth } from '@/contexts/AuthContext'
 
@@ -19,7 +19,17 @@ const PresetContext = createContext<PresetContextType | undefined>(undefined)
 export function PresetProvider({ children }: { children: ReactNode }) {
   const { user } = useAuth()
   const { data, isLoading, error } = useQuery({
-    ...listPresetsOptions(),
+    // Scoped to `user?.id` for the same reason as ProjectsContext's query --
+    // the generated `listPresetsOptions()` key carries no identity, and the
+    // 1-hour staleTime below means a re-enabled query on an identity-
+    // independent key could serve a previous account's presets from cache
+    // without ever refetching after a different account signs in without a
+    // full page reload. Each account gets its own cache slot instead.
+    queryKey: ['listPresets', user?.id] as const,
+    queryFn: async ({ signal }) => {
+      const { data } = await listPresets({ signal, throwOnError: true })
+      return data
+    },
     staleTime: 1000 * 60 * 60, // Cache for 1 hour
     gcTime: 1000 * 60 * 60 * 24, // Keep in cache for 24 hours
     // PresetProvider wraps the whole app, including the logged-out login

--- a/web/src/contexts/PresetContext.tsx
+++ b/web/src/contexts/PresetContext.tsx
@@ -5,6 +5,7 @@ import { createContext, useContext, ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { listPresetsOptions } from '@/api/client/@tanstack/react-query.gen'
 import type { PresetResponse } from '@/api/client'
+import { useAuth } from '@/contexts/AuthContext'
 
 interface PresetContextType {
   presets: PresetResponse[]
@@ -16,10 +17,15 @@ interface PresetContextType {
 const PresetContext = createContext<PresetContextType | undefined>(undefined)
 
 export function PresetProvider({ children }: { children: ReactNode }) {
+  const { user } = useAuth()
   const { data, isLoading, error } = useQuery({
     ...listPresetsOptions(),
     staleTime: 1000 * 60 * 60, // Cache for 1 hour
     gcTime: 1000 * 60 * 60 * 24, // Keep in cache for 24 hours
+    // PresetProvider wraps the whole app, including the logged-out login
+    // screen -- see the matching comment in ProjectsContext.tsx for why this
+    // must not fire while logged out.
+    enabled: !!user,
   })
 
   const presets = data?.presets || []

--- a/web/src/contexts/ProjectsContext.tsx
+++ b/web/src/contexts/ProjectsContext.tsx
@@ -5,6 +5,7 @@ import { ProjectResponse } from '@/api/client'
 import { getProjectsOptions } from '@/api/client/@tanstack/react-query.gen'
 import { useQuery } from '@tanstack/react-query'
 import { createContext, useContext } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
 
 interface ProjectsContextType {
   projects: ProjectResponse[]
@@ -17,6 +18,7 @@ const ProjectsContext = createContext<ProjectsContextType>({
 })
 
 export function ProjectsProvider({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth()
   const { data, isLoading } = useQuery({
     ...getProjectsOptions({
       query: {
@@ -24,6 +26,12 @@ export function ProjectsProvider({ children }: { children: React.ReactNode }) {
         per_page: 4,
       },
     }),
+    // ProjectsProvider wraps the whole app, including the logged-out login
+    // screen. Without this, every logged-out visitor's browser fires this
+    // authenticated query, gets a 401, and (via App.tsx's QueryCache.onError)
+    // invalidates the current-user query -- which flips AuthContext's
+    // loading state and remounts <Login />, wiping in-progress form input.
+    enabled: !!user,
   })
 
   return (

--- a/web/src/contexts/ProjectsContext.tsx
+++ b/web/src/contexts/ProjectsContext.tsx
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2024-2026 Temps Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-import { ProjectResponse } from '@/api/client'
-import { getProjectsOptions } from '@/api/client/@tanstack/react-query.gen'
+import { getProjects, ProjectResponse } from '@/api/client'
 import { useQuery } from '@tanstack/react-query'
 import { createContext, useContext } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
@@ -20,12 +19,23 @@ const ProjectsContext = createContext<ProjectsContextType>({
 export function ProjectsProvider({ children }: { children: React.ReactNode }) {
   const { user } = useAuth()
   const { data, isLoading } = useQuery({
-    ...getProjectsOptions({
-      query: {
-        page: 1,
-        per_page: 4,
-      },
-    }),
+    // The generated `getProjectsOptions()` key carries no identity, so a
+    // session that expires and is followed by a different account signing
+    // in (no full page reload in between) would re-enable that same cache
+    // entry and could serve the previous account's cached projects while
+    // this query's background refetch is in flight. Scoping the key to
+    // `user?.id` directly (instead of overriding the generated options'
+    // key, which is typed as a fixed-shape tuple) gives every account its
+    // own cache slot, so switching accounts always starts from empty.
+    queryKey: ['getProjects', { page: 1, per_page: 4 }, user?.id] as const,
+    queryFn: async ({ signal }) => {
+      const { data } = await getProjects({
+        query: { page: 1, per_page: 4 },
+        signal,
+        throwOnError: true,
+      })
+      return data
+    },
     // ProjectsProvider wraps the whole app, including the logged-out login
     // screen. Without this, every logged-out visitor's browser fires this
     // authenticated query, gets a 401, and (via App.tsx's QueryCache.onError)


### PR DESCRIPTION
## Summary
Reported bug (confirmed in prod, not just local dev): typing into the login screen's email/password fields would suddenly lose everything typed.

Root cause was a **remount**, not a real page reload:
- `ProjectsProvider` and `PresetProvider` are mounted above the router (`App.tsx`), so they're active on the logged-out login screen too, and their `getProjects`/`listPresets` queries always fire and always 401 while logged out.
- The global `QueryCache.onError` handler in `App.tsx` reacts to any non-current-user 401 by invalidating the current-user query, which momentarily resets its status to `'pending'` — TanStack Query resets a query's status on every refetch when it has no cached data (always true here for a logged-out `getCurrentUser`).
- `ProtectedLayout` renders a full-screen spinner while `isLoading` is `true`, swapping `<Login/>` out for the spinner and back on every one of these refetches — destroying the login form's local `react-hook-form` state each time.

## Fix
Two parts, addressing both the trigger and the fragile render logic:
1. Gate `ProjectsContext`'s and `PresetContext`'s queries with `enabled: !!user`, so logged-out visitors never fire them — removing the 401 storm at the source.
2. `AuthContext` now latches `isLoading` false after the query's first resolution (success or error), so a background refetch of an already-settled, still-erroring `getCurrentUser` can no longer flip `isLoading` back to `true` and force `ProtectedLayout` to remount the login screen. This also hardens against any *other* future always-mounted authenticated query causing the same symptom.

## Test plan
- [x] `bun run tsc --noEmit` in `web/` — clean.
- [x] `bunx eslint` on the three changed files — clean (no errors; only pre-existing `react-refresh/only-export-components` warnings unrelated to this change).
- [x] `python3 scripts/source_attribution.py check` — passed.
- [x] Live browser verification (Playwright) against a local dev server: typed into email/password fields with 600ms delays between keystrokes (~20s total including idle time) — form values fully preserved throughout, and zero 401s observed from `/api/projects` or `/api/presets` (only the expected `/api/user/me` check). Confirmed via screenshot/console inspection.
- [x] Live browser verification that a real login still completes end-to-end (redirects to `/projects`, no console errors) — regression check that the fix doesn't break normal auth flow.