### PR TITLE
fix(web): remove redundant deployment success toasts

### DIFF
--- a/web/src/components/project/ProjectDeployments.tsx
+++ b/web/src/components/project/ProjectDeployments.tsx
@@ -131,7 +131,6 @@ export function ProjectDeployments({ project }: { project: ProjectResponse }) {
         }
         setSearchParams({}, { replace: true })
         initialDeploymentCountRef.current = null
-        toast.success('New deployment detected!')
       } else {
         // No new deployment yet, set up refresh interval
         if (!refreshIntervalRef.current) {

--- a/web/src/pages/DeploymentDetails.tsx
+++ b/web/src/pages/DeploymentDetails.tsx
@@ -923,7 +923,6 @@ export function DeploymentDetails({ project }: DeploymentDetailsProps) {
       errorTitle: 'Failed to create deployment',
     },
     onSuccess: () => {
-      toast.success('Deployment created successfully')
       setIsRedeployModalOpen(false)
     },
   })
@@ -935,7 +934,6 @@ export function DeploymentDetails({ project }: DeploymentDetailsProps) {
       errorTitle: 'Failed to redeploy image',
     },
     onSuccess: () => {
-      toast.success('Deployment created successfully')
       setIsRedeployModalOpen(false)
     },
   })


### PR DESCRIPTION
## Summary
Removes two success toasts that duplicate information already visible on screen:
- `"New deployment detected!"` in `ProjectDeployments.tsx` — fires when the auto-refresh-after-redeploy polling picks up the new deployment row, which the user already sees appear in the list.
- `"Deployment created successfully"` in `DeploymentDetails.tsx` (both the git-pipeline redeploy and the docker-image redeploy mutations) — fires right as the redeploy modal closes and the deployment's status badge starts updating in place.

Both toasts added a second, noisier signal for state changes the UI already surfaces directly.

## Test plan
- [x] `bun run tsc --noEmit` in `web/` — clean.
- [x] `bunx eslint` on both changed files — clean, no new warnings.
- [x] `python3 scripts/source_attribution.py check` — passed.
- [x] Confirmed `toast` import is still used elsewhere in both files (other toasts for pause/resume/cancel/rollback/errors are untouched), so no unused-import cleanup needed.