### PR TITLE
fix(web): send symbolic comparator values for service alert rules

### DIFF
--- a/web/src/lib/service-alert-comparator.test.ts
+++ b/web/src/lib/service-alert-comparator.test.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { describe, expect, test } from 'bun:test'
+import { SERVICE_ALERT_COMPARATOR_OPTIONS } from './service-alert-comparator'
+
+describe('service alert comparator options', () => {
+  test('only offers the symbolic operators the backend accepts', () => {
+    // Mirrors validate_comparator in
+    // crates/temps-providers/src/handlers/metrics_handlers.rs. Regression
+    // test for a bug where the UI sent text forms ("gt", "gte", "lt", "lte")
+    // that the handler rejected with 400 Bad Request.
+    const backendAccepted = new Set(['>', '<', '>=', '<='])
+    const optionValues = SERVICE_ALERT_COMPARATOR_OPTIONS.map((o) => o.value)
+
+    expect(optionValues.length).toBeGreaterThan(0)
+    for (const value of optionValues) {
+      expect(backendAccepted.has(value)).toBe(true)
+    }
+  })
+
+  test('has no duplicate values', () => {
+    const values = SERVICE_ALERT_COMPARATOR_OPTIONS.map((o) => o.value)
+    expect(new Set(values).size).toBe(values.length)
+  })
+})

