### PR TITLE
fix(otel): support proto3 optional fields in release builds

### DIFF
--- a/.github/scripts/test-nightly-release-workflows.sh
+++ b/.github/scripts/test-nightly-release-workflows.sh
@@ -9,6 +9,7 @@ nightly_workflow="$repository_root/.github/workflows/nightly-release.yml"
 release_workflow="$repository_root/.github/workflows/release.yml"
 sandbox_workflow="$repository_root/.github/workflows/sandbox-images-beta.yml"
 e2e_workflow="$repository_root/.github/workflows/e2e-tests.yml"
+rust_tests_workflow="$repository_root/.github/workflows/rust-tests.yml"
 decision_script="$repository_root/.github/scripts/nightly-release-decision.sh"
 validation_script="$repository_root/.github/scripts/validate-release-ref.sh"
 
@@ -47,7 +48,7 @@ if [[ "$tag_aware_dispatch_count" -ne 5 ]]; then
   fail "expected release channel and version logic to distinguish dry-runs from tag dispatches"
 fi
 
-ruby - "$repository_root" "$nightly_workflow" "$release_workflow" "$sandbox_workflow" "$e2e_workflow" <<'RUBY'
+ruby - "$repository_root" "$nightly_workflow" "$release_workflow" "$sandbox_workflow" "$e2e_workflow" "$rust_tests_workflow" <<'RUBY'
 require "yaml"
 
 repository_root = ARGV[0]
@@ -55,6 +56,7 @@ nightly = YAML.safe_load(File.read(ARGV[1]), aliases: true)
 release = YAML.safe_load(File.read(ARGV[2]), aliases: true)
 sandbox = YAML.safe_load(File.read(ARGV[3]), aliases: true)
 e2e = YAML.safe_load(File.read(ARGV[4]), aliases: true)
+rust_tests = YAML.safe_load(File.read(ARGV[5]), aliases: true)
 
 e2e_sandbox_channel = e2e.dig("jobs", "e2e-test", "env", "TEMPS_SANDBOX_CHANNEL")
 abort "E2E must pull the beta sandbox images published for main and PR builds" unless
@@ -133,6 +135,17 @@ unless actual_release_permissions == expected_release_permissions
   abort "release job permissions differ from the least-privilege allowlist:\n" \
     "expected #{expected_release_permissions.inspect}\nactual #{actual_release_permissions.inspect}"
 end
+
+otel_protobuf_compat = rust_tests.fetch("jobs").fetch("otel-protobuf-compat")
+abort "OTEL protobuf compatibility must use the release runner image" unless
+  otel_protobuf_compat["runs-on"] == "ubuntu-22.04"
+otel_protobuf_steps = otel_protobuf_compat.fetch("steps")
+protobuf_install = otel_protobuf_steps.find { |step| step["name"] == "Install protobuf compiler" }
+abort "OTEL protobuf compatibility must install protobuf-compiler" unless
+  protobuf_install&.fetch("run", "")&.include?("protobuf-compiler")
+protobuf_compile = otel_protobuf_steps.find { |step| step["name"] == "Compile OTEL protobuf bindings" }
+abort "OTEL protobuf compatibility must compile temps-otel" unless
+  protobuf_compile&.fetch("run", "") == "cargo check --lib -p temps-otel"
 
 release_steps = release.fetch("jobs").values.flat_map { |job| job.fetch("steps", []) }
 bun_versions = release_steps.map { |step| step.dig("with", "bun-version") }.compact

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -59,6 +59,31 @@ jobs:
       - name: Verify source attribution headers
         run: python3 scripts/source_attribution.py check
 
+  otel-protobuf-compat:
+    name: OTEL protobuf compatibility (Ubuntu 22.04)
+    # The release workflow uses Ubuntu 22.04, whose protobuf compiler requires
+    # an explicit proto3-optional flag for the OpenTelemetry metrics schema.
+    # Keep this check on the same runner so newer `protoc` versions cannot mask
+    # a release-only build failure.
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7.0.1
+
+      - name: Install protobuf compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+
+      - name: Compile OTEL protobuf bindings
+        run: cargo check --lib -p temps-otel
+
   # ---------------------------------------------------------------------------
   # One `temps` binary, two consumers.
   #

--- a/crates/temps-otel/build.rs
+++ b/crates/temps-otel/build.rs
@@ -3,8 +3,16 @@
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let proto_root = "proto";
+    let mut config = prost_build::Config::new();
 
-    prost_build::Config::new().btree_map(["."]).compile_protos(
+    // Ubuntu 22.04's protoc requires this flag for the `optional` fields in
+    // the OpenTelemetry metrics schema. Newer protoc releases accept them
+    // without it, which previously hid this release-build-only failure.
+    config
+        .btree_map(["."])
+        .protoc_arg("--experimental_allow_proto3_optional");
+
+    config.compile_protos(
         &[
             "proto/opentelemetry/proto/common/v1/common.proto",
             "proto/opentelemetry/proto/resource/v1/resource.proto",


### PR DESCRIPTION
## Summary

- Pass the proto3-optional compatibility flag to the OTEL protobuf generator.
- Restore Linux nightly release builds on Ubuntu 22.04's Protobuf compiler.

## Root cause

The OpenTelemetry metrics schema uses proto3 optional fields. The Linux release runners use Ubuntu 22.04's Protobuf compiler, which rejects those fields unless explicitly passed `--experimental_allow_proto3_optional`. Newer local Protobuf versions accepted the schema and masked this release-only failure.

## Evidence

**OTEL protobuf build configuration**: the changed build script compiles successfully.

```bash
cargo check --lib -p temps-otel
```

```text
cargo build: 0 errors, 2 warnings (658 crates)
```

**OTEL library suite**: tests pass against the changed build configuration.

```bash
cargo test --lib -p temps-otel
```

```text
cargo test: 565 passed (1 suite, 0.14s)
```

**Repository checks**: required pre-commit hooks, including workspace Clippy, passed before commit. The PR's Linux release CI is the final Ubuntu-22.04 reproduction.

**Regression coverage**: PR CI now runs `cargo check --lib -p temps-otel` on `ubuntu-22.04` after installing that runner's `protobuf-compiler`. The workflow-contract test verified this pinned runner, compiler installation, and command locally.
