### PR TITLE
fix(web): persist Docker registry settings

### DIFF
--- a/web/src/api/platformSettings.test.ts
+++ b/web/src/api/platformSettings.test.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { describe, expect, test } from 'bun:test'
+import { buildPlatformSettingsUpdateBody } from './platformSettings'
+import type { PlatformSettings } from './platformSettings'
+
+describe('buildPlatformSettingsUpdateBody', () => {
+  test('includes Docker registry configuration in the settings request', () => {
+    const dockerRegistry = {
+      enabled: true,
+      registry_url: 'https://registry.example.test',
+      username: 'registry-user',
+      password: 'registry-token',
+      tls_verify: true,
+      ca_certificate: null,
+    }
+
+    const body = buildPlatformSettingsUpdateBody({
+      docker_registry: dockerRegistry,
+    } as PlatformSettings)
+
+    expect(body.docker_registry).toEqual(dockerRegistry)
+  })
+})

--- a/web/src/api/platformSettings.ts
+++ b/web/src/api/platformSettings.ts
@@ -3,6 +3,7 @@
 
 import { getSettings, updateSettings } from '@/api/client'
 import type {
+  AppSettings,
   AppSettingsResponse,
   LetsEncryptSettings,
   ScreenshotSettings,
@@ -162,7 +163,6 @@ export interface PlatformSettings extends AppSettingsResponse {
   disk_space_alert: DiskSpaceAlertSettings
   ai_config: AiConfigSettings
   insecure_tls: boolean
-  attack_mode?: boolean
   build_limits: BuildLimitsSettings
   /** Enabled, running services included in the metrics scrape cycle. */
   monitored_services_count: number | null
@@ -213,7 +213,27 @@ export async function updatePlatformSettings(
 
   validateSettings(updated)
 
-  const body: any = {
+  const body = buildPlatformSettingsUpdateBody(updated)
+  const result = await updateSettings({ body })
+  if (result.error) {
+    // The generated client resolves (rather than throws) on non-2xx
+    // responses, so a failed save must be surfaced explicitly here —
+    // otherwise the caller sees a resolved promise and reports "saved"
+    // for a change that was actually rejected (e.g. a validation error).
+    const detail =
+      (result.error as { detail?: string })?.detail || 'Failed to save settings'
+    throw new Error(detail)
+  }
+
+  // The PUT endpoint returns only an ack message, so we hand back our
+  // merged view. Callers that need the absolute server state should refetch.
+  return updated
+}
+
+export function buildPlatformSettingsUpdateBody(
+  updated: PlatformSettings
+): AppSettings {
+  return {
     dns_provider: updated.dns_provider,
     external_url: updated.external_url,
     internal_url: updated.internal_url,
@@ -227,10 +247,16 @@ export async function updatePlatformSettings(
     screenshots: updated.screenshots,
     security_headers: updated.security_headers,
     rate_limiting: updated.rate_limiting,
+    // The settings endpoint replaces the full AppSettings document. Omitting
+    // this field makes serde restore DockerRegistrySettings::default(), so a
+    // successful save immediately clears the registry configuration.
+    docker_registry: updated.docker_registry,
     disk_space_alert: updated.disk_space_alert,
-    agent_sandbox: updated.agent_sandbox,
+    // The response replaces encrypted provider credentials with masked status
+    // fields. The server restores those omitted secrets from storage on PUT.
+    agent_sandbox:
+      updated.agent_sandbox as unknown as AppSettings['agent_sandbox'],
     ai_config: updated.ai_config,
-    attack_mode: updated.attack_mode,
     build_limits: updated.build_limits,
     ai_chat_limits: updated.ai_chat_limits,
     request_timeouts: updated.request_timeouts,
@@ -253,20 +279,6 @@ export async function updatePlatformSettings(
     // every unrelated settings save.
     mcp_server: updated.mcp_server,
   }
-  const result = await updateSettings({ body })
-  if (result.error) {
-    // The generated client resolves (rather than throws) on non-2xx
-    // responses, so a failed save must be surfaced explicitly here —
-    // otherwise the caller sees a resolved promise and reports "saved"
-    // for a change that was actually rejected (e.g. a validation error).
-    const detail =
-      (result.error as { detail?: string })?.detail || 'Failed to save settings'
-    throw new Error(detail)
-  }
-
-  // The PATCH endpoint returns only an ack message, so we hand back our
-  // merged view. Callers that need the absolute server state should refetch.
-  return updated
 }
 
 /**


### PR DESCRIPTION
## Summary

- include the complete Docker registry configuration in platform settings updates
- extract a typed request-body builder so the API projection can be tested directly
- add a regression test covering every Docker registry field

Closes #874

## Root cause

The settings mutation merged `docker_registry` into local state but omitted it from the manually constructed `PUT /api/settings` body. The backend therefore persisted the field's default value, and the subsequent query invalidation made the UI appear to reset.

## Evidence

**Frontend regression test**: the settings request projection preserves the complete Docker registry object.

```bash
cd web && bun test src/api/platformSettings.test.ts
```

```text
1 pass
0 fail
1 expect() calls
Ran 1 test across 1 file.
```

The regression test was first run against the original implementation and failed because `body.docker_registry` was `undefined`; it passes with this fix.

**Runtime browser walkthrough**: exercised the Docker Registry settings page against an isolated local Temps instance, saved a synthetic configuration, and performed a full page reload.

```text
GET http://localhost:3022/api/settings 200
PUT http://localhost:3022/api/settings 200
GET http://localhost:3022/api/settings 200
```

Redacted Docker registry object sent by the UI:

```json
{
  "enabled": true,
  "registry_url": "https://registry.example.test",
  "username": "registry-user",
  "password": "<redacted; present>",
  "tls_verify": true,
  "ca_certificate": "synthetic-ca-certificate"
}
```

The follow-up response returned the same enabled state, URL, username, TLS setting, and CA certificate, with the password masked as `******`. After a full browser reload, those values remained populated and enabled.

**Broader checks**

```bash
cd web && bun run test
cd web && bunx tsc --noEmit
cd web && bunx eslint src/api/platformSettings.ts src/api/platformSettings.test.ts
cd web && bunx prettier --check src/api/platformSettings.ts src/api/platformSettings.test.ts
cargo check --lib
python3 scripts/source_attribution.py check
```

```text
bun run test: 458 pass, 0 fail (84 files)
TypeScript: passed
ESLint (changed files): passed
Prettier (changed files): passed
cargo check --lib: passed (existing environment/dependency warnings only)
Source attribution: passed for 3337 source files
```

The repository-wide frontend lint command remains red on the existing baseline (231 errors and 4249 warnings outside these changed files); targeted lint on both changed files passes.

## Security review note

Security sign-off is withheld pending a maintainer decision on the existing Docker registry credential-storage design. The backend masks registry passwords in API responses, but currently serializes the password into the database-backed settings JSON without encryption at rest. This behavior predates #874, but restoring the intended UI persistence path makes it merge-relevant under the repository's credential policy. Remediation requires a separate encrypted-storage migration and masked round-trip coverage; it is not included in this focused frontend fix.
