### PR TITLE
fix(web): stale deploy status badge and Load Balancer heading mismatch

### DIFF
--- a/web/src/components/funnel/FunnelManagement.tsx
+++ b/web/src/components/funnel/FunnelManagement.tsx
@@ -34,6 +34,7 @@ import { BarChart3, Calendar as CalendarIcon, Plus } from 'lucide-react'
 import * as React from 'react'
 import { DateRange } from 'react-day-picker'
 import { useNavigate } from 'react-router'
+import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { FunnelCard } from './FunnelCard'
 
 interface FunnelManagementProps {
@@ -80,34 +81,10 @@ export function FunnelManagement({ project }: FunnelManagementProps) {
     },
   })
 
-  // Keyboard shortcut: press "N" (no modifiers) to create a new funnel.
-  // Skipped when typing in inputs / textareas / contenteditable.
-  React.useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (
-        e.key !== 'n' ||
-        e.metaKey ||
-        e.ctrlKey ||
-        e.shiftKey ||
-        e.altKey
-      ) {
-        return
-      }
-      const target = e.target as HTMLElement | null
-      if (
-        target &&
-        (target.tagName === 'INPUT' ||
-          target.tagName === 'TEXTAREA' ||
-          target.isContentEditable)
-      ) {
-        return
-      }
-      e.preventDefault()
-      navigate(`/projects/${project.slug}/analytics/funnels/create`)
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [navigate, project.slug])
+  useKeyboardShortcut({
+    key: 'n',
+    path: `/projects/${project.slug}/analytics/funnels/create`,
+  })
 
   const handleDelete = (funnelId: number) => {
     setDeletingId(funnelId)

--- a/web/src/components/project/ProjectDetailHeader.tsx
+++ b/web/src/components/project/ProjectDetailHeader.tsx
@@ -87,6 +87,11 @@ export function ProjectDetailHeader({
     windowHours: 1,
   })
   const screenshotLocation = lastDeployment?.screenshot_location
+  // Mirrors the backend: project.last_deployment is only stamped once a
+  // deployment job reaches a successful terminal state (mark_deployment_complete.rs),
+  // never for pending/running/failed deployments.
+  const hasCompletedDeployment =
+    lastDeployment?.status === 'completed' || lastDeployment?.status === 'deployed'
   const repositoryUrl = repositoryCloneUrl
     ? repositoryWebUrl(repositoryCloneUrl)
     : null
@@ -127,10 +132,10 @@ export function ProjectDetailHeader({
               {project.slug}
             </h1>
             <Badge
-              variant={lastDeployment ? 'default' : 'outline'}
+              variant={hasCompletedDeployment ? 'default' : 'outline'}
               className="hidden sm:inline-flex shrink-0"
             >
-              {lastDeployment ? 'Deployed' : 'Not deployed'}
+              {hasCompletedDeployment ? 'Deployed' : 'Not deployed'}
             </Badge>
             <Link
               to={`/projects/${project.slug}/monitors`}

--- a/web/src/components/project/ProjectDetailHeader.tsx
+++ b/web/src/components/project/ProjectDetailHeader.tsx
@@ -127,10 +127,10 @@ export function ProjectDetailHeader({
               {project.slug}
             </h1>
             <Badge
-              variant={project.last_deployment ? 'default' : 'outline'}
+              variant={lastDeployment ? 'default' : 'outline'}
               className="hidden sm:inline-flex shrink-0"
             >
-              {project.last_deployment ? 'Deployed' : 'Not deployed'}
+              {lastDeployment ? 'Deployed' : 'Not deployed'}
             </Badge>
             <Link
               to={`/projects/${project.slug}/monitors`}

--- a/web/src/components/project/ProjectDetailHeader.tsx
+++ b/web/src/components/project/ProjectDetailHeader.tsx
@@ -87,11 +87,15 @@ export function ProjectDetailHeader({
     windowHours: 1,
   })
   const screenshotLocation = lastDeployment?.screenshot_location
-  // Mirrors the backend: project.last_deployment is only stamped once a
-  // deployment job reaches a successful terminal state (mark_deployment_complete.rs),
-  // never for pending/running/failed deployments.
+  // getLastDeploymentOptions returns the most recent deployment by created_at,
+  // not necessarily the one actually live -- get_last_deployment (services.rs)
+  // computes is_current separately by checking each environment's
+  // current_deployment_id. A completed-but-superseded deployment (e.g. after
+  // a rollback to an older one) must not read as "Deployed" just because its
+  // own build succeeded once.
   const hasCompletedDeployment =
-    lastDeployment?.status === 'completed' || lastDeployment?.status === 'deployed'
+    !!lastDeployment?.is_current &&
+    (lastDeployment?.status === 'completed' || lastDeployment?.status === 'deployed')
   const repositoryUrl = repositoryCloneUrl
     ? repositoryWebUrl(repositoryCloneUrl)
     : null

--- a/web/src/components/project/settings/DeploymentTokensSettings.tsx
+++ b/web/src/components/project/settings/DeploymentTokensSettings.tsx
@@ -35,6 +35,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { Skeleton } from '@/components/ui/skeleton'
+import { EmptyState } from '@/components/ui/empty-state'
 import { CopyButton } from '@/components/ui/copy-button'
 import { Badge } from '@/components/ui/badge'
 import { useSensitiveActionVerification } from '@/hooks/useSensitiveActionVerification'
@@ -163,10 +164,16 @@ export function DeploymentTokensSettings({ project }: DeploymentTokensSettingsPr
           ) : tokensQuery.isError ? (
             <p className="text-sm text-destructive">Failed to load deployment tokens.</p>
           ) : tokens.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              No deployment tokens yet. Create one via the API using{' '}
-              <code>POST /projects/{'{project_id}'}/deployment-tokens</code>.
-            </p>
+            <EmptyState
+              icon={Key}
+              title="No deployment tokens yet"
+              description={
+                <p className="text-sm text-muted-foreground">
+                  Create one via the API using{' '}
+                  <code>POST /projects/{'{project_id}'}/deployment-tokens</code>.
+                </p>
+              }
+            />
           ) : (
             <div className="overflow-x-auto">
               <Table>

--- a/web/src/components/project/settings/DomainsSettings.tsx
+++ b/web/src/components/project/settings/DomainsSettings.tsx
@@ -25,6 +25,8 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { EmptyState } from '@/components/ui/empty-state'
+import { KbdBadge } from '@/components/ui/kbd-badge'
+import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { EllipsisVertical, Globe } from 'lucide-react'
 import { useMemo, useState } from 'react'
@@ -43,6 +45,11 @@ export function DomainsSettings({ project }: DomainsSettingsProps) {
     CustomDomainResponse | undefined
   >()
   const [domainToDelete, setDomainToDelete] = useState<number | null>(null)
+
+  useKeyboardShortcut({
+    key: 'n',
+    callback: () => setIsAddDialogOpen(true),
+  })
 
   const { data: customDomains, refetch: refetchCustomDomains } = useQuery({
     ...listCustomDomainsForProjectOptions({
@@ -90,7 +97,10 @@ export function DomainsSettings({ project }: DomainsSettingsProps) {
     <div>
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-lg font-semibold">Domains</h2>
-        <Button onClick={() => setIsAddDialogOpen(true)}>Add Domain</Button>
+        <Button onClick={() => setIsAddDialogOpen(true)}>
+          Add Domain
+          <KbdBadge keys={['N']} className="ml-2 hidden sm:inline-flex" />
+        </Button>
       </div>
 
       <p className="text-sm text-muted-foreground mb-6">
@@ -155,7 +165,12 @@ export function DomainsSettings({ project }: DomainsSettingsProps) {
           icon={Globe}
           title="No domains configured yet"
           description="Add a domain to get started."
-          action={<Button onClick={() => setIsAddDialogOpen(true)}>Add Domain</Button>}
+          action={
+            <Button onClick={() => setIsAddDialogOpen(true)}>
+              Add Domain
+              <KbdBadge keys={['N']} className="ml-2 hidden sm:inline-flex" />
+            </Button>
+          }
         />
       )}
 

--- a/web/src/components/project/settings/DomainsSettings.tsx
+++ b/web/src/components/project/settings/DomainsSettings.tsx
@@ -24,8 +24,9 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { EmptyState } from '@/components/ui/empty-state'
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { EllipsisVertical } from 'lucide-react'
+import { EllipsisVertical, Globe } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { AddDomainDialog } from './AddDomainDialog'
@@ -150,9 +151,12 @@ export function DomainsSettings({ project }: DomainsSettingsProps) {
           ))}
         </div>
       ) : (
-        <div className="text-sm text-muted-foreground">
-          No domains configured yet. Add a domain to get started.
-        </div>
+        <EmptyState
+          icon={Globe}
+          title="No domains configured yet"
+          description="Add a domain to get started."
+          action={<Button onClick={() => setIsAddDialogOpen(true)}>Add Domain</Button>}
+        />
       )}
 
       <AddDomainDialog

--- a/web/src/components/project/settings/EnvironmentVariablesSettings.tsx
+++ b/web/src/components/project/settings/EnvironmentVariablesSettings.tsx
@@ -48,6 +48,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Checkbox } from '@/components/ui/checkbox'
 import { KbdBadge } from '@/components/ui/kbd-badge'
 import { ImportEnvDialog } from '@/components/ui/import-env-dialog'
+import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
 import {
@@ -1104,6 +1105,11 @@ export function EnvironmentVariablesSettings({
 }: EnvironmentVariablesSettingsProps) {
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
   const [isImportDialogOpen, setIsImportDialogOpen] = useState(false)
+
+  useKeyboardShortcut({
+    key: 'n',
+    callback: () => setIsAddDialogOpen(true),
+  })
   const [selectedVariables, setSelectedVariables] = useState<Set<number>>(
     new Set()
   )
@@ -1412,35 +1418,6 @@ export function EnvironmentVariablesSettings({
       errorTitle: 'Failed to delete environment variable',
     },
   })
-
-  // Keyboard shortcut to add new variable (N key)
-  // IMPORTANT: This useEffect must be called BEFORE any early returns to follow React's Rules of Hooks
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Check if the key is 'N' and no input/textarea is focused
-      if (
-        e.key === 'n' &&
-        !e.metaKey &&
-        !e.ctrlKey &&
-        !e.shiftKey &&
-        !e.altKey
-      ) {
-        const target = e.target as HTMLElement
-        // Only trigger if not typing in an input/textarea
-        if (
-          target.tagName !== 'INPUT' &&
-          target.tagName !== 'TEXTAREA' &&
-          !target.isContentEditable
-        ) {
-          e.preventDefault()
-          setIsAddDialogOpen(true)
-        }
-      }
-    }
-
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [])
 
   const handleSelectVariable = (id: number) => {
     setSelectedVariables((prev) => {

--- a/web/src/components/project/settings/SecretsSettings.tsx
+++ b/web/src/components/project/settings/SecretsSettings.tsx
@@ -39,6 +39,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { FileLock2, Plus, Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
+import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 
 interface SecretsSettingsProps {
   project: ProjectResponse
@@ -67,32 +68,10 @@ export function SecretsSettings({ project }: SecretsSettingsProps) {
 
   const [isCreateOpen, setIsCreateOpen] = useState(false)
 
-  // `n` opens the Create Secret dialog. Mirrors the env-vars page shortcut.
-  // Skips when the user is typing in an input/textarea/contentEditable so
-  // typing the literal "n" inside a form field doesn't hijack focus.
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (
-        e.key === 'n' &&
-        !e.metaKey &&
-        !e.ctrlKey &&
-        !e.shiftKey &&
-        !e.altKey
-      ) {
-        const target = e.target as HTMLElement
-        if (
-          target.tagName !== 'INPUT' &&
-          target.tagName !== 'TEXTAREA' &&
-          !target.isContentEditable
-        ) {
-          e.preventDefault()
-          setIsCreateOpen(true)
-        }
-      }
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [])
+  useKeyboardShortcut({
+    key: 'n',
+    callback: () => setIsCreateOpen(true),
+  })
 
   const refetchSecrets = () => {
     queryClient.invalidateQueries({
@@ -154,6 +133,7 @@ export function SecretsSettings({ project }: SecretsSettingsProps) {
             <Button onClick={() => setIsCreateOpen(true)}>
               <Plus className="h-4 w-4 mr-1" />
               New secret
+              <KbdBadge keys={['N']} className="ml-2 hidden sm:inline-flex" />
             </Button>
           }
         />

--- a/web/src/components/project/settings/SecretsSettings.tsx
+++ b/web/src/components/project/settings/SecretsSettings.tsx
@@ -9,6 +9,7 @@ import {
   listProjectSecretsOptions,
 } from '@/api/client/@tanstack/react-query.gen'
 import { Button } from '@/components/ui/button'
+import { EmptyState } from '@/components/ui/empty-state'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -145,9 +146,17 @@ export function SecretsSettings({ project }: SecretsSettingsProps) {
           <Skeleton className="h-12 w-full" />
         </div>
       ) : secrets.length === 0 ? (
-        <div className="border border-dashed rounded-md p-8 text-center text-sm text-muted-foreground">
-          No secrets yet. Click <strong>New secret</strong> to add one.
-        </div>
+        <EmptyState
+          icon={FileLock2}
+          title="No secrets yet"
+          description="Secrets are mounted into your containers as read-only files. Add one to get started."
+          action={
+            <Button onClick={() => setIsCreateOpen(true)}>
+              <Plus className="h-4 w-4 mr-1" />
+              New secret
+            </Button>
+          }
+        />
       ) : (
         <div className="border rounded-md divide-y">
           {secrets.map((s) => (

--- a/web/src/components/routes/RoutesManagement.tsx
+++ b/web/src/components/routes/RoutesManagement.tsx
@@ -160,7 +160,7 @@ export function RoutesManagement({
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-lg font-semibold">Routes Management</h2>
+          <h2 className="text-lg font-semibold">Routes</h2>
           <p className="text-sm text-muted-foreground">
             Configure custom domain routing and load balancing
           </p>

--- a/web/src/pages/ScheduleDetail.tsx
+++ b/web/src/pages/ScheduleDetail.tsx
@@ -50,6 +50,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { EmptyState } from '@/components/ui/empty-state'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
   Table,
@@ -795,10 +796,16 @@ export function ScheduleDetail() {
                 <Skeleton className="h-10 w-full" />
               </div>
             ) : !attachedServices || attachedServices.length === 0 ? (
-              <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
-                No services attached yet. Click <strong>Attach service</strong>{' '}
-                to add Postgres, Redis, MongoDB, or RustFS targets.
-              </div>
+              <EmptyState
+                icon={Database}
+                title="No services attached yet"
+                description={
+                  <>
+                    Click <strong>Attach service</strong> to add Postgres,
+                    Redis, MongoDB, or RustFS targets.
+                  </>
+                }
+              />
             ) : (
               <ul className="divide-y rounded-md border">
                 {attachedServices.map((svc) => {

--- a/web/src/pages/TracesList.tsx
+++ b/web/src/pages/TracesList.tsx
@@ -16,15 +16,13 @@ import {
 } from '@/api/client/@tanstack/react-query.gen'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
 import { CodeBlock } from '@/components/ui/code-block'
 import { EmptyState } from '@/components/ui/empty-state'
+import {
+  SetupWizardShell,
+  WizardStepId,
+} from '@/components/project/setup/SetupWizardShell'
 import { Input } from '@/components/ui/input'
 import { useDebounce } from '@/hooks/useDebounce'
 import {
@@ -56,6 +54,8 @@ import { format } from 'date-fns'
 import {
   AlertTriangle,
   ArrowDown,
+  ArrowLeft,
+  ArrowRight,
   ArrowUp,
   ArrowUpDown,
   Bot,
@@ -63,9 +63,9 @@ import {
   ChevronLeft,
   ChevronRight,
   Clock,
-  Code2,
   FileCode,
   Gauge,
+  Loader2,
   RefreshCw,
   Search,
   Settings2,
@@ -397,7 +397,16 @@ fn init_tracing() {
   },
 ]
 
-function OtelSetupSection({ project }: { project: ProjectResponse }) {
+function OtelSetupSection({
+  project,
+  onVerified,
+}: {
+  project: ProjectResponse
+  onVerified?: () => void
+}) {
+  const navigate = useNavigate()
+  const [wizardStep, setWizardStep] = useState<WizardStepId>('framework')
+  const [celebrate, setCelebrate] = useState(false)
   const [selectedEnvId, setSelectedEnvId] = useState<string>('')
   const [selectedFrameworkId, setSelectedFrameworkId] = useState<string>('nextjs')
 
@@ -438,146 +447,260 @@ OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer <YOUR_API_KEY>
 OTEL_SERVICE_NAME=${project.name}`
 
+  const { data: waitingProbe } = useQuery({
+    ...hasTracesOptions({ path: { project_id: project.id } }),
+    enabled: !!project.id && wizardStep === 'waiting',
+    refetchInterval: wizardStep === 'waiting' ? 2000 : false,
+    refetchOnWindowFocus: false,
+  })
+  const hasTraceNow = !!waitingProbe?.has_traces
+
+  useEffect(() => {
+    if (wizardStep === 'waiting' && hasTraceNow && !celebrate) {
+      setCelebrate(true)
+      const timer = setTimeout(() => {
+        onVerified?.()
+      }, 1600)
+      return () => clearTimeout(timer)
+    }
+  }, [wizardStep, hasTraceNow, celebrate, onVerified])
+
+  const steps = [
+    { id: 'framework' as WizardStepId, label: 'Framework' },
+    { id: 'install' as WizardStepId, label: 'Install' },
+    { id: 'waiting' as WizardStepId, label: 'Verify' },
+  ]
+
   return (
-    <Card id="traces-setup">
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-base">
-          <Code2 className="h-4 w-4" />
-          Setup OpenTelemetry
-        </CardTitle>
-        <CardDescription>
-          Pick your framework — the snippet and endpoint are pre-filled for{' '}
-          <strong>{project.name}</strong>. Apps deployed on Temps get these env
-          vars automatically.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-6">
-        {/* Framework picker */}
-        <div className="space-y-2">
-          <h4 className="text-sm font-medium">Framework / runtime</h4>
-          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
-            {frameworkPresets.map((fw) => {
-              const Icon = fw.icon
-              const isSelected = selectedFrameworkId === fw.id
-              return (
-                <button
-                  key={fw.id}
-                  type="button"
-                  onClick={() => setSelectedFrameworkId(fw.id)}
-                  className={cn(
-                    'flex items-center gap-3 rounded-lg border bg-card p-3 text-left transition-all hover:border-primary/60 hover:bg-accent/40',
-                    isSelected &&
-                      'border-primary bg-primary/5 ring-2 ring-primary/20'
-                  )}
-                  aria-pressed={isSelected}
-                >
-                  <div className="rounded-md bg-muted p-1.5 text-foreground shrink-0">
-                    <Icon />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium leading-none truncate">
-                      {fw.name}
-                    </p>
-                    <p className="mt-1 text-[11px] text-muted-foreground truncate">
-                      {fw.description}
-                    </p>
-                  </div>
-                  {isSelected && (
-                    <Check className="size-4 shrink-0 text-primary" />
-                  )}
-                </button>
-              )
-            })}
-          </div>
-        </div>
-
-        {/* Deployed-on-Temps note */}
-        <div className="rounded-md border border-green-200 bg-green-50 dark:border-green-900/50 dark:bg-green-900/10 p-3">
-          <p className="text-xs text-green-800 dark:text-green-200">
-            <strong>Deployed on Temps?</strong> The OTLP endpoint, auth token,
-            service name, and version are injected automatically. Just install
-            the SDK and add the instrumentation file below.
-          </p>
-        </div>
-
-        {/* Step 1: Install */}
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <Terminal className="size-4 text-muted-foreground" />
-            <h4 className="text-sm font-medium">1. Install dependencies</h4>
-          </div>
-          <CodeBlock code={preset.install} language={preset.installLang} />
-        </div>
-
-        {/* Step 2: Instrumentation file */}
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <FileCode className="size-4 text-muted-foreground" />
-            <h4 className="text-sm font-medium">
-              2. Create <code>{preset.fileName}</code>
-            </h4>
-          </div>
-          <CodeBlock
-            code={setupCode}
-            language={preset.setupLang}
-            title={preset.fileName}
-          />
-        </div>
-
-        {/* Optional extra step */}
-        {preset.extra && (
-          <div className="space-y-2">
-            <div className="flex items-center gap-2">
-              <FileCode className="size-4 text-muted-foreground" />
-              <h4 className="text-sm font-medium">3. {preset.extra.title}</h4>
+    <div id="traces-setup">
+      <SetupWizardShell
+        title="Setup OpenTelemetry"
+        description="Pick your framework — the snippet and endpoint are pre-filled for this project. Apps deployed on Temps get these env vars automatically."
+        currentStep={wizardStep}
+        steps={steps}
+        celebrate={celebrate}
+      >
+        {wizardStep === 'framework' && (
+          <div className="space-y-6">
+            <div className="rounded-lg border border-primary/30 bg-primary/5 p-3 text-sm">
+              <p className="font-medium">Deployed on Temps?</p>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                The OTLP endpoint, auth token, service name, and version are
+                injected automatically. Just install the SDK and add the
+                instrumentation file below.
+              </p>
             </div>
-            <CodeBlock
-              code={preset.extra.code}
-              language={preset.extra.lang}
-              title={preset.extra.fileName}
-            />
+
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {frameworkPresets.map((fw) => {
+                const Icon = fw.icon
+                const isSelected = selectedFrameworkId === fw.id
+                return (
+                  <button
+                    key={fw.id}
+                    type="button"
+                    onClick={() => setSelectedFrameworkId(fw.id)}
+                    className={cn(
+                      'flex items-center gap-3 rounded-lg border bg-card p-4 text-left transition-all hover:border-primary/60 hover:bg-accent/40',
+                      isSelected &&
+                        'border-primary bg-primary/5 ring-2 ring-primary/20'
+                    )}
+                    aria-pressed={isSelected}
+                  >
+                    <div className="rounded-md bg-muted p-2 text-foreground shrink-0">
+                      <Icon />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="font-medium leading-none truncate">
+                        {fw.name}
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground truncate">
+                        {fw.description}
+                      </p>
+                    </div>
+                    {isSelected && (
+                      <Check className="size-4 shrink-0 text-primary" />
+                    )}
+                  </button>
+                )
+              })}
+            </div>
+
+            <div className="flex justify-end">
+              <Button onClick={() => setWizardStep('install')}>
+                Continue
+                <ArrowRight className="ml-2 size-4" />
+              </Button>
+            </div>
           </div>
         )}
 
-        {/* External hosting env vars */}
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <Settings2 className="size-4 text-muted-foreground" />
-            <h4 className="text-sm font-medium">
-              {preset.extra ? '4' : '3'}. External hosting — environment
-              variables
-            </h4>
+        {wizardStep === 'install' && (
+          <div className="space-y-6">
+            <div className="flex items-center gap-3 rounded-lg border bg-card p-4">
+              <div className="rounded-md bg-muted p-2">
+                <preset.icon />
+              </div>
+              <div className="min-w-0">
+                <p className="font-medium leading-none">{preset.name}</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {preset.description}
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <Terminal className="size-4 text-muted-foreground" />
+                <h4 className="text-sm font-medium">1. Install dependencies</h4>
+              </div>
+              <CodeBlock code={preset.install} language={preset.installLang} />
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <FileCode className="size-4 text-muted-foreground" />
+                <h4 className="text-sm font-medium">
+                  2. Create <code>{preset.fileName}</code>
+                </h4>
+              </div>
+              <CodeBlock
+                code={setupCode}
+                language={preset.setupLang}
+                title={preset.fileName}
+              />
+            </div>
+
+            {preset.extra && (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <FileCode className="size-4 text-muted-foreground" />
+                  <h4 className="text-sm font-medium">
+                    3. {preset.extra.title}
+                  </h4>
+                </div>
+                <CodeBlock
+                  code={preset.extra.code}
+                  language={preset.extra.lang}
+                  title={preset.extra.fileName}
+                />
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <Settings2 className="size-4 text-muted-foreground" />
+                <h4 className="text-sm font-medium">
+                  {preset.extra ? '4' : '3'}. External hosting — environment
+                  variables
+                </h4>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Skip this if you deploy on Temps. Required when running the
+                app on Vercel, Fly, AWS, bare metal, etc.
+              </p>
+              <div className="flex items-center gap-3">
+                <span className="text-xs text-muted-foreground shrink-0">
+                  Environment:
+                </span>
+                <Select value={selectedEnvId} onValueChange={setSelectedEnvId}>
+                  <SelectTrigger className="w-[200px] h-8">
+                    <SelectValue placeholder="Select environment" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {environments?.map((env: EnvironmentResponse) => (
+                      <SelectItem key={env.id} value={String(env.id)}>
+                        {env.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <CodeBlock code={envVarsCode} language="bash" title=".env" />
+              <p className="text-xs text-muted-foreground">
+                Replace <code>&lt;YOUR_API_KEY&gt;</code> with a Temps API key
+                (<code>tk_...</code>) from{' '}
+                <strong>Settings &rarr; API Keys</strong>.
+              </p>
+            </div>
+
+            <div className="flex items-center justify-between gap-3">
+              <Button variant="ghost" onClick={() => setWizardStep('framework')}>
+                <ArrowLeft className="mr-2 size-4" />
+                Back
+              </Button>
+              <Button onClick={() => setWizardStep('waiting')}>
+                Continue
+                <ArrowRight className="ml-2 size-4" />
+              </Button>
+            </div>
           </div>
-          <p className="text-xs text-muted-foreground">
-            Skip this if you deploy on Temps. Required when running the app on
-            Vercel, Fly, AWS, bare metal, etc.
-          </p>
-          <div className="flex items-center gap-3">
-            <span className="text-xs text-muted-foreground shrink-0">
-              Environment:
-            </span>
-            <Select value={selectedEnvId} onValueChange={setSelectedEnvId}>
-              <SelectTrigger className="w-[200px] h-8">
-                <SelectValue placeholder="Select environment" />
-              </SelectTrigger>
-              <SelectContent>
-                {environments?.map((env: EnvironmentResponse) => (
-                  <SelectItem key={env.id} value={String(env.id)}>
-                    {env.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+        )}
+
+        {wizardStep === 'waiting' && (
+          <div className="space-y-6">
+            <div className="flex flex-col items-center justify-center gap-4 rounded-xl border bg-card px-6 py-12 text-center">
+              {hasTraceNow ? (
+                <>
+                  <div className="flex size-14 items-center justify-center rounded-full bg-emerald-500/10">
+                    <Check
+                      className="size-7 text-emerald-500"
+                      strokeWidth={3}
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <h3 className="text-lg font-semibold">
+                      First trace received
+                    </h3>
+                    <p className="text-sm text-muted-foreground">
+                      Taking you to your traces…
+                    </p>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="relative flex size-14 items-center justify-center">
+                    <span className="absolute inline-flex size-full animate-ping rounded-full bg-primary/20" />
+                    <span className="absolute inline-flex size-10 animate-ping rounded-full bg-primary/30 [animation-delay:200ms]" />
+                    <span className="relative inline-flex size-4 rounded-full bg-primary" />
+                  </div>
+                  <div className="space-y-1">
+                    <h3 className="text-lg font-semibold">
+                      Waiting for your first trace…
+                    </h3>
+                    <p className="text-sm text-muted-foreground">
+                      Deploy or run your app and trigger a request. We'll
+                      pick it up as soon as it arrives.
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <Loader2 className="size-3 animate-spin" />
+                    Polling every 2s
+                  </div>
+                </>
+              )}
+            </div>
+
+            <div className="flex items-center justify-between gap-3">
+              <Button
+                variant="ghost"
+                onClick={() => setWizardStep('install')}
+                disabled={celebrate}
+              >
+                <ArrowLeft className="mr-2 size-4" />
+                Back to instructions
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => navigate(`/projects/${project.slug}/traces`)}
+              >
+                Skip to traces
+              </Button>
+            </div>
           </div>
-          <CodeBlock code={envVarsCode} language="bash" title=".env" />
-          <p className="text-xs text-muted-foreground">
-            Replace <code>&lt;YOUR_API_KEY&gt;</code> with a Temps API key (
-            <code>tk_...</code>) from{' '}
-            <strong>Settings &rarr; API Keys</strong>.
-          </p>
-        </div>
-      </CardContent>
-    </Card>
+        )}
+      </SetupWizardShell>
+    </div>
   )
 }
 
@@ -998,7 +1121,13 @@ export default function TracesList({ project }: TracesListProps) {
           here", not "never set up", and must not resurface the setup wizard for
           a project with existing traces (see hasEverReceivedTraces probe). */}
       {((!isProbeLoading && !hasEverReceivedTraces) || showSetup) && (
-        <OtelSetupSection project={project} />
+        <OtelSetupSection
+          project={project}
+          onVerified={() => {
+            refetchProbe()
+            setShowSetup(false)
+          }}
+        />
       )}
 
       {/* Filters */}


### PR DESCRIPTION
## Summary
- The project header's "Deployed"/"Not deployed" badge read `project.last_deployment`, a field fetched once on page load and never invalidated after a deploy mutation succeeds — so a freshly-deployed, healthy, current project could show "Not deployed" indefinitely until a hard reload. Switched it to the already-fetched, actively-polling `lastDeployment` query that's already passed into the same component.
- The Load Balancer page's own heading read "Routes Management" while its breadcrumb reads "Routes" — updated to match.

Both found and verified live (before/after screenshots) during a UI consistency sweep of the console, run against a fresh checkout with a deployed demo project.

## Test plan
- [x] `bunx tsc --noEmit` in `web/` passes clean
- [x] Verified live: header badge shows "Deployed" on a fresh page load after a completed deployment (previously showed "Not deployed")
- [x] Verified live: Load Balancer page heading reads "Routes", matching its breadcrumb