### PR TITLE
fix(deployments): honor configured port over image EXPOSE detection

### DIFF
--- a/crates/temps-deployments/src/jobs/deploy_image.rs
+++ b/crates/temps-deployments/src/jobs/deploy_image.rs
@@ -260,7 +260,17 @@ pub struct DeploymentJobConfig {
     pub namespace: String,
     pub service_name: String,
     pub replicas: u32,
+    /// Fallback container port: the environment/project-configured port when
+    /// set, otherwise the default (3000). Used when `configured_port` is
+    /// `None` and image `EXPOSE` auto-detection finds nothing either.
     pub port: u32,
+    /// Explicit port override from the environment or project scope (in that
+    /// priority order), as resolved by the job planner. When `Some`, this
+    /// wins over image `EXPOSE` auto-detection in `resolve_container_port()`
+    /// — an operator's explicit configuration must never be overridden by a
+    /// heuristic guess at the image's listening port. `None` means neither
+    /// scope configured a port, so auto-detection is allowed to run.
+    pub configured_port: Option<u16>,
     pub environment_variables: HashMap<String, String>,
     /// Secret values (decrypted plaintext) mounted into the container as
     /// files under `/run/secrets/<KEY>` by the deployer. Never injected as
@@ -328,6 +338,7 @@ impl Default for DeploymentJobConfig {
             service_name: "app".to_string(),
             replicas: 1,
             port: 8080,
+            configured_port: None,
             environment_variables: HashMap::new(),
             secrets: HashMap::new(),
             resources: ResourceUsage::default(),
@@ -879,12 +890,29 @@ impl DeployImageJob {
     /// Resolve the actual container port to expose
     ///
     /// Priority order:
-    /// 1. Auto-detected from Docker image EXPOSE directive (source of truth)
-    /// 2. Configured port from environment/project/default (fallback)
+    /// 1. Explicit environment-level or project-level port override
+    ///    (`self.config.configured_port`) — an operator's explicit
+    ///    configuration always wins over a heuristic guess.
+    /// 2. Auto-detected from the Docker image's EXPOSE directive
+    /// 3. Configured/default port (`self.config.port`, e.g. 3000)
     ///
-    /// This method inspects the built image and extracts exposed ports.
+    /// This method inspects the built image and extracts exposed ports, but
+    /// only when neither scope explicitly configures a port.
     async fn resolve_container_port(&self, image_tag: &str, context: &WorkflowContext) -> u16 {
-        // Try to inspect the image and get exposed ports
+        if let Some(configured) = self.config.configured_port {
+            let _ = self
+                .log(
+                    context,
+                    format!(
+                        "Using explicitly configured port: {} (environment/project override)",
+                        configured
+                    ),
+                )
+                .await;
+            return configured;
+        }
+
+        // No explicit override — try to inspect the image and get exposed ports
         match bollard::Docker::connect_with_local_defaults() {
             Ok(docker) => {
                 match crate::utils::docker_inspect::get_primary_port(&docker, image_tag).await {
@@ -934,7 +962,7 @@ impl DeployImageJob {
             }
         }
 
-        // Fallback to configured port (from environment/project/default)
+        // Fallback to configured/default port
         self.config.port as u16
     }
 
@@ -1475,7 +1503,7 @@ impl DeployImageJob {
         let log_path = std::env::temp_dir().join(format!("deploy_{}.log", self.job_id));
 
         // Determine the actual container port to expose
-        // Priority: Image EXPOSE directive > configured port (from environment/project/default)
+        // Priority: explicit environment/project override > Image EXPOSE directive > default
         let container_port = self.resolve_container_port(image_tag, context).await;
 
         // For local deployments, allocate a port on this host.
@@ -2381,6 +2409,14 @@ impl DeployImageJobBuilder {
 
     pub fn port(mut self, port: u32) -> Self {
         self.config.port = port;
+        self
+    }
+
+    /// Explicit port override from the environment/project scope. When
+    /// `Some`, `resolve_container_port()` uses it directly and skips image
+    /// `EXPOSE` auto-detection entirely.
+    pub fn configured_port(mut self, configured_port: Option<u16>) -> Self {
+        self.config.configured_port = configured_port;
         self
     }
 
@@ -3299,6 +3335,64 @@ mod tests {
         // The default standard path is left untouched; precedence is resolved at
         // execution time (override > .temps.yaml > default).
         assert_eq!(job.config.health_check_path, Some("/".to_string()));
+    }
+
+    /// Regression test for https://github.com/gotempsh/temps/issues/879:
+    /// an explicit environment/project port override must win over image
+    /// EXPOSE auto-detection, not the other way around. The image tag here
+    /// doesn't exist, so any attempt to consult it would fail; the override
+    /// must be returned without ever needing a successful inspection.
+    #[tokio::test]
+    async fn test_resolve_container_port_prefers_explicit_override_over_image_detection() {
+        let job = DeployImageJobBuilder::new()
+            .job_id("deploy".to_string())
+            .build_job_id("build_image".to_string())
+            .target(DeploymentTarget::Docker {
+                registry_url: "local".to_string(),
+                network: None,
+            })
+            .service_name("app".to_string())
+            .port(3000)
+            .configured_port(Some(9090))
+            .build(Arc::new(TrackingMockContainerDeployer::new()))
+            .unwrap();
+
+        let context = crate::test_utils::create_test_context("run-1".to_string(), 1, 1, 1);
+
+        let port = job
+            .resolve_container_port("temps-test-nonexistent-image:latest", &context)
+            .await;
+
+        assert_eq!(port, 9090);
+    }
+
+    /// When neither environment nor project configures a port, image
+    /// inspection is attempted; if it fails (as it always will here, since
+    /// the image tag doesn't exist), resolution falls back to the
+    /// configured/default port.
+    #[tokio::test]
+    async fn test_resolve_container_port_falls_back_to_default_without_override() {
+        let job = DeployImageJobBuilder::new()
+            .job_id("deploy".to_string())
+            .build_job_id("build_image".to_string())
+            .target(DeploymentTarget::Docker {
+                registry_url: "local".to_string(),
+                network: None,
+            })
+            .service_name("app".to_string())
+            .port(4000)
+            .build(Arc::new(TrackingMockContainerDeployer::new()))
+            .unwrap();
+
+        assert_eq!(job.config.configured_port, None);
+
+        let context = crate::test_utils::create_test_context("run-1".to_string(), 1, 1, 1);
+
+        let port = job
+            .resolve_container_port("temps-test-nonexistent-image:latest", &context)
+            .await;
+
+        assert_eq!(port, 4000);
     }
 
     #[tokio::test]

--- a/crates/temps-deployments/src/jobs/deploy_image.rs
+++ b/crates/temps-deployments/src/jobs/deploy_image.rs
@@ -260,9 +260,12 @@ pub struct DeploymentJobConfig {
     pub namespace: String,
     pub service_name: String,
     pub replicas: u32,
-    /// Fallback container port: the environment/project-configured port when
-    /// set, otherwise the default (3000). Used when `configured_port` is
-    /// `None` and image `EXPOSE` auto-detection finds nothing either.
+    /// Fallback container port, used when `configured_port` is `None` and
+    /// image `EXPOSE` auto-detection finds nothing either. Every caller that
+    /// builds a real deployment job resolves and sets this explicitly (3000
+    /// when neither environment nor project configures a port); the `8080`
+    /// in [`Default::default`] below is only a placeholder for tests and is
+    /// never meant to reach `resolve_container_port()` unmodified.
     pub port: u32,
     /// Explicit port override from the environment or project scope (in that
     /// priority order), as resolved by the job planner. When `Some`, this

--- a/crates/temps-deployments/src/services/mod.rs
+++ b/crates/temps-deployments/src/services/mod.rs
@@ -20,6 +20,9 @@ pub use managed_environment_variables::*;
 pub mod env_resolver;
 pub use env_resolver::*;
 
+pub mod port_resolver;
+pub use port_resolver::*;
+
 pub mod workflow_execution_service;
 pub use workflow_execution_service::*;
 

--- a/crates/temps-deployments/src/services/port_resolver.rs
+++ b/crates/temps-deployments/src/services/port_resolver.rs
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared resolver for a container's explicit port override, keyed on the
+//! *selected environment*.
+//!
+//! Every deploy path — the normal pipeline (via [`WorkflowPlanner`]), a
+//! promotion, and a rollback — must resolve this the same way, since it is
+//! what tells [`DeployImageJob::resolve_container_port`] to trust an
+//! operator's explicit configuration over image `EXPOSE` auto-detection. A
+//! path that recomputes this inline instead of calling
+//! [`configured_port_override`] risks losing that precedence and silently
+//! reintroducing the bug this function exists to prevent.
+//!
+//! [`WorkflowPlanner`]: super::workflow_planner::WorkflowPlanner
+//! [`DeployImageJob::resolve_container_port`]: crate::jobs::deploy_image::DeployImageJob
+
+use temps_entities::{environments, projects};
+use tracing::debug;
+
+/// Explicit port override configured at the environment or project scope,
+/// in that priority order. `None` means neither scope configures one, in
+/// which case the deploy job falls back to image `EXPOSE` auto-detection
+/// and finally the default port.
+pub fn configured_port_override(
+    environment: &environments::Model,
+    project: &projects::Model,
+) -> Option<u16> {
+    // 1. Environment-level port override (from deployment_config)
+    if let Some(port) = environment
+        .deployment_config
+        .as_ref()
+        .and_then(|c| c.exposed_port)
+    {
+        debug!(
+            "Using environment-level port override: {} (environment: {})",
+            port, environment.name
+        );
+        return Some(port as u16);
+    }
+
+    // 2. Project-level port override (from deployment_config)
+    if let Some(port) = project
+        .deployment_config
+        .as_ref()
+        .and_then(|c| c.exposed_port)
+    {
+        debug!(
+            "Using project-level port override: {} (project: {})",
+            port, project.name
+        );
+        return Some(port as u16);
+    }
+
+    None
+}

--- a/crates/temps-deployments/src/services/services.rs
+++ b/crates/temps-deployments/src/services/services.rs
@@ -2353,17 +2353,9 @@ impl DeploymentService {
 
             // Step 1: Execute DeployImageJob with external image
             // Use the NEW rollback slug as the container name (not the old deployment's slug)
-            let exposed_port = environment
-                .deployment_config
-                .as_ref()
-                .and_then(|config| config.exposed_port)
-                .or_else(|| {
-                    project
-                        .deployment_config
-                        .as_ref()
-                        .and_then(|config| config.exposed_port)
-                })
-                .unwrap_or(3000) as u32;
+            let configured_port =
+                super::port_resolver::configured_port_override(&environment, &project);
+            let exposed_port = configured_port.map(u32::from).unwrap_or(3000);
             let mut deploy_builder = crate::jobs::DeployImageJobBuilder::new()
                 .job_id("deploy_container".to_string())
                 .build_job_id("external-image".to_string())
@@ -2387,6 +2379,7 @@ impl DeploymentService {
                         .unwrap_or(1),
                 )
                 .port(exposed_port)
+                .configured_port(configured_port)
                 .log_id(deploy_log_id.clone())
                 .log_service(self.log_service.clone());
 
@@ -3027,17 +3020,9 @@ impl DeploymentService {
             info!("Promotion: Deploying image: {}", image_name);
 
             // Execute DeployImageJob with external image
-            let exposed_port = target_env
-                .deployment_config
-                .as_ref()
-                .and_then(|config| config.exposed_port)
-                .or_else(|| {
-                    project
-                        .deployment_config
-                        .as_ref()
-                        .and_then(|config| config.exposed_port)
-                })
-                .unwrap_or(3000) as u32;
+            let configured_port =
+                super::port_resolver::configured_port_override(&target_env, &project);
+            let exposed_port = configured_port.map(u32::from).unwrap_or(3000);
             let mut deploy_builder = crate::jobs::DeployImageJobBuilder::new()
                 .job_id("deploy_container".to_string())
                 .build_job_id("external-image".to_string())
@@ -3061,6 +3046,7 @@ impl DeploymentService {
                         .unwrap_or(1),
                 )
                 .port(exposed_port)
+                .configured_port(configured_port)
                 .log_id(deploy_log_id.clone())
                 .log_service(self.log_service.clone());
 

--- a/crates/temps-deployments/src/services/workflow_execution_service.rs
+++ b/crates/temps-deployments/src/services/workflow_execution_service.rs
@@ -1313,6 +1313,14 @@ impl WorkflowExecutionService {
 
                 let port = config.get("port").and_then(|v| v.as_i64()).unwrap_or(3000) as u16;
 
+                // Explicit environment/project port override, as resolved by the
+                // planner. `Some` here means `resolve_container_port()` must use
+                // it directly instead of falling back to image EXPOSE detection.
+                let configured_port = config
+                    .get("configured_port")
+                    .and_then(|v| v.as_i64())
+                    .map(|p| p as u16);
+
                 // Get replicas with priority: environment > project > job config > default (1)
                 let replicas = environment
                     .deployment_config
@@ -1480,6 +1488,7 @@ impl WorkflowExecutionService {
                     .service_name(deployment.slug.clone())
                     .namespace("default".to_string())
                     .port(port as u32)
+                    .configured_port(configured_port)
                     .replicas(replicas)
                     .environment_variables(env_variables)
                     .remote_environment_variables(remote_env_variables)

--- a/crates/temps-deployments/src/services/workflow_planner.rs
+++ b/crates/temps-deployments/src/services/workflow_planner.rs
@@ -1177,52 +1177,6 @@ impl WorkflowPlanner {
         Ok(created_jobs)
     }
 
-    /// Explicit port override configured at the environment or project scope,
-    /// in that priority order. `None` means neither scope configures one, in
-    /// which case the deploy job falls back to image `EXPOSE` auto-detection
-    /// and finally the default port.
-    ///
-    /// This is shared between `resolve_exposed_port()` (which also needs a
-    /// concrete fallback for the `PORT` env var / job config default) and the
-    /// job planner call sites, which additionally stash this value verbatim
-    /// as `job_config["configured_port"]` so `DeployImageJob::resolve_container_port()`
-    /// can tell "explicitly configured" apart from "defaulted to 3000" —
-    /// otherwise an explicit override of 3000 would be indistinguishable from
-    /// no override at all, and image `EXPOSE` detection would incorrectly
-    /// take precedence over it.
-    fn configured_port_override(
-        environment: &environments::Model,
-        project: &projects::Model,
-    ) -> Option<u16> {
-        // 1. Environment-level port override (from deployment_config)
-        if let Some(port) = environment
-            .deployment_config
-            .as_ref()
-            .and_then(|c| c.exposed_port)
-        {
-            debug!(
-                "Using environment-level port override: {} (environment: {})",
-                port, environment.name
-            );
-            return Some(port as u16);
-        }
-
-        // 2. Project-level port override (from deployment_config)
-        if let Some(port) = project
-            .deployment_config
-            .as_ref()
-            .and_then(|c| c.exposed_port)
-        {
-            debug!(
-                "Using project-level port override: {} (project: {})",
-                port, project.name
-            );
-            return Some(port as u16);
-        }
-
-        None
-    }
-
     /// Determine the fallback port configuration for the container
     ///
     /// This method resolves manual port overrides during job planning.
@@ -1237,8 +1191,8 @@ impl WorkflowPlanner {
     /// Note: Image inspection happens in the deploy job (after build completes),
     /// not during planning, since the image doesn't exist yet at planning time.
     /// This method only returns the value used as fallback/default (steps 1, 2
-    /// and 4); callers must separately consult `configured_port_override()` to
-    /// pass the "was this explicit" distinction through to the deploy job.
+    /// and 4); callers must separately consult `super::port_resolver::configured_port_override()`
+    /// to pass the "was this explicit" distinction through to the deploy job.
     ///
     /// # Arguments
     /// * `environment` - Environment model with optional exposed_port
@@ -1250,7 +1204,7 @@ impl WorkflowPlanner {
         project: &projects::Model,
         _image_name: Option<&str>, // Unused - inspection happens in deploy job after build
     ) -> u16 {
-        if let Some(port) = Self::configured_port_override(environment, project) {
+        if let Some(port) = super::port_resolver::configured_port_override(environment, project) {
             return port;
         }
 
@@ -1833,7 +1787,8 @@ impl WorkflowPlanner {
             let exposed_port = self
                 .resolve_exposed_port(environment, project, Some(&image_name))
                 .await;
-            let configured_port = Self::configured_port_override(environment, project);
+            let configured_port =
+                super::port_resolver::configured_port_override(environment, project);
 
             debug!(
                 "📡 Container will expose port {} (image: {})",
@@ -2469,7 +2424,7 @@ impl WorkflowPlanner {
         let exposed_port = self
             .resolve_exposed_port(environment, project, Some(&external_image_ref))
             .await;
-        let configured_port = Self::configured_port_override(environment, project);
+        let configured_port = super::port_resolver::configured_port_override(environment, project);
 
         // Release identity for image deploys. Unlike git builds (which have a
         // commit SHA), an image deploy is pinned to an image tag/digest — that

--- a/crates/temps-deployments/src/services/workflow_planner.rs
+++ b/crates/temps-deployments/src/services/workflow_planner.rs
@@ -1177,19 +1177,68 @@ impl WorkflowPlanner {
         Ok(created_jobs)
     }
 
+    /// Explicit port override configured at the environment or project scope,
+    /// in that priority order. `None` means neither scope configures one, in
+    /// which case the deploy job falls back to image `EXPOSE` auto-detection
+    /// and finally the default port.
+    ///
+    /// This is shared between `resolve_exposed_port()` (which also needs a
+    /// concrete fallback for the `PORT` env var / job config default) and the
+    /// job planner call sites, which additionally stash this value verbatim
+    /// as `job_config["configured_port"]` so `DeployImageJob::resolve_container_port()`
+    /// can tell "explicitly configured" apart from "defaulted to 3000" —
+    /// otherwise an explicit override of 3000 would be indistinguishable from
+    /// no override at all, and image `EXPOSE` detection would incorrectly
+    /// take precedence over it.
+    fn configured_port_override(
+        environment: &environments::Model,
+        project: &projects::Model,
+    ) -> Option<u16> {
+        // 1. Environment-level port override (from deployment_config)
+        if let Some(port) = environment
+            .deployment_config
+            .as_ref()
+            .and_then(|c| c.exposed_port)
+        {
+            debug!(
+                "Using environment-level port override: {} (environment: {})",
+                port, environment.name
+            );
+            return Some(port as u16);
+        }
+
+        // 2. Project-level port override (from deployment_config)
+        if let Some(port) = project
+            .deployment_config
+            .as_ref()
+            .and_then(|c| c.exposed_port)
+        {
+            debug!(
+                "Using project-level port override: {} (project: {})",
+                port, project.name
+            );
+            return Some(port as u16);
+        }
+
+        None
+    }
+
     /// Determine the fallback port configuration for the container
     ///
     /// This method resolves manual port overrides during job planning.
-    /// The actual port used at deployment time is determined by inspecting the built image
-    /// in DeployImageJob.resolve_container_port() with this priority:
+    /// The actual port used at deployment time is determined by
+    /// `DeployImageJob.resolve_container_port()` with this priority:
     ///
-    /// 1. Image EXPOSE directive (inspected after build - highest priority)
-    /// 2. Environment-level exposed_port
-    /// 3. Project-level exposed_port
+    /// 1. Environment-level exposed_port override
+    /// 2. Project-level exposed_port setting
+    /// 3. Image EXPOSE directive (inspected after build)
     /// 4. Default: 3000
     ///
     /// Note: Image inspection happens in the deploy job (after build completes),
     /// not during planning, since the image doesn't exist yet at planning time.
+    /// This method only returns the value used as fallback/default (steps 1, 2
+    /// and 4); callers must separately consult `configured_port_override()` to
+    /// pass the "was this explicit" distinction through to the deploy job.
     ///
     /// # Arguments
     /// * `environment` - Environment model with optional exposed_port
@@ -1201,31 +1250,14 @@ impl WorkflowPlanner {
         project: &projects::Model,
         _image_name: Option<&str>, // Unused - inspection happens in deploy job after build
     ) -> u16 {
-        // 1. Check environment-level port override (from deployment_config)
-        if let Some(ref deployment_config) = environment.deployment_config {
-            if let Some(port) = deployment_config.exposed_port {
-                debug!(
-                    "Using environment-level port override: {} (environment: {})",
-                    port, environment.name
-                );
-                return port as u16;
-            }
+        if let Some(port) = Self::configured_port_override(environment, project) {
+            return port;
         }
 
-        // 2. Check project-level port override (from deployment_config)
-        if let Some(ref deployment_config) = project.deployment_config {
-            if let Some(port) = deployment_config.exposed_port {
-                debug!(
-                    "Using project-level port override: {} (project: {})",
-                    port, project.name
-                );
-                return port as u16;
-            }
-        }
-
-        // 3. Default to 3000
         // Note: Image EXPOSE directive will be checked in DeployImageJob after build completes
-        debug!("Using default port: 3000 (will be overridden by image EXPOSE if present)");
+        debug!(
+            "Using default port: 3000 (may be overridden by image EXPOSE detection since neither environment nor project configures a port)"
+        );
         3000
     }
 
@@ -1801,6 +1833,7 @@ impl WorkflowPlanner {
             let exposed_port = self
                 .resolve_exposed_port(environment, project, Some(&image_name))
                 .await;
+            let configured_port = Self::configured_port_override(environment, project);
 
             debug!(
                 "📡 Container will expose port {} (image: {})",
@@ -1827,6 +1860,7 @@ impl WorkflowPlanner {
 
             let mut job_config = serde_json::json!({
                 "port": exposed_port,
+                "configured_port": configured_port,
                 "replicas": replicas,
                 "image_name": image_name
             });
@@ -2435,6 +2469,7 @@ impl WorkflowPlanner {
         let exposed_port = self
             .resolve_exposed_port(environment, project, Some(&external_image_ref))
             .await;
+        let configured_port = Self::configured_port_override(environment, project);
 
         // Release identity for image deploys. Unlike git builds (which have a
         // commit SHA), an image deploy is pinned to an image tag/digest — that
@@ -2480,6 +2515,7 @@ impl WorkflowPlanner {
 
         let mut job_config = serde_json::json!({
             "port": exposed_port,
+            "configured_port": configured_port,
             "replicas": replicas,
             "image_name": external_image_ref,
             "use_external_image": true,


### PR DESCRIPTION
## Summary
- An explicitly configured environment/project port override was ignored whenever the deployed image also declared a Docker `EXPOSE` directive — `resolve_container_port()` tried image auto-detection first and only fell back to the configured port when detection failed, so an override could never win.
- Threads the explicit override through job planning as `job_config["configured_port"]` (distinct from the `"port"` fallback used for the 3000 default), so the deploy job can tell "explicitly configured" apart from "defaulted to 3000".
- New priority order: environment override > project override > image `EXPOSE` detection > default `3000`, matching the order requested in the issue.

## Test plan
- [x] `cargo test --lib -p temps-deployments` — 691 passed, 0 failed (3 ignored, require Docker)
- [x] Added `test_resolve_container_port_prefers_explicit_override_over_image_detection` and `test_resolve_container_port_falls_back_to_default_without_override` regression tests
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] **End-to-end verification against a local Temps instance:**
  - Built a Docker image with `EXPOSE 9999` (decoy port) whose app actually listens on `$PORT`
  - Created a project with an explicit port override of `4500` (different from the decoy)
  - Deployed the image and confirmed the deployment log shows:
    ```
    📡 Exposed ports: 9999/tcp
    Using explicitly configured port: 4500 (environment/project override)
    🔌 Allocated host port: 64748 → container port: 4500
    ```
  - `docker ps` confirmed the real port mapping was `127.0.0.1:64748->4500/tcp` (not 9999)
  - `curl` against both the host port and the proxy-routed hostname returned the app's actual response, confirming end-to-end routing worked on the configured port rather than the auto-detected one

Fixes #879