### PR TITLE
fix(deployer): pull compose images before force-recreate teardown

### DIFF
--- a/crates/temps-deployer/src/compose.rs
+++ b/crates/temps-deployer/src/compose.rs
@@ -1203,30 +1203,54 @@ impl ComposeExecutor {
 
     /// Tear down containers before a redeploy. Preserves volumes (database data,
     /// uploads, etc.) so they survive between deployments.
+    ///
+    /// Passes `remove_secrets: false` because an upcoming `deploy_prepared()`
+    /// call will consume the secrets that `prepare_and_pull()` just materialized.
+    /// Deleting them here would cause the new containers to start with missing
+    /// or empty secret files.
     pub async fn teardown_for_redeploy(&self, project_name: &str) -> Result<(), ComposeError> {
-        self.teardown_at(project_name, None, None, &HashMap::new())
+        self.teardown_at(project_name, None, None, &HashMap::new(), false)
             .await
     }
 
     /// Tear down a Compose stack from the exact directory used for `up`.
     /// Uploaded/Git deployments run Compose inside their checkout rather than
     /// the data-dir fallback, so compensation must retain that location.
+    ///
+    /// `remove_secrets` controls whether the on-disk directory of materialized
+    /// secret files (`data_dir/compose-secrets/<project_name>/`) is deleted.
+    ///
+    /// **HAZARD**: In a `prepare_and_pull()` → `teardown_at()` → `deploy_prepared()`
+    /// sequence the secrets have just been materialized and `deploy_prepared()`
+    /// is about to bind-mount them into new containers. Passing `remove_secrets:
+    /// true` in that sequence deletes the files that the new containers need,
+    /// causing them to start with missing or empty secrets — a silent credential
+    /// loss that only surfaces at container runtime. Always pass `false` when
+    /// an immediate `deploy_prepared()` follows.
+    ///
+    /// Pass `true` only when the deploy attempt is definitively over: compensating
+    /// cleanup on failure, zero-services edge-case teardown, cancellation cleanup,
+    /// or final destruction of a project/environment.
     pub async fn teardown_at(
         &self,
         project_name: &str,
         repo_dir: Option<&Path>,
         compose_path: Option<&str>,
         _environment_vars: &HashMap<String, String>,
+        remove_secrets: bool,
     ) -> Result<(), ComposeError> {
         if let Some(compose_path) = compose_path {
             Self::validate_relative_path(compose_path, "compose_path")?;
         }
-        // Drop the plaintext secret files first, and regardless of whether the
-        // stack directory still exists. `deploy()` re-materializes them before
-        // `up`, so this is safe on the redeploy path and stops a failed deploy
-        // from leaving credentials on disk for a stack that is no longer
-        // running.
-        self.remove_secrets_dir(project_name).await;
+        // Only delete the plaintext secret files when this teardown is the last
+        // step — i.e. the deploy attempt is over and nothing downstream will
+        // consume the files that were just materialized. When `remove_secrets`
+        // is false, the caller is about to call `deploy_prepared()` and those
+        // files must remain on disk so the new containers can bind-mount them.
+        // See the hazard note on `teardown_at`'s doc comment.
+        if remove_secrets {
+            self.remove_secrets_dir(project_name).await;
+        }
 
         let project_dir = repo_dir
             .map(Path::to_path_buf)
@@ -8350,5 +8374,90 @@ services:
 
         assert!(sanitized.len() < diagnostic.len());
         assert!(sanitized.contains("diagnostic truncated"));
+    }
+
+    /// `teardown_at` with `remove_secrets: false` must preserve the on-disk
+    /// secrets directory even when the project stack directory does not exist
+    /// (the early-return path is taken, which is what allows this test to run
+    /// without Docker).
+    #[tokio::test]
+    async fn test_teardown_at_remove_secrets_false_preserves_secrets_dir() {
+        let docker = Docker::connect_with_defaults();
+        if docker.is_err() {
+            // Docker unavailable — we can still run this test because
+            // teardown_at returns early when the project directory does not
+            // exist, before it attempts any Docker call.
+        }
+        // Use a real temporary directory so the secrets-dir assertion is
+        // meaningful (we are asserting on actual filesystem state).
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let data_dir = tmp.path().to_path_buf();
+
+        // Build a minimal ComposeExecutor backed by a placeholder Docker
+        // handle. teardown_at returns early before any Docker call when the
+        // project directory does not exist, so the handle is never used.
+        let docker_handle = match Docker::connect_with_defaults() {
+            Ok(d) => Arc::new(d),
+            Err(_) => {
+                // No Docker: synthesise a handle via connect_with_local_defaults
+                // which also won't be called. If even that fails, skip.
+                match Docker::connect_with_local_defaults() {
+                    Ok(d) => Arc::new(d),
+                    Err(_) => return,
+                }
+            }
+        };
+        let executor = ComposeExecutor::new(docker_handle, data_dir.clone());
+
+        // Manually create the secrets directory that teardown_at would
+        // otherwise delete, mirroring what materialize_secrets() produces.
+        let project_name = "test-remove-secrets-false";
+        let secrets_dir = data_dir.join("compose-secrets").join(project_name);
+        std::fs::create_dir_all(&secrets_dir).expect("create secrets dir");
+        std::fs::write(secrets_dir.join("MY_SECRET"), b"hunter2").expect("write dummy secret");
+
+        // Project directory intentionally does not exist → teardown_at returns
+        // early after (conditionally) running the secrets-dir deletion logic.
+        executor
+            .teardown_at(project_name, None, None, &HashMap::new(), false)
+            .await
+            .expect("teardown_at should succeed with no project dir");
+
+        assert!(
+            secrets_dir.exists(),
+            "secrets dir must still exist after teardown_at with remove_secrets=false"
+        );
+    }
+
+    /// `teardown_at` with `remove_secrets: true` must delete the on-disk
+    /// secrets directory (same early-return path as above, no Docker needed).
+    #[tokio::test]
+    async fn test_teardown_at_remove_secrets_true_deletes_secrets_dir() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let data_dir = tmp.path().to_path_buf();
+
+        let docker_handle = match Docker::connect_with_defaults() {
+            Ok(d) => Arc::new(d),
+            Err(_) => match Docker::connect_with_local_defaults() {
+                Ok(d) => Arc::new(d),
+                Err(_) => return,
+            },
+        };
+        let executor = ComposeExecutor::new(docker_handle, data_dir.clone());
+
+        let project_name = "test-remove-secrets-true";
+        let secrets_dir = data_dir.join("compose-secrets").join(project_name);
+        std::fs::create_dir_all(&secrets_dir).expect("create secrets dir");
+        std::fs::write(secrets_dir.join("MY_SECRET"), b"hunter2").expect("write dummy secret");
+
+        executor
+            .teardown_at(project_name, None, None, &HashMap::new(), true)
+            .await
+            .expect("teardown_at should succeed with no project dir");
+
+        assert!(
+            !secrets_dir.exists(),
+            "secrets dir must be deleted after teardown_at with remove_secrets=true"
+        );
     }
 }

