### PR TITLE
fix(agent): bound worker memory during remote operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,25 @@ Always use `git commit -s` (and `-s` on `--amend`/`revert`). Like the
 Changelog check, the DCO check validates every commit in `base..HEAD`,
 not just the tip.
 
+This is a mandatory agent pre-commit gate. Never run a plain `git commit`:
+
+```bash
+git commit -s -m "type(scope): description"
+```
+
+If a commit was created without the trailer, repair it before pushing:
+
+```bash
+git commit --amend --no-edit -s
+```
+
+Before opening or updating a PR, verify every commit in the PR range contains
+the trailer. Do not assume the pre-commit hooks add it automatically:
+
+```bash
+git log origin/main..HEAD --format='%h%n%B%n---'
+```
+
 ## Per-record config columns, not env vars
 
 When adding a new runtime knob, default to a column on the relevant

--- a/crates/temps-agent/src/exec_timeout.rs
+++ b/crates/temps-agent/src/exec_timeout.rs
@@ -62,6 +62,24 @@ pub(crate) enum ExecTerminationError {
 }
 
 #[derive(Debug, thiserror::Error)]
+pub(crate) enum ContainerIdentityError {
+    #[error("Failed to inspect Docker container reference '{container_ref}': {source}")]
+    Inspect {
+        container_ref: String,
+        source: bollard::errors::Error,
+    },
+    #[error("Docker container reference '{container_ref}' did not report its canonical ID")]
+    MissingId { container_ref: String },
+    #[error(
+        "Docker container reference '{container_ref}' reported malformed canonical ID '{container_id}'"
+    )]
+    InvalidId {
+        container_ref: String,
+        container_id: String,
+    },
+}
+
+#[derive(Debug, thiserror::Error)]
 pub(crate) enum ExecCompletionError {
     #[error(
         "Docker exec '{exec_id}' output ended without a positively stopped state (running={running:?})"
@@ -112,15 +130,17 @@ pub(crate) fn exec_start_was_rejected(error: &bollard::errors::Error) -> bool {
 /// Axum may drop a handler before its internal deadline (for example when an
 /// upstream request times out). Keeping this guard armed across every await
 /// ensures that cancellation and ambiguous output/inspection failures retain
-/// the capture permit and start the same pinned-container restart workflow.
-/// Only a positively completed exec or a successful synchronous restart may
-/// disarm it.
+/// operation and per-container ownership while starting the same pinned-
+/// container restart workflow. Capture capacity is released as soon as its
+/// buffers disappear. Only a positively completed exec or a successful
+/// synchronous restart may disarm the lifecycle guard.
 pub(crate) struct ExecCleanupGuard {
     docker: Docker,
     exec_id: String,
     container_id: String,
     capture_permit: Option<OwnedSemaphorePermit>,
     operation_permit: Option<OwnedSemaphorePermit>,
+    container_permit: Option<OwnedSemaphorePermit>,
     armed: bool,
 }
 
@@ -131,6 +151,7 @@ impl ExecCleanupGuard {
         container_id: String,
         capture_permit: OwnedSemaphorePermit,
         operation_permit: OwnedSemaphorePermit,
+        container_permit: OwnedSemaphorePermit,
     ) -> Self {
         Self {
             docker,
@@ -138,6 +159,25 @@ impl ExecCleanupGuard {
             container_id,
             capture_permit: Some(capture_permit),
             operation_permit: Some(operation_permit),
+            container_permit: Some(container_permit),
+            armed: true,
+        }
+    }
+
+    pub(crate) fn new_without_capture(
+        docker: Docker,
+        exec_id: String,
+        container_id: String,
+        operation_permit: Option<OwnedSemaphorePermit>,
+        container_permit: OwnedSemaphorePermit,
+    ) -> Self {
+        Self {
+            docker,
+            exec_id,
+            container_id,
+            capture_permit: None,
+            operation_permit,
+            container_permit: Some(container_permit),
             armed: true,
         }
     }
@@ -146,6 +186,16 @@ impl ExecCleanupGuard {
         self.armed = false;
         self.capture_permit.take();
         self.operation_permit.take();
+        self.container_permit.take();
+    }
+
+    /// Mark a positively completed exec safe while transferring capture
+    /// accounting to the HTTP response that now owns its buffered output.
+    pub(crate) fn disarm_and_take_capture(&mut self) -> Option<OwnedSemaphorePermit> {
+        self.armed = false;
+        self.operation_permit.take();
+        self.container_permit.take();
+        self.capture_permit.take()
     }
 }
 
@@ -160,15 +210,59 @@ impl Drop for ExecCleanupGuard {
         // and prevents overlapping exec/backup/restore work.
         self.capture_permit.take();
         let Some(operation_permit) = self.operation_permit.take() else {
+            let Some(container_permit) = self.container_permit.take() else {
+                return;
+            };
+            hold_permits_until_exec_stops(
+                self.docker.clone(),
+                self.exec_id.clone(),
+                self.container_id.clone(),
+                None,
+                container_permit,
+            );
             return;
         };
-        hold_permit_until_exec_stops(
+        let Some(container_permit) = self.container_permit.take() else {
+            return;
+        };
+        hold_permits_until_exec_stops(
             self.docker.clone(),
             self.exec_id.clone(),
             self.container_id.clone(),
-            operation_permit,
+            Some(operation_permit),
+            container_permit,
         );
     }
+}
+
+/// Resolve an operator-facing container name/ID to Docker's immutable,
+/// canonical ID before allocating an exec or reserving per-container work.
+pub(crate) async fn resolve_container_id(
+    docker: &Docker,
+    container_ref: &str,
+) -> Result<String, ContainerIdentityError> {
+    let inspect = docker
+        .inspect_container(
+            container_ref,
+            None::<bollard::query_parameters::InspectContainerOptions>,
+        )
+        .await
+        .map_err(|source| ContainerIdentityError::Inspect {
+            container_ref: container_ref.to_string(),
+            source,
+        })?;
+    let container_id = inspect
+        .id
+        .ok_or_else(|| ContainerIdentityError::MissingId {
+            container_ref: container_ref.to_string(),
+        })?;
+    if !is_canonical_container_id(&container_id) {
+        return Err(ContainerIdentityError::InvalidId {
+            container_ref: container_ref.to_string(),
+            container_id,
+        });
+    }
+    Ok(container_id)
 }
 
 /// Resolve and validate the immutable container identity before an exec starts.
@@ -299,11 +393,12 @@ fn is_canonical_container_id(container_id: &str) -> bool {
 /// when the request ends; this permit prevents overlapping mutating work until
 /// Docker confirms the restart (or that the pinned container no longer
 /// exists). Retry traffic and journal volume remain bounded during outages.
-pub(crate) fn hold_permit_until_exec_stops(
+pub(crate) fn hold_permits_until_exec_stops(
     docker: Docker,
     exec_id: String,
     container_id: String,
-    operation_permit: OwnedSemaphorePermit,
+    operation_permit: Option<OwnedSemaphorePermit>,
+    container_permit: OwnedSemaphorePermit,
 ) {
     tokio::spawn(async move {
         let mut retry_delay = ORPHAN_INITIAL_RETRY;
@@ -317,7 +412,7 @@ pub(crate) fn hold_permit_until_exec_stops(
                         container_id = %container_id,
                         retry_seconds = sleep_for.as_secs(),
                         reason = %error,
-                        "Timed-out Docker exec restart still pending; retaining operation slot"
+                        "Timed-out Docker exec restart still pending; retaining lifecycle slots"
                     );
                     retry_delay = retry_delay.saturating_mul(2).min(ORPHAN_MAX_RETRY);
                     tokio::time::sleep(sleep_for).await;
@@ -325,7 +420,39 @@ pub(crate) fn hold_permit_until_exec_stops(
             }
         }
         drop(operation_permit);
-        tracing::info!(exec_id = %exec_id, container_id = %container_id, "Timed-out Docker exec container restarted; released operation slot");
+        drop(container_permit);
+        tracing::info!(exec_id = %exec_id, container_id = %container_id, "Timed-out Docker exec container restarted; released lifecycle slots");
+    });
+}
+
+/// Retain lifecycle ownership for a successfully started exec that outlives
+/// its initiating HTTP/WebSocket request. A positive stopped state releases
+/// the guard without disruption; an ambiguous inspect failure drops the armed
+/// guard and schedules the pinned-container restart workflow.
+pub(crate) fn monitor_exec_until_stopped(
+    docker: Docker,
+    exec_id: String,
+    container_id: String,
+    operation: &'static str,
+    mut cleanup_guard: ExecCleanupGuard,
+) {
+    tokio::spawn(async move {
+        loop {
+            match docker.inspect_exec(&exec_id).await {
+                Ok(inspect) if inspect.running == Some(false) => {
+                    cleanup_guard.disarm();
+                    tracing::info!(exec_id = %exec_id, container_id = %container_id, operation, "Docker exec completed; released lifecycle capacity");
+                    break;
+                }
+                Ok(_) => {
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+                Err(error) => {
+                    tracing::error!(exec_id = %exec_id, container_id = %container_id, operation, reason = %error, "Docker exec state became ambiguous; scheduling containing-container restart");
+                    break;
+                }
+            }
+        }
     });
 }
 
@@ -345,6 +472,7 @@ mod tests {
     struct MockDockerState {
         restart_calls: AtomicUsize,
         stall_restart: AtomicBool,
+        exec_running: AtomicBool,
     }
 
     async fn mock_docker_api(
@@ -354,8 +482,14 @@ mod tests {
         let path = request.uri().path();
         if path.ends_with("/exec/exec-1/json") {
             return Json(serde_json::json!({
-                "Running": true,
+                "Running": state.exec_running.load(Ordering::SeqCst),
                 "ContainerID": CONTAINER_ID,
+            }))
+            .into_response();
+        }
+        if path.ends_with("/containers/service-a/json") {
+            return Json(serde_json::json!({
+                "Id": CONTAINER_ID,
             }))
             .into_response();
         }
@@ -382,6 +516,7 @@ mod tests {
         let state = Arc::new(MockDockerState {
             restart_calls: AtomicUsize::new(0),
             stall_restart: AtomicBool::new(stall_restart),
+            exec_running: AtomicBool::new(true),
         });
         let router = Router::new()
             .fallback(mock_docker_api)
@@ -550,6 +685,90 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn container_reference_resolves_to_canonical_id_before_admission(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (docker, _state, server) = mock_docker(false).await?;
+
+        let result = resolve_container_id(&docker, "service-a").await;
+
+        server.abort();
+        assert!(matches!(result, Ok(container_id) if container_id == CONTAINER_ID));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn request_ended_exec_retains_container_ownership_until_stopped(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (docker, state, server) = mock_docker(false).await?;
+        let container_slots = Arc::new(tokio::sync::Semaphore::new(1));
+        let container_permit = container_slots.clone().acquire_owned().await?;
+        let guard = ExecCleanupGuard::new_without_capture(
+            docker.clone(),
+            "exec-1".to_string(),
+            CONTAINER_ID.to_string(),
+            None,
+            container_permit,
+        );
+
+        monitor_exec_until_stopped(
+            docker,
+            "exec-1".to_string(),
+            CONTAINER_ID.to_string(),
+            "test terminal",
+            guard,
+        );
+        tokio::task::yield_now().await;
+        assert_eq!(container_slots.available_permits(), 0);
+
+        state.exec_running.store(false, Ordering::SeqCst);
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while container_slots.available_permits() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await?;
+
+        server.abort();
+        assert_eq!(container_slots.available_permits(), 1);
+        assert_eq!(state.restart_calls.load(Ordering::SeqCst), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn monitor_inspect_failure_restarts_before_releasing_container_ownership(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (docker, state, server) = mock_docker(false).await?;
+        let container_slots = Arc::new(tokio::sync::Semaphore::new(1));
+        let container_permit = container_slots.clone().acquire_owned().await?;
+        let guard = ExecCleanupGuard::new_without_capture(
+            docker.clone(),
+            "missing-exec".to_string(),
+            CONTAINER_ID.to_string(),
+            None,
+            container_permit,
+        );
+
+        monitor_exec_until_stopped(
+            docker,
+            "missing-exec".to_string(),
+            CONTAINER_ID.to_string(),
+            "test terminal",
+            guard,
+        );
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while container_slots.available_permits() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await?;
+
+        server.abort();
+        assert_eq!(container_slots.available_permits(), 1);
+        assert_eq!(state.restart_calls.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn timeout_cleanup_restarts_the_containing_container(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (docker, state, server) = mock_docker(false).await?;
@@ -567,14 +786,17 @@ mod tests {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (docker, state, server) = mock_docker(false).await?;
         let operation_slots = Arc::new(tokio::sync::Semaphore::new(1));
+        let container_slots = Arc::new(tokio::sync::Semaphore::new(1));
         let operation_permit = operation_slots.clone().acquire_owned().await?;
+        let container_permit = container_slots.clone().acquire_owned().await?;
         assert_eq!(operation_slots.available_permits(), 0);
 
-        hold_permit_until_exec_stops(
+        hold_permits_until_exec_stops(
             docker,
             "exec-1".to_string(),
             CONTAINER_ID.to_string(),
-            operation_permit,
+            Some(operation_permit),
+            container_permit,
         );
         tokio::time::timeout(Duration::from_secs(1), async {
             while operation_slots.available_permits() == 0 {
@@ -585,6 +807,7 @@ mod tests {
 
         server.abort();
         assert_eq!(operation_slots.available_permits(), 1);
+        assert_eq!(container_slots.available_permits(), 1);
         assert_eq!(state.restart_calls.load(Ordering::SeqCst), 1);
         Ok(())
     }
@@ -595,14 +818,17 @@ mod tests {
         let (docker, state, server) = mock_docker(false).await?;
         let capture_slots = Arc::new(tokio::sync::Semaphore::new(1));
         let operation_slots = Arc::new(tokio::sync::Semaphore::new(1));
+        let container_slots = Arc::new(tokio::sync::Semaphore::new(1));
         let capture_permit = capture_slots.clone().acquire_owned().await?;
         let operation_permit = operation_slots.clone().acquire_owned().await?;
+        let container_permit = container_slots.clone().acquire_owned().await?;
         let mut guard = ExecCleanupGuard::new(
             docker,
             "exec-1".to_string(),
             CONTAINER_ID.to_string(),
             capture_permit,
             operation_permit,
+            container_permit,
         );
         let rejection = bollard::errors::Error::DockerResponseServerError {
             status_code: 409,
@@ -619,6 +845,7 @@ mod tests {
         assert_eq!(state.restart_calls.load(Ordering::SeqCst), 0);
         assert_eq!(capture_slots.available_permits(), 1);
         assert_eq!(operation_slots.available_permits(), 1);
+        assert_eq!(container_slots.available_permits(), 1);
         Ok(())
     }
 
@@ -628,14 +855,17 @@ mod tests {
         let (docker, state, server) = mock_docker(false).await?;
         let capture_slots = Arc::new(tokio::sync::Semaphore::new(1));
         let operation_slots = Arc::new(tokio::sync::Semaphore::new(1));
+        let container_slots = Arc::new(tokio::sync::Semaphore::new(1));
         let capture_permit = capture_slots.clone().acquire_owned().await?;
         let operation_permit = operation_slots.clone().acquire_owned().await?;
+        let container_permit = container_slots.clone().acquire_owned().await?;
         let guard = ExecCleanupGuard::new(
             docker,
             "exec-1".to_string(),
             CONTAINER_ID.to_string(),
             capture_permit,
             operation_permit,
+            container_permit,
         );
 
         let request = tokio::spawn(async move {
@@ -657,6 +887,7 @@ mod tests {
         assert_eq!(state.restart_calls.load(Ordering::SeqCst), 1);
         assert_eq!(capture_slots.available_permits(), 1);
         assert_eq!(operation_slots.available_permits(), 1);
+        assert_eq!(container_slots.available_permits(), 1);
         Ok(())
     }
 
@@ -666,14 +897,17 @@ mod tests {
         let (docker, state, server) = mock_docker(true).await?;
         let capture_slots = Arc::new(tokio::sync::Semaphore::new(1));
         let operation_slots = Arc::new(tokio::sync::Semaphore::new(1));
+        let container_slots = Arc::new(tokio::sync::Semaphore::new(1));
         let capture_permit = capture_slots.clone().acquire_owned().await?;
         let operation_permit = operation_slots.clone().acquire_owned().await?;
+        let container_permit = container_slots.clone().acquire_owned().await?;
         let guard = ExecCleanupGuard::new(
             docker,
             "exec-1".to_string(),
             CONTAINER_ID.to_string(),
             capture_permit,
             operation_permit,
+            container_permit,
         );
 
         drop(guard);
@@ -686,6 +920,7 @@ mod tests {
 
         assert_eq!(capture_slots.available_permits(), 1);
         assert_eq!(operation_slots.available_permits(), 0);
+        assert_eq!(container_slots.available_permits(), 0);
         server.abort();
         Ok(())
     }

--- a/crates/temps-agent/src/exec_timeout.rs
+++ b/crates/temps-agent/src/exec_timeout.rs
@@ -1,0 +1,713 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Deadline handling for Docker exec processes.
+//!
+//! Docker has no API for cancelling an exec. Dropping Bollard's attached
+//! output stream leaves the command running, and killing only the exec leader
+//! can orphan shell pipeline children. On timeout, the agent therefore asks
+//! the Docker daemon to kill the containing container. This is deliberately
+//! disruptive, but it is the only daemon-mediated operation that reliably
+//! stops the complete exec workload for both local and remote Docker hosts.
+//! The container is restarted rather than left manually stopped so production
+//! services recover even when they use an `unless-stopped` restart policy.
+
+use bollard::query_parameters::RestartContainerOptionsBuilder;
+use bollard::Docker;
+use std::future::Future;
+use std::time::Duration;
+use tokio::sync::OwnedSemaphorePermit;
+
+const ORPHAN_INITIAL_RETRY: Duration = Duration::from_secs(5);
+const ORPHAN_MAX_RETRY: Duration = Duration::from_secs(5 * 60);
+const RESTART_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug)]
+pub(crate) enum ExecDeadlineOutcome<T> {
+    Completed(T),
+    ContainerRestarted,
+    TerminationFailed(ExecTerminationError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ExecTerminationError {
+    #[error("Failed to inspect timed-out Docker exec '{exec_id}': {source}")]
+    Inspect {
+        exec_id: String,
+        source: bollard::errors::Error,
+    },
+    #[error("Timed-out Docker exec '{exec_id}' did not report its container ID")]
+    MissingContainerId { exec_id: String },
+    #[error("Timed-out Docker exec '{exec_id}' reported malformed container ID '{container_id}'")]
+    InvalidContainerId {
+        exec_id: String,
+        container_id: String,
+    },
+    #[error(
+        "Failed to restart container '{container_id}' for timed-out Docker exec '{exec_id}': {source}"
+    )]
+    RestartContainer {
+        exec_id: String,
+        container_id: String,
+        source: bollard::errors::Error,
+    },
+    #[error(
+        "Timed out after {timeout_seconds}s restarting container '{container_id}' for Docker exec '{exec_id}'"
+    )]
+    RestartTimedOut {
+        exec_id: String,
+        container_id: String,
+        timeout_seconds: u64,
+    },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ExecCompletionError {
+    #[error(
+        "Docker exec '{exec_id}' output ended without a positively stopped state (running={running:?})"
+    )]
+    NotStopped {
+        exec_id: String,
+        running: Option<bool>,
+    },
+    #[error("Stopped Docker exec '{exec_id}' did not report an exit code")]
+    MissingExitCode { exec_id: String },
+}
+
+/// Accept completion only when Docker positively reports a stopped exec.
+/// ExitCode defaults to zero in the Docker API and is not sufficient evidence
+/// by itself that an attached command actually ended.
+pub(crate) fn completed_exec_exit_code(
+    inspect: &bollard::models::ExecInspectResponse,
+    exec_id: &str,
+) -> Result<i64, ExecCompletionError> {
+    if inspect.running != Some(false) {
+        return Err(ExecCompletionError::NotStopped {
+            exec_id: exec_id.to_string(),
+            running: inspect.running,
+        });
+    }
+    inspect
+        .exit_code
+        .ok_or_else(|| ExecCompletionError::MissingExitCode {
+            exec_id: exec_id.to_string(),
+        })
+}
+
+/// A concrete Docker rejection proves the exec did not start, so restarting a
+/// healthy container would be destructive and unnecessary. Transport errors,
+/// server errors, and request timeouts remain ambiguous and keep cleanup armed.
+pub(crate) fn exec_start_was_rejected(error: &bollard::errors::Error) -> bool {
+    matches!(
+        error,
+        bollard::errors::Error::DockerResponseServerError {
+            status_code: 400 | 404 | 409,
+            ..
+        }
+    )
+}
+
+/// Cancellation-safe ownership of a running attached exec.
+///
+/// Axum may drop a handler before its internal deadline (for example when an
+/// upstream request times out). Keeping this guard armed across every await
+/// ensures that cancellation and ambiguous output/inspection failures retain
+/// the capture permit and start the same pinned-container restart workflow.
+/// Only a positively completed exec or a successful synchronous restart may
+/// disarm it.
+pub(crate) struct ExecCleanupGuard {
+    docker: Docker,
+    exec_id: String,
+    container_id: String,
+    capture_permit: Option<OwnedSemaphorePermit>,
+    operation_permit: Option<OwnedSemaphorePermit>,
+    armed: bool,
+}
+
+impl ExecCleanupGuard {
+    pub(crate) fn new(
+        docker: Docker,
+        exec_id: String,
+        container_id: String,
+        capture_permit: OwnedSemaphorePermit,
+        operation_permit: OwnedSemaphorePermit,
+    ) -> Self {
+        Self {
+            docker,
+            exec_id,
+            container_id,
+            capture_permit: Some(capture_permit),
+            operation_permit: Some(operation_permit),
+            armed: true,
+        }
+    }
+
+    pub(crate) fn disarm(&mut self) {
+        self.armed = false;
+        self.capture_permit.take();
+        self.operation_permit.take();
+    }
+}
+
+impl Drop for ExecCleanupGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // The output future and its bounded buffers are gone when the handler
+        // drops this guard, so memory-capture capacity can be returned at once.
+        // The separate operation permit remains charged until cleanup succeeds
+        // and prevents overlapping exec/backup/restore work.
+        self.capture_permit.take();
+        let Some(operation_permit) = self.operation_permit.take() else {
+            return;
+        };
+        hold_permit_until_exec_stops(
+            self.docker.clone(),
+            self.exec_id.clone(),
+            self.container_id.clone(),
+            operation_permit,
+        );
+    }
+}
+
+/// Resolve and validate the immutable container identity before an exec starts.
+///
+/// Keeping this value independently of Docker's in-memory exec store means a
+/// daemon restart cannot turn a later exec-inspect 404 into false proof that a
+/// live-restored workload stopped.
+pub(crate) async fn resolve_exec_container_id(
+    docker: &Docker,
+    exec_id: &str,
+) -> Result<String, ExecTerminationError> {
+    let inspect =
+        docker
+            .inspect_exec(exec_id)
+            .await
+            .map_err(|source| ExecTerminationError::Inspect {
+                exec_id: exec_id.to_string(),
+                source,
+            })?;
+    exec_container_id(&inspect, exec_id)
+}
+
+pub(crate) async fn run_exec_with_deadline<T, F>(
+    docker: &Docker,
+    exec_id: &str,
+    container_id: &str,
+    deadline: Duration,
+    operation: F,
+) -> ExecDeadlineOutcome<T>
+where
+    F: Future<Output = T>,
+{
+    run_with_timeout_cleanup(deadline, operation, || {
+        restart_exec_container(docker, exec_id, container_id)
+    })
+    .await
+}
+
+async fn run_with_timeout_cleanup<T, F, C, CleanupFuture>(
+    deadline: Duration,
+    operation: F,
+    cleanup: C,
+) -> ExecDeadlineOutcome<T>
+where
+    F: Future<Output = T>,
+    C: FnOnce() -> CleanupFuture,
+    CleanupFuture: Future<Output = Result<(), ExecTerminationError>>,
+{
+    match tokio::time::timeout(deadline, operation).await {
+        Ok(output) => ExecDeadlineOutcome::Completed(output),
+        Err(_) => match cleanup().await {
+            Ok(()) => ExecDeadlineOutcome::ContainerRestarted,
+            Err(error) => ExecDeadlineOutcome::TerminationFailed(error),
+        },
+    }
+}
+
+async fn restart_exec_container(
+    docker: &Docker,
+    exec_id: &str,
+    container_id: &str,
+) -> Result<(), ExecTerminationError> {
+    restart_exec_container_with_timeout(docker, exec_id, container_id, RESTART_REQUEST_TIMEOUT)
+        .await
+}
+
+async fn restart_exec_container_with_timeout(
+    docker: &Docker,
+    exec_id: &str,
+    container_id: &str,
+    request_timeout: Duration,
+) -> Result<(), ExecTerminationError> {
+    let options = RestartContainerOptionsBuilder::default()
+        .signal("SIGKILL")
+        .t(0)
+        .build();
+    let restart = tokio::time::timeout(
+        request_timeout,
+        docker.restart_container(container_id, Some(options)),
+    )
+    .await
+    .map_err(|_| ExecTerminationError::RestartTimedOut {
+        exec_id: exec_id.to_string(),
+        container_id: container_id.to_string(),
+        timeout_seconds: request_timeout.as_secs(),
+    })?;
+    match restart {
+        Ok(()) => Ok(()),
+        // A missing container has no remaining workload to overlap a retry.
+        Err(bollard::errors::Error::DockerResponseServerError {
+            status_code: 404, ..
+        }) => Ok(()),
+        Err(source) => Err(ExecTerminationError::RestartContainer {
+            exec_id: exec_id.to_string(),
+            container_id: container_id.to_string(),
+            source,
+        }),
+    }
+}
+
+fn exec_container_id(
+    inspect: &bollard::models::ExecInspectResponse,
+    exec_id: &str,
+) -> Result<String, ExecTerminationError> {
+    let container_id = inspect.container_id.as_deref().ok_or_else(|| {
+        ExecTerminationError::MissingContainerId {
+            exec_id: exec_id.to_string(),
+        }
+    })?;
+    if !is_canonical_container_id(container_id) {
+        return Err(ExecTerminationError::InvalidContainerId {
+            exec_id: exec_id.to_string(),
+            container_id: container_id.to_string(),
+        });
+    }
+    Ok(container_id.to_string())
+}
+
+fn is_canonical_container_id(container_id: &str) -> bool {
+    container_id.len() == 64
+        && container_id
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+/// Keep an operation slot charged to an exec whose container could not
+/// initially be restarted. The memory-capture slot is released separately
+/// when the request ends; this permit prevents overlapping mutating work until
+/// Docker confirms the restart (or that the pinned container no longer
+/// exists). Retry traffic and journal volume remain bounded during outages.
+pub(crate) fn hold_permit_until_exec_stops(
+    docker: Docker,
+    exec_id: String,
+    container_id: String,
+    operation_permit: OwnedSemaphorePermit,
+) {
+    tokio::spawn(async move {
+        let mut retry_delay = ORPHAN_INITIAL_RETRY;
+        loop {
+            match restart_exec_container(&docker, &exec_id, &container_id).await {
+                Ok(()) => break,
+                Err(error) => {
+                    let sleep_for = retry_delay;
+                    tracing::warn!(
+                        exec_id = %exec_id,
+                        container_id = %container_id,
+                        retry_seconds = sleep_for.as_secs(),
+                        reason = %error,
+                        "Timed-out Docker exec restart still pending; retaining operation slot"
+                    );
+                    retry_delay = retry_delay.saturating_mul(2).min(ORPHAN_MAX_RETRY);
+                    tokio::time::sleep(sleep_for).await;
+                }
+            }
+        }
+        drop(operation_permit);
+        tracing::info!(exec_id = %exec_id, container_id = %container_id, "Timed-out Docker exec container restarted; released operation slot");
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::{Request, State};
+    use axum::http::StatusCode;
+    use axum::response::{IntoResponse, Response};
+    use axum::{Json, Router};
+    use std::future::IntoFuture;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    const CONTAINER_ID: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    struct MockDockerState {
+        restart_calls: AtomicUsize,
+        stall_restart: AtomicBool,
+    }
+
+    async fn mock_docker_api(
+        State(state): State<Arc<MockDockerState>>,
+        request: Request,
+    ) -> Response {
+        let path = request.uri().path();
+        if path.ends_with("/exec/exec-1/json") {
+            return Json(serde_json::json!({
+                "Running": true,
+                "ContainerID": CONTAINER_ID,
+            }))
+            .into_response();
+        }
+        if path.ends_with(&format!("/containers/{CONTAINER_ID}/restart")) {
+            state.restart_calls.fetch_add(1, Ordering::SeqCst);
+            if state.stall_restart.load(Ordering::SeqCst) {
+                std::future::pending::<()>().await;
+            }
+            return StatusCode::NO_CONTENT.into_response();
+        }
+        StatusCode::NOT_FOUND.into_response()
+    }
+
+    async fn mock_docker(
+        stall_restart: bool,
+    ) -> Result<
+        (
+            Docker,
+            Arc<MockDockerState>,
+            tokio::task::JoinHandle<Result<(), std::io::Error>>,
+        ),
+        Box<dyn std::error::Error>,
+    > {
+        let state = Arc::new(MockDockerState {
+            restart_calls: AtomicUsize::new(0),
+            stall_restart: AtomicBool::new(stall_restart),
+        });
+        let router = Router::new()
+            .fallback(mock_docker_api)
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let address = listener.local_addr()?;
+        let server = tokio::spawn(axum::serve(listener, router).into_future());
+        let docker = Docker::connect_with_http(
+            &format!("http://{address}"),
+            5,
+            bollard::API_DEFAULT_VERSION,
+        )?;
+        Ok((docker, state, server))
+    }
+
+    #[tokio::test]
+    async fn timeout_waits_for_cleanup_before_returning() {
+        let cleaned_up = Arc::new(AtomicBool::new(false));
+        let cleanup_flag = cleaned_up.clone();
+
+        let outcome = run_with_timeout_cleanup(
+            Duration::ZERO,
+            std::future::pending::<()>(),
+            move || async move {
+                cleanup_flag.store(true, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .await;
+
+        assert!(matches!(outcome, ExecDeadlineOutcome::ContainerRestarted));
+        assert!(cleaned_up.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn completed_operation_does_not_run_cleanup() {
+        let cleaned_up = Arc::new(AtomicBool::new(false));
+        let cleanup_flag = cleaned_up.clone();
+
+        let outcome =
+            run_with_timeout_cleanup(Duration::from_secs(1), async { 42 }, move || async move {
+                cleanup_flag.store(true, Ordering::SeqCst);
+                Ok(())
+            })
+            .await;
+
+        assert!(matches!(outcome, ExecDeadlineOutcome::Completed(42)));
+        assert!(!cleaned_up.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn timeout_reports_cleanup_failure() {
+        let outcome =
+            run_with_timeout_cleanup(Duration::ZERO, std::future::pending::<()>(), || async {
+                Err(ExecTerminationError::MissingContainerId {
+                    exec_id: "exec-1".to_string(),
+                })
+            })
+            .await;
+
+        assert!(matches!(
+            outcome,
+            ExecDeadlineOutcome::TerminationFailed(ExecTerminationError::MissingContainerId { .. })
+        ));
+    }
+
+    #[test]
+    fn running_exec_requires_a_canonical_container_id() {
+        let missing = bollard::models::ExecInspectResponse {
+            running: Some(true),
+            ..Default::default()
+        };
+        assert!(matches!(
+            exec_container_id(&missing, "exec-1"),
+            Err(ExecTerminationError::MissingContainerId { .. })
+        ));
+
+        for malformed in ["", "/", "abc123", &CONTAINER_ID.to_uppercase()] {
+            let inspect = bollard::models::ExecInspectResponse {
+                running: Some(true),
+                container_id: Some(malformed.to_string()),
+                ..Default::default()
+            };
+            assert!(matches!(
+                exec_container_id(&inspect, "exec-1"),
+                Err(ExecTerminationError::InvalidContainerId { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn canonical_container_id_is_accepted() {
+        let inspect = bollard::models::ExecInspectResponse {
+            running: Some(true),
+            container_id: Some(CONTAINER_ID.to_string()),
+            ..Default::default()
+        };
+        assert!(matches!(
+            exec_container_id(&inspect, "exec-1"),
+            Ok(container_id) if container_id == CONTAINER_ID
+        ));
+    }
+
+    #[test]
+    fn exit_code_does_not_prove_a_running_exec_completed() {
+        for running in [Some(true), None] {
+            let inspect = bollard::models::ExecInspectResponse {
+                running,
+                exit_code: Some(0),
+                ..Default::default()
+            };
+            assert!(matches!(
+                completed_exec_exit_code(&inspect, "exec-1"),
+                Err(ExecCompletionError::NotStopped { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn stopped_exec_requires_and_returns_its_exit_code() {
+        let missing = bollard::models::ExecInspectResponse {
+            running: Some(false),
+            ..Default::default()
+        };
+        assert!(matches!(
+            completed_exec_exit_code(&missing, "exec-1"),
+            Err(ExecCompletionError::MissingExitCode { .. })
+        ));
+
+        let completed = bollard::models::ExecInspectResponse {
+            running: Some(false),
+            exit_code: Some(17),
+            ..Default::default()
+        };
+        assert!(matches!(
+            completed_exec_exit_code(&completed, "exec-1"),
+            Ok(17)
+        ));
+    }
+
+    #[test]
+    fn only_definitive_docker_start_rejections_skip_cleanup() {
+        for status_code in [400, 404, 409] {
+            let error = bollard::errors::Error::DockerResponseServerError {
+                status_code,
+                message: "rejected".to_string(),
+            };
+            assert!(exec_start_was_rejected(&error));
+        }
+        let ambiguous = bollard::errors::Error::DockerResponseServerError {
+            status_code: 500,
+            message: "unknown outcome".to_string(),
+        };
+        assert!(!exec_start_was_rejected(&ambiguous));
+    }
+
+    #[tokio::test]
+    async fn exec_container_id_is_pinned_before_start() -> Result<(), Box<dyn std::error::Error>> {
+        let (docker, _state, server) = mock_docker(false).await?;
+
+        let result = resolve_exec_container_id(&docker, "exec-1").await;
+
+        server.abort();
+        assert!(matches!(result, Ok(container_id) if container_id == CONTAINER_ID));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn timeout_cleanup_restarts_the_containing_container(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (docker, state, server) = mock_docker(false).await?;
+
+        let result = restart_exec_container(&docker, "exec-1", CONTAINER_ID).await;
+
+        server.abort();
+        assert!(result.is_ok());
+        assert_eq!(state.restart_calls.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn successful_restart_releases_held_operation_permit(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (docker, state, server) = mock_docker(false).await?;
+        let operation_slots = Arc::new(tokio::sync::Semaphore::new(1));
+        let operation_permit = operation_slots.clone().acquire_owned().await?;
+        assert_eq!(operation_slots.available_permits(), 0);
+
+        hold_permit_until_exec_stops(
+            docker,
+            "exec-1".to_string(),
+            CONTAINER_ID.to_string(),
+            operation_permit,
+        );
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while operation_slots.available_permits() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await?;
+
+        server.abort();
+        assert_eq!(operation_slots.available_permits(), 1);
+        assert_eq!(state.restart_calls.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn definitively_rejected_start_does_not_restart_container(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (docker, state, server) = mock_docker(false).await?;
+        let capture_slots = Arc::new(tokio::sync::Semaphore::new(1));
+        let operation_slots = Arc::new(tokio::sync::Semaphore::new(1));
+        let capture_permit = capture_slots.clone().acquire_owned().await?;
+        let operation_permit = operation_slots.clone().acquire_owned().await?;
+        let mut guard = ExecCleanupGuard::new(
+            docker,
+            "exec-1".to_string(),
+            CONTAINER_ID.to_string(),
+            capture_permit,
+            operation_permit,
+        );
+        let rejection = bollard::errors::Error::DockerResponseServerError {
+            status_code: 409,
+            message: "container is paused".to_string(),
+        };
+
+        if exec_start_was_rejected(&rejection) {
+            guard.disarm();
+        }
+        drop(guard);
+        tokio::task::yield_now().await;
+
+        server.abort();
+        assert_eq!(state.restart_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(capture_slots.available_permits(), 1);
+        assert_eq!(operation_slots.available_permits(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn canceled_request_restarts_container_before_releasing_permit(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (docker, state, server) = mock_docker(false).await?;
+        let capture_slots = Arc::new(tokio::sync::Semaphore::new(1));
+        let operation_slots = Arc::new(tokio::sync::Semaphore::new(1));
+        let capture_permit = capture_slots.clone().acquire_owned().await?;
+        let operation_permit = operation_slots.clone().acquire_owned().await?;
+        let guard = ExecCleanupGuard::new(
+            docker,
+            "exec-1".to_string(),
+            CONTAINER_ID.to_string(),
+            capture_permit,
+            operation_permit,
+        );
+
+        let request = tokio::spawn(async move {
+            let _guard = guard;
+            std::future::pending::<()>().await;
+        });
+        request.abort();
+        let _cancellation = request.await;
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while capture_slots.available_permits() == 0 || operation_slots.available_permits() == 0
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await?;
+
+        server.abort();
+        assert_eq!(state.restart_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(capture_slots.available_permits(), 1);
+        assert_eq!(operation_slots.available_permits(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn pending_cleanup_releases_capture_but_retains_operation_capacity(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (docker, state, server) = mock_docker(true).await?;
+        let capture_slots = Arc::new(tokio::sync::Semaphore::new(1));
+        let operation_slots = Arc::new(tokio::sync::Semaphore::new(1));
+        let capture_permit = capture_slots.clone().acquire_owned().await?;
+        let operation_permit = operation_slots.clone().acquire_owned().await?;
+        let guard = ExecCleanupGuard::new(
+            docker,
+            "exec-1".to_string(),
+            CONTAINER_ID.to_string(),
+            capture_permit,
+            operation_permit,
+        );
+
+        drop(guard);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while state.restart_calls.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await?;
+
+        assert_eq!(capture_slots.available_permits(), 1);
+        assert_eq!(operation_slots.available_permits(), 0);
+        server.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stalled_restart_request_is_bounded() -> Result<(), Box<dyn std::error::Error>> {
+        let (docker, state, server) = mock_docker(true).await?;
+
+        let result = restart_exec_container_with_timeout(
+            &docker,
+            "exec-1",
+            CONTAINER_ID,
+            Duration::from_millis(10),
+        )
+        .await;
+
+        server.abort();
+        assert!(matches!(
+            result,
+            Err(ExecTerminationError::RestartTimedOut { .. })
+        ));
+        assert_eq!(state.restart_calls.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+}

--- a/crates/temps-agent/src/handlers.rs
+++ b/crates/temps-agent/src/handlers.rs
@@ -20,17 +20,99 @@ use bollard::exec::StartExecResults;
 use bollard::query_parameters::LogsOptions;
 use futures::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use temps_deployer::{ContainerDeployer, DeployRequest, ImageBuilder};
 use tokio::io::AsyncWriteExt;
 use utoipa::{OpenApi, ToSchema};
 
+use crate::exec_timeout::{
+    completed_exec_exit_code, exec_start_was_rejected, resolve_exec_container_id,
+    run_exec_with_deadline, ExecCleanupGuard, ExecCompletionError, ExecDeadlineOutcome,
+};
+use crate::output_buffer::{BoundedTailBuffer, MAX_CAPTURED_STREAM_BYTES};
 use crate::NodeHealthReport;
+
+pub(crate) const MAX_CONCURRENT_OUTPUT_CAPTURES: usize = 4;
+pub(crate) const MAX_CONCURRENT_EXEC_OPERATIONS: usize = 4;
+pub(crate) const MAX_CONCURRENT_IMAGE_IMPORTS: usize = 1;
+const MAX_IMAGE_IMPORT_BYTES: u64 = 10 * 1024 * 1024 * 1024;
+const IMAGE_IMPORT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+const CONTAINER_LOG_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+pub(crate) struct AttachedExecPermits {
+    pub(crate) operation: tokio::sync::OwnedSemaphorePermit,
+    pub(crate) capture: tokio::sync::OwnedSemaphorePermit,
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum ExecAdmissionError {
+    OperationsBusy,
+    CapturesBusy,
+}
+
+/// Reserve lifecycle capacity before memory capacity and before any Docker
+/// exec allocation. This keeps cleanup outages from consuming log-capture
+/// slots or accumulating unstarted Docker exec metadata.
+pub(crate) fn try_acquire_attached_exec_permits(
+    operation_slots: &Arc<tokio::sync::Semaphore>,
+    capture_slots: &Arc<tokio::sync::Semaphore>,
+) -> Result<AttachedExecPermits, ExecAdmissionError> {
+    let operation = operation_slots
+        .clone()
+        .try_acquire_owned()
+        .map_err(|_| ExecAdmissionError::OperationsBusy)?;
+    let capture = capture_slots
+        .clone()
+        .try_acquire_owned()
+        .map_err(|_| ExecAdmissionError::CapturesBusy)?;
+    Ok(AttachedExecPermits { operation, capture })
+}
+
+#[cfg(test)]
+mod exec_admission_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn exhausted_operation_capacity_rejects_before_capture_or_docker_allocation() {
+        let operation_slots = Arc::new(tokio::sync::Semaphore::new(0));
+        let capture_slots = Arc::new(tokio::sync::Semaphore::new(1));
+        let docker_allocations = AtomicUsize::new(0);
+
+        let admission = try_acquire_attached_exec_permits(&operation_slots, &capture_slots);
+        if admission.is_ok() {
+            docker_allocations.fetch_add(1, Ordering::SeqCst);
+        }
+
+        assert!(matches!(admission, Err(ExecAdmissionError::OperationsBusy)));
+        assert_eq!(capture_slots.available_permits(), 1);
+        assert_eq!(docker_allocations.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn capture_rejection_returns_the_reserved_operation_slot() {
+        let operation_slots = Arc::new(tokio::sync::Semaphore::new(1));
+        let capture_slots = Arc::new(tokio::sync::Semaphore::new(0));
+
+        let admission = try_acquire_attached_exec_permits(&operation_slots, &capture_slots);
+
+        assert!(matches!(admission, Err(ExecAdmissionError::CapturesBusy)));
+        assert_eq!(operation_slots.available_permits(), 1);
+    }
+}
 
 /// Shared state for all agent handlers.
 pub struct AgentState {
     pub container_deployer: Arc<dyn ContainerDeployer>,
     pub image_builder: Arc<dyn ImageBuilder>,
+    /// Bounds aggregate memory retained by one-shot logs and exec responses.
+    pub output_capture_slots: Arc<tokio::sync::Semaphore>,
+    /// Bounds attached exec lifecycles independently from memory capture.
+    /// Failed cleanup retains one of these slots without blocking log capture.
+    pub exec_operation_slots: Arc<tokio::sync::Semaphore>,
+    /// Docker image load is deliberately serialized per worker node.
+    pub image_import_slots: Arc<tokio::sync::Semaphore>,
     /// Direct Docker client for service operations (create/exec/backup).
     /// None if Docker is not available (shouldn't happen on a real agent).
     pub docker: Option<bollard::Docker>,
@@ -417,18 +499,37 @@ pub async fn get_container_logs(
     State(state): State<Arc<AgentState>>,
     Path(container_id): Path<String>,
 ) -> impl IntoResponse {
+    let _capture_permit = match state.output_capture_slots.clone().try_acquire_owned() {
+        Ok(permit) => permit,
+        Err(_) => {
+            return error_response(
+                StatusCode::TOO_MANY_REQUESTS,
+                format!(
+                    "Cannot capture logs for container {container_id}: all output capture slots are busy"
+                ),
+            )
+            .into_response();
+        }
+    };
+
     tracing::debug!(container_id = %container_id, "Fetching container logs");
-    match state
-        .container_deployer
-        .get_container_logs(&container_id)
-        .await
+    match tokio::time::timeout(
+        CONTAINER_LOG_TIMEOUT,
+        state.container_deployer.get_container_logs(&container_id),
+    )
+    .await
     {
-        Ok(logs) => AgentResponse::ok(logs).into_response(),
-        Err(e) => {
-            tracing::error!(container_id = %container_id, "Failed to get logs: {}", e);
+        Err(_) => error_response(
+            StatusCode::GATEWAY_TIMEOUT,
+            format!("Timed out capturing logs for container {container_id} after 60 seconds"),
+        )
+        .into_response(),
+        Ok(Ok(logs)) => AgentResponse::ok(logs).into_response(),
+        Ok(Err(error)) => {
+            tracing::error!(container_id = %container_id, reason = %error, "Failed to get container logs");
             error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get logs for container {}: {}", container_id, e),
+                format!("Failed to get logs for container {container_id}: {error}"),
             )
             .into_response()
         }
@@ -485,6 +586,32 @@ pub struct AgentExecResponse {
     pub stderr: String,
 }
 
+#[derive(Debug, thiserror::Error)]
+enum ContainerExecCaptureError {
+    #[error("Failed to start Docker exec '{exec_id}': {source}")]
+    Start {
+        exec_id: String,
+        source: bollard::errors::Error,
+    },
+    #[error("Docker exec '{exec_id}' unexpectedly started detached")]
+    UnexpectedDetached { exec_id: String },
+    #[error("Failed while reading output from Docker exec '{exec_id}': {source}")]
+    Stream {
+        exec_id: String,
+        source: bollard::errors::Error,
+    },
+    #[error("Failed to inspect completed Docker exec '{exec_id}': {source}")]
+    Inspect {
+        exec_id: String,
+        source: bollard::errors::Error,
+    },
+    #[error("Docker exec completion could not be confirmed: {source}")]
+    Completion {
+        #[from]
+        source: ExecCompletionError,
+    },
+}
+
 /// Run a one-shot command inside a container on this worker.
 ///
 /// Container exec is timeout-bounded (default 30s, max 300s) so a hung
@@ -526,6 +653,33 @@ pub async fn exec_container(
         .into_response();
     };
 
+    let permits = match try_acquire_attached_exec_permits(
+        &state.exec_operation_slots,
+        &state.output_capture_slots,
+    ) {
+        Ok(permits) => permits,
+        Err(ExecAdmissionError::OperationsBusy) => {
+            return error_response(
+                StatusCode::TOO_MANY_REQUESTS,
+                format!(
+                    "Cannot execute command in container {container_id}: all exec operation slots are busy"
+                ),
+            )
+            .into_response();
+        }
+        Err(ExecAdmissionError::CapturesBusy) => {
+            return error_response(
+                StatusCode::TOO_MANY_REQUESTS,
+                format!(
+                    "Cannot execute command in container {container_id}: all output capture slots are busy"
+                ),
+            )
+            .into_response();
+        }
+    };
+    let capture_permit = permits.capture;
+    let operation_permit = permits.operation;
+
     let timeout_secs = std::cmp::min(request.timeout_seconds.unwrap_or(30), 300);
 
     tracing::info!(
@@ -562,65 +716,145 @@ pub async fn exec_container(
             .into_response();
         }
     };
+    let cleanup_container_id = match resolve_exec_container_id(&docker, &exec.id).await {
+        Ok(container_id) => container_id,
+        Err(error) => {
+            tracing::error!(container_id = %container_id, exec_id = %exec.id, reason = %error, "Failed to pin exec container identity");
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to prepare command cleanup: {error}"),
+            )
+            .into_response();
+        }
+    };
+    let mut cleanup_guard = ExecCleanupGuard::new(
+        docker.clone(),
+        exec.id.clone(),
+        cleanup_container_id.clone(),
+        capture_permit,
+        operation_permit,
+    );
 
     let start_config = bollard::exec::StartExecOptions {
         detach: false,
         ..Default::default()
     };
 
-    let result = tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), async {
-        let output = docker.start_exec(&exec.id, Some(start_config)).await?;
-        let mut stdout = String::new();
-        let mut stderr = String::new();
-        if let bollard::exec::StartExecResults::Attached { mut output, .. } = output {
-            while let Some(Ok(msg)) = output.next().await {
-                match msg {
+    let result = run_exec_with_deadline(
+        &docker,
+        &exec.id,
+        &cleanup_container_id,
+        std::time::Duration::from_secs(timeout_secs),
+        async {
+            let output = docker
+                .start_exec(&exec.id, Some(start_config))
+                .await
+                .map_err(|source| ContainerExecCaptureError::Start {
+                    exec_id: exec.id.clone(),
+                    source,
+                })?;
+            let mut stdout = BoundedTailBuffer::new(MAX_CAPTURED_STREAM_BYTES);
+            let mut stderr = BoundedTailBuffer::new(MAX_CAPTURED_STREAM_BYTES);
+            let mut output = match output {
+                bollard::exec::StartExecResults::Attached { output, .. } => output,
+                bollard::exec::StartExecResults::Detached => {
+                    return Err(ContainerExecCaptureError::UnexpectedDetached {
+                        exec_id: exec.id.clone(),
+                    });
+                }
+            };
+            while let Some(message) = output.next().await {
+                match message.map_err(|source| ContainerExecCaptureError::Stream {
+                    exec_id: exec.id.clone(),
+                    source,
+                })? {
                     bollard::container::LogOutput::StdOut { message } => {
-                        stdout.push_str(&String::from_utf8_lossy(&message));
+                        stdout.push(message);
                     }
                     bollard::container::LogOutput::StdErr { message } => {
-                        stderr.push_str(&String::from_utf8_lossy(&message));
+                        stderr.push(message);
                     }
                     _ => {}
                 }
             }
-        }
-        Ok::<_, bollard::errors::Error>((stdout, stderr))
-    })
+
+            let inspect = docker.inspect_exec(&exec.id).await.map_err(|source| {
+                ContainerExecCaptureError::Inspect {
+                    exec_id: exec.id.clone(),
+                    source,
+                }
+            })?;
+            let exit_code = completed_exec_exit_code(&inspect, &exec.id)?;
+            Ok::<_, ContainerExecCaptureError>((
+                exit_code,
+                stdout.into_string(),
+                stderr.into_string(),
+            ))
+        },
+    )
     .await;
 
     match result {
-        Ok(Ok((stdout, stderr))) => {
-            let exit_code = docker
-                .inspect_exec(&exec.id)
-                .await
-                .ok()
-                .and_then(|i| i.exit_code);
+        ExecDeadlineOutcome::Completed(Ok((exit_code, stdout, stderr))) => {
+            cleanup_guard.disarm();
             tracing::info!(
                 container_id = %container_id,
-                exit_code = ?exit_code,
+                exit_code,
                 "Exec completed"
             );
             AgentResponse::ok(AgentExecResponse {
-                exit_code,
+                exit_code: Some(exit_code),
                 stdout,
                 stderr,
             })
             .into_response()
         }
-        Ok(Err(e)) => {
-            tracing::error!(container_id = %container_id, "Exec error: {}", e);
+        ExecDeadlineOutcome::Completed(Err(e)) => {
+            let cleanup_scheduled = !matches!(
+                &e,
+                ContainerExecCaptureError::Start { source, .. }
+                    if exec_start_was_rejected(source)
+            );
+            if !cleanup_scheduled {
+                cleanup_guard.disarm();
+            }
+            let cleanup_note = if cleanup_scheduled {
+                format!(
+                    "container {container_id} restart was scheduled to stop any ambiguous command workload"
+                )
+            } else {
+                "Docker definitively rejected the command before it started; the container was not restarted".to_string()
+            };
+            tracing::error!(container_id = %container_id, cleanup_scheduled, "Exec error: {}", e);
             error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Exec error: {}", e),
+                format!("Exec error: {e}; {cleanup_note}"),
             )
             .into_response()
         }
-        Err(_) => {
-            tracing::warn!(container_id = %container_id, timeout_secs, "Exec timed out");
+        ExecDeadlineOutcome::ContainerRestarted => {
+            cleanup_guard.disarm();
+            tracing::warn!(container_id = %container_id, timeout_secs, "Exec timed out; containing container was restarted to stop the complete workload");
             error_response(
                 StatusCode::GATEWAY_TIMEOUT,
-                format!("Command timed out after {}s", timeout_secs),
+                format!(
+                    "Command timed out after {timeout_secs}s; container {container_id} was restarted to stop the complete command workload"
+                ),
+            )
+            .into_response()
+        }
+        ExecDeadlineOutcome::TerminationFailed(error) => {
+            tracing::error!(
+                container_id = %container_id,
+                timeout_secs,
+                reason = %error,
+                "Exec timed out and its container could not be restarted"
+            );
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "Command timed out after {timeout_secs}s, but the worker could not restart its container to stop the complete workload: {error}"
+                ),
             )
             .into_response()
         }
@@ -1100,6 +1334,34 @@ pub async fn image_exists(
     }
 }
 
+fn image_upload_stream(
+    body: Body,
+    received_bytes: Arc<AtomicU64>,
+    max_bytes: u64,
+) -> temps_deployer::ImageImportStream {
+    Box::pin(body.into_data_stream().map(move |result| {
+        match result {
+            Ok(chunk) => {
+                let chunk_bytes = u64::try_from(chunk.len()).unwrap_or(u64::MAX);
+                let previous = received_bytes.fetch_add(chunk_bytes, Ordering::Relaxed);
+                let total = previous.saturating_add(chunk_bytes);
+                if total > max_bytes {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::FileTooLarge,
+                        format!(
+                            "Image upload exceeded the {max_bytes}-byte worker limit after receiving {total} bytes"
+                        ),
+                    ));
+                }
+                Ok(chunk)
+            }
+            Err(error) => Err(std::io::Error::other(format!(
+                "Failed to read image upload body: {error}"
+            ))),
+        }
+    }))
+}
+
 /// Import a Docker image from a tar archive streamed in the request body.
 ///
 /// The control plane calls this to transfer locally-built images to worker nodes.
@@ -1135,64 +1397,114 @@ pub async fn import_image(
 
     tracing::info!(image = %tag, "Receiving image tar from control plane");
 
-    // Stream the body to a temp file
-    let tmp_dir = std::env::temp_dir();
-    let tmp_path = tmp_dir.join(format!("temps-image-import-{}.tar", uuid::Uuid::new_v4()));
-
-    let write_result = async {
-        use http_body_util::BodyExt;
-
-        let mut file = tokio::fs::File::create(&tmp_path).await?;
-        let mut total_bytes: u64 = 0;
-
-        let mut body = body;
-        while let Some(frame) = BodyExt::frame(&mut body).await {
-            let frame =
-                frame.map_err(|e| std::io::Error::other(format!("Body read error: {}", e)))?;
-            if let Ok(data) = frame.into_data() {
-                tokio::io::AsyncWriteExt::write_all(&mut file, &data).await?;
-                total_bytes += data.len() as u64;
+    if let Some(content_length) = headers.get(header::CONTENT_LENGTH) {
+        let content_length: u64 = match content_length
+            .to_str()
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+        {
+            Some(length) => length,
+            None => {
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "Invalid Content-Length header for image import".to_string(),
+                )
+                .into_response();
             }
+        };
+        if content_length > MAX_IMAGE_IMPORT_BYTES {
+            return error_response(
+                StatusCode::PAYLOAD_TOO_LARGE,
+                format!(
+                    "Image import is {content_length} bytes; worker limit is {MAX_IMAGE_IMPORT_BYTES} bytes"
+                ),
+            )
+            .into_response();
         }
-        tokio::io::AsyncWriteExt::flush(&mut file).await?;
-
-        tracing::info!(
-            image = %tag,
-            size_mb = format!("{:.1}", total_bytes as f64 / 1_048_576.0),
-            "Image tar received, loading into Docker"
-        );
-        Ok::<_, std::io::Error>(())
-    }
-    .await;
-
-    if let Err(e) = write_result {
-        let _ = tokio::fs::remove_file(&tmp_path).await;
-        return error_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to write image tar: {}", e),
-        )
-        .into_response();
     }
 
-    // Import the image via the image builder (docker load)
-    let result = state
-        .image_builder
-        .import_image(tmp_path.clone(), &tag)
-        .await;
+    let deadline = tokio::time::Instant::now() + IMAGE_IMPORT_TIMEOUT;
+    let _import_permit =
+        match tokio::time::timeout_at(deadline, state.image_import_slots.clone().acquire_owned())
+            .await
+        {
+            Ok(Ok(permit)) => permit,
+            Ok(Err(error)) => {
+                return error_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    format!("Image import capacity is unavailable: {error}"),
+                )
+                .into_response();
+            }
+            Err(_) => {
+                return error_response(
+                    StatusCode::GATEWAY_TIMEOUT,
+                    format!("Image import '{tag}' waited 30 minutes for worker capacity"),
+                )
+                .into_response();
+            }
+        };
 
-    // Clean up temp file
-    let _ = tokio::fs::remove_file(&tmp_path).await;
+    // Forward request chunks directly to Docker. Backpressure propagates from
+    // the daemon to the request body, keeping memory bounded without a full
+    // temporary archive whose page cache is charged to this service's cgroup.
+    let received_bytes = Arc::new(AtomicU64::new(0));
+    let image_stream = image_upload_stream(body, received_bytes.clone(), MAX_IMAGE_IMPORT_BYTES);
+
+    let result = match tokio::time::timeout_at(
+        deadline,
+        state.image_builder.import_image_stream(image_stream, &tag),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            return error_response(
+                StatusCode::GATEWAY_TIMEOUT,
+                format!("Image import '{tag}' exceeded the 30-minute worker deadline"),
+            )
+            .into_response();
+        }
+    };
+    let total_bytes = received_bytes.load(Ordering::Relaxed);
 
     match result {
         Ok(image_id) => {
-            tracing::info!(image = %tag, image_id = %image_id, "Image imported successfully");
+            tracing::info!(
+                image = %tag,
+                image_id = %image_id,
+                size_mb = format!("{:.1}", total_bytes as f64 / 1_048_576.0),
+                "Streamed image imported successfully"
+            );
             AgentResponse::ok(image_id).into_response()
         }
-        Err(e) => error_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to import image '{}': {}", tag, e),
-        )
-        .into_response(),
+        Err(error) => {
+            if total_bytes > MAX_IMAGE_IMPORT_BYTES {
+                tracing::warn!(
+                    image = %tag,
+                    received_bytes = total_bytes,
+                    "Rejected oversized streamed image import"
+                );
+                return error_response(
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    format!("Image import exceeded the {MAX_IMAGE_IMPORT_BYTES}-byte worker limit"),
+                )
+                .into_response();
+            }
+            tracing::error!(
+                image = %tag,
+                received_bytes = total_bytes,
+                reason = %error,
+                "Streamed image import failed"
+            );
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "Failed to import image '{tag}' after receiving {total_bytes} bytes: {error}"
+                ),
+            )
+            .into_response()
+        }
     }
 }
 
@@ -1249,5 +1561,73 @@ async fn collect_system_metrics(state: &AgentState) -> NodeHealthReport {
         // Empty means "not discovered yet" — the control plane treats a blank
         // platform as unknown rather than as a claim about this node.
         platform: crate::server::read_platform(&state.platform).unwrap_or_default(),
+    }
+}
+
+#[cfg(test)]
+mod image_import_tests {
+    use super::*;
+    use bytes::Bytes;
+    use std::sync::atomic::AtomicUsize;
+
+    #[tokio::test]
+    async fn image_upload_stream_is_lazy_and_backpressure_aware() {
+        const CHUNK_BYTES: usize = 1024 * 1024;
+        const TOTAL_CHUNKS: usize = 100;
+
+        let source_polls = Arc::new(AtomicUsize::new(0));
+        let source_counter = source_polls.clone();
+        let source = futures::stream::unfold(0usize, move |index| {
+            let source_counter = source_counter.clone();
+            async move {
+                if index == TOTAL_CHUNKS {
+                    return None;
+                }
+                source_counter.fetch_add(1, Ordering::Relaxed);
+                Some((
+                    Ok::<_, std::io::Error>(Bytes::from(vec![0; CHUNK_BYTES])),
+                    index + 1,
+                ))
+            }
+        });
+
+        let received_bytes = Arc::new(AtomicU64::new(0));
+        let mut upload = image_upload_stream(
+            Body::from_stream(source),
+            received_bytes.clone(),
+            (CHUNK_BYTES * TOTAL_CHUNKS) as u64,
+        );
+
+        assert_eq!(source_polls.load(Ordering::Relaxed), 0);
+        let first = upload
+            .next()
+            .await
+            .expect("stream should produce its first chunk")
+            .expect("first chunk should be readable");
+
+        assert_eq!(first.len(), CHUNK_BYTES);
+        assert_eq!(received_bytes.load(Ordering::Relaxed), CHUNK_BYTES as u64);
+        assert!(
+            source_polls.load(Ordering::Relaxed) < TOTAL_CHUNKS,
+            "reading one chunk must not eagerly materialize the 100 MiB upload"
+        );
+    }
+
+    #[tokio::test]
+    async fn image_upload_stream_rejects_bytes_past_limit() {
+        let received_bytes = Arc::new(AtomicU64::new(0));
+        let mut upload = image_upload_stream(
+            Body::from(Bytes::from_static(b"12345")),
+            received_bytes.clone(),
+            4,
+        );
+
+        let error = upload
+            .next()
+            .await
+            .expect("body should yield one result")
+            .expect_err("five bytes must exceed a four-byte limit");
+        assert!(error.to_string().contains("4-byte worker limit"));
+        assert_eq!(received_bytes.load(Ordering::Relaxed), 5);
     }
 }

--- a/crates/temps-agent/src/handlers.rs
+++ b/crates/temps-agent/src/handlers.rs
@@ -10,7 +10,7 @@ use axum::{
     body::Body,
     extract::{
         ws::{Message, WebSocket, WebSocketUpgrade},
-        Path, Query, State,
+        Extension, Path, Query, State,
     },
     http::{header, StatusCode},
     response::{IntoResponse, Response},
@@ -20,17 +20,22 @@ use bollard::exec::StartExecResults;
 use bollard::query_parameters::LogsOptions;
 use futures::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::future::Future;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use temps_deployer::{ContainerDeployer, DeployRequest, ImageBuilder};
 use tokio::io::AsyncWriteExt;
 use utoipa::{OpenApi, ToSchema};
 
 use crate::exec_timeout::{
-    completed_exec_exit_code, exec_start_was_rejected, resolve_exec_container_id,
-    run_exec_with_deadline, ExecCleanupGuard, ExecCompletionError, ExecDeadlineOutcome,
+    completed_exec_exit_code, exec_start_was_rejected, monitor_exec_until_stopped,
+    resolve_container_id, resolve_exec_container_id, run_exec_with_deadline,
+    ContainerIdentityError, ExecCleanupGuard, ExecCompletionError, ExecDeadlineOutcome,
 };
-use crate::output_buffer::{BoundedTailBuffer, MAX_CAPTURED_STREAM_BYTES};
+use crate::output_buffer::{
+    json_response_with_capture_permit, BoundedTailBuffer, MAX_CAPTURED_STREAM_BYTES,
+};
 use crate::NodeHealthReport;
 
 pub(crate) const MAX_CONCURRENT_OUTPUT_CAPTURES: usize = 4;
@@ -43,30 +48,127 @@ const CONTAINER_LOG_TIMEOUT: std::time::Duration = std::time::Duration::from_sec
 pub(crate) struct AttachedExecPermits {
     pub(crate) operation: tokio::sync::OwnedSemaphorePermit,
     pub(crate) capture: tokio::sync::OwnedSemaphorePermit,
+    pub(crate) container: tokio::sync::OwnedSemaphorePermit,
+}
+
+pub(crate) struct ExecLifecyclePermits {
+    pub(crate) operation: tokio::sync::OwnedSemaphorePermit,
+    pub(crate) container: tokio::sync::OwnedSemaphorePermit,
 }
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum ExecAdmissionError {
-    OperationsBusy,
-    CapturesBusy,
+    OperationsExhausted,
+    CapturesExhausted,
+    ContainerOwned,
+}
+
+#[derive(Default)]
+struct ContainerOperationRegistry {
+    slots: parking_lot::Mutex<HashMap<String, Weak<tokio::sync::Semaphore>>>,
+}
+
+impl ContainerOperationRegistry {
+    fn try_acquire(
+        &self,
+        container_id: &str,
+    ) -> Result<tokio::sync::OwnedSemaphorePermit, ExecAdmissionError> {
+        let slot = {
+            let mut slots = self.slots.lock();
+            slots.retain(|_, slot| slot.strong_count() > 0);
+            if let Some(slot) = slots.get(container_id).and_then(Weak::upgrade) {
+                slot
+            } else {
+                let slot = Arc::new(tokio::sync::Semaphore::new(1));
+                slots.insert(container_id.to_string(), Arc::downgrade(&slot));
+                slot
+            }
+        };
+        slot.try_acquire_owned()
+            .map_err(|_| ExecAdmissionError::ContainerOwned)
+    }
+}
+
+/// Per-agent limits live in router extensions rather than public `AgentState`
+/// fields. This keeps synchronization internals out of the crate's public
+/// state construction API.
+pub struct AgentResourceLimits {
+    output_capture_slots: Arc<tokio::sync::Semaphore>,
+    exec_operation_slots: Arc<tokio::sync::Semaphore>,
+    image_import_slots: Arc<tokio::sync::Semaphore>,
+    container_operations: ContainerOperationRegistry,
+}
+
+impl AgentResourceLimits {
+    pub fn new() -> Self {
+        Self {
+            output_capture_slots: Arc::new(tokio::sync::Semaphore::new(
+                MAX_CONCURRENT_OUTPUT_CAPTURES,
+            )),
+            exec_operation_slots: Arc::new(tokio::sync::Semaphore::new(
+                MAX_CONCURRENT_EXEC_OPERATIONS,
+            )),
+            image_import_slots: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_IMAGE_IMPORTS)),
+            container_operations: ContainerOperationRegistry::default(),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_capacities(operations: usize, captures: usize, imports: usize) -> Self {
+        Self {
+            output_capture_slots: Arc::new(tokio::sync::Semaphore::new(captures)),
+            exec_operation_slots: Arc::new(tokio::sync::Semaphore::new(operations)),
+            image_import_slots: Arc::new(tokio::sync::Semaphore::new(imports)),
+            container_operations: ContainerOperationRegistry::default(),
+        }
+    }
+}
+
+impl Default for AgentResourceLimits {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 /// Reserve lifecycle capacity before memory capacity and before any Docker
 /// exec allocation. This keeps cleanup outages from consuming log-capture
 /// slots or accumulating unstarted Docker exec metadata.
 pub(crate) fn try_acquire_attached_exec_permits(
-    operation_slots: &Arc<tokio::sync::Semaphore>,
-    capture_slots: &Arc<tokio::sync::Semaphore>,
+    limits: &AgentResourceLimits,
+    container_id: &str,
 ) -> Result<AttachedExecPermits, ExecAdmissionError> {
-    let operation = operation_slots
+    let operation = limits
+        .exec_operation_slots
         .clone()
         .try_acquire_owned()
-        .map_err(|_| ExecAdmissionError::OperationsBusy)?;
-    let capture = capture_slots
+        .map_err(|_| ExecAdmissionError::OperationsExhausted)?;
+    let container = limits.container_operations.try_acquire(container_id)?;
+    let capture = limits
+        .output_capture_slots
         .clone()
         .try_acquire_owned()
-        .map_err(|_| ExecAdmissionError::CapturesBusy)?;
-    Ok(AttachedExecPermits { operation, capture })
+        .map_err(|_| ExecAdmissionError::CapturesExhausted)?;
+    Ok(AttachedExecPermits {
+        operation,
+        capture,
+        container,
+    })
+}
+
+pub(crate) fn try_acquire_exec_lifecycle_permits(
+    limits: &AgentResourceLimits,
+    container_id: &str,
+) -> Result<ExecLifecyclePermits, ExecAdmissionError> {
+    let operation = limits
+        .exec_operation_slots
+        .clone()
+        .try_acquire_owned()
+        .map_err(|_| ExecAdmissionError::OperationsExhausted)?;
+    let container = limits.container_operations.try_acquire(container_id)?;
+    Ok(ExecLifecyclePermits {
+        operation,
+        container,
+    })
 }
 
 #[cfg(test)]
@@ -76,29 +178,70 @@ mod exec_admission_tests {
 
     #[test]
     fn exhausted_operation_capacity_rejects_before_capture_or_docker_allocation() {
-        let operation_slots = Arc::new(tokio::sync::Semaphore::new(0));
-        let capture_slots = Arc::new(tokio::sync::Semaphore::new(1));
+        let limits = AgentResourceLimits::with_capacities(0, 1, 1);
         let docker_allocations = AtomicUsize::new(0);
 
-        let admission = try_acquire_attached_exec_permits(&operation_slots, &capture_slots);
+        let admission = try_acquire_attached_exec_permits(&limits, "container-a");
         if admission.is_ok() {
             docker_allocations.fetch_add(1, Ordering::SeqCst);
         }
 
-        assert!(matches!(admission, Err(ExecAdmissionError::OperationsBusy)));
-        assert_eq!(capture_slots.available_permits(), 1);
+        assert!(matches!(
+            admission,
+            Err(ExecAdmissionError::OperationsExhausted)
+        ));
+        assert_eq!(limits.output_capture_slots.available_permits(), 1);
         assert_eq!(docker_allocations.load(Ordering::SeqCst), 0);
     }
 
     #[test]
     fn capture_rejection_returns_the_reserved_operation_slot() {
-        let operation_slots = Arc::new(tokio::sync::Semaphore::new(1));
-        let capture_slots = Arc::new(tokio::sync::Semaphore::new(0));
+        let limits = AgentResourceLimits::with_capacities(1, 0, 1);
 
-        let admission = try_acquire_attached_exec_permits(&operation_slots, &capture_slots);
+        let admission = try_acquire_attached_exec_permits(&limits, "container-a");
 
-        assert!(matches!(admission, Err(ExecAdmissionError::CapturesBusy)));
-        assert_eq!(operation_slots.available_permits(), 1);
+        assert!(matches!(
+            admission,
+            Err(ExecAdmissionError::CapturesExhausted)
+        ));
+        assert_eq!(limits.exec_operation_slots.available_permits(), 1);
+        assert!(limits
+            .container_operations
+            .try_acquire("container-a")
+            .is_ok());
+    }
+
+    #[test]
+    fn same_container_is_single_flight_while_other_containers_can_run() {
+        let limits = AgentResourceLimits::with_capacities(3, 3, 1);
+        let first = try_acquire_attached_exec_permits(&limits, "container-a")
+            .expect("first container operation is admitted");
+
+        assert!(matches!(
+            try_acquire_attached_exec_permits(&limits, "container-a"),
+            Err(ExecAdmissionError::ContainerOwned)
+        ));
+        assert!(try_acquire_attached_exec_permits(&limits, "container-b").is_ok());
+
+        drop(first);
+        assert!(try_acquire_attached_exec_permits(&limits, "container-a").is_ok());
+    }
+
+    #[test]
+    fn detached_exec_reserves_operation_and_container_lifecycle_capacity() {
+        let limits = AgentResourceLimits::with_capacities(1, 1, 1);
+        let detached = try_acquire_exec_lifecycle_permits(&limits, "container-a")
+            .expect("first detached operation is admitted");
+
+        assert_eq!(limits.exec_operation_slots.available_permits(), 0);
+        assert!(matches!(
+            try_acquire_exec_lifecycle_permits(&limits, "container-a"),
+            Err(ExecAdmissionError::OperationsExhausted)
+        ));
+        assert_eq!(limits.output_capture_slots.available_permits(), 1);
+
+        drop(detached);
+        assert!(try_acquire_exec_lifecycle_permits(&limits, "container-a").is_ok());
     }
 }
 
@@ -106,13 +249,6 @@ mod exec_admission_tests {
 pub struct AgentState {
     pub container_deployer: Arc<dyn ContainerDeployer>,
     pub image_builder: Arc<dyn ImageBuilder>,
-    /// Bounds aggregate memory retained by one-shot logs and exec responses.
-    pub output_capture_slots: Arc<tokio::sync::Semaphore>,
-    /// Bounds attached exec lifecycles independently from memory capture.
-    /// Failed cleanup retains one of these slots without blocking log capture.
-    pub exec_operation_slots: Arc<tokio::sync::Semaphore>,
-    /// Docker image load is deliberately serialized per worker node.
-    pub image_import_slots: Arc<tokio::sync::Semaphore>,
     /// Direct Docker client for service operations (create/exec/backup).
     /// None if Docker is not available (shouldn't happen on a real agent).
     pub docker: Option<bollard::Docker>,
@@ -170,6 +306,52 @@ fn error_response(status: StatusCode, message: String) -> impl IntoResponse {
             error: Some(message),
         }),
     )
+}
+
+pub(crate) fn captured_ok_response<T: Serialize>(
+    data: T,
+    permit: tokio::sync::OwnedSemaphorePermit,
+) -> Response {
+    json_response_with_capture_permit(
+        StatusCode::OK,
+        AgentResponse {
+            success: true,
+            data: Some(data),
+            error: None,
+        },
+        permit,
+    )
+}
+
+pub(crate) fn captured_error_response(
+    status: StatusCode,
+    message: String,
+    permit: tokio::sync::OwnedSemaphorePermit,
+) -> Response {
+    json_response_with_capture_permit(
+        status,
+        AgentResponse::<()> {
+            success: false,
+            data: None,
+            error: Some(message),
+        },
+        permit,
+    )
+}
+
+pub(crate) fn container_identity_error_status(error: &ContainerIdentityError) -> StatusCode {
+    match error {
+        ContainerIdentityError::Inspect {
+            source:
+                bollard::errors::Error::DockerResponseServerError {
+                    status_code: 404, ..
+                },
+            ..
+        } => StatusCode::NOT_FOUND,
+        ContainerIdentityError::Inspect { .. }
+        | ContainerIdentityError::MissingId { .. }
+        | ContainerIdentityError::InvalidId { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+    }
 }
 
 fn remove_error_status(error: &temps_deployer::DeployerError) -> StatusCode {
@@ -491,15 +673,18 @@ mod remove_tests {
     responses(
         (status = 200, description = "Container logs", body = AgentResponse<String>),
         (status = 401, description = "Unauthorized"),
+        (status = 429, description = "Output capture capacity exhausted"),
+        (status = 504, description = "Log capture timed out"),
         (status = 500, description = "Failed to get logs")
     ),
     security(("bearer_auth" = []))
 )]
 pub async fn get_container_logs(
     State(state): State<Arc<AgentState>>,
+    Extension(limits): Extension<Arc<AgentResourceLimits>>,
     Path(container_id): Path<String>,
 ) -> impl IntoResponse {
-    let _capture_permit = match state.output_capture_slots.clone().try_acquire_owned() {
+    let capture_permit = match limits.output_capture_slots.clone().try_acquire_owned() {
         Ok(permit) => permit,
         Err(_) => {
             return error_response(
@@ -524,7 +709,7 @@ pub async fn get_container_logs(
             format!("Timed out capturing logs for container {container_id} after 60 seconds"),
         )
         .into_response(),
-        Ok(Ok(logs)) => AgentResponse::ok(logs).into_response(),
+        Ok(Ok(logs)) => captured_ok_response(logs, capture_permit),
         Ok(Err(error)) => {
             tracing::error!(container_id = %container_id, reason = %error, "Failed to get container logs");
             error_response(
@@ -630,6 +815,10 @@ enum ContainerExecCaptureError {
         (status = 200, description = "Exec result", body = AgentResponse<AgentExecResponse>),
         (status = 400, description = "Invalid command"),
         (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Container not found"),
+        (status = 409, description = "Container identity changed before exec start"),
+        (status = 429, description = "Exec or capture capacity exhausted"),
+        (status = 503, description = "Docker unavailable"),
         (status = 500, description = "Exec failed"),
         (status = 504, description = "Exec timed out")
     ),
@@ -637,6 +826,7 @@ enum ContainerExecCaptureError {
 )]
 pub async fn exec_container(
     State(state): State<Arc<AgentState>>,
+    Extension(limits): Extension<Arc<AgentResourceLimits>>,
     Path(container_id): Path<String>,
     Json(request): Json<AgentExecRequest>,
 ) -> impl IntoResponse {
@@ -653,12 +843,20 @@ pub async fn exec_container(
         .into_response();
     };
 
-    let permits = match try_acquire_attached_exec_permits(
-        &state.exec_operation_slots,
-        &state.output_capture_slots,
-    ) {
+    let cleanup_container_id = match resolve_container_id(&docker, &container_id).await {
+        Ok(container_id) => container_id,
+        Err(error) => {
+            return error_response(
+                container_identity_error_status(&error),
+                format!("Failed to resolve container '{container_id}' before exec: {error}"),
+            )
+            .into_response();
+        }
+    };
+
+    let permits = match try_acquire_attached_exec_permits(&limits, &cleanup_container_id) {
         Ok(permits) => permits,
-        Err(ExecAdmissionError::OperationsBusy) => {
+        Err(ExecAdmissionError::OperationsExhausted) => {
             return error_response(
                 StatusCode::TOO_MANY_REQUESTS,
                 format!(
@@ -667,11 +865,20 @@ pub async fn exec_container(
             )
             .into_response();
         }
-        Err(ExecAdmissionError::CapturesBusy) => {
+        Err(ExecAdmissionError::CapturesExhausted) => {
             return error_response(
                 StatusCode::TOO_MANY_REQUESTS,
                 format!(
                     "Cannot execute command in container {container_id}: all output capture slots are busy"
+                ),
+            )
+            .into_response();
+        }
+        Err(ExecAdmissionError::ContainerOwned) => {
+            return error_response(
+                StatusCode::TOO_MANY_REQUESTS,
+                format!(
+                    "Cannot execute command in container {container_id}: another operation already owns that container"
                 ),
             )
             .into_response();
@@ -696,7 +903,7 @@ pub async fn exec_container(
         ..Default::default()
     };
 
-    let exec = match docker.create_exec(&container_id, exec_config).await {
+    let exec = match docker.create_exec(&cleanup_container_id, exec_config).await {
         Ok(e) => e,
         Err(bollard::errors::Error::DockerResponseServerError {
             status_code: 404, ..
@@ -716,7 +923,7 @@ pub async fn exec_container(
             .into_response();
         }
     };
-    let cleanup_container_id = match resolve_exec_container_id(&docker, &exec.id).await {
+    let exec_container_id = match resolve_exec_container_id(&docker, &exec.id).await {
         Ok(container_id) => container_id,
         Err(error) => {
             tracing::error!(container_id = %container_id, exec_id = %exec.id, reason = %error, "Failed to pin exec container identity");
@@ -727,12 +934,22 @@ pub async fn exec_container(
             .into_response();
         }
     };
+    if exec_container_id != cleanup_container_id {
+        return error_response(
+            StatusCode::CONFLICT,
+            format!(
+                "Container '{container_id}' changed from '{cleanup_container_id}' to '{exec_container_id}' before exec start"
+            ),
+        )
+        .into_response();
+    }
     let mut cleanup_guard = ExecCleanupGuard::new(
         docker.clone(),
         exec.id.clone(),
         cleanup_container_id.clone(),
         capture_permit,
         operation_permit,
+        permits.container,
     );
 
     let start_config = bollard::exec::StartExecOptions {
@@ -796,18 +1013,28 @@ pub async fn exec_container(
 
     match result {
         ExecDeadlineOutcome::Completed(Ok((exit_code, stdout, stderr))) => {
-            cleanup_guard.disarm();
+            let Some(capture_permit) = cleanup_guard.disarm_and_take_capture() else {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!(
+                        "Exec in container {container_id} completed without response capture ownership"
+                    ),
+                )
+                .into_response();
+            };
             tracing::info!(
                 container_id = %container_id,
                 exit_code,
                 "Exec completed"
             );
-            AgentResponse::ok(AgentExecResponse {
-                exit_code: Some(exit_code),
-                stdout,
-                stderr,
-            })
-            .into_response()
+            captured_ok_response(
+                AgentExecResponse {
+                    exit_code: Some(exit_code),
+                    stdout,
+                    stderr,
+                },
+                capture_permit,
+            )
         }
         ExecDeadlineOutcome::Completed(Err(e)) => {
             let cleanup_scheduled = !matches!(
@@ -875,6 +1102,7 @@ pub async fn exec_container(
 /// against a remote container. No protocol translation in the middle.
 pub async fn terminal_container(
     State(state): State<Arc<AgentState>>,
+    Extension(limits): Extension<Arc<AgentResourceLimits>>,
     Path(container_id): Path<String>,
     ws: WebSocketUpgrade,
 ) -> Response {
@@ -886,8 +1114,36 @@ pub async fn terminal_container(
         .into_response();
     };
 
-    ws.on_upgrade(move |socket| handle_terminal_session(socket, docker, container_id))
-        .into_response()
+    let canonical_container_id = match resolve_container_id(&docker, &container_id).await {
+        Ok(container_id) => container_id,
+        Err(error) => {
+            return error_response(
+                container_identity_error_status(&error),
+                format!("Failed to resolve terminal container '{container_id}': {error}"),
+            )
+            .into_response();
+        }
+    };
+    let container_permit = match limits
+        .container_operations
+        .try_acquire(&canonical_container_id)
+    {
+        Ok(permit) => permit,
+        Err(_) => {
+            return error_response(
+                StatusCode::TOO_MANY_REQUESTS,
+                format!(
+                    "Cannot open terminal for container {container_id}: another operation already owns that container"
+                ),
+            )
+            .into_response();
+        }
+    };
+
+    ws.on_upgrade(move |socket| {
+        handle_terminal_session(socket, docker, canonical_container_id, container_permit)
+    })
+    .into_response()
 }
 
 #[derive(Deserialize)]
@@ -898,7 +1154,12 @@ struct TerminalControl {
     data: Option<String>,
 }
 
-async fn handle_terminal_session(socket: WebSocket, docker: bollard::Docker, container_id: String) {
+async fn handle_terminal_session(
+    socket: WebSocket,
+    docker: bollard::Docker,
+    container_id: String,
+    container_permit: tokio::sync::OwnedSemaphorePermit,
+) {
     tracing::debug!(container_id = %container_id, "Agent terminal session started");
 
     // Try bash, fall back to sh — same shape as the CP-local terminal so
@@ -924,6 +1185,24 @@ async fn handle_terminal_session(socket: WebSocket, docker: bollard::Docker, con
         }
     };
     let exec_id = exec.id.clone();
+    let exec_container_id = match resolve_exec_container_id(&docker, &exec_id).await {
+        Ok(container_id) => container_id,
+        Err(error) => {
+            tracing::error!(reason = %error, container_id = %container_id, exec_id = %exec_id, "Failed to pin terminal exec container identity");
+            return;
+        }
+    };
+    if exec_container_id != container_id {
+        tracing::error!(container_id = %container_id, exec_container_id = %exec_container_id, exec_id = %exec_id, "Terminal container identity changed before exec start");
+        return;
+    }
+    let mut cleanup_guard = ExecCleanupGuard::new_without_capture(
+        docker.clone(),
+        exec_id.clone(),
+        container_id.clone(),
+        None,
+        container_permit,
+    );
 
     let start_config = bollard::exec::StartExecOptions {
         detach: false,
@@ -937,11 +1216,15 @@ async fn handle_terminal_session(socket: WebSocket, docker: bollard::Docker, con
     {
         Ok(StartExecResults::Attached { output, input }) => (output, input),
         Ok(StartExecResults::Detached) => {
-            tracing::error!("Exec started in detached mode unexpectedly");
+            tracing::error!(container_id = %container_id, exec_id = %exec_id, "Terminal exec started detached unexpectedly; scheduling containing-container restart");
             return;
         }
-        Err(e) => {
-            tracing::error!(error = %e, container_id = %container_id, "Failed to start exec for terminal");
+        Err(error) => {
+            let cleanup_scheduled = !exec_start_was_rejected(&error);
+            if !cleanup_scheduled {
+                cleanup_guard.disarm();
+            }
+            tracing::error!(reason = %error, container_id = %container_id, exec_id = %exec_id, cleanup_scheduled, "Failed to start exec for terminal");
             return;
         }
     };
@@ -1032,8 +1315,16 @@ async fn handle_terminal_session(socket: WebSocket, docker: bollard::Docker, con
         }
     }
 
+    let _ = docker_input.shutdown().await;
     output_task.abort();
-    tracing::info!(container_id = %container_id, "Agent terminal session ended");
+    monitor_exec_until_stopped(
+        docker,
+        exec_id,
+        container_id.clone(),
+        "terminal exec",
+        cleanup_guard,
+    );
+    tracing::info!(container_id = %container_id, "Agent terminal session ended; lifecycle ownership retained until Docker confirms exec completion");
 }
 
 /// Query parameters for the streaming logs endpoint. Mirrors the control
@@ -1362,6 +1653,20 @@ fn image_upload_stream(
     }))
 }
 
+fn spawn_permit_owned_task<T, F>(
+    permit: tokio::sync::OwnedSemaphorePermit,
+    future: F,
+) -> tokio::task::JoinHandle<T>
+where
+    T: Send + 'static,
+    F: Future<Output = T> + Send + 'static,
+{
+    tokio::spawn(async move {
+        let _permit = permit;
+        future.await
+    })
+}
+
 /// Import a Docker image from a tar archive streamed in the request body.
 ///
 /// The control plane calls this to transfer locally-built images to worker nodes.
@@ -1375,12 +1680,16 @@ fn image_upload_stream(
         (status = 200, description = "Image imported successfully", body = AgentResponse<String>),
         (status = 400, description = "Missing x-image-tag header"),
         (status = 401, description = "Unauthorized"),
+        (status = 413, description = "Image exceeds the worker import limit"),
+        (status = 503, description = "Image import capacity unavailable"),
+        (status = 504, description = "Image import deadline exceeded"),
         (status = 500, description = "Import failed")
     ),
     security(("bearer_auth" = []))
 )]
 pub async fn import_image(
     State(state): State<Arc<AgentState>>,
+    Extension(limits): Extension<Arc<AgentResourceLimits>>,
     headers: axum::http::HeaderMap,
     body: axum::body::Body,
 ) -> impl IntoResponse {
@@ -1424,8 +1733,8 @@ pub async fn import_image(
     }
 
     let deadline = tokio::time::Instant::now() + IMAGE_IMPORT_TIMEOUT;
-    let _import_permit =
-        match tokio::time::timeout_at(deadline, state.image_import_slots.clone().acquire_owned())
+    let import_permit =
+        match tokio::time::timeout_at(deadline, limits.image_import_slots.clone().acquire_owned())
             .await
         {
             Ok(Ok(permit)) => permit,
@@ -1451,14 +1760,24 @@ pub async fn import_image(
     let received_bytes = Arc::new(AtomicU64::new(0));
     let image_stream = image_upload_stream(body, received_bytes.clone(), MAX_IMAGE_IMPORT_BYTES);
 
-    let result = match tokio::time::timeout_at(
-        deadline,
-        state.image_builder.import_image_stream(image_stream, &tag),
-    )
-    .await
-    {
-        Ok(result) => result,
+    let image_builder = state.image_builder.clone();
+    let import_tag = tag.clone();
+    let mut import_task = spawn_permit_owned_task(import_permit, async move {
+        image_builder
+            .import_image_stream(image_stream, &import_tag)
+            .await
+    });
+    let result = match tokio::time::timeout_at(deadline, &mut import_task).await {
+        Ok(Ok(result)) => result,
+        Ok(Err(error)) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Image import task for '{tag}' failed: {error}"),
+            )
+            .into_response();
+        }
         Err(_) => {
+            tracing::warn!(image = %tag, "Image import request exceeded its deadline; Docker import continues to own the worker slot until it ends");
             return error_response(
                 StatusCode::GATEWAY_TIMEOUT,
                 format!("Image import '{tag}' exceeded the 30-minute worker deadline"),
@@ -1629,5 +1948,70 @@ mod image_import_tests {
             .expect_err("five bytes must exceed a four-byte limit");
         assert!(error.to_string().contains("4-byte worker limit"));
         assert_eq!(received_bytes.load(Ordering::Relaxed), 5);
+    }
+
+    #[tokio::test]
+    async fn dropped_import_waiter_does_not_release_import_capacity() {
+        let slots = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = slots
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("test semaphore remains open");
+        let finish = Arc::new(tokio::sync::Notify::new());
+        let task_finish = finish.clone();
+        let task = spawn_permit_owned_task(permit, async move {
+            task_finish.notified().await;
+        });
+
+        drop(task);
+        assert!(slots.clone().try_acquire_owned().is_err());
+
+        finish.notify_one();
+        let released = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            slots.clone().acquire_owned(),
+        )
+        .await
+        .expect("owned import task releases capacity after completion")
+        .expect("test semaphore remains open");
+        drop(released);
+    }
+}
+
+#[cfg(test)]
+mod openapi_response_tests {
+    use super::*;
+
+    #[test]
+    fn resource_limit_and_lifecycle_statuses_are_documented() {
+        let spec = serde_json::to_value(AgentApiDoc::openapi())
+            .expect("agent OpenAPI document serializes");
+        for pointer in [
+            "/paths/~1agent~1containers~1{id}~1logs/get/responses/429",
+            "/paths/~1agent~1containers~1{id}~1logs/get/responses/504",
+            "/paths/~1agent~1containers~1{id}~1exec/post/responses/404",
+            "/paths/~1agent~1containers~1{id}~1exec/post/responses/409",
+            "/paths/~1agent~1containers~1{id}~1exec/post/responses/429",
+            "/paths/~1agent~1containers~1{id}~1exec/post/responses/503",
+            "/paths/~1agent~1containers~1{id}~1exec/post/responses/504",
+            "/paths/~1agent~1images~1import/post/responses/413",
+            "/paths/~1agent~1images~1import/post/responses/503",
+            "/paths/~1agent~1images~1import/post/responses/504",
+            "/paths/~1agent~1services~1exec/post/responses/404",
+            "/paths/~1agent~1services~1exec/post/responses/409",
+            "/paths/~1agent~1services~1exec/post/responses/429",
+            "/paths/~1agent~1services~1exec/post/responses/504",
+            "/paths/~1agent~1services~1backup/post/responses/404",
+            "/paths/~1agent~1services~1backup/post/responses/409",
+            "/paths/~1agent~1services~1backup/post/responses/429",
+            "/paths/~1agent~1services~1backup/post/responses/504",
+            "/paths/~1agent~1services~1restore/post/responses/404",
+            "/paths/~1agent~1services~1restore/post/responses/409",
+            "/paths/~1agent~1services~1restore/post/responses/429",
+            "/paths/~1agent~1services~1restore/post/responses/504",
+        ] {
+            assert!(spec.pointer(pointer).is_some(), "missing OpenAPI {pointer}");
+        }
     }
 }

--- a/crates/temps-agent/src/lib.rs
+++ b/crates/temps-agent/src/lib.rs
@@ -8,9 +8,11 @@
 //! and external services.
 
 pub mod auth;
+mod exec_timeout;
 pub mod handlers;
 pub mod internal_proxy;
 pub mod network_sync;
+mod output_buffer;
 pub mod route_store;
 pub mod route_sync_client;
 pub mod server;

--- a/crates/temps-agent/src/output_buffer.rs
+++ b/crates/temps-agent/src/output_buffer.rs
@@ -8,7 +8,18 @@
 //! worker agent until it is OOM-killed. This buffer retains only the newest
 //! bytes and records that earlier output was discarded.
 
+use axum::{
+    body::Body,
+    http::{header, HeaderValue, StatusCode},
+    response::Response,
+};
 use bytes::Bytes;
+use futures::Stream;
+use serde::Serialize;
+use std::convert::Infallible;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::sync::OwnedSemaphorePermit;
 
 /// Maximum captured bytes per stdout/stderr stream.
 ///
@@ -16,7 +27,81 @@ use bytes::Bytes;
 /// serialization can briefly create another bounded copy.
 pub(crate) const MAX_CAPTURED_STREAM_BYTES: usize = 4 * 1024 * 1024;
 
+/// Keep response frames small enough for HTTP backpressure to prevent a slow
+/// peer from moving an entire multi-megabyte capture outside the semaphore's
+/// accounting in one poll.
+const CAPTURE_RESPONSE_CHUNK_BYTES: usize = 64 * 1024;
+
 const TRUNCATION_NOTICE: &str = "[… earlier output truncated by worker …]\n";
+
+struct CaptureResponseStream {
+    payload: Bytes,
+    offset: usize,
+    permit: Option<OwnedSemaphorePermit>,
+}
+
+impl Stream for CaptureResponseStream {
+    type Item = Result<Bytes, Infallible>;
+
+    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.offset >= self.payload.len() {
+            self.payload = Bytes::new();
+            self.permit.take();
+            return Poll::Ready(None);
+        }
+
+        let end = self
+            .offset
+            .saturating_add(CAPTURE_RESPONSE_CHUNK_BYTES)
+            .min(self.payload.len());
+        // Use an independent allocation rather than `Bytes::slice`: a slice
+        // would keep the complete multi-megabyte JSON allocation alive after
+        // the permit is released merely because Hyper still owns one frame.
+        let chunk = Bytes::copy_from_slice(&self.payload[self.offset..end]);
+        self.offset = end;
+        Poll::Ready(Some(Ok(chunk)))
+    }
+}
+
+/// Serialize a captured result while its permit is held, then retain that
+/// permit until the response body reaches EOF or is dropped by the server.
+/// Chunking allows Hyper's normal transport backpressure to bound data queued
+/// beyond the body stream.
+pub(crate) fn json_response_with_capture_permit<T: Serialize>(
+    status: StatusCode,
+    value: T,
+    permit: OwnedSemaphorePermit,
+) -> Response {
+    let payload = match serde_json::to_vec(&value) {
+        Ok(payload) => Bytes::from(payload),
+        Err(error) => {
+            tracing::error!(reason = %error, "Failed to serialize captured agent response");
+            drop(permit);
+            let mut response = Response::new(Body::from(
+                r#"{"success":false,"data":null,"error":"Failed to serialize agent response"}"#,
+            ));
+            *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+            response.headers_mut().insert(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            );
+            return response;
+        }
+    };
+
+    let body = Body::from_stream(CaptureResponseStream {
+        payload,
+        offset: 0,
+        permit: Some(permit),
+    });
+    let mut response = Response::new(body);
+    *response.status_mut() = status;
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/json"),
+    );
+    response
+}
 
 fn append_printable_utf8(output: &mut String, input: &str) {
     for character in input.chars() {
@@ -132,6 +217,8 @@ impl BoundedTailBuffer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use http_body_util::BodyExt;
+    use std::sync::Arc;
 
     #[test]
     fn retains_complete_output_below_limit() {
@@ -213,5 +300,45 @@ mod tests {
         output.push(Bytes::from_static("😀".as_bytes()));
 
         assert_eq!(output.into_string(), format!("{TRUNCATION_NOTICE}z😀"));
+    }
+
+    #[tokio::test]
+    async fn capture_permit_is_held_until_response_body_finishes_or_drops() {
+        let slots = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = slots
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("test semaphore remains open");
+        let payload = "x".repeat(CAPTURE_RESPONSE_CHUNK_BYTES * 2);
+        let response = json_response_with_capture_permit(StatusCode::OK, &payload, permit);
+        let mut body = response.into_body();
+
+        let first = body
+            .frame()
+            .await
+            .expect("response has a first frame")
+            .expect("response frame is infallible")
+            .into_data()
+            .expect("response frame contains data");
+        assert!(first.len() <= CAPTURE_RESPONSE_CHUNK_BYTES);
+        assert!(slots.clone().try_acquire_owned().is_err());
+
+        drop(body);
+        assert_eq!(slots.available_permits(), 1);
+
+        let permit = slots
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("test semaphore remains open");
+        let response = json_response_with_capture_permit(StatusCode::OK, &payload, permit);
+        let collected = response
+            .into_body()
+            .collect()
+            .await
+            .expect("response body is infallible");
+        assert!(!collected.to_bytes().is_empty());
+        assert_eq!(slots.available_permits(), 1);
     }
 }

--- a/crates/temps-agent/src/output_buffer.rs
+++ b/crates/temps-agent/src/output_buffer.rs
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Bounded tail buffers for Docker command output.
+//!
+//! Docker exec, backup, and restore streams are controlled by workloads, so
+//! collecting them into an unbounded `String` lets a noisy container grow the
+//! worker agent until it is OOM-killed. This buffer retains only the newest
+//! bytes and records that earlier output was discarded.
+
+use bytes::Bytes;
+
+/// Maximum captured bytes per stdout/stderr stream.
+///
+/// Two active streams therefore retain at most 8 MiB of payload. Response
+/// serialization can briefly create another bounded copy.
+pub(crate) const MAX_CAPTURED_STREAM_BYTES: usize = 4 * 1024 * 1024;
+
+const TRUNCATION_NOTICE: &str = "[… earlier output truncated by worker …]\n";
+
+fn append_printable_utf8(output: &mut String, input: &str) {
+    for character in input.chars() {
+        if character.is_control() && !matches!(character, '\n' | '\r' | '\t') {
+            output.push('?');
+        } else {
+            output.push(character);
+        }
+    }
+}
+
+fn append_sanitized_utf8(output: &mut String, mut input: &[u8]) {
+    while !input.is_empty() {
+        match std::str::from_utf8(input) {
+            Ok(valid) => {
+                append_printable_utf8(output, valid);
+                break;
+            }
+            Err(error) => {
+                let valid_bytes = error.valid_up_to();
+                if let Ok(valid) = std::str::from_utf8(&input[..valid_bytes]) {
+                    append_printable_utf8(output, valid);
+                }
+                output.push('?');
+                match error.error_len() {
+                    Some(invalid_bytes) => input = &input[valid_bytes + invalid_bytes..],
+                    None => break,
+                }
+            }
+        }
+    }
+}
+
+pub(crate) struct BoundedTailBuffer {
+    bytes: Vec<u8>,
+    start: usize,
+    limit: usize,
+    truncated: bool,
+}
+
+impl BoundedTailBuffer {
+    pub(crate) fn new(limit: usize) -> Self {
+        Self {
+            bytes: Vec::new(),
+            start: 0,
+            limit,
+            truncated: false,
+        }
+    }
+
+    pub(crate) fn push(&mut self, chunk: Bytes) {
+        if chunk.is_empty() {
+            return;
+        }
+
+        if self.limit == 0 {
+            self.truncated = true;
+            return;
+        }
+
+        if chunk.len() >= self.limit {
+            self.truncated |= self.len() > 0 || chunk.len() > self.limit;
+            self.bytes.clear();
+            self.start = 0;
+            self.bytes
+                .extend_from_slice(&chunk[chunk.len() - self.limit..]);
+            return;
+        }
+
+        let mut append_bytes = 0;
+        if self.bytes.len() < self.limit {
+            append_bytes = chunk.len().min(self.limit - self.bytes.len());
+            self.bytes.extend_from_slice(&chunk[..append_bytes]);
+            if append_bytes == chunk.len() {
+                return;
+            }
+        }
+
+        // Once full, overwrite the oldest bytes in place. Each push is
+        // O(chunk size), even when Docker emits millions of tiny frames.
+        let overwrite = &chunk[append_bytes..];
+        let first = overwrite.len().min(self.limit - self.start);
+        self.bytes[self.start..self.start + first].copy_from_slice(&overwrite[..first]);
+        if first < overwrite.len() {
+            self.bytes[..overwrite.len() - first].copy_from_slice(&overwrite[first..]);
+        }
+        self.start = (self.start + overwrite.len()) % self.limit;
+        self.truncated = true;
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    pub(crate) fn into_string(mut self) -> String {
+        let notice_len = if self.truncated {
+            TRUNCATION_NOTICE.len()
+        } else {
+            0
+        };
+        let mut output = String::with_capacity(self.bytes.len().saturating_add(notice_len));
+        if self.truncated {
+            output.push_str(TRUNCATION_NOTICE);
+        }
+        if self.bytes.len() == self.limit && self.start > 0 {
+            self.bytes.rotate_left(self.start);
+        }
+        append_sanitized_utf8(&mut output, &self.bytes);
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retains_complete_output_below_limit() {
+        let mut output = BoundedTailBuffer::new(16);
+        output.push(Bytes::from_static(b"hello "));
+        output.push(Bytes::from_static(b"world"));
+
+        assert_eq!(output.len(), 11);
+        assert_eq!(output.into_string(), "hello world");
+    }
+
+    #[test]
+    fn retains_only_tail_across_chunk_boundaries() {
+        let mut output = BoundedTailBuffer::new(8);
+        output.push(Bytes::from_static(b"abcd"));
+        output.push(Bytes::from_static(b"efgh"));
+        output.push(Bytes::from_static(b"ijkl"));
+
+        assert_eq!(output.len(), 8);
+        assert_eq!(output.into_string(), format!("{TRUNCATION_NOTICE}efghijkl"));
+    }
+
+    #[test]
+    fn large_single_chunk_is_bounded() {
+        let mut output = BoundedTailBuffer::new(4);
+        output.push(Bytes::from_static(b"0123456789"));
+
+        assert_eq!(output.len(), 4);
+        assert_eq!(output.into_string(), format!("{TRUNCATION_NOTICE}6789"));
+    }
+
+    #[test]
+    fn zero_limit_discards_output_without_panicking() {
+        let mut output = BoundedTailBuffer::new(0);
+        output.push(Bytes::from_static(b"discard me"));
+
+        assert_eq!(output.len(), 0);
+        assert_eq!(output.into_string(), TRUNCATION_NOTICE);
+    }
+
+    #[test]
+    fn many_tiny_frames_use_a_fixed_capacity_ring() {
+        const LIMIT: usize = 64 * 1024;
+        let mut output = BoundedTailBuffer::new(LIMIT);
+        for _ in 0..200_000 {
+            output.push(Bytes::from_static(b"x"));
+        }
+
+        assert_eq!(output.len(), LIMIT);
+        assert_eq!(output.bytes.len(), LIMIT);
+        assert_eq!(output.into_string().len(), TRUNCATION_NOTICE.len() + LIMIT);
+    }
+
+    #[test]
+    fn invalid_utf8_does_not_expand_the_output() {
+        let mut output = BoundedTailBuffer::new(128);
+        output.push(Bytes::from(vec![0xff; 128]));
+
+        let output = output.into_string();
+        assert_eq!(output.len(), 128);
+        assert!(output.bytes().all(|byte| byte == b'?'));
+    }
+
+    #[test]
+    fn control_bytes_do_not_expand_during_json_serialization() {
+        let mut output = BoundedTailBuffer::new(128);
+        output.push(Bytes::from(vec![0; 128]));
+
+        let output = output.into_string();
+        assert_eq!(output.len(), 128);
+        assert!(output.bytes().all(|byte| byte == b'?'));
+    }
+
+    #[test]
+    fn preserves_utf8_character_split_across_ring_wrap() {
+        let mut output = BoundedTailBuffer::new(5);
+        output.push(Bytes::from_static(b"abcde"));
+        output.push(Bytes::from_static(b"wxyz"));
+        output.push(Bytes::from_static("😀".as_bytes()));
+
+        assert_eq!(output.into_string(), format!("{TRUNCATION_NOTICE}z😀"));
+    }
+}

--- a/crates/temps-agent/src/server.rs
+++ b/crates/temps-agent/src/server.rs
@@ -54,6 +54,15 @@ pub fn build_router(
     let state = Arc::new(AgentState {
         container_deployer,
         image_builder,
+        output_capture_slots: Arc::new(tokio::sync::Semaphore::new(
+            handlers::MAX_CONCURRENT_OUTPUT_CAPTURES,
+        )),
+        exec_operation_slots: Arc::new(tokio::sync::Semaphore::new(
+            handlers::MAX_CONCURRENT_EXEC_OPERATIONS,
+        )),
+        image_import_slots: Arc::new(tokio::sync::Semaphore::new(
+            handlers::MAX_CONCURRENT_IMAGE_IMPORTS,
+        )),
         docker,
         overlay_bridge_address,
         overlay_peers,

--- a/crates/temps-agent/src/server.rs
+++ b/crates/temps-agent/src/server.rs
@@ -54,20 +54,12 @@ pub fn build_router(
     let state = Arc::new(AgentState {
         container_deployer,
         image_builder,
-        output_capture_slots: Arc::new(tokio::sync::Semaphore::new(
-            handlers::MAX_CONCURRENT_OUTPUT_CAPTURES,
-        )),
-        exec_operation_slots: Arc::new(tokio::sync::Semaphore::new(
-            handlers::MAX_CONCURRENT_EXEC_OPERATIONS,
-        )),
-        image_import_slots: Arc::new(tokio::sync::Semaphore::new(
-            handlers::MAX_CONCURRENT_IMAGE_IMPORTS,
-        )),
         docker,
         overlay_bridge_address,
         overlay_peers,
         platform,
     });
+    let resource_limits = Arc::new(handlers::AgentResourceLimits::new());
 
     let auth = Arc::new(AgentAuth::new(&config.token));
 
@@ -150,6 +142,7 @@ pub fn build_router(
         )
         .layer(middleware::from_fn(require_agent_auth))
         .layer(Extension(auth))
+        .layer(Extension(resource_limits))
         .with_state(state);
 
     // Swagger UI — no auth required so it's accessible for documentation

--- a/crates/temps-agent/src/service_handlers.rs
+++ b/crates/temps-agent/src/service_handlers.rs
@@ -19,7 +19,14 @@ use bollard::query_parameters::{
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::handlers::{AgentResponse, AgentState};
+use crate::exec_timeout::{
+    completed_exec_exit_code, exec_start_was_rejected, resolve_exec_container_id,
+    run_exec_with_deadline, ExecCleanupGuard, ExecCompletionError, ExecDeadlineOutcome,
+};
+use crate::handlers::{
+    try_acquire_attached_exec_permits, AgentResponse, AgentState, ExecAdmissionError,
+};
+use crate::output_buffer::{BoundedTailBuffer, MAX_CAPTURED_STREAM_BYTES};
 use crate::{
     ServiceBackupRequest, ServiceBackupResponse, ServiceCreateRequest, ServiceCreateResponse,
     ServiceExecRequest, ServiceExecResponse, ServiceRestoreRequest, ServiceStatus,
@@ -28,6 +35,156 @@ use temps_providers::remote_service_client::{
     RemoteHealthProbeRequest, RemoteHealthProbeResponse, RemoteRuntimeEnvRequest,
     RemoteRuntimeEnvResponse,
 };
+
+const SERVICE_EXEC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+const SERVICE_DATA_OPERATION_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(2 * 60 * 60);
+const DATA_OPERATION_STDERR_CAPTURE_BYTES: usize = 64 * 1024;
+
+#[derive(Clone, Copy)]
+struct ExecCaptureLimits {
+    stdout: usize,
+    stderr: usize,
+}
+
+const SERVICE_EXEC_CAPTURE_LIMITS: ExecCaptureLimits = ExecCaptureLimits {
+    stdout: MAX_CAPTURED_STREAM_BYTES,
+    stderr: MAX_CAPTURED_STREAM_BYTES,
+};
+const DATA_OPERATION_CAPTURE_LIMITS: ExecCaptureLimits = ExecCaptureLimits {
+    stdout: 0,
+    stderr: DATA_OPERATION_STDERR_CAPTURE_BYTES,
+};
+const POSTGRES_DUMP_SCRIPT: &str =
+    "pg_dumpall --clean --if-exists --no-acl --no-owner -U postgres | gzip > /tmp/backup.sql.gz && echo 'dump_complete'";
+
+fn postgres_dump_command() -> Vec<String> {
+    vec![
+        "bash".to_string(),
+        "-o".to_string(),
+        "pipefail".to_string(),
+        "-c".to_string(),
+        POSTGRES_DUMP_SCRIPT.to_string(),
+    ]
+}
+
+struct CapturedExecOutput {
+    exit_code: i64,
+    stdout: String,
+    stderr: String,
+    received_stdout_bytes: usize,
+    received_stderr_bytes: usize,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum CaptureExecError {
+    #[error("Failed to start Docker exec '{exec_id}': {source}")]
+    Start {
+        exec_id: String,
+        source: bollard::errors::Error,
+    },
+    #[error("Docker exec '{exec_id}' unexpectedly started detached")]
+    UnexpectedDetached { exec_id: String },
+    #[error("Failed while reading output from Docker exec '{exec_id}': {source}")]
+    Stream {
+        exec_id: String,
+        source: bollard::errors::Error,
+    },
+    #[error("Failed to inspect completed Docker exec '{exec_id}': {source}")]
+    Inspect {
+        exec_id: String,
+        source: bollard::errors::Error,
+    },
+    #[error("Docker exec completion could not be confirmed: {source}")]
+    Completion {
+        #[from]
+        source: ExecCompletionError,
+    },
+}
+
+async fn capture_exec_output(
+    docker: &bollard::Docker,
+    exec_id: &str,
+    limits: ExecCaptureLimits,
+) -> Result<CapturedExecOutput, CaptureExecError> {
+    use bollard::exec::{StartExecOptions, StartExecResults};
+    use futures::StreamExt;
+
+    let mut output = match docker
+        .start_exec(exec_id, None::<StartExecOptions>)
+        .await
+        .map_err(|source| CaptureExecError::Start {
+            exec_id: exec_id.to_string(),
+            source,
+        })? {
+        StartExecResults::Attached { output, .. } => output,
+        StartExecResults::Detached => {
+            return Err(CaptureExecError::UnexpectedDetached {
+                exec_id: exec_id.to_string(),
+            });
+        }
+    };
+
+    let mut stdout = BoundedTailBuffer::new(limits.stdout);
+    let mut stderr = BoundedTailBuffer::new(limits.stderr);
+    let mut received_stdout_bytes = 0usize;
+    let mut received_stderr_bytes = 0usize;
+    while let Some(chunk) = output.next().await {
+        match chunk.map_err(|source| CaptureExecError::Stream {
+            exec_id: exec_id.to_string(),
+            source,
+        })? {
+            bollard::container::LogOutput::StdOut { message } => {
+                received_stdout_bytes = received_stdout_bytes.saturating_add(message.len());
+                stdout.push(message);
+            }
+            bollard::container::LogOutput::StdErr { message } => {
+                received_stderr_bytes = received_stderr_bytes.saturating_add(message.len());
+                stderr.push(message);
+            }
+            _ => {}
+        }
+    }
+
+    let inspect =
+        docker
+            .inspect_exec(exec_id)
+            .await
+            .map_err(|source| CaptureExecError::Inspect {
+                exec_id: exec_id.to_string(),
+                source,
+            })?;
+    let exit_code = completed_exec_exit_code(&inspect, exec_id)?;
+
+    Ok(CapturedExecOutput {
+        exit_code,
+        stdout: stdout.into_string(),
+        stderr: stderr.into_string(),
+        received_stdout_bytes,
+        received_stderr_bytes,
+    })
+}
+
+fn exec_failure_message(
+    operation: &str,
+    container_name: &str,
+    output: &CapturedExecOutput,
+) -> Option<String> {
+    if output.exit_code == 0 {
+        return None;
+    }
+
+    let stderr = output.stderr.trim();
+    let context = if stderr.is_empty() {
+        String::new()
+    } else {
+        format!(": {stderr}")
+    };
+    Some(format!(
+        "{operation} command in '{container_name}' exited with status {}{context}",
+        output.exit_code
+    ))
+}
 
 fn error_response(status: StatusCode, message: String) -> impl IntoResponse {
     (
@@ -705,7 +862,8 @@ pub async fn service_exec(
 ) -> impl IntoResponse {
     tracing::info!(
         container = %request.container_name,
-        command = ?request.command,
+        command_argc = request.command.len(),
+        detached = request.detach,
         "Executing command in service container"
     );
 
@@ -730,6 +888,37 @@ pub async fn service_exec(
     let env_refs: Vec<&str> = env_strings.iter().map(|s| &s[..]).collect();
 
     let cmd_refs: Vec<&str> = request.command.iter().map(|s| &s[..]).collect();
+
+    let permits = if request.detach {
+        None
+    } else {
+        match try_acquire_attached_exec_permits(
+            &state.exec_operation_slots,
+            &state.output_capture_slots,
+        ) {
+            Ok(permits) => Some(permits),
+            Err(ExecAdmissionError::OperationsBusy) => {
+                return error_response(
+                    StatusCode::TOO_MANY_REQUESTS,
+                    format!(
+                        "Cannot execute command in '{}': all exec operation slots are busy",
+                        request.container_name
+                    ),
+                )
+                .into_response();
+            }
+            Err(ExecAdmissionError::CapturesBusy) => {
+                return error_response(
+                    StatusCode::TOO_MANY_REQUESTS,
+                    format!(
+                        "Cannot execute command in '{}': all output capture slots are busy",
+                        request.container_name
+                    ),
+                )
+                .into_response();
+            }
+        }
+    };
 
     let exec_config = CreateExecOptions {
         cmd: Some(cmd_refs),
@@ -788,57 +977,110 @@ pub async fn service_exec(
         .into_response();
     }
 
-    // Start attached — collect output
-    let output = match docker
-        .start_exec(&exec_create.id, None::<StartExecOptions>)
-        .await
-    {
-        Ok(bollard::exec::StartExecResults::Attached { mut output, .. }) => {
-            use futures::StreamExt;
-            let mut stdout = String::new();
-            let mut stderr = String::new();
-            while let Some(chunk) = output.next().await {
-                match chunk {
-                    Ok(bollard::container::LogOutput::StdOut { message }) => {
-                        stdout.push_str(&String::from_utf8_lossy(&message));
-                    }
-                    Ok(bollard::container::LogOutput::StdErr { message }) => {
-                        stderr.push_str(&String::from_utf8_lossy(&message));
-                    }
-                    Ok(_) => {}
-                    Err(e) => {
-                        stderr.push_str(&format!("Stream error: {}\n", e));
-                    }
-                }
-            }
-            (stdout, stderr)
-        }
-        Ok(bollard::exec::StartExecResults::Detached) => (String::new(), String::new()),
-        Err(e) => {
+    let cleanup_container_id = match resolve_exec_container_id(docker, &exec_create.id).await {
+        Ok(container_id) => container_id,
+        Err(error) => {
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to start exec: {}", e),
+                format!("Failed to prepare command cleanup: {error}"),
             )
             .into_response();
         }
     };
 
-    // Get exit code
-    let exit_code = match docker.inspect_exec(&exec_create.id).await {
-        Ok(info) => info.exit_code.unwrap_or(-1),
-        Err(_) => -1,
+    let permits = match permits {
+        Some(permits) => permits,
+        None => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "Missing output capture permit for attached command in '{}'",
+                    request.container_name
+                ),
+            )
+            .into_response();
+        }
+    };
+    let capture_permit = permits.capture;
+    let operation_permit = permits.operation;
+    let mut cleanup_guard = ExecCleanupGuard::new(
+        docker.clone(),
+        exec_create.id.clone(),
+        cleanup_container_id.clone(),
+        capture_permit,
+        operation_permit,
+    );
+
+    let output = match run_exec_with_deadline(
+        docker,
+        &exec_create.id,
+        &cleanup_container_id,
+        SERVICE_EXEC_TIMEOUT,
+        capture_exec_output(docker, &exec_create.id, SERVICE_EXEC_CAPTURE_LIMITS),
+    )
+    .await
+    {
+        ExecDeadlineOutcome::Completed(Ok(output)) => {
+            cleanup_guard.disarm();
+            output
+        }
+        ExecDeadlineOutcome::Completed(Err(error)) => {
+            let cleanup_scheduled = !matches!(
+                &error,
+                CaptureExecError::Start { source, .. } if exec_start_was_rejected(source)
+            );
+            if !cleanup_scheduled {
+                cleanup_guard.disarm();
+            }
+            let cleanup_note = if cleanup_scheduled {
+                "its container restart was scheduled to stop any ambiguous command workload"
+            } else {
+                "Docker definitively rejected the command before it started; its container was not restarted"
+            };
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "Failed to execute command in '{}': {error}; {cleanup_note}",
+                    request.container_name
+                ),
+            )
+            .into_response();
+        }
+        ExecDeadlineOutcome::ContainerRestarted => {
+            cleanup_guard.disarm();
+            return error_response(
+                StatusCode::GATEWAY_TIMEOUT,
+                format!(
+                    "Command in '{}' exceeded the 5-minute worker deadline; its container was restarted to stop the complete command workload",
+                    request.container_name
+                ),
+            )
+            .into_response();
+        }
+        ExecDeadlineOutcome::TerminationFailed(error) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "Command in '{}' exceeded the 5-minute worker deadline, but the worker could not restart its container to stop the complete workload: {error}",
+                    request.container_name
+                ),
+            )
+            .into_response();
+        }
     };
 
     tracing::info!(
         container = %request.container_name,
-        exit_code = exit_code,
+        exit_code = output.exit_code,
+        received_stdout_bytes = output.received_stdout_bytes,
+        received_stderr_bytes = output.received_stderr_bytes,
         "Exec completed"
     );
 
     ok_response(ServiceExecResponse {
-        exit_code,
-        stdout: output.0,
-        stderr: output.1,
+        exit_code: output.exit_code,
+        stdout: output.stdout,
+        stderr: output.stderr,
     })
     .into_response()
 }
@@ -1098,12 +1340,7 @@ pub async fn backup_service(
             // pg_dumpall dumps the entire cluster (all databases, roles, tablespaces).
             // Output is plain SQL (custom format is not supported by pg_dumpall), so the
             // restore path must use `psql -f` rather than `pg_restore`.
-            let cmd = vec![
-                "bash".to_string(),
-                "-c".to_string(),
-                "pg_dumpall --clean --if-exists --no-acl --no-owner -U postgres | gzip > /tmp/backup.sql.gz && echo 'dump_complete'"
-                    .to_string(),
-            ];
+            let cmd = postgres_dump_command();
             (cmd, Some("postgres"))
         }
         ("redis", _) => {
@@ -1136,9 +1373,37 @@ pub async fn backup_service(
         }
     };
 
-    // Execute the backup command inside the container
-    use bollard::exec::{CreateExecOptions, StartExecOptions, StartExecResults};
-    use futures::StreamExt;
+    let permits = match try_acquire_attached_exec_permits(
+        &state.exec_operation_slots,
+        &state.output_capture_slots,
+    ) {
+        Ok(permits) => permits,
+        Err(ExecAdmissionError::OperationsBusy) => {
+            return error_response(
+                StatusCode::TOO_MANY_REQUESTS,
+                format!(
+                    "Cannot back up '{}': all exec operation slots are busy",
+                    request.container_name
+                ),
+            )
+            .into_response();
+        }
+        Err(ExecAdmissionError::CapturesBusy) => {
+            return error_response(
+                StatusCode::TOO_MANY_REQUESTS,
+                format!(
+                    "Cannot back up '{}': all output capture slots are busy",
+                    request.container_name
+                ),
+            )
+            .into_response();
+        }
+    };
+    let capture_permit = permits.capture;
+    let operation_permit = permits.operation;
+
+    // Execute the backup command inside the container.
+    use bollard::exec::CreateExecOptions;
 
     let env_strings: Vec<String> = s3_env.iter().map(|(k, v)| format!("{}={}", k, v)).collect();
     let env_refs: Vec<&str> = env_strings.iter().map(|s| &s[..]).collect();
@@ -1170,72 +1435,107 @@ pub async fn backup_service(
             .into_response();
         }
     };
+    let cleanup_container_id = match resolve_exec_container_id(docker, &exec_create.id).await {
+        Ok(container_id) => container_id,
+        Err(error) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to prepare backup cleanup: {error}"),
+            )
+            .into_response();
+        }
+    };
+    let mut cleanup_guard = ExecCleanupGuard::new(
+        docker.clone(),
+        exec_create.id.clone(),
+        cleanup_container_id.clone(),
+        capture_permit,
+        operation_permit,
+    );
 
-    let start_opts = StartExecOptions {
-        ..Default::default()
+    let output = match run_exec_with_deadline(
+        docker,
+        &exec_create.id,
+        &cleanup_container_id,
+        SERVICE_DATA_OPERATION_TIMEOUT,
+        capture_exec_output(docker, &exec_create.id, DATA_OPERATION_CAPTURE_LIMITS),
+    )
+    .await
+    {
+        ExecDeadlineOutcome::Completed(Ok(output)) => {
+            cleanup_guard.disarm();
+            output
+        }
+        ExecDeadlineOutcome::Completed(Err(error)) => {
+            let cleanup_scheduled = !matches!(
+                &error,
+                CaptureExecError::Start { source, .. } if exec_start_was_rejected(source)
+            );
+            if !cleanup_scheduled {
+                cleanup_guard.disarm();
+            }
+            let cleanup_note = if cleanup_scheduled {
+                "its container restart was scheduled to stop any ambiguous backup workload"
+            } else {
+                "Docker definitively rejected the backup before it started; its container was not restarted"
+            };
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "Failed to run backup command in '{}': {error}; {cleanup_note}",
+                    request.container_name
+                ),
+            )
+            .into_response();
+        }
+        ExecDeadlineOutcome::ContainerRestarted => {
+            cleanup_guard.disarm();
+            return error_response(
+                StatusCode::GATEWAY_TIMEOUT,
+                format!(
+                    "Backup command in '{}' exceeded the 2-hour worker deadline; its container was restarted to stop the complete backup workload",
+                    request.container_name
+                ),
+            )
+            .into_response();
+        }
+        ExecDeadlineOutcome::TerminationFailed(error) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "Backup command in '{}' exceeded the 2-hour worker deadline, but the worker could not restart its container to stop the complete workload: {error}",
+                    request.container_name
+                ),
+            )
+            .into_response();
+        }
     };
 
-    match docker.start_exec(&exec_create.id, Some(start_opts)).await {
-        Ok(StartExecResults::Attached { mut output, .. }) => {
-            let mut stdout = String::new();
-            let mut stderr = String::new();
-
-            while let Some(chunk) = output.next().await {
-                match chunk {
-                    Ok(bollard::container::LogOutput::StdOut { message }) => {
-                        stdout.push_str(&String::from_utf8_lossy(&message));
-                    }
-                    Ok(bollard::container::LogOutput::StdErr { message }) => {
-                        stderr.push_str(&String::from_utf8_lossy(&message));
-                    }
-                    Ok(_) => {}
-                    Err(e) => {
-                        return error_response(
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            format!("Error reading backup output: {}", e),
-                        )
-                        .into_response();
-                    }
-                }
-            }
-
-            if stderr.contains("error") || stderr.contains("FATAL") {
-                tracing::error!(
-                    container = %request.container_name,
-                    "Backup failed: {}", stderr
-                );
-                return error_response(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Backup failed: {}", stderr),
-                )
-                .into_response();
-            }
-
-            tracing::info!(
-                container = %request.container_name,
-                stdout = %stdout,
-                "Backup completed successfully"
-            );
-
-            ok_response(ServiceBackupResponse {
-                s3_location: request.s3_path.clone(),
-                size_bytes: 0,
-                compression_type: "gzip".to_string(),
-                checksum: None,
-            })
-            .into_response()
-        }
-        Ok(StartExecResults::Detached) => error_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Backup exec unexpectedly detached".to_string(),
-        )
-        .into_response(),
-        Err(e) => error_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to start backup exec: {}", e),
-        )
-        .into_response(),
+    if let Some(message) = exec_failure_message("Backup", &request.container_name, &output) {
+        tracing::error!(
+            container = %request.container_name,
+            exit_code = output.exit_code,
+            received_stdout_bytes = output.received_stdout_bytes,
+            received_stderr_bytes = output.received_stderr_bytes,
+            "Backup command failed"
+        );
+        return error_response(StatusCode::INTERNAL_SERVER_ERROR, message).into_response();
     }
+
+    tracing::info!(
+        container = %request.container_name,
+        received_stdout_bytes = output.received_stdout_bytes,
+        received_stderr_bytes = output.received_stderr_bytes,
+        "Backup completed successfully"
+    );
+
+    ok_response(ServiceBackupResponse {
+        s3_location: request.s3_path.clone(),
+        size_bytes: 0,
+        compression_type: "gzip".to_string(),
+        checksum: None,
+    })
+    .into_response()
 }
 
 /// Restore a service from S3.
@@ -1315,8 +1615,36 @@ pub async fn restore_service(
         }
     };
 
-    use bollard::exec::{CreateExecOptions, StartExecOptions, StartExecResults};
-    use futures::StreamExt;
+    let permits = match try_acquire_attached_exec_permits(
+        &state.exec_operation_slots,
+        &state.output_capture_slots,
+    ) {
+        Ok(permits) => permits,
+        Err(ExecAdmissionError::OperationsBusy) => {
+            return error_response(
+                StatusCode::TOO_MANY_REQUESTS,
+                format!(
+                    "Cannot restore '{}': all exec operation slots are busy",
+                    request.container_name
+                ),
+            )
+            .into_response();
+        }
+        Err(ExecAdmissionError::CapturesBusy) => {
+            return error_response(
+                StatusCode::TOO_MANY_REQUESTS,
+                format!(
+                    "Cannot restore '{}': all output capture slots are busy",
+                    request.container_name
+                ),
+            )
+            .into_response();
+        }
+    };
+    let capture_permit = permits.capture;
+    let operation_permit = permits.operation;
+
+    use bollard::exec::CreateExecOptions;
 
     let env_strings: Vec<String> = s3_env.iter().map(|(k, v)| format!("{}={}", k, v)).collect();
     let env_refs: Vec<&str> = env_strings.iter().map(|s| &s[..]).collect();
@@ -1348,61 +1676,105 @@ pub async fn restore_service(
             .into_response();
         }
     };
+    let cleanup_container_id = match resolve_exec_container_id(docker, &exec_create.id).await {
+        Ok(container_id) => container_id,
+        Err(error) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to prepare restore cleanup: {error}"),
+            )
+            .into_response();
+        }
+    };
+    let mut cleanup_guard = ExecCleanupGuard::new(
+        docker.clone(),
+        exec_create.id.clone(),
+        cleanup_container_id.clone(),
+        capture_permit,
+        operation_permit,
+    );
 
-    let start_opts = StartExecOptions {
-        ..Default::default()
+    let output = match run_exec_with_deadline(
+        docker,
+        &exec_create.id,
+        &cleanup_container_id,
+        SERVICE_DATA_OPERATION_TIMEOUT,
+        capture_exec_output(docker, &exec_create.id, DATA_OPERATION_CAPTURE_LIMITS),
+    )
+    .await
+    {
+        ExecDeadlineOutcome::Completed(Ok(output)) => {
+            cleanup_guard.disarm();
+            output
+        }
+        ExecDeadlineOutcome::Completed(Err(error)) => {
+            let cleanup_scheduled = !matches!(
+                &error,
+                CaptureExecError::Start { source, .. } if exec_start_was_rejected(source)
+            );
+            if !cleanup_scheduled {
+                cleanup_guard.disarm();
+            }
+            let cleanup_note = if cleanup_scheduled {
+                "its container restart was scheduled to stop any ambiguous restore workload"
+            } else {
+                "Docker definitively rejected the restore before it started; its container was not restarted"
+            };
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "Failed to run restore command in '{}': {error}; {cleanup_note}",
+                    request.container_name
+                ),
+            )
+            .into_response();
+        }
+        ExecDeadlineOutcome::ContainerRestarted => {
+            cleanup_guard.disarm();
+            return error_response(
+                StatusCode::GATEWAY_TIMEOUT,
+                format!(
+                    "Restore command in '{}' exceeded the 2-hour worker deadline; its container was restarted to stop the complete restore workload",
+                    request.container_name
+                ),
+            )
+            .into_response();
+        }
+        ExecDeadlineOutcome::TerminationFailed(error) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "Restore command in '{}' exceeded the 2-hour worker deadline, but the worker could not restart its container to stop the complete workload: {error}",
+                    request.container_name
+                ),
+            )
+            .into_response();
+        }
     };
 
-    match docker.start_exec(&exec_create.id, Some(start_opts)).await {
-        Ok(StartExecResults::Attached { mut output, .. }) => {
-            let mut stderr = String::new();
-
-            while let Some(chunk) = output.next().await {
-                match chunk {
-                    Ok(bollard::container::LogOutput::StdErr { message }) => {
-                        stderr.push_str(&String::from_utf8_lossy(&message));
-                    }
-                    Ok(_) => {}
-                    Err(e) => {
-                        return error_response(
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            format!("Error reading restore output: {}", e),
-                        )
-                        .into_response();
-                    }
-                }
-            }
-
-            if stderr.contains("error") || stderr.contains("FATAL") {
-                return error_response(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Restore failed: {}", stderr),
-                )
-                .into_response();
-            }
-
-            tracing::info!(
-                container = %request.container_name,
-                "Restore completed successfully"
-            );
-
-            ok_response(serde_json::json!({
-                "status": "restored",
-                "container_name": request.container_name,
-            }))
-            .into_response()
-        }
-        Ok(StartExecResults::Detached) => error_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Restore exec unexpectedly detached".to_string(),
-        )
-        .into_response(),
-        Err(e) => error_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to start restore exec: {}", e),
-        )
-        .into_response(),
+    if let Some(message) = exec_failure_message("Restore", &request.container_name, &output) {
+        tracing::error!(
+            container = %request.container_name,
+            exit_code = output.exit_code,
+            received_stdout_bytes = output.received_stdout_bytes,
+            received_stderr_bytes = output.received_stderr_bytes,
+            "Restore command failed"
+        );
+        return error_response(StatusCode::INTERNAL_SERVER_ERROR, message).into_response();
     }
+
+    tracing::info!(
+        container = %request.container_name,
+        received_stdout_bytes = output.received_stdout_bytes,
+        received_stderr_bytes = output.received_stderr_bytes,
+        "Restore completed successfully"
+    );
+
+    ok_response(serde_json::json!({
+        "status": "restored",
+        "container_name": request.container_name,
+    }))
+    .into_response()
 }
 
 /// Build S3 environment variables for backup commands (WAL-G, etc.)
@@ -1666,5 +2038,55 @@ mod overlay_ip_tests {
 
         assert!(names.contains("mongodb-orders_data"));
         assert!(names.contains("temps-mongodb-orders_data"));
+    }
+
+    #[test]
+    fn nonzero_exec_exit_includes_bounded_stderr_context() {
+        let output = CapturedExecOutput {
+            exit_code: 17,
+            stdout: String::new(),
+            // Model a diagnostic split across Docker frames before capture.
+            stderr: ["FA", "TAL: upload failed"].concat(),
+            received_stdout_bytes: 0,
+            received_stderr_bytes: 20,
+        };
+
+        let message = exec_failure_message("Backup", "postgres-orders", &output)
+            .expect("a nonzero exit must fail regardless of frame boundaries");
+        assert!(message.contains("postgres-orders"));
+        assert!(message.contains("status 17"));
+        assert!(message.contains("FATAL: upload failed"));
+    }
+
+    #[test]
+    fn zero_exec_exit_is_success_even_when_stderr_contains_error_word() {
+        let output = CapturedExecOutput {
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: "non-fatal error counter: 0".to_string(),
+            received_stdout_bytes: 0,
+            received_stderr_bytes: 26,
+        };
+
+        assert!(exec_failure_message("Restore", "redis-cache", &output).is_none());
+    }
+
+    #[test]
+    fn data_operations_discard_stdout_and_keep_small_stderr_tail() {
+        assert_eq!(DATA_OPERATION_CAPTURE_LIMITS.stdout, 0);
+        assert_eq!(
+            DATA_OPERATION_CAPTURE_LIMITS.stderr,
+            DATA_OPERATION_STDERR_CAPTURE_BYTES
+        );
+    }
+
+    #[test]
+    fn postgres_dump_pipeline_enables_pipefail() {
+        let command = postgres_dump_command();
+
+        assert_eq!(&command[..4], ["bash", "-o", "pipefail", "-c"]);
+        assert!(command[4].contains("pg_dumpall"));
+        assert!(command[4].contains("| gzip"));
+        assert!(command[4].contains("&& echo 'dump_complete'"));
     }
 }

--- a/crates/temps-agent/src/service_handlers.rs
+++ b/crates/temps-agent/src/service_handlers.rs
@@ -7,7 +7,7 @@
 //! (PostgreSQL, Redis, MongoDB, S3) on any node in the cluster.
 
 use axum::{
-    extract::{Path, State},
+    extract::{Extension, Path, State},
     http::StatusCode,
     response::IntoResponse,
     Json,
@@ -20,11 +20,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::exec_timeout::{
-    completed_exec_exit_code, exec_start_was_rejected, resolve_exec_container_id,
-    run_exec_with_deadline, ExecCleanupGuard, ExecCompletionError, ExecDeadlineOutcome,
+    completed_exec_exit_code, exec_start_was_rejected, monitor_exec_until_stopped,
+    resolve_container_id, resolve_exec_container_id, run_exec_with_deadline, ExecCleanupGuard,
+    ExecCompletionError, ExecDeadlineOutcome,
 };
 use crate::handlers::{
-    try_acquire_attached_exec_permits, AgentResponse, AgentState, ExecAdmissionError,
+    captured_error_response, captured_ok_response, container_identity_error_status,
+    try_acquire_attached_exec_permits, try_acquire_exec_lifecycle_permits, AgentResourceLimits,
+    AgentResponse, AgentState, ExecAdmissionError,
 };
 use crate::output_buffer::{BoundedTailBuffer, MAX_CAPTURED_STREAM_BYTES};
 use crate::{
@@ -852,12 +855,17 @@ pub async fn service_status(
     responses(
         (status = 200, description = "Command executed", body = AgentResponse<ServiceExecResponse>),
         (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Service container not found"),
+        (status = 409, description = "Container identity changed before exec start"),
+        (status = 429, description = "Exec or capture capacity exhausted"),
+        (status = 504, description = "Exec deadline exceeded"),
         (status = 500, description = "Exec failed")
     ),
     security(("bearer_auth" = []))
 )]
 pub async fn service_exec(
     State(state): State<Arc<AgentState>>,
+    Extension(limits): Extension<Arc<AgentResourceLimits>>,
     Json(request): Json<ServiceExecRequest>,
 ) -> impl IntoResponse {
     tracing::info!(
@@ -877,6 +885,19 @@ pub async fn service_exec(
             .into_response();
         }
     };
+    let cleanup_container_id = match resolve_container_id(docker, &request.container_name).await {
+        Ok(container_id) => container_id,
+        Err(error) => {
+            return error_response(
+                container_identity_error_status(&error),
+                format!(
+                    "Failed to resolve service container '{}' before exec: {error}",
+                    request.container_name
+                ),
+            )
+            .into_response();
+        }
+    };
 
     use bollard::exec::{CreateExecOptions, StartExecOptions};
 
@@ -889,15 +910,44 @@ pub async fn service_exec(
 
     let cmd_refs: Vec<&str> = request.command.iter().map(|s| &s[..]).collect();
 
-    let permits = if request.detach {
-        None
+    let (operation_permit, container_permit, capture_permit) = if request.detach {
+        match try_acquire_exec_lifecycle_permits(&limits, &cleanup_container_id) {
+            Ok(permits) => (permits.operation, permits.container, None),
+            Err(ExecAdmissionError::OperationsExhausted) => {
+                return error_response(
+                    StatusCode::TOO_MANY_REQUESTS,
+                    format!(
+                        "Cannot execute detached command in '{}': all exec operation slots are busy",
+                        request.container_name
+                    ),
+                )
+                .into_response();
+            }
+            Err(ExecAdmissionError::ContainerOwned) => {
+                return error_response(
+                    StatusCode::TOO_MANY_REQUESTS,
+                    format!(
+                        "Cannot execute detached command in '{}': another operation already owns that container",
+                        request.container_name
+                    ),
+                )
+                .into_response();
+            }
+            Err(ExecAdmissionError::CapturesExhausted) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!(
+                        "Detached command in '{}' unexpectedly required output capture capacity",
+                        request.container_name
+                    ),
+                )
+                .into_response();
+            }
+        }
     } else {
-        match try_acquire_attached_exec_permits(
-            &state.exec_operation_slots,
-            &state.output_capture_slots,
-        ) {
-            Ok(permits) => Some(permits),
-            Err(ExecAdmissionError::OperationsBusy) => {
+        match try_acquire_attached_exec_permits(&limits, &cleanup_container_id) {
+            Ok(permits) => (permits.operation, permits.container, Some(permits.capture)),
+            Err(ExecAdmissionError::OperationsExhausted) => {
                 return error_response(
                     StatusCode::TOO_MANY_REQUESTS,
                     format!(
@@ -907,11 +957,21 @@ pub async fn service_exec(
                 )
                 .into_response();
             }
-            Err(ExecAdmissionError::CapturesBusy) => {
+            Err(ExecAdmissionError::CapturesExhausted) => {
                 return error_response(
                     StatusCode::TOO_MANY_REQUESTS,
                     format!(
                         "Cannot execute command in '{}': all output capture slots are busy",
+                        request.container_name
+                    ),
+                )
+                .into_response();
+            }
+            Err(ExecAdmissionError::ContainerOwned) => {
+                return error_response(
+                    StatusCode::TOO_MANY_REQUESTS,
+                    format!(
+                        "Cannot execute command in '{}': another operation already owns that container",
                         request.container_name
                     ),
                 )
@@ -933,10 +993,7 @@ pub async fn service_exec(
         ..Default::default()
     };
 
-    let exec_create = match docker
-        .create_exec(&request.container_name, exec_config)
-        .await
-    {
+    let exec_create = match docker.create_exec(&cleanup_container_id, exec_config).await {
         Ok(r) => r,
         Err(e) => {
             return error_response(
@@ -950,34 +1007,7 @@ pub async fn service_exec(
         }
     };
 
-    if request.detach {
-        // Start detached — don't wait for output
-        if let Err(e) = docker
-            .start_exec(
-                &exec_create.id,
-                Some(StartExecOptions {
-                    detach: true,
-                    ..Default::default()
-                }),
-            )
-            .await
-        {
-            return error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to start exec (detached): {}", e),
-            )
-            .into_response();
-        }
-
-        return ok_response(ServiceExecResponse {
-            exit_code: 0,
-            stdout: String::new(),
-            stderr: "detached".to_string(),
-        })
-        .into_response();
-    }
-
-    let cleanup_container_id = match resolve_exec_container_id(docker, &exec_create.id).await {
+    let exec_container_id = match resolve_exec_container_id(docker, &exec_create.id).await {
         Ok(container_id) => container_id,
         Err(error) => {
             return error_response(
@@ -987,9 +1017,69 @@ pub async fn service_exec(
             .into_response();
         }
     };
+    if exec_container_id != cleanup_container_id {
+        return error_response(
+            StatusCode::CONFLICT,
+            format!(
+                "Service container '{}' changed from '{}' to '{}' before exec start",
+                request.container_name, cleanup_container_id, exec_container_id
+            ),
+        )
+        .into_response();
+    }
 
-    let permits = match permits {
-        Some(permits) => permits,
+    if request.detach {
+        let mut cleanup_guard = ExecCleanupGuard::new_without_capture(
+            docker.clone(),
+            exec_create.id.clone(),
+            cleanup_container_id.clone(),
+            Some(operation_permit),
+            container_permit,
+        );
+        let start_result = docker
+            .start_exec(
+                &exec_create.id,
+                Some(StartExecOptions {
+                    detach: true,
+                    ..Default::default()
+                }),
+            )
+            .await;
+        if let Err(error) = start_result {
+            let cleanup_scheduled = !exec_start_was_rejected(&error);
+            if !cleanup_scheduled {
+                cleanup_guard.disarm();
+            }
+            let cleanup_note = if cleanup_scheduled {
+                "its container restart was scheduled because Docker did not definitively reject the workload"
+            } else {
+                "Docker definitively rejected the workload before start; its container was not restarted"
+            };
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to start detached exec: {error}; {cleanup_note}"),
+            )
+            .into_response();
+        }
+
+        monitor_exec_until_stopped(
+            docker.clone(),
+            exec_create.id.clone(),
+            cleanup_container_id,
+            "detached service exec",
+            cleanup_guard,
+        );
+
+        return ok_response(ServiceExecResponse {
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: "detached".to_string(),
+        })
+        .into_response();
+    }
+
+    let capture_permit = match capture_permit {
+        Some(permit) => permit,
         None => {
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1001,17 +1091,16 @@ pub async fn service_exec(
             .into_response();
         }
     };
-    let capture_permit = permits.capture;
-    let operation_permit = permits.operation;
     let mut cleanup_guard = ExecCleanupGuard::new(
         docker.clone(),
         exec_create.id.clone(),
         cleanup_container_id.clone(),
         capture_permit,
         operation_permit,
+        container_permit,
     );
 
-    let output = match run_exec_with_deadline(
+    let (output, response_permit) = match run_exec_with_deadline(
         docker,
         &exec_create.id,
         &cleanup_container_id,
@@ -1021,8 +1110,17 @@ pub async fn service_exec(
     .await
     {
         ExecDeadlineOutcome::Completed(Ok(output)) => {
-            cleanup_guard.disarm();
-            output
+            let Some(response_permit) = cleanup_guard.disarm_and_take_capture() else {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!(
+                        "Command in '{}' completed without response capture ownership",
+                        request.container_name
+                    ),
+                )
+                .into_response();
+            };
+            (output, response_permit)
         }
         ExecDeadlineOutcome::Completed(Err(error)) => {
             let cleanup_scheduled = !matches!(
@@ -1077,12 +1175,14 @@ pub async fn service_exec(
         "Exec completed"
     );
 
-    ok_response(ServiceExecResponse {
-        exit_code: output.exit_code,
-        stdout: output.stdout,
-        stderr: output.stderr,
-    })
-    .into_response()
+    captured_ok_response(
+        ServiceExecResponse {
+            exit_code: output.exit_code,
+            stdout: output.stdout,
+            stderr: output.stderr,
+        },
+        response_permit,
+    )
 }
 
 /// Provision a project's logical database, bucket, or Redis allocation on
@@ -1288,12 +1388,17 @@ pub async fn list_services(State(state): State<Arc<AgentState>>) -> impl IntoRes
     responses(
         (status = 200, description = "Backup completed", body = AgentResponse<ServiceBackupResponse>),
         (status = 400, description = "Unsupported service type"),
+        (status = 404, description = "Service container not found"),
+        (status = 409, description = "Container identity changed before backup start"),
+        (status = 429, description = "Exec or capture capacity exhausted"),
+        (status = 504, description = "Backup deadline exceeded"),
         (status = 500, description = "Backup failed")
     ),
     security(("bearer_auth" = []))
 )]
 pub async fn backup_service(
     State(state): State<Arc<AgentState>>,
+    Extension(limits): Extension<Arc<AgentResourceLimits>>,
     Json(request): Json<ServiceBackupRequest>,
 ) -> impl IntoResponse {
     tracing::info!(
@@ -1309,6 +1414,19 @@ pub async fn backup_service(
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Docker client not available".to_string(),
+            )
+            .into_response();
+        }
+    };
+    let cleanup_container_id = match resolve_container_id(docker, &request.container_name).await {
+        Ok(container_id) => container_id,
+        Err(error) => {
+            return error_response(
+                container_identity_error_status(&error),
+                format!(
+                    "Failed to resolve service container '{}' before backup: {error}",
+                    request.container_name
+                ),
             )
             .into_response();
         }
@@ -1373,12 +1491,9 @@ pub async fn backup_service(
         }
     };
 
-    let permits = match try_acquire_attached_exec_permits(
-        &state.exec_operation_slots,
-        &state.output_capture_slots,
-    ) {
+    let permits = match try_acquire_attached_exec_permits(&limits, &cleanup_container_id) {
         Ok(permits) => permits,
-        Err(ExecAdmissionError::OperationsBusy) => {
+        Err(ExecAdmissionError::OperationsExhausted) => {
             return error_response(
                 StatusCode::TOO_MANY_REQUESTS,
                 format!(
@@ -1388,7 +1503,7 @@ pub async fn backup_service(
             )
             .into_response();
         }
-        Err(ExecAdmissionError::CapturesBusy) => {
+        Err(ExecAdmissionError::CapturesExhausted) => {
             return error_response(
                 StatusCode::TOO_MANY_REQUESTS,
                 format!(
@@ -1398,9 +1513,20 @@ pub async fn backup_service(
             )
             .into_response();
         }
+        Err(ExecAdmissionError::ContainerOwned) => {
+            return error_response(
+                StatusCode::TOO_MANY_REQUESTS,
+                format!(
+                    "Cannot back up '{}': another operation already owns that container",
+                    request.container_name
+                ),
+            )
+            .into_response();
+        }
     };
     let capture_permit = permits.capture;
     let operation_permit = permits.operation;
+    let container_permit = permits.container;
 
     // Execute the backup command inside the container.
     use bollard::exec::CreateExecOptions;
@@ -1422,10 +1548,7 @@ pub async fn backup_service(
         ..Default::default()
     };
 
-    let exec_create = match docker
-        .create_exec(&request.container_name, exec_config)
-        .await
-    {
+    let exec_create = match docker.create_exec(&cleanup_container_id, exec_config).await {
         Ok(r) => r,
         Err(e) => {
             return error_response(
@@ -1435,7 +1558,7 @@ pub async fn backup_service(
             .into_response();
         }
     };
-    let cleanup_container_id = match resolve_exec_container_id(docker, &exec_create.id).await {
+    let exec_container_id = match resolve_exec_container_id(docker, &exec_create.id).await {
         Ok(container_id) => container_id,
         Err(error) => {
             return error_response(
@@ -1445,15 +1568,26 @@ pub async fn backup_service(
             .into_response();
         }
     };
+    if exec_container_id != cleanup_container_id {
+        return error_response(
+            StatusCode::CONFLICT,
+            format!(
+                "Service container '{}' changed from '{}' to '{}' before backup start",
+                request.container_name, cleanup_container_id, exec_container_id
+            ),
+        )
+        .into_response();
+    }
     let mut cleanup_guard = ExecCleanupGuard::new(
         docker.clone(),
         exec_create.id.clone(),
         cleanup_container_id.clone(),
         capture_permit,
         operation_permit,
+        container_permit,
     );
 
-    let output = match run_exec_with_deadline(
+    let (output, response_permit) = match run_exec_with_deadline(
         docker,
         &exec_create.id,
         &cleanup_container_id,
@@ -1463,8 +1597,17 @@ pub async fn backup_service(
     .await
     {
         ExecDeadlineOutcome::Completed(Ok(output)) => {
-            cleanup_guard.disarm();
-            output
+            let Some(response_permit) = cleanup_guard.disarm_and_take_capture() else {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!(
+                        "Backup in '{}' completed without response capture ownership",
+                        request.container_name
+                    ),
+                )
+                .into_response();
+            };
+            (output, response_permit)
         }
         ExecDeadlineOutcome::Completed(Err(error)) => {
             let cleanup_scheduled = !matches!(
@@ -1519,7 +1662,11 @@ pub async fn backup_service(
             received_stderr_bytes = output.received_stderr_bytes,
             "Backup command failed"
         );
-        return error_response(StatusCode::INTERNAL_SERVER_ERROR, message).into_response();
+        return captured_error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            message,
+            response_permit,
+        );
     }
 
     tracing::info!(
@@ -1529,13 +1676,15 @@ pub async fn backup_service(
         "Backup completed successfully"
     );
 
-    ok_response(ServiceBackupResponse {
-        s3_location: request.s3_path.clone(),
-        size_bytes: 0,
-        compression_type: "gzip".to_string(),
-        checksum: None,
-    })
-    .into_response()
+    captured_ok_response(
+        ServiceBackupResponse {
+            s3_location: request.s3_path.clone(),
+            size_bytes: 0,
+            compression_type: "gzip".to_string(),
+            checksum: None,
+        },
+        response_permit,
+    )
 }
 
 /// Restore a service from S3.
@@ -1549,12 +1698,17 @@ pub async fn backup_service(
     responses(
         (status = 200, description = "Restore completed"),
         (status = 400, description = "Unsupported service type"),
+        (status = 404, description = "Service container not found"),
+        (status = 409, description = "Container identity changed before restore start"),
+        (status = 429, description = "Exec or capture capacity exhausted"),
+        (status = 504, description = "Restore deadline exceeded"),
         (status = 500, description = "Restore failed")
     ),
     security(("bearer_auth" = []))
 )]
 pub async fn restore_service(
     State(state): State<Arc<AgentState>>,
+    Extension(limits): Extension<Arc<AgentResourceLimits>>,
     Json(request): Json<ServiceRestoreRequest>,
 ) -> impl IntoResponse {
     tracing::info!(
@@ -1570,6 +1724,19 @@ pub async fn restore_service(
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Docker client not available".to_string(),
+            )
+            .into_response();
+        }
+    };
+    let cleanup_container_id = match resolve_container_id(docker, &request.container_name).await {
+        Ok(container_id) => container_id,
+        Err(error) => {
+            return error_response(
+                container_identity_error_status(&error),
+                format!(
+                    "Failed to resolve service container '{}' before restore: {error}",
+                    request.container_name
+                ),
             )
             .into_response();
         }
@@ -1615,12 +1782,9 @@ pub async fn restore_service(
         }
     };
 
-    let permits = match try_acquire_attached_exec_permits(
-        &state.exec_operation_slots,
-        &state.output_capture_slots,
-    ) {
+    let permits = match try_acquire_attached_exec_permits(&limits, &cleanup_container_id) {
         Ok(permits) => permits,
-        Err(ExecAdmissionError::OperationsBusy) => {
+        Err(ExecAdmissionError::OperationsExhausted) => {
             return error_response(
                 StatusCode::TOO_MANY_REQUESTS,
                 format!(
@@ -1630,7 +1794,7 @@ pub async fn restore_service(
             )
             .into_response();
         }
-        Err(ExecAdmissionError::CapturesBusy) => {
+        Err(ExecAdmissionError::CapturesExhausted) => {
             return error_response(
                 StatusCode::TOO_MANY_REQUESTS,
                 format!(
@@ -1640,9 +1804,20 @@ pub async fn restore_service(
             )
             .into_response();
         }
+        Err(ExecAdmissionError::ContainerOwned) => {
+            return error_response(
+                StatusCode::TOO_MANY_REQUESTS,
+                format!(
+                    "Cannot restore '{}': another operation already owns that container",
+                    request.container_name
+                ),
+            )
+            .into_response();
+        }
     };
     let capture_permit = permits.capture;
     let operation_permit = permits.operation;
+    let container_permit = permits.container;
 
     use bollard::exec::CreateExecOptions;
 
@@ -1663,10 +1838,7 @@ pub async fn restore_service(
         ..Default::default()
     };
 
-    let exec_create = match docker
-        .create_exec(&request.container_name, exec_config)
-        .await
-    {
+    let exec_create = match docker.create_exec(&cleanup_container_id, exec_config).await {
         Ok(r) => r,
         Err(e) => {
             return error_response(
@@ -1676,7 +1848,7 @@ pub async fn restore_service(
             .into_response();
         }
     };
-    let cleanup_container_id = match resolve_exec_container_id(docker, &exec_create.id).await {
+    let exec_container_id = match resolve_exec_container_id(docker, &exec_create.id).await {
         Ok(container_id) => container_id,
         Err(error) => {
             return error_response(
@@ -1686,15 +1858,26 @@ pub async fn restore_service(
             .into_response();
         }
     };
+    if exec_container_id != cleanup_container_id {
+        return error_response(
+            StatusCode::CONFLICT,
+            format!(
+                "Service container '{}' changed from '{}' to '{}' before restore start",
+                request.container_name, cleanup_container_id, exec_container_id
+            ),
+        )
+        .into_response();
+    }
     let mut cleanup_guard = ExecCleanupGuard::new(
         docker.clone(),
         exec_create.id.clone(),
         cleanup_container_id.clone(),
         capture_permit,
         operation_permit,
+        container_permit,
     );
 
-    let output = match run_exec_with_deadline(
+    let (output, response_permit) = match run_exec_with_deadline(
         docker,
         &exec_create.id,
         &cleanup_container_id,
@@ -1704,8 +1887,17 @@ pub async fn restore_service(
     .await
     {
         ExecDeadlineOutcome::Completed(Ok(output)) => {
-            cleanup_guard.disarm();
-            output
+            let Some(response_permit) = cleanup_guard.disarm_and_take_capture() else {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!(
+                        "Restore in '{}' completed without response capture ownership",
+                        request.container_name
+                    ),
+                )
+                .into_response();
+            };
+            (output, response_permit)
         }
         ExecDeadlineOutcome::Completed(Err(error)) => {
             let cleanup_scheduled = !matches!(
@@ -1760,7 +1952,11 @@ pub async fn restore_service(
             received_stderr_bytes = output.received_stderr_bytes,
             "Restore command failed"
         );
-        return error_response(StatusCode::INTERNAL_SERVER_ERROR, message).into_response();
+        return captured_error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            message,
+            response_permit,
+        );
     }
 
     tracing::info!(
@@ -1770,11 +1966,13 @@ pub async fn restore_service(
         "Restore completed successfully"
     );
 
-    ok_response(serde_json::json!({
-        "status": "restored",
-        "container_name": request.container_name,
-    }))
-    .into_response()
+    captured_ok_response(
+        serde_json::json!({
+            "status": "restored",
+            "container_name": request.container_name,
+        }),
+        response_permit,
+    )
 }
 
 /// Build S3 environment variables for backup commands (WAL-G, etc.)

--- a/crates/temps-cli/src/commands/agent.rs
+++ b/crates/temps-cli/src/commands/agent.rs
@@ -10,6 +10,12 @@ use clap::Args;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+const MAX_AGENT_WORKER_THREADS: usize = 8;
+
+fn agent_worker_threads(available_parallelism: usize) -> usize {
+    available_parallelism.clamp(1, MAX_AGENT_WORKER_THREADS)
+}
+
 /// Resolve the agent data directory (`TEMPS_DATA_DIR` env var, or
 /// `~/.temps`, or `./` as a last resort). Used for the saved agent
 /// config and the per-node DNS resolver snapshot (`<dir>/dns/zone.json`).
@@ -54,7 +60,15 @@ pub struct AgentCommand {
 
 impl AgentCommand {
     pub fn execute(self) -> anyhow::Result<()> {
+        let available_parallelism = std::thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(1);
+        let worker_threads = agent_worker_threads(available_parallelism);
         let rt = tokio::runtime::Builder::new_multi_thread()
+            // The agent is predominantly network and Docker-socket I/O. Tokio's
+            // default of one worker per logical CPU needlessly multiplies
+            // thread stacks and allocator arenas on large worker hosts.
+            .worker_threads(worker_threads)
             .enable_all()
             .build()?;
 
@@ -109,7 +123,12 @@ impl AgentCommand {
             let deployer: Arc<dyn temps_deployer::ContainerDeployer> = docker_runtime.clone();
             let builder: Arc<dyn temps_deployer::ImageBuilder> = docker_runtime;
 
-            tracing::info!("Starting temps agent (node_id={})...", config.node_id);
+            tracing::info!(
+                node_id = config.node_id,
+                worker_threads,
+                available_parallelism,
+                "Starting temps agent"
+            );
 
             // Nightly Docker image + build-cache prune. Worker nodes build
             // and pull images locally but never run the console's plugin
@@ -376,4 +395,26 @@ async fn read_bridge_ip_from_kernel(iface: &str) -> Option<std::net::IpAddr> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_runtime_uses_available_threads_on_small_hosts() {
+        assert_eq!(agent_worker_threads(1), 1);
+        assert_eq!(agent_worker_threads(4), 4);
+    }
+
+    #[test]
+    fn agent_runtime_caps_threads_on_large_hosts() {
+        assert_eq!(agent_worker_threads(16), MAX_AGENT_WORKER_THREADS);
+        assert_eq!(agent_worker_threads(128), MAX_AGENT_WORKER_THREADS);
+    }
+
+    #[test]
+    fn agent_runtime_never_builds_with_zero_workers() {
+        assert_eq!(agent_worker_threads(0), 1);
+    }
 }

--- a/crates/temps-deployer/src/docker.rs
+++ b/crates/temps-deployer/src/docker.rs
@@ -6,8 +6,8 @@
 use crate::static_ingestion::{MAX_STATIC_ENTRIES, MAX_STATIC_ENTRY_BYTES, MAX_STATIC_TOTAL_BYTES};
 use crate::{
     BuildRequest, BuildResult, BuilderError, ContainerDeployer, ContainerInfo, ContainerRuntime,
-    ContainerStatus, DeployRequest, DeployResult, DeployerError, ImageBuilder, PortMapping,
-    Protocol, RuntimeInfo,
+    ContainerStatus, DeployRequest, DeployResult, DeployerError, ImageBuilder, ImageImportStream,
+    PortMapping, Protocol, RuntimeInfo,
 };
 use async_trait::async_trait;
 use bollard::{
@@ -31,6 +31,189 @@ use tracing::{debug, error, info, warn};
 
 const MAX_STATIC_ARCHIVE_STREAM_BYTES: u64 =
     MAX_STATIC_TOTAL_BYTES + (MAX_STATIC_ENTRIES as u64 * 1024) + (1024 * 1024);
+
+/// Maximum payload returned by the one-shot container logs endpoint.
+///
+/// The control plane persists at most 8 MiB during container teardown, so
+/// retaining more on a worker only increases memory and transfer cost.
+const MAX_CONTAINER_LOG_BYTES: usize = 8 * 1024 * 1024;
+const LOG_TRUNCATION_NOTICE: &str = "[… earlier container logs truncated by worker …]\n";
+
+fn append_printable_log_utf8(output: &mut String, input: &str) {
+    for character in input.chars() {
+        if character.is_control() && !matches!(character, '\n' | '\r' | '\t') {
+            output.push('?');
+        } else {
+            output.push(character);
+        }
+    }
+}
+
+fn append_sanitized_log_utf8(output: &mut String, mut input: &[u8]) {
+    while !input.is_empty() {
+        match std::str::from_utf8(input) {
+            Ok(valid) => {
+                append_printable_log_utf8(output, valid);
+                break;
+            }
+            Err(error) => {
+                let valid_bytes = error.valid_up_to();
+                if let Ok(valid) = std::str::from_utf8(&input[..valid_bytes]) {
+                    append_printable_log_utf8(output, valid);
+                }
+                output.push('?');
+                match error.error_len() {
+                    Some(invalid_bytes) => input = &input[valid_bytes + invalid_bytes..],
+                    None => break,
+                }
+            }
+        }
+    }
+}
+
+struct DockerLogTail {
+    bytes: Vec<u8>,
+    start: usize,
+    limit: usize,
+    truncated: bool,
+}
+
+impl DockerLogTail {
+    fn new(limit: usize) -> Self {
+        Self {
+            bytes: Vec::new(),
+            start: 0,
+            limit,
+            truncated: false,
+        }
+    }
+
+    fn push(&mut self, chunk: bytes::Bytes) {
+        if chunk.is_empty() {
+            return;
+        }
+
+        if self.limit == 0 {
+            self.truncated = true;
+            return;
+        }
+
+        if chunk.len() >= self.limit {
+            self.truncated |= !self.bytes.is_empty() || chunk.len() > self.limit;
+            self.bytes.clear();
+            self.start = 0;
+            self.bytes
+                .extend_from_slice(&chunk[chunk.len() - self.limit..]);
+            return;
+        }
+
+        let mut append_bytes = 0;
+        if self.bytes.len() < self.limit {
+            append_bytes = chunk.len().min(self.limit - self.bytes.len());
+            self.bytes.extend_from_slice(&chunk[..append_bytes]);
+            if append_bytes == chunk.len() {
+                return;
+            }
+        }
+
+        let overwrite = &chunk[append_bytes..];
+        let first = overwrite.len().min(self.limit - self.start);
+        self.bytes[self.start..self.start + first].copy_from_slice(&overwrite[..first]);
+        if first < overwrite.len() {
+            self.bytes[..overwrite.len() - first].copy_from_slice(&overwrite[first..]);
+        }
+        self.start = (self.start + overwrite.len()) % self.limit;
+        self.truncated = true;
+    }
+
+    fn into_string(mut self) -> String {
+        let notice_len = if self.truncated {
+            LOG_TRUNCATION_NOTICE.len()
+        } else {
+            0
+        };
+        let mut output = String::with_capacity(self.bytes.len().saturating_add(notice_len));
+        if self.truncated {
+            output.push_str(LOG_TRUNCATION_NOTICE);
+        }
+        if self.bytes.len() == self.limit && self.start > 0 {
+            self.bytes.rotate_left(self.start);
+        }
+        append_sanitized_log_utf8(&mut output, &self.bytes);
+        output
+    }
+}
+
+fn split_repository_and_tag(image: &str) -> (&str, &str) {
+    match image.rsplit_once(':') {
+        Some((repository, image_tag)) if !image_tag.contains('/') => (repository, image_tag),
+        _ => (image, "latest"),
+    }
+}
+
+async fn import_stream_into_docker(
+    docker: &Docker,
+    image_stream: ImageImportStream,
+    tag: &str,
+) -> Result<String, BuilderError> {
+    let import_stream = docker.import_image_stream(
+        bollard::query_parameters::ImportImageOptions {
+            quiet: false,
+            ..Default::default()
+        },
+        image_stream,
+        None,
+    );
+
+    let mut image_id = None;
+    let mut stream = std::pin::Pin::new(Box::new(import_stream));
+
+    while let Some(result) = futures::StreamExt::next(&mut stream).await {
+        match result {
+            Ok(info) => {
+                if let Some(stream_msg) = info.stream {
+                    info!(message = %stream_msg.trim(), "Docker image import progress");
+                    if stream_msg.contains("Loaded image:") {
+                        image_id = stream_msg
+                            .split("Loaded image: ")
+                            .nth(1)
+                            .map(|value| value.trim().to_string());
+                    }
+                }
+            }
+            Err(error) => {
+                return Err(BuilderError::Other(format!(
+                    "Failed to import image '{tag}' into Docker: {error}"
+                )));
+            }
+        }
+    }
+
+    let image_id = image_id.ok_or_else(|| {
+        BuilderError::Other(format!(
+            "Docker completed the import for image '{tag}' without reporting an image ID"
+        ))
+    })?;
+
+    let (repository, image_tag) = split_repository_and_tag(tag);
+
+    docker
+        .tag_image(
+            &image_id,
+            Some(TagImageOptions {
+                repo: Some(repository.to_string()),
+                tag: Some(image_tag.to_string()),
+            }),
+        )
+        .await
+        .map_err(|error| {
+            BuilderError::Other(format!(
+                "Failed to tag imported Docker image '{tag}' from ID '{image_id}': {error}"
+            ))
+        })?;
+
+    Ok(image_id)
+}
 
 struct DockerContainerCleanupGuard {
     docker: Arc<Docker>,
@@ -2063,59 +2246,21 @@ impl ImageBuilder for DockerRuntime {
             .await
             .map_err(BuilderError::IoError)?;
 
-        let byte_stream =
+        let byte_stream: ImageImportStream = Box::pin(
             tokio_util::codec::FramedRead::new(file, tokio_util::codec::BytesCodec::new())
-                .map(|r| r.map(|b| b.freeze()));
-
-        let import_stream = self.docker.import_image_stream(
-            bollard::query_parameters::ImportImageOptions {
-                quiet: false,
-                ..Default::default()
-            },
-            byte_stream,
-            None,
+                .map(|result| result.map(|bytes| bytes.freeze())),
         );
 
-        let mut image_id = None;
-        let mut stream = std::pin::Pin::new(Box::new(import_stream));
+        import_stream_into_docker(&self.docker, byte_stream, tag).await
+    }
 
-        while let Some(result) = futures::StreamExt::next(&mut stream).await {
-            match result {
-                Ok(info) => {
-                    if let Some(stream_msg) = info.stream {
-                        info!("Import progress: {}", stream_msg.trim());
-                        if stream_msg.contains("Loaded image:") {
-                            image_id = stream_msg
-                                .split("Loaded image: ")
-                                .nth(1)
-                                .map(|s| s.trim().to_string());
-                        }
-                    }
-                }
-                Err(e) => {
-                    return Err(BuilderError::Other(format!(
-                        "Failed to import image: {}",
-                        e
-                    )));
-                }
-            }
-        }
-
-        let id = image_id.ok_or_else(|| BuilderError::Other("No image ID found".to_string()))?;
-
-        // Tag the image
-        self.docker
-            .tag_image(
-                &id,
-                Some(TagImageOptions {
-                    repo: Some(tag.split(':').next().unwrap_or(tag).to_string()),
-                    tag: Some(tag.split(':').nth(1).unwrap_or("latest").to_string()),
-                }),
-            )
-            .await
-            .map_err(|e| BuilderError::Other(format!("Failed to tag image: {}", e)))?;
-
-        Ok(id)
+    async fn import_image_stream(
+        &self,
+        image_stream: ImageImportStream,
+        tag: &str,
+    ) -> Result<String, BuilderError> {
+        info!(image = %tag, "Importing streamed image into Docker");
+        import_stream_into_docker(&self.docker, image_stream, tag).await
     }
 
     async fn save_image(&self, image_name: &str, output_path: &Path) -> Result<(), BuilderError> {
@@ -3072,23 +3217,26 @@ impl ContainerDeployer for DockerRuntime {
     }
 
     async fn get_container_logs(&self, container_id: &str) -> Result<String, DeployerError> {
-        let logs_stream = self
-            .docker
-            .logs(
-                container_id,
-                Some(LogsOptions {
-                    stdout: true,
-                    stderr: true,
-                    tail: "10000".to_string(),
-                    ..Default::default()
-                }),
-            )
-            .map(|chunk| chunk.map(|c| String::from_utf8_lossy(&c.into_bytes()).to_string()))
-            .try_collect::<Vec<_>>()
-            .await
-            .map_err(|e| DeployerError::Other(format!("Failed to get logs: {}", e)))?;
+        let mut logs_stream = self.docker.logs(
+            container_id,
+            Some(LogsOptions {
+                stdout: true,
+                stderr: true,
+                tail: "10000".to_string(),
+                ..Default::default()
+            }),
+        );
+        let mut logs = DockerLogTail::new(MAX_CONTAINER_LOG_BYTES);
 
-        Ok(logs_stream.join(""))
+        while let Some(chunk) = logs_stream.try_next().await.map_err(|error| {
+            DeployerError::Other(format!(
+                "Failed to read logs for container '{container_id}': {error}"
+            ))
+        })? {
+            logs.push(chunk.into_bytes());
+        }
+
+        Ok(logs.into_string())
     }
 
     async fn stream_container_logs(
@@ -3417,6 +3565,76 @@ mod docker_tests {
     use tempfile::TempDir;
     use tokio::fs;
     use tokio::time::{timeout, Duration};
+
+    #[test]
+    fn docker_log_tail_keeps_memory_bounded_and_retains_newest_bytes() {
+        let mut logs = DockerLogTail::new(8);
+        logs.push(bytes::Bytes::from_static(b"abcd"));
+        logs.push(bytes::Bytes::from_static(b"efgh"));
+        logs.push(bytes::Bytes::from_static(b"ijkl"));
+
+        assert_eq!(
+            logs.into_string(),
+            format!("{LOG_TRUNCATION_NOTICE}efghijkl")
+        );
+    }
+
+    #[test]
+    fn docker_log_tail_uses_a_fixed_capacity_ring() {
+        const LIMIT: usize = 64 * 1024;
+        let mut logs = DockerLogTail::new(LIMIT);
+        for _ in 0..200_000 {
+            logs.push(bytes::Bytes::from_static(b"x"));
+        }
+
+        assert_eq!(logs.bytes.len(), LIMIT);
+        assert_eq!(
+            logs.into_string().len(),
+            LOG_TRUNCATION_NOTICE.len() + LIMIT
+        );
+    }
+
+    #[test]
+    fn docker_log_tail_invalid_utf8_does_not_expand_output() {
+        let mut logs = DockerLogTail::new(128);
+        logs.push(bytes::Bytes::from(vec![0xff; 128]));
+
+        let logs = logs.into_string();
+        assert_eq!(logs.len(), 128);
+        assert!(logs.bytes().all(|byte| byte == b'?'));
+    }
+
+    #[test]
+    fn docker_log_tail_control_bytes_do_not_expand_in_json() {
+        let mut logs = DockerLogTail::new(128);
+        logs.push(bytes::Bytes::from(vec![0; 128]));
+
+        let logs = logs.into_string();
+        assert_eq!(logs.len(), 128);
+        assert!(logs.bytes().all(|byte| byte == b'?'));
+    }
+
+    #[test]
+    fn docker_log_tail_preserves_utf8_split_across_ring_wrap() {
+        let mut logs = DockerLogTail::new(5);
+        logs.push(bytes::Bytes::from_static(b"abcde"));
+        logs.push(bytes::Bytes::from_static(b"wxyz"));
+        logs.push(bytes::Bytes::from_static("😀".as_bytes()));
+
+        assert_eq!(logs.into_string(), format!("{LOG_TRUNCATION_NOTICE}z😀"));
+    }
+
+    #[test]
+    fn image_tag_split_preserves_registry_ports() {
+        assert_eq!(
+            split_repository_and_tag("registry.example:5000/team/app:v2"),
+            ("registry.example:5000/team/app", "v2")
+        );
+        assert_eq!(
+            split_repository_and_tag("registry.example:5000/team/app"),
+            ("registry.example:5000/team/app", "latest")
+        );
+    }
 
     #[test]
     fn extraction_and_cleanup_errors_preserve_both_causes() {

--- a/crates/temps-deployer/src/lib.rs
+++ b/crates/temps-deployer/src/lib.rs
@@ -17,6 +17,14 @@ use std::pin::Pin;
 use temps_core::UtcDateTime;
 use thiserror::Error;
 
+/// Backpressure-aware byte stream used when importing an OCI image.
+///
+/// Keeping this at the trait boundary lets remote agents forward an upload
+/// directly to Docker instead of first materializing the complete archive in
+/// a temporary file (and charging that file's page cache to the agent cgroup).
+pub type ImageImportStream =
+    Pin<Box<dyn futures::Stream<Item = Result<bytes::Bytes, std::io::Error>> + Send>>;
+
 pub mod compose;
 
 /// Callback function type for processing build logs in real-time
@@ -575,6 +583,60 @@ pub trait ImageBuilder: Send + Sync {
 
     /// Import an image from a tar archive
     async fn import_image(&self, image_path: PathBuf, tag: &str) -> Result<String, BuilderError>;
+
+    /// Import an image from a backpressure-aware byte stream.
+    ///
+    /// Implementations that accept remote uploads should override this. The
+    /// default preserves compatibility for builders that only support files.
+    async fn import_image_stream(
+        &self,
+        mut stream: ImageImportStream,
+        tag: &str,
+    ) -> Result<String, BuilderError> {
+        use futures::StreamExt;
+        use tokio::io::AsyncWriteExt;
+
+        // File-only builders keep their previous behavior. DockerRuntime
+        // overrides this method and forwards chunks directly to dockerd, so
+        // worker image transfers do not take this compatibility path.
+        let archive = tempfile::NamedTempFile::new().map_err(|source| {
+            BuilderError::IoError(std::io::Error::new(
+                source.kind(),
+                format!("Failed to create temporary image archive for '{tag}': {source}"),
+            ))
+        })?;
+        let archive_file = archive.reopen().map_err(|source| {
+            BuilderError::IoError(std::io::Error::new(
+                source.kind(),
+                format!("Failed to open temporary image archive for '{tag}': {source}"),
+            ))
+        })?;
+        let mut archive_file = tokio::fs::File::from_std(archive_file);
+
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|source| {
+                BuilderError::IoError(std::io::Error::new(
+                    source.kind(),
+                    format!("Failed while receiving image archive for '{tag}': {source}"),
+                ))
+            })?;
+            archive_file.write_all(&chunk).await.map_err(|source| {
+                BuilderError::IoError(std::io::Error::new(
+                    source.kind(),
+                    format!("Failed to write temporary image archive for '{tag}': {source}"),
+                ))
+            })?;
+        }
+        archive_file.flush().await.map_err(|source| {
+            BuilderError::IoError(std::io::Error::new(
+                source.kind(),
+                format!("Failed to flush temporary image archive for '{tag}': {source}"),
+            ))
+        })?;
+        drop(archive_file);
+
+        self.import_image(archive.path().to_path_buf(), tag).await
+    }
 
     /// Export (save) an image to a tar archive file.
     /// Equivalent to `docker save <image_name> -o <output_path>`.

--- a/crates/temps-deployer/src/remote.rs
+++ b/crates/temps-deployer/src/remote.rs
@@ -19,6 +19,10 @@ use crate::{
     ImageInfo,
 };
 
+/// Slightly exceeds the worker's 30-minute queue-and-import deadline so the
+/// control plane receives the worker's contextual timeout response.
+const IMAGE_IMPORT_REQUEST_TIMEOUT: Duration = Duration::from_secs(31 * 60);
+
 /// Response envelope from the agent API.
 #[derive(Deserialize)]
 struct AgentResponse<T> {
@@ -484,7 +488,19 @@ impl ImageBuilder for RemoteNodeDeployer {
             ))
         })?;
 
-        let file_size = file.metadata().await.map(|m| m.len()).unwrap_or(0);
+        let file_size = file
+            .metadata()
+            .await
+            .map_err(|source| {
+                BuilderError::IoError(std::io::Error::new(
+                    source.kind(),
+                    format!(
+                        "Failed to read image archive metadata for {:?}: {source}",
+                        image_path
+                    ),
+                ))
+            })?
+            .len();
 
         let stream = tokio_util::codec::FramedRead::new(file, tokio_util::codec::BytesCodec::new());
         let body = reqwest::Body::wrap_stream(stream.map_ok(|b| b.freeze()));
@@ -494,7 +510,9 @@ impl ImageBuilder for RemoteNodeDeployer {
             .client
             .post(&url)
             .bearer_auth(&self.token)
+            .timeout(IMAGE_IMPORT_REQUEST_TIMEOUT)
             .header("content-type", "application/x-tar")
+            .header(reqwest::header::CONTENT_LENGTH, file_size)
             .header("x-image-tag", tag)
             .body(body)
             .send()


### PR DESCRIPTION
## Summary

- stream remote image archives directly into Docker instead of staging a full tar in `/tmp`
- bound container logs and exec output with fixed-capacity tail buffers and aggregate capture limits
- cap agent runtime threads and add deadlines/concurrency controls for image imports, logs, exec, backup, and restore operations
- use Docker exec exit codes for backup/restore outcomes while avoiding sensitive argv and raw stderr journaling
- make timed-out or canceled Docker exec cleanup cancellation-safe without leaving child processes or production containers offline

## Root cause

Remote image deployment first wrote the complete archive to a temporary file and then read it back into Docker. Linux charged that file's page cache to the agent cgroup, producing RAM peaks close to the archive size. Log and exec paths also accumulated workload-controlled output in unbounded strings/vectors, while Tokio used one worker thread per logical CPU.

## Implementation

- added a backpressure-aware `ImageImportStream` trait path with a compatibility fallback for file-only builders
- serialized Docker image loads per worker, enforced a 10 GiB streaming limit, and aligned the 30-minute worker deadline with a 31-minute control-plane request timeout
- retained at most 8 MiB of container logs and 4 MiB per exec stdout/stderr stream
- limited aggregate output captures to four operations
- implemented O(chunk-size), fixed-capacity ring buffers with size-preserving invalid/control-byte sanitization
- made stream and exec-inspection failures typed and contextual instead of returning partial success
- retained only a 64 KiB stderr tail for backup/restore and discarded their stdout while counting received bytes
- enabled `pipefail` for PostgreSQL dump pipelines
- capped the agent Tokio runtime at eight workers on large hosts
- pinned each attached exec's canonical container ID before start; on timeout, cancellation, or ambiguous completion, force-restarted that container through Docker and retained lifecycle ownership until cleanup succeeded
- required Docker to positively report `Running: false` plus an exit code before treating an exec as complete
- avoided restarting healthy containers after definitive Docker start rejections and capped every Docker restart RPC at 30 seconds before bounded background retry
- separated memory-capture slots from exec-lifecycle slots so stalled cleanup remains fail-closed for new commands without blocking bounded log capture or retaining output-buffer capacity

## Evidence

**Image transfer**: request bodies remain lazy and backpressure-aware instead of materializing the archive.

```bash
cargo test --lib -p temps-agent image_upload_stream_is_lazy_and_backpressure_aware
```

```text
cargo test: 1 passed, 67 filtered out (1 suite, 0.00s)
```

**Exec capture**: fixed-capacity output buffers handle truncation, tiny frames, invalid UTF-8, control bytes, and UTF-8 across ring wrap.

```bash
cargo test --lib -p temps-agent output_buffer
```

```text
cargo test: 8 passed, 60 filtered out (1 suite, 0.01s)
```

**Backup failure handling**: a nonzero Docker exec status remains authoritative and preserves bounded diagnostic context.

```bash
cargo test --lib -p temps-agent nonzero_exec_exit_includes_bounded_stderr_context
```

```text
cargo test: 1 passed, 67 filtered out (1 suite, 0.00s)
```

**Container logs**: bounded log-tail tests cover ordering, fixed-capacity behavior, and serialization amplification cases.

```bash
cargo test --lib -p temps-deployer docker_log_tail
```

```text
cargo test: 5 passed, 293 filtered out (1 suite, 0.01s)
```

**Agent runtime**: worker-thread selection is bounded on large hosts.

```bash
cargo test --lib -p temps-cli agent_runtime
```

```text
cargo test: 3 passed, 242 filtered out (1 suite, 0.00s)
```

**Exec lifecycle**: mock-Docker tests cover pre-start identity pinning, forced restart, permit retention/release, request cancellation, and ambiguous `Running: true` completion.

```bash
cargo test --lib -p temps-agent exec_timeout
```

```text
cargo test: 15 passed, 68 filtered out (1 suite, 0.02s)
```

**Admission ordering**: operation capacity is reserved before capture memory or Docker exec allocation, and capture rejection returns the operation slot.

```bash
cargo test --lib -p temps-agent exec_admission_tests
```

```text
cargo test: 2 passed, 83 filtered out (1 suite, 0.00s)
```

## Validation

- `cargo test --lib -p temps-agent` — 93 passed
- `cargo test --lib -p temps-deployer` — 298 passed outside the sandbox (localhost-binding tests require socket access)
- `cargo test --lib -p temps-cli` — 245 passed outside the sandbox
- `cargo check --lib` — passed with zero errors
- affected-crate all-target clippy with `-D warnings` — passed
- repository pre-commit hooks — passed
- Rust review — approved
- security review — approved

## Residual verification

A production-sized Docker-backed transfer benchmark is still useful after deployment to quantify peak RSS reduction on representative worker hardware. The changed streaming adapter, limits, backpressure behavior, and Docker log buffers are covered by unit tests; there is not yet a Docker-backed endpoint integration test for `/agent/images/import`.


## Review-fix evidence

**Slow-response memory accounting**: captured JSON keeps its semaphore permit through body EOF/drop and emits independent 64 KiB frames.

```bash
cargo test --lib -p temps-agent capture_permit_is_held_until_response_body_finishes_or_drops -- --nocapture
```

```text
cargo test: 1 passed, 92 filtered out (1 suite, 0.00s)
```

**Canonical lifecycle admission**: operations are single-flight per canonical container, detached execs consume lifecycle capacity, and unrelated containers can still run concurrently.

```bash
cargo test --lib -p temps-agent exec_admission_tests -- --nocapture
```

```text
cargo test: 4 passed, 87 filtered out (1 suite, 0.00s)
```

**Cancellation-safe image import**: dropping the request waiter does not release the sole import slot while Docker work continues.

```bash
cargo test --lib -p temps-agent dropped_import_waiter_does_not_release_import_capacity -- --nocapture
```

```text
cargo test: 1 passed, 90 filtered out (1 suite, 0.00s)
```

**Terminal disconnect lifecycle**: canonical ownership remains charged until Docker positively reports the terminal exec stopped.

```bash
cargo test --lib -p temps-agent request_ended_exec_retains_container_ownership_until_stopped -- --nocapture
```

```text
cargo test: 1 passed, 92 filtered out (1 suite, 0.00s)
```

**OpenAPI resource statuses**: generated agent paths include the emitted 404/409/413/429/503/504 responses.

```bash
cargo test --lib -p temps-agent resource_limit_and_lifecycle_statuses_are_documented -- --nocapture
```

```text
cargo test: 1 passed, 90 filtered out (1 suite, 0.01s)
```

Final validation: `cargo test --lib -p temps-agent` — 93 passed; workspace `cargo check --lib` — passed; affected-crate Clippy with `-D warnings` — passed; formatting, attribution, and diff checks — passed. Independent Rust and security reviews approved the final lifecycle design.