--- a/web/src/lib/service-alert-comparator.test.ts
+++ b/web/src/lib/service-alert-comparator.test.ts
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 import { describe, expect, test } from 'bun:test'
-import { SERVICE_ALERT_COMPARATOR_OPTIONS } from './service-alert-comparator'
+import {
+  SERVICE_ALERT_COMPARATOR_OPTIONS,
+  type ServiceAlertComparator,
+} from './service-alert-comparator'
 
 describe('service alert comparator options', () => {
   test('only offers the symbolic operators the backend accepts', () => {
@@ -10,13 +13,15 @@ describe('service alert comparator options', () => {
     // crates/temps-providers/src/handlers/metrics_handlers.rs. Regression
     // test for a bug where the UI sent text forms ("gt", "gte", "lt", "lte")
     // that the handler rejected with 400 Bad Request.
-    const backendAccepted = new Set(['>', '<', '>=', '<='])
+    const backendAccepted = new Set<ServiceAlertComparator>([
+      '>',
+      '<',
+      '>=',
+      '<=',
+    ])
     const optionValues = SERVICE_ALERT_COMPARATOR_OPTIONS.map((o) => o.value)
 
-    expect(optionValues.length).toBeGreaterThan(0)
-    for (const value of optionValues) {
-      expect(backendAccepted.has(value)).toBe(true)
-    }
+    expect(new Set(optionValues)).toEqual(backendAccepted)
   })
 
   test('has no duplicate values', () => {

--- a/web/src/lib/service-alert-comparator.ts
+++ b/web/src/lib/service-alert-comparator.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+/** Comparator values accepted by
+ *  `POST /external-services/{id}/metrics/alert-rules`. Must stay in sync with
+ *  `validate_comparator` in
+ *  `crates/temps-providers/src/handlers/metrics_handlers.rs` and the
+ *  `monitoring_alert_rules.comparator` CHECK constraint — both only accept
+ *  the symbolic operators below, not text forms like `gt`/`gte`. */
+export type ServiceAlertComparator = '>' | '>=' | '<' | '<='
+
+export const SERVICE_ALERT_COMPARATOR_OPTIONS: {
+  value: ServiceAlertComparator
+  label: string
+}[] = [
+  { value: '>', label: '> greater than' },
+  { value: '>=', label: '≥ greater or equal' },
+  { value: '<', label: '< less than' },
+  { value: '<=', label: '≤ less or equal' },
+]

--- a/web/src/pages/ServiceMonitoring.tsx
+++ b/web/src/pages/ServiceMonitoring.tsx
@@ -80,6 +80,10 @@ import {
   CartesianGrid,
 } from 'recharts'
 import { formatBytes } from '@/lib/utils'
+import {
+  SERVICE_ALERT_COMPARATOR_OPTIONS,
+  type ServiceAlertComparator,
+} from '@/lib/service-alert-comparator'
 
 // ---------------------------------------------------------------------------
 // View-model types (derived from the generated SDK responses)
@@ -89,9 +93,9 @@ import { formatBytes } from '@/lib/utils'
  *  `metrics/latest` endpoint returns. */
 type MetricLatest = { name: string; value: number }
 
-/** Alert-rule form-state unions. The API accepts `comparator`/`severity` as
- *  plain strings; these constrain the UI selects to the supported values. */
-type Comparator = 'gt' | 'lt' | 'gte' | 'lte'
+/** Alert-rule form-state union for `severity`. The API accepts it as a plain
+ *  string; this constrains the UI select to the supported values.
+ *  `comparator` has its own type — see `@/lib/service-alert-comparator`. */
 type Severity = 'info' | 'warning' | 'critical'
 
 /** Extract a comparable message from whatever the SDK throws on a failed
@@ -774,7 +778,7 @@ function AddAlertRuleDialog({
   const [name, setName] = useState('')
   const [metricName, setMetricName] = useState(ALL_METRICS[engine][0] ?? '')
   const [threshold, setThreshold] = useState('0')
-  const [comparator, setComparator] = useState<Comparator>('gt')
+  const [comparator, setComparator] = useState<ServiceAlertComparator>('>')
   const [severity, setSeverity] = useState<Severity>('warning')
 
   const create = useMutation({
@@ -834,16 +838,19 @@ function AddAlertRuleDialog({
               </label>
               <Select
                 value={comparator}
-                onValueChange={(v) => setComparator(v as Comparator)}
+                onValueChange={(v) =>
+                  setComparator(v as ServiceAlertComparator)
+                }
               >
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="gt">&gt; greater than</SelectItem>
-                  <SelectItem value="gte">&ge; greater or equal</SelectItem>
-                  <SelectItem value="lt">&lt; less than</SelectItem>
-                  <SelectItem value="lte">&le; less or equal</SelectItem>
+                  {SERVICE_ALERT_COMPARATOR_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>


### PR DESCRIPTION
## Summary
- The "Add Alert Rule" dialog on a service's monitoring page (`ServiceMonitoring.tsx`) sent `comparator` values `gt`/`gte`/`lt`/`lte`, but `POST /external-services/{id}/metrics/alert-rules` only ever accepts the symbolic operators `>`, `<`, `>=`, `<=` — matching the OpenAPI spec, the `monitoring_alert_rules` DB CHECK constraint, and the default seed rules. Every submission from that form was rejected with `400 Bad Request: comparator must be one of: >, <, >=, <=`.
- Root cause: this page calls the older external-services alert-rules API, but its comparator options were apparently copied from a different, newer alerts API (OTel detectors) that *does* use text-form values — the two APIs have different contracts and this form used the wrong one.
- Fix: extracted the comparator type/options into `web/src/lib/service-alert-comparator.ts` (symbolic values matching the actual endpoint), updated `ServiceMonitoring.tsx` to use it, and added a regression test (`service-alert-comparator.test.ts`) asserting the options never drift from the backend's accepted set again.
- No backend changes — the Rust handler, DB constraint, and OpenAPI spec were already correct.

## Test plan
- [x] `bun test src` — all 460 existing frontend tests + 2 new ones pass.
- [x] `bunx tsc --noEmit` — clean.
- [x] Reproduced the original bug directly against a local server: `comparator: "gt"` → `400`.
- [x] Confirmed the fixed frontend's value succeeds against the same unmodified backend: `comparator: ">"` → `201`.
- [x] Full browser walkthrough: logged into a local dev instance, created a Postgres external service, opened its monitoring page, filled out "Add Alert Rule" (comparator dropdown now shows `> greater than`, `≥ greater or equal`, `< less than`, `≤ less or equal`), submitted, and got a `201` response plus an "Alert rule created" success toast, with the new rule appearing in the alert rules table.