--- a/crates/temps-deployer/src/compose.rs
+++ b/crates/temps-deployer/src/compose.rs
@@ -1027,6 +1027,17 @@ impl ComposeExecutor {
             .await?;
         }
 
+        // 3. Pull images for plain `image:` services BEFORE tearing down old
+        // containers. Image-fetch latency (seconds to minutes on slow registries
+        // or fat images) would otherwise occur inside the downtime window between
+        // old-container-stop and new-container-healthy. By pulling here, while
+        // the old stack is still serving traffic, we minimise the actual gap.
+        // `--ignore-buildable` skips services that only have a `build:` directive
+        // (those were already handled above by `compose_build`), so this call is
+        // safe regardless of whether the project mixes built and pulled services.
+        self.compose_pull(&effective_dir, &project_name, compose_file, &redact_values)
+            .await?;
+
         // Ensure the shared Temps network exists before `up` attaches every
         // service to it (docker-compose.temps-network.yml, written above) —
         // this is the same network Temps-managed external services and
@@ -1034,7 +1045,10 @@ impl ComposeExecutor {
         // reach a Temps-managed database by name.
         self.ensure_temps_network_exists().await?;
 
-        // 3. Run docker compose up (pulls pre-built images, starts built + pulled).
+        // 4. Run docker compose up. Images are already pulled (step 3) or built
+        // (step 2), so `--pull never` would also work, but omitting `--pull`
+        // entirely lets Compose fall back to its default (only pull if absent
+        // locally), which is safe and avoids a redundant network round-trip.
         // If a user-provided `container_name` conflicts with an existing
         // container, let Compose report the conflict instead of deleting
         // containers outside this Temps project boundary.
@@ -1047,7 +1061,7 @@ impl ComposeExecutor {
         )
         .await?;
 
-        // 3b. `up -d` returns as soon as containers are created/started, not
+        // 4b. `up -d` returns as soon as containers are created/started, not
         // once they're actually ready. Wait for every service to reach
         // `running` (and `healthy`, for services that define a healthcheck)
         // so a crash-looping or slow-starting service surfaces as a failed
@@ -1062,12 +1076,12 @@ impl ComposeExecutor {
         )
         .await?;
 
-        // 4. Discover running containers
+        // 5. Discover running containers
         let containers = self
             .discover_containers(&effective_dir, &project_name, compose_file)
             .await?;
 
-        // 4. Apply Temps labels to each container
+        // 5b. Apply Temps labels to each container
         for container in &containers {
             if let Err(e) = self
                 .apply_labels(
@@ -3593,6 +3607,57 @@ impl ComposeExecutor {
             })
     }
 
+    /// Pull images for every `image:`-based service in the compose stack.
+    ///
+    /// This is intentionally a separate step from [`compose_up`] so that
+    /// image-fetch latency — which can range from seconds to minutes depending
+    /// on registry speed and image size — occurs while the *old* containers are
+    /// still running and serving traffic, not during the downtime window between
+    /// old-container-stop and new-container-healthy. By the time `compose_up`
+    /// tears down and recreates containers the images are already local, which
+    /// keeps the actual downtime window as short as possible.
+    ///
+    /// `--ignore-buildable` skips services that only declare a `build:` stanza
+    /// and have no pullable `image:` tag; those services are handled by
+    /// `compose_build`. This makes the call safe regardless of whether the
+    /// project mixes built and pulled services.
+    async fn compose_pull(
+        &self,
+        project_dir: &Path,
+        project_name: &str,
+        compose_file: &str,
+        redact_values: &[String],
+    ) -> Result<(), ComposeError> {
+        let mut cmd = isolated_docker_command();
+        cmd.args(["compose", "-p", project_name]);
+        Self::append_compose_file_args(&mut cmd, project_dir, compose_file);
+        Self::append_compose_env_file_args(&mut cmd, project_dir);
+
+        cmd.args(["pull", "--ignore-buildable"])
+            .current_dir(project_dir)
+            .env("PWD", project_dir.to_string_lossy().to_string());
+
+        // Cancellation drops the command future; terminate the Compose CLI so
+        // compensating `compose down` cannot race a still-running `compose pull`.
+        cmd.kill_on_drop(true);
+
+        debug!(project = %project_name, "Running docker compose pull");
+
+        let output = cmd.output().await?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stderr = sanitize_compose_diagnostic(&stderr, redact_values);
+            return Err(ComposeError::CommandFailed {
+                project: project_name.to_string(),
+                reason: format!("docker compose pull failed: {stderr}"),
+            });
+        }
+
+        info!(project = %project_name, "docker compose pull completed");
+        Ok(())
+    }
+
     async fn compose_up(
         &self,
         project_dir: &Path,
@@ -3606,15 +3671,8 @@ impl ComposeExecutor {
         Self::append_compose_file_args(&mut cmd, project_dir, compose_file);
         Self::append_compose_env_file_args(&mut cmd, project_dir);
 
-        cmd.args([
-            "up",
-            "-d",
-            "--pull",
-            "always",
-            "--remove-orphans",
-            "--force-recreate",
-        ])
-        .current_dir(project_dir);
+        cmd.args(["up", "-d", "--remove-orphans", "--force-recreate"])
+            .current_dir(project_dir);
 
         // Set PWD so compose files using ${PWD} resolve correctly
         cmd.env("PWD", project_dir.to_string_lossy().to_string());

--- a/crates/temps-deployer/src/compose.rs
+++ b/crates/temps-deployer/src/compose.rs
@@ -30,6 +30,13 @@ const COMPOSE_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_sec
 /// Interval between `docker compose ps` polls while waiting for readiness.
 const COMPOSE_READY_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
 
+/// Maximum time allowed for `docker compose pull` to complete. Pulls can be
+/// slow on large images or slow registries, but an unbounded pull would stall a
+/// deployment forever. 300 s matches [`COMPOSE_READY_TIMEOUT`] — both bound a
+/// single phase of the deployment that should complete within minutes, not
+/// hours, on any reasonable network.
+const COMPOSE_PULL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
 /// How long a single TCP connect attempt against a published port may take
 /// before `port_reachable` gives up and reports the port not yet listening.
 /// Short by design: this runs once per poll interval, not once total, so a
@@ -482,6 +489,25 @@ pub struct ComposePortBinding {
     pub host_port: u16,
     pub container_port: u16,
     pub protocol: String,
+}
+
+/// State produced by [`ComposeExecutor::prepare_and_pull`] and consumed by
+/// [`ComposeExecutor::deploy_prepared`].
+///
+/// Carrying these fields out of `prepare_and_pull` avoids re-computing them in
+/// `deploy_prepared` and keeps the split-phase API type-safe: a caller cannot
+/// pass an arbitrary directory to `deploy_prepared` — it must come from the
+/// same preparation step that wrote the files to disk.
+pub struct PreparedComposeDeploy {
+    /// Resolved working directory (repo checkout when available, otherwise the
+    /// Temps data-dir project directory).
+    pub effective_dir: PathBuf,
+    /// Compose project name (e.g., `"temps-{project_id}-{env_id}"`).
+    pub project_name: String,
+    /// Compose file name relative to `effective_dir`.
+    pub compose_file: String,
+    /// Values to strip from diagnostic messages (secrets, env values, etc.).
+    pub redact_values: Vec<String>,
 }
 
 /// Docker Compose deployment executor.
@@ -939,15 +965,21 @@ impl ComposeExecutor {
         }
     }
 
-    /// Deploy a compose stack: write files, pull images, start containers,
-    /// wait for every service to become ready, then discover and label them.
-    /// Returns one result per service. Fails (rather than reporting a false
-    /// success) if a service never reaches `running`/`healthy` within
-    /// [`COMPOSE_READY_TIMEOUT`].
-    pub async fn deploy(
+    /// Prepare compose files on disk, build images (if required), and pull
+    /// images for `image:`-based services.
+    ///
+    /// This is the first half of a two-phase deploy. It MUST be called while
+    /// the previously-running stack is **still alive** so that image-fetch
+    /// latency falls outside the downtime window. If this step fails, the
+    /// caller MUST NOT call [`Self::teardown_at`] — the old stack is still
+    /// serving traffic and should keep doing so.
+    ///
+    /// On success, returns a [`PreparedComposeDeploy`] that must be passed to
+    /// [`Self::deploy_prepared`] after [`Self::teardown_at`].
+    pub async fn prepare_and_pull(
         &self,
-        request: ComposeDeployRequest,
-    ) -> Result<Vec<ComposeServiceResult>, ComposeError> {
+        request: &ComposeDeployRequest,
+    ) -> Result<PreparedComposeDeploy, ComposeError> {
         let project_dir = self.project_dir(&request.project_name);
         let project_name = request.project_name.clone();
         Self::validate_relative_path(
@@ -971,13 +1003,26 @@ impl ComposeExecutor {
         if let Some(ref compose_override) = request.compose_override {
             self.validate_compose_security_policy("compose override", compose_override)?;
         }
-        let has_build = self.has_build_directives(&request.compose_content);
+
+        // Check for build directives in BOTH the base file and the override.
+        // `compose_pull --ignore-buildable` sees the Compose-CLI-merged config
+        // (base + all override files), so a service that only has `build:` in
+        // the override — not in the base — is still treated as buildable there.
+        // If we skip `compose_build` for such a service (because the base has
+        // no build directive) and `compose_pull` also skips it (because the
+        // merged view shows a `build:` stanza), the service is neither built
+        // nor pulled and `compose_up` fails on a missing or stale local image.
+        let has_build = self.has_build_directives(&request.compose_content)
+            || request
+                .compose_override
+                .as_deref()
+                .is_some_and(|o| self.has_build_directives(o));
 
         // Every value that must never appear in a deployment error, including
         // the secrets this deploy is about to mount: a container that echoes
         // its own secret while crash-looping would otherwise have it captured
         // into the failure diagnostic and persisted on the deployment.
-        let redact_values = collect_redactable_values(&request);
+        let redact_values = collect_redactable_values(request);
 
         // Always use the repo checkout directory when available.
         // Compose files often reference local paths (bind mounts, configs,
@@ -988,12 +1033,13 @@ impl ComposeExecutor {
             .unwrap_or_else(|| project_dir.clone());
 
         // 1. Write compose files + env overrides to disk
-        self.write_compose_files(&effective_dir, &request).await?;
+        self.write_compose_files(&effective_dir, request).await?;
 
         let compose_file = request
             .compose_path
             .as_deref()
-            .unwrap_or("docker-compose.yml");
+            .unwrap_or("docker-compose.yml")
+            .to_string();
 
         // Lexical path validation cannot see repository symlinks. Resolve every
         // host path from the same base directory Docker Compose uses, after the
@@ -1002,14 +1048,14 @@ impl ComposeExecutor {
         // configs/secrets, local-driver binds, and build paths.
         Self::validate_compose_filesystem_confinement(
             &effective_dir,
-            compose_file,
+            &compose_file,
             "compose file",
             &request.compose_content,
         )?;
         if let Some(ref compose_override) = request.compose_override {
             Self::validate_compose_filesystem_confinement(
                 &effective_dir,
-                compose_file,
+                &compose_file,
                 "compose override",
                 compose_override,
             )?;
@@ -1020,7 +1066,7 @@ impl ComposeExecutor {
             self.compose_build(
                 &effective_dir,
                 &project_name,
-                compose_file,
+                &compose_file,
                 &redact_values,
                 &request.build_args,
             )
@@ -1035,8 +1081,35 @@ impl ComposeExecutor {
         // `--ignore-buildable` skips services that only have a `build:` directive
         // (those were already handled above by `compose_build`), so this call is
         // safe regardless of whether the project mixes built and pulled services.
-        self.compose_pull(&effective_dir, &project_name, compose_file, &redact_values)
+        self.compose_pull(&effective_dir, &project_name, &compose_file, &redact_values)
             .await?;
+
+        Ok(PreparedComposeDeploy {
+            effective_dir,
+            project_name,
+            compose_file,
+            redact_values,
+        })
+    }
+
+    /// Complete a deployment after the old stack has been torn down.
+    ///
+    /// This is the second half of a two-phase deploy. It expects a
+    /// [`PreparedComposeDeploy`] produced by a prior call to
+    /// [`Self::prepare_and_pull`] (images are already local at this point),
+    /// creates the shared network if needed, starts the new containers, waits
+    /// for readiness, discovers containers, and applies Temps labels.
+    pub async fn deploy_prepared(
+        &self,
+        prepared: PreparedComposeDeploy,
+        request: &ComposeDeployRequest,
+    ) -> Result<Vec<ComposeServiceResult>, ComposeError> {
+        let PreparedComposeDeploy {
+            effective_dir,
+            project_name,
+            compose_file,
+            redact_values,
+        } = prepared;
 
         // Ensure the shared Temps network exists before `up` attaches every
         // service to it (docker-compose.temps-network.yml, written above) —
@@ -1055,7 +1128,7 @@ impl ComposeExecutor {
         self.compose_up(
             &effective_dir,
             &project_name,
-            compose_file,
+            &compose_file,
             &redact_values,
             &request.relaxed_capability_services,
         )
@@ -1069,7 +1142,7 @@ impl ComposeExecutor {
         self.wait_for_services_ready(
             &effective_dir,
             &project_name,
-            compose_file,
+            &compose_file,
             &redact_values,
             &request.relaxed_capability_services,
             COMPOSE_READY_TIMEOUT,
@@ -1078,7 +1151,7 @@ impl ComposeExecutor {
 
         // 5. Discover running containers
         let containers = self
-            .discover_containers(&effective_dir, &project_name, compose_file)
+            .discover_containers(&effective_dir, &project_name, &compose_file)
             .await?;
 
         // 5b. Apply Temps labels to each container
@@ -1107,6 +1180,25 @@ impl ComposeExecutor {
         );
 
         Ok(containers)
+    }
+
+    /// Deploy a compose stack: write files, pull images, start containers,
+    /// wait for every service to become ready, then discover and label them.
+    /// Returns one result per service. Fails (rather than reporting a false
+    /// success) if a service never reaches `running`/`healthy` within
+    /// [`COMPOSE_READY_TIMEOUT`].
+    ///
+    /// This is a thin wrapper over [`Self::prepare_and_pull`] followed by
+    /// [`Self::deploy_prepared`]. Callers that need to tear down an existing
+    /// stack between the two phases (the common redeploy path) should call
+    /// `prepare_and_pull` and `deploy_prepared` directly so that image-fetch
+    /// latency falls outside the downtime window.
+    pub async fn deploy(
+        &self,
+        request: ComposeDeployRequest,
+    ) -> Result<Vec<ComposeServiceResult>, ComposeError> {
+        let prepared = self.prepare_and_pull(&request).await?;
+        self.deploy_prepared(prepared, &request).await
     }
 
     /// Tear down containers before a redeploy. Preserves volumes (database data,
@@ -3643,7 +3735,15 @@ impl ComposeExecutor {
 
         debug!(project = %project_name, "Running docker compose pull");
 
-        let output = cmd.output().await?;
+        let output = tokio::time::timeout(COMPOSE_PULL_TIMEOUT, cmd.output())
+            .await
+            .map_err(|_| ComposeError::CommandFailed {
+                project: project_name.to_string(),
+                reason: format!(
+                    "docker compose pull timed out after {} seconds",
+                    COMPOSE_PULL_TIMEOUT.as_secs()
+                ),
+            })??;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -5537,6 +5637,68 @@ networks:
         assert!(executor.has_build_directives(
             "services:\n  web:\n    build:\n      context: .\n      dockerfile: Dockerfile\n"
         ));
+    }
+
+    /// `has_build_directives` must detect a `build:` stanza that appears only
+    /// in the compose override, not in the base file. This is the Bug 2 scenario:
+    /// a user override adds `build:` to a service that only has `image:` in the
+    /// base, making `compose_pull --ignore-buildable` skip that service (because
+    /// the merged view has a build stanza), while the old code skipped
+    /// `compose_build` too (because it only scanned the base file). The service
+    /// ended up neither built nor pulled.
+    #[test]
+    fn test_has_build_in_override_only_is_detected() {
+        let docker = Docker::connect_with_defaults();
+        if docker.is_err() {
+            return;
+        }
+        let executor = ComposeExecutor::new(Arc::new(docker.unwrap()), PathBuf::from("/tmp/test"));
+
+        // Base file has no build directive.
+        let base = "services:\n  web:\n    image: nginx:latest\n";
+        // Override adds a build stanza to the same service.
+        let override_yaml = "services:\n  web:\n    build: ./custom\n";
+
+        // The base alone should NOT look like a build project.
+        assert!(
+            !executor.has_build_directives(base),
+            "base without build: should not be detected as a build project"
+        );
+        // The override alone SHOULD be detected.
+        assert!(
+            executor.has_build_directives(override_yaml),
+            "override with build: should be detected"
+        );
+        // The combined check — as used in prepare_and_pull — must fire when
+        // the override has the directive even if the base does not.
+        let combined =
+            executor.has_build_directives(base) || executor.has_build_directives(override_yaml);
+        assert!(
+            combined,
+            "combined base+override check must detect build: in the override"
+        );
+    }
+
+    /// Verify that the combined base+override check does NOT produce a false
+    /// positive when neither document contains a `build:` directive (e.g. a
+    /// purely `image:`-based stack with an override that only changes env vars).
+    #[test]
+    fn test_no_build_in_base_or_override_is_not_detected() {
+        let docker = Docker::connect_with_defaults();
+        if docker.is_err() {
+            return;
+        }
+        let executor = ComposeExecutor::new(Arc::new(docker.unwrap()), PathBuf::from("/tmp/test"));
+
+        let base = "services:\n  web:\n    image: nginx:latest\n";
+        let override_yaml = "services:\n  web:\n    environment:\n      - FOO=bar\n";
+
+        let combined =
+            executor.has_build_directives(base) || executor.has_build_directives(override_yaml);
+        assert!(
+            !combined,
+            "stack with no build: directives in either document must not be flagged as a build project"
+        );
     }
 
     #[test]

--- a/crates/temps-deployments/src/jobs/deploy_compose.rs
+++ b/crates/temps-deployments/src/jobs/deploy_compose.rs
@@ -743,6 +743,11 @@ impl WorkflowTask for DeployComposeJob {
                 repo_path.as_deref(),
                 Some(compose_file_name),
                 &self.environment_vars,
+                // Secrets must NOT be deleted here: prepare_and_pull() just
+                // materialized them and deploy_prepared() is about to bind-mount
+                // them into the new containers. Deleting them now would cause
+                // the new containers to start with missing or empty secrets.
+                false,
             )
             .await
         {
@@ -769,6 +774,10 @@ impl WorkflowTask for DeployComposeJob {
                         repo_path.as_deref(),
                         Some(compose_file_name),
                         &self.environment_vars,
+                        // Deploy attempt is over; remove secrets so plaintext
+                        // credentials are not left on disk for a stack that
+                        // is no longer running.
+                        true,
                     )
                     .await
                     .err();
@@ -821,6 +830,10 @@ impl WorkflowTask for DeployComposeJob {
                     repo_path.as_deref(),
                     Some(compose_file_name),
                     &self.environment_vars,
+                    // Deploy attempt is over; remove secrets so plaintext
+                    // credentials are not left on disk for a stack that
+                    // is no longer running.
+                    true,
                 )
                 .await;
             let error_msg = "No containers found after docker compose up".to_string();
@@ -981,6 +994,10 @@ impl WorkflowTask for DeployComposeJob {
                         cleanup_repo_path.as_deref(),
                         Some(compose_file_name),
                         &self.environment_vars,
+                        // Deploy attempt is aborted; remove secrets so plaintext
+                        // credentials are not left on disk for a stack that
+                        // is no longer running.
+                        true,
                     )
                     .await
                     .map_err(|error| WorkflowError::JobExecutionFailed(format!(

--- a/crates/temps-deployments/src/jobs/deploy_compose.rs
+++ b/crates/temps-deployments/src/jobs/deploy_compose.rs
@@ -673,7 +673,60 @@ impl WorkflowTask for DeployComposeJob {
             }
         }
 
-        // Tear down previous containers (preserve volumes for data persistence)
+        // Build the deploy request here so it is available to prepare_and_pull
+        // BEFORE teardown. This is required for pull latency to fall outside the
+        // downtime window (see below).
+        let request = ComposeDeployRequest {
+            project_name: project_name.clone(),
+            compose_content,
+            env_content,
+            work_dir: PathBuf::from("/tmp"),
+            compose_path: self.compose_path.clone(),
+            environment_vars: self.environment_vars.clone(),
+            secrets: self.secrets.clone(),
+            secret_compose_services: self.secret_compose_services.clone(),
+            build_args: self.build_args.clone(),
+            labels,
+            repo_dir: repo_path.clone(),
+            compose_override: self.compose_override.clone(),
+            relaxed_capability_services: self.relaxed_capability_services.clone(),
+            unsandboxed_services: self.unsandboxed_services.clone(),
+        };
+
+        // Prepare compose files, build (if needed), and pull images BEFORE
+        // tearing down the old stack. This keeps image-fetch latency — which
+        // can span minutes on large images or slow registries — outside the
+        // downtime window: the old containers keep serving traffic while the
+        // new images are fetched. If this step fails (bad image reference,
+        // registry unreachable, build error), we return early WITHOUT calling
+        // teardown_at, so the still-working old stack continues to run.
+        // Rejecting after teardown would cause downtime for what is an
+        // image/build configuration problem — the same logic already applied
+        // above for security-policy validation.
+        if let Some(ref log_id) = self.log_id {
+            let _ = self
+                .log_service
+                .log_info(
+                    log_id,
+                    "Pulling images (old stack remains live during fetch)",
+                )
+                .await;
+        }
+        let prepared = match self.compose_executor.prepare_and_pull(&request).await {
+            Ok(p) => p,
+            Err(e) => {
+                let error_msg = format!("Compose prepare/pull failed: {}", e);
+                tracing::error!(error = %error_msg, "Docker Compose prepare_and_pull failed");
+                if let Some(ref log_id) = self.log_id {
+                    let _ = self.log_service.log_error(log_id, &error_msg).await;
+                }
+                return Err(WorkflowError::JobExecutionFailed(error_msg));
+            }
+        };
+
+        // Tear down previous containers (preserve volumes for data persistence).
+        // Images are already local at this point, so the actual downtime window
+        // is now only: old-container-stop → new-container-healthy (no pull).
         if let Some(ref log_id) = self.log_id {
             let _ = self
                 .log_service
@@ -700,25 +753,13 @@ impl WorkflowTask for DeployComposeJob {
             );
         }
 
-        let request = ComposeDeployRequest {
-            project_name: project_name.clone(),
-            compose_content,
-            env_content,
-            work_dir: PathBuf::from("/tmp"),
-            compose_path: self.compose_path.clone(),
-            environment_vars: self.environment_vars.clone(),
-            secrets: self.secrets.clone(),
-            secret_compose_services: self.secret_compose_services.clone(),
-            build_args: self.build_args.clone(),
-            labels,
-            repo_dir: repo_path.clone(),
-            compose_override: self.compose_override.clone(),
-            relaxed_capability_services: self.relaxed_capability_services.clone(),
-            unsandboxed_services: self.unsandboxed_services.clone(),
-        };
-
-        // Deploy
-        let services = match self.compose_executor.deploy(request).await {
+        // Deploy (network + up + wait + discover + label). Images are already
+        // local from prepare_and_pull so this is the live downtime window.
+        let services = match self
+            .compose_executor
+            .deploy_prepared(prepared, &request)
+            .await
+        {
             Ok(s) => s,
             Err(e) => {
                 let cleanup_error = self


### PR DESCRIPTION
## Summary
- Docker Compose deploys ran `docker compose up -d --pull always --remove-orphans --force-recreate` as a single command, so image-fetch latency for plain `image:` services landed inside the downtime window between the old container being stopped and the new one becoming healthy.
- **Split `ComposeExecutor::deploy()` into two phases**: `prepare_and_pull()` (write compose files, build if needed, pull images) and `deploy_prepared()` (network, `up --force-recreate`, health-wait, discover, label). `deploy()` itself is now a thin wrapper of the two for any caller that doesn't need the split.
- `DeployComposeJob` now calls `prepare_and_pull()` **before** `teardown_at()` tears down the previous stack — this was the actual fix needed. An earlier version of this PR only moved the pull ahead of `--force-recreate` *inside* `deploy()`, but `teardown_at()` runs before `deploy()` is ever called, so that version provided zero downtime benefit on redeploy (caught by review). A pull/build failure now returns early **without** tearing down the working stack, mirroring the existing preflight-validation-before-teardown pattern already in this job.
- `has_build` detection now scans `compose_override` as well as the base file, since `compose_pull --ignore-buildable` sees the Compose-CLI-merged config — a `build:` stanza added only via a permitted override was previously invisible to `compose_build`'s gate but visible (and skipped) by `--ignore-buildable`, leaving the service neither built nor pulled.
- `teardown_at()` no longer deletes the just-materialized secrets directory when it's part of the prepare→teardown→deploy sequence (also caught by review, a regression from splitting `deploy()`): added a `remove_secrets: bool` param, `false` at that call site, `true` everywhere the deploy attempt is actually over (failure cleanup, zero-services cleanup, cancellation, full project/environment destroy).
- Added a timeout around the pull command and unit tests for the override-aware build detection and the secrets-preservation behavior.
- True zero-downtime isn't feasible for Compose deploys (host-bound ports/volumes), so this narrows the window to just the stop→start swap rather than eliminating it.

## Test plan
Verified against a live local instance end-to-end at every stage, not just `cargo check` — including two rounds of review catching real regressions that got re-verified live after each fix:
- [x] `cargo check --lib -p temps-deployer` / `-p temps-deployments` — 0 errors, clippy clean
- [x] Fresh deploy + redeploy against a real compose stack: deployment log shows `Pulling images (old stack remains live during fetch)` before `Stopping previous compose stack`
- [x] Failure-path safety: redeployed with an unresolvable image reference — deploy failed at the prepare/pull stage, previous container left running and still serving traffic (same container ID, uninterrupted)
- [x] Secrets survive redeploy: created a real Temps-managed project secret, deployed, then redeployed twice more — `/run/secrets/MY_TEST_SECRET` bind mount and its correct value survive the teardown→recreate cycle both times, confirmed via `docker inspect` mounts and reading the file from inside the new container's mounted host path
- [x] `cargo test --lib -p temps-deployer` — new tests for override-aware `has_build` detection and `remove_secrets` behavior pass