### PR TITLE
fix(web): send comparator symbols when creating an alert rule

### DIFF
--- a/web/src/components/storage/MonitoringCard.tsx
+++ b/web/src/components/storage/MonitoringCard.tsx
@@ -96,7 +96,18 @@ type MetricLatest = {
 /** Alert-rule form-state unions. The API accepts `comparator`/`severity` as
  *  plain strings; these constrain the UI selects to the supported values. */
 type Comparator = 'gt' | 'lt' | 'gte' | 'lte'
-type Severity = 'info' | 'warning' | 'critical'
+type Severity = 'warning' | 'critical'
+
+/** The API validates `comparator` against the literal symbols (`>`, `<`,
+ *  `>=`, `<=`), not the `Comparator` union's keys — see
+ *  `validate_comparator` in `crates/temps-providers/src/handlers/metrics_handlers.rs`.
+ *  Sending the union key directly (e.g. `"gt"`) fails validation with a 400. */
+const COMPARATOR_SYMBOLS: Record<Comparator, string> = {
+  gt: '>',
+  lt: '<',
+  gte: '>=',
+  lte: '<=',
+}
 
 /** Map the human range selector (hours) to the API's `range` query value. */
 const HOURS_TO_RANGE: Record<number, string> = {
@@ -485,7 +496,6 @@ function AddAlertRuleDialog({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="info">Info</SelectItem>
                 <SelectItem value="warning">Warning</SelectItem>
                 <SelectItem value="critical">Critical</SelectItem>
               </SelectContent>
@@ -503,7 +513,7 @@ function AddAlertRuleDialog({
                 body: {
                   name,
                   metric_name: metricName,
-                  comparator,
+                  comparator: COMPARATOR_SYMBOLS[comparator],
                   threshold: parseFloat(threshold),
                   severity,
                 },


### PR DESCRIPTION
## Summary
- The "Add Alert Rule" dialog on a database service's Monitoring card sent the comparator as its UI-facing key (`gt`/`lt`/`gte`/`lte`) instead of the symbol the backend actually validates (`>`, `<`, `>=`, `<=`), so creating any custom alert rule always failed with a 400 (`comparator must be one of: >, <, >=, <=`, from `validate_comparator` in `crates/temps-providers/src/handlers/metrics_handlers.rs`).
- Also drops the "Info" severity option from the dialog, since `validate_severity` only ever accepted `warning`/`critical` there too — same class of bug, would 400 the same way if selected.

## Verification
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on the changed file
- [x] Traced the mismatch by reading the frontend request body against the backend's `validate_comparator`/`validate_severity`
- [ ] Not manually re-tested end-to-end against a running instance (no working local Docker environment available at the time) — would appreciate a manual click-through before merge