### PR TITLE
fix(projects): address project creation review findings

### DIFF
--- a/crates/temps-auth/src/permission_guard.rs
+++ b/crates/temps-auth/src/permission_guard.rs
@@ -1299,6 +1299,7 @@ mod tests {
             // with the instance-wide FlagsWrite the default role carries.
             "temps-flags",
             "temps-projects",
+            "temps-providers",
             "temps-proxy",
             "temps-status-page",
         ];

--- a/crates/temps-backup/src/engines/dispatch.rs
+++ b/crates/temps-backup/src/engines/dispatch.rs
@@ -248,6 +248,7 @@ mod tests {
             default_backup_provisioned: false,
             ai_data_access: false,
             container_name: None,
+            created_by_user_id: None,
         }
     }
 

--- a/crates/temps-backup/src/services/backup.rs
+++ b/crates/temps-backup/src/services/backup.rs
@@ -12015,6 +12015,7 @@ mod tests {
             default_backup_provisioned: Set(false),
             ai_data_access: Set(false),
             container_name: Set(None),
+            created_by_user_id: Set(None),
             created_at: Set(chrono::Utc::now()),
             updated_at: Set(chrono::Utc::now()),
         };
@@ -12193,6 +12194,7 @@ mod tests {
             default_backup_provisioned: Set(false),
             ai_data_access: Set(false),
             container_name: Set(None),
+            created_by_user_id: Set(None),
             created_at: Set(chrono::Utc::now()),
             updated_at: Set(chrono::Utc::now()),
         }
@@ -12628,6 +12630,7 @@ mod tests {
             default_backup_provisioned: Set(false),
             ai_data_access: Set(false),
             container_name: Set(None),
+            created_by_user_id: Set(None),
             created_at: Set(chrono::Utc::now()),
             updated_at: Set(chrono::Utc::now()),
         }

--- a/crates/temps-deployments/src/handlers/deployments.rs
+++ b/crates/temps-deployments/src/handlers/deployments.rs
@@ -463,6 +463,13 @@ impl From<crate::services::services::DeploymentError> for Problem {
                     .with_title("Invalid Bundle Path")
                     .with_detail(format!("Bundle path '{path}' is invalid: {reason}"))
             }
+            error @ (DeploymentError::AssetOriginNotFound { .. }
+            | DeploymentError::AssetOriginCycle { .. }
+            | DeploymentError::EnvironmentResolution(_)) => {
+                problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
+                    .with_title("Deployment Configuration Error")
+                    .with_detail(error.to_string())
+            }
             DeploymentError::Other(msg) => problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
                 .with_title("Internal Server Error")
                 .with_detail(msg),
