### PR TITLE
fix(git): support self-hosted GitLab repository discovery

### DIFF
--- a/apps/temps-cli/openapi.json
+++ b/apps/temps-cli/openapi.json
@@ -66758,6 +66758,18 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.",
+            "in": "query",
+            "name": "base_url",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
           }
         ],
         "responses": {
@@ -66773,6 +66785,9 @@
           },
           "400": {
             "description": "Provider not supported"
+          },
+          "401": {
+            "description": "Authentication required for custom GitLab origins"
           },
           "403": {
             "description": "Git provider permission required"
@@ -66825,6 +66840,18 @@
             }
           },
           {
+            "description": "HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.",
+            "in": "query",
+            "name": "base_url",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
             "description": "Force fetch fresh data, bypassing cache (default: false)",
             "in": "query",
             "name": "fresh",
@@ -66847,6 +66874,9 @@
           },
           "400": {
             "description": "Provider not supported"
+          },
+          "401": {
+            "description": "Authentication required for custom GitLab origins"
           },
           "403": {
             "description": "Git provider permission required"
@@ -66899,6 +66929,18 @@
             }
           },
           {
+            "description": "HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.",
+            "in": "query",
+            "name": "base_url",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
             "description": "Branch to read the compose file from (default: repository's default branch)",
             "in": "query",
             "name": "branch",
@@ -66933,6 +66975,12 @@
           },
           "400": {
             "description": "Provider not supported, or the compose file could not be parsed"
+          },
+          "401": {
+            "description": "Authentication required for custom GitLab origins"
+          },
+          "403": {
+            "description": "Git provider permission required"
           },
           "404": {
             "description": "Repository, branch, or compose file not found"
@@ -66978,6 +67026,18 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.",
+            "in": "query",
+            "name": "base_url",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
           }
         ],
         "requestBody": {
@@ -67003,6 +67063,12 @@
           },
           "400": {
             "description": "Compose file or override is invalid"
+          },
+          "401": {
+            "description": "Authentication required for custom GitLab origins"
+          },
+          "403": {
+            "description": "Git provider permission required"
           },
           "404": {
             "description": "Repository, branch, or compose file not found"
@@ -67046,6 +67112,18 @@
             }
           },
           {
+            "description": "HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.",
+            "in": "query",
+            "name": "base_url",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
             "description": "Branch name to inspect (default: repository's default branch)",
             "in": "query",
             "name": "branch",
@@ -67083,6 +67161,12 @@
           },
           "400": {
             "description": "Provider not supported"
+          },
+          "401": {
+            "description": "Authentication required for custom GitLab origins"
+          },
+          "403": {
+            "description": "Git provider permission required"
           },
           "404": {
             "description": "Repository or branch not found"
@@ -67132,6 +67216,18 @@
             }
           },
           {
+            "description": "HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.",
+            "in": "query",
+            "name": "base_url",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
             "description": "Branch name to detect presets for (default: repository's default branch)",
             "in": "query",
             "name": "branch",
@@ -67166,6 +67262,9 @@
           },
           "400": {
             "description": "Provider not supported"
+          },
+          "401": {
+            "description": "Authentication required for custom GitLab origins"
           },
           "403": {
             "description": "Git provider permission required"

--- a/apps/temps-cli/src/api/types.gen.ts
+++ b/apps/temps-cli/src/api/types.gen.ts
@@ -34033,7 +34033,12 @@ export type GetPublicRepositoryData = {
          */
         repo: string;
     };
-    query?: never;
+    query?: {
+        /**
+         * HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.
+         */
+        base_url?: string | null;
+    };
     url: '/git/public/{provider}/{owner}/{repo}';
 };
 
