### PR TITLE
test(proxy): raise captcha PoW attempt cap to stop random CI flakes

### DIFF
--- a/crates/temps-proxy/src/handler/captcha.rs
+++ b/crates/temps-proxy/src/handler/captcha.rs
@@ -238,8 +238,13 @@ mod tests {
         let mut nonce = 0u64;
         let mut solution_found = false;
 
-        while nonce < 5_000_000 {
-            // Limit attempts to avoid infinite loop in tests (20 bits needs ~1M average)
+        // 20 bits needs ~1M attempts on average (geometric distribution with
+        // p = 2^-20). A 5M cap left a ~0.85% chance of a false-failure on any
+        // given run purely from an unlucky random challenge -- exactly what
+        // caused this test to flake in CI. 20M attempts pushes the odds of a
+        // spurious failure down to ~2e-9 while leaving the (much faster)
+        // typical run unaffected.
+        while nonce < 20_000_000 {
             let hash = compute_hash(&challenge, &nonce.to_string());
 
             if has_leading_zero_bits(&hash, difficulty) {
@@ -258,7 +263,7 @@ mod tests {
 
         assert!(
             solution_found,
-            "Failed to find solution within 5,000,000 attempts"
+            "Failed to find solution within 20,000,000 attempts"
         );
     }
 


### PR DESCRIPTION
## Summary
- `test_generate_and_solve_challenge` brute-forces a proof-of-work solution for a freshly-random challenge at 20 leading zero bits (~1,048,576 attempts expected on average) but capped the search at 5,000,000 attempts.
- That cap left roughly a 0.85% chance per run of exceeding the budget purely from an unlucky random challenge (geometric distribution tail), independent of any code change — this is what caused it to fail during PR #864's CI run.
- Raise the cap to 20,000,000 attempts, dropping the false-failure probability to ~2e-9 while leaving the typical run time unaffected (sub-second in the common case, observed locally at 152ms–1.57s across several runs).

## Test plan
- [x] `cargo test --lib -p temps-proxy` — 574 passed, 0 failed
- [x] Ran `test_generate_and_solve_challenge` in isolation 3x to confirm it passes reliably and stays fast
- [x] `cargo clippy -p temps-proxy --all-targets -- -D warnings` (real clippy, not the rtk proxy) — clean
- [x] `cargo fmt --check` — clean