### PR TITLE
feat(presets): detect Dockerfile exposed ports

### DIFF
--- a/crates/temps-git/src/handlers/base.rs
+++ b/crates/temps-git/src/handlers/base.rs
@@ -526,7 +526,7 @@ pub struct ProjectPresetResponse {
     pub path: String,
     pub preset: String,
     pub preset_label: String,
-    /// Default exposed port for this preset (e.g., 3000 for Next.js, 8000 for FastAPI)
+    /// Detected Dockerfile EXPOSE port, or the preset's default port.
     pub exposed_port: Option<i32>,
     /// Icon URL for the preset
     pub icon_url: Option<String>,

--- a/crates/temps-git/src/handlers/base.rs
+++ b/crates/temps-git/src/handlers/base.rs
@@ -526,7 +526,7 @@ pub struct ProjectPresetResponse {
     pub path: String,
     pub preset: String,
     pub preset_label: String,
-    /// Detected Dockerfile EXPOSE port, or the preset's default port.
+    /// Default exposed port for this preset (e.g., 3000 for Next.js, 8000 for FastAPI)
     pub exposed_port: Option<i32>,
     /// Icon URL for the preset
     pub icon_url: Option<String>,

--- a/crates/temps-git/src/handlers/public.rs
+++ b/crates/temps-git/src/handlers/public.rs
@@ -12,7 +12,7 @@ use super::types::GitAppState as AppState;
 use crate::services::cache::{CachedPresetInfo, PublicBranchCacheKey, PublicPresetCacheKey};
 use crate::services::git_provider::Branch;
 use crate::services::public_repo::{
-    detect_presets_from_files, PublicRepoError, PublicRepoProviderFactory,
+    detect_presets_from_files, PublicRepoError, PublicRepoProvider, PublicRepoProviderFactory,
 };
 use axum::{
     extract::{Path, Query, State},
@@ -25,7 +25,10 @@ use std::sync::Arc;
 use temps_auth::{AuthContext, Permission};
 use temps_core::problemdetails::{new as problem_new, Problem};
 use temps_entities::preset::ComposePortMapping;
+use tracing::warn;
 use utoipa::{IntoParams, OpenApi, ToSchema};
+
+const MAX_DOCKERFILES_TO_SCAN: usize = 16;
 
 /// Query parameters for public repository endpoints
 #[derive(Debug, Deserialize, IntoParams)]
@@ -97,7 +100,7 @@ pub struct PresetInfo {
     pub preset: String,
     /// Human-readable preset label
     pub preset_label: String,
-    /// Default exposed port for this preset
+    /// Detected Dockerfile EXPOSE port, or the preset's default port
     pub exposed_port: Option<i32>,
     /// Icon URL for this preset
     pub icon_url: Option<String>,
@@ -616,7 +619,15 @@ pub async fn detect_public_presets(
         .map_err(|e| map_error(e, &owner, &repo))?;
 
     // Use centralized preset detection
-    let detected = detect_presets_from_files(&files);
+    let mut detected = detect_presets_from_files(&files);
+    enrich_public_dockerfile_exposed_ports(
+        repo_provider.as_ref(),
+        &owner,
+        &repo,
+        &target_branch,
+        &mut detected,
+    )
+    .await;
 
     // Convert to CachedPresetInfo for caching
     let cached_presets: Vec<CachedPresetInfo> = detected
@@ -657,6 +668,50 @@ pub async fn detect_public_presets(
         branch: target_branch,
         presets,
     }))
+}
+
+async fn enrich_public_dockerfile_exposed_ports(
+    repo_provider: &dyn PublicRepoProvider,
+    owner: &str,
+    repository_name: &str,
+    target_branch: &str,
+    detected: &mut [crate::services::public_repo::DetectedPreset],
+) {
+    let dockerfiles: Vec<(usize, String)> = detected
+        .iter()
+        .enumerate()
+        .filter(|(_, preset)| preset.preset == "dockerfile")
+        .take(MAX_DOCKERFILES_TO_SCAN)
+        .map(|(index, preset)| {
+            let path = if preset.path == "./" || preset.path.is_empty() {
+                "Dockerfile".to_string()
+            } else {
+                format!("{}/Dockerfile", preset.path.trim_end_matches('/'))
+            };
+            (index, path)
+        })
+        .collect();
+
+    for (preset_index, dockerfile_path) in dockerfiles {
+        match repo_provider
+            .get_file_content(owner, repository_name, &dockerfile_path, target_branch)
+            .await
+        {
+            Ok(file) => {
+                let content = decode_file_content(&file.content, &file.encoding);
+                detected[preset_index].exposed_port =
+                    temps_presets::detect_primary_exposed_port(&content).map(i32::from);
+            }
+            Err(error) => warn!(
+                owner,
+                repository = repository_name,
+                branch = target_branch,
+                dockerfile = dockerfile_path,
+                error = %error,
+                "Could not inspect public Dockerfile EXPOSE metadata during preset detection"
+            ),
+        }
+    }
 }
 
 /// Decode a provider file's content. GitHub and GitLab both return base64
@@ -1019,9 +1074,115 @@ pub struct PublicRepositoriesApiDoc;
 mod tests {
     use super::*;
     use crate::services::cache::GitProviderCacheManager;
+    use crate::services::git_provider::FileContent;
     use crate::services::public_repo::{
-        GitHubPublicProvider, GitLabPublicProvider, PublicRepoProvider,
+        GitHubPublicProvider, GitLabPublicProvider, PublicBranch, PublicRepoInfo,
+        PublicRepoProvider,
     };
+
+    struct DockerfilePortProvider {
+        fail_reads: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl PublicRepoProvider for DockerfilePortProvider {
+        fn provider_name(&self) -> &'static str {
+            "test"
+        }
+
+        async fn get_repository(
+            &self,
+            _owner: &str,
+            _repo: &str,
+        ) -> Result<PublicRepoInfo, PublicRepoError> {
+            panic!("repository metadata is not needed for this test")
+        }
+
+        async fn list_branches(
+            &self,
+            _owner: &str,
+            _repo: &str,
+        ) -> Result<Vec<PublicBranch>, PublicRepoError> {
+            panic!("branch listing is not needed for this test")
+        }
+
+        async fn get_file_tree(
+            &self,
+            _owner: &str,
+            _repo: &str,
+            _reference: &str,
+        ) -> Result<Vec<String>, PublicRepoError> {
+            panic!("file tree lookup is not needed for this test")
+        }
+
+        async fn get_file_content(
+            &self,
+            _owner: &str,
+            _repo: &str,
+            path: &str,
+            _reference: &str,
+        ) -> Result<FileContent, PublicRepoError> {
+            if self.fail_reads {
+                return Err(PublicRepoError::ApiError(format!(
+                    "simulated read failure for {path}"
+                )));
+            }
+            let content = match path {
+                "Dockerfile" => "FROM alpine\nEXPOSE 3000\n",
+                "apps/api/Dockerfile" => "FROM alpine\nEXPOSE 8080\n",
+                other => panic!("unexpected Dockerfile path: {other}"),
+            };
+            Ok(FileContent {
+                path: path.to_string(),
+                content: content.to_string(),
+                encoding: "utf-8".to_string(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn public_preset_detection_enriches_each_dockerfile_port() {
+        let files = vec!["Dockerfile".to_string(), "apps/api/Dockerfile".to_string()];
+        let mut presets = detect_presets_from_files(&files);
+
+        enrich_public_dockerfile_exposed_ports(
+            &DockerfilePortProvider { fail_reads: false },
+            "example-owner",
+            "example-repository",
+            "main",
+            &mut presets,
+        )
+        .await;
+
+        let root = presets
+            .iter()
+            .find(|preset| preset.path == "./")
+            .expect("root Dockerfile preset should be detected");
+        let api = presets
+            .iter()
+            .find(|preset| preset.path == "apps/api")
+            .expect("nested Dockerfile preset should be detected");
+        assert_eq!(root.exposed_port, Some(3000));
+        assert_eq!(api.exposed_port, Some(8080));
+    }
+
+    #[tokio::test]
+    async fn dockerfile_read_failure_keeps_detected_preset_available() {
+        let mut presets = detect_presets_from_files(&["Dockerfile".to_string()]);
+
+        enrich_public_dockerfile_exposed_ports(
+            &DockerfilePortProvider { fail_reads: true },
+            "example-owner",
+            "example-repository",
+            "main",
+            &mut presets,
+        )
+        .await;
+
+        assert_eq!(presets.len(), 1);
+        assert_eq!(presets[0].preset, "dockerfile");
+        assert_eq!(presets[0].exposed_port, None);
+    }
 
     // =============================================================================
     // Unit Tests - Cache Key Tests

--- a/crates/temps-git/src/handlers/public.rs
+++ b/crates/temps-git/src/handlers/public.rs
@@ -28,7 +28,7 @@ use temps_entities::preset::ComposePortMapping;
 use tracing::warn;
 use utoipa::{IntoParams, OpenApi, ToSchema};
 
-const MAX_DOCKERFILES_TO_SCAN: usize = 16;
+const MAX_PUBLIC_DOCKERFILES_TO_SCAN: usize = 1;
 
 /// Query parameters for public repository endpoints
 #[derive(Debug, Deserialize, IntoParams)]
@@ -100,7 +100,7 @@ pub struct PresetInfo {
     pub preset: String,
     /// Human-readable preset label
     pub preset_label: String,
-    /// Detected Dockerfile EXPOSE port, or the preset's default port
+    /// Default exposed port for this preset
     pub exposed_port: Option<i32>,
     /// Icon URL for this preset
     pub icon_url: Option<String>,
@@ -301,7 +301,10 @@ async fn provider_for_public_request(
     Problem,
 > {
     let token = if provider.eq_ignore_ascii_case("github") {
-        if let Some(user_id) = auth.and_then(AuthContext::user_id_opt) {
+        if let Some(user_id) = auth
+            .filter(|auth| auth.has_permission(&Permission::GitRepositoriesRead))
+            .and_then(AuthContext::user_id_opt)
+        {
             state
                 .git_provider_manager
                 .get_valid_github_token_for_user(user_id)
@@ -366,6 +369,25 @@ fn authorize_custom_gitlab_origin(
             ));
     }
 
+    Ok(())
+}
+
+fn authorize_public_preset_refresh(auth: Option<&AuthContext>, fresh: bool) -> Result<(), Problem> {
+    if !fresh {
+        return Ok(());
+    }
+    let auth = auth.ok_or_else(|| {
+        problem_new(StatusCode::UNAUTHORIZED)
+            .with_title("Authentication Required")
+            .with_detail("Refreshing public repository presets requires authentication.")
+    })?;
+    if !auth.has_permission(&Permission::GitRepositoriesRead) {
+        return Err(problem_new(StatusCode::FORBIDDEN)
+            .with_title("Insufficient Permissions")
+            .with_detail(
+                "Refreshing public repository presets requires the git_repositories:read permission.",
+            ));
+    }
     Ok(())
 }
 
@@ -564,6 +586,8 @@ pub async fn detect_public_presets(
     Path((provider, owner, repo)): Path<(String, String, String)>,
     Query(params): Query<PresetQueryParams>,
 ) -> Result<Json<PublicPresetResponse>, Problem> {
+    authorize_public_preset_refresh(auth.as_ref().map(|Extension(auth)| auth), params.fresh)?;
+
     let (repo_provider, repo_info, cache_scope) = provider_for_public_request(
         state.as_ref(),
         auth.as_ref().map(|Extension(auth)| auth),
@@ -681,7 +705,7 @@ async fn enrich_public_dockerfile_exposed_ports(
         .iter()
         .enumerate()
         .filter(|(_, preset)| preset.preset == "dockerfile")
-        .take(MAX_DOCKERFILES_TO_SCAN)
+        .take(MAX_PUBLIC_DOCKERFILES_TO_SCAN)
         .map(|(index, preset)| {
             let path = if preset.path == "./" || preset.path.is_empty() {
                 "Dockerfile".to_string()
@@ -1141,7 +1165,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn public_preset_detection_enriches_each_dockerfile_port() {
+    async fn public_preset_detection_limits_anonymous_provider_work() {
         let files = vec!["Dockerfile".to_string(), "apps/api/Dockerfile".to_string()];
         let mut presets = detect_presets_from_files(&files);
 
@@ -1163,7 +1187,7 @@ mod tests {
             .find(|preset| preset.path == "apps/api")
             .expect("nested Dockerfile preset should be detected");
         assert_eq!(root.exposed_port, Some(3000));
-        assert_eq!(api.exposed_port, Some(8080));
+        assert_eq!(api.exposed_port, None);
     }
 
     #[tokio::test]
@@ -1227,6 +1251,26 @@ mod tests {
         .expect_err("a principal without repository-read permission must be denied");
         assert_eq!(error.status_code, StatusCode::FORBIDDEN);
         assert!(authorize_custom_gitlab_origin(None, None).is_ok());
+    }
+
+    #[test]
+    fn fresh_public_preset_detection_requires_repository_read_permission() {
+        assert!(authorize_public_preset_refresh(None, false).is_ok());
+        let error = authorize_public_preset_refresh(None, true)
+            .expect_err("anonymous callers must not bypass the shared preset cache");
+        assert_eq!(error.status_code, StatusCode::UNAUTHORIZED);
+
+        let deployment_token = AuthContext::new_deployment_token(
+            1,
+            None,
+            None,
+            1,
+            "test-token".to_string(),
+            Vec::new(),
+        );
+        let error = authorize_public_preset_refresh(Some(&deployment_token), true)
+            .expect_err("unrelated authenticated principals must not bypass the cache");
+        assert_eq!(error.status_code, StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]

--- a/crates/temps-git/src/services/git_provider_manager.rs
+++ b/crates/temps-git/src/services/git_provider_manager.rs
@@ -6420,6 +6420,140 @@ services:
         file_content.assert_async().await;
     }
 
+    #[tokio::test]
+    async fn connected_preset_detection_uses_selected_branch_and_preserves_read_failures() {
+        use crate::services::git_provider::{AuthMethod, GitProviderService};
+        use crate::services::github_provider::GitHubProvider;
+        use base64::Engine;
+        use sea_orm::{DatabaseBackend, MockDatabase};
+
+        let mut server = mockito::Server::new_async().await;
+        let validate_token = server
+            .mock("GET", "/rate_limit")
+            .match_header("authorization", "Bearer test-access-token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"resources":{"core":{"remaining":4999}}}"#)
+            .expect(3)
+            .create_async()
+            .await;
+        let tree = server
+            .mock(
+                "GET",
+                "/repos/example-owner/example-repository/git/trees/release-port",
+            )
+            .match_query(mockito::Matcher::UrlEncoded(
+                "recursive".to_string(),
+                "1".to_string(),
+            ))
+            .match_header("authorization", "Bearer test-access-token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"tree":[{"path":"Dockerfile","type":"blob"},{"path":"apps/api/Dockerfile","type":"blob"}]}"#,
+            )
+            .create_async()
+            .await;
+        let missing_nested_dockerfile = server
+            .mock(
+                "GET",
+                "/repos/example-owner/example-repository/contents/apps/api/Dockerfile",
+            )
+            .match_query(mockito::Matcher::UrlEncoded(
+                "ref".to_string(),
+                "release-port".to_string(),
+            ))
+            .match_header("authorization", "Bearer test-access-token")
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"message":"simulated missing file"}"#)
+            .create_async()
+            .await;
+        let dockerfile = server
+            .mock(
+                "GET",
+                "/repos/example-owner/example-repository/contents/Dockerfile",
+            )
+            .match_query(mockito::Matcher::UrlEncoded(
+                "ref".to_string(),
+                "release-port".to_string(),
+            ))
+            .match_header("authorization", "Bearer test-access-token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "path": "Dockerfile",
+                    "content": base64::engine::general_purpose::STANDARD
+                        .encode("FROM alpine\nEXPOSE 4321\n"),
+                    "encoding": "base64"
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let encryption_service = Arc::new(
+            temps_core::EncryptionService::new(
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            )
+            .expect("test encryption key should be valid"),
+        );
+        let mut connection = connection_fixture(11, Some(5));
+        connection.access_token = Some(
+            encryption_service
+                .encrypt_string("test-access-token")
+                .expect("test access token should encrypt"),
+        );
+        let repository = repository_fixture(connection.id);
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([[repository.clone()]])
+                .append_query_results([[connection.clone()]])
+                .append_query_results([[connection.clone()]])
+                .append_query_results([[connection.clone()]])
+                .append_query_results([[connection]])
+                .append_query_results([[repository]])
+                .into_connection(),
+        );
+        let manager = GitProviderManager::new(
+            db.clone(),
+            encryption_service,
+            Arc::new(MockJobQueue) as Arc<dyn JobQueue>,
+            create_test_config_service(db),
+        );
+        let provider: Arc<dyn GitProviderService> = Arc::new(GitHubProvider::new(
+            Some(server.url()),
+            AuthMethod::PersonalAccessToken {
+                token: "unused-constructor-token".to_string(),
+            },
+        ));
+        manager.providers_cache.write().await.insert(7, provider);
+
+        let result = manager
+            .calculate_repository_preset_live(42, Some("release-port".to_string()))
+            .await
+            .expect("connected preset detection should succeed");
+
+        assert_eq!(result.presets.len(), 2);
+        let root = result
+            .presets
+            .iter()
+            .find(|preset| preset.path == "./")
+            .expect("root Dockerfile preset should remain available");
+        let nested = result
+            .presets
+            .iter()
+            .find(|preset| preset.path == "apps/api")
+            .expect("unreadable nested Dockerfile preset should remain available");
+        assert_eq!(root.exposed_port, Some(4321));
+        assert_eq!(nested.exposed_port, None);
+        validate_token.assert_async().await;
+        tree.assert_async().await;
+        dockerfile.assert_async().await;
+        missing_nested_dockerfile.assert_async().await;
+    }
+
     // Helper function to create a test ConfigService
     fn create_test_config_service(db: Arc<DatabaseConnection>) -> Arc<temps_config::ConfigService> {
         let server_config = Arc::new(

--- a/crates/temps-git/src/services/git_provider_manager.rs
+++ b/crates/temps-git/src/services/git_provider_manager.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::RwLock;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use super::git_provider::{
     AuthMethod, GitProviderError, GitProviderFactory, GitProviderService, GitProviderType,
@@ -21,6 +21,7 @@ use temps_entities::{git_provider_connections, git_providers, projects, reposito
 
 // OAuth scope constants
 const GITLAB_OAUTH_SCOPES: &str = "api read_api read_repository";
+const MAX_DOCKERFILES_TO_SCAN: usize = 16;
 // Create JWT token for authentication
 use octocrab::models::{AppId, InstallationId, InstallationToken};
 use octocrab::params::apps::CreateInstallationAccessToken;
@@ -3310,7 +3311,16 @@ impl GitProviderManager {
             .await?;
 
         // Detect presets in root and subdirectories
-        let presets = self.detect_presets_in_directories(&files).await;
+        let mut presets = self.detect_presets_in_directories(&files).await;
+        self.enrich_dockerfile_exposed_ports(
+            &mut presets,
+            connection_id,
+            &provider_service,
+            &repository.owner,
+            &repository.name,
+            &target_branch,
+        )
+        .await;
 
         // Cache presets in repositories.preset as HashMap<branch, preset_data>
         let calculated_at = chrono::Utc::now();
@@ -3620,6 +3630,74 @@ impl GitProviderManager {
                 }
             })
             .collect()
+    }
+
+    /// Read a bounded number of detected Dockerfiles and attach their final
+    /// stage's primary `EXPOSE` port to preset metadata. Detection remains
+    /// best-effort: a provider read failure must not hide an otherwise valid
+    /// preset or prevent project creation.
+    async fn enrich_dockerfile_exposed_ports(
+        &self,
+        presets: &mut [ProjectPresetDomain],
+        connection_id: i32,
+        provider_service: &Arc<dyn GitProviderService>,
+        owner: &str,
+        repository_name: &str,
+        target_branch: &str,
+    ) {
+        let dockerfiles: Vec<(usize, String)> = presets
+            .iter()
+            .enumerate()
+            .filter(|(_, preset)| preset.preset == "dockerfile")
+            .take(MAX_DOCKERFILES_TO_SCAN)
+            .map(|(index, preset)| {
+                let path = if preset.path == "./" || preset.path.is_empty() {
+                    "Dockerfile".to_string()
+                } else {
+                    format!("{}/Dockerfile", preset.path.trim_end_matches('/'))
+                };
+                (index, path)
+            })
+            .collect();
+
+        for (preset_index, dockerfile_path) in dockerfiles {
+            let file = self
+                .execute_with_refresh(connection_id, |access_token| {
+                    let provider_service = provider_service.clone();
+                    let owner = owner.to_string();
+                    let repository_name = repository_name.to_string();
+                    let target_branch = target_branch.to_string();
+                    let dockerfile_path = dockerfile_path.clone();
+                    async move {
+                        provider_service
+                            .get_file_content(
+                                &access_token,
+                                &owner,
+                                &repository_name,
+                                &dockerfile_path,
+                                Some(&target_branch),
+                            )
+                            .await
+                    }
+                })
+                .await;
+
+            match file {
+                Ok(file) => {
+                    let content = decode_file_content(&file.content, &file.encoding);
+                    presets[preset_index].exposed_port =
+                        temps_presets::detect_primary_exposed_port(&content);
+                }
+                Err(error) => warn!(
+                    owner,
+                    repository = repository_name,
+                    branch = target_branch,
+                    dockerfile = dockerfile_path,
+                    error = %error,
+                    "Could not inspect Dockerfile EXPOSE metadata during preset detection"
+                ),
+            }
+        }
     }
 
     /// Update access token for a connection (for when tokens expire or are rotated)

--- a/crates/temps-presets/src/dockerfile_expose.rs
+++ b/crates/temps-presets/src/dockerfile_expose.rs
@@ -5,6 +5,8 @@
 
 use std::collections::HashMap;
 
+const MAX_DOCKERFILE_BYTES: usize = 1024 * 1024;
+
 /// Return the first TCP port exposed by the Dockerfile's final stage.
 ///
 /// Docker routes image metadata from the final stage, so ports declared only
@@ -16,12 +18,17 @@ use std::collections::HashMap;
 /// intentionally ignored rather than guessed; the built image remains the
 /// source of truth for those Dockerfiles.
 pub fn detect_primary_exposed_port(dockerfile: &str) -> Option<u16> {
-    let mut named_stages: HashMap<String, Vec<u16>> = HashMap::new();
+    if dockerfile.len() > MAX_DOCKERFILE_BYTES {
+        return None;
+    }
+
+    let escape_character = dockerfile_escape_character(dockerfile);
+    let mut named_stages: HashMap<String, Option<u16>> = HashMap::new();
     let mut current_alias: Option<String> = None;
-    let mut current_ports = Vec::new();
+    let mut current_port = None;
     let mut saw_from = false;
 
-    for line in logical_lines(dockerfile) {
+    for line in logical_lines(dockerfile, escape_character) {
         let Some((instruction, arguments)) = split_instruction(&line) else {
             continue;
         };
@@ -29,40 +36,57 @@ pub fn detect_primary_exposed_port(dockerfile: &str) -> Option<u16> {
         if instruction.eq_ignore_ascii_case("FROM") {
             if saw_from {
                 if let Some(alias) = current_alias.take() {
-                    named_stages.insert(alias, current_ports.clone());
+                    named_stages.insert(alias, current_port);
                 }
             }
 
             let Some((base, alias)) = parse_from(arguments) else {
                 continue;
             };
-            current_ports = named_stages
+            current_port = named_stages
                 .get(&base.to_ascii_lowercase())
-                .cloned()
+                .copied()
                 .unwrap_or_default();
             current_alias = alias.map(|value| value.to_ascii_lowercase());
             saw_from = true;
             continue;
         }
 
-        if instruction.eq_ignore_ascii_case("EXPOSE") {
-            for token in arguments.split_whitespace() {
-                if token.starts_with('#') {
-                    break;
-                }
-                if let Some(port) = parse_tcp_port(token) {
-                    if !current_ports.contains(&port) {
-                        current_ports.push(port);
-                    }
-                }
-            }
+        if instruction.eq_ignore_ascii_case("EXPOSE") && current_port.is_none() {
+            current_port = arguments
+                .split_whitespace()
+                .take_while(|token| !token.starts_with('#'))
+                .find_map(parse_tcp_port);
         }
     }
 
-    current_ports.first().copied()
+    current_port
 }
 
-fn logical_lines(dockerfile: &str) -> Vec<String> {
+fn dockerfile_escape_character(dockerfile: &str) -> char {
+    for raw_line in dockerfile.lines() {
+        let trimmed = raw_line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Some(comment) = trimmed.strip_prefix('#') else {
+            break;
+        };
+        let Some((name, value)) = comment.trim().split_once('=') else {
+            continue;
+        };
+        if name.trim().eq_ignore_ascii_case("escape") {
+            return match value.trim() {
+                "`" => '`',
+                "\\" => '\\',
+                _ => '\\',
+            };
+        }
+    }
+    '\\'
+}
+
+fn logical_lines(dockerfile: &str, escape_character: char) -> Vec<String> {
     let mut lines = Vec::new();
     let mut current = String::new();
 
@@ -72,9 +96,9 @@ fn logical_lines(dockerfile: &str) -> Vec<String> {
             continue;
         }
 
-        let continued = trimmed.ends_with('\\');
+        let continued = trimmed.ends_with(escape_character);
         let part = if continued {
-            trimmed.trim_end_matches('\\').trim_end()
+            trimmed.trim_end_matches(escape_character).trim_end()
         } else {
             trimmed
         };
@@ -180,5 +204,30 @@ mod tests {
         let dockerfile = "FROM alpine\nEXPOSE 3000 # 4000 is documentation only\n";
 
         assert_eq!(detect_primary_exposed_port(dockerfile), Some(3000));
+    }
+
+    #[test]
+    fn honors_backtick_escape_directive() {
+        let dockerfile = "# escape=`\nFROM alpine\nEXPOSE `\n  8080/tcp\n";
+
+        assert_eq!(detect_primary_exposed_port(dockerfile), Some(8080));
+    }
+
+    #[test]
+    fn rejects_oversized_dockerfiles_before_parsing() {
+        let dockerfile = format!("FROM alpine\nEXPOSE 8080\n{}", "#".repeat(1024 * 1024));
+
+        assert_eq!(detect_primary_exposed_port(&dockerfile), None);
+    }
+
+    #[test]
+    fn large_expose_lists_return_without_quadratic_deduplication() {
+        let ports = (1..=u16::MAX)
+            .map(|port| port.to_string())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let dockerfile = format!("FROM alpine\nEXPOSE {ports}\n");
+
+        assert_eq!(detect_primary_exposed_port(&dockerfile), Some(1));
     }
 }

--- a/crates/temps-presets/src/dockerfile_expose.rs
+++ b/crates/temps-presets/src/dockerfile_expose.rs
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Best-effort Dockerfile `EXPOSE` detection for pre-deployment configuration.
+
+use std::collections::HashMap;
+
+/// Return the first TCP port exposed by the Dockerfile's final stage.
+///
+/// Docker routes image metadata from the final stage, so ports declared only
+/// in an earlier build stage must not become the project's default. Named
+/// stage inheritance (`FROM base`) is followed because inherited `EXPOSE`
+/// metadata is retained by the resulting image.
+///
+/// Only literal ports are returned. Variable expressions and port ranges are
+/// intentionally ignored rather than guessed; the built image remains the
+/// source of truth for those Dockerfiles.
+pub fn detect_primary_exposed_port(dockerfile: &str) -> Option<u16> {
+    let mut named_stages: HashMap<String, Vec<u16>> = HashMap::new();
+    let mut current_alias: Option<String> = None;
+    let mut current_ports = Vec::new();
+    let mut saw_from = false;
+
+    for line in logical_lines(dockerfile) {
+        let Some((instruction, arguments)) = split_instruction(&line) else {
+            continue;
+        };
+
+        if instruction.eq_ignore_ascii_case("FROM") {
+            if saw_from {
+                if let Some(alias) = current_alias.take() {
+                    named_stages.insert(alias, current_ports.clone());
+                }
+            }
+
+            let Some((base, alias)) = parse_from(arguments) else {
+                continue;
+            };
+            current_ports = named_stages
+                .get(&base.to_ascii_lowercase())
+                .cloned()
+                .unwrap_or_default();
+            current_alias = alias.map(|value| value.to_ascii_lowercase());
+            saw_from = true;
+            continue;
+        }
+
+        if instruction.eq_ignore_ascii_case("EXPOSE") {
+            for token in arguments.split_whitespace() {
+                if token.starts_with('#') {
+                    break;
+                }
+                if let Some(port) = parse_tcp_port(token) {
+                    if !current_ports.contains(&port) {
+                        current_ports.push(port);
+                    }
+                }
+            }
+        }
+    }
+
+    current_ports.first().copied()
+}
+
+fn logical_lines(dockerfile: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+
+    for raw_line in dockerfile.lines() {
+        let trimmed = raw_line.trim();
+        if trimmed.is_empty() || (current.is_empty() && trimmed.starts_with('#')) {
+            continue;
+        }
+
+        let continued = trimmed.ends_with('\\');
+        let part = if continued {
+            trimmed.trim_end_matches('\\').trim_end()
+        } else {
+            trimmed
+        };
+
+        if !current.is_empty() {
+            current.push(' ');
+        }
+        current.push_str(part);
+
+        if !continued {
+            lines.push(std::mem::take(&mut current));
+        }
+    }
+
+    if !current.is_empty() {
+        lines.push(current);
+    }
+
+    lines
+}
+
+fn split_instruction(line: &str) -> Option<(&str, &str)> {
+    let instruction_end = line.find(char::is_whitespace).unwrap_or(line.len());
+    let instruction = &line[..instruction_end];
+    let arguments = line[instruction_end..].trim();
+    (!instruction.is_empty() && !arguments.is_empty()).then_some((instruction, arguments))
+}
+
+fn parse_from(arguments: &str) -> Option<(&str, Option<&str>)> {
+    let mut parts = arguments
+        .split_whitespace()
+        .skip_while(|part| part.starts_with("--"));
+    let base = parts.next()?;
+    let remaining: Vec<&str> = parts.collect();
+    let alias = remaining.windows(2).find_map(|pair| {
+        pair[0]
+            .eq_ignore_ascii_case("AS")
+            .then_some(pair[1])
+    });
+    Some((base, alias))
+}
+
+fn parse_tcp_port(token: &str) -> Option<u16> {
+    let (port, protocol) = token.split_once('/').unwrap_or((token, "tcp"));
+    if !protocol.eq_ignore_ascii_case("tcp") {
+        return None;
+    }
+    let port = port.parse::<u16>().ok()?;
+    (port > 0).then_some(port)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::detect_primary_exposed_port;
+
+    #[test]
+    fn detects_literal_tcp_port_case_insensitively() {
+        let dockerfile = "FROM alpine\nexpose 8080/tcp\n";
+
+        assert_eq!(detect_primary_exposed_port(dockerfile), Some(8080));
+    }
+
+    #[test]
+    fn uses_first_tcp_port_from_final_stage() {
+        let dockerfile = r#"
+            FROM rust:1 AS build
+            EXPOSE 9000
+            FROM debian:bookworm-slim
+            EXPOSE 53/udp \
+              8080/tcp 8443
+        "#;
+
+        assert_eq!(detect_primary_exposed_port(dockerfile), Some(8080));
+    }
+
+    #[test]
+    fn ignores_ports_declared_only_in_build_stage() {
+        let dockerfile = "FROM node:22 AS build\nEXPOSE 3000\nFROM nginx:alpine\n";
+
+        assert_eq!(detect_primary_exposed_port(dockerfile), None);
+    }
+
+    #[test]
+    fn preserves_expose_metadata_inherited_from_named_stage() {
+        let dockerfile = r#"
+            FROM alpine AS app-base
+            EXPOSE 4321
+            FROM app-base AS production
+        "#;
+
+        assert_eq!(detect_primary_exposed_port(dockerfile), Some(4321));
+    }
+
+    #[test]
+    fn ignores_variable_ranges_and_invalid_ports() {
+        let dockerfile = "FROM alpine\nEXPOSE $PORT 8000-8005 0 70000\n";
+
+        assert_eq!(detect_primary_exposed_port(dockerfile), None);
+    }
+
+    #[test]
+    fn stops_at_inline_comment_token() {
+        let dockerfile = "FROM alpine\nEXPOSE 3000 # 4000 is documentation only\n";
+
+        assert_eq!(detect_primary_exposed_port(dockerfile), Some(3000));
+    }
+}

--- a/crates/temps-presets/src/dockerfile_expose.rs
+++ b/crates/temps-presets/src/dockerfile_expose.rs
@@ -67,20 +67,26 @@ fn dockerfile_escape_character(dockerfile: &str) -> char {
     for raw_line in dockerfile.lines() {
         let trimmed = raw_line.trim();
         if trimmed.is_empty() {
-            continue;
+            break;
         }
         let Some(comment) = trimmed.strip_prefix('#') else {
             break;
         };
         let Some((name, value)) = comment.trim().split_once('=') else {
-            continue;
+            break;
         };
-        if name.trim().eq_ignore_ascii_case("escape") {
-            return match value.trim() {
-                "`" => '`',
-                "\\" => '\\',
-                _ => '\\',
-            };
+        match name.trim().to_ascii_lowercase().as_str() {
+            "escape" => {
+                return match value.trim() {
+                    "`" => '`',
+                    "\\" => '\\',
+                    _ => '\\',
+                };
+            }
+            // Docker permits multiple parser directives in the initial
+            // directive block. Other comments end that block.
+            "syntax" | "check" => continue,
+            _ => break,
         }
     }
     '\\'
@@ -208,7 +214,16 @@ mod tests {
 
     #[test]
     fn honors_backtick_escape_directive() {
-        let dockerfile = "# escape=`\nFROM alpine\nEXPOSE `\n  8080/tcp\n";
+        let dockerfile =
+            "# syntax=docker/dockerfile:1\n# escape=`\nFROM alpine\nEXPOSE `\n  8080/tcp\n";
+
+        assert_eq!(detect_primary_exposed_port(dockerfile), Some(8080));
+    }
+
+    #[test]
+    fn ignores_escape_comments_after_the_parser_directive_block() {
+        let dockerfile =
+            "# ordinary comment\n# escape=`\nFROM alpine\nEXPOSE \\\n  8080/tcp\n";
 
         assert_eq!(detect_primary_exposed_port(dockerfile), Some(8080));
     }

--- a/crates/temps-presets/src/lib.rs
+++ b/crates/temps-presets/src/lib.rs
@@ -19,6 +19,7 @@ pub use mod_rs::docker_compose::{
     list_compose_services, list_compose_services_with_override, render_effective_compose_preview,
     ComposeParseError, ComposeServicePreview, EffectiveComposePreview,
 };
+pub use mod_rs::dockerfile_expose::detect_primary_exposed_port;
 pub use mod_rs::env_example::{
     detect_env_example_files, detect_env_example_files_in_directory, parse_env_example,
     EnvExampleVariable, ENV_EXAMPLE_FILE_NAMES,

--- a/crates/temps-presets/src/mod.rs
+++ b/crates/temps-presets/src/mod.rs
@@ -8,6 +8,7 @@ mod autopack_preset;
 mod build_system;
 mod docker;
 pub mod docker_compose;
+pub mod dockerfile_expose;
 mod docker_custom;
 mod docusaurus;
 pub mod env_example;

--- a/web/src/components/project/GitImportClone.tsx
+++ b/web/src/components/project/GitImportClone.tsx
@@ -7,10 +7,8 @@ import { useQuery, useMutation } from '@tanstack/react-query'
 import {
   listConnectionsOptions,
   getRepositoryBranchesOptions,
-  getRepositoryPresetLiveOptions,
   createProjectMutation,
   getPublicBranchesOptions,
-  detectPublicPresetsOptions,
   listProjectTemplatesOptions,
   listGitProvidersOptions,
 } from '@/api/client/@tanstack/react-query.gen'
@@ -374,50 +372,6 @@ export function GitImportClone({
   // Use the appropriate branches based on whether it's a public repo
   const branches = useGitUrl ? publicBranches : authenticatedBranches
 
-  // Query for presets from authenticated connection
-  const {
-    data: authenticatedPresetData,
-    refetch: refetchAuthenticatedPresetData,
-  } = useQuery({
-    ...getRepositoryPresetLiveOptions({
-      path: {
-        repository_id: selectedRepository?.id || 0,
-      },
-    }),
-    enabled: !useGitUrl && !!selectedRepository && !!selectedRepository?.id,
-  })
-
-  // Query for presets from public repository
-  const { data: publicPresetData, refetch: refetchPublicPresetData } = useQuery(
-    {
-      ...detectPublicPresetsOptions({
-        path: {
-          provider: parsedPublicRepo?.provider || 'github',
-          owner: parsedPublicRepo?.owner || '',
-          repo: parsedPublicRepo?.repo || '',
-        },
-        query: {
-          branch: selectedRepository?.default_branch,
-          base_url: parsedPublicRepo?.instanceUrl,
-        },
-      }),
-      enabled: useGitUrl && !!parsedPublicRepo && !!selectedRepository,
-    }
-  )
-
-  // Transform public preset data to match ProjectPresetResponse format (camelCase)
-  const presetData = useGitUrl
-    ? publicPresetData?.presets?.map((p) => ({
-        preset: p.preset,
-        presetLabel: p.preset_label,
-        exposedPort: p.exposed_port,
-        iconUrl: p.icon_url,
-        projectType: p.project_type,
-        path: p.path,
-        composeFiles: (p as any).compose_files as string[] | undefined,
-      }))
-    : authenticatedPresetData?.presets
-
   const createProjectMutationM = useMutation({
     ...createProjectMutation(),
     meta: {
@@ -648,12 +602,6 @@ export function GitImportClone({
                     baseUrl: parsedPublicRepo.instanceUrl,
                   }
                 : null
-            }
-            presetData={presetData}
-            onRefreshPresets={() =>
-              useGitUrl
-                ? refetchPublicPresetData()
-                : refetchAuthenticatedPresetData()
             }
             branches={branches?.branches}
             mode="wizard"

--- a/web/src/components/project/ProjectConfigurator.tsx
+++ b/web/src/components/project/ProjectConfigurator.tsx
@@ -115,6 +115,7 @@ import {
   toggleDatabaseSelection,
 } from '@/lib/template-service-requirements'
 import { useAllServices } from '@/hooks/useAllServices'
+import { detectedPortForSelection } from '@/lib/dockerfile-port'
 
 // Derives a browsable repo URL from whatever the API gave us. clone_url is an
 // HTTPS URL (possibly `.git`-suffixed) for connected providers, but for the
@@ -987,11 +988,54 @@ export function ProjectConfigurator({
     control: form.control,
     name: 'preset',
   })
+  const selectedPort = useWatch({
+    control: form.control,
+    name: 'port',
+  })
+  const selectedDockerfilePath = useWatch({
+    control: form.control,
+    name: 'dockerfilePath',
+  })
+  const detectedPresetPort = useMemo(
+    () => detectedPortForSelection(presetData?.presets, selectedPreset),
+    [presetData?.presets, selectedPreset]
+  )
+  const selectedPresetName = selectedPreset?.split('::')[0]?.toLowerCase()
+  const effectiveDetectedPort =
+    selectedPresetName === 'dockerfile' &&
+    (selectedDockerfilePath || 'Dockerfile') === 'Dockerfile'
+      ? detectedPresetPort
+      : undefined
+  const hasDockerfilePortMismatch =
+    selectedPresetName === 'dockerfile' &&
+    effectiveDetectedPort !== undefined &&
+    selectedPort !== undefined &&
+    selectedPort !== effectiveDetectedPort
+  const lastAutoPortPreset = useRef<string | null>(null)
+
   // Auto-update port based on selected preset
   useEffect(() => {
-    if (!selectedPreset || !allPresetsData?.presets) {
+    if (!selectedPreset) {
       return
     }
+
+    if (
+      lastAutoPortPreset.current === selectedPreset &&
+      form.getFieldState('port').isDirty
+    ) {
+      return
+    }
+
+    if (effectiveDetectedPort !== undefined) {
+      form.setValue('port', effectiveDetectedPort, {
+        shouldValidate: true,
+        shouldDirty: false,
+      })
+      lastAutoPortPreset.current = selectedPreset
+      return
+    }
+
+    if (!allPresetsData?.presets) return
 
     // Extract preset name from "preset::path" format
     const [presetName] = selectedPreset.split('::')
@@ -1011,8 +1055,9 @@ export function ProjectConfigurator({
         shouldValidate: true,
         shouldDirty: false,
       })
+      lastAutoPortPreset.current = selectedPreset
     }
-  }, [selectedPreset, allPresetsData, form])
+  }, [selectedPreset, effectiveDetectedPort, allPresetsData, form])
 
   // Environment variable management
   const addEnvironmentVariable = () => {
@@ -1511,8 +1556,23 @@ export function ProjectConfigurator({
                 />
               </FormControl>
               <p className="text-xs text-muted-foreground">
-                Port your application will listen on (e.g., 3000, 8080)
+                {effectiveDetectedPort !== undefined
+                  ? `Detected from EXPOSE ${effectiveDetectedPort} in this Dockerfile.`
+                  : 'Port your application will listen on (e.g., 3000, 8080)'}
               </p>
+              {hasDockerfilePortMismatch && (
+                <Alert variant="destructive" className="mt-2">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertDescription>
+                    This Dockerfile exposes port {effectiveDetectedPort}, but
+                    the project is configured for port {selectedPort}. Temps
+                    routes to the exposed image port after the build, so an app
+                    that listens on the configured PORT value may fail its
+                    health check. Make these ports match unless your startup
+                    command intentionally ignores PORT.
+                  </AlertDescription>
+                </Alert>
+              )}
               <FormMessage />
             </FormItem>
           )}

--- a/web/src/components/project/ProjectConfigurator.tsx
+++ b/web/src/components/project/ProjectConfigurator.tsx
@@ -5,6 +5,7 @@ import {
   createProjectMutation,
   getRepositoryBranchesOptions,
   getRepositoryPresetLiveOptions,
+  detectPublicPresetsOptions,
   getRepositoryEnvExampleLiveOptions,
   detectPublicEnvExampleOptions,
   getRepositoryComposeServicesLiveOptions,
@@ -12,6 +13,7 @@ import {
   listPresetsOptions,
   revealServiceEnvironmentVariablesOptions,
 } from '@/api/client/@tanstack/react-query.gen'
+import { detectPublicPresets } from '@/api/client/sdk.gen'
 import {
   CreatableServiceTypeRoute,
   RepositoryResponse,
@@ -562,17 +564,14 @@ interface ProjectConfiguratorProps {
 
   // Optional data
   branches?: BranchInfo[]
-  /** Pre-loaded preset data (for public repos or when already fetched) */
+  /** Pre-loaded preset data for callers that already fetched it */
   presetData?: ProjectPresetResponse[]
   /**
    * Overrides the "Refresh" button's default behavior of refetching this
-   * component's own `getRepositoryPresetLive` query. Required whenever
+   * component's own preset query. Required whenever
    * `presetData` is supplied: that internal query is keyed on `repository.id`,
    * which is a real value only when the repo comes from `getRepositoryById`.
-   * Callers that source presets another way (e.g. `detectPublicPresets` for a
-   * public "git URL" import, where `repository.id` is a synthetic `0`) must
-   * pass their own refetch here, or the button will hit a nonexistent
-   * `repositories/0` route.
+   * Callers that source presets another way must pass their own refetch here.
    */
   onRefreshPresets?: () => Promise<unknown>
   /**
@@ -752,22 +751,54 @@ export function ProjectConfigurator({
     name: 'rootDirectory',
   })
 
-  // Fetch preset data (will refetch when branch changes due to query key)
-  // Skip fetching if presetData is already provided (e.g., for public repos)
+  // Fetch connected preset data (will refetch when branch changes due to query key).
   const {
     data: fetchedPresetData,
-    isLoading: presetLoading,
-    isFetching: presetFetching,
-    error: presetError,
+    isLoading: connectedPresetLoading,
+    isFetching: connectedPresetFetching,
+    error: connectedPresetError,
     refetch: refetchPresets,
   } = useQuery({
     ...getRepositoryPresetLiveOptions({
       path: { repository_id: repository.id || 0 },
       query: { branch: selectedBranch },
     }),
-    enabled: !providedPresetData && !!repository.id && !!selectedBranch,
+    enabled:
+      !providedPresetData &&
+      !publicRepo &&
+      !!repository.id &&
+      !!selectedBranch,
     // Key includes branch, so React Query will refetch when branch changes
   })
+
+  const publicPresetQueryOptions = detectPublicPresetsOptions({
+    path: {
+      provider: publicRepo?.provider || 'github',
+      owner: publicRepo?.owner || '',
+      repo: publicRepo?.repo || '',
+    },
+    query: {
+      branch: selectedBranch,
+      base_url: publicRepo?.baseUrl,
+    },
+  })
+  const {
+    data: fetchedPublicPresetData,
+    isLoading: publicPresetLoading,
+    isFetching: publicPresetFetching,
+    error: publicPresetError,
+  } = useQuery({
+    ...publicPresetQueryOptions,
+    enabled: !providedPresetData && !!publicRepo && !!selectedBranch,
+  })
+
+  const presetLoading = publicRepo
+    ? publicPresetLoading
+    : connectedPresetLoading
+  const presetFetching = publicRepo
+    ? publicPresetFetching
+    : connectedPresetFetching
+  const presetError = publicRepo ? publicPresetError : connectedPresetError
 
   // Holds the manual "Refresh" click for a minimum visible duration so a
   // fast response doesn't cut the spin icon off before it completes a turn.
@@ -776,9 +807,33 @@ export function ProjectConfigurator({
   const handleRefreshPresets = async () => {
     setIsManuallyRefreshingPresets(true)
     try {
-      await withMinDuration(() =>
-        onRefreshPresets ? onRefreshPresets() : refetchPresets()
-      )
+      await withMinDuration(async () => {
+        if (onRefreshPresets) {
+          await onRefreshPresets()
+          return
+        }
+        if (publicRepo) {
+          const response = await detectPublicPresets({
+            path: {
+              provider: publicRepo.provider,
+              owner: publicRepo.owner,
+              repo: publicRepo.repo,
+            },
+            query: {
+              branch: selectedBranch,
+              base_url: publicRepo.baseUrl,
+              fresh: true,
+            },
+            throwOnError: true,
+          })
+          queryClient.setQueryData(
+            publicPresetQueryOptions.queryKey,
+            response.data
+          )
+          return
+        }
+        await refetchPresets()
+      })
     } finally {
       setIsManuallyRefreshingPresets(false)
     }
@@ -790,8 +845,21 @@ export function ProjectConfigurator({
     if (providedPresetData) {
       return { presets: providedPresetData }
     }
+    if (fetchedPublicPresetData) {
+      return {
+        presets: fetchedPublicPresetData.presets.map((preset) => ({
+          preset: preset.preset,
+          presetLabel: preset.preset_label,
+          exposedPort: preset.exposed_port,
+          iconUrl: preset.icon_url,
+          projectType: preset.project_type,
+          path: preset.path,
+          composeFiles: preset.compose_files,
+        })),
+      }
+    }
     return fetchedPresetData
-  }, [providedPresetData, fetchedPresetData])
+  }, [providedPresetData, fetchedPublicPresetData, fetchedPresetData])
 
   // Detect a .env.example (or common variant) directly inside the selected
   // project root. Including the root directory in the query key makes preset
@@ -1011,7 +1079,7 @@ export function ProjectConfigurator({
     effectiveDetectedPort !== undefined &&
     selectedPort !== undefined &&
     selectedPort !== effectiveDetectedPort
-  const lastAutoPortPreset = useRef<string | null>(null)
+  const portWasManuallyEdited = useRef(false)
 
   // Auto-update port based on selected preset
   useEffect(() => {
@@ -1019,10 +1087,7 @@ export function ProjectConfigurator({
       return
     }
 
-    if (
-      lastAutoPortPreset.current === selectedPreset &&
-      form.getFieldState('port').isDirty
-    ) {
+    if (portWasManuallyEdited.current) {
       return
     }
 
@@ -1031,7 +1096,6 @@ export function ProjectConfigurator({
         shouldValidate: true,
         shouldDirty: false,
       })
-      lastAutoPortPreset.current = selectedPreset
       return
     }
 
@@ -1055,7 +1119,6 @@ export function ProjectConfigurator({
         shouldValidate: true,
         shouldDirty: false,
       })
-      lastAutoPortPreset.current = selectedPreset
     }
   }, [selectedPreset, effectiveDetectedPort, allPresetsData, form])
 
@@ -1550,6 +1613,7 @@ export function ProjectConfigurator({
                   onBlur={field.onBlur}
                   value={field.value ?? 3000}
                   onChange={(e) => {
+                    portWasManuallyEdited.current = true
                     const v = e.target.valueAsNumber
                     field.onChange(Number.isNaN(v) ? undefined : v)
                   }}

--- a/web/src/lib/dockerfile-port.test.ts
+++ b/web/src/lib/dockerfile-port.test.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { describe, expect, test } from 'bun:test'
+import { detectedPortForSelection } from './dockerfile-port'
+
+describe('detectedPortForSelection', () => {
+  const presets = [
+    {
+      preset: 'dockerfile',
+      path: './',
+      exposedPort: 3000,
+    },
+    {
+      preset: 'dockerfile',
+      path: 'apps/api',
+      exposed_port: 8080,
+    },
+  ]
+
+  test('uses the port from the selected Dockerfile directory', () => {
+    expect(detectedPortForSelection(presets, 'dockerfile::apps/api')).toBe(8080)
+  })
+
+  test('normalizes the root directory selector', () => {
+    expect(detectedPortForSelection(presets, 'dockerfile::root')).toBe(3000)
+  })
+
+  test('supports a bare preset selection when only the slug is available', () => {
+    expect(detectedPortForSelection(presets, 'dockerfile')).toBe(3000)
+  })
+
+  test('rejects missing and invalid detected ports', () => {
+    expect(
+      detectedPortForSelection(
+        [{ preset: 'dockerfile', path: './', exposedPort: 0 }],
+        'dockerfile::root'
+      )
+    ).toBeUndefined()
+    expect(
+      detectedPortForSelection(presets, 'dockerfile::apps/worker')
+    ).toBeUndefined()
+  })
+})

--- a/web/src/lib/dockerfile-port.test.ts
+++ b/web/src/lib/dockerfile-port.test.ts
@@ -41,4 +41,27 @@ describe('detectedPortForSelection', () => {
       detectedPortForSelection(presets, 'dockerfile::apps/worker')
     ).toBeUndefined()
   })
+
+  test('accepts only finite TCP port boundaries', () => {
+    expect(
+      detectedPortForSelection(
+        [{ preset: 'dockerfile', path: './', exposedPort: 65535 }],
+        'dockerfile::root'
+      )
+    ).toBe(65535)
+    for (const exposedPort of [-1, 65536, Number.NaN]) {
+      expect(
+        detectedPortForSelection(
+          [{ preset: 'dockerfile', path: './', exposedPort }],
+          'dockerfile::root'
+        )
+      ).toBeUndefined()
+    }
+  })
+
+  test('normalizes a trailing slash in nested preset paths', () => {
+    expect(
+      detectedPortForSelection(presets, 'dockerfile::apps/api/')
+    ).toBe(8080)
+  })
 })

--- a/web/src/lib/dockerfile-port.ts
+++ b/web/src/lib/dockerfile-port.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+type DetectedPresetWithPort = {
+  preset: string
+  path?: string | null
+  exposedPort?: number | null
+  exposed_port?: number | null
+}
+
+function normalizePath(path: string | undefined | null): string {
+  if (!path || path === '.' || path === './' || path === 'root') return 'root'
+  return path.replace(/^\.\//, '').replace(/\/$/, '')
+}
+
+/** Resolve the detected port for a `preset::path` selector value. */
+export function detectedPortForSelection(
+  presets: DetectedPresetWithPort[] | undefined,
+  selection: string | undefined
+): number | undefined {
+  if (!presets?.length || !selection) return undefined
+
+  const [slug, selectedPath] = selection.split('::')
+  const candidates = presets.filter((preset) => preset.preset === slug)
+  const match = selectedPath
+    ? candidates.find(
+        (preset) => normalizePath(preset.path) === normalizePath(selectedPath)
+      )
+    : candidates[0]
+  const port = match?.exposedPort ?? match?.exposed_port
+
+  return typeof port === 'number' && port > 0 && port <= 65535
+    ? port
+    : undefined
+}


### PR DESCRIPTION
## Summary

- inspect detected Dockerfiles for literal TCP `EXPOSE` ports from the final image stage
- attach ports to authenticated and public preset metadata; authenticated scans are bounded to 16 files, while public requests inspect only the primary Dockerfile to limit anonymous provider work
- keep preset metadata branch-aware, default the configurator to the detected port, and warn when a manual port differs
- preserve an explicitly edited port across metadata refreshes
- restrict public cache bypass to principals with `git_repositories:read`, and parse at most 1 MiB with linear parser work

## Evidence

### Dockerfile parser and repository enrichment

```text
$ cargo test --lib -p temps-presets dockerfile_expose -- --nocapture
cargo test: 10 passed, 243 filtered out (1 suite, 0.00s)

$ cargo test --lib -p temps-git connected_preset_detection_uses_selected_branch_and_preserves_read_failures -- --nocapture
cargo test: 1 passed, 330 filtered out (1 suite, 0.04s)

$ cargo test --lib -p temps-git fresh_public_preset_detection_requires_repository_read_permission -- --nocapture
cargo test: 1 passed, 330 filtered out (1 suite, 0.00s)
```

### Rendered project configurator

Command:

```bash
python3 .agents/skills/webapp-testing/scripts/with_server.py \
  --server "cd web && bun run dev --port 4175" --port 4175 --timeout 60 \
  -- python3 /private/tmp/dockerfile_port_evidence.py
```

Walkthrough against `http://localhost:4175/projects/new?source=git-url` with deterministic API fixtures:

1. Entered `https://github.com/example/docker-port-demo.git` and continued.
2. Observed default branch `main`, detected `EXPOSE 8080`, and port value `8080`.
3. Switched to `feature-port`; observed a branch-scoped preset request and port value `9090`.
4. Entered port `3000`, clicked **Refresh**, and observed the forced `feature-port&fresh=true` request.
5. Confirmed port `3000` and the `9090/3000` warning remained after refresh.

```text
UI_EVIDENCE_OK
default_port=8080
detected_copy=Detected from EXPOSE 8080 in this Dockerfile.
branch_switch_port=9090
branch_copy=Detected from EXPOSE 9090 in this Dockerfile.
manual_port_after_refresh=3000
mismatch_copy=This Dockerfile exposes port 9090, but the project is configured for port 3000. Temps routes to the exposed image port after the build, so an app that listens on the configured PORT value may fail its health check. Make these ports match unless your startup command intentionally ignores PORT.
preset_requests=[...presets?branch=main, ...presets?branch=feature-port, ...presets?branch=feature-port&fresh=true]
console_errors=[]
```

## Verification

- `cargo test --lib -p temps-presets` — 253 passed
- `cargo test --lib -p temps-git` — 331 passed
- `cargo check --lib`
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `bun test src/lib/dockerfile-port.test.ts` — 6 passed
- `bunx tsc --noEmit`
- `bun run lint`
- `python3 scripts/source_attribution.py check` — 3315 files passed
- `git diff --check`