@@ -3208,6 +3215,95 @@ mod tests {
     /// Helper to create a mock AuthContext for testing
     fn create_test_auth_context() -> temps_auth::AuthContext {
         create_test_auth_context_for_role(temps_auth::Role::Admin)
+    }
+
+    #[tokio::test]
+    async fn managed_environment_variables_route_enforces_contract() {
+        use axum::body::{to_bytes, Body};
+        use axum::http::Request;
+        use tower::ServiceExt;
+
+        let app = Router::new().route(
+            "/deployments/managed-environment-variables",
+            axum::routing::get(list_managed_environment_variables),
+        );
+
+        let mut success_request = Request::builder()
+            .uri("/deployments/managed-environment-variables?preset=nextjs")
+            .body(Body::empty())
+            .expect("build request");
+        success_request
+            .extensions_mut()
+            .insert(create_test_auth_context());
+        let success = app
+            .clone()
+            .oneshot(success_request)
+            .await
+            .expect("route responds");
+        assert_eq!(success.status(), StatusCode::OK);
+        let body = to_bytes(success.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        let variables: Vec<ManagedEnvironmentVariable> =
+            serde_json::from_slice(&body).expect("managed-variable response");
+        assert!(variables
+            .iter()
+            .any(|variable| variable.name == "SENTRY_DSN"));
+
+        let mut invalid_request = Request::builder()
+            .uri("/deployments/managed-environment-variables?preset=unknown")
+            .body(Body::empty())
+            .expect("build request");
+        invalid_request
+            .extensions_mut()
+            .insert(create_test_auth_context());
+        assert_eq!(
+            app.clone()
+                .oneshot(invalid_request)
+                .await
+                .expect("route responds")
+                .status(),
+            StatusCode::BAD_REQUEST
+        );
+
+        let unauthenticated = Request::builder()
+            .uri("/deployments/managed-environment-variables?preset=nextjs")
+            .body(Body::empty())
+            .expect("build request");
+        assert_eq!(
+            app.clone()
+                .oneshot(unauthenticated)
+                .await
+                .expect("route responds")
+                .status(),
+            StatusCode::UNAUTHORIZED
+        );
+
+        let mut forbidden_request = Request::builder()
+            .uri("/deployments/managed-environment-variables?preset=nextjs")
+            .body(Body::empty())
+            .expect("build request");
+        forbidden_request
+            .extensions_mut()
+            .insert(create_test_auth_context_for_role(temps_auth::Role::Reader));
+        assert_eq!(
+            app.oneshot(forbidden_request)
+                .await
+                .expect("route responds")
+                .status(),
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    #[test]
+    fn managed_environment_variables_route_is_in_openapi() {
+        use utoipa::OpenApi;
+
+        let spec = DeploymentsApiDoc::openapi();
+        assert!(spec
+            .paths
+            .paths
+            .contains_key("/deployments/managed-environment-variables"));
     }
 
     /// Helper to create a mock AuthContext with a persisted session (non-None

--- a/crates/temps-deployments/src/services/env_resolver.rs
+++ b/crates/temps-deployments/src/services/env_resolver.rs
@@ -17,14 +17,121 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
-use temps_core::EncryptionService;
+use sea_orm::{ColumnTrait, DatabaseConnection, DbErr, EntityTrait, QueryFilter};
+use temps_core::{EncryptionService, SecretsManagerResolver};
 use temps_entities::{deployments, environments, preset::Preset, projects};
+use thiserror::Error;
 use tracing::{debug, info};
 
 use super::deployment_token_service::DeploymentTokenService;
 use super::managed_environment_variables::{public_sentry_dsn_var, public_sentry_tunnel_var};
 use super::workflow_planner::SecretsResolverSlot;
+
+#[derive(Debug, Error)]
+pub enum DeploymentEnvResolutionError {
+    #[error(
+        "Failed to query environment-variable bindings for project {project_id}, environment {environment_id}: {source}"
+    )]
+    EnvironmentVariableBindingsQuery {
+        project_id: i32,
+        environment_id: i32,
+        #[source]
+        source: DbErr,
+    },
+
+    #[error(
+        "Failed to query environment variables for project {project_id}, environment {environment_id}: {source}"
+    )]
+    EnvironmentVariablesQuery {
+        project_id: i32,
+        environment_id: i32,
+        #[source]
+        source: DbErr,
+    },
+
+    #[error(
+        "Failed to decrypt environment variable '{key}' (id {variable_id}) for project {project_id}, environment {environment_id}: {reason}"
+    )]
+    EnvironmentVariableDecryption {
+        project_id: i32,
+        environment_id: i32,
+        variable_id: i32,
+        key: String,
+        reason: String,
+    },
+
+    #[error(
+        "Failed to query linked services for project {project_id}, environment {environment_id}: {source}"
+    )]
+    LinkedServicesQuery {
+        project_id: i32,
+        environment_id: i32,
+        #[source]
+        source: DbErr,
+    },
+
+    #[error(
+        "Failed to gather environment variables from linked services for project {project_id}, environment {environment_id}: {failures}"
+    )]
+    LinkedServiceVariables {
+        project_id: i32,
+        environment_id: i32,
+        failures: String,
+    },
+
+    #[error(
+        "Secrets-manager resolution failed for project {project_id}, environment {environment_id}: {reason}. Verify provider connectivity and credentials"
+    )]
+    SecretsManager {
+        project_id: i32,
+        environment_id: i32,
+        reason: String,
+    },
+}
+
+async fn apply_secrets_manager_layer(
+    resolved: &mut HashMap<String, String>,
+    resolver: Option<Arc<dyn SecretsManagerResolver>>,
+    project_id: i32,
+    environment_id: i32,
+) -> Result<(), DeploymentEnvResolutionError> {
+    let Some(resolver) = resolver else {
+        return Ok(());
+    };
+
+    let secret_bindings = resolver
+        .resolve_secrets_for_deployment(project_id, environment_id)
+        .await
+        .map_err(|error| DeploymentEnvResolutionError::SecretsManager {
+            project_id,
+            environment_id,
+            reason: error.to_string(),
+        })?;
+
+    info!(
+        "Resolved {} secret(s) for project {} environment {}: [{}]",
+        secret_bindings.len(),
+        project_id,
+        environment_id,
+        secret_bindings
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    for key in secret_bindings.keys() {
+        if resolved.contains_key(key) {
+            tracing::warn!(
+                "Secrets binding overwrites existing env var '{}' for project {} environment {}",
+                key,
+                project_id,
+                environment_id,
+            );
+        }
+    }
+    resolved.extend(secret_bindings);
+    Ok(())
+}
 
 /// Build the OpenTelemetry SDK header-list value for a deployed project.
 ///
@@ -119,7 +226,7 @@ impl DeploymentEnvResolver {
         project: &projects::Model,
         environment: &environments::Model,
         deployment: &deployments::Model,
-    ) -> anyhow::Result<HashMap<String, String>> {
+    ) -> Result<HashMap<String, String>, DeploymentEnvResolutionError> {
         use temps_entities::{env_var_environments, env_vars, project_services};
 
         let mut env_vars_map = HashMap::new();
@@ -137,7 +244,14 @@ impl DeploymentEnvResolver {
         let env_var_ids: Vec<i32> = env_var_environments::Entity::find()
             .filter(env_var_environments::Column::EnvironmentId.eq(environment.id))
             .all(self.db.as_ref())
-            .await?
+            .await
+            .map_err(
+                |source| DeploymentEnvResolutionError::EnvironmentVariableBindingsQuery {
+                    project_id: project.id,
+                    environment_id: environment.id,
+                    source,
+                },
+            )?
             .into_iter()
             .map(|eve| eve.env_var_id)
             .collect();
@@ -147,19 +261,27 @@ impl DeploymentEnvResolver {
                 .filter(env_vars::Column::Id.is_in(env_var_ids))
                 .filter(env_vars::Column::ProjectId.eq(project.id))
                 .all(self.db.as_ref())
-                .await?;
+                .await
+                .map_err(
+                    |source| DeploymentEnvResolutionError::EnvironmentVariablesQuery {
+                        project_id: project.id,
+                        environment_id: environment.id,
+                        source,
+                    },
+                )?;
 
             for env_var in env_vars_list {
                 let value = if env_var.is_encrypted {
                     self.encryption_service
                         .decrypt_string(&env_var.value)
-                        .map_err(|e| {
-                            anyhow::anyhow!(
-                                "Failed to decrypt environment variable '{}' (id={}): {}",
-                                env_var.key,
-                                env_var.id,
-                                e
-                            )
+                        .map_err(|error| {
+                            DeploymentEnvResolutionError::EnvironmentVariableDecryption {
+                                project_id: project.id,
+                                environment_id: environment.id,
+                                variable_id: env_var.id,
+                                key: env_var.key.clone(),
+                                reason: error.to_string(),
+                            }
                         })?
                 } else {
                     env_var.value
@@ -178,7 +300,12 @@ impl DeploymentEnvResolver {
         let project_services_list = project_services::Entity::find()
             .filter(project_services::Column::ProjectId.eq(project.id))
             .all(self.db.as_ref())
-            .await?;
+            .await
+            .map_err(|source| DeploymentEnvResolutionError::LinkedServicesQuery {
+                project_id: project.id,
+                environment_id: environment.id,
+                source,
+            })?;
 
         debug!(
             "🔌 Found {} external services linked to project {}",
@@ -237,14 +364,11 @@ impl DeploymentEnvResolver {
                 .collect::<Vec<_>>()
                 .join("\n");
 
-            let error_message = format!(
-                "Failed to gather environment variables from {} external service(s). \
-                The deployment cannot proceed without all required external services configured:\n{}",
-                failed_services.len(),
-                failure_details
-            );
-
-            return Err(anyhow::anyhow!(error_message));
+            return Err(DeploymentEnvResolutionError::LinkedServiceVariables {
+                project_id: project.id,
+                environment_id: environment.id,
+                failures: format!("{} service(s):\n{failure_details}", failed_services.len()),
+            });
         }
 
         // Linked-service variables are defaults. Explicit project variables
@@ -264,43 +388,13 @@ impl DeploymentEnvResolver {
             let guard = self.secrets_resolver.read().await;
             guard.as_ref().cloned()
         };
-        if let Some(secrets_resolver) = maybe_secrets_resolver {
-            let secret_bindings = secrets_resolver
-                .resolve_secrets_for_deployment(project.id, environment.id)
-                .await
-                .map_err(|error| {
-                    anyhow::anyhow!(
-                        "Secrets-manager resolution failed for project {} environment {}: {}. \
-                         The deployment cannot proceed. Verify provider connectivity and credentials.",
-                        project.id,
-                        environment.id,
-                        error
-                    )
-                })?;
-
-            info!(
-                "Resolved {} secret(s) for project {} environment {}: [{}]",
-                secret_bindings.len(),
-                project.id,
-                environment.id,
-                secret_bindings
-                    .keys()
-                    .cloned()
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
-            for key in secret_bindings.keys() {
-                if env_vars_map.contains_key(key) {
-                    tracing::warn!(
-                        "Secrets binding overwrites existing env var '{}' for project {} environment {}",
-                        key,
-                        project.id,
-                        environment.id,
-                    );
-                }
-            }
-            env_vars_map.extend(secret_bindings);
-        }
+        apply_secrets_manager_layer(
+            &mut env_vars_map,
+            maybe_secrets_resolver,
+            project.id,
+            environment.id,
+        )
+        .await?;
 
         // 3. Get or create Sentry DSN for error tracking
         // Generate/fetch DSN for this project/environment combination
@@ -499,12 +593,33 @@ impl DeploymentEnvResolver {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::Arc;
 
+    use async_trait::async_trait;
+    use temps_core::SecretsManagerResolver;
     use temps_entities::preset::Preset;
 
     use super::{
-        apply_deployment_owned_variables, merge_environment_variable_layers, otel_exporter_headers,
+        apply_deployment_owned_variables, apply_secrets_manager_layer,
+        merge_environment_variable_layers, otel_exporter_headers, DeploymentEnvResolutionError,
     };
+
+    struct TestSecretsResolver {
+        result: Result<HashMap<String, String>, String>,
+    }
+
+    #[async_trait]
+    impl SecretsManagerResolver for TestSecretsResolver {
+        async fn resolve_secrets_for_deployment(
+            &self,
+            _project_id: i32,
+            _environment_id: i32,
+        ) -> Result<HashMap<String, String>, Box<dyn std::error::Error + Send + Sync>> {
+            self.result
+                .clone()
+                .map_err(|reason| std::io::Error::other(reason).into())
+        }
+    }
 
     #[test]
     fn explicit_project_vars_override_linked_service_defaults() {
@@ -555,6 +670,62 @@ mod tests {
         assert_eq!(
             resolved.get("SENTRY_DSN").map(String::as_str),
             Some("https://temps-managed.example/2")
+        );
+    }
+
+    #[tokio::test]
+    async fn secrets_manager_values_override_tenant_layers() {
+        let mut resolved = HashMap::from([("DATABASE_URL".to_string(), "tenant".to_string())]);
+        let resolver = Arc::new(TestSecretsResolver {
+            result: Ok(HashMap::from([
+                ("DATABASE_URL".to_string(), "secret".to_string()),
+                ("API_KEY".to_string(), "managed".to_string()),
+            ])),
+        });
+
+        apply_secrets_manager_layer(&mut resolved, Some(resolver), 41, 52)
+            .await
+            .expect("the test secrets resolver should succeed");
+
+        assert_eq!(
+            resolved.get("DATABASE_URL").map(String::as_str),
+            Some("secret")
+        );
+        assert_eq!(resolved.get("API_KEY").map(String::as_str), Some("managed"));
+    }
+
+    #[tokio::test]
+    async fn secrets_manager_failure_is_typed_and_contextual() {
+        let resolver = Arc::new(TestSecretsResolver {
+            result: Err("provider unavailable".to_string()),
+        });
+
+        let error = apply_secrets_manager_layer(&mut HashMap::new(), Some(resolver), 41, 52)
+            .await
+            .expect_err("secret resolution must fail closed");
+
+        assert!(matches!(
+            error,
+            DeploymentEnvResolutionError::SecretsManager {
+                project_id: 41,
+                environment_id: 52,
+                ..
+            }
+        ));
+        assert!(error.to_string().contains("provider unavailable"));
+    }
+
+    #[tokio::test]
+    async fn missing_secrets_manager_is_a_no_op() {
+        let mut resolved = HashMap::from([("DATABASE_URL".to_string(), "tenant".to_string())]);
+
+        apply_secrets_manager_layer(&mut resolved, None, 41, 52)
+            .await
+            .expect("an unconfigured optional secrets manager should be a no-op");
+
+        assert_eq!(
+            resolved.get("DATABASE_URL").map(String::as_str),
+            Some("tenant")
         );
     }
 

--- a/crates/temps-deployments/src/services/services.rs
+++ b/crates/temps-deployments/src/services/services.rs
@@ -7,6 +7,7 @@ use sea_orm::{
     PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Set, Statement, TransactionTrait,
 };
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::pin::Pin;
 use std::sync::Arc;
 use temps_entities::{
@@ -94,6 +95,27 @@ pub enum DeploymentError {
     #[error("Invalid bundle path '{path}': {reason}")]
     InvalidBundlePath { path: String, reason: String },
 
+    #[error(
+        "Cannot resolve the build artifact for deployment {deployment_id} in project {project_id}: source deployment {source_deployment_id} was not found"
+    )]
+    AssetOriginNotFound {
+        project_id: i32,
+        deployment_id: i32,
+        source_deployment_id: i32,
+    },
+
+    #[error(
+        "Cannot resolve the build artifact for deployment {deployment_id} in project {project_id}: deployment reuse metadata contains a cycle at deployment {source_deployment_id}"
+    )]
+    AssetOriginCycle {
+        project_id: i32,
+        deployment_id: i32,
+        source_deployment_id: i32,
+    },
+
+    #[error(transparent)]
+    EnvironmentResolution(#[from] super::env_resolver::DeploymentEnvResolutionError),
+
     #[error("Other error: {0}")]
     Other(String),
 }
@@ -151,12 +173,12 @@ struct DeploymentAssetOrigin {
 /// Resolve the immutable build artifact behind a deployment. Promotion and
 /// rollback rows may already reference an earlier source, so propagating the
 /// immediate row would lose assets after the second hop.
-fn canonical_deployment_asset_origin(
+fn complete_deployment_asset_origin(
     deployment_id: i32,
     environment_id: i32,
     slug: &str,
     context: Option<&serde_json::Value>,
-) -> DeploymentAssetOrigin {
+) -> Option<DeploymentAssetOrigin> {
     let source_deployment_id = context
         .and_then(|value| value.get("source_deployment_id"))
         .and_then(serde_json::Value::as_i64)
@@ -170,26 +192,76 @@ fn canonical_deployment_asset_origin(
         .and_then(serde_json::Value::as_str);
 
     match (source_deployment_id, source_environment_id, source_slug) {
-        (Some(deployment_id), Some(environment_id), Some(slug)) => DeploymentAssetOrigin {
+        (Some(deployment_id), Some(environment_id), Some(slug)) => Some(DeploymentAssetOrigin {
             deployment_id,
             environment_id,
             slug: slug.to_string(),
-        },
-        _ => DeploymentAssetOrigin {
+        }),
+        (None, None, None) => Some(DeploymentAssetOrigin {
             deployment_id,
             environment_id,
             slug: slug.to_string(),
-        },
+        }),
+        _ => None,
     }
 }
 
-fn deployment_asset_origin(deployment: &deployments::Model) -> DeploymentAssetOrigin {
-    canonical_deployment_asset_origin(
-        deployment.id,
-        deployment.environment_id,
-        &deployment.slug,
-        deployment.context_vars.as_ref(),
-    )
+fn source_deployment_id(context: Option<&serde_json::Value>) -> Option<i32> {
+    context
+        .and_then(|value| value.get("source_deployment_id"))
+        .and_then(serde_json::Value::as_i64)
+        .and_then(|value| i32::try_from(value).ok())
+}
+
+/// Resolve both the current complete reuse metadata and the partial metadata
+/// written by Temps before source slugs were persisted. Legacy rows are walked
+/// back to the immutable build deployment so a second promotion/rollback does
+/// not perpetuate an intermediate, asset-less deployment.
+async fn deployment_asset_origin(
+    db: &temps_database::DbConnection,
+    deployment: &deployments::Model,
+) -> Result<DeploymentAssetOrigin, DeploymentError> {
+    let root_deployment_id = deployment.id;
+    let project_id = deployment.project_id;
+    let mut current = deployment.clone();
+    let mut visited = HashSet::from([current.id]);
+
+    loop {
+        if let Some(origin) = complete_deployment_asset_origin(
+            current.id,
+            current.environment_id,
+            &current.slug,
+            current.context_vars.as_ref(),
+        ) {
+            return Ok(origin);
+        }
+
+        let Some(source_id) = source_deployment_id(current.context_vars.as_ref()) else {
+            return Ok(DeploymentAssetOrigin {
+                deployment_id: current.id,
+                environment_id: current.environment_id,
+                slug: current.slug,
+            });
+        };
+
+        if !visited.insert(source_id) {
+            return Err(DeploymentError::AssetOriginCycle {
+                project_id,
+                deployment_id: root_deployment_id,
+                source_deployment_id: source_id,
+            });
+        }
+
+        current = deployments::Entity::find_by_id(source_id)
+            .filter(deployments::Column::ProjectId.eq(project_id))
+            .one(db)
+            .await?
+            .ok_or(DeploymentError::AssetOriginNotFound {
+                project_id,
+                deployment_id: root_deployment_id,
+                source_deployment_id: source_id,
+            })?;
+    }
 }
 
 #[derive(Clone)]
@@ -2052,7 +2124,8 @@ impl DeploymentService {
 
         let rollback_slug = format!("{}-{}", project.slug, deployment_number);
 
-        let rollback_asset_origin = deployment_asset_origin(&target_deployment);
+        let rollback_asset_origin =
+            deployment_asset_origin(self.db.as_ref(), &target_deployment).await?;
         let rollback_metadata = DeploymentMetadata {
             is_rollback: true,
             rolled_back_from_id: Some(deployment_id),
@@ -2346,13 +2419,7 @@ impl DeploymentService {
             let resolved_env = if let Some(resolver) = self.env_resolver.get() {
                 let mut resolved = resolver
                     .resolve(&project, &environment, &rollback_deployment)
-                    .await
-                    .map_err(|e| {
-                        DeploymentError::Other(format!(
-                            "Failed to resolve environment variables for rollback in environment {}: {}",
-                            environment_id, e
-                        ))
-                    })?;
+                    .await?;
                 crate::services::env_resolver::apply_deployment_owned_variables(
                     &mut resolved,
                     project.preset,
@@ -2757,7 +2824,7 @@ impl DeploymentService {
             )
         });
 
-        let promotion_asset_origin = deployment_asset_origin(&source);
+        let promotion_asset_origin = deployment_asset_origin(self.db.as_ref(), &source).await?;
         let new_deployment = deployments::ActiveModel {
             id: sea_orm::NotSet,
             project_id: Set(project_id),
@@ -3022,13 +3089,7 @@ impl DeploymentService {
             let resolved_env = if let Some(resolver) = self.env_resolver.get() {
                 let mut resolved = resolver
                     .resolve(&project, &target_env, &promoted_deployment)
-                    .await
-                    .map_err(|e| {
-                        DeploymentError::Other(format!(
-                            "Failed to resolve environment variables for promotion to environment {}: {}",
-                            target_environment_id, e
-                        ))
-                    })?;
+                    .await?;
                 crate::services::env_resolver::apply_deployment_owned_variables(
                     &mut resolved,
                     project.preset,
@@ -5005,19 +5066,16 @@ mod tests {
     }
 
     #[test]
-    fn deployment_asset_origin_stays_canonical_across_reuse_hops() {
+    fn complete_asset_origin_stays_canonical_across_reuse_hops() {
         let first_reuse_context = serde_json::json!({
             "source_deployment_id": 10,
             "source_environment_id": 20,
             "source_deployment_slug": "original-build",
         });
 
-        let origin = canonical_deployment_asset_origin(
-            30,
-            40,
-            "first-promotion",
-            Some(&first_reuse_context),
-        );
+        let origin =
+            complete_deployment_asset_origin(30, 40, "first-promotion", Some(&first_reuse_context))
+                .expect("complete reuse metadata should resolve without a database lookup");
         assert_eq!(
             origin,
             DeploymentAssetOrigin {
@@ -5033,13 +5091,13 @@ mod tests {
             "source_deployment_slug": origin.slug.clone(),
         });
         assert_eq!(
-            canonical_deployment_asset_origin(
+            complete_deployment_asset_origin(
                 50,
                 60,
                 "second-promotion",
                 Some(&second_reuse_context),
             ),
-            origin
+            Some(origin)
         );
     }
     use temps_database::test_utils::TestDatabase;
@@ -5178,6 +5236,64 @@ mod tests {
         let deployment = deployment.insert(db.as_ref()).await?;
 
         Ok((project, environment, deployment))
+    }
+
+    #[tokio::test]
+    async fn legacy_asset_origin_walks_partial_reuse_metadata_to_original_build() {
+        let test_db = match TestDatabase::with_migrations().await {
+            Ok(db) => db,
+            Err(error) => {
+                println!("Test database not available, skipping: {error}");
+                return;
+            }
+        };
+        let db = test_db.connection_arc().clone();
+        let (project, environment, original) = setup_test_data(&db)
+            .await
+            .expect("create deployment fixtures");
+
+        let first_reuse = deployments::ActiveModel {
+            project_id: Set(project.id),
+            environment_id: Set(environment.id),
+            slug: Set("legacy-promotion".to_string()),
+            state: Set("deployed".to_string()),
+            context_vars: Set(Some(serde_json::json!({
+                "trigger": "promotion",
+                "source_deployment_id": original.id,
+                "source_environment_id": original.environment_id,
+            }))),
+            created_at: Set(Utc::now()),
+            updated_at: Set(Utc::now()),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .expect("insert legacy promotion");
+
+        let second_reuse = deployments::ActiveModel {
+            project_id: Set(project.id),
+            environment_id: Set(environment.id),
+            slug: Set("legacy-rollback".to_string()),
+            state: Set("deployed".to_string()),
+            context_vars: Set(Some(serde_json::json!({
+                "trigger": "rollback",
+                "source_deployment_id": first_reuse.id,
+            }))),
+            created_at: Set(Utc::now()),
+            updated_at: Set(Utc::now()),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .expect("insert legacy rollback");
+
+        let origin = deployment_asset_origin(db.as_ref(), &second_reuse)
+            .await
+            .expect("legacy reuse metadata should resolve");
+
+        assert_eq!(origin.deployment_id, original.id);
+        assert_eq!(origin.environment_id, original.environment_id);
+        assert_eq!(origin.slug, original.slug);
     }
 
     #[tokio::test]

--- a/crates/temps-deployments/src/services/services.rs
+++ b/crates/temps-deployments/src/services/services.rs
@@ -5257,6 +5257,9 @@ mod tests {
             environment_id: Set(environment.id),
             slug: Set("legacy-promotion".to_string()),
             state: Set("deployed".to_string()),
+            metadata: Set(Some(
+                temps_entities::deployments::DeploymentMetadata::default(),
+            )),
             context_vars: Set(Some(serde_json::json!({
                 "trigger": "promotion",
                 "source_deployment_id": original.id,
@@ -5275,6 +5278,9 @@ mod tests {
             environment_id: Set(environment.id),
             slug: Set("legacy-rollback".to_string()),
             state: Set("deployed".to_string()),
+            metadata: Set(Some(
+                temps_entities::deployments::DeploymentMetadata::default(),
+            )),
             context_vars: Set(Some(serde_json::json!({
                 "trigger": "rollback",
                 "source_deployment_id": first_reuse.id,

--- a/crates/temps-entities/src/external_services.rs
+++ b/crates/temps-entities/src/external_services.rs
@@ -75,6 +75,10 @@ pub struct Model {
     /// `m20260804_000001_add_ai_data_access_to_external_services`.
     #[sea_orm(default_value = false)]
     pub ai_data_access: bool,
+    /// Human principal that created this service through the authenticated
+    /// API. This allows a newly-created, not-yet-linked service to be claimed
+    /// by that same user during project creation without trusting a guessed ID.
+    pub created_by_user_id: Option<i32>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/temps-import-caprover/src/importer.rs
+++ b/crates/temps-import-caprover/src/importer.rs
@@ -1221,6 +1221,8 @@ async fn execute_plan(
         ),
         automatic_deploy: true,
         storage_service_ids: vec![],
+        storage_service_claim_ids: vec![],
+        storage_service_claim_user_id: None,
         is_public_repo,
         git_url,
         git_provider_connection_id: context.git_provider_connection_id,

--- a/crates/temps-import-coolify/src/importer.rs
+++ b/crates/temps-import-coolify/src/importer.rs
@@ -1253,6 +1253,8 @@ async fn execute_plan(
         ),
         automatic_deploy: true,
         storage_service_ids: vec![],
+        storage_service_claim_ids: vec![],
+        storage_service_claim_user_id: None,
         is_public_repo,
         git_url,
         git_provider_connection_id: context.git_provider_connection_id,

--- a/crates/temps-import-docker/src/importer.rs
+++ b/crates/temps-import-docker/src/importer.rs
@@ -671,6 +671,8 @@ impl WorkloadImporter for DockerImporter {
             ),
             automatic_deploy: true,
             storage_service_ids: vec![],
+            storage_service_claim_ids: vec![],
+            storage_service_claim_user_id: None,
             is_public_repo: None,
             git_url: None,
             git_provider_connection_id: context.git_provider_connection_id,

--- a/crates/temps-import-dokploy/src/importer.rs
+++ b/crates/temps-import-dokploy/src/importer.rs
@@ -1232,6 +1232,8 @@ async fn execute_plan(
         ),
         automatic_deploy: true,
         storage_service_ids: vec![],
+        storage_service_claim_ids: vec![],
+        storage_service_claim_user_id: None,
         is_public_repo,
         git_url,
         git_provider_connection_id: context.git_provider_connection_id,

--- a/crates/temps-import-kamal/src/importer.rs
+++ b/crates/temps-import-kamal/src/importer.rs
@@ -1129,6 +1129,8 @@ async fn execute_plan(
         ),
         automatic_deploy: true,
         storage_service_ids: vec![],
+        storage_service_claim_ids: vec![],
+        storage_service_claim_user_id: None,
         is_public_repo: None,
         git_url: None,
         git_provider_connection_id: context.git_provider_connection_id,

--- a/crates/temps-import-kubernetes/src/importer.rs
+++ b/crates/temps-import-kubernetes/src/importer.rs
@@ -1929,6 +1929,8 @@ async fn execute_plan(
         ),
         automatic_deploy: true,
         storage_service_ids: vec![],
+        storage_service_claim_ids: vec![],
+        storage_service_claim_user_id: None,
         is_public_repo: None,
         git_url: None,
         git_provider_connection_id: context.git_provider_connection_id,

--- a/crates/temps-import-portainer/src/importer.rs
+++ b/crates/temps-import-portainer/src/importer.rs
@@ -1100,6 +1100,8 @@ async fn execute_plan(
         ),
         automatic_deploy: true,
         storage_service_ids: vec![],
+        storage_service_claim_ids: vec![],
+        storage_service_claim_user_id: None,
         is_public_repo: None,
         git_url: None,
         git_provider_connection_id: context.git_provider_connection_id,

--- a/crates/temps-migrations/src/migration/m20260830_000001_add_external_service_creator.rs
+++ b/crates/temps-migrations/src/migration/m20260830_000001_add_external_service_creator.rs
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ExternalServices::Table)
+                    .add_column(
+                        ColumnDef::new(ExternalServices::CreatedByUserId)
+                            .integer()
+                            .null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_foreign_key(
+                ForeignKey::create()
+                    .name("fk_external_services_created_by_user")
+                    .from(ExternalServices::Table, ExternalServices::CreatedByUserId)
+                    .to(Users::Table, Users::Id)
+                    .on_delete(ForeignKeyAction::SetNull)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_external_services_created_by_user")
+                    .table(ExternalServices::Table)
+                    .col(ExternalServices::CreatedByUserId)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx_external_services_created_by_user")
+                    .table(ExternalServices::Table)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .drop_foreign_key(
+                ForeignKey::drop()
+                    .name("fk_external_services_created_by_user")
+                    .table(ExternalServices::Table)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ExternalServices::Table)
+                    .drop_column(ExternalServices::CreatedByUserId)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum ExternalServices {
+    Table,
+    CreatedByUserId,
+}
+
+#[derive(DeriveIden)]
+enum Users {
+    Table,
+    Id,
+}

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -208,6 +208,7 @@ mod m20260827_000001_create_notification_routes;
 mod m20260828_000001_alarms_nullable_project;
 mod m20260828_000002_add_alarms_silenced_until;
 mod m20260829_000001_allow_duplicate_ready_snapshot_digests;
+mod m20260830_000001_add_external_service_creator;
 
 pub struct Migrator;
 
@@ -450,6 +451,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260828_000001_alarms_nullable_project::Migration),
             Box::new(m20260828_000002_add_alarms_silenced_until::Migration),
             Box::new(m20260829_000001_allow_duplicate_ready_snapshot_digests::Migration),
+            Box::new(m20260830_000001_add_external_service_creator::Migration),
         ]
     }
 }

--- a/crates/temps-migrations/tests/migration_tests.rs
+++ b/crates/temps-migrations/tests/migration_tests.rs
@@ -2586,9 +2586,8 @@ async fn feature_flag_table_count(db: &DatabaseConnection) -> anyhow::Result<i32
     Ok(row.try_get("", "n")?)
 }
 
-/// Existing installations must gain both the project opt-in column and the
-/// provider-key model catalog with its ownership constraint after a normal
-/// forward migration.
+/// A normal forward migration must include the latest security-relevant
+/// ownership and AI catalog schema.
 #[tokio::test]
 async fn test_api_traffic_ai_and_model_catalog_migrations() -> anyhow::Result<()> {
     if external_db_configured() {
@@ -2636,7 +2635,12 @@ async fn test_api_traffic_ai_and_model_catalog_migrations() -> anyhow::Result<()
                 (SELECT COUNT(*)::int FROM information_schema.columns \
                   WHERE table_schema = 'public' AND table_name = 'ai_gateway_config' \
                     AND column_name IN ('summary_provider_id', 'summary_model', \
-                                        'summary_thinking_level')) AS summary_columns"
+                                        'summary_thinking_level')) AS summary_columns, \
+                EXISTS (SELECT 1 FROM information_schema.columns \
+                  WHERE table_schema = 'public' AND table_name = 'external_services' \
+                    AND column_name = 'created_by_user_id') AS service_creator_column, \
+                EXISTS (SELECT 1 FROM pg_constraint \
+                  WHERE conname = 'fk_external_services_created_by_user') AS service_creator_fk"
                 .to_string(),
         ))
         .await?
@@ -2645,6 +2649,36 @@ async fn test_api_traffic_ai_and_model_catalog_migrations() -> anyhow::Result<()
     assert!(schema.try_get::<bool>("", "model_table")?);
     assert!(schema.try_get::<bool>("", "model_key_fk")?);
     assert_eq!(schema.try_get::<i32>("", "summary_columns")?, 3);
+    assert!(schema.try_get::<bool>("", "service_creator_column")?);
+    assert!(schema.try_get::<bool>("", "service_creator_fk")?);
+
+    // The creator-ownership migration is the latest migration. Exercise its
+    // reversal and re-application so upgrades retain an emergency rollback.
+    Migrator::down(&db, Some(1)).await?;
+    let creator_column_after_down = db
+        .query_one(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT EXISTS (SELECT 1 FROM information_schema.columns \
+               WHERE table_schema = 'public' AND table_name = 'external_services' \
+                 AND column_name = 'created_by_user_id') AS present"
+                .to_string(),
+        ))
+        .await?
+        .expect("creator column rollback query");
+    assert!(!creator_column_after_down.try_get::<bool>("", "present")?);
+
+    Migrator::up(&db, Some(1)).await?;
+    let creator_column_after_reapply = db
+        .query_one(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT EXISTS (SELECT 1 FROM information_schema.columns \
+               WHERE table_schema = 'public' AND table_name = 'external_services' \
+                 AND column_name = 'created_by_user_id') AS present"
+                .to_string(),
+        ))
+        .await?
+        .expect("creator column reapply query");
+    assert!(creator_column_after_reapply.try_get::<bool>("", "present")?);
 
     Ok(())
 }

--- a/crates/temps-monitoring/src/alarm_service.rs
+++ b/crates/temps-monitoring/src/alarm_service.rs
@@ -1548,6 +1548,7 @@ mod tests {
             default_backup_provisioned: false,
             ai_data_access: false,
             container_name: None,
+            created_by_user_id: None,
         }
     }
 

--- a/crates/temps-projects/src/handlers/handlers.rs
+++ b/crates/temps-projects/src/handlers/handlers.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use temps_auth::{
     permission_guard, project_access_guard, project_permission_guard, project_scope_guard,
 };
-use temps_auth::{AuthContext, RequireAuth};
+use temps_auth::{AuthContext, Permission, RequireAuth, Role};
 use temps_core::RequestMetadata;
 use tracing::{debug, error, info, warn};
 
@@ -35,7 +35,7 @@ use super::types::{
 use crate::services::types::CreateProjectEnvVar;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use serde::Serialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Read;
 use temps_core::problemdetails;
 use temps_core::problemdetails::Problem;
@@ -103,6 +103,134 @@ pub fn configure_routes() -> Router<Arc<AppState>> {
         )
         // Merge custom domain routes
         .merge(custom_domain_routes)
+}
+
+fn storage_service_access_denied() -> Problem {
+    problemdetails::new(StatusCode::FORBIDDEN)
+        .with_title("Insufficient Permissions")
+        .with_detail("You do not have access to one or more selected databases")
+}
+
+async fn require_storage_services_access(
+    state: &AppState,
+    auth: &AuthContext,
+    service_ids: &[i32],
+) -> Result<Vec<i32>, Problem> {
+    if service_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let scopes = state
+        .external_service_manager
+        .project_scopes_for_services(service_ids)
+        .await
+        .map_err(|error| match error {
+            temps_providers::ExternalServiceError::ServiceNotFound { .. } => {
+                storage_service_access_denied()
+            }
+            error => {
+                error!(error = %error, "failed to resolve selected database access scopes");
+                problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
+                    .with_title("Database Authorization Failed")
+                    .with_detail("The selected databases could not be authorized")
+            }
+        })?;
+
+    authorize_storage_service_scopes(auth, state.project_access_checker.as_deref(), &scopes).await
+}
+
+async fn authorize_storage_service_scopes(
+    auth: &AuthContext,
+    checker: Option<&dyn temps_core::ProjectAccessChecker>,
+    scopes: &[temps_providers::ExternalServiceProjectScope],
+) -> Result<Vec<i32>, Problem> {
+    if auth.is_admin() || auth.has_role(&Role::PlatformAdmin) {
+        return Ok(Vec::new());
+    }
+    let Some(checker) = checker else {
+        // Plain OSS has no team boundary.
+        return Ok(Vec::new());
+    };
+
+    let project_ids: Vec<i32> = scopes
+        .iter()
+        .flat_map(|scope| scope.project_ids.iter().copied())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let permissions = checker
+        .effective_project_permissions_batch(auth.user_id(), &project_ids)
+        .await
+        .map_err(|checker_error| {
+            error!(
+                user_id = auth.user_id(),
+                ?project_ids,
+                error = %checker_error,
+                "selected database permission resolution failed closed"
+            );
+            problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
+                .with_title("Database Authorization Failed")
+                .with_detail("Project permissions for the selected databases could not be resolved")
+        })?;
+    if project_ids
+        .iter()
+        .any(|project_id| !permissions.contains_key(project_id))
+    {
+        error!(
+            user_id = auth.user_id(),
+            ?project_ids,
+            "selected database permission result omitted a project"
+        );
+        return Err(problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
+            .with_title("Database Authorization Failed")
+            .with_detail("Project permissions for the selected databases were incomplete"));
+    }
+
+    let fallback_ids: Vec<i32> = project_ids
+        .iter()
+        .copied()
+        .filter(|project_id| matches!(permissions.get(project_id), Some(None)))
+        .collect();
+    let coarse_access = checker
+        .user_can_access_projects(auth.user_id(), &fallback_ids)
+        .await
+        .map_err(|checker_error| {
+            error!(
+                user_id = auth.user_id(),
+                ?fallback_ids,
+                error = %checker_error,
+                "selected database membership resolution failed closed"
+            );
+            problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
+                .with_title("Database Authorization Failed")
+                .with_detail("Project access for the selected databases could not be resolved")
+        })?;
+    if fallback_ids
+        .iter()
+        .any(|project_id| !coarse_access.contains_key(project_id))
+    {
+        return Err(problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
+            .with_title("Database Authorization Failed")
+            .with_detail("Project access for the selected databases was incomplete"));
+    }
+
+    let required_permission = Permission::ExternalServicesWrite.to_string();
+    let can_access_project = |project_id: &i32| match permissions.get(project_id) {
+        Some(Some(project_permissions)) => project_permissions.contains(&required_permission),
+        Some(None) => coarse_access.get(project_id).copied().unwrap_or(false),
+        None => false,
+    };
+    let mut creator_claims = Vec::new();
+    for scope in scopes {
+        if scope.project_ids.is_empty() && scope.created_by_user_id == Some(auth.user_id()) {
+            creator_claims.push(scope.service_id);
+        } else if scope.project_ids.is_empty() || !scope.project_ids.iter().any(can_access_project)
+        {
+            return Err(storage_service_access_denied());
+        }
+    }
+
+    Ok(creator_claims)
 }
 
 #[derive(OpenApi)]
@@ -552,6 +680,12 @@ pub async fn create_project(
     Json(project): Json<CreateProjectRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsCreate);
+    let storage_service_claim_ids = if !project.storage_service_ids.is_empty() {
+        permission_guard!(auth, ExternalServicesWrite);
+        require_storage_services_access(state.as_ref(), &auth, &project.storage_service_ids).await?
+    } else {
+        Vec::new()
+    };
 
     // Only require repo_name and repo_owner for Git source type
     // For docker_image and static_files, Git info is optional
@@ -577,6 +711,8 @@ pub async fn create_project(
         environment_variables: project.environment_variables,
         automatic_deploy: project.automatic_deploy.unwrap_or(false),
         storage_service_ids: project.storage_service_ids,
+        storage_service_claim_ids,
+        storage_service_claim_user_id: Some(auth.user_id()),
         is_public_repo: project.is_public_repo,
         git_url: project.git_url,
         git_provider_connection_id: project.git_provider_connection_id,
@@ -850,6 +986,8 @@ pub async fn update_project(
         environment_variables: project.environment_variables.clone(),
         automatic_deploy: project.automatic_deploy.unwrap_or(false),
         storage_service_ids: project.storage_service_ids.clone(),
+        storage_service_claim_ids: Vec::new(),
+        storage_service_claim_user_id: None,
         is_public_repo: None,               // Keep existing setting
         git_url: None,                      // Keep existing setting
         git_provider_connection_id: None,   // Keep existing setting
@@ -2091,6 +2229,12 @@ pub async fn create_project_from_template(
     Json(request): Json<super::templates::CreateProjectFromTemplateRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ProjectsCreate);
+    let storage_service_claim_ids = if !request.storage_service_ids.is_empty() {
+        permission_guard!(auth, ExternalServicesWrite);
+        require_storage_services_access(state.as_ref(), &auth, &request.storage_service_ids).await?
+    } else {
+        Vec::new()
+    };
 
     // 1. Get the template
     let template = state
@@ -2155,6 +2299,8 @@ pub async fn create_project_from_template(
             environment_variables: env_vars,
             automatic_deploy: false,
             storage_service_ids: request.storage_service_ids.clone(),
+            storage_service_claim_ids: storage_service_claim_ids.clone(),
+            storage_service_claim_user_id: Some(auth.user_id()),
             is_public_repo: None,
             git_url: None,
             git_provider_connection_id: None,
@@ -2227,6 +2373,8 @@ pub async fn create_project_from_template(
                     environment_variables: env_vars,
                     automatic_deploy: request.automatic_deploy,
                     storage_service_ids: request.storage_service_ids.clone(),
+                    storage_service_claim_ids: storage_service_claim_ids.clone(),
+                    storage_service_claim_user_id: Some(auth.user_id()),
                     is_public_repo: Some(!new_repo.private),
                     git_url: Some(new_repo.clone_url.clone()),
                     git_provider_connection_id: Some(connection_id),
@@ -2273,6 +2421,8 @@ pub async fn create_project_from_template(
                     // auto-deploy-on-push is meaningless here regardless of request.
                     automatic_deploy: false,
                     storage_service_ids: request.storage_service_ids.clone(),
+                    storage_service_claim_ids: storage_service_claim_ids.clone(),
+                    storage_service_claim_user_id: Some(auth.user_id()),
                     is_public_repo: Some(true),
                     git_url: Some(template.git.url.clone()),
                     git_provider_connection_id: None,
@@ -2385,13 +2535,16 @@ pub async fn create_project_from_template(
 #[cfg(test)]
 mod tests {
     use super::{
-        compose_path_for_candidate, parse_owner_repo_from_git_url,
-        project_created_from_template_telemetry_event, require_git_settings_permissions,
+        authorize_storage_service_scopes, compose_path_for_candidate,
+        parse_owner_repo_from_git_url, project_created_from_template_telemetry_event,
+        require_git_settings_permissions,
     };
+    use axum::http::StatusCode;
     use chrono::Utc;
     use std::collections::BTreeMap;
     use temps_auth::{AuthContext, Permission};
     use temps_entities::users;
+    use temps_providers::ExternalServiceProjectScope;
 
     fn custom_api_key(permissions: Vec<Permission>) -> AuthContext {
         let now = Utc::now();
@@ -2436,6 +2589,217 @@ mod tests {
             Permission::GitRepositoriesRead,
         ]);
         assert!(require_git_settings_permissions(&authorized).is_ok());
+    }
+
+    struct StorageAccessChecker {
+        permissions: BTreeMap<i32, Option<Vec<String>>>,
+        coarse_access: BTreeMap<i32, bool>,
+    }
+
+    #[temps_core::async_trait::async_trait]
+    impl temps_core::ProjectAccessChecker for StorageAccessChecker {
+        async fn user_can_access_project(
+            &self,
+            _user_id: i32,
+            project_id: i32,
+        ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(self
+                .coarse_access
+                .get(&project_id)
+                .copied()
+                .unwrap_or(false))
+        }
+
+        async fn user_can_access_projects(
+            &self,
+            _user_id: i32,
+            project_ids: &[i32],
+        ) -> Result<BTreeMap<i32, bool>, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(project_ids
+                .iter()
+                .filter_map(|project_id| {
+                    self.coarse_access
+                        .get(project_id)
+                        .copied()
+                        .map(|allowed| (*project_id, allowed))
+                })
+                .collect())
+        }
+
+        async fn effective_project_permissions_batch(
+            &self,
+            _user_id: i32,
+            project_ids: &[i32],
+        ) -> Result<BTreeMap<i32, Option<Vec<String>>>, Box<dyn std::error::Error + Send + Sync>>
+        {
+            Ok(project_ids
+                .iter()
+                .filter_map(|project_id| {
+                    self.permissions
+                        .get(project_id)
+                        .cloned()
+                        .map(|permissions| (*project_id, permissions))
+                })
+                .collect())
+        }
+    }
+
+    fn service_scope(service_id: i32, project_ids: Vec<i32>) -> ExternalServiceProjectScope {
+        ExternalServiceProjectScope {
+            service_id,
+            project_ids,
+            created_by_user_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn selected_database_requires_write_access_to_each_service_scope() {
+        let auth = custom_api_key(vec![
+            Permission::ProjectsCreate,
+            Permission::ExternalServicesWrite,
+        ]);
+        let checker = StorageAccessChecker {
+            permissions: BTreeMap::from([
+                (7, Some(vec![Permission::ExternalServicesWrite.to_string()])),
+                (8, Some(vec![Permission::ExternalServicesRead.to_string()])),
+            ]),
+            coarse_access: BTreeMap::new(),
+        };
+
+        let allowed =
+            authorize_storage_service_scopes(&auth, Some(&checker), &[service_scope(1, vec![7])])
+                .await;
+        assert!(allowed.is_ok());
+
+        let denied = authorize_storage_service_scopes(
+            &auth,
+            Some(&checker),
+            &[service_scope(1, vec![7]), service_scope(2, vec![8])],
+        )
+        .await
+        .expect_err("every selected database must be authorized");
+        assert_eq!(denied.status_code, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn selected_unlinked_database_is_denied_when_project_auth_is_active() {
+        let auth = custom_api_key(vec![
+            Permission::ProjectsCreate,
+            Permission::ExternalServicesWrite,
+        ]);
+        let checker = StorageAccessChecker {
+            permissions: BTreeMap::new(),
+            coarse_access: BTreeMap::new(),
+        };
+
+        let denied = authorize_storage_service_scopes(
+            &auth,
+            Some(&checker),
+            &[service_scope(1, Vec::new())],
+        )
+        .await
+        .expect_err("unlinked databases have no trustworthy tenant owner");
+
+        assert_eq!(denied.status_code, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn creator_can_claim_a_new_unlinked_database_for_project_creation() {
+        let auth = custom_api_key(vec![
+            Permission::ProjectsCreate,
+            Permission::ExternalServicesWrite,
+        ]);
+        let checker = StorageAccessChecker {
+            permissions: BTreeMap::new(),
+            coarse_access: BTreeMap::new(),
+        };
+        let owned_scope = ExternalServiceProjectScope {
+            service_id: 1,
+            project_ids: Vec::new(),
+            created_by_user_id: Some(auth.user_id()),
+        };
+
+        let claims = authorize_storage_service_scopes(&auth, Some(&checker), &[owned_scope])
+            .await
+            .expect("creator should receive the one-time bootstrap claim");
+        assert_eq!(claims, vec![1]);
+    }
+
+    #[tokio::test]
+    async fn creator_cannot_bypass_permissions_after_database_is_linked() {
+        let auth = custom_api_key(vec![
+            Permission::ProjectsCreate,
+            Permission::ExternalServicesWrite,
+        ]);
+        let checker = StorageAccessChecker {
+            permissions: BTreeMap::from([(
+                7,
+                Some(vec![Permission::ExternalServicesRead.to_string()]),
+            )]),
+            coarse_access: BTreeMap::new(),
+        };
+        let linked_scope = ExternalServiceProjectScope {
+            service_id: 1,
+            project_ids: vec![7],
+            created_by_user_id: Some(auth.user_id()),
+        };
+
+        let denied = authorize_storage_service_scopes(&auth, Some(&checker), &[linked_scope])
+            .await
+            .expect_err("creator marker must not bypass linked-project permissions");
+        assert_eq!(denied.status_code, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn selected_database_coarse_access_fallback_and_oss_mode_are_supported() {
+        let auth = custom_api_key(vec![
+            Permission::ProjectsCreate,
+            Permission::ExternalServicesWrite,
+        ]);
+        let checker = StorageAccessChecker {
+            permissions: BTreeMap::from([(7, None)]),
+            coarse_access: BTreeMap::from([(7, true)]),
+        };
+        let scopes = [service_scope(1, vec![7])];
+
+        assert!(
+            authorize_storage_service_scopes(&auth, Some(&checker), &scopes)
+                .await
+                .is_ok()
+        );
+        assert!(authorize_storage_service_scopes(&auth, None, &scopes)
+            .await
+            .is_ok());
+    }
+
+    #[test]
+    fn project_creation_handlers_preflight_selected_database_permissions() {
+        let source = include_str!("handlers.rs");
+        for handler_name in ["create_project", "create_project_from_template"] {
+            let start = source
+                .find(&format!("pub async fn {handler_name}"))
+                .expect("project creation handler exists");
+            let tail = &source[start + 1..];
+            let end = tail.find("pub async fn").unwrap_or(tail.len());
+            let body = &source[start..start + 1 + end];
+
+            assert!(body.contains("permission_guard!(auth, ExternalServicesWrite)"));
+            assert!(body.contains("require_storage_services_access"));
+        }
+
+        let template_start = source
+            .find("pub async fn create_project_from_template")
+            .expect("template handler exists");
+        let template_body = &source[template_start..];
+        assert!(
+            template_body
+                .find("require_storage_services_access")
+                .expect("authorization preflight")
+                < template_body
+                    .find("get_template(&request.template_slug)")
+                    .expect("template lookup"),
+            "database authorization must precede template/repository side effects"
+        );
     }
 
     #[test]

--- a/crates/temps-projects/src/handlers/types.rs
+++ b/crates/temps-projects/src/handlers/types.rs
@@ -20,6 +20,7 @@ use temps_presets::preset_config_schema::PresetConfigSchema;
 
 pub struct AppState {
     pub project_service: Arc<ProjectService>,
+    pub external_service_manager: Arc<temps_providers::ExternalServiceManager>,
     pub deployment_canceller: Arc<dyn temps_core::DeploymentCanceller>,
     pub deployment_container_cleaner: Arc<dyn temps_core::DeploymentContainerCleaner>,
     pub custom_domain_service: Arc<CustomDomainService>,

--- a/crates/temps-projects/src/handlers/types.rs
+++ b/crates/temps-projects/src/handlers/types.rs
@@ -1085,7 +1085,7 @@ impl From<ProjectError> for Problem {
 
             err @ (ProjectError::EnvironmentCreationFailed { .. }
             | ProjectError::EnvVarCreationFailed { .. }
-            | ProjectError::StorageLinkFailed { .. }) => {
+            | ProjectError::StorageLinksFailed { .. }) => {
                 problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
                     .with_title("Project Creation Failed")
                     .with_detail(err.to_string())

--- a/crates/temps-projects/src/plugin.rs
+++ b/crates/temps-projects/src/plugin.rs
@@ -74,6 +74,8 @@ impl TempsPlugin for ProjectsPlugin {
 
     fn configure_routes(&self, context: &PluginContext) -> Option<PluginRoutes> {
         let project_service = context.require_service::<ProjectService>();
+        let external_service_manager =
+            context.require_service::<temps_providers::ExternalServiceManager>();
         let deployment_canceller = context.require_service::<dyn temps_core::DeploymentCanceller>();
         let deployment_container_cleaner =
             context.require_service::<dyn temps_core::DeploymentContainerCleaner>();
@@ -93,6 +95,7 @@ impl TempsPlugin for ProjectsPlugin {
         let project_access_checker = context.get_service::<dyn temps_core::ProjectAccessChecker>();
         let app_state = Arc::new(crate::handlers::AppState {
             project_service,
+            external_service_manager,
             deployment_canceller,
             deployment_container_cleaner,
             custom_domain_service,

--- a/crates/temps-projects/src/services/project.rs
+++ b/crates/temps-projects/src/services/project.rs
@@ -711,6 +711,8 @@ impl ProjectService {
                 &project_found_db,
                 request.environment_variables,
                 request.storage_service_ids,
+                request.storage_service_claim_ids,
+                request.storage_service_claim_user_id,
             )
             .await
         {
@@ -983,6 +985,8 @@ impl ProjectService {
         project: &projects::Model,
         environment_variables: Option<Vec<CreateProjectEnvVar>>,
         storage_service_ids: Vec<i32>,
+        storage_service_claim_ids: Vec<i32>,
+        storage_service_claim_user_id: Option<i32>,
     ) -> Result<temps_entities::environments::Model, ProjectError> {
         let default_environment = self
             .environment_service
@@ -1038,8 +1042,16 @@ impl ProjectService {
                 project.id
             );
             for storage_service_id in storage_service_ids {
+                let claim_user_id = storage_service_claim_ids
+                    .contains(&storage_service_id)
+                    .then_some(storage_service_claim_user_id)
+                    .flatten();
                 self.external_service_manager
-                    .link_service_to_project(storage_service_id, project.id)
+                    .link_service_to_project_with_claim(
+                        storage_service_id,
+                        project.id,
+                        claim_user_id,
+                    )
                     .await
                     .map_err(|e| ProjectError::StorageLinkFailed {
                         project_id: project.id,
@@ -4792,6 +4804,8 @@ mod tests {
             exposed_port: None,
             is_public_repo: None,
             storage_service_ids: vec![],
+            storage_service_claim_ids: vec![],
+            storage_service_claim_user_id: None,
             source_type: temps_entities::source_type::SourceType::Git,
             template_slug: None,
         };
@@ -5266,6 +5280,8 @@ mod tests {
             environment_variables: None,
             automatic_deploy: false,
             storage_service_ids: vec![],
+            storage_service_claim_ids: vec![],
+            storage_service_claim_user_id: None,
             is_public_repo: None,
             git_url: None,
             git_provider_connection_id: None,
@@ -5386,6 +5402,8 @@ mod tests {
             exposed_port: None,
             is_public_repo: None,
             storage_service_ids: vec![],
+            storage_service_claim_ids: vec![],
+            storage_service_claim_user_id: None,
             source_type: temps_entities::source_type::SourceType::Git,
             template_slug: None,
         }

--- a/crates/temps-projects/src/services/project.rs
+++ b/crates/temps-projects/src/services/project.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024-2026 Temps Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use temps_core::url_validation::{redact_url_password, validate_git_url};
 use tracing::{error, info, warn};
@@ -1041,24 +1041,22 @@ impl ProjectService {
                 storage_service_ids.len(),
                 project.id
             );
-            for storage_service_id in storage_service_ids {
-                let claim_user_id = storage_service_claim_ids
-                    .contains(&storage_service_id)
-                    .then_some(storage_service_claim_user_id)
-                    .flatten();
-                self.external_service_manager
-                    .link_service_to_project_with_claim(
-                        storage_service_id,
-                        project.id,
-                        claim_user_id,
-                    )
-                    .await
-                    .map_err(|e| ProjectError::StorageLinkFailed {
-                        project_id: project.id,
-                        service_id: storage_service_id,
-                        reason: e.to_string(),
-                    })?;
-            }
+            let claims = storage_service_claim_user_id
+                .map(|user_id| {
+                    storage_service_claim_ids
+                        .into_iter()
+                        .map(|service_id| (service_id, user_id))
+                        .collect::<BTreeMap<_, _>>()
+                })
+                .unwrap_or_default();
+            self.external_service_manager
+                .link_services_to_project_with_claims(&storage_service_ids, project.id, &claims)
+                .await
+                .map_err(|e| ProjectError::StorageLinksFailed {
+                    project_id: project.id,
+                    service_ids: storage_service_ids,
+                    reason: e.to_string(),
+                })?;
         }
 
         Ok(default_environment)

--- a/crates/temps-projects/src/services/types.rs
+++ b/crates/temps-projects/src/services/types.rs
@@ -253,6 +253,12 @@ pub struct CreateProjectRequest {
     pub environment_variables: Option<Vec<CreateProjectEnvVar>>,
     pub automatic_deploy: bool,
     pub storage_service_ids: Vec<i32>,
+    /// Services whose authorization relied on their one-time creator claim.
+    /// Internal only: handlers populate this after access checks.
+    #[serde(default)]
+    pub storage_service_claim_ids: Vec<i32>,
+    #[serde(default)]
+    pub storage_service_claim_user_id: Option<i32>,
     pub is_public_repo: Option<bool>,
     pub git_url: Option<String>,
     pub git_provider_connection_id: Option<i32>,

--- a/crates/temps-projects/src/services/types.rs
+++ b/crates/temps-projects/src/services/types.rs
@@ -328,10 +328,10 @@ pub enum ProjectError {
         reason: String,
     },
 
-    #[error("Failed to link storage service {service_id} to project {project_id}: {reason}")]
-    StorageLinkFailed {
+    #[error("Failed to link storage services {service_ids:?} to project {project_id}: {reason}")]
+    StorageLinksFailed {
         project_id: i32,
-        service_id: i32,
+        service_ids: Vec<i32>,
         reason: String,
     },
 

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -6412,6 +6412,7 @@ mod tests {
             default_backup_provisioned: false,
             ai_data_access: false,
             container_name: None,
+            created_by_user_id: None,
         };
         // Build a MockDatabase for the `pool` slot — restore_pitr for
         // Postgres doesn't touch it in the legacy-reject path.

--- a/crates/temps-providers/src/externalsvc/test_utils.rs
+++ b/crates/temps-providers/src/externalsvc/test_utils.rs
@@ -465,6 +465,7 @@ pub fn create_mock_external_service(
         default_backup_provisioned: false,
         ai_data_access: false,
         container_name: None,
+        created_by_user_id: None,
     }
 }
 

--- a/crates/temps-providers/src/handlers/handlers.rs
+++ b/crates/temps-providers/src/handlers/handlers.rs
@@ -14,7 +14,8 @@ use axum::{
 };
 use temps_auth::RequireAuth;
 use temps_auth::{
-    deny_deployment_token, permission_guard, project_access_guard, project_scope_guard,
+    deny_deployment_token, permission_guard, project_access_guard, project_permission_guard,
+    project_scope_guard,
 };
 use temps_core::{
     error_builder::{
@@ -30,6 +31,7 @@ use super::audit::{
     ExternalServiceClusterMemberRemovedAudit, ExternalServiceCreatedAudit,
     ExternalServiceDeletedAudit, ExternalServiceEnvironmentVariableRevealedAudit,
     ExternalServiceEnvironmentVariablesRevealedAudit, ExternalServiceParameterRevealedAudit,
+    ExternalServiceProjectLinkedAudit, ExternalServiceProjectUnlinkedAudit,
     ExternalServiceRuntimeCredentialsIssuedAudit, ExternalServiceStatusChangedAudit,
     ExternalServiceUpdatedAudit, ServiceHealthChecked,
 };
@@ -558,7 +560,7 @@ async fn create_service(
 
     match app_state
         .external_service_manager
-        .create_service(service_config)
+        .create_service_for_user(service_config, auth.user_id())
         .await
     {
         Ok(service) => {
@@ -830,6 +832,64 @@ async fn require_service_parameter_project_access(
     } else {
         Ok(())
     }
+}
+
+async fn authorize_service_link_source(
+    auth: &temps_auth::AuthContext,
+    scope: &crate::services::ExternalServiceProjectScope,
+    checker: Option<&dyn temps_core::ProjectAccessChecker>,
+) -> Result<Option<i32>, Problem> {
+    if auth.is_admin() || auth.has_role(&temps_auth::Role::PlatformAdmin) {
+        return Ok(None);
+    }
+    let Some(checker) = checker else {
+        return Ok(None);
+    };
+
+    if scope.project_ids.is_empty() {
+        return if scope.created_by_user_id == Some(auth.user_id()) {
+            Ok(Some(auth.user_id()))
+        } else {
+            Err(forbidden()
+                .title("Service Access Denied")
+                .detail("The selected database is not available to this user")
+                .build())
+        };
+    }
+
+    let required = temps_auth::Permission::ExternalServicesWrite.to_string();
+    let mut infrastructure_error = None;
+    for project_id in &scope.project_ids {
+        match checker
+            .effective_project_permissions(auth.user_id(), *project_id)
+            .await
+        {
+            Ok(Some(permissions)) if permissions.contains(&required) => return Ok(None),
+            Ok(Some(_)) => {}
+            Ok(None) => match checker
+                .user_can_access_project(auth.user_id(), *project_id)
+                .await
+            {
+                Ok(true) => return Ok(None),
+                Ok(false) => {}
+                Err(error) => infrastructure_error = Some(error),
+            },
+            Err(error) => infrastructure_error = Some(error),
+        }
+    }
+
+    if let Some(error) = infrastructure_error {
+        error!(service_id = scope.service_id, error = %error, "service link authorization failed closed");
+        return Err(internal_server_error()
+            .title("Service Authorization Failed")
+            .detail("Could not verify access to the selected database")
+            .build());
+    }
+
+    Err(forbidden()
+        .title("Service Access Denied")
+        .detail("Your project role cannot link this database")
+        .build())
 }
 
 fn require_reveal_audit(
@@ -1901,20 +1961,76 @@ async fn link_service_to_project(
     State(app_state): State<Arc<AppState>>,
     Path(id): Path<i32>,
     RequireAuth(auth): RequireAuth,
+    Extension(metadata): Extension<RequestMetadata>,
     Json(request): Json<LinkServiceRequest>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, ExternalServicesWrite);
+    project_permission_guard!(
+        auth,
+        ExternalServicesWrite,
+        request.project_id,
+        app_state.project_access_checker
+    );
+    project_scope_guard!(auth, request.project_id);
+
+    let claim_user_id = if auth.is_deployment_token() {
+        super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
+        None
+    } else {
+        let scope = app_state
+            .external_service_manager
+            .project_scopes_for_services(&[id])
+            .await
+            .map_err(|error| match error {
+                crate::services::ExternalServiceError::ServiceNotFound { .. } => {
+                    not_found().detail("Service not found").build()
+                }
+                _ => internal_server_error()
+                    .detail("Failed to authorize service link")
+                    .build(),
+            })?
+            .into_iter()
+            .next()
+            .ok_or_else(|| not_found().detail("Service not found").build())?;
+        authorize_service_link_source(&auth, &scope, app_state.project_access_checker.as_deref())
+            .await?
+    };
 
     match app_state
         .external_service_manager
-        .link_service_to_project(id, request.project_id)
+        .link_service_to_project_with_claim(id, request.project_id, claim_user_id)
         .await
     {
-        Ok(info) => Ok((StatusCode::CREATED, Json(info))),
-        Err(e) => match e.to_string().as_str() {
-            "Service not found" | "Project not found" => {
+        Ok(info) => {
+            let service_name = app_state
+                .external_service_manager
+                .get_service(id)
+                .await
+                .map(|service| service.name)
+                .unwrap_or_default();
+            let audit = ExternalServiceProjectLinkedAudit {
+                context: AuditContext {
+                    user_id: auth.user_id(),
+                    ip_address: Some(metadata.ip_address.clone()),
+                    user_agent: metadata.user_agent,
+                },
+                service_id: id,
+                service_name,
+                project_id: request.project_id,
+            };
+            if let Err(error) = app_state.audit_service.create_audit_log(&audit).await {
+                error!(service_id = id, project_id = request.project_id, error = %error, "failed to audit service link");
+            }
+            Ok((StatusCode::CREATED, Json(info)))
+        }
+        Err(e) => match e {
+            crate::services::ExternalServiceError::ServiceNotFound { .. }
+            | crate::services::ExternalServiceError::ProjectNotFound { .. } => {
                 Err(not_found().detail(e.to_string()).build())
             }
+            crate::services::ExternalServiceError::ServiceClaimDenied { .. } => Err(forbidden()
+                .title("Service Claim Expired")
+                .detail("This database has already been claimed by another project")
+                .build()),
             _ => Err(internal_server_error()
                 .detail(format!("Failed to link service: {}", e))
                 .build()),
@@ -1941,15 +2057,43 @@ async fn unlink_service_from_project(
     State(app_state): State<Arc<AppState>>,
     Path((id, project_id)): Path<(i32, i32)>,
     RequireAuth(auth): RequireAuth,
+    Extension(metadata): Extension<RequestMetadata>,
 ) -> Result<impl IntoResponse, Problem> {
-    permission_guard!(auth, ExternalServicesWrite);
+    project_permission_guard!(
+        auth,
+        ExternalServicesWrite,
+        project_id,
+        app_state.project_access_checker
+    );
+    project_scope_guard!(auth, project_id);
 
     match app_state
         .external_service_manager
         .unlink_service_from_project(id, project_id)
         .await
     {
-        Ok(_) => Ok(StatusCode::NO_CONTENT),
+        Ok(_) => {
+            let service_name = app_state
+                .external_service_manager
+                .get_service(id)
+                .await
+                .map(|service| service.name)
+                .unwrap_or_default();
+            let audit = ExternalServiceProjectUnlinkedAudit {
+                context: AuditContext {
+                    user_id: auth.user_id(),
+                    ip_address: Some(metadata.ip_address.clone()),
+                    user_agent: metadata.user_agent,
+                },
+                service_id: id,
+                service_name,
+                project_id,
+            };
+            if let Err(error) = app_state.audit_service.create_audit_log(&audit).await {
+                error!(service_id = id, project_id, error = %error, "failed to audit service unlink");
+            }
+            Ok(StatusCode::NO_CONTENT)
+        }
         Err(e) => match e.to_string().as_str() {
             "Service link not found" => Err(not_found().detail(e.to_string()).build()),
             _ => Err(internal_server_error()
@@ -1981,12 +2125,29 @@ async fn list_service_projects(
     Query(pagination): Query<temps_core::PaginationParams>,
 ) -> Result<impl IntoResponse, Problem> {
     permission_guard!(auth, ExternalServicesRead);
+    super::metrics_handlers::assert_service_owned_by_caller(id, &auth, &app_state).await?;
 
     let (page, page_size) = pagination.normalize();
+    let hidden_project_ids = if auth.is_admin() || auth.has_role(&temps_auth::Role::PlatformAdmin) {
+        Vec::new()
+    } else if let Some(checker) = app_state.project_access_checker.as_ref() {
+        checker
+            .hidden_project_ids(auth.user_id())
+            .await
+            .map_err(|error| {
+                error!(service_id = id, error = %error, "failed to filter service projects");
+                internal_server_error()
+                    .detail("Failed to filter service projects")
+                    .build()
+            })?
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
 
     match app_state
         .external_service_manager
-        .list_service_projects_paginated(id, page, page_size)
+        .list_service_projects_paginated(id, page, page_size, &hidden_project_ids)
         .await
     {
         Ok(projects) => Ok((StatusCode::OK, Json(projects))),
@@ -3151,6 +3312,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unlinked_service_creator_gets_one_time_link_claim() {
+        let auth = test_auth_context_with_role(temps_auth::Role::Reader);
+        let checker = TestProjectAccessChecker {
+            allowed_project_ids: Vec::new(),
+            fail: false,
+        };
+        let scope = crate::services::ExternalServiceProjectScope {
+            service_id: 7,
+            project_ids: Vec::new(),
+            created_by_user_id: Some(auth.user_id()),
+        };
+
+        assert_eq!(
+            authorize_service_link_source(&auth, &scope, Some(&checker))
+                .await
+                .expect("creator should be able to claim an unlinked service"),
+            Some(auth.user_id())
+        );
+    }
+
+    #[tokio::test]
+    async fn creator_marker_does_not_bypass_linked_project_access() {
+        let auth = test_auth_context_with_role(temps_auth::Role::Reader);
+        let checker = TestProjectAccessChecker {
+            allowed_project_ids: vec![99],
+            fail: false,
+        };
+        let scope = crate::services::ExternalServiceProjectScope {
+            service_id: 7,
+            project_ids: vec![10],
+            created_by_user_id: Some(auth.user_id()),
+        };
+
+        let problem = authorize_service_link_source(&auth, &scope, Some(&checker))
+            .await
+            .expect_err("creator must use linked-project authorization after first claim");
+        assert_eq!(problem.into_response().status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
     async fn credential_reveal_returns_no_store_response_and_writes_audit() {
         let encryption_service = Arc::new(temps_core::EncryptionService::new_from_password(
             "service-handler-reveal-test",
@@ -3186,6 +3387,7 @@ mod tests {
             default_backup_provisioned: false,
             ai_data_access: false,
             container_name: None,
+            created_by_user_id: None,
         };
         let db = Arc::new(
             MockDatabase::new(sea_orm::DatabaseBackend::Postgres)

--- a/crates/temps-providers/src/handlers/handlers.rs
+++ b/crates/temps-providers/src/handlers/handlers.rs
@@ -201,7 +201,7 @@ async fn import_external_service(
 
     let service = state
         .external_service_manager
-        .import_service(service_request)
+        .import_service_for_user(service_request, auth.user_id())
         .await
         .map_err(|e| {
             error!("Failed to import service: {}", e);
@@ -424,10 +424,18 @@ async fn list_services(
                 .list_services_paginated(page, page_size)
                 .await
         }
-        ExternalServiceListScope::ProjectLinked { hidden_project_ids } => {
+        ExternalServiceListScope::ProjectLinked {
+            hidden_project_ids,
+            creator_user_id,
+        } => {
             app_state
                 .external_service_manager
-                .list_project_accessible_services_paginated(page, page_size, &hidden_project_ids)
+                .list_project_accessible_services_paginated(
+                    page,
+                    page_size,
+                    &hidden_project_ids,
+                    creator_user_id,
+                )
                 .await
         }
     };
@@ -446,7 +454,10 @@ async fn list_services(
 #[derive(Debug, PartialEq, Eq)]
 enum ExternalServiceListScope {
     FleetWide,
-    ProjectLinked { hidden_project_ids: Vec<i32> },
+    ProjectLinked {
+        hidden_project_ids: Vec<i32>,
+        creator_user_id: i32,
+    },
 }
 
 async fn resolve_external_service_list_scope(
@@ -457,16 +468,17 @@ async fn resolve_external_service_list_scope(
         return Ok(ExternalServiceListScope::FleetWide);
     }
 
-    let Some(checker) = checker else {
-        return Ok(ExternalServiceListScope::ProjectLinked {
-            hidden_project_ids: Vec::new(),
-        });
-    };
     let Some(user_id) = auth.user_id_opt() else {
         return Err(forbidden()
             .title("Project Access Denied")
             .detail("Could not resolve caller identity")
             .build());
+    };
+    let Some(checker) = checker else {
+        return Ok(ExternalServiceListScope::ProjectLinked {
+            hidden_project_ids: Vec::new(),
+            creator_user_id: user_id,
+        });
     };
 
     checker
@@ -474,6 +486,7 @@ async fn resolve_external_service_list_scope(
         .await
         .map(|hidden| ExternalServiceListScope::ProjectLinked {
             hidden_project_ids: hidden.unwrap_or_default(),
+            creator_user_id: user_id,
         })
         .map_err(|error| {
             error!(user_id, error = %error, "Failed to resolve external-service list access");
@@ -858,32 +871,69 @@ async fn authorize_service_link_source(
     }
 
     let required = temps_auth::Permission::ExternalServicesWrite.to_string();
-    let mut infrastructure_error = None;
-    for project_id in &scope.project_ids {
-        match checker
-            .effective_project_permissions(auth.user_id(), *project_id)
-            .await
-        {
-            Ok(Some(permissions)) if permissions.contains(&required) => return Ok(None),
-            Ok(Some(_)) => {}
-            Ok(None) => match checker
-                .user_can_access_project(auth.user_id(), *project_id)
-                .await
-            {
-                Ok(true) => return Ok(None),
-                Ok(false) => {}
-                Err(error) => infrastructure_error = Some(error),
-            },
-            Err(error) => infrastructure_error = Some(error),
-        }
-    }
-
-    if let Some(error) = infrastructure_error {
-        error!(service_id = scope.service_id, error = %error, "service link authorization failed closed");
+    let permissions = checker
+        .effective_project_permissions_batch(auth.user_id(), &scope.project_ids)
+        .await
+        .map_err(|error| {
+            error!(service_id = scope.service_id, error = %error, "service link permission resolution failed closed");
+            internal_server_error()
+                .title("Service Authorization Failed")
+                .detail("Could not verify access to the selected database")
+                .build()
+        })?;
+    if scope
+        .project_ids
+        .iter()
+        .any(|project_id| !permissions.contains_key(project_id))
+    {
+        error!(
+            service_id = scope.service_id,
+            project_ids = ?scope.project_ids,
+            "service link permission result omitted a project"
+        );
         return Err(internal_server_error()
             .title("Service Authorization Failed")
             .detail("Could not verify access to the selected database")
             .build());
+    }
+    if permissions.values().any(
+        |permissions| matches!(permissions, Some(permissions) if permissions.contains(&required)),
+    ) {
+        return Ok(None);
+    }
+
+    let fallback_ids = scope
+        .project_ids
+        .iter()
+        .copied()
+        .filter(|project_id| matches!(permissions.get(project_id), Some(None)))
+        .collect::<Vec<_>>();
+    let coarse_access = checker
+        .user_can_access_projects(auth.user_id(), &fallback_ids)
+        .await
+        .map_err(|error| {
+            error!(service_id = scope.service_id, error = %error, "service link membership resolution failed closed");
+            internal_server_error()
+                .title("Service Authorization Failed")
+                .detail("Could not verify access to the selected database")
+                .build()
+        })?;
+    if fallback_ids
+        .iter()
+        .any(|project_id| !coarse_access.contains_key(project_id))
+    {
+        error!(
+            service_id = scope.service_id,
+            project_ids = ?fallback_ids,
+            "service link membership result omitted a project"
+        );
+        return Err(internal_server_error()
+            .title("Service Authorization Failed")
+            .detail("Could not verify access to the selected database")
+            .build());
+    }
+    if coarse_access.values().any(|allowed| *allowed) {
+        return Ok(None);
     }
 
     Err(forbidden()
@@ -1950,7 +2000,10 @@ async fn stop_service(
     request_body = LinkServiceRequest,
     responses(
         (status = 201, description = "Service linked to project successfully", body = ProjectServiceInfo),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Insufficient permission to link this service"),
         (status = 404, description = "Service or project not found"),
+        (status = 409, description = "Project already has a database of this type"),
         (status = 500, description = "Internal server error")
     ),
     params(
@@ -2031,6 +2084,9 @@ async fn link_service_to_project(
                 .title("Service Claim Expired")
                 .detail("This database has already been claimed by another project")
                 .build()),
+            crate::services::ExternalServiceError::DuplicateServiceType { .. } => {
+                Err(conflict().detail(e.to_string()).build())
+            }
             _ => Err(internal_server_error()
                 .detail(format!("Failed to link service: {}", e))
                 .build()),
@@ -2045,6 +2101,8 @@ async fn link_service_to_project(
     tag = "External Services",
     responses(
         (status = 204, description = "Service unlinked from project successfully"),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Insufficient permission to unlink this service"),
         (status = 404, description = "Service link not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -2094,8 +2152,11 @@ async fn unlink_service_from_project(
             }
             Ok(StatusCode::NO_CONTENT)
         }
-        Err(e) => match e.to_string().as_str() {
-            "Service link not found" => Err(not_found().detail(e.to_string()).build()),
+        Err(e) => match e {
+            crate::services::ExternalServiceError::ServiceNotFound { .. }
+            | crate::services::ExternalServiceError::ServiceNotLinkedToProject { .. } => {
+                Err(not_found().detail(e.to_string()).build())
+            }
             _ => Err(internal_server_error()
                 .detail(format!("Failed to unlink service: {}", e))
                 .build()),
@@ -2110,6 +2171,8 @@ async fn unlink_service_from_project(
     tag = "External Services",
     responses(
         (status = 200, description = "List of linked projects", body = Vec<ProjectServiceInfo>),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Insufficient permission to view this service"),
         (status = 404, description = "Service not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -2151,8 +2214,10 @@ async fn list_service_projects(
         .await
     {
         Ok(projects) => Ok((StatusCode::OK, Json(projects))),
-        Err(e) => match e.to_string().as_str() {
-            "Service not found" => Err(not_found().detail("Service not found").build()),
+        Err(e) => match e {
+            crate::services::ExternalServiceError::ServiceNotFound { .. } => {
+                Err(not_found().detail("Service not found").build())
+            }
             _ => Err(internal_server_error()
                 .detail(format!("Failed to list projects: {}", e))
                 .build()),
@@ -3085,6 +3150,58 @@ mod tests {
         calls: Mutex<usize>,
     }
 
+    struct BatchProjectAccessChecker {
+        permission_batch_calls: Mutex<usize>,
+        access_batch_calls: Mutex<usize>,
+    }
+
+    #[async_trait::async_trait]
+    impl temps_core::ProjectAccessChecker for BatchProjectAccessChecker {
+        async fn user_can_access_project(
+            &self,
+            _user_id: i32,
+            _project_id: i32,
+        ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+            panic!("service-link authorization must use the batch access method")
+        }
+
+        async fn user_can_access_projects(
+            &self,
+            _user_id: i32,
+            project_ids: &[i32],
+        ) -> Result<std::collections::BTreeMap<i32, bool>, Box<dyn std::error::Error + Send + Sync>>
+        {
+            *self
+                .access_batch_calls
+                .lock()
+                .expect("access batch counter mutex") += 1;
+            Ok(project_ids
+                .iter()
+                .copied()
+                .map(|project_id| (project_id, project_id == 11))
+                .collect())
+        }
+
+        async fn effective_project_permissions_batch(
+            &self,
+            _user_id: i32,
+            project_ids: &[i32],
+        ) -> Result<
+            std::collections::BTreeMap<i32, Option<Vec<String>>>,
+            Box<dyn std::error::Error + Send + Sync>,
+        > {
+            *self
+                .permission_batch_calls
+                .lock()
+                .expect("permission batch counter mutex") += 1;
+            Ok(project_ids
+                .iter()
+                .copied()
+                .map(|project_id| (project_id, None))
+                .collect())
+        }
+    }
+
     #[async_trait::async_trait]
     impl temps_core::ProjectAccessChecker for ListProjectAccessChecker {
         async fn user_can_access_project(
@@ -3156,7 +3273,8 @@ mod tests {
         assert_eq!(
             scope,
             ExternalServiceListScope::ProjectLinked {
-                hidden_project_ids: vec![10, 11]
+                hidden_project_ids: vec![10, 11],
+                creator_user_id: auth.user_id(),
             }
         );
         assert_eq!(*checker.calls.lock().expect("calls mutex"), 1);
@@ -3349,6 +3467,38 @@ mod tests {
             .await
             .expect_err("creator must use linked-project authorization after first claim");
         assert_eq!(problem.into_response().status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn linked_service_authorization_batches_project_access_checks() {
+        let auth = test_auth_context_with_role(temps_auth::Role::Reader);
+        let checker = BatchProjectAccessChecker {
+            permission_batch_calls: Mutex::new(0),
+            access_batch_calls: Mutex::new(0),
+        };
+        let scope = crate::services::ExternalServiceProjectScope {
+            service_id: 7,
+            project_ids: vec![10, 11],
+            created_by_user_id: None,
+        };
+
+        authorize_service_link_source(&auth, &scope, Some(&checker))
+            .await
+            .expect("coarse access to one linked project should authorize the link");
+        assert_eq!(
+            *checker
+                .permission_batch_calls
+                .lock()
+                .expect("permission batch counter mutex"),
+            1
+        );
+        assert_eq!(
+            *checker
+                .access_batch_calls
+                .lock()
+                .expect("access batch counter mutex"),
+            1
+        );
     }
 
     #[tokio::test]

--- a/crates/temps-providers/src/handlers/metrics_handlers.rs
+++ b/crates/temps-providers/src/handlers/metrics_handlers.rs
@@ -1487,11 +1487,10 @@ fn validate_severity(sev: &str) -> Result<(), Problem> {
 /// permission can fetch metrics for any service ID — including services owned
 /// by other projects/tenants.  This violates row-level access control.
 ///
-/// The check joins `project_services` against the service ID.  If no row
-/// matches, it means either:
-/// - The service does not exist (return 404), or
-/// - The service exists but is not linked to the user's project (return 404
-///   — do not distinguish these cases to avoid leaking service existence).
+/// The check joins `project_services` against the service ID. A session caller
+/// may also access an unlinked service while its authenticated creator marker
+/// belongs to that caller; this is the bootstrap window between creating a
+/// database and selecting it for a project. Linking consumes that marker.
 ///
 /// For deployment tokens, the token's bound `project_id` is checked directly
 /// against `project_services`. For session/API-key/CLI callers there is no
@@ -1545,16 +1544,21 @@ pub(crate) async fn assert_service_owned_by_caller(
     // full project metadata with a `projects` table lookup per linked row,
     // which is unneeded N+1 cost here (only the IDs matter) on a path now
     // shared by every session/API-key/CLI request across 30+ handlers.
-    let service_exists = state
+    let service = state
         .external_service_manager
         .get_service(service_id)
         .await
-        .is_ok();
-    if !service_exists {
-        return Err(not_found()
-            .detail(format!("External service {} not found", service_id))
-            .build());
-    }
+        .map_err(|error| match error {
+            crate::services::ExternalServiceError::ServiceNotFound { .. } => not_found()
+                .detail(format!("External service {} not found", service_id))
+                .build(),
+            error => {
+                tracing::error!(service_id, error = %error, "assert_service_owned: service lookup failed");
+                internal_server_error()
+                    .detail("Failed to verify service ownership")
+                    .build()
+            }
+        })?;
 
     let project_ids: Vec<i32> = project_services::Entity::find()
         .filter(project_services::Column::ServiceId.eq(service_id))
@@ -1570,12 +1574,25 @@ pub(crate) async fn assert_service_owned_by_caller(
         .map(|link| link.project_id)
         .collect();
 
+    if unlinked_service_creator_may_access(auth.user_id(), &project_ids, service.created_by_user_id)
+    {
+        return Ok(());
+    }
+
     session_caller_may_access_linked_projects(
         auth,
         &project_ids,
         state.project_access_checker.as_deref(),
     )
     .await
+}
+
+fn unlinked_service_creator_may_access(
+    user_id: i32,
+    project_ids: &[i32],
+    created_by_user_id: Option<i32>,
+) -> bool {
+    project_ids.is_empty() && created_by_user_id == Some(user_id)
 }
 
 /// Pure authorization decision for the session/API-key/CLI branch of
@@ -1969,6 +1986,14 @@ mod tests {
     // row match), these callers have no single bound project, so ownership
     // is expressed through the `ProjectAccessChecker` EE extension point —
     // a no-op in OSS, real team-based enforcement in EE.
+
+    #[test]
+    fn creator_access_only_applies_while_service_is_unlinked() {
+        assert!(unlinked_service_creator_may_access(42, &[], Some(42)));
+        assert!(!unlinked_service_creator_may_access(42, &[], Some(7)));
+        assert!(!unlinked_service_creator_may_access(42, &[9], Some(42)));
+        assert!(!unlinked_service_creator_may_access(42, &[], None));
+    }
 
     struct TestProjectAccessChecker {
         allowed_project_ids: Vec<i32>,

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -23,11 +23,12 @@ use anyhow::Result;
 use bollard::Docker;
 use chrono::Utc;
 use sea_orm::{
-    sea_query::Expr, ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait,
-    PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Set, TransactionTrait,
+    sea_query::{Expr, LockType},
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter,
+    QueryOrder, QuerySelect, Set, TransactionTrait,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 use temps_entities::{
     external_service_backups, external_service_health_checks, external_services, nodes,
@@ -186,6 +187,9 @@ pub enum ExternalServiceError {
     #[error("Service {service_id} is not linked to project {project_id}")]
     ServiceNotLinkedToProject { service_id: i32, project_id: i32 },
 
+    #[error("Service {service_id} is no longer available to claim")]
+    ServiceClaimDenied { service_id: i32 },
+
     #[error("Project {id} not found")]
     ProjectNotFound { id: i32 },
 
@@ -249,6 +253,26 @@ pub enum ExternalServiceError {
 
     #[error("Internal error: {reason}")]
     InternalError { reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalServiceProjectScope {
+    pub service_id: i32,
+    pub project_ids: Vec<i32>,
+    pub created_by_user_id: Option<i32>,
+}
+
+fn validate_creator_claim(
+    service_id: i32,
+    created_by_user_id: Option<i32>,
+    already_linked: bool,
+    claim_user_id: i32,
+) -> Result<(), ExternalServiceError> {
+    if already_linked || created_by_user_id != Some(claim_user_id) {
+        Err(ExternalServiceError::ServiceClaimDenied { service_id })
+    } else {
+        Ok(())
+    }
 }
 
 impl From<sea_orm::DbErr> for ExternalServiceError {
@@ -1078,6 +1102,59 @@ pub struct ExternalServiceManager {
 }
 
 impl ExternalServiceManager {
+    /// Resolve project links for each requested service in a fixed number of
+    /// queries. Every requested service must exist; unlinked services are
+    /// returned with an empty project list so authorization callers can deny
+    /// them explicitly instead of confusing them with unknown IDs.
+    pub async fn project_scopes_for_services(
+        &self,
+        service_ids: &[i32],
+    ) -> Result<Vec<ExternalServiceProjectScope>, ExternalServiceError> {
+        let unique_ids: BTreeSet<i32> = service_ids.iter().copied().collect();
+        if unique_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let requested_ids: Vec<i32> = unique_ids.iter().copied().collect();
+
+        let existing_services: Vec<(i32, Option<i32>)> = external_services::Entity::find()
+            .select_only()
+            .column(external_services::Column::Id)
+            .column(external_services::Column::CreatedByUserId)
+            .filter(external_services::Column::Id.is_in(requested_ids.clone()))
+            .into_tuple()
+            .all(self.db.as_ref())
+            .await?;
+        let creators_by_service: BTreeMap<i32, Option<i32>> =
+            existing_services.into_iter().collect();
+        let existing_ids: BTreeSet<i32> = creators_by_service.keys().copied().collect();
+        if let Some(id) = unique_ids.difference(&existing_ids).next().copied() {
+            return Err(ExternalServiceError::ServiceNotFound { id });
+        }
+
+        let links = project_services::Entity::find()
+            .filter(project_services::Column::ServiceId.is_in(requested_ids))
+            .all(self.db.as_ref())
+            .await?;
+        let mut projects_by_service: BTreeMap<i32, BTreeSet<i32>> = unique_ids
+            .into_iter()
+            .map(|service_id| (service_id, BTreeSet::new()))
+            .collect();
+        for link in links {
+            if let Some(project_ids) = projects_by_service.get_mut(&link.service_id) {
+                project_ids.insert(link.project_id);
+            }
+        }
+
+        Ok(projects_by_service
+            .into_iter()
+            .map(|(service_id, project_ids)| ExternalServiceProjectScope {
+                service_id,
+                project_ids: project_ids.into_iter().collect(),
+                created_by_user_id: creators_by_service.get(&service_id).copied().flatten(),
+            })
+            .collect())
+    }
+
     /// Construct with all required dependencies. The `DnsRegistry` is
     /// required (not optional) so cluster lifecycle hooks always have a
     /// place to write A records — the historical `Option<DnsRegistry>` +
@@ -1651,6 +1728,23 @@ impl ExternalServiceManager {
         &self,
         request: CreateExternalServiceRequest,
     ) -> Result<ExternalServiceInfo, ExternalServiceError> {
+        self.create_service_with_creator(request, None).await
+    }
+
+    pub async fn create_service_for_user(
+        &self,
+        request: CreateExternalServiceRequest,
+        user_id: i32,
+    ) -> Result<ExternalServiceInfo, ExternalServiceError> {
+        self.create_service_with_creator(request, Some(user_id))
+            .await
+    }
+
+    async fn create_service_with_creator(
+        &self,
+        request: CreateExternalServiceRequest,
+        created_by_user_id: Option<i32>,
+    ) -> Result<ExternalServiceInfo, ExternalServiceError> {
         info!("Creating new external service");
 
         #[allow(deprecated)]
@@ -1769,6 +1863,7 @@ impl ExternalServiceManager {
                         // default stays `false` so existing rows and out-of-band inserts
                         // are unaffected.
                         metrics_enabled: Set(true),
+                        created_by_user_id: Set(created_by_user_id),
                         created_at: Set(Utc::now()),
                         updated_at: Set(Utc::now()),
                         ..Default::default()
@@ -8320,44 +8415,96 @@ echo "[restore] Pre-seed complete"
         service_id_val: i32,
         project_id_val: i32,
     ) -> Result<ProjectServiceInfo, ExternalServiceError> {
-        // Verify service exists and get its type
-        let service = self.get_service(service_id_val).await?;
-        let service_type = service.service_type.clone();
+        self.link_service_to_project_with_claim(service_id_val, project_id_val, None)
+            .await
+    }
 
-        // Verify project exists
-        let _project = projects::Entity::find_by_id(project_id_val)
-            .one(self.db.as_ref())
-            .await?
-            .ok_or(ExternalServiceError::ProjectNotFound { id: project_id_val })?;
+    /// Link a service and atomically consume its one-time creator claim.
+    ///
+    /// `claim_user_id` is supplied only when authorization relied on an
+    /// unlinked service's creator marker. The row lock makes that decision and
+    /// the link insertion one atomic operation: a concurrent request cannot
+    /// reuse the same bootstrap grant, and unlinking later cannot restore it.
+    pub async fn link_service_to_project_with_claim(
+        &self,
+        service_id_val: i32,
+        project_id_val: i32,
+        claim_user_id: Option<i32>,
+    ) -> Result<ProjectServiceInfo, ExternalServiceError> {
+        let link = self
+            .db
+            .transaction::<_, project_services::Model, ExternalServiceError>(|txn| {
+                Box::pin(async move {
+                    let service = external_services::Entity::find_by_id(service_id_val)
+                        .lock(LockType::Update)
+                        .one(txn)
+                        .await?
+                        .ok_or(ExternalServiceError::ServiceNotFound { id: service_id_val })?;
 
-        // Check for duplicate service type
-        // Get all existing project_services for this project
-        let existing_links = project_services::Entity::find()
-            .filter(project_services::Column::ProjectId.eq(project_id_val))
-            .all(self.db.as_ref())
+                    projects::Entity::find_by_id(project_id_val)
+                        .one(txn)
+                        .await?
+                        .ok_or(ExternalServiceError::ProjectNotFound { id: project_id_val })?;
+
+                    if let Some(user_id) = claim_user_id {
+                        let already_linked = project_services::Entity::find()
+                            .filter(project_services::Column::ServiceId.eq(service_id_val))
+                            .one(txn)
+                            .await?
+                            .is_some();
+                        validate_creator_claim(
+                            service_id_val,
+                            service.created_by_user_id,
+                            already_linked,
+                            user_id,
+                        )?;
+                    }
+
+                    let existing_links = project_services::Entity::find()
+                        .filter(project_services::Column::ProjectId.eq(project_id_val))
+                        .all(txn)
+                        .await?;
+                    let existing_service_ids = existing_links
+                        .into_iter()
+                        .map(|link| link.service_id)
+                        .collect::<Vec<_>>();
+                    let duplicate_type_exists = !existing_service_ids.is_empty()
+                        && external_services::Entity::find()
+                            .filter(external_services::Column::Id.is_in(existing_service_ids))
+                            .filter(
+                                external_services::Column::ServiceType
+                                    .eq(service.service_type.clone()),
+                            )
+                            .one(txn)
+                            .await?
+                            .is_some();
+                    if duplicate_type_exists {
+                        return Err(ExternalServiceError::DuplicateServiceType {
+                            project_id: project_id_val,
+                            service_type: service.service_type.clone(),
+                        });
+                    }
+
+                    let link = project_services::ActiveModel {
+                        project_id: Set(project_id_val),
+                        service_id: Set(service_id_val),
+                        created_at: Set(Utc::now()),
+                        updated_at: Set(Utc::now()),
+                        ..Default::default()
+                    }
+                    .insert(txn)
+                    .await?;
+
+                    if service.created_by_user_id.is_some() {
+                        let mut service_update: external_services::ActiveModel = service.into();
+                        service_update.created_by_user_id = Set(None);
+                        service_update.update(txn).await?;
+                    }
+
+                    Ok(link)
+                })
+            })
             .await?;
-
-        // Check if any existing service has the same type
-        for existing_link in existing_links {
-            let existing_service = self.get_service(existing_link.service_id).await?;
-            if existing_service.service_type == service_type {
-                return Err(ExternalServiceError::DuplicateServiceType {
-                    project_id: project_id_val,
-                    service_type,
-                });
-            }
-        }
-
-        // Create link
-        let new_link = project_services::ActiveModel {
-            project_id: Set(project_id_val),
-            service_id: Set(service_id_val),
-            created_at: Set(Utc::now()),
-            updated_at: Set(Utc::now()),
-            ..Default::default()
-        };
-
-        let link = new_link.insert(self.db.as_ref()).await?;
         let service_info = self.get_service_info(service_id_val).await?;
 
         // Fetch project metadata
@@ -9042,40 +9189,44 @@ echo "[restore] Pre-seed complete"
         service_id_val: i32,
         page: u64,
         page_size: u64,
+        hidden_project_ids: &[i32],
     ) -> Result<Vec<ProjectServiceInfo>, ExternalServiceError> {
         // Verify service exists and get service info
         let service_info = self.get_service_info(service_id_val).await?;
 
-        // Get paginated project links for this service
-        let links = project_services::Entity::find()
-            .filter(project_services::Column::ServiceId.eq(service_id_val))
+        // Filter hidden projects before pagination so authorized callers get a
+        // full page without exposing tenant metadata or producing sparse pages.
+        let mut query = project_services::Entity::find()
+            .filter(project_services::Column::ServiceId.eq(service_id_val));
+        if !hidden_project_ids.is_empty() {
+            query = query.filter(
+                project_services::Column::ProjectId.is_not_in(hidden_project_ids.iter().copied()),
+            );
+        }
+        let links = query
+            .find_also_related(projects::Entity)
             .order_by_desc(project_services::Column::Id)
             .paginate(self.db.as_ref(), page_size)
             .fetch_page(page - 1)
             .await?;
 
-        // Convert to ProjectServiceInfo with project metadata
-        let mut project_services_list = Vec::new();
-        for link in links {
-            let project = projects::Entity::find_by_id(link.project_id)
-                .one(self.db.as_ref())
-                .await?
-                .ok_or(ExternalServiceError::ProjectNotFound {
+        links
+            .into_iter()
+            .map(|(link, project)| {
+                let project = project.ok_or(ExternalServiceError::ProjectNotFound {
                     id: link.project_id,
                 })?;
-
-            project_services_list.push(ProjectServiceInfo {
-                id: link.id,
-                project: ProjectInfo {
-                    id: project.id,
-                    slug: project.slug,
-                    created_at: project.created_at.to_rfc3339(),
-                },
-                service: service_info.clone(),
-            });
-        }
-
-        Ok(project_services_list)
+                Ok(ProjectServiceInfo {
+                    id: link.id,
+                    project: ProjectInfo {
+                        id: project.id,
+                        slug: project.slug,
+                        created_at: project.created_at.to_rfc3339(),
+                    },
+                    service: service_info.clone(),
+                })
+            })
+            .collect()
     }
 
     pub async fn list_project_services(
@@ -11016,6 +11167,23 @@ async fn precreate_cluster_members(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn creator_claim_is_one_time_and_cannot_reappear_after_unlink() {
+        assert!(validate_creator_claim(7, Some(42), false, 42).is_ok());
+        assert!(matches!(
+            validate_creator_claim(7, Some(42), true, 42),
+            Err(ExternalServiceError::ServiceClaimDenied { service_id: 7 })
+        ));
+        assert!(matches!(
+            validate_creator_claim(7, None, false, 42),
+            Err(ExternalServiceError::ServiceClaimDenied { service_id: 7 })
+        ));
+        assert!(matches!(
+            validate_creator_claim(7, Some(99), false, 42),
+            Err(ExternalServiceError::ServiceClaimDenied { service_id: 7 })
+        ));
+    }
 
     // ── Cluster write availability ──────────────────────────────────────
 
@@ -13147,6 +13315,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn project_scopes_for_services_are_complete_deduplicated_and_sorted() {
+        let service_a = encrypted_service_model(17, serde_json::json!({}));
+        let mut service_b = encrypted_service_model(23, serde_json::json!({}));
+        service_b.created_by_user_id = Some(42);
+        let now = Utc::now();
+        let links = vec![
+            project_services::Model {
+                id: 1,
+                project_id: 9,
+                service_id: 17,
+                created_at: now,
+                updated_at: now,
+            },
+            project_services::Model {
+                id: 2,
+                project_id: 4,
+                service_id: 17,
+                created_at: now,
+                updated_at: now,
+            },
+        ];
+        let manager = mock_service_manager_with_db(Arc::new(
+            sea_orm::MockDatabase::new(sea_orm::DatabaseBackend::Postgres)
+                .append_query_results([vec![service_b, service_a]])
+                .append_query_results([links])
+                .into_connection(),
+        ));
+
+        let scopes = manager
+            .project_scopes_for_services(&[23, 17, 17])
+            .await
+            .expect("service scopes should resolve");
+
+        assert_eq!(
+            scopes,
+            vec![
+                ExternalServiceProjectScope {
+                    service_id: 17,
+                    project_ids: vec![4, 9],
+                    created_by_user_id: None,
+                },
+                ExternalServiceProjectScope {
+                    service_id: 23,
+                    project_ids: Vec::new(),
+                    created_by_user_id: Some(42),
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn project_scopes_for_services_reject_unknown_ids() {
+        let manager = mock_service_manager(vec![Vec::new()]);
+
+        let error = manager
+            .project_scopes_for_services(&[404])
+            .await
+            .expect_err("unknown services must not be returned as ownerless");
+
+        assert!(matches!(
+            error,
+            ExternalServiceError::ServiceNotFound { id: 404 }
+        ));
+    }
+
+    #[tokio::test]
     async fn project_accessible_service_list_filters_links_before_pagination() {
         let model = encrypted_service_model(17, serde_json::json!({}));
         let db = Arc::new(
@@ -13243,6 +13477,7 @@ mod tests {
             default_backup_provisioned: false,
             ai_data_access: false,
             container_name: None,
+            created_by_user_id: None,
         }
     }
 

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -24,8 +24,8 @@ use bollard::Docker;
 use chrono::Utc;
 use sea_orm::{
     sea_query::{Expr, LockType},
-    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter,
-    QueryOrder, QuerySelect, Set, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, Condition, DatabaseConnection, EntityTrait, PaginatorTrait,
+    QueryFilter, QueryOrder, QuerySelect, Set, TransactionTrait,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -1116,16 +1116,14 @@ impl ExternalServiceManager {
         }
         let requested_ids: Vec<i32> = unique_ids.iter().copied().collect();
 
-        let existing_services: Vec<(i32, Option<i32>)> = external_services::Entity::find()
-            .select_only()
-            .column(external_services::Column::Id)
-            .column(external_services::Column::CreatedByUserId)
+        let existing_services = external_services::Entity::find()
             .filter(external_services::Column::Id.is_in(requested_ids.clone()))
-            .into_tuple()
             .all(self.db.as_ref())
             .await?;
-        let creators_by_service: BTreeMap<i32, Option<i32>> =
-            existing_services.into_iter().collect();
+        let creators_by_service: BTreeMap<i32, Option<i32>> = existing_services
+            .into_iter()
+            .map(|service| (service.id, service.created_by_user_id))
+            .collect();
         let existing_ids: BTreeSet<i32> = creators_by_service.keys().copied().collect();
         if let Some(id) = unique_ids.difference(&existing_ids).next().copied() {
             return Err(ExternalServiceError::ServiceNotFound { id });
@@ -2147,29 +2145,40 @@ impl ExternalServiceManager {
         Ok(result)
     }
 
-    /// List services linked to at least one project visible to the caller.
+    /// List services linked to at least one project visible to the caller, plus
+    /// services the caller has just created but has not linked yet.
     ///
     /// `hidden_project_ids` comes from the registered `ProjectAccessChecker`.
-    /// The join deliberately excludes unlinked services and applies the access
-    /// filter before pagination, so restricted callers cannot enumerate a
-    /// service through sparse or misleading pages. `DISTINCT` prevents a
-    /// service linked to multiple visible projects from appearing twice.
+    /// The left join and creator condition apply access filtering before
+    /// pagination, so restricted callers cannot enumerate another user's
+    /// unlinked service or receive sparse/misleading pages. `DISTINCT` prevents
+    /// a service linked to multiple visible projects from appearing twice.
     pub async fn list_project_accessible_services_paginated(
         &self,
         page: u64,
         page_size: u64,
         hidden_project_ids: &[i32],
+        creator_user_id: i32,
     ) -> Result<Vec<ExternalServiceInfo>, ExternalServiceError> {
-        let mut query = external_services::Entity::find()
-            .inner_join(project_services::Entity)
+        let linked_to_visible_project = if hidden_project_ids.is_empty() {
+            Condition::all().add(project_services::Column::ServiceId.is_not_null())
+        } else {
+            Condition::all().add(
+                project_services::Column::ProjectId.is_not_in(hidden_project_ids.iter().copied()),
+            )
+        };
+        let creator_owned_and_unlinked = Condition::all()
+            .add(external_services::Column::CreatedByUserId.eq(creator_user_id))
+            .add(project_services::Column::ServiceId.is_null());
+        let query = external_services::Entity::find()
+            .left_join(project_services::Entity)
+            .filter(
+                Condition::any()
+                    .add(linked_to_visible_project)
+                    .add(creator_owned_and_unlinked),
+            )
             .distinct()
             .order_by_desc(external_services::Column::CreatedAt);
-
-        if !hidden_project_ids.is_empty() {
-            query = query.filter(
-                project_services::Column::ProjectId.is_not_in(hidden_project_ids.iter().copied()),
-            );
-        }
 
         let services = query
             .paginate(self.db.as_ref(), page_size)
@@ -8431,80 +8440,20 @@ echo "[restore] Pre-seed complete"
         project_id_val: i32,
         claim_user_id: Option<i32>,
     ) -> Result<ProjectServiceInfo, ExternalServiceError> {
-        let link = self
-            .db
-            .transaction::<_, project_services::Model, ExternalServiceError>(|txn| {
-                Box::pin(async move {
-                    let service = external_services::Entity::find_by_id(service_id_val)
-                        .lock(LockType::Update)
-                        .one(txn)
-                        .await?
-                        .ok_or(ExternalServiceError::ServiceNotFound { id: service_id_val })?;
-
-                    projects::Entity::find_by_id(project_id_val)
-                        .one(txn)
-                        .await?
-                        .ok_or(ExternalServiceError::ProjectNotFound { id: project_id_val })?;
-
-                    if let Some(user_id) = claim_user_id {
-                        let already_linked = project_services::Entity::find()
-                            .filter(project_services::Column::ServiceId.eq(service_id_val))
-                            .one(txn)
-                            .await?
-                            .is_some();
-                        validate_creator_claim(
-                            service_id_val,
-                            service.created_by_user_id,
-                            already_linked,
-                            user_id,
-                        )?;
-                    }
-
-                    let existing_links = project_services::Entity::find()
-                        .filter(project_services::Column::ProjectId.eq(project_id_val))
-                        .all(txn)
-                        .await?;
-                    let existing_service_ids = existing_links
-                        .into_iter()
-                        .map(|link| link.service_id)
-                        .collect::<Vec<_>>();
-                    let duplicate_type_exists = !existing_service_ids.is_empty()
-                        && external_services::Entity::find()
-                            .filter(external_services::Column::Id.is_in(existing_service_ids))
-                            .filter(
-                                external_services::Column::ServiceType
-                                    .eq(service.service_type.clone()),
-                            )
-                            .one(txn)
-                            .await?
-                            .is_some();
-                    if duplicate_type_exists {
-                        return Err(ExternalServiceError::DuplicateServiceType {
-                            project_id: project_id_val,
-                            service_type: service.service_type.clone(),
-                        });
-                    }
-
-                    let link = project_services::ActiveModel {
-                        project_id: Set(project_id_val),
-                        service_id: Set(service_id_val),
-                        created_at: Set(Utc::now()),
-                        updated_at: Set(Utc::now()),
-                        ..Default::default()
-                    }
-                    .insert(txn)
-                    .await?;
-
-                    if service.created_by_user_id.is_some() {
-                        let mut service_update: external_services::ActiveModel = service.into();
-                        service_update.created_by_user_id = Set(None);
-                        service_update.update(txn).await?;
-                    }
-
-                    Ok(link)
-                })
-            })
+        let claims = claim_user_id
+            .map(|user_id| BTreeMap::from([(service_id_val, user_id)]))
+            .unwrap_or_default();
+        let mut links = self
+            .link_services_to_project_transactionally(&[service_id_val], project_id_val, &claims)
             .await?;
+        let link = links
+            .pop()
+            .ok_or_else(|| ExternalServiceError::InternalError {
+                reason: format!(
+                    "linking service {} to project {} produced no link",
+                    service_id_val, project_id_val
+                ),
+            })?;
         let service_info = self.get_service_info(service_id_val).await?;
 
         // Fetch project metadata
@@ -8524,6 +8473,141 @@ echo "[restore] Pre-seed complete"
             },
             service: service_info,
         })
+    }
+
+    /// Link every selected service and consume creator claims in one transaction.
+    ///
+    /// Project creation uses this bulk operation so a validation or insert failure
+    /// for a later database cannot leave an earlier database unlinked with its
+    /// one-time creator claim already consumed.
+    pub async fn link_services_to_project_with_claims(
+        &self,
+        service_ids: &[i32],
+        project_id: i32,
+        claims: &BTreeMap<i32, i32>,
+    ) -> Result<(), ExternalServiceError> {
+        self.link_services_to_project_transactionally(service_ids, project_id, claims)
+            .await?;
+        Ok(())
+    }
+
+    async fn link_services_to_project_transactionally(
+        &self,
+        service_ids: &[i32],
+        project_id: i32,
+        claims: &BTreeMap<i32, i32>,
+    ) -> Result<Vec<project_services::Model>, ExternalServiceError> {
+        let mut ordered_service_ids = service_ids.to_vec();
+        ordered_service_ids.sort_unstable();
+        ordered_service_ids.dedup();
+        if ordered_service_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let claims = claims.clone();
+        self.db
+            .transaction::<_, Vec<project_services::Model>, ExternalServiceError>(|txn| {
+                Box::pin(async move {
+                    let services = external_services::Entity::find()
+                        .filter(external_services::Column::Id.is_in(ordered_service_ids.clone()))
+                        .order_by_asc(external_services::Column::Id)
+                        .lock(LockType::Update)
+                        .all(txn)
+                        .await?;
+                    if services.len() != ordered_service_ids.len() {
+                        let found_ids = services
+                            .iter()
+                            .map(|service| service.id)
+                            .collect::<BTreeSet<_>>();
+                        let missing_id = ordered_service_ids
+                            .iter()
+                            .find(|service_id| !found_ids.contains(service_id))
+                            .copied()
+                            .unwrap_or_default();
+                        return Err(ExternalServiceError::ServiceNotFound { id: missing_id });
+                    }
+
+                    projects::Entity::find_by_id(project_id)
+                        .lock(LockType::Update)
+                        .one(txn)
+                        .await?
+                        .ok_or(ExternalServiceError::ProjectNotFound { id: project_id })?;
+
+                    let selected_links = project_services::Entity::find()
+                        .filter(
+                            project_services::Column::ServiceId.is_in(ordered_service_ids.clone()),
+                        )
+                        .all(txn)
+                        .await?;
+                    let already_linked_ids = selected_links
+                        .iter()
+                        .map(|link| link.service_id)
+                        .collect::<BTreeSet<_>>();
+                    for service in &services {
+                        if let Some(user_id) = claims.get(&service.id) {
+                            validate_creator_claim(
+                                service.id,
+                                service.created_by_user_id,
+                                already_linked_ids.contains(&service.id),
+                                *user_id,
+                            )?;
+                        }
+                    }
+
+                    let existing_links = project_services::Entity::find()
+                        .filter(project_services::Column::ProjectId.eq(project_id))
+                        .all(txn)
+                        .await?;
+                    let existing_service_ids = existing_links
+                        .into_iter()
+                        .map(|link| link.service_id)
+                        .collect::<Vec<_>>();
+                    let mut linked_service_types = if existing_service_ids.is_empty() {
+                        BTreeSet::new()
+                    } else {
+                        external_services::Entity::find()
+                            .filter(external_services::Column::Id.is_in(existing_service_ids))
+                            .all(txn)
+                            .await?
+                            .into_iter()
+                            .map(|service| service.service_type)
+                            .collect::<BTreeSet<_>>()
+                    };
+                    for service in &services {
+                        if !linked_service_types.insert(service.service_type.clone()) {
+                            return Err(ExternalServiceError::DuplicateServiceType {
+                                project_id,
+                                service_type: service.service_type.clone(),
+                            });
+                        }
+                    }
+
+                    let now = Utc::now();
+                    let mut links = Vec::with_capacity(services.len());
+                    for service in services {
+                        let link = project_services::ActiveModel {
+                            project_id: Set(project_id),
+                            service_id: Set(service.id),
+                            created_at: Set(now),
+                            updated_at: Set(now),
+                            ..Default::default()
+                        }
+                        .insert(txn)
+                        .await?;
+                        links.push(link);
+
+                        if service.created_by_user_id.is_some() {
+                            let mut service_update: external_services::ActiveModel = service.into();
+                            service_update.created_by_user_id = Set(None);
+                            service_update.update(txn).await?;
+                        }
+                    }
+
+                    Ok(links)
+                })
+            })
+            .await
+            .map_err(ExternalServiceError::from)
     }
 
     pub async fn get_service_environment_variables(
@@ -9984,6 +10068,25 @@ echo "[restore] Pre-seed complete"
         &self,
         request: ImportExternalServiceRequest,
     ) -> Result<ExternalServiceInfo> {
+        self.import_service_with_creator(request, None).await
+    }
+
+    /// Import a service on behalf of an authenticated user, preserving the
+    /// same one-time pre-link ownership semantics as newly provisioned services.
+    pub async fn import_service_for_user(
+        &self,
+        request: ImportExternalServiceRequest,
+        user_id: i32,
+    ) -> Result<ExternalServiceInfo> {
+        self.import_service_with_creator(request, Some(user_id))
+            .await
+    }
+
+    async fn import_service_with_creator(
+        &self,
+        request: ImportExternalServiceRequest,
+        created_by_user_id: Option<i32>,
+    ) -> Result<ExternalServiceInfo> {
         // Get the service-specific implementation based on Docker inspection
         let container = self
             .docker
@@ -10186,6 +10289,7 @@ echo "[restore] Pre-seed complete"
             status: Set("running".to_string()),
             config: Set(Some(encrypted_config)),
             container_name: Set(imported_container_name),
+            created_by_user_id: Set(created_by_user_id),
             ..Default::default()
         }
         .insert(self.db.as_ref())
@@ -13394,7 +13498,7 @@ mod tests {
         let manager = mock_service_manager_with_db(db.clone());
 
         let services = manager
-            .list_project_accessible_services_paginated(1, 25, &[10, 11])
+            .list_project_accessible_services_paginated(1, 25, &[10, 11], 42)
             .await
             .expect("project-scoped external-service list should succeed");
         assert_eq!(services.len(), 1);
@@ -13405,19 +13509,24 @@ mod tests {
         let log = db.into_transaction_log();
         let list_sql = &log[0].statements()[0].sql;
         assert!(
-            list_sql.contains("INNER JOIN \"project_services\""),
-            "unlinked services must be excluded by the database query: {list_sql}"
+            list_sql.contains("LEFT JOIN \"project_services\""),
+            "creator-owned unlinked services require a left join: {list_sql}"
         );
         assert!(
             list_sql.contains("\"project_services\".\"project_id\" NOT IN ($1, $2)"),
             "hidden projects must be excluded before pagination: {list_sql}"
         );
         assert!(
+            list_sql.contains("\"external_services\".\"created_by_user_id\" = $3")
+                && list_sql.contains("\"project_services\".\"service_id\" IS NULL"),
+            "only the caller's unlinked services may supplement visible links: {list_sql}"
+        );
+        assert!(
             list_sql.contains("SELECT DISTINCT"),
             "services linked to multiple accessible projects must be deduplicated: {list_sql}"
         );
         assert!(
-            list_sql.contains("LIMIT $3 OFFSET $4"),
+            list_sql.contains("LIMIT $4 OFFSET $5"),
             "access filtering must be part of the paginated query: {list_sql}"
         );
     }
@@ -14130,6 +14239,94 @@ mod tests {
 
         // Cleanup
         let _ = manager.delete_service(service_id).await;
+    }
+
+    #[cfg(feature = "docker-tests")]
+    #[tokio::test]
+    async fn bulk_link_failure_preserves_every_creator_claim() {
+        use temps_entities::preset::Preset;
+        use temps_entities::users;
+
+        let (manager, test_db) = setup_test_manager_or_skip!();
+        let now = Utc::now();
+        let user = users::ActiveModel {
+            name: Set("Database Creator".to_string()),
+            email: Set(format!(
+                "bulk-link-creator-{}@test.local",
+                now.timestamp_nanos_opt().unwrap_or(0)
+            )),
+            email_verified: Set(true),
+            mfa_enabled: Set(false),
+            created_at: Set(now),
+            updated_at: Set(now),
+            ..Default::default()
+        }
+        .insert(test_db.db.as_ref())
+        .await
+        .expect("insert creator");
+        let project = projects::ActiveModel {
+            name: Set("atomic database links".to_string()),
+            preset: Set(Preset::Static),
+            slug: Set(format!("atomic-database-links-{}", now.timestamp_millis())),
+            directory: Set(".".to_string()),
+            main_branch: Set("main".to_string()),
+            repo_name: Set("test-repo".to_string()),
+            repo_owner: Set("test-owner".to_string()),
+            ..Default::default()
+        }
+        .insert(test_db.db.as_ref())
+        .await
+        .expect("insert project");
+
+        let mut service_ids = Vec::new();
+        for suffix in ["one", "two"] {
+            let service = external_services::ActiveModel {
+                name: Set(format!("atomic-postgres-{suffix}")),
+                service_type: Set("postgres".to_string()),
+                version: Set(Some("17".to_string())),
+                status: Set("creating".to_string()),
+                slug: Set(Some(format!("atomic-postgres-{suffix}"))),
+                created_by_user_id: Set(Some(user.id)),
+                created_at: Set(now),
+                updated_at: Set(now),
+                ..Default::default()
+            }
+            .insert(test_db.db.as_ref())
+            .await
+            .expect("insert claimed service");
+            service_ids.push(service.id);
+        }
+        let claims = service_ids
+            .iter()
+            .copied()
+            .map(|service_id| (service_id, user.id))
+            .collect::<BTreeMap<_, _>>();
+
+        let error = manager
+            .link_services_to_project_with_claims(&service_ids, project.id, &claims)
+            .await
+            .expect_err("duplicate database types must reject the whole bulk link");
+        assert!(matches!(
+            error,
+            ExternalServiceError::DuplicateServiceType { .. }
+        ));
+
+        let links = project_services::Entity::find()
+            .filter(project_services::Column::ProjectId.eq(project.id))
+            .all(test_db.db.as_ref())
+            .await
+            .expect("query project links");
+        assert!(links.is_empty(), "a failed bulk link must create no links");
+
+        let services = external_services::Entity::find()
+            .filter(external_services::Column::Id.is_in(service_ids))
+            .all(test_db.db.as_ref())
+            .await
+            .expect("query claimed services");
+        assert_eq!(services.len(), 2);
+        assert!(services
+            .iter()
+            .all(|service| service.created_by_user_id == Some(user.id)));
     }
 
     #[cfg(feature = "docker-tests")]

--- a/crates/temps-proxy/src/proxy.rs
+++ b/crates/temps-proxy/src/proxy.rs
@@ -462,6 +462,16 @@ fn deployment_asset_scope(
         .flatten()
 }
 
+fn legacy_deployment_asset_scope(
+    current_deployment_slug: &str,
+    origin: &crate::service::static_asset_lookup::LegacyAssetOrigin,
+    requested_deployment_slug: &str,
+) -> Option<(i32, i32)> {
+    (requested_deployment_slug == current_deployment_slug
+        || requested_deployment_slug == origin.slug)
+        .then_some((origin.environment_id, origin.deployment_id))
+}
+
 fn inherited_https_policy(production_https: bool, host_has_cert: bool) -> bool {
     production_https || host_has_cert
 }
@@ -502,9 +512,10 @@ fn should_apply_production_https_default(
 #[cfg(test)]
 mod deployment_asset_scope_tests {
     use super::{
-        deployment_asset_scope, inherited_https_policy, should_apply_production_https_default,
-        should_redirect_to_https,
+        deployment_asset_scope, inherited_https_policy, legacy_deployment_asset_scope,
+        should_apply_production_https_default, should_redirect_to_https,
     };
+    use crate::service::static_asset_lookup::LegacyAssetOrigin;
 
     #[test]
     fn prefixed_asset_resolves_current_or_reused_source_artifact() {
@@ -534,6 +545,28 @@ mod deployment_asset_scope_tests {
                 Some(20),
                 "unknown",
             ),
+            None
+        );
+    }
+
+    #[test]
+    fn legacy_prefixed_asset_maps_both_old_current_and_original_slugs_to_origin() {
+        let origin = LegacyAssetOrigin {
+            deployment_id: 10,
+            environment_id: 20,
+            slug: "original-build".to_string(),
+        };
+
+        assert_eq!(
+            legacy_deployment_asset_scope("legacy-promotion", &origin, "legacy-promotion"),
+            Some((20, 10))
+        );
+        assert_eq!(
+            legacy_deployment_asset_scope("legacy-promotion", &origin, "original-build"),
+            Some((20, 10))
+        );
+        assert_eq!(
+            legacy_deployment_asset_scope("legacy-promotion", &origin, "unrelated"),
             None
         );
     }
@@ -5065,26 +5098,50 @@ impl ProxyHttp for LoadBalancer {
             if let Some(slash_pos) = after_prefix.find('/') {
                 let deployment_slug = &after_prefix[..slash_pos];
                 let asset_path = after_prefix[slash_pos + 1..].to_string();
-                let asset_scope = ctx.deployment.as_ref().and_then(|deployment| {
+                let mut legacy_source = None;
+                let mut legacy_current_slug = None;
+                let mut asset_scope = ctx.deployment.as_ref().and_then(|deployment| {
                     let context = deployment.context_vars.as_ref();
+                    let source_slug = context
+                        .and_then(|value| value.get("source_deployment_slug"))
+                        .and_then(serde_json::Value::as_str);
+                    let source_deployment_id = context
+                        .and_then(|value| value.get("source_deployment_id"))
+                        .and_then(serde_json::Value::as_i64)
+                        .and_then(|value| i32::try_from(value).ok());
+                    if source_slug.is_none() {
+                        legacy_source = source_deployment_id;
+                        legacy_current_slug = Some(deployment.slug.clone());
+                    }
                     deployment_asset_scope(
                         &deployment.slug,
                         deployment.environment_id,
                         deployment.id,
-                        context
-                            .and_then(|value| value.get("source_deployment_slug"))
-                            .and_then(serde_json::Value::as_str),
+                        source_slug,
                         context
                             .and_then(|value| value.get("source_environment_id"))
                             .and_then(serde_json::Value::as_i64)
                             .and_then(|value| i32::try_from(value).ok()),
-                        context
-                            .and_then(|value| value.get("source_deployment_id"))
-                            .and_then(serde_json::Value::as_i64)
-                            .and_then(|value| i32::try_from(value).ok()),
+                        source_deployment_id,
                         deployment_slug,
                     )
                 });
+                if let (Some(project_id), Some(source_deployment_id)) = (
+                    ctx.project.as_ref().map(|project| project.id),
+                    legacy_source,
+                ) {
+                    if let Some(origin) = self
+                        .static_asset_lookup
+                        .resolve_legacy_asset_origin(project_id, source_deployment_id)
+                        .await
+                    {
+                        asset_scope = legacy_deployment_asset_scope(
+                            legacy_current_slug.as_deref().unwrap_or_default(),
+                            &origin,
+                            deployment_slug,
+                        );
+                    }
+                }
                 if Self::is_cacheable_static_asset(&asset_path) {
                     if let Some(asset_scope) = asset_scope {
                         if let Ok(true) = self

--- a/crates/temps-proxy/src/service/static_asset_lookup.rs
+++ b/crates/temps-proxy/src/service/static_asset_lookup.rs
@@ -4,11 +4,12 @@
 use moka::future::Cache;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use sha2::{Digest, Sha256};
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 use temps_core::static_files::MAX_STATIC_ASSET_URL_PATH_BYTES;
 use temps_database::DbConnection;
-use temps_entities::static_asset_cache;
+use temps_entities::{deployments, static_asset_cache};
 use tokio::sync::Semaphore;
 use tracing::debug;
 
@@ -51,6 +52,19 @@ struct StaticAssetCacheKey {
     environment_id: i32,
     deployment_id: i32,
     url_path_digest: [u8; 32],
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+struct LegacyAssetOriginCacheKey {
+    project_id: i32,
+    source_deployment_id: i32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LegacyAssetOrigin {
+    pub deployment_id: i32,
+    pub environment_id: i32,
+    pub slug: String,
 }
 
 impl StaticAssetCacheKey {
@@ -98,6 +112,9 @@ pub struct StaticAssetLookup {
     db: Arc<DbConnection>,
     /// `(project_id, environment_id, deployment_id, url_path) → asset metadata`.
     cache: Cache<StaticAssetCacheKey, Option<StaticAssetMetadata>>,
+    /// Legacy reuse rows omitted the source slug. Cache the resolved immutable
+    /// build origin so compatibility never adds an uncached query per asset.
+    legacy_origin_cache: Cache<LegacyAssetOriginCacheKey, Option<LegacyAssetOrigin>>,
     db_lookup_slots: Arc<Semaphore>,
 }
 
@@ -122,11 +139,101 @@ impl StaticAssetLookup {
             .max_capacity(ASSET_STORE_CACHE_MAX_CAPACITY)
             .time_to_live(ttl)
             .build();
+        let legacy_origin_cache = Cache::builder()
+            .max_capacity(ASSET_STORE_CACHE_MAX_CAPACITY)
+            .time_to_live(ttl)
+            .build();
         Self {
             db,
             cache,
+            legacy_origin_cache,
             db_lookup_slots: Arc::new(Semaphore::new(max_concurrent_db_lookups)),
         }
+    }
+
+    /// Resolve the immutable build behind pre-source-slug promotion and
+    /// rollback metadata. Results (including missing/cyclic metadata) are
+    /// cached and project-scoped to prevent cross-project ID traversal.
+    pub async fn resolve_legacy_asset_origin(
+        &self,
+        project_id: i32,
+        source_deployment_id: i32,
+    ) -> Option<LegacyAssetOrigin> {
+        let key = LegacyAssetOriginCacheKey {
+            project_id,
+            source_deployment_id,
+        };
+        if let Some(cached) = self.legacy_origin_cache.get(&key).await {
+            return cached;
+        }
+
+        let db = self.db.clone();
+        let db_lookup_slots = self.db_lookup_slots.clone();
+        self.legacy_origin_cache
+            .try_get_with(key, async move {
+                let _permit = db_lookup_slots
+                    .try_acquire_owned()
+                    .map_err(|_| AssetStoreLookupSaturated)?;
+                let mut current_id = source_deployment_id;
+                let mut visited = HashSet::new();
+
+                loop {
+                    if !visited.insert(current_id) {
+                        return Ok::<Option<LegacyAssetOrigin>, AssetStoreLookupSaturated>(None);
+                    }
+                    let Some(deployment) = deployments::Entity::find_by_id(current_id)
+                        .filter(deployments::Column::ProjectId.eq(project_id))
+                        .one(db.as_ref())
+                        .await
+                        .ok()
+                        .flatten()
+                    else {
+                        return Ok::<Option<LegacyAssetOrigin>, AssetStoreLookupSaturated>(None);
+                    };
+
+                    let context = deployment.context_vars.as_ref();
+                    let nested_source_id = context
+                        .and_then(|value| value.get("source_deployment_id"))
+                        .and_then(serde_json::Value::as_i64)
+                        .and_then(|value| i32::try_from(value).ok());
+                    let complete_source_environment_id = context
+                        .and_then(|value| value.get("source_environment_id"))
+                        .and_then(serde_json::Value::as_i64)
+                        .and_then(|value| i32::try_from(value).ok());
+                    let complete_source_slug = context
+                        .and_then(|value| value.get("source_deployment_slug"))
+                        .and_then(serde_json::Value::as_str);
+
+                    match (
+                        nested_source_id,
+                        complete_source_environment_id,
+                        complete_source_slug,
+                    ) {
+                        (Some(deployment_id), Some(environment_id), Some(slug)) => {
+                            return Ok::<Option<LegacyAssetOrigin>, AssetStoreLookupSaturated>(
+                                Some(LegacyAssetOrigin {
+                                    deployment_id,
+                                    environment_id,
+                                    slug: slug.to_string(),
+                                }),
+                            );
+                        }
+                        (Some(next_id), _, _) => current_id = next_id,
+                        (None, _, _) => {
+                            return Ok::<Option<LegacyAssetOrigin>, AssetStoreLookupSaturated>(
+                                Some(LegacyAssetOrigin {
+                                    deployment_id: deployment.id,
+                                    environment_id: deployment.environment_id,
+                                    slug: deployment.slug,
+                                }),
+                            );
+                        }
+                    }
+                }
+            })
+            .await
+            .ok()
+            .flatten()
     }
 
     /// Return bounded-serving metadata for the exact routed deployment, or
@@ -252,6 +359,105 @@ mod tests {
             size_bytes: 1024,
             created_at: Utc::now(),
         }
+    }
+
+    fn deployment_model(
+        id: i32,
+        project_id: i32,
+        environment_id: i32,
+        slug: &str,
+        context_vars: Option<serde_json::Value>,
+    ) -> deployments::Model {
+        deployments::Model {
+            id,
+            project_id,
+            environment_id,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            slug: slug.to_string(),
+            state: "deployed".to_string(),
+            metadata: None,
+            deploying_at: None,
+            ready_at: None,
+            started_at: None,
+            finished_at: None,
+            context_vars,
+            branch_ref: None,
+            tag_ref: None,
+            commit_sha: None,
+            commit_message: None,
+            commit_author: None,
+            commit_json: None,
+            cancelled_reason: None,
+            static_dir_location: None,
+            screenshot_location: None,
+            image_name: None,
+            deployment_config: None,
+            promoted_from_deployment_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn legacy_reuse_origin_walks_to_original_build_and_is_cached() {
+        let legacy_promotion = deployment_model(
+            20,
+            7,
+            3,
+            "legacy-promotion",
+            Some(serde_json::json!({
+                "trigger": "promotion",
+                "source_deployment_id": 10,
+                "source_environment_id": 2,
+            })),
+        );
+        let original = deployment_model(10, 7, 2, "original-build", None);
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![vec![legacy_promotion], vec![original]])
+                .into_connection(),
+        );
+        let lookup = StaticAssetLookup::new(db.clone());
+
+        let origin = lookup
+            .resolve_legacy_asset_origin(7, 20)
+            .await
+            .expect("legacy origin should resolve");
+        assert_eq!(
+            origin,
+            LegacyAssetOrigin {
+                deployment_id: 10,
+                environment_id: 2,
+                slug: "original-build".to_string(),
+            }
+        );
+        assert_eq!(
+            lookup.resolve_legacy_asset_origin(7, 20).await,
+            Some(origin)
+        );
+
+        drop(lookup);
+        let db = Arc::try_unwrap(db).expect("lookup releases database");
+        assert_eq!(db.into_transaction_log().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn legacy_reuse_origin_fails_closed_when_source_is_outside_project() {
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![Vec::<deployments::Model>::new()])
+                .into_connection(),
+        );
+        let lookup = StaticAssetLookup::new(db.clone());
+
+        assert!(lookup.resolve_legacy_asset_origin(7, 99).await.is_none());
+
+        drop(lookup);
+        let db = Arc::try_unwrap(db).expect("lookup releases database");
+        let transactions = db.into_transaction_log();
+        assert_eq!(transactions.len(), 1);
+        assert!(transactions[0].statements()[0]
+            .to_string()
+            .contains("\"project_id\" = 7"));
     }
 
     /// A repeated miss for the same `(project_id, url_path)` within the TTL

--- a/web/e2e/anonymous/project-creation-environment.spec.ts
+++ b/web/e2e/anonymous/project-creation-environment.spec.ts
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { expect, test } from '@playwright/test'
+
+const managedVariables = [
+  {
+    name: 'SENTRY_DSN',
+    source: 'error_tracking',
+    is_secret: false,
+    is_user_overridable: false,
+    description: 'Sentry-compatible DSN scoped to the project environment.',
+  },
+  {
+    name: 'SENTRY_RELEASE',
+    source: 'error_tracking',
+    is_secret: false,
+    is_user_overridable: true,
+    description: 'Deployment commit, tag, or image version when available.',
+  },
+  {
+    name: 'OTEL_EXPORTER_OTLP_ENDPOINT',
+    source: 'open_telemetry',
+    is_secret: false,
+    is_user_overridable: false,
+    description: 'OpenTelemetry ingestion endpoint for this deployment.',
+  },
+  {
+    name: 'TEMPS_API_TOKEN',
+    source: 'temps',
+    is_secret: true,
+    is_user_overridable: false,
+    description: 'Deployment-scoped token for authenticated Temps APIs.',
+  },
+]
+
+test('renders backend-managed and selected-database variables without a false empty state', async ({
+  page,
+}, testInfo) => {
+  await page.route('**/api/**', async (route) => {
+    const url = new URL(route.request().url())
+    const path = url.pathname.replace(/^\/api/, '')
+    let body: unknown = []
+
+    if (path === '/user/me') {
+      body = {
+        id: 42,
+        name: 'Project Owner',
+        username: 'owner',
+        email: 'owner@example.com',
+        avatar_url: '',
+        mfa_enabled: false,
+        role: 'admin',
+      }
+    } else if (path === '/plugins' || path === '/x/plugins') {
+      body = []
+    } else if (path === '/git-connections') {
+      body = { connections: [], page: 1, per_page: 20, total_count: 0 }
+    } else if (path === '/git-providers') {
+      body = []
+    } else if (path === '/external-services') {
+      await new Promise((resolve) => setTimeout(resolve, 400))
+      body = [
+        {
+          id: 7,
+          name: 'primary-postgres',
+          service_type: 'postgres',
+          status: 'running',
+          topology: 'standalone',
+          created_at: '2026-08-30T10:00:00Z',
+          updated_at: '2026-08-30T10:00:00Z',
+        },
+      ]
+    } else if (path === '/external-services/7/preview-environment-names') {
+      body = ['POSTGRES_URL', 'POSTGRES_HOST']
+    } else if (path === '/deployments/managed-environment-variables') {
+      body = managedVariables
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    })
+  })
+
+  await page.goto('/projects/new?source=manual')
+  await expect(page.getByRole('heading', { name: 'New Project' })).toBeVisible()
+  await expect(page.getByLabel('Loading databases')).toBeVisible()
+  await expect(page.getByText('primary-postgres')).toBeVisible()
+  await expect(page.getByText('No databases configured yet')).toHaveCount(0)
+
+  await page.getByRole('checkbox', { name: /primary-postgres/i }).click()
+  await page
+    .getByRole('button', {
+      name: 'Show environment variables provided by Temps',
+    })
+    .click()
+  await expect(page.getByText('SENTRY_DSN', { exact: true })).toBeVisible()
+  await expect(page.getByText('POSTGRES_URL', { exact: true })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Add Variable' }).click()
+  await page.getByPlaceholder('DATABASE_URL').fill('SENTRY_DSN')
+  await expect(page.getByRole('status')).toContainText(
+    'Temps will override this value'
+  )
+
+  await page.screenshot({
+    path: testInfo.outputPath('project-creation-environment.png'),
+    fullPage: true,
+  })
+})

--- a/web/src/components/project/ManualProjectConfigurator.tsx
+++ b/web/src/components/project/ManualProjectConfigurator.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { ServiceLogo } from '@/components/ui/service-logo'
+import { Skeleton } from '@/components/ui/skeleton'
 import { cn } from '@/lib/utils'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
@@ -64,11 +65,13 @@ import {
   ProvidedEnvironmentVariables,
   ProvidedEnvironmentVariableWarning,
 } from './ProvidedEnvironmentVariables'
-import type { ProvidedEnvironmentVariableCollision } from '@/lib/provided-environment-variables'
+import {
+  isNonOverridableProvidedEnvironmentVariable,
+  type ProvidedEnvironmentVariableCollision,
+} from '@/lib/provided-environment-variables'
 import { ADD_SERVICE_TYPES } from '@/lib/addServiceTypes'
 import {
   isLikelySecretProjectEnvironmentVariable,
-  isTempsManagedProjectEnvironmentVariable,
   projectEnvironmentVariablesSchema,
 } from '@/lib/project-environment-variables'
 import {
@@ -150,7 +153,7 @@ export function ManualProjectConfigurator({
   const [showSecrets, setShowSecrets] = useState<{ [key: number]: boolean }>({})
   const [isImportEnvOpen, setIsImportEnvOpen] = useState(false)
   const [providedEnvironmentVariables, setProvidedEnvironmentVariables] =
-    useState<ProvidedEnvironmentVariableCollision[]>([])
+    useState<ProvidedEnvironmentVariableCollision[] | null>(null)
   const [newlyCreatedServices, setNewlyCreatedServices] = useState<
     ExternalServiceInfo[]
   >([])
@@ -175,7 +178,12 @@ export function ManualProjectConfigurator({
     name: 'sourceType',
   })
   // Fetch existing services
-  const { data: existingServices, refetch: refetchServices } = useAllServices()
+  const {
+    data: existingServices,
+    isPending: areServicesPending,
+    isError: didServicesFail,
+    refetch: refetchServices,
+  } = useAllServices()
   const availableServices = useMemo(() => {
     const servicesById = new Map<number, ExternalServiceInfo>()
     existingServices?.forEach((service) =>
@@ -260,6 +268,23 @@ export function ManualProjectConfigurator({
     if (isSubmittingRef.current) return
     isSubmittingRef.current = true
     try {
+      if (providedEnvironmentVariables === null) {
+        toast.error('Wait for the provided environment variables to load.')
+        return
+      }
+      const blockedIndex = data.environmentVariables.findIndex((variable) =>
+        isNonOverridableProvidedEnvironmentVariable(
+          variable.key,
+          providedEnvironmentVariables
+        )
+      )
+      if (blockedIndex >= 0) {
+        form.setError(`environmentVariables.${blockedIndex}.key`, {
+          message: 'Temps provides this variable automatically at deployment',
+        })
+        toast.error('Remove the environment variable managed by Temps.')
+        return
+      }
       setIsSubmitting(true)
 
       const finalData = {
@@ -487,7 +512,12 @@ export function ManualProjectConfigurator({
   const renderAddDatabaseMenu = () => (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button type="button" variant="outline" size="sm">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={areServicesPending}
+        >
           <Plus className="h-4 w-4 mr-2" />
           Add Database
           <ChevronDown className="h-4 w-4 ml-1" />
@@ -544,6 +574,33 @@ export function ManualProjectConfigurator({
 
     return (
       <div className="space-y-4">
+        {areServicesPending && (
+          <div
+            className="grid grid-cols-1 gap-3 md:grid-cols-2"
+            aria-label="Loading databases"
+          >
+            <Skeleton className="h-20 w-full rounded-lg" />
+            <Skeleton className="h-20 w-full rounded-lg" />
+          </div>
+        )}
+
+        {didServicesFail && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription className="flex items-center justify-between gap-3">
+              <span>Databases could not be loaded.</span>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => void refetchServices()}
+              >
+                Try again
+              </Button>
+            </AlertDescription>
+          </Alert>
+        )}
+
         {availableServices.length > 0 && (
           <div>
             <h4 className="text-sm font-medium mb-3">Existing Databases</h4>
@@ -616,18 +673,20 @@ export function ManualProjectConfigurator({
           </Alert>
         )}
 
-        {availableServices.length === 0 && (
-          <div className="text-center py-8">
-            <Database className="h-12 w-12 mx-auto text-muted-foreground mb-3" />
-            <p className="text-sm text-muted-foreground">
-              No databases configured yet
-            </p>
-            <p className="text-xs text-muted-foreground mt-1">
-              Add PostgreSQL, Redis, MongoDB, or object storage when your app
-              needs it
-            </p>
-          </div>
-        )}
+        {!areServicesPending &&
+          !didServicesFail &&
+          availableServices.length === 0 && (
+            <div className="text-center py-8">
+              <Database className="h-12 w-12 mx-auto text-muted-foreground mb-3" />
+              <p className="text-sm text-muted-foreground">
+                No databases configured yet
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
+                Add PostgreSQL, Redis, MongoDB, or object storage when your app
+                needs it
+              </p>
+            </div>
+          )}
       </div>
     )
   }
@@ -665,7 +724,10 @@ export function ManualProjectConfigurator({
             const currentVars = form.getValues('environmentVariables') || []
             const configurableVariables = variables.filter(
               (variable) =>
-                !isTempsManagedProjectEnvironmentVariable(variable.key)
+                !isNonOverridableProvidedEnvironmentVariable(
+                  variable.key,
+                  providedEnvironmentVariables ?? []
+                )
             )
             const skippedCount = variables.length - configurableVariables.length
             const newVars = configurableVariables.map((v) => ({
@@ -723,7 +785,9 @@ export function ManualProjectConfigurator({
                           <FormMessage />
                           <ProvidedEnvironmentVariableWarning
                             variableName={watchedEnvVars[index]?.key ?? ''}
-                            providedVariables={providedEnvironmentVariables}
+                            providedVariables={
+                              providedEnvironmentVariables ?? []
+                            }
                           />
                         </FormItem>
                       )}

--- a/web/src/components/project/ProjectConfigurator.tsx
+++ b/web/src/components/project/ProjectConfigurator.tsx
@@ -51,6 +51,7 @@ import {
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { ServiceLogo } from '@/components/ui/service-logo'
+import { Skeleton } from '@/components/ui/skeleton'
 import {
   Tooltip,
   TooltipContent,
@@ -90,7 +91,10 @@ import {
   ProvidedEnvironmentVariables,
   ProvidedEnvironmentVariableWarning,
 } from './ProvidedEnvironmentVariables'
-import type { ProvidedEnvironmentVariableCollision } from '@/lib/provided-environment-variables'
+import {
+  isNonOverridableProvidedEnvironmentVariable,
+  type ProvidedEnvironmentVariableCollision,
+} from '@/lib/provided-environment-variables'
 import { repositoryFilePath } from '@/lib/repository-file-path'
 import { FrameworkSelector } from './FrameworkSelector'
 import { ProviderLogo } from '@/components/git/ProviderLogo'
@@ -107,7 +111,6 @@ import {
 import { useSettings } from '@/hooks/useSettings'
 import {
   isLikelySecretProjectEnvironmentVariable,
-  isTempsManagedProjectEnvironmentVariable,
   projectEnvironmentVariablesSchema,
 } from '@/lib/project-environment-variables'
 import {
@@ -646,7 +649,7 @@ export function ProjectConfigurator({
   const [showSecrets, setShowSecrets] = useState<{ [key: number]: boolean }>({})
   const [isImportEnvOpen, setIsImportEnvOpen] = useState(false)
   const [providedEnvironmentVariables, setProvidedEnvironmentVariables] =
-    useState<ProvidedEnvironmentVariableCollision[]>([])
+    useState<ProvidedEnvironmentVariableCollision[] | null>(null)
   const [newlyCreatedServices, setNewlyCreatedServices] = useState<
     ExternalServiceInfo[]
   >([])
@@ -672,7 +675,12 @@ export function ProjectConfigurator({
   })
 
   // Fetch existing services
-  const { data: existingServices, refetch: refetchServices } = useAllServices()
+  const {
+    data: existingServices,
+    isPending: areServicesPending,
+    isError: didServicesFail,
+    refetch: refetchServices,
+  } = useAllServices()
   const availableServices = useMemo(() => {
     const servicesById = new Map<number, ExternalServiceInfo>()
     existingServices?.forEach((service) =>
@@ -858,9 +866,13 @@ export function ProjectConfigurator({
   const envExampleVariables = useMemo(
     () =>
       detectedEnvExampleVariables.filter(
-        (variable) => !isTempsManagedProjectEnvironmentVariable(variable.key)
+        (variable) =>
+          !isNonOverridableProvidedEnvironmentVariable(
+            variable.key,
+            providedEnvironmentVariables ?? []
+          )
       ),
-    [detectedEnvExampleVariables]
+    [detectedEnvExampleVariables, providedEnvironmentVariables]
   )
 
   const [envExampleDismissed, setEnvExampleDismissed] = useState(false)
@@ -1148,6 +1160,23 @@ export function ProjectConfigurator({
     if (isSubmittingRef.current) return
     isSubmittingRef.current = true
     try {
+      if (providedEnvironmentVariables === null) {
+        toast.error('Wait for the provided environment variables to load.')
+        return
+      }
+      const blockedIndex = data.environmentVariables.findIndex((variable) =>
+        isNonOverridableProvidedEnvironmentVariable(
+          variable.key,
+          providedEnvironmentVariables
+        )
+      )
+      if (blockedIndex >= 0) {
+        form.setError(`environmentVariables.${blockedIndex}.key`, {
+          message: 'Temps provides this variable automatically at deployment',
+        })
+        toast.error('Remove the environment variable managed by Temps.')
+        return
+      }
       setIsSubmitting(true)
 
       // Extract just the preset name from "preset::path" format for backend
@@ -1524,7 +1553,12 @@ export function ProjectConfigurator({
   const renderAddDatabaseMenu = () => (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button type="button" variant="outline" size="sm">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={areServicesPending}
+        >
           <Plus className="h-4 w-4 mr-2" />
           Add Database
           <ChevronDown className="h-4 w-4 ml-1" />
@@ -1578,6 +1612,33 @@ export function ProjectConfigurator({
 
     return (
       <div className="space-y-4">
+        {areServicesPending && (
+          <div
+            className="grid grid-cols-1 gap-3 md:grid-cols-2"
+            aria-label="Loading databases"
+          >
+            <Skeleton className="h-20 w-full rounded-lg" />
+            <Skeleton className="h-20 w-full rounded-lg" />
+          </div>
+        )}
+
+        {didServicesFail && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription className="flex items-center justify-between gap-3">
+              <span>Databases could not be loaded.</span>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => void refetchServices()}
+              >
+                Try again
+              </Button>
+            </AlertDescription>
+          </Alert>
+        )}
+
         {availableServices.length > 0 && (
           <div>
             <h4 className="text-sm font-medium mb-3">Existing Databases</h4>
@@ -1650,18 +1711,20 @@ export function ProjectConfigurator({
           </Alert>
         )}
 
-        {availableServices.length === 0 && (
-          <div className="text-center py-8">
-            <Database className="h-12 w-12 mx-auto text-muted-foreground mb-3" />
-            <p className="text-sm text-muted-foreground">
-              No databases configured yet
-            </p>
-            <p className="text-xs text-muted-foreground mt-1">
-              Add PostgreSQL, Redis, MongoDB, or object storage when your app
-              needs it
-            </p>
-          </div>
-        )}
+        {!areServicesPending &&
+          !didServicesFail &&
+          availableServices.length === 0 && (
+            <div className="text-center py-8">
+              <Database className="h-12 w-12 mx-auto text-muted-foreground mb-3" />
+              <p className="text-sm text-muted-foreground">
+                No databases configured yet
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
+                Add PostgreSQL, Redis, MongoDB, or object storage when your app
+                needs it
+              </p>
+            </div>
+          )}
       </div>
     )
   }
@@ -1922,7 +1985,10 @@ export function ProjectConfigurator({
             const currentVars = form.getValues('environmentVariables') || []
             const configurableVariables = variables.filter(
               (variable) =>
-                !isTempsManagedProjectEnvironmentVariable(variable.key)
+                !isNonOverridableProvidedEnvironmentVariable(
+                  variable.key,
+                  providedEnvironmentVariables ?? []
+                )
             )
             const skippedCount = variables.length - configurableVariables.length
             const newVars = configurableVariables.map((v) => ({
@@ -1980,7 +2046,9 @@ export function ProjectConfigurator({
                           <FormMessage />
                           <ProvidedEnvironmentVariableWarning
                             variableName={watchedEnvVars[index]?.key ?? ''}
-                            providedVariables={providedEnvironmentVariables}
+                            providedVariables={
+                              providedEnvironmentVariables ?? []
+                            }
                           />
                         </FormItem>
                       )}

--- a/web/src/components/project/ProvidedEnvironmentVariables.test.ts
+++ b/web/src/components/project/ProvidedEnvironmentVariables.test.ts
@@ -7,12 +7,14 @@ import {
   databaseProvidedEnvironmentVariable,
   findProvidedEnvironmentVariableCollision,
   groupManagedEnvironmentVariables,
+  isNonOverridableProvidedEnvironmentVariable,
   normalizeCreationPreset,
 } from '@/lib/provided-environment-variables'
 
 describe('ProvidedEnvironmentVariables', () => {
   test('normalizes repository presets and keeps only the preset slug', () => {
     expect(normalizeCreationPreset('NextJS::apps/web')).toBe('nextjs')
+    expect(normalizeCreationPreset('custom')).toBe('static')
     expect(normalizeCreationPreset('')).toBe('dockerfile')
   })
 
@@ -82,5 +84,29 @@ describe('ProvidedEnvironmentVariables', () => {
       provider: 'database "app-db"',
       isUserOverridable: true,
     })
+  })
+
+  test('uses backend override metadata instead of a frontend reserved-key list', () => {
+    const providedVariables = [
+      { name: 'SENTRY_DSN', provider: 'Temps', isUserOverridable: false },
+      {
+        name: 'SENTRY_RELEASE',
+        provider: 'Temps',
+        isUserOverridable: true,
+      },
+    ]
+
+    expect(
+      isNonOverridableProvidedEnvironmentVariable(
+        'SENTRY_DSN',
+        providedVariables
+      )
+    ).toBe(true)
+    expect(
+      isNonOverridableProvidedEnvironmentVariable(
+        'SENTRY_RELEASE',
+        providedVariables
+      )
+    ).toBe(false)
   })
 })

--- a/web/src/components/project/ProvidedEnvironmentVariables.tsx
+++ b/web/src/components/project/ProvidedEnvironmentVariables.tsx
@@ -11,6 +11,7 @@ import type {
 } from '@/api/client/types.gen'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
 import {
   Collapsible,
   CollapsibleContent,
@@ -29,7 +30,6 @@ import {
   Braces,
   ChevronDown,
   Database,
-  Loader2,
   LockKeyhole,
   ServerCog,
   TriangleAlert,
@@ -46,7 +46,7 @@ interface ProvidedEnvironmentVariablesProps {
   preset: string
   databases: ProvidedEnvironmentVariableDatabase[]
   onVariablesChange?: (
-    variables: ProvidedEnvironmentVariableCollision[]
+    variables: ProvidedEnvironmentVariableCollision[] | null
   ) => void
 }
 
@@ -121,15 +121,27 @@ export function ProvidedEnvironmentVariables({
   const collisionVariablesSignature = JSON.stringify(collisionVariables)
 
   useEffect(() => {
-    if (
-      !onVariablesChange ||
-      collisionVariablesSignature === lastReportedVariablesRef.current
-    ) {
+    if (!onVariablesChange) return
+    const hasError =
+      platformQuery.isError || databaseQueries.some((query) => query.isError)
+    if (isLoading || hasError) {
+      if (lastReportedVariablesRef.current !== '__unavailable__') {
+        lastReportedVariablesRef.current = '__unavailable__'
+        onVariablesChange(null)
+      }
       return
     }
+    if (collisionVariablesSignature === lastReportedVariablesRef.current) return
     lastReportedVariablesRef.current = collisionVariablesSignature
     onVariablesChange(collisionVariables)
-  }, [collisionVariables, collisionVariablesSignature, onVariablesChange])
+  }, [
+    collisionVariables,
+    collisionVariablesSignature,
+    databaseQueries,
+    isLoading,
+    onVariablesChange,
+    platformQuery.isError,
+  ])
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
@@ -149,7 +161,7 @@ export function ProvidedEnvironmentVariables({
                 <div className="flex flex-wrap items-center gap-2">
                   <span className="text-sm font-medium">Provided by Temps</span>
                   {isLoading ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+                    <Skeleton className="h-4 w-20 rounded-full" />
                   ) : totalVariableCount > 0 ? (
                     <Badge
                       variant="secondary"
@@ -345,9 +357,14 @@ export function ProvidedEnvironmentVariableWarning({
 
 function LoadingRow({ label }: { label: string }) {
   return (
-    <div className="flex items-center gap-2 text-xs text-muted-foreground">
-      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-      {label}
+    <div
+      className="space-y-2"
+      aria-label={label}
+      role="status"
+      aria-live="polite"
+    >
+      <Skeleton className="h-3 w-2/5" />
+      <Skeleton className="h-8 w-full" />
     </div>
   )
 }

--- a/web/src/components/templates/TemplateConfigurator.tsx
+++ b/web/src/components/templates/TemplateConfigurator.tsx
@@ -62,7 +62,10 @@ import {
   ProvidedEnvironmentVariables,
   ProvidedEnvironmentVariableWarning,
 } from '@/components/project/ProvidedEnvironmentVariables'
-import type { ProvidedEnvironmentVariableCollision } from '@/lib/provided-environment-variables'
+import {
+  isNonOverridableProvidedEnvironmentVariable,
+  type ProvidedEnvironmentVariableCollision,
+} from '@/lib/provided-environment-variables'
 import { TemplateImage } from '@/components/templates/TemplateImage'
 import {
   runGenerator,
@@ -75,7 +78,6 @@ import { cn } from '@/lib/utils'
 import { ADD_SERVICE_TYPES } from '@/lib/addServiceTypes'
 import {
   isLikelySecretProjectEnvironmentVariable,
-  isTempsManagedProjectEnvironmentVariable,
   projectEnvironmentVariablesSchema,
 } from '@/lib/project-environment-variables'
 import {
@@ -215,7 +217,7 @@ export function TemplateConfigurator({
     ExternalServiceInfo[]
   >([])
   const [providedEnvironmentVariables, setProvidedEnvironmentVariables] =
-    useState<ProvidedEnvironmentVariableCollision[]>([])
+    useState<ProvidedEnvironmentVariableCollision[] | null>(null)
 
   // Fetch connections
   const { data: connectionsData, isLoading: isLoadingConnections } = useQuery({
@@ -281,10 +283,7 @@ export function TemplateConfigurator({
   )
 
   const configurableTemplateEnvVars = useMemo(
-    () =>
-      template.env_vars.filter(
-        (env) => !isTempsManagedProjectEnvironmentVariable(env.name)
-      ),
+    () => template.env_vars,
     [template.env_vars]
   )
 
@@ -317,6 +316,27 @@ export function TemplateConfigurator({
       }),
     },
   })
+
+  useEffect(() => {
+    if (providedEnvironmentVariables === null) return
+    const templateKeys = new Set(
+      template.env_vars.map((variable) => variable.name)
+    )
+    const currentVariables = form.getValues('environmentVariables') || []
+    const configurableVariables = currentVariables.filter(
+      (variable) =>
+        !templateKeys.has(variable.key) ||
+        !isNonOverridableProvidedEnvironmentVariable(
+          variable.key,
+          providedEnvironmentVariables
+        )
+    )
+    if (configurableVariables.length !== currentVariables.length) {
+      form.setValue('environmentVariables', configurableVariables, {
+        shouldValidate: false,
+      })
+    }
+  }, [form, providedEnvironmentVariables, template.env_vars])
 
   // Track which generator-produced values are still "untouched" by the user so
   // we can re-run repo-name-dependent generators (`app_url`) when the slug changes.
@@ -498,6 +518,23 @@ export function TemplateConfigurator({
     }
     if (isServicesError) {
       toast.error('Reload the database list before creating this project.')
+      return
+    }
+    if (providedEnvironmentVariables === null) {
+      toast.error('Wait for the provided environment variables to load.')
+      return
+    }
+    const blockedIndex = data.environmentVariables.findIndex((variable) =>
+      isNonOverridableProvidedEnvironmentVariable(
+        variable.key,
+        providedEnvironmentVariables
+      )
+    )
+    if (blockedIndex >= 0) {
+      form.setError(`environmentVariables.${blockedIndex}.key`, {
+        message: 'Temps provides this variable automatically at deployment',
+      })
+      toast.error('Remove the environment variable managed by Temps.')
       return
     }
     const missingServiceRequirements = getTemplateServiceRequirements(
@@ -1413,7 +1450,7 @@ export function TemplateConfigurator({
                                     <ProvidedEnvironmentVariableWarning
                                       variableName={envVar.key}
                                       providedVariables={
-                                        providedEnvironmentVariables
+                                        providedEnvironmentVariables ?? []
                                       }
                                     />
                                   </FormItem>

--- a/web/src/lib/project-environment-variables.test.ts
+++ b/web/src/lib/project-environment-variables.test.ts
@@ -4,7 +4,6 @@
 import { describe, expect, test } from 'bun:test'
 import {
   isLikelySecretProjectEnvironmentVariable,
-  isTempsManagedProjectEnvironmentVariable,
   projectEnvironmentVariablesSchema,
 } from './project-environment-variables'
 
@@ -72,45 +71,17 @@ describe('projectEnvironmentVariablesSchema', () => {
     'SENTRY_DSN',
     'NEXT_PUBLIC_SENTRY_DSN',
     'OTEL_EXPORTER_OTLP_ENDPOINT',
-    'OTEL_EXPORTER_OTLP_TOKEN',
-  ])('rejects platform-managed variable %s', (key) => {
-    const result = projectEnvironmentVariablesSchema.safeParse([
-      { key, value: 'user-value', isSecret: false },
-    ])
-
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues).toContainEqual(
-      expect.objectContaining({
-        message: 'Temps provides this variable automatically at deployment',
-        path: [0, 'key'],
-      })
-    )
-  })
-})
-
-describe('isTempsManagedProjectEnvironmentVariable', () => {
-  test.each([
-    'SENTRY_DSN',
-    'SENTRY_TUNNEL',
-    'NEXT_PUBLIC_SENTRY_DSN',
-    'VITE_SENTRY_DSN',
-    'TEMPS_API_TOKEN',
-    'PORT',
-    'TEMPS_ASSET_PREFIX',
-    'NEXT_PUBLIC_TEMPS_ASSET_PREFIX',
-    'TEMPS_NODE_NAME',
-    'OTEL_EXPORTER_OTLP_ENDPOINT',
-    'OTEL_EXPORTER_OTLP_HEADERS',
-    'OTEL_EXPORTER_OTLP_TOKEN',
-  ])('recognizes %s as platform-managed', (key) => {
-    expect(isTempsManagedProjectEnvironmentVariable(key)).toBe(true)
-  })
-
-  test.each(['SENTRY_DSN_BACKUP', 'OTEL_RESOURCE_ATTRIBUTES', 'API_TOKEN'])(
-    'keeps user-owned variable %s configurable',
+    'SENTRY_RELEASE',
+    'OTEL_SERVICE_VERSION',
+    'HOST',
+  ])(
+    'leaves backend-owned policy decisions to the managed catalog for %s',
     (key) => {
-      expect(isTempsManagedProjectEnvironmentVariable(key)).toBe(false)
+      const result = projectEnvironmentVariablesSchema.safeParse([
+        { key, value: 'user-value', isSecret: false },
+      ])
+
+      expect(result.success).toBe(true)
     }
   )
 })

--- a/web/src/lib/project-environment-variables.ts
+++ b/web/src/lib/project-environment-variables.ts
@@ -9,57 +9,6 @@ const LIKELY_SECRET_KEY =
   /(?:^|_)(?:SECRET|PASSWORD|PASSWD|TOKEN|API_KEY|PRIVATE_KEY|ACCESS_KEY|DATABASE_URL|POSTGRES_URL|MYSQL_URL|MONGODB_URL|MONGODB_URI|REDIS_URL|AMQP_URL|CONNECTION_STRING|DSN|WEBHOOK_URL)(?:_|$)/i
 
 /**
- * Variables written after user configuration is resolved by the deployment
- * planner. Letting users configure these during project creation is misleading:
- * the generated value wins at deploy time. OTEL_EXPORTER_OTLP_TOKEN is kept in
- * this list as a legacy alias used by an older bundled template; Temps now
- * injects the standard OTEL_EXPORTER_OTLP_HEADERS value instead.
- *
- * This is only a conservative client-side validation guard. The inventory
- * shown to users comes from the backend managed-environment-variables endpoint,
- * whose canonical catalog lives in
- * `temps-deployments/src/services/managed_environment_variables.rs`.
- */
-export const TEMPS_MANAGED_PROJECT_ENVIRONMENT_VARIABLES = [
-  'SENTRY_DSN',
-  'SENTRY_TUNNEL',
-  'NEXT_PUBLIC_SENTRY_DSN',
-  'NUXT_PUBLIC_SENTRY_DSN',
-  'VITE_SENTRY_DSN',
-  'PUBLIC_SENTRY_DSN',
-  'REACT_APP_SENTRY_DSN',
-  'NEXT_PUBLIC_SENTRY_TUNNEL',
-  'NUXT_PUBLIC_SENTRY_TUNNEL',
-  'VITE_SENTRY_TUNNEL',
-  'PUBLIC_SENTRY_TUNNEL',
-  'REACT_APP_SENTRY_TUNNEL',
-  'SENTRY_RELEASE',
-  'TEMPS_API_URL',
-  'TEMPS_API_TOKEN',
-  'CRON_SECRET',
-  'PORT',
-  'TEMPS_ASSET_PREFIX',
-  'NEXT_PUBLIC_TEMPS_ASSET_PREFIX',
-  'TEMPS_NODE_NAME',
-  'TEMPS_NODE_ID',
-  'TEMPS_REPLICA',
-  'OTEL_EXPORTER_OTLP_ENDPOINT',
-  'OTEL_EXPORTER_OTLP_PROTOCOL',
-  'OTEL_EXPORTER_OTLP_HEADERS',
-  'OTEL_EXPORTER_OTLP_TOKEN',
-  'OTEL_SERVICE_NAME',
-  'OTEL_SERVICE_VERSION',
-] as const
-
-const TEMPS_MANAGED_PROJECT_ENVIRONMENT_VARIABLE_SET = new Set<string>(
-  TEMPS_MANAGED_PROJECT_ENVIRONMENT_VARIABLES
-)
-
-export function isTempsManagedProjectEnvironmentVariable(key: string): boolean {
-  return TEMPS_MANAGED_PROJECT_ENVIRONMENT_VARIABLE_SET.has(key.trim())
-}
-
-/**
  * Picks a safe initial value for the explicit "Encrypt as secret" control.
  * This intentionally avoids broad matches such as `AUTH`, which would mark
  * public values like `NEXTAUTH_URL` as write-only.
@@ -89,13 +38,6 @@ export const projectEnvironmentVariablesSchema = z
         message: 'A secret needs a value — it cannot be filled in later',
         path: ['value'],
       })
-      .refine(
-        (variable) => !isTempsManagedProjectEnvironmentVariable(variable.key),
-        {
-          message: 'Temps provides this variable automatically at deployment',
-          path: ['key'],
-        }
-      )
   )
   .superRefine((variables, context) => {
     const firstIndexByKey = new Map<string, number>()

--- a/web/src/lib/provided-environment-variables.ts
+++ b/web/src/lib/provided-environment-variables.ts
@@ -20,7 +20,8 @@ const SOURCE_ORDER: ManagedEnvironmentVariableSource[] = [
 
 export function normalizeCreationPreset(preset: string): string {
   const [name] = preset.split('::')
-  return name.trim().toLowerCase() || 'dockerfile'
+  const normalized = name.trim().toLowerCase() || 'dockerfile'
+  return normalized === 'custom' ? 'static' : normalized
 }
 
 export function groupManagedEnvironmentVariables(
@@ -38,6 +39,16 @@ export function findProvidedEnvironmentVariableCollision(
 ) {
   const normalizedName = variableName.trim()
   return providedVariables.find((variable) => variable.name === normalizedName)
+}
+
+export function isNonOverridableProvidedEnvironmentVariable(
+  variableName: string,
+  providedVariables: ProvidedEnvironmentVariableCollision[]
+): boolean {
+  return (
+    findProvidedEnvironmentVariableCollision(variableName, providedVariables)
+      ?.isUserOverridable === false
+  )
 }
 
 export function databaseProvidedEnvironmentVariable(


### PR DESCRIPTION
## Summary

- make the backend-managed environment-variable catalog the source of truth, keep overridable release/version variables editable, map custom projects to the static preset, and show database loading/error states without a false empty state
- preserve static assets for legacy promotion/rollback metadata and return typed deployment environment-resolution errors
- authorize selected databases and direct service link/unlink operations across project/team boundaries, with all selected links and one-time creator claims committed atomically
- keep creator-owned databases visible and pollable before their first project link, including authenticated container imports
- add reversible creator ownership metadata, route/OpenAPI coverage, resolver/legacy compatibility tests, and a route-mocked browser regression

## Security

- closes the project-creation and direct service link/unlink IDOR paths
- checks both source-service and target-project authorization
- locks the target project and selected services, then validates and commits every link and creator-claim update in one transaction; a partial failure preserves every claim
- batches source-project permission checks and fails closed on errors or incomplete authorization results
- filters hidden project metadata before pagination
- security-auditor verdict on `258c67a19`: **approved; no critical, high, medium, or low findings**

## Evidence

### Rust

```text
$ cargo check --lib -p temps-projects -p temps-providers -p temps-deployments -p temps-proxy -p temps-migrations -p temps-entities -p temps-monitoring -p temps-backup
cargo build: 0 errors, 2 warnings (7 crates)

$ cargo clippy --lib -p temps-projects -p temps-providers -p temps-deployments -p temps-proxy -p temps-migrations -- -D warnings
cargo clippy: 0 errors, 2 warnings

$ cargo test --lib -p temps-providers
cargo test: 583 passed (1 suite, 8.17s)

$ cargo test --lib -p temps-projects
cargo test: 141 passed (1 suite, 81.60s)

$ cargo test --lib -p temps-providers --features docker-tests bulk_link_failure_preserves_every_creator_claim -- --nocapture
cargo test: 1 passed, 657 filtered out (1 suite, 12.52s)

$ cargo test --lib -p temps-providers creator_
cargo test: 3 passed, 578 filtered out (1 suite, 0.00s)

$ cargo test --lib -p temps-projects selected_database
cargo test: 3 passed, 138 filtered out (1 suite, 0.00s)

$ cargo test --lib -p temps-projects creator_can_claim
cargo test: 1 passed, 140 filtered out (1 suite, 0.00s)

$ cargo test --lib -p temps-projects creator_cannot_bypass
cargo test: 1 passed, 140 filtered out (1 suite, 0.00s)

$ cargo test --lib -p temps-deployments managed_environment_variables
cargo test: 7 passed, 680 filtered out (1 suite, 0.00s)

$ cargo test --lib -p temps-deployments env_resolver
cargo test: 11 passed, 676 filtered out (1 suite, 0.00s)

$ cargo test --lib -p temps-deployments asset_origin
cargo test: 2 passed, 685 filtered out (1 suite, 0.00s)

$ cargo test --lib -p temps-proxy legacy
cargo test: 4 passed, 569 filtered out (1 suite, 0.01s)
```

### Migration (real PostgreSQL)

The integration test verifies the creator column/foreign key, migrates down one step and verifies removal, then migrates up and verifies restoration.

```text
$ cargo test -p temps-migrations --test migration_tests test_api_traffic_ai_and_model_catalog_migrations -- --nocapture
cargo test: 1 passed, 17 filtered out (1 suite, 3.36s)
```

### Frontend and generated contract

```text
$ bun test src/components/project/ProvidedEnvironmentVariables.test.ts src/lib/project-environment-variables.test.ts
27 pass
0 fail
33 expect() calls

$ bunx tsc --noEmit
exit 0

$ bun run spec:check
openapi.json is canonical (729 paths)

$ bun run typecheck
exit 0
```

### Browser walkthrough

Route-mocked Chromium exercised `/projects/new?source=manual` against the rendered console and asserted:

1. database skeleton appears while the service catalog is pending
2. `primary-postgres` appears without flashing the empty state
3. selecting it exposes `POSTGRES_URL` alongside backend-managed `SENTRY_DSN`
4. adding `SENTRY_DSN` shows the discrete “Temps will override this value” warning

```text
$ E2E_BASE_URL=http://127.0.0.1:3001 bunx playwright test e2e/anonymous/project-creation-environment.spec.ts --project=chromium-anonymous --reporter=list
✓ 1 renders backend-managed and selected-database variables without a false empty state (2.4s)
1 passed (2.8s)
```

The test also captures `project-creation-environment.png` in its Playwright output directory.

## Notes

- `public_sentry_dsn_var` remains in the canonical managed-variable module and is used by both the workflow planner and deployment resolver.
- The CLI OpenAPI/SDK contract was already canonical on the merged base, so this PR produces no generated CLI diff.
