### PR TITLE
perf(otel): bound relay forwarding memory

### DIFF
--- a/crates/temps-otel/src/handlers/ingest_handler.rs
+++ b/crates/temps-otel/src/handlers/ingest_handler.rs
@@ -9,6 +9,7 @@
 
 use std::collections::HashMap;
 use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use axum::body::Bytes;
 use axum::extract::{FromRequestParts, Path, State};
@@ -30,6 +31,18 @@ use temps_core::ProblemDetails;
 use temps_metrics::{
     validate_metric_name, MetricKind, MetricPoint as StoreMetricPoint, SourceKind,
 };
+
+const RELAY_DROP_LOG_EVERY: u64 = 1024;
+static RELAY_DROPPED_BATCHES: AtomicU64 = AtomicU64::new(0);
+
+fn relay_drop_log_sample() -> Option<u64> {
+    let dropped_total = RELAY_DROPPED_BATCHES.fetch_add(1, Ordering::Relaxed) + 1;
+    if dropped_total == 1 || dropped_total.is_multiple_of(RELAY_DROP_LOG_EVERY) {
+        Some(dropped_total)
+    } else {
+        None
+    }
+}
 
 impl From<OtelError> for Problem {
     fn from(error: OtelError) -> Self {
@@ -598,20 +611,27 @@ async fn do_ingest_metrics(
 
     // Fire decoded batch at the relay extension point (non-blocking).
     // `data.clone()` is O(1) — bytes::Bytes is ref-counted. The relay channel
-    // is bounded; try_send drops silently on full rather than blocking.
+    // is bounded; try_send drops on full rather than blocking.
     if let Some(tx) = &state.otel_relay_tx {
         let msg = crate::relay::OtelRelayMessage {
             project_id: ctx.project_id,
             environment_id: ctx.environment_id,
             deployment_id: ctx.deployment_id,
             signal: crate::relay::OtelSignal::Metrics,
+            item_count: count,
             payload: data.clone(),
         };
-        if tx.try_send(msg).is_err() {
-            tracing::warn!(
-                project_id = ctx.project_id,
-                "otel relay channel full; metrics batch dropped (backpressure)"
-            );
+        if let Err(reason) = tx.try_send(msg) {
+            if let Some(dropped_total) = relay_drop_log_sample() {
+                tracing::warn!(
+                    project_id = ctx.project_id,
+                    item_count = count,
+                    payload_bytes = data.len(),
+                    reason = reason.as_str(),
+                    dropped_batches_total = dropped_total,
+                    "otel relay channel full; metrics batch dropped (backpressure)"
+                );
+            }
         }
     }
 
@@ -705,13 +725,20 @@ async fn do_ingest_traces(
             environment_id: ctx.environment_id,
             deployment_id: ctx.deployment_id,
             signal: crate::relay::OtelSignal::Traces,
+            item_count: count,
             payload: data.clone(),
         };
-        if tx.try_send(msg).is_err() {
-            tracing::warn!(
-                project_id = ctx.project_id,
-                "otel relay channel full; traces batch dropped (backpressure)"
-            );
+        if let Err(reason) = tx.try_send(msg) {
+            if let Some(dropped_total) = relay_drop_log_sample() {
+                tracing::warn!(
+                    project_id = ctx.project_id,
+                    item_count = count,
+                    payload_bytes = data.len(),
+                    reason = reason.as_str(),
+                    dropped_batches_total = dropped_total,
+                    "otel relay channel full; traces batch dropped (backpressure)"
+                );
+            }
         }
     }
 
@@ -813,13 +840,20 @@ async fn do_ingest_logs(
             environment_id: ctx.environment_id,
             deployment_id: ctx.deployment_id,
             signal: crate::relay::OtelSignal::Logs,
+            item_count: count,
             payload: data.clone(),
         };
-        if tx.try_send(msg).is_err() {
-            tracing::warn!(
-                project_id = ctx.project_id,
-                "otel relay channel full; logs batch dropped (backpressure)"
-            );
+        if let Err(reason) = tx.try_send(msg) {
+            if let Some(dropped_total) = relay_drop_log_sample() {
+                tracing::warn!(
+                    project_id = ctx.project_id,
+                    item_count = count,
+                    payload_bytes = data.len(),
+                    reason = reason.as_str(),
+                    dropped_batches_total = dropped_total,
+                    "otel relay channel full; logs batch dropped (backpressure)"
+                );
+            }
         }
     }
 
@@ -1724,16 +1758,17 @@ mod tests {
 
     #[test]
     fn relay_channel_full_try_send_returns_err_not_panic() {
-        use crate::relay::{OtelRelayMessage, OtelSignal};
+        use crate::relay::{bounded_relay_queue, OtelRelayMessage, OtelSignal};
 
         // Capacity-1 channel: fill it with the first send.
-        let (tx, _rx) = tokio::sync::mpsc::channel::<OtelRelayMessage>(1);
+        let (tx, _rx) = bounded_relay_queue(1, 1024);
 
         let make_msg = |project_id: i32| OtelRelayMessage {
             project_id,
             environment_id: None,
             deployment_id: None,
             signal: OtelSignal::Metrics,
+            item_count: 0,
             payload: bytes::Bytes::new(),
         };
 
@@ -1751,10 +1786,10 @@ mod tests {
 
     #[test]
     fn relay_channel_closed_try_send_returns_err_not_panic() {
-        use crate::relay::{OtelRelayMessage, OtelSignal};
+        use crate::relay::{bounded_relay_queue, OtelRelayMessage, OtelSignal};
 
         // Drop the receiver immediately — channel is closed.
-        let (tx, rx) = tokio::sync::mpsc::channel::<OtelRelayMessage>(10);
+        let (tx, rx) = bounded_relay_queue(10, 1024);
         drop(rx);
 
         let msg = OtelRelayMessage {
@@ -1762,6 +1797,7 @@ mod tests {
             environment_id: None,
             deployment_id: None,
             signal: OtelSignal::Traces,
+            item_count: 0,
             payload: bytes::Bytes::new(),
         };
 

--- a/crates/temps-otel/src/handlers/ingest_handler.rs
+++ b/crates/temps-otel/src/handlers/ingest_handler.rs
@@ -622,6 +622,7 @@ async fn do_ingest_metrics(
             payload: data.clone(),
         };
         if let Err(reason) = tx.try_send(msg) {
+            state.otel_service.record_relay_drop(count);
             if let Some(dropped_total) = relay_drop_log_sample() {
                 tracing::warn!(
                     project_id = ctx.project_id,
@@ -729,6 +730,7 @@ async fn do_ingest_traces(
             payload: data.clone(),
         };
         if let Err(reason) = tx.try_send(msg) {
+            state.otel_service.record_relay_drop(count);
             if let Some(dropped_total) = relay_drop_log_sample() {
                 tracing::warn!(
                     project_id = ctx.project_id,
@@ -844,6 +846,7 @@ async fn do_ingest_logs(
             payload: data.clone(),
         };
         if let Err(reason) = tx.try_send(msg) {
+            state.otel_service.record_relay_drop(count);
             if let Some(dropped_total) = relay_drop_log_sample() {
                 tracing::warn!(
                     project_id = ctx.project_id,

--- a/crates/temps-otel/src/lib.rs
+++ b/crates/temps-otel/src/lib.rs
@@ -36,6 +36,7 @@ pub mod detectors;
 pub mod error;
 pub mod handlers;
 pub mod ingest;
+pub mod memory;
 pub mod plugin;
 pub mod proto;
 pub mod relay;

--- a/crates/temps-otel/src/lib.rs
+++ b/crates/temps-otel/src/lib.rs
@@ -114,9 +114,9 @@ pub struct OtelAppState {
     /// [`crate::relay::OtelRelaySlot::relay`], which dispatches to whichever
     /// [`crate::relay::OtelRelay`] implementation was registered by a plugin
     /// (defaulting to the no-op). When the channel is full the batch is
-    /// silently dropped and a warning is emitted — relay loss is non-fatal and
+    /// dropped and a warning is emitted — relay loss is non-fatal and
     /// must never add latency to the OTLP HTTP response.
-    pub otel_relay_tx: Option<tokio::sync::mpsc::Sender<crate::relay::OtelRelayMessage>>,
+    pub otel_relay_tx: Option<crate::relay::OtelRelayQueueSender>,
     /// Optional checker for team-based project access (human sessions only).
     pub project_access_checker: Option<std::sync::Arc<dyn temps_core::ProjectAccessChecker>>,
 }

--- a/crates/temps-otel/src/memory.rs
+++ b/crates/temps-otel/src/memory.rs
@@ -1,0 +1,311 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Startup-time memory sizing for the OTel ingest and relay paths.
+//!
+//! Limits are derived once from the effective process memory ceiling. Inside a
+//! container that is the lower of the cgroup limit and host RAM; on a regular
+//! host it is physical RAM. This deliberately does not react to free memory or
+//! RSS at runtime, which would make admission capacity oscillate under load.
+
+const MIB: u64 = 1024 * 1024;
+const GIB: u64 = 1024 * MIB;
+
+/// Conservative effective-memory fallback when neither procfs nor cgroups are
+/// readable. It produces 8 concurrent ingests, an 8 MiB OSS relay handoff,
+/// and a 32 MiB external-forwarding budget.
+pub const FALLBACK_EFFECTIVE_MEMORY_BYTES: u64 = 2 * GIB;
+
+pub const MIN_INGEST_CONCURRENCY: usize = 2;
+pub const MAX_INGEST_CONCURRENCY: usize = 32;
+pub const MIN_RELAY_QUEUE_BYTES: usize = 4 * 1024 * 1024;
+pub const MAX_RELAY_QUEUE_BYTES: usize = 16 * 1024 * 1024;
+pub const MIN_EXTERNAL_RELAY_BYTES: usize = 8 * 1024 * 1024;
+pub const MAX_EXTERNAL_RELAY_BYTES: usize = 64 * 1024 * 1024;
+
+/// Source of the effective memory value selected at startup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryLimitSource {
+    CgroupV2,
+    CgroupV1,
+    Host,
+    Fallback,
+}
+
+impl MemoryLimitSource {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::CgroupV2 => "cgroup_v2",
+            Self::CgroupV1 => "cgroup_v1",
+            Self::Host => "host",
+            Self::Fallback => "fallback",
+        }
+    }
+}
+
+/// Fixed-for-process-lifetime limits selected from effective memory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OtelMemoryProfile {
+    pub effective_memory_bytes: u64,
+    pub source: MemoryLimitSource,
+    pub max_concurrent_ingest_requests: usize,
+    pub relay_queue_max_bytes: usize,
+    /// Budget available to a plugin-owned external-forwarding queue.
+    pub external_relay_max_bytes: usize,
+}
+
+impl OtelMemoryProfile {
+    /// Detect the effective memory ceiling and derive bounded OTel limits.
+    pub fn detect() -> Self {
+        let host = read_host_memory_bytes();
+        let membership = std::fs::read_to_string("/proc/self/cgroup").ok();
+        let cgroup_v2 = lowest_limit(
+            read_cgroup_limit("/sys/fs/cgroup/memory.max"),
+            membership.as_deref().and_then(|contents| {
+                cgroup_relative_path(contents, None).and_then(|relative| {
+                    read_cgroup_hierarchy_limit("/sys/fs/cgroup", relative, "memory.max")
+                })
+            }),
+        );
+        let cgroup_v1 = lowest_limit(
+            read_cgroup_limit("/sys/fs/cgroup/memory/memory.limit_in_bytes"),
+            membership.as_deref().and_then(|contents| {
+                cgroup_relative_path(contents, Some("memory")).and_then(|relative| {
+                    read_cgroup_hierarchy_limit(
+                        "/sys/fs/cgroup/memory",
+                        relative,
+                        "memory.limit_in_bytes",
+                    )
+                })
+            }),
+        );
+        Self::from_detected(host, cgroup_v2, cgroup_v1)
+    }
+
+    /// Conservative deterministic profile used by `Default` and detection
+    /// fallback paths.
+    pub const fn fallback() -> Self {
+        Self::for_memory_bytes(FALLBACK_EFFECTIVE_MEMORY_BYTES, MemoryLimitSource::Fallback)
+    }
+
+    /// Derive limits from a known effective-memory ceiling.
+    pub const fn for_memory_bytes(memory_bytes: u64, source: MemoryLimitSource) -> Self {
+        let ingest = clamp_u64(
+            memory_bytes / (256 * MIB),
+            MIN_INGEST_CONCURRENCY as u64,
+            MAX_INGEST_CONCURRENCY as u64,
+        ) as usize;
+        let relay = clamp_u64(
+            memory_bytes / 256,
+            MIN_RELAY_QUEUE_BYTES as u64,
+            MAX_RELAY_QUEUE_BYTES as u64,
+        ) as usize;
+        let external_relay = clamp_u64(
+            memory_bytes / 64,
+            MIN_EXTERNAL_RELAY_BYTES as u64,
+            MAX_EXTERNAL_RELAY_BYTES as u64,
+        ) as usize;
+
+        Self {
+            effective_memory_bytes: memory_bytes,
+            source,
+            max_concurrent_ingest_requests: ingest,
+            relay_queue_max_bytes: relay,
+            external_relay_max_bytes: external_relay,
+        }
+    }
+
+    fn from_detected(host: Option<u64>, cgroup_v2: Option<u64>, cgroup_v1: Option<u64>) -> Self {
+        let candidates = [
+            cgroup_v2.map(|bytes| (bytes, MemoryLimitSource::CgroupV2)),
+            cgroup_v1.map(|bytes| (bytes, MemoryLimitSource::CgroupV1)),
+            host.map(|bytes| (bytes, MemoryLimitSource::Host)),
+        ];
+
+        candidates
+            .into_iter()
+            .flatten()
+            .min_by_key(|(bytes, _)| *bytes)
+            .map_or_else(Self::fallback, |(bytes, source)| {
+                Self::for_memory_bytes(bytes, source)
+            })
+    }
+}
+
+impl Default for OtelMemoryProfile {
+    fn default() -> Self {
+        Self::fallback()
+    }
+}
+
+const fn clamp_u64(value: u64, min: u64, max: u64) -> u64 {
+    if value < min {
+        min
+    } else if value > max {
+        max
+    } else {
+        value
+    }
+}
+
+fn read_host_memory_bytes() -> Option<u64> {
+    let contents = std::fs::read_to_string("/proc/meminfo").ok()?;
+    parse_meminfo_total(&contents)
+}
+
+fn parse_meminfo_total(contents: &str) -> Option<u64> {
+    let line = contents
+        .lines()
+        .find(|line| line.starts_with("MemTotal:"))?;
+    let kib = line.split_ascii_whitespace().nth(1)?.parse::<u64>().ok()?;
+    kib.checked_mul(1024).filter(|bytes| *bytes > 0)
+}
+
+fn read_cgroup_limit(path: &str) -> Option<u64> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    parse_cgroup_limit(&contents)
+}
+
+fn read_cgroup_hierarchy_limit(base: &str, relative: &str, filename: &str) -> Option<u64> {
+    use std::path::{Component, Path};
+
+    let base = Path::new(base);
+    let relative = Path::new(relative.trim_start_matches('/'));
+    if relative
+        .components()
+        .any(|part| !matches!(part, Component::Normal(_) | Component::CurDir))
+    {
+        return None;
+    }
+
+    // A child can inherit a tighter ceiling from any ancestor. Walk back to
+    // the mount root and keep the smallest finite value in the hierarchy.
+    let mut current = base.join(relative);
+    let mut limit = None;
+    loop {
+        let path = current.join(filename);
+        let at_current = std::fs::read_to_string(path)
+            .ok()
+            .and_then(|contents| parse_cgroup_limit(&contents));
+        limit = lowest_limit(limit, at_current);
+
+        if current == base || !current.pop() {
+            break;
+        }
+    }
+    limit
+}
+
+fn cgroup_relative_path<'a>(contents: &'a str, controller: Option<&str>) -> Option<&'a str> {
+    contents.lines().find_map(|line| {
+        let mut fields = line.splitn(3, ':');
+        let _hierarchy_id = fields.next()?;
+        let controllers = fields.next()?;
+        let path = fields.next()?;
+
+        let matches = match controller {
+            None => controllers.is_empty(),
+            Some(wanted) => controllers.split(',').any(|value| value == wanted),
+        };
+        matches.then_some(path)
+    })
+}
+
+fn lowest_limit(first: Option<u64>, second: Option<u64>) -> Option<u64> {
+    match (first, second) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(value), None) | (None, Some(value)) => Some(value),
+        (None, None) => None,
+    }
+}
+
+fn parse_cgroup_limit(contents: &str) -> Option<u64> {
+    let value = contents.trim();
+    if value == "max" {
+        return None;
+    }
+
+    // Cgroup v1 commonly represents "unlimited" with a huge sentinel close
+    // to i64::MAX. Treat anything at or above 1 EiB as unbounded.
+    value
+        .parse::<u64>()
+        .ok()
+        .filter(|bytes| *bytes > 0 && *bytes < (1_u64 << 60))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derives_expected_limits_at_reference_sizes() {
+        let cases = [
+            (512 * MIB, 2, 4 * MIB, 8 * MIB),
+            (GIB, 4, 4 * MIB, 16 * MIB),
+            (2 * GIB, 8, 8 * MIB, 32 * MIB),
+            (4 * GIB, 16, 16 * MIB, 64 * MIB),
+            (8 * GIB, 32, 16 * MIB, 64 * MIB),
+        ];
+
+        for (memory, ingest, relay, external) in cases {
+            let profile = OtelMemoryProfile::for_memory_bytes(memory, MemoryLimitSource::Host);
+            assert_eq!(profile.max_concurrent_ingest_requests, ingest);
+            assert_eq!(profile.relay_queue_max_bytes as u64, relay);
+            assert_eq!(profile.external_relay_max_bytes as u64, external);
+        }
+    }
+
+    #[test]
+    fn bounds_tiny_and_large_machines() {
+        let tiny = OtelMemoryProfile::for_memory_bytes(64 * MIB, MemoryLimitSource::Host);
+        assert_eq!(tiny.max_concurrent_ingest_requests, MIN_INGEST_CONCURRENCY);
+        assert_eq!(tiny.relay_queue_max_bytes, MIN_RELAY_QUEUE_BYTES);
+        assert_eq!(tiny.external_relay_max_bytes, MIN_EXTERNAL_RELAY_BYTES);
+
+        let large = OtelMemoryProfile::for_memory_bytes(128 * GIB, MemoryLimitSource::Host);
+        assert_eq!(large.max_concurrent_ingest_requests, MAX_INGEST_CONCURRENCY);
+        assert_eq!(large.relay_queue_max_bytes, MAX_RELAY_QUEUE_BYTES);
+        assert_eq!(large.external_relay_max_bytes, MAX_EXTERNAL_RELAY_BYTES);
+    }
+
+    #[test]
+    fn parses_procfs_and_cgroup_formats() {
+        assert_eq!(
+            parse_meminfo_total("MemTotal:       1048576 kB\n"),
+            Some(GIB)
+        );
+        assert_eq!(parse_cgroup_limit("536870912\n"), Some(512 * MIB));
+        assert_eq!(parse_cgroup_limit("max\n"), None);
+        assert_eq!(parse_cgroup_limit("9223372036854771712\n"), None);
+        assert_eq!(parse_cgroup_limit("invalid"), None);
+    }
+
+    #[test]
+    fn parses_nested_cgroup_membership_paths() {
+        let v2 = "0::/system.slice/temps.service\n";
+        assert_eq!(
+            cgroup_relative_path(v2, None),
+            Some("/system.slice/temps.service")
+        );
+
+        let v1 = "7:cpu,cpuacct:/docker/abc\n5:memory:/docker/abc\n";
+        assert_eq!(
+            cgroup_relative_path(v1, Some("memory")),
+            Some("/docker/abc")
+        );
+        assert_eq!(cgroup_relative_path(v1, None), None);
+    }
+
+    #[test]
+    fn selects_the_lowest_available_ceiling() {
+        let profile = OtelMemoryProfile::from_detected(Some(8 * GIB), Some(GIB), None);
+        assert_eq!(profile.effective_memory_bytes, GIB);
+        assert_eq!(profile.source, MemoryLimitSource::CgroupV2);
+
+        let host_only = OtelMemoryProfile::from_detected(Some(4 * GIB), None, None);
+        assert_eq!(host_only.source, MemoryLimitSource::Host);
+
+        let fallback = OtelMemoryProfile::from_detected(None, None, None);
+        assert_eq!(fallback, OtelMemoryProfile::fallback());
+    }
+}

--- a/crates/temps-otel/src/plugin.rs
+++ b/crates/temps-otel/src/plugin.rs
@@ -207,7 +207,7 @@ fn parse_max_concurrent_ingest_requests(v: &str) -> Option<usize> {
 
 /// Number of counters the OTel pipeline-stats sampler publishes each cycle —
 /// one per [`crate::types::PipelineStats`] field.
-pub const OTEL_PIPELINE_STAT_COUNT: usize = 13;
+pub const OTEL_PIPELINE_STAT_COUNT: usize = 15;
 
 /// How often the pipeline-stats sampler snapshots the counters, in seconds.
 ///
@@ -250,6 +250,8 @@ pub const OTEL_PIPELINE_METRIC_NAMES: [&str; OTEL_PIPELINE_STAT_COUNT] = [
     "otel.logs_stored_s3",
     "otel.logs_dropped",
     "otel.ingest_errors",
+    "otel.relay_dropped_batches",
+    "otel.relay_dropped_items",
 ];
 
 /// Turn a pipeline-stats snapshot plus the previous cycle's checkpoint into the
@@ -321,6 +323,16 @@ fn pipeline_stat_deltas(
         (
             "otel.ingest_errors",
             snap.ingest_errors.saturating_sub(prev.ingest_errors),
+        ),
+        (
+            "otel.relay_dropped_batches",
+            snap.relay_dropped_batches
+                .saturating_sub(prev.relay_dropped_batches),
+        ),
+        (
+            "otel.relay_dropped_items",
+            snap.relay_dropped_items
+                .saturating_sub(prev.relay_dropped_items),
         ),
     ]
 }
@@ -991,7 +1003,7 @@ impl TempsPlugin for OtelPlugin {
             // keeping the alarm falsely active. Always writing — including
             // zeros — lets the metric self-resolve on the next cycle, exactly
             // like the proxy sampler's fixed-size point set does. The storage
-            // cost is a fixed 16 rows per minute (13 counters plus three
+            // cost is a fixed 18 rows per minute (15 counters plus three
             // resource-limit gauges) regardless of ingest volume.
             {
                 let stats_otel_service = otel_service.clone();
@@ -1325,6 +1337,8 @@ mod tests {
             ingest_errors: 11,
             rate_limited_requests: 12,
             quota_exceeded_requests: 13,
+            relay_dropped_batches: 14,
+            relay_dropped_items: 15,
         };
 
         let deltas = pipeline_stat_deltas(&snap, &zero);
@@ -1345,6 +1359,8 @@ mod tests {
         assert_eq!(by_name["otel.ingest_errors"], 11);
         assert_eq!(by_name["otel.rate_limited_requests"], 12);
         assert_eq!(by_name["otel.quota_exceeded_requests"], 13);
+        assert_eq!(by_name["otel.relay_dropped_batches"], 14);
+        assert_eq!(by_name["otel.relay_dropped_items"], 15);
     }
 
     /// The writer's names and the reader's published list must be identical,

--- a/crates/temps-otel/src/plugin.rs
+++ b/crates/temps-otel/src/plugin.rs
@@ -24,6 +24,7 @@ use crate::handlers::metric_alert_handler;
 use crate::handlers::query_handler;
 use crate::ingest::auth::OtelAuthService;
 use crate::ingest::rate_limit::RateLimiter;
+use crate::memory::OtelMemoryProfile;
 use crate::relay::OtelRelay;
 use crate::services::cross_project::{prune_stale_hints, CrossProjectTraceService, TraceHintMsg};
 use crate::services::facet_service::FacetService;
@@ -69,6 +70,13 @@ pub struct OtelConfig {
     // Ingest backpressure. Process-wide operational tuning knob (not
     // per-tenant config) — see `crate::services::otel_service::DEFAULT_MAX_CONCURRENT_INGEST_REQUESTS`.
     pub max_concurrent_ingest_requests: usize,
+
+    /// Startup-derived memory bounds shared by ingest and relay queues.
+    pub memory_profile: OtelMemoryProfile,
+
+    /// Whether the ingest concurrency was explicitly configured instead of
+    /// selected from effective memory.
+    pub ingest_concurrency_overridden: bool,
 }
 
 impl Default for OtelConfig {
@@ -89,6 +97,8 @@ impl Default for OtelConfig {
             enable_anomaly_detection: true,
             max_concurrent_ingest_requests:
                 crate::services::otel_service::DEFAULT_MAX_CONCURRENT_INGEST_REQUESTS,
+            memory_profile: OtelMemoryProfile::fallback(),
+            ingest_concurrency_overridden: false,
         }
     }
 }
@@ -96,7 +106,12 @@ impl Default for OtelConfig {
 impl OtelConfig {
     /// Read configuration from `TEMPS_OTEL_*` environment variables.
     pub fn from_env() -> Self {
-        let mut config = Self::default();
+        let memory_profile = OtelMemoryProfile::detect();
+        let mut config = Self {
+            max_concurrent_ingest_requests: memory_profile.max_concurrent_ingest_requests,
+            memory_profile,
+            ..Self::default()
+        };
 
         if let Ok(v) = std::env::var("TEMPS_OTEL_S3_REGION") {
             config.s3_region = Some(v);
@@ -152,11 +167,14 @@ impl OtelConfig {
         }
         if let Ok(v) = std::env::var("TEMPS_OTEL_MAX_CONCURRENT_INGEST_REQUESTS") {
             match parse_max_concurrent_ingest_requests(&v) {
-                Some(limit) => config.max_concurrent_ingest_requests = limit,
+                Some(limit) => {
+                    config.max_concurrent_ingest_requests = limit;
+                    config.ingest_concurrency_overridden = true;
+                }
                 None => warn!(
                     value = %v,
                     "TEMPS_OTEL_MAX_CONCURRENT_INGEST_REQUESTS is set but is not a positive \
-                     integer within the supported range; keeping the default ingest \
+                     integer within the supported range; keeping the automatically selected ingest \
                      concurrency ceiling"
                 ),
             }
@@ -504,6 +522,16 @@ impl TempsPlugin for OtelPlugin {
     ) -> Pin<Box<dyn Future<Output = Result<(), PluginError>> + Send + 'a>> {
         Box::pin(async move {
             let config = OtelConfig::from_env();
+            info!(
+                effective_memory_bytes = config.memory_profile.effective_memory_bytes,
+                memory_limit_source = config.memory_profile.source.as_str(),
+                max_concurrent_ingest_requests = config.max_concurrent_ingest_requests,
+                ingest_concurrency_overridden = config.ingest_concurrency_overridden,
+                relay_queue_max_bytes = config.memory_profile.relay_queue_max_bytes,
+                external_relay_max_bytes = config.memory_profile.external_relay_max_bytes,
+                "OTel startup memory limits selected"
+            );
+            context.register_service(Arc::new(config.memory_profile));
             let db = context.require_service::<sea_orm::DatabaseConnection>();
 
             // Create S3 archiver if configured
@@ -702,7 +730,7 @@ impl TempsPlugin for OtelPlugin {
             // decoded OTLP batches. Ingest handlers never wait for capacity.
             let (otel_relay_tx, mut otel_relay_rx) = crate::relay::bounded_relay_queue(
                 crate::relay::RELAY_QUEUE_MAX_BATCHES,
-                crate::relay::RELAY_QUEUE_MAX_BYTES,
+                config.memory_profile.relay_queue_max_bytes,
             );
 
             let cross_project_service =
@@ -963,10 +991,13 @@ impl TempsPlugin for OtelPlugin {
             // keeping the alarm falsely active. Always writing — including
             // zeros — lets the metric self-resolve on the next cycle, exactly
             // like the proxy sampler's fixed-size point set does. The storage
-            // cost is a fixed 13 rows per minute regardless of ingest volume.
+            // cost is a fixed 16 rows per minute (13 counters plus three
+            // resource-limit gauges) regardless of ingest volume.
             {
                 let stats_otel_service = otel_service.clone();
                 let stats_metrics_store = metrics_store.clone();
+                let stats_memory_profile = config.memory_profile;
+                let stats_ingest_limit = config.max_concurrent_ingest_requests;
                 tokio::spawn(async move {
                     use chrono::Utc;
                     use std::collections::HashMap;
@@ -992,7 +1023,7 @@ impl TempsPlugin for OtelPlugin {
                         let deltas = pipeline_stat_deltas(&snap, &prev);
 
                         let now = Utc::now();
-                        let points: Vec<MetricPoint> = deltas
+                        let mut points: Vec<MetricPoint> = deltas
                             .iter()
                             .map(|(name, delta)| MetricPoint {
                                 time: now,
@@ -1007,6 +1038,45 @@ impl TempsPlugin for OtelPlugin {
                                 labels: HashMap::new(),
                             })
                             .collect();
+                        points.extend([
+                            MetricPoint {
+                                time: now,
+                                source_kind: SourceKind::Node,
+                                source_id: CONTROL_PLANE_NODE_ID,
+                                name: "otel.effective_memory_limit_bytes".to_string(),
+                                value: stats_memory_profile.effective_memory_bytes as f64,
+                                kind: MetricKind::Gauge,
+                                engine: Some("otel".to_string()),
+                                environment: None,
+                                node_id: Some(CONTROL_PLANE_NODE_ID),
+                                labels: HashMap::new(),
+                            },
+                            MetricPoint {
+                                time: now,
+                                source_kind: SourceKind::Node,
+                                source_id: CONTROL_PLANE_NODE_ID,
+                                name: "otel.ingest_concurrency_limit".to_string(),
+                                value: stats_ingest_limit as f64,
+                                kind: MetricKind::Gauge,
+                                engine: Some("otel".to_string()),
+                                environment: None,
+                                node_id: Some(CONTROL_PLANE_NODE_ID),
+                                labels: HashMap::new(),
+                            },
+                            MetricPoint {
+                                time: now,
+                                source_kind: SourceKind::Node,
+                                source_id: CONTROL_PLANE_NODE_ID,
+                                name: "otel.relay_buffer_limit_bytes".to_string(),
+                                value: stats_memory_profile.relay_queue_max_bytes as f64,
+                                kind: MetricKind::Gauge,
+                                engine: Some("otel".to_string()),
+                                environment: None,
+                                node_id: Some(CONTROL_PLANE_NODE_ID),
+                                labels: HashMap::new(),
+                            },
+                        ]);
+                        let point_count = points.len();
 
                         // Only advance the checkpoints once the write actually lands.
                         // Advancing them unconditionally would discard this cycle's
@@ -1028,7 +1098,7 @@ impl TempsPlugin for OtelPlugin {
                                 snap.ingest_errors.saturating_sub(prev.ingest_errors);
                             prev = snap;
                             debug!(
-                                points = deltas.len(),
+                                points = point_count,
                                 spans_dropped,
                                 ingest_errors,
                                 "OTel pipeline stats sampled and written"

--- a/crates/temps-otel/src/plugin.rs
+++ b/crates/temps-otel/src/plugin.rs
@@ -698,12 +698,12 @@ impl TempsPlugin for OtelPlugin {
             let relay_slot = Arc::new(crate::relay::OtelRelaySlot::new_default());
             let _ = self.relay_slot.set(relay_slot.clone());
 
-            // Bounded channel (capacity 1 000 messages) for fire-and-forget
-            // relay of decoded OTLP batches. Ingest handlers call `try_send`
-            // (non-blocking); when the channel is full the batch is dropped
-            // and a warning is emitted — relay loss is non-fatal.
-            let (otel_relay_tx, mut otel_relay_rx) =
-                tokio::sync::mpsc::channel::<crate::relay::OtelRelayMessage>(1000);
+            // Count- and byte-bounded handoff for fire-and-forget relay of
+            // decoded OTLP batches. Ingest handlers never wait for capacity.
+            let (otel_relay_tx, mut otel_relay_rx) = crate::relay::bounded_relay_queue(
+                crate::relay::RELAY_QUEUE_MAX_BATCHES,
+                crate::relay::RELAY_QUEUE_MAX_BYTES,
+            );
 
             let cross_project_service =
                 Arc::new(CrossProjectTraceService::new(db.clone(), storage.clone()));

--- a/crates/temps-otel/src/relay.rs
+++ b/crates/temps-otel/src/relay.rs
@@ -28,7 +28,7 @@ pub const RELAY_QUEUE_MAX_BATCHES: usize = 128;
 /// Maximum decompressed OTLP payload bytes retained by the process-wide relay
 /// handoff. This is independent of the queue's batch-count bound so a stream of
 /// maximum-size requests cannot consume the count limit times request limit.
-pub const RELAY_QUEUE_MAX_BYTES: usize = 16 * 1024 * 1024;
+pub const RELAY_QUEUE_MAX_BYTES: usize = crate::memory::MAX_RELAY_QUEUE_BYTES;
 
 /// Which OTLP signal type a relay batch belongs to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/temps-otel/src/relay.rs
+++ b/crates/temps-otel/src/relay.rs
@@ -17,6 +17,19 @@
 
 use std::sync::Arc;
 
+use tokio::sync::{mpsc, OwnedSemaphorePermit, Semaphore};
+
+/// Maximum number of batches waiting in the process-wide relay handoff.
+///
+/// The consumer only dispatches into a plugin-owned queue, so a large message
+/// backlog here adds memory without improving destination outage tolerance.
+pub const RELAY_QUEUE_MAX_BATCHES: usize = 128;
+
+/// Maximum decompressed OTLP payload bytes retained by the process-wide relay
+/// handoff. This is independent of the queue's batch-count bound so a stream of
+/// maximum-size requests cannot consume the count limit times request limit.
+pub const RELAY_QUEUE_MAX_BYTES: usize = 16 * 1024 * 1024;
+
 /// Which OTLP signal type a relay batch belongs to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OtelSignal {
@@ -45,8 +58,94 @@ pub struct OtelRelayMessage {
     pub deployment_id: Option<i32>,
     /// OTLP signal type (Metrics / Traces / Logs).
     pub signal: OtelSignal,
+    /// Number of signal items in the batch (spans, log records, or metric
+    /// points). Relays use this for drop and throughput accounting without
+    /// decoding the protobuf a second time.
+    pub item_count: usize,
     /// Decompressed OTLP protobuf bytes (see module-level note).
     pub payload: bytes::Bytes,
+}
+
+/// Why a non-blocking enqueue into the process-wide relay handoff failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OtelRelayEnqueueError {
+    /// The batch-count limit was reached.
+    BatchCapacity,
+    /// Retaining this payload would exceed the byte budget.
+    ByteCapacity,
+    /// The background relay consumer has exited.
+    Closed,
+}
+
+impl OtelRelayEnqueueError {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::BatchCapacity => "batch_capacity",
+            Self::ByteCapacity => "byte_capacity",
+            Self::Closed => "closed",
+        }
+    }
+}
+
+struct QueuedOtelRelayMessage {
+    message: OtelRelayMessage,
+    _byte_permit: OwnedSemaphorePermit,
+}
+
+/// Non-blocking, byte-aware sender used by OTLP ingest handlers.
+///
+/// A byte permit lives with each queued message and is released when the relay
+/// consumer dequeues that message. Both limits are therefore strict,
+/// and enqueue never waits for capacity on the latency-sensitive ingest path.
+#[derive(Clone)]
+pub struct OtelRelayQueueSender {
+    tx: mpsc::Sender<QueuedOtelRelayMessage>,
+    byte_budget: Arc<Semaphore>,
+}
+
+pub struct OtelRelayQueueReceiver {
+    rx: mpsc::Receiver<QueuedOtelRelayMessage>,
+}
+
+pub fn bounded_relay_queue(
+    max_batches: usize,
+    max_bytes: usize,
+) -> (OtelRelayQueueSender, OtelRelayQueueReceiver) {
+    let (tx, rx) = mpsc::channel(max_batches.max(1));
+    let byte_budget = Arc::new(Semaphore::new(max_bytes.max(1)));
+    (
+        OtelRelayQueueSender { tx, byte_budget },
+        OtelRelayQueueReceiver { rx },
+    )
+}
+
+impl OtelRelayQueueSender {
+    pub fn try_send(&self, message: OtelRelayMessage) -> Result<(), OtelRelayEnqueueError> {
+        let payload_bytes = message.payload.len().max(1);
+        let permits =
+            u32::try_from(payload_bytes).map_err(|_| OtelRelayEnqueueError::ByteCapacity)?;
+        let byte_permit = self
+            .byte_budget
+            .clone()
+            .try_acquire_many_owned(permits)
+            .map_err(|_| OtelRelayEnqueueError::ByteCapacity)?;
+
+        self.tx
+            .try_send(QueuedOtelRelayMessage {
+                message,
+                _byte_permit: byte_permit,
+            })
+            .map_err(|error| match error {
+                mpsc::error::TrySendError::Full(_) => OtelRelayEnqueueError::BatchCapacity,
+                mpsc::error::TrySendError::Closed(_) => OtelRelayEnqueueError::Closed,
+            })
+    }
+}
+
+impl OtelRelayQueueReceiver {
+    pub async fn recv(&mut self) -> Option<OtelRelayMessage> {
+        self.rx.recv().await.map(|queued| queued.message)
+    }
 }
 
 /// Extension point for observing or relaying decoded OTLP batches.
@@ -164,8 +263,55 @@ mod tests {
             environment_id: None,
             deployment_id: None,
             signal,
+            item_count: 1,
             payload: bytes::Bytes::from_static(b"test-payload"),
         }
+    }
+
+    fn sized_msg(payload_bytes: usize) -> OtelRelayMessage {
+        OtelRelayMessage {
+            project_id: 1,
+            environment_id: None,
+            deployment_id: None,
+            signal: OtelSignal::Traces,
+            item_count: 10,
+            payload: bytes::Bytes::from(vec![0; payload_bytes]),
+        }
+    }
+
+    #[tokio::test]
+    async fn bounded_queue_enforces_and_releases_byte_budget() {
+        let (tx, mut rx) = bounded_relay_queue(4, 8);
+
+        assert!(tx.try_send(sized_msg(8)).is_ok());
+        assert_eq!(
+            tx.try_send(sized_msg(1)),
+            Err(OtelRelayEnqueueError::ByteCapacity)
+        );
+
+        let received = rx.recv().await.expect("queued message");
+        assert_eq!(received.payload.len(), 8);
+        assert!(tx.try_send(sized_msg(8)).is_ok());
+    }
+
+    #[test]
+    fn bounded_queue_rejects_batch_larger_than_byte_budget() {
+        let (tx, _rx) = bounded_relay_queue(4, 8);
+        assert_eq!(
+            tx.try_send(sized_msg(9)),
+            Err(OtelRelayEnqueueError::ByteCapacity)
+        );
+    }
+
+    #[test]
+    fn bounded_queue_enforces_batch_capacity_independently() {
+        let (tx, _rx) = bounded_relay_queue(1, 1024);
+
+        assert!(tx.try_send(sized_msg(8)).is_ok());
+        assert_eq!(
+            tx.try_send(sized_msg(8)),
+            Err(OtelRelayEnqueueError::BatchCapacity)
+        );
     }
 
     // ── Test double ──────────────────────────────────────────────────────

--- a/crates/temps-otel/src/services/otel_service.rs
+++ b/crates/temps-otel/src/services/otel_service.rs
@@ -170,6 +170,10 @@ struct PipelineStatsAtomic {
     /// Ingest requests rejected because the per-project storage quota was
     /// exhausted (→ HTTP 413).
     quota_exceeded_requests: AtomicU64,
+    /// Relay batches rejected by the bounded handoff queue.
+    relay_dropped_batches: AtomicU64,
+    /// Signal items contained in relay batches rejected by the handoff queue.
+    relay_dropped_items: AtomicU64,
 }
 
 impl Default for PipelineStatsAtomic {
@@ -188,6 +192,8 @@ impl Default for PipelineStatsAtomic {
             ingest_errors: AtomicU64::new(0),
             rate_limited_requests: AtomicU64::new(0),
             quota_exceeded_requests: AtomicU64::new(0),
+            relay_dropped_batches: AtomicU64::new(0),
+            relay_dropped_items: AtomicU64::new(0),
         }
     }
 }
@@ -698,6 +704,17 @@ impl OtelService {
 
     // ── Observability ───────────────────────────────────────────────
 
+    /// Record loss of a best-effort relay copy without affecting primary
+    /// ingest success. Called only after the non-blocking relay enqueue fails.
+    pub fn record_relay_drop(&self, item_count: usize) {
+        self.stats
+            .relay_dropped_batches
+            .fetch_add(1, Ordering::Relaxed);
+        self.stats
+            .relay_dropped_items
+            .fetch_add(item_count as u64, Ordering::Relaxed);
+    }
+
     /// Get pipeline statistics snapshot.
     pub fn pipeline_stats(&self) -> PipelineStats {
         PipelineStats {
@@ -714,6 +731,8 @@ impl OtelService {
             ingest_errors: self.stats.ingest_errors.load(Ordering::Relaxed),
             rate_limited_requests: self.stats.rate_limited_requests.load(Ordering::Relaxed),
             quota_exceeded_requests: self.stats.quota_exceeded_requests.load(Ordering::Relaxed),
+            relay_dropped_batches: self.stats.relay_dropped_batches.load(Ordering::Relaxed),
+            relay_dropped_items: self.stats.relay_dropped_items.load(Ordering::Relaxed),
         }
     }
 
@@ -2152,6 +2171,17 @@ mod tests {
 
         drop(permits);
         assert!(service.try_acquire_ingest_permit().is_ok());
+    }
+
+    #[test]
+    fn relay_drops_are_exposed_in_pipeline_stats() {
+        let (service, _storage) = make_service(MockOtelStorage::new());
+        service.record_relay_drop(27);
+        service.record_relay_drop(15);
+
+        let stats = service.pipeline_stats();
+        assert_eq!(stats.relay_dropped_batches, 2);
+        assert_eq!(stats.relay_dropped_items, 42);
     }
 
     // ── span-stats query validation ─────────────────────────────────

--- a/crates/temps-otel/src/services/otel_service.rs
+++ b/crates/temps-otel/src/services/otel_service.rs
@@ -49,16 +49,17 @@ pub struct OtelService {
     stats: PipelineStatsAtomic,
 }
 
-/// Default process-wide limit for OTLP requests that may authenticate,
-/// decompress, decode, and write concurrently. The permit is acquired before
-/// Axum buffers the request body, bounding both task and payload memory
-/// during exporter retry storms.
+/// Conservative fallback process-wide limit for OTLP requests that may
+/// authenticate, decompress, decode, and write concurrently. Normal startup
+/// replaces this with a value derived from effective memory. The permit is
+/// acquired before Axum buffers the request body, bounding both task and
+/// payload memory during exporter retry storms.
 ///
 /// This is a process-wide operational tuning knob, not per-tenant config, so
 /// deployments that need a higher ceiling (larger hardware, many
 /// projects/services sharing one instance) can override it via
 /// `TEMPS_OTEL_MAX_CONCURRENT_INGEST_REQUESTS` — see `OtelConfig::from_env`.
-pub const DEFAULT_MAX_CONCURRENT_INGEST_REQUESTS: usize = 64;
+pub const DEFAULT_MAX_CONCURRENT_INGEST_REQUESTS: usize = 8;
 
 /// Max `si_` ingest requests per service per window. ~10 req/s — far above a
 /// healthy exporter's cadence, low enough to stop a tight-loop flood from

--- a/crates/temps-otel/src/types.rs
+++ b/crates/temps-otel/src/types.rs
@@ -635,6 +635,11 @@ pub struct PipelineStats {
     /// storage quota was exceeded (→ HTTP 413). Written to the metrics store
     /// as `otel.quota_exceeded_requests` (SourceKind::Node, node_id 0) every 60s.
     pub quota_exceeded_requests: u64,
+    /// Cumulative count of best-effort relay batches rejected because the
+    /// bounded relay handoff was saturated or closed.
+    pub relay_dropped_batches: u64,
+    /// Cumulative signal-item count contained in rejected relay batches.
+    pub relay_dropped_items: u64,
 }
 
 // ── Query types ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- replace the batch-count-only OTEL relay channel with independent 128-batch and 16 MiB bounds
- keep the ingest path non-blocking and report whether drops are caused by batch, byte, or closed-channel capacity
- carry signal item counts for downstream throughput/drop accounting
- sample overload warnings to prevent log amplification during sustained saturation

## Saturation behavior

Relay copies are dropped when either bound is reached. Primary OTEL ingestion continues without waiting on forwarding.

## Validation

- cargo test -p temps-otel --lib (568 passed)
- cargo clippy -p temps-otel --lib --tests -- -D warnings
- cargo fmt --all
- OSS boundary grep passed