@@ -34042,6 +34047,10 @@ export type GetPublicRepositoryErrors = {
      * Provider not supported
      */
     400: unknown;
+    /**
+     * Authentication required for custom GitLab origins
+     */
+    401: unknown;
     /**
      * Git provider permission required
      */
@@ -34087,6 +34096,10 @@ export type GetPublicBranchesData = {
     };
     query?: {
         /**
+         * HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.
+         */
+        base_url?: string | null;
+        /**
          * Force fetch fresh data, bypassing cache (default: false)
          */
         fresh?: boolean;
@@ -34099,6 +34112,10 @@ export type GetPublicBranchesErrors = {
      * Provider not supported
      */
     400: unknown;
+    /**
+     * Authentication required for custom GitLab origins
+     */
+    401: unknown;
     /**
      * Git provider permission required
      */
@@ -34144,6 +34161,10 @@ export type GetPublicComposeServicesData = {
     };
     query: {
         /**
+         * HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.
+         */
+        base_url?: string | null;
+        /**
          * Branch to read the compose file from (default: repository's default branch)
          */
         branch?: string | null;
@@ -34161,6 +34182,14 @@ export type GetPublicComposeServicesErrors = {
      * Provider not supported, or the compose file could not be parsed
      */
     400: unknown;
+    /**
+     * Authentication required for custom GitLab origins
+     */
+    401: unknown;
+    /**
+     * Git provider permission required
+     */
+    403: unknown;
     /**
      * Repository, branch, or compose file not found
      */
@@ -34200,7 +34229,12 @@ export type GetPublicComposePreviewData = {
          */
         repo: string;
     };
-    query?: never;
+    query?: {
+        /**
+         * HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.
+         */
+        base_url?: string | null;
+    };
     url: '/git/public/{provider}/{owner}/{repo}/compose-file';
 };
 
@@ -34209,6 +34243,14 @@ export type GetPublicComposePreviewErrors = {
      * Compose file or override is invalid
      */
     400: unknown;
+    /**
+     * Authentication required for custom GitLab origins
+     */
+    401: unknown;
+    /**
+     * Git provider permission required
+     */
+    403: unknown;
     /**
      * Repository, branch, or compose file not found
      */
@@ -34242,6 +34284,10 @@ export type DetectPublicEnvExampleData = {
     };
     query?: {
         /**
+         * HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.
+         */
+        base_url?: string | null;
+        /**
          * Branch name to inspect (default: repository's default branch)
          */
         branch?: string | null;
@@ -34258,6 +34304,14 @@ export type DetectPublicEnvExampleErrors = {
      * Provider not supported
      */
     400: unknown;
+    /**
+     * Authentication required for custom GitLab origins
+     */
+    401: unknown;
+    /**
+     * Git provider permission required
+     */
+    403: unknown;
     /**
      * Repository or branch not found
      */
@@ -34299,6 +34353,10 @@ export type DetectPublicPresetsData = {
     };
     query?: {
         /**
+         * HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.
+         */
+        base_url?: string | null;
+        /**
          * Branch name to detect presets for (default: repository's default branch)
          */
         branch?: string | null;
@@ -34315,6 +34373,10 @@ export type DetectPublicPresetsErrors = {
      * Provider not supported
      */
     400: unknown;
+    /**
+     * Authentication required for custom GitLab origins
+     */
+    401: unknown;
     /**
      * Git provider permission required
      */

--- a/crates/temps-git/src/handlers/public.rs
+++ b/crates/temps-git/src/handlers/public.rs
@@ -22,7 +22,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use temps_auth::AuthContext;
+use temps_auth::{AuthContext, Permission};
 use temps_core::problemdetails::{new as problem_new, Problem};
 use temps_entities::preset::ComposePortMapping;
 use utoipa::{IntoParams, OpenApi, ToSchema};
@@ -30,14 +30,25 @@ use utoipa::{IntoParams, OpenApi, ToSchema};
 /// Query parameters for public repository endpoints
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct PublicRepoQueryParams {
+    /// HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.
+    pub base_url: Option<String>,
     /// Force fetch fresh data, bypassing cache (default: false)
     #[serde(default)]
     pub fresh: bool,
 }
 
+/// Query parameters for endpoints that do not expose cache controls.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct PublicGitLabQueryParams {
+    /// HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.
+    pub base_url: Option<String>,
+}
+
 /// Query parameters for preset detection
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct PresetQueryParams {
+    /// HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.
+    pub base_url: Option<String>,
     /// Branch name to detect presets for (default: repository's default branch)
     pub branch: Option<String>,
     /// Force fetch fresh data, bypassing cache (default: false)
@@ -48,6 +59,8 @@ pub struct PresetQueryParams {
 /// Query parameters for env-example detection.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct EnvExampleQueryParams {
+    /// HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.
+    pub base_url: Option<String>,
     /// Branch name to inspect (default: repository's default branch)
     pub branch: Option<String>,
     /// Project root directory to search (default: repository root)
@@ -131,6 +144,8 @@ pub struct PublicEnvExampleResponse {
 /// Query params for public compose-file service preview
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct PublicComposeFileQueryParams {
+    /// HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.
+    pub base_url: Option<String>,
     /// Branch to read the compose file from (default: repository's default branch)
     pub branch: Option<String>,
     /// Compose file path to fetch and parse (from the `compose_files` list
@@ -236,6 +251,14 @@ fn map_error(err: PublicRepoError, owner: &str, repo: &str) -> Problem {
         PublicRepoError::Internal(msg) => problem_new(StatusCode::INTERNAL_SERVER_ERROR)
             .with_title("Internal Error")
             .with_detail(format!("An unexpected error occurred: {}", msg)),
+        PublicRepoError::ResponseTooLarge {
+            context,
+            limit_bytes,
+        } => problem_new(StatusCode::BAD_GATEWAY)
+            .with_title("Git Provider Response Too Large")
+            .with_detail(format!(
+                "The provider response for {context} exceeded the {limit_bytes}-byte safety limit."
+            )),
     }
 }
 
@@ -265,10 +288,12 @@ async fn provider_for_public_request(
     provider: &str,
     owner: &str,
     repo: &str,
+    base_url: Option<&str>,
 ) -> Result<
     (
         Box<dyn crate::services::public_repo::PublicRepoProvider>,
         crate::services::public_repo::PublicRepoInfo,
+        String,
     ),
     Problem,
 > {
@@ -284,8 +309,17 @@ async fn provider_for_public_request(
     } else {
         None
     };
-    let repo_provider = PublicRepoProviderFactory::create_with_token(provider, token)
-        .map_err(|error| map_error(error, owner, repo))?;
+    authorize_custom_gitlab_origin(auth, base_url)?;
+    let gitlab_instance = validated_gitlab_instance(provider, base_url).await?;
+    let cache_scope = public_cache_scope(
+        provider,
+        gitlab_instance
+            .as_ref()
+            .map(|(base_url, _, _)| base_url.as_str()),
+    );
+    let repo_provider =
+        PublicRepoProviderFactory::create_with_gitlab_instance(provider, token, gitlab_instance)
+            .map_err(|error| map_error(error, owner, repo))?;
 
     // Always verify current visibility, including before shared cache hits.
     // A repository can become private while a branch or preset entry remains
@@ -296,7 +330,114 @@ async fn provider_for_public_request(
         .map_err(|error| map_error(error, owner, repo))?;
     let info = require_public_repository(info, owner, repo)
         .map_err(|error| map_error(error, owner, repo))?;
-    Ok((repo_provider, info))
+    Ok((repo_provider, info, cache_scope))
+}
+
+fn public_cache_scope(provider: &str, gitlab_base_url: Option<&str>) -> String {
+    gitlab_base_url
+        .map(|base_url| format!("gitlab@{base_url}"))
+        .unwrap_or_else(|| provider.to_ascii_lowercase())
+}
+
+fn authorize_custom_gitlab_origin(
+    auth: Option<&AuthContext>,
+    base_url: Option<&str>,
+) -> Result<(), Problem> {
+    let has_custom_origin = base_url
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty());
+    if !has_custom_origin {
+        return Ok(());
+    }
+
+    let auth = auth.ok_or_else(|| {
+        problem_new(StatusCode::UNAUTHORIZED)
+            .with_title("Authentication Required")
+            .with_detail("Authentication is required to access a custom GitLab instance.")
+    })?;
+    if !auth.has_permission(&Permission::GitRepositoriesRead) {
+        return Err(problem_new(StatusCode::FORBIDDEN)
+            .with_title("Insufficient Permissions")
+            .with_detail(
+                "Accessing a custom GitLab instance requires the git_repositories:read permission.",
+            ));
+    }
+
+    Ok(())
+}
+
+/// Validate and normalize a user-supplied self-hosted GitLab origin.
+///
+/// The result contains the normalized origin, hostname, and the exact public
+/// addresses the HTTP client must use. Redirects are disabled by the provider.
+async fn validated_gitlab_instance(
+    provider: &str,
+    base_url: Option<&str>,
+) -> Result<Option<(String, String, Vec<std::net::SocketAddr>)>, Problem> {
+    let Some(base_url) = base_url.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    if !provider.eq_ignore_ascii_case("gitlab") {
+        return Err(problem_new(StatusCode::BAD_REQUEST)
+            .with_title("Invalid Git Provider URL")
+            .with_detail("A custom base_url can only be used with the GitLab provider."));
+    }
+
+    let mut parsed =
+        temps_core::url_validation::validate_external_url(base_url).map_err(|error| {
+            problem_new(StatusCode::BAD_REQUEST)
+                .with_title("Invalid GitLab Instance URL")
+                .with_detail(format!(
+                    "The GitLab base_url is not a safe external URL: {error}"
+                ))
+        })?;
+    if parsed.scheme() != "https" {
+        return Err(problem_new(StatusCode::BAD_REQUEST)
+            .with_title("Invalid GitLab Instance URL")
+            .with_detail("The GitLab base_url must use HTTPS."));
+    }
+    if parsed.port_or_known_default() != Some(443) {
+        return Err(problem_new(StatusCode::BAD_REQUEST)
+            .with_title("Invalid GitLab Instance URL")
+            .with_detail("The GitLab base_url must use the standard HTTPS port 443."));
+    }
+    if !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || !matches!(parsed.path(), "" | "/")
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+    {
+        return Err(problem_new(StatusCode::BAD_REQUEST)
+            .with_title("Invalid GitLab Instance URL")
+            .with_detail(
+                "The GitLab base_url must be an HTTPS origin without credentials, a path, a query, or a fragment.",
+            ));
+    }
+
+    let hostname = parsed.host_str().ok_or_else(|| {
+        problem_new(StatusCode::BAD_REQUEST)
+            .with_title("Invalid GitLab Instance URL")
+            .with_detail("The GitLab base_url must include a hostname.")
+    })?;
+    let addresses = temps_core::url_validation::resolve_and_validate_domain(
+        hostname,
+        parsed.port_or_known_default().unwrap_or(443),
+    )
+    .await
+    .map_err(|error| {
+        problem_new(StatusCode::BAD_REQUEST)
+            .with_title("Invalid GitLab Instance URL")
+            .with_detail(format!(
+                "The GitLab base_url did not resolve exclusively to public addresses: {error}"
+            ))
+    })?;
+    let hostname = hostname.to_string();
+    parsed.set_path("");
+    Ok(Some((
+        parsed.as_str().trim_end_matches('/').to_string(),
+        hostname,
+        addresses,
+    )))
 }
 
 /// Get branches for a public repository (supports GitHub and GitLab)
@@ -312,6 +453,7 @@ async fn provider_for_public_request(
     responses(
         (status = 200, description = "List of branches", body = BranchListResponse),
         (status = 400, description = "Provider not supported"),
+        (status = 401, description = "Authentication required for custom GitLab origins"),
         (status = 403, description = "Git provider permission required"),
         (status = 404, description = "Repository not found"),
         (status = 429, description = "API rate limit exceeded"),
@@ -325,17 +467,18 @@ pub async fn get_public_branches(
     Path((provider, owner, repo)): Path<(String, String, String)>,
     Query(params): Query<PublicRepoQueryParams>,
 ) -> Result<Json<BranchListResponse>, Problem> {
-    let (repo_provider, _) = provider_for_public_request(
+    let (repo_provider, _, cache_scope) = provider_for_public_request(
         state.as_ref(),
         auth.as_ref().map(|Extension(auth)| auth),
         &provider,
         &owner,
         &repo,
+        params.base_url.as_deref(),
     )
     .await?;
 
     // Create cache key for public repos
-    let cache_key = PublicBranchCacheKey::new(provider.clone(), owner.clone(), repo.clone());
+    let cache_key = PublicBranchCacheKey::new(cache_scope, owner.clone(), repo.clone());
 
     // Try cache first (unless fresh=true)
     if !params.fresh {
@@ -404,6 +547,7 @@ pub async fn get_public_branches(
     responses(
         (status = 200, description = "Detected presets", body = PublicPresetResponse),
         (status = 400, description = "Provider not supported"),
+        (status = 401, description = "Authentication required for custom GitLab origins"),
         (status = 403, description = "Git provider permission required"),
         (status = 404, description = "Repository or branch not found"),
         (status = 429, description = "API rate limit exceeded"),
@@ -417,12 +561,13 @@ pub async fn detect_public_presets(
     Path((provider, owner, repo)): Path<(String, String, String)>,
     Query(params): Query<PresetQueryParams>,
 ) -> Result<Json<PublicPresetResponse>, Problem> {
-    let (repo_provider, repo_info) = provider_for_public_request(
+    let (repo_provider, repo_info, cache_scope) = provider_for_public_request(
         state.as_ref(),
         auth.as_ref().map(|Extension(auth)| auth),
         &provider,
         &owner,
         &repo,
+        params.base_url.as_deref(),
     )
     .await?;
 
@@ -435,7 +580,7 @@ pub async fn detect_public_presets(
 
     // Create cache key
     let cache_key = PublicPresetCacheKey::new(
-        provider.clone(),
+        cache_scope,
         owner.clone(),
         repo.clone(),
         target_branch.clone(),
@@ -542,6 +687,8 @@ fn decode_file_content(content: &str, encoding: &str) -> String {
     responses(
         (status = 200, description = "Detected env-example variables", body = PublicEnvExampleResponse),
         (status = 400, description = "Provider not supported"),
+        (status = 401, description = "Authentication required for custom GitLab origins"),
+        (status = 403, description = "Git provider permission required"),
         (status = 404, description = "Repository or branch not found"),
         (status = 429, description = "API rate limit exceeded"),
         (status = 500, description = "Internal server error")
@@ -554,12 +701,13 @@ pub async fn detect_public_env_example(
     Path((provider, owner, repo)): Path<(String, String, String)>,
     Query(params): Query<EnvExampleQueryParams>,
 ) -> Result<Json<PublicEnvExampleResponse>, Problem> {
-    let (repo_provider, repo_info) = provider_for_public_request(
+    let (repo_provider, repo_info, _) = provider_for_public_request(
         state.as_ref(),
         auth.as_ref().map(|Extension(auth)| auth),
         &provider,
         &owner,
         &repo,
+        params.base_url.as_deref(),
     )
     .await?;
 
@@ -625,6 +773,8 @@ pub async fn detect_public_env_example(
     responses(
         (status = 200, description = "Compose services parsed successfully", body = PublicComposeServicesResponse),
         (status = 400, description = "Provider not supported, or the compose file could not be parsed"),
+        (status = 401, description = "Authentication required for custom GitLab origins"),
+        (status = 403, description = "Git provider permission required"),
         (status = 404, description = "Repository, branch, or compose file not found"),
         (status = 429, description = "API rate limit exceeded"),
         (status = 500, description = "Internal server error")
@@ -637,12 +787,13 @@ pub async fn get_public_compose_services(
     Path((provider, owner, repo)): Path<(String, String, String)>,
     Query(params): Query<PublicComposeFileQueryParams>,
 ) -> Result<Json<PublicComposeServicesResponse>, Problem> {
-    let (repo_provider, repo_info) = provider_for_public_request(
+    let (repo_provider, repo_info, _) = provider_for_public_request(
         state.as_ref(),
         auth.as_ref().map(|Extension(auth)| auth),
         &provider,
         &owner,
         &repo,
+        params.base_url.as_deref(),
     )
     .await?;
 
@@ -693,12 +844,15 @@ pub async fn get_public_compose_services(
     params(
         ("provider" = String, Path, description = "Git provider (github or gitlab)"),
         ("owner" = String, Path, description = "Repository owner"),
-        ("repo" = String, Path, description = "Repository name")
+        ("repo" = String, Path, description = "Repository name"),
+        PublicGitLabQueryParams
     ),
     request_body = PublicComposePreviewRequest,
     responses(
         (status = 200, description = "Effective Compose preview rendered", body = PublicComposePreviewResponse),
         (status = 400, description = "Compose file or override is invalid"),
+        (status = 401, description = "Authentication required for custom GitLab origins"),
+        (status = 403, description = "Git provider permission required"),
         (status = 404, description = "Repository, branch, or compose file not found")
     ),
     tag = "Public Repositories"
@@ -707,14 +861,16 @@ pub async fn get_public_compose_preview(
     State(state): State<Arc<AppState>>,
     auth: Option<Extension<AuthContext>>,
     Path((provider, owner, repo)): Path<(String, String, String)>,
+    Query(params): Query<PublicGitLabQueryParams>,
     Json(request): Json<PublicComposePreviewRequest>,
 ) -> Result<Json<PublicComposePreviewResponse>, Problem> {
-    let (repo_provider, repo_info) = provider_for_public_request(
+    let (repo_provider, repo_info, _) = provider_for_public_request(
         state.as_ref(),
         auth.as_ref().map(|Extension(auth)| auth),
         &provider,
         &owner,
         &repo,
+        params.base_url.as_deref(),
     )
     .await?;
     let target_branch = if let Some(branch) = request.branch {
@@ -759,10 +915,12 @@ pub async fn get_public_compose_preview(
         ("provider" = String, Path, description = "Git provider (github or gitlab)"),
         ("owner" = String, Path, description = "Repository owner"),
         ("repo" = String, Path, description = "Repository name"),
+        PublicGitLabQueryParams
     ),
     responses(
         (status = 200, description = "Repository information", body = PublicRepositoryInfo),
         (status = 400, description = "Provider not supported"),
+        (status = 401, description = "Authentication required for custom GitLab origins"),
         (status = 403, description = "Git provider permission required"),
         (status = 404, description = "Repository not found"),
         (status = 429, description = "API rate limit exceeded"),
@@ -774,13 +932,15 @@ pub async fn get_public_repository(
     State(state): State<Arc<AppState>>,
     auth: Option<Extension<AuthContext>>,
     Path((provider, owner, repo)): Path<(String, String, String)>,
+    Query(params): Query<PublicGitLabQueryParams>,
 ) -> Result<Json<PublicRepositoryInfo>, Problem> {
-    let (_repo_provider, repo_info) = provider_for_public_request(
+    let (_repo_provider, repo_info, _) = provider_for_public_request(
         state.as_ref(),
         auth.as_ref().map(|Extension(auth)| auth),
         &provider,
         &owner,
         &repo,
+        params.base_url.as_deref(),
     )
     .await?;
 
@@ -866,6 +1026,90 @@ mod tests {
     // =============================================================================
     // Unit Tests - Cache Key Tests
     // =============================================================================
+
+    #[test]
+    fn self_hosted_gitlab_instances_use_separate_cache_scopes() {
+        let first = public_cache_scope("gitlab", Some("https://gitlab-one.example"));
+        let second = public_cache_scope("gitlab", Some("https://gitlab-two.example"));
+
+        assert_ne!(first, second);
+        assert_eq!(public_cache_scope("GitLab", None), "gitlab");
+    }
+
+    #[tokio::test]
+    async fn rejects_custom_origins_for_non_gitlab_providers() {
+        assert!(
+            validated_gitlab_instance("github", Some("https://gitlab.example.com"))
+                .await
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn custom_gitlab_origins_require_authentication() {
+        let error = authorize_custom_gitlab_origin(None, Some("https://source.example.com"))
+            .expect_err("custom origins must not create unauthenticated egress");
+        assert_eq!(error.status_code, StatusCode::UNAUTHORIZED);
+
+        let deployment_token = AuthContext::new_deployment_token(
+            1,
+            None,
+            None,
+            1,
+            "test-token".to_string(),
+            Vec::new(),
+        );
+        let error = authorize_custom_gitlab_origin(
+            Some(&deployment_token),
+            Some("https://source.example.com"),
+        )
+        .expect_err("a principal without repository-read permission must be denied");
+        assert_eq!(error.status_code, StatusCode::FORBIDDEN);
+        assert!(authorize_custom_gitlab_origin(None, None).is_ok());
+    }
+
+    #[tokio::test]
+    async fn rejects_private_and_non_origin_gitlab_urls() {
+        assert!(
+            validated_gitlab_instance("gitlab", Some("https://127.0.0.1"))
+                .await
+                .is_err()
+        );
+        assert!(
+            validated_gitlab_instance("gitlab", Some("https://gitlab.example.com/group"))
+                .await
+                .is_err()
+        );
+        assert!(
+            validated_gitlab_instance("gitlab", Some("https://gitlab.example.com:8443"))
+                .await
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn every_public_repository_operation_documents_the_gitlab_origin() {
+        let document = serde_json::to_value(PublicRepositoriesApiDoc::openapi())
+            .expect("serialize the public repository OpenAPI document");
+        for (path, method) in [
+            ("/git/public/{provider}/{owner}/{repo}", "get"),
+            ("/git/public/{provider}/{owner}/{repo}/branches", "get"),
+            ("/git/public/{provider}/{owner}/{repo}/compose-file", "get"),
+            ("/git/public/{provider}/{owner}/{repo}/compose-file", "post"),
+            ("/git/public/{provider}/{owner}/{repo}/env-example", "get"),
+            ("/git/public/{provider}/{owner}/{repo}/presets", "get"),
+        ] {
+            let parameters = document["paths"][path][method]["parameters"]
+                .as_array()
+                .unwrap_or_else(|| panic!("{method} {path} must document query parameters"));
+            assert!(
+                parameters
+                    .iter()
+                    .any(|parameter| parameter["name"] == "base_url"),
+                "{method} {path} must document base_url"
+            );
+        }
+    }
 
     #[test]
     fn test_public_branch_cache_key_equality() {
@@ -1345,7 +1589,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_gitlab_provider_get_repository() {
-        let provider = GitLabPublicProvider::new(None);
+        let provider = GitLabPublicProvider::new();
 
         // Using gitlab-org/gitlab as a well-known public repo
         match provider.get_repository("gitlab-org", "gitlab").await {
@@ -1363,7 +1607,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_gitlab_provider_list_branches() {
-        let provider = GitLabPublicProvider::new(None);
+        let provider = GitLabPublicProvider::new();
 
         // Using a smaller public GitLab repo for faster testing
         match provider.list_branches("gitlab-org", "gitlab-runner").await {
@@ -1389,7 +1633,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_gitlab_provider_nonexistent_repo() {
-        let provider = GitLabPublicProvider::new(None);
+        let provider = GitLabPublicProvider::new();
 
         let result = provider
             .get_repository("this-does-not-exist-12345", "fake-repo")

--- a/crates/temps-git/src/services/git_provider.rs
+++ b/crates/temps-git/src/services/git_provider.rs
@@ -615,6 +615,21 @@ pub trait GitProviderService: Send + Sync {
         reference: Option<&str>,
     ) -> Result<Vec<RepoDirEntry>, GitProviderError>;
 
+    /// List every file in a repository recursively at `reference`.
+    ///
+    /// Providers with a recursive tree API should override this so callers do
+    /// not need to reconstruct provider URLs or authentication headers. That
+    /// distinction matters for self-hosted instances and PAT-specific headers.
+    async fn list_repository_files(
+        &self,
+        _access_token: &str,
+        _owner: &str,
+        _repo: &str,
+        _reference: &str,
+    ) -> Result<Vec<String>, GitProviderError> {
+        Err(GitProviderError::NotImplemented)
+    }
+
     /// Get latest commit for a branch
     async fn get_latest_commit(
         &self,

--- a/crates/temps-git/src/services/git_provider_manager.rs
+++ b/crates/temps-git/src/services/git_provider_manager.rs
@@ -1923,43 +1923,6 @@ impl GitProviderManager {
         }
     }
 
-    /// Classify a failed provider HTTP response into a typed error.
-    ///
-    /// Provider 401/403 responses MUST become
-    /// [`GitProviderError::AuthenticationFailed`] rather than a generic
-    /// `ApiError`, for two reasons:
-    ///
-    /// 1. [`Self::is_authentication_error`] drives the token
-    ///    force-refresh-and-retry path. A 401 flattened into `ApiError`
-    ///    silently skips that retry, so an expired-but-refreshable token
-    ///    hard-fails instead of recovering.
-    /// 2. The HTTP layer maps `AuthenticationFailed` to a distinct problem
-    ///    type, so clients can tell "reconnect this git account" apart from
-    ///    "the provider is having a bad day" and say so to the user.
-    ///
-    /// `operation` names what was being fetched, so the message stays
-    /// greppable and specific (e.g. "get tree for owner/repo@main").
-    fn classify_provider_response_error(
-        status: reqwest::StatusCode,
-        operation: &str,
-    ) -> GitProviderError {
-        if status == reqwest::StatusCode::UNAUTHORIZED {
-            GitProviderError::AuthenticationFailed(format!(
-                "provider rejected the stored credential while trying to {}: HTTP {}",
-                operation, status
-            ))
-        } else if status == reqwest::StatusCode::FORBIDDEN {
-            GitProviderError::PermissionDenied {
-                operation: operation.to_string(),
-                required_permission:
-                    "repository access with the permission required by this operation".to_string(),
-                provider_message: format!("HTTP {}", status),
-            }
-        } else {
-            GitProviderError::ApiError(format!("Failed to {}: HTTP {}", operation, status))
-        }
-    }
-
     /// Check if a GitProviderError is an authentication error (401)
     fn is_authentication_error(&self, error: &super::git_provider::GitProviderError) -> bool {
         matches!(
@@ -3247,98 +3210,11 @@ impl GitProviderManager {
         repo: &str,
         branch: &str,
     ) -> Result<Vec<String>, GitProviderError> {
-        // For GitHub, we can use the tree API to get file list
-        // For other providers, we may need different approaches
-
-        // Try to get file list from the root of the repository
-        // This is a simplified approach - in production you might want to be more thorough
-
-        let client = reqwest::Client::new();
-
         match provider_service.provider_type() {
-            GitProviderType::GitHub => {
-                // Use GitHub API to get tree
-                let url = format!(
-                    "https://api.github.com/repos/{}/{}/git/trees/{}?recursive=1",
-                    owner, repo, branch
-                );
-
-                let response = client
-                    .get(&url)
-                    .header("Authorization", format!("Bearer {}", access_token))
-                    .header("User-Agent", "Temps-Engine")
-                    .send()
+            GitProviderType::GitHub | GitProviderType::GitLab => {
+                provider_service
+                    .list_repository_files(access_token, owner, repo, branch)
                     .await
-                    .map_err(|e| {
-                        GitProviderError::ApiError(format!("Failed to get tree: {}", e))
-                    })?;
-
-                if !response.status().is_success() {
-                    return Err(Self::classify_provider_response_error(
-                        response.status(),
-                        &format!("get tree for {}/{}@{}", owner, repo, branch),
-                    ));
-                }
-
-                let tree_data: serde_json::Value = response.json().await.map_err(|e| {
-                    GitProviderError::ApiError(format!("Failed to parse tree response: {}", e))
-                })?;
-
-                let files = tree_data["tree"]
-                    .as_array()
-                    .ok_or_else(|| GitProviderError::ApiError("No tree in response".to_string()))?
-                    .iter()
-                    .filter_map(|item| {
-                        if item["type"].as_str() == Some("blob") {
-                            item["path"].as_str().map(|s| s.to_string())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-
-                Ok(files)
-            }
-            GitProviderType::GitLab => {
-                // GitLab tree API
-                let url = format!(
-                    "https://gitlab.com/api/v4/projects/{}/repository/tree?ref={}&recursive=true&per_page=100",
-                    urlencoding::encode(&format!("{}/{}", owner, repo)),
-                    branch
-                );
-
-                let response = client
-                    .get(&url)
-                    .header("Authorization", format!("Bearer {}", access_token))
-                    .send()
-                    .await
-                    .map_err(|e| {
-                        GitProviderError::ApiError(format!("Failed to get tree: {}", e))
-                    })?;
-
-                if !response.status().is_success() {
-                    return Err(Self::classify_provider_response_error(
-                        response.status(),
-                        &format!("get tree for {}/{}@{}", owner, repo, branch),
-                    ));
-                }
-
-                let tree_data: Vec<serde_json::Value> = response.json().await.map_err(|e| {
-                    GitProviderError::ApiError(format!("Failed to parse tree response: {}", e))
-                })?;
-
-                let files = tree_data
-                    .iter()
-                    .filter_map(|item| {
-                        if item["type"].as_str() == Some("blob") {
-                            item["path"].as_str().map(|s| s.to_string())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-
-                Ok(files)
             }
             _ => {
                 // For other providers, return empty list for now
@@ -3412,9 +3288,8 @@ impl GitProviderManager {
         // the user. This previously decrypted the token inline and called
         // directly, so preset detection was the one provider path that never
         // got the refresh treatment — and because a provider 401 was also
-        // flattened into a generic `ApiError`, the retry could not have fired
-        // even if it had been wrapped (see
-        // `classify_provider_response_error`).
+        // flattened into a generic `ApiError`, the retry could not fire. The
+        // provider implementation now preserves typed authentication errors.
         let files = self
             .execute_with_refresh(connection_id, |access_token| {
                 let provider_service = provider_service.clone();
@@ -5786,86 +5661,6 @@ impl GitProviderManagerTrait for GitProviderManager {
                 connection_id, owner, repo, e
             ))),
         }
-    }
-}
-
-#[cfg(test)]
-mod classify_provider_response_error_tests {
-    use super::*;
-
-    /// A provider 401 MUST become `AuthenticationFailed`, not `ApiError`.
-    /// `is_authentication_error` keys off this variant to drive the token
-    /// force-refresh-and-retry, and the HTTP layer maps it to 401 +
-    /// `errors/authentication_failed` so clients can say "reconnect this
-    /// account" instead of "the provider is down".
-    #[test]
-    fn unauthorized_is_classified_as_authentication_failure() {
-        let err = GitProviderManager::classify_provider_response_error(
-            reqwest::StatusCode::UNAUTHORIZED,
-            "get tree for owner/repo@main",
-        );
-        assert!(
-            matches!(err, GitProviderError::AuthenticationFailed(_)),
-            "401 must map to AuthenticationFailed, got {err:?}"
-        );
-    }
-
-    /// A valid credential that lacks a repository capability is not an
-    /// authentication failure: clients must tell the operator which grant to
-    /// add instead of asking them to reconnect the same credential.
-    #[test]
-    fn forbidden_is_classified_as_permission_denied() {
-        let err = GitProviderManager::classify_provider_response_error(
-            reqwest::StatusCode::FORBIDDEN,
-            "get tree for owner/repo@main",
-        );
-        assert!(
-            matches!(err, GitProviderError::PermissionDenied { .. }),
-            "403 must map to PermissionDenied, got {err:?}"
-        );
-        assert!(err.to_string().contains("owner/repo@main"));
-    }
-
-    /// Everything else stays a generic API error — a provider outage is not
-    /// a credential problem and must not tell the user to reconnect.
-    #[test]
-    fn server_error_stays_a_generic_api_error() {
-        let err = GitProviderManager::classify_provider_response_error(
-            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
-            "get tree for owner/repo@main",
-        );
-        assert!(
-            matches!(err, GitProviderError::ApiError(_)),
-            "500 must stay ApiError, got {err:?}"
-        );
-    }
-
-    #[test]
-    fn not_found_stays_a_generic_api_error() {
-        let err = GitProviderManager::classify_provider_response_error(
-            reqwest::StatusCode::NOT_FOUND,
-            "get tree for owner/repo@main",
-        );
-        assert!(matches!(err, GitProviderError::ApiError(_)));
-    }
-
-    /// The operation and status must survive into the message — these errors
-    /// are the only breadcrumb when a self-hosted user debugs alone.
-    #[test]
-    fn message_names_the_operation_and_status() {
-        let err = GitProviderManager::classify_provider_response_error(
-            reqwest::StatusCode::UNAUTHORIZED,
-            "get tree for gotempsh/temps-examples@main",
-        );
-        let msg = err.to_string();
-        assert!(
-            msg.contains("gotempsh/temps-examples@main"),
-            "message should name the operation: {msg}"
-        );
-        assert!(
-            msg.contains("401"),
-            "message should carry the status: {msg}"
-        );
     }
 }
 

--- a/crates/temps-git/src/services/github_provider.rs
+++ b/crates/temps-git/src/services/github_provider.rs
@@ -1550,6 +1550,59 @@ impl GitProviderService for GitHubProvider {
         Ok(entries)
     }
 
+    async fn list_repository_files(
+        &self,
+        access_token: &str,
+        owner: &str,
+        repo: &str,
+        reference: &str,
+    ) -> Result<Vec<String>, GitProviderError> {
+        let client = self.get_client();
+        let headers = self.get_headers(access_token);
+        let url = format!(
+            "{}/repos/{}/{}/git/trees/{}?recursive=1",
+            self.api_url,
+            owner,
+            repo,
+            urlencoding::encode(reference)
+        );
+        let response = self
+            .send_with_retry(|| client.get(&url).headers(headers.clone()))
+            .await?;
+        if !response.status().is_success() {
+            return Err(github_response_error(
+                response,
+                format!("get tree for {owner}/{repo}@{reference}"),
+                "Contents: read and access to the target repository",
+            )
+            .await);
+        }
+
+        #[derive(Deserialize)]
+        struct TreeResponse {
+            tree: Vec<TreeEntry>,
+        }
+
+        #[derive(Deserialize)]
+        struct TreeEntry {
+            path: String,
+            #[serde(rename = "type")]
+            entry_type: String,
+        }
+
+        let tree: TreeResponse = response.json().await.map_err(|error| {
+            GitProviderError::ApiError(format!(
+                "Failed to parse tree response for {owner}/{repo}@{reference}: {error}"
+            ))
+        })?;
+        Ok(tree
+            .tree
+            .into_iter()
+            .filter(|entry| entry.entry_type == "blob")
+            .map(|entry| entry.path)
+            .collect())
+    }
+
     async fn get_latest_commit(
         &self,
         access_token: &str,

--- a/crates/temps-git/src/services/gitlab_provider.rs
+++ b/crates/temps-git/src/services/gitlab_provider.rs
@@ -176,11 +176,10 @@ impl GitLabProvider {
 
                     let status = response.status();
                     if status.is_server_error() || status.as_u16() == 429 {
-                        let error_text = response.text().await.unwrap_or_default();
-                        return Err(GitProviderError::ApiError(format!(
-                            "HTTP {}: {}",
-                            status, error_text
-                        )));
+                        // Provider bodies are untrusted and may contain echoed
+                        // secrets or be arbitrarily large. Status is enough to
+                        // classify a transient retry without logging the body.
+                        return Err(GitProviderError::ApiError(format!("HTTP {status}")));
                     }
 
                     Ok(response)
@@ -220,6 +219,101 @@ impl GitLabProvider {
         }
 
         headers
+    }
+
+    async fn decode_bounded_json<T>(
+        response: reqwest::Response,
+        limit_bytes: usize,
+        context: &str,
+    ) -> Result<(T, usize), GitProviderError>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        if response
+            .content_length()
+            .is_some_and(|length| length > limit_bytes as u64)
+        {
+            return Err(GitProviderError::ApiError(format!(
+                "Provider response for {context} exceeded the {limit_bytes}-byte safety limit"
+            )));
+        }
+
+        let mut body = Vec::with_capacity(
+            response
+                .content_length()
+                .unwrap_or(0)
+                .min(limit_bytes as u64) as usize,
+        );
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|error| {
+                GitProviderError::ApiError(format!(
+                    "Failed to read provider response for {context}: {error}"
+                ))
+            })?;
+            if body.len().saturating_add(chunk.len()) > limit_bytes {
+                return Err(GitProviderError::ApiError(format!(
+                    "Provider response for {context} exceeded the {limit_bytes}-byte safety limit"
+                )));
+            }
+            body.extend_from_slice(&chunk);
+        }
+
+        let body_len = body.len();
+        serde_json::from_slice(&body)
+            .map(|value| (value, body_len))
+            .map_err(|error| {
+                GitProviderError::ApiError(format!(
+                    "Failed to parse provider response for {context}: {error}"
+                ))
+            })
+    }
+
+    fn append_bounded_repository_paths<I>(
+        files: &mut Vec<String>,
+        retained_path_bytes: &mut usize,
+        paths: I,
+        max_files: usize,
+        max_path_bytes: usize,
+        max_total_path_bytes: usize,
+        context: &str,
+    ) -> Result<(), GitProviderError>
+    where
+        I: IntoIterator<Item = String>,
+    {
+        for path in paths {
+            let path_bytes = path.len();
+            if path_bytes > max_path_bytes
+                || files.len() >= max_files
+                || retained_path_bytes.saturating_add(path_bytes) > max_total_path_bytes
+            {
+                return Err(GitProviderError::ApiError(format!(
+                    "Provider tree for {context} exceeded its repository path safety limit"
+                )));
+            }
+            *retained_path_bytes += path_bytes;
+            files.push(path);
+        }
+        Ok(())
+    }
+
+    fn record_tree_page_budget(
+        total_entries: &mut usize,
+        total_response_bytes: &mut usize,
+        page_entries: usize,
+        page_response_bytes: usize,
+        max_entries: usize,
+        max_response_bytes: usize,
+        context: &str,
+    ) -> Result<(), GitProviderError> {
+        *total_entries = total_entries.saturating_add(page_entries);
+        *total_response_bytes = total_response_bytes.saturating_add(page_response_bytes);
+        if *total_entries > max_entries || *total_response_bytes > max_response_bytes {
+            return Err(GitProviderError::ApiError(format!(
+                "Provider tree for {context} exceeded its whole-operation safety limit"
+            )));
+        }
+        Ok(())
     }
 
     /// Refresh an access token using a refresh token
@@ -1013,6 +1107,104 @@ impl GitProviderService for GitLabProvider {
         all_entries.sort_by(|a, b| b.is_dir.cmp(&a.is_dir).then_with(|| a.name.cmp(&b.name)));
 
         Ok(all_entries)
+    }
+
+    async fn list_repository_files(
+        &self,
+        access_token: &str,
+        owner: &str,
+        repo: &str,
+        reference: &str,
+    ) -> Result<Vec<String>, GitProviderError> {
+        const PER_PAGE: usize = 100;
+        const MAX_PAGES: u32 = 100;
+        const MAX_PAGE_BYTES: usize = 2 * 1024 * 1024;
+        const MAX_FILES: usize = 100_000;
+        const MAX_ENTRIES: usize = 100_000;
+        const MAX_PATH_BYTES: usize = 4 * 1024;
+        const MAX_TOTAL_PATH_BYTES: usize = 8 * 1024 * 1024;
+        const MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
+
+        let client = self.get_client();
+        let headers = self.get_headers(access_token);
+        let encoded_project = urlencoding::encode(&format!("{owner}/{repo}")).into_owned();
+        let encoded_reference = urlencoding::encode(reference);
+        let operation = format!("get tree for {owner}/{repo}@{reference}");
+        let mut files = Vec::new();
+        let mut retained_path_bytes = 0usize;
+        let mut total_entries = 0usize;
+        let mut total_response_bytes = 0usize;
+
+        for page in 1..=MAX_PAGES {
+            let url = format!(
+                "{}/api/v4/projects/{}/repository/tree?ref={}&recursive=true&per_page={}&page={}",
+                self.base_url, encoded_project, encoded_reference, PER_PAGE, page
+            );
+            let response = self
+                .send_with_retry(|| client.get(&url).headers(headers.clone()))
+                .await?;
+            let status = response.status();
+            if !status.is_success() {
+                return Err(match status {
+                    reqwest::StatusCode::UNAUTHORIZED => {
+                        GitProviderError::AuthenticationFailed(format!(
+                            "provider rejected the stored credential while trying to {operation}: HTTP {status}"
+                        ))
+                    }
+                    reqwest::StatusCode::FORBIDDEN => GitProviderError::PermissionDenied {
+                        operation,
+                        required_permission: "read_repository".to_string(),
+                        provider_message: format!("HTTP {status}"),
+                    },
+                    _ => GitProviderError::ApiError(format!(
+                        "Failed to {operation}: HTTP {status}"
+                    )),
+                });
+            }
+
+            #[derive(Deserialize)]
+            struct TreeEntry {
+                path: String,
+                #[serde(rename = "type")]
+                entry_type: String,
+            }
+
+            let (entries, page_response_bytes): (Vec<TreeEntry>, _) = Self::decode_bounded_json(
+                response,
+                MAX_PAGE_BYTES,
+                &format!("tree for {owner}/{repo}@{reference} page {page}"),
+            )
+            .await?;
+            let entry_count = entries.len();
+            Self::record_tree_page_budget(
+                &mut total_entries,
+                &mut total_response_bytes,
+                entry_count,
+                page_response_bytes,
+                MAX_ENTRIES,
+                MAX_RESPONSE_BYTES,
+                &format!("{owner}/{repo}@{reference}"),
+            )?;
+            Self::append_bounded_repository_paths(
+                &mut files,
+                &mut retained_path_bytes,
+                entries
+                    .into_iter()
+                    .filter(|entry| entry.entry_type == "blob")
+                    .map(|entry| entry.path),
+                MAX_FILES,
+                MAX_PATH_BYTES,
+                MAX_TOTAL_PATH_BYTES,
+                &format!("{owner}/{repo}@{reference}"),
+            )?;
+            if entry_count < PER_PAGE {
+                return Ok(files);
+            }
+        }
+
+        Err(GitProviderError::ApiError(format!(
+            "GitLab tree for {owner}/{repo}@{reference} exceeded {MAX_PAGES} pages"
+        )))
     }
 
     async fn create_webhook(
@@ -2120,5 +2312,186 @@ mod list_directory_tests {
         let entries = map_and_sort(vec![("tests", "tests", "tree")]);
         assert_eq!(entries.len(), 1);
         assert!(entries[0].is_dir);
+    }
+}
+
+#[cfg(test)]
+mod repository_file_tree_tests {
+    use super::*;
+
+    #[test]
+    fn cumulative_repository_path_limit_spans_pages() {
+        let mut files = Vec::new();
+        let mut retained_path_bytes = 0;
+        GitLabProvider::append_bounded_repository_paths(
+            &mut files,
+            &mut retained_path_bytes,
+            ["one".to_string(), "two".to_string()],
+            3,
+            16,
+            32,
+            "platform/example-service@main",
+        )
+        .expect("the first full page should fit");
+
+        let error = GitLabProvider::append_bounded_repository_paths(
+            &mut files,
+            &mut retained_path_bytes,
+            ["three".to_string(), "four".to_string()],
+            3,
+            16,
+            32,
+            "platform/example-service@main",
+        )
+        .expect_err("a later page must share the same cumulative limit");
+
+        assert!(error.to_string().contains("path safety limit"));
+        assert_eq!(files, vec!["one", "two", "three"]);
+    }
+
+    #[test]
+    fn cumulative_tree_budget_counts_directory_only_page_bytes() {
+        let mut entries = 0;
+        let mut response_bytes = 0;
+        GitLabProvider::record_tree_page_budget(
+            &mut entries,
+            &mut response_bytes,
+            100,
+            8,
+            150,
+            15,
+            "platform/example-service@main",
+        )
+        .expect("the first directory-only page should fit");
+
+        let error = GitLabProvider::record_tree_page_budget(
+            &mut entries,
+            &mut response_bytes,
+            100,
+            8,
+            150,
+            15,
+            "platform/example-service@main",
+        )
+        .expect_err("the next directory-only page must share the raw response budget");
+
+        assert!(error.to_string().contains("whole-operation safety limit"));
+    }
+
+    #[tokio::test]
+    async fn retry_errors_do_not_include_provider_bodies() {
+        let mut server = mockito::Server::new_async().await;
+        let upstream_marker = "sensitive-upstream-marker";
+        let failure = server
+            .mock("GET", "/transient-failure")
+            .with_status(500)
+            .with_body(upstream_marker)
+            .expect(3)
+            .create_async()
+            .await;
+        let provider = GitLabProvider::new(
+            None,
+            AuthMethod::PersonalAccessToken {
+                token: "unused-test-token".to_string(),
+            },
+        );
+        let url = format!("{}/transient-failure", server.url());
+
+        let error = provider
+            .send_with_retry(|| reqwest::Client::new().get(&url))
+            .await
+            .expect_err("the transient response should exhaust retries");
+
+        failure.assert_async().await;
+        assert!(!error.to_string().contains(upstream_marker));
+        assert_eq!(
+            error.to_string(),
+            "API error: HTTP 500 Internal Server Error"
+        );
+    }
+
+    #[tokio::test]
+    async fn uses_the_self_hosted_instance_and_pat_header() {
+        let mut server = mockito::Server::new_async().await;
+        let tree = server
+            .mock(
+                "GET",
+                mockito::Matcher::Regex(
+                    r"^/api/v4/projects/platform%2Fexample-service/repository/tree$".to_string(),
+                ),
+            )
+            .match_header("private-token", "instance-pat")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("ref".into(), "main".into()),
+                mockito::Matcher::UrlEncoded("recursive".into(), "true".into()),
+                mockito::Matcher::UrlEncoded("per_page".into(), "100".into()),
+                mockito::Matcher::UrlEncoded("page".into(), "1".into()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"[{"path":"Cargo.toml","type":"blob"},{"path":"src","type":"tree"}]"#)
+            .create_async()
+            .await;
+        let provider = GitLabProvider::new(
+            Some(server.url()),
+            AuthMethod::PersonalAccessToken {
+                token: "stored-token".to_string(),
+            },
+        );
+
+        let files = <GitLabProvider as GitProviderService>::list_repository_files(
+            &provider,
+            "instance-pat",
+            "platform",
+            "example-service",
+            "main",
+        )
+        .await
+        .expect("self-hosted GitLab tree should be readable");
+
+        tree.assert_async().await;
+        assert_eq!(files, vec!["Cargo.toml"]);
+    }
+
+    #[tokio::test]
+    async fn preserves_unauthorized_as_an_authentication_failure() {
+        let mut server = mockito::Server::new_async().await;
+        let tree = server
+            .mock(
+                "GET",
+                mockito::Matcher::Regex(
+                    r"^/api/v4/projects/platform%2Fexample-service/repository/tree$".to_string(),
+                ),
+            )
+            .match_header("private-token", "expired-pat")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("ref".into(), "main".into()),
+                mockito::Matcher::UrlEncoded("recursive".into(), "true".into()),
+                mockito::Matcher::UrlEncoded("per_page".into(), "100".into()),
+                mockito::Matcher::UrlEncoded("page".into(), "1".into()),
+            ]))
+            .with_status(401)
+            .create_async()
+            .await;
+        let provider = GitLabProvider::new(
+            Some(server.url()),
+            AuthMethod::PersonalAccessToken {
+                token: "stored-token".to_string(),
+            },
+        );
+
+        let error = <GitLabProvider as GitProviderService>::list_repository_files(
+            &provider,
+            "expired-pat",
+            "platform",
+            "example-service",
+            "main",
+        )
+        .await
+        .expect_err("a rejected PAT must remain an authentication failure");
+
+        tree.assert_async().await;
+        assert!(matches!(error, GitProviderError::AuthenticationFailed(_)));
+        assert!(error.to_string().contains("platform/example-service@main"));
     }
 }

--- a/crates/temps-git/src/services/public_repo.rs
+++ b/crates/temps-git/src/services/public_repo.rs
@@ -8,8 +8,12 @@
 
 use crate::services::git_provider::FileContent;
 use async_trait::async_trait;
+use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+use std::sync::{Arc, OnceLock};
 use thiserror::Error;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 /// Errors that can occur when accessing public repositories
 #[derive(Error, Debug)]
@@ -42,6 +46,9 @@ pub enum PublicRepoError {
 
     #[error("Internal error: {0}")]
     Internal(String),
+
+    #[error("Provider response for {context} exceeded the {limit_bytes}-byte safety limit")]
+    ResponseTooLarge { context: String, limit_bytes: usize },
 }
 
 /// Information about a public repository
@@ -500,20 +507,78 @@ impl PublicRepoProvider for GitHubPublicProvider {
 pub struct GitLabPublicProvider {
     client: reqwest::Client,
     base_url: String,
+    custom_egress_limiter: Option<Arc<Semaphore>>,
+}
+
+fn custom_gitlab_egress_limiter() -> Arc<Semaphore> {
+    static LIMITER: OnceLock<Arc<Semaphore>> = OnceLock::new();
+    LIMITER.get_or_init(|| Arc::new(Semaphore::new(16))).clone()
 }
 
 impl GitLabPublicProvider {
-    pub fn new(base_url: Option<String>) -> Self {
+    const MAX_METADATA_BYTES: usize = 1024 * 1024;
+    const MAX_LIST_BYTES: usize = 4 * 1024 * 1024;
+    const MAX_FILE_BYTES: usize = 8 * 1024 * 1024;
+    const MAX_TREE_FILES: usize = 100_000;
+    const MAX_TREE_ENTRIES: usize = 100_000;
+    const MAX_TREE_PATH_BYTES: usize = 4 * 1024;
+    const MAX_TREE_TOTAL_PATH_BYTES: usize = 8 * 1024 * 1024;
+    const MAX_TREE_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
+
+    pub fn new() -> Self {
         let client = reqwest::Client::builder()
             .user_agent("Temps-Engine/1.0")
             .timeout(std::time::Duration::from_secs(30))
+            // Public repository URLs are user-controlled. Never allow an
+            // otherwise safe GitLab origin to redirect requests into an
+            // internal network.
+            .redirect(reqwest::redirect::Policy::none())
             .build()
             .expect("Failed to create HTTP client");
 
         Self {
             client,
-            base_url: base_url.unwrap_or_else(|| "https://gitlab.com".to_string()),
+            base_url: "https://gitlab.com".to_string(),
+            custom_egress_limiter: None,
         }
+    }
+
+    #[cfg(test)]
+    fn with_test_base_url(base_url: String) -> Self {
+        let mut provider = Self::new();
+        provider.base_url = base_url;
+        provider
+    }
+
+    /// Build a provider for a validated self-hosted GitLab origin and pin its
+    /// hostname to the addresses checked by the caller. Pinning closes the
+    /// DNS-rebinding window between validation and the outbound request.
+    pub fn with_resolved_base_url(
+        base_url: String,
+        hostname: &str,
+        addresses: &[SocketAddr],
+    ) -> Result<Self, PublicRepoError> {
+        let client = reqwest::Client::builder()
+            .user_agent("Temps-Engine/1.0")
+            .timeout(std::time::Duration::from_secs(30))
+            .redirect(reqwest::redirect::Policy::none())
+            // `resolve_to_addrs` only pins direct connections. A system HTTPS
+            // proxy would resolve the hostname itself and reopen the DNS-
+            // rebinding window, so custom origins must bypass proxy settings.
+            .no_proxy()
+            .resolve_to_addrs(hostname, addresses)
+            .build()
+            .map_err(|error| {
+                PublicRepoError::Internal(format!(
+                    "Failed to create HTTP client for GitLab instance {base_url}: {error}"
+                ))
+            })?;
+
+        Ok(Self {
+            client,
+            base_url,
+            custom_egress_limiter: Some(custom_gitlab_egress_limiter()),
+        })
     }
 
     /// Send an HTTP request with retry logic for transient failures.
@@ -534,11 +599,9 @@ impl GitLabPublicProvider {
 
                     let status = response.status();
                     if status.is_server_error() || status.as_u16() == 429 {
-                        let error_text = response.text().await.unwrap_or_default();
-                        return Err(PublicRepoError::ApiError(format!(
-                            "HTTP {}: {}",
-                            status, error_text
-                        )));
+                        // Do not buffer or log an attacker-controlled response
+                        // body. Status is sufficient to drive the retry.
+                        return Err(PublicRepoError::ApiError(format!("HTTP {status}")));
                     }
 
                     Ok(response)
@@ -583,11 +646,126 @@ impl GitLabPublicProvider {
     fn encode_project_path(owner: &str, repo: &str) -> String {
         urlencoding::encode(&format!("{}/{}", owner, repo)).to_string()
     }
+
+    async fn acquire_custom_egress_permit(
+        &self,
+    ) -> Result<Option<OwnedSemaphorePermit>, PublicRepoError> {
+        match &self.custom_egress_limiter {
+            Some(limiter) => limiter
+                .clone()
+                .acquire_owned()
+                .await
+                .map(Some)
+                .map_err(|error| {
+                    PublicRepoError::Internal(format!(
+                        "Custom GitLab request limiter is unavailable: {error}"
+                    ))
+                }),
+            None => Ok(None),
+        }
+    }
+
+    async fn decode_bounded_json<T>(
+        response: reqwest::Response,
+        limit_bytes: usize,
+        context: &str,
+    ) -> Result<(T, usize), PublicRepoError>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        if response
+            .content_length()
+            .is_some_and(|length| length > limit_bytes as u64)
+        {
+            return Err(PublicRepoError::ResponseTooLarge {
+                context: context.to_string(),
+                limit_bytes,
+            });
+        }
+
+        let mut body = Vec::with_capacity(
+            response
+                .content_length()
+                .unwrap_or(0)
+                .min(limit_bytes as u64) as usize,
+        );
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|error| {
+                PublicRepoError::ApiError(format!(
+                    "Failed to read provider response for {context}: {error}"
+                ))
+            })?;
+            if body.len().saturating_add(chunk.len()) > limit_bytes {
+                return Err(PublicRepoError::ResponseTooLarge {
+                    context: context.to_string(),
+                    limit_bytes,
+                });
+            }
+            body.extend_from_slice(&chunk);
+        }
+
+        let body_len = body.len();
+        serde_json::from_slice(&body)
+            .map(|value| (value, body_len))
+            .map_err(|error| {
+                PublicRepoError::ApiError(format!(
+                    "Failed to parse provider response for {context}: {error}"
+                ))
+            })
+    }
+
+    fn append_bounded_tree_paths<I>(
+        files: &mut Vec<String>,
+        retained_path_bytes: &mut usize,
+        paths: I,
+        max_files: usize,
+        max_path_bytes: usize,
+        max_total_path_bytes: usize,
+    ) -> Result<(), PublicRepoError>
+    where
+        I: IntoIterator<Item = String>,
+    {
+        for path in paths {
+            let path_bytes = path.len();
+            if path_bytes > max_path_bytes
+                || files.len() >= max_files
+                || retained_path_bytes.saturating_add(path_bytes) > max_total_path_bytes
+            {
+                return Err(PublicRepoError::ResponseTooLarge {
+                    context: "repository tree paths".to_string(),
+                    limit_bytes: max_total_path_bytes,
+                });
+            }
+            *retained_path_bytes += path_bytes;
+            files.push(path);
+        }
+        Ok(())
+    }
+
+    fn record_tree_page_budget(
+        total_entries: &mut usize,
+        total_response_bytes: &mut usize,
+        page_entries: usize,
+        page_response_bytes: usize,
+        max_entries: usize,
+        max_response_bytes: usize,
+    ) -> Result<(), PublicRepoError> {
+        *total_entries = total_entries.saturating_add(page_entries);
+        *total_response_bytes = total_response_bytes.saturating_add(page_response_bytes);
+        if *total_entries > max_entries || *total_response_bytes > max_response_bytes {
+            return Err(PublicRepoError::ResponseTooLarge {
+                context: "repository tree operation".to_string(),
+                limit_bytes: max_response_bytes,
+            });
+        }
+        Ok(())
+    }
 }
 
 impl Default for GitLabPublicProvider {
     fn default() -> Self {
-        Self::new(None)
+        Self::new()
     }
 }
 
@@ -602,6 +780,7 @@ impl PublicRepoProvider for GitLabPublicProvider {
         owner: &str,
         repo: &str,
     ) -> Result<PublicRepoInfo, PublicRepoError> {
+        let _egress_permit = self.acquire_custom_egress_permit().await?;
         let encoded_path = Self::encode_project_path(owner, repo);
         let url = format!("{}/api/v4/projects/{}", self.base_url, encoded_path);
 
@@ -626,10 +805,9 @@ impl PublicRepoProvider for GitLabPublicProvider {
             path: String,
         }
 
-        let project: GitLabProject = response
-            .json()
-            .await
-            .map_err(|e| PublicRepoError::ApiError(format!("Failed to parse response: {}", e)))?;
+        let (project, _): (GitLabProject, _) =
+            Self::decode_bounded_json(response, Self::MAX_METADATA_BYTES, "repository metadata")
+                .await?;
 
         ensure_repository_is_public(project.visibility == "public", owner, repo)?;
 
@@ -656,6 +834,7 @@ impl PublicRepoProvider for GitLabPublicProvider {
         owner: &str,
         repo: &str,
     ) -> Result<Vec<PublicBranch>, PublicRepoError> {
+        let _egress_permit = self.acquire_custom_egress_permit().await?;
         #[derive(Deserialize)]
         struct GitLabBranch {
             name: String,
@@ -686,9 +865,9 @@ impl PublicRepoProvider for GitLabPublicProvider {
                 &format!("Branches for {}/{}", owner, repo),
             )?;
 
-            let branches: Vec<GitLabBranch> = response.json().await.map_err(|e| {
-                PublicRepoError::ApiError(format!("Failed to parse branches: {}", e))
-            })?;
+            let (branches, _): (Vec<GitLabBranch>, _) =
+                Self::decode_bounded_json(response, Self::MAX_LIST_BYTES, "repository branches")
+                    .await?;
 
             let count = branches.len();
             all_branches.extend(branches.into_iter().map(|b| PublicBranch {
@@ -712,11 +891,15 @@ impl PublicRepoProvider for GitLabPublicProvider {
         repo: &str,
         reference: &str,
     ) -> Result<Vec<String>, PublicRepoError> {
+        let _egress_permit = self.acquire_custom_egress_permit().await?;
         let encoded_path = Self::encode_project_path(owner, repo);
         let encoded_ref = urlencoding::encode(reference);
 
         // GitLab requires pagination for tree, fetch all files recursively
         let mut all_files = Vec::new();
+        let mut retained_path_bytes = 0usize;
+        let mut total_entries = 0usize;
+        let mut total_response_bytes = 0usize;
         let mut page = 1;
         let per_page = 100;
 
@@ -740,19 +923,31 @@ impl PublicRepoProvider for GitLabPublicProvider {
                 entry_type: String,
             }
 
-            let entries: Vec<TreeEntry> = response
-                .json()
-                .await
-                .map_err(|e| PublicRepoError::ApiError(format!("Failed to parse tree: {}", e)))?;
+            let (entries, page_response_bytes): (Vec<TreeEntry>, _) =
+                Self::decode_bounded_json(response, Self::MAX_LIST_BYTES, "repository tree")
+                    .await?;
 
             let count = entries.len();
+            Self::record_tree_page_budget(
+                &mut total_entries,
+                &mut total_response_bytes,
+                count,
+                page_response_bytes,
+                Self::MAX_TREE_ENTRIES,
+                Self::MAX_TREE_RESPONSE_BYTES,
+            )?;
 
-            // Filter only blobs (files)
-            for entry in entries {
-                if entry.entry_type == "blob" {
-                    all_files.push(entry.path);
-                }
-            }
+            Self::append_bounded_tree_paths(
+                &mut all_files,
+                &mut retained_path_bytes,
+                entries
+                    .into_iter()
+                    .filter(|entry| entry.entry_type == "blob")
+                    .map(|entry| entry.path),
+                Self::MAX_TREE_FILES,
+                Self::MAX_TREE_PATH_BYTES,
+                Self::MAX_TREE_TOTAL_PATH_BYTES,
+            )?;
 
             // If we got fewer entries than per_page, we've reached the end
             if count < per_page {
@@ -777,6 +972,7 @@ impl PublicRepoProvider for GitLabPublicProvider {
         path: &str,
         reference: &str,
     ) -> Result<FileContent, PublicRepoError> {
+        let _egress_permit = self.acquire_custom_egress_permit().await?;
         let encoded_project = Self::encode_project_path(owner, repo);
         let encoded_path = urlencoding::encode(path);
         let url = format!(
@@ -801,9 +997,8 @@ impl PublicRepoProvider for GitLabPublicProvider {
             encoding: String,
         }
 
-        let file: GitLabFile = response.json().await.map_err(|e| {
-            PublicRepoError::ApiError(format!("Failed to parse file content: {}", e))
-        })?;
+        let (file, _): (GitLabFile, _) =
+            Self::decode_bounded_json(response, Self::MAX_FILE_BYTES, "repository file").await?;
 
         Ok(FileContent {
             path: file.file_path,
@@ -821,7 +1016,7 @@ impl PublicRepoProviderFactory {
     pub fn create(provider: &str) -> Result<Box<dyn PublicRepoProvider>, PublicRepoError> {
         match provider.to_lowercase().as_str() {
             "github" => Ok(Box::new(GitHubPublicProvider::new())),
-            "gitlab" => Ok(Box::new(GitLabPublicProvider::new(None))),
+            "gitlab" => Ok(Box::new(GitLabPublicProvider::new())),
             _ => Err(PublicRepoError::ProviderNotSupported(provider.to_string())),
         }
     }
@@ -836,14 +1031,38 @@ impl PublicRepoProviderFactory {
                 Some(t) => Ok(Box::new(GitHubPublicProvider::with_token(t))),
                 None => Ok(Box::new(GitHubPublicProvider::new())),
             },
-            "gitlab" => Ok(Box::new(GitLabPublicProvider::new(None))),
+            "gitlab" => Ok(Box::new(GitLabPublicProvider::new())),
             _ => Err(PublicRepoError::ProviderNotSupported(provider.to_string())),
         }
     }
 
-    /// Create a GitLab provider with a custom base URL (for self-hosted instances)
-    pub fn create_gitlab_with_url(base_url: &str) -> Box<dyn PublicRepoProvider> {
-        Box::new(GitLabPublicProvider::new(Some(base_url.to_string())))
+    /// Create a provider and optionally target a validated, DNS-pinned
+    /// self-hosted GitLab instance.
+    pub fn create_with_gitlab_instance(
+        provider: &str,
+        token: Option<String>,
+        gitlab_instance: Option<(String, String, Vec<SocketAddr>)>,
+    ) -> Result<Box<dyn PublicRepoProvider>, PublicRepoError> {
+        match provider.to_lowercase().as_str() {
+            "github" => {
+                if gitlab_instance.is_some() {
+                    return Err(PublicRepoError::ProviderNotSupported(
+                        "Custom base URLs are supported only for GitLab".to_string(),
+                    ));
+                }
+                match token {
+                    Some(token) => Ok(Box::new(GitHubPublicProvider::with_token(token))),
+                    None => Ok(Box::new(GitHubPublicProvider::new())),
+                }
+            }
+            "gitlab" => match gitlab_instance {
+                Some((base_url, hostname, addresses)) => Ok(Box::new(
+                    GitLabPublicProvider::with_resolved_base_url(base_url, &hostname, &addresses)?,
+                )),
+                None => Ok(Box::new(GitLabPublicProvider::new())),
+            },
+            _ => Err(PublicRepoError::ProviderNotSupported(provider.to_string())),
+        }
     }
 }
 
@@ -910,6 +1129,82 @@ mod tests {
         ));
     }
 
+    #[tokio::test]
+    async fn gitlab_rejects_oversized_metadata_without_decoding_it() {
+        let mut server = mockito::Server::new_async().await;
+        let response = server
+            .mock("GET", "/api/v4/projects/platform%2Fexample-service")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(vec![b' '; GitLabPublicProvider::MAX_METADATA_BYTES + 1])
+            .create_async()
+            .await;
+        let provider = GitLabPublicProvider::with_test_base_url(server.url());
+
+        let error = provider
+            .get_repository("platform", "example-service")
+            .await
+            .expect_err("oversized provider metadata must be rejected before decoding");
+
+        response.assert_async().await;
+        assert!(matches!(error, PublicRepoError::ResponseTooLarge { .. }));
+    }
+
+    #[test]
+    fn gitlab_tree_limits_are_cumulative_across_pages() {
+        let mut files = Vec::new();
+        let mut retained_path_bytes = 0;
+        GitLabPublicProvider::append_bounded_tree_paths(
+            &mut files,
+            &mut retained_path_bytes,
+            ["one".to_string(), "two".to_string()],
+            3,
+            16,
+            32,
+        )
+        .expect("the first full page should fit");
+
+        let error = GitLabPublicProvider::append_bounded_tree_paths(
+            &mut files,
+            &mut retained_path_bytes,
+            ["three".to_string(), "four".to_string()],
+            3,
+            16,
+            32,
+        )
+        .expect_err("a later page must share the same cumulative limit");
+
+        assert!(matches!(error, PublicRepoError::ResponseTooLarge { .. }));
+        assert_eq!(files, vec!["one", "two", "three"]);
+    }
+
+    #[test]
+    fn gitlab_tree_budget_counts_directory_only_page_bytes() {
+        let mut entries = 0;
+        let mut response_bytes = 0;
+        GitLabPublicProvider::record_tree_page_budget(
+            &mut entries,
+            &mut response_bytes,
+            100,
+            8,
+            150,
+            15,
+        )
+        .expect("the first directory-only page should fit");
+
+        let error = GitLabPublicProvider::record_tree_page_budget(
+            &mut entries,
+            &mut response_bytes,
+            100,
+            8,
+            150,
+            15,
+        )
+        .expect_err("the next directory-only page must share the raw response budget");
+
+        assert!(matches!(error, PublicRepoError::ResponseTooLarge { .. }));
+    }
+
     #[test]
     fn github_forbidden_response_is_not_misreported_as_rate_limit() {
         let error = GitHubPublicProvider::check_response_status(
@@ -972,13 +1267,6 @@ mod tests {
             }
             _ => panic!("Expected ProviderNotSupported error"),
         }
-    }
-
-    #[test]
-    fn test_gitlab_custom_url() {
-        let provider =
-            PublicRepoProviderFactory::create_gitlab_with_url("https://gitlab.example.com");
-        assert_eq!(provider.provider_name(), "gitlab");
     }
 
     // =============================================================================
@@ -1192,7 +1480,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_gitlab_get_repository_real_api() {
-        let provider = GitLabPublicProvider::new(None);
+        let provider = GitLabPublicProvider::new();
 
         // Using gitlab-org/gitlab as a well-known public repo
         match provider.get_repository("gitlab-org", "gitlab").await {
@@ -1210,7 +1498,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_gitlab_list_branches_real_api() {
-        let provider = GitLabPublicProvider::new(None);
+        let provider = GitLabPublicProvider::new();
 
         // Using a smaller public GitLab repo for faster testing
         match provider.list_branches("gitlab-org", "gitlab-runner").await {
@@ -1236,7 +1524,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_gitlab_get_file_tree_real_api() {
-        let provider = GitLabPublicProvider::new(None);
+        let provider = GitLabPublicProvider::new();
 
         // Using a smaller repo for file tree test
         match provider
@@ -1262,7 +1550,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_gitlab_nonexistent_repo() {
-        let provider = GitLabPublicProvider::new(None);
+        let provider = GitLabPublicProvider::new();
 
         let result = provider
             .get_repository("this-does-not-exist-12345", "fake-repo")

--- a/crates/temps-providers/src/externalsvc/mongodb.rs
+++ b/crates/temps-providers/src/externalsvc/mongodb.rs
@@ -3769,6 +3769,44 @@ mod tests {
         assert_eq!(service.get_container_name(), "temps-mongodb-test-service");
     }
 
+    #[tokio::test]
+    async fn init_preserves_a_persisted_port_owned_by_the_running_service() {
+        let held = std::net::TcpListener::bind(("127.0.0.1", 0))
+            .expect("reserve a port as a running MongoDB container would");
+        let persisted_port = held.local_addr().expect("read reserved port").port();
+        let docker = Arc::new(Docker::connect_with_local_defaults().unwrap());
+        let service = MongodbService::new("existing-service".to_string(), docker);
+        let config = ServiceConfig {
+            name: "existing-service".to_string(),
+            service_type: ServiceType::Mongodb,
+            version: None,
+            parameters: serde_json::json!({
+                "host": "localhost",
+                "port": persisted_port.to_string(),
+                "database": "admin",
+                "username": "root",
+                "password": "persisted-password",
+                "docker_image": "gotempsh/mongodb-walg:8.0"
+            }),
+        };
+
+        let inferred = service
+            .init(config)
+            .await
+            .expect("initializing an existing service must keep its persisted endpoint");
+
+        assert_eq!(inferred.get("port"), Some(&persisted_port.to_string()));
+        assert_eq!(
+            service
+                .config
+                .read()
+                .await
+                .as_ref()
+                .map(|runtime| runtime.port.as_str()),
+            Some(persisted_port.to_string().as_str())
+        );
+    }
+
     #[test]
     fn test_get_effective_address_docker_mode_uses_imported_container_name() {
         let _lock = crate::externalsvc::DEPLOYMENT_MODE_MUTEX

--- a/crates/temps-providers/src/externalsvc/port_util.rs
+++ b/crates/temps-providers/src/externalsvc/port_util.rs
@@ -98,7 +98,13 @@ pub async fn find_available_port_async(docker: &Docker, start_port: u16) -> Opti
 /// another allocator grabbed it first. Safe to retry with a fresh port when
 /// this returns true; any other error should propagate as-is.
 pub fn is_port_conflict_error(message: &str) -> bool {
-    message.contains("port is already allocated") || message.contains("address already in use")
+    let message = message.to_ascii_lowercase();
+    message.contains("port is already allocated")
+        || message.contains("address already in use")
+        || message.contains("port is already in use")
+        || message.contains("ports are not available")
+        || message.contains("failed to bind host port")
+        || message.contains("only one usage of each socket address")
 }
 
 /// Collect every host port currently published by a Docker container. Returns
@@ -183,5 +189,19 @@ mod tests {
             a, b,
             "consecutive allocations must not return the same port"
         );
+    }
+
+    #[test]
+    fn recognizes_docker_port_conflict_variants() {
+        for message in [
+            "Ports are not available: exposing port TCP 127.0.0.1:27017",
+            "failed to bind host port for 127.0.0.1:27017: port is already in use",
+            "Only one usage of each socket address is normally permitted",
+        ] {
+            assert!(
+                is_port_conflict_error(message),
+                "Docker port conflict was not recognized: {message}"
+            );
+        }
     }
 }

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -34033,7 +34033,12 @@ export type GetPublicRepositoryData = {
          */
         repo: string;
     };
-    query?: never;
+    query?: {
+        /**
+         * HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.
+         */
+        base_url?: string | null;
+    };
     url: '/git/public/{provider}/{owner}/{repo}';
 };
 
@@ -34042,6 +34047,10 @@ export type GetPublicRepositoryErrors = {
      * Provider not supported
      */
     400: unknown;
+    /**
+     * Authentication required for custom GitLab origins
+     */
+    401: unknown;
     /**
      * Git provider permission required
      */
@@ -34087,6 +34096,10 @@ export type GetPublicBranchesData = {
     };
     query?: {
         /**
+         * HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.
+         */
+        base_url?: string | null;
+        /**
          * Force fetch fresh data, bypassing cache (default: false)
          */
         fresh?: boolean;
@@ -34099,6 +34112,10 @@ export type GetPublicBranchesErrors = {
      * Provider not supported
      */
     400: unknown;
+    /**
+     * Authentication required for custom GitLab origins
+     */
+    401: unknown;
     /**
      * Git provider permission required
      */
@@ -34144,6 +34161,10 @@ export type GetPublicComposeServicesData = {
     };
     query: {
         /**
+         * HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.
+         */
+        base_url?: string | null;
+        /**
          * Branch to read the compose file from (default: repository's default branch)
          */
         branch?: string | null;
@@ -34161,6 +34182,14 @@ export type GetPublicComposeServicesErrors = {
      * Provider not supported, or the compose file could not be parsed
      */
     400: unknown;
+    /**
+     * Authentication required for custom GitLab origins
+     */
+    401: unknown;
+    /**
+     * Git provider permission required
+     */
+    403: unknown;
     /**
      * Repository, branch, or compose file not found
      */
@@ -34200,7 +34229,12 @@ export type GetPublicComposePreviewData = {
          */
         repo: string;
     };
-    query?: never;
+    query?: {
+        /**
+         * HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.
+         */
+        base_url?: string | null;
+    };
     url: '/git/public/{provider}/{owner}/{repo}/compose-file';
 };
 
@@ -34209,6 +34243,14 @@ export type GetPublicComposePreviewErrors = {
      * Compose file or override is invalid
      */
     400: unknown;
+    /**
+     * Authentication required for custom GitLab origins
+     */
+    401: unknown;
+    /**
+     * Git provider permission required
+     */
+    403: unknown;
     /**
      * Repository, branch, or compose file not found
      */
@@ -34242,6 +34284,10 @@ export type DetectPublicEnvExampleData = {
     };
     query?: {
         /**
+         * HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.
+         */
+        base_url?: string | null;
+        /**
          * Branch name to inspect (default: repository's default branch)
          */
         branch?: string | null;
@@ -34258,6 +34304,14 @@ export type DetectPublicEnvExampleErrors = {
      * Provider not supported
      */
     400: unknown;
+    /**
+     * Authentication required for custom GitLab origins
+     */
+    401: unknown;
+    /**
+     * Git provider permission required
+     */
+    403: unknown;
     /**
      * Repository or branch not found
      */
@@ -34299,6 +34353,10 @@ export type DetectPublicPresetsData = {
     };
     query?: {
         /**
+         * HTTPS/443 origin of a self-hosted GitLab instance. Requires authentication and git_repositories:read.
+         */
+        base_url?: string | null;
+        /**
          * Branch name to detect presets for (default: repository's default branch)
          */
         branch?: string | null;
@@ -34315,6 +34373,10 @@ export type DetectPublicPresetsErrors = {
      * Provider not supported
      */
     400: unknown;
+    /**
+     * Authentication required for custom GitLab origins
+     */
+    401: unknown;
     /**
      * Git provider permission required
      */

--- a/web/src/components/deployments/BranchSelector.tsx
+++ b/web/src/components/deployments/BranchSelector.tsx
@@ -40,15 +40,7 @@ import { useMemo, useState, useEffect } from 'react'
 import { isExpiredTokenError } from '@/utils/errorHandling'
 import { Link } from 'react-router'
 import { toast } from 'sonner'
-
-/** Detect git provider from a git URL */
-function detectProviderFromUrl(gitUrl: string): 'github' | 'gitlab' | null {
-  if (gitUrl.includes('github.com') || gitUrl.includes('github'))
-    return 'github'
-  if (gitUrl.includes('gitlab.com') || gitUrl.includes('gitlab'))
-    return 'gitlab'
-  return null
-}
+import { parsePublicRepositoryUrl } from '@/lib/public-repository'
 
 /** Normalized branch shape the combobox renders, regardless of source. */
 export interface ResolvedBranch {
@@ -95,13 +87,16 @@ export function BranchSelector({
   const queryClient = useQueryClient()
 
   // Detect if this is a public repo (no connection but has gitUrl)
-  const publicProvider = useMemo(() => {
+  const publicRepository = useMemo(() => {
     if (connectionId) return null
-    if (gitUrl) return detectProviderFromUrl(gitUrl)
+    if (gitUrl) return parsePublicRepositoryUrl(gitUrl)
     // Default to github if we have owner/name but no connection
-    if (repoOwner && repoName) return 'github' as const
+    if (repoOwner && repoName) {
+      return { provider: 'github' as const, owner: repoOwner, name: repoName }
+    }
     return null
   }, [connectionId, gitUrl, repoOwner, repoName])
+  const publicProvider = publicRepository?.provider ?? null
 
   // Fetch branches from authenticated API (when connectionId exists)
   const branchesQuery = useQuery({
@@ -127,6 +122,7 @@ export function BranchSelector({
         owner: repoOwner,
         repo: repoName,
       },
+      query: { base_url: publicRepository?.instanceUrl },
     }),
     enabled:
       !providedBranches &&
@@ -188,6 +184,7 @@ export function BranchSelector({
                 owner: repoOwner,
                 repo: repoName,
               },
+              query: { base_url: publicRepository?.instanceUrl },
             }).queryKey,
           })
         }

--- a/web/src/components/project/GitImportClone.tsx
+++ b/web/src/components/project/GitImportClone.tsx
@@ -51,6 +51,8 @@ import {
 import { Drop } from '@/pages/Drop'
 import { toast } from 'sonner'
 import { Badge } from '@/components/ui/badge'
+import { parsePublicRepositoryUrl } from '@/lib/public-repository'
+import { getPublicRepository } from '@/api/client/sdk.gen'
 
 const SOURCE_VALUES: ProjectSource[] = [
   'templates',
@@ -69,6 +71,7 @@ interface ParsedGitUrl {
   provider: 'github' | 'gitlab'
   owner: string
   repo: string
+  instanceUrl?: string
 }
 
 /**
@@ -76,50 +79,15 @@ interface ParsedGitUrl {
  * Supports: https://github.com/owner/repo, https://gitlab.com/owner/repo, etc.
  */
 function parseGitUrl(url: string): ParsedGitUrl | null {
-  try {
-    // Clean up the URL
-    const cleanUrl = url.trim().replace(/\.git$/, '')
-
-    // Try to parse as URL
-    let hostname: string
-    let pathname: string
-
-    if (cleanUrl.startsWith('http://') || cleanUrl.startsWith('https://')) {
-      const parsed = new URL(cleanUrl)
-      hostname = parsed.hostname.toLowerCase()
-      pathname = parsed.pathname
-    } else if (cleanUrl.includes('@') && cleanUrl.includes(':')) {
-      // SSH URL format: git@github.com:owner/repo
-      const match = cleanUrl.match(/@([^:]+):(.+)/)
-      if (!match) return null
-      hostname = match[1].toLowerCase()
-      pathname = '/' + match[2]
-    } else {
-      return null
-    }
-
-    // Determine provider
-    let provider: 'github' | 'gitlab'
-    if (hostname.includes('github')) {
-      provider = 'github'
-    } else if (hostname.includes('gitlab')) {
-      provider = 'gitlab'
-    } else {
-      return null
-    }
-
-    // Extract owner and repo from pathname
-    const parts = pathname.split('/').filter(Boolean)
-    if (parts.length < 2) return null
-
-    return {
-      provider,
-      owner: parts[0],
-      repo: parts[1],
-    }
-  } catch {
-    return null
-  }
+  const parsed = parsePublicRepositoryUrl(url)
+  return parsed
+    ? {
+        provider: parsed.provider,
+        owner: parsed.owner,
+        repo: parsed.name,
+        instanceUrl: parsed.instanceUrl,
+      }
+    : null
 }
 
 interface GitImportCloneProps {
@@ -398,6 +366,7 @@ export function GitImportClone({
         owner: parsedPublicRepo?.owner || '',
         repo: parsedPublicRepo?.repo || '',
       },
+      query: { base_url: parsedPublicRepo?.instanceUrl },
     }),
     enabled: useGitUrl && !!parsedPublicRepo && !!selectedRepository,
   })
@@ -429,6 +398,7 @@ export function GitImportClone({
         },
         query: {
           branch: selectedRepository?.default_branch,
+          base_url: parsedPublicRepo?.instanceUrl,
         },
       }),
       enabled: useGitUrl && !!parsedPublicRepo && !!selectedRepository,
@@ -493,14 +463,20 @@ export function GitImportClone({
       setIsValidatingUrl(true)
 
       try {
-        const response = await fetch(
-          `/api/git/public/${parsed.provider}/${parsed.owner}/${parsed.repo}`
-        )
+        const result = await getPublicRepository({
+          path: {
+            provider: parsed.provider,
+            owner: parsed.owner,
+            repo: parsed.repo,
+          },
+          query: { base_url: parsed.instanceUrl },
+          throwOnError: false,
+        })
 
-        if (!response.ok) {
-          if (response.status === 404) {
+        if (!result.data) {
+          if (result.response?.status === 404) {
             toast.error('Repository not found or is not public')
-          } else if (response.status === 429) {
+          } else if (result.response?.status === 429) {
             toast.error('Rate limit exceeded. Please try again later.')
           } else {
             toast.error('Failed to fetch repository information')
@@ -509,7 +485,7 @@ export function GitImportClone({
           return
         }
 
-        const repoInfo = await response.json()
+        const repoInfo = result.data
 
         const repoFromApi: RepositoryResponse = {
           id: 0,
@@ -669,6 +645,7 @@ export function GitImportClone({
                     provider: parsedPublicRepo.provider || 'github',
                     owner: parsedPublicRepo.owner,
                     repo: parsedPublicRepo.repo,
+                    baseUrl: parsedPublicRepo.instanceUrl,
                   }
                 : null
             }

--- a/web/src/components/project/ProjectConfigurator.tsx
+++ b/web/src/components/project/ProjectConfigurator.tsx
@@ -250,7 +250,12 @@ function ComposeFileSelector({
   repositoryId: number | undefined
   branch: string | undefined
   /** Set for public "git URL" imports, where there's no `repositoryId` to key the live preview query on. */
-  publicRepo?: { provider: string; owner: string; repo: string } | null
+  publicRepo?: {
+    provider: string
+    owner: string
+    repo: string
+    baseUrl?: string
+  } | null
 }) {
   const [isCustomPath, setIsCustomPath] = useState(false)
   const rootDirectory = form.watch('rootDirectory') || './'
@@ -325,7 +330,11 @@ function ComposeFileSelector({
         owner: publicRepo?.owner || '',
         repo: publicRepo?.repo || '',
       },
-      query: { branch, path: composeRepositoryPath },
+      query: {
+        branch,
+        path: composeRepositoryPath,
+        base_url: publicRepo?.baseUrl,
+      },
     }),
     enabled:
       !!publicRepo && !!publicRepo.owner && !!publicRepo.repo && !!composePath,
@@ -419,8 +428,8 @@ function ComposeFileSelector({
                       </span>
                     </TooltipTrigger>
                     <TooltipContent className="max-w-xs">
-                      This looks like a database container — it won&apos;t have Temps
-                      backup/restore. Consider excluding it and using a
+                      This looks like a database container — it won&apos;t have
+                      Temps backup/restore. Consider excluding it and using a
                       Temps-managed database instead.
                     </TooltipContent>
                   </Tooltip>
@@ -577,7 +586,12 @@ interface ProjectConfiguratorProps {
    * and docker-compose services) query public endpoints instead of using the
    * synthetic `repository.id` from this flow.
    */
-  publicRepo?: { provider: string; owner: string; repo: string } | null
+  publicRepo?: {
+    provider: string
+    owner: string
+    repo: string
+    baseUrl?: string
+  } | null
 
   // Display modes
   mode?: 'wizard' | 'inline' | 'compact'
@@ -797,6 +811,7 @@ export function ProjectConfigurator({
       query: {
         branch: selectedBranch,
         root_directory: selectedRootDirectory || './',
+        base_url: publicRepo?.baseUrl,
       },
     }),
     enabled: !!publicRepo && !!selectedBranch,
@@ -812,25 +827,23 @@ export function ProjectConfigurator({
       : fetchedPublicEnvExampleData
         ? fetchedPublicEnvExampleData.path
         : (providedEnvExampleData?.path ?? null)
-  const envExampleVariables = useMemo(
-    () => {
-      if (isFetchingEnvExample) return []
-      if (fetchedEnvExampleData) return fetchedEnvExampleData.variables
-      if (fetchedPublicEnvExampleData) {
-        return fetchedPublicEnvExampleData.variables.map((variable) => ({
-          key: variable.key,
-          defaultValue: variable.default_value,
-          description: variable.description,
-        }))
-      }
-      return providedEnvExampleData?.variables ?? []
-    }, [
-      providedEnvExampleData,
-      fetchedEnvExampleData,
-      fetchedPublicEnvExampleData,
-      isFetchingEnvExample,
-    ]
-  )
+  const envExampleVariables = useMemo(() => {
+    if (isFetchingEnvExample) return []
+    if (fetchedEnvExampleData) return fetchedEnvExampleData.variables
+    if (fetchedPublicEnvExampleData) {
+      return fetchedPublicEnvExampleData.variables.map((variable) => ({
+        key: variable.key,
+        defaultValue: variable.default_value,
+        description: variable.description,
+      }))
+    }
+    return providedEnvExampleData?.variables ?? []
+  }, [
+    providedEnvExampleData,
+    fetchedEnvExampleData,
+    fetchedPublicEnvExampleData,
+    isFetchingEnvExample,
+  ])
 
   const [envExampleDismissed, setEnvExampleDismissed] = useState(false)
   const [selectedEnvExampleKeys, setSelectedEnvExampleKeys] = useState<
@@ -2033,7 +2046,9 @@ export function ProjectConfigurator({
                                           >
                                             <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
                                             <div className="flex flex-col min-w-0">
-                                              <span>This project&apos;s URL</span>
+                                              <span>
+                                                This project&apos;s URL
+                                              </span>
                                               <span className="text-xs text-muted-foreground truncate">
                                                 {suggestedAppUrl}
                                               </span>

--- a/web/src/components/project/settings/EnvironmentVariablesSettings.tsx
+++ b/web/src/components/project/settings/EnvironmentVariablesSettings.tsx
@@ -71,7 +71,10 @@ import {
 } from '@/lib/credential-reveal-state'
 import { IntegrationBadge } from './IntegrationBadge'
 import { Link } from 'react-router'
-import { publicRepositoryProvider } from '@/lib/public-repository'
+import {
+  parsePublicRepositoryUrl,
+  publicRepositoryProvider,
+} from '@/lib/public-repository'
 import {
   discoverComposeEnvironmentVariables,
   type DiscoveredEnvironmentVariable,
@@ -1156,6 +1159,7 @@ export function EnvironmentVariablesSettings({
   const isDockerCompose = project.preset === 'docker-compose'
   const isPublicRepository = project.is_public_repo
   const publicProvider = publicRepositoryProvider(project.git_url)
+  const publicRepository = parsePublicRepositoryUrl(project.git_url)
   const composeConfig =
     (project.preset_config as Record<string, unknown> | null) ?? {}
   const composePath =
@@ -1222,6 +1226,7 @@ export function EnvironmentVariablesSettings({
       query: {
         branch: project.main_branch,
         root_directory: project.directory || './',
+        base_url: publicRepository?.instanceUrl,
       },
     }),
     enabled:
@@ -1244,7 +1249,11 @@ export function EnvironmentVariablesSettings({
         owner: project.repo_owner ?? '',
         repo: project.repo_name ?? '',
       },
-      query: { branch: project.main_branch, path: composeRepositoryPath },
+      query: {
+        branch: project.main_branch,
+        path: composeRepositoryPath,
+        base_url: publicRepository?.instanceUrl,
+      },
     }),
     enabled:
       isDockerCompose &&

--- a/web/src/components/project/settings/GitSettings.tsx
+++ b/web/src/components/project/settings/GitSettings.tsx
@@ -188,6 +188,7 @@ function GitSettingsInline({
   const isUploadedSource = project.source_type === 'uploaded_source'
   const sections = projectSettingsSections(view, project.source_type)
   const publicProvider = publicRepositoryProvider(project?.git_url)
+  const publicRepository = parsePublicRepositoryUrl(project?.git_url)
 
   const { data: providersData } = useQuery({ ...listGitProvidersOptions() })
   const providers = providersData || []
@@ -243,6 +244,7 @@ function GitSettingsInline({
         owner: project?.repo_owner || '',
         repo: project?.repo_name || '',
       },
+      query: { base_url: publicRepository?.instanceUrl },
     }),
     enabled: isPublicRepo && !!project?.repo_owner && !!project?.repo_name,
     retry: false,
@@ -311,6 +313,7 @@ function GitSettingsInline({
         owner: project?.repo_owner || '',
         repo: project?.repo_name || '',
       },
+      query: { base_url: publicRepository?.instanceUrl },
     }),
     enabled: isPublicRepo && !!project?.repo_owner && !!project?.repo_name,
   })
@@ -321,6 +324,7 @@ function GitSettingsInline({
         owner: project?.repo_owner || '',
         repo: project?.repo_name || '',
       },
+      query: { base_url: publicRepository?.instanceUrl },
     }),
     enabled: isPublicRepo && !!project?.repo_owner && !!project?.repo_name,
   })
@@ -511,6 +515,7 @@ function GitSettingsInline({
       'effective-compose-preview',
       repositoryData?.id,
       publicProvider,
+      publicRepository?.instanceUrl,
       project.repo_owner,
       project.repo_name,
       project.main_branch,
@@ -526,6 +531,7 @@ function GitSettingsInline({
               provider: publicProvider,
               owner: project.repo_owner || '',
               repo: project.repo_name || '',
+              baseUrl: publicRepository?.instanceUrl,
             }
           : {
               kind: 'connected',
@@ -2027,6 +2033,7 @@ function ExcludedServicesInline({
     string | null
   >(null)
   const publicProvider = publicRepositoryProvider(project.git_url)
+  const publicRepository = parsePublicRepositoryUrl(project.git_url)
 
   // Persisted snapshot (captured at creation, refreshed after every
   // successful deploy) is the primary data source — no live git fetch on
@@ -2066,7 +2073,11 @@ function ExcludedServicesInline({
         owner: project.repo_owner || '',
         repo: project.repo_name || '',
       },
-      query: { branch: project.main_branch, path: composeRepositoryPath },
+      query: {
+        branch: project.main_branch,
+        path: composeRepositoryPath,
+        base_url: publicRepository?.instanceUrl,
+      },
     }),
     enabled: false,
   })
@@ -2584,6 +2595,7 @@ export function ChangeRepositoryPage({ project, refetch }: GitSettingsProps) {
     provider: 'github' | 'gitlab'
     owner: string
     name: string
+    instanceUrl?: string
   } | null>(() => parsePublicRepositoryUrl(initialPublicUrl))
   // Branch to connect. Seeded from the currently-connected project's branch,
   // and reset whenever the user picks a different repository (below) so the
@@ -2628,6 +2640,7 @@ export function ChangeRepositoryPage({ project, refetch }: GitSettingsProps) {
         owner: parsedPublic?.owner || '',
         repo: parsedPublic?.name || '',
       },
+      query: { base_url: parsedPublic?.instanceUrl },
     }),
     enabled: mode === 'public' && !!parsedPublic,
   })
@@ -2641,6 +2654,7 @@ export function ChangeRepositoryPage({ project, refetch }: GitSettingsProps) {
         owner: parsedPublic?.owner || '',
         repo: parsedPublic?.name || '',
       },
+      query: { base_url: parsedPublic?.instanceUrl },
     }),
     enabled: mode === 'public' && !!parsedPublic,
   })
@@ -2745,9 +2759,12 @@ export function ChangeRepositoryPage({ project, refetch }: GitSettingsProps) {
       }
     }
     if (mode === 'public') {
-      const providerHost =
-        parsedPublic?.provider === 'gitlab' ? 'gitlab.com' : 'github.com'
-      body.git_url = `https://${providerHost}/${repoToConnect.owner}/${repoToConnect.name}`
+      const providerOrigin =
+        parsedPublic?.instanceUrl ??
+        (parsedPublic?.provider === 'gitlab'
+          ? 'https://gitlab.com'
+          : 'https://github.com')
+      body.git_url = `${providerOrigin}/${repoToConnect.owner}/${repoToConnect.name}`
       body.is_public_repo = true
       body.git_provider_connection_id = null
     } else {
@@ -3023,7 +3040,7 @@ export function ChangeRepositoryPage({ project, refetch }: GitSettingsProps) {
                 }
                 gitUrl={
                   mode === 'public' && parsedPublic
-                    ? `https://${parsedPublic.provider === 'gitlab' ? 'gitlab.com' : 'github.com'}/${parsedPublic.owner}/${parsedPublic.name}`
+                    ? `${parsedPublic.instanceUrl ?? (parsedPublic.provider === 'gitlab' ? 'https://gitlab.com' : 'https://github.com')}/${parsedPublic.owner}/${parsedPublic.name}`
                     : undefined
                 }
                 value={branch}

--- a/web/src/lib/compose-preview.ts
+++ b/web/src/lib/compose-preview.ts
@@ -28,6 +28,7 @@ export type ComposePreviewRepository =
       provider: string
       owner: string
       repo: string
+      baseUrl?: string
     }
 
 export function composePreviewEndpoint(repository: ComposePreviewRepository): {
@@ -68,6 +69,7 @@ export async function fetchComposePreview(
             owner: repository.owner,
             repo: repository.repo,
           },
+          query: { base_url: repository.baseUrl },
           body: request,
           signal,
           throwOnError: false,

--- a/web/src/lib/public-repository.test.ts
+++ b/web/src/lib/public-repository.test.ts
@@ -22,13 +22,34 @@ describe('public repository location', () => {
     })
   })
 
+  test('keeps accepting schemeless public repository URLs', () => {
+    expect(parsePublicRepositoryUrl('gitlab.com/example/project')).toEqual({
+      provider: 'gitlab',
+      owner: 'example',
+      name: 'project',
+    })
+  })
+
   test('defaults old records without a URL to GitHub', () => {
     expect(publicRepositoryProvider(null)).toBe('github')
   })
 
-  test('rejects unsupported hosts', () => {
+  test('retains a neutral origin for a self-hosted GitLab repository', () => {
     expect(
-      parsePublicRepositoryUrl('https://example.test/owner/repo')
+      parsePublicRepositoryUrl(
+        'https://source.example.com/platform/example-service.git'
+      )
+    ).toEqual({
+      provider: 'gitlab',
+      owner: 'platform',
+      name: 'example-service',
+      instanceUrl: 'https://source.example.com',
+    })
+  })
+
+  test('rejects unsupported protocols', () => {
+    expect(
+      parsePublicRepositoryUrl('ftp://source.example.com/owner/repo')
     ).toBeNull()
   })
 })

--- a/web/src/lib/public-repository.ts
+++ b/web/src/lib/public-repository.ts
@@ -5,6 +5,8 @@ export type PublicRepositoryLocation = {
   provider: 'github' | 'gitlab'
   owner: string
   name: string
+  /** GitLab origin for self-hosted instances; omitted for gitlab.com. */
+  instanceUrl?: string
 }
 
 export type RepositoryCoordinates = {
@@ -20,7 +22,10 @@ export type RepositoryCoordinates = {
 export function parseRepositoryCoordinates(
   value: string | null | undefined
 ): RepositoryCoordinates | null {
-  let reference = (value || '').trim().replace(/\/$/, '').replace(/\.git$/, '')
+  let reference = (value || '')
+    .trim()
+    .replace(/\/$/, '')
+    .replace(/\.git$/, '')
   if (!reference) return null
 
   const sshMatch = reference.match(/^git@[^:]+:(.+)$/)
@@ -44,19 +49,60 @@ export function parseRepositoryCoordinates(
 export function parsePublicRepositoryUrl(
   value: string | null | undefined
 ): PublicRepositoryLocation | null {
-  const match = (value || '')
+  const raw = (value || '')
     .trim()
-    .match(
-      /(?:https?:\/\/|ssh:\/\/git@|git@)?(github\.com|gitlab\.com)[/:]([^/\s]+)\/([^/\s]+)/i
-    )
-  if (!match) return null
+    .replace(/\/$/, '')
+    .replace(/\.git$/, '')
+  if (!raw) return null
+  if (raw.includes('://') && !/^(?:https?|ssh):\/\//i.test(raw)) return null
 
-  const name = match[3].replace(/\.git\/?$/, '').replace(/\/$/, '')
-  if (!match[2] || !name) return null
+  let hostname: string
+  let pathname: string
+  let origin: string
+  try {
+    if (/^https?:\/\//i.test(raw) || /^ssh:\/\//i.test(raw)) {
+      const parsed = new URL(raw)
+      hostname = parsed.hostname.toLowerCase()
+      pathname = parsed.pathname
+      origin = `https://${parsed.host}`
+    } else {
+      const ssh = raw.match(/^git@([^:]+):(.+)$/i)
+      if (ssh) {
+        hostname = ssh[1].toLowerCase()
+        pathname = `/${ssh[2]}`
+        origin = `https://${ssh[1]}`
+      } else {
+        const schemeless = raw.match(/^([^/]+)\/(.+)$/)
+        if (!schemeless) return null
+        hostname = schemeless[1].toLowerCase()
+        pathname = `/${schemeless[2]}`
+        origin = `https://${schemeless[1]}`
+      }
+    }
+  } catch {
+    return null
+  }
+
+  // GitHub public clone URLs use github.com. Any other HTTPS/SSH host is
+  // treated as a self-hosted GitLab origin; GitLab instances frequently use
+  // neutral corporate hostnames that do not contain the word "gitlab".
+  const provider = hostname === 'github.com' ? 'github' : 'gitlab'
+
+  const parts = pathname.split('/').filter(Boolean)
+  if (parts.length < 2 || (provider === 'github' && parts.length !== 2)) {
+    return null
+  }
+  const name = parts.pop()
+  if (!name) return null
+  const owner = parts.join('/')
+
   return {
-    provider: match[1].toLowerCase() === 'gitlab.com' ? 'gitlab' : 'github',
-    owner: match[2],
+    provider,
+    owner,
     name,
+    ...(provider === 'gitlab' && hostname !== 'gitlab.com'
+      ? { instanceUrl: origin }
+      : {}),
   }
 }
 


### PR DESCRIPTION
## Summary

- Route authenticated repository tree discovery through each configured provider so self-hosted GitLab origins and PAT-specific headers are preserved.
- Carry validated self-hosted GitLab origins through public import, branch, preset, environment, and Compose flows.
- Harden custom-origin requests with authentication, HTTPS validation, DNS pinning, proxy and redirect blocking, concurrency control, and response limits.
- Expand cross-platform Docker host-port conflict detection while preserving persisted MongoDB ports during service initialization.

## Security

- Custom origins require an authenticated principal with `git_repositories:read`.
- Requests are restricted to validated public HTTPS/443 destinations.
- Provider responses and recursive tree enumeration have per-request and cumulative limits.
- Credentialed retry errors never include upstream response bodies.
- Independent security review passed with no remaining findings.

## Evidence

### GitLab repository discovery

```text
cargo test --lib -p temps-git
cargo test: 327 passed (1 suite, 8.42s)
```

This includes regressions for:

- Self-hosted instance routing and PAT headers
- Typed authentication failures
- Custom-origin authentication and URL validation
- Response-size and cumulative tree limits
- Upstream error-body redaction

### Host-port conflicts

```text
cargo test --lib -p temps-providers
cargo test: 576 passed (1 suite, 8.28s)
```

This includes regressions for cross-platform Docker conflict messages and preserving the configured port of an existing MongoDB service.

### Frontend and generated API

```text
bun test src/lib/public-repository.test.ts
11 pass
0 fail

tsc --noEmit
passed

bun run scripts/check-openapi.ts
openapi.json is canonical (722 paths)
```

The UI layout is unchanged; these checks cover URL classification, custom-origin retention, SDK request integration, and type safety.

### Static checks

```text
cargo check --lib -p temps-git -p temps-providers
0 errors

cargo clippy --lib -p temps-git -p temps-providers -- -D warnings
0 errors

cargo fmt --all -- --check
passed

python3 scripts/source_attribution.py check
Attribution check passed for 3299 source files.
```

## Notes

- MongoDB provisioning remains synchronous.
- Existing MongoDB endpoints are preserved; conflict recovery stays scoped to container startup retries.
- No migrations